### PR TITLE
[cxx-interop] Add support for C++ comparison operators.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1426,16 +1426,16 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_Percent:
     case clang::OverloadedOperatorKind::OO_Amp:
     case clang::OverloadedOperatorKind::OO_Pipe:
-    case clang::OverloadedOperatorKind::OO_LessLess:
-    case clang::OverloadedOperatorKind::OO_GreaterGreater:
-    case clang::OverloadedOperatorKind::OO_AmpAmp:
-    case clang::OverloadedOperatorKind::OO_PipePipe:
     case clang::OverloadedOperatorKind::OO_Less:
     case clang::OverloadedOperatorKind::OO_Greater:
+    case clang::OverloadedOperatorKind::OO_LessLess:
+    case clang::OverloadedOperatorKind::OO_GreaterGreater:
     case clang::OverloadedOperatorKind::OO_EqualEqual:
     case clang::OverloadedOperatorKind::OO_ExclaimEqual:
     case clang::OverloadedOperatorKind::OO_LessEqual:
     case clang::OverloadedOperatorKind::OO_GreaterEqual:
+    case clang::OverloadedOperatorKind::OO_AmpAmp:
+    case clang::OverloadedOperatorKind::OO_PipePipe:
       if (auto FD = dyn_cast<clang::FunctionDecl>(D)) {
         baseName = clang::getOperatorSpelling(op);
         isFunction = true;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1430,6 +1430,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_GreaterGreater:
     case clang::OverloadedOperatorKind::OO_AmpAmp:
     case clang::OverloadedOperatorKind::OO_PipePipe:
+    case clang::OverloadedOperatorKind::OO_Less:
+    case clang::OverloadedOperatorKind::OO_Greater:
+    case clang::OverloadedOperatorKind::OO_EqualEqual:
+    case clang::OverloadedOperatorKind::OO_ExclaimEqual:
+    case clang::OverloadedOperatorKind::OO_LessEqual:
+    case clang::OverloadedOperatorKind::OO_GreaterEqual:
       if (auto FD = dyn_cast<clang::FunctionDecl>(D)) {
         baseName = clang::getOperatorSpelling(op);
         isFunction = true;

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -41,6 +41,30 @@ inline IntBox operator>>(IntBox lhs, IntBox rhs) {
   return IntBox{.value = lhs.value >> rhs.value};
 }
 
+inline bool operator<(IntBox lhs, IntBox rhs) {
+  return lhs.value < rhs.value;
+}
+
+inline bool operator>(IntBox lhs, IntBox rhs) {
+  return lhs.value > rhs.value;
+}
+
+inline bool operator==(IntBox lhs, IntBox rhs) {
+  return lhs.value == rhs.value;
+}
+
+inline bool operator!=(IntBox lhs, IntBox rhs) {
+  return lhs.value != rhs.value;
+}
+
+inline bool operator<=(IntBox lhs, IntBox rhs) {
+  return lhs.value == rhs.value;
+}
+
+inline bool operator>=(IntBox lhs, IntBox rhs) {
+  return lhs.value != rhs.value;
+}
+
 struct BoolBox {
   bool value;
 };

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -41,13 +41,9 @@ inline IntBox operator>>(IntBox lhs, IntBox rhs) {
   return IntBox{.value = lhs.value >> rhs.value};
 }
 
-inline bool operator<(IntBox lhs, IntBox rhs) {
-  return lhs.value < rhs.value;
-}
+inline bool operator<(IntBox lhs, IntBox rhs) { return lhs.value < rhs.value; }
 
-inline bool operator>(IntBox lhs, IntBox rhs) {
-  return lhs.value > rhs.value;
-}
+inline bool operator>(IntBox lhs, IntBox rhs) { return lhs.value > rhs.value; }
 
 inline bool operator==(IntBox lhs, IntBox rhs) {
   return lhs.value == rhs.value;

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -9,6 +9,12 @@
 // CHECK-NEXT: func | (lhs: IntBox, rhs: IntBox) -> IntBox
 // CHECK-NEXT: func << (lhs: IntBox, rhs: IntBox) -> IntBox
 // CHECK-NEXT: func >> (lhs: IntBox, rhs: IntBox) -> IntBox
+// CHECK-NEXT: func < (lhs: IntBox, rhs: IntBox) -> Bool
+// CHECK-NEXT: func > (lhs: IntBox, rhs: IntBox) -> Bool
+// CHECK-NEXT: func == (lhs: IntBox, rhs: IntBox) -> Bool
+// CHECK-NEXT: func != (lhs: IntBox, rhs: IntBox) -> Bool
+// CHECK-NEXT: func <= (lhs: IntBox, rhs: IntBox) -> Bool
+// CHECK-NEXT: func >= (lhs: IntBox, rhs: IntBox) -> Bool
 
 // CHECK:      func && (lhs: BoolBox, rhs: BoolBox) -> BoolBox
 // CHECK-NEXT: func || (lhs: BoolBox, rhs: BoolBox) -> BoolBox

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -14,6 +14,12 @@ let resultAmp = lhs & rhs
 let resultPipe = lhs | rhs
 let resultLessLess = lhs << rhs
 let resultGreaterGreater = lhs >> rhs
+let resultLess = lhs < rhs
+let resultGreater = lhs > rhs
+let resultEqualEqual = lhs == rhs
+let resultExclaimEqual = lhs != rhs
+let resultLessEqual = lhs <= rhs
+let resultGreaterEqual = lhs >= rhs
 
 var lhsBool = BoolBox(value: true)
 var rhsBool = BoolBox(value: false)

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -106,4 +106,58 @@ OperatorsTestSuite.test("pipe pipe (||)") {
   expectEqual(true, result.value)
 }
 
+OperatorsTestSuite.test("less (<)") {
+  let lhs = IntBox(value: 5)
+  let rhs = IntBox(value: 6)
+
+  let result = lhs < rhs
+
+  expectEqual(true, result)
+}
+
+OperatorsTestSuite.test("greater (>)") {
+  let lhs = IntBox(value: 5)
+  let rhs = IntBox(value: 6)
+
+  let result = lhs > rhs
+
+  expectEqual(false, result)
+}
+
+OperatorsTestSuite.test("equal equal (==)") {
+  let lhs = IntBox(value: 5)
+  let rhs = IntBox(value: 5)
+
+  let result = lhs == rhs
+
+  expectEqual(true, result)
+}
+
+OperatorsTestSuite.test("exclaim equal (!=)") {
+  let lhs = IntBox(value: 5)
+  let rhs = IntBox(value: 5)
+
+  let result = lhs != rhs
+
+  expectEqual(false, result)
+}
+
+OperatorsTestSuite.test("less equal (<=)") {
+  let lhs = IntBox(value: 5)
+  let rhs = IntBox(value: 5)
+
+  let result = lhs <= rhs
+
+  expectEqual(true, result)
+}
+
+OperatorsTestSuite.test("greater equal (>=)") {
+  let lhs = IntBox(value: 6)
+  let rhs = IntBox(value: 5)
+
+  let result = lhs >= rhs
+
+  expectEqual(true, result)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -43,7 +43,7 @@ OperatorsTestSuite.test("slash (/)") {
   expectEqual(1, result.value)
 }
 
-OperatorsTestSuite.test("percent") {
+OperatorsTestSuite.test("percent (%)") {
   let lhs = IntBox(value: 11)
   let rhs = IntBox(value: 2)
 
@@ -52,7 +52,7 @@ OperatorsTestSuite.test("percent") {
   expectEqual(1, result.value)
 }
 
-OperatorsTestSuite.test("amp") {
+OperatorsTestSuite.test("amp (&)") {
   let lhs = IntBox(value: 6)
   let rhs = IntBox(value: 5)
 
@@ -61,49 +61,13 @@ OperatorsTestSuite.test("amp") {
   expectEqual(4, result.value)
 }
 
-OperatorsTestSuite.test("pipe") {
+OperatorsTestSuite.test("pipe (|)") {
   let lhs = IntBox(value: 6)
   let rhs = IntBox(value: 5)
 
   let result = lhs | rhs
 
   expectEqual(7, result.value)
-}
-
-OperatorsTestSuite.test("less less (<<)") {
-  let lhs = IntBox(value: 2)
-  let rhs = IntBox(value: 4)
-
-  let result = lhs << rhs
-
-  expectEqual(32, result.value)
-}
-
-OperatorsTestSuite.test("greater greater (>>)") {
-  let lhs = IntBox(value: 512)
-  let rhs = IntBox(value: 8)
-
-  let result = lhs >> rhs
-
-  expectEqual(2, result.value)
-}
-
-OperatorsTestSuite.test("amp amp (&&)") {
-  let lhs = BoolBox(value: true)
-  let rhs = BoolBox(value: false)
-
-  let result = lhs && rhs
-
-  expectEqual(false, result.value)
-}
-
-OperatorsTestSuite.test("pipe pipe (||)") {
-  let lhs = BoolBox(value: true)
-  let rhs = BoolBox(value: false)
-
-  let result = lhs || rhs
-
-  expectEqual(true, result.value)
 }
 
 OperatorsTestSuite.test("less (<)") {
@@ -122,6 +86,24 @@ OperatorsTestSuite.test("greater (>)") {
   let result = lhs > rhs
 
   expectEqual(false, result)
+}
+
+OperatorsTestSuite.test("less less (<<)") {
+  let lhs = IntBox(value: 2)
+  let rhs = IntBox(value: 4)
+
+  let result = lhs << rhs
+
+  expectEqual(32, result.value)
+}
+
+OperatorsTestSuite.test("greater greater (>>)") {
+  let lhs = IntBox(value: 512)
+  let rhs = IntBox(value: 8)
+
+  let result = lhs >> rhs
+
+  expectEqual(2, result.value)
 }
 
 OperatorsTestSuite.test("equal equal (==)") {
@@ -158,6 +140,24 @@ OperatorsTestSuite.test("greater equal (>=)") {
   let result = lhs >= rhs
 
   expectEqual(true, result)
+}
+
+OperatorsTestSuite.test("amp amp (&&)") {
+  let lhs = BoolBox(value: true)
+  let rhs = BoolBox(value: false)
+
+  let result = lhs && rhs
+
+  expectEqual(false, result.value)
+}
+
+OperatorsTestSuite.test("pipe pipe (||)") {
+  let lhs = BoolBox(value: true)
+  let rhs = BoolBox(value: false)
+
+  let result = lhs || rhs
+
+  expectEqual(true, result.value)
 }
 
 runAllTests()


### PR DESCRIPTION
Adds support for C++ operators: `<`, `>`, `==`, `!=`, `<=`, and `>=`.
