### PR TITLE
[CS] Fix a crash in AllowArgumentMismatch

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3456,6 +3456,13 @@ void constraints::simplifyLocator(ASTNode &anchor,
       if (auto subscriptExpr = getAsExpr<SubscriptExpr>(anchor)) {
         anchor = subscriptExpr->getIndex();
         path = path.slice(1);
+
+        // TODO: It would be better if the index expression was always wrapped
+        // in a ParenExpr (if there is no label).
+        if (!(isExpr<TupleExpr>(anchor) || isExpr<ParenExpr>(anchor)) &&
+            !path.empty() && path[0].is<LocatorPathElt::ApplyArgToParam>()) {
+          path = path.slice(1);
+        }
         continue;
       }
 

--- a/validation-test/compiler_crashers_2_fixed/sr12990.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12990.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+
+class ContainerTransition {
+  var viewControllers: [Int: String]?
+  func completeTransition() {
+    viewControllers?[Int//.max
+    // expected-error@-1 {{no exact matches in call to subscript}}
+    // expected-note@-2 {{found candidate with type '((Int).Type) -> Dictionary<Int, String>.SubSequence' (aka '(Int.Type) -> Slice<Dictionary<Int, String>>')}}
+    // expected-note@-3 {{to match this opening '['}}
+  } // expected-error {{expected ']' in expression list}}
+}


### PR DESCRIPTION
The compiler was crashing because `AllowArgumentMismatch` relies on `getFunctionArgApplyInfo()` returning a non-optional `FunctionArgApplyInfo` value, which we failed to provide in a situation when `simplifyLocator` couldn't simplify a locator where a `TypeExpr` was provided as a subscript argument.

Resolves SR-12990
Resolves rdar://problem/64303153

