### PR TITLE
[Gardening] Ignored Package.resolved for swift-inspect.

### DIFF
--- a/tools/swift-inspect/.gitignore
+++ b/tools/swift-inspect/.gitignore
@@ -1,0 +1,1 @@
+Package.resolved


### PR DESCRIPTION
When running build-script with --swift-inspect, the Package.resolved file is created in tools/swift-inspect.  Ignore it.