### PR TITLE
[5.3] [CS] Fix a crash in AllowArgumentMismatch

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3334,6 +3334,13 @@ void constraints::simplifyLocator(Expr *&anchor,
       if (auto subscriptExpr = dyn_cast<SubscriptExpr>(anchor)) {
         anchor = subscriptExpr->getIndex();
         path = path.slice(1);
+
+        // TODO: It would be better if the index expression was always wrapped
+        // in a ParenExpr (if there is no label).
+        if (!(isa<TupleExpr>(anchor) || isa<ParenExpr>(anchor)) &&
+            !path.empty() && path[0].is<LocatorPathElt::ApplyArgToParam>()) {
+          path = path.slice(1);
+        }
         continue;
       }
 

--- a/validation-test/compiler_crashers_2_fixed/sr12990.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12990.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+
+class ContainerTransition {
+  var viewControllers: [Int: String]?
+  func completeTransition() {
+    viewControllers?[Int//.max
+    // expected-error@-1 {{no exact matches in call to subscript}}
+    // expected-note@-2 {{found candidate with type '((Int).Type) -> Dictionary<Int, String>.SubSequence' (aka '(Int.Type) -> Slice<Dictionary<Int, String>>')}}
+    // expected-note@-3 {{to match this opening '['}}
+  } // expected-error {{expected ']' in expression list}}
+}


### PR DESCRIPTION
Cherry-pick of #32356 with an adjustment (using `isa` instead of `isExpr` as it doesn't exist on 5.3 branch).

---

**Explanation**: The compiler was crashing because `AllowArgumentMismatch` relies on `getFunctionArgApplyInfo()` returning a non-optional `FunctionArgApplyInfo` value, which we failed to provide in a situation when `simplifyLocator` couldn't simplify a locator where a `TypeExpr` was provided as a subscript argument.

**Scope**: Affects use of subscript expressions.

**SR Issue**: SR-12990.

**Risk**: Low. This fixes a compiler crash which was found by the stress tester.

**Testing**: Added a validation test

**Reviewed by:** @xedin

Resolves: rdar://problem/64303153