### PR TITLE
Fix the hardcoded Swift AST section / segment name for Mach-O

### DIFF
--- a/include/swift/Basic/Dwarf.h
+++ b/include/swift/Basic/Dwarf.h
@@ -23,8 +23,8 @@ namespace swift {
   /// The DWARF version emitted by the Swift compiler.
   const unsigned DWARFVersion = 4;
 
-  static const char MachOASTSegmentName[] = "__SWIFT";
-  static const char MachOASTSectionName[] = "__ast";
+  static const char MachOASTSegmentName[] = "__DWARF";
+  static const char MachOASTSectionName[] = "__swift_ast";
   static const char ELFASTSectionName[] = ".swift_ast";
   static const char COFFASTSectionName[] = "swiftast";
   static const char WasmASTSectionName[] = ".swift_ast";

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1364,6 +1364,10 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
   assert(!Ctx.hadError());
 
   IRGenOptions Opts;
+  // This tool doesn't pass  the necessary runtime library path to
+  // TypeConverter, because this feature isn't needed.
+  Opts.DisableLegacyTypeInfo = true;
+
   Opts.OutputKind = IRGenOutputKind::ObjectFile;
   IRGenerator irgen(Opts, SILMod);
 

--- a/test/DebugInfo/ASTSection-single.swift
+++ b/test/DebugInfo/ASTSection-single.swift
@@ -1,0 +1,14 @@
+// REQUIRES: executable_test
+// REQUIRES: swift_tools_extra
+
+// Test that a module-wrapped Swift AST section can be parsed.
+
+// RUN: %empty-directory(%t)
+
+// RUN: echo "public let a0 = 0"  >%t/a0.swift
+// RUN: %target-build-swift %t/a0.swift -emit-module -emit-module-path %t/a0.swiftmodule
+// RUN: %target-swift-modulewrap %t/a0.swiftmodule -o %t/a0-mod.o
+
+// RUN: %lldb-moduleimport-test -verbose %t/a0-mod.o | %FileCheck %s
+// CHECK: Importing a0... ok!
+

--- a/test/DebugInfo/ASTSection_linker.swift
+++ b/test/DebugInfo/ASTSection_linker.swift
@@ -6,7 +6,7 @@
 // RUN: %swift-ide-test -test-CompilerInvocation-from-module -source-filename=%t/ASTSection.swiftmodule
 
 // Test the inline section mechanism.
-// RUN: %target-ld %t/ASTSection.o -sectcreate __SWIFT __ast %t/ASTSection.swiftmodule -o %t/ASTSection.dylib -dylib -lSystem -lobjc
+// RUN: %target-ld %t/ASTSection.o -sectcreate __DWARF __swift_ast %t/ASTSection.swiftmodule -o %t/ASTSection.dylib -dylib -lSystem -lobjc
 // RUN: %lldb-moduleimport-test -verbose %t/ASTSection.dylib | %FileCheck %s
 
 // Test the symbol table entry.


### PR DESCRIPTION
to match the one specified in LLVM's Mach-O parser.
Otherwise LLDB could not possibly find it!

This name is used by the swift -modulewrap subcommand, which is currently unused
on Darwin, and primarily intended for use under Linux. However, it may be useful
to better support static archives (.a) files with Swift debug info in the
future. To fully support this, dsymutil and LLDB need to know to look for Swift
AST sections in Mach-O objects other than .dSYM bundled.

Implementation note: It would be nice to get the section name out of libObject,
but with the current architecture this needs a major refactoring that didn't
seem justified, given that there is an end-to-end test to prevent such a mishap
in the future.

<rdar://problem/63991514>
