### PR TITLE
[test] Handle architecture aliasing for OpenBSD.

### DIFF
--- a/test/ModuleInterface/ModuleCache/prebuilt-module-cache-archs.swift
+++ b/test/ModuleInterface/ModuleCache/prebuilt-module-cache-archs.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/include/Lib.swiftmodule)
-// RUN: cp %S/Inputs/prebuilt-module-cache/Lib.swiftinterface %t/include/Lib.swiftmodule/%target-cpu.swiftinterface
+// RUN: cp %S/Inputs/prebuilt-module-cache/Lib.swiftinterface %t/include/Lib.swiftmodule/%target-swiftinterface-name
 
 // Baseline check: if the prebuilt cache path does not exist, everything should
 // still work.

--- a/test/ModuleInterface/ModuleCache/prebuilt-module-cache-unusable.swift
+++ b/test/ModuleInterface/ModuleCache/prebuilt-module-cache-unusable.swift
@@ -2,10 +2,10 @@
 // RUN: %empty-directory(%t/MCP)
 // RUN: %empty-directory(%t/prebuilt-cache/Lib.swiftmodule)
 // RUN: %empty-directory(%t/include/Lib.swiftmodule)
-// RUN: cp %S/Inputs/prebuilt-module-cache/Lib.swiftinterface %t/include/Lib.swiftmodule/%target-cpu.swiftinterface
+// RUN: cp %S/Inputs/prebuilt-module-cache/Lib.swiftinterface %t/include/Lib.swiftmodule/%target-swiftinterface-name
 
 // Prebuild a module for the current target CPU, and put it in the prebuilt cache under some imaginary CPU.
-// RUN: sed -e 's/FromInterface/FromPrebuilt/g' %t/include/Lib.swiftmodule/%target-cpu.swiftinterface | %target-swift-frontend -parse-stdlib -module-cache-path %t/MCP -emit-module-path %t/prebuilt-cache/Lib.swiftmodule/leg128.swiftmodule - -module-name Lib
+// RUN: sed -e 's/FromInterface/FromPrebuilt/g' %t/include/Lib.swiftmodule/%target-swiftinterface-name | %target-swift-frontend -parse-stdlib -module-cache-path %t/MCP -emit-module-path %t/prebuilt-cache/Lib.swiftmodule/leg128.swiftmodule - -module-name Lib
 
 // Make sure that, if there's a module for a different architecture
 // present in the prebuilt cache, it's ignored and the module is

--- a/test/ModuleInterface/ModuleCache/prefer-local-module-to-sdk-framework.swift
+++ b/test/ModuleInterface/ModuleCache/prefer-local-module-to-sdk-framework.swift
@@ -5,11 +5,11 @@
 // RUN: echo 'public func showsUpInBothPlaces() {}' > %t/Lib.swift
 
 // 1. Create a .swiftinterface file containing just one API, and put it inside a second build dir (without a .swiftmodule)
-// RUN: %target-swift-frontend -typecheck %t/Lib.swift -emit-module-interface-path %t/SecondBuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-cpu.swiftinterface -module-name Lib
+// RUN: %target-swift-frontend -typecheck %t/Lib.swift -emit-module-interface-path %t/SecondBuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name -module-name Lib
 
 // 2. Add a new API to the module, and compile just the serialized version in the build dir.
 // RUN: echo 'public func onlyInTheCompiledModule() {}' >> %t/Lib.swift
-// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-cpu.swiftmodule -emit-module-interface-path %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-cpu.swiftinterface -module-name Lib
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftmodule-name -emit-module-interface-path %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name -module-name Lib
 
 // 3. Make sure when we compile this test file, we can access both APIs since we'll
 //    load the compiled .swiftmodule instead of the .swiftinterface in the SDK.
@@ -19,7 +19,7 @@
 // RUN: ls %t/ModuleCache | not grep 'swiftmodule'
 
 // 5. This should also work if the swiftinterface isn't present in the first build dir.
-// RUN: rm %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-cpu.swiftinterface
+// RUN: rm %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name
 // RUN: %target-swift-frontend -typecheck %s -F %t/BuildDir -F %t/SecondBuildDir -module-cache-path %t/ModuleCache
 
 // 6. Make sure we /still/ didn't compile any .swiftinterfaces into the module cache.

--- a/test/ModuleInterface/default-prebuilt-module-location.swift
+++ b/test/ModuleInterface/default-prebuilt-module-location.swift
@@ -10,7 +10,7 @@
 // 3. Compile this into a module and put it into the default prebuilt cache
 //    location relative to the fake resource dir. Also drop an interface into
 //    the build dir.
-// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/PrebuiltModule.swiftmodule/%target-cpu.swiftmodule -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-cpu.swiftinterface
+// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/PrebuiltModule.swiftmodule/%target-swiftmodule-name -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name
 
 // 4. Import this prebuilt module, but DON'T pass in -prebuilt-module-cache-path, it should use the implicit one.
 // RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t

--- a/test/ModuleInterface/swift_build_sdk_interfaces/check-only-mode.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/check-only-mode.swift
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t/sdk/usr/lib/swift/Normal.swiftmodule
 // RUN: mkdir -p %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule
 
-// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name Normal
+// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Normal
 // RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat
-// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name FMWK
+// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name FMWK
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -v -o %t/prebuilt -check-only
 // RUN: ls %t/prebuilt | %FileCheck %s
@@ -18,7 +18,7 @@
 // Touch a file in the SDK (to make it look like it changed) and try again.
 // In -check-only mode, this should force a rebuild.
 // RUN: rm -rf %t/MCP
-// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface
+// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: not %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Normal-*.swiftmodule
 

--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-uses-prebuilt.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-uses-prebuilt.swift
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t/sdk/usr/lib/swift/Normal.swiftmodule
 // RUN: mkdir -p %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule
 
-// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name Normal
+// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Normal
 // RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat
-// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name FMWK
+// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name FMWK
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -v -o %t/prebuilt
 // RUN: ls %t/prebuilt | %FileCheck %s
@@ -19,7 +19,7 @@
 // This should still be able to use the prebuilt modules because they track
 // content hashes, not just size+mtime.
 // RUN: rm -rf %t/MCP
-// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface
+// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: ls %t/MCP/*.swiftmodule | %FileCheck -check-prefix CHECK-CACHE %s
 // RUN: %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/*.swiftmodule
@@ -31,7 +31,7 @@
 // Actually change a file in the SDK, to check that we're tracking dependencies
 // at all.
 // RUN: rm -rf %t/MCP
-// RUN: echo "public func another()" >> %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface
+// RUN: echo "public func another()" >> %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: ls %t/MCP/*.swiftmodule | %FileCheck -check-prefix CHECK-CACHE %s
 // RUN: not %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Normal-*.swiftmodule

--- a/test/ModuleInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/system-dependencies-sdk %t/sdk
-// RUN: echo 'import Platform; public func usesCStruct(_: SomeCStruct?) {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Swifty.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name Swifty -sdk %t/sdk
+// RUN: echo 'import Platform; public func usesCStruct(_: SomeCStruct?) {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Swifty.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Swifty -sdk %t/sdk
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -v -o %t/prebuilt
 // RUN: ls %t/prebuilt | %FileCheck %s

--- a/test/Serialization/load-target-fallback.swift
+++ b/test/Serialization/load-target-fallback.swift
@@ -5,23 +5,23 @@
 
 // RUN: mkdir %t/TargetLibrary.swiftmodule
 // RUN: %target-swift-frontend -emit-module -o %t/TargetLibrary.swiftmodule/%module-target-triple.swiftmodule %S/Inputs/def_func.swift -module-name TargetLibrary
-// RUN: touch %t/TargetLibrary.swiftmodule/%target-cpu.swiftmodule
+// RUN: touch %t/TargetLibrary.swiftmodule/%target-swiftmodule-name
 
 import TargetLibrary
 
 // RUN: mkdir %t/ArchLibrary.swiftmodule
-// RUN: %target-swift-frontend -emit-module -o %t/ArchLibrary.swiftmodule/%target-cpu.swiftmodule %S/Inputs/def_func.swift -module-name ArchLibrary
+// RUN: %target-swift-frontend -emit-module -o %t/ArchLibrary.swiftmodule/%target-swiftmodule-name %S/Inputs/def_func.swift -module-name ArchLibrary
 
 import ArchLibrary
 
 // RUN: mkdir -p %t/TargetModule.framework/Modules/TargetModule.swiftmodule
 // RUN: %target-swift-frontend -emit-module -o %t/TargetModule.framework/Modules/TargetModule.swiftmodule/%module-target-triple.swiftmodule %S/Inputs/def_func.swift -module-name TargetModule
-// RUN: touch %t/TargetModule.framework/Modules/TargetModule.swiftmodule/%target-cpu.swiftmodule
+// RUN: touch %t/TargetModule.framework/Modules/TargetModule.swiftmodule/%target-swiftmodule-name
 
 import TargetModule
 
 // RUN: mkdir -p %t/ArchModule.framework/Modules/ArchModule.swiftmodule
-// RUN: %target-swift-frontend -emit-module -o %t/ArchModule.framework/Modules/ArchModule.swiftmodule/%target-cpu.swiftmodule %S/Inputs/def_func.swift -module-name ArchModule
+// RUN: %target-swift-frontend -emit-module -o %t/ArchModule.framework/Modules/ArchModule.swiftmodule/%target-swiftmodule-name %S/Inputs/def_func.swift -module-name ArchModule
 
 import ArchModule
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -311,6 +311,11 @@ if run_vers.endswith('-simulator'):
 else:
     run_environment=''
 
+target_arch = run_cpu
+if run_os == 'openbsd' and run_cpu == 'amd64':
+   target_arch = run_cpu
+   run_cpu = 'x86_64'
+
 run_ptrsize = '64' if ('64' in run_cpu or run_cpu == "s390x") else '32'
 run_ptrauth = 'ptrauth' if run_cpu == 'arm64e' else 'noptrauth'
 run_endian = 'little' if run_cpu != 's390x' else 'big'
@@ -1625,7 +1630,7 @@ if swift_execution_tests_extra_flags:
 
 platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
 if run_vendor != 'apple':
-    platform_module_dir = make_path(platform_module_dir, run_cpu)
+    platform_module_dir = make_path(platform_module_dir, target_arch)
 
 platform_dylib_dir = platform_module_dir
 if run_os == 'maccatalyst' and config.darwin_maccatalyst_build_flavor == "ios-like":
@@ -1873,6 +1878,7 @@ config.substitutions.append(('%xcode-extra-frameworks-dir', extra_frameworks_dir
 config.substitutions.append(('%target-swiftmodule-name', target_specific_module_triple + '.swiftmodule'))
 config.substitutions.append(('%target-swiftdoc-name', target_specific_module_triple + '.swiftdoc'))
 config.substitutions.append(('%target-swiftsourceinfo-name', target_specific_module_triple + '.swiftsourceinfo'))
+config.substitutions.append(('%target-swiftinterface-name', target_specific_module_triple + '.swiftinterface'))
 
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))


### PR DESCRIPTION
Swift calls the architecture x86_64, OpenBSD calls it amd64. If we use
run_cpu in lit.cfg as-is, then we may need to duplicate lines in each
test for 'x86_64' and 'amd64', which puts a maintenance burden on unit
test developers to ensure they are duplicating changes to each line.

Instead, alias 'amd64' to 'x86_64' for `run_cpu`, but keep the platform
module path referring to 'amd64', in order to distinguish the target
architecture name and the Swift architecture name. This is particularly
relevant for the %target-.*-name pseudovariables used, which should
reference the Swift architecture names.

However, some unit tests are directly referencing %target-cpu directly,
which would break the aliasing. This is done only for swiftinterface
files, so a new substitution is defined in lit.cfg for these variables,
and the affected unit test cases are migrated.