### PR TITLE
[Typechecker] Diagnose use of magic literals as raw value for enum case

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2665,6 +2665,9 @@ ERROR(enum_non_integer_convertible_raw_type_no_value,none,
       "expressible by integer or string literal", ())
 ERROR(enum_raw_value_not_unique,none,
       "raw value for enum case is not unique", ())
+ERROR(enum_raw_value_magic_literal,none,
+      "use of '%0' literal as raw value for enum case is not supported",
+      (StringRef))
 NOTE(enum_raw_value_used_here,none,
      "raw value previously used here", ())
 NOTE(enum_raw_value_incrementing_from_here,none,

--- a/test/Sema/enum_raw_representable_object_literals.swift
+++ b/test/Sema/enum_raw_representable_object_literals.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=ios
+
+import UIKit
+
+struct FooLiteral: _ExpressibleByColorLiteral, _ExpressibleByImageLiteral, _ExpressibleByFileReferenceLiteral {
+  init(_colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
+  init(imageLiteralResourceName: String) {}
+  init(fileReferenceLiteralResourceName: String) {}
+}
+
+enum Foo: FooLiteral { // expected-error {{raw type 'FooLiteral' is not expressible by a string, integer, or floating-point literal}}
+  typealias RawValue = Never
+  var rawValue: Never { fatalError() }
+  init(rawValue: Never) { fatalError() }
+  case bar1 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
+  case bar2 = #imageLiteral(resourceName: "hello.png")
+  case bar3 = #fileLiteral(resourceName: "what.txt")
+}

--- a/validation-test/compiler_crashers_2_fixed/sr12998.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12998.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+
+enum FooString: String { // expected-error {{'FooString' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  case bar1 = #file // expected-error {{use of '#file' literal as raw value for enum case is not supported}}
+  case bar2 = #function // expected-error {{use of '#function' literal as raw value for enum case is not supported}}
+  case bar3 = #filePath // expected-error {{use of '#filePath' literal as raw value for enum case is not supported}}
+  case bar4 = #line // expected-error {{cannot convert value of type 'Int' to raw type 'String'}}
+  case bar5 = #column // expected-error {{cannot convert value of type 'Int' to raw type 'String'}}
+  case bar6 = #dsohandle // expected-error {{cannot convert value of type 'UnsafeRawPointer' to raw type 'String'}}
+}
+
+enum FooInt: Int { // expected-error {{'FooInt' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  case bar1 = #file // expected-error {{cannot convert value of type 'String' to raw type 'Int'}}
+  case bar2 = #function // expected-error {{cannot convert value of type 'String' to raw type 'Int'}}
+  case bar3 = #filePath // expected-error {{cannot convert value of type 'String' to raw type 'Int'}}
+  case bar4 = #line // expected-error {{use of '#line' literal as raw value for enum case is not supported}}
+  case bar5 = #column // expected-error {{use of '#column' literal as raw value for enum case is not supported}}
+  case bar6 = #dsohandle // expected-error {{cannot convert value of type 'UnsafeRawPointer' to raw type 'Int'}}
+}


### PR DESCRIPTION
We don't support use of magic literals like `#file` or `#line` as raw values for an enum case. At the moment, the compiler simply crashes when it comes across such literals. I think we can support them but that involves a bit more work so for now let's just diagnose them as unsupported instead of crashing the compiler.

Resolves SR-12998