### PR TITLE
[Sema] Solution nodeTypes from MapVector to DenseMap.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1016,7 +1016,7 @@ public:
   llvm::SmallPtrSet<ConstraintLocator *, 2> DefaultedConstraints;
 
   /// The node -> type mappings introduced by this solution.
-  llvm::MapVector<ASTNode, Type> nodeTypes;
+  llvm::DenseMap<ASTNode, Type> nodeTypes;
 
   /// Contextual types introduced by this solution.
   std::vector<std::pair<ASTNode, ContextualTypeInfo>> contextualTypes;


### PR DESCRIPTION
ConstraintSystem node->type map requires ordering because it is a stack that can be partially undone, but Solution node->type map is all or nothing, so can be cheaper with just a DenseMap.

Impact is small, but this does save ~5% of the time in Sema for expressions with a whole lot of ASTNodes, such as array literals, e.g. https://bugs.swift.org/browse/SR-8314.
