### PR TITLE
[Runtime] Zero out the entire witness table during instantiation.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4537,8 +4537,8 @@ WitnessTableCacheEntry::allocate(
   // Find the allocation.
   void **fullTable = reinterpret_cast<void**>(this + 1);
 
-  // Zero out the private storage area.
-  memset(fullTable, 0, privateSizeInWords * sizeof(void*));
+  // Zero out the witness table.
+  memset(fullTable, 0, getWitnessTableSize(conformance));
 
   // Advance the address point; the private storage area is accessed via
   // negative offsets.


### PR DESCRIPTION
During witness table instantiation, the witness table is constructed
several sources: the pattern, the resilient witnesses, the private
data, and default implementations. The private data area is the only
one that was being zeroed out; the rest we rely on always filling in
the data from the conformance descriptor and provided info.

However, witness table instantiation uses the presence of a NULL
pointer for a particular witness in the resulting table to indicate
that no witness fulfilled that requirement, so that it can fill in the
default witnesss. Except that, without zeroing that part of the table
beforehand, we aren't guaranteed to have a NULL pointer for witness
entries that the client (protocol conformance) did not know about at
the time it was compiled.

Zero out the entire witness table so default implementations can be
filled in appropriately.

Fixes rdar://problem/64295849.
