### PR TITLE
[NFC] Add abstract class which resolves external references

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -29,6 +29,7 @@
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILDefaultWitnessTable.h"
 #include "swift/SIL/SILDifferentiabilityWitness.h"
+#include "swift/SIL/SILReferenceResolver.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/SILPrintContext.h"
@@ -104,7 +105,7 @@ enum class SILStage {
 
 /// A SIL module. The SIL module owns all of the SILFunctions generated
 /// when a Swift compilation context is lowered to SIL.
-class SILModule {
+class SILModule : public SILReferenceResolver {
   friend class SILFunctionBuilder;
 
 public:
@@ -534,7 +535,7 @@ public:
 
   /// Attempt to deserialize the SILFunction. Returns true if deserialization
   /// succeeded, false otherwise.
-  bool loadFunction(SILFunction *F);
+  bool loadFunction(SILFunction *F) override;
 
   /// Update the linkage of the SILFunction with the linkage of the serialized
   /// function.
@@ -576,7 +577,7 @@ public:
   SILWitnessTable *
   lookUpWitnessTable(ProtocolConformanceRef C, bool deserializeLazily=true);
   SILWitnessTable *
-  lookUpWitnessTable(const ProtocolConformance *C, bool deserializeLazily=true);
+  lookUpWitnessTable(const ProtocolConformance *C, bool deserializeLazily=true) override;
 
   /// Attempt to lookup \p Member in the witness table for \p C.
   std::pair<SILFunction *, SILWitnessTable *>
@@ -595,7 +596,7 @@ public:
                                       bool deserializeLazily=true);
 
   /// Look up the VTable mapped to the given ClassDecl. Returns null on failure.
-  SILVTable *lookUpVTable(const ClassDecl *C, bool deserializeLazily = true);
+  SILVTable *lookUpVTable(const ClassDecl *C, bool deserializeLazily = true) override;
 
   /// Attempt to lookup the function corresponding to \p Member in the class
   /// hierarchy of \p Class.

--- a/include/swift/SIL/SILReferenceResolver.h
+++ b/include/swift/SIL/SILReferenceResolver.h
@@ -1,0 +1,43 @@
+//===--- SILReferenceResolver.h - Class for resolving reference -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_REFERENCE_RESOLVER_H
+#define SWIFT_SIL_REFERENCE_RESOLVER_H
+
+#include "swift/AST/Decl.h"
+#include "swift/SIL/SILFunction.h"
+
+namespace swift {
+
+/// An abstract class used to resolve external references.
+///
+/// The implementors should resolve SILFunction, SILVTable and SILWitnessTable
+/// for external modules.
+class SILReferenceResolver {
+public:
+  virtual ~SILReferenceResolver() = default;
+
+  /// Attempt to load the SILFunction. Returns true if loading
+  /// succeeded, false otherwise.
+  virtual bool loadFunction(SILFunction *F) = 0;
+
+  /// Look up the VTable mapped to the given ClassDecl. Returns null on failure.
+  virtual SILVTable *lookUpVTable(const ClassDecl *C, bool deserializeLazily = true) = 0;
+
+  /// Look up the SILWitnessTable representing the lowering of a protocol
+  /// conformance, and collect the substitutions to apply to the referenced
+  /// witnesses, if any.
+  virtual SILWitnessTable *lookUpWitnessTable(const ProtocolConformance *C, bool deserializeLazily=true) = 0;
+};
+
+}
+#endif

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -80,7 +80,7 @@ void SILLinkerVisitor::addFunctionToWorklist(SILFunction *F) {
 
   LLVM_DEBUG(llvm::dbgs() << "Imported function: "
                           << F->getName() << "\n");
-  if (Mod.loadFunction(F)) {
+  if (Resolver.loadFunction(F)) {
     if (F->isExternalDeclaration())
       return;
 
@@ -118,6 +118,7 @@ void SILLinkerVisitor::maybeAddFunctionToWorklist(SILFunction *F) {
   // Update the linkage of the function in case it's different in the serialized
   // SIL than derived from the AST. This can be the case with cross-module-
   // optimizations.
+  auto &Mod = F->getModule();
   Mod.updateFunctionLinkage(F);
 }
 
@@ -144,7 +145,7 @@ void SILLinkerVisitor::linkInVTable(ClassDecl *D) {
   assert(isLinkAll());
 
   // Attempt to lookup the Vtbl from the SILModule.
-  SILVTable *Vtbl = Mod.lookUpVTable(D);
+  SILVTable *Vtbl = Resolver.lookUpVTable(D);
   if (!Vtbl)
     return;
 
@@ -217,7 +218,7 @@ void SILLinkerVisitor::visitProtocolConformance(
   if (!VisitedConformances.insert(C).second)
     return;
 
-  auto *WT = Mod.lookUpWitnessTable(C, mustDeserialize);
+  auto *WT = Resolver.lookUpWitnessTable(C, mustDeserialize);
 
   // If the looked up witness table is a declaration, there is nothing we can
   // do here.

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -36,12 +36,15 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, void> {
   /// The current linking mode.
   LinkingMode Mode;
 
+  /// The external reference resolver.
+  SILReferenceResolver &Resolver;
+
   /// Whether any functions were deserialized.
   bool Changed;
 
 public:
-  SILLinkerVisitor(SILModule &M, SILModule::LinkingMode LinkingMode)
-      : Mod(M), Worklist(), Mode(LinkingMode), Changed(false) {}
+  SILLinkerVisitor(SILModule &M, SILModule::LinkingMode LinkingMode, SILReferenceResolver &R)
+      : Mod(M), Worklist(), Mode(LinkingMode), Resolver(R), Changed(false) {}
 
   /// Process F, recursively deserializing any thing F may reference.
   /// Returns true if any deserialization was performed.

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -353,7 +353,7 @@ void SILModule::updateFunctionLinkage(SILFunction *F) {
 }
 
 bool SILModule::linkFunction(SILFunction *F, SILModule::LinkingMode Mode) {
-  return SILLinkerVisitor(*this, Mode).processFunction(F);
+  return SILLinkerVisitor(*this, Mode, *this).processFunction(F);
 }
 
 SILFunction *SILModule::findFunction(StringRef Name, SILLinkage Linkage) {


### PR DESCRIPTION
SILLinker derives referent SILFunction, VTable and WitnessTable from
SILModule directly. This design works well if there is only one
SILModule. But for LTO, LTO pipeline loads multiple SILModules, so needs
to resolve referent components from each loaded SILModules, not from
SILLoader.

For that kind of new resolution strategy, this adds new abstract class
that abstracts how to resolve external references.

CC: @compnerd

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
