### PR TITLE
[LTO] Extend SILPassManager to be available with multiple modules

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -86,13 +86,15 @@ namespace swift {
     template<typename T>
     T* getAnalysis() { return PM->getAnalysis<T>(); }
 
-    const SILOptions &getOptions() { return PM->getOptions(); }
   };
 
   /// A transformation that operates on functions.
   class SILFunctionTransform : public SILTransform {
     friend class PrettyStackTraceSILFunctionTransform;
     SILFunction *F;
+
+  protected:
+    const SILOptions &getOptions() { return getModule().getOptions(); }
 
   public:
     /// C'tor.
@@ -125,6 +127,7 @@ namespace swift {
     void restartPassPipeline() { PM->restartWithCurrentFunction(this); }
 
     SILFunction *getFunction() { return F; }
+    SILModule &getModule() { return F->getModule(); }
 
     void invalidateAnalysis(SILAnalysis::InvalidationKind K) {
       PM->invalidateAnalysis(F, K);
@@ -134,6 +137,9 @@ namespace swift {
   /// A transformation that operates on modules.
   class SILModuleTransform : public SILTransform {
     SILModule *M;
+
+  protected:
+    const SILOptions &getOptions() { return getModule()->getOptions(); }
 
   public:
     /// C'tor.

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -408,7 +408,8 @@ replaceLoadsByKnownValue(SILFunction *InitF, SILGlobalVariable *SILG,
     // constant, e.g.
     //    let a = 1
     //    let b = a + 1
-    ConstantFolder constFolder(FunctionBuilder, PM->getOptions().AssertConfig);
+    ConstantFolder constFolder(FunctionBuilder,
+                               Module->getOptions().AssertConfig);
     for (SILInstruction *inst : insertedInsts) {
       constFolder.addToWorklist(inst);
     }

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -98,9 +98,9 @@ namespace {
   public:
     SimplifyCFG(SILFunction &Fn, SILTransform &T, bool Verify,
                 bool EnableJumpThread)
-        : FuncBuilder(T), Fn(Fn), PM(T.getPassManager()),
-          ConstFolder(FuncBuilder, PM->getOptions().AssertConfig,
-                      /* EnableDiagnostics */false,
+        : FuncBuilder(T, Fn.getModule()), Fn(Fn), PM(T.getPassManager()),
+          ConstFolder(FuncBuilder, Fn.getModule().getOptions().AssertConfig,
+                      /* EnableDiagnostics */ false,
                       [&](SILInstruction *I) { constFoldingCallback(I); }),
           ShouldVerify(Verify), EnableJumpThread(EnableJumpThread) {}
 


### PR DESCRIPTION
Extend SILPassManager to be available with multiple SILModules. This
extension is necessary to run LTO passes which have multiple modules for
optimization. After this change, we can optimize across modules.

CC: @compnerd 