### PR TITLE
[NameLookup] Ensure extensions are updated after module load

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1331,6 +1331,12 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
 
   decl->prepareLookupTable();
 
+  // If we're allowed to load extensions, call prepareExtensions to ensure we
+  // properly invalidate the lazily-complete cache for any extensions brought in
+  // by modules loaded after-the-fact. This can happen with the LLDB REPL.
+  if (!disableAdditionalExtensionLoading)
+    decl->prepareExtensions();
+
   auto &Table = *decl->LookupTable;
   if (!useNamedLazyMemberLoading) {
     // Make sure we have the complete list of members (in this nominal and in


### PR DESCRIPTION
Call `prepareExtensions` in `prepareLookupTable` to make sure we load in any new extensions brought in by modules loaded after-the-fact. This isn't an issue for normal compilations as we load all the modules up-front in import resolution, but clients such as the LLDB REPL may load in modules later.

As the LLDB REPL appears to be the only client affected by this, the test case is in https://github.com/apple/llvm-project/pull/1338.

Resolves rdar://64040436.