### PR TITLE
[SR-5688] [Sema] Handle key path component base type on MemberAccessOnOptionalBaseFailure

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1076,7 +1076,7 @@ NOTE(optional_base_chain,none,
      "chain the optional using '?' to access member %0 only for non-'nil' "
      "base values", (DeclNameRef))
 NOTE(optional_base_remove_optional_for_keypath_root, none,
-    "remove optional '?' form key path root base type %0", (Type))
+    "remove optional '?' from key path root base type %0", (Type))
 
 ERROR(missing_unwrap_optional_try,none,
       "value of optional type %0 not unwrapped; did you mean to use 'try!' "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1076,7 +1076,7 @@ NOTE(optional_base_chain,none,
      "chain the optional using '?' to access member %0 only for non-'nil' "
      "base values", (DeclNameRef))
 NOTE(optional_base_remove_optional_for_keypath_root, none,
-    "remove optional '?' from key path root base type %0", (Type))
+     "use unwrapped type %0 as key path root", (Type))
 
 ERROR(missing_unwrap_optional_try,none,
       "value of optional type %0 not unwrapped; did you mean to use 'try!' "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1076,7 +1076,7 @@ NOTE(optional_base_chain,none,
      "chain the optional using '?' to access member %0 only for non-'nil' "
      "base values", (DeclNameRef))
 NOTE(optional_base_remove_optional_for_keypath_root, none,
-    "remove optional '?' form key path root type %0", (Type))
+    "remove optional '?' form key path root base type %0", (Type))
 
 ERROR(missing_unwrap_optional_try,none,
       "value of optional type %0 not unwrapped; did you mean to use 'try!' "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1075,6 +1075,9 @@ ERROR(optional_base_not_unwrapped,none,
 NOTE(optional_base_chain,none,
      "chain the optional using '?' to access member %0 only for non-'nil' "
      "base values", (DeclNameRef))
+NOTE(optional_base_remove_optional_for_keypath_root, none,
+    "remove optional '?' form key path root type %0", (Type))
+
 ERROR(missing_unwrap_optional_try,none,
       "value of optional type %0 not unwrapped; did you mean to use 'try!' "
       "or chain with '?'?",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5380,6 +5380,13 @@ public:
       return Loc;
     }
     
+    SourceRange getSourceRange() const {
+      if (auto *indexExpr = getIndexExpr()) {
+        return indexExpr->getSourceRange();
+      }
+      return Loc;
+    }
+    
     Kind getKind() const {
       return KindValue;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1036,10 +1036,7 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
       emitDiagnostic(diag::optional_base_remove_optional_for_keypath_root,
                      unwrappedBaseType)
           .fixItReplace(rootType->getSourceRange(),
-                        unwrappedBaseType.getStringAsComponent());
-    } else {
-      emitDiagnostic(diag::optional_base_chain, Member)
-          .fixItInsertAfter(keyPathExpr->getLoc(), "?");
+                        unwrappedBaseType.getString());
     }
   } else {
     // FIXME: It would be nice to immediately offer "base?.member ?? defaultValue"

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -985,10 +985,14 @@ bool MissingExplicitConversionFailure::diagnoseAsError() {
 }
 
 Type MemberAccessOnOptionalBaseFailure::getMemberBaseType() const {
-  if (auto *memberBaseTypeVar = MemberBaseType->getAs<TypeVariableType>()) {
-    return getSolution().getFixedType(memberBaseTypeVar);
+  auto locator = getLocator();
+  if (locator->isForKeyPathComponent()) {
+    if (auto *memberBaseTypeVar = MemberBaseType->getAs<TypeVariableType>()) {
+      return getSolution().getFixedType(memberBaseTypeVar);
+    }
+    return MemberBaseType;
   }
-  return MemberBaseType;
+  return getType(getAnchor());
 }
 
 SourceRange MemberAccessOnOptionalBaseFailure::getMemberBaseSourceRange() const {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1029,8 +1029,7 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
       locator->getLastElementAs<LocatorPathElt::KeyPathComponent>();
   if (componentPathElt && componentPathElt->getIndex() == 0) {
     // For members where the base type is an optional key path root
-    // let's emit a tailored note suggesting to remove the '?' and a
-    // fix to replace the optional type with its unwrapped type.
+    // let's emit a tailored note suggesting to use its unwrapped type.
     auto *keyPathExpr = castToExpr<KeyPathExpr>(getAnchor());
     if (auto rootType = keyPathExpr->getRootType()) {
       emitDiagnostic(diag::optional_base_remove_optional_for_keypath_root,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1055,6 +1055,7 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
           .fixItInsertAfter(sourceRange.End, "!");
     }
   }
+
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -985,8 +985,7 @@ bool MissingExplicitConversionFailure::diagnoseAsError() {
 }
 
 Type MemberAccessOnOptionalBaseFailure::getMemberBaseType() const {
-  auto locator = getLocator();
-  if (locator->isForKeyPathComponent()) {
+  if (getLocator()->isForKeyPathComponent()) {
     if (auto *memberBaseTypeVar = MemberBaseType->getAs<TypeVariableType>()) {
       return getSolution().getFixedType(memberBaseTypeVar);
     }
@@ -1044,7 +1043,7 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
     // fix to replace the optional type with its unwrapped type.
     if (auto *nominalDecl = unwrappedBaseType->getAnyNominal()) {
       auto *keyPathExpr = castToExpr<KeyPathExpr>(getAnchor());
-      auto unwrappedName = unwrappedBaseType->getAnyNominal()->getBaseName();
+      auto unwrappedName = nominalDecl->getBaseName();
       emitDiagnostic(diag::optional_base_remove_optional_for_keypath_root,
                      baseType)
           .fixItReplace(keyPathExpr->getRootType()->getSourceRange(),

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1036,7 +1036,7 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
       locator->getLastElementAs<LocatorPathElt::KeyPathComponent>();
   if (componentPathElt && componentPathElt->getIndex() == 0) {
     // For members where the base type is an optional key path root
-    // let's emit tailored note suggesting to remove the '?' and a
+    // let's emit a tailored note suggesting to remove the '?' and a
     // fix to replace the optional type with its unwrapped type.
     if (auto *nominalDecl = unwrappedBaseType->getAnyNominal()) {
       auto *keyPathExpr = castToExpr<KeyPathExpr>(getAnchor());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -991,7 +991,7 @@ Type MemberAccessOnOptionalBaseFailure::getMemberBaseType() const {
   return MemberBaseType;
 }
 
-SourceRange MemberAccessOnOptionalBaseFailure::getMemberSourceRange() const {
+SourceRange MemberAccessOnOptionalBaseFailure::getMemberBaseSourceRange() const {
   auto anchor = getAnchor();
   auto locator = getLocator();
 
@@ -1027,10 +1027,10 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
   if (!unwrappedBaseType)
     return false;
   
-  auto sourceRange = getMemberSourceRange();
+  auto baseSourceRange = getMemberBaseSourceRange();
   
-  emitDiagnosticAt(sourceRange.End, diag::optional_base_not_unwrapped, baseType,
-                   Member, unwrappedBaseType);
+  emitDiagnosticAt(baseSourceRange.End, diag::optional_base_not_unwrapped,
+                   baseType, Member, unwrappedBaseType);
 
   auto componentPathElt =
       locator->getLastElementAs<LocatorPathElt::KeyPathComponent>();
@@ -1054,11 +1054,11 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
     // in MissingOptionalUnwrapFailure:diagnose() to offer a default value during
     // the next compile.
     emitDiagnostic(diag::optional_base_chain, Member)
-        .fixItInsertAfter(sourceRange.End, "?");
+        .fixItInsertAfter(baseSourceRange.End, "?");
 
     if (!resultIsOptional) {
       emitDiagnostic(diag::unwrap_with_force_value)
-          .fixItInsertAfter(sourceRange.End, "!");
+          .fixItInsertAfter(baseSourceRange.End, "!");
     }
   }
   return true;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -498,6 +498,7 @@ public:
   }
   
   SourceLoc getLoc() const override {
+    // The end location points the dot in the member access.
     return getSourceRange().End;
   }
   

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -498,10 +498,7 @@ public:
   }
   
   SourceLoc getLoc() const override {
-    if (getLocator()->isForKeyPathComponent()) {
-      return getSourceRange().End;
-    }
-    return FailureDiagnostic::getLoc();
+    return getSourceRange().End;
   }
   
   SourceRange getSourceRange() const override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -490,7 +490,7 @@ public:
                                     bool resultOptional)
       : FailureDiagnostic(solution, locator), Member(memberName),
         MemberBaseType(memberBaseType), ResultTypeIsOptional(resultOptional) {}
-  
+
   bool diagnoseAsError() override;
   
   Type getMemberBaseType() const;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -492,7 +492,10 @@ public:
         MemberBaseType(memberBaseType), ResultTypeIsOptional(resultOptional) {}
   
   bool diagnoseAsError() override;
+  
   Type getMemberBaseType() const;
+  SourceRange getMemberSourceRange() const;
+
 };
 
 /// Diagnose errors associated with rvalues in positions

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -493,8 +493,19 @@ public:
 
   bool diagnoseAsError() override;
   
-  Type getMemberBaseType() const;
-  SourceRange getMemberBaseSourceRange() const;
+  Type getMemberBaseType() const {
+    return getSolution().simplifyType(MemberBaseType)->getRValueType();
+  }
+  
+  SourceLoc getLoc() const override {
+    if (getLocator()->isForKeyPathComponent()) {
+      return getSourceRange().End;
+    }
+    return FailureDiagnostic::getLoc();
+  }
+  
+  SourceRange getSourceRange() const override;
+  
 
 };
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -505,7 +505,6 @@ public:
   }
   
   SourceRange getSourceRange() const override;
-  
 
 };
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -489,12 +489,13 @@ public:
                                     Type memberBaseType,
                                     bool resultOptional)
       : FailureDiagnostic(solution, locator), Member(memberName),
-        MemberBaseType(memberBaseType), ResultTypeIsOptional(resultOptional) {}
+        MemberBaseType(resolveType(memberBaseType)),
+        ResultTypeIsOptional(resultOptional) {}
 
   bool diagnoseAsError() override;
   
   Type getMemberBaseType() const {
-    return getSolution().simplifyType(MemberBaseType)->getRValueType();
+    return MemberBaseType;
   }
   
   SourceLoc getLoc() const override {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -498,7 +498,7 @@ public:
   }
   
   SourceLoc getLoc() const override {
-    // The end location points the dot in the member access.
+    // The end location points to the dot in the member access.
     return getSourceRange().End;
   }
   

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -479,16 +479,20 @@ public:
 /// type without optional chaining or force-unwrapping it first.
 class MemberAccessOnOptionalBaseFailure final : public FailureDiagnostic {
   DeclNameRef Member;
+  Type MemberBaseType;
   bool ResultTypeIsOptional;
 
 public:
   MemberAccessOnOptionalBaseFailure(const Solution &solution,
                                     ConstraintLocator *locator,
-                                    DeclNameRef memberName, bool resultOptional)
+                                    DeclNameRef memberName,
+                                    Type memberBaseType,
+                                    bool resultOptional)
       : FailureDiagnostic(solution, locator), Member(memberName),
-        ResultTypeIsOptional(resultOptional) {}
-
+        MemberBaseType(memberBaseType), ResultTypeIsOptional(resultOptional) {}
+  
   bool diagnoseAsError() override;
+  Type getMemberBaseType() const;
 };
 
 /// Diagnose errors associated with rvalues in positions

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -494,7 +494,7 @@ public:
   bool diagnoseAsError() override;
   
   Type getMemberBaseType() const;
-  SourceRange getMemberSourceRange() const;
+  SourceRange getMemberBaseSourceRange() const;
 
 };
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -83,21 +83,24 @@ bool UnwrapOptionalBase::diagnose(const Solution &solution, bool asNote) const {
   bool resultIsOptional =
       getKind() == FixKind::UnwrapOptionalBaseWithOptionalResult;
   MemberAccessOnOptionalBaseFailure failure(solution, getLocator(), MemberName,
-                                            resultIsOptional);
+                                            MemberBaseType, resultIsOptional);
   return failure.diagnose(asNote);
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::create(ConstraintSystem &cs,
                                                DeclNameRef member,
+                                               Type memberBaseType,
                                                ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      UnwrapOptionalBase(cs, FixKind::UnwrapOptionalBase, member, locator);
+  return new (cs.getAllocator()) UnwrapOptionalBase(
+      cs, FixKind::UnwrapOptionalBase, member, memberBaseType, locator);
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::createWithOptionalResult(
-    ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator) {
-  return new (cs.getAllocator()) UnwrapOptionalBase(
-      cs, FixKind::UnwrapOptionalBaseWithOptionalResult, member, locator);
+    ConstraintSystem &cs, DeclNameRef member, Type memberBaseType,
+    ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      UnwrapOptionalBase(cs, FixKind::UnwrapOptionalBaseWithOptionalResult,
+                         member, memberBaseType, locator);
 }
 
 bool AddAddressOf::diagnose(const Solution &solution, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -336,10 +336,12 @@ protected:
 /// Unwrap an optional base when we have a member access.
 class UnwrapOptionalBase final : public ConstraintFix {
   DeclNameRef MemberName;
+  Type MemberBaseType;
 
   UnwrapOptionalBase(ConstraintSystem &cs, FixKind kind, DeclNameRef member,
-                     ConstraintLocator *locator)
-      : ConstraintFix(cs, kind, locator), MemberName(member) {
+                     Type memberBaseType, ConstraintLocator *locator)
+      : ConstraintFix(cs, kind, locator), MemberName(member),
+        MemberBaseType(memberBaseType) {
     assert(kind == FixKind::UnwrapOptionalBase ||
            kind == FixKind::UnwrapOptionalBaseWithOptionalResult);
   }
@@ -352,11 +354,12 @@ public:
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclNameRef member,
+                                    Type memberBaseType,
                                     ConstraintLocator *locator);
 
   static UnwrapOptionalBase *
   createWithOptionalResult(ConstraintSystem &cs, DeclNameRef member,
-                           ConstraintLocator *locator);
+                           Type memberBaseType, ConstraintLocator *locator);
 };
 
 // Treat rvalue as if it was an lvalue

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6950,12 +6950,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       SmallVector<Constraint *, 2> optionalities;
       auto nonoptionalResult = Constraint::createFixed(
           *this, ConstraintKind::Bind,
-          UnwrapOptionalBase::create(*this, member, locator), memberTy, innerTV,
-          locator);
-      auto optionalResult = Constraint::createFixed(
-          *this, ConstraintKind::Bind,
-          UnwrapOptionalBase::createWithOptionalResult(*this, member, locator),
-          optTy, memberTy, locator);
+          UnwrapOptionalBase::create(*this, member, baseObjTy, locator),
+          memberTy, innerTV, locator);
+      auto optionalResult =
+          Constraint::createFixed(*this, ConstraintKind::Bind,
+                                  UnwrapOptionalBase::createWithOptionalResult(
+                                      *this, member, baseObjTy, locator),
+                                  optTy, memberTy, locator);
       optionalities.push_back(nonoptionalResult);
       optionalities.push_back(optionalResult);
       addDisjunctionConstraint(optionalities, locator);

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1342,3 +1342,10 @@ func rdar62989214() {
     arr[flag].isTrue // expected-error {{cannot convert value of type 'Flag' to expected argument type 'Int'}}
   }
 }
+
+// SR-5688
+func SR5688_1() -> String? { "" }
+SR5688_1!.count // expected-error {{function 'SR5688_1' was used as a property; add () to call it}} {{9-9=()}}
+
+func SR5688_2() -> Int? { 0 }
+let _: Int = SR5688_2! // expected-error {{function 'SR5688_2' was used as a property; add () to call it}} {{22-22=()}}

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -110,8 +110,7 @@ class T {
     func m1() {
       // <rdar://problem/17741575>
       let l = self.m2!.prop1
-      // expected-error@-1 {{cannot force unwrap value of non-optional type '() -> U?'}} {{22-23=}}
-      // expected-error@-2 {{method 'm2' was used as a property; add () to call it}}  {{22-22=()}}
+      // expected-error@-1 {{method 'm2' was used as a property; add () to call it}}  {{22-22=()}}
     }
 
     func m2() -> U! {

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -948,6 +948,10 @@ struct SR5688_C {
     var d: Int
 }
 
+struct SR5688_S {
+  subscript(_ x: Int) -> String? { "" }
+}
+
 func testMemberAccessOnOptionalKeyPathComponent() {
 
   _ = \SR5688_A.b.m
@@ -969,6 +973,15 @@ func testMemberAccessOnOptionalKeyPathComponent() {
   // expected-error@-1 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
   // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{21-21=?}}
   // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{21-21=!}}
+
+  \String?.count 
+  // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
+  // expected-note@-2 {{remove optional '?' form key path root type 'String?'}} {{4-11=String}}
+
+  \SR5688_S.[5].count 
+  // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'count' only for non-'nil' base values}}{{16-16=?}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}{{16-16=!}}
 
 }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -952,6 +952,14 @@ struct SR5688_S {
   subscript(_ x: Int) -> String? { "" }
 }
 
+struct SR5688_O {
+  struct Nested {
+    var foo = ""
+  }
+}
+
+func SR5688_KP(_ kp: KeyPath<String?, Int>) {}
+
 func testMemberAccessOnOptionalKeyPathComponent() {
 
   _ = \SR5688_A.b.m
@@ -976,13 +984,29 @@ func testMemberAccessOnOptionalKeyPathComponent() {
 
   \String?.count 
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
-  // expected-note@-2 {{remove optional '?' from key path root base type 'String?'}} {{4-11=String}}
+  // expected-note@-2 {{use unwrapped type 'String' as key path root}} {{4-11=String}}
+  
+  \Optional<String>.count 
+  // expected-error@-1 {{value of optional type 'Optional<String>' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
+  // expected-note@-2 {{use unwrapped type 'String' as key path root}} {{4-20=String}}
 
   \SR5688_S.[5].count 
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
   // expected-note@-2 {{chain the optional using '?' to access member 'count' only for non-'nil' base values}}{{16-16=?}}
   // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}{{16-16=!}}
 
+
+  \SR5688_O.Nested?.foo.count
+  // expected-error@-1 {{value of optional type 'SR5688_O.Nested?' must be unwrapped to refer to member 'foo' of wrapped base type 'SR5688_O.Nested'}}
+  // expected-note@-2 {{use unwrapped type 'SR5688_O.Nested' as key path root}}{{4-20=SR5688_O.Nested}}
+  
+  \(Int, Int)?.0
+  // expected-error@-1 {{value of optional type '(Int, Int)?' must be unwrapped to refer to member '0' of wrapped base type '(Int, Int)'}}
+  // expected-note@-2 {{use unwrapped type '(Int, Int)' as key path root}}{{4-15=(Int, Int)}}
+  
+  SR5688_KP(\.count)
+  // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'count' only for non-'nil' base values}}{{14-14=?}}
 }
 
 func testSyntaxErrors() { // expected-note{{}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1004,6 +1004,7 @@ func testMemberAccessOnOptionalKeyPathComponent() {
   // expected-error@-1 {{value of optional type '(Int, Int)?' must be unwrapped to refer to member '0' of wrapped base type '(Int, Int)'}}
   // expected-note@-2 {{use unwrapped type '(Int, Int)' as key path root}}{{4-15=(Int, Int)}}
   
+  // TODO(diagnostics) Improve diagnostics refering to key path root not able to be infered as an optional type.
   SR5688_KP(\.count)
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
 }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1006,7 +1006,6 @@ func testMemberAccessOnOptionalKeyPathComponent() {
   
   SR5688_KP(\.count)
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
-  // expected-note@-2 {{chain the optional using '?' to access member 'count' only for non-'nil' base values}}{{14-14=?}}
 }
 
 func testSyntaxErrors() { // expected-note{{}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -949,25 +949,27 @@ struct SR5688_C {
 }
 
 func testMemberAccessOnOptionalKeyPathComponent() {
+
   _ = \SR5688_A.b.m
   // expected-error@-1 {{value of optional type 'SR5688_B?' must be unwrapped to refer to member 'm' of wrapped base type 'SR5688_B'}}
-  // expected-note@-2 {{chain the optional using '?' to access member 'm' only for non-'nil' base values}}
-  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'm' only for non-'nil' base values}} {{18-18=?}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{18-18=!}}
 
   _ = \SR5688_A.b.c.d 
-  // expected-error@-1 {{value of optional type 'SR5688_B?' must be unwrapped to refer to member 'c' of wrapped base type 'SR5688_B'}}
-  // expected-note@-2 {{chain the optional using '?' to access member 'c' only for non-'nil' base values}}
-  // expected-error@-3 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
-  // expected-note@-4 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}}
-  // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  // expected-error@-1 {{value of optional type 'SR5688_B?' must be unwrapped to refer to member 'c' of wrapped base type 'SR5688_B'}} 
+  // expected-note@-2 {{chain the optional using '?' to access member 'c' only for non-'nil' base values}} {{18-18=?}}
+  // expected-error@-3 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}} 
+  // expected-note@-4 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{20-20=?}}
+  // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{20-20=!}}
   _ = \SR5688_A.b?.c.d 
   // expected-error@-1 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
-  // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{21-21=?}}
 
   _ = \SR5688_AA.b.c.d
   // expected-error@-1 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
-  // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}}
-  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{21-21=?}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{21-21=!}}
+
 }
 
 func testSyntaxErrors() { // expected-note{{}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -976,7 +976,7 @@ func testMemberAccessOnOptionalKeyPathComponent() {
 
   \String?.count 
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
-  // expected-note@-2 {{remove optional '?' form key path root type 'String?'}} {{4-11=String}}
+  // expected-note@-2 {{remove optional '?' form key path root base type 'String?'}} {{4-11=String}}
 
   \SR5688_S.[5].count 
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -976,7 +976,7 @@ func testMemberAccessOnOptionalKeyPathComponent() {
 
   \String?.count 
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
-  // expected-note@-2 {{remove optional '?' form key path root base type 'String?'}} {{4-11=String}}
+  // expected-note@-2 {{remove optional '?' from key path root base type 'String?'}} {{4-11=String}}
 
   \SR5688_S.[5].count 
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -930,6 +930,46 @@ func testMissingMember() {
   _ = \String.x.y // expected-error {{value of type 'String' has no member 'x'}}
 }
 
+// SR-5688
+struct  SR5688_A {
+    var b: SR5688_B?
+}
+
+struct SR5688_AA {
+    var b: SR5688_B
+}
+
+struct SR5688_B {
+    var m: Int
+    var c: SR5688_C?
+}
+
+struct SR5688_C {
+    var d: Int
+}
+
+func testMemberAccessOnOptionalKeyPathComponent() {
+  _ = \SR5688_A.b.m
+  // expected-error@-1 {{value of optional type 'SR5688_B?' must be unwrapped to refer to member 'm' of wrapped base type 'SR5688_B'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'm' only for non-'nil' base values}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+
+  _ = \SR5688_A.b.c.d 
+  // expected-error@-1 {{value of optional type 'SR5688_B?' must be unwrapped to refer to member 'c' of wrapped base type 'SR5688_B'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'c' only for non-'nil' base values}}
+  // expected-error@-3 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
+  // expected-note@-4 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}}
+  // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  _ = \SR5688_A.b?.c.d 
+  // expected-error@-1 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}}
+
+  _ = \SR5688_AA.b.c.d
+  // expected-error@-1 {{value of optional type 'SR5688_C?' must be unwrapped to refer to member 'd' of wrapped base type 'SR5688_C'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
<!-- What's in this pull request? -->
The fix was being recorded but it was failing to handle the key path component type.
This just handles the `KeyPathComponent` locator.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-5688.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
