### PR TITLE
[cxx-interop] Use user defined copy constructor to copy C++ objects.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2788,20 +2788,10 @@ void IRGenModule::emitDynamicReplacementOriginalFunctionThunk(SILFunction *f) {
     IGF.Builder.CreateRet(Res);
 }
 
-/// If the calling convention for `ctor` doesn't match the calling convention
-/// that we assumed for it when we imported it as `initializer`, emit and
-/// return a thunk that conforms to the assumed calling convention. The thunk
-/// is marked `alwaysinline`, so it doesn't generate any runtime overhead.
-/// If the assumed calling convention was correct, just return `ctor`.
-///
-/// See also comments in CXXMethodConventions in SIL/IR/SILFunctionType.cpp.
-static llvm::Constant *
-emitCXXConstructorThunkIfNeeded(IRGenModule &IGM, SILFunction *initializer,
-                                const clang::CXXConstructorDecl *ctor,
-                                const LinkEntity &entity,
-                                llvm::Constant *ctorAddress) {
-  Signature signature = IGM.getSignature(initializer->getLoweredFunctionType());
-
+llvm::Constant *swift::irgen::emitCXXConstructorThunkIfNeeded(
+    IRGenModule &IGM, Signature signature,
+    const clang::CXXConstructorDecl *ctor, StringRef name,
+    llvm::Constant *ctorAddress) {
   llvm::FunctionType *assumedFnType = signature.getType();
   llvm::FunctionType *ctorFnType =
       cast<llvm::FunctionType>(ctorAddress->getType()->getPointerElementType());
@@ -2809,13 +2799,6 @@ emitCXXConstructorThunkIfNeeded(IRGenModule &IGM, SILFunction *initializer,
   if (assumedFnType == ctorFnType) {
     return ctorAddress;
   }
-
-  // The thunk has private linkage, so it doesn't need to have a predictable
-  // mangled name -- we just need to make sure the name is unique.
-  llvm::SmallString<32> name;
-  llvm::raw_svector_ostream stream(name);
-  stream << "__swift_cxx_ctor";
-  entity.mangle(stream);
 
   llvm::Function *thunk = llvm::Function::Create(
       assumedFnType, llvm::Function::PrivateLinkage, name, &IGM.Module);
@@ -2892,11 +2875,20 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
     } else {
       auto globalDecl = getClangGlobalDeclForFunction(clangDecl);
       clangAddr = getAddrOfClangGlobalDecl(globalDecl, forDefinition);
+    }
 
-      if (auto ctor = dyn_cast<clang::CXXConstructorDecl>(clangDecl)) {
-        clangAddr =
-            emitCXXConstructorThunkIfNeeded(*this, f, ctor, entity, clangAddr);
-      }
+    if (auto ctor = dyn_cast<clang::CXXConstructorDecl>(clangDecl)) {
+      Signature signature = getSignature(f->getLoweredFunctionType());
+
+      // The thunk has private linkage, so it doesn't need to have a predictable
+      // mangled name -- we just need to make sure the name is unique.
+      llvm::SmallString<32> name;
+      llvm::raw_svector_ostream stream(name);
+      stream << "__swift_cxx_ctor";
+      entity.mangle(stream);
+
+      clangAddr = emitCXXConstructorThunkIfNeeded(*this, signature, ctor, name,
+                                                  clangAddr);
     }
   }
 

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -17,12 +17,13 @@
 #ifndef SWIFT_IRGEN_GENDECL_H
 #define SWIFT_IRGEN_GENDECL_H
 
-#include "swift/Basic/OptimizationMode.h"
-#include "swift/SIL/SILLocation.h"
-#include "llvm/IR/CallingConv.h"
-#include "llvm/Support/CommandLine.h"
 #include "DebugTypeInfo.h"
 #include "IRGen.h"
+#include "swift/Basic/OptimizationMode.h"
+#include "swift/SIL/SILLocation.h"
+#include "clang/AST/DeclCXX.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace llvm {
   class AttributeList;
@@ -57,6 +58,18 @@ namespace irgen {
   createLinkerDirectiveVariable(IRGenModule &IGM, StringRef Name);
 
   void disableAddressSanitizer(IRGenModule &IGM, llvm::GlobalVariable *var);
+
+  /// If the calling convention for `ctor` doesn't match the calling convention
+  /// that we assumed for it when we imported it as `initializer`, emit and
+  /// return a thunk that conforms to the assumed calling convention. The thunk
+  /// is marked `alwaysinline`, so it doesn't generate any runtime overhead.
+  /// If the assumed calling convention was correct, just return `ctor`.
+  ///
+  /// See also comments in CXXMethodConventions in SIL/IR/SILFunctionType.cpp.
+  llvm::Constant *
+  emitCXXConstructorThunkIfNeeded(IRGenModule &IGM, Signature signature,
+                                  const clang::CXXConstructorDecl *ctor,
+                                  StringRef name, llvm::Constant *ctorAddress);
 }
 }
 

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -18,7 +18,7 @@
 // This definition is a placeholder for importing into Swift.
 // It provides size and alignment but cannot be manipulated safely there.
 typedef struct {
-  __swift_uintptr_t refCounts SWIFT_ATTRIBUTE_UNAVAILABLE;
+  __swift_uintptr_t refCounts;
 } InlineRefCountsPlaceholder;
 
 #if defined(__swift__)

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -63,6 +63,17 @@ struct TemplatedConstructorWithExtraArg {
   TemplatedConstructorWithExtraArg(T value, U other) { }
 };
 
+struct HasUserProvidedCopyConstructor {
+  int numCopies;
+  HasUserProvidedCopyConstructor(int numCopies = 0) : numCopies(numCopies) {}
+  HasUserProvidedCopyConstructor(const HasUserProvidedCopyConstructor &other)
+      : numCopies(other.numCopies + 1) {}
+};
+
+struct DeletedCopyConstructor {
+  DeletedCopyConstructor(const DeletedCopyConstructor &) = delete;
+};
+
 // TODO: we should be able to import this constructor correctly. Until we can,
 // make sure not to crash.
 struct UsingBaseConstructor : ConstructorWithParam {

--- a/test/Interop/Cxx/class/constructors-copy-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen.swift
@@ -1,0 +1,47 @@
+// Target-specific tests for C++ copy constructor code generation.
+
+// RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name Swift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
+
+import Constructors
+import TypeClassification
+
+typealias Void = ()
+struct UnsafePointer<T> { }
+struct UnsafeMutablePointer<T> { }
+
+// ITANIUM_X64-LABEL: define swiftcc void @"$ss35copyWithUserProvidedCopyConstructorySo03HascdeF0V_ACtACF"
+// ITANIUM_X64-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])
+// ITANIUM_X64: [[ARG0_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_X64: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_X64: call void @_ZN30HasUserProvidedCopyConstructorC1ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_X64: [[ARG1_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_X64: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_X64: call void @_ZN30HasUserProvidedCopyConstructorC1ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_X64: ret void
+
+// ITANIUM_ARM-LABEL: define protected swiftcc void @"$ss35copyWithUserProvidedCopyConstructorySo03HascdeF0V_ACtACF"
+// ITANIUM_ARM-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])
+// ITANIUM_ARM: [[ARG0_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_ARM: call %struct.HasUserProvidedCopyConstructor* @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM: [[ARG1_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// ITANIUM_ARM: call %struct.HasUserProvidedCopyConstructor* @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM: ret void
+
+// MICROSOFT_X64-LABEL: define dllexport swiftcc void @"$ss35copyWithUserProvidedCopyConstructorySo03HascdeF0V_ACtACF"
+// MICROSOFT_X64-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])
+// MICROSOFT_X64: [[ARG0_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0]] to %struct.HasUserProvidedCopyConstructor*
+// MICROSOFT_X64: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// MICROSOFT_X64: call %struct.HasUserProvidedCopyConstructor* @"??0HasUserProvidedCopyConstructor@@QEAA@AEBU0@@Z"(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// MICROSOFT_X64: [[ARG1_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1]] to %struct.HasUserProvidedCopyConstructor*
+// MICROSOFT_X64: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// MICROSOFT_X64: call %struct.HasUserProvidedCopyConstructor* @"??0HasUserProvidedCopyConstructor@@QEAA@AEBU0@@Z"(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// MICROSOFT_X64: ret void
+
+public func copyWithUserProvidedCopyConstructor(_ x: HasUserProvidedCopyConstructor)
+  -> (HasUserProvidedCopyConstructor, HasUserProvidedCopyConstructor) {
+  return (x, x)
+}

--- a/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-copy-module-interface.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// Make sure we don't import non-copyable types because we will have no way to
+// represent and copy/move these in swift with correct semantics.
+// CHECK-NOT: DeletedCopyConstructor

--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -52,19 +52,25 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
   // ITANIUM_X64-LABEL: define swiftcc void @"$ss48createStructWithSubobjectCopyConstructorAndValueyyF"()
   // ITANIUM_X64: [[MEMBER:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_X64: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
+  // ITANIUM_X64: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_X64: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
   // ITANIUM_X64: void @_ZN33StructWithCopyConstructorAndValueC1Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
-  // ITANIUM_X64: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOc"(%TSo33StructWithCopyConstructorAndValueV* [[MEMBER]], %TSo33StructWithCopyConstructorAndValueV* [[TMP:%.*]])
+  // ITANIUM_X64: [[TMP_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TMP]] to %struct.StructWithCopyConstructorAndValue*
+  // ITANIUM_X64: [[MEMBER_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
+  // ITANIUM_X64: call void @_ZN33StructWithCopyConstructorAndValueC1ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
   // ITANIUM_X64: [[OBJ_MEMBER:%.*]] = getelementptr inbounds %TSo42StructWithSubobjectCopyConstructorAndValueV, %TSo42StructWithSubobjectCopyConstructorAndValueV* [[OBJ]], i32 0, i32 0
   // ITANIUM_X64: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOb"(%TSo33StructWithCopyConstructorAndValueV* [[TMP]], %TSo33StructWithCopyConstructorAndValueV* [[OBJ_MEMBER]])
   // ITANIUM_X64: ret void
-
+  
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$ss48createStructWithSubobjectCopyConstructorAndValueyyF"()
   // ITANIUM_ARM: [[MEMBER:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
+  // ITANIUM_ARM: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_ARM: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
   // ITANIUM_ARM: call %struct.StructWithCopyConstructorAndValue* @_ZN33StructWithCopyConstructorAndValueC2Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
-  // ITANIUM_ARM: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOc"(%TSo33StructWithCopyConstructorAndValueV* [[MEMBER]], %TSo33StructWithCopyConstructorAndValueV* [[TMP:%.*]])
+  // ITANIUM_ARM: [[TMP_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TMP]] to %struct.StructWithCopyConstructorAndValue*
+  // ITANIUM_ARM: [[MEMBER_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
+  // ITANIUM_ARM: call %struct.StructWithCopyConstructorAndValue* @_ZN33StructWithCopyConstructorAndValueC2ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
   // ITANIUM_ARM: [[OBJ_MEMBER:%.*]] = getelementptr inbounds %TSo42StructWithSubobjectCopyConstructorAndValueV, %TSo42StructWithSubobjectCopyConstructorAndValueV* [[OBJ]], i32 0, i32 0
   // ITANIUM_ARM: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOb"(%TSo33StructWithCopyConstructorAndValueV* [[TMP]], %TSo33StructWithCopyConstructorAndValueV* [[OBJ_MEMBER]])
   // ITANIUM_ARM: ret void
@@ -72,9 +78,12 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
   // MICROSOFT_X64-LABEL: define dllexport swiftcc void @"$ss48createStructWithSubobjectCopyConstructorAndValueyyF"()
   // MICROSOFT_X64: [[MEMBER:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // MICROSOFT_X64: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
+  // MICROSOFT_X64: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // MICROSOFT_X64: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
   // MICROSOFT_X64: call %struct.StructWithCopyConstructorAndValue* @"??0StructWithCopyConstructorAndValue@@QEAA@XZ"(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
-  // MICROSOFT_X64: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOc"(%TSo33StructWithCopyConstructorAndValueV* [[MEMBER]], %TSo33StructWithCopyConstructorAndValueV* [[TMP:%.*]])
+  // MICROSOFT_X64: [[TMP_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TMP]] to %struct.StructWithCopyConstructorAndValue*
+  // MICROSOFT_X64: [[MEMBER_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
+  // MICROSOFT_X64: call %struct.StructWithCopyConstructorAndValue* @"??0StructWithCopyConstructorAndValue@@QEAA@AEBU0@@Z"(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
   // MICROSOFT_X64: [[OBJ_MEMBER:%.*]] = getelementptr inbounds %TSo42StructWithSubobjectCopyConstructorAndValueV, %TSo42StructWithSubobjectCopyConstructorAndValueV* [[OBJ]], i32 0, i32 0
   // MICROSOFT_X64: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOb"(%TSo33StructWithCopyConstructorAndValueV* [[TMP]], %TSo33StructWithCopyConstructorAndValueV* [[OBJ_MEMBER]])
   // MICROSOFT_X64: ret void

--- a/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
@@ -52,21 +52,6 @@ func pass(s: StructWithSubobjectDefaultedCopyConstructor) {
   // CHECK: bb0(%0 : $StructWithSubobjectDefaultedCopyConstructor):
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithPrivateDefaultedCopyConstructor)
-func pass(s: StructWithPrivateDefaultedCopyConstructor) {
-  // CHECK: bb0(%0 : $*StructWithPrivateDefaultedCopyConstructor):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithInheritedPrivateDefaultedCopyConstructor)
-func pass(s: StructWithInheritedPrivateDefaultedCopyConstructor) {
-  // CHECK: bb0(%0 : $*StructWithInheritedPrivateDefaultedCopyConstructor):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithSubobjectPrivateDefaultedCopyConstructor)
-func pass(s: StructWithSubobjectPrivateDefaultedCopyConstructor) {
-  // CHECK: bb0(%0 : $*StructWithSubobjectPrivateDefaultedCopyConstructor):
-}
-
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithMoveConstructor)
 func pass(s: StructWithMoveConstructor) {
   // CHECK: bb0(%0 : $*StructWithMoveConstructor):
@@ -149,12 +134,7 @@ func pass(s: StructTriviallyCopyableMovable) {
   // CHECK: bb0(%0 : $StructTriviallyCopyableMovable):
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructNonCopyableTriviallyMovable)
-func pass(s: StructNonCopyableTriviallyMovable) {
-  // CHECK: bb0(%0 : $*StructNonCopyableTriviallyMovable):
-}
-
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructNonCopyableNonMovable)
 func pass(s: StructNonCopyableNonMovable) {
-  // CHECK: bb0(%0 : $*StructNonCopyableNonMovable):
+  // CHECK: bb0(%0 : $StructNonCopyableNonMovable):
 }

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -1,6 +1,10 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
-// Make sure we don't import objects that we can't destroy.
+// Make sure we don't import objects that we can't copy or destroy.
+// CHECK-NOT: StructWithPrivateDefaultedCopyConstructor
+// CHECK-NOT: StructWithInheritedPrivateDefaultedCopyConstructor
+// CHECK-NOT: StructWithSubobjectPrivateDefaultedCopyConstructor
+// CHECK-NOT: StructNonCopyableTriviallyMovable
 // CHECK-NOT: StructWithPrivateDefaultedDestructor
 // CHECK-NOT: StructWithInheritedPrivateDefaultedDestructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedDestructor

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -50,8 +50,11 @@ public func testStructWithSubobjectCopyConstructorAndValue() -> Bool {
 // CHECK: [[MEMBER_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
 // CHECK: call {{.*}}@{{_ZN33StructWithCopyConstructorAndValueC(1|2)Ei|"\?\?0StructWithCopyConstructorAndValue@@QEAA@H@Z"}}(%struct.StructWithCopyConstructorAndValue* {{(noalias )?}}[[MEMBER_STRUCT]], i32 42)
 // CHECK: [[TEMP_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TEMP]] to %struct.StructWithCopyConstructorAndValue*
-// CHECK: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo037StructWithCopyConstructorAndSubobjectcdE5ValueV* [[OBJ]] to %struct.StructWithCopyConstructorAndSubobjectCopyConstructorAndValue*
-// CHECK: call {{.*}}@{{_ZN60StructWithCopyConstructorAndSubobjectCopyConstructorAndValueC(1|2)E33StructWithCopyConstructorAndValue|"\?\?0StructWithCopyConstructorAndSubobjectCopyConstructorAndValue@@QEAA@UStructWithCopyConstructorAndValue@@@Z"}}(%struct.StructWithCopyConstructorAndSubobjectCopyConstructorAndValue* {{(noalias )?}}[[OBJ_AS_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[TEMP_AS_STRUCT]])
+// CHECK: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
+// CHECK: call {{.*}}@{{_ZN33StructWithCopyConstructorAndValueC(1|2)ERKS_|"\?\?0StructWithCopyConstructorAndValue@@QEAA@AEBU0@@Z"}}(%struct.StructWithCopyConstructorAndValue* [[TEMP_AS_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
+// CHECK: [[TEMP_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TEMP]] to %struct.StructWithCopyConstructorAndValue*
+// CHECK: [[OBJ_AS_STRUCT_2:%.*]] = bitcast %TSo037StructWithCopyConstructorAndSubobjectcdE5ValueV* [[OBJ]] to %struct.StructWithCopyConstructorAndSubobjectCopyConstructorAndValue*
+// CHECK: call {{.*}}@{{_ZN60StructWithCopyConstructorAndSubobjectCopyConstructorAndValueC(1|2)E33StructWithCopyConstructorAndValue|"\?\?0StructWithCopyConstructorAndSubobjectCopyConstructorAndValue@@QEAA@UStructWithCopyConstructorAndValue@@@Z"}}(%struct.StructWithCopyConstructorAndSubobjectCopyConstructorAndValue* {{(noalias )?}}[[OBJ_AS_STRUCT_2]], %struct.StructWithCopyConstructorAndValue* [[TEMP_AS_STRUCT_2]])
 // CHECK: [[TEMP_MEMBER:%.*]] = getelementptr inbounds %TSo33StructWithCopyConstructorAndValueV, %TSo33StructWithCopyConstructorAndValueV* [[TEMP2]], i32 0, i32 0
 // CHECK: [[TEMP_MEMBER_VAL:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[TEMP_MEMBER]], i32 0, i32 0
 // CHECK: [[LHS:%.*]] = load i32, i32* [[TEMP_MEMBER_VAL]]

--- a/test/Interop/Cxx/value-witness-table/Inputs/copy-constructors.h
+++ b/test/Interop/Cxx/value-witness-table/Inputs/copy-constructors.h
@@ -1,0 +1,30 @@
+#ifndef TEST_INTEROP_CXX_VALUE_WITNESS_TABLE_INPUTS_COPY_CONSTRUCTORS_H
+#define TEST_INTEROP_CXX_VALUE_WITNESS_TABLE_INPUTS_COPY_CONSTRUCTORS_H
+
+struct HasUserProvidedCopyConstructor {
+  int numCopies;
+  HasUserProvidedCopyConstructor(int numCopies = 0) : numCopies(numCopies) {}
+  HasUserProvidedCopyConstructor(const HasUserProvidedCopyConstructor &other)
+      : numCopies(other.numCopies + 1) {}
+};
+
+struct HasNonTrivialImplicitCopyConstructor {
+  HasUserProvidedCopyConstructor box;
+  HasNonTrivialImplicitCopyConstructor()
+      : box(HasUserProvidedCopyConstructor()) {}
+};
+
+struct HasNonTrivialDefaultCopyConstructor {
+  HasUserProvidedCopyConstructor box;
+  HasNonTrivialDefaultCopyConstructor()
+      : box(HasUserProvidedCopyConstructor()) {}
+  HasNonTrivialDefaultCopyConstructor(
+      const HasNonTrivialDefaultCopyConstructor &) = default;
+};
+
+// Make sure that we don't crash on struct templates with copy-constructors.
+template <typename T> struct S {
+  S(S const &) {}
+};
+
+#endif // TEST_INTEROP_CXX_VALUE_WITNESS_TABLE_INPUTS_COPY_CONSTRUCTORS_H

--- a/test/Interop/Cxx/value-witness-table/Inputs/module.modulemap
+++ b/test/Interop/Cxx/value-witness-table/Inputs/module.modulemap
@@ -7,3 +7,8 @@ module WitnessLayoutOpts {
   header "witness-layout-opts.h"
   requires cplusplus
 }
+
+module CopyConstructors {
+  header "copy-constructors.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/value-witness-table/copy-constructors-execution.swift
+++ b/test/Interop/Cxx/value-witness-table/copy-constructors-execution.swift
@@ -1,0 +1,51 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import CopyConstructors
+import StdlibUnittest
+
+var CXXCopyConstructorTestSuite = TestSuite("CXX Copy Constructor")
+
+// It doesn't really matter how many copies were made (as long as it's at least
+// one). What we really want to be checking is that the correct copy constructor
+// was eventually called.
+
+CXXCopyConstructorTestSuite.test("Basic object with custom copy constructor") {
+  // Make sure we don't inline this function. We should copy "userCC" into the
+  // two tuple elements (in the return address). If we inline this function, it
+  // would allow Swift to put "userCC" directly into "expectTrue" which would
+  // eliminate the copy.
+  @inline(never)
+  func createHasUserProvidedCopyConstructor() -> (HasUserProvidedCopyConstructor, HasUserProvidedCopyConstructor) {
+    let userCC = HasUserProvidedCopyConstructor(0)
+    return (userCC, userCC)
+  }
+  
+  let result = createHasUserProvidedCopyConstructor()
+  expectTrue(result.0.numCopies + result.1.numCopies > 0)
+}
+
+CXXCopyConstructorTestSuite.test("Implicit copy constructor, member with user-defined copy constructor") {
+  @inline(never)
+  func createTypeWithNonTrivialImplicitCopyConstructor() -> (HasNonTrivialImplicitCopyConstructor, HasNonTrivialImplicitCopyConstructor) {
+    let implicit = HasNonTrivialImplicitCopyConstructor()
+    return (implicit, implicit)
+  }
+
+  let result = createTypeWithNonTrivialImplicitCopyConstructor()
+  expectTrue(result.0.box.numCopies + result.1.box.numCopies > 0)
+}
+
+CXXCopyConstructorTestSuite.test("Default copy constructor, member with user-defined copy constructor") {
+  @inline(never)
+  func createTypeWithNonTrivialDefaultCopyConstructor() -> (HasNonTrivialDefaultCopyConstructor, HasNonTrivialDefaultCopyConstructor) {
+    let def = HasNonTrivialDefaultCopyConstructor()
+    return (def, def)
+  }
+  
+  let result = createTypeWithNonTrivialDefaultCopyConstructor()
+  expectTrue(result.0.box.numCopies + result.1.box.numCopies > 0)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/value-witness-table/copy-constructors-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/copy-constructors-irgen.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+
+// REQUIRES: CPU=x86_64
+// REQUIRES: objc_interop
+
+import CopyConstructors
+
+// CHECK-LABEL: define swiftcc void @"$s4main31testUserProvidedCopyConstructor3objSo03HascdeF0V_AEtAE_tF"
+// CHECK: [[T0_DEST:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0:%[0-9]+]] to %struct.HasUserProvidedCopyConstructor*
+// CHECK: [[T0_SRC:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2:%[0-9]+]] to %struct.HasUserProvidedCopyConstructor*
+// CHECK: call void @_ZN30HasUserProvidedCopyConstructorC1ERKS_(%struct.HasUserProvidedCopyConstructor* [[T0_DEST]], %struct.HasUserProvidedCopyConstructor* [[T0_SRC]])
+// CHECK: [[T1_DEST:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1:%[0-9]+]] to %struct.HasUserProvidedCopyConstructor*
+// CHECK: [[T1_SRC:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
+// CHECK: call void @_ZN30HasUserProvidedCopyConstructorC1ERKS_(%struct.HasUserProvidedCopyConstructor* [[T1_DEST]], %struct.HasUserProvidedCopyConstructor* [[T1_SRC]])
+// CHECK: ret void
+
+// CHECK-LABEL: define linkonce_odr void @_ZN30HasUserProvidedCopyConstructorC1ERKS_
+
+public func testUserProvidedCopyConstructor(obj : HasUserProvidedCopyConstructor) -> (HasUserProvidedCopyConstructor, HasUserProvidedCopyConstructor) {
+  return (obj, obj)
+}
+
+// CHECK-LABEL: define swiftcc void @"$s4main26testDefaultCopyConstructor3defSo013HasNonTrivialcdE0V_AEtAE_tF"
+// CHECK: call void @_ZN35HasNonTrivialDefaultCopyConstructorC1ERKS_
+// CHECK: call void @_ZN35HasNonTrivialDefaultCopyConstructorC1ERKS_
+
+// Make sure we call the copy constructor of our member (HasUserProvidedCopyConstructor)
+// CHECK-LABEL: define linkonce_odr void @_ZN35HasNonTrivialDefaultCopyConstructorC1ERKS_
+// CHECK: call void @_ZN35HasNonTrivialDefaultCopyConstructorC2ERKS_
+
+public func testDefaultCopyConstructor(def : HasNonTrivialDefaultCopyConstructor) -> (HasNonTrivialDefaultCopyConstructor, HasNonTrivialDefaultCopyConstructor) {
+  return (def, def)
+}
+
+// CHECK-LABEL: define swiftcc void @"$s4main27testImplicitCopyConstructor3impSo013HasNonTrivialcdE0V_AEtAE_tF"
+// CHECK: call void @_ZN36HasNonTrivialImplicitCopyConstructorC1ERKS_
+// CHECK: call void @_ZN36HasNonTrivialImplicitCopyConstructorC1ERKS_
+
+// Same as above.
+// CHECK-LABEL: define linkonce_odr void @_ZN36HasNonTrivialImplicitCopyConstructorC1ERKS_
+// CHECK: call void  @_ZN36HasNonTrivialImplicitCopyConstructorC2ERKS_
+
+public func testImplicitCopyConstructor(imp : HasNonTrivialImplicitCopyConstructor) -> (HasNonTrivialImplicitCopyConstructor, HasNonTrivialImplicitCopyConstructor) {
+  return (imp, imp)
+}


### PR DESCRIPTION
Calls user-defined copy constructor when present. Based on #30630 (probably best to wait until that lands to review this).