### PR TITLE
build: do not assume that XML2 should be enabled

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -218,7 +218,7 @@ foreach(SDK ${SWIFT_SDKS})
     set(validation_test_bin_dir
         "${CMAKE_CURRENT_BINARY_DIR}/../validation-test${VARIANT_SUFFIX}")
 
-    if(LibXml2_FOUND)
+    if(LLVM_ENABLE_LIBXML2)
       set(SWIFT_HAVE_LIBXML2 TRUE)
     else()
       set(SWIFT_HAVE_LIBXML2 FALSE)

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(swift-ide-test
                         swiftIDE)
 
 # If libxml2 is available, make it available for swift-ide-test.
-if(LibXml2_FOUND)
+if(LLVM_ENABLE_LIBXML2)
   include_directories(SYSTEM ${LIBXML2_INCLUDE_DIR})
   target_link_libraries(swift-ide-test PRIVATE ${LIBXML2_LIBRARIES})
   target_compile_definitions(swift-ide-test PRIVATE SWIFT_HAVE_LIBXML=1)


### PR DESCRIPTION
Allow user control over libxml2 usage via `LLVM_ENABLE_LIBXML2` rather
than assuming that if it is found, it should be enabled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
