### PR TITLE
[5.3] MandatoryInlining: fix a memory lifetime bug related to partial_apply with in_guaranteed parameters.

### DIFF
--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1428,3 +1428,38 @@ bb0(%0 : $@callee_guaranteed () -> ()):
   %9999 = tuple()
   return %9999 : $()
 }
+
+struct Mystruct {
+  var s: String
+}
+
+sil  @use_string : $@convention(thin) (@guaranteed String) -> ()
+
+sil private [transparent] [ossa] @callee_with_guaranteed : $@convention(thin) (Bool, @in_guaranteed Mystruct) -> () {
+bb0(%0 : $Bool, %1 : $*Mystruct):
+  %4 = struct_element_addr %1 : $*Mystruct, #Mystruct.s
+  %5 = load [copy] %4 : $*String
+  %6 = function_ref  @use_string : $@convention(thin) (@guaranteed String) -> ()
+  %7 = apply %6(%5)  : $@convention(thin) (@guaranteed String) -> ()
+  destroy_value %5 : $String
+  %19 = tuple ()
+  return %19 : $()
+}
+
+// Make sure that this doesn't cause a memory lifetime failure.
+//
+// CHECK-LABEL: sil [ossa] @partial_apply_with_indirect_param
+// CHECK: } // end sil function 'partial_apply_with_indirect_param'
+sil [ossa] @partial_apply_with_indirect_param : $@convention(thin) (@in_guaranteed Mystruct, Bool) -> () {
+bb0(%0 : $*Mystruct, %1 : $Bool):
+  %216 = function_ref @callee_with_guaranteed : $@convention(thin) (Bool, @in_guaranteed Mystruct) -> ()
+  %217 = alloc_stack $Mystruct
+  copy_addr %0 to [initialization] %217 : $*Mystruct
+  %219 = partial_apply [callee_guaranteed] %216(%217) : $@convention(thin) (Bool, @in_guaranteed Mystruct) -> ()
+  %220 = apply %219(%1) : $@callee_guaranteed (Bool) -> ()
+  destroy_value %219 : $@callee_guaranteed (Bool) -> ()
+  dealloc_stack %217 : $*Mystruct
+  %19 = tuple ()
+  return %19 : $()
+}
+


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/32317.

---

**Explanation**: When creating a closure context, all captured arguments are taken "owned". We failed to copy arguments which are address-only ("indirect arguments"). An assert build of the compiler asserts with a memory lifetime failure. But a non-assert build can show different symptoms. In the reported bug the compiler just hangs. It could also be that a non-assert compiler produces a miscompile.

**Scope**: It affects closures which capture non-trivial arguments by address (indirect arguments). It's not a new bug and I'm surprised that we didn't see this earlier.

**Risk**: Low. The logic to fix the problem was just taken from direct arguments.

**Testing**: Added a validation test

**Reviewed by:** @gottesmm

Resolves: rdar://problem/64035105
