### PR TITLE
stdlib: enable runtime checking for COW support by default in assert builds.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2109,7 +2109,8 @@ VarargsInfo Lowering::emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
 }
 
 ManagedValue Lowering::emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
-                                      VarargsInfo &&varargs) {
+                                      VarargsInfo &&varargs,
+                                      unsigned numElements) {
   // Kill the abort cleanup.
   SGF.Cleanups.setCleanupState(varargs.getAbortCleanup(), CleanupState::Dead);
 
@@ -2118,6 +2119,14 @@ ManagedValue Lowering::emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
   if (array.hasCleanup())
     SGF.Cleanups.setCleanupState(array.getCleanup(), CleanupState::Active);
 
+  // Array literals only need to be finalized, if the array is really allocated.
+  // In case of zero elements, no allocation is done, but the empty-array
+  // singleton is used. "Finalization" means to emit an end_cow_mutation
+  // instruction on the array. As the empty-array singleton is a read-only and
+  // shared object, it's not legal to do a end_cow_mutation on it.
+  if (numElements == 0)
+    return array;
+    
   return SGF.emitUninitializedArrayFinalization(loc, std::move(array));
 }
 
@@ -3870,7 +3879,7 @@ RValue RValueEmitter::visitCollectionExpr(CollectionExpr *E, SGFContext C) {
     SGF.Cleanups.setCleanupState(destCleanup, CleanupState::Dead);
 
   RValue array(SGF, loc, arrayType,
-             emitEndVarargs(SGF, loc, std::move(varargsInfo)));
+        emitEndVarargs(SGF, loc, std::move(varargsInfo), E->getNumElements()));
 
   array = scope.popPreservingValue(std::move(array));
 

--- a/lib/SILGen/Varargs.h
+++ b/lib/SILGen/Varargs.h
@@ -68,7 +68,8 @@ VarargsInfo emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
 
 /// Successfully end a varargs emission sequence.
 ManagedValue emitEndVarargs(SILGenFunction &SGF, SILLocation loc,
-                            VarargsInfo &&varargs); 
+                            VarargsInfo &&varargs,
+                             unsigned numElements); 
 
 } // end namespace Lowering
 } // end namespace swift

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -540,13 +540,15 @@ static SILValue emitCodeForConstantArray(ArrayRef<SILValue> elements,
   assert(arrayAllocateFun);
 
   SILFunction *arrayFinalizeFun = nullptr;
-  if (FuncDecl *arrayFinalizeDecl = astContext.getFinalizeUninitializedArray()) {
-    std::string finalizeMangledName =
-        SILDeclRef(arrayFinalizeDecl, SILDeclRef::Kind::Func).mangle();
-    arrayFinalizeFun =
-        module.findFunction(finalizeMangledName, SILLinkage::SharedExternal);
-    assert(arrayFinalizeFun);
-    module.linkFunction(arrayFinalizeFun);
+  if (numElements != 0) {
+    if (FuncDecl *arrayFinalizeDecl = astContext.getFinalizeUninitializedArray()) {
+      std::string finalizeMangledName =
+          SILDeclRef(arrayFinalizeDecl, SILDeclRef::Kind::Func).mangle();
+      arrayFinalizeFun =
+          module.findFunction(finalizeMangledName, SILLinkage::SharedExternal);
+      assert(arrayFinalizeFun);
+      module.linkFunction(arrayFinalizeFun);
+    }
   }
 
   // Call the _allocateUninitializedArray function with numElementsSIL. The

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -454,18 +454,12 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   internal var isImmutable: Bool {
     get {
-// TODO: Enable COW runtime checks by default (when INTERNAL_CHECKS_ENABLED
-//       is set). Currently there is a problem with remote AST which needs to be
-//       fixed.
-#if ENABLE_COW_RUNTIME_CHECKS
       if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
         return capacity == 0 || _swift_isImmutableCOWBuffer(_storage)
       }
-#endif
       return true
     }
     nonmutating set {
-#if ENABLE_COW_RUNTIME_CHECKS
       if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
         if newValue {
           if capacity > 0 {
@@ -481,17 +475,14 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
             "re-setting mutable array buffer to mutable")
         }
       }
-#endif
     }
   }
   
   @_alwaysEmitIntoClient
   internal var isMutable: Bool {
-#if ENABLE_COW_RUNTIME_CHECKS
     if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
       return !_swift_isImmutableCOWBuffer(_storage)
     }
-#endif
     return true
   }
 #endif

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -486,9 +486,7 @@ func test_variadics() {
   // CHECK: [[FN_REF:%[0-9]+]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK: [[MAKE_ARR:%[0-9]+]] = apply [[FN_REF]]<Int>([[ARR_COUNT]])
   // CHECK: ([[ARR:%[0-9]+]], %{{[0-9]+}}) = destructure_tuple [[MAKE_ARR]] : $(Array<Int>, Builtin.RawPointer)
-  // CHECK: [[FIN_REF:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK: [[FIN_ARR:%[0-9]+]] = apply [[FIN_REF]]<Int>([[ARR]])
-  // CHECK: keypath $KeyPath<SubscriptVariadic1, Int>, (root $SubscriptVariadic1; gettable_property $Int,  id @$s8keypaths18SubscriptVariadic1VyS2id_tcig : $@convention(method) (@guaranteed Array<Int>, SubscriptVariadic1) -> Int, getter @$s8keypaths18SubscriptVariadic1VyS2id_tcipACTK : $@convention(thin) (@in_guaranteed SubscriptVariadic1, UnsafeRawPointer) -> @out Int, indices [%$0 : $Array<Int> : $Array<Int>], indices_equals @$sSaySiGTH : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @$sSaySiGTh : $@convention(thin) (UnsafeRawPointer) -> Int) ([[FIN_ARR]])
+  // CHECK: keypath $KeyPath<SubscriptVariadic1, Int>, (root $SubscriptVariadic1; gettable_property $Int,  id @$s8keypaths18SubscriptVariadic1VyS2id_tcig : $@convention(method) (@guaranteed Array<Int>, SubscriptVariadic1) -> Int, getter @$s8keypaths18SubscriptVariadic1VyS2id_tcipACTK : $@convention(thin) (@in_guaranteed SubscriptVariadic1, UnsafeRawPointer) -> @out Int, indices [%$0 : $Array<Int> : $Array<Int>], indices_equals @$sSaySiGTH : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @$sSaySiGTh : $@convention(thin) (UnsafeRawPointer) -> Int) ([[ARR]])
   _ = \SubscriptVariadic1.[]
   
   _ = \SubscriptVariadic2.["", "1"]

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -68,8 +68,6 @@ variadicFirst(x)
 // CHECK: [[X:%.*]] = load [trivial] [[READ]]
 // CHECK: [[ALLOC_ARRAY:%.*]] = apply {{.*}} -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: ([[ARRAY:%.*]], [[MEMORY:%.*]]) = destructure_tuple [[ALLOC_ARRAY]]
-// CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-// CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Int>([[ARRAY]])
 // CHECK: [[VARIADIC_SECOND:%.*]] = function_ref @$s20scalar_to_tuple_args14variadicSecondyySi_SidtF
-// CHECK: apply [[VARIADIC_SECOND]]([[X]], [[FIN_ARR]])
+// CHECK: apply [[VARIADIC_SECOND]]([[X]], [[ARRAY]])
 variadicSecond(x)


### PR DESCRIPTION
This was blocked by an LLDB problem, which is now fixed (https://github.com/apple/llvm-project/pull/1333)

Also: fix a bug with array literal finalization (see commit message for details)