### PR TITLE
[TypeChecker] Add a entry point to be used for code completion

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4728,6 +4728,31 @@ public:
                                  = FreeTypeVariableBinding::Disallow,
                                  bool allowFixes = false);
 
+  /// Construct and solve a system of constraints based on the given expression
+  /// and its contextual information.
+  ///
+  /// This menthod is designed to be used for code completion which means that
+  /// it doesn't mutate given expression, even if there is a single valid
+  /// solution, and constraint solver is allowed to produce partially correct
+  /// solutions, such solutions can have any number of holes in them, alongside
+  /// with valid ones.
+  ///
+  /// \param expr The expression involved in code completion.
+  ///
+  /// \param DC The declaration context this expression is found in.
+  ///
+  /// \param contextualType The type expression is being converted to.
+  ///
+  /// \param CTP When contextualType is specified, this indicates what
+  /// the conversion is doing.
+  ///
+  /// \param callback The callback to be used to provide results to
+  /// code completion.
+  static void
+  solveForCodeCompletion(Expr *expr, DeclContext *DC, Type contextualType,
+                         ContextualTypePurpose CTP,
+                         llvm::function_ref<void(const Solution &)> callback);
+
 private:
   /// Solve the system of constraints.
   ///

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2328,6 +2328,19 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
   }
 }
 
+void TypeChecker::typeCheckForCodeCompletion(
+    Expr *expr, DeclContext *DC, Type contextualType, ContextualTypePurpose CTP,
+    llvm::function_ref<void(const Solution &)> callback) {
+  auto &Context = DC->getASTContext();
+
+  FrontendStatsTracer StatsTracer(Context.Stats,
+                                  "typecheck-for-code-completion", expr);
+  PrettyStackTraceExpr stackTrace(Context, "code-completion", expr);
+
+  ConstraintSystem::solveForCodeCompletion(expr, DC, contextualType, CTP,
+                                           callback);
+}
+
 bool TypeChecker::typeCheckBinding(
     Pattern *&pattern, Expr *&initializer, DeclContext *DC,
     Type patternType, PatternBindingDecl *PBD, unsigned patternNumber) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -700,6 +700,17 @@ FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
                                           DeclRefKind refKind,
                                           ConcreteDeclRef &refdDecl);
 
+/// Type check the given expression and provide results back to code completion
+/// via specified callback.
+///
+/// This menthod is designed to be used for code completion which means that
+/// it doesn't mutate AST and constraint solver is allowed to produce partially
+/// correct solutions, such solutions can have any number of holes in them,
+/// alongside with valid ones.
+void typeCheckForCodeCompletion(
+    Expr *expr, DeclContext *DC, Type contextualType, ContextualTypePurpose CTP,
+    llvm::function_ref<void(const constraints::Solution &)> callback);
+
 /// Check the key-path expression.
 ///
 /// Returns the type of the last component of the key-path.


### PR DESCRIPTION
As part of the code completion redesign this new entry point is going
to replace use of:

- `typeCheckExpression`
- `getTypeOfExpressionWithoutApplying` (which could be removed)

and possibly other methods currently used to retrieve information
for code completion purposes.

Advantages of a new approach:

- Avoids mutating AST;
- Allows to avoid sub-expression type-checking;
- Allows code completion access to multiple solutions in ambiguous cases;
- Provides all possible solutions - valid and invalid (with holes);
- Allows code completion to easily access not only types but
  overload choices and other supplimentary information associated
  with each solution.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
