### PR TITLE
[Sema] Allow trailing closures to skip back past multiple defaulted params.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1177,6 +1177,9 @@ ERROR(extra_trailing_closure_in_call,none,
 ERROR(trailing_closure_bad_param,none,
       "trailing closure passed to parameter of type %0 that does not "
       "accept a closure", (Type))
+ERROR(trailing_closure_too_many_defaulted,none,
+      "trailing closure not allowed in call with more than one "
+      "defaulted trailing parameter", ())
 NOTE(candidate_with_extraneous_args,none,
       "candidate %0 requires %1 argument%s1, "
       "but %2 %select{were|was}3 %select{provided|used in closure body}4",

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5761,6 +5761,12 @@ bool InvalidUseOfTrailingClosure::diagnoseAsError() {
   return true;
 }
 
+bool InvalidUseOfTooManyDefaultedTrailingClosure::diagnoseAsError() {
+  emitDiagnostic(diag::trailing_closure_too_many_defaulted)
+      .highlight(getSourceRange());
+  return true;
+}
+
 void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   auto getPointerKind = [](Type ty) -> PointerTypeKind {
     PointerTypeKind pointerKind;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1927,6 +1927,16 @@ public:
   bool diagnoseAsError() override;
 };
 
+class InvalidUseOfTooManyDefaultedTrailingClosure final
+    : public FailureDiagnostic {
+public:
+  InvalidUseOfTooManyDefaultedTrailingClosure(const Solution &solution,
+                                              ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose the invalid conversion of a temporary pointer argument generated
 /// from an X-to-pointer conversion to an @_nonEphemeral parameter.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1209,6 +1209,19 @@ AllowInvalidUseOfTrailingClosure::create(ConstraintSystem &cs, Type argType,
       AllowInvalidUseOfTrailingClosure(cs, argType, paramType, locator);
 }
 
+bool AllowInvalidUseOfTooManyDefaultedTrailingClosure::diagnose(
+    const Solution &solution, bool asNote) const {
+  InvalidUseOfTooManyDefaultedTrailingClosure failure(solution, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowInvalidUseOfTooManyDefaultedTrailingClosure *
+AllowInvalidUseOfTooManyDefaultedTrailingClosure::create(
+    ConstraintSystem &cs, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowInvalidUseOfTooManyDefaultedTrailingClosure(cs, locator);
+}
+
 bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
   NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1714,6 +1714,24 @@ public:
                                                   ConstraintLocator *locator);
 };
 
+class AllowInvalidUseOfTooManyDefaultedTrailingClosure final
+    : public ConstraintFix {
+  AllowInvalidUseOfTooManyDefaultedTrailingClosure(ConstraintSystem &cs,
+                                                   ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowInvalidUseOfTrailingClosure, locator) {}
+
+public:
+  std::string getName() const {
+    return "allow invalid use of trailing closure because of too many "
+           "defaulted trailing params";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const;
+
+  static AllowInvalidUseOfTooManyDefaultedTrailingClosure *
+  create(ConstraintSystem &cs, ConstraintLocator *locator);
+};
+
 class TreatEphemeralAsNonEphemeral final : public AllowArgumentMismatch {
   ConversionRestrictionKind ConversionKind;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5041,6 +5041,16 @@ public:
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
   virtual bool trailingClosureMismatch(unsigned paramIdx, unsigned argIdx);
+
+  /// Indicates that the trailing closure argument at the given \c argIdx
+  /// cannot be passed to the last parameter at \c paramIdx because there are
+  /// two or more defaulted parameters in between, which we do not accept for
+  /// compatibility reasons.
+  ///
+  /// \returns true to indicate that this should cause a failure, false
+  /// otherwise.
+  virtual bool trailingClosureTooManyDefaulted(unsigned paramIdx,
+                                               unsigned argIdx);
 };
 
 /// Match the call arguments (as described by the given argument type) to

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1007,10 +1007,10 @@ func rdar52204414() {
 }
 
 // SR-12291 - trailing closure is used as an argument to the last (positionally) parameter
-func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {}
-func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {}
+func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note {{found this candidate}}
+func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note {{found this candidate}}
 
-overloaded_with_default { 0 } // Ok (could be ambiguous if trailing was allowed to match `a:` in first overload)
+overloaded_with_default { 0 } // expected-error {{ambiguous use of 'overloaded_with_default'}}
 
 func overloaded_with_default_and_autoclosure<T>(_ a: @autoclosure () -> T, b: Int = 0) {}
 func overloaded_with_default_and_autoclosure<T>(b: Int = 0, c: @escaping () -> T?) {}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1007,10 +1007,10 @@ func rdar52204414() {
 }
 
 // SR-12291 - trailing closure is used as an argument to the last (positionally) parameter
-func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note {{found this candidate}}
-func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note {{found this candidate}}
+func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {}
+func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {}
 
-overloaded_with_default { 0 } // expected-error {{ambiguous use of 'overloaded_with_default'}}
+overloaded_with_default { 0 } // Ok
 
 func overloaded_with_default_and_autoclosure<T>(_ a: @autoclosure () -> T, b: Int = 0) {}
 func overloaded_with_default_and_autoclosure<T>(b: Int = 0, c: @escaping () -> T?) {}

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -41,6 +41,13 @@ trailingClosureSingle2() { 1 }
 // expected-error@-1 {{missing argument for parameter 'x' in call}} {{24-24=x: <#() -> Int#>}}
 // expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
 
+func trailingClosureDefaults(x: () -> Int, y: Int = 0, z: Int = 1) {} // expected-note * {{here}}
+trailingClosureDefaults { 1 }
+trailingClosureDefaults { "foo" }
+// expected-error@-1 {{cannot convert value of type 'String' to closure result type 'Int'}}
+trailingClosureDefaults(x: { 1 }) { 2 }
+// expected-error@-1 {{extra trailing closure passed in call}}
+
 func trailingClosureMulti1(x: Int, y: Int, z: () -> Int) {} // expected-note * {{here}}
 trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#Int#>, }}
 trailingClosureMulti1(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#Int#>}}

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -43,8 +43,10 @@ trailingClosureSingle2() { 1 }
 
 func trailingClosureDefaults(x: () -> Int, y: Int = 0, z: Int = 1) {} // expected-note * {{here}}
 trailingClosureDefaults { 1 }
+// expected-error@-1 {{trailing closure not allowed in call with more than one defaulted trailing parameter}}
 trailingClosureDefaults { "foo" }
 // expected-error@-1 {{cannot convert value of type 'String' to closure result type 'Int'}}
+// expected-error@-2 {{trailing closure not allowed in call with more than one defaulted trailing parameter}}
 trailingClosureDefaults(x: { 1 }) { 2 }
 // expected-error@-1 {{extra trailing closure passed in call}}
 

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -66,6 +66,19 @@ trailingClosureMulti2(x: 1) { 1 }
 // expected-error@-1 {{missing argument for parameter 'y' in call}} {{27-27=, y: <#() -> Int#>}}
 // expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
 
+func trailingClosureMulti3(x: () -> Int, y: () -> Int, z: () -> Int, d: Int = 0) {} // expected-note * {{here}}
+trailingClosureMulti3 { 1 }
+// expected-error@-1 {{missing arguments for parameters 'x', 'y' in call}}
+trailingClosureMulti3() { 2 } z: { 3 }
+// expected-error@-1 {{missing argument for parameter 'x' in call}}
+trailingClosureMulti3() { 1 } x: { 2 } z: { 3 }
+// expected-error@-1 {{missing argument for parameter 'y' in call}}
+// expected-error@-2 {{extra argument in call}}
+
+func trailingClosureMulti4(x: () -> Int, c: Int = 0, d: Int = 0, z: () -> Int) {} // expected-note * {{here}}
+trailingClosureMulti4() { 1 } z: { 3 }
+// expected-error@-1 {{trailing closure not allowed in call with more than one defaulted trailing parameter}}
+
 func param2Func(x: Int, y: Int) {} // expected-note * {{here}}
 param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}
 param2Func(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#Int#>, }}

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -420,11 +420,11 @@ func variadicAndNonOverloadLabel(b: (() -> Void)...) -> Int { return 0 }
 func testVariadic() {
   variadic {}
   variadic() {}
-  variadic({}) {} // expected-error {{extra argument in call}}
+  variadic({}) {} // expected-error {{extra trailing closure passed in call}}
 
   variadicLabel {}
   variadicLabel() {}
-  variadicLabel(closures: {}) {} // expected-error {{extra argument 'closures' in call}}
+  variadicLabel(closures: {}) {} // expected-error {{extra trailing closure passed in call}}
 
   let a1 = variadicOverloadMismatch {}
   _ = a1 as String // expected-error {{cannot convert value of type 'Bool' to type 'String'}}


### PR DESCRIPTION
Also changes the order of binding params so that labeled trailing closures continue to bind first, then all normal args, and finally the unlabeled trailing closure (if any). This improves error messages in cases where we'd prematurely bind the trailing closure to some param, and complain about either the closure's type being wrong (for non-function-type last params), or the previous normal closure arg being extra, when in both cases it was the trailing closure that was extra.

Resolves SR-11542.

Note also the specific check added for trailing closures not matching autoclosure params, which seems both good practice, and is also now required for this code not to regress SR-12291. 
