### PR TITLE
[test][stdlib] Add strto*_l stubs for OpenBSD.

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -41,9 +41,28 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__) || defined(__OpenBSD__)
+#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__)
 #include <sstream>
 #include <cmath>
+#elif defined(__OpenBSD__)
+#include <locale.h>
+
+static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
+  return strtod(nptr, endptr);
+}
+
+static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
+  return strtof(nptr, endptr);
+}
+
+static long double swift_strtold_l(const char *nptr, char **endptr,
+                                   locale_t loc) {
+  return strtold(nptr, endptr);
+}
+
+#define strtod_l swift_strtod_l
+#define strtof_l swift_strtof_l
+#define strtold_l swift_strtold_l
 #elif defined(__ANDROID__)
 #include <locale.h>
 
@@ -369,7 +388,7 @@ static bool swift_stringIsSignalingNaN(const char *nptr) {
   return strcasecmp(nptr, "snan") == 0;
 }
 
-#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__) || defined(__OpenBSD__)
+#if defined(__CYGWIN__) || defined(_WIN32) || defined(__HAIKU__)
 // Cygwin does not support uselocale(), but we can use the locale feature 
 // in stringstream object.
 template <typename T>


### PR DESCRIPTION
The template defined for Cygwin and friends does not handle failure cases
properly so the NumericParsing unit test fails.  To get the correct test
behavior, we need to use an implementation such as like in the Windows
specializations or the non-Cygwin implementation that takes a function
pointer.

However, adding additional specializations would be too wordy, and
OpenBSD doesn't have locale-dependent definitions of the relevant strto*
functions. We could add a specialization for a two-argument function
pointer, but that becomes too repetitive.

Instead, implement a few stubs and use the preprocessor, a la the
implementation for Android.