### PR TITLE
IRGen: Use the right descriminator for AutoDiffDerivativeFunctions

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -397,6 +397,16 @@ struct SILDeclRef {
 
   bool canBeDynamicReplacement() const;
 
+  bool isAutoDiffDerivativeFunction() const {
+    return derivativeFunctionIdentifier != nullptr;
+  }
+
+  AutoDiffDerivativeFunctionIdentifier *
+  getAutoDiffDerivativeFunctionIdentifier() const {
+    assert(isAutoDiffDerivativeFunction());
+    return derivativeFunctionIdentifier;
+  }
+
 private:
   friend struct llvm::DenseMapInfo<swift::SILDeclRef>;
   /// Produces a SILDeclRef from an opaque value.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -739,6 +739,9 @@ namespace {
                            isa<ConstructorDecl>(func.getDecl())
                              ? SILDeclRef::Kind::Allocator
                              : SILDeclRef::Kind::Func);
+        if (entry.getFunction().isAutoDiffDerivativeFunction())
+          declRef = declRef.asAutoDiffDerivativeFunction(
+              entry.getFunction().getAutoDiffDerivativeFunctionIdentifier());
         addDiscriminator(flags, schema, declRef);
       }
 


### PR DESCRIPTION
Fixes the failure in AutoDiff/validation-test/forward_mode.swift on arm64e.

rdar://64192250