### PR TITLE
Remove Type's hash_value function

### DIFF
--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -142,7 +142,7 @@ public:
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::SameType:
-      second = hash_value(requirement.getSecondType());
+      second = hash_value(requirement.getSecondType().getPointer());
       break;
 
     case RequirementKind::Layout:

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -325,11 +325,6 @@ public:
   /// Return the name of the type as a string, for use in diagnostics only.
   std::string getString(const PrintOptions &PO = PrintOptions()) const;
 
-  friend llvm::hash_code hash_value(Type type) {
-    using llvm::hash_value;
-    return hash_value(type.getPointer());
-  }
-
   /// Return the name of the type, adding parens in cases where
   /// appending or prepending text to the result would cause that text
   /// to be appended to only a portion of the returned type. For
@@ -501,6 +496,10 @@ public:
   // Direct comparison is allowed for CanTypes - they are known canonical.
   bool operator==(CanType T) const { return getPointer() == T.getPointer(); }
   bool operator!=(CanType T) const { return !operator==(T); }
+
+  friend llvm::hash_code hash_value(CanType T) {
+    return llvm::hash_value(T.getPointer());
+  }
 
   bool operator<(CanType T) const { return getPointer() < T.getPointer(); }
 };

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -206,7 +206,7 @@ public:
   }
 
   friend llvm::hash_code hash_value(const TypeWitnessAndDecl &owner) {
-    return llvm::hash_combine(owner.witnessType,
+    return llvm::hash_combine(owner.witnessType.getPointer(),
                               owner.witnessDecl);
   }
 

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -212,7 +212,7 @@ public:
 
   friend bool operator==(const TypeWitnessAndDecl &lhs,
                          const TypeWitnessAndDecl &rhs) {
-    return lhs.witnessType->isEqual(rhs.witnessType) &&
+    return lhs.witnessType.getPointer() == rhs.witnessType.getPointer() &&
            lhs.witnessDecl == rhs.witnessDecl;
   }
 


### PR DESCRIPTION
Defining `hash_value` for `Type` makes it easy to forget that the underlying pointer is being hashed directly without canonicalization. Instead, define it only for `CanType`, and make `Type` users spell `getPointer` explicitly.

In addition, fix `TypeWitnessAndDecl`'s equality to match its hashing implementation.