### PR TITLE
test: disable AutoDiff test which is flakey

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr12493-differentiable-function-extract-subst-function-type.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12493-differentiable-function-extract-subst-function-type.swift
@@ -1,4 +1,5 @@
 // RUN: %target-build-swift -O %s
+// REQUIRES: SR-12493
 
 // SR-12493: SIL verification error regarding substituted function types and
 // `differentiable_function_extract` instruction. Occurs only with `-O`.


### PR DESCRIPTION
This test is flakey, sometimes crashing the linker (likely an invalid
object file emission).  This has failed a few times on Windows, and
fails often with Android, and recently was spotted failing on Ubuntu
20.04 as well.  Disable the test until it can be properly investigated.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
