### PR TITLE
[cxx-interop] Mark types with a destructor a non-trivial.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1453,6 +1453,7 @@ namespace {
 
       if (D->isCxxNotTriviallyCopyable()) {
         properties.setAddressOnly();
+        properties.setNonTrivial();
       }
 
       auto subMap = structType->getContextSubstitutionMap(&TC.M, D);

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -2,8 +2,8 @@ module AccessSpecifiers {
   header "access-specifiers.h"
 }
 
-module LoadableTypes {
-  header "loadable-types.h"
+module TypeClassification {
+  header "type-classification.h"
 }
 
 module MemberwiseInitializer {

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -80,7 +80,7 @@ struct StructWithSubobjectMoveAssignment {
 };
 
 struct StructWithDestructor {
-  ~StructWithDestructor(){}
+  ~StructWithDestructor() {}
 };
 
 struct StructWithInheritedDestructor : StructWithDestructor {};

--- a/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
@@ -3,7 +3,7 @@
 // This test checks that we classify C++ types as loadable and address-only
 // correctly.
 
-import LoadableTypes
+import TypeClassification
 
 // Tests for individual special members
 

--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-sil %s | %FileCheck %s
+
+import TypeClassification
+
+// Make sure that "StructWithDestructor" is marked as non-trivial by checking for a
+// "destroy_addr".
+// CHECK-LABEL: @$s4main24testStructWithDestructoryyF
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithDestructor
+// CHECK: destroy_addr [[AS]]
+// CHECK-LABEL: end sil function '$s4main24testStructWithDestructoryyF'
+public func testStructWithDestructor() {
+  let d = StructWithDestructor()
+}
+
+// Make sure that "HasMemberWithDestructor" is marked as non-trivial by checking
+// for a "destroy_addr".
+// CHECK-LABEL: @$s4main33testStructWithSubobjectDestructoryyF
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithSubobjectDestructor
+// CHECK: destroy_addr [[AS]]
+// CHECK-LABEL: end sil function '$s4main33testStructWithSubobjectDestructoryyF'
+public func testStructWithSubobjectDestructor() {
+  let d = StructWithSubobjectDestructor()
+}
+
+


### PR DESCRIPTION
Any C++ type that isn't trivially copyable is now also not a trivial type. This will preserve the destructor (among other things).
