### PR TITLE
[Frontend] Move some stats + outputs to end of pipeline

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -287,9 +287,6 @@ public:
   /// -dump-scope-maps.
   SmallVector<std::pair<unsigned, unsigned>, 2> DumpScopeMapLocations;
 
-  /// Indicates whether the action will immediately run code.
-  static bool isActionImmediate(ActionType);
-
   /// \return true if action only parses without doing other compilation steps.
   static bool shouldActionOnlyParse(ActionType);
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -539,7 +539,8 @@ bool ArgsToFrontendOptionsConverter::checkUnusedSupplementaryOutputPaths()
      return true;
    }
   if (!FrontendOptions::canActionEmitInterface(Opts.RequestedAction) &&
-      Opts.InputsAndOutputs.hasModuleInterfaceOutputPath()) {
+      (Opts.InputsAndOutputs.hasModuleInterfaceOutputPath() ||
+       Opts.InputsAndOutputs.hasPrivateModuleInterfaceOutputPath())) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_interface);
     return true;
   }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -67,45 +67,6 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   llvm_unreachable("Unknown ActionType");
 }
 
-bool FrontendOptions::isActionImmediate(ActionType action) {
-  switch (action) {
-  case ActionType::NoneAction:
-  case ActionType::Parse:
-  case ActionType::ResolveImports:
-  case ActionType::Typecheck:
-  case ActionType::DumpParse:
-  case ActionType::DumpAST:
-  case ActionType::EmitSyntax:
-  case ActionType::DumpInterfaceHash:
-  case ActionType::PrintAST:
-  case ActionType::DumpScopeMaps:
-  case ActionType::DumpTypeRefinementContexts:
-  case ActionType::EmitPCH:
-  case ActionType::EmitSILGen:
-  case ActionType::EmitSIL:
-  case ActionType::EmitSIBGen:
-  case ActionType::EmitSIB:
-  case ActionType::EmitModuleOnly:
-  case ActionType::MergeModules:
-  case ActionType::CompileModuleFromInterface:
-    return false;
-  case ActionType::Immediate:
-  case ActionType::REPL:
-    return true;
-  case ActionType::EmitAssembly:
-  case ActionType::EmitIR:
-  case ActionType::EmitBC:
-  case ActionType::EmitObject:
-  case ActionType::EmitImportedModules:
-  case ActionType::DumpTypeInfo:
-  case ActionType::EmitPCM:
-  case ActionType::DumpPCM:
-  case ActionType::ScanDependencies:
-    return false;
-  }
-  llvm_unreachable("Unknown ActionType");
-}
-
 bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   switch (action) {
   case FrontendOptions::ActionType::Parse:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1256,6 +1256,9 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   emitMakeDependenciesIfNeeded(Instance.getDiags(),
                                Instance.getDependencyTracker(), opts);
 
+  // Emit information about the parsed primaries.
+  emitSwiftRangesForAllPrimaryInputsIfNeeded(Instance);
+  emitCompiledSourceForAllPrimaryInputsIfNeeded(Instance);
 }
 
 /// Performs the compile requested by the user.
@@ -1353,9 +1356,6 @@ static bool performCompile(CompilerInstance &Instance,
 
   if (auto r = dumpASTIfNeeded(Instance))
     return *r;
-
-  emitSwiftRangesForAllPrimaryInputsIfNeeded(Instance);
-  emitCompiledSourceForAllPrimaryInputsIfNeeded(Instance);
 
   if (Context.hadError())
     return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1247,6 +1247,9 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   // Verify the AST for all the modules we've loaded.
   ctx.verifyAllLoadedModules();
 
+  // Verify generic signatures if we've been asked to.
+  verifyGenericSignaturesIfNeeded(Invocation, ctx);
+
   // Emit dependencies and index data.
   emitReferenceDependenciesForAllPrimaryInputsIfNeeded(Instance);
   emitIndexData(Instance);
@@ -1344,8 +1347,6 @@ static bool performCompile(CompilerInstance &Instance,
     else if (CrashMode == FrontendOptions::DebugCrashMode::CrashAfterParse)
       debugFailWithCrash();
   }
-
-  verifyGenericSignaturesIfNeeded(Invocation, Context);
 
   (void)migrator::updateCodeAndEmitRemapIfNeeded(&Instance);
 

--- a/test/Frontend/supplementary-output-support.swift
+++ b/test/Frontend/supplementary-output-support.swift
@@ -28,3 +28,8 @@
 // PARSE_NO_INTERFACE: error: this mode does not support emitting module interface files{{$}}
 // RUN: not %target-swift-frontend -emit-silgen -emit-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=SILGEN_NO_INTERFACE %s
 // SILGEN_NO_INTERFACE: error: this mode does not support emitting module interface files{{$}}
+
+// RUN: not %target-swift-frontend -parse -emit-private-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_PRIVATE_INTERFACE %s
+// PARSE_NO_PRIVATE_INTERFACE: error: this mode does not support emitting module interface files{{$}}
+// RUN: not %target-swift-frontend -emit-silgen -emit-private-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=SILGEN_NO_PRIVATE_INTERFACE %s
+// SILGEN_NO_PRIVATE_INTERFACE: error: this mode does not support emitting module interface files{{$}}


### PR DESCRIPTION
Move some stat collection and supplementary output logic to `performEndOfPipelineActions` to better fit the model of an inverted pipeline.