### PR TITLE
Build Module Interfaces in WMO

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -244,7 +244,6 @@ private:
   llvm::StringSaver ArgSaver;
   std::vector<StringRef> GenericArgs;
   CompilerInvocation subInvocation;
-  std::vector<SupplementaryOutputPaths> ModuleOutputPaths;
 
   template<typename ...ArgTypes>
   InFlightDiagnostic diagnose(StringRef interfacePath,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1340,7 +1340,7 @@ bool InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleN
   assert(BuildArgs.size() == GenericArgs.size());
   // Configure inputs
   subInvocation.getFrontendOptions().InputsAndOutputs
-    .addPrimaryInputFile(interfacePath);
+    .addInputFile(interfacePath);
   BuildArgs.push_back(interfacePath);
   subInvocation.setModuleName(moduleName);
   BuildArgs.push_back("-module-name");
@@ -1357,13 +1357,12 @@ bool InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleN
   }
 
   // Configure the outputs in front-end options. There must be an equal number of
-  // primary inputs and outputs.
-  auto N = subInvocation.getFrontendOptions().InputsAndOutputs
-    .primaryInputCount();
-  std::vector<std::string> outputFiles(N, "/<unused>");
+  // inputs and outputs.
+  std::vector<std::string> outputFiles{"/<unused>"};
+  std::vector<SupplementaryOutputPaths> ModuleOutputPaths;
   ModuleOutputPaths.emplace_back();
   ModuleOutputPaths.back().ModuleOutputPath = outputPath.str();
-  assert(N == ModuleOutputPaths.size());
+  assert(subInvocation.getFrontendOptions().InputsAndOutputs.isWholeModule());
   subInvocation.getFrontendOptions().InputsAndOutputs
     .setMainAndSupplementaryOutputs(outputFiles, ModuleOutputPaths);
 


### PR DESCRIPTION
Building in incremental mode incurs the overhead associated with the
incremental dependency tracking infrastructure. Considering we're
throwing away all of this stuff anyways, let's just build in WMO to
avoid that.