### PR TITLE
ABI-checker: include Swift symbols only when ABI checking is enabled

### DIFF
--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -26,9 +26,7 @@ cake: InfixOperator ..*.. has been changed to a PrefixOperator
 cake: Protocol ProtocolToEnum has been changed to a Enum
 
 /* Renamed Decls */
-cake: Class SwiftObjcClass has ObjC name change from OldObjCClass to NewObjCClass
 cake: Func S1.foo5(x:y:) has been renamed to Func foo5(x:y:z:)
-cake: Func SwiftObjcClass.foo(a:b:c:) has ObjC name change from OldObjCFool:OldObjCA:OldObjCB: to NewObjCFool:NewObjCA:NewObjCB:
 cake: Struct Somestruct2 has been renamed to Struct NSSomestruct2
 
 /* Type Changes */
@@ -54,7 +52,6 @@ cake: Accessor GlobalLetChangedToVar.Set() is a new API without @available attri
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Modify() is a new API without @available attribute
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Set() is a new API without @available attribute
 cake: Class C0 is a new API without @available attribute
-cake: Class C5 is now without @objc
 cake: Class C8 is a new API without @available attribute
 cake: Constructor C1.init(_:) is a new API without @available attribute
 cake: Constructor ClassWithMissingDesignatedInits.init() is a new API without @available attribute
@@ -62,7 +59,6 @@ cake: Constructor SubclassWithMissingDesignatedInits.init() is a new API without
 cake: Enum IceKind is now without @frozen
 cake: EnumElement FrozenKind.AddedCase is a new API without @available attribute
 cake: Func C1.foo1() is now not static
-cake: Func C5.dy_foo() is now with dynamic
 cake: Func FinalFuncContainer.NewFinalFunc() is now with final
 cake: Func FinalFuncContainer.NoLongerFinalFunc() is now without final
 cake: Func Float.floatHigher() is a new API without @available attribute
@@ -94,8 +90,6 @@ cake: Var fixedLayoutStruct2.NoLongerWithFixedBinaryOrder is no longer a stored 
 /* Protocol Conformance Change */
 cake: Class C7 has added a conformance to an existing protocol P1
 cake: Class SuperClassChange has added a conformance to an existing protocol P1
-cake: Func ObjCProtocol.addOptional() is now an optional requirement
-cake: Func ObjCProtocol.removeOptional() is no longer an optional requirement
 cake: Protocol P3 has added inherited protocol P4
 cake: Protocol P3 has removed inherited protocol P2
 cake: Struct fixedLayoutStruct has added a conformance to an existing protocol P2
@@ -110,7 +104,6 @@ cake: Func RequiementChanges.addedFunc() has been added as a protocol requiremen
 cake: Var RequiementChanges.addedVar has been added as a protocol requirement
 
 /* Class Inheritance Change */
-cake: Class C4 has changed its super class from APINotesTest.OldType to APINotesTest.NewType
 cake: Class SubGenericClass has changed its super class from cake.GenericClass<cake.P1> to cake.GenericClass<cake.P2>
 cake: Class SuperClassRemoval has removed its super class cake.C3
 cake: Class SuperClassRemoval no longer inherits convenience inits from its superclass

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -18,8 +18,5 @@
 // RUN: not %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module cake -I %t.mod2 -I %S/Inputs/APINotesLeft -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -o %t.result -compiler-style-diags 2> %t.abi.compiler.diags
 // RUN: %FileCheck %s < %t.abi.compiler.diags
 
-// CHECK: cake_current/cake.swift:31:14: error: cake: Class C4 has changed its super class from APINotesTest.OldType to APINotesTest.NewType
-// CHECK: cake_current/cake.swift:33:14: error: cake: Class C5 is now without @objc
-// CHECK: cake_current/cake.swift:35:23: error: cake: Func C5.dy_foo() is now with dynamic
 // CHECK: cake_current/cake.swift:39:15: error: cake: Struct C6 is now with @frozen
 // CHECK: cake_current/cake.swift:41:13: error: cake: Enum IceKind is now without @frozen

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1573,6 +1573,7 @@ SwiftDeclCollector::constructInitNode(ConstructorDecl *CD) {
 bool swift::ide::api::
 SDKContext::shouldIgnore(Decl *D, const Decl* Parent) const {
   // Exclude all clang nodes if we're comparing Swift decls specifically.
+  // FIXME: isFromClang also excludes Swift decls with @objc. We should allow those.
   if (Opts.SwiftOnly && isFromClang(D)) {
     return true;
   }

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2653,7 +2653,9 @@ static CheckerOptions getCheckOpts(int argc, char *argv[]) {
   Opts.AbortOnModuleLoadFailure = options::AbortOnModuleLoadFailure;
   Opts.LocationFilter = options::LocationFilter;
   Opts.PrintModule = options::PrintModule;
-  Opts.SwiftOnly = options::SwiftOnly;
+  // When ABI checking is enabled, we should only include Swift symbols because
+  // the checking logics are language-specific.
+  Opts.SwiftOnly = options::Abi || options::SwiftOnly;
   Opts.SkipOSCheck = options::DisableOSChecks;
   for (int i = 1; i < argc; ++i)
     Opts.ToolArgs.push_back(argv[i]);


### PR DESCRIPTION
ABI checking logics are largely Swift-specific, so we should exclude
symbols from the underlying Clang module.

rdar://64373983
