### PR TITLE
[5.3][CodeCompletion] Typecheck without CodeCompletionExpr

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6166,15 +6166,33 @@ void CodeCompletionCallbacksImpl::doneParsing() {
         if (analyzedExpr->getEndLoc() != CodeCompleteTokenExpr->getLoc())
           break;
 
-        // If the call expression doesn't have a type, infer it from the
-        // possible callee info.
         Type resultTy = analyzedExpr->getType();
-        if (!resultTy) {
-          if (ContextInfo.getPossibleCallees().empty())
-            break;
-          auto calleeInfo = ContextInfo.getPossibleCallees()[0];
-          resultTy = calleeInfo.Type->getResult();
-          analyzedExpr->setType(resultTy);
+        // If the call expression doesn't have a type, fallback to:
+        if (!resultTy || resultTy->is<ErrorType>()) {
+          // 1) Try to type check removing CodeCompletionExpr from the call.
+          Expr *removedExpr = analyzedExpr;
+          removeCodeCompletionExpr(CurDeclContext->getASTContext(),
+                                   removedExpr);
+          ConcreteDeclRef referencedDecl;
+          auto optT = getTypeOfCompletionContextExpr(
+              CurDeclContext->getASTContext(), CurDeclContext,
+              CompletionTypeCheckKind::Normal, removedExpr, referencedDecl);
+          if (optT) {
+            resultTy = *optT;
+            analyzedExpr->setType(resultTy);
+          }
+        }
+        if (!resultTy || resultTy->is<ErrorType>()) {
+          // 2) Infer it from the possible callee info.
+          if (!ContextInfo.getPossibleCallees().empty()) {
+            auto calleeInfo = ContextInfo.getPossibleCallees()[0];
+            resultTy = calleeInfo.Type->getResult();
+            analyzedExpr->setType(resultTy);
+          }
+        }
+        if (!resultTy || resultTy->is<ErrorType>()) {
+          // 3) Give up providing postfix completions.
+          break;
         }
 
         auto &SM = CurDeclContext->getASTContext().SourceMgr;

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -34,6 +34,13 @@ void typeCheckContextUntil(DeclContext *DC, SourceLoc Loc);
 /// exact the same as \p TargetRange. Returns \c nullptr if not found.
 Expr *findParsedExpr(const DeclContext *DC, SourceRange TargetRange);
 
+/// Remove \c CodeCompletionExpr from \p expr . Returns \c true if it actually
+/// mutated the expression.
+///
+/// NOTE: Currently, this only removes CodeCompletionExpr at call argument
+///       position.
+bool removeCodeCompletionExpr(ASTContext &Ctx, Expr *&expr);
+
 /// Returns expected return type of the given decl context.
 /// \p DC should be an \c AbstractFunctionDecl or an \c AbstractClosureExpr.
 Type getReturnTypeFromContext(const DeclContext *DC);

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -13,6 +13,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_REQUIRED_NEWLINE_2 | %FileCheck %s -check-prefix=INIT_REQUIRED_NEWLINE_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_REQUIRED_SAMELINE_3 | %FileCheck %s -check-prefix=INIT_REQUIRED_SAMELINE_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_REQUIRED_NEWLINE_3 | %FileCheck %s -check-prefix=INIT_REQUIRED_NEWLINE_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_FALLBACK_1 | %FileCheck %s -check-prefix=INIT_FALLBACK
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_FALLBACK_2 | %FileCheck %s -check-prefix=INIT_FALLBACK
 
 func globalFunc1(fn1: () -> Int, fn2: () -> String) {}
 func testGlobalFunc() {
@@ -183,4 +185,25 @@ func testOptionalInit() {
 // INIT_REQUIRED_NEWLINE_3-NOT: name=fn2
 // INIT_REQUIRED_NEWLINE_3-NOT: name=fn3
 // INIT_REQUIRED_NEWLINE_3: End completions
+}
+
+struct MyStruct4<T> {
+  init(arg1: Int = 0, arg2: () -> T) {}
+  init(name: String, arg2: () -> String, arg3: () -> T) {}
+
+  func testStructMethod() {}
+}
+func testFallbackPostfix() {
+  let _ = MyStruct4 {
+    1
+  } #^INIT_FALLBACK_1^#
+// INIT_FALLBACK: Begin completions, 2 items
+// INIT_FALLBACK-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
+// INIT_FALLBACK-DAG: Keyword[self]/CurrNominal:          .self[#MyStruct4<Int>#];
+// INIT_FALLBACK: End completions
+  let _ = MyStruct4(name: "test") {
+    ""
+  } arg3: {
+    1
+  } #^INIT_FALLBACK_2^#
 }


### PR DESCRIPTION
Cherry-pick of #32283 into `release/5.3`

* **Explanation**: When labeled trailing closure completion for multiple trailing closures fails, it fallback to normal postfix completion. However, it used to give up postfix completion in case the normal context analysis didn't give any informations. In such cases, re-typechecking is needed with cleaned-up expression (i.e. `CodeCompletionExpr` removed).
* **Scope**: Code completion after trailing closure
* **Risk**: Low-Mid. This manipulates AST and type checking is involved.
* **Testing**: Added regression test cases. Passed stress testing suite locally.
* **Issue**: rdar://problem/64176730
* **Reviewer**: Ben Langmuir (@benlangmuir)
