### PR TITLE
Disable flaky test

### DIFF
--- a/test/Driver/loaded_module_trace_swiftinterface.swift
+++ b/test/Driver/loaded_module_trace_swiftinterface.swift
@@ -1,4 +1,5 @@
 // UNSUPPORTED: -windows-msvc
+// REQUIRES: rdar64315441
 
 // 1) If there is no swiftmodule, use the swiftinterface
 //


### PR DESCRIPTION
This test has been breaking erratically on a number of different CI build configurations.

Disable it until we can figure out why.

Resolves: rdar://64315441

