### PR TITLE
Sema: Relax associated type default circularity check

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1730,7 +1730,8 @@ public:
       auto mentionsItself =
         defaultType.findIf([&](Type defaultType) {
           if (auto DMT = defaultType->getAs<DependentMemberType>()) {
-            return DMT->getAssocType() == AT;
+            return (DMT->getAssocType() == AT &&
+                    DMT->getBase()->isEqual(proto->getSelfInterfaceType()));
           }
           return false;
         });

--- a/test/decl/protocol/req/associated_type_default.swift
+++ b/test/decl/protocol/req/associated_type_default.swift
@@ -34,3 +34,9 @@ protocol P4 {
 }
 
 struct X4 : P4 {} // expected-error{{type 'X4' does not conform to protocol 'P4'}}
+
+// rdar://62355224 - circularity check for default type was over-eager
+protocol Seq {
+  associatedtype SubSeq: Seq
+  associatedtype Index = SubSeq.Index
+}


### PR DESCRIPTION
We should allow an associated type's default to reference the
same associated type with a base other than 'Self'.

Note that it now becomes easier to defeat this check, but it
was never air-tight anyway -- for example, you could have a
cycle of length two if each associated type's default was the
other associated type.

This is fine, because this check is purely 'cosmetic'; nothing
goes really wrong if you have a cycle here, except that the
diagnostic shifts from the declaration of the protocol to the
conforming type.

Fixes <rdar://problem/62355224>.
