### PR TITLE
[SymbolGraph] Only include where clause constraints in `swiftExtension`

### DIFF
--- a/lib/SymbolGraphGen/JSON.h
+++ b/lib/SymbolGraphGen/JSON.h
@@ -45,11 +45,19 @@ void serialize(const swift::GenericTypeParamType *Param,
                llvm::json::OStream &OS);
 
 
-/// Filter generic requirements that aren't relevant for documentation.
+/// Filter generic requirements on an extension that aren't relevant
+/// for documentation.
 void
 filterGenericRequirements(ArrayRef<Requirement> Requirements,
                           const NominalTypeDecl *Self,
                           SmallVectorImpl<Requirement> &FilteredRequirements);
+
+/// Filter generic requirements on an extension that aren't relevant
+/// for documentation.
+void
+filterGenericRequirements(const ExtensionDecl *Extension,
+                          SmallVectorImpl<Requirement> &FilteredRequirements);
+
 } // end namespace symbolgraphgen
 } // end namespace swift
 

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -280,8 +280,8 @@ void Symbol::serializeSwiftGenericMixin(llvm::json::OStream &OS) const {
       }
 
       filterGenericRequirements(Generics->getRequirements(),
-                         Self,
-                         FilteredRequirements);
+                                Self,
+                                FilteredRequirements);
 
       if (FilteredParams.empty() && FilteredRequirements.empty()) {
         return;

--- a/test/SymbolGraph/Symbols/Mixins/Extension/GetFromExtension.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Extension/GetFromExtension.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name Extension -emit-module-path %t/Extension.swiftmodule
-// RUN: %target-swift-symbolgraph-extract -module-name Extension -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/Extension.symbols.json
+// RUN: %target-build-swift %s -module-name GetFromExtension -emit-module-path %t/GetFromExtension.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name GetFromExtension -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/GetFromExtension.symbols.json
 
 public struct Outer<T> {
   public var x: T

--- a/test/SymbolGraph/Symbols/Mixins/Extension/IgnoreInherited.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Extension/IgnoreInherited.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name IgnoreInherited -emit-module-path %t/IgnoreInherited.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name IgnoreInherited -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/IgnoreInherited.symbols.json
+
+public protocol P {
+  associatedtype T
+  static func foo() -> T
+}
+
+public struct S<T> {}
+
+extension S: P where T: Sequence, T.Element == Int {
+  public static func foo() -> AnySequence<Int> {
+    return AnySequence([0])
+  }
+}
+
+// CHECK-LABEL: "precise": "s:15IgnoreInherited1SVAASTRzSi7ElementRtzlE3foos11AnySequenceVySiGyFZ"
+// CHECK: swiftExtension
+// CHECK: "constraints": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "conformance",
+// CHECK-NEXT:     "lhs": "T",
+// CHECK-NEXT:     "rhs": "Sequence"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "sameType",
+// CHECK-NEXT:     "lhs": "T.Element",
+// CHECK-NEXT:     "rhs": "Int"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]


### PR DESCRIPTION
Otherwise, this creates noise in conditional conformance phrasings.

rdar://64425199