### PR TITLE
[LTO] Build lld on Windows CI

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -97,6 +97,7 @@ git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %
 git clone --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project llvm-project %exitOnError%
 mklink /D "%source_root%\clang" "%source_root%\llvm-project\clang"
 mklink /D "%source_root%\llvm" "%source_root%\llvm-project\llvm"
+mklink /D "%source_root%\lld" "%source_root%\llvm-project\lld"
 mklink /D "%source_root%\lldb" "%source_root%\llvm-project\lldb"
 mklink /D "%source_root%\compiler-rt" "%source_root%\llvm-project\compiler-rt"
 mklink /D "%source_root%\libcxx" "%source_root%\llvm-project\libcxx"
@@ -165,7 +166,7 @@ cmake^
     -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc^
     -DLLVM_ENABLE_PDB:BOOL=YES^
     -DLLVM_ENABLE_ASSERTIONS:BOOL=YES^
-    -DLLVM_ENABLE_PROJECTS:STRING=clang^
+    -DLLVM_ENABLE_PROJECTS:STRING=lld;clang^
     -DLLVM_TARGETS_TO_BUILD:STRING="AArch64;ARM;X86"^
     -DLLVM_INCLUDE_BENCHMARKS:BOOL=NO^
     -DLLVM_INCLUDE_DOCS:BOOL=NO^


### PR DESCRIPTION
lld is necessary to enable LTO for LLVM bitcode files on Windows. This is pulled out from https://github.com/apple/swift/pull/32237

CC: @compnerd 

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
