### PR TITLE
SILOptimizer: A new "TempLValueOpt" optimization for copy_addr

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -375,6 +375,12 @@ public:
     /// The instruction may read memory.
     MayRead,
     /// The instruction may write to memory.
+    /// This includes destroying or taking from memory (e.g. destroy_addr,
+    /// copy_addr [take], load [take]).
+    /// Although, physically, destroying or taking does not modify the memory,
+    /// it is important to model it is a write. Optimizations must not assume
+    /// that the value stored in memory is still available for loading after
+    /// the memory is destroyed or taken.
     MayWrite,
     /// The instruction may read or write memory.
     MayReadWrite,

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -283,6 +283,8 @@ PASS(PerformanceSILLinker, "performance-linker",
      "Deserialize all referenced SIL functions")
 PASS(RawSILInstLowering, "raw-sil-inst-lowering",
      "Lower all raw SIL instructions to canonical equivalents.")
+PASS(TempLValueOpt, "temp-lvalue-opt",
+     "Remove short-lived immutable temporary l-values")
 PASS(TempRValueOpt, "temp-rvalue-opt",
      "Remove short-lived immutable temporary copies")
 PASS(SideEffectsDumper, "side-effects-dump",

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -174,6 +174,7 @@ public:
 
   MemBehavior visitLoadInst(LoadInst *LI);
   MemBehavior visitStoreInst(StoreInst *SI);
+  MemBehavior visitCopyAddrInst(CopyAddrInst *CAI);
   MemBehavior visitApplyInst(ApplyInst *AI);
   MemBehavior visitTryApplyInst(TryApplyInst *AI);
   MemBehavior visitBuiltinInst(BuiltinInst *BI);
@@ -270,6 +271,34 @@ MemBehavior MemoryBehaviorVisitor::visitStoreInst(StoreInst *SI) {
   LLVM_DEBUG(llvm::dbgs() << "  Could not prove store does not alias inst. "
                              "Returning MayWrite.\n");
   return MemBehavior::MayWrite;
+}
+
+MemBehavior MemoryBehaviorVisitor::visitCopyAddrInst(CopyAddrInst *CAI) {
+  // If it's an assign to the destination, a destructor might be called on the
+  // old value. This can have any side effects.
+  // We could also check if it's a trivial type (which cannot have any side
+  // effect on destruction), but such copy_addr instructions are optimized to
+  // load/stores anyway, so it's probably not worth it.
+  if (!CAI->isInitializationOfDest())
+    return MemBehavior::MayHaveSideEffects;
+
+  bool mayWrite = mayAlias(CAI->getDest());
+  bool mayRead = mayAlias(CAI->getSrc());
+  
+  if (mayRead) {
+    if (mayWrite)
+      return MemBehavior::MayReadWrite;
+
+    // A take is modelled as a write. See MemoryBehavior::MayWrite.
+    if (CAI->isTakeOfSrc())
+      return MemBehavior::MayReadWrite;
+
+    return MemBehavior::MayRead;
+  }
+  if (mayWrite)
+    return MemBehavior::MayWrite;
+
+  return MemBehavior::None;
 }
 
 MemBehavior MemoryBehaviorVisitor::visitBuiltinInst(BuiltinInst *BI) {

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -245,6 +245,10 @@ MemBehavior MemoryBehaviorVisitor::visitLoadInst(LoadInst *LI) {
   if (!mayAlias(LI->getOperand()))
     return MemBehavior::None;
 
+  // A take is modelled as a write. See MemoryBehavior::MayWrite.
+  if (LI->getOwnershipQualifier() == LoadOwnershipQualifier::Take)
+      return MemBehavior::MayReadWrite;
+
   LLVM_DEBUG(llvm::dbgs() << "  Could not prove that load inst does not alias "
                              "pointer. Returning may read.\n");
   return MemBehavior::MayRead;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -283,6 +283,9 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // splits up copy_addr.
   P.addCopyForwarding();
 
+  // Optimize copies from a temporary (an "l-value") to a destination.
+  P.addTempLValueOpt();
+
   // Split up opaque operations (copy_addr, retain_value, etc.).
   P.addLowerAggregateInstrs();
 

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -38,5 +38,6 @@ target_sources(swiftSILOptimizer PRIVATE
   Sink.cpp
   SpeculativeDevirtualizer.cpp
   StackPromotion.cpp
+  TempLValueOpt.cpp
   TempRValueElimination.cpp
   UnsafeGuaranteedPeephole.cpp)

--- a/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
+++ b/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
@@ -1,0 +1,299 @@
+//===--- TempLValueOpt.cpp - Optimize temporary l-values ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass optimizes copies from a temporary (an "l-value") to a destination.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "cow-opts"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/Projection.h"
+#include "swift/SIL/SILBuilder.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Optimizes copies from a temporary (an "l-value") to a destination.
+///
+/// \code
+///   %temp = alloc_stack $Ty
+///   instructions_which_store_to %temp
+///   copy_addr [take] %temp to %destination
+///   dealloc_stack %temp
+/// \endcode
+///
+/// is optimized to
+///
+/// \code
+///   destroy_addr %destination
+///   instructions_which_store_to %destination
+/// \endcode
+///
+/// The name TempLValueOpt refers to the TempRValueOpt pass, which performs
+/// a related transformation, just with the temporary on the "right" side.
+///
+/// Note that TempLValueOpt is similar to CopyForwarding::backwardPropagateCopy.
+/// It's more restricted (e.g. the copy-source must be an alloc_stack).
+/// That enables other patterns to be optimized, which backwardPropagateCopy
+/// cannot handle.
+///
+/// The pass also performs a peephole optimization on copy_addr - destroy
+/// sequences.
+/// It replaces
+///
+/// \code
+///   copy_addr %source to %destination
+///   destroy_addr %source
+/// \endcode
+///
+/// with
+///
+/// \code
+///   copy_addr [take] %source to %destination
+/// \endcode
+///
+/// This peephole optimization is also done by the DestroyHoisting pass. But
+/// DestroyHoisting currently only runs on OSSA.
+/// TODO: when DestroyHoisting can run later in the pipeline, check if we still
+///       need this peephole here.
+class TempLValueOptPass : public SILFunctionTransform {
+public:
+  TempLValueOptPass() {}
+
+  void run() override;
+
+private:
+  AliasAnalysis *AA = nullptr;
+  
+  bool tempLValueOpt(CopyAddrInst *copyInst);
+  bool combineCopyAndDestroy(CopyAddrInst *copyInst);
+};
+
+void TempLValueOptPass::run() {
+  SILFunction *F = getFunction();
+  if (!F->shouldOptimize())
+    return;
+
+  LLVM_DEBUG(llvm::dbgs() << "*** TempLValueOptPass on function: "
+                          << F->getName() << " ***\n");
+
+  AA = PM->getAnalysis<AliasAnalysis>();
+
+  bool changed = false;
+  for (SILBasicBlock &block : *F) {
+    // First collect all copy_addr instructions upfront to avoid iterator
+    // invalidation problems (the optimizations might delete the copy_addr
+    // itself or any following instruction).
+    llvm::SmallVector<CopyAddrInst *, 32> copyInsts;
+    for (SILInstruction &inst : block) {
+      if (auto *copyInst = dyn_cast<CopyAddrInst>(&inst))
+        copyInsts.push_back(copyInst);
+    }
+    // Do the optimizations.
+    for (CopyAddrInst *copyInst : copyInsts) {
+      changed |=combineCopyAndDestroy(copyInst);
+      changed |=tempLValueOpt(copyInst);
+    }
+  }
+
+  if (changed) {
+    invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+}
+
+static SingleValueInstruction *isMovableProjection(SILValue addr) {
+  if (auto *enumData = dyn_cast<InitEnumDataAddrInst>(addr))
+    return enumData;
+  if (auto *existentialAddr = dyn_cast<InitExistentialAddrInst>(addr))
+    return existentialAddr;
+    
+  if (SingleValueInstruction *svi = Projection::isAddressProjection(addr)) {
+    if (svi->getNumOperands() == 1)
+      return svi;
+  }
+  return nullptr;
+}
+
+bool TempLValueOptPass::tempLValueOpt(CopyAddrInst *copyInst) {
+
+  // An overview of the algorithm:
+  //
+  //   alloc_stack %temp
+  //   ...
+  //   first_use_of %temp // beginOfLiferange
+  //   ... // no reads or writes from/to %destination
+  //   copy_addr [take] %temp to %destination // copyInst
+  //   ... // no further uses of %temp (copyInst is the end of %temp liferange)
+  //   dealloc_stack %temp
+  //
+  // All projections to %destination are hoisted above the first use of %temp.
+  // Then all uses of %temp are replaced by %destination.
+  // In case the copyInst is not initializing %destination, a
+  // 'destroy_addr %destination' is inserted before the first use of %temp.
+
+  if (!copyInst->isTakeOfSrc())
+    return false;
+
+  auto *temporary = dyn_cast<AllocStackInst>(copyInst->getSrc());
+  if (!temporary)
+    return false;
+
+  // Collect all users of the temporary into a set. Also, for simplicity,
+  // require that all users are within a single basic block.
+  SmallPtrSet<SILInstruction *, 8> users;
+  SILBasicBlock *block = temporary->getParent();
+  for (Operand *use : temporary->getUses()) {
+    SILInstruction *user = use->getUser();
+    if (user->getParent() != block)
+      return false;
+    users.insert(user);
+  }
+
+  // Collect all address projections of the destination - in case we need to
+  // hoist them.
+  SmallPtrSet<SILInstruction *, 4> projections;
+  SILValue destination = copyInst->getDest();
+  SILValue destRootAddr = destination;
+  while (SingleValueInstruction *projInst = isMovableProjection(destRootAddr)) {
+    // In theory, users of the temporary and address projections of the
+    // destination should be completely distinct. Otherwise the copyInst would
+    // be an identity copy (source == destination).
+    // Just to be on the safe side, bail if it's not the case (instead of an
+    // assert).
+    if (users.count(projInst))
+      return false;
+    projections.insert(projInst);
+    destRootAddr = projInst->getOperand(0);
+  }
+  // The root address of the destination. It's null if it's not an instruction,
+  // but a block argument.
+  SILInstruction *destRootInst = destRootAddr->getDefiningInstruction();
+
+  // Iterate over the liferange of the temporary and make some validity checks.
+  SILInstruction *beginOfLiferange = nullptr;
+  bool endOfLiferangeReached = false;
+  for (auto iter = temporary->getIterator(); iter != block->end(); ++iter) {
+    SILInstruction *inst = &*iter;
+    // The dealloc_stack is the last user of the temporary.
+    if (isa<DeallocStackInst>(inst) && inst->getOperand(0) == temporary)
+      break;
+
+    if (users.count(inst) != 0) {
+      // Check if the copyInst is the last user of the temporary (beside the
+      // dealloc_stack).
+      if (endOfLiferangeReached)
+        return false;
+
+      // Find the first user of the temporary to get a more precise liferange.
+      // It would be too conservative to treat the alloc_stack itself as the
+      // begin of the liferange.
+      if (!beginOfLiferange)
+        beginOfLiferange = inst;
+
+      if (inst == copyInst)
+        endOfLiferangeReached = true;
+    }
+    if (beginOfLiferange && !endOfLiferangeReached) {
+      // If the root address of the destination is within the liferange of the
+      // temporary, we cannot replace all uses of the temporary with the
+      // destination (it would break the def-use dominance rule).
+      if (inst == destRootInst)
+        return false;
+        
+      // Check if the destination is not accessed within the liferange of
+      // the temporary.
+      // This is unlikely, because the destination is initialized at the
+      // copyInst. But still, the destination could contain an initialized value
+      // which is destroyed before the copyInst.
+      if (AA->mayReadOrWriteMemory(inst, destination) &&
+          // Needed to treat init_existential_addr as not-writing projection.
+          projections.count(inst) == 0)
+        return false;
+    }
+  }
+  assert(endOfLiferangeReached);
+
+  // Move all projections of the destination address before the liferange of
+  // the temporary.
+  for (auto iter = beginOfLiferange->getIterator();
+       iter != copyInst->getIterator();) {
+    SILInstruction *inst = &*iter++;
+    if (projections.count(inst))
+      inst->moveBefore(beginOfLiferange);
+  }
+
+  if (!copyInst->isInitializationOfDest()) {
+    // Make sure the the destination is uninitialized before the liferange of
+    // the temporary.
+    SILBuilderWithScope builder(beginOfLiferange);
+    builder.createDestroyAddr(copyInst->getLoc(), destination);
+  }
+
+  // Replace all uses of the temporary with the destination address.
+  while (!temporary->use_empty()) {
+    Operand *use = *temporary->use_begin();
+    SILInstruction *user = use->getUser();
+    switch (user->getKind()) {
+      case SILInstructionKind::DeallocStackInst:
+        user->eraseFromParent();
+        break;
+      default:
+        use->set(destination);
+    }
+  }
+  temporary->eraseFromParent();
+  copyInst->eraseFromParent();
+  return true;
+}
+
+bool TempLValueOptPass::combineCopyAndDestroy(CopyAddrInst *copyInst) {
+  if (copyInst->isTakeOfSrc())
+    return false;
+
+  // Find a destroy_addr of the copy's source address.
+  DestroyAddrInst *destroy = nullptr;
+  for (Operand *srcUse : copyInst->getSrc()->getUses()) {
+    if ((destroy = dyn_cast<DestroyAddrInst>(srcUse->getUser())))
+      break;
+  }
+  SILBasicBlock *block = copyInst->getParent();
+  if (!destroy || destroy->getParent() != block)
+    return false;
+  assert(destroy->getOperand() == copyInst->getSrc());
+
+  // Check if the destroy_addr is after the copy_addr and if there are no
+  // memory accesses between them.
+  for (auto iter = std::next(copyInst->getIterator());
+       iter != block->end(); ++iter) {
+    SILInstruction *inst = &*iter;
+    if (inst == destroy) {
+      copyInst->setIsTakeOfSrc(IsTake);
+      destroy->eraseFromParent();
+      return true;
+    }
+    if (inst->mayReadOrWriteMemory())
+      return false;
+  }
+  return false;
+}
+
+} // end anonymous namespace
+
+SILTransform *swift::createTempLValueOpt() {
+  return new TempLValueOptPass();
+}
+

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -579,3 +579,97 @@ bb0:
   %2 = tuple()
   return %2 : $()
 }
+
+struct TwoInts {
+  var a: Int
+  var b: Int
+}
+
+struct StructWithOptional {
+  var i: Optional<TwoInts>
+}
+
+// CHECK-LABEL: @init_enum_data_addr
+// CHECK:      PAIR #3.
+// CHECK-NEXT: %0 = argument of bb0 : $*StructWithOptional
+// CHECK-NEXT:   %3 = init_enum_data_addr %2 : $*Optional<TwoInts>, #Optional.some!enumelt
+// CHECK-NEXT: NoAlias
+// CHECK:      PAIR #4.
+// CHECK-NEXT: %0 = argument of bb0 : $*StructWithOptional
+// CHECK-NEXT:   %4 = struct_element_addr %3 : $*TwoInts, #TwoInts.a
+// CHECK-NEXT: NoAlias
+// CHECK:      PAIR #5.
+// CHECK-NEXT: %0 = argument of bb0 : $*StructWithOptional
+// CHECK-NEXT:   %5 = struct_element_addr %3 : $*TwoInts, #TwoInts.b
+// CHECK-NEXT: NoAlias
+// CHECK:      PAIR #14.
+// CHECK-NEXT:   %2 = struct_element_addr %1 : $*StructWithOptional, #StructWithOptional.i
+// CHECK-NEXT:   %3 = init_enum_data_addr %2 : $*Optional<TwoInts>, #Optional.some!enumelt
+// CHECK-NEXT: MayAlias
+// CHECK:      PAIR #15.
+// CHECK-NEXT:   %2 = struct_element_addr %1 : $*StructWithOptional, #StructWithOptional.i
+// CHECK-NEXT:   %4 = struct_element_addr %3 : $*TwoInts, #TwoInts.a
+// CHECK-NEXT: MayAlias
+// CHECK:      PAIR #16.
+// CHECK-NEXT:   %2 = struct_element_addr %1 : $*StructWithOptional, #StructWithOptional.i
+// CHECK-NEXT:   %5 = struct_element_addr %3 : $*TwoInts, #TwoInts.b
+// CHECK-NEXT: MayAlias
+// CHECK:      PAIR #19.
+// CHECK-NEXT:   %3 = init_enum_data_addr %2 : $*Optional<TwoInts>, #Optional.some!enumelt
+// CHECK-NEXT:   %4 = struct_element_addr %3 : $*TwoInts, #TwoInts.a
+// CHECK-NEXT: PartialAlias
+// CHECK:      PAIR #20.
+// CHECK-NEXT:   %3 = init_enum_data_addr %2 : $*Optional<TwoInts>, #Optional.some!enumelt
+// CHECK-NEXT:   %5 = struct_element_addr %3 : $*TwoInts, #TwoInts.b
+// CHECK-NEXT: PartialAlias
+// CHECK:      PAIR #23.
+// CHECK-NEXT:   %4 = struct_element_addr %3 : $*TwoInts, #TwoInts.a
+// CHECK-NEXT:   %5 = struct_element_addr %3 : $*TwoInts, #TwoInts.b
+// CHECK-NEXT: NoAlias
+sil @init_enum_data_addr : $@convention(thin) (@in_guaranteed StructWithOptional) -> () {
+bb0(%0 : $*StructWithOptional):
+  %1 = alloc_stack $StructWithOptional
+  %2 = struct_element_addr %1 : $*StructWithOptional, #StructWithOptional.i
+  %3 = init_enum_data_addr %2 : $*Optional<TwoInts>, #Optional.some!enumelt
+  %4 = struct_element_addr %3 : $*TwoInts, #TwoInts.a
+  %5 = struct_element_addr %3 : $*TwoInts, #TwoInts.b
+  dealloc_stack %1 : $*StructWithOptional
+  %6 = tuple ()
+  return %6 : $()
+}
+
+protocol P {}
+
+struct S : P {
+  var i: Int
+}
+
+// CHECK-LABEL: @init_existential_addr
+// CHECK:      PAIR #3.
+// CHECK-NEXT:   %0 = argument of bb0 : $P
+// CHECK-NEXT:   %3 = init_existential_addr %2 : $*P, $S
+// CHECK-NEXT: NoAlias
+// CHECK:      PAIR #12.
+// CHECK-NEXT:   %2 = alloc_stack $P
+// CHECK-NEXT:   %3 = init_existential_addr %2 : $*P, $S
+// CHECK-NEXT: MayAlias
+// CHECK:      PAIR #13.
+// CHECK-NEXT:   %2 = alloc_stack $P
+// CHECK-NEXT:   %4 = struct_element_addr %3 : $*S, #S.i
+// CHECK-NEXT: MayAlias
+// CHECK:      PAIR #16.
+// CHECK-NEXT:   %3 = init_existential_addr %2 : $*P, $S
+// CHECK-NEXT:   %4 = struct_element_addr %3 : $*S, #S.i
+// CHECK-NEXT: PartialAlias
+sil @init_existential_addr : $@convention(thin) (P) -> () {
+bb0(%0 : $P):
+  %1 = alloc_stack $S
+  %2 = alloc_stack $P
+  %3 = init_existential_addr %2 : $*P, $S
+  %4 = struct_element_addr %3 : $*S, #S.i
+  dealloc_stack %2 : $*P
+  dealloc_stack %1 : $*S
+  %6 = tuple ()
+  return %6 : $()
+}
+

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -113,6 +113,21 @@ bb0(%0 : $*Builtin.Int32):
   return %val : $Builtin.Int32
 }
 
+// CHECK-LABEL: @testLoadTake
+// CHECK:      PAIR #0.
+// CHECK-NEXT:   %2 = load [take] %0 : $*C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK:      PAIR #1.
+// CHECK-NEXT:   %2 = load [take] %0 : $*C
+// CHECK-NEXT:   %1 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0,se=0
+sil [ossa] @testLoadTake : $@convention(thin) (@in C, @in_guaranteed C) -> @owned C {
+bb0(%0 : $*C, %1 : $*C):
+  %2 = load [take] %0 : $*C
+  return %2 : $C
+}
+
 // ===-----------------------------------------------------------------------===
 // Test the effect of a [deinit] access on a global 'let'
 //

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -183,3 +183,64 @@ bb0(%0 : $*Int64Wrapper):
   %8 = tuple ()
   return %8 : $()
 }
+
+// CHECK-LABEL: @test_copy_addr_initialize
+// CHECK:      PAIR #0.
+// CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=1,se=1
+// CHECK:      PAIR #1.
+// CHECK-NEXT:    copy_addr %1 to [initialization] %0 : $*C
+// CHECK-NEXT:    %1 = argument of bb0 : $*C
+// CHECK-NEXT:    r=1,w=0,se=0
+// CHECK:      PAIR #2.
+// CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   %2 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0,se=0
+sil @test_copy_addr_initialize : $@convention(thin) (@inout C, @inout C) -> @out C {
+bb0(%0 : $*C, %1 : $*C, %2: $*C):
+  copy_addr %1 to [initialization] %0 : $*C
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: @test_copy_addr_assign
+// CHECK:      PAIR #0.
+// CHECK-NEXT:   copy_addr %1 to %0 : $*C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK:      PAIR #1.
+// CHECK-NEXT:    copy_addr %1 to %0 : $*C
+// CHECK-NEXT:    %1 = argument of bb0 : $*C
+// CHECK-NEXT:    r=1,w=1,se=1
+// CHECK:      PAIR #2.
+// CHECK-NEXT:   copy_addr %1 to %0 : $*C
+// CHECK-NEXT:   %2 = argument of bb0 : $*C
+// CHECK-NEXT:   r=1,w=1,se=1
+sil @test_copy_addr_assign : $@convention(thin) (@inout C, @inout C, @inout C) -> () {
+bb0(%0 : $*C, %1 : $*C, %2: $*C):
+  copy_addr %1 to %0 : $*C
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: @test_copy_addr_take
+// CHECK:      PAIR #0.
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=1,se=1
+// CHECK:      PAIR #1.
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   %1 = argument of bb0 : $*C
+// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK:      PAIR #2.
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   %2 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0,se=0
+sil @test_copy_addr_take : $@convention(thin) (@in C, @inout C) -> @out C {
+bb0(%0 : $*C, %1 : $*C, %2: $*C):
+  copy_addr [take] %1 to [initialization] %0 : $*C
+  %6 = tuple ()
+  return %6 : $()
+}
+

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -16,6 +16,11 @@ struct GS<Base> {
 
 class Klass {}
 
+struct Str {
+  var kl: Klass
+  var _value: Builtin.Int64
+}
+
 sil @unknown : $@convention(thin) () -> ()
 
 sil @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
@@ -32,6 +37,8 @@ bb0(%0 : $*Klass, %1 : $*Klass):
 }
 
 sil @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
+
+sil [ossa] @takeStr : $@convention(thin) (@owned Str) -> ()
 
 ///////////
 // Tests //
@@ -124,6 +131,26 @@ bb0(%0 : $*B, %1 : $*GS<B>):
   return %9999 : $()
 }
 
+// Check that we don't cause a memory lifetime failure with load [take]
+
+// CHECK-LABEL: sil [ossa] @take_from_source
+// CHECK: alloc_stack
+// CHECK: copy_addr
+// CHECK: load
+// CHECK: load
+// CHECK: } // end sil function 'take_from_source'
+sil [ossa] @take_from_source : $@convention(thin) (@in Str) -> @owned Str {
+bb0(%0 : $*Str):
+  %1 = alloc_stack $Str
+  copy_addr %0 to [initialization] %1 : $*Str
+  %3 = load [take] %0 : $*Str
+  %4 = load [copy] %1 : $*Str
+  %f = function_ref @takeStr : $@convention(thin) (@owned Str) -> ()
+  %a = apply %f(%4) : $@convention(thin) (@owned Str) -> ()
+  destroy_addr %1 : $*Str
+  dealloc_stack %1 : $*Str
+  return %3 : $Str
+}
 // CHECK-LABEL: sil @load_in_wrong_block
 // CHECK:      bb0(%0 : $*GS<B>):
 // CHECK-NEXT:   alloc_stack

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -1,0 +1,251 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -temp-lvalue-opt | %FileCheck %s
+
+import Swift
+import Builtin
+
+// CHECK-LABEL: sil @test_enum_with_initialize
+// CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
+// CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
+// CHECK-NOT:    copy_addr
+// CHECK: } // end sil function 'test_enum_with_initialize'
+sil @test_enum_with_initialize : $@convention(thin) (@in Any) -> @out Optional<Any> {
+bb0(%0 : $*Optional<Any>, %1 : $*Any):
+  %2 = alloc_stack $Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %1 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  dealloc_stack %2 : $*Optional<Any>
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @test_enum_without_initialize
+// CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
+// CHECK-NEXT:   destroy_addr %0
+// CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
+// CHECK-NOT:    copy_addr
+// CHECK: } // end sil function 'test_enum_without_initialize'
+sil @test_enum_without_initialize : $@convention(thin) (@in Any) -> @out Optional<Any> {
+bb0(%0 : $*Optional<Any>, %1 : $*Any):
+  %2 = alloc_stack $Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %1 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %2 to %0 : $*Optional<Any>
+  dealloc_stack %2 : $*Optional<Any>
+  %6 = tuple ()
+  return %6 : $()
+}
+
+protocol Proto {}
+
+struct ConformingStruct : Proto {
+  @_hasStorage let a: Any
+}
+
+// CHECK-LABEL: sil @test_existential
+// CHECK:      bb0(%0 : $*Proto, %1 : $*ConformingStruct):
+// CHECK-NEXT:   [[E:%[0-9]+]] = init_existential_addr %0
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NOT:    copy_addr
+// CHECK: } // end sil function 'test_existential'
+sil @test_existential : $@convention(thin) (@in ConformingStruct) -> @out Proto {
+bb0(%0 : $*Proto, %1 : $*ConformingStruct):
+  %2 = alloc_stack $Proto
+  %3 = init_existential_addr %2 : $*Proto, $ConformingStruct
+  copy_addr [take] %1 to [initialization] %3 : $*ConformingStruct
+  copy_addr [take] %2 to [initialization] %0 : $*Proto
+  dealloc_stack %2 : $*Proto
+  %6 = tuple ()
+  return %6 : $()
+}
+
+enum Either<Left, Right> {
+  case left(Left), right(Right)
+}
+
+public struct TestStruct {
+  @_hasStorage var e: Either<AddressOnlyPayload, Int>
+}
+
+struct AddressOnlyPayload {
+  @_hasStorage let a: Any
+  @_hasStorage let i: Int
+}
+
+// There should only be a single copy_addr after optimization.
+//
+// CHECK-LABEL: sil @test_initialize_struct
+// CHECK:      bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
+// CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
+// CHECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
+// CHECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
+// CHECK-NEXT:   copy_addr %1 to [initialization] [[A]]
+// CHECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
+// CHECK-NEXT:   store %2 to [[I]]
+// CHECK-NEXT:   inject_enum_addr [[E]]
+// CHECK-NOT:    copy_addr
+// CHECK: } // end sil function 'test_initialize_struct'
+sil @test_initialize_struct : $@convention(method) (@in Any, Int) -> @out TestStruct {
+bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
+  %3 = alloc_stack $TestStruct
+  %4 = alloc_stack $Either<AddressOnlyPayload, Int>
+  %5 = alloc_stack $AddressOnlyPayload
+  %6 = struct_element_addr %5 : $*AddressOnlyPayload, #AddressOnlyPayload.a
+  copy_addr %1 to [initialization] %6 : $*Any
+  %8 = struct_element_addr %5 : $*AddressOnlyPayload, #AddressOnlyPayload.i
+  store %2 to %8 : $*Int
+  %10 = init_enum_data_addr %4 : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
+  copy_addr [take] %5 to [initialization] %10 : $*AddressOnlyPayload
+  inject_enum_addr %4 : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
+  dealloc_stack %5 : $*AddressOnlyPayload
+  %14 = struct_element_addr %3 : $*TestStruct, #TestStruct.e
+  copy_addr [take] %4 to [initialization] %14 : $*Either<AddressOnlyPayload, Int>
+  dealloc_stack %4 : $*Either<AddressOnlyPayload, Int>
+  copy_addr %3 to [initialization] %0 : $*TestStruct
+  destroy_addr %3 : $*TestStruct
+  dealloc_stack %3 : $*TestStruct
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// CHECK-LABEL: sil @bail_on_write_to_dest
+// CHECK:   alloc_stack
+// CHECK:   copy_addr
+// CHECK:   copy_addr
+// CHECK: } // end sil function 'bail_on_write_to_dest'
+sil @bail_on_write_to_dest : $@convention(thin) (@inout Optional<Any>, @in Any) -> () {
+bb0(%0 : $*Optional<Any>, %1 : $*Any):
+  %2 = alloc_stack $Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %1 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  destroy_addr %0 : $*Optional<Any>
+  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  dealloc_stack %2 : $*Optional<Any>
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @write_to_dest_ok_if_before_liferange
+// CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
+// CHECK-NEXT:   destroy_addr
+// CHECK-NEXT:   init_enum_data_addr
+// CHECK-NEXT:   copy_addr
+// CHECK-NEXT:   inject_enum_addr
+// CHECK-NOT:    copy_addr
+// CHECK: } // end sil function 'write_to_dest_ok_if_before_liferange'
+sil @write_to_dest_ok_if_before_liferange : $@convention(thin) (@inout Optional<Any>, @in Any) -> () {
+bb0(%0 : $*Optional<Any>, %1 : $*Any):
+  %2 = alloc_stack $Optional<Any>
+  destroy_addr %0 : $*Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %1 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  dealloc_stack %2 : $*Optional<Any>
+  %6 = tuple ()
+  return %6 : $()
+}
+
+enum Enum {
+  case A(Optional<Any>), B
+}
+
+struct StructWithEnum : Proto {
+  @_hasStorage let e: Enum
+}
+
+// CHECK-LABEL: sil @move_projections
+// CHECK:      bb0(%0 : $*Proto, %1 : $*Any):
+// CHECK-NEXT:   [[S:%[0-9]+]] = init_existential_addr %0 : $*Proto, $StructWithEnum
+// CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
+// CHECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
+// CHECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[OPTIONAL]] : $*Any
+// CHECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
+// CHECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
+// CHECK-NOT:    copy_addr
+// CHECK: } // end sil function 'move_projections'
+sil @move_projections : $@convention(thin) (@in Any) -> @out Proto {
+bb0(%0 : $*Proto, %1 : $*Any):
+  %2 = alloc_stack $Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %1 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  %4 = init_existential_addr %0 : $*Proto, $StructWithEnum
+  %5 = struct_element_addr %4 : $*StructWithEnum, #StructWithEnum.e
+  %6 = init_enum_data_addr %5 : $*Enum, #Enum.A!enumelt
+  copy_addr [take] %2 to [initialization] %6 : $*Optional<Any>
+  inject_enum_addr %5 : $*Enum, #Enum.A!enumelt
+  dealloc_stack %2 : $*Optional<Any>
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @cant_move_projections
+// CHECK:   alloc_stack
+// CHECK:   copy_addr
+// CHECK:   load
+// CHECK:   copy_addr
+// CHECK: } // end sil function 'cant_move_projections'
+sil @cant_move_projections : $@convention(thin) (@in Any, @in_guaranteed Builtin.RawPointer) -> () {
+bb0(%0 : $*Any, %1 : $*Builtin.RawPointer):
+  %2 = alloc_stack $Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %0 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  %4 = load %1 : $*Builtin.RawPointer
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to $*Optional<Any>
+  copy_addr [take] %2 to [initialization] %5 : $*Optional<Any>
+  dealloc_stack %2 : $*Optional<Any>
+  %10 = tuple ()
+  return %10 : $()
+}
+
+sil @init_optional : $@convention(thin) () -> @out Optional<Any>
+
+// CHECK-LABEL: sil @instructions_after_copy_addr
+// CHECK:   alloc_stack
+// CHECK:   copy_addr
+// CHECK:   copy_addr
+// CHECK:   apply
+// CHECK: } // end sil function 'instructions_after_copy_addr'
+sil @instructions_after_copy_addr : $@convention(thin) (@in Any) -> @out Optional<Any> {
+bb0(%0 : $*Optional<Any>, %1 : $*Any):
+  %2 = alloc_stack $Optional<Any>
+  %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %1 to [initialization] %3 : $*Any
+  inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
+  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  %4 = function_ref @init_optional : $@convention(thin) () -> @out Optional<Any>
+  %5 = apply %4(%2) : $@convention(thin) () -> @out Optional<Any>
+  destroy_addr %2 : $*Optional<Any>
+  dealloc_stack %2 : $*Optional<Any>
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @dont_optimize_swap
+// CHECK:   alloc_stack
+// CHECK:   copy_addr
+// CHECK:   copy_addr
+// CHECK:   copy_addr
+// CHECK:   dealloc_stack
+// CHECK: } // end sil function 'dont_optimize_swap'
+sil @dont_optimize_swap : $@convention(thin) <T> (@inout T, @inout T) -> () {
+bb0(%0 : $*T, %1 : $*T):
+  %2 = alloc_stack $T
+  copy_addr [take] %0 to [initialization] %2 : $*T
+  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %2 to [initialization] %1 : $*T
+  dealloc_stack %2 : $*T
+  %78 = tuple ()
+  return %78 : $()
+}
+

--- a/test/SILOptimizer/templvalueopt.swift
+++ b/test/SILOptimizer/templvalueopt.swift
@@ -1,0 +1,61 @@
+// RUN: %target-swift-frontend -module-name=test -O -emit-sil  %s | %FileCheck %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
+// Check that the compiler creates optimal code for address-only enum initializations.
+
+public enum Either<Left, Right> {
+  case left(Left), right(Right)
+}
+
+internal struct AddressOnlyPayload {
+  let a: Any
+  let i: Int
+}
+
+public struct TestStruct {
+  internal var e: Either<AddressOnlyPayload, Int>
+
+  // CHECK-LABEL: sil [noinline] @$s4test10TestStructVyACyp_SitcfC
+  // CHECK: [[E:%[0-9]+]] = struct_element_addr %0 : $*TestStruct, #TestStruct.e
+  // CHECK: [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]] : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
+  // CHECK: [[A:%[0-9]+]] = struct_element_addr [[LEFT]] : $*AddressOnlyPayload, #AddressOnlyPayload.a
+  // CHECK: copy_addr [take] %1 to [initialization] [[A]] : $*Any
+  // CHECK: [[I:%[0-9]+]] = struct_element_addr [[LEFT]] : $*AddressOnlyPayload, #AddressOnlyPayload.i
+  // CHECK: store %2 to [[I]] : $*Int
+  // CHECK: inject_enum_addr [[E]] : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
+  // CHECK: } // end sil function '$s4test10TestStructVyACyp_SitcfC'
+  @inline(never)
+  public init(_ a: Any, _ i: Int) {
+    e = Either.left(AddressOnlyPayload(a: a, i: i))
+  }
+}
+
+// CHECK-LABEL: sil [noinline] @$s4test13createAnyLeftyAA6EitherOyypSgSiGypF
+// CHECK:  [[E:%[0-9]+]] = init_enum_data_addr %0 : $*Either<Optional<Any>, Int>, #Either.left!enumelt
+// CHECK:  [[SOME:%[0-9]+]] = init_enum_data_addr [[E]] : $*Optional<Any>, #Optional.some!enumelt
+// CHECK:  copy_addr %1 to [initialization] [[SOME]] : $*Any
+// CHECK:  inject_enum_addr [[E]] : $*Optional<Any>, #Optional.some!enumelt
+// CHECK:  inject_enum_addr %0 : $*Either<Optional<Any>, Int>, #Either.left!enumelt
+// CHECK: } // end sil function '$s4test13createAnyLeftyAA6EitherOyypSgSiGypF'
+@inline(never)
+public func createAnyLeft(_ a: Any) -> Either<Any?, Int> {
+  return Either.left(a)
+}
+
+
+// CHECK-OUTPUT: TestStruct(e: test.Either<test.AddressOnlyPayload, Swift.Int>.left(test.AddressOnlyPayload(a: 27, i: 1)))
+// CHECK-OUTPUT: TestStruct(e: test.Either<test.AddressOnlyPayload, Swift.Int>.left(test.AddressOnlyPayload(a: "A non-trivial value", i: 1)))
+print(TestStruct(27, 1))
+print(TestStruct("A non-trivial value", 1))
+
+// CHECK-OUTPUT: left(Optional(27))
+// CHECK-OUTPUT: left(Optional("A non-trivial value"))
+print(createAnyLeft(27))
+print(createAnyLeft("A non-trivial value"))
+


### PR DESCRIPTION
Optimizes copies from a temporary (an "l-value") to a destination.
```
    %temp = alloc_stack $Ty
    instructions_which_store_to %temp
    copy_addr [take] %temp to [initialization] %destination
    dealloc_stack %temp
```
is optimized to
```
    instructions_which_store_to %destination
```
The name tempLValueOpt refers to the TempRValueOpt pass, which performs a related transformation, just with the temporary on the "right" side.
The tempLValueOpt is similar to CopyForwarding::backwardPropagateCopy.
It's more restricted (e.g. the copy-source must be an alloc_stack, the copy-destination must be initialized).
That enables other patterns to be optimized, which backwardPropagateCopy cannot handle.

This PR also contains some other small improvements related to copy_addr and other address instructions. For details see the commit messages.

The effect of this optimizations is that code with address-only types (e.g. generic functions) has significantly less copy instructions, especially initializations of address-only enums (e.g. optionals).
This is a benefit for performance and code size and can also reduce the amount of generic metadata which is generated at runtime.
