### PR TITLE
[LTO] Support LLVM LTO for driver 

### DIFF
--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -328,15 +328,19 @@ public:
 class DynamicLinkJobAction : public JobAction {
   virtual void anchor();
   LinkKind Kind;
+  bool ShouldPerformLTO;
 
 public:
-  DynamicLinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K)
+  DynamicLinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K,
+                       bool ShouldPerformLTO)
       : JobAction(Action::Kind::DynamicLinkJob, Inputs, file_types::TY_Image),
-        Kind(K) {
+        Kind(K), ShouldPerformLTO(ShouldPerformLTO) {
     assert(Kind != LinkKind::None && Kind != LinkKind::StaticLibrary);
   }
 
   LinkKind getKind() const { return Kind; }
+
+  bool shouldPerformLTO() const { return ShouldPerformLTO; }
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::DynamicLinkJob;

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -101,6 +101,14 @@ public:
   /// The output type which should be used for compile actions.
   file_types::ID CompilerOutputType = file_types::ID::TY_INVALID;
 
+  enum class LTOKind {
+    None,
+    LLVMThin,
+    LLVMFull,
+  };
+
+  LTOKind LTOVariant = LTOKind::None;
+
   /// Describes if and how the output of compile actions should be
   /// linked together.
   LinkKind LinkAction = LinkKind::None;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1433,12 +1433,29 @@ static bool isSDKTooOld(StringRef sdkPath, const llvm::Triple &target) {
 void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
                              const bool BatchMode, const InputFileList &Inputs,
                              OutputInfo &OI) const {
+
+  if (const Arg *A = Args.getLastArg(options::OPT_lto)) {
+    auto LTOVariant =
+        llvm::StringSwitch<Optional<OutputInfo::LTOKind>>(A->getValue())
+            .Case("llvm-thin", OutputInfo::LTOKind::LLVMThin)
+            .Case("llvm-full", OutputInfo::LTOKind::LLVMFull)
+            .Default(llvm::None);
+    if (LTOVariant)
+      OI.LTOVariant = LTOVariant.getValue();
+    else
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+  }
+
+  auto CompilerOutputType = OI.LTOVariant != OutputInfo::LTOKind::None
+                             ? file_types::TY_LLVM_BC
+                             : file_types::TY_Object;
   // By default, the driver does not link its output; this will be updated
   // appropriately below if linking is required.
 
   OI.CompilerOutputType = driverKind == DriverKind::Interactive
                               ? file_types::TY_Nothing
-                              : file_types::TY_Object;
+                              : CompilerOutputType;
 
   if (const Arg *A = Args.getLastArg(options::OPT_num_threads)) {
     if (BatchMode) {
@@ -1468,14 +1485,14 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
                        diag::error_static_emit_executable_disallowed);
                        
       OI.LinkAction = LinkKind::Executable;
-      OI.CompilerOutputType = file_types::TY_Object;
+      OI.CompilerOutputType = CompilerOutputType;
       break;
 
     case options::OPT_emit_library:
       OI.LinkAction = Args.hasArg(options::OPT_static) ?
                       LinkKind::StaticLibrary :
                       LinkKind::DynamicLibrary;
-      OI.CompilerOutputType = file_types::TY_Object;
+      OI.CompilerOutputType = CompilerOutputType;
       break;
 
     case options::OPT_static:
@@ -2119,15 +2136,16 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     MergeModuleAction = C.createAction<MergeModuleJobAction>(AllModuleInputs);
   }
 
+  bool shouldPerformLTO = OI.LTOVariant != OutputInfo::LTOKind::None;
   if (OI.shouldLink() && !AllLinkerInputs.empty()) {
     JobAction *LinkAction = nullptr;
 
     if (OI.LinkAction == LinkKind::StaticLibrary) {
-      LinkAction = C.createAction<StaticLinkJobAction>(AllLinkerInputs,
-                                                    OI.LinkAction);
+      LinkAction =
+          C.createAction<StaticLinkJobAction>(AllLinkerInputs, OI.LinkAction);
     } else {
-      LinkAction = C.createAction<DynamicLinkJobAction>(AllLinkerInputs,
-                                                 OI.LinkAction);
+      LinkAction = C.createAction<DynamicLinkJobAction>(
+          AllLinkerInputs, OI.LinkAction, shouldPerformLTO);
     }
 
     // On ELF platforms there's no built in autolinking mechanism, so we
@@ -2149,9 +2167,10 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
         AutolinkExtractInputs.push_back(A);
       }
     const bool AutolinkExtractRequired =
-        (Triple.getObjectFormat() == llvm::Triple::ELF && !Triple.isPS4()) ||
-        Triple.getObjectFormat() == llvm::Triple::Wasm ||
-        Triple.isOSCygMing();
+        ((Triple.getObjectFormat() == llvm::Triple::ELF && !Triple.isPS4()) ||
+         Triple.getObjectFormat() == llvm::Triple::Wasm ||
+         Triple.isOSCygMing()) &&
+        !shouldPerformLTO;
     if (!AutolinkExtractInputs.empty() && AutolinkExtractRequired) {
       auto *AutolinkExtractAction =
           C.createAction<AutolinkExtractJobAction>(AutolinkExtractInputs);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -128,6 +128,19 @@ static bool addOutputsOfType(ArgStringList &Arguments,
   return Added;
 }
 
+static void addLTOArgs(const OutputInfo &OI, ArgStringList &arguments) {
+  switch (OI.LTOVariant) {
+  case OutputInfo::LTOKind::None:
+    break;
+  case OutputInfo::LTOKind::LLVMThin:
+    arguments.push_back("-lto=llvm-thin");
+    break;
+  case OutputInfo::LTOKind::LLVMFull:
+    arguments.push_back("-lto=llvm-full");
+    break;
+  }
+}
+
 void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                                       const CommandOutput &output,
                                       const ArgList &inputArgs,
@@ -283,6 +296,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back("-Xcc");
     arguments.push_back(inputArgs.MakeArgString(workingDirectory));
   }
+
+  addLTOArgs(OI, arguments);
 
   // -g implies -enable-anonymous-context-mangled-names, because the extra
   // metadata aids debugging.

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -48,6 +48,9 @@ protected:
   void addDeploymentTargetArgs(llvm::opt::ArgStringList &Arguments,
                                const JobContext &context) const;
 
+  void addLTOLibArgs(llvm::opt::ArgStringList &Arguments,
+                     const JobContext &context) const;
+
   void addCommonFrontendArgs(
       const OutputInfo &OI, const CommandOutput &output,
       const llvm::opt::ArgList &inputArgs,

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -72,7 +72,10 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
 
   Arguments.push_back("-o");
   Arguments.push_back(
@@ -165,9 +168,18 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 
   // Select the linker to use.
   std::string Linker;
+  if (context.OI.LTOVariant != OutputInfo::LTOKind::None) {
+    // Force to use lld for LTO on Unix-like platform (not including Darwin)
+    // because we don't support gold LTO or something else except for lld LTO
+    // at this time.
+    Linker = "lld";
+  }
+
   if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
     Linker = A->getValue();
-  } else {
+  }
+
+  if (Linker.empty()) {
     Linker = getDefaultLinker();
   }
   if (!Linker.empty()) {
@@ -218,6 +230,17 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     Arguments.push_back("-pie");
   }
 
+  switch (context.OI.LTOVariant) {
+  case OutputInfo::LTOKind::LLVMThin:
+    Arguments.push_back("-flto=thin");
+    break;
+  case OutputInfo::LTOKind::LLVMFull:
+    Arguments.push_back("-flto=full");
+    break;
+  case OutputInfo::LTOKind::None:
+    break;
+  }
+
   bool staticExecutable = false;
   bool staticStdlib = false;
 
@@ -253,7 +276,10 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
 
   for (const Arg *arg :
        context.Args.filtered(options::OPT_F, options::OPT_Fsystem)) {
@@ -368,7 +394,8 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
   ArgStringList Arguments;
 
   // Configure the toolchain.
-  const char *AR = "ar";
+  const char *AR =
+      context.OI.LTOVariant != OutputInfo::LTOKind::None ? "llvm-ar" : "ar";
   Arguments.push_back("crs");
 
   Arguments.push_back(
@@ -376,7 +403,10 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
 
   InvocationInfo II{AR, Arguments};
 

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -76,6 +76,24 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld)) {
     Linker = A->getValue();
   }
+
+  switch (context.OI.LTOVariant) {
+  case OutputInfo::LTOKind::LLVMThin:
+    Arguments.push_back("-flto=thin");
+    break;
+  case OutputInfo::LTOKind::LLVMFull:
+    Arguments.push_back("-flto=full");
+    break;
+  case OutputInfo::LTOKind::None:
+    break;
+  }
+
+  if (Linker.empty() && context.OI.LTOVariant != OutputInfo::LTOKind::None) {
+    // Force to use lld for LTO on Windows because we don't support link LTO or
+    // something else except for lld LTO at this time.
+    Linker = "lld";
+  }
+
   if (!Linker.empty())
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
 
@@ -143,7 +161,10 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
 
   for (const Arg *arg :
        context.Args.filtered(options::OPT_F, options::OPT_Fsystem)) {

--- a/test/Driver/link-time-opt-darwin-ld-lib.swift
+++ b/test/Driver/link-time-opt-darwin-ld-lib.swift
@@ -1,0 +1,26 @@
+// REQUIRES: OS=macosx
+
+// Check that ld gets "-lto_library"
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-apple-macosx10.9     | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-macosx
+
+// CHECK-SIMPLE-THIN: swift
+// CHECK-SIMPLE-THIN-DAG: -emit-bc
+// CHECK-SIMPLE-THIN-DAG: -lto=llvm-thin
+// CHECK-SIMPLE-THIN-DAG: -o [[OBJECTFILE:.*\.bc]]
+
+// CHECK-SIMPLE-THIN-macosx: ld
+// CHECK-SIMPLE-THIN-macosx-DAG: -lto_library {{.+}}/lib/libLTO.dylib
+// CHECK-SIMPLE-THIN-macosx-DAG: [[OBJECTFILE]]
+
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -target x86_64-apple-macosx10.9     | %FileCheck %s --check-prefix=CHECK-SIMPLE-FULL --check-prefix=CHECK-SIMPLE-FULL-macosx 
+
+// CHECK-SIMPLE-FULL: swift
+// CHECK-SIMPLE-FULL-DAG: -emit-bc
+// CHECK-SIMPLE-FULL-DAG: -lto=llvm-full
+// CHECK-SIMPLE-FULL-DAG: -o [[OBJECTFILE:.*\.bc]]
+
+// CHECK-SIMPLE-FULL-macosx: ld
+// CHECK-SIMPLE-FULL-macosx-DAG: -lto_library {{.+}}/lib/libLTO.dylib
+// CHECK-SIMPLE-FULL-macosx-DAG: [[OBJECTFILE]]

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -1,0 +1,82 @@
+// REQUIRES: lld_lto
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-unknown-linux-gnu    | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-linux-gnu
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-unknown-windows-msvc | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-windows-msvc
+
+// CHECK-SIMPLE-THIN: swift
+// CHECK-SIMPLE-THIN-DAG: -emit-bc
+// CHECK-SIMPLE-THIN-DAG: -lto=llvm-thin
+// CHECK-SIMPLE-THIN-DAG: -o [[BITCODEFILE:.*\.bc]]
+
+// CHECK-SIMPLE-THIN-windows-msvc: clang
+// CHECK-SIMPLE-THIN-windows-msvc-DAG: -fuse-ld=lld
+// CHECK-SIMPLE-THIN-windows-msvc-DAG: -flto=thin
+// CHECK-SIMPLE-THIN-windows-msvc-DAG: [[BITCODEFILE]]
+
+// CHECK-SIMPLE-THIN-linux-gnu: clang
+// CHECK-SIMPLE-THIN-linux-gnu-DAG: -flto=thin
+// CHECK-SIMPLE-THIN-linux-gnu-DAG: -fuse-ld=lld
+// CHECK-SIMPLE-THIN-linux-gnu-DAG: [[BITCODEFILE]]
+// CHECK-SIMPLE-THIN-linux-gnu-NOT: swift-autolink-extract
+
+
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -target x86_64-unknown-linux-gnu    | %FileCheck %s --check-prefix=CHECK-SIMPLE-FULL --check-prefix=CHECK-SIMPLE-FULL-linux-gnu
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -target x86_64-unknown-windows-msvc | %FileCheck %s --check-prefix=CHECK-SIMPLE-FULL --check-prefix=CHECK-SIMPLE-FULL-windows-msvc
+
+// CHECK-SIMPLE-FULL: swift
+// CHECK-SIMPLE-FULL-DAG: -emit-bc
+// CHECK-SIMPLE-FULL-DAG: -lto=llvm-full
+// CHECK-SIMPLE-FULL-DAG: -o [[BITCODEFILE:.*\.bc]]
+
+// CHECK-SIMPLE-FULL-windows-msvc: clang
+// CHECK-SIMPLE-FULL-windows-msvc-DAG: -fuse-ld=lld
+// CHECK-SIMPLE-FULL-windows-msvc-DAG: -flto=full
+// CHECK-SIMPLE-FULL-windows-msvc-DAG: [[BITCODEFILE]]
+
+// CHECK-SIMPLE-FULL-linux-gnu: clang
+// CHECK-SIMPLE-FULL-linux-gnu-DAG: -flto=full
+// CHECK-SIMPLE-FULL-linux-gnu-DAG: -fuse-ld=lld
+// CHECK-SIMPLE-FULL-linux-gnu-DAG: [[BITCODEFILE]]
+// CHECK-SIMPLE-FULL-linux-gnu-NOT: swift-autolink-extract
+
+
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -static -emit-library -target x86_64-apple-macosx10.9  | %FileCheck %s --check-prefix=CHECK-STATIC-LIB-THIN --check-prefix=CHECK-STATIC-LIB-THIN-macosx
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -static -emit-library -target x86_64-unknown-linux-gnu | %FileCheck %s --check-prefix=CHECK-STATIC-LIB-THIN --check-prefix=CHECK-STATIC-LIB-THIN-linux-gnu
+
+// CHECK-STATIC-LIB-THIN: swift
+// CHECK-STATIC-LIB-THIN-DAG: -emit-bc
+// CHECK-STATIC-LIB-THIN-DAG: -lto=llvm-thin
+// CHECK-STATIC-LIB-THIN-DAG: -o [[BITCODEFILE:.*\.bc]]
+
+// CHECK-STATIC-LIB-THIN-macosx: libtool
+// CHECK-STATIC-LIB-THIN-macosx-DAG: [[BITCODEFILE]]
+
+// CHECK-STATIC-LIB-THIN-linux-gnu: llvm-ar
+// CHECK-STATIC-LIB-THIN-linux-gnu-DAG: [[BITCODEFILE]]
+// CHECK-STATIC-LIB-THIN-linux-gnu-NOT: swift-autolink-extract
+
+
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -static -emit-library -target x86_64-apple-macosx10.9  | %FileCheck %s --check-prefix=CHECK-STATIC-LIB-FULL --check-prefix=CHECK-STATIC-LIB-FULL-macosx
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -static -emit-library -target x86_64-unknown-linux-gnu | %FileCheck %s --check-prefix=CHECK-STATIC-LIB-FULL --check-prefix=CHECK-STATIC-LIB-FULL-linux-gnu
+
+// CHECK-STATIC-LIB-FULL: swift
+// CHECK-STATIC-LIB-FULL-DAG: -emit-bc
+// CHECK-STATIC-LIB-FULL-DAG: -lto=llvm-full
+// CHECK-STATIC-LIB-FULL-DAG: -o [[BITCODEFILE:.*\.bc]]
+
+// CHECK-STATIC-LIB-FULL-macosx: libtool
+// CHECK-STATIC-LIB-FULL-macosx-DAG: [[BITCODEFILE]]
+
+// CHECK-STATIC-LIB-FULL-linux-gnu: llvm-ar
+// CHECK-STATIC-LIB-FULL-linux-gnu-DAG: [[BITCODEFILE]]
+// CHECK-STATIC-LIB-FULL-linux-gnu-NOT: swift-autolink-extract
+
+
+
+// Ensure that -use-ld wins even if getting -lto option
+// RUN: %swiftc_driver -driver-print-jobs %s -lto=llvm-thin -use-ld=gold -target x86_64-unknown-linux-gnu    | %FileCheck -check-prefix PREFER_USE_LD %s
+// RUN: %swiftc_driver -driver-print-jobs %s -lto=llvm-thin -use-ld=gold -target x86_64-unknown-windows-msvc | %FileCheck -check-prefix PREFER_USE_LD %s
+// PREFER_USE_LD: -fuse-ld=gold

--- a/test/Interpreter/Inputs/lto/module1.swift
+++ b/test/Interpreter/Inputs/lto/module1.swift
@@ -1,0 +1,1 @@
+public func unusedPublicFunction() {}

--- a/test/Interpreter/llvm_link_time_opt.swift
+++ b/test/Interpreter/llvm_link_time_opt.swift
@@ -1,0 +1,11 @@
+// UNSUPPORTED: OS=windows-msvc
+// static library is not well supported yet on Windows
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -emit-library -static -lto=llvm-full -emit-module %S/Inputs/lto/module1.swift -working-directory %t
+// RUN: %target-swiftc_driver -lto=llvm-full %s -I%t -L%t -lmodule1 -module-name main -o %t/main
+// RUN: %llvm-nm --defined-only %t/main | %FileCheck %s
+
+// CHECK-NOT: _$s7module120unusedPublicFunctionyyF
+
+import module1

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -351,6 +351,11 @@ differentiable_programming = lit_config.params.get('differentiable_programming',
 if differentiable_programming is not None:
     config.available_features.add('differentiable_programming')
 
+# On Android, LLVM LTO is only supported when the driver uses lld.
+# And skip lto tests when driver uses gold linker.
+if not (run_os in ['linux-android', 'linux-androideabi']) or (config.android_linker_name == 'lld'):
+    config.available_features.add('lld_lto')
+
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:
     config.swift_test_options += ' '


### PR DESCRIPTION
This commit adds LTO support for handling linker options and LLVM BC
emission. Even for ELF, swift-autolink-extract is unnecessary because
linker options are embedded in LLVM BC content when LTO.

This is pulled out from https://github.com/apple/swift/pull/32237 and based on https://github.com/apple/swift/pull/32429


<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
