### PR TITLE
[Refactoring] Fix a crasher in AddEquatableContext

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3451,7 +3451,9 @@ getDeclarationContextFromInfo(ResolvedCursorInfo Info) {
       return AddEquatableContext(NomDecl);
     }
   } else if (auto *ExtDecl = Info.ExtTyRef) {
-    return AddEquatableContext(ExtDecl);
+    if (ExtDecl->getExtendedNominal()) {
+      return AddEquatableContext(ExtDecl);
+    }
   }
   return AddEquatableContext();
 }

--- a/test/refactoring/RefactoringKind/crashers.swift
+++ b/test/refactoring/RefactoringKind/crashers.swift
@@ -38,3 +38,11 @@ func test_42098130<T>(e1: T, e2: E_42098130) {
 // RUN: %refactor -source-filename %s -pos=31:3 | %FileCheck %s -check-prefix=CHECK3
 // RUN: %refactor -source-filename %s -pos=32:3 | %FileCheck %s -check-prefix=CHECK3
 // CHECK3: Action begins
+
+// SR-13000
+enum Foo {}
+typealias Bar = (Any, Any) -> Foo
+extension /*invoke here:*/Bar {}
+
+// RUN: %refactor --actions -source-filename %s -pos=45:27 | %FileCheck %s -check-prefix=CHECK4
+// CHECK4: Action begins


### PR DESCRIPTION
When computing available refactoring kinds, we should only create `AddEquatableContext` for an extension if it extends a nominal type.

Resolves SR-13000
Resolves rdar://problem/64316798