### PR TITLE
[build-script] Prioritize SDK paths in CMake find_ functions

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -584,6 +584,12 @@ function set_build_options_for_host() {
 
             cmake_os_sysroot="$(xcrun --sdk ${platform} --show-sdk-path)"
 
+            # Give the SDK sysroot higher priority in calls to CMake `find_*`
+            # functions, over paths that may come from `pkg-config`. This fixes
+            # compile failures caused when `pkg-config` returns CommandLineTools
+            # paths instead of Xcode paths.
+            export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${cmake_os_sysroot}/usr"
+
             cmark_cmake_options=(
                 -DCMAKE_C_FLAGS="$(cmark_c_flags ${host})"
                 -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -584,10 +584,15 @@ function set_build_options_for_host() {
 
             cmake_os_sysroot="$(xcrun --sdk ${platform} --show-sdk-path)"
 
-            # Give the SDK sysroot higher priority in calls to CMake `find_*`
-            # functions, over paths that may come from `pkg-config`. This fixes
-            # compile failures caused when `pkg-config` returns CommandLineTools
-            # paths instead of Xcode paths.
+            # Customize the CMake `find_*` search paths to search the SDK
+            # sysroot before searching `pkg-config` paths. This prevents compile
+            # failures caused when `pkg-config` returns CommandLineTools paths
+            # instead of Xcode paths.
+            #
+            # These search paths can be user customized either by setting the
+            # `CMAKE_PREFIX_PATH` environment variable, or by setting the same
+            # CMake variable via the command line (`-DCMAKE_PREFIX_PATH`).
+            # See https://cmake.org/cmake/help/latest/command/find_path.html
             export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${cmake_os_sysroot}/usr"
 
             cmark_cmake_options=(


### PR DESCRIPTION
Fixes a build failure that happens on macOS when both the CommandLineTools and homebrew `pkg-config` are installed.

Homebrew's `pkg-config` is setup to hardcode CommandLineTools paths, which [causes many issues](https://github.com/Homebrew/brew/issues/5068). As a result, when `find_package()` consults `pkg-config`, targets can have paths containing CommandLineTools, which can result in non-obvious [build failures](https://bugs.swift.org/browse/SR-12726). Two example packages are libedit and libxml2.

This fix assumes that, as a default, `xcrun --sdk macosx --show-sdk-path` should be preferred to `pkg-config`.

The CMake documentation shows the search order that the `find_` functions use (see [find_path](http://cmake.org/cmake/help/v3.17/command/find_path.html#command:find_path)). This change makes use of `CMAKE_PREFIX_PATH` as an environment variable to prioritize the SDK sysroot over `pkg-config`. This is the 3rd search pass, just above the `HINTS` search pass (which is what's used by packages such as `FindLibEdit.cmake`).

If needed, to explicitly build with a custom package, the documentation shows that higher priority search passes are available, such as setting `-DCMAKE_PREFIX_PATH=...`.

Setting the environment variable is also composable with a user supplied `CMAKE_PREFIX_PATH` env variable.

Resolves SR-12726.
