### PR TITLE
[build-script] Isolate CMake from the system

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1964,6 +1964,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
         }
       case file_types::TY_AutolinkFile:
       case file_types::TY_Object:
+      case file_types::TY_TBD:
         // Object inputs are only okay if linking.
         if (OI.shouldLink()) {
           AllLinkerInputs.push_back(Current);
@@ -1987,7 +1988,6 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_IndexData:
       case file_types::TY_PCH:
       case file_types::TY_ImportedModules:
-      case file_types::TY_TBD:
       case file_types::TY_ModuleTrace:
       case file_types::TY_YAMLOptRecord:
       case file_types::TY_BitstreamOptRecord:

--- a/utils/build-script
+++ b/utils/build-script
@@ -702,7 +702,9 @@ class BuildScriptInvocation(object):
             ]
 
             # Isolate build from the system; Darwin toolchains build against SDKs.
-            args.extra_cmake_options.append('-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib')
+            args.extra_cmake_options.append(
+                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib'
+            )
 
         if toolchain.libtool is not None:
             impl_args += [

--- a/utils/build-script
+++ b/utils/build-script
@@ -701,6 +701,9 @@ class BuildScriptInvocation(object):
                 "--host-lipo", toolchain.lipo,
             ]
 
+            # Isolate build from the system; Darwin toolchains build against SDKs.
+            args.extra_cmake_options.append('-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib')
+
         if toolchain.libtool is not None:
             impl_args += [
                 "--host-libtool", toolchain.libtool,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1942,7 +1942,6 @@ for host in "${ALL_HOSTS[@]}"; do
                         "${cmake_options[@]}"
 
                         -DSQLite3_INCLUDE_DIR:PATH="$(xcrun -sdk macosx -show-sdk-path)/usr/include"
-                        -DSQLite3_LIBRARY:PATH="/usr/lib/libsqlite3.dylib"
                     )
                 fi
                 ;;


### PR DESCRIPTION
When building on Darwin, we're supposed to build against the SDK,
not the host system. Isolate the build further from the system.

This continues the work of https://github.com/apple/swift/pull/32419