### PR TITLE
[ConstraintSystem] Stop type checking TapExpr elements in shrink()

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -800,6 +800,12 @@ void ConstraintSystem::shrink(Expr *expr) {
         return {false, expr};
       }
 
+      // Similar to 'ClosureExpr', 'TapExpr' has a 'VarDecl' the type of which
+      // is determined by type checking the parent interpolated string literal.
+      if (isa<TapExpr>(expr)) {
+        return {false, expr};
+      }
+
       if (auto coerceExpr = dyn_cast<CoerceExpr>(expr)) {
         if (coerceExpr->isLiteralInit())
           ApplyExprs.push_back({coerceExpr, 1});


### PR DESCRIPTION
`TapExpr` has a `VarDecl` the type of which is determined by type checking the parent interpolated string literal expression. Type checking `TapExpr` elements before that always fails, thus a waste of the computing time.