### PR TITLE
[CodeCompletion] Suggest 'macOS' instead of 'OSX'

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4430,9 +4430,17 @@ public:
     if (AttrKind == DAK_Available) {
       if (ParamIndex == 0) {
         addDeclAttrParamKeyword("*", "Platform", false);
+
+      // For code completion, suggest 'macOS' instead of 'OSX'.
 #define AVAILABILITY_PLATFORM(X, PrettyName)                                  \
+      if (StringRef(#X) == "OSX")                                             \
+        addDeclAttrParamKeyword("macOS", "Platform", false);                  \
+      else if (StringRef(#X) == "OSXApplicationExtension")                    \
+        addDeclAttrParamKeyword("macOSApplicationExtension", "Platform", false); \
+      else                                                                    \
         addDeclAttrParamKeyword(#X, "Platform", false);
 #include "swift/AST/PlatformKinds.def"
+
       } else {
         addDeclAttrParamKeyword("unavailable", "", false);
         addDeclAttrParamKeyword("message", "Specify message", true);

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -32,11 +32,11 @@ struct MyStruct {}
 // AVAILABILITY1-NEXT: Keyword/None:                       iOS[#Platform#]; name=iOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       tvOS[#Platform#]; name=tvOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       watchOS[#Platform#]; name=watchOS{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       OSX[#Platform#]; name=OSX{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macOS[#Platform#]; name=macOS{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       iOSApplicationExtension[#Platform#]; name=iOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       tvOSApplicationExtension[#Platform#]; name=tvOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       watchOSApplicationExtension[#Platform#]; name=watchOSApplicationExtension{{$}}
-// AVAILABILITY1-NEXT: Keyword/None:                       OSXApplicationExtension[#Platform#]; name=OSXApplicationExtension{{$}}
+// AVAILABILITY1-NEXT: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalyst[#Platform#]; name=macCatalyst
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalystApplicationExtension[#Platform#]; name=macCatalystApplicationExtension
 // AVAILABILITY1-NEXT: End completions

--- a/test/IDE/complete_pound_statement.swift
+++ b/test/IDE/complete_pound_statement.swift
@@ -18,11 +18,19 @@
 {
   #available(iOS >= 7.0, #^PLATFORM4^#
 }
-// PLATFORM1: Keyword/None:                       *[#Platform#]; name=*{{$}}
-// PLATFORM1: Keyword/None:                       iOS[#Platform#]; name=iOS{{$}}
-// PLATFORM1: Keyword/None:                       tvOS[#Platform#]; name=tvOS{{$}}
-// PLATFORM1: Keyword/None:                       watchOS[#Platform#]; name=watchOS{{$}}
-// PLATFORM1: Keyword/None:                       OSX[#Platform#]; name=OSX{{$}}
+// PLATFORM1: Begin completions
+// PLATFORM1-DAG: Keyword/None:                       *[#Platform#]; name=*{{$}}
+// PLATFORM1-DAG: Keyword/None:                       iOS[#Platform#]; name=iOS{{$}}
+// PLATFORM1-DAG: Keyword/None:                       tvOS[#Platform#]; name=tvOS{{$}}
+// PLATFORM1-DAG: Keyword/None:                       watchOS[#Platform#]; name=watchOS{{$}}
+// PLATFORM1-DAG: Keyword/None:                       macOS[#Platform#]; name=macOS{{$}}
+// PLATFORM1-DAG: Keyword/None:                       iOSApplicationExtension[#Platform#]; name=iOSApplicationExtension{{$}}
+// PLATFORM1-DAG: Keyword/None:                       tvOSApplicationExtension[#Platform#]; name=tvOSApplicationExtension{{$}}
+// PLATFORM1-DAG: Keyword/None:                       watchOSApplicationExtension[#Platform#]; name=watchOSApplicationExtension{{$}}
+// PLATFORM1-DAG: Keyword/None:                       macOSApplicationExtension[#Platform#]; name=macOSApplicationExtension{{$}}
+// PLATFORM1-DAG: Keyword/None:                       macCatalyst[#Platform#]; name=macCatalyst
+// PLATFORM1-DAG: Keyword/None:                       macCatalystApplicationExtension[#Platform#]; name=macCatalystApplicationExtension
+// PLATFORM1: End completions
 
 class C1 {
   func foo() {


### PR DESCRIPTION
'macOS' is the preferred name for specifying the platform. Since 'OSX' is deprecated, we don't need to suggest 'OSX' variants.

rdar://problem/64379019
