### PR TITLE
[AST] Add a pointer to parent statement in 'CaseStmt'

### DIFF
--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -479,6 +479,9 @@ SwitchStmt *SwitchStmt::create(LabeledStmtInfo LabelInfo, SourceLoc SwitchLoc,
 
   std::uninitialized_copy(Cases.begin(), Cases.end(),
                           theSwitch->getTrailingObjects<ASTNode>());
+  for (auto *caseStmt : theSwitch->getCases())
+    caseStmt->setParentStmt(theSwitch);
+
   return theSwitch;
 }
 


### PR DESCRIPTION
So that clients can easily get `SwitchStmt` or `DoCatchStmt` from a `CaseStmt`.

This is a preparation for on-demand `VarDecl` type checking in `CaseStmt` patterns. [Similar to patterns in `if`/`guard` conditions](https://github.com/apple/swift/blob/f387ea337bad4b33ed9aee80d82afc892cd6dc5e/lib/Sema/TypeCheckDecl.cpp#L2381-L2389), we want to type check `VarDecl` in `switch`/`do-catch` statement on demand.