### PR TITLE
allow #file to #filePath forwarding without warnings

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -442,6 +442,19 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           *calleeDefaultArg == *callerDefaultArg)
         return;
 
+      // If the caller passes #file and the callee expects #filePath, this is
+      // fine because:
+      //  - Right now, #file == #filePath
+      //  - There is no warning-free way to forward #file to #filePath (
+      //     https://bugs.swift.org/browse/SR-13041 and
+      //     https://bugs.swift.org/browse/SR-12934)
+      //  - Making #file != #filePath is source-breaking and would therefore
+      //    require a bump of `swift-version`
+      //    (https://bugs.swift.org/browse/SR-12936).
+      if (calleeDefaultArg == MagicIdentifierLiteralExpr::Kind::FilePath &&
+          callerDefaultArg == MagicIdentifierLiteralExpr::Kind::File)
+        return;
+
       StringRef calleeDefaultArgString =
           MagicIdentifierLiteralExpr::getKindString(*calleeDefaultArg);
       StringRef callerDefaultArgString =

--- a/test/Sema/diag_mismatched_magic_literals.swift
+++ b/test/Sema/diag_mismatched_magic_literals.swift
@@ -3,6 +3,7 @@
 func callee(file: String = #file) {} // expected-note {{'file' declared here}}
 func callee(optFile: String? = #file) {} // expected-note {{'optFile' declared here}}
 func callee(arbitrary: String) {}
+func callee(filePath: String = #filePath) {}
 
 class SomeClass {
   static func callee(file: String = #file) {} // expected-note 2{{'file' declared here}}
@@ -39,6 +40,8 @@ func bad(function: String = #function) {
 // `#file`-defaulted argument.
 func good(file: String = #file) {
   callee(file: file)
+
+  callee(filePath: file)
 
   SomeClass.callee(file: file)
 


### PR DESCRIPTION
### Motivation

As of `master`/5.3 branch, `#file` == `#filePath`. However, libraries will switch to defaulting `file` parameters to `#filePath` and some already have. Unfortunately, before this patch forwarding `#file` to a parameter defaulted to `#filePath` will issue a warning.

The warning suggests a way to silence the warning (using an extra set of parenthesis `file: (#file)`) but unfortunately, this forwarding does _not_ actually work. You will get the `#file` from where the (`(#file)`) has been written and not the callee's `#file`.

For all packages that do SemVer (ie. lots of them) we need to retain compatibility with Swift versions prior to 5.3 so we cannot just adopt `#filePath`. I documented the various serious problems and concerns with the current implementation in the following three issues.

- https://bugs.swift.org/browse/SR-12936
- https://bugs.swift.org/browse/SR-12934
- https://bugs.swift.org/browse/SR-13041

This patch switches this particular warning (`#file` to `#filePath`) off. And if none of the other issues above are fixed independently, this needs to go into Swift 5.3.
