### PR TITLE
Improve performance of Collection.removeFirst(_:) where Self == SubSequence

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1669,7 +1669,5 @@ extension Collection where SubSequence == Self {
         "Can't remove more items from a collection than it contains")
     }
     self = self[idx..<endIndex]
-      "Can't remove more items from a collection than it contains")
-    self = self[index(startIndex, offsetBy: k)..<endIndex]
   }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1664,7 +1664,7 @@ extension Collection where SubSequence == Self {
   public mutating func removeFirst(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= k,
+    _precondition(index(startIndex, offsetBy: k, limitedBy: endIndex) != nil,
       "Can't remove more items from a collection than it contains")
     self = self[index(startIndex, offsetBy: k)..<endIndex]
   }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1665,7 +1665,8 @@ extension Collection where SubSequence == Self {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
     guard let idx = index(startIndex, offsetBy: k, limitedBy: endIndex) else {
-      _preconditionFailure("Can't remove more items from a collection than it contains")
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
     }
     self = self[idx..<endIndex]
       "Can't remove more items from a collection than it contains")

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1664,7 +1664,10 @@ extension Collection where SubSequence == Self {
   public mutating func removeFirst(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(index(startIndex, offsetBy: k, limitedBy: endIndex) != nil,
+    guard let idx = index(startIndex, offsetBy: k, limitedBy: endIndex) else {
+      _preconditionFailure("Can't remove more items from a collection than it contains")
+    }
+    self = self[idx..<endIndex]
       "Can't remove more items from a collection than it contains")
     self = self[index(startIndex, offsetBy: k)..<endIndex]
   }

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -590,9 +590,10 @@ extension RangeReplaceableCollection {
   public mutating func removeFirst(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= k,
-      "Can't remove more items from a collection than it has")
-    let end = index(startIndex, offsetBy: k)
+    guard let end = index(startIndex, offsetBy: k, limitedBy: endIndex) else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it has")
+    }
     removeSubrange(startIndex..<end)
   }
 
@@ -698,9 +699,11 @@ extension RangeReplaceableCollection where SubSequence == Self {
   public mutating func removeFirst(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= k,
-      "Can't remove more items from a collection than it contains")
-    self = self[index(startIndex, offsetBy: k)..<endIndex]
+    guard let idx = index(startIndex, offsetBy: k, limitedBy: endIndex) else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
+    }
+    self = self[idx..<endIndex]
   }
 }
 


### PR DESCRIPTION
This PR updates `Collection.removeFirst(_:) where Self == SubSequence` to do a bounds check using `index(_:offsetBy:limitedBy:)` instead of `count` to avoid an O(N) complexity where N is the size of the collection (which is incorrectly documented as O(K) where K is the value passed to `removeFirst`).

A benchmark working on a large substring before the change:

```sh
name                                        time          std        iterations
-------------------------------------------------------------------------------
Substring.removeFirst()                          132.0 ns ± 274.18 %    1000000
Substring.removeFirst(1)                    93850715.0 ns ±   2.25 %         15
Substring.UnicodeScalarView.removeFirst()        109.0 ns ± 241.26 %    1000000
Substring.UnicodeScalarView.removeFirst(1)  18106959.0 ns ±   5.49 %         66
Substring.UTF8View.removeFirst()                 117.0 ns ± 313.89 %    1000000
Substring.UTF8View.removeFirst(1)                118.0 ns ± 287.76 %    1000000
Substring.UTF16View.removeFirst()                108.0 ns ± 323.84 %    1000000
Substring.UTF16View.removeFirst(1)               126.0 ns ± 330.52 %    1000000
```

After:

```sh
name                                       time     std        iterations
-------------------------------------------------------------------------
Substring.removeFirst()                    107.0 ns ± 407.56 %    1000000
Substring.removeFirst(1)                    90.0 ns ± 185.21 %    1000000
Substring.UnicodeScalarView.removeFirst()  102.0 ns ± 426.49 %    1000000
Substring.UnicodeScalarView.removeFirst(1)  95.0 ns ± 282.41 %    1000000
Substring.UTF8View.removeFirst()           105.0 ns ± 180.93 %    1000000
Substring.UTF8View.removeFirst(1)           89.0 ns ± 351.59 %    1000000
Substring.UTF16View.removeFirst()          105.0 ns ± 367.93 %    1000000
Substring.UTF16View.removeFirst(1)         102.0 ns ± 177.51 %    1000000
```

Context: https://forums.swift.org/t/performance-of-removefirst-vs-removefirst-1/37712