### PR TITLE
[CSApply] Always try to load arguments constructing object literals

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2563,6 +2563,7 @@ namespace {
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
       expr->setInitializer(witness);
+      expr->setArg(cs.coerceToRValue(expr->getArg()));
       return expr;
     }
 

--- a/test/Sema/object_literals_osx.swift
+++ b/test/Sema/object_literals_osx.swift
@@ -35,3 +35,13 @@ let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expecte
 #fileLiteral() // expected-error{{missing argument for parameter 'resourceName' in call}}
 // expected-error@-1{{could not infer type of file reference literal}}
 // expected-note@-2{{import Foundation to use 'URL' as the default file reference literal type}}
+
+// rdar://problem/62927467
+func test_literal_arguments_are_loaded() {
+  var resource = "foo.txt" // expected-warning {{variable 'resource' was never mutated; consider changing to 'let' constant}}
+  let _: Path = #fileLiteral(resourceName: resource) // Ok
+
+  func test(red: inout Float, green: inout Float) -> S {
+    return #colorLiteral(red: red, green: green, blue: 1, alpha: 1) // Ok
+  }
+}


### PR DESCRIPTION
AST rewriter needs to make sure that all of the arguments are loaded
since it's currently possible to pass l-value type as an argument to
object literal (`#{file, color, image}Literal`).

Resolves: rdar://problem/62927467

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
