### PR TITLE
build: repair dependencies after 4ff5dd4ed918ceed8b056de4d58ddb9741d6…

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,10 +43,23 @@ function(get_test_dependencies SDK result_var_name)
 
   if (SWIFT_INCLUDE_TOOLS)
     list(APPEND deps_binaries
-      swift swift-ide-test swift-syntax-test sil-opt swift-llvm-opt swift-demangle
-      sil-func-extractor sil-llvm-gen sil-nm sil-passpipeline-dumper
-      lldb-moduleimport-test swift-reflection-dump swift-remoteast-test
-      swift-api-digester swift-refactor swift-demangle-yamldump)
+      lldb-moduleimport-test
+      sil-func-extractor
+      sil-llvm-gen
+      sil-nm
+      sil-opt
+      sil-passpipeline-dumper
+      swift
+      swift-api-digester
+      swift-demangle
+      swift-demangle-yamldump
+      swift-dependency-tool
+      swift-ide-test
+      swift-llvm-opt
+      swift-refactor
+      swift-reflection-dump
+      swift-remoteast-test
+      swift-syntax-test)
 
     if(SWIFT_BUILD_SYNTAXPARSERLIB)
       list(APPEND deps_binaries swift-syntax-parser-test)


### PR DESCRIPTION
…3a40

4ff5dd4ed918ceed8b056de4d58ddb9741d63a40 introduced a new tool and a
dependency on it in the tests but did not update the test dependencies.
Correct the dependencies.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
