### PR TITLE
[AST] Fix a crash in getUnwrappedCurryThunkExpr() while indexing

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2012,7 +2012,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
     body = body->getSemanticsProvidingExpr();
 
     if (auto *openExistential = dyn_cast<OpenExistentialExpr>(body)) {
-      body = openExistential->getSubExpr();
+      body = openExistential->getSubExpr()->getSemanticsProvidingExpr();
     }
 
     if (auto *outerCall = dyn_cast<ApplyExpr>(body)) {
@@ -2032,7 +2032,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
       innerBody = innerBody->getSemanticsProvidingExpr();
 
       if (auto *openExistential = dyn_cast<OpenExistentialExpr>(innerBody)) {
-        innerBody = openExistential->getSubExpr();
+        innerBody = openExistential->getSubExpr()->getSemanticsProvidingExpr();
         if (auto *ICE = dyn_cast<ImplicitConversionExpr>(innerBody))
           innerBody = ICE->getSyntacticSubExpr();
       }

--- a/validation-test/compiler_crashers_2_fixed/sr12994.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12994.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s -verify
+
+protocol MyProto {
+  func compile() throws
+}
+
+func compile(x: MyProto) throws {
+  try x.compile 
+  // expected-error@-1 {{expression resolves to an unused function}}
+  // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
+}


### PR DESCRIPTION
We need to get the semantics providing `Expr` from the `OpenExistentialExpr`'s sub-expression, so we can look through expressions such as a `TryExpr`.

Resolves SR-12994
Resolves rdar://problem/64306636