### PR TITLE
[ASTMangler] Don't verify the USR mangling for invalid abstract storage decls

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -677,8 +677,10 @@ std::string ASTMangler::mangleAccessorEntityAsUSR(AccessorKind kind,
   llvm::SaveAndRestore<bool> allowUnnamedRAII(AllowNamelessEntities, true);
   Buffer << USRPrefix;
   appendAccessorEntity(getCodeForAccessorKind(kind), decl, isStatic);
-  // We have a custom prefix, so finalize() won't verify for us. Do it manually.
-  verify(Storage.str().drop_front(USRPrefix.size()));
+  // We have a custom prefix, so finalize() won't verify for us. If we're not
+  // in invalid code (coming from an IDE caller) verify manually.
+  if (!decl->isInvalid())
+    verify(Storage.str().drop_front(USRPrefix.size()));
   return finalize();
 }
 

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -24,8 +24,12 @@ func resyncParser2() {}
 
 Swift(label: 3)
 
-enum Outer {
-  case Inner(IDontExist)
+enum Outer1 {
+  case Inner1(IDontExist)
+}
+
+enum Outer2 {
+  case Inner2(x: Undefined)
 }
 
 // RUN: %sourcekitd-test -req=cursor -pos=4:13 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
@@ -68,6 +72,10 @@ enum Outer {
 
 // RUN: %sourcekitd-test -req=cursor -pos=25:7 %s -- %s | %FileCheck -check-prefix=DIAG %s
 
-// RUN: %sourcekitd-test -req=cursor -pos=28:8 %s -- %s | %FileCheck -check-prefix=INVALID_ENUM %s
-// INVALID_ENUM: source.lang.swift.decl.enumelement (28:8-28:13)
-// INVALID_ENUM: Inner(_:)
+// RUN: %sourcekitd-test -req=cursor -pos=28:8 %s -- %s | %FileCheck -check-prefix=INVALID_ENUM1 %s
+// INVALID_ENUM1: source.lang.swift.decl.enumelement (28:8-28:14)
+// INVALID_ENUM1: Inner1(_:)
+
+// RUN: %sourcekitd-test -req=cursor -pos=32:8 %s -- %s | %FileCheck -check-prefix=INVALID_ENUM2 %s
+// INVALID_ENUM2: source.lang.swift.decl.enumelement (32:8-32:14)
+// INVALID_ENUM2: Inner2(x:)


### PR DESCRIPTION
There is no need for USR mangling verification for invalid `AbstractStorageDecl`s, similar to how we don't do it for regular invalid `Decl`s.

Resolves SR-12995
Resolves rdar://problem/64310839