### PR TITLE
Always link SIL for partial modules in SILGen

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -40,11 +40,6 @@ public:
   /// Controls the aggressiveness of the loop unroller.
   int UnrollThreshold = 250;
 
-  /// Controls whether to pull in SIL from partial modules during the
-  /// merge modules step. Could perhaps be merged with the link mode
-  /// above but the interactions between all the flags are tricky.
-  bool MergePartialModules = false;
-
   /// Remove all runtime assertions during optimizations.
   bool RemoveRuntimeAsserts = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -554,8 +554,9 @@ def sil_unroll_threshold : Separate<["-"], "sil-unroll-threshold">,
   MetaVarName<"<250>">,
   HelpText<"Controls the aggressiveness of loop unrolling">;
 
+// FIXME: This option is now redundant and should eventually be removed.
 def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
-  HelpText<"Merge SIL from all partial swiftmodules into the final module">;
+  Alias<merge_modules>;
 
 def sil_verify_all : Flag<["-"], "sil-verify-all">,
   HelpText<"Verify SIL after each transform">;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -561,10 +561,6 @@ public:
   /// i.e. it can be linked by linkFunction.
   bool hasFunction(StringRef Name);
 
-  /// Link all definitions in all segments that are logically part of
-  /// the same AST module.
-  void linkAllFromCurrentModule();
-
   /// Look up the SILWitnessTable representing the lowering of a protocol
   /// conformance, and collect the substitutions to apply to the referenced
   /// witnesses, if any.

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -74,10 +74,6 @@ public:
 
   bool invalidateFunction(SILFunction *F);
 
-  /// Deserialize all SILFunctions, VTables, and WitnessTables in all
-  /// SILModules.
-  void getAll();
-
   /// Deserialize all SILFunctions, VTables, and WitnessTables for
   /// a given Module.
   ///

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1049,9 +1049,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (FEOpts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly)
     Opts.StopOptimizationAfterSerialization = true;
 
-  if (Args.hasArg(OPT_sil_merge_partial_modules))
-    Opts.MergePartialModules = true;
-
   // Propagate the typechecker's understanding of
   // -experimental-skip-non-inlinable-function-bodies to SIL.
   Opts.SkipNonInlinableFunctionBodies = TCOpts.SkipNonInlinableFunctionBodies;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -982,22 +982,17 @@ void CompilerInstance::freeASTContext() {
 /// Perform "stable" optimizations that are invariant across compiler versions.
 static bool performMandatorySILPasses(CompilerInvocation &Invocation,
                                       SILModule *SM) {
+  // Don't run diagnostic passes at all when merging modules.
   if (Invocation.getFrontendOptions().RequestedAction ==
       FrontendOptions::ActionType::MergeModules) {
-    // Don't run diagnostic passes at all.
-  } else if (!Invocation.getDiagnosticOptions().SkipDiagnosticPasses) {
-    if (runSILDiagnosticPasses(*SM))
-      return true;
-  } else {
+    return false;
+  }
+  if (Invocation.getDiagnosticOptions().SkipDiagnosticPasses) {
     // Even if we are not supposed to run the diagnostic passes, we still need
     // to run the ownership evaluator.
-    if (runSILOwnershipEliminatorPass(*SM))
-      return true;
+    return runSILOwnershipEliminatorPass(*SM);
   }
-
-  if (Invocation.getSILOptions().MergePartialModules)
-    SM->linkAllFromCurrentModule();
-  return false;
+  return runSILDiagnosticPasses(*SM);
 }
 
 /// Perform SIL optimization passes if optimizations haven't been disabled.

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -427,11 +427,6 @@ bool SILModule::hasFunction(StringRef Name) {
   return getSILLoader()->hasSILFunction(Name);
 }
 
-void SILModule::linkAllFromCurrentModule() {
-  getSILLoader()->getAllForModule(getSwiftModule()->getName(),
-                                  /*PrimaryFile=*/nullptr);
-}
-
 void SILModule::invalidateSILLoaderCaches() {
   getSILLoader()->invalidateCaches();
 }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1751,8 +1751,9 @@ public:
               "[dynamically_replaceable] function");
 
     // In canonical SIL, direct reference to a shared_external declaration
-    // is an error; we should have deserialized a body. In raw SIL, we may
-    // not have deserialized the body yet.
+    // is an error; we should have deserialized a body. In raw SIL, including
+    // the merge-modules phase, we may not have deserialized the body yet as we
+    // may not have run the SILLinker pass.
     if (F.getModule().getStage() >= SILStage::Canonical) {
       if (RefF->isExternalDeclaration()) {
         require(SingleFunction ||
@@ -5560,20 +5561,13 @@ void SILModule::verify() const {
   // Uniquing set to catch symbol name collisions.
   llvm::DenseSet<StringRef> symbolNames;
 
-  // When merging partial modules, we only link functions from the current
-  // module, without enabling "LinkAll" mode or running the SILLinker pass;
-  // in this case, we need to relax some of the checks.
-  bool SingleFunction = false;
-  if (getOptions().MergePartialModules)
-    SingleFunction = true;
-
   // Check all functions.
   for (const SILFunction &f : *this) {
     if (!symbolNames.insert(f.getName()).second) {
       llvm::errs() << "Symbol redefined: " << f.getName() << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }
-    f.verify(SingleFunction);
+    f.verify(/*singleFunction*/ false);
   }
 
   // Check all globals.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1928,12 +1928,12 @@ ASTLoweringRequest::evaluate(Evaluator &evaluator,
   }
 
   // Also make sure to process any intermediate files that may contain SIL.
-  bool hasSIB = llvm::any_of(desc.getFiles(), [](const FileUnit *File) -> bool {
-    auto *SASTF = dyn_cast<SerializedASTFile>(File);
-    return SASTF && SASTF->isSIB();
-  });
-  if (hasSIB) {
-    auto primary = desc.context.dyn_cast<FileUnit *>();
+  bool shouldDeserialize =
+      llvm::any_of(desc.getFiles(), [](const FileUnit *File) -> bool {
+        return isa<SerializedASTFile>(File);
+      });
+  if (shouldDeserialize) {
+    auto *primary = desc.context.dyn_cast<FileUnit *>();
     silMod->getSILLoader()->getAllForModule(silMod->getSwiftModule()->getName(),
                                             primary);
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -597,7 +597,13 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
 
     fn->setSerialized(IsSerialized_t(isSerialized));
 
-    if (SILMod.getOptions().MergePartialModules)
+    // If the serialized function comes from the same module, we're merging
+    // modules, and can update the the linkage directly. This is needed to
+    // correctly update the linkage for forward declarations to entities defined
+    // in another file of the same module – we want to ensure the linkage
+    // reflects the fact that the entity isn't really external and shouldn't be
+    // dropped from the resulting merged module.
+    if (getFile()->getParentModule() == SILMod.getSwiftModule())
       fn->setLinkage(linkage);
 
     // Don't override the transparency or linkage of a function with

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -156,11 +156,6 @@ bool SerializedSILLoader::invalidateFunction(SILFunction *F) {
   return false;
 }
 
-void SerializedSILLoader::getAll() {
-  for (auto &Des : LoadedSILSections)
-    Des->getAll();
-}
-
 // FIXME: Not the best interface. We know exactly which FileUnits may have SIL
 // those in the main module.
 void SerializedSILLoader::getAllForModule(Identifier Mod,

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/derivative_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/derivative_attr.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/derivative_attr.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/differentiable_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/Serialization/differentiable_function.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/differentiable_function.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_function.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/differentiable_function.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: llvm-bcanalyzer %t/transpose_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/transpose_attr.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/transpose_attr.swiftmodule -o - | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/Frontend/sil-merge-partial-modules-stdlib.swift
+++ b/test/Frontend/sil-merge-partial-modules-stdlib.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -emit-module -primary-file %s -module-name test -o %t/partial.swiftmodule -O
 
-// RUN: %target-swift-frontend -emit-module %t/partial.swiftmodule -module-name test -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -o %t/test.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -emit-module %t/partial.swiftmodule -module-name test -o %t/test.swiftmodule
 
 public func makeMirror(object x: Any) -> Mirror {
   return Mirror(reflecting: x)

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -5,7 +5,7 @@
 
 // RUN: %target-swift-frontend -emit-module %t/partial.a.swiftmodule %t/partial.b.swiftmodule -module-name test -enable-library-evolution -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -o %t/test.swiftmodule
 
-// RUN: %target-sil-opt %t/test.swiftmodule -disable-sil-linking -emit-sorted-sil > %t/dump.sil
+// RUN: %target-sil-opt %t/test.swiftmodule -emit-sorted-sil > %t/dump.sil
 // RUN: %FileCheck %s < %t/dump.sil
 // RUN: %FileCheck %s --check-prefix=NEGATIVE < %t/dump.sil
 

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -primary-file %s %S/Inputs/sil-merge-partial-modules-other.swift -module-name test -enable-library-evolution -o %t/partial.a.swiftmodule
 // RUN: %target-swift-frontend -emit-module %s -primary-file %S/Inputs/sil-merge-partial-modules-other.swift -module-name test -enable-library-evolution -o %t/partial.b.swiftmodule
 
-// RUN: %target-swift-frontend -emit-module %t/partial.a.swiftmodule %t/partial.b.swiftmodule -module-name test -enable-library-evolution -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -o %t/test.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -emit-module %t/partial.a.swiftmodule %t/partial.b.swiftmodule -module-name test -enable-library-evolution -o %t/test.swiftmodule
 
 // RUN: %target-sil-opt %t/test.swiftmodule -emit-sorted-sil > %t/dump.sil
 // RUN: %FileCheck %s < %t/dump.sil

--- a/test/ModuleInterface/ModuleCache/SerializedSIL.swiftinterface
+++ b/test/ModuleInterface/ModuleCache/SerializedSIL.swiftinterface
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: echo 'import SerializedSIL' | %target-swift-frontend -typecheck -module-cache-path %t -I %S -
-// RUN: %target-sil-opt -disable-sil-linking %t/SerializedSIL-*.swiftmodule -module-name SerializedSIL > %t/SerializedSIL.sil
+// RUN: %target-sil-opt %t/SerializedSIL-*.swiftmodule -module-name SerializedSIL > %t/SerializedSIL.sil
 // RUN: %FileCheck %s < %t/SerializedSIL.sil
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t/SerializedSIL.sil
 

--- a/test/SIL/Parser/stage.swift
+++ b/test/SIL/Parser/stage.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %s -O -parse-stdlib -parse-as-library -emit-module -o %t/stage.swiftmodule
-// RUN: %target-sil-opt %t/stage.swiftmodule -disable-sil-linking -sil-disable-ast-dump -o %t/stage.sil
+// RUN: %target-sil-opt %t/stage.swiftmodule -sil-disable-ast-dump -o %t/stage.sil
 // RUN: %target-sil-opt %t/stage.sil -o - | %FileCheck %s
 
 // FIXME: We create all SIL modules in the 'raw' stage regardless of the input

--- a/test/SIL/Serialization/dynamically_replaceable.sil
+++ b/test/SIL/Serialization/dynamically_replaceable.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -o %t/tmp.swiftmodule
-// RUN: %target-sil-opt %t/tmp.swiftmodule -disable-sil-linking -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.swiftmodule -emit-sorted-sil | %FileCheck %s
 
 
 // CHECK-DAG-LABEL: sil [serialized] [dynamically_replacable] [canonical] @test_dynamically_replaceable

--- a/test/SIL/Serialization/globals.sil
+++ b/test/SIL/Serialization/globals.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -o %t/tmp.swiftmodule
-// RUN: %target-sil-opt %t/tmp.swiftmodule -disable-sil-linking | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.swiftmodule | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/switch_enum_resilient.swift
+++ b/test/SILOptimizer/switch_enum_resilient.swift
@@ -4,16 +4,16 @@
 // module vs. inlinable SIL.
 
 // RUN: %target-swift-frontend -emit-sil -O -primary-file %s -emit-module-path %t/O-fragile.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix CHECK-FRAGILE -check-prefix CHECK-FRAGILE-NOINLINE %s
-// RUN: %target-sil-opt %t/O-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
+// RUN: %target-sil-opt %t/O-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
 
 // RUN: %target-swift-frontend -emit-sil -Osize -primary-file %s -emit-module-path %t/Osize-fragile.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix CHECK-FRAGILE -check-prefix CHECK-FRAGILE-NOINLINE %s
-// RUN: %target-sil-opt %t/Osize-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
+// RUN: %target-sil-opt %t/Osize-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
 
 // RUN: %target-swift-frontend -emit-sil -enable-library-evolution -O -primary-file %s -emit-module-path %t/O-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT -check-prefix=CHECK-RESILIENT-NOINLINE %s
-// RUN: %target-sil-opt %t/O-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
+// RUN: %target-sil-opt %t/O-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
 
 // RUN: %target-swift-frontend -emit-sil -enable-library-evolution -Osize -primary-file %s -emit-module-path %t/Osize-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT -check-prefix=CHECK-RESILIENT-NOINLINE %s
-// RUN: %target-sil-opt %t/Osize-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
+// RUN: %target-sil-opt %t/Osize-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
 
 public enum Alpha : Int {
   case a, b, c, d, e

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -17,7 +17,7 @@
 
 /// Serialize and deserialize this module, then print.
 // RUN: %target-swift-frontend -emit-module %s -emit-module-path %t/merged-partial.swiftmodule -swift-version 5 -I %t -module-name merged -enable-library-evolution
-// RUN: %target-swift-frontend -merge-modules %t/merged-partial.swiftmodule -module-name merged -sil-merge-partial-modules -emit-module -emit-module-path %t/merged.swiftmodule -I %t -emit-module-interface-path %t/merged.swiftinterface -emit-private-module-interface-path %t/merged.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t
+// RUN: %target-swift-frontend -merge-modules %t/merged-partial.swiftmodule -module-name merged -emit-module -emit-module-path %t/merged.swiftmodule -I %t -emit-module-interface-path %t/merged.swiftinterface -emit-private-module-interface-path %t/merged.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t
 // RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/merged.swiftinterface
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/merged.private.swiftinterface
 

--- a/test/Sema/composition_extension.swift
+++ b/test/Sema/composition_extension.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -primary-file %s %S/Inputs/composition_extension_usage.swift -emit-module-path %t/P-partial.swiftmodule -module-name SR11227 -enable-testing
 // RUN: %target-swift-frontend -primary-file %S/Inputs/composition_extension_usage.swift %s -emit-module-path %t/S-partial.swiftmodule -module-name SR11227 -enable-testing
-// RUN: %target-swift-frontend -sil-merge-partial-modules %t/P-partial.swiftmodule %t/S-partial.swiftmodule -emit-module -o %t/SR11227.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -emit-module %t/P-partial.swiftmodule %t/S-partial.swiftmodule -o %t/SR11227.swiftmodule
 
 protocol P1 {}
 

--- a/test/Serialization/alignment.swift
+++ b/test/Serialization/alignment.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
-// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/alignment.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/alignment.swiftmodule -o - | %FileCheck %s
 
 //CHECK: @_alignment(16) struct Foo {
 @_alignment(16) struct Foo {}

--- a/test/Serialization/default-witness-table-deserialization.swift
+++ b/test/Serialization/default-witness-table-deserialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -module-name Test -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -disable-sil-linking -module-name="Test" | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name Test -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -module-name="Test" | %FileCheck %s
 
 // Check that default witness tables are properly deserialized.
 // rdar://problem/29173229

--- a/test/Serialization/global_init.swift
+++ b/test/Serialization/global_init.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t %s
 // RUN: llvm-bcanalyzer %t/global_init.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-sil-verify-all -disable-sil-linking %t/global_init.swiftmodule | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/global_init.swiftmodule | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/Serialization/property_wrappers.swift
+++ b/test/Serialization/property_wrappers.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
 // RUN: %target-swift-frontend -emit-module -o %t-scratch/def_property_wrappers~partial.swiftmodule -primary-file %S/Inputs/def_property_wrappers.swift -module-name def_property_wrappers -enable-testing
-// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -enable-testing %t-scratch/def_property_wrappers~partial.swiftmodule -module-name def_property_wrappers -o %t/def_property_wrappers.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_property_wrappers~partial.swiftmodule -module-name def_property_wrappers -o %t/def_property_wrappers.swiftmodule
 // RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown
 
 @testable import def_property_wrappers

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend  -module-name serialize_attr -emit-module -parse-as-library -o %t %s
 // RUN: llvm-bcanalyzer %t/serialize_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-sil-verify-all -disable-sil-linking %t/serialize_attr.swiftmodule | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/serialize_attr.swiftmodule | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -275,16 +275,10 @@ int main(int argc, char **argv) {
   auto SILMod = performASTLowering(CI.getMainModule(), CI.getSILTypes(),
                                    CI.getSILOptions());
 
-  // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
-  // us.
+  // Load in all the SIL if we're allowed to.
   if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
-    auto SL = SerializedSILLoader::create(
-        CI.getASTContext(), SILMod.get(), nullptr);
-
-    if (DisableSILLinking)
-      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
-    else
-      SL->getAll();
+    if (!DisableSILLinking)
+      SILMod->getSILLoader()->getAll();
   }
 
   if (CommandLineFunctionNames.empty() && FunctionNameFile.empty())

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -111,11 +111,6 @@ DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
                llvm::cl::init(false),
                llvm::cl::desc("Do not dump AST."));
 
-static llvm::cl::opt<bool>
-DisableSILLinking("disable-sil-linking",
-                  llvm::cl::init(true),
-                  llvm::cl::desc("Disable SIL linking"));
-
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
 // getMainExecutable (since some platforms don't support taking the
@@ -274,12 +269,6 @@ int main(int argc, char **argv) {
 
   auto SILMod = performASTLowering(CI.getMainModule(), CI.getSILTypes(),
                                    CI.getSILOptions());
-
-  // Load in all the SIL if we're allowed to.
-  if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
-    if (!DisableSILLinking)
-      SILMod->getSILLoader()->getAll();
-  }
 
   if (CommandLineFunctionNames.empty() && FunctionNameFile.empty())
     return CI.getASTContext().hadError();

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -195,14 +195,6 @@ int main(int argc, char **argv) {
                                 CI.getSILOptions());
   }
 
-  // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
-  // us.
-  if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
-    auto SL = SerializedSILLoader::create(
-        CI.getASTContext(), SILMod.get(), nullptr);
-    SL->getAll();
-  }
-
   const PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
   auto Mod = performIRGeneration(Opts, CI.getMainModule(), std::move(SILMod),
                                  CI.getMainModule()->getName().str(), PSPs,

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -188,15 +188,6 @@ int main(int argc, char **argv) {
 
   auto SILMod = performASTLowering(CI.getMainModule(), CI.getSILTypes(),
                                    CI.getSILOptions());
-
-  // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
-  // us.
-  if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
-    auto SL = SerializedSILLoader::create(
-        CI.getASTContext(), SILMod.get(), nullptr);
-    SL->getAll();
-  }
-
   nmModule(SILMod.get());
 
   return CI.getASTContext().hadError();

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -464,15 +464,10 @@ int main(int argc, char **argv) {
   }
   SILMod->setSerializeSILAction([]{});
 
-  // Load the SIL if we have a non-SIB serialized module. SILGen handles SIB for
-  // us.
+  // Load in all the SIL if we're allowed to.
   if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
-    auto SL = SerializedSILLoader::create(
-        CI.getASTContext(), SILMod.get(), nullptr);
-    if (DisableSILLinking)
-      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
-    else
-      SL->getAll();
+    if (!DisableSILLinking)
+      SILMod->getSILLoader()->getAll();
   }
 
   if (!RemarksFilename.empty()) {

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -172,10 +172,6 @@ static llvm::cl::opt<unsigned>
 AssertConfId("assert-conf-id", llvm::cl::Hidden,
              llvm::cl::init(0));
 
-static llvm::cl::opt<bool>
-DisableSILLinking("disable-sil-linking",
-                  llvm::cl::desc("Disable SIL linking"));
-
 static llvm::cl::opt<int>
 SILInlineThreshold("sil-inline-threshold", llvm::cl::Hidden,
                    llvm::cl::init(-1));
@@ -463,12 +459,6 @@ int main(int argc, char **argv) {
                                 CI.getSILOptions());
   }
   SILMod->setSerializeSILAction([]{});
-
-  // Load in all the SIL if we're allowed to.
-  if (Invocation.hasSerializedAST() && !extendedInfo.isSIB()) {
-    if (!DisableSILLinking)
-      SILMod->getSILLoader()->getAll();
-  }
 
   if (!RemarksFilename.empty()) {
     llvm::Expected<llvm::remarks::Format> formatOrErr =


### PR DESCRIPTION
Previously we would only link `.sib` partial modules in SILGen, with other kinds of serialized ASTs being linked just before the SILOptimizer if `-sil-merge-partial-modules` was specified. However linking always seems to be the desired behaviour, so adjust SILGen to always link SIL for all serialized AST inputs.

This allows us to remove some duplicated linking code from the SIL tools and will let us remove the `-sil-merge-partial-modules` frontend flag in favour of `-merge-modules`.