### PR TITLE
stdlib: add a utility to print what and where dynamic metadata is created.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -829,6 +829,9 @@ const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type
 SWIFT_RUNTIME_EXPORT
 const HeapObject *swift_getKeyPath(const void *pattern, const void *arguments);
 
+SWIFT_RUNTIME_EXPORT
+void swift_setMetadataDebugLogLevel(int level);
+
 #if defined(swiftCore_EXPORTS)
 /// Given a pointer to a borrowed value of type `Root` and a
 /// `KeyPath<Root, Value>`, project a pointer to a borrowed value of type

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -132,3 +132,12 @@ public func _getTypeByMangledNameInContext(
   genericContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type?
+
+/// Sets the log level for printing type metadata creation.
+///
+/// 0 ... No debug logging (default)
+/// 1 ... Print the name of types for which dynamic metadata is created.
+/// 2 ... Like '1' but also prints the backtrace.
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@_silgen_name("swift_setMetadataDebugLogLevel")
+public func _setMetaDataDebugging(logLevel: Int)

--- a/test/stdlib/metadata_debugging.swift
+++ b/test/stdlib/metadata_debugging.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | grep 'check-prefix' > %t/prefix-option
+// RUN: %target-run %t/a.out 2>&1 >/dev/null | %FileCheck `cat %t/prefix-option` %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// This test doesn't use StdlibUnittest because it's primarily concerned with
+// checking the presence and absence of output.
+
+// A tricky way to make the FileCheck tests conditional on the OS version.
+if #available(macOS 9999, *) {
+  print("-check-prefix=CHECK")
+} else {
+  print("-check-prefix=DONT-CHECK")
+  // Need at least one check, otherwise FileCheck will complain.
+  // DONT-CHECK: {{.}}
+}
+
+if #available(macOS 9999, *) {
+  _setMetaDataDebugging(logLevel: 2)
+}
+
+struct S<T> {
+}
+
+class K<T> {
+}
+
+@_optimize(none)
+func test_tuple<T>(_ t: T) -> Any {
+    return (t, t)
+}
+
+// CHECK: ### test.S<Swift.Float>
+// CHECK: {{^[0-9]+ +a.out +}}
+public let s: Any = S<Float>()
+
+// CHECK: ### (Swift.Int, Swift.Int)
+// CHECK: {{^[0-9]+ +a.out +}}
+public let t: Any = test_tuple(27)
+
+// CHECK: ### test.K<Swift.Int>
+// CHECK: {{^[0-9]+ +a.out +}}
+public let k: Any = K<Int>()
+


### PR DESCRIPTION
The logging can be enabled at runtime with _setMetaDataDebugging(logLevel: Int).
Depending on the log level it prints what metadata is created and also where it is created (the backtrace).
