### PR TITLE
ExplictModuleLoader: don't fail while no explicit Swift module map is specified

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1602,8 +1602,11 @@ ExplicitSwiftModuleLoader::create(ASTContext &ctx,
     new ExplicitSwiftModuleLoader(ctx, tracker, loadMode,
                                   IgnoreSwiftSourceInfoFile));
   auto &Impl = result->Impl;
-  // Parse a JSON file to collect explicitly built modules.
-  Impl.parseSwiftExplicitModuleMap(ExplicitSwiftModuleMap);
+  // If the explicit module map is given, try parse it.
+  if (!ExplicitSwiftModuleMap.empty()) {
+    // Parse a JSON file to collect explicitly built modules.
+    Impl.parseSwiftExplicitModuleMap(ExplicitSwiftModuleMap);
+  }
   // Collect .swiftmodule paths from -swift-module-path
   // FIXME: remove these.
   for (auto path: ExplicitModulePaths) {


### PR DESCRIPTION
We will eventually move the protocol entirely to using a JSON file for
explicit Swift modules. Before we finish migrating, we should be forgiving
about using the legacy -swift-module-file argument.