### PR TITLE
[Serialization] Refactor subset of `ModuleFile` into `ModuleFileCore`

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -58,7 +58,7 @@ class SerializedModuleLoaderBase : public ModuleLoader {
   using LoadedModulePair = std::pair<std::unique_ptr<ModuleFile>, unsigned>;
   std::vector<LoadedModulePair> LoadedModuleFiles;
 
-  SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 2> OrphanedMemoryBuffers;
+  SmallVector<std::unique_ptr<ModuleFile>, 2> OrphanedModuleFiles;
 
 protected:
   ASTContext &Ctx;

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -26,6 +26,8 @@ constexpr static const StringLiteral SWIFT_ONONE_SUPPORT = "SwiftOnoneSupport";
 constexpr static const StringLiteral SWIFT_SHIMS_NAME = "SwiftShims";
 /// The name of the Builtin module, which contains Builtin functions.
 constexpr static const StringLiteral BUILTIN_NAME = "Builtin";
+/// The name of the clang imported header module.
+constexpr static const StringLiteral CLANG_HEADER_MODULE_NAME = "__ObjC";
 /// The prefix of module names used by LLDB to capture Swift expressions
 constexpr static const StringLiteral LLDB_EXPRESSIONS_MODULE_NAME_PREFIX =
     "__lldb_expr_";

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -40,6 +40,7 @@
 #include "swift/Config.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
+#include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
@@ -1196,7 +1197,8 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
     = clangContext.Selectors.getSelector(2, setObjectForKeyedSubscriptIdents);
 
   // Set up the imported header module.
-  auto *importedHeaderModule = ModuleDecl::create(ctx.getIdentifier("__ObjC"), ctx);
+  auto *importedHeaderModule =
+      ModuleDecl::create(ctx.getIdentifier(CLANG_HEADER_MODULE_NAME), ctx);
   importer->Impl.ImportedHeaderUnit =
     new (ctx) ClangModuleUnit(*importedHeaderModule, importer->Impl, nullptr);
   importedHeaderModule->addFile(*importer->Impl.ImportedHeaderUnit);

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_host_library(swiftSerialization STATIC
   DeserializeSIL.cpp
   ModuleDependencyScanner.cpp
   ModuleFile.cpp
+  ModuleFileSharedCore.cpp
   Serialization.cpp
   SerializedModuleLoader.cpp
   SerializedSILLoader.cpp

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -21,8 +21,10 @@
 
 namespace swift {
 class ModuleFile;
+class ModuleFileSharedCore;
 
 StringRef getNameOfModule(const ModuleFile *);
+StringRef getNameOfModule(const ModuleFileSharedCore *);
 
 namespace serialization {
 
@@ -453,6 +455,17 @@ public:
 
   void print(raw_ostream &os) const override {
     os << Action << " \'" << getNameOfModule(&MF) << "'\n";
+  }
+};
+
+class PrettyStackTraceModuleFileCore : public llvm::PrettyStackTraceEntry {
+  const ModuleFileSharedCore &MF;
+public:
+  explicit PrettyStackTraceModuleFileCore(ModuleFileSharedCore &module)
+      : MF(module) {}
+
+  void print(raw_ostream &os) const override {
+    os << "While reading from \'" << getNameOfModule(&MF) << "'\n";
   }
 };
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -666,7 +666,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   // Mark this function as deserialized. This avoids rerunning diagnostic
   // passes. Certain passes in the madatory pipeline may not work as expected
   // after arbitrary optimization and lowering.
-  if (!MF->IsSIB)
+  if (!MF->isSIB())
     fn->setWasDeserializedCanonical();
 
   fn->setBare(IsBare);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -11,10 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "ModuleFile.h"
+#include "ModuleFileCoreTableInfo.h"
 #include "BCReadingExtras.h"
 #include "DeserializationErrors.h"
-#include "DocFormat.h"
-#include "SourceInfoFormat.h"
 #include "ModuleFormat.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Subsystems.h"
@@ -30,7 +29,6 @@
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Chrono.h"
-#include "llvm/Support/DJB.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
 
@@ -41,1288 +39,6 @@ using llvm::Expected;
 
 static_assert(IsTriviallyDestructible<SerializedASTFile>::value,
               "SerializedASTFiles are BumpPtrAllocated; d'tors are not called");
-
-static bool checkModuleSignature(llvm::BitstreamCursor &cursor,
-                                 ArrayRef<unsigned char> signature) {
-  for (unsigned char byte : signature) {
-    if (cursor.AtEndOfStream())
-      return false;
-    if (Expected<llvm::SimpleBitstreamCursor::word_t> maybeRead =
-            cursor.Read(8)) {
-      if (maybeRead.get() != byte)
-        return false;
-    } else {
-      consumeError(maybeRead.takeError());
-      return false;
-    }
-  }
-  return true;
-}
-
-static bool enterTopLevelModuleBlock(llvm::BitstreamCursor &cursor,
-                                     unsigned ID,
-                                     bool shouldReadBlockInfo = true) {
-  Expected<llvm::BitstreamEntry> maybeNext = cursor.advance();
-  if (!maybeNext) {
-    // FIXME this drops the error on the floor.
-    consumeError(maybeNext.takeError());
-    return false;
-  }
-  llvm::BitstreamEntry next = maybeNext.get();
-
-  if (next.Kind != llvm::BitstreamEntry::SubBlock)
-    return false;
-
-  if (next.ID == llvm::bitc::BLOCKINFO_BLOCK_ID) {
-    if (shouldReadBlockInfo) {
-      if (!cursor.ReadBlockInfoBlock())
-        return false;
-    } else {
-      if (cursor.SkipBlock())
-        return false;
-    }
-    return enterTopLevelModuleBlock(cursor, ID, false);
-  }
-
-  if (next.ID != ID)
-    return false;
-
-  if (llvm::Error Err = cursor.EnterSubBlock(ID)) {
-    // FIXME this drops the error on the floor.
-    consumeError(std::move(Err));
-    return false;
-  }
-
-  return true;
-}
-
-/// Populate \p extendedInfo with the data from the options block.
-///
-/// Returns true on success.
-static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
-                             SmallVectorImpl<uint64_t> &scratch,
-                             ExtendedValidationInfo &extendedInfo) {
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      return false;
-    }
-    llvm::BitstreamEntry entry = maybeEntry.get();
-    if (entry.Kind == llvm::BitstreamEntry::EndBlock)
-      break;
-
-    if (entry.Kind == llvm::BitstreamEntry::Error)
-      return false;
-
-    if (entry.Kind == llvm::BitstreamEntry::SubBlock) {
-      // Unknown metadata sub-block, possibly for use by a future version of
-      // the module format.
-      if (cursor.SkipBlock())
-        return false;
-      continue;
-    }
-
-    scratch.clear();
-    StringRef blobData;
-    Expected<unsigned> maybeKind =
-        cursor.readRecord(entry.ID, scratch, &blobData);
-    if (!maybeKind) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeKind.takeError());
-      return false;
-    }
-    unsigned kind = maybeKind.get();
-    switch (kind) {
-    case options_block::SDK_PATH:
-      extendedInfo.setSDKPath(blobData);
-      break;
-    case options_block::XCC:
-      extendedInfo.addExtraClangImporterOption(blobData);
-      break;
-    case options_block::IS_SIB:
-      bool IsSIB;
-      options_block::IsSIBLayout::readRecord(scratch, IsSIB);
-      extendedInfo.setIsSIB(IsSIB);
-      break;
-    case options_block::IS_TESTABLE:
-      extendedInfo.setIsTestable(true);
-      break;
-    case options_block::ARE_PRIVATE_IMPORTS_ENABLED:
-      extendedInfo.setPrivateImportsEnabled(true);
-      break;
-    case options_block::IS_IMPLICIT_DYNAMIC_ENABLED:
-      extendedInfo.setImplicitDynamicEnabled(true);
-      break;
-    case options_block::RESILIENCE_STRATEGY:
-      unsigned Strategy;
-      options_block::ResilienceStrategyLayout::readRecord(scratch, Strategy);
-      extendedInfo.setResilienceStrategy(ResilienceStrategy(Strategy));
-      break;
-    default:
-      // Unknown options record, possibly for use by a future version of the
-      // module format.
-      break;
-    }
-  }
-
-  return true;
-}
-
-static ValidationInfo
-validateControlBlock(llvm::BitstreamCursor &cursor,
-                     SmallVectorImpl<uint64_t> &scratch,
-                     std::pair<uint16_t, uint16_t> expectedVersion,
-                     ExtendedValidationInfo *extendedInfo) {
-  // The control block is malformed until we've at least read a major version
-  // number.
-  ValidationInfo result;
-  bool versionSeen = false;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      result.status = Status::Malformed;
-      return result;
-    }
-    llvm::BitstreamEntry entry = maybeEntry.get();
-    if (entry.Kind == llvm::BitstreamEntry::EndBlock)
-      break;
-
-    if (entry.Kind == llvm::BitstreamEntry::Error) {
-      result.status = Status::Malformed;
-      return result;
-    }
-
-    if (entry.Kind == llvm::BitstreamEntry::SubBlock) {
-      if (entry.ID == OPTIONS_BLOCK_ID && extendedInfo) {
-        if (llvm::Error Err = cursor.EnterSubBlock(OPTIONS_BLOCK_ID)) {
-          // FIXME this drops the error on the floor.
-          consumeError(std::move(Err));
-          result.status = Status::Malformed;
-          return result;
-        }
-        if (!readOptionsBlock(cursor, scratch, *extendedInfo)) {
-          result.status = Status::Malformed;
-          return result;
-        }
-      } else {
-        // Unknown metadata sub-block, possibly for use by a future version of
-        // the module format.
-        if (cursor.SkipBlock()) {
-          result.status = Status::Malformed;
-          return result;
-        }
-      }
-      continue;
-    }
-
-    scratch.clear();
-    StringRef blobData;
-    Expected<unsigned> maybeKind =
-        cursor.readRecord(entry.ID, scratch, &blobData);
-    if (!maybeKind) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeKind.takeError());
-      result.status = Status::Malformed;
-      return result;
-    }
-    unsigned kind = maybeKind.get();
-    switch (kind) {
-    case control_block::METADATA: {
-      if (versionSeen) {
-        result.status = Status::Malformed;
-        break;
-      }
-
-      uint16_t versionMajor = scratch[0];
-      if (versionMajor > expectedVersion.first)
-        result.status = Status::FormatTooNew;
-      else if (versionMajor < expectedVersion.first)
-        result.status = Status::FormatTooOld;
-      else
-        result.status = Status::Valid;
-
-      // Major version 0 does not have stable minor versions.
-      if (versionMajor == 0) {
-        uint16_t versionMinor = scratch[1];
-        if (versionMinor != expectedVersion.second) {
-          if (versionMinor < expectedVersion.second)
-            result.status = Status::FormatTooOld;
-          else
-            result.status = Status::FormatTooNew;
-        }
-      }
-
-      // These fields were added later; be resilient against their absence.
-      switch (scratch.size()) {
-      default:
-        // Add new cases here, in descending order.
-      case 4:
-        if (scratch[3] != 0) {
-          result.compatibilityVersion =
-            version::Version(blobData.substr(scratch[2]+1, scratch[3]),
-                             SourceLoc(), nullptr);
-        }
-        LLVM_FALLTHROUGH;
-      case 3:
-        result.shortVersion = blobData.slice(0, scratch[2]);
-        LLVM_FALLTHROUGH;
-      case 2:
-      case 1:
-      case 0:
-        break;
-      }
-
-      result.miscVersion = blobData;
-      versionSeen = true;
-      break;
-    }
-    case control_block::MODULE_NAME:
-      result.name = blobData;
-      break;
-    case control_block::TARGET:
-      result.targetTriple = blobData;
-      break;
-    default:
-      // Unknown metadata record, possibly for use by a future version of the
-      // module format.
-      break;
-    }
-  }
-
-  return result;
-}
-
-static bool validateInputBlock(
-    llvm::BitstreamCursor &cursor, SmallVectorImpl<uint64_t> &scratch,
-    SmallVectorImpl<SerializationOptions::FileDependency> &dependencies) {
-  SmallVector<StringRef, 4> dependencyDirectories;
-  SmallString<256> dependencyFullPathBuffer;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      return true;
-    }
-    llvm::BitstreamEntry entry = maybeEntry.get();
-    if (entry.Kind == llvm::BitstreamEntry::EndBlock)
-      break;
-
-    if (entry.Kind == llvm::BitstreamEntry::Error)
-      return true;
-
-    scratch.clear();
-    StringRef blobData;
-    Expected<unsigned> maybeKind =
-        cursor.readRecord(entry.ID, scratch, &blobData);
-    if (!maybeKind) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeKind.takeError());
-      return true;
-    }
-    unsigned kind = maybeKind.get();
-    switch (kind) {
-    case input_block::FILE_DEPENDENCY: {
-      bool isHashBased = scratch[2] != 0;
-      bool isSDKRelative = scratch[3] != 0;
-
-      StringRef path = blobData;
-      size_t directoryIndex = scratch[4];
-      if (directoryIndex != 0) {
-        if (directoryIndex > dependencyDirectories.size())
-          return true;
-        dependencyFullPathBuffer = dependencyDirectories[directoryIndex-1];
-        llvm::sys::path::append(dependencyFullPathBuffer, blobData);
-        path = dependencyFullPathBuffer;
-      }
-
-      if (isHashBased) {
-        dependencies.push_back(
-          SerializationOptions::FileDependency::hashBased(
-            path, isSDKRelative, scratch[0], scratch[1]));
-      } else {
-        dependencies.push_back(
-          SerializationOptions::FileDependency::modTimeBased(
-            path, isSDKRelative, scratch[0], scratch[1]));
-      }
-      break;
-    }
-    case input_block::DEPENDENCY_DIRECTORY:
-      dependencyDirectories.push_back(blobData);
-      break;
-    default:
-      // Unknown metadata record, possibly for use by a future version of the
-      // module format.
-      break;
-    }
-  }
-  return false;
-}
-
-
-bool serialization::isSerializedAST(StringRef data) {
-  StringRef signatureStr(reinterpret_cast<const char *>(SWIFTMODULE_SIGNATURE),
-                         llvm::array_lengthof(SWIFTMODULE_SIGNATURE));
-  return data.startswith(signatureStr);
-}
-
-ValidationInfo serialization::validateSerializedAST(
-    StringRef data,
-    ExtendedValidationInfo *extendedInfo,
-    SmallVectorImpl<SerializationOptions::FileDependency> *dependencies) {
-  ValidationInfo result;
-
-  // Check 32-bit alignment.
-  if (data.size() % SWIFTMODULE_ALIGNMENT != 0 ||
-      reinterpret_cast<uintptr_t>(data.data()) % SWIFTMODULE_ALIGNMENT != 0)
-    return result;
-
-  llvm::BitstreamCursor cursor(data);
-  SmallVector<uint64_t, 32> scratch;
-
-  if (!checkModuleSignature(cursor, SWIFTMODULE_SIGNATURE) ||
-      !enterTopLevelModuleBlock(cursor, MODULE_BLOCK_ID, false))
-    return result;
-
-  llvm::BitstreamEntry topLevelEntry;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry =
-        cursor.advance(AF_DontPopBlockAtEnd);
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      result.status = Status::Malformed;
-      return result;
-    }
-    topLevelEntry = maybeEntry.get();
-    if (topLevelEntry.Kind != llvm::BitstreamEntry::SubBlock)
-      break;
-
-    if (topLevelEntry.ID == CONTROL_BLOCK_ID) {
-      if (llvm::Error Err = cursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        result.status = Status::Malformed;
-        return result;
-      }
-      result = validateControlBlock(cursor, scratch,
-                                    {SWIFTMODULE_VERSION_MAJOR,
-                                     SWIFTMODULE_VERSION_MINOR},
-                                    extendedInfo);
-      if (result.status == Status::Malformed)
-        return result;
-    } else if (dependencies &&
-               result.status == Status::Valid &&
-               topLevelEntry.ID == INPUT_BLOCK_ID) {
-      if (llvm::Error Err = cursor.EnterSubBlock(INPUT_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        result.status = Status::Malformed;
-        return result;
-      }
-      if (validateInputBlock(cursor, scratch, *dependencies)) {
-        result.status = Status::Malformed;
-        return result;
-      }
-    } else {
-      if (cursor.SkipBlock()) {
-        result.status = Status::Malformed;
-        return result;
-      }
-    }
-  }
-
-  if (topLevelEntry.Kind == llvm::BitstreamEntry::EndBlock) {
-    cursor.ReadBlockEnd();
-    assert(cursor.GetCurrentBitNo() % CHAR_BIT == 0);
-    result.bytes = cursor.GetCurrentBitNo() / CHAR_BIT;
-  } else {
-    result.status = Status::Malformed;
-  }
-
-  return result;
-}
-
-std::string ModuleFile::Dependency::getPrettyPrintedPath() const {
-  StringRef pathWithoutScope = RawPath;
-  if (isScoped()) {
-    size_t splitPoint = pathWithoutScope.find_last_of('\0');
-    pathWithoutScope = pathWithoutScope.slice(0, splitPoint);
-  }
-  std::string output = pathWithoutScope.str();
-  std::replace(output.begin(), output.end(), '\0', '.');
-  return output;
-}
-
-/// Used to deserialize entries in the on-disk decl hash table.
-class ModuleFile::DeclTableInfo {
-public:
-  using internal_key_type = std::pair<DeclBaseName::Kind, StringRef>;
-  using external_key_type = DeclBaseName;
-  using data_type = SmallVector<std::pair<uint8_t, DeclID>, 8>;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    if (ID.getKind() == DeclBaseName::Kind::Normal) {
-      return {DeclBaseName::Kind::Normal, ID.getIdentifier().str()};
-    } else {
-      return {ID.getKind(), StringRef()};
-    }
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    if (key.first == DeclBaseName::Kind::Normal) {
-      return llvm::djbHash(key.second, SWIFTMODULE_HASH_SEED);
-    } else {
-      return (hash_value_type)key.first;
-    }
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    uint8_t kind = endian::readNext<uint8_t, little, unaligned>(data);
-    switch (kind) {
-    case static_cast<uint8_t>(DeclNameKind::Normal): {
-      StringRef str(reinterpret_cast<const char *>(data),
-                    length - sizeof(uint8_t));
-      return {DeclBaseName::Kind::Normal, str};
-    }
-    case static_cast<uint8_t>(DeclNameKind::Subscript):
-      return {DeclBaseName::Kind::Subscript, StringRef()};
-    case static_cast<uint8_t>(DeclNameKind::Destructor):
-      return {DeclBaseName::Kind::Destructor, StringRef()};
-    default:
-      llvm_unreachable("Unknown DeclNameKind");
-    }
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    data_type result;
-    while (length > 0) {
-      uint8_t kind = *data++;
-      DeclID offset = endian::readNext<uint32_t, little, unaligned>(data);
-      result.push_back({ kind, offset });
-      length -= 5;
-    }
-
-    return result;
-  }
-};
-
-/// Used to deserialize entries in the on-disk decl hash table.
-class ModuleFile::ExtensionTableInfo {
-  ModuleFile &File;
-public:
-  using internal_key_type = StringRef;
-  using external_key_type = Identifier;
-  using data_type = SmallVector<std::pair<StringRef, DeclID>, 8>;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    return ID.str();
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return StringRef(reinterpret_cast<const char *>(data), length);
-  }
-
-  data_type ReadData(internal_key_type key, const uint8_t *data,
-                     unsigned length) {
-    data_type result;
-    const uint8_t *limit = data + length;
-    while (data < limit) {
-      DeclID offset = endian::readNext<uint32_t, little, unaligned>(data);
-
-      int32_t nameIDOrLength =
-          endian::readNext<int32_t, little, unaligned>(data);
-      StringRef moduleNameOrMangledBase;
-      if (nameIDOrLength < 0) {
-        const ModuleDecl *module = File.getModule(-nameIDOrLength);
-        if (module)
-          moduleNameOrMangledBase = module->getName().str();
-      } else {
-        moduleNameOrMangledBase =
-            StringRef(reinterpret_cast<const char *>(data), nameIDOrLength);
-        data += nameIDOrLength;
-      }
-
-      result.push_back({ moduleNameOrMangledBase, offset });
-    }
-
-    return result;
-  }
-
-  explicit ExtensionTableInfo(ModuleFile &file) : File(file) {}
-};
-
-/// Used to deserialize entries in the on-disk decl hash table.
-class ModuleFile::LocalDeclTableInfo {
-public:
-  using internal_key_type = StringRef;
-  using external_key_type = internal_key_type;
-  using data_type = DeclID;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    return ID;
-  }
-
-  external_key_type GetExternalKey(internal_key_type ID) {
-    return ID;
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, sizeof(uint32_t) };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return StringRef(reinterpret_cast<const char *>(data), length);
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    return endian::readNext<uint32_t, little, unaligned>(data);
-  }
-};
-
-class ModuleFile::NestedTypeDeclsTableInfo {
-public:
-  using internal_key_type = StringRef;
-  using external_key_type = Identifier;
-  using data_type = SmallVector<std::pair<DeclID, DeclID>, 4>;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    return ID.str();
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return StringRef(reinterpret_cast<const char *>(data), length);
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    data_type result;
-    while (length > 0) {
-      DeclID parentID = endian::readNext<uint32_t, little, unaligned>(data);
-      DeclID childID = endian::readNext<uint32_t, little, unaligned>(data);
-      result.push_back({ parentID, childID });
-      length -= sizeof(uint32_t) * 2;
-    }
-
-    return result;
-  }
-};
-
-// Indexing the members of all Decls (well, NominalTypeDecls anyway) is
-// accomplished by a 2-level hashtable scheme. The outer table here maps from
-// DeclBaseNames to serialization::BitOffsets of sub-tables. The sub-tables --
-// SerializedDeclMembersTables, one table per name -- map from the enclosing
-// (NominalTypeDecl) DeclID to a vector of DeclIDs of members of the nominal
-// with the name. See DeclMembersTableInfo below.
-class ModuleFile::DeclMemberNamesTableInfo {
-public:
-  using internal_key_type = std::pair<DeclBaseName::Kind, StringRef>;
-  using external_key_type = DeclBaseName;
-  using data_type = serialization::BitOffset;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    if (ID.getKind() == DeclBaseName::Kind::Normal) {
-      return {DeclBaseName::Kind::Normal, ID.getIdentifier().str()};
-    } else {
-      return {ID.getKind(), StringRef()};
-    }
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    if (key.first == DeclBaseName::Kind::Normal) {
-      return llvm::djbHash(key.second, SWIFTMODULE_HASH_SEED);
-    } else {
-      return (hash_value_type)key.first;
-    }
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, sizeof(uint32_t) };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    uint8_t kind = endian::readNext<uint8_t, little, unaligned>(data);
-    switch (kind) {
-    case static_cast<uint8_t>(DeclNameKind::Normal): {
-      StringRef str(reinterpret_cast<const char *>(data),
-                    length - sizeof(uint8_t));
-      return {DeclBaseName::Kind::Normal, str};
-    }
-    case static_cast<uint8_t>(DeclNameKind::Subscript):
-      return {DeclBaseName::Kind::Subscript, StringRef()};
-    case static_cast<uint8_t>(DeclNameKind::Destructor):
-      return {DeclBaseName::Kind::Destructor, StringRef()};
-    case static_cast<uint8_t>(DeclNameKind::Constructor):
-      return {DeclBaseName::Kind::Constructor, StringRef()};
-    default:
-      llvm_unreachable("Unknown DeclNameKind");
-    }
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    assert(length == sizeof(uint32_t));
-    return endian::readNext<uint32_t, little, unaligned>(data);
-  }
-};
-
-// Second half of the 2-level member name lookup scheme, see
-// DeclMemberNamesTableInfo above. There is one of these tables for each member
-// DeclBaseName N in the module, and it maps from enclosing DeclIDs (say: each
-// NominalTypeDecl T that has members named N) to the set of N-named members of
-// T. In other words, there are no names in this table: the names are one level
-// up, this table just maps { Owner-DeclID => [Member-DeclID, ...] }.
-class ModuleFile::DeclMembersTableInfo {
-public:
-  using internal_key_type = uint32_t;
-  using external_key_type = DeclID;
-  using data_type = SmallVector<DeclID, 2>;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    return ID;
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::hash_value(key);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { sizeof(uint32_t), dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return endian::readNext<uint32_t, little, unaligned>(data);
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    data_type result;
-    while (length > 0) {
-      DeclID declID = endian::readNext<uint32_t, little, unaligned>(data);
-      result.push_back(declID);
-      length -= sizeof(uint32_t);
-    }
-    return result;
-  }
-};
-
-
-std::unique_ptr<ModuleFile::SerializedDeclTable>
-ModuleFile::readDeclTable(ArrayRef<uint64_t> fields, StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::DeclListLayout::readRecord(fields, tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedDeclTable>;
-  return OwnedTable(SerializedDeclTable::Create(base + tableOffset,
-                                                base + sizeof(uint32_t), base));
-}
-
-std::unique_ptr<ModuleFile::SerializedExtensionTable>
-ModuleFile::readExtensionTable(ArrayRef<uint64_t> fields, StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::DeclListLayout::readRecord(fields, tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedExtensionTable>;
-  return OwnedTable(SerializedExtensionTable::Create(base + tableOffset,
-    base + sizeof(uint32_t), base, ExtensionTableInfo(*this)));
-}
-
-std::unique_ptr<ModuleFile::SerializedLocalDeclTable>
-ModuleFile::readLocalDeclTable(ArrayRef<uint64_t> fields, StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::DeclListLayout::readRecord(fields, tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedLocalDeclTable>;
-  return OwnedTable(SerializedLocalDeclTable::Create(base + tableOffset,
-    base + sizeof(uint32_t), base));
-}
-
-std::unique_ptr<ModuleFile::SerializedNestedTypeDeclsTable>
-ModuleFile::readNestedTypeDeclsTable(ArrayRef<uint64_t> fields,
-                                     StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::NestedTypeDeclsLayout::readRecord(fields, tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedNestedTypeDeclsTable>;
-  return OwnedTable(SerializedNestedTypeDeclsTable::Create(base + tableOffset,
-      base + sizeof(uint32_t), base));
-}
-
-std::unique_ptr<ModuleFile::SerializedDeclMemberNamesTable>
-ModuleFile::readDeclMemberNamesTable(ArrayRef<uint64_t> fields,
-                                     StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::DeclMemberNamesLayout::readRecord(fields, tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedDeclMemberNamesTable>;
-  return OwnedTable(SerializedDeclMemberNamesTable::Create(base + tableOffset,
-      base + sizeof(uint32_t), base));
-}
-
-std::unique_ptr<ModuleFile::SerializedDeclMembersTable>
-ModuleFile::readDeclMembersTable(ArrayRef<uint64_t> fields,
-                                     StringRef blobData) {
-  uint32_t tableOffset;
-  decl_member_tables_block::DeclMembersLayout::readRecord(fields,
-                                                          tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedDeclMembersTable>;
-  return OwnedTable(SerializedDeclMembersTable::Create(base + tableOffset,
-      base + sizeof(uint32_t), base));
-}
-
-/// Used to deserialize entries in the on-disk Objective-C method table.
-class ModuleFile::ObjCMethodTableInfo {
-public:
-  using internal_key_type = std::string;
-  using external_key_type = ObjCSelector;
-  using data_type = SmallVector<std::tuple<std::string, bool, DeclID>, 8>;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type ID) {
-    llvm::SmallString<32> scratch;
-    return ID.getString(scratch).str();
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
-    return { keyLength, dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return std::string(reinterpret_cast<const char *>(data), length);
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    const constexpr auto recordSize = sizeof(uint32_t) + 1 + sizeof(uint32_t);
-    data_type result;
-    while (length > 0) {
-      unsigned ownerLen = endian::readNext<uint32_t, little, unaligned>(data);
-      bool isInstanceMethod = *data++ != 0;
-      DeclID methodID = endian::readNext<uint32_t, little, unaligned>(data);
-      std::string ownerName((const char *)data, ownerLen);
-      result.push_back(
-        std::make_tuple(std::move(ownerName), isInstanceMethod, methodID));
-      data += ownerLen;
-      length -= (recordSize + ownerLen);
-    }
-
-    return result;
-  }
-};
-
-std::unique_ptr<ModuleFile::SerializedObjCMethodTable>
-ModuleFile::readObjCMethodTable(ArrayRef<uint64_t> fields, StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::ObjCMethodTableLayout::readRecord(fields, tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedObjCMethodTable>;
-  return OwnedTable(
-           SerializedObjCMethodTable::Create(base + tableOffset,
-                                             base + sizeof(uint32_t), base));
-}
-
-/// Used to deserialize entries in the on-disk derivative function configuration
-/// table.
-class ModuleFile::DerivativeFunctionConfigTableInfo {
-public:
-  using internal_key_type = StringRef;
-  using external_key_type = internal_key_type;
-  using data_type = SmallVector<std::pair<std::string, GenericSignatureID>, 8>;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  external_key_type GetExternalKey(internal_key_type ID) { return ID; }
-
-  internal_key_type GetInternalKey(external_key_type ID) { return ID; }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return {keyLength, dataLength};
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return StringRef(reinterpret_cast<const char *>(data), length);
-  }
-
-  static data_type ReadData(internal_key_type key, const uint8_t *data,
-                            unsigned length) {
-    data_type result;
-    const uint8_t *limit = data + length;
-    while (data < limit) {
-      DeclID genSigId = endian::readNext<uint32_t, little, unaligned>(data);
-      int32_t nameLength = endian::readNext<int32_t, little, unaligned>(data);
-      StringRef mangledName(reinterpret_cast<const char *>(data), nameLength);
-      data += nameLength;
-      result.push_back({mangledName, genSigId});
-    }
-    return result;
-  }
-};
-
-std::unique_ptr<ModuleFile::SerializedDerivativeFunctionConfigTable>
-ModuleFile::readDerivativeFunctionConfigTable(ArrayRef<uint64_t> fields,
-                                              StringRef blobData) {
-  uint32_t tableOffset;
-  index_block::DerivativeFunctionConfigTableLayout::readRecord(fields,
-                                                               tableOffset);
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  using OwnedTable = std::unique_ptr<SerializedDerivativeFunctionConfigTable>;
-  return OwnedTable(SerializedDerivativeFunctionConfigTable::Create(
-      base + tableOffset, base + sizeof(uint32_t), base));
-}
-
-bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
-  if (llvm::Error Err = cursor.EnterSubBlock(INDEX_BLOCK_ID)) {
-    // FIXME this drops the error on the floor.
-    consumeError(std::move(Err));
-    return false;
-  }
-
-  SmallVector<uint64_t, 4> scratch;
-  StringRef blobData;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      return false;
-    }
-    llvm::BitstreamEntry entry = maybeEntry.get();
-    switch (entry.Kind) {
-    case llvm::BitstreamEntry::EndBlock:
-      return true;
-
-    case llvm::BitstreamEntry::Error:
-      return false;
-
-    case llvm::BitstreamEntry::SubBlock:
-      if (entry.ID == DECL_MEMBER_TABLES_BLOCK_ID) {
-        DeclMemberTablesCursor = cursor;
-        if (llvm::Error Err = DeclMemberTablesCursor.EnterSubBlock(
-                DECL_MEMBER_TABLES_BLOCK_ID)) {
-          // FIXME this drops the error on the floor.
-          consumeError(std::move(Err));
-          return false;
-        }
-        llvm::BitstreamEntry subentry;
-        do {
-          // Scan forward, to load the cursor with any abbrevs we'll need while
-          // seeking inside this block later.
-          Expected<llvm::BitstreamEntry> maybeEntry =
-              DeclMemberTablesCursor.advance(
-                  llvm::BitstreamCursor::AF_DontPopBlockAtEnd);
-          if (!maybeEntry) {
-            // FIXME this drops the error on the floor.
-            consumeError(maybeEntry.takeError());
-            return false;
-          }
-          subentry = maybeEntry.get();
-        } while (!DeclMemberTablesCursor.AtEndOfStream() &&
-                 subentry.Kind != llvm::BitstreamEntry::Record &&
-                 subentry.Kind != llvm::BitstreamEntry::EndBlock);
-      }
-      if (cursor.SkipBlock())
-        return false;
-      break;
-
-    case llvm::BitstreamEntry::Record:
-      scratch.clear();
-      blobData = {};
-      Expected<unsigned> maybeKind =
-          cursor.readRecord(entry.ID, scratch, &blobData);
-      if (!maybeKind) {
-        // FIXME this drops the error on the floor.
-        consumeError(maybeKind.takeError());
-        return false;
-      }
-      unsigned kind = maybeKind.get();
-
-      switch (kind) {
-      case index_block::DECL_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(Decls, scratch);
-        break;
-      case index_block::TYPE_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(Types, scratch);
-        break;
-      case index_block::CLANG_TYPE_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(ClangTypes, scratch);
-        break;
-      case index_block::IDENTIFIER_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(Identifiers, scratch);
-        break;
-      case index_block::TOP_LEVEL_DECLS:
-        TopLevelDecls = readDeclTable(scratch, blobData);
-        break;
-      case index_block::OPERATORS:
-        OperatorDecls = readDeclTable(scratch, blobData);
-        break;
-      case index_block::PRECEDENCE_GROUPS:
-        PrecedenceGroupDecls = readDeclTable(scratch, blobData);
-        break;
-      case index_block::EXTENSIONS:
-        ExtensionDecls = readExtensionTable(scratch, blobData);
-        break;
-      case index_block::CLASS_MEMBERS_FOR_DYNAMIC_LOOKUP:
-        ClassMembersForDynamicLookup = readDeclTable(scratch, blobData);
-        break;
-      case index_block::OPERATOR_METHODS:
-        OperatorMethodDecls = readDeclTable(scratch, blobData);
-        break;
-      case index_block::OBJC_METHODS:
-        ObjCMethods = readObjCMethodTable(scratch, blobData);
-        break;
-      case index_block::DERIVATIVE_FUNCTION_CONFIGURATIONS:
-        DerivativeFunctionConfigurations =
-            readDerivativeFunctionConfigTable(scratch, blobData);
-        break;
-      case index_block::ENTRY_POINT:
-        assert(blobData.empty());
-        setEntryPointClassID(scratch.front());
-        break;
-      case index_block::ORDERED_TOP_LEVEL_DECLS:
-        allocateBuffer(OrderedTopLevelDecls, scratch);
-        break;
-      case index_block::LOCAL_TYPE_DECLS:
-        LocalTypeDecls = readLocalDeclTable(scratch, blobData);
-        break;
-      case index_block::OPAQUE_RETURN_TYPE_DECLS:
-        OpaqueReturnTypeDecls = readLocalDeclTable(scratch, blobData);
-        break;
-      case index_block::NESTED_TYPE_DECLS:
-        NestedTypeDecls = readNestedTypeDeclsTable(scratch, blobData);
-        break;
-      case index_block::DECL_MEMBER_NAMES:
-        DeclMemberNames = readDeclMemberNamesTable(scratch, blobData);
-        break;
-      case index_block::LOCAL_DECL_CONTEXT_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(LocalDeclContexts, scratch);
-        break;
-      case index_block::GENERIC_SIGNATURE_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(GenericSignatures, scratch);
-        break;
-      case index_block::SUBSTITUTION_MAP_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(SubstitutionMaps, scratch);
-        break;
-      case index_block::NORMAL_CONFORMANCE_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(NormalConformances, scratch);
-        break;
-      case index_block::SIL_LAYOUT_OFFSETS:
-        assert(blobData.empty());
-        allocateBuffer(SILLayouts, scratch);
-        break;
-
-      default:
-        // Unknown index kind, which this version of the compiler won't use.
-        break;
-      }
-      break;
-    }
-  }
-
-  return false;
-}
-
-class ModuleFile::DeclCommentTableInfo {
-  ModuleFile &F;
-
-public:
-  using internal_key_type = StringRef;
-  using external_key_type = StringRef;
-  using data_type = CommentInfo;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  DeclCommentTableInfo(ModuleFile &F) : F(F) {}
-
-  internal_key_type GetInternalKey(external_key_type key) {
-    return key;
-  }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    assert(!key.empty());
-    return llvm::djbHash(key, SWIFTDOC_HASH_SEED_5_1);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint32_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
-    return { keyLength, dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return StringRef(reinterpret_cast<const char *>(data), length);
-  }
-
-  data_type ReadData(internal_key_type key, const uint8_t *data,
-                     unsigned length) {
-    data_type result;
-
-    {
-      unsigned BriefSize = endian::readNext<uint32_t, little, unaligned>(data);
-      result.Brief = StringRef(reinterpret_cast<const char *>(data), BriefSize);
-      data += BriefSize;
-    }
-
-    unsigned NumComments = endian::readNext<uint32_t, little, unaligned>(data);
-    MutableArrayRef<SingleRawComment> Comments =
-        F.getContext().AllocateUninitialized<SingleRawComment>(NumComments);
-
-    for (unsigned i = 0; i != NumComments; ++i) {
-      unsigned StartColumn =
-          endian::readNext<uint32_t, little, unaligned>(data);
-      unsigned RawSize = endian::readNext<uint32_t, little, unaligned>(data);
-      auto RawText = StringRef(reinterpret_cast<const char *>(data), RawSize);
-      data += RawSize;
-
-      new (&Comments[i]) SingleRawComment(RawText, StartColumn);
-    }
-    result.Raw = RawComment(Comments);
-    result.Group = endian::readNext<uint32_t, little, unaligned>(data);
-    result.SourceOrder = endian::readNext<uint32_t, little, unaligned>(data);
-    return result;
-  }
-};
-
-std::unique_ptr<ModuleFile::SerializedDeclCommentTable>
-ModuleFile::readDeclCommentTable(ArrayRef<uint64_t> fields,
-                                 StringRef blobData) {
-  if (fields.empty() || blobData.empty())
-    return nullptr;
-  uint32_t tableOffset = static_cast<uint32_t>(fields.front());
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-
-  return std::unique_ptr<SerializedDeclCommentTable>(
-    SerializedDeclCommentTable::Create(base + tableOffset,
-                                       base + sizeof(uint32_t), base,
-                                       DeclCommentTableInfo(*this)));
-}
-
-std::unique_ptr<ModuleFile::GroupNameTable>
-ModuleFile::readGroupTable(ArrayRef<uint64_t> Fields, StringRef BlobData) {
-  std::unique_ptr<ModuleFile::GroupNameTable> pMap(
-    new ModuleFile::GroupNameTable);
-  auto Data = reinterpret_cast<const uint8_t *>(BlobData.data());
-  unsigned GroupCount = endian::readNext<uint32_t, little, unaligned>(Data);
-  for (unsigned I = 0; I < GroupCount; ++I) {
-    auto RawSize = endian::readNext<uint32_t, little, unaligned>(Data);
-    auto RawText = StringRef(reinterpret_cast<const char *>(Data), RawSize);
-    Data += RawSize;
-    (*pMap)[I] = RawText;
-  }
-  return pMap;
-}
-
-bool ModuleFile::readCommentBlock(llvm::BitstreamCursor &cursor) {
-  if (llvm::Error Err = cursor.EnterSubBlock(COMMENT_BLOCK_ID)) {
-    // FIXME this drops the error on the floor.
-    consumeError(std::move(Err));
-    return false;
-  }
-
-  SmallVector<uint64_t, 4> scratch;
-  StringRef blobData;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      return false;
-    }
-    llvm::BitstreamEntry entry = maybeEntry.get();
-    switch (entry.Kind) {
-    case llvm::BitstreamEntry::EndBlock:
-      return true;
-
-    case llvm::BitstreamEntry::Error:
-      return false;
-
-    case llvm::BitstreamEntry::SubBlock:
-      // Unknown sub-block, which this version of the compiler won't use.
-      if (cursor.SkipBlock())
-        return false;
-      break;
-
-    case llvm::BitstreamEntry::Record:
-      scratch.clear();
-      Expected<unsigned> maybeKind =
-          cursor.readRecord(entry.ID, scratch, &blobData);
-      if (!maybeKind) {
-        // FIXME this drops the error on the floor.
-        consumeError(maybeKind.takeError());
-        return false;
-      }
-      unsigned kind = maybeKind.get();
-
-      switch (kind) {
-      case comment_block::DECL_COMMENTS:
-        DeclCommentTable = readDeclCommentTable(scratch, blobData);
-        break;
-      case comment_block::GROUP_NAMES:
-        GroupNamesMap = readGroupTable(scratch, blobData);
-        break;
-      default:
-        // Unknown index kind, which this version of the compiler won't use.
-        break;
-      }
-      break;
-    }
-  }
-
-  return false;
-}
-
-static Optional<swift::LibraryKind> getActualLibraryKind(unsigned rawKind) {
-  auto stableKind = static_cast<serialization::LibraryKind>(rawKind);
-  if (stableKind != rawKind)
-    return None;
-
-  switch (stableKind) {
-  case serialization::LibraryKind::Library:
-    return swift::LibraryKind::Library;
-  case serialization::LibraryKind::Framework:
-    return swift::LibraryKind::Framework;
-  }
-
-  // If there's a new case value in the module file, ignore it.
-  return None;
-}
-
-static Optional<ModuleDecl::ImportFilterKind>
-getActualImportControl(unsigned rawValue) {
-  // We switch on the raw value rather than the enum in order to handle future
-  // values.
-  switch (rawValue) {
-  case static_cast<unsigned>(serialization::ImportControl::Normal):
-    return ModuleDecl::ImportFilterKind::Private;
-  case static_cast<unsigned>(serialization::ImportControl::Exported):
-    return ModuleDecl::ImportFilterKind::Public;
-  case static_cast<unsigned>(serialization::ImportControl::ImplementationOnly):
-    return ModuleDecl::ImportFilterKind::ImplementationOnly;
-  default:
-    return None;
-  }
-}
 
 static bool areCompatibleArchitectures(const llvm::Triple &moduleTarget,
                                        const llvm::Triple &ctxTarget) {
@@ -1374,610 +90,32 @@ static bool isTargetTooNew(const llvm::Triple &moduleTarget,
   return ctxTarget.isOSVersionLT(major, minor, micro);
 }
 
-bool ModuleFile::readModuleDocIfPresent() {
-  if (!this->ModuleDocInputBuffer)
-    return true;
-
-  llvm::BitstreamCursor docCursor{ModuleDocInputBuffer->getMemBufferRef()};
-  if (!checkModuleSignature(docCursor, SWIFTDOC_SIGNATURE) ||
-      !enterTopLevelModuleBlock(docCursor, MODULE_DOC_BLOCK_ID)) {
-    return false;
-  }
-
-  SmallVector<uint64_t, 64> scratch;
-  llvm::BitstreamEntry topLevelEntry;
-
-  bool hasValidControlBlock = false;
-  ValidationInfo info;
-
-  while (!docCursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry =
-        docCursor.advance(AF_DontPopBlockAtEnd);
-    if (!maybeEntry) {
-      // FIXME this drops the error on the floor.
-      consumeError(maybeEntry.takeError());
-      return false;
-    }
-    topLevelEntry = maybeEntry.get();
-    if (topLevelEntry.Kind != llvm::BitstreamEntry::SubBlock)
-      break;
-
-    switch (topLevelEntry.ID) {
-    case CONTROL_BLOCK_ID: {
-      if (llvm::Error Err = docCursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        return false;
-      }
-
-      info = validateControlBlock(docCursor, scratch,
-                                  {SWIFTDOC_VERSION_MAJOR,
-                                   SWIFTDOC_VERSION_MINOR},
-                                  /*extendedInfo*/nullptr);
-      if (info.status != Status::Valid)
-        return false;
-      // Check that the swiftdoc is actually for this module.
-      if (info.name != Name)
-        return false;
-      hasValidControlBlock = true;
-      break;
-    }
-
-    case COMMENT_BLOCK_ID: {
-      if (!hasValidControlBlock || !readCommentBlock(docCursor))
-        return false;
-      break;
-    }
-
-    default:
-      // Unknown top-level block, possibly for use by a future version of the
-      // module format.
-      if (docCursor.SkipBlock())
-        return false;
-      break;
-    }
-  }
-
-  if (topLevelEntry.Kind != llvm::BitstreamEntry::EndBlock)
-    return false;
-
-  return true;
-}
-
-class ModuleFile::DeclUSRTableInfo {
-public:
-  using internal_key_type = StringRef;
-  using external_key_type = StringRef;
-  using data_type = uint32_t;
-  using hash_value_type = uint32_t;
-  using offset_type = unsigned;
-
-  internal_key_type GetInternalKey(external_key_type key) { return key; }
-
-  hash_value_type ComputeHash(internal_key_type key) {
-    assert(!key.empty());
-    return llvm::djbHash(key, SWIFTSOURCEINFO_HASH_SEED);
-  }
-
-  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
-    return lhs == rhs;
-  }
-
-  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    unsigned keyLength = endian::readNext<uint32_t, little, unaligned>(data);
-    unsigned dataLength = 4;
-    return { keyLength, dataLength };
-  }
-
-  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    return StringRef(reinterpret_cast<const char*>(data), length);
-  }
-
-  data_type ReadData(internal_key_type key, const uint8_t *data, unsigned length) {
-    assert(length == 4);
-    return endian::readNext<uint32_t, little, unaligned>(data);
-  }
-};
-
-std::unique_ptr<ModuleFile::SerializedDeclUSRTable>
-ModuleFile::readDeclUSRsTable(ArrayRef<uint64_t> fields, StringRef blobData) {
-  if (fields.empty() || blobData.empty())
-    return nullptr;
-  uint32_t tableOffset = static_cast<uint32_t>(fields.front());
-  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
-  return std::unique_ptr<SerializedDeclUSRTable>(
-    SerializedDeclUSRTable::Create(base + tableOffset, base + sizeof(uint32_t),
-                                   base));
-}
-
-bool ModuleFile::readDeclLocsBlock(llvm::BitstreamCursor &cursor) {
-  if (llvm::Error Err = cursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
-    consumeError(std::move(Err));
-    return false;
-  }
-
-  SmallVector<uint64_t, 4> scratch;
-  StringRef blobData;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> entry = cursor.advance();
-    if (!entry) {
-      consumeError(entry.takeError());
-      return false;
-    }
-    switch (entry->Kind) {
-    case llvm::BitstreamEntry::EndBlock:
-      return true;
-
-    case llvm::BitstreamEntry::Error:
-      return false;
-
-    case llvm::BitstreamEntry::SubBlock:
-      // Unknown sub-block, which this version of the compiler won't use.
-      if (cursor.SkipBlock())
-        return false;
-      break;
-
-    case llvm::BitstreamEntry::Record:
-      scratch.clear();
-      Expected<unsigned> kind =
-          cursor.readRecord(entry->ID, scratch, &blobData);
-      if (!kind) {
-        consumeError(kind.takeError());
-        return false;
-      }
-      switch (*kind) {
-      case decl_locs_block::BASIC_DECL_LOCS:
-        BasicDeclLocsData = blobData;
-        break;
-      case decl_locs_block::TEXT_DATA:
-        SourceLocsTextData = blobData;
-        break;
-      case decl_locs_block::DECL_USRS:
-        DeclUSRsTable = readDeclUSRsTable(scratch, blobData);
-        break;
-      case decl_locs_block::DOC_RANGES:
-        DocRangesData = blobData;
-        break;
-      default:
-        // Unknown index kind, which this version of the compiler won't use.
-        break;
-      }
-      break;
-    }
-  }
-
-  return false;
-}
-
-bool ModuleFile::readModuleSourceInfoIfPresent() {
-  if (!this->ModuleSourceInfoInputBuffer)
-    return true;
-
-  llvm::BitstreamCursor infoCursor{ModuleSourceInfoInputBuffer->getMemBufferRef()};
-  if (!checkModuleSignature(infoCursor, SWIFTSOURCEINFO_SIGNATURE) ||
-      !enterTopLevelModuleBlock(infoCursor, MODULE_SOURCEINFO_BLOCK_ID)) {
-    return false;
-  }
-
-  SmallVector<uint64_t, 64> scratch;
-
-  bool hasValidControlBlock = false;
-  ValidationInfo info;
-  unsigned kind = llvm::BitstreamEntry::Error;
-
-  while (!infoCursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> topLevelEntry =
-        infoCursor.advance(AF_DontPopBlockAtEnd);
-    if (!topLevelEntry) {
-      consumeError(topLevelEntry.takeError());
-      return false;
-    }
-    kind = topLevelEntry->Kind;
-    if (kind != llvm::BitstreamEntry::SubBlock)
-      break;
-
-    switch (topLevelEntry->ID) {
-    case CONTROL_BLOCK_ID: {
-      if (llvm::Error Err = infoCursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
-        consumeError(std::move(Err));
-        return false;
-      }
-      info = validateControlBlock(infoCursor, scratch,
-                                  {SWIFTSOURCEINFO_VERSION_MAJOR,
-                                   SWIFTSOURCEINFO_VERSION_MINOR},
-                                  /*extendedInfo*/nullptr);
-      if (info.status != Status::Valid)
-        return false;
-      // Check that the swiftsourceinfo is actually for this module.
-      if (info.name != Name)
-        return false;
-      hasValidControlBlock = true;
-      break;
-    }
-
-    case DECL_LOCS_BLOCK_ID: {
-      if (!hasValidControlBlock || !readDeclLocsBlock(infoCursor))
-        return false;
-      break;
-    }
-
-    default:
-      // Unknown top-level block, possibly for use by a future version of the
-      // module format.
-      if (infoCursor.SkipBlock())
-        return false;
-      break;
-    }
-  }
-
-  if (kind != llvm::BitstreamEntry::EndBlock)
-    return false;
-
-  return true;
-}
-
-ModuleFile::ModuleFile(
-    std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-    bool isFramework, serialization::ValidationInfo &info,
-    serialization::ExtendedValidationInfo *extInfo)
-    : ModuleInputBuffer(std::move(moduleInputBuffer)),
-      ModuleDocInputBuffer(std::move(moduleDocInputBuffer)),
-      ModuleSourceInfoInputBuffer(std::move(moduleSourceInfoInputBuffer)),
+ModuleFile::ModuleFile(std::shared_ptr<const ModuleFileSharedCore> core)
+    : Core(core),
       DeserializedTypeCallback([](Type ty) {}) {
-  assert(!hasError());
-  Bits.IsFramework = isFramework;
+  assert(!core->hasError());
 
-  PrettyStackTraceModuleFile stackEntry(*this);
+  DeclTypeCursor = core->DeclTypeCursor;
+  SILCursor = core->SILCursor;
+  SILIndexCursor = core->SILIndexCursor;
+  DeclMemberTablesCursor = core->DeclMemberTablesCursor;
 
-  llvm::BitstreamCursor cursor{ModuleInputBuffer->getMemBufferRef()};
-
-  if (!checkModuleSignature(cursor, SWIFTMODULE_SIGNATURE) ||
-      !enterTopLevelModuleBlock(cursor, MODULE_BLOCK_ID)) {
-    info.status = error(Status::Malformed);
-    return;
+  for (const auto &coreDep : core->Dependencies) {
+    Dependencies.emplace_back(coreDep);
   }
 
-  // Future-proofing: make sure we validate the control block before we try to
-  // read any other blocks.
-  bool hasValidControlBlock = false;
-  SmallVector<uint64_t, 64> scratch;
-
-  llvm::BitstreamEntry topLevelEntry;
-
-  while (!cursor.AtEndOfStream()) {
-    Expected<llvm::BitstreamEntry> maybeEntry =
-        cursor.advance(AF_DontPopBlockAtEnd);
-    if (!maybeEntry) {
-      // FIXME this drops the error diagnostic on the floor.
-      consumeError(maybeEntry.takeError());
-      info.status = error(Status::Malformed);
-      return;
-    }
-    topLevelEntry = maybeEntry.get();
-    if (topLevelEntry.Kind != llvm::BitstreamEntry::SubBlock)
-      break;
-
-    switch (topLevelEntry.ID) {
-    case CONTROL_BLOCK_ID: {
-      if (llvm::Error Err = cursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      info = validateControlBlock(cursor, scratch,
-                                  {SWIFTMODULE_VERSION_MAJOR,
-                                   SWIFTMODULE_VERSION_MINOR},
-                                  extInfo);
-      if (info.status != Status::Valid) {
-        error(info.status);
-        return;
-      }
-      Name = info.name;
-      TargetTriple = info.targetTriple;
-      CompatibilityVersion = info.compatibilityVersion;
-      IsSIB = extInfo->isSIB();
-      MiscVersion = info.miscVersion;
-
-      hasValidControlBlock = true;
-      break;
-    }
-
-    case INPUT_BLOCK_ID: {
-      if (!hasValidControlBlock) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      if (llvm::Error Err = cursor.EnterSubBlock(INPUT_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      Expected<llvm::BitstreamEntry> maybeNext = cursor.advance();
-      if (!maybeNext) {
-        // FIXME this drops the error on the floor.
-        consumeError(maybeNext.takeError());
-        info.status = error(Status::Malformed);
-        return;
-      }
-      llvm::BitstreamEntry next = maybeNext.get();
-      while (next.Kind == llvm::BitstreamEntry::Record) {
-        scratch.clear();
-        StringRef blobData;
-        Expected<unsigned> maybeKind =
-            cursor.readRecord(next.ID, scratch, &blobData);
-        if (!maybeKind) {
-          // FIXME this drops the error on the floor.
-          consumeError(maybeKind.takeError());
-          info.status = error(Status::Malformed);
-          return;
-        }
-        unsigned kind = maybeKind.get();
-        switch (kind) {
-        case input_block::IMPORTED_MODULE: {
-          unsigned rawImportControl;
-          bool scoped;
-          bool hasSPI;
-          input_block::ImportedModuleLayout::readRecord(scratch,
-                                                        rawImportControl,
-                                                        scoped, hasSPI);
-          auto importKind = getActualImportControl(rawImportControl);
-          if (!importKind) {
-            // We don't know how to import this dependency.
-            info.status = error(Status::Malformed);
-            return;
-          }
-
-          StringRef spiBlob;
-          if (hasSPI) {
-            scratch.clear();
-
-            llvm::BitstreamEntry entry =
-                fatalIfUnexpected(cursor.advance(AF_DontPopBlockAtEnd));
-            unsigned recordID =
-                fatalIfUnexpected(cursor.readRecord(entry.ID, scratch, &spiBlob));
-            assert(recordID == input_block::IMPORTED_MODULE_SPIS);
-            input_block::ImportedModuleLayoutSPI::readRecord(scratch);
-            (void) recordID;
-          } else {
-            spiBlob = StringRef();
-          }
-
-          Dependencies.push_back({blobData, spiBlob, importKind.getValue(), scoped});
-          break;
-        }
-        case input_block::LINK_LIBRARY: {
-          uint8_t rawKind;
-          bool shouldForceLink;
-          input_block::LinkLibraryLayout::readRecord(scratch, rawKind,
-                                                     shouldForceLink);
-          if (auto libKind = getActualLibraryKind(rawKind))
-            LinkLibraries.push_back({blobData, *libKind, shouldForceLink});
-          // else ignore the dependency...it'll show up as a linker error.
-          break;
-        }
-        case input_block::IMPORTED_HEADER: {
-          assert(!importedHeaderInfo.fileSize && "only one header allowed");
-          bool exported;
-          input_block::ImportedHeaderLayout::readRecord(scratch,
-            exported, importedHeaderInfo.fileSize,
-            importedHeaderInfo.fileModTime);
-          Dependencies.push_back(Dependency::forHeader(blobData, exported));
-          break;
-        }
-        case input_block::IMPORTED_HEADER_CONTENTS: {
-          assert(Dependencies.back().isHeader() && "must follow header record");
-          assert(importedHeaderInfo.contents.empty() &&
-                 "contents seen already");
-          importedHeaderInfo.contents = blobData;
-          break;
-        }
-        case input_block::SEARCH_PATH: {
-          bool isFramework;
-          bool isSystem;
-          input_block::SearchPathLayout::readRecord(scratch, isFramework,
-                                                    isSystem);
-          SearchPaths.push_back({blobData, isFramework, isSystem});
-          break;
-        }
-        case input_block::MODULE_INTERFACE_PATH: {
-          ModuleInterfacePath = blobData;
-          break;
-        }
-        default:
-          // Unknown input kind, possibly for use by a future version of the
-          // module format.
-          // FIXME: Should we warn about this?
-          break;
-        }
-
-        maybeNext = cursor.advance();
-        if (!maybeNext) {
-          // FIXME this drops the error on the floor.
-          consumeError(maybeNext.takeError());
-          info.status = error(Status::Malformed);
-          return;
-        }
-        next = maybeNext.get();
-      }
-
-      if (next.Kind != llvm::BitstreamEntry::EndBlock)
-        info.status = error(Status::Malformed);
-
-      break;
-    }
-
-    case DECLS_AND_TYPES_BLOCK_ID: {
-      if (!hasValidControlBlock) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      // The decls-and-types block is lazily loaded. Save the cursor and load
-      // any abbrev records at the start of the block.
-      DeclTypeCursor = cursor;
-      if (llvm::Error Err =
-              DeclTypeCursor.EnterSubBlock(DECLS_AND_TYPES_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      Expected<llvm::BitstreamEntry> maybeCursor = DeclTypeCursor.advance();
-      if (!maybeCursor) {
-        // FIXME this drops the error on the floor.
-        consumeError(maybeCursor.takeError());
-        info.status = error(Status::Malformed);
-        return;
-      }
-      if (maybeCursor.get().Kind == llvm::BitstreamEntry::Error)
-        info.status = error(Status::Malformed);
-
-      // With the main cursor, skip over the block and continue.
-      if (cursor.SkipBlock()) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-      break;
-    }
-
-    case IDENTIFIER_DATA_BLOCK_ID: {
-      if (!hasValidControlBlock) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      if (llvm::Error Err = cursor.EnterSubBlock(IDENTIFIER_DATA_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      Expected<llvm::BitstreamEntry> maybeNext =
-          cursor.advanceSkippingSubblocks();
-      if (!maybeNext) {
-        // FIXME this drops the error on the floor.
-        consumeError(maybeNext.takeError());
-        info.status = error(Status::Malformed);
-        return;
-      }
-      llvm::BitstreamEntry next = maybeNext.get();
-      while (next.Kind == llvm::BitstreamEntry::Record) {
-        scratch.clear();
-        StringRef blobData;
-        Expected<unsigned> maybeKind =
-            cursor.readRecord(next.ID, scratch, &blobData);
-        if (!maybeKind) {
-          // FIXME this drops the error on the floor.
-          consumeError(maybeKind.takeError());
-          info.status = error(Status::Malformed);
-          return;
-        }
-        unsigned kind = maybeKind.get();
-
-        switch (kind) {
-        case identifier_block::IDENTIFIER_DATA:
-          assert(scratch.empty());
-          IdentifierData = blobData;
-          break;
-        default:
-          // Unknown identifier data, which this version of the compiler won't
-          // use.
-          break;
-        }
-
-        maybeNext = cursor.advanceSkippingSubblocks();
-        if (!maybeNext) {
-          // FIXME this drops the error on the floor.
-          consumeError(maybeNext.takeError());
-          info.status = error(Status::Malformed);
-          return;
-        }
-        next = maybeNext.get();
-      }
-
-      if (next.Kind != llvm::BitstreamEntry::EndBlock) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      break;
-    }
-
-    case INDEX_BLOCK_ID: {
-      if (!hasValidControlBlock || !readIndexBlock(cursor)) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-      break;
-    }
-
-    case SIL_INDEX_BLOCK_ID: {
-      // Save the cursor.
-      SILIndexCursor = cursor;
-      if (llvm::Error Err = SILIndexCursor.EnterSubBlock(SIL_INDEX_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      // With the main cursor, skip over the block and continue.
-      if (cursor.SkipBlock()) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-      break;
-    }
-
-    case SIL_BLOCK_ID: {
-      // Save the cursor.
-      SILCursor = cursor;
-      if (llvm::Error Err = SILCursor.EnterSubBlock(SIL_BLOCK_ID)) {
-        // FIXME this drops the error on the floor.
-        consumeError(std::move(Err));
-        info.status = error(Status::Malformed);
-        return;
-      }
-
-      // With the main cursor, skip over the block and continue.
-      if (cursor.SkipBlock()) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-      break;
-    }
-
-    default:
-      // Unknown top-level block, possibly for use by a future version of the
-      // module format.
-      if (cursor.SkipBlock()) {
-        info.status = error(Status::Malformed);
-        return;
-      }
-      break;
-    }
-  }
-
-  if (topLevelEntry.Kind != llvm::BitstreamEntry::EndBlock) {
-    info.status = error(Status::Malformed);
-    return;
-  }
-  // Read source info file.
-  readModuleSourceInfoIfPresent();
-  if (!readModuleDocIfPresent()) {
-    info.status = error(Status::MalformedDocumentation);
-    return;
-  }
+  // `ModuleFileSharedCore` has immutable data, we copy these into `ModuleFile`
+  // so we can mutate the arrays and replace the offsets with AST object
+  // pointers as we lazily deserialize them.
+  allocateBuffer(Decls, core->Decls);
+  allocateBuffer(LocalDeclContexts, core->LocalDeclContexts);
+  allocateBuffer(NormalConformances, core->NormalConformances);
+  allocateBuffer(SILLayouts, core->SILLayouts);
+  allocateBuffer(Types, core->Types);
+  allocateBuffer(ClangTypes, core->ClangTypes);
+  allocateBuffer(GenericSignatures, core->GenericSignatures);
+  allocateBuffer(SubstitutionMaps, core->SubstitutionMaps);
+  allocateBuffer(Identifiers, core->Identifiers);
 }
 
 Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
@@ -1988,12 +126,12 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
   FileContext = file;
 
   ModuleDecl *M = file->getParentModule();
-  if (M->getName().str() != Name)
+  if (M->getName().str() != Core->Name)
     return error(Status::NameMismatch);
 
   ASTContext &ctx = getContext();
 
-  llvm::Triple moduleTarget(llvm::Triple::normalize(TargetTriple));
+  llvm::Triple moduleTarget(llvm::Triple::normalize(Core->TargetTriple));
   if (!areCompatibleArchitectures(moduleTarget, ctx.LangOpts.Target) ||
       !areCompatibleOSs(moduleTarget, ctx.LangOpts.Target)) {
     return error(Status::TargetIncompatible);
@@ -2004,7 +142,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
     return error(Status::TargetTooNew);
   }
 
-  for (const auto &searchPath : SearchPaths)
+  for (const auto &searchPath : Core->SearchPaths)
     ctx.addSearchPath(searchPath.Path, searchPath.IsFramework,
                       searchPath.IsSystem);
 
@@ -2017,13 +155,13 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
     if (dependency.isHeader()) {
       // The path may be empty if the file being loaded is a partial AST,
       // and the current compiler invocation is a merge-modules step.
-      if (!dependency.RawPath.empty()) {
+      if (!dependency.Core.RawPath.empty()) {
         bool hadError =
-            clangImporter->importHeader(dependency.RawPath,
+            clangImporter->importHeader(dependency.Core.RawPath,
                                         file->getParentModule(),
-                                        importedHeaderInfo.fileSize,
-                                        importedHeaderInfo.fileModTime,
-                                        importedHeaderInfo.contents,
+                                        Core->importedHeaderInfo.fileSize,
+                                        Core->importedHeaderInfo.fileModTime,
+                                        Core->importedHeaderInfo.contents,
                                         diagLoc);
         if (hadError)
           return error(Status::FailedToLoadBridgingHeader);
@@ -2049,7 +187,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
       continue;
     }
 
-    StringRef modulePathStr = dependency.RawPath;
+    StringRef modulePathStr = dependency.Core.RawPath;
     StringRef scopePath;
     if (dependency.isScoped()) {
       auto splitPoint = modulePathStr.find_last_of('\0');
@@ -2094,7 +232,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
     }
 
     // SPI
-    StringRef spisStr = dependency.RawSPIs;
+    StringRef spisStr = dependency.Core.RawSPIs;
     while (!spisStr.empty()) {
       StringRef nextComponent;
       std::tie(nextComponent, spisStr) = spisStr.split('\0');
@@ -2113,7 +251,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
     return error(Status::MissingDependency);
   }
 
-  if (Bits.HasEntryPoint) {
+  if (Core->Bits.HasEntryPoint) {
     FileContext->getParentModule()->registerEntryPointFile(FileContext,
                                                            SourceLoc(),
                                                            None);
@@ -2122,15 +260,13 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
   return Status::Valid;
 }
 
-std::unique_ptr<llvm::MemoryBuffer> ModuleFile::takeBufferForDiagnostics() {
-  assert(hasError());
+bool ModuleFile::mayHaveDiagnosticsPointingAtBuffer() const {
+  if (!hasError())
+    return false;
 
   // Today, the only buffer that might have diagnostics in them is the input
   // buffer, and even then only if it has imported module contents.
-  if (!importedHeaderInfo.contents.empty())
-    return std::move(ModuleInputBuffer);
-
-  return nullptr;
+  return !Core->importedHeaderInfo.contents.empty();
 }
 
 ModuleFile::~ModuleFile() { }
@@ -2139,13 +275,13 @@ void ModuleFile::lookupValue(DeclName name,
                              SmallVectorImpl<ValueDecl*> &results) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
-  if (TopLevelDecls) {
+  if (Core->TopLevelDecls) {
     // Find top-level declarations with the given name.
     // FIXME: As a bit of a hack, do lookup by the simple name, then filter
     // compound decls, to avoid having to completely redo how modules are
     // serialized.
-    auto iter = TopLevelDecls->find(name.getBaseName());
-    if (iter != TopLevelDecls->end()) {
+    auto iter = Core->TopLevelDecls->find(name.getBaseName());
+    if (iter != Core->TopLevelDecls->end()) {
       for (auto item : *iter) {
         Expected<Decl *> declOrError = getDeclChecked(item.second);
         if (!declOrError) {
@@ -2162,9 +298,9 @@ void ModuleFile::lookupValue(DeclName name,
   }
 
   // If the name is an operator name, also look for operator methods.
-  if (name.isOperator() && OperatorMethodDecls) {
-    auto iter = OperatorMethodDecls->find(name.getBaseName());
-    if (iter != OperatorMethodDecls->end()) {
+  if (name.isOperator() && Core->OperatorMethodDecls) {
+    auto iter = Core->OperatorMethodDecls->find(name.getBaseName());
+    if (iter != Core->OperatorMethodDecls->end()) {
       for (auto item : *iter) {
         Expected<Decl *> declOrError = getDeclChecked(item.second);
         if (!declOrError) {
@@ -2183,11 +319,11 @@ void ModuleFile::lookupValue(DeclName name,
 TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
-  if (!LocalTypeDecls)
+  if (!Core->LocalTypeDecls)
     return nullptr;
 
-  auto iter = LocalTypeDecls->find(MangledName);
-  if (iter == LocalTypeDecls->end())
+  auto iter = Core->LocalTypeDecls->find(MangledName);
+  if (iter == Core->LocalTypeDecls->end())
     return nullptr;
 
   return cast<TypeDecl>(getDecl(*iter));
@@ -2202,29 +338,39 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
   if (!moduleBuf)
     return nullptr;
 
+  // FIXME: This goes through the full cost of creating a ModuleFile object
+  // and then it keeps just the name and discards the whole object.
+  // The user of this API is `ExplicitSwiftModuleLoader`, this API should
+  // change to return a `ModuleFileSharedCore` object that
+  // `ExplicitSwiftModuleLoader` caches.
+
   // Load the module file without validation.
-  std::unique_ptr<ModuleFile> loadedModuleFile;
+  std::unique_ptr<llvm::MemoryBuffer> newBuf =
+    llvm::MemoryBuffer::getMemBuffer(llvm::MemoryBufferRef(*moduleBuf.get()),
+    /*RequiresNullTerminator=*/false);
+  std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   ExtendedValidationInfo ExtInfo;
   bool isFramework = false;
   serialization::ValidationInfo loadInfo =
-     ModuleFile::load(modulePath.str(),
-                      std::move(moduleBuf.get()),
+     ModuleFileSharedCore::load(modulePath.str(),
+                      std::move(newBuf),
                       nullptr,
                       nullptr,
                       /*isFramework*/isFramework, loadedModuleFile,
                       &ExtInfo);
+
   Name = loadedModuleFile->Name;
-  return std::move(loadedModuleFile->ModuleInputBuffer);
+  return std::move(moduleBuf.get());
 }
 
 OpaqueTypeDecl *ModuleFile::lookupOpaqueResultType(StringRef MangledName) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
-  if (!OpaqueReturnTypeDecls)
+  if (!Core->OpaqueReturnTypeDecls)
     return nullptr;
   
-  auto iter = OpaqueReturnTypeDecls->find(MangledName);
-  if (iter == OpaqueReturnTypeDecls->end())
+  auto iter = Core->OpaqueReturnTypeDecls->find(MangledName);
+  if (iter == Core->OpaqueReturnTypeDecls->end())
     return nullptr;
   
   return cast<OpaqueTypeDecl>(getDecl(*iter));
@@ -2234,9 +380,9 @@ TypeDecl *ModuleFile::lookupNestedType(Identifier name,
                                        const NominalTypeDecl *parent) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
-  if (NestedTypeDecls) {
-    auto iter = NestedTypeDecls->find(name);
-    if (iter != NestedTypeDecls->end()) {
+  if (Core->NestedTypeDecls) {
+    auto iter = Core->NestedTypeDecls->find(name);
+    if (iter != Core->NestedTypeDecls->end()) {
       for (std::pair<DeclID, DeclID> entry : *iter) {
         assert(entry.first);
         auto declOrOffset = Decls[entry.first - 1];
@@ -2265,11 +411,11 @@ OperatorDecl *ModuleFile::lookupOperator(Identifier name,
                                          OperatorFixity fixity) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
-  if (!OperatorDecls)
+  if (!Core->OperatorDecls)
     return nullptr;
 
-  auto iter = OperatorDecls->find(name);
-  if (iter == OperatorDecls->end())
+  auto iter = Core->OperatorDecls->find(name);
+  if (iter == Core->OperatorDecls->end())
     return nullptr;
 
   for (auto item : *iter) {
@@ -2282,11 +428,11 @@ OperatorDecl *ModuleFile::lookupOperator(Identifier name,
 PrecedenceGroupDecl *ModuleFile::lookupPrecedenceGroup(Identifier name) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
-  if (!PrecedenceGroupDecls)
+  if (!Core->PrecedenceGroupDecls)
     return nullptr;
 
-  auto iter = PrecedenceGroupDecls->find(name);
-  if (iter == PrecedenceGroupDecls->end())
+  auto iter = Core->PrecedenceGroupDecls->find(name);
+  if (iter == Core->PrecedenceGroupDecls->end())
     return nullptr;
 
   auto data = *iter;
@@ -2332,7 +478,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
       if (Dep.isHeader())
         continue;
 
-      StringRef ModulePathStr = Dep.RawPath;
+      StringRef ModulePathStr = Dep.Core.RawPath;
       StringRef ScopePath;
       if (Dep.isScoped())
         std::tie(ModulePathStr, ScopePath) = ModulePathStr.rsplit('\0');
@@ -2397,7 +543,7 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
   PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
-  if (!TopLevelDecls)
+  if (!Core->TopLevelDecls)
     return;
 
   auto tryImport = [this, &consumer](DeclID ID) {
@@ -2413,8 +559,8 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
   };
 
   if (!accessPath.empty()) {
-    auto iter = TopLevelDecls->find(accessPath.front().Item);
-    if (iter == TopLevelDecls->end())
+    auto iter = Core->TopLevelDecls->find(accessPath.front().Item);
+    if (iter == Core->TopLevelDecls->end())
       return;
 
     for (auto item : *iter)
@@ -2423,7 +569,7 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
     return;
   }
 
-  for (auto entry : TopLevelDecls->data()) {
+  for (auto entry : Core->TopLevelDecls->data()) {
     for (auto item : entry)
       tryImport(item.second);
   }
@@ -2431,11 +577,11 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
 
 void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
   PrettyStackTraceModuleFile stackEntry(*this);
-  if (!ExtensionDecls)
+  if (!Core->ExtensionDecls)
     return;
 
-  auto iter = ExtensionDecls->find(nominal->getName());
-  if (iter == ExtensionDecls->end())
+  auto iter = Core->ExtensionDecls->find(nominal->getName());
+  if (iter == Core->ExtensionDecls->end())
     return;
 
   if (nominal->getEffectiveAccess() < AccessLevel::Internal) {
@@ -2479,12 +625,12 @@ void ModuleFile::loadObjCMethods(
        bool isInstanceMethod,
        llvm::TinyPtrVector<AbstractFunctionDecl *> &methods) {
   // If we don't have an Objective-C method table, there's nothing to do.
-  if (!ObjCMethods)
+  if (!Core->ObjCMethods)
     return;
 
   // Look for all methods in the module file with this selector.
-  auto known = ObjCMethods->find(selector);
-  if (known == ObjCMethods->end()) {
+  auto known = Core->ObjCMethods->find(selector);
+  if (known == Core->ObjCMethods->end()) {
     return;
   }
 
@@ -2510,13 +656,13 @@ void ModuleFile::loadObjCMethods(
 void ModuleFile::loadDerivativeFunctionConfigurations(
     AbstractFunctionDecl *originalAFD,
     llvm::SetVector<AutoDiffConfig> &results) {
-  if (!DerivativeFunctionConfigurations)
+  if (!Core->DerivativeFunctionConfigurations)
     return;
   auto &ctx = originalAFD->getASTContext();
   Mangle::ASTMangler Mangler;
   auto mangledName = Mangler.mangleDeclAsUSR(originalAFD, "");
-  auto configs = DerivativeFunctionConfigurations->find(mangledName);
-  if (configs == DerivativeFunctionConfigurations->end())
+  auto configs = Core->DerivativeFunctionConfigurations->find(mangledName);
+  if (configs == Core->DerivativeFunctionConfigurations->end())
     return;
   for (auto entry : *configs) {
     auto *parameterIndices = IndexSubset::getFromString(ctx, entry.first);
@@ -2541,11 +687,11 @@ ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
   PrettyStackTraceDecl trace("loading members for", IDC->getDecl());
 
   assert(IDC->wasDeserialized());
-  assert(DeclMemberNames);
+  assert(Core->DeclMemberNames);
 
   TinyPtrVector<ValueDecl *> results;
-  auto i = DeclMemberNames->find(N);
-  if (i == DeclMemberNames->end())
+  auto i = Core->DeclMemberNames->find(N);
+  if (i == Core->DeclMemberNames->end())
     return results;
 
   BitOffset subTableOffset = *i;
@@ -2566,7 +712,7 @@ ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
         DeclMemberTablesCursor.readRecord(entry.ID, scratch, &blobData));
     assert(kind == decl_member_tables_block::DECL_MEMBERS);
     (void)kind;
-    subTable = readDeclMembersTable(scratch, blobData);
+    subTable = Core->readDeclMembersTable(scratch, blobData);
   }
 
   assert(subTable);
@@ -2595,11 +741,11 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
   PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
-  if (!ClassMembersForDynamicLookup)
+  if (!Core->ClassMembersForDynamicLookup)
     return;
 
-  auto iter = ClassMembersForDynamicLookup->find(name.getBaseName());
-  if (iter == ClassMembersForDynamicLookup->end())
+  auto iter = Core->ClassMembersForDynamicLookup->find(name.getBaseName());
+  if (iter == Core->ClassMembersForDynamicLookup->end())
     return;
 
   if (!accessPath.empty()) {
@@ -2644,11 +790,11 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
   PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
-  if (!ClassMembersForDynamicLookup)
+  if (!Core->ClassMembersForDynamicLookup)
     return;
 
   if (!accessPath.empty()) {
-    for (const auto &list : ClassMembersForDynamicLookup->data()) {
+    for (const auto &list : Core->ClassMembersForDynamicLookup->data()) {
       for (auto item : list) {
         auto vd = cast<ValueDecl>(getDecl(item.second));
         auto dc = vd->getDeclContext();
@@ -2663,7 +809,7 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
     return;
   }
 
-  for (const auto &list : ClassMembersForDynamicLookup->data()) {
+  for (const auto &list : Core->ClassMembersForDynamicLookup->data()) {
     for (auto item : list)
       consumer.foundDecl(cast<ValueDecl>(getDecl(item.second)),
                          DeclVisibilityKind::DynamicLookup,
@@ -2675,11 +821,11 @@ void ModuleFile::lookupObjCMethods(
        ObjCSelector selector,
        SmallVectorImpl<AbstractFunctionDecl *> &results) {
   // If we don't have an Objective-C method table, there's nothing to do.
-  if (!ObjCMethods) return;
+  if (!Core->ObjCMethods) return;
 
   // Look for all methods in the module file with this selector.
-  auto known = ObjCMethods->find(selector);
-  if (known == ObjCMethods->end()) return;
+  auto known = Core->ObjCMethods->find(selector);
+  if (known == Core->ObjCMethods->end()) return;
 
   auto found = *known;
   for (const auto &result : found) {
@@ -2704,17 +850,17 @@ void ModuleFile::lookupImportedSPIGroups(
 
 void
 ModuleFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const {
-  for (auto &lib : LinkLibraries)
+  for (const auto &lib : Core->LinkLibraries)
     callback(lib);
-  if (Bits.IsFramework)
-    callback(LinkLibrary(Name, LibraryKind::Framework));
+  if (Core->Bits.IsFramework)
+    callback(LinkLibrary(Core->Name, LibraryKind::Framework));
 }
 
 void ModuleFile::getTopLevelDecls(
        SmallVectorImpl<Decl *> &results,
        llvm::function_ref<bool(DeclAttributes)> matchAttributes) {
   PrettyStackTraceModuleFile stackEntry(*this);
-  for (DeclID entry : OrderedTopLevelDecls) {
+  for (DeclID entry : Core->OrderedTopLevelDecls) {
     Expected<Decl *> declOrError = getDeclChecked(entry, matchAttributes);
     if (!declOrError) {
       if (declOrError.errorIsA<DeclAttributesDidNotMatch>()) {
@@ -2735,10 +881,10 @@ void ModuleFile::getTopLevelDecls(
 
 void ModuleFile::getOperatorDecls(SmallVectorImpl<OperatorDecl *> &results) {
   PrettyStackTraceModuleFile stackEntry(*this);
-  if (!OperatorDecls)
+  if (!Core->OperatorDecls)
     return;
 
-  for (auto entry : OperatorDecls->data()) {
+  for (auto entry : Core->OperatorDecls->data()) {
     for (auto item : entry)
       results.push_back(cast<OperatorDecl>(getDecl(item.second)));
   }
@@ -2747,8 +893,8 @@ void ModuleFile::getOperatorDecls(SmallVectorImpl<OperatorDecl *> &results) {
 void ModuleFile::getPrecedenceGroups(
        SmallVectorImpl<PrecedenceGroupDecl*> &results) {
   PrettyStackTraceModuleFile stackEntry(*this);
-  if (PrecedenceGroupDecls) {
-    for (auto entry : PrecedenceGroupDecls->data()) {
+  if (Core->PrecedenceGroupDecls) {
+    for (auto entry : Core->PrecedenceGroupDecls->data()) {
       for (auto item : entry)
         results.push_back(cast<PrecedenceGroupDecl>(getDecl(item.second)));
     }
@@ -2758,10 +904,10 @@ void ModuleFile::getPrecedenceGroups(
 void
 ModuleFile::getLocalTypeDecls(SmallVectorImpl<TypeDecl *> &results) {
   PrettyStackTraceModuleFile stackEntry(*this);
-  if (!LocalTypeDecls)
+  if (!Core->LocalTypeDecls)
     return;
 
-  for (auto DeclID : LocalTypeDecls->data()) {
+  for (auto DeclID : Core->LocalTypeDecls->data()) {
     auto TD = cast<TypeDecl>(getDecl(DeclID));
     results.push_back(TD);
   }
@@ -2771,10 +917,10 @@ void
 ModuleFile::getOpaqueReturnTypeDecls(SmallVectorImpl<OpaqueTypeDecl *> &results)
 {
   PrettyStackTraceModuleFile stackEntry(*this);
-  if (!OpaqueReturnTypeDecls)
+  if (!Core->OpaqueReturnTypeDecls)
     return;
 
-  for (auto DeclID : OpaqueReturnTypeDecls->data()) {
+  for (auto DeclID : Core->OpaqueReturnTypeDecls->data()) {
     auto TD = cast<OpaqueTypeDecl>(getDecl(DeclID));
     results.push_back(TD);
   }
@@ -2799,7 +945,7 @@ Optional<CommentInfo> ModuleFile::getCommentForDecl(const Decl *D) const {
   assert(D->getDeclContext()->getModuleScopeContext() == FileContext &&
          "Decl is from a different serialized file");
 
-  if (!DeclCommentTable)
+  if (!Core->DeclCommentTable)
     return None;
   if (D->isImplicit())
     return None;
@@ -2822,10 +968,10 @@ ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const {
          "cannot find comments for Clang decls in Swift modules");
   assert(D->getDeclContext()->getModuleScopeContext() == FileContext &&
          "Decl is from a different serialized file");
-  if (!DeclUSRsTable)
+  if (!Core->DeclUSRsTable)
     return None;
   // Future compilers may not provide BasicDeclLocsData anymore.
-  if (BasicDeclLocsData.empty())
+  if (Core->BasicDeclLocsData.empty())
     return None;
   if (D->isImplicit())
     return None;
@@ -2835,8 +981,8 @@ ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const {
   if (ide::printDeclUSR(D, OS))
     return None;
 
-  auto It = DeclUSRsTable->find(OS.str());
-  if (It == DeclUSRsTable->end())
+  auto It = Core->DeclUSRsTable->find(OS.str());
+  if (It == Core->DeclUSRsTable->end())
     return None;
   auto UsrId = *It;
   uint32_t NumSize = 4;
@@ -2848,23 +994,23 @@ ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const {
     NumSize + // Offset into doc ranges blob
     NumSize * 2 * LineColumnCount; // Line/column of: Loc, StartLoc, EndLoc
   uint32_t RecordOffset = RecordSize * UsrId;
-  assert(RecordOffset < BasicDeclLocsData.size());
-  assert(BasicDeclLocsData.size() % RecordSize == 0);
+  assert(RecordOffset < Core->BasicDeclLocsData.size());
+  assert(Core->BasicDeclLocsData.size() % RecordSize == 0);
   BasicDeclLocs Result;
-  auto *Record = BasicDeclLocsData.data() + RecordOffset;
+  auto *Record = Core->BasicDeclLocsData.data() + RecordOffset;
   auto ReadNext = [&Record]() {
     return endian::readNext<uint32_t, little, unaligned>(Record);
   };
 
-  auto FilePath = SourceLocsTextData.substr(ReadNext());
+  auto FilePath = Core->SourceLocsTextData.substr(ReadNext());
   size_t TerminatorOffset = FilePath.find('\0');
   assert(TerminatorOffset != StringRef::npos && "unterminated string data");
   Result.SourceFilePath = FilePath.slice(0, TerminatorOffset);
 
   const auto DocRangesOffset = ReadNext();
   if (DocRangesOffset) {
-    assert(!DocRangesData.empty());
-    const auto *Data = DocRangesData.data() + DocRangesOffset;
+    assert(!Core->DocRangesData.empty());
+    const auto *Data = Core->DocRangesData.data() + DocRangesOffset;
     const auto NumLocs = endian::readNext<uint32_t, little, unaligned>(Data);
     assert(NumLocs);
 
@@ -2890,9 +1036,13 @@ Result.X.Column = ReadNext();
 const static StringRef Separator = "/";
 
 Optional<StringRef> ModuleFile::getGroupNameById(unsigned Id) const {
-  if (!GroupNamesMap || GroupNamesMap->count(Id) == 0)
+  if (!Core->GroupNamesMap)
     return None;
-  auto Original = (*GroupNamesMap)[Id];
+  const auto &GroupNamesMap = *Core->GroupNamesMap;
+  auto it = GroupNamesMap.find(Id);
+  if (it == GroupNamesMap.end())
+    return None;
+  StringRef Original = it->second;
   if (Original.empty())
     return None;
   auto SepPos = Original.find_last_of(Separator);
@@ -2901,9 +1051,13 @@ Optional<StringRef> ModuleFile::getGroupNameById(unsigned Id) const {
 }
 
 Optional<StringRef> ModuleFile::getSourceFileNameById(unsigned Id) const {
-  if (!GroupNamesMap || GroupNamesMap->count(Id) == 0)
+  if (!Core->GroupNamesMap)
     return None;
-  auto Original = (*GroupNamesMap)[Id];
+  const auto &GroupNamesMap = *Core->GroupNamesMap;
+  auto it = GroupNamesMap.find(Id);
+  if (it == GroupNamesMap.end())
+    return None;
+  StringRef Original = it->second;
   if (Original.empty())
     return None;
   auto SepPos = Original.find_last_of(Separator);
@@ -2941,9 +1095,10 @@ ModuleFile::getSourceOrderForDecl(const Decl *D) const {
 }
 
 void ModuleFile::collectAllGroups(std::vector<StringRef> &Names) const {
-  if (!GroupNamesMap)
+  if (!Core->GroupNamesMap)
     return;
-  for (auto It = GroupNamesMap->begin(); It != GroupNamesMap->end(); ++ It) {
+  for (auto It = Core->GroupNamesMap->begin(); It != Core->GroupNamesMap->end();
+       ++It) {
     StringRef FullGroupName = It->getSecond();
     if (FullGroupName.empty())
       continue;
@@ -2959,14 +1114,27 @@ void ModuleFile::collectAllGroups(std::vector<StringRef> &Names) const {
 
 Optional<CommentInfo>
 ModuleFile::getCommentForDeclByUSR(StringRef USR) const {
-  if (!DeclCommentTable)
+  if (!Core->DeclCommentTable)
     return None;
 
-  auto I = DeclCommentTable->find(USR);
-  if (I == DeclCommentTable->end())
+  // Use the comment cache to preserve the memory that the array of
+  // `SingleRawComment`s, inside `CommentInfo`, points to, and generally avoid
+  // allocating memory every time we query `Core->DeclCommentTable`.
+  auto it = CommentsCache.find(USR);
+  if (it != CommentsCache.end()) {
+    const auto &cachePtr = it->second;
+    if (!cachePtr)
+      return None;
+    return cachePtr->Info;
+  }
+
+  auto I = Core->DeclCommentTable->find(USR);
+  if (I == Core->DeclCommentTable->end())
     return None;
 
-  return *I;
+  auto &cachePtr = CommentsCache[USR];
+  cachePtr = *I;
+  return cachePtr->Info;
 }
 
 Optional<StringRef>
@@ -2993,7 +1161,7 @@ void ModuleFile::verify() const {
 }
 
 bool SerializedASTFile::hasEntryPoint() const {
-  return File.Bits.HasEntryPoint;
+  return File.hasEntryPoint();
 }
 
 bool SerializedASTFile::getAllGenericSignatures(
@@ -3009,11 +1177,11 @@ bool SerializedASTFile::getAllGenericSignatures(
 
 Decl *SerializedASTFile::getMainDecl() const {
   assert(hasEntryPoint());
-  return File.getDecl(File.Bits.EntryPointDeclID);
+  return File.getDecl(File.getEntryPointDeclID());
 }
 
 const version::Version &SerializedASTFile::getLanguageVersionBuiltWith() const {
-  return File.CompatibilityVersion;
+  return File.getCompatibilityVersion();
 }
 
 StringRef SerializedASTFile::getModuleDefiningPath() const {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -14,6 +14,7 @@
 #define SWIFT_SERIALIZATION_MODULEFILE_H
 
 #include "ModuleFormat.h"
+#include "ModuleFileSharedCore.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/LinkLibrary.h"
@@ -57,16 +58,15 @@ class ModuleFile
   using Status = serialization::Status;
   using TypeID = serialization::TypeID;
 
+  /// The core data of a serialized module file. This is accessed as immutable
+  /// and thread-safe.
+  const std::shared_ptr<const ModuleFileSharedCore> Core;
+
   /// A reference back to the AST representation of the file.
   FileUnit *FileContext = nullptr;
 
   /// The module that this module is an overlay of, if any.
   ModuleDecl *UnderlyingModule = nullptr;
-
-  /// The module file data.
-  std::unique_ptr<llvm::MemoryBuffer> ModuleInputBuffer;
-  std::unique_ptr<llvm::MemoryBuffer> ModuleDocInputBuffer;
-  std::unique_ptr<llvm::MemoryBuffer> ModuleSourceInfoInputBuffer;
 
   /// The cursor used to lazily load things from the file.
   llvm::BitstreamCursor DeclTypeCursor;
@@ -75,35 +75,10 @@ class ModuleFile
   llvm::BitstreamCursor SILIndexCursor;
   llvm::BitstreamCursor DeclMemberTablesCursor;
 
-  /// The name of the module.
-  StringRef Name;
   friend StringRef getNameOfModule(const ModuleFile *);
-
-  /// The target the module was built for.
-  StringRef TargetTriple;
-
-  /// The name of the module interface this module was compiled from.
-  ///
-  /// Empty if this module didn't come from an interface file.
-  StringRef ModuleInterfacePath;
-
-  /// The Swift compatibility version in use when this module was built.
-  version::Version CompatibilityVersion;
-
-  /// The data blob containing all of the module's identifiers.
-  StringRef IdentifierData;
 
   /// A callback to be invoked every time a type was deserialized.
   std::function<void(Type)> DeserializedTypeCallback;
-
-  /// Is this module file actually a .sib file? .sib files are serialized SIL at
-  /// arbitrary granularity and arbitrary stage; unlike serialized Swift
-  /// modules, which are assumed to contain canonical SIL for an entire module.
-  bool IsSIB = false;
-
-  // Full blob from the misc. version field of the metadata block. This should
-  // include the version string of the compiler that built the module.
-  StringRef MiscVersion;
 
 public:
   static std::unique_ptr<llvm::MemoryBuffer> getModuleName(ASTContext &Ctx,
@@ -113,84 +88,32 @@ public:
   /// Represents another module that has been imported as a dependency.
   class Dependency {
   public:
+    const ModuleFileSharedCore::Dependency &Core;
+
     llvm::Optional<ModuleDecl::ImportedModule> Import = llvm::None;
-    const StringRef RawPath;
-    const StringRef RawSPIs;
     SmallVector<Identifier, 4> spiGroups;
 
-  private:
-    using ImportFilterKind = ModuleDecl::ImportFilterKind;
-    const unsigned RawImportControl : 2;
-    const unsigned IsHeader : 1;
-    const unsigned IsScoped : 1;
-
-    static unsigned rawControlFromKind(ImportFilterKind importKind) {
-      return llvm::countTrailingZeros(static_cast<unsigned>(importKind));
-    }
-    ImportFilterKind getImportControl() const {
-      return static_cast<ImportFilterKind>(1 << RawImportControl);
-    }
-
-    Dependency(StringRef path, StringRef spiGroups, bool isHeader, ImportFilterKind importControl,
-               bool isScoped)
-      : RawPath(path), RawSPIs(spiGroups), RawImportControl(rawControlFromKind(importControl)),
-        IsHeader(isHeader), IsScoped(isScoped) {
-      assert(llvm::countPopulation(static_cast<unsigned>(importControl)) == 1 &&
-             "must be a particular filter option, not a bitset");
-      assert(getImportControl() == importControl && "not enough bits");
-    }
-
-  public:
-    Dependency(StringRef path, StringRef spiGroups, ImportFilterKind importControl, bool isScoped)
-      : Dependency(path, spiGroups, false, importControl, isScoped) {}
-
-    static Dependency forHeader(StringRef headerPath, bool exported) {
-      auto importControl = exported ? ImportFilterKind::Public
-                                    : ImportFilterKind::Private;
-      return Dependency(headerPath, StringRef(), true, importControl, false);
-    }
+    Dependency(const ModuleFileSharedCore::Dependency &coreDependency)
+      : Core(coreDependency) {}
 
     bool isLoaded() const {
       return Import.hasValue() && Import->importedModule != nullptr;
     }
 
     bool isExported() const {
-      return getImportControl() == ImportFilterKind::Public;
+      return Core.isExported();
     }
     bool isImplementationOnly() const {
-      return getImportControl() == ImportFilterKind::ImplementationOnly;
+      return Core.isImplementationOnly();
     }
 
-    bool isHeader() const { return IsHeader; }
-    bool isScoped() const { return IsScoped; }
-
-    std::string getPrettyPrintedPath() const;
+    bool isHeader() const { return Core.isHeader(); }
+    bool isScoped() const { return Core.isScoped(); }
   };
 
 private:
   /// All modules this module depends on.
   SmallVector<Dependency, 8> Dependencies;
-
-  struct SearchPath {
-    StringRef Path;
-    bool IsFramework;
-    bool IsSystem;
-  };
-  /// Search paths this module may provide.
-  ///
-  /// This is not intended for use by frameworks, but may show up in debug
-  /// modules.
-  std::vector<SearchPath> SearchPaths;
-
-  /// Info for the (lone) imported header for this module.
-  struct {
-    off_t fileSize;
-    time_t fileModTime;
-    StringRef contents;
-  } importedHeaderInfo = {};
-
-  /// All of this module's link-time dependencies.
-  SmallVector<LinkLibrary, 8> LinkLibraries;
 
 public:
   template <typename T>
@@ -357,103 +280,23 @@ private:
   /// Identifiers referenced by this module.
   MutableArrayRef<SerializedIdentifier> Identifiers;
 
-  class DeclTableInfo;
-  using SerializedDeclTable =
-      llvm::OnDiskIterableChainedHashTable<DeclTableInfo>;
-
-  class ExtensionTableInfo;
-  using SerializedExtensionTable =
-      llvm::OnDiskIterableChainedHashTable<ExtensionTableInfo>;
-
-  class LocalDeclTableInfo;
-  using SerializedLocalDeclTable =
-      llvm::OnDiskIterableChainedHashTable<LocalDeclTableInfo>;
-      
-  using OpaqueReturnTypeDeclTableInfo = LocalDeclTableInfo;
-  using SerializedOpaqueReturnTypeDeclTable =
-      llvm::OnDiskIterableChainedHashTable<OpaqueReturnTypeDeclTableInfo>;
-
-  class NestedTypeDeclsTableInfo;
-  using SerializedNestedTypeDeclsTable =
-      llvm::OnDiskIterableChainedHashTable<NestedTypeDeclsTableInfo>;
-
-  class DeclMemberNamesTableInfo;
-  using SerializedDeclMemberNamesTable =
-      llvm::OnDiskIterableChainedHashTable<DeclMemberNamesTableInfo>;
-
-  class DeclMembersTableInfo;
   using SerializedDeclMembersTable =
-      llvm::OnDiskIterableChainedHashTable<DeclMembersTableInfo>;
-
-  std::unique_ptr<SerializedDeclTable> TopLevelDecls;
-  std::unique_ptr<SerializedDeclTable> OperatorDecls;
-  std::unique_ptr<SerializedDeclTable> PrecedenceGroupDecls;
-  std::unique_ptr<SerializedDeclTable> ClassMembersForDynamicLookup;
-  std::unique_ptr<SerializedDeclTable> OperatorMethodDecls;
-  std::unique_ptr<SerializedExtensionTable> ExtensionDecls;
-  std::unique_ptr<SerializedLocalDeclTable> LocalTypeDecls;
-  std::unique_ptr<SerializedOpaqueReturnTypeDeclTable> OpaqueReturnTypeDecls;
-  std::unique_ptr<SerializedNestedTypeDeclsTable> NestedTypeDecls;
-  std::unique_ptr<SerializedDeclMemberNamesTable> DeclMemberNames;
+      ModuleFileSharedCore::SerializedDeclMembersTable;
 
   llvm::DenseMap<uint32_t,
            std::unique_ptr<SerializedDeclMembersTable>> DeclMembersTables;
-
-  class ObjCMethodTableInfo;
-  using SerializedObjCMethodTable =
-    llvm::OnDiskIterableChainedHashTable<ObjCMethodTableInfo>;
-
-  std::unique_ptr<SerializedObjCMethodTable> ObjCMethods;
 
   llvm::DenseMap<const ValueDecl *, Identifier> PrivateDiscriminatorsByValue;
   llvm::DenseMap<const ValueDecl *, StringRef> FilenamesForPrivateValues;
 
   TinyPtrVector<Decl *> ImportDecls;
 
-  ArrayRef<serialization::DeclID> OrderedTopLevelDecls;
-
-  class DeclCommentTableInfo;
-  using SerializedDeclCommentTable =
-      llvm::OnDiskIterableChainedHashTable<DeclCommentTableInfo>;
-
-  using GroupNameTable = llvm::DenseMap<unsigned, StringRef>;
-
-  std::unique_ptr<GroupNameTable> GroupNamesMap;
-  std::unique_ptr<SerializedDeclCommentTable> DeclCommentTable;
-
-  class DeclUSRTableInfo;
-  using SerializedDeclUSRTable =
-      llvm::OnDiskIterableChainedHashTable<DeclUSRTableInfo>;
-  std::unique_ptr<SerializedDeclUSRTable> DeclUSRsTable;
-
-  class DerivativeFunctionConfigTableInfo;
-  using SerializedDerivativeFunctionConfigTable =
-      llvm::OnDiskIterableChainedHashTable<DerivativeFunctionConfigTableInfo>;
-  std::unique_ptr<SerializedDerivativeFunctionConfigTable>
-      DerivativeFunctionConfigurations;
-
-  /// A blob of 0 terminated string segments referenced in \c SourceLocsTextData
-  StringRef SourceLocsTextData;
-
-  /// An array of fixed size source location data for each USR appearing in
-  /// \c DeclUSRsTable.
-  StringRef BasicDeclLocsData;
-
-  /// An array of fixed-size location data for each `SingleRawComment` piece
-  /// of declaration's documentation `RawComment`s.
-  StringRef DocRangesData;
+  /// Maps USRs to their deserialized comment object.
+  mutable llvm::StringMap<
+      std::unique_ptr<ModuleFileSharedCore::DeserializedCommentInfo>>
+      CommentsCache;
 
   struct ModuleBits {
-    /// The decl ID of the main class in this module file, if it has one.
-    unsigned EntryPointDeclID : 31;
-
-    /// Whether or not this module file comes from a context that had a main
-    /// entry point.
-    unsigned HasEntryPoint : 1;
-
-    /// Whether this module file comes from a framework.
-    unsigned IsFramework : 1;
-
     /// Whether or not ImportDecls is valid.
     unsigned ComputedImportDecls : 1;
 
@@ -466,25 +309,22 @@ private:
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 
   bool hasError() const {
-    return Bits.HasError;
+    return Bits.HasError || Core->hasError();
   }
 
-  void setEntryPointClassID(serialization::DeclID DID) {
-    Bits.HasEntryPoint = true;
-    Bits.EntryPointDeclID = DID;
-    assert(Bits.EntryPointDeclID == DID && "not enough bits for DeclID");
+  /// Whether or not this module file comes from a context that had a main entry point.
+  bool hasEntryPoint() const {
+    return Core->Bits.HasEntryPoint;
+  }
+
+  /// The decl ID of the main class in this module file, if it has one.
+  unsigned getEntryPointDeclID() const {
+    return Core->Bits.EntryPointDeclID;
   }
 
   /// Creates a new AST node to represent a deserialized decl.
   template <typename T, typename ...Args>
   T *createDecl(Args &&... args);
-
-  /// Constructs a new module and validates it.
-  ModuleFile(std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
-             std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
-             std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-             bool isFramework, serialization::ValidationInfo &info,
-             serialization::ExtendedValidationInfo *extInfo);
 
 public:
   /// Change the status of the current module.
@@ -530,85 +370,6 @@ public:
   }
 
 private:
-  /// Read an on-disk decl hash table stored in index_block::DeclListLayout
-  /// format.
-  std::unique_ptr<SerializedDeclTable>
-  readDeclTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk local decl hash table stored in
-  /// index_block::DeclListLayout format.
-  std::unique_ptr<SerializedLocalDeclTable>
-  readLocalDeclTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk Objective-C method table stored in
-  /// index_block::ObjCMethodTableLayout format.
-  std::unique_ptr<ModuleFile::SerializedObjCMethodTable>
-  readObjCMethodTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk local decl hash table stored in
-  /// index_block::ExtensionTableLayout format.
-  std::unique_ptr<SerializedExtensionTable>
-  readExtensionTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk local decl hash table stored in
-  /// index_block::NestedTypeDeclsLayout format.
-  std::unique_ptr<SerializedNestedTypeDeclsTable>
-  readNestedTypeDeclsTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk local decl-name hash table stored in
-  /// index_block::DeclMemberNamesLayout format.
-  std::unique_ptr<SerializedDeclMemberNamesTable>
-  readDeclMemberNamesTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk local decl-members hash table stored in
-  /// index_block::DeclMembersLayout format.
-  std::unique_ptr<SerializedDeclMembersTable>
-  readDeclMembersTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Read an on-disk derivative function configuration table stored in
-  /// index_block::DerivativeFunctionConfigTableLayout format.
-  std::unique_ptr<ModuleFile::SerializedDerivativeFunctionConfigTable>
-  readDerivativeFunctionConfigTable(ArrayRef<uint64_t> fields,
-                                    StringRef blobData);
-
-  /// Reads the index block, which contains global tables.
-  ///
-  /// Returns false if there was an error.
-  bool readIndexBlock(llvm::BitstreamCursor &cursor);
-
-  /// Read an on-disk decl hash table stored in
-  /// \c comment_block::DeclCommentListLayout format.
-  std::unique_ptr<SerializedDeclCommentTable>
-  readDeclCommentTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  std::unique_ptr<GroupNameTable>
-  readGroupTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  /// Reads the comment block, which contains USR to comment mappings.
-  ///
-  /// Returns false if there was an error.
-  bool readCommentBlock(llvm::BitstreamCursor &cursor);
-
-  /// Loads data from #ModuleDocInputBuffer.
-  ///
-  /// Returns false if there was an error.
-  bool readModuleDocIfPresent();
-
-  /// Reads the source loc block, which contains USR to decl location mapping.
-  ///
-  /// Returns false if there was an error.
-  bool readDeclLocsBlock(llvm::BitstreamCursor &cursor);
-
-  /// Loads data from #ModuleSourceInfoInputBuffer.
-  ///
-  /// Returns false if there was an error.
-  bool readModuleSourceInfoIfPresent();
-
-  /// Read an on-disk decl hash table stored in
-  /// \c sourceinfo_block::DeclUSRSLayout format.
-  std::unique_ptr<SerializedDeclUSRTable>
-  readDeclUSRsTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
   /// Recursively reads a pattern from \c DeclTypeCursor.
   llvm::Expected<Pattern *> readPattern(DeclContext *owningDC);
 
@@ -648,9 +409,6 @@ private:
   llvm::Expected<Decl *> resolveCrossReference(serialization::ModuleID MID,
                                                uint32_t pathLen);
 
-  /// Populates TopLevelIDs for name lookup.
-  void buildTopLevelDeclMap();
-
   struct AccessorRecord {
     SmallVector<serialization::DeclID, 8> IDs;
   };
@@ -664,39 +422,28 @@ private:
                         AccessorRecord &accessors);
 
 public:
-  /// Loads a module from the given memory buffer.
-  ///
-  /// \param moduleInputBuffer A memory buffer containing the serialized module
-  /// data. The created ModuleFile takes ownership of the buffer, even if
-  /// there's an error in loading.
-  /// \param moduleDocInputBuffer An optional memory buffer containing
-  /// documentation data for the module. The created ModuleFile takes ownership
-  /// of the buffer, even if there's an error in loading.
-  /// \param isFramework If true, this is treated as a framework module for
-  /// linking purposes.
-  /// \param[out] theModule The loaded module.
-  /// \param[out] extInfo Optionally, extra info serialized about the module.
-  /// \returns Whether the module was successfully loaded, or what went wrong
-  ///          if it was not.
-  static serialization::ValidationInfo
-  load(StringRef moduleInterfacePath,
-       std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
-       std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
-       std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-       bool isFramework, std::unique_ptr<ModuleFile> &theModule,
-       serialization::ExtendedValidationInfo *extInfo = nullptr) {
-    serialization::ValidationInfo info;
-    theModule.reset(new ModuleFile(std::move(moduleInputBuffer),
-                                   std::move(moduleDocInputBuffer),
-                                   std::move(moduleSourceInfoInputBuffer),
-                                   isFramework, info, extInfo));
-    if (!moduleInterfacePath.empty())
-      theModule->ModuleInterfacePath = moduleInterfacePath;
-    return info;
-  }
+  /// Constructs a new module.
+  explicit ModuleFile(std::shared_ptr<const ModuleFileSharedCore> core);
 
   // Out of line to avoid instantiation OnDiskChainedHashTable here.
   ~ModuleFile();
+
+  /// The name of the module.
+  StringRef getName() const {
+    return Core->Name;
+  }
+
+  /// The Swift compatibility version in use when this module was built.
+  const version::Version &getCompatibilityVersion() const {
+    return Core->CompatibilityVersion;
+  }
+
+  /// Is this module file actually a .sib file? .sib files are serialized SIL at
+  /// arbitrary granularity and arbitrary stage; unlike serialized Swift
+  /// modules, which are assumed to contain canonical SIL for an entire module.
+  bool isSIB() const {
+    return Core->IsSIB;
+  }
 
   /// Associates this module file with the AST node representing it.
   ///
@@ -715,13 +462,13 @@ public:
   /// compiled for a different OS.
   Status associateWithFileContext(FileUnit *file, SourceLoc diagLoc);
 
-  /// Transfers ownership of a buffer that might contain source code where
-  /// other parts of the compiler could have emitted diagnostics, to keep them
-  /// alive even if the ModuleFile is destroyed.
+  /// Returns `true` if there is a buffer that might contain source code where
+  /// other parts of the compiler could have emitted diagnostics, to indicate
+  /// that the object must be kept alive as long as the diagnostics exist.
   ///
   /// Should only be called when a failure has been reported from
   /// ModuleFile::load or ModuleFile::associateWithFileContext.
-  std::unique_ptr<llvm::MemoryBuffer> takeBufferForDiagnostics();
+  bool mayHaveDiagnosticsPointingAtBuffer() const;
 
   /// Returns the list of modules this module depends on.
   ArrayRef<Dependency> getDependencies() const {
@@ -855,14 +602,14 @@ public:
   void getDisplayDecls(SmallVectorImpl<Decl*> &results);
 
   StringRef getModuleFilename() const {
-    if (!ModuleInterfacePath.empty())
-      return ModuleInterfacePath;
+    if (!Core->ModuleInterfacePath.empty())
+      return Core->ModuleInterfacePath;
     // FIXME: This seems fragile, maybe store the filename separately ?
-    return ModuleInputBuffer->getBufferIdentifier();
+    return Core->ModuleInputBuffer->getBufferIdentifier();
   }
 
   StringRef getTargetTriple() const {
-    return TargetTriple;
+    return Core->TargetTriple;
   }
 
   /// AST-verify imported decls.

--- a/lib/Serialization/ModuleFileCoreTableInfo.h
+++ b/lib/Serialization/ModuleFileCoreTableInfo.h
@@ -1,0 +1,571 @@
+//===--- ModuleFileCoreTableInfo.h - Hash table info structures -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_MODULEFILECORETABLEINFO_H
+#define SWIFT_SERIALIZATION_MODULEFILECORETABLEINFO_H
+
+#include "ModuleFileSharedCore.h"
+#include "DocFormat.h"
+#include "SourceInfoFormat.h"
+#include "llvm/Support/DJB.h"
+
+namespace swift {
+
+/// Used to deserialize entries in the on-disk decl hash table.
+class ModuleFileSharedCore::DeclTableInfo {
+public:
+  using internal_key_type = std::pair<DeclBaseName::Kind, StringRef>;
+  using external_key_type = DeclBaseName;
+  using data_type = SmallVector<std::pair<uint8_t, DeclID>, 8>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    if (ID.getKind() == DeclBaseName::Kind::Normal) {
+      return {DeclBaseName::Kind::Normal, ID.getIdentifier().str()};
+    } else {
+      return {ID.getKind(), StringRef()};
+    }
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    if (key.first == DeclBaseName::Kind::Normal) {
+      return llvm::djbHash(key.second, serialization::SWIFTMODULE_HASH_SEED);
+    } else {
+      return (hash_value_type)key.first;
+    }
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return { keyLength, dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    using namespace swift::serialization;
+    using namespace llvm::support;
+    uint8_t kind = endian::readNext<uint8_t, little, unaligned>(data);
+    switch (kind) {
+    case static_cast<uint8_t>(DeclNameKind::Normal): {
+      StringRef str(reinterpret_cast<const char *>(data),
+                    length - sizeof(uint8_t));
+      return {DeclBaseName::Kind::Normal, str};
+    }
+    case static_cast<uint8_t>(DeclNameKind::Subscript):
+      return {DeclBaseName::Kind::Subscript, StringRef()};
+    case static_cast<uint8_t>(DeclNameKind::Destructor):
+      return {DeclBaseName::Kind::Destructor, StringRef()};
+    default:
+      llvm_unreachable("Unknown DeclNameKind");
+    }
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    data_type result;
+    while (length > 0) {
+      uint8_t kind = *data++;
+      DeclID offset = endian::readNext<uint32_t, little, unaligned>(data);
+      result.push_back({ kind, offset });
+      length -= 5;
+    }
+
+    return result;
+  }
+};
+
+/// Used to deserialize entries in the on-disk decl hash table.
+class ModuleFileSharedCore::ExtensionTableInfo {
+  const ModuleFileSharedCore &Core;
+public:
+  using internal_key_type = StringRef;
+  using external_key_type = Identifier;
+  using data_type = SmallVector<std::pair<StringRef, DeclID>, 8>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    return ID.str();
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    return llvm::djbHash(key, serialization::SWIFTMODULE_HASH_SEED);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return { keyLength, dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return StringRef(reinterpret_cast<const char *>(data), length);
+  }
+
+  data_type ReadData(internal_key_type key, const uint8_t *data,
+                     unsigned length) {
+    using namespace llvm::support;
+    data_type result;
+    const uint8_t *limit = data + length;
+    while (data < limit) {
+      DeclID offset = endian::readNext<uint32_t, little, unaligned>(data);
+
+      int32_t nameIDOrLength =
+          endian::readNext<int32_t, little, unaligned>(data);
+      StringRef moduleNameOrMangledBase;
+      if (nameIDOrLength < 0) {
+        StringRef moduleName = Core.getModuleNameFromID(-nameIDOrLength);
+        if (!moduleName.empty())
+          moduleNameOrMangledBase = moduleName;
+      } else {
+        moduleNameOrMangledBase =
+            StringRef(reinterpret_cast<const char *>(data), nameIDOrLength);
+        data += nameIDOrLength;
+      }
+
+      result.push_back({ moduleNameOrMangledBase, offset });
+    }
+
+    return result;
+  }
+
+  explicit ExtensionTableInfo(const ModuleFileSharedCore &core) : Core(core) {}
+};
+
+/// Used to deserialize entries in the on-disk decl hash table.
+class ModuleFileSharedCore::LocalDeclTableInfo {
+public:
+  using internal_key_type = StringRef;
+  using external_key_type = internal_key_type;
+  using data_type = DeclID;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    return ID;
+  }
+
+  external_key_type GetExternalKey(internal_key_type ID) {
+    return ID;
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    return llvm::djbHash(key, serialization::SWIFTMODULE_HASH_SEED);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return { keyLength, sizeof(uint32_t) };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return StringRef(reinterpret_cast<const char *>(data), length);
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    return endian::readNext<uint32_t, little, unaligned>(data);
+  }
+};
+
+class ModuleFileSharedCore::NestedTypeDeclsTableInfo {
+public:
+  using internal_key_type = StringRef;
+  using external_key_type = Identifier;
+  using data_type = SmallVector<std::pair<DeclID, DeclID>, 4>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    return ID.str();
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    return llvm::djbHash(key, serialization::SWIFTMODULE_HASH_SEED);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return { keyLength, dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return StringRef(reinterpret_cast<const char *>(data), length);
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    data_type result;
+    while (length > 0) {
+      DeclID parentID = endian::readNext<uint32_t, little, unaligned>(data);
+      DeclID childID = endian::readNext<uint32_t, little, unaligned>(data);
+      result.push_back({ parentID, childID });
+      length -= sizeof(uint32_t) * 2;
+    }
+
+    return result;
+  }
+};
+
+// Indexing the members of all Decls (well, NominalTypeDecls anyway) is
+// accomplished by a 2-level hashtable scheme. The outer table here maps from
+// DeclBaseNames to serialization::BitOffsets of sub-tables. The sub-tables --
+// SerializedDeclMembersTables, one table per name -- map from the enclosing
+// (NominalTypeDecl) DeclID to a vector of DeclIDs of members of the nominal
+// with the name. See DeclMembersTableInfo below.
+class ModuleFileSharedCore::DeclMemberNamesTableInfo {
+public:
+  using internal_key_type = std::pair<DeclBaseName::Kind, StringRef>;
+  using external_key_type = DeclBaseName;
+  using data_type = serialization::BitOffset;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    if (ID.getKind() == DeclBaseName::Kind::Normal) {
+      return {DeclBaseName::Kind::Normal, ID.getIdentifier().str()};
+    } else {
+      return {ID.getKind(), StringRef()};
+    }
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    if (key.first == DeclBaseName::Kind::Normal) {
+      return llvm::djbHash(key.second, serialization::SWIFTMODULE_HASH_SEED);
+    } else {
+      return (hash_value_type)key.first;
+    }
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return { keyLength, sizeof(uint32_t) };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    using namespace swift::serialization;
+    using namespace llvm::support;
+    uint8_t kind = endian::readNext<uint8_t, little, unaligned>(data);
+    switch (kind) {
+    case static_cast<uint8_t>(DeclNameKind::Normal): {
+      StringRef str(reinterpret_cast<const char *>(data),
+                    length - sizeof(uint8_t));
+      return {DeclBaseName::Kind::Normal, str};
+    }
+    case static_cast<uint8_t>(DeclNameKind::Subscript):
+      return {DeclBaseName::Kind::Subscript, StringRef()};
+    case static_cast<uint8_t>(DeclNameKind::Destructor):
+      return {DeclBaseName::Kind::Destructor, StringRef()};
+    case static_cast<uint8_t>(DeclNameKind::Constructor):
+      return {DeclBaseName::Kind::Constructor, StringRef()};
+    default:
+      llvm_unreachable("Unknown DeclNameKind");
+    }
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    assert(length == sizeof(uint32_t));
+    return endian::readNext<uint32_t, little, unaligned>(data);
+  }
+};
+
+// Second half of the 2-level member name lookup scheme, see
+// DeclMemberNamesTableInfo above. There is one of these tables for each member
+// DeclBaseName N in the module, and it maps from enclosing DeclIDs (say: each
+// NominalTypeDecl T that has members named N) to the set of N-named members of
+// T. In other words, there are no names in this table: the names are one level
+// up, this table just maps { Owner-DeclID => [Member-DeclID, ...] }.
+class ModuleFileSharedCore::DeclMembersTableInfo {
+public:
+  using internal_key_type = uint32_t;
+  using external_key_type = DeclID;
+  using data_type = SmallVector<DeclID, 2>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    return ID;
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    return llvm::hash_value(key);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return { sizeof(uint32_t), dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    using namespace llvm::support;
+    return endian::readNext<uint32_t, little, unaligned>(data);
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    data_type result;
+    while (length > 0) {
+      DeclID declID = endian::readNext<uint32_t, little, unaligned>(data);
+      result.push_back(declID);
+      length -= sizeof(uint32_t);
+    }
+    return result;
+  }
+};
+
+/// Used to deserialize entries in the on-disk Objective-C method table.
+class ModuleFileSharedCore::ObjCMethodTableInfo {
+public:
+  using internal_key_type = std::string;
+  using external_key_type = ObjCSelector;
+  using data_type = SmallVector<std::tuple<std::string, bool, DeclID>, 8>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type ID) {
+    llvm::SmallString<32> scratch;
+    return ID.getString(scratch).str();
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    return llvm::djbHash(key, serialization::SWIFTMODULE_HASH_SEED);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
+    return { keyLength, dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return std::string(reinterpret_cast<const char *>(data), length);
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    const constexpr auto recordSize = sizeof(uint32_t) + 1 + sizeof(uint32_t);
+    data_type result;
+    while (length > 0) {
+      unsigned ownerLen = endian::readNext<uint32_t, little, unaligned>(data);
+      bool isInstanceMethod = *data++ != 0;
+      DeclID methodID = endian::readNext<uint32_t, little, unaligned>(data);
+      std::string ownerName((const char *)data, ownerLen);
+      result.push_back(
+        std::make_tuple(std::move(ownerName), isInstanceMethod, methodID));
+      data += ownerLen;
+      length -= (recordSize + ownerLen);
+    }
+
+    return result;
+  }
+};
+
+/// Used to deserialize entries in the on-disk derivative function configuration
+/// table.
+class ModuleFileSharedCore::DerivativeFunctionConfigTableInfo {
+public:
+  using internal_key_type = StringRef;
+  using external_key_type = internal_key_type;
+  using data_type =
+      SmallVector<std::pair<std::string, serialization::GenericSignatureID>, 8>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  external_key_type GetExternalKey(internal_key_type ID) { return ID; }
+
+  internal_key_type GetInternalKey(external_key_type ID) { return ID; }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    return llvm::djbHash(key, serialization::SWIFTMODULE_HASH_SEED);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    return {keyLength, dataLength};
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return StringRef(reinterpret_cast<const char *>(data), length);
+  }
+
+  static data_type ReadData(internal_key_type key, const uint8_t *data,
+                            unsigned length) {
+    using namespace llvm::support;
+    data_type result;
+    const uint8_t *limit = data + length;
+    while (data < limit) {
+      DeclID genSigId = endian::readNext<uint32_t, little, unaligned>(data);
+      int32_t nameLength = endian::readNext<int32_t, little, unaligned>(data);
+      StringRef mangledName(reinterpret_cast<const char *>(data), nameLength);
+      data += nameLength;
+      result.push_back({mangledName, genSigId});
+    }
+    return result;
+  }
+};
+
+struct ModuleFileSharedCore::DeserializedCommentInfo {
+  SmallVector<SingleRawComment, 2> RawCommentStore;
+  CommentInfo Info;
+};
+
+class ModuleFileSharedCore::DeclCommentTableInfo {
+public:
+  using internal_key_type = StringRef;
+  using external_key_type = StringRef;
+  using data_type = std::unique_ptr<DeserializedCommentInfo>;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type key) {
+    return key;
+  }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    assert(!key.empty());
+    return llvm::djbHash(key, serialization::SWIFTDOC_HASH_SEED_5_1);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint32_t, little, unaligned>(data);
+    unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
+    return { keyLength, dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return StringRef(reinterpret_cast<const char *>(data), length);
+  }
+
+  data_type ReadData(internal_key_type key, const uint8_t *data,
+                     unsigned length) {
+    using namespace llvm::support;
+    data_type result = std::make_unique<DeserializedCommentInfo>();
+
+    {
+      unsigned BriefSize = endian::readNext<uint32_t, little, unaligned>(data);
+      result->Info.Brief = StringRef(reinterpret_cast<const char *>(data), BriefSize);
+      data += BriefSize;
+    }
+
+    unsigned NumComments = endian::readNext<uint32_t, little, unaligned>(data);
+
+    for (unsigned i = 0; i != NumComments; ++i) {
+      unsigned StartColumn =
+          endian::readNext<uint32_t, little, unaligned>(data);
+      unsigned RawSize = endian::readNext<uint32_t, little, unaligned>(data);
+      auto RawText = StringRef(reinterpret_cast<const char *>(data), RawSize);
+      data += RawSize;
+
+      result->RawCommentStore.emplace_back(RawText, StartColumn);
+    }
+    result->Info.Raw = RawComment(result->RawCommentStore);
+    result->Info.Group = endian::readNext<uint32_t, little, unaligned>(data);
+    result->Info.SourceOrder = endian::readNext<uint32_t, little, unaligned>(data);
+    return result;
+  }
+};
+
+class ModuleFileSharedCore::DeclUSRTableInfo {
+public:
+  using internal_key_type = StringRef;
+  using external_key_type = StringRef;
+  using data_type = uint32_t;
+  using hash_value_type = uint32_t;
+  using offset_type = unsigned;
+
+  internal_key_type GetInternalKey(external_key_type key) { return key; }
+
+  hash_value_type ComputeHash(internal_key_type key) {
+    assert(!key.empty());
+    return llvm::djbHash(key, serialization::SWIFTSOURCEINFO_HASH_SEED);
+  }
+
+  static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
+    return lhs == rhs;
+  }
+
+  static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
+    using namespace llvm::support;
+    unsigned keyLength = endian::readNext<uint32_t, little, unaligned>(data);
+    unsigned dataLength = 4;
+    return { keyLength, dataLength };
+  }
+
+  static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    return StringRef(reinterpret_cast<const char*>(data), length);
+  }
+
+  data_type ReadData(internal_key_type key, const uint8_t *data, unsigned length) {
+    using namespace llvm::support;
+    assert(length == 4);
+    return endian::readNext<uint32_t, little, unaligned>(data);
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1,0 +1,1447 @@
+//===--- ModuleFileSharedCore.cpp - Core of a serialized module -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ModuleFileSharedCore.h"
+#include "ModuleFileCoreTableInfo.h"
+#include "BCReadingExtras.h"
+#include "DeserializationErrors.h"
+#include "swift/Strings.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/OnDiskHashTable.h"
+
+using namespace swift;
+using namespace swift::serialization;
+using namespace llvm::support;
+using llvm::Expected;
+
+StringRef swift::getNameOfModule(const ModuleFileSharedCore *MF) {
+  return MF->getName();
+}
+
+static bool checkModuleSignature(llvm::BitstreamCursor &cursor,
+                                 ArrayRef<unsigned char> signature) {
+  for (unsigned char byte : signature) {
+    if (cursor.AtEndOfStream())
+      return false;
+    if (Expected<llvm::SimpleBitstreamCursor::word_t> maybeRead =
+            cursor.Read(8)) {
+      if (maybeRead.get() != byte)
+        return false;
+    } else {
+      consumeError(maybeRead.takeError());
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool enterTopLevelModuleBlock(llvm::BitstreamCursor &cursor,
+                                     unsigned ID,
+                                     bool shouldReadBlockInfo = true) {
+  Expected<llvm::BitstreamEntry> maybeNext = cursor.advance();
+  if (!maybeNext) {
+    // FIXME this drops the error on the floor.
+    consumeError(maybeNext.takeError());
+    return false;
+  }
+  llvm::BitstreamEntry next = maybeNext.get();
+
+  if (next.Kind != llvm::BitstreamEntry::SubBlock)
+    return false;
+
+  if (next.ID == llvm::bitc::BLOCKINFO_BLOCK_ID) {
+    if (shouldReadBlockInfo) {
+      if (!cursor.ReadBlockInfoBlock())
+        return false;
+    } else {
+      if (cursor.SkipBlock())
+        return false;
+    }
+    return enterTopLevelModuleBlock(cursor, ID, false);
+  }
+
+  if (next.ID != ID)
+    return false;
+
+  if (llvm::Error Err = cursor.EnterSubBlock(ID)) {
+    // FIXME this drops the error on the floor.
+    consumeError(std::move(Err));
+    return false;
+  }
+
+  return true;
+}
+
+/// Populate \p extendedInfo with the data from the options block.
+///
+/// Returns true on success.
+static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
+                             SmallVectorImpl<uint64_t> &scratch,
+                             ExtendedValidationInfo &extendedInfo) {
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      return false;
+    }
+    llvm::BitstreamEntry entry = maybeEntry.get();
+    if (entry.Kind == llvm::BitstreamEntry::EndBlock)
+      break;
+
+    if (entry.Kind == llvm::BitstreamEntry::Error)
+      return false;
+
+    if (entry.Kind == llvm::BitstreamEntry::SubBlock) {
+      // Unknown metadata sub-block, possibly for use by a future version of
+      // the module format.
+      if (cursor.SkipBlock())
+        return false;
+      continue;
+    }
+
+    scratch.clear();
+    StringRef blobData;
+    Expected<unsigned> maybeKind =
+        cursor.readRecord(entry.ID, scratch, &blobData);
+    if (!maybeKind) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeKind.takeError());
+      return false;
+    }
+    unsigned kind = maybeKind.get();
+    switch (kind) {
+    case options_block::SDK_PATH:
+      extendedInfo.setSDKPath(blobData);
+      break;
+    case options_block::XCC:
+      extendedInfo.addExtraClangImporterOption(blobData);
+      break;
+    case options_block::IS_SIB:
+      bool IsSIB;
+      options_block::IsSIBLayout::readRecord(scratch, IsSIB);
+      extendedInfo.setIsSIB(IsSIB);
+      break;
+    case options_block::IS_TESTABLE:
+      extendedInfo.setIsTestable(true);
+      break;
+    case options_block::ARE_PRIVATE_IMPORTS_ENABLED:
+      extendedInfo.setPrivateImportsEnabled(true);
+      break;
+    case options_block::IS_IMPLICIT_DYNAMIC_ENABLED:
+      extendedInfo.setImplicitDynamicEnabled(true);
+      break;
+    case options_block::RESILIENCE_STRATEGY:
+      unsigned Strategy;
+      options_block::ResilienceStrategyLayout::readRecord(scratch, Strategy);
+      extendedInfo.setResilienceStrategy(ResilienceStrategy(Strategy));
+      break;
+    default:
+      // Unknown options record, possibly for use by a future version of the
+      // module format.
+      break;
+    }
+  }
+
+  return true;
+}
+
+static ValidationInfo
+validateControlBlock(llvm::BitstreamCursor &cursor,
+                     SmallVectorImpl<uint64_t> &scratch,
+                     std::pair<uint16_t, uint16_t> expectedVersion,
+                     ExtendedValidationInfo *extendedInfo) {
+  // The control block is malformed until we've at least read a major version
+  // number.
+  ValidationInfo result;
+  bool versionSeen = false;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      result.status = Status::Malformed;
+      return result;
+    }
+    llvm::BitstreamEntry entry = maybeEntry.get();
+    if (entry.Kind == llvm::BitstreamEntry::EndBlock)
+      break;
+
+    if (entry.Kind == llvm::BitstreamEntry::Error) {
+      result.status = Status::Malformed;
+      return result;
+    }
+
+    if (entry.Kind == llvm::BitstreamEntry::SubBlock) {
+      if (entry.ID == OPTIONS_BLOCK_ID && extendedInfo) {
+        if (llvm::Error Err = cursor.EnterSubBlock(OPTIONS_BLOCK_ID)) {
+          // FIXME this drops the error on the floor.
+          consumeError(std::move(Err));
+          result.status = Status::Malformed;
+          return result;
+        }
+        if (!readOptionsBlock(cursor, scratch, *extendedInfo)) {
+          result.status = Status::Malformed;
+          return result;
+        }
+      } else {
+        // Unknown metadata sub-block, possibly for use by a future version of
+        // the module format.
+        if (cursor.SkipBlock()) {
+          result.status = Status::Malformed;
+          return result;
+        }
+      }
+      continue;
+    }
+
+    scratch.clear();
+    StringRef blobData;
+    Expected<unsigned> maybeKind =
+        cursor.readRecord(entry.ID, scratch, &blobData);
+    if (!maybeKind) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeKind.takeError());
+      result.status = Status::Malformed;
+      return result;
+    }
+    unsigned kind = maybeKind.get();
+    switch (kind) {
+    case control_block::METADATA: {
+      if (versionSeen) {
+        result.status = Status::Malformed;
+        break;
+      }
+
+      uint16_t versionMajor = scratch[0];
+      if (versionMajor > expectedVersion.first)
+        result.status = Status::FormatTooNew;
+      else if (versionMajor < expectedVersion.first)
+        result.status = Status::FormatTooOld;
+      else
+        result.status = Status::Valid;
+
+      // Major version 0 does not have stable minor versions.
+      if (versionMajor == 0) {
+        uint16_t versionMinor = scratch[1];
+        if (versionMinor != expectedVersion.second) {
+          if (versionMinor < expectedVersion.second)
+            result.status = Status::FormatTooOld;
+          else
+            result.status = Status::FormatTooNew;
+        }
+      }
+
+      // These fields were added later; be resilient against their absence.
+      switch (scratch.size()) {
+      default:
+        // Add new cases here, in descending order.
+      case 4:
+        if (scratch[3] != 0) {
+          result.compatibilityVersion =
+            version::Version(blobData.substr(scratch[2]+1, scratch[3]),
+                             SourceLoc(), nullptr);
+        }
+        LLVM_FALLTHROUGH;
+      case 3:
+        result.shortVersion = blobData.slice(0, scratch[2]);
+        LLVM_FALLTHROUGH;
+      case 2:
+      case 1:
+      case 0:
+        break;
+      }
+
+      result.miscVersion = blobData;
+      versionSeen = true;
+      break;
+    }
+    case control_block::MODULE_NAME:
+      result.name = blobData;
+      break;
+    case control_block::TARGET:
+      result.targetTriple = blobData;
+      break;
+    default:
+      // Unknown metadata record, possibly for use by a future version of the
+      // module format.
+      break;
+    }
+  }
+
+  return result;
+}
+
+static bool validateInputBlock(
+    llvm::BitstreamCursor &cursor, SmallVectorImpl<uint64_t> &scratch,
+    SmallVectorImpl<SerializationOptions::FileDependency> &dependencies) {
+  SmallVector<StringRef, 4> dependencyDirectories;
+  SmallString<256> dependencyFullPathBuffer;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      return true;
+    }
+    llvm::BitstreamEntry entry = maybeEntry.get();
+    if (entry.Kind == llvm::BitstreamEntry::EndBlock)
+      break;
+
+    if (entry.Kind == llvm::BitstreamEntry::Error)
+      return true;
+
+    scratch.clear();
+    StringRef blobData;
+    Expected<unsigned> maybeKind =
+        cursor.readRecord(entry.ID, scratch, &blobData);
+    if (!maybeKind) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeKind.takeError());
+      return true;
+    }
+    unsigned kind = maybeKind.get();
+    switch (kind) {
+    case input_block::FILE_DEPENDENCY: {
+      bool isHashBased = scratch[2] != 0;
+      bool isSDKRelative = scratch[3] != 0;
+
+      StringRef path = blobData;
+      size_t directoryIndex = scratch[4];
+      if (directoryIndex != 0) {
+        if (directoryIndex > dependencyDirectories.size())
+          return true;
+        dependencyFullPathBuffer = dependencyDirectories[directoryIndex-1];
+        llvm::sys::path::append(dependencyFullPathBuffer, blobData);
+        path = dependencyFullPathBuffer;
+      }
+
+      if (isHashBased) {
+        dependencies.push_back(
+          SerializationOptions::FileDependency::hashBased(
+            path, isSDKRelative, scratch[0], scratch[1]));
+      } else {
+        dependencies.push_back(
+          SerializationOptions::FileDependency::modTimeBased(
+            path, isSDKRelative, scratch[0], scratch[1]));
+      }
+      break;
+    }
+    case input_block::DEPENDENCY_DIRECTORY:
+      dependencyDirectories.push_back(blobData);
+      break;
+    default:
+      // Unknown metadata record, possibly for use by a future version of the
+      // module format.
+      break;
+    }
+  }
+  return false;
+}
+
+
+bool serialization::isSerializedAST(StringRef data) {
+  StringRef signatureStr(reinterpret_cast<const char *>(SWIFTMODULE_SIGNATURE),
+                         llvm::array_lengthof(SWIFTMODULE_SIGNATURE));
+  return data.startswith(signatureStr);
+}
+
+ValidationInfo serialization::validateSerializedAST(
+    StringRef data,
+    ExtendedValidationInfo *extendedInfo,
+    SmallVectorImpl<SerializationOptions::FileDependency> *dependencies) {
+  ValidationInfo result;
+
+  // Check 32-bit alignment.
+  if (data.size() % SWIFTMODULE_ALIGNMENT != 0 ||
+      reinterpret_cast<uintptr_t>(data.data()) % SWIFTMODULE_ALIGNMENT != 0)
+    return result;
+
+  llvm::BitstreamCursor cursor(data);
+  SmallVector<uint64_t, 32> scratch;
+
+  if (!checkModuleSignature(cursor, SWIFTMODULE_SIGNATURE) ||
+      !enterTopLevelModuleBlock(cursor, MODULE_BLOCK_ID, false))
+    return result;
+
+  llvm::BitstreamEntry topLevelEntry;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry =
+        cursor.advance(AF_DontPopBlockAtEnd);
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      result.status = Status::Malformed;
+      return result;
+    }
+    topLevelEntry = maybeEntry.get();
+    if (topLevelEntry.Kind != llvm::BitstreamEntry::SubBlock)
+      break;
+
+    if (topLevelEntry.ID == CONTROL_BLOCK_ID) {
+      if (llvm::Error Err = cursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        result.status = Status::Malformed;
+        return result;
+      }
+      result = validateControlBlock(cursor, scratch,
+                                    {SWIFTMODULE_VERSION_MAJOR,
+                                     SWIFTMODULE_VERSION_MINOR},
+                                    extendedInfo);
+      if (result.status == Status::Malformed)
+        return result;
+    } else if (dependencies &&
+               result.status == Status::Valid &&
+               topLevelEntry.ID == INPUT_BLOCK_ID) {
+      if (llvm::Error Err = cursor.EnterSubBlock(INPUT_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        result.status = Status::Malformed;
+        return result;
+      }
+      if (validateInputBlock(cursor, scratch, *dependencies)) {
+        result.status = Status::Malformed;
+        return result;
+      }
+    } else {
+      if (cursor.SkipBlock()) {
+        result.status = Status::Malformed;
+        return result;
+      }
+    }
+  }
+
+  if (topLevelEntry.Kind == llvm::BitstreamEntry::EndBlock) {
+    cursor.ReadBlockEnd();
+    assert(cursor.GetCurrentBitNo() % CHAR_BIT == 0);
+    result.bytes = cursor.GetCurrentBitNo() / CHAR_BIT;
+  } else {
+    result.status = Status::Malformed;
+  }
+
+  return result;
+}
+
+std::string ModuleFileSharedCore::Dependency::getPrettyPrintedPath() const {
+  StringRef pathWithoutScope = RawPath;
+  if (isScoped()) {
+    size_t splitPoint = pathWithoutScope.find_last_of('\0');
+    pathWithoutScope = pathWithoutScope.slice(0, splitPoint);
+  }
+  std::string output = pathWithoutScope.str();
+  std::replace(output.begin(), output.end(), '\0', '.');
+  return output;
+}
+
+void ModuleFileSharedCore::fatal(llvm::Error error) {
+  logAllUnhandledErrors(std::move(error), llvm::errs(),
+                        "\n*** DESERIALIZATION FAILURE (please include this "
+                        "section in any bug report) ***\n");
+  abort();
+}
+
+ModuleFileSharedCore::~ModuleFileSharedCore() { }
+
+std::unique_ptr<ModuleFileSharedCore::SerializedDeclTable>
+ModuleFileSharedCore::readDeclTable(ArrayRef<uint64_t> fields,
+                              StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::DeclListLayout::readRecord(fields, tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedDeclTable>;
+  return OwnedTable(SerializedDeclTable::Create(base + tableOffset,
+                                                base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedExtensionTable>
+ModuleFileSharedCore::readExtensionTable(ArrayRef<uint64_t> fields,
+                                   StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::DeclListLayout::readRecord(fields, tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedExtensionTable>;
+  return OwnedTable(SerializedExtensionTable::Create(base + tableOffset,
+    base + sizeof(uint32_t), base, ExtensionTableInfo(*this)));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedLocalDeclTable>
+ModuleFileSharedCore::readLocalDeclTable(ArrayRef<uint64_t> fields,
+                                   StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::DeclListLayout::readRecord(fields, tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedLocalDeclTable>;
+  return OwnedTable(SerializedLocalDeclTable::Create(base + tableOffset,
+    base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedNestedTypeDeclsTable>
+ModuleFileSharedCore::readNestedTypeDeclsTable(ArrayRef<uint64_t> fields,
+                                     StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::NestedTypeDeclsLayout::readRecord(fields, tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedNestedTypeDeclsTable>;
+  return OwnedTable(SerializedNestedTypeDeclsTable::Create(base + tableOffset,
+      base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedDeclMemberNamesTable>
+ModuleFileSharedCore::readDeclMemberNamesTable(ArrayRef<uint64_t> fields,
+                                     StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::DeclMemberNamesLayout::readRecord(fields, tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedDeclMemberNamesTable>;
+  return OwnedTable(SerializedDeclMemberNamesTable::Create(base + tableOffset,
+      base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedDeclMembersTable>
+ModuleFileSharedCore::readDeclMembersTable(ArrayRef<uint64_t> fields,
+                                     StringRef blobData) const {
+  uint32_t tableOffset;
+  decl_member_tables_block::DeclMembersLayout::readRecord(fields,
+                                                          tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedDeclMembersTable>;
+  return OwnedTable(SerializedDeclMembersTable::Create(base + tableOffset,
+      base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedObjCMethodTable>
+ModuleFileSharedCore::readObjCMethodTable(ArrayRef<uint64_t> fields,
+                                    StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::ObjCMethodTableLayout::readRecord(fields, tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedObjCMethodTable>;
+  return OwnedTable(
+           SerializedObjCMethodTable::Create(base + tableOffset,
+                                             base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedDerivativeFunctionConfigTable>
+ModuleFileSharedCore::readDerivativeFunctionConfigTable(
+    ArrayRef<uint64_t> fields, StringRef blobData) const {
+  uint32_t tableOffset;
+  index_block::DerivativeFunctionConfigTableLayout::readRecord(fields,
+                                                               tableOffset);
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  using OwnedTable = std::unique_ptr<SerializedDerivativeFunctionConfigTable>;
+  return OwnedTable(SerializedDerivativeFunctionConfigTable::Create(
+      base + tableOffset, base + sizeof(uint32_t), base));
+}
+
+bool ModuleFileSharedCore::readIndexBlock(llvm::BitstreamCursor &cursor) {
+  if (llvm::Error Err = cursor.EnterSubBlock(INDEX_BLOCK_ID)) {
+    // FIXME this drops the error on the floor.
+    consumeError(std::move(Err));
+    return false;
+  }
+
+  SmallVector<uint64_t, 4> scratch;
+  StringRef blobData;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      return false;
+    }
+    llvm::BitstreamEntry entry = maybeEntry.get();
+    switch (entry.Kind) {
+    case llvm::BitstreamEntry::EndBlock:
+      return true;
+
+    case llvm::BitstreamEntry::Error:
+      return false;
+
+    case llvm::BitstreamEntry::SubBlock:
+      if (entry.ID == DECL_MEMBER_TABLES_BLOCK_ID) {
+        DeclMemberTablesCursor = cursor;
+        if (llvm::Error Err = DeclMemberTablesCursor.EnterSubBlock(
+                DECL_MEMBER_TABLES_BLOCK_ID)) {
+          // FIXME this drops the error on the floor.
+          consumeError(std::move(Err));
+          return false;
+        }
+        llvm::BitstreamEntry subentry;
+        do {
+          // Scan forward, to load the cursor with any abbrevs we'll need while
+          // seeking inside this block later.
+          Expected<llvm::BitstreamEntry> maybeEntry =
+              DeclMemberTablesCursor.advance(
+                  llvm::BitstreamCursor::AF_DontPopBlockAtEnd);
+          if (!maybeEntry) {
+            // FIXME this drops the error on the floor.
+            consumeError(maybeEntry.takeError());
+            return false;
+          }
+          subentry = maybeEntry.get();
+        } while (!DeclMemberTablesCursor.AtEndOfStream() &&
+                 subentry.Kind != llvm::BitstreamEntry::Record &&
+                 subentry.Kind != llvm::BitstreamEntry::EndBlock);
+      }
+      if (cursor.SkipBlock())
+        return false;
+      break;
+
+    case llvm::BitstreamEntry::Record:
+      scratch.clear();
+      blobData = {};
+      Expected<unsigned> maybeKind =
+          cursor.readRecord(entry.ID, scratch, &blobData);
+      if (!maybeKind) {
+        // FIXME this drops the error on the floor.
+        consumeError(maybeKind.takeError());
+        return false;
+      }
+      unsigned kind = maybeKind.get();
+
+      switch (kind) {
+      case index_block::DECL_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(Decls, scratch);
+        break;
+      case index_block::TYPE_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(Types, scratch);
+        break;
+      case index_block::CLANG_TYPE_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(ClangTypes, scratch);
+        break;
+      case index_block::IDENTIFIER_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(Identifiers, scratch);
+        break;
+      case index_block::TOP_LEVEL_DECLS:
+        TopLevelDecls = readDeclTable(scratch, blobData);
+        break;
+      case index_block::OPERATORS:
+        OperatorDecls = readDeclTable(scratch, blobData);
+        break;
+      case index_block::PRECEDENCE_GROUPS:
+        PrecedenceGroupDecls = readDeclTable(scratch, blobData);
+        break;
+      case index_block::EXTENSIONS:
+        ExtensionDecls = readExtensionTable(scratch, blobData);
+        break;
+      case index_block::CLASS_MEMBERS_FOR_DYNAMIC_LOOKUP:
+        ClassMembersForDynamicLookup = readDeclTable(scratch, blobData);
+        break;
+      case index_block::OPERATOR_METHODS:
+        OperatorMethodDecls = readDeclTable(scratch, blobData);
+        break;
+      case index_block::OBJC_METHODS:
+        ObjCMethods = readObjCMethodTable(scratch, blobData);
+        break;
+      case index_block::DERIVATIVE_FUNCTION_CONFIGURATIONS:
+        DerivativeFunctionConfigurations =
+            readDerivativeFunctionConfigTable(scratch, blobData);
+        break;
+      case index_block::ENTRY_POINT:
+        assert(blobData.empty());
+        setEntryPointClassID(scratch.front());
+        break;
+      case index_block::ORDERED_TOP_LEVEL_DECLS:
+        allocateBuffer(OrderedTopLevelDecls, scratch);
+        break;
+      case index_block::LOCAL_TYPE_DECLS:
+        LocalTypeDecls = readLocalDeclTable(scratch, blobData);
+        break;
+      case index_block::OPAQUE_RETURN_TYPE_DECLS:
+        OpaqueReturnTypeDecls = readLocalDeclTable(scratch, blobData);
+        break;
+      case index_block::NESTED_TYPE_DECLS:
+        NestedTypeDecls = readNestedTypeDeclsTable(scratch, blobData);
+        break;
+      case index_block::DECL_MEMBER_NAMES:
+        DeclMemberNames = readDeclMemberNamesTable(scratch, blobData);
+        break;
+      case index_block::LOCAL_DECL_CONTEXT_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(LocalDeclContexts, scratch);
+        break;
+      case index_block::GENERIC_SIGNATURE_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(GenericSignatures, scratch);
+        break;
+      case index_block::SUBSTITUTION_MAP_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(SubstitutionMaps, scratch);
+        break;
+      case index_block::NORMAL_CONFORMANCE_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(NormalConformances, scratch);
+        break;
+      case index_block::SIL_LAYOUT_OFFSETS:
+        assert(blobData.empty());
+        allocateBuffer(SILLayouts, scratch);
+        break;
+
+      default:
+        // Unknown index kind, which this version of the compiler won't use.
+        break;
+      }
+      break;
+    }
+  }
+
+  return false;
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedDeclCommentTable>
+ModuleFileSharedCore::readDeclCommentTable(ArrayRef<uint64_t> fields,
+                                 StringRef blobData) const {
+  if (fields.empty() || blobData.empty())
+    return nullptr;
+  uint32_t tableOffset = static_cast<uint32_t>(fields.front());
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+
+  return std::unique_ptr<SerializedDeclCommentTable>(
+    SerializedDeclCommentTable::Create(base + tableOffset,
+                                       base + sizeof(uint32_t), base));
+}
+
+std::unique_ptr<ModuleFileSharedCore::GroupNameTable>
+ModuleFileSharedCore::readGroupTable(ArrayRef<uint64_t> Fields,
+                                     StringRef BlobData) const {
+  auto pMap = std::make_unique<llvm::DenseMap<unsigned, StringRef>>();
+  auto Data = reinterpret_cast<const uint8_t *>(BlobData.data());
+  unsigned GroupCount = endian::readNext<uint32_t, little, unaligned>(Data);
+  for (unsigned I = 0; I < GroupCount; ++I) {
+    auto RawSize = endian::readNext<uint32_t, little, unaligned>(Data);
+    auto RawText = StringRef(reinterpret_cast<const char *>(Data), RawSize);
+    Data += RawSize;
+    (*pMap)[I] = RawText;
+  }
+  return std::unique_ptr<ModuleFileSharedCore::GroupNameTable>(pMap.release());
+}
+
+bool ModuleFileSharedCore::readCommentBlock(llvm::BitstreamCursor &cursor) {
+  if (llvm::Error Err = cursor.EnterSubBlock(COMMENT_BLOCK_ID)) {
+    // FIXME this drops the error on the floor.
+    consumeError(std::move(Err));
+    return false;
+  }
+
+  SmallVector<uint64_t, 4> scratch;
+  StringRef blobData;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry = cursor.advance();
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      return false;
+    }
+    llvm::BitstreamEntry entry = maybeEntry.get();
+    switch (entry.Kind) {
+    case llvm::BitstreamEntry::EndBlock:
+      return true;
+
+    case llvm::BitstreamEntry::Error:
+      return false;
+
+    case llvm::BitstreamEntry::SubBlock:
+      // Unknown sub-block, which this version of the compiler won't use.
+      if (cursor.SkipBlock())
+        return false;
+      break;
+
+    case llvm::BitstreamEntry::Record:
+      scratch.clear();
+      Expected<unsigned> maybeKind =
+          cursor.readRecord(entry.ID, scratch, &blobData);
+      if (!maybeKind) {
+        // FIXME this drops the error on the floor.
+        consumeError(maybeKind.takeError());
+        return false;
+      }
+      unsigned kind = maybeKind.get();
+
+      switch (kind) {
+      case comment_block::DECL_COMMENTS:
+        DeclCommentTable = readDeclCommentTable(scratch, blobData);
+        break;
+      case comment_block::GROUP_NAMES:
+        GroupNamesMap = readGroupTable(scratch, blobData);
+        break;
+      default:
+        // Unknown index kind, which this version of the compiler won't use.
+        break;
+      }
+      break;
+    }
+  }
+
+  return false;
+}
+
+static Optional<swift::LibraryKind> getActualLibraryKind(unsigned rawKind) {
+  auto stableKind = static_cast<serialization::LibraryKind>(rawKind);
+  if (stableKind != rawKind)
+    return None;
+
+  switch (stableKind) {
+  case serialization::LibraryKind::Library:
+    return swift::LibraryKind::Library;
+  case serialization::LibraryKind::Framework:
+    return swift::LibraryKind::Framework;
+  }
+
+  // If there's a new case value in the module file, ignore it.
+  return None;
+}
+
+static Optional<ModuleDecl::ImportFilterKind>
+getActualImportControl(unsigned rawValue) {
+  // We switch on the raw value rather than the enum in order to handle future
+  // values.
+  switch (rawValue) {
+  case static_cast<unsigned>(serialization::ImportControl::Normal):
+    return ModuleDecl::ImportFilterKind::Private;
+  case static_cast<unsigned>(serialization::ImportControl::Exported):
+    return ModuleDecl::ImportFilterKind::Public;
+  case static_cast<unsigned>(serialization::ImportControl::ImplementationOnly):
+    return ModuleDecl::ImportFilterKind::ImplementationOnly;
+  default:
+    return None;
+  }
+}
+
+bool ModuleFileSharedCore::readModuleDocIfPresent() {
+  if (!this->ModuleDocInputBuffer)
+    return true;
+
+  llvm::BitstreamCursor docCursor{ModuleDocInputBuffer->getMemBufferRef()};
+  if (!checkModuleSignature(docCursor, SWIFTDOC_SIGNATURE) ||
+      !enterTopLevelModuleBlock(docCursor, MODULE_DOC_BLOCK_ID)) {
+    return false;
+  }
+
+  SmallVector<uint64_t, 64> scratch;
+  llvm::BitstreamEntry topLevelEntry;
+
+  bool hasValidControlBlock = false;
+  ValidationInfo info;
+
+  while (!docCursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry =
+        docCursor.advance(AF_DontPopBlockAtEnd);
+    if (!maybeEntry) {
+      // FIXME this drops the error on the floor.
+      consumeError(maybeEntry.takeError());
+      return false;
+    }
+    topLevelEntry = maybeEntry.get();
+    if (topLevelEntry.Kind != llvm::BitstreamEntry::SubBlock)
+      break;
+
+    switch (topLevelEntry.ID) {
+    case CONTROL_BLOCK_ID: {
+      if (llvm::Error Err = docCursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        return false;
+      }
+
+      info = validateControlBlock(docCursor, scratch,
+                                  {SWIFTDOC_VERSION_MAJOR,
+                                   SWIFTDOC_VERSION_MINOR},
+                                  /*extendedInfo*/nullptr);
+      if (info.status != Status::Valid)
+        return false;
+      // Check that the swiftdoc is actually for this module.
+      if (info.name != Name)
+        return false;
+      hasValidControlBlock = true;
+      break;
+    }
+
+    case COMMENT_BLOCK_ID: {
+      if (!hasValidControlBlock || !readCommentBlock(docCursor))
+        return false;
+      break;
+    }
+
+    default:
+      // Unknown top-level block, possibly for use by a future version of the
+      // module format.
+      if (docCursor.SkipBlock())
+        return false;
+      break;
+    }
+  }
+
+  if (topLevelEntry.Kind != llvm::BitstreamEntry::EndBlock)
+    return false;
+
+  return true;
+}
+
+std::unique_ptr<ModuleFileSharedCore::SerializedDeclUSRTable>
+ModuleFileSharedCore::readDeclUSRsTable(ArrayRef<uint64_t> fields,
+                                  StringRef blobData) const {
+  if (fields.empty() || blobData.empty())
+    return nullptr;
+  uint32_t tableOffset = static_cast<uint32_t>(fields.front());
+  auto base = reinterpret_cast<const uint8_t *>(blobData.data());
+  return std::unique_ptr<SerializedDeclUSRTable>(
+    SerializedDeclUSRTable::Create(base + tableOffset, base + sizeof(uint32_t),
+                                   base));
+}
+
+bool ModuleFileSharedCore::readDeclLocsBlock(llvm::BitstreamCursor &cursor) {
+  if (llvm::Error Err = cursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
+    consumeError(std::move(Err));
+    return false;
+  }
+
+  SmallVector<uint64_t, 4> scratch;
+  StringRef blobData;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> entry = cursor.advance();
+    if (!entry) {
+      consumeError(entry.takeError());
+      return false;
+    }
+    switch (entry->Kind) {
+    case llvm::BitstreamEntry::EndBlock:
+      return true;
+
+    case llvm::BitstreamEntry::Error:
+      return false;
+
+    case llvm::BitstreamEntry::SubBlock:
+      // Unknown sub-block, which this version of the compiler won't use.
+      if (cursor.SkipBlock())
+        return false;
+      break;
+
+    case llvm::BitstreamEntry::Record:
+      scratch.clear();
+      Expected<unsigned> kind =
+          cursor.readRecord(entry->ID, scratch, &blobData);
+      if (!kind) {
+        consumeError(kind.takeError());
+        return false;
+      }
+      switch (*kind) {
+      case decl_locs_block::BASIC_DECL_LOCS:
+        BasicDeclLocsData = blobData;
+        break;
+      case decl_locs_block::TEXT_DATA:
+        SourceLocsTextData = blobData;
+        break;
+      case decl_locs_block::DECL_USRS:
+        DeclUSRsTable = readDeclUSRsTable(scratch, blobData);
+        break;
+      case decl_locs_block::DOC_RANGES:
+        DocRangesData = blobData;
+        break;
+      default:
+        // Unknown index kind, which this version of the compiler won't use.
+        break;
+      }
+      break;
+    }
+  }
+
+  return false;
+}
+
+bool ModuleFileSharedCore::readModuleSourceInfoIfPresent() {
+  if (!this->ModuleSourceInfoInputBuffer)
+    return true;
+
+  llvm::BitstreamCursor infoCursor{
+      ModuleSourceInfoInputBuffer->getMemBufferRef()};
+  if (!checkModuleSignature(infoCursor, SWIFTSOURCEINFO_SIGNATURE) ||
+      !enterTopLevelModuleBlock(infoCursor, MODULE_SOURCEINFO_BLOCK_ID)) {
+    return false;
+  }
+
+  SmallVector<uint64_t, 64> scratch;
+
+  bool hasValidControlBlock = false;
+  ValidationInfo info;
+  unsigned kind = llvm::BitstreamEntry::Error;
+
+  while (!infoCursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> topLevelEntry =
+        infoCursor.advance(AF_DontPopBlockAtEnd);
+    if (!topLevelEntry) {
+      consumeError(topLevelEntry.takeError());
+      return false;
+    }
+    kind = topLevelEntry->Kind;
+    if (kind != llvm::BitstreamEntry::SubBlock)
+      break;
+
+    switch (topLevelEntry->ID) {
+    case CONTROL_BLOCK_ID: {
+      if (llvm::Error Err = infoCursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
+        consumeError(std::move(Err));
+        return false;
+      }
+      info = validateControlBlock(infoCursor, scratch,
+                                  {SWIFTSOURCEINFO_VERSION_MAJOR,
+                                   SWIFTSOURCEINFO_VERSION_MINOR},
+                                  /*extendedInfo*/nullptr);
+      if (info.status != Status::Valid)
+        return false;
+      // Check that the swiftsourceinfo is actually for this module.
+      if (info.name != Name)
+        return false;
+      hasValidControlBlock = true;
+      break;
+    }
+
+    case DECL_LOCS_BLOCK_ID: {
+      if (!hasValidControlBlock || !readDeclLocsBlock(infoCursor))
+        return false;
+      break;
+    }
+
+    default:
+      // Unknown top-level block, possibly for use by a future version of the
+      // module format.
+      if (infoCursor.SkipBlock())
+        return false;
+      break;
+    }
+  }
+
+  if (kind != llvm::BitstreamEntry::EndBlock)
+    return false;
+
+  return true;
+}
+
+StringRef ModuleFileSharedCore::getModuleNameFromID(ModuleID MID) const {
+  if (MID < NUM_SPECIAL_IDS) {
+    switch (static_cast<SpecialIdentifierID>(static_cast<uint8_t>(MID))) {
+    case BUILTIN_MODULE_ID:
+      return BUILTIN_NAME;
+    case CURRENT_MODULE_ID:
+      return Name;
+    case OBJC_HEADER_MODULE_ID:
+      return CLANG_HEADER_MODULE_NAME;
+    case SUBSCRIPT_ID:
+    case CONSTRUCTOR_ID:
+    case DESTRUCTOR_ID:
+      llvm_unreachable("Modules cannot be named with special names");
+    case NUM_SPECIAL_IDS:
+      llvm_unreachable("implementation detail only");
+    }
+  }
+  return getIdentifierText(MID);
+}
+
+StringRef ModuleFileSharedCore::getIdentifierText(IdentifierID IID) const {
+  if (IID == 0)
+    return StringRef();
+
+  assert(IID >= NUM_SPECIAL_IDS);
+
+  size_t rawID = IID - NUM_SPECIAL_IDS;
+  assert(rawID < Identifiers.size() && "invalid identifier ID");
+  auto offset = Identifiers[rawID];
+
+  assert(!IdentifierData.empty() && "no identifier data in module");
+
+  StringRef rawStrPtr = IdentifierData.substr(offset);
+  size_t terminatorOffset = rawStrPtr.find('\0');
+  assert(terminatorOffset != StringRef::npos &&
+         "unterminated identifier string data");
+  return rawStrPtr.slice(0, terminatorOffset);
+}
+
+ModuleFileSharedCore::ModuleFileSharedCore(
+    std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
+    bool isFramework, serialization::ValidationInfo &info,
+    serialization::ExtendedValidationInfo *extInfo)
+    : ModuleInputBuffer(std::move(moduleInputBuffer)),
+      ModuleDocInputBuffer(std::move(moduleDocInputBuffer)),
+      ModuleSourceInfoInputBuffer(std::move(moduleSourceInfoInputBuffer)) {
+  assert(!hasError());
+  Bits.IsFramework = isFramework;
+
+  PrettyStackTraceModuleFileCore stackEntry(*this);
+
+  llvm::BitstreamCursor cursor{ModuleInputBuffer->getMemBufferRef()};
+
+  if (!checkModuleSignature(cursor, SWIFTMODULE_SIGNATURE) ||
+      !enterTopLevelModuleBlock(cursor, MODULE_BLOCK_ID)) {
+    info.status = error(Status::Malformed);
+    return;
+  }
+
+  // Future-proofing: make sure we validate the control block before we try to
+  // read any other blocks.
+  bool hasValidControlBlock = false;
+  SmallVector<uint64_t, 64> scratch;
+
+  llvm::BitstreamEntry topLevelEntry;
+
+  while (!cursor.AtEndOfStream()) {
+    Expected<llvm::BitstreamEntry> maybeEntry =
+        cursor.advance(AF_DontPopBlockAtEnd);
+    if (!maybeEntry) {
+      // FIXME this drops the error diagnostic on the floor.
+      consumeError(maybeEntry.takeError());
+      info.status = error(Status::Malformed);
+      return;
+    }
+    topLevelEntry = maybeEntry.get();
+    if (topLevelEntry.Kind != llvm::BitstreamEntry::SubBlock)
+      break;
+
+    switch (topLevelEntry.ID) {
+    case CONTROL_BLOCK_ID: {
+      if (llvm::Error Err = cursor.EnterSubBlock(CONTROL_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      info = validateControlBlock(cursor, scratch,
+                                  {SWIFTMODULE_VERSION_MAJOR,
+                                   SWIFTMODULE_VERSION_MINOR},
+                                  extInfo);
+      if (info.status != Status::Valid) {
+        error(info.status);
+        return;
+      }
+      Name = info.name;
+      TargetTriple = info.targetTriple;
+      CompatibilityVersion = info.compatibilityVersion;
+      IsSIB = extInfo->isSIB();
+      MiscVersion = info.miscVersion;
+
+      hasValidControlBlock = true;
+      break;
+    }
+
+    case INPUT_BLOCK_ID: {
+      if (!hasValidControlBlock) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      if (llvm::Error Err = cursor.EnterSubBlock(INPUT_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      Expected<llvm::BitstreamEntry> maybeNext = cursor.advance();
+      if (!maybeNext) {
+        // FIXME this drops the error on the floor.
+        consumeError(maybeNext.takeError());
+        info.status = error(Status::Malformed);
+        return;
+      }
+      llvm::BitstreamEntry next = maybeNext.get();
+      while (next.Kind == llvm::BitstreamEntry::Record) {
+        scratch.clear();
+        StringRef blobData;
+        Expected<unsigned> maybeKind =
+            cursor.readRecord(next.ID, scratch, &blobData);
+        if (!maybeKind) {
+          // FIXME this drops the error on the floor.
+          consumeError(maybeKind.takeError());
+          info.status = error(Status::Malformed);
+          return;
+        }
+        unsigned kind = maybeKind.get();
+        switch (kind) {
+        case input_block::IMPORTED_MODULE: {
+          unsigned rawImportControl;
+          bool scoped;
+          bool hasSPI;
+          input_block::ImportedModuleLayout::readRecord(scratch,
+                                                        rawImportControl,
+                                                        scoped, hasSPI);
+          auto importKind = getActualImportControl(rawImportControl);
+          if (!importKind) {
+            // We don't know how to import this dependency.
+            info.status = error(Status::Malformed);
+            return;
+          }
+
+          StringRef spiBlob;
+          if (hasSPI) {
+            scratch.clear();
+
+            llvm::BitstreamEntry entry =
+                fatalIfUnexpected(cursor.advance(AF_DontPopBlockAtEnd));
+            unsigned recordID = fatalIfUnexpected(
+                cursor.readRecord(entry.ID, scratch, &spiBlob));
+            assert(recordID == input_block::IMPORTED_MODULE_SPIS);
+            input_block::ImportedModuleLayoutSPI::readRecord(scratch);
+            (void) recordID;
+          } else {
+            spiBlob = StringRef();
+          }
+
+          Dependencies.push_back(
+              {blobData, spiBlob, importKind.getValue(), scoped});
+          break;
+        }
+        case input_block::LINK_LIBRARY: {
+          uint8_t rawKind;
+          bool shouldForceLink;
+          input_block::LinkLibraryLayout::readRecord(scratch, rawKind,
+                                                     shouldForceLink);
+          if (auto libKind = getActualLibraryKind(rawKind))
+            LinkLibraries.push_back({blobData, *libKind, shouldForceLink});
+          // else ignore the dependency...it'll show up as a linker error.
+          break;
+        }
+        case input_block::IMPORTED_HEADER: {
+          assert(!importedHeaderInfo.fileSize && "only one header allowed");
+          bool exported;
+          input_block::ImportedHeaderLayout::readRecord(scratch,
+            exported, importedHeaderInfo.fileSize,
+            importedHeaderInfo.fileModTime);
+          Dependencies.push_back(Dependency::forHeader(blobData, exported));
+          break;
+        }
+        case input_block::IMPORTED_HEADER_CONTENTS: {
+          assert(Dependencies.back().isHeader() && "must follow header record");
+          assert(importedHeaderInfo.contents.empty() &&
+                 "contents seen already");
+          importedHeaderInfo.contents = blobData;
+          break;
+        }
+        case input_block::SEARCH_PATH: {
+          bool isFramework;
+          bool isSystem;
+          input_block::SearchPathLayout::readRecord(scratch, isFramework,
+                                                    isSystem);
+          SearchPaths.push_back({blobData, isFramework, isSystem});
+          break;
+        }
+        case input_block::MODULE_INTERFACE_PATH: {
+          ModuleInterfacePath = blobData;
+          break;
+        }
+        default:
+          // Unknown input kind, possibly for use by a future version of the
+          // module format.
+          // FIXME: Should we warn about this?
+          break;
+        }
+
+        maybeNext = cursor.advance();
+        if (!maybeNext) {
+          // FIXME this drops the error on the floor.
+          consumeError(maybeNext.takeError());
+          info.status = error(Status::Malformed);
+          return;
+        }
+        next = maybeNext.get();
+      }
+
+      if (next.Kind != llvm::BitstreamEntry::EndBlock)
+        info.status = error(Status::Malformed);
+
+      break;
+    }
+
+    case DECLS_AND_TYPES_BLOCK_ID: {
+      if (!hasValidControlBlock) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      // The decls-and-types block is lazily loaded. Save the cursor and load
+      // any abbrev records at the start of the block.
+      DeclTypeCursor = cursor;
+      if (llvm::Error Err =
+              DeclTypeCursor.EnterSubBlock(DECLS_AND_TYPES_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      Expected<llvm::BitstreamEntry> maybeCursor = DeclTypeCursor.advance();
+      if (!maybeCursor) {
+        // FIXME this drops the error on the floor.
+        consumeError(maybeCursor.takeError());
+        info.status = error(Status::Malformed);
+        return;
+      }
+      if (maybeCursor.get().Kind == llvm::BitstreamEntry::Error)
+        info.status = error(Status::Malformed);
+
+      // With the main cursor, skip over the block and continue.
+      if (cursor.SkipBlock()) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+      break;
+    }
+
+    case IDENTIFIER_DATA_BLOCK_ID: {
+      if (!hasValidControlBlock) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      if (llvm::Error Err = cursor.EnterSubBlock(IDENTIFIER_DATA_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      Expected<llvm::BitstreamEntry> maybeNext =
+          cursor.advanceSkippingSubblocks();
+      if (!maybeNext) {
+        // FIXME this drops the error on the floor.
+        consumeError(maybeNext.takeError());
+        info.status = error(Status::Malformed);
+        return;
+      }
+      llvm::BitstreamEntry next = maybeNext.get();
+      while (next.Kind == llvm::BitstreamEntry::Record) {
+        scratch.clear();
+        StringRef blobData;
+        Expected<unsigned> maybeKind =
+            cursor.readRecord(next.ID, scratch, &blobData);
+        if (!maybeKind) {
+          // FIXME this drops the error on the floor.
+          consumeError(maybeKind.takeError());
+          info.status = error(Status::Malformed);
+          return;
+        }
+        unsigned kind = maybeKind.get();
+
+        switch (kind) {
+        case identifier_block::IDENTIFIER_DATA:
+          assert(scratch.empty());
+          IdentifierData = blobData;
+          break;
+        default:
+          // Unknown identifier data, which this version of the compiler won't
+          // use.
+          break;
+        }
+
+        maybeNext = cursor.advanceSkippingSubblocks();
+        if (!maybeNext) {
+          // FIXME this drops the error on the floor.
+          consumeError(maybeNext.takeError());
+          info.status = error(Status::Malformed);
+          return;
+        }
+        next = maybeNext.get();
+      }
+
+      if (next.Kind != llvm::BitstreamEntry::EndBlock) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      break;
+    }
+
+    case INDEX_BLOCK_ID: {
+      if (!hasValidControlBlock || !readIndexBlock(cursor)) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+      break;
+    }
+
+    case SIL_INDEX_BLOCK_ID: {
+      // Save the cursor.
+      SILIndexCursor = cursor;
+      if (llvm::Error Err = SILIndexCursor.EnterSubBlock(SIL_INDEX_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      // With the main cursor, skip over the block and continue.
+      if (cursor.SkipBlock()) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+      break;
+    }
+
+    case SIL_BLOCK_ID: {
+      // Save the cursor.
+      SILCursor = cursor;
+      if (llvm::Error Err = SILCursor.EnterSubBlock(SIL_BLOCK_ID)) {
+        // FIXME this drops the error on the floor.
+        consumeError(std::move(Err));
+        info.status = error(Status::Malformed);
+        return;
+      }
+
+      // With the main cursor, skip over the block and continue.
+      if (cursor.SkipBlock()) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+      break;
+    }
+
+    default:
+      // Unknown top-level block, possibly for use by a future version of the
+      // module format.
+      if (cursor.SkipBlock()) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+      break;
+    }
+  }
+
+  if (topLevelEntry.Kind != llvm::BitstreamEntry::EndBlock) {
+    info.status = error(Status::Malformed);
+    return;
+  }
+  // Read source info file.
+  readModuleSourceInfoIfPresent();
+  if (!readModuleDocIfPresent()) {
+    info.status = error(Status::MalformedDocumentation);
+    return;
+  }
+}

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -1,0 +1,499 @@
+//===--- ModuleFileSharedCore.h - Core of a serialized module ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_MODULEFILECORE_H
+#define SWIFT_SERIALIZATION_MODULEFILECORE_H
+
+#include "ModuleFormat.h"
+#include "swift/AST/LinkLibrary.h"
+#include "swift/AST/Module.h"
+#include "swift/Serialization/Validation.h"
+#include "llvm/Bitstream/BitstreamReader.h"
+
+namespace llvm {
+  template <typename Info> class OnDiskIterableChainedHashTable;
+}
+
+namespace swift {
+
+/// Serialized core data of a module. The difference with `ModuleFile` is that
+/// `ModuleFileSharedCore` provides immutable data and is independent of a
+/// particular ASTContext. It is designed to be able to be shared across
+/// multiple `ModuleFile`s of different `ASTContext`s in a thread-safe manner.
+///
+/// It is **important** to preserve the following properties for
+/// `ModuleFileSharedCore`:
+///   * a `ModuleFile` should access its assigned `ModuleFileSharedCore` as
+///   immutable and thread-safe
+///   * `ModuleFileSharedCore` should be Independent of an `ASTContext` object.
+class ModuleFileSharedCore {
+  friend class ModuleFile;
+  using DeclID = serialization::DeclID;
+  using Status = serialization::Status;
+
+  /// The module file data.
+  std::unique_ptr<llvm::MemoryBuffer> ModuleInputBuffer;
+  std::unique_ptr<llvm::MemoryBuffer> ModuleDocInputBuffer;
+  std::unique_ptr<llvm::MemoryBuffer> ModuleSourceInfoInputBuffer;
+
+  /// The cursor used to lazily load things from the file.
+  llvm::BitstreamCursor DeclTypeCursor;
+
+  llvm::BitstreamCursor SILCursor;
+  llvm::BitstreamCursor SILIndexCursor;
+  llvm::BitstreamCursor DeclMemberTablesCursor;
+
+  /// The name of the module.
+  StringRef Name;
+
+  /// The target the module was built for.
+  StringRef TargetTriple;
+
+  /// The name of the module interface this module was compiled from.
+  ///
+  /// Empty if this module didn't come from an interface file.
+  StringRef ModuleInterfacePath;
+
+  /// The Swift compatibility version in use when this module was built.
+  version::Version CompatibilityVersion;
+
+  /// The data blob containing all of the module's identifiers.
+  StringRef IdentifierData;
+
+  /// Is this module file actually a .sib file? .sib files are serialized SIL at
+  /// arbitrary granularity and arbitrary stage; unlike serialized Swift
+  /// modules, which are assumed to contain canonical SIL for an entire module.
+  bool IsSIB = false;
+
+  // Full blob from the misc. version field of the metadata block. This should
+  // include the version string of the compiler that built the module.
+  StringRef MiscVersion;
+
+public:
+  /// Represents another module that has been imported as a dependency.
+  class Dependency {
+  public:
+    const StringRef RawPath;
+    const StringRef RawSPIs;
+
+  private:
+    using ImportFilterKind = ModuleDecl::ImportFilterKind;
+    const unsigned RawImportControl : 2;
+    const unsigned IsHeader : 1;
+    const unsigned IsScoped : 1;
+
+    static unsigned rawControlFromKind(ImportFilterKind importKind) {
+      return llvm::countTrailingZeros(static_cast<unsigned>(importKind));
+    }
+    ImportFilterKind getImportControl() const {
+      return static_cast<ImportFilterKind>(1 << RawImportControl);
+    }
+
+    Dependency(StringRef path, StringRef spiGroups, bool isHeader,
+               ImportFilterKind importControl, bool isScoped)
+        : RawPath(path),
+          RawSPIs(spiGroups),
+          RawImportControl(rawControlFromKind(importControl)),
+          IsHeader(isHeader),
+          IsScoped(isScoped) {
+      assert(llvm::countPopulation(static_cast<unsigned>(importControl)) == 1 &&
+             "must be a particular filter option, not a bitset");
+      assert(getImportControl() == importControl && "not enough bits");
+    }
+
+  public:
+   Dependency(StringRef path, StringRef spiGroups,
+              ImportFilterKind importControl, bool isScoped)
+       : Dependency(path, spiGroups, false, importControl, isScoped) {}
+
+   static Dependency forHeader(StringRef headerPath, bool exported) {
+     auto importControl =
+         exported ? ImportFilterKind::Public : ImportFilterKind::Private;
+     return Dependency(headerPath, StringRef(), true, importControl, false);
+    }
+
+    bool isExported() const {
+      return getImportControl() == ImportFilterKind::Public;
+    }
+    bool isImplementationOnly() const {
+      return getImportControl() == ImportFilterKind::ImplementationOnly;
+    }
+
+    bool isHeader() const { return IsHeader; }
+    bool isScoped() const { return IsScoped; }
+
+    std::string getPrettyPrintedPath() const;
+  };
+
+private:
+  /// All modules this module depends on.
+  SmallVector<Dependency, 8> Dependencies;
+
+  struct SearchPath {
+    StringRef Path;
+    bool IsFramework;
+    bool IsSystem;
+  };
+  /// Search paths this module may provide.
+  ///
+  /// This is not intended for use by frameworks, but may show up in debug
+  /// modules.
+  std::vector<SearchPath> SearchPaths;
+
+  /// Info for the (lone) imported header for this module.
+  struct {
+    off_t fileSize;
+    time_t fileModTime;
+    StringRef contents;
+  } importedHeaderInfo = {};
+
+  /// All of this module's link-time dependencies.
+  SmallVector<LinkLibrary, 8> LinkLibraries;
+
+public:
+  using RawBitOffset = uint64_t;
+
+private:
+  /// An allocator for buffers owned by the file.
+  llvm::BumpPtrAllocator Allocator;
+
+  /// Allocates a buffer using #Allocator and initializes it with the contents
+  /// of the container \p rawData, then stores it in \p buffer.
+  ///
+  /// \p buffer is passed as an argument rather than returned so that the
+  /// element type can be inferred.
+  template <typename T, typename RawData>
+  void allocateBuffer(MutableArrayRef<T> &buffer, const RawData &rawData);
+
+  /// Allocates a buffer using #Allocator and initializes it with the contents
+  /// of the container \p rawData, then stores it in \p buffer.
+  ///
+  /// \p buffer is passed as an argument rather than returned so that the
+  /// element type can be inferred.
+  template <typename T, typename RawData>
+  void allocateBuffer(ArrayRef<T> &buffer, const RawData &rawData) {
+    assert(buffer.empty());
+    MutableArrayRef<T> result;
+    allocateBuffer(result, rawData);
+    buffer = result;
+  }
+
+  /// Decls referenced by this module.
+  ArrayRef<RawBitOffset> Decls;
+
+  /// Local DeclContexts referenced by this module.
+  ArrayRef<RawBitOffset> LocalDeclContexts;
+
+  /// Normal protocol conformances referenced by this module.
+  ArrayRef<RawBitOffset> NormalConformances;
+
+  /// SILLayouts referenced by this module.
+  ArrayRef<RawBitOffset> SILLayouts;
+
+  /// Types referenced by this module.
+  ArrayRef<RawBitOffset> Types;
+
+  /// Clang types referenced by this module.
+  ArrayRef<RawBitOffset> ClangTypes;
+
+  /// Generic signatures referenced by this module.
+  ArrayRef<RawBitOffset> GenericSignatures;
+
+  /// Substitution maps referenced by this module.
+  ArrayRef<RawBitOffset> SubstitutionMaps;
+
+  /// Identifiers referenced by this module.
+  ArrayRef<RawBitOffset> Identifiers;
+
+  class DeclTableInfo;
+  using SerializedDeclTable =
+      llvm::OnDiskIterableChainedHashTable<DeclTableInfo>;
+
+  class ExtensionTableInfo;
+  using SerializedExtensionTable =
+      llvm::OnDiskIterableChainedHashTable<ExtensionTableInfo>;
+
+  class LocalDeclTableInfo;
+  using SerializedLocalDeclTable =
+      llvm::OnDiskIterableChainedHashTable<LocalDeclTableInfo>;
+
+  using OpaqueReturnTypeDeclTableInfo = LocalDeclTableInfo;
+  using SerializedOpaqueReturnTypeDeclTable =
+      llvm::OnDiskIterableChainedHashTable<OpaqueReturnTypeDeclTableInfo>;
+
+  class NestedTypeDeclsTableInfo;
+  using SerializedNestedTypeDeclsTable =
+      llvm::OnDiskIterableChainedHashTable<NestedTypeDeclsTableInfo>;
+
+  class DeclMemberNamesTableInfo;
+  using SerializedDeclMemberNamesTable =
+      llvm::OnDiskIterableChainedHashTable<DeclMemberNamesTableInfo>;
+
+  class DeclMembersTableInfo;
+  using SerializedDeclMembersTable =
+      llvm::OnDiskIterableChainedHashTable<DeclMembersTableInfo>;
+
+  std::unique_ptr<SerializedDeclTable> TopLevelDecls;
+  std::unique_ptr<SerializedDeclTable> OperatorDecls;
+  std::unique_ptr<SerializedDeclTable> PrecedenceGroupDecls;
+  std::unique_ptr<SerializedDeclTable> ClassMembersForDynamicLookup;
+  std::unique_ptr<SerializedDeclTable> OperatorMethodDecls;
+  std::unique_ptr<SerializedExtensionTable> ExtensionDecls;
+  std::unique_ptr<SerializedLocalDeclTable> LocalTypeDecls;
+  std::unique_ptr<SerializedOpaqueReturnTypeDeclTable> OpaqueReturnTypeDecls;
+  std::unique_ptr<SerializedNestedTypeDeclsTable> NestedTypeDecls;
+  std::unique_ptr<SerializedDeclMemberNamesTable> DeclMemberNames;
+
+  class ObjCMethodTableInfo;
+  using SerializedObjCMethodTable =
+    llvm::OnDiskIterableChainedHashTable<ObjCMethodTableInfo>;
+
+  std::unique_ptr<SerializedObjCMethodTable> ObjCMethods;
+
+  ArrayRef<serialization::DeclID> OrderedTopLevelDecls;
+
+  class DeclCommentTableInfo;
+  using SerializedDeclCommentTable =
+      llvm::OnDiskIterableChainedHashTable<DeclCommentTableInfo>;
+  struct DeserializedCommentInfo;
+
+  using GroupNameTable = const llvm::DenseMap<unsigned, StringRef>;
+
+  std::unique_ptr<GroupNameTable> GroupNamesMap;
+  std::unique_ptr<SerializedDeclCommentTable> DeclCommentTable;
+
+  class DeclUSRTableInfo;
+  using SerializedDeclUSRTable =
+      llvm::OnDiskIterableChainedHashTable<DeclUSRTableInfo>;
+  std::unique_ptr<SerializedDeclUSRTable> DeclUSRsTable;
+
+  class DerivativeFunctionConfigTableInfo;
+  using SerializedDerivativeFunctionConfigTable =
+      llvm::OnDiskIterableChainedHashTable<DerivativeFunctionConfigTableInfo>;
+  std::unique_ptr<SerializedDerivativeFunctionConfigTable>
+      DerivativeFunctionConfigurations;
+
+  /// A blob of 0 terminated string segments referenced in \c SourceLocsTextData
+  StringRef SourceLocsTextData;
+
+  /// An array of fixed size source location data for each USR appearing in
+  /// \c DeclUSRsTable.
+  StringRef BasicDeclLocsData;
+
+  /// An array of fixed-size location data for each `SingleRawComment` piece
+  /// of declaration's documentation `RawComment`s.
+  StringRef DocRangesData;
+
+  struct ModuleBits {
+    /// The decl ID of the main class in this module file, if it has one.
+    unsigned EntryPointDeclID : 31;
+
+    /// Whether or not this module file comes from a context that had a main
+    /// entry point.
+    unsigned HasEntryPoint : 1;
+
+    /// Whether this module file comes from a framework.
+    unsigned IsFramework : 1;
+
+    /// Whether an error has been detected setting up this module file.
+    unsigned HasError : 1;
+
+    // Explicitly pad out to the next word boundary.
+    unsigned : 0;
+  } Bits = {};
+  static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
+
+  bool hasError() const {
+    return Bits.HasError;
+  }
+
+  void setEntryPointClassID(serialization::DeclID DID) {
+    Bits.HasEntryPoint = true;
+    Bits.EntryPointDeclID = DID;
+    assert(Bits.EntryPointDeclID == DID && "not enough bits for DeclID");
+  }
+
+  /// Constructs a new module and validates it.
+  ModuleFileSharedCore(std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
+                 std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
+                 std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
+                 bool isFramework, serialization::ValidationInfo &info,
+                 serialization::ExtendedValidationInfo *extInfo);
+
+  /// Change the status of the current module.
+  Status error(Status issue) {
+    assert(issue != Status::Valid);
+    Bits.HasError = true;
+    return issue;
+  }
+
+  /// Emits one last diagnostic, logs the error, and then aborts for the stack
+  /// trace.
+  LLVM_ATTRIBUTE_NORETURN static void fatal(llvm::Error error);
+  void fatalIfNotSuccess(llvm::Error error) {
+    if (error)
+      fatal(std::move(error));
+  }
+  template <typename T> T fatalIfUnexpected(llvm::Expected<T> expected) {
+    if (expected)
+      return std::move(expected.get());
+    fatal(expected.takeError());
+  }
+
+  /// Read an on-disk decl hash table stored in index_block::DeclListLayout
+  /// format.
+  std::unique_ptr<SerializedDeclTable>
+  readDeclTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk local decl hash table stored in
+  /// index_block::DeclListLayout format.
+  std::unique_ptr<SerializedLocalDeclTable>
+  readLocalDeclTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk Objective-C method table stored in
+  /// index_block::ObjCMethodTableLayout format.
+  std::unique_ptr<ModuleFileSharedCore::SerializedObjCMethodTable>
+  readObjCMethodTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk local decl hash table stored in
+  /// index_block::ExtensionTableLayout format.
+  std::unique_ptr<SerializedExtensionTable>
+  readExtensionTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk local decl hash table stored in
+  /// index_block::NestedTypeDeclsLayout format.
+  std::unique_ptr<SerializedNestedTypeDeclsTable>
+  readNestedTypeDeclsTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk local decl-name hash table stored in
+  /// index_block::DeclMemberNamesLayout format.
+  std::unique_ptr<SerializedDeclMemberNamesTable>
+  readDeclMemberNamesTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk local decl-members hash table stored in
+  /// index_block::DeclMembersLayout format.
+  std::unique_ptr<SerializedDeclMembersTable>
+  readDeclMembersTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Read an on-disk derivative function configuration table stored in
+  /// index_block::DerivativeFunctionConfigTableLayout format.
+  std::unique_ptr<ModuleFileSharedCore::SerializedDerivativeFunctionConfigTable>
+  readDerivativeFunctionConfigTable(ArrayRef<uint64_t> fields,
+                                    StringRef blobData) const;
+
+  /// Reads the index block, which contains global tables.
+  ///
+  /// Returns false if there was an error.
+  bool readIndexBlock(llvm::BitstreamCursor &cursor);
+
+  /// Read an on-disk decl hash table stored in
+  /// \c comment_block::DeclCommentListLayout format.
+  std::unique_ptr<SerializedDeclCommentTable>
+  readDeclCommentTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  std::unique_ptr<GroupNameTable>
+  readGroupTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Reads the comment block, which contains USR to comment mappings.
+  ///
+  /// Returns false if there was an error.
+  bool readCommentBlock(llvm::BitstreamCursor &cursor);
+
+  /// Loads data from #ModuleDocInputBuffer.
+  ///
+  /// Returns false if there was an error.
+  bool readModuleDocIfPresent();
+
+  /// Reads the source loc block, which contains USR to decl location mapping.
+  ///
+  /// Returns false if there was an error.
+  bool readDeclLocsBlock(llvm::BitstreamCursor &cursor);
+
+  /// Loads data from #ModuleSourceInfoInputBuffer.
+  ///
+  /// Returns false if there was an error.
+  bool readModuleSourceInfoIfPresent();
+
+  /// Read an on-disk decl hash table stored in
+  /// \c sourceinfo_block::DeclUSRSLayout format.
+  std::unique_ptr<SerializedDeclUSRTable>
+  readDeclUSRsTable(ArrayRef<uint64_t> fields, StringRef blobData) const;
+
+  /// Returns the appropriate module name for the given ID.
+  StringRef getModuleNameFromID(serialization::ModuleID MID) const;
+
+  /// Convenience method to retrieve the text of the name with the given ID.
+  /// Asserts that the name with this ID is not special.
+  StringRef getIdentifierText(serialization::IdentifierID IID) const;
+
+public:
+  /// Loads a module from the given memory buffer.
+  ///
+  /// \param moduleInputBuffer A memory buffer containing the serialized module
+  /// data. The created ModuleFile takes ownership of the buffer, even if
+  /// there's an error in loading.
+  /// \param moduleDocInputBuffer An optional memory buffer containing
+  /// documentation data for the module. The created ModuleFile takes ownership
+  /// of the buffer, even if there's an error in loading.
+  /// \param isFramework If true, this is treated as a framework module for
+  /// linking purposes.
+  /// \param[out] theModule The loaded module.
+  /// \param[out] extInfo Optionally, extra info serialized about the module.
+  /// \returns Whether the module was successfully loaded, or what went wrong
+  ///          if it was not.
+  static serialization::ValidationInfo
+  load(StringRef moduleInterfacePath,
+       std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
+       std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
+       std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
+       bool isFramework, std::shared_ptr<const ModuleFileSharedCore> &theModule,
+       serialization::ExtendedValidationInfo *extInfo = nullptr) {
+    serialization::ValidationInfo info;
+    auto *core = new ModuleFileSharedCore(
+        std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
+        std::move(moduleSourceInfoInputBuffer), isFramework, info, extInfo);
+    if (!moduleInterfacePath.empty())
+      core->ModuleInterfacePath = moduleInterfacePath;
+    theModule.reset(core);
+    return info;
+  }
+
+  // Out of line to avoid instantiation OnDiskChainedHashTable here.
+  ~ModuleFileSharedCore();
+
+  /// The name of the module.
+  StringRef getName() const {
+    return Name;
+  }
+
+  /// Returns the list of modules this module depends on.
+  ArrayRef<Dependency> getDependencies() const {
+    return Dependencies;
+  }
+};
+
+template <typename T, typename RawData>
+void ModuleFileSharedCore::allocateBuffer(MutableArrayRef<T> &buffer,
+                                    const RawData &rawData) {
+  assert(buffer.empty() && "reallocating deserialized buffer");
+  if (rawData.empty())
+    return;
+
+  void *rawBuffer = Allocator.Allocate(sizeof(T) * rawData.size(), alignof(T));
+  buffer = llvm::makeMutableArrayRef(static_cast<T *>(rawBuffer),
+                                     rawData.size());
+  std::uninitialized_copy(rawData.begin(), rawData.end(), buffer.begin());
+}
+
+} // end namespace swift
+
+#endif


### PR DESCRIPTION
The difference with `ModuleFile` is that `ModuleFileCore` provides immutable data and is independent of a particular ASTContext.
It is designed to be able to be shared across multiple `ModuleFile`s of different `ASTContext`s in a thread-safe manner.