### PR TITLE
[SymbolGraph] Add back isUnconditionallyUnavailable

### DIFF
--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -70,7 +70,8 @@ Availability::Availability(const AvailableAttr &AvAttr)
     Obsoleted(AvAttr.Obsoleted),
     Message(AvAttr.Message),
     Renamed(AvAttr.Rename),
-    IsUnconditionallyDeprecated(AvAttr.isUnconditionallyDeprecated()) {
+    IsUnconditionallyDeprecated(AvAttr.isUnconditionallyDeprecated()),
+    IsUnconditionallyUnavailable(AvAttr.isUnconditionallyUnavailable()) {
       assert(!Domain.empty());
 }
 
@@ -92,6 +93,9 @@ Availability::updateFromDuplicate(const Availability &Other) {
 
   // Same for `deprecated` with no version.
   IsUnconditionallyDeprecated = Other.IsUnconditionallyDeprecated;
+
+  // Same for `unavailable` with no version.
+  IsUnconditionallyUnavailable = Other.IsUnconditionallyUnavailable;
 
   // Same for `obsoleted`.
   Obsoleted = Other.Obsoleted;
@@ -150,6 +154,10 @@ Availability::updateFromParent(const Availability &Parent) {
   // If a parent is unconditionally deprecated, then so are all
   // of its children.
   IsUnconditionallyDeprecated |= Parent.IsUnconditionallyDeprecated;
+
+  // If a parent is unconditionally unavailable, then so are all
+  // of its children.
+  IsUnconditionallyUnavailable |= Parent.IsUnconditionallyUnavailable;
 }
 
 void Availability::serialize(llvm::json::OStream &OS) const {
@@ -176,6 +184,9 @@ void Availability::serialize(llvm::json::OStream &OS) const {
     if (IsUnconditionallyDeprecated) {
       OS.attribute("isUnconditionallyDeprecated", true);
     }
+    if (IsUnconditionallyUnavailable) {
+      OS.attribute("isUnconditionallyUnavailable", true);
+    }
   }); // end availability object
 }
 
@@ -183,5 +194,6 @@ bool Availability::empty() const {
   return !Introduced.hasValue() &&
          !Deprecated.hasValue() &&
          !Obsoleted.hasValue() &&
-         !IsUnconditionallyDeprecated;
+         !IsUnconditionallyDeprecated &&
+         !IsUnconditionallyUnavailable;
 }

--- a/lib/SymbolGraphGen/AvailabilityMixin.h
+++ b/lib/SymbolGraphGen/AvailabilityMixin.h
@@ -46,6 +46,9 @@ struct Availability {
   /// If \c true, is unconditionally deprecated in this \c Domain.
   bool IsUnconditionallyDeprecated;
 
+  /// If \c true, is unconditionally unavailable in this \c Domain.
+  bool IsUnconditionallyUnavailable;
+
   Availability(const AvailableAttr &AvAttr);
 
   /// Update this availability from a duplicate @available

--- a/test/SymbolGraph/Symbols/Mixins/Availability/Inherited/UnconditionallyUnavailable.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/Inherited/UnconditionallyUnavailable.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name UnavailableFilled -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name UnavailableFilled -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/UnavailableFilled.symbols.json
+
+// REQUIRES: OS=macosx
+
+@available(iOS, unavailable)
+public struct S {
+  public func foo() {}
+}
+
+// CHECK-LABEL: "precise": "s:17UnavailableFilled1SV3fooyyF",
+// CHECK: "availability": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "domain": "iOS",
+// CHECK-NEXT:     "isUnconditionallyUnavailable": true
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/SymbolGraph/Symbols/Mixins/Availability/UnconditionallyUnavailable.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/UnconditionallyUnavailable.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name UnconditionallyUnavailable -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name UnconditionallyUnavailable -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/UnconditionallyUnavailable.symbols.json
+
+@available(iOS, unavailable)
+public struct UnconditionallyUnavailable {}
+
+// CHECK: "availability": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "domain": "iOS",
+// CHECK-NEXT:     "isUnconditionallyUnavailable": true
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]


### PR DESCRIPTION
It turns out this needed to prevent automatically inheriting a
default introduced availability for a given module.

rdar://64536460