### PR TITLE
Add benchmarks for Substring.dropFirst(_:) and dropLast(_:)

### DIFF
--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -36,7 +36,7 @@ let longWide = "fὢasὢodὢijὢadὢolὢsjὢalὢsdὢjlὢasὢdfὢijὢ
 let (s1, ss1) = equivalentWithDistinctBuffers()
 let (s2, ss2) = equivalentWithDistinctBuffers()
 
-let quiteLong = String(repeating: "0", count: 10_000)
+let quiteLong = String(repeating: "0", count: 15_000)[...]
 
 @inline(never)
 public func run_SubstringFromLongString(_ N: Int) {
@@ -132,16 +132,16 @@ public func run_EqualSubstringSubstringGenericEquatable(_ N: Int) {
 
 @inline(never)
 public func run_SubstringDropFirst1(_ N: Int) {
-  let s = quiteLong[...]
-  for _ in 1...N*500 {
+  let s = quiteLong
+  for _ in 1...N*1000 {
     blackHole(!s.dropFirst(1).isEmpty)
   }
 }
 
 @inline(never)
 public func run_SubstringDropLast1(_ N: Int) {
-  let s = quiteLong[...]
-  for _ in 1...N*500 {
+  let s = quiteLong
+  for _ in 1...N*1000 {
     blackHole(!s.dropLast(1).isEmpty)
   }
 }

--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -17,6 +17,8 @@ public let SubstringTest = [
   BenchmarkInfo(name: "EqualSubstringString", runFunction: run_EqualSubstringString, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "EqualSubstringSubstring", runFunction: run_EqualSubstringSubstring, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "EqualSubstringSubstringGenericEquatable", runFunction: run_EqualSubstringSubstringGenericEquatable, tags: [.validation, .api, .String]),
+  BenchmarkInfo(name: "SubstringDropFirst1", runFunction: run_SubstringDropFirst1, tags: [.validation, .api, .String]),
+  BenchmarkInfo(name: "SubstringDropLast1", runFunction: run_SubstringDropLast1, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "LessSubstringSubstring", runFunction: run_LessSubstringSubstring, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "LessSubstringSubstringGenericComparable", runFunction: run_LessSubstringSubstringGenericComparable, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "StringFromLongWholeSubstring", runFunction: run_StringFromLongWholeSubstring, tags: [.validation, .api, .String]),
@@ -33,6 +35,8 @@ public let SubstringTest = [
 let longWide = "fὢasὢodὢijὢadὢolὢsjὢalὢsdὢjlὢasὢdfὢijὢliὢsdὢjøὢslὢdiὢalὢiὢ"
 let (s1, ss1) = equivalentWithDistinctBuffers()
 let (s2, ss2) = equivalentWithDistinctBuffers()
+
+let quiteLong = String(repeating: "0", count: 10_000)
 
 @inline(never)
 public func run_SubstringFromLongString(_ N: Int) {
@@ -123,6 +127,22 @@ public func run_EqualSubstringSubstringGenericEquatable(_ N: Int) {
   }
   for _ in 1...N*500 {
     check(a, b)
+  }
+}
+
+@inline(never)
+public func run_SubstringDropFirst1(_ N: Int) {
+  let s = quiteLong[...]
+  for _ in 1...N*500 {
+    blackHole(!s.dropFirst(1).isEmpty)
+  }
+}
+
+@inline(never)
+public func run_SubstringDropLast1(_ N: Int) {
+  let s = quiteLong[...]
+  for _ in 1...N*500 {
+    blackHole(!s.dropLast(1).isEmpty)
   }
 }
 


### PR DESCRIPTION
These are self-slicing operations, so they should be fast even for this non-random-access collection.

Hoping to see a difference in this new benchmark from the change in https://github.com/apple/swift/pull/32451.