### PR TITLE
[android] Switch %swiftc_driver for %target-swiftc_driver

### DIFF
--- a/test/Driver/SourceRanges/range-incremental-no-build-record.swift
+++ b/test/Driver/SourceRanges/range-incremental-no-build-record.swift
@@ -4,6 +4,7 @@
 // First, build without range dependencies with no new options.
 // =============================================================================
 
+// REQUIRES: executable_test
 
 // Copy in the inputs.
 // The lack of a build record or swiftdeps files should disable incremental compilation
@@ -12,7 +13,7 @@
 // Ensure that the extra outputs are not generated when they should not be:
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/range-incremental-no-build-record/* %t
-// RUN: cd %t && %swiftc_driver -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental  >& %t/output0
+// RUN: cd %t && %target-swiftc_driver -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental  >& %t/output0
 
 // RUN: %FileCheck -match-full-lines -check-prefix=CHECK-NO-BUILD-REC %s < %t/output0
 // CHECK-NO-BUILD-REC: Incremental compilation could not read build record.
@@ -29,7 +30,7 @@
 
 // CHECK-HAS-BATCHES: Batchable: {compile:
 
-// RUN: %t/main | tee run0 | grep Any > /dev/null && rm %t/main
+// RUN: %target-run %t/main | tee run0 | grep Any > /dev/null && rm %t/main
 
 // =============================================================================
 // Same, except force the driver to compute both strategies via -driver-compare-incremental-schemes
@@ -43,11 +44,11 @@
 // Ensure that the extra outputs are not generated when they should not be:
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/range-incremental-no-build-record/* %t
-// RUN: cd %t && %swiftc_driver -driver-compare-incremental-schemes -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental  >& %t/output1
+// RUN: cd %t && %target-swiftc_driver -driver-compare-incremental-schemes -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental  >& %t/output1
 
 // RUN: %FileCheck -match-full-lines -check-prefix=CHECK-NO-BUILD-REC %s < %t/output1
 
 // RUN: %FileCheck -match-full-lines -check-prefix=CHECK-COMPARE-DISABLED-NO-BUILD-RECORD %s < %t/output1
 // CHECK-COMPARE-DISABLED-NO-BUILD-RECORD: *** Incremental build disabled because could not read build record, cannot compare ***
 
-// RUN: %t/main | tee run1 | grep Any > /dev/null && rm %t/main
+// RUN: %target-run %t/main | tee run1 | grep Any > /dev/null && rm %t/main

--- a/test/Driver/autolink-force-load-comdat.swift
+++ b/test/Driver/autolink-force-load-comdat.swift
@@ -1,5 +1,5 @@
-// RUN: %swiftc_driver -incremental -autolink-force-load %s 2>&1 | %FileCheck -check-prefix=AUTOLINK_FORCE_LOAD %s
-// RUN: %swiftc_driver -autolink-force-load -incremental %s 2>&1 | %FileCheck -check-prefix=AUTOLINK_FORCE_LOAD %s
+// RUN: %target-swiftc_driver -incremental -autolink-force-load %s 2>&1 | %FileCheck -check-prefix=AUTOLINK_FORCE_LOAD %s
+// RUN: %target-swiftc_driver -autolink-force-load -incremental %s 2>&1 | %FileCheck -check-prefix=AUTOLINK_FORCE_LOAD %s
 
 // MACHO targets do not support COMDAT
 // UNSUPPORTED: OS=macosx
@@ -8,4 +8,3 @@
 // UNSUPPORTED: OS=ios
 
 // AUTOLINK_FORCE_LOAD-NOT: error: '-autolink-force-load' is not supported with '-incremental'
-

--- a/test/Driver/batch_mode_dependencies_make_wrong_order.swift
+++ b/test/Driver/batch_mode_dependencies_make_wrong_order.swift
@@ -6,14 +6,14 @@
 // RUN: echo 'public func main() {}' >%t/main.swift
 //
 // First prime the incremental state, but note that we're building in the d c b a (reverse-alphabetical) order.
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift
+// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift
 //
 // Now perturb the interface of a.swift and delete its output
 // RUN: echo 'class a { var x : Int = 10 }' >%t/a.swift
 // RUN: rm %t/a.o
 //
 // Now rebuild, which will rebuild a.swift then do a cascading dep-graph invalidation
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
+// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
 // RUN: %FileCheck %s <%t/out.txt
 //
 // Check that we saw invalidation happen in command-line argument order

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -121,11 +121,11 @@
 // BAD_DEBUG_LEVEL_ERROR: error: argument '-debug-info-format=codeview' is not allowed with '{{.*}}'
 
 // RUN: %swift_driver -F %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
-// RUN: %swiftc_driver -F %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %target-swiftc_driver -F %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // RUN: %swift_driver -Fsystem %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
-// RUN: %swiftc_driver -Fsystem %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %target-swiftc_driver -Fsystem %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // RUN: %swift_driver -F %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
-// RUN: %swiftc_driver -F %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %target-swiftc_driver -F %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // RUN: %swift_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
-// RUN: %swiftc_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %target-swiftc_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION: warning: framework search path ends in ".framework"

--- a/test/Frontend/Fingerprints/class-fingerprint.swift
+++ b/test/Frontend/Fingerprints/class-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -53,7 +53,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -67,7 +67,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Frontend/Fingerprints/enum-fingerprint.swift
+++ b/test/Frontend/Fingerprints/enum-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -53,7 +53,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -67,7 +67,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Frontend/Fingerprints/extension-adds-member.swift
+++ b/test/Frontend/Fingerprints/extension-adds-member.swift
@@ -21,7 +21,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output1
 
 
 // Change one type, but uses of all types get recompiled
@@ -33,7 +33,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json  >& %t/output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json  >& %t/output2
 
 
 // This test checks for the status quo; it would be OK to be more conservative
@@ -60,7 +60,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
 
 // Change one type, only uses of that type get recompiled
 
@@ -71,7 +71,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
 // RUN: %FileCheck -check-prefix=CHECK-NOT-RECOMPILED-W %s < %t/output4

--- a/test/Frontend/Fingerprints/protocol-fingerprint.swift
+++ b/test/Frontend/Fingerprints/protocol-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -53,7 +53,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -67,9 +67,8 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
-

--- a/test/Frontend/Fingerprints/struct-fingerprint.swift
+++ b/test/Frontend/Fingerprints/struct-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -53,7 +53,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -67,7 +67,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Frontend/PrivateFingerprints/class-fingerprint.swift
+++ b/test/Frontend/PrivateFingerprints/class-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -52,7 +52,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -66,7 +66,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Frontend/PrivateFingerprints/enum-fingerprint.swift
+++ b/test/Frontend/PrivateFingerprints/enum-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -52,7 +52,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -66,7 +66,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Frontend/PrivateFingerprints/extension-adds-member.swift
+++ b/test/Frontend/PrivateFingerprints/extension-adds-member.swift
@@ -21,7 +21,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output1
 
 
 // Change one type, but uses of all types get recompiled
@@ -33,7 +33,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json  >& %t/output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json  >& %t/output2
 
 
 // This test checks for the status quo; it would be OK to be more conservative
@@ -60,7 +60,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
 
 // Change one type, only uses of that type get recompiled
 
@@ -71,7 +71,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
 // RUN: %FileCheck -check-prefix=CHECK-NOT-RECOMPILED-W %s < %t/output4

--- a/test/Frontend/PrivateFingerprints/protocol-fingerprint.swift
+++ b/test/Frontend/PrivateFingerprints/protocol-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -52,7 +52,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -66,9 +66,8 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
-

--- a/test/Frontend/PrivateFingerprints/struct-fingerprint.swift
+++ b/test/Frontend/PrivateFingerprints/struct-fingerprint.swift
@@ -16,7 +16,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output1
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
 
@@ -29,7 +29,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift  -module-name main -output-file-map ofm.json >&output2
 
 // Save for debugging:
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB1.swiftdeps
@@ -52,7 +52,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -66,7 +66,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/superfluous-cascade.swift
+++ b/test/Incremental/superfluous-cascade.swift
@@ -9,7 +9,7 @@
 // RUN: cp %t/definesPoint{-before,}.swift
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json >&output1
+// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json >&output1
 
 // Change one type - the cascading edge causes us to rebuild everything but main
 
@@ -18,7 +18,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesPoint.swift
 
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json >&output2
+// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -j2 -incremental -disable-direct-intramodule-dependencies -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json >&output2
 
 // RUN: %FileCheck -check-prefix=CHECK-STATUS-QUO-RECOMPILED %s < %t/output2
 
@@ -37,7 +37,7 @@
 // RUN: cp %t/definesPoint{-before,}.swift
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json -enable-direct-intramodule-dependencies >&output3
+// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json -enable-direct-intramodule-dependencies >&output3
 
 // Change one type - now only the user of that type rebuilds
 
@@ -46,11 +46,9 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesPoint.swift
 
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json -enable-direct-intramodule-dependencies >&output4
+// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json -enable-direct-intramodule-dependencies >&output4
 
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE-RECOMPILED %s --dump-input=always < %t/output4
 
 // CHECK-PRIVATE-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesPoint.o <= usesPoint.swift}
 // CHECK-PRIVATE-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesDisplay.o <= usesDisplay.swift}
-
-


### PR DESCRIPTION
When compiling against a platform different than the host, like it
happens when testing against Android stdlib from a Linux host, one needs
to use %target-swiftc_driver to setup the tools directory correctly and
the target options, otherwise errors will happen when trying to link a
host targetted file against the destination platform libraries.

