### PR TITLE
[CSDiagnostics] Improve MissingRawRepresentableInitFailure diagnostic fix-it

### DIFF
--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -297,3 +297,41 @@ enum MismatchedRawValues {
   }
 }
 
+// The fix-it should not suggest adding a default value (i.e. ?? <#default value>) if we have a
+// non-failable init(rawValue:).
+enum FooRawReprNonFailable1: RawRepresentable {
+  init(rawValue: Int) {}
+  var rawValue: Int { return 0 }
+}
+
+enum FooRawReprNonFailable2: RawRepresentable {
+  init(rawValue: Int?) {}
+  var rawValue: Int? { return 0 }
+}
+
+func takesNonFailableFoo1(_: FooRawReprNonFailable1) {}
+func takesNonFailableFoo2(_: FooRawReprNonFailable2) {}
+
+takesNonFailableFoo1(0)
+// expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'FooRawReprNonFailable1'}} {{22-22=FooRawReprNonFailable1(rawValue: }} {{23-23=)}}
+
+takesNonFailableFoo2(0)
+// expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'FooRawReprNonFailable2'}} {{22-22=FooRawReprNonFailable2(rawValue: }} {{23-23=)}}
+
+func rawReprNonFailable3() {
+  enum E: RawRepresentable {
+    init(rawValue: Int) {}
+    var rawValue: Int { return 0 }
+  }
+    
+  let items1: [Int] = [0, 1]
+  let items2: [Int]? = [0]
+    
+  let myE1: E = items1.first
+  // expected-error@-1 {{cannot convert value of type 'Int?' to specified type 'E'}}
+  // expected-note@-2 {{construct 'E' from unwrapped 'Int' value}} {{17-17=E(rawValue: }} {{29-29=!)}}
+
+  let myE2: E = items2?.first
+  // expected-error@-1 {{cannot convert value of type 'Int?' to specified type 'E'}}
+  // expected-note@-2 {{construct 'E' from unwrapped 'Int' value}} {{17-17=E(rawValue: (}} {{30-30=)!)}}
+}


### PR DESCRIPTION
The `MissingRawRepresentableInitFailure` fix currently provides a fix-it where it always suggests a `?? <default value>"`, even if the `init(rawValue:)` is not failable. For example:

```swift
enum Foo: RawRepresentable {
  init(rawValue: Int) {}
  var rawValue: Int { return 0 }
}
func takesFoo(_: Foo) {}

takesFoo(0) // fix-it => Foo(rawValue:  ) ?? <#default value#>
```

This is not ideal, because now the user has to manually remove the `?? <#default value>` bit. Some users might not realise that the initialiser is not failable and will actually pass a default value, in which case they'll see: `left side of nil coalescing operator '??' has non-optional type 'Foo', so the right side is never used`.

So, if the initialiser is not failable, strip the default value suggestion.