### PR TITLE
[ConstraintSystem] Rework handling of object literal expressions

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2885,6 +2885,10 @@ public:
 
     Param getWithoutLabel() const { return Param(Ty, Identifier(), Flags); }
 
+    Param withLabel(Identifier newLabel) const {
+      return Param(Ty, newLabel, Flags);
+    }
+
     Param withType(Type newType) const { return Param(newType, Label, Flags); }
 
     Param withFlags(ParameterTypeFlags flags) const {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1110,8 +1110,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
         fix = SpecifyClosureParameterType::create(cs, dstLocator);
       } else if (TypeVar->getImpl().isClosureResultType()) {
         fix = SpecifyClosureReturnType::create(cs, dstLocator);
-      } else if (srcLocator->getAnchor() &&
-                 isExpr<ObjectLiteralExpr>(srcLocator->getAnchor())) {
+      } else if (srcLocator->directlyAt<ObjectLiteralExpr>()) {
         fix = SpecifyObjectLiteralTypeImport::create(cs, dstLocator);
       } else if (srcLocator->isKeyPathRoot()) {
         fix = SpecifyKeyPathRootType::create(cs, dstLocator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6754,7 +6754,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       return SolutionKind::Solved;
     } else if ((kind == ConstraintKind::ValueMember ||
                 kind == ConstraintKind::ValueWitness) &&
-               baseObjTy->isHole()) {
+               baseObjTy->getMetatypeInstanceType()->isHole()) {
       // If base type is a "hole" there is no reason to record any
       // more "member not found" fixes for chained member references.
       markMemberTypeAsPotentialHole(memberTy);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1057,9 +1057,6 @@ ProtocolDecl *getLiteralProtocol(ASTContext &ctx, Expr *expr);
 DeclName getObjectLiteralConstructorName(ASTContext &ctx,
                                          ObjectLiteralExpr *expr);
 
-Type getObjectLiteralParameterType(ObjectLiteralExpr *expr,
-                                   ConstructorDecl *ctor);
-
 /// Get the module appropriate for looking up standard library types.
 ///
 /// This is "Swift", if that module is imported, or the current module if

--- a/test/Sema/object_literals_ios.swift
+++ b/test/Sema/object_literals_ios.swift
@@ -8,9 +8,12 @@ struct S: _ExpressibleByColorLiteral {
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
 let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{could not infer type of color literal}}
 // expected-note@-1{{import UIKit to use 'UIColor' as the default color literal type}}
-let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}}
+let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1)
 // expected-error@-1 {{could not infer type of color literal}}
 // expected-note@-2 {{import UIKit to use 'UIColor' as the default color literal type}}
+
+let _: S = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1)
+// expected-error@-1{{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}} {{34-39=green}} {{44-48=blue}}
 
 struct I: _ExpressibleByImageLiteral {
   init(imageLiteralResourceName: String) {}

--- a/test/Sema/object_literals_osx.swift
+++ b/test/Sema/object_literals_osx.swift
@@ -8,9 +8,12 @@ struct S: _ExpressibleByColorLiteral {
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
 let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{could not infer type of color literal}}
 // expected-note@-1{{import AppKit to use 'NSColor' as the default color literal type}}
-let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}}
+let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1)
 // expected-error@-1{{could not infer type of color literal}}
 // expected-note@-2{{import AppKit to use 'NSColor' as the default color literal type}}
+
+let _: S = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1)
+// expected-error@-1 {{incorrect argument labels in call (have 'red:bleen:grue:alpha:', expected 'red:green:blue:alpha:')}} {{34-39=green}} {{44-48=blue}}
 
 struct I: _ExpressibleByImageLiteral {
   init(imageLiteralResourceName: String) {}
@@ -21,7 +24,7 @@ let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not i
 // expected-note@-1{{import AppKit to use 'NSImage' as the default image literal type}}
 
 struct Path: _ExpressibleByFileReferenceLiteral {
-  init(fileReferenceLiteralResourceName: String) {}
+  init(fileReferenceLiteralResourceName: String) {} // expected-note {{'init(fileReferenceLiteralResourceName:)' declared here}}
 }
 
 let p1: Path = #fileLiteral(resourceName: "what.txt")
@@ -32,9 +35,11 @@ let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expecte
 // expected-note@-1{{import Foundation to use 'URL' as the default file reference literal type}}
 
 // rdar://problem/49861813
-#fileLiteral() // expected-error{{missing argument for parameter 'resourceName' in call}}
+#fileLiteral()
 // expected-error@-1{{could not infer type of file reference literal}}
 // expected-note@-2{{import Foundation to use 'URL' as the default file reference literal type}}
+
+let _: Path = #fileLiteral() // expected-error {{missing argument for parameter 'resourceName' in call}}
 
 // rdar://problem/62927467
 func test_literal_arguments_are_loaded() {


### PR DESCRIPTION
Instead of special-casing argument-to-parameter matching for
object literal expressions, let's allow constraint system to
lookup a witness initializer and apply it to the given set
of arguments.

This also simplifies constraint application because
`coerceCallArguments` could be used to form type-checked
argument expression.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
