### PR TITLE
[DNM] workarounds for regression SR-12831 on master/5.3 since Feb 7th

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1380,8 +1380,9 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   }
 
   bool error = readLegacyTypeInfo(*fs, path);
-  if (error)
-    llvm::report_fatal_error("Cannot read '" + path + "'");
+// avoids error: "<unknown>:1:1: Cannot read '/usr/lib/swift/layouts-x86_64.yaml'"
+//  if (error)
+//    llvm::report_fatal_error("Cannot read '" + path + "'");
 }
 
 TypeConverter::~TypeConverter() {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5008,7 +5008,14 @@ public:
       MF.fatal();
 
     const clang::Type *clangFunctionType = nullptr;
-    if (clangTypeID) {
+    // avoids: "error: Segmentation fault: 11" (SR-12831)
+    // during "merge module" containing the following code:
+    /*
+    static var onEntry: @convention(c) (_ swizzle: Swizzle, _ returnAddress: UnsafeRawPointer,
+        _ stackPointer: UnsafeMutablePointer<UInt64>) -> IMP? = {
+            (swizzle, returnAddress, stackPointer) -> IMP? in
+     */
+    if (clangTypeID && false) {
       auto loadedClangType = MF.getClangType(clangTypeID);
       if (!loadedClangType)
         return loadedClangType.takeError();


### PR DESCRIPTION
Hi Apple,

OK, so it’s a busy week but I thought I’d file a quick workaround I’ve had to use to get one of my repos [johnno1962/SwiftTrace](https://github.com/johnno1962/SwiftTrace) to be able to compile with a toolchain built from master & 5.3 branch. At the moment you get a `Segmentation fault: 11` during module merge due to dereferencing a nullptr as detailed in [the ticket](https://bugs.swift.org/browse/SR-12831).  I've bisected the various recent downloadable toolchains and this dates back to commits on February 7th and looking at where it crashes it seems to be related to [this new functionality](https://github.com/apple/swift/pull/29670) cc: @rjmccall.

The problem declaration is [this](https://github.com/johnno1962/SwiftTrace/blob/master/SwiftTrace/SwiftSwizzle.swift#L93) which is `@convention(c)` but actually a SwiftDecl:
```Swift
       static var onEntry: @convention(c) (_ swizzle: Swizzle, _ returnAddress: UnsafeRawPointer,
           _ stackPointer: UnsafeMutablePointer<UInt64>) -> IMP? = {
               (swizzle, returnAddress, stackPointer) -> IMP? in
               // etc...
```
If I remove the `@convention(c)` it will compile but give an error at runtime. I need to store a pointer to a C function in a static. This has been compiling fine previously.
 
Works around [SR-12831](https://bugs.swift.org/browse/SR-12831).
