### PR TITLE
[LTO] Enable sil-opt to accept multiple SIB modules

### DIFF
--- a/test/sil-opt/Inputs/lib.swift
+++ b/test/sil-opt/Inputs/lib.swift
@@ -1,0 +1,3 @@
+public struct LibX {}
+
+public func getLibX() -> LibX { return LibX() }

--- a/test/sil-opt/Inputs/main.swift
+++ b/test/sil-opt/Inputs/main.swift
@@ -1,0 +1,3 @@
+import lib
+
+_ = getLibX()

--- a/test/sil-opt/multiple-input.swift
+++ b/test/sil-opt/multiple-input.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -emit-module %S/Inputs/lib.swift -emit-module-path %t
+// RUN: %target-swift-frontend -emit-sib %S/Inputs/lib.swift -parse-as-library -o %t/lib.sib
+// RUN: %target-swift-frontend -emit-sib -I%t  %S/Inputs/main.swift -o %t/main.sib
+
+// RUN: %sil-opt -emit-sorted-sil %t/lib.sib %t/main.sib | %FileCheck %s
+
+// CHECK: sil hidden @$s3lib4LibXVACycfC : $@convention(method) (@thin LibX.Type) -> LibX {
+// CHECK: sil @$s3lib7getLibXAA0C1XVyF : $@convention(thin) () -> LibX {
+// CHECK: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+


### PR DESCRIPTION
Merge multiple modules into a single module and do optimizations across modules.
This will be used for cross-module optimization tests for LTO.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
