### PR TITLE
GSB: Teach 'derived via concrete' computation about superclass constraints

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -845,6 +845,11 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
 
       if (parentEquivClass->concreteType)
         derivedViaConcrete = true;
+      else if (parentEquivClass->superclass &&
+               builder.lookupConformance(parentType->getCanonicalType(),
+                                         parentEquivClass->superclass,
+                                         source->getProtocolDecl()))
+        derivedViaConcrete = true;
 
       // The parent potential archetype must conform to the protocol in which
       // this requirement resides. Add this constraint.

--- a/test/Generics/superclass_constraint_self_derived.swift
+++ b/test/Generics/superclass_constraint_self_derived.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype T : Q
+}
+
+protocol Q {
+  associatedtype T : R
+
+  var t: T { get }
+}
+
+protocol R {}
+
+func takesR<T : R>(_: T) {}
+
+class C<T : Q> : P {}
+
+struct Outer<T : P> {
+  struct Inner<U> where T : C<U> {
+    func doStuff(_ u: U) {
+      takesR(u.t)
+    }
+  }
+}

--- a/test/SILGen/class_conforms_with_default_implementation.swift
+++ b/test/SILGen/class_conforms_with_default_implementation.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+protocol P {
+  associatedtype T : Q
+  func foo()
+}
+
+extension P {
+  func foo() {}
+}
+
+protocol Q {}
+
+class C<T : Q> : P {}
+
+protocol PP {
+  associatedtype T : QQ
+  func foo()
+}
+
+extension PP {
+  func foo() {}
+}
+
+class QQ {}
+
+class CC<T : QQ> : PP {}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s42class_conforms_with_default_implementation1CCyqd__GAA1PA2aEP3fooyyFTW : $@convention(witness_method: P) <τ_0_0><τ_1_0 where τ_0_0 : C<τ_1_0>, τ_1_0 : Q> (@in_guaranteed τ_0_0) -> () {
+// CHECK: [[WITNESS:%.*]] = function_ref @$s42class_conforms_with_default_implementation1PPAAE3fooyyF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[WITNESS]]<τ_0_0>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+// CHECK: return
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s42class_conforms_with_default_implementation2CCCyqd__GAA2PPA2aEP3fooyyFTW : $@convention(witness_method: PP) <τ_0_0><τ_1_0 where τ_0_0 : CC<τ_1_0>, τ_1_0 : QQ> (@in_guaranteed τ_0_0) -> () {
+// CHECK: [[WITNESS:%.*]] = function_ref @$s42class_conforms_with_default_implementation2PPPAAE3fooyyF : $@convention(method) <τ_0_0 where τ_0_0 : PP> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[WITNESS]]<τ_0_0>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : PP> (@in_guaranteed τ_0_0) -> ()
+// CHECK: return
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Q> C<T>: P module class_conforms_with_default_implementation {
+// CHECK-NEXT: associated_type_protocol (T: Q): dependent
+// CHECK-NEXT: associated_type T: T
+// CHECK-NEXT: method #P.foo: <Self where Self : P> (Self) -> () -> () : @$s42class_conforms_with_default_implementation1CCyqd__GAA1PA2aEP3fooyyFTW
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : QQ> CC<T>: PP module class_conforms_with_default_implementation {
+// CHECK-NEXT: associated_type T: T
+// CHECK-NEXT: method #PP.foo: <Self where Self : PP> (Self) -> () -> () : @$s42class_conforms_with_default_implementation2CCCyqd__GAA2PPA2aEP3fooyyFTW
+// CHECK-NEXT: }

--- a/validation-test/compiler_crashers_2_fixed/sr11108.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11108.swift
@@ -1,6 +1,4 @@
-// RUN: not --crash %target-swift-emit-silgen %s
-
-// REQUIRES: asserts
+// RUN: %target-swift-emit-silgen %s
 
 protocol Example {
     associatedtype Signed: SignedInteger


### PR DESCRIPTION
Under certain circumstances, introducing a concrete same-type or
superclass constraint can re-introduce conformance constraints
which were previously redundant.

For example, consider this code, which we correctly support today:

```
protocol P {
  associatedtype T : Q
}

protocol Q {}

class SomeClass<U : Q> {}

struct Outer<T> where T : P {
  func inner<U>(_: U) where T == SomeClass<U>, U : Q {}
}
```

The constraint `T == SomeClass<U>` makes the outer constraint
`T : P` redundant, because SomeClass already conforms to P.
It also introduces an implied same-type constraint `U == T.T`.

However, whereas `T : P` together with `U == T.T` make `U : Q`
redundant, the introduction of the constraint `T == SomeClass<U>`
removes`'T : P`, so we re-introduce an explicit constraint `U : Q`
in order to get a valid generic signature.

This code path did the right thing for constraints derived via
concrete same-type constraints, but it did not handle superclass
constraints.

As a result, this case was broken:

```
struct Outer<T> where T : P {
  func inner<U>(_: U) where T : SomeClass<U>, U : Q {}
}
```

This is the same example as above, except T is related via a
superclass constraint to `SomeClass<U>`, instead of via a concrete
same-type constraint.

The subtlety here is that we must check if the superclass type
actually conforms to the requirement source's protocol, because it
is possible to have a superclass-constrained generic parameter
where some conformances are abstract. Eg, if SomeClass did not
conform to another protocol P2, we could write

```
func foo<T, U>(_: T, _: U) where T : SomeClass<U>, T : P2 {}
```

In this case, `T : P2` is an abstract conformance on the type `T`.

The common case where this would come up in real code is when you
have a class that conforms to a protocol with an associated type,
and one of the protocol requirements was fulfilled by a default in
a protocol extension, eg:

```
protocol P {
  associatedtype T : Q

  func foo()
}

extension P {
  func foo() {}
}

class ConformsWithDefault<T : Q> : P {}
```

The above used to crash; now it will type-check correctly.

Fixes <rdar://problem/44736411>, <https://bugs.swift.org/browse/SR-8814>.