### PR TITLE
[5.3][ConstraintSystem] Don't propagate holes through supertype inference

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -69,6 +69,9 @@ void ConstraintSystem::inferTransitiveSupertypeBindings(
 
       auto type = binding.BindingType;
 
+      if (type->isHole())
+        continue;
+
       if (!existingTypes.insert(type->getCanonicalType()).second)
         continue;
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -238,3 +238,10 @@ func autoclosure1<T>(_: [T], _: X) { }
 func test_autoclosure1(ia: [Int]) {
   autoclosure1(ia, X()) // okay: resolves to the second function
 }
+
+// rdar://problem/64368545 - failed to produce diagnostic (hole propagated to func result without recording a fix)
+func test_no_hole_propagation() {
+  func test(withArguments arguments: [String]) -> String {
+    return arguments.reduce(0, +) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32449

---

- Explanation:

Disallow holes to be inferred as supertype bindings  while inferring
bindings from other type variables (based on transitivity of subtype
conversions), otherwise it would be possible to record a hole without
recording associated fix.

- Scope: Affects situations in diagnostic mode where there is a subtype relationship between two type variables and supertype has a hole as one of the potential bindings.

- Resolves: rdar://problem/64368545

- Risk: Very low

- Testing: Added regression tests

- Reviewer: @DougGregor 

Resolves: rdar://problem/64368545
(cherry picked from commit 22832080e23de9718831eed9ad63800c676420fa)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
