### PR TITLE
[5.3][CSApply] Always try to load arguments constructing object literals

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2643,6 +2643,7 @@ namespace {
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
       expr->setInitializer(witness);
+      expr->setArg(cs.coerceToRValue(expr->getArg()));
       return expr;
     }
 

--- a/test/Sema/object_literals_osx.swift
+++ b/test/Sema/object_literals_osx.swift
@@ -27,3 +27,13 @@ let text = #fileLiteral(resourceName: "TextFile.txt").relativeString! // expecte
 
 // rdar://problem/49861813
 #fileLiteral() // expected-error{{missing argument for parameter 'resourceName' in call}} expected-error{{could not infer type of file reference literal}} expected-note{{import Foundation to use 'URL' as the default file reference literal type}}
+
+// rdar://problem/62927467
+func test_literal_arguments_are_loaded() {
+  var resource = "foo.txt" // expected-warning {{variable 'resource' was never mutated; consider changing to 'let' constant}}
+  let _: Path = #fileLiteral(resourceName: resource) // Ok
+
+  func test(red: inout Float, green: inout Float) -> S {
+    return #colorLiteral(red: red, green: green, blue: 1, alpha: 1) // Ok
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32452

---
- Explanation:

AST rewriter needs to make sure that all of the arguments are loaded
since it's currently possible to pass l-value type as an argument to
object literal (`#{file, color, image}Literal`).

- Scope: Limited to object literals with l-value arguments.

- Resolves: rdar://problem/62927467

- Risk: Low

- Testing: Added regression tests

- Reviewer: @DougGregor 

Resolves: rdar://problem/62927467
(cherry picked from commit baaff0d46920b7bb2b0f24e4f6b4944552d885a3)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
