### PR TITLE
Move 'MetadataSections' from 'ImageInspectionElf.h' to SwiftShims

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources
   KeyPath.h
   LibcOverlayShims.h
   LibcShims.h
+  MetadataSections.h
   Random.h
   RefCount.h
   RuntimeShims.h

--- a/stdlib/public/SwiftShims/MetadataSections.h
+++ b/stdlib/public/SwiftShims/MetadataSections.h
@@ -1,0 +1,63 @@
+//===--- MetadataSections.h -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the MetadataSectionsRange and 
+/// MetadataSections struct, which represent, respectively,  information about  
+/// an image's section, and an image's metadata information (which is composed
+/// of multiple section information).
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_METADATASECTIONS_H
+#define SWIFT_STDLIB_SHIMS_METADATASECTIONS_H
+
+#include "SwiftStddef.h"
+#include "SwiftStdint.h"
+
+#ifdef __cplusplus
+namespace swift { 
+extern "C" {
+#endif
+
+typedef struct MetadataSectionRange {
+  __swift_uintptr_t start;
+  __swift_size_t length;
+} MetadataSectionRange;
+
+struct MetadataSections {
+  __swift_uintptr_t version;
+  __swift_uintptr_t reserved;
+
+  struct MetadataSections *next;
+  struct MetadataSections *prev;
+
+
+  MetadataSectionRange swift5_protocols;
+  MetadataSectionRange swift5_protocol_conformances;
+  MetadataSectionRange swift5_type_metadata;
+  MetadataSectionRange swift5_typeref;
+  MetadataSectionRange swift5_reflstr;
+  MetadataSectionRange swift5_fieldmd;
+  MetadataSectionRange swift5_assocty;
+  MetadataSectionRange swift5_replace;
+  MetadataSectionRange swift5_replac2;
+  MetadataSectionRange swift5_builtin;
+  MetadataSectionRange swift5_capture;
+};
+
+#ifdef __cplusplus
+} //extern "C"
+} // namespace swift
+#endif
+
+#endif // SWIFT_STDLIB_SHIMS_METADATASECTIONS_H

--- a/stdlib/public/SwiftShims/module.modulemap
+++ b/stdlib/public/SwiftShims/module.modulemap
@@ -6,6 +6,7 @@ module SwiftShims {
   header "HeapObject.h"
   header "KeyPath.h"
   header "LibcShims.h"
+  header "MetadataSections.h"
   header "Random.h"
   header "RefCount.h"
   header "RuntimeShims.h"

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -21,7 +21,6 @@
 #ifndef SWIFT_RUNTIME_IMAGEINSPECTION_H
 #define SWIFT_RUNTIME_IMAGEINSPECTION_H
 
-#include "ImageInspectionELF.h"
 #include <cstdint>
 #include <cstddef>
 #if defined(__cplusplus)

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -34,31 +34,6 @@ struct SectionInfo {
 };
 
 static constexpr const uintptr_t CurrentSectionMetadataVersion = 1;
-
-struct MetadataSections {
-  uintptr_t version;
-  uintptr_t reserved;
-
-  mutable const MetadataSections *next;
-  mutable const MetadataSections *prev;
-
-  struct Range {
-    uintptr_t start;
-    size_t length;
-  };
-
-  Range swift5_protocols;
-  Range swift5_protocol_conformances;
-  Range swift5_type_metadata;
-  Range swift5_typeref;
-  Range swift5_reflstr;
-  Range swift5_fieldmd;
-  Range swift5_assocty;
-  Range swift5_replace;
-  Range swift5_replac2;
-  Range swift5_builtin;
-  Range swift5_capture;
-};
 } // namespace swift
 
 // Called by injected constructors when a dynamic library is loaded.

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImageInspectionELF.h"
+#include "../SwiftShims/MetadataSections.h"
 
 #include <cstddef>
 


### PR DESCRIPTION
This PR moves the `MetadataSections` definition from ImageInspectionELF to SwiftShims. This is part of the work in unifying the definition of `MetadataSections`, in order to be used by both ELF and COFF-specific procedures, as well as being acessible from Swift for testing purposes.