### PR TITLE
Warn when using Clang declarations from implicitly textually included headers

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_CLANG_MODULE_LOADER_H
 #define SWIFT_AST_CLANG_MODULE_LOADER_H
 
+#include "clang/Basic/SourceLocation.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/Basic/TaggedUnion.h"
 
@@ -184,6 +185,11 @@ public:
   /// Print the Clang type.
   virtual void printClangType(const clang::Type *type,
                               llvm::raw_ostream &os) const = 0;
+
+  /// Return a Swift source location that corresponds to the given Clang
+  /// source location.
+  virtual SourceLoc
+  resolveSourceLocation(clang::SourceLocation clangLoc) const = 0;
 
   /// Try to find a stable serialization path for the given declaration,
   /// if there is one.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -865,6 +865,17 @@ ERROR(imported_decl_is_wrong_kind_typealias,none,
 ERROR(ambiguous_decl_in_module,none,
       "ambiguous name %0 in module %1", (Identifier, Identifier))
 
+WARNING(decl_from_textual_header,none,
+  "module %0 may not intend to export %1 %2, which is defined in a non-modular "
+  "header that the module includes textually",
+  (StringRef, DescriptiveDeclKind, DeclName))
+NOTE(decl_from_textual_header_note_header,none,
+  "%0 defined in this textually included header (preferred fix: create a "
+  "module map for this header, then import the new module)", (DeclName))
+NOTE(decl_from_textual_header_note_module,none,
+  "module %0 defined here (alternative fix: add 'exports *' to the definition "
+  "of this module)", (StringRef))
+
 ERROR(module_not_testable,Fatal,
       "module %0 was not compiled for testing", (Identifier))
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -464,6 +464,9 @@ public:
   void printClangType(const clang::Type *type,
                       llvm::raw_ostream &os) const override;
 
+  SourceLoc
+  resolveSourceLocation(clang::SourceLocation clangLoc) const override;
+
   StableSerializationPath
   findStableSerializationPath(const clang::Decl *decl) const override;
 
@@ -473,6 +476,7 @@ public:
 
   bool isSerializable(const clang::Type *type,
                       bool checkCanonical) const override;
+
   ArrayRef<std::string> getExtraClangArgs() const;
 };
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3284,6 +3284,14 @@ void ClangImporter::printClangType(const clang::Type *type,
   clang::QualType(type, 0).print(os, policy);
 }
 
+SourceLoc
+ClangImporter::resolveSourceLocation(clang::SourceLocation clangLoc) const {
+  auto &srcMgr = getClangASTContext().getSourceManager();
+  ClangSourceBufferImporter &bufferImporter =
+      Impl.getBufferImporterForDiagnostics();
+  return bufferImporter.resolveSourceLocation(srcMgr, clangLoc);
+}
+
 //===----------------------------------------------------------------------===//
 // ClangModule Implementation
 //===----------------------------------------------------------------------===//

--- a/test/Interop/C/modules/Inputs/fake-glibc.h
+++ b/test/Interop/C/modules/Inputs/fake-glibc.h
@@ -1,0 +1,1 @@
+#include <fake-math.h>

--- a/test/Interop/C/modules/Inputs/fake-math.h
+++ b/test/Interop/C/modules/Inputs/fake-math.h
@@ -1,0 +1,1 @@
+double fakeCos(double);

--- a/test/Interop/C/modules/Inputs/module.modulemap
+++ b/test/Interop/C/modules/Inputs/module.modulemap
@@ -1,0 +1,8 @@
+module FakeGlibc {
+  header "fake-glibc.h"
+  export *
+}
+
+module WarnOnImplicitTextualIncludes {
+  header "warn-on-implicit-textual-includes.h"
+}

--- a/test/Interop/C/modules/Inputs/warn-on-implicit-textual-includes.h
+++ b/test/Interop/C/modules/Inputs/warn-on-implicit-textual-includes.h
@@ -1,0 +1,3 @@
+#include "fake-math.h"
+
+double userFunction();

--- a/test/Interop/C/modules/warn-on-implicit-textual-includes.swift
+++ b/test/Interop/C/modules/warn-on-implicit-textual-includes.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs
+
+import FakeGlibc
+import WarnOnImplicitTextualIncludes
+
+// Calling a function from a modularized header (whether qualified or
+// unqualified) is fine.
+_ = userFunction()
+_ = RejectTextualIncludes.userFunction()
+
+// Calling `fakeCos` without qualification is OK. The declaration comes from a
+// textually included header, but `FakeGlibc` has an `export *` statement.
+_ = fakeCos(0.0)
+_ = FakeGlibc.fakeCos(0.0)
+
+// Calling `fakeCos` with a `RejectTextualIncludes` qualification is not OK
+// because the definition comes from a textually included header and
+// `RejectTextualIncludes` does not contain an `export *` statement.
+_ = RejectTextualIncludes.fakeCos(0.0)


### PR DESCRIPTION
The immediate motivation for this comes from this proposal to change the `SwiftGlibc` module map, which will result in glibc headers being textually included:

https://forums.swift.org/t/problems-with-swiftglibc-and-proposed-fix/37594

In this context, we want to prevent user modules from starting to export declarations from libc headers. However, the new diagnostic is useful generally.

Currently, the diagnostic we output is always a warning. A followup PR will change this to an error for declarations that came from a textually included libc header.