### PR TITLE
build: correct handling of argument generation

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -57,9 +57,11 @@ function(add_swift_unittest test_dirname)
       _ENABLE_EXTENDED_ALIGNED_STORAGE)
   endif()
 
-  if(SWIFT_USE_LINKER)
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
-      LINK_FLAGS " -fuse-ld=${SWIFT_USE_LINKER}")
+  if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+    if(SWIFT_USE_LINKER)
+      target_link_options(${test_dirname} PRIVATE
+        -fuse-ld=${SWIFT_USE_LINKER}$<$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>:.exe>)
+    endif()
   endif()
 
   if(SWIFT_ANALYZE_CODE_COVERAGE)


### PR DESCRIPTION
This adjusts the target specific argument handling to use the same logic
as the toolchain, and in doing so, silences the spurious warnings when
building with a MSVC toolchain.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
