### PR TITLE
[verifier] Do not use llvm::report_fatal_error since it swallows PrettyStackTrace.

### DIFF
--- a/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
+++ b/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
@@ -208,7 +208,7 @@ private:
     }
 
     llvm::errs() << "Found ownership error?!\n";
-    llvm::report_fatal_error("triggering standard assertion failure routine");
+    assert(0 && "triggering standard assertion failure routine");
   }
 };
 


### PR DESCRIPTION
I thought this was me being more standard but I keep on hitting this so I am
returning back to an assert(0) version of this. This is only enabled if NDEBUG
is set, so this is ok.
