### PR TITLE
[DepScan] NFC: Remove check for OnoneSupport

### DIFF
--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -459,12 +459,6 @@ bool swift::scanDependencies(CompilerInstance &instance) {
       break;
     }
 
-    // Swift -Onone support library.
-    if (invocation.shouldImportSwiftONoneSupport()) {
-      mainDependencies.addModuleDependency(
-          SWIFT_ONONE_SUPPORT, alreadyAddedModules);
-    }
-
     // Add any implicit module names.
     for (const auto &moduleName : importInfo.ModuleNames) {
       mainDependencies.addModuleDependency(moduleName.str(), alreadyAddedModules);


### PR DESCRIPTION
This dependency is already recorded in the `importInfo`'s `ModuleNames`.
