### PR TITLE
[android] Set linux-androideabi (Android ARM 32 bits) as ABI stable during testing.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -693,7 +693,7 @@ if (run_os == 'maccatalyst'):
   target_os_abi = 'macosx'
   target_os_is_maccatalyst = "TRUE"
   config.available_features.add("OS=ios")
-if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android']):
+if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android', 'linux-androideabi']):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')
 config.substitutions.append(('%target-os-abi', target_os_abi))
@@ -1354,7 +1354,7 @@ elif run_os == 'wasi':
         '-target', config.variant_triple,
         '-Xcc', '--sysroot=%s' % config.variant_sdk,
         '-Xclang-linker', '--sysroot=%s' % config.variant_sdk,
-        '-toolchain-stdlib-rpath', resource_dir_opt, 
+        '-toolchain-stdlib-rpath', resource_dir_opt,
         mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
@@ -1400,7 +1400,7 @@ elif run_os == 'wasi':
         "%s -target %s %s -fobjc-runtime=ios-5.0" %
         (config.clang, config.variant_triple, clang_mcp_opt))
     config.target_ld = (
-        "%s -L%r" % 
+        "%s -L%r" %
         (config.wasm_ld, make_path(test_resource_dir, config.target_sdk_name)))
 
     # The Swift interpreter is not available when targeting WebAssembly/WASI.
@@ -1686,7 +1686,7 @@ if not kIsWindows:
 			"LD_LIBRARY_PATH='{0}:{1}' " # Linux option
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
 			.format(all_stdlib_path, libdispatch_path)) + config.target_run
-			
+
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized = SubstituteCaptures(
         "%%empty-directory(%%t) && "


### PR DESCRIPTION
Seems that Android ARM 32 bits, which uses linux-androideabi as OS
generates code that is ABI stable. Mark the OS as ABI stable, as it was
already for Android ARM 64 bits.

There's also some white space removal in unrelated lines.
