### PR TITLE
[Runtime] Add entry point to canonicalize metadata.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -658,6 +658,10 @@ public:
   /// platform.
   AvailabilityContext getCompareProtocolConformanceDescriptorsAvailability();
 
+  /// Get the runtime availability of support for inter-module prespecialized
+  /// generic metadata.
+  AvailabilityContext getIntermodulePrespecializedGenericMetadataAvailability();
+
   /// Get the runtime availability of features introduced in the Swift 5.2
   /// compiler for the target platform.
   AvailabilityContext getSwift52Availability();

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -320,6 +320,26 @@ MetadataResponse
 swift_getSingletonMetadata(MetadataRequest request,
                            const TypeContextDescriptor *description);
 
+/// Fetch a uniqued metadata object for the generic nominal type described by
+/// the provided candidate metadata, using that candidate metadata if there is
+/// not already a canonical metadata.
+///
+/// Runtime availability: Swift 5.4
+///
+/// \param candidate A prespecialized metadata record for a type which is not
+///                  statically made to be canonical which will be canonicalized
+///                  if no other canonical metadata exists for the type.
+/// \param cache A pointer to a cache which will be set to the canonical 
+///              metadata record for the type described by the candidate 
+///              metadata record.  If the cache has already been populated, its
+///              contents will be returned.
+/// \returns The canonical metadata for the specialized generic type described
+///          by the provided candidate metadata.
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift) MetadataResponse
+    swift_getCanonicalSpecializedMetadata(MetadataRequest request,
+                                          const Metadata *candidate,
+                                          const Metadata **cache);
+
 /// Fetch a uniqued metadata object for a generic nominal type.
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 MetadataResponse

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -645,6 +645,14 @@ FUNCTION(GetGenericMetadata, swift_getGenericMetadata,
          ARGS(SizeTy, Int8PtrTy, TypeContextDescriptorPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
+// MetadataResponse swift_getCanonicalSpecializedMetadata(MetadataRequest request,
+//                                                        Metadata *candidate);
+FUNCTION(GetCanonicalSpecializedMetadata, swift_getCanonicalSpecializedMetadata,
+         SwiftCC, GetCanonicalSpecializedMetadataAvailability,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrPtrTy),
+         ATTRS(NoUnwind, ReadOnly))
+
 // MetadataResponse swift_getOpaqueTypeMetadata(MetadataRequest request,
 //                                     const void * const *arguments,
 //                                     const OpaqueTypeDescriptor *descriptor,

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -318,6 +318,11 @@ ASTContext::getCompareProtocolConformanceDescriptorsAvailability() {
   return getSwiftFutureAvailability();
 }
 
+AvailabilityContext
+ASTContext::getIntermodulePrespecializedGenericMetadataAvailability() {
+  return getSwiftFutureAvailability();
+}
+
 AvailabilityContext ASTContext::getSwift52Availability() {
   auto target = LangOpts.Target;
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -271,6 +271,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     MetadataKindTy          // MetadataKind Kind;
   });
   TypeMetadataPtrTy = TypeMetadataStructTy->getPointerTo(DefaultAS);
+  TypeMetadataPtrPtrTy = TypeMetadataPtrTy->getPointerTo(DefaultAS);
 
   TypeMetadataResponseTy = createStructType(*this, "swift.metadata_response", {
     TypeMetadataPtrTy,
@@ -666,6 +667,16 @@ namespace RuntimeConstants {
     auto featureAvailability =
         Context.getCompareProtocolConformanceDescriptorsAvailability();
     if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+      return RuntimeAvailability::ConditionallyAvailable;
+    }
+    return RuntimeAvailability::AlwaysAvailable;
+  }
+
+  RuntimeAvailability
+  GetCanonicalSpecializedMetadataAvailability(ASTContext &context) {
+    auto featureAvailability =
+        context.getIntermodulePrespecializedGenericMetadataAvailability();
+    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -635,6 +635,7 @@ public:
   llvm::FunctionType *DeallocatingDtorTy; /// void (%swift.refcounted*)
   llvm::StructType *TypeMetadataStructTy; /// %swift.type = type { ... }
   llvm::PointerType *TypeMetadataPtrTy;/// %swift.type*
+  llvm::PointerType *TypeMetadataPtrPtrTy; /// %swift.type**
   union {
     llvm::StructType *TypeMetadataResponseTy;   /// { %swift.type*, iSize }
     llvm::StructType *TypeMetadataDependencyTy; /// { %swift.type*, iSize }


### PR DESCRIPTION
The new function `swift_getCanonicalSpecializedMetadata` takes a metadata request, a prespecialized non-canonical metadata, and a cache as its arguments.  The idea of the function is either to bless the provided prespecialized metadata as canonical if there is not currently a canonical metadata record for the type it describes or else to return the actual canonical metadata.

When called, the metadata cache checks for a preexisting entry for this metadata.  If none is found, the passed-in prespecialized metadata is added to the cache.  Otherwise, the metadata record found in the cache is returned.

Until the ability to look through a type's canonical prespecializations is added, `swift_getCanonicalSpecializedMetadata` can't look through the canonical prespecializations that have been created for the generic nominal type in order to return it.  Consequently, it must only be called with arguments which can be statically known not to have been possible to canonically prespecialize--for example, it would be sufficient to know that one of the generic arguments is from the module in which the non-canonical prespecialization is defined.

rdar://problem/56995359