### PR TITLE
README: Add git-lfs to ubuntu dependencies #trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ sudo apt-get install    \
   clang                 \
   cmake                 \
   git                   \
+  git-lfs               \
   icu-devtools          \
   libcurl4-openssl-dev  \
   libedit-dev           \


### PR DESCRIPTION
Looks like the latest azure ubuntu doesn't come with `git-lfs` installed, which leads to `utils/update-checkout` failing while cloning `icu`

```bash
error: external filter 'git lfs smudge %f' failed 1
error: external filter 'git lfs smudge %f' failed
fatal: icu4j/main/shared/data/icudata.jar: smudge filter lfs failed
```