### PR TITLE
test: make `binary_sub` python 2, 3 compatible

### DIFF
--- a/test/Serialization/Inputs/binary_sub.py
+++ b/test/Serialization/Inputs/binary_sub.py
@@ -5,5 +5,9 @@ import sys
 (_, old, new) = sys.argv
 assert(len(old) == len(new))
 
-data = sys.stdin.read()
-sys.stdout.write(data.replace(old, new))
+if sys.version_info[0] < 3:
+    data = sys.stdin.read()
+    sys.stdout.write(data.replace(old, new))
+else:
+    data = sys.stdin.buffer.read()
+    sys.stdout.buffer.write(data.replace(old.encode('utf-8'), new.encode('utf-8')))


### PR DESCRIPTION
In order to access `stdin`, `stdout` as binary, you must use the
`buffer` member in Python 3.  The replacement of the binary data
requires that pattern and the replacement be byte objects.  Convert the
pattern and replacement to UTF-8 encoded bytes.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
