### PR TITLE
utils: update `remote-run` for Python 3 compatibility

### DIFF
--- a/utils/remote-run
+++ b/utils/remote-run
@@ -41,19 +41,19 @@ class CommandRunner(object):
     def send(self, local_to_remote_files):
         # Prepare the remote directory structure.
         # FIXME: This could be folded into the sftp connection below.
-        dirs_to_make = self._dirnames(local_to_remote_files.viewvalues())
+        dirs_to_make = self._dirnames(local_to_remote_files.values())
         self.run_remote(['/bin/mkdir', '-p'] + dirs_to_make)
 
         # Send the local files.
         sftp_commands = ("-put {0} {1}".format(quote(local_file), 
                                                quote(remote_file))
                          for local_file, remote_file
-                         in local_to_remote_files.viewitems())
+                         in local_to_remote_files.items())
         self.run_sftp(sftp_commands)
 
     def fetch(self, local_to_remote_files):
         # Prepare the local directory structure.
-        dirs_to_make = self._dirnames(local_to_remote_files.viewkeys())
+        dirs_to_make = self._dirnames(local_to_remote_files.keys())
         mkdir_command = ['/bin/mkdir', '-p'] + dirs_to_make
         if self.verbose:
             print(' '.join(mkdir_command), file=sys.stderr)
@@ -64,11 +64,11 @@ class CommandRunner(object):
         sftp_commands = ("-get {0} {1}".format(quote(remote_file), 
                                                quote(local_file))
                          for local_file, remote_file
-                         in local_to_remote_files.viewitems())
+                         in local_to_remote_files.items())
         self.run_sftp(sftp_commands)
 
     def run_remote(self, command, remote_env={}):
-        env_strings = ['{0}={1}'.format(k,v) for k,v in remote_env.viewitems()]
+        env_strings = ['{0}={1}'.format(k,v) for k,v in remote_env.items()]
         remote_invocation = self.remote_invocation(
             ['/usr/bin/env'] + env_strings + command)
         remote_proc = self.popen(remote_invocation, stdin=subprocess.PIPE,
@@ -213,16 +213,16 @@ def main():
         remote_dir = posixpath.join(args.remote_dir, args.remote_input_prefix)
         input_files = find_transfers(args.command, args.input_prefix, 
                                      remote_dir)
-        assert not any(upload_files.has_key(f) for f in input_files)
+        assert not any(f in upload_files for f in input_files)
         upload_files.update(input_files)
     if args.output_prefix:
         assert not args.remote_output_prefix.startswith("..")
         remote_dir = posixpath.join(args.remote_dir, args.remote_output_prefix)
         test_files = find_transfers(args.command, args.output_prefix, 
                                     remote_dir)
-        assert not any(upload_files.has_key(f) for f in test_files)
+        assert not any(f in upload_files for f in test_files)
         upload_files.update(test_files)
-        assert not any(download_files.has_key(f) for f in test_files)
+        assert not any(f in download_files for f in test_files)
         download_files.update(test_files)
         remote_test_specific_dir = remote_dir
 


### PR DESCRIPTION
Make `remote-run` be compatible with python 2 and python 3.  The changes
are:
- replace `viewitems` with `items`
- replace `viewvalues` with `values`
- replace `viewkeys` with `keys`
- replace `haskey` with `in`

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
