### PR TITLE
[build-presets] Enable stdlib assertions on Linux installations

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -760,7 +760,6 @@ assertions
 # compiler significantly.
 [preset: mixin_lightweight_assertions]
 assertions
-no-swift-stdlib-assertions
 
 # FIXME: This should be:
 # no-assertions
@@ -771,6 +770,12 @@ dash-dash
 
 # AST verifier slows down the compiler significantly.
 swift-enable-ast-verifier=0
+
+[preset: mixin_lightweight_assertions,no-stdlib-asserts]
+mixin-preset=
+    mixin_lightweight_assertions
+
+no-swift-stdlib-assertions
 
 #===------------------------------------------------------------------------===#
 # Linux Builders
@@ -870,7 +875,7 @@ mixin-preset=
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build]
 mixin-preset=
-    mixin_lightweight_assertions
+    mixin_lightweight_assertions,no-stdlib-asserts
     mixin_linux_install_components_with_clang
 build-subdir=buildbot_linux
 
@@ -1287,7 +1292,7 @@ installable-package=%(installable_package)s
 mixin-preset=
     mixin_osx_package_base
     mixin_osx_package_test
-    mixin_lightweight_assertions
+    mixin_lightweight_assertions,no-stdlib-asserts
 
 
 [preset: buildbot_osx_package,no_assertions]


### PR DESCRIPTION
Enable stdlib assertions in mixin_linux_installation.

Other presets which use mixin_lightweight_assertions, such as
buildbot_linux_crosscompile_android and buildbot_osx_package, are not
affected by this change.

Stdlib assertions are needed by reflection validation tests on Linux
(see https://github.com/apple/swift/pull/32339).

cc @augusto2112 