### PR TITLE
[SourceKit/Indentation] Fix over-indent after function decl with no param list or body.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -1907,6 +1907,11 @@ private:
       return Aligner.getContextAndSetAlignment(CtxOverride);
     }
 
+    // There are no parens at this point, so if there are no parameters either,
+    // this shouldn't be a context (it's an implicit parameter list).
+    if (!PL->size())
+      return None;
+
     ListAligner Aligner(SM, TargetLocation, ContextLoc, Range.Start);
     for (auto *PD: *PL)
       Aligner.updateAlignment(PD->getSourceRange(), PD);

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -1036,3 +1036,19 @@ private var secondThing = item
     .filter {},
     firstThing = 20,
     thirdThing = 56
+
+
+// Function decls missing their parameter list and body shouldn't pick up the next token as a continuation.
+
+struct BarType {
+    func bar
+}
+
+struct <#name#> {
+    <#fields#>
+}
+
+struct <#name#> {
+    <#fields#>
+    func foo() {}
+}


### PR DESCRIPTION
Indentation after an incompletion function declaration with no parameter list or body always indents the next line relative to it, incorrectly.

E.g:
```
struct Foo {
  bar
    } // this gets indented relative to 'bar'

struct Foo {
  bar
    func foo() {} // this gets indented relative to 'bar'
} 
```
This is particularly bad because we treat a placeholder in a struct/class body as if it were an incompletion function declaration, and when completing on a struct/class keyword in Xcode you get the snippet below with such a placeholder and the incorrect indentation:

```
struct <#name#> {
  <#fields#>
    }
```

Resolves rdar://problem/64618791