### PR TITLE
[test] Reinstate CoreGraphics↔︎NSValue bridging tests on iOS/watchOS/tvOS

### DIFF
--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -23,6 +23,10 @@ import StdlibUnittestFoundationExtras
 import Foundation
 import CoreGraphics
 
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#endif
+
 var nsValueBridging = TestSuite("NSValueBridging")
 
 func rangesEqual(_ x: NSRange, _ y: NSRange) -> Bool {
@@ -63,6 +67,16 @@ ${ testCase("CGPoint",           "CGPoint(x: 17, y: 38)",                      "
 ${ testCase("CGSize",            "CGSize(width: 6, height: 79)",               "size",  "(==)") }
 ${ testCase("CGVector",          "CGVector(dx: 6, dy: 79)",                    None,    "(==)") }
 ${ testCase("CGAffineTransform", "CGAffineTransform(rotationAngle: .pi)",      None,    "(==)") }
+
+#endif
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+
+${ testCase("CGRect",            "CGRect(x: 17, y: 38, width: 6, height: 79)", "cgRect",            "(==)") }
+${ testCase("CGPoint",           "CGPoint(x: 17, y: 38)",                      "cgPoint",           "(==)") }
+${ testCase("CGSize",            "CGSize(width: 6, height: 79)",               "cgSize",            "(==)") }
+${ testCase("CGVector",          "CGVector(dx: 6, dy: 79)",                    "cgVector",          "(==)") }
+${ testCase("CGAffineTransform", "CGAffineTransform(rotationAngle: .pi)",      "cgAffineTransform", "(==)") }
 
 #endif
 

--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -18,6 +18,9 @@
 //
 // REQUIRES: objc_interop
 
+// The UIKit overlay isn't present on iOS 10.3.
+// UNSUPPORTED: CPU=i386
+
 import StdlibUnittest
 import StdlibUnittestFoundationExtras
 import Foundation


### PR DESCRIPTION
This is a followup to #32502, reinstating a Foundation test.