### PR TITLE
Correct Bogus NULL-Returns in _swift_stdlib_getUnsafeArgvArgc

### DIFF
--- a/stdlib/public/stubs/CommandLine.cpp
+++ b/stdlib/public/stubs/CommandLine.cpp
@@ -89,7 +89,7 @@ char **_swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   }
   fclose(cmdline);
   *outArgLen = argvec.size();
-  char **outBuf = (char **)calloc(argvec.size() + 1, sizeof(char *));
+  auto outBuf = static_cast<char **>(calloc(argvec.size() + 1, sizeof(char *)));
   std::copy(argvec.begin(), argvec.end(), outBuf);
   outBuf[argvec.size()] = nullptr;
 
@@ -175,7 +175,7 @@ char **_swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   size_t argPtrSize = 0;
   for (int i = 0; i < 3 && !argPtr; ++i) { // give up after 3 tries
     if (sysctl(mib, 4, nullptr, &argPtrSize, nullptr, 0) != -1) {
-      argPtr = (char *)malloc(argPtrSize);
+      argPtr = static_cast<char *>(malloc(argPtrSize));
       if (sysctl(mib, 4, argPtr, &argPtrSize, nullptr, 0) == -1) {
         free(argPtr);
         argPtr = nullptr;
@@ -199,7 +199,7 @@ char **_swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   for (; curPtr < endPtr; curPtr += strlen(curPtr) + 1)
     argvec.push_back(strdup(curPtr));
   *outArgLen = argvec.size();
-  char **outBuf = (char **)calloc(argvec.size() + 1, sizeof(char *));
+  auto outBuf = static_cast<char **>(calloc(argvec.size() + 1, sizeof(char *)));
   std::copy(argvec.begin(), argvec.end(), outBuf);
   outBuf[argvec.size()] = nullptr;
 
@@ -230,8 +230,8 @@ char **_swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
     return nullptr;
 
   size_t num_ptrs = argc + 1;
-  char *argv_buf = (char *)malloc(argv_buf_size);
-  char **argv = (char **)calloc(num_ptrs, sizeof(char *));
+  char *argv_buf = static_cast<char *>(alloc(argv_buf_size));
+  char **argv = static_cast<char **>(calloc(num_ptrs, sizeof(char *)));
 
   err = __wasi_args_get((uint8_t **)argv, (uint8_t *)argv_buf);
   if (err != __WASI_ERRNO_SUCCESS) {


### PR DESCRIPTION
Correct multiple platforms' bad behavior on error handling paths. The nullability annotations on the return type of `_swift_stdlib_getUnsafeArgvArgc` **forbids** this function from returning `nullptr`. Therefore just crash. There's very little else that we can do here that will produce a coherent result for these failing cases.

While I'm here, modernize some C-style casts in all of the platforms.