### PR TITLE
Add Order File Flag

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -973,6 +973,11 @@ def num_threads : Separate<["-"], "num-threads">,
   HelpText<"Enable multi-threading and specify number of threads">,
   MetaVarName<"<n>">;
 
+def order_file_instrumentation : Separate<["-"], "-order-file-instrumentation">,
+  Flags<[FrontendOption, NoDriverOption]>,
+  HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)">,
+  MetaVarName<"<n>">;
+
 def Xfrontend : Separate<["-"], "Xfrontend">, Flags<[HelpHidden]>,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to the Swift frontend">;
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -456,6 +456,11 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back(remarksFilter->getValue());
   }
 
+  if (context.Args.hasArg(options::OPT_order_file_instrumentation)) {
+    Arguments.push_back("-mllvm");
+    Arguments.push_back("-enable-order-file-instrumentation");
+  }
+
   if (context.Args.hasArg(options::OPT_migrate_keep_objc_visibility)) {
     Arguments.push_back("-migrate-keep-objc-visibility");
   }


### PR DESCRIPTION
As discussed in https://forums.swift.org/t/order-file-generation-support-in-swiftc/37012/2, it would be great to have a simple flag to enable order file support and match clang's behavior. Order files are used with success by some of the largest apps in the world, and adding first-class support would make using them with Swift easier. According to the thread, @vedantk believes that just adding this LLVM pass should do everything that's necessary. Besides that, my one concern is as we see in clang:
```
  if (Args.hasArg(options::OPT_forder_file_instrumentation)) {
     CmdArgs.push_back("-forder-file-instrumentation");
     // Enable order file instrumentation when ThinLTO is not on. When ThinLTO is
     // on, we need to pass these flags as linker flags and that will be handled
     // outside of the compiler.
     if (!D.isUsingLTO()) {
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-enable-order-file-instrumentation");
     }
  }
```

I'm not sure which linker flags would enable this with LTO, but since Swift doesn't support LTO currently anyways (correct?), I guess we could cross that bridge when we get there