### PR TITLE
[CodeCompletion] Fallback to nominal member completion after trailing closure

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3225,7 +3225,7 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
       if (CodeCompletion)
         CodeCompletion->completeLabeledTrailingClosure(CCExpr, Tok.isAtStartOfLine());
       consumeToken(tok::code_complete);
-      result.hasCodeCompletion();
+      result.setHasCodeCompletion();
       closures.push_back({Identifier(), SourceLoc(), CCExpr});
       continue;
     }

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -15,6 +15,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_REQUIRED_NEWLINE_3 | %FileCheck %s -check-prefix=INIT_REQUIRED_NEWLINE_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_FALLBACK_1 | %FileCheck %s -check-prefix=INIT_FALLBACK
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_FALLBACK_2 | %FileCheck %s -check-prefix=INIT_FALLBACK
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBERDECL_SAMELINE | %FileCheck %s -check-prefix=MEMBERDECL_SAMELINE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBERDECL_NEWLINE | %FileCheck %s -check-prefix=MEMBERDECL_NEWLINE
 
 func globalFunc1(fn1: () -> Int, fn2: () -> String) {}
 func testGlobalFunc() {
@@ -206,4 +208,29 @@ func testFallbackPostfix() {
   } arg3: {
     1
   } #^INIT_FALLBACK_2^#
+}
+
+protocol P {
+  func foo()
+}
+struct TestNominalMember: P {
+  var value = MyStruct().method1 { 1 } #^MEMBERDECL_SAMELINE^#
+  #^MEMBERDECL_NEWLINE^#
+
+// MEMBERDECL_SAMELINE: Begin completions, 4 items
+// MEMBERDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// MEMBERDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#]; name=enumFunc()
+// MEMBERDECL_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#]; name=+ SimpleEnum
+// MEMBERDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#]; name=self
+// MEMBERDECL_SAMELINE: End completions
+
+// MEMBERDECL_NEWLINE: Begin completions
+// MEMBERDECL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// MEMBERDECL_NEWLINE-DAG: Keyword[enum]/None:                 enum; name=enum
+// MEMBERDECL_NEWLINE-DAG: Keyword[func]/None:                 func; name=func
+// MEMBERDECL_NEWLINE-DAG: Keyword[private]/None:              private; name=private
+// MEMBERDECL_NEWLINE-DAG: Keyword/None:                       lazy; name=lazy
+// MEMBERDECL_NEWLINE-DAG: Keyword[var]/None:                  var; name=var
+// MEMBERDECL_NEWLINE-DAG: Decl[InstanceMethod]/Super:         func foo() {|}; name=foo()
+// MEMBERDECL_NEWLINE: End completions
 }


### PR DESCRIPTION
After trailing closure, we perform "Labeled trailing closure" completion and fall back to other completion depending on the position. If the completion happens at a newline position, it used to fallback to global expression completion, but in type context, we should do override completion instead.

Also, it didn't use to propagate `hasCodeCompletion()` status properly.

rdar://problem/64650782
