### PR TITLE
Driver: update old doc comments from when clang++ was the linker driver

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -103,10 +103,9 @@ $ NDK_PATH="path/to/android-ndk21"
 $ build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \     # The Swift compiler built in the previous step.
                                                                 # The location of the tools used to build Android binaries
     -tools-directory ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/ \
-    -target armv7a-none-linux-androideabi \                     # Targeting android-armv7.
-    -sdk ${NDK_PATH}/platforms/android-21/arch-arm \            # Use the same architecture and API version as you used to build the stdlib in the previous step.
-    -Xclang-linker -nostdlib++ \                                # Don't link libc++, and supply the path to libgcc.
+    -target armv7a-none-linux-androideabi \                     # Targeting android-armv7, and supply the path to libgcc.
     -L ${NDK_PATH}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/armv7-a \
+    -sdk ${NDK_PATH}/platforms/android-21/arch-arm \            # Use the same architecture and API version as you used to build the stdlib in the previous step.
     hello.swift
 ```
 

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -337,7 +337,7 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
         Twine("-u", llvm::getInstrProfRuntimeHookVarName())));
   }
 
-  // Run clang++ in verbose mode if "-v" is set
+  // Run clang in verbose mode if "-v" is set
   if (context.Args.hasArg(options::OPT_v)) {
     Arguments.push_back("-v");
   }

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -112,7 +112,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   // Rely on `-libc` to correctly identify the MSVC Runtime Library.  We use
   // `-nostartfiles` as that limits the difference to just the
-  // `-defaultlib:libcmt` which is passed unconditionally with the `clang++`
+  // `-defaultlib:libcmt` which is passed unconditionally with the `clang`
   // driver rather than the `clang-cl` driver.
   Arguments.push_back("-nostartfiles");
 
@@ -186,7 +186,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 
-  // Run clang++ in verbose mode if "-v" is set
+  // Run clang in verbose mode if "-v" is set
   if (context.Args.hasArg(options::OPT_v)) {
     Arguments.push_back("-v");
   }


### PR DESCRIPTION
I noticed that these could all be updated since #26110 last year, which changed the linker driver on these platforms from `clang++` to `clang`.