### PR TITLE
test: make `make-unreadable` Python 3 friendly

### DIFF
--- a/test/ModuleInterface/Inputs/make-unreadable.py
+++ b/test/ModuleInterface/Inputs/make-unreadable.py
@@ -7,7 +7,7 @@ if platform.system() == 'Windows':
     import ctypes
     AdvAPI32 = ctypes.windll.Advapi32
 
-    from ctypes.wintypes import POINTER
+    from ctypes import POINTER
 
     UNLEN = 256
 


### PR DESCRIPTION
Make `make-unreadable` python 3 compatible.  `POINTER` is now in
`ctypes` rather than in `ctypes.wintypes`.  Use the new location which
is compatible across python 2 and python 3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
