### PR TITLE
[AutoDiff] Fix false `Differentiable` derived conformances warning.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -45,7 +45,7 @@ getStoredPropertiesForDifferentiation(NominalTypeDecl *nominal, DeclContext *DC,
     if (auto *originalProperty = vd->getOriginalWrappedProperty()) {
       // Skip immutable wrapped properties. `mutating func move(along:)` cannot
       // be synthesized to update these properties.
-      if (!originalProperty->getAccessor(AccessorKind::Set))
+      if (!originalProperty->isSettable(DC))
         continue;
       // Use the original wrapped property.
       vd = originalProperty;
@@ -791,7 +791,7 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
       // Diagnose wrapped properties whose property wrappers do not define
       // `wrappedValue.set`. `mutating func move(along:)` cannot be synthesized
       // to update these properties.
-      if (!originalProperty->getAccessor(AccessorKind::Set)) {
+      if (!originalProperty->isSettable(DC)) {
         auto *wrapperDecl =
             vd->getInterfaceType()->getNominalOrBoundGenericNominal();
         auto loc =

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -525,7 +525,6 @@ class SR_12793: Differentiable {
 }
 
 // Test property wrappers.
-// TF-1190: Test `@noDerivative` warning for property wrapper backing storage properties.
 
 @propertyWrapper
 struct ImmutableWrapper<Value> {
@@ -559,10 +558,13 @@ class WrappedProperties: Differentiable {
 
   @Wrapper var float: Generic<Float> = Generic()
   @ClassWrapper var float2: Generic<Float> = Generic()
+  // SR-13071: Test `@differentiable` wrapped property.
+  @differentiable @Wrapper var float3: Generic<Float> = Generic()
+
   @noDerivative @ImmutableWrapper var nondiff: Generic<Int> = Generic()
 
   static func testTangentMemberwiseInitializer() {
-    _ = TangentVector(float: .init(), float2: .init())
+    _ = TangentVector(float: .init(), float2: .init(), float3: .init())
   }
 }
 

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -341,7 +341,6 @@ struct SR_12793: Differentiable {
 }
 
 // Test property wrappers.
-// TF-1190: Test `@noDerivative` warning for property wrapper backing storage properties.
 
 @propertyWrapper
 struct ImmutableWrapper<Value> {
@@ -372,10 +371,13 @@ struct WrappedProperties: Differentiable {
 
   @Wrapper var float: Generic<Float>
   @ClassWrapper var float2: Generic<Float>
+  // SR-13071: Test `@differentiable` wrapped property.
+  @differentiable @Wrapper var float3: Generic<Float>
+
   @noDerivative @ImmutableWrapper var nondiff: Generic<Int>
 
   static func testTangentMemberwiseInitializer() {
-    _ = TangentVector(float: .init(), float2: .init())
+    _ = TangentVector(float: .init(), float2: .init(), float3: .init())
   }
 }
 


### PR DESCRIPTION
Fix false `Differentiable` derived conformances warning on `@differentiable` property-wrapped properties.

Check property mutability using `VarDecl::isSettable` instead of `VarDecl::getAccessor(AccessorKind::Set)`.
Some settable properties do not have setters, depending on the underlying `WriteImplKind`.

Resolves SR-13071.