### PR TITLE
AST: isEquivalentToExtendedContext() should consider use patterns of @_originallyDefinedIn

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1297,7 +1297,12 @@ bool ExtensionDecl::isConstrainedExtension() const {
 
 bool ExtensionDecl::isEquivalentToExtendedContext() const {
   auto decl = getExtendedNominal();
-  return getParentModule() == decl->getParentModule()
+  auto extendDeclfromSameModule =
+    getParentModule() == decl->getParentModule() ||
+    // if the extended type was defined in the same module with the extension,
+    // we should consider them as the same module to preserve ABI stability.
+    decl->getAlternateModuleName() == getParentModule()->getNameStr();
+  return extendDeclfromSameModule
     && !isConstrainedExtension()
     && !getDeclaredInterfaceType()->isExistentialType();
 }

--- a/test/TBD/move_to_extension.swift
+++ b/test/TBD/move_to_extension.swift
@@ -1,0 +1,54 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/before_move.tbd -D BEFORE_MOVE -module-name Foo -enable-library-evolution
+// RUN: %FileCheck %s < %t/before_move.tbd
+
+// RUN: %target-swift-frontend %s -emit-module -emit-module-path %t/FooCore.swiftmodule -D AFTER_MOVE_FOO_CORE -module-name FooCore -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/after_move.tbd -D AFTER_MOVE_FOO -module-name Foo -I %t -enable-library-evolution
+// RUN: %FileCheck %s < %t/after_move.tbd
+
+// CHECK: '_$s3Foo4DateC14getCurrentYearSiyFZ'
+// CHECK: '_$s3Foo9DateValueV4yearACSi_tcfC'
+// CHECK: '_$s3Foo9DateValueV4yearSivg'
+// CHECK: '_$s3Foo9DateValueV4yearSivpMV'
+
+#if BEFORE_MOVE
+
+public class Date {
+  public static func getCurrentYear() -> Int { return 2020 }
+}
+
+public struct DateValue {
+  public init(year: Int) {}
+  public var year: Int { return 2020 }
+}
+
+#endif
+
+#if AFTER_MOVE_FOO_CORE
+
+@available(OSX 10.7, *)
+@_originallyDefinedIn(module: "Foo", OSX 10.9)
+public class Date {}
+
+@available(OSX 10.7, *)
+@_originallyDefinedIn(module: "Foo", OSX 10.9)
+public struct DateValue {}
+
+#endif
+
+#if AFTER_MOVE_FOO
+
+@_exported import FooCore
+
+public extension Date {
+  public static func getCurrentYear() -> Int { return 2020 }
+}
+
+public extension DateValue {
+  public init(year: Int) {}
+  public var year: Int { return 2020 }
+}
+
+#endif


### PR DESCRIPTION
When a nominal type and its extensions coexist in the same module, mangling may
use the nominal type as the context for extension members. We should preserve this
mechanism for types marked as @_originallyDefinedIn to maintain ABI stability.

rdar://64538537