### PR TITLE
[IRGen] Consume all arguments when generating Builtin.ZeroInitializer.

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -980,6 +980,7 @@ if (Builtin.ID == BuiltinValueKind::id) { \
   }
   
   if (Builtin.ID == BuiltinValueKind::ZeroInitializer) {
+    (void)args.claimAll();
     // Build a zero initializer of the result type.
     auto valueTy = getLoweredTypeAndTypeInfo(IGF.IGM,
                                              substitutions.getReplacementTypes()[0]);

--- a/validation-test/IRGen/builtin-zero-initializer-consume-all-args.sil
+++ b/validation-test/IRGen/builtin-zero-initializer-consume-all-args.sil
@@ -1,0 +1,16 @@
+// RUN: %swift -module-name main %s -emit-ir | %FileCheck %s
+
+import Builtin
+
+// All we need to do here is check that we didn't run into any assertions.
+// CHECK-LABEL: define swiftcc void @test
+// CHECK: ret void
+sil @test : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Builtin.Int32
+  %1 = builtin "zeroInitializer"<Builtin.Int32>(%0 : $*Builtin.Int32) : $()
+  dealloc_stack %0 : $*Builtin.Int32
+  %t = tuple ()
+  return %t : $()
+}
+


### PR DESCRIPTION
Before this patch, the Explosion destructor would assert because the arguments weren't consumed. This patch simply consumes all arguments in the `BuiltinValueKind::ZeroInitializer` case.

Refs #32402.
