### PR TITLE
[5.3][CodeCompletion] Assume non-'isSimpleDidSet' in code completion

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1152,6 +1152,10 @@ bool SimpleDidSetRequest::evaluate(Evaluator &evaluator,
     return false;
   }
 
+  // Always assume non-simple 'didSet' in code completion mode.
+  if (decl->getASTContext().SourceMgr.hasCodeCompletionBuffer())
+    return false;
+
   // didSet must have a single parameter.
   if (decl->getParameters()->size() != 1) {
     return false;

--- a/test/IDE/complete_in_accessors.swift
+++ b/test/IDE/complete_in_accessors.swift
@@ -113,6 +113,13 @@
 // RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_DECLS < %t.txt
 // RUN: %FileCheck %s -check-prefix=ACCESSORS_IN_MEMBER_FUNC_2 < %t.txt
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_OLDVALUE_COPIED | %FileCheck %s -check-prefix=IMPLICIT_OLDVALUE_COPIED
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_OLDVALUE_MEMBER | %FileCheck %s -check-prefix=IMPLICIT_OLDVALUE_MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_OLDVALUE_COPIEDMEMBER | %FileCheck %s -check-prefix=IMPLICIT_OLDVALUE_COPIEDMEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXPLICIT_OLDVALUE_COPIED | %FileCheck %s -check-prefix=EXPLICIT_OLDVALUE_COPIED
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXPLICIT_OLDVALUE_MEMBER | %FileCheck %s -check-prefix=EXPLICIT_OLDVALUE_MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXPLICIT_OLDVALUE_COPIEDMEMBER | %FileCheck %s -check-prefix=EXPLICIT_OLDVALUE_COPIEDMEMBER
+
 //===--- Helper types that are used in this test
 
 struct FooStruct {
@@ -247,18 +254,18 @@ willSet {
 }
 
 var globalAccessorDidSet1: Int {
-  didSet(oldValue) {
+  didSet {
     #^GLOBAL_ACCESSOR_DIDSET_1^#
   }
 }
 var globalAccessorDidSet2: Int {
-  didSet(oldValue) {
+  didSet {
     var fs = FooStruct()
     fs.#^GLOBAL_ACCESSOR_DIDSET_2^#
   }
 }
 var globalAccessorDidSet3 = 42 {
-didSet(oldValue) {
+didSet {
   #^GLOBAL_ACCESSOR_DIDSET_3^#
 }
 }
@@ -337,18 +344,18 @@ struct MemberAccessors {
   }
 
   var memberAccessorDidSet1: Int {
-    didSet(oldValue) {
+    didSet {
       #^MEMBER_ACCESSOR_DIDSET_1^#
     }
   }
   var memberAccessorDidSet2: Int {
-    didSet(oldValue) {
+    didSet {
       var fs = FooStruct()
       fs.#^MEMBER_ACCESSOR_DIDSET_2^#
     }
   }
   var memberAccessorDidSet3 = 42 {
-    didSet(oldValue) {
+    didSet {
       #^MEMBER_ACCESSOR_DIDSET_3^#
     }
   }
@@ -424,18 +431,18 @@ func accessorsInFunction(_ functionParam: Int) {
   }
 
   var memberAccessorDidSet1: Int {
-    didSet(oldValue) {
+    didSet {
       #^LOCAL_ACCESSOR_DIDSET_1^#
     }
   }
   var memberAccessorDidSet2: Int {
-    didSet(oldValue) {
+    didSet {
       var fs = FooStruct()
       fs.#^LOCAL_ACCESSOR_DIDSET_2^#
     }
   }
   var memberAccessorDidSet3: Int {
-    didSet(oldValue) {
+    didSet {
       #^LOCAL_ACCESSOR_DIDSET_3^#
     }
   }
@@ -479,5 +486,63 @@ struct AccessorsInMemberFunction {
         #^ACCESSOR_IN_MEMBER_FUNC_2^#
       }
     }
+  }
+}
+
+var testImplicitOldValue1: Int = 0 {
+  didSet {
+    var oldV = oldValue
+    #^IMPLICIT_OLDVALUE_COPIED^#
+// IMPLICIT_OLDVALUE_COPIED: Begin completions
+// IMPLICIT_OLDVALUE_COPIED-DAG: Decl[LocalVar]/Local:               oldV[#Int#];
+// IMPLICIT_OLDVALUE_COPIED-DAG: Decl[LocalVar]/Local:               oldValue[#Int#];
+// IMPLICIT_OLDVALUE_COPIED: End completions
+  }
+}
+var testImplicitOldValue2: Int = 0 {
+  didSet {
+    oldValue.#^IMPLICIT_OLDVALUE_MEMBER^#
+// IMPLICIT_OLDVALUE_MEMBER: Begin completions
+// IMPLICIT_OLDVALUE_MEMBER-DAG: Keyword[self]/CurrNominal:          self[#Int#];
+// IMPLICIT_OLDVALUE_MEMBER: End completions
+  }
+}
+var testImplicitOldValue3: Int = 0 {
+  didSet {
+    var oldV = oldValue
+    oldV.#^IMPLICIT_OLDVALUE_COPIEDMEMBER^#
+// IMPLICIT_OLDVALUE_COPIEDMEMBER: Begin completions
+// IMPLICIT_OLDVALUE_COPIEDMEMBER-DAG: Keyword[self]/CurrNominal:          self[#Int#];
+// IMPLICIT_OLDVALUE_COPIEDMEMBER: End completions
+  }
+}
+
+var testExplicitOldValue1: Int = 0 {
+  didSet(oldVal) {
+    var oldV = oldVal
+    #^EXPLICIT_OLDVALUE_COPIED^#
+// EXPLICIT_OLDVALUE_COPIED: Begin completions
+// EXPLICIT_OLDVALUE_COPIED-NOT: oldValue
+// EXPLICIT_OLDVALUE_COPIED-DAG: Decl[LocalVar]/Local:               oldV[#Int#];
+// EXPLICIT_OLDVALUE_COPIED-DAG: Decl[LocalVar]/Local:               oldVal[#Int#];
+// EXPLICIT_OLDVALUE_COPIED-NOT: oldValue
+// EXPLICIT_OLDVALUE_COPIED: End completions
+  }
+}
+var testExplicitOldValue2: Int = 0 {
+  didSet(oldVal) {
+    oldVal.#^EXPLICIT_OLDVALUE_MEMBER^#
+// EXPLICIT_OLDVALUE_MEMBER: Begin completions
+// EXPLICIT_OLDVALUE_MEMBER-DAG: Keyword[self]/CurrNominal:          self[#Int#];
+// EXPLICIT_OLDVALUE_MEMBER: End completions
+  }
+}
+var testExplicitOldValue3: Int = 0 {
+  didSet(oldVal) {
+    var oldV = oldVal
+    oldV.#^EXPLICIT_OLDVALUE_COPIEDMEMBER^#
+// EXPLICIT_OLDVALUE_COPIEDMEMBER: Begin completions
+// EXPLICIT_OLDVALUE_COPIEDMEMBER-DAG: Keyword[self]/CurrNominal:          self[#Int#];
+// EXPLICIT_OLDVALUE_COPIEDMEMBER: End completions
   }
 }


### PR DESCRIPTION
Cherry-pick #32528 into `release/5.3`

* **Explanation**: As a side effect of [SE-0268 implementation](https://github.com/apple/swift/pull/26632/files#diff-e05169281e309d1d8b64b08a525071ed), Code completion stopped suggesting implicit `oldValue` in `didSet` blocks. This patch fixes the regression by retuning `false` from `SimpleDidSetRequest` in code completion mode so that the `oldValue` is  correctly populated.
* **Scope**: Code completion inside `didSet` block
* **Risk**: Low
* **Testing**: Added regression test cases
* **Issue**: rdar://problem/64699286
* **Reviewer**: Ben Langmuir (@benlangmuir), Suyash Srijan (@theblixguy)