### PR TITLE
[5.3][SourceKit/Indentation] Fix over-indent after function declaration with no param list or body.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -1906,6 +1906,11 @@ private:
       return Aligner.getContextAndSetAlignment(CtxOverride);
     }
 
+    // There are no parens at this point, so if there are no parameters either,
+    // this shouldn't be a context (it's an implicit parameter list).
+    if (!PL->size())
+      return None;
+
     ListAligner Aligner(SM, TargetLocation, ContextLoc, Range.Start);
     for (auto *PD: *PL)
       Aligner.updateAlignment(PD->getSourceRange(), PD);

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -1036,3 +1036,19 @@ private var secondThing = item
     .filter {},
     firstThing = 20,
     thirdThing = 56
+
+
+// Function decls missing their parameter list and body shouldn't pick up the next token as a continuation.
+
+struct BarType {
+    func bar
+}
+
+struct <#name#> {
+    <#fields#>
+}
+
+struct <#name#> {
+    <#fields#>
+    func foo() {}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32513 for 5.3

- **Explanation**:
Indentation after an incompletion function declaration with no parameter list or body always indents the next line relative to it, incorrectly.

  E.g:
  ```
  struct Foo {
    bar // this is parsed as a function decl with missing func keyword, parameter list and body
      } // this is incorrectly indented relative to 'bar'

  struct Foo {
    bar
      func foo() {} // this is incorrectly indented relative to 'bar'
  } 
  ```
  This is particularly bad because we treat an editor placeholder in a struct/class body as if it were an incomplete function declaration, and when completing on a struct/class keyword in Xcode you get the snippet below with such a placeholder and the incorrect indentation:
  ```
  struct <#name#> {
    <#fields#>
      } // This gets indented relative to '<#fields#>'
  ``` 
- **Scope**: Only affects sourcekitd's format request, used for automatic indentation of swift code. Doesn't affect the compiler or sourcekitd's other requests.
- **Risk**: Low. It's a simple self-contained fix.
- **Testing**: Added regression test for this case
- **Reviewer**: Ben Langmuir (@benlangmuir)

Resolves rdar://problem/64618791