### PR TITLE
[cxx-interop] Do not give the default C++ constructor's return statement a result.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1272,11 +1272,7 @@ synthesizeStructDefaultConstructorBody(AbstractFunctionDecl *afd,
   auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), call, /*implicit*/ true);
   assign->setType(emptyTuple);
 
-  auto result = TupleExpr::createEmpty(ctx, SourceLoc(), SourceLoc(),
-                                       /*Implicit=*/true);
-  result->setType(emptyTuple);
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), result, /*Implicit=*/true);
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
 
   // Create the function body.
   auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc());

--- a/validation-test/SILGen/Inputs/cxx-types.h
+++ b/validation-test/SILGen/Inputs/cxx-types.h
@@ -1,0 +1,3 @@
+struct HasCustomCopyConst {
+  HasCustomCopyConst(HasCustomCopyConst const&) { }
+};

--- a/validation-test/SILGen/Inputs/module.modulemap
+++ b/validation-test/SILGen/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module CXXTypes {
+  header "cxx-types.h"
+}

--- a/validation-test/SILGen/cxx-address-only-object-init.swift
+++ b/validation-test/SILGen/cxx-address-only-object-init.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-silgen | %FileCheck %s
+
+import CXXTypes
+
+// Just make sure we create the object and don't crash.
+// CHECK-LABEL: @$s4main4testyyF
+// CHECK: alloc_stack
+// CHECK: apply
+// CHECK: return %{{[0-9]+}} : $()
+public func test() {
+  let c = HasCustomCopyConst()
+}


### PR DESCRIPTION
The default C++ object constructor assigns the newly created object out of the function so, it should not return a value. Returning a value will trigger SILGen assertions.

Refs #32402.