### PR TITLE
[stdlib] Simplify the strto* platform stubs.

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -355,51 +355,61 @@ static bool swift_stringIsSignalingNaN(const char *nptr) {
 static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
   return strtod(nptr, endptr);
 }
+#elif defined(__ANDROID_API__) && __ANDROID_API__ < 26
+static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
+  return strtod(nptr, endptr);
+}
+#elif defined(_WIN32)
+static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
+  return _strtod_l(nptr, endptr, getCLocale());
+}
+#endif
 
+#if defined(__OpenBSD__)
 static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
   return strtof(nptr, endptr);
 }
+#elif defined(__ANDROID_API__) && __ANDROID_API__ < 26
+static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
+  return strtof(nptr, endptr);
+}
+#elif defined(_WIN32)
+static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
+  return _strtof_l(nptr, endptr, getCLocale());
+}
+#endif
 
+#if defined(__OpenBSD__)
 static long double swift_strtold_l(const char *nptr, char **endptr,
                                    locale_t loc) {
   return strtold(nptr, endptr);
 }
+#elif defined(__ANDROID_API__) && __ANDROID_API__ < 21
+static long double swift_strtold_l(const char *nptr, char **endptr,
+                                   locale_t loc) {
+  return strtod(nptr, endptr);
+}
+#elif defined(_WIN32)
+static long double swift_strtold_l(const char *nptr, char **endptr,
+                                   locale_t loc) {
+  return _strtod_l(nptr, endptr, getCLocale());
+}
+#endif
 
+#if defined(__OpenBSD__) || defined(_WIN32)
 #define strtod_l swift_strtod_l
 #define strtof_l swift_strtof_l
 #define strtold_l swift_strtold_l
 #elif defined(__ANDROID__)
 #if __ANDROID_API__ < 21 // Introduced in Android API 21 - L
-static inline long double swift_strtold_l(const char *nptr, char **endptr,
-                                          locale_t) {
-  return strtod(nptr, endptr);
-}
 #define strtold_l swift_strtold_l
 #endif
 
 #if __ANDROID_API__ < 26 // Introduced in Android API 26 - O
-static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
-  return strtod(nptr, endptr);
-}
-static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
-  return strtof(nptr, endptr);
-}
 #define strtod_l swift_strtod_l
 #define strtof_l swift_strtof_l
 #endif
 #elif defined(_WIN32)
-static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
-  return _strtod_l(str, &end, getCLocale());
-}
-
-static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
-  return _strtof_l(str, &end, getCLocale());
-}
-
-static long double swift_strtold_l(const char *nptr, char **endptr,
-                                   locale_t loc) {
-  return _strtod_l(str, &end, getCLocale());
-}
 #define strtod_l swift_strtod_l
 #define strtof_l swift_strtof_l
 #define strtold_l swift_strtold_l


### PR DESCRIPTION
Currently, _swift_stdlib_strtoX_clocale_impl is present here twice: one
general definition for most platforms that wraps the standard strto*
functions, and another general definition with a slightly different
implementation for Cygwin, Haiku, and Windows, using stringstreams to
achieve a similar result. Furthermore, for Windows, the stringstream
implementation isn't even used but specialized away.

Firstly: the stringstream implementation is slightly broken, since it
causes some of the unit tests to fail; secondly, there is an awful lot
of repetition here that is ripe for simplification.

Instead of duplicating twice and using template specialization to induce
platform-specific behavior, we massage the stringstream implementation
for Cygwin and Haiku into something that looks like a standard strto*
function.

Now we have one definition (for each type) of swift_strto*_l. By
default, the _swift_stdlib_strto*_clocale stubs will refer to strto*_l,
and platforms withing to make use of the swift_strto*_l stubs can make
the necessary preprocessor definitions to utilize them.

This is the suggested cleanup mentioned in #32395.