### PR TITLE
[Function builders] Run syntactic diagnostics for function bodies.

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1045,7 +1045,6 @@ private:
   llvm::StringMap<llvm::Constant*> GlobalUTF16Strings;
   llvm::StringMap<std::pair<llvm::GlobalVariable*, llvm::Constant*>>
     StringsForTypeRef;
-  llvm::DenseMap<CanType, llvm::GlobalVariable*> TypeRefs;
   llvm::StringMap<std::pair<llvm::GlobalVariable*, llvm::Constant*>> FieldNames;
   llvm::StringMap<llvm::Constant*> ObjCSelectorRefs;
   llvm::StringMap<llvm::Constant*> ObjCMethodNames;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1387,6 +1387,63 @@ BraceStmt *swift::applyFunctionBuilderTransform(
         captured.first, captured.second)));
 }
 
+/// Produce any additional syntactic diagnostics for the body of a
+static void performAddOnDiagnostics(BraceStmt *stmt, DeclContext *dc) {
+  class AddOnDiagnosticWalker : public ASTWalker {
+    SmallVector<DeclContext *, 4> dcStack;
+
+  public:
+    AddOnDiagnosticWalker(DeclContext *dc) {
+      dcStack.push_back(dc);
+    }
+
+    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      performSyntacticExprDiagnostics(
+          expr, dcStack.back(), /*isExprStmt=*/false);
+
+      if (auto closure = dyn_cast<ClosureExpr>(expr)) {
+        if (closure->wasSeparatelyTypeChecked()) {
+          dcStack.push_back(closure);
+          return { true, expr };
+        }
+      }
+
+      return { false, expr };
+    }
+
+    Expr *walkToExprPost(Expr *expr) override {
+      if (auto closure = dyn_cast<ClosureExpr>(expr)) {
+        if (closure->wasSeparatelyTypeChecked()) {
+          assert(dcStack.back() == closure);
+          dcStack.pop_back();
+        }
+      }
+
+      return expr;
+    }
+
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
+      performStmtDiagnostics(dcStack.back()->getASTContext(), stmt);
+      return { true, stmt };
+    }
+
+    std::pair<bool, Pattern*> walkToPatternPre(Pattern *pattern) override {
+      return { false, pattern };
+    }
+
+    bool walkToTypeLocPre(TypeLoc &typeLoc) override { return false; }
+
+    bool walkToTypeReprPre(TypeRepr *typeRepr) override { return false; }
+
+    bool walkToParameterListPre(ParameterList *params) override {
+      return false;
+    }
+  };
+
+  AddOnDiagnosticWalker walker(dc);
+  stmt->walk(walker);
+}
+
 Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
     FuncDecl *func, Type builderType) {
   // Pre-check the body: pre-check any expressions in it and look
@@ -1505,6 +1562,7 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   if (auto result = cs.applySolution(
           solutions.front(),
           SolutionApplicationTarget(func))) {
+    performAddOnDiagnostics(result->getFunctionBody(), func);
     return result->getFunctionBody();
   }
 

--- a/test/decl/var/function_builders_availability.swift
+++ b/test/decl/var/function_builders_availability.swift
@@ -1,0 +1,86 @@
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx10.15 %s
+// REQUIRES: OS=macosx
+
+enum Either<T,U> {
+  case first(T)
+  case second(U)
+}
+
+struct Do<T> {
+  var value: T
+}
+
+@_functionBuilder
+struct TupleBuilder {
+  static func buildBlock<T1>(_ t1: T1) -> (T1) {
+    return (t1)
+  }
+
+  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
+    return (t1, t2)
+  }
+  
+  static func buildBlock<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
+      -> (T1, T2, T3) {
+    return (t1, t2, t3)
+  }
+
+  static func buildBlock<T1, T2, T3, T4>(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4)
+      -> (T1, T2, T3, T4) {
+    return (t1, t2, t3, t4)
+  }
+
+  static func buildBlock<T1, T2, T3, T4, T5>(
+    _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5
+  ) -> (T1, T2, T3, T4, T5) {
+    return (t1, t2, t3, t4, t5)
+  }
+
+  static func buildDo<T1>(_ t1: T1) -> Do<(T1)> {
+    .init(value: t1)
+  }
+
+  static func buildDo<T1, T2>(_ t1: T1, _ t2: T2) -> Do<(T1, T2)> {
+    .init(value: (t1, t2))
+  }
+  
+  static func buildDo<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
+      -> Do<(T1, T2, T3)> {
+    .init(value: (t1, t2, t3))
+  }
+
+  static func buildIf<T>(_ value: T?) -> T? { return value }
+
+  static func buildEither<T,U>(first value: T) -> Either<T,U> {
+    return .first(value)
+  }
+  static func buildEither<T,U>(second value: U) -> Either<T,U> {
+    return .second(value)
+  }
+
+  static func buildArray<T>(_ array: [T]) -> [T] { return array }
+}
+
+@available(macOS 10.14, *)
+enum Option {
+  @available(macOS 10.15.4, *)
+  case best
+}
+
+@TupleBuilder
+func bestTuple() -> some Any { // expected-note{{add @available attribute to enclosing global function}}
+  "Hello"
+  Option.best // expected-error{{'best' is only available in macOS 10.15.4 or newer}}
+  // expected-note@-1{{add 'if #available' version check}}
+}
+
+func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
+  print(body(cond))
+}
+
+tuplify(true) { x in
+  x
+  "Hello"
+  Option.best // expected-error{{'best' is only available in macOS 10.15.4 or newer}}
+  // expected-note@-1{{add 'if #available' version check}}
+}


### PR DESCRIPTION
When a function body has had a function builder applied to it, make
sure that we run all of the syntactic diagnostics for expressions and
statements within the body.

Fixes rdar://problem/64493626.