### PR TITLE
[Frontend] Add --version as a frontend flag.

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -134,6 +134,7 @@ public:
     DumpPCM, ///< Dump information about a precompiled Clang module
 
     ScanDependencies,   ///< Scan dependencies of Swift source files
+    PrintVersion,       ///< Print version information.
   };
 
   /// Indicates the action the user requested that the frontend perform.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -213,7 +213,7 @@ def help_hidden : Flag<["-", "--"], "help-hidden">,
 
 def v : Flag<["-"], "v">, Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Show commands to run and use verbose output">;
-def version : Flag<["-", "--"], "version">,
+def version : Flag<["-", "--"], "version">, Flags<[FrontendOption]>,
   HelpText<"Print version information and exit">;
 
 def parseable_output : Flag<["-"], "parseable-output">,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -314,6 +314,10 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
       // (Setting up module output will be handled below.)
       return FrontendOptions::ActionType::EmitModuleOnly;
     }
+
+    if (args.hasArg(OPT_version))
+      return FrontendOptions::ActionType::PrintVersion;
+
     return FrontendOptions::ActionType::NoneAction;
   }
   Option Opt = A->getOption();
@@ -386,7 +390,8 @@ bool ArgsToFrontendOptionsConverter::setUpInputKindAndImmediateArgs() {
   if (Opts.InputsAndOutputs.verifyInputs(
           Diags, treatAsSIL,
           Opts.RequestedAction == FrontendOptions::ActionType::REPL,
-          Opts.RequestedAction == FrontendOptions::ActionType::NoneAction)) {
+          (Opts.RequestedAction == FrontendOptions::ActionType::NoneAction ||
+           Opts.RequestedAction == FrontendOptions::ActionType::PrintVersion))){
     return true;
   }
   if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate) {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -53,6 +53,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
     return true;
   case ActionType::Immediate:
   case ActionType::REPL:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::EmitAssembly:
   case ActionType::EmitIR:
@@ -75,6 +76,7 @@ bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   case FrontendOptions::ActionType::DumpInterfaceHash:
   case FrontendOptions::ActionType::EmitImportedModules:
   case FrontendOptions::ActionType::ScanDependencies:
+  case FrontendOptions::ActionType::PrintVersion:
     return true;
   default:
     return false;
@@ -124,6 +126,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::DumpPCM:
+  case ActionType::PrintVersion:
     return TY_Nothing;
 
   case ActionType::EmitPCH:
@@ -191,6 +194,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::DumpPCM:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -232,6 +236,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -279,6 +284,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -315,6 +321,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -357,6 +364,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -410,6 +418,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitBC:
   case ActionType::EmitAssembly:
   case ActionType::EmitObject:
+  case ActionType::PrintVersion:
     return true;
   }
   llvm_unreachable("unhandled action");
@@ -449,6 +458,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Immediate:
   case ActionType::REPL:
+  case ActionType::PrintVersion:
     return false;
   }
   llvm_unreachable("Unknown ActionType");
@@ -488,6 +498,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return true;
   }
   llvm_unreachable("unhandled action");
@@ -512,6 +523,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -557,6 +569,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
     return false;
   case ActionType::Immediate:
   case ActionType::REPL:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1297,7 +1297,13 @@ static bool performCompile(CompilerInstance &Instance,
     return precompileClangModule(Instance);
   if (Action == FrontendOptions::ActionType::DumpPCM)
     return dumpPrecompiledClangModule(Instance);
-
+  if (Action == FrontendOptions::ActionType::PrintVersion) {
+    llvm::outs() << version::getSwiftFullVersion(
+      version::Version::getCurrentLanguageVersion()) << '\n';
+    llvm::outs() << "Target: "
+      << Invocation.getLangOptions().Target.str() << '\n';
+    return false;
+  }
   if (Action == FrontendOptions::ActionType::CompileModuleFromInterface)
     return buildModuleFromInterface(Instance);
 

--- a/test/Frontend/version.swift
+++ b/test/Frontend/version.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend --version | %FileCheck %s
+
+// CHECK: Swift version
+// CHECK-NEXT: Target


### PR DESCRIPTION
The new driver will defer to the frontend to print version information,
rather than embedding the version information itself.
