### PR TITLE
test: unixise the paths on the test (NFC)

### DIFF
--- a/test/NameLookup/scope_map_top_level.swift
+++ b/test/NameLookup/scope_map_top_level.swift
@@ -21,7 +21,7 @@ extension Int {
 var i: Int = b.my_identity()
 
 
-// RUN: %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
+// RUN: %target-swift-frontend -dump-scope-maps expanded %/s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
 


### PR DESCRIPTION
This converts the path to use Unix path separators.  This is required to
ensure that the `SOURCE_DIR` substitution works properly in the case
that the path uses mixed path separators.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
