### PR TITLE
Sema: silence some uncovered warnings on MSVC (NFC)

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -917,6 +917,7 @@ public:
           (lhs.storage.patternBindingEntry.index
              == rhs.storage.patternBindingEntry.index);
     }
+    llvm_unreachable("invalid SolutionApplicationTargetsKey kind");
   }
 
   friend bool operator!=(
@@ -951,6 +952,7 @@ public:
           DenseMapInfo<unsigned>::getHashValue(
               storage.patternBindingEntry.index));
     }
+    llvm_unreachable("invalid statement kind");
   }
 };
 


### PR DESCRIPTION
This adds an unreachable to indicate to MSVC that the switch is covered.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
