### PR TITLE
test: remove stray comment markers (NFC)

### DIFF
--- a/test/PCMacro/elseif.swift
+++ b/test/PCMacro/elseif.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
-/*// RUN: %target-codesign %t/main*/
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift 
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/func_throw_notype.swift
+++ b/test/PCMacro/func_throw_notype.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
-/*// RUN: %target-codesign %t/main*/
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift 
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/getset.swift
+++ b/test/PCMacro/getset.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
-/*// RUN: %target-codesign %t/main*/
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift 
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PCMacro/init.swift
+++ b/test/PCMacro/init.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/PCMacroRuntime.swift %S/Inputs/SilentPlaygroundsRuntime.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
-/*// RUN: %target-codesign %t/main*/
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift 
 // RUN: %target-run %t/main | %FileCheck %s


### PR DESCRIPTION
This removes the stray comment on the RUN commands that cause issues
with Python 3 and lit which will treat the last argument as a glob
pattern rather than a valid run command.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
