### PR TITLE
[AST] Add a pointer to parent 'TapExpr' expression in 'VarDecl'

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4905,7 +4905,7 @@ public:
   };
 
 protected:
-  PointerUnion<PatternBindingDecl *, Stmt *, VarDecl *> Parent;
+  PointerUnion<PatternBindingDecl *, Stmt *, VarDecl *, Expr *> Parent;
 
   VarDecl(DeclKind kind, bool isStatic, Introducer introducer,
           bool isCaptureList, SourceLoc nameLoc, Identifier name,
@@ -5014,6 +5014,22 @@ public:
   void setParentVarDecl(VarDecl *v) {
     assert(v && v != this);
     Parent = v;
+  }
+
+  /// Returns the parent expression that owns this var decl.
+  ///
+  /// Concrete use cases:
+  ///   * 'TapExpr' for interpolated string literal expression
+  Expr *getParentExpr() const {
+    if (!Parent)
+      return nullptr;
+    return Parent.dyn_cast<Expr *>();
+  }
+
+  /// Set \p e to be the expression that owns this var decl.
+  void setParentExpr(Expr *e) {
+    assert(e);
+    Parent = e;
   }
 
   NamedPattern *getNamingPattern() const;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2401,6 +2401,7 @@ TapExpr::TapExpr(Expr * SubExpr, BraceStmt *Body)
     assert(!Body->empty() &&
          Body->getFirstElement().isDecl(DeclKind::Var) &&
          "First element of Body should be a variable to init with the subExpr");
+    getVar()->setParentExpr(this);
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2222,12 +2222,16 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
   case DeclKind::Var: {
     auto *VD = cast<VarDecl>(D);
-    auto *namingPattern = VD->getNamingPattern();
-    if (!namingPattern) {
-      return ErrorType::get(Context);
+    Type interfaceType;
+    if (auto *parentE = VD->getParentExpr()) {
+      interfaceType = parentE->getType();
+    } else if (auto *namingPattern = VD->getNamingPattern()) {
+      interfaceType = namingPattern->getType();
     }
 
-    Type interfaceType = namingPattern->getType();
+    if (!interfaceType)
+      return ErrorType::get(Context);
+
     if (interfaceType->hasArchetype())
       interfaceType = interfaceType->mapTypeOutOfContext();
 


### PR DESCRIPTION
Preparation for on-demand `VarDecl` type checking in interpolated string literals.

