### PR TITLE
Switch to benchmark remove* instead of drop*

### DIFF
--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -17,8 +17,8 @@ public let SubstringTest = [
   BenchmarkInfo(name: "EqualSubstringString", runFunction: run_EqualSubstringString, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "EqualSubstringSubstring", runFunction: run_EqualSubstringSubstring, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "EqualSubstringSubstringGenericEquatable", runFunction: run_EqualSubstringSubstringGenericEquatable, tags: [.validation, .api, .String]),
-  BenchmarkInfo(name: "SubstringDropFirst1", runFunction: run_SubstringDropFirst1, tags: [.validation, .api, .String]),
-  BenchmarkInfo(name: "SubstringDropLast1", runFunction: run_SubstringDropLast1, tags: [.validation, .api, .String]),
+  BenchmarkInfo(name: "SubstringRemoveFirst1", runFunction: run_SubstringRemoveFirst1, tags: [.validation, .api, .String]),
+  BenchmarkInfo(name: "SubstringRemoveLast1", runFunction: run_SubstringRemoveLast1, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "LessSubstringSubstring", runFunction: run_LessSubstringSubstring, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "LessSubstringSubstringGenericComparable", runFunction: run_LessSubstringSubstringGenericComparable, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "StringFromLongWholeSubstring", runFunction: run_StringFromLongWholeSubstring, tags: [.validation, .api, .String]),
@@ -36,7 +36,7 @@ let longWide = "fὢasὢodὢijὢadὢolὢsjὢalὢsdὢjlὢasὢdfὢijὢ
 let (s1, ss1) = equivalentWithDistinctBuffers()
 let (s2, ss2) = equivalentWithDistinctBuffers()
 
-let quiteLong = String(repeating: "0", count: 15_000)[...]
+let quiteLong = String(repeating: "0", count: 10_000)[...]
 
 @inline(never)
 public func run_SubstringFromLongString(_ N: Int) {
@@ -131,18 +131,20 @@ public func run_EqualSubstringSubstringGenericEquatable(_ N: Int) {
 }
 
 @inline(never)
-public func run_SubstringDropFirst1(_ N: Int) {
-  let s = quiteLong
-  for _ in 1...N*1000 {
-    blackHole(!s.dropFirst(1).isEmpty)
+public func run_SubstringRemoveFirst1(_ N: Int) {
+  for _ in 1...N {
+    var s = quiteLong
+    s.removeFirst(1)
+    blackHole(s.first == "0")
   }
 }
 
 @inline(never)
-public func run_SubstringDropLast1(_ N: Int) {
-  let s = quiteLong
-  for _ in 1...N*1000 {
-    blackHole(!s.dropLast(1).isEmpty)
+public func run_SubstringRemoveLast1(_ N: Int) {
+  for _ in 1...N {
+    var s = quiteLong
+    s.removeLast(1)
+    blackHole(s.first == "0")
   }
 }
 


### PR DESCRIPTION
I added a benchmark in #32473 that was meant to help test performance of `removeFirst` and `removeLast`, but used `dropFirst` and `dropLast` instead. This rectifies that mistake!