### PR TITLE
[AST] ParamDecl::isNonEphemeral() not to evaluate InterfaceTypeRequest

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5502,35 +5502,10 @@ public:
   }
 
   /// Does this parameter reject temporary pointer conversions?
-  bool isNonEphemeral() const {
-    if (getAttrs().hasAttribute<NonEphemeralAttr>())
-      return true;
-
-    // Only pointer parameters can be non-ephemeral.
-    auto ty = getInterfaceType();
-    if (!ty->lookThroughSingleOptionalType()->getAnyPointerElementType())
-      return false;
-
-    // Enum element pointer parameters are always non-ephemeral.
-    auto *parentDecl = getDeclContext()->getAsDecl();
-    if (parentDecl && isa<EnumElementDecl>(parentDecl))
-      return true;
-
-    return false;
-  }
+  bool isNonEphemeral() const;
 
   /// Attempt to apply an implicit `@_nonEphemeral` attribute to this parameter.
-  void setNonEphemeralIfPossible() {
-    // Don't apply the attribute if this isn't a pointer param.
-    auto type = getInterfaceType();
-    if (!type->lookThroughSingleOptionalType()->getAnyPointerElementType())
-      return;
-
-    if (!getAttrs().hasAttribute<NonEphemeralAttr>()) {
-      auto &ctx = getASTContext();
-      getAttrs().add(new (ctx) NonEphemeralAttr(/*IsImplicit*/ true));
-    }
-  }
+  void setNonEphemeralIfPossible();
 
   /// Remove the type of this varargs element designator, without the array
   /// type wrapping it.  A parameter like "Int..." will have formal parameter

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -900,6 +900,12 @@ namespace {
 
     void visitEnumElementDecl(EnumElementDecl *EED) {
       printCommon(EED, "enum_element_decl");
+      if (auto *paramList = EED->getParameterList()) {
+        Indent += 2;
+        OS << "\n";
+        printParameterList(paramList);
+        Indent -= 2;
+      }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
@@ -1011,7 +1017,7 @@ namespace {
       if (P->isAutoClosure())
         OS << " autoclosure";
 
-      if (P->isNonEphemeral())
+      if (P->getAttrs().hasAttribute<NonEphemeralAttr>())
         OS << " nonEphemeral";
 
       if (P->getDefaultArgumentKind() != DefaultArgumentKind::None) {
@@ -1038,11 +1044,6 @@ namespace {
       OS.indent(Indent);
       PrintWithColorRAII(OS, ParenthesisColor) << '(';
       PrintWithColorRAII(OS, ParameterColor) << "parameter_list";
-      Indent += 2;
-      for (auto P : *params) {
-        OS << '\n';
-        printParameter(P);
-      }
 
       if (!ctx && params->size() != 0 && params->get(0))
         ctx = &params->get(0)->getASTContext();
@@ -1056,8 +1057,14 @@ namespace {
         }
       }
 
-      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+      Indent += 2;
+      for (auto P : *params) {
+        OS << '\n';
+        printParameter(P);
+      }
       Indent -= 2;
+
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
     void printAbstractFunctionDecl(AbstractFunctionDecl *D) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6266,6 +6266,36 @@ SourceRange ParamDecl::getSourceRange() const {
   return startLoc;
 }
 
+bool ParamDecl::isNonEphemeral() const {
+  if (getAttrs().hasAttribute<NonEphemeralAttr>())
+    return true;
+
+  // Only enum element parameters are non-ephemeral without '@_nonEphemeral'.
+  auto *parentDecl = getDeclContext()->getAsDecl();
+  if (!parentDecl || !isa<EnumElementDecl>(parentDecl))
+    return false;
+
+  // Only pointer parameters can be non-ephemeral.
+  auto ty = getInterfaceType();
+  if (!ty->lookThroughSingleOptionalType()->getAnyPointerElementType())
+    return false;
+
+  return true;
+}
+
+void ParamDecl::setNonEphemeralIfPossible() {
+  assert(hasInterfaceType() && "Must be pre-typechecked.");
+  // Don't apply the attribute if this isn't a pointer param.
+  auto type = getInterfaceType();
+  if (!type->lookThroughSingleOptionalType()->getAnyPointerElementType())
+    return;
+
+  if (!getAttrs().hasAttribute<NonEphemeralAttr>()) {
+    auto &ctx = getASTContext();
+    getAttrs().add(new (ctx) NonEphemeralAttr(/*IsImplicit*/ true));
+  }
+}
+
 Type ParamDecl::getVarargBaseTy(Type VarArgT) {
   TypeBase *T = VarArgT.getPointer();
   if (auto *AT = dyn_cast<ArraySliceType>(T))

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -104,3 +104,22 @@ enum MyEnum {
 // CHECK-NEXT:            (parameter "v"))
 // CHECK-NEXT:          (brace_stmt range=[{{.+}}])))))
 _ = { (v: MyEnum) in }
+
+// CHECK-LABEL: (struct_decl range=[{{.+}}] "SelfParam"
+struct SelfParam {
+
+  // CHECK-LABEL: (func_decl range=[{{.+}}] "createOptional()" type
+  // CHECK-NEXT:    (parameter "self")
+  // CHECK-NEXT:    (parameter_list range=[{{.+}}])
+  // CHECK-NEXT:    (result
+  // CHECK-NEXT:      (type_optional
+  // CHECK-NEXT:        (type_ident
+  // CHECK-NEXT:          (component id='SelfParam' bind=none))))
+  static func createOptional() -> SelfParam? {
+
+    // CHECK-LABEL: (call_expr type='<null>' arg_labels=
+    // CHECK-NEXT:    (unresolved_decl_ref_expr type='<null>' name=SelfParam function_ref=unapplied)
+    // CHECK-NEXT:    (tuple_expr type='()'{{.*}}))
+    SelfParam()
+  }
+}

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -73,3 +73,34 @@ nonescaping({ $0 })
 // CHECK-AST:        (declref_expr type='((Int) -> Int) -> ()'
 // CHECK-AST-NEXT:        (paren_expr
 // CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single-expression
+
+// CHECK-LABEL: (struct_decl range=[{{.+}}] "MyStruct")
+struct MyStruct {}
+
+// CHECK-LABEL: (enum_decl range=[{{.+}}] "MyEnum"
+enum MyEnum {
+
+    // CHECK-LABEL: (enum_case_decl range=[{{.+}}]
+    // CHECK-NEXT:    (enum_element_decl range=[{{.+}}]  "foo(x:)"
+    // CHECK-NEXT:      (parameter_list range=[{{.+}}]
+    // CHECK-NEXT:         (parameter "x" apiName=x)))
+    // CHECK-NEXT:     (enum_element_decl range=[{{.+}}] "bar"))
+    // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "foo(x:)"
+    // CHECK-NEXT:    (parameter_list range=[{{.+}}]
+    // CHECK-NEXT:      (parameter "x" apiName=x)))
+    // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "bar"))
+    case foo(x: MyStruct), bar
+}
+
+// CHECK-LABEL: (top_level_code_decl range=[{{.+}}]
+// CHECK-NEXT:    (brace_stmt implicit range=[{{.+}}]
+// CHECK-NEXT:      (sequence_expr type='<null>'
+// CHECK-NEXT:        (discard_assignment_expr type='<null>')
+// CHECK-NEXT:        (assign_expr type='<null>'
+// CHECK-NEXT:          (**NULL EXPRESSION**)
+// CHECK-NEXT:          (**NULL EXPRESSION**))
+// CHECK-NEXT:        (closure_expr type='<null>' discriminator={{[0-9]+}}
+// CHECK-NEXT:          (parameter_list range=[{{.+}}]
+// CHECK-NEXT:            (parameter "v"))
+// CHECK-NEXT:          (brace_stmt range=[{{.+}}])))))
+_ = { (v: MyEnum) in }


### PR DESCRIPTION
`-dump-parse` for the following code used to hit an assertion failure:

```
  struct MyStruct {}
  _ = { (val: MyStruct) in }
```

Because `isNonEphemeral()` on `val` parameter unintentionally causes `InterfaceTypeRequest::evaluate()`. ~~Since `isNonEphemeral()` inference based on the interface type is not possible after type checking, return `false` unless `hasInterfaceType()`.~~ Use the presence of `@_nonEphemeral` attribute in ASTDumper instead.

Also:
  * Dump parameter list on `EnumElementDecl` as well
  * Adjust the position of `range=...` in dumping parameter list


https://bugs.swift.org/browse/SR-12728 / rdar://problem/62895098