### PR TITLE
Sema: Filter out conflicting requirements when printing stubs

### DIFF
--- a/test/decl/protocol/conforms/fixit_stub_editor.swift
+++ b/test/decl/protocol/conforms/fixit_stub_editor.swift
@@ -3,18 +3,31 @@
 
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -diagnostics-editor-mode
 
+protocol P0_A { associatedtype T }
+protocol P0_B { associatedtype T }
+
+class C0: P0_A, P0_B {} // expected-error{{type 'C0' does not conform to protocol 'P0_A'}} expected-error{{type 'C0' does not conform to protocol 'P0_B'}} expected-note{{do you want to add protocol stubs?}}{{23-23=\n    typealias T = <#type#>\n}}
+
 protocol P1 {
   @available(*, deprecated)
   func foo1()
   func foo2()
+  func foo3(arg: Int, arg2: String)
+  func foo4<T: P1>(_: T)
 }
 
 protocol P2 {
   func bar1()
   func bar2()
+
+  func foo2()
+  func foo3(arg: Int, arg2: String)
+  func foo3(arg: Int, arg2: Int)
+  func foo4<T: P1>(_: T)
+  func foo4<T: P2>(_: T)
 }
 
-class C1 : P1, P2 {} // expected-error{{type 'C1' does not conform to protocol 'P1'}} expected-error{{type 'C1' does not conform to protocol 'P2'}} expected-note{{do you want to add protocol stubs?}}{{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}
+class C1 : P1, P2 {} // expected-error{{type 'C1' does not conform to protocol 'P1'}} expected-error{{type 'C1' does not conform to protocol 'P2'}} expected-note{{do you want to add protocol stubs?}}{{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3(arg: Int, arg2: String) {\n        <#code#>\n    \}\n\n    func foo4<T>(_: T) where T : P1 {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func foo3(arg: Int, arg2: Int) {\n        <#code#>\n    \}\n}}
 
 protocol P3 {
   associatedtype T1
@@ -23,6 +36,7 @@ protocol P3 {
 }
 
 protocol P4 : P3 {
+  associatedtype T1
   associatedtype T4 = T1
   associatedtype T5 = T2
   associatedtype T6 = T3
@@ -30,6 +44,21 @@ protocol P4 : P3 {
 
 class C2 : P4 {} // expected-error{{type 'C2' does not conform to protocol 'P4'}} expected-error{{type 'C2' does not conform to protocol 'P3'}} expected-note{{do you want to add protocol stubs?}}{{16-16=\n    typealias T1 = <#type#>\n\n    typealias T2 = <#type#>\n\n    typealias T3 = <#type#>\n}}
 
+protocol P5 {
+  func foo1()
+  func foo2(arg: Int, arg2: String)
+  func foo3<T: P3>(_: T)
+}
+
+protocol P6: P5 {
+  func foo1()
+  func foo2(arg: Int, arg2: String)
+  func foo2(arg: Int, arg2: Int)
+  func foo3<T: P3>(_: T)
+  func foo3<T: P4>(_: T)
+}
+
+class C3 : P6 {} // expected-error{{type 'C3' does not conform to protocol 'P5'}} expected-error{{type 'C3' does not conform to protocol 'P6'}} expected-note{{do you want to add protocol stubs?}}{{16-16=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2(arg: Int, arg2: String) {\n        <#code#>\n    \}\n\n    func foo2(arg: Int, arg2: Int) {\n        <#code#>\n    \}\n\n    func foo3<T>(_: T) where T : P3 {\n        <#code#>\n    \}\n}}
 
 // =============================================================================
 // Test how we print stubs for mutating and non-mutating requirements.


### PR DESCRIPTION
Resolves SR-12557

Ideally, this and code completion's `OverrideFilteringConsumer` should eventually use a common entry point to filter and rank conflicting protocol requirements.