### PR TITLE
CMake: Remove workaround fixed in CMake 2.8.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,16 +487,6 @@ if(NOT SWIFT_LIPO)
   find_toolchain_tool(SWIFT_LIPO "${SWIFT_DARWIN_XCRUN_TOOLCHAIN}" lipo)
 endif()
 
-# Reset CMAKE_SYSTEM_PROCESSOR if not cross-compiling.
-# CMake refuses to use `uname -m` on OS X
-# http://public.kitware.com/Bug/view.php?id=10326
-if(NOT CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_PROCESSOR STREQUAL "i386")
-  execute_process(
-      COMMAND "uname" "-m"
-      OUTPUT_VARIABLE CMAKE_SYSTEM_PROCESSOR
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-
 get_filename_component(SWIFT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} REALPATH)
 set(SWIFT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(SWIFT_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
<!-- What's in this pull request? -->
It looks like this workaround was written in 2014, and was fixed by CMake in v2.8.4 https://public.kitware.com/Bug/view.php?id=10326
Since we require CMake to be > 3.12.4, we shouldn't need it anymore

@compnerd could you review?