### PR TITLE
[SourceKit/CursorInfo] Still print implicit decls in cursorinfo to handle compiler synthesized decls

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_info_synthesized_refs.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_synthesized_refs.swift
@@ -1,0 +1,18 @@
+struct Foo {
+    let x: Int
+    let y: String
+    func perform(_ action: (Int, Int) -> ()) {}
+}
+
+func test() {
+    let x = Foo.init(x: 2, y: "hello")
+    x.perform {
+        print($0 + $1)
+    }
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=8:17 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
+// CHECK1: <Declaration>init(x: <Type usr="s:Si">Int</Type>, y: <Type usr="s:SS">String</Type>)</Declaration>
+
+// RUN: %sourcekitd-test -req=cursor -pos=10:15 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+// CHECK2: <Declaration>let $0: <Type usr="s:Si">Int</Type></Declaration>

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -415,14 +415,13 @@ static void printAnnotatedDeclaration(const ValueDecl *VD,
   while (VD->isImplicit() && VD->getOverriddenDecl())
     VD = VD->getOverriddenDecl();
 
-  // If this is a property wrapper backing property (_foo) or projected value
-  // ($foo) and the wrapped property is not implicit, still print it.
-  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
-    if (auto *Wrapped = VarD->getOriginalWrappedProperty()) {
-      if (!Wrapped->isImplicit())
-        PO.TreatAsExplicitDeclList.push_back(VD);
-    }
-  }
+  // VD may be a compiler synthesized member, constructor, or shorthand argument
+  // so always print it even if it's implicit.
+  //
+  // FIXME: Update PrintOptions::printQuickHelpDeclaration to print implicit
+  // decls by default. That causes issues due to newlines being printed before
+  // implicit OpaqueTypeDecls at time of writing.
+  PO.TreatAsExplicitDeclList.push_back(VD);
 
   // Wrap this up in XML, as that's what we'll use for documentation comments.
   OS<<"<Declaration>";
@@ -446,14 +445,14 @@ void SwiftLangSupport::printFullyAnnotatedDeclaration(const ValueDecl *VD,
   while (VD->isImplicit() && VD->getOverriddenDecl())
     VD = VD->getOverriddenDecl();
 
-  // If this is a property wrapper backing property (_foo) or projected value
-  // ($foo) and the wrapped property is not implicit, still print it.
-  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
-    if (auto *Wrapped = VarD->getOriginalWrappedProperty()) {
-      if (!Wrapped->isImplicit())
-        PO.TreatAsExplicitDeclList.push_back(VD);
-    }
-  }
+  // VD may be a compiler synthesized member, constructor, or shorthand argument
+  // so always print it even if it's implicit.
+  //
+  // FIXME: Update PrintOptions::printQuickHelpDeclaration to print implicit
+  // decls by default. That causes issues due to newlines being printed before
+  // implicit OpaqueTypeDecls at time of writing.
+  PO.TreatAsExplicitDeclList.push_back(VD);
+
   VD->print(Printer, PO);
 }
 


### PR DESCRIPTION
We weren't printing member-wise inits, shorthand arguments (e.g. `$0`, `$1`), and other implicit decls, so cursor info would give empty annotated decl and fully annotated decl fields for them.

Resolves rdar://problem/58929991