### PR TITLE
SourceKit: silence as `-Wmisleading-indent` warning (NFCI)

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1208,8 +1208,8 @@ public:
     ImmutableTextSnapshotRef InputSnap;
     if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(InputFile))
       InputSnap = EditorDoc->getLatestSnapshot();
-      if (!InputSnap)
-        return false;
+    if (!InputSnap)
+      return false;
 
     auto mappedBackOffset = [&]()->llvm::Optional<unsigned> {
       for (auto &Snap : Snapshots) {


### PR DESCRIPTION
The code was indented such as to indicate that the check was meant to be
an early return in the `if` condition only.  However, because it would
just always trigger previously, the code would happen to have the
correct behaviour.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
