### PR TITLE
Try to derive a type witness in a known conformance before attempting associated type inference

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -814,7 +814,7 @@ static void checkAndDiagnoseImplicitNoDerivative(ASTContext &Context,
 }
 
 /// Get or synthesize `TangentVector` struct type.
-static Type
+static std::pair<Type, TypeDecl *>
 getOrSynthesizeTangentVectorStructType(DerivedConformance &derived) {
   auto *parentDC = derived.getConformanceContext();
   auto *nominal = derived.Nominal;
@@ -824,17 +824,20 @@ getOrSynthesizeTangentVectorStructType(DerivedConformance &derived) {
   auto *tangentStruct =
       getOrSynthesizeTangentVectorStruct(derived, C.Id_TangentVector);
   if (!tangentStruct)
-    return nullptr;
+    return std::make_pair(nullptr, nullptr);
+
   // Check and emit warnings for implicit `@noDerivative` members.
   checkAndDiagnoseImplicitNoDerivative(C, nominal, parentDC);
 
   // Return the `TangentVector` struct type.
-  return parentDC->mapTypeIntoContext(
-      tangentStruct->getDeclaredInterfaceType());
+  return std::make_pair(
+    parentDC->mapTypeIntoContext(
+      tangentStruct->getDeclaredInterfaceType()),
+    tangentStruct);
 }
 
 /// Synthesize the `TangentVector` struct type.
-static Type
+static std::pair<Type, TypeDecl *>
 deriveDifferentiable_TangentVectorStruct(DerivedConformance &derived) {
   auto *parentDC = derived.getConformanceContext();
   auto *nominal = derived.Nominal;
@@ -842,7 +845,7 @@ deriveDifferentiable_TangentVectorStruct(DerivedConformance &derived) {
   // If nominal type can derive `TangentVector` as the contextual `Self` type,
   // return it.
   if (canDeriveTangentVectorAsSelf(nominal, parentDC))
-    return parentDC->getSelfTypeInContext();
+    return std::make_pair(parentDC->getSelfTypeInContext(), nullptr);
 
   // Otherwise, get or synthesize `TangentVector` struct type.
   return getOrSynthesizeTangentVectorStructType(derived);
@@ -883,16 +886,17 @@ ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
   return nullptr;
 }
 
-Type DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
+std::pair<Type, TypeDecl *>
+DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
   // Diagnose unknown requirements.
   if (requirement->getBaseName() != Context.Id_TangentVector) {
     Context.Diags.diagnose(requirement->getLoc(),
                            diag::broken_differentiable_requirement);
-    return nullptr;
+    return std::make_pair(nullptr, nullptr);
   }
   // Diagnose conformances in disallowed contexts.
   if (checkAndDiagnoseDisallowedContext(requirement))
-    return nullptr;
+    return std::make_pair(nullptr, nullptr);
 
   // Start an error diagnostic before attempting derivation.
   // If derivation succeeds, cancel the diagnostic.
@@ -908,5 +912,5 @@ Type DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
   }
 
   // Otherwise, return nullptr.
-  return nullptr;
+  return std::make_pair(nullptr, nullptr);
 }

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -122,7 +122,8 @@ public:
   /// Derive a Differentiable type witness for a nominal type.
   ///
   /// \returns the derived member, which will also be added to the type.
-  Type deriveDifferentiable(AssociatedTypeDecl *assocType);
+  std::pair<Type, TypeDecl *>
+  deriveDifferentiable(AssociatedTypeDecl *assocType);
 
   /// Derive a CaseIterable requirement for an enum if it has no associated
   /// values for any of its cases.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5579,15 +5579,16 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   llvm_unreachable("unknown derivable protocol kind");
 }
 
-Type TypeChecker::deriveTypeWitness(DeclContext *DC,
-                                    NominalTypeDecl *TypeDecl,
-                                    AssociatedTypeDecl *AssocType) {
+std::pair<Type, TypeDecl *>
+TypeChecker::deriveTypeWitness(DeclContext *DC,
+                               NominalTypeDecl *TypeDecl,
+                               AssociatedTypeDecl *AssocType) {
   auto *protocol = cast<ProtocolDecl>(AssocType->getDeclContext());
 
   auto knownKind = protocol->getKnownProtocolKind();
   
   if (!knownKind)
-    return nullptr;
+    return std::make_pair(nullptr, nullptr);
 
   auto Decl = DC->getInnermostDeclarationDeclContext();
 
@@ -5595,13 +5596,13 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
                              protocol);
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
-    return derived.deriveRawRepresentable(AssocType);
+    return std::make_pair(derived.deriveRawRepresentable(AssocType), nullptr);
   case KnownProtocolKind::CaseIterable:
-    return derived.deriveCaseIterable(AssocType);
+    return std::make_pair(derived.deriveCaseIterable(AssocType), nullptr);
   case KnownProtocolKind::Differentiable:
     return derived.deriveDifferentiable(AssocType);
   default:
-    return nullptr;
+    return std::make_pair(nullptr, nullptr);
   }
 }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -822,7 +822,8 @@ private:
 
   /// Compute the "derived" type witness for an associated type that is
   /// known to the compiler.
-  Type computeDerivedTypeWitness(AssociatedTypeDecl *assocType);
+  std::pair<Type, TypeDecl *>
+  computeDerivedTypeWitness(AssociatedTypeDecl *assocType);
 
   /// Compute a type witness without using a specific potential witness,
   /// e.g., using a fixed type (from a refined protocol), default type

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -827,10 +827,7 @@ private:
   /// Compute a type witness without using a specific potential witness,
   /// e.g., using a fixed type (from a refined protocol), default type
   /// on an associated type, or deriving the type.
-  ///
-  /// \param allowDerived Whether to allow "derived" type witnesses.
-  Type computeAbstractTypeWitness(AssociatedTypeDecl *assocType,
-                                  bool allowDerived);
+  Type computeAbstractTypeWitness(AssociatedTypeDecl *assocType);
 
   /// Substitute the current type witnesses into the given interface type.
   Type substCurrentTypeWitnesses(Type type);

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -898,8 +898,7 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
 
 Type
 AssociatedTypeInference::computeAbstractTypeWitness(
-                                              AssociatedTypeDecl *assocType,
-                                              bool allowDerived) {
+                                              AssociatedTypeDecl *assocType) {
   // We don't have a type witness for this associated type, so go
   // looking for more options.
   if (Type concreteType = computeFixedTypeWitness(assocType))
@@ -910,10 +909,8 @@ AssociatedTypeInference::computeAbstractTypeWitness(
     return defaultType;
 
   // If we can derive a type witness, do so.
-  if (allowDerived) {
-    if (Type derivedType = computeDerivedTypeWitness(assocType))
-      return derivedType;
-  }
+  if (Type derivedType = computeDerivedTypeWitness(assocType))
+    return derivedType;
 
   // If there is a generic parameter of the named type, use that.
   if (auto genericSig = dc->getGenericSignatureOfContext()) {
@@ -1197,8 +1194,7 @@ void AssociatedTypeInference::findSolutionsRec(
 
       // Try to compute the type without the aid of a specific potential
       // witness.
-      if (Type type = computeAbstractTypeWitness(assocType,
-                                                 /*allowDerived=*/true)) {
+      if (Type type = computeAbstractTypeWitness(assocType)) {
         if (type->hasError()) {
           recordMissing();
           return;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -911,8 +911,9 @@ ValueDecl *deriveProtocolRequirement(DeclContext *DC,
 /// Derive an implicit type witness for the given associated type in
 /// the conformance of the given nominal type to some known
 /// protocol.
-Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
-                       AssociatedTypeDecl *assocType);
+std::pair<Type, TypeDecl *>
+deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
+                  AssociatedTypeDecl *assocType);
 
 /// \name Name lookup
 ///

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -46,7 +46,8 @@ var doubles: [Double] = serialize([Bar.a, .b, .c])
 var foos: [Foo] = deserialize([1, 2, 3])
 var bars: [Bar] = deserialize([1.2, 3.4, 5.6])
 
-// Infer RawValue from witnesses.
+// We reject enums where the raw type stated in the inheritance clause does not
+// match the types of the witnesses.
 enum Color : Int {
   case red
   case blue
@@ -56,11 +57,13 @@ enum Color : Int {
   }
 
   var rawValue: Double {
+  // expected-error@-1 {{invalid redeclaration of synthesized implementation for protocol requirement 'rawValue'}}
     return 1.0
   }
 }
 
 var colorRaw: Color.RawValue = 7.5
+// expected-error@-1 {{cannot convert value of type 'Double' to specified type 'Color.RawValue' (aka 'Int')}}
 
 // Mismatched case types
 

--- a/test/Sema/enum_raw_representable_circularity.swift
+++ b/test/Sema/enum_raw_representable_circularity.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+// This used to fail with "reference to invalid associated type 'RawValue' of type 'E'"
+_ = E(rawValue: 123)
+
+enum E : Int {
+  case a = 123
+
+  init?(rawValue: RawValue) {
+    self = .a
+  }
+}
+


### PR DESCRIPTION
Sema can infer type witnesses for a small set of known conformances, to RawRepresentable, CaseIterable, and Differentiable.
    
Previously, we would try to compute the type witness in this order:
    
1) First, via name lookup, to find an explicit nested type with the same name as an associated type.
    
2) Second, we would attempt inference.
    
3) Third, we would attempt derivation.
    
Instead, let's do 3) before 2). This avoids circularity errors in situations where the witness can be derived, but inference fails.
    
This breaks source compatibility with enum declarations where the raw type in the inheritance clause is a lie, and the user defines their own witnesses with mismatched types. However, I suspect this does not come up in practice, because if you don't synthesize witnesses, there is no way to access the actual raw literal values of the enum cases.
