### PR TITLE
[5.3][SourceKit] Enable ASTContext caching in other completion-like requests

### DIFF
--- a/include/swift/IDE/ConformingMethodList.h
+++ b/include/swift/IDE/ConformingMethodList.h
@@ -42,6 +42,7 @@ class ConformingMethodListConsumer {
 public:
   virtual ~ConformingMethodListConsumer() {}
   virtual void handleResult(const ConformingMethodListResult &result) = 0;
+  virtual void setReusingASTContext(bool flag) = 0;
 };
 
 /// Printing consumer
@@ -53,6 +54,7 @@ public:
   PrintingConformingMethodListConsumer(llvm::raw_ostream &OS) : OS(OS) {}
 
   void handleResult(const ConformingMethodListResult &result) override;
+  void setReusingASTContext(bool flag) override {}
 };
 
 /// Create a factory for code completion callbacks.

--- a/include/swift/IDE/TypeContextInfo.h
+++ b/include/swift/IDE/TypeContextInfo.h
@@ -38,6 +38,7 @@ class TypeContextInfoConsumer {
 public:
   virtual ~TypeContextInfoConsumer() {}
   virtual void handleResults(ArrayRef<TypeContextInfoItem>) = 0;
+  virtual void setReusingASTContext(bool flag) = 0;
 };
 
 /// Printing consumer
@@ -48,6 +49,7 @@ public:
   PrintingTypeContextInfoConsumer(llvm::raw_ostream &OS) : OS(OS) {}
 
   void handleResults(ArrayRef<TypeContextInfoItem>) override;
+  void setReusingASTContext(bool flag) override {}
 };
 
 /// Create a factory for code completion callbacks.

--- a/test/SourceKit/ConformingMethods/basic.swift
+++ b/test/SourceKit/ConformingMethods/basic.swift
@@ -28,3 +28,10 @@ func testing(obj: C) {
 
 // RUN: %sourcekitd-test -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s > %t.response
 // RUN: %diff -u %s.response %t.response
+// RUN: %sourcekitd-test -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD',reuseastcontext=0 -- -module-name MyModule %s | %FileCheck %s --check-prefix=DISABLED
+
+// DISABLED-NOT: key.reuseastcontext
+// DISABLED: key.members: [
+// DISABLED-NOT: key.reuseastcontext
+// DISABLED: key.members: [
+// DISABLED-NOT: key.reuseastcontext

--- a/test/SourceKit/ConformingMethods/basic.swift.response
+++ b/test/SourceKit/ConformingMethods/basic.swift.response
@@ -18,3 +18,24 @@
     }
   ]
 }
+{
+  key.typename: "C",
+  key.typeusr: "$s8MyModule1CCD",
+  key.members: [
+    {
+      key.name: "methodForTarget1()",
+      key.sourcetext: "methodForTarget1()",
+      key.description: "methodForTarget1()",
+      key.typename: "ConcreteTarget1",
+      key.typeusr: "$s8MyModule15ConcreteTarget1VD"
+    },
+    {
+      key.name: "methodForTarget2()",
+      key.sourcetext: "methodForTarget2()",
+      key.description: "methodForTarget2()",
+      key.typename: "ConcreteTarget2",
+      key.typeusr: "$s8MyModule15ConcreteTarget2VD"
+    }
+  ],
+  key.reusingastcontext: 1
+}

--- a/test/SourceKit/Misc/mixed_completion_sequence.swift
+++ b/test/SourceKit/Misc/mixed_completion_sequence.swift
@@ -13,11 +13,14 @@ protocol P {
 extension P {
   func protocolMethod(asc: Assoc) -> Self { return self }
 }
+enum MyEnum {
+    case foo, bar
+}
 
 class C : P {
   typealias Assoc = String
   static func staticMethod() -> Self {}
-  func instanceMethod(x: Int) -> C {}
+  func instanceMethod(x: MyEnum) -> C {}
   func methodForTarget1() -> ConcreteTarget1 {}
   func methodForTarget2() -> ConcreteTarget2 {}
 }
@@ -25,6 +28,14 @@ class C : P {
 func testing(obj: C) {
   let _ = obj.
 }
+func testing(obj: C) {
+  let _ = obj.instanceMethod(x: )
+}
 
-// RUN: %sourcekitd-test -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s > %t.response
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=29:14 %s -- %s -module-name MyModule == \
+// RUN:   -req=conformingmethods -pos=29:14 -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' %s -- %s -module-name MyModule == \
+// RUN:   -req=typecontextinfo -pos=32:33 %s -- %s -module-name MyModule == \
+// RUN:   -req=complete -pos=29:14 %s -- %s -module-name MyModule > %t.response
 // RUN: %diff -u %s.response %t.response

--- a/test/SourceKit/Misc/mixed_completion_sequence.swift.response
+++ b/test/SourceKit/Misc/mixed_completion_sequence.swift.response
@@ -1,0 +1,215 @@
+{
+  key.results: [
+    {
+      key.kind: source.lang.swift.decl.function.operator.infix,
+      key.name: "!==",
+      key.sourcetext: " !== <#T##AnyObject?#>",
+      key.description: "!==",
+      key.typename: "Bool",
+      key.context: source.codecompletion.context.othermodule,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.is_system: 1,
+      key.modulename: "Swift"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.operator.infix,
+      key.name: "===",
+      key.sourcetext: " === <#T##AnyObject?#>",
+      key.description: "===",
+      key.typename: "Bool",
+      key.context: source.codecompletion.context.othermodule,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.is_system: 1,
+      key.modulename: "Swift"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "instanceMethod(x:)",
+      key.sourcetext: ".instanceMethod(x: <#T##MyEnum#>)",
+      key.description: "instanceMethod(x: MyEnum)",
+      key.typename: "C",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1CC14instanceMethod1xAcA0A4EnumO_tF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "methodForTarget1()",
+      key.sourcetext: ".methodForTarget1()",
+      key.description: "methodForTarget1()",
+      key.typename: "ConcreteTarget1",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1CC16methodForTarget1AA08ConcreteE0VyF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "methodForTarget2()",
+      key.sourcetext: ".methodForTarget2()",
+      key.description: "methodForTarget2()",
+      key.typename: "ConcreteTarget2",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1CC16methodForTarget2AA08ConcreteE0VyF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "protocolMethod(asc:)",
+      key.sourcetext: ".protocolMethod(asc: <#T##String#>)",
+      key.description: "protocolMethod(asc: String)",
+      key.typename: "C",
+      key.context: source.codecompletion.context.superclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1PPAAE14protocolMethod3ascx5AssocQz_tF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "self",
+      key.sourcetext: ".self",
+      key.description: "self",
+      key.typename: "C",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0
+    }
+  ]
+}
+{
+  key.typename: "C",
+  key.typeusr: "$s8MyModule1CCD",
+  key.members: [
+    {
+      key.name: "methodForTarget1()",
+      key.sourcetext: "methodForTarget1()",
+      key.description: "methodForTarget1()",
+      key.typename: "ConcreteTarget1",
+      key.typeusr: "$s8MyModule15ConcreteTarget1VD"
+    },
+    {
+      key.name: "methodForTarget2()",
+      key.sourcetext: "methodForTarget2()",
+      key.description: "methodForTarget2()",
+      key.typename: "ConcreteTarget2",
+      key.typeusr: "$s8MyModule15ConcreteTarget2VD"
+    }
+  ],
+  key.reusingastcontext: 1
+}
+{
+  key.results: [
+    {
+      key.typename: "MyEnum",
+      key.typeusr: "$s8MyModule0A4EnumOD",
+      key.implicitmembers: [
+        {
+          key.name: "foo",
+          key.sourcetext: "foo",
+          key.description: "foo"
+        },
+        {
+          key.name: "bar",
+          key.sourcetext: "bar",
+          key.description: "bar"
+        }
+      ]
+    }
+  ],
+  key.reusingastcontext: 1
+}
+{
+  key.results: [
+    {
+      key.kind: source.lang.swift.decl.function.operator.infix,
+      key.name: "!==",
+      key.sourcetext: " !== <#T##AnyObject?#>",
+      key.description: "!==",
+      key.typename: "Bool",
+      key.context: source.codecompletion.context.othermodule,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.is_system: 1,
+      key.modulename: "Swift"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.operator.infix,
+      key.name: "===",
+      key.sourcetext: " === <#T##AnyObject?#>",
+      key.description: "===",
+      key.typename: "Bool",
+      key.context: source.codecompletion.context.othermodule,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.is_system: 1,
+      key.modulename: "Swift"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "instanceMethod(x:)",
+      key.sourcetext: ".instanceMethod(x: <#T##MyEnum#>)",
+      key.description: "instanceMethod(x: MyEnum)",
+      key.typename: "C",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1CC14instanceMethod1xAcA0A4EnumO_tF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "methodForTarget1()",
+      key.sourcetext: ".methodForTarget1()",
+      key.description: "methodForTarget1()",
+      key.typename: "ConcreteTarget1",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1CC16methodForTarget1AA08ConcreteE0VyF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "methodForTarget2()",
+      key.sourcetext: ".methodForTarget2()",
+      key.description: "methodForTarget2()",
+      key.typename: "ConcreteTarget2",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1CC16methodForTarget2AA08ConcreteE0VyF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "protocolMethod(asc:)",
+      key.sourcetext: ".protocolMethod(asc: <#T##String#>)",
+      key.description: "protocolMethod(asc: String)",
+      key.typename: "C",
+      key.context: source.codecompletion.context.superclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:8MyModule1PPAAE14protocolMethod3ascx5AssocQz_tF",
+      key.modulename: "MyModule"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "self",
+      key.sourcetext: ".self",
+      key.description: "self",
+      key.typename: "C",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unknown,
+      key.num_bytes_to_erase: 0
+    }
+  ],
+  key.reusingastcontext: 1
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_basic.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_basic.swift
@@ -27,3 +27,10 @@ func test(obj: C) {
 
 // RUN: %sourcekitd-test -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -- %s > %t.response
 // RUN: %diff -u %s.response %t.response
+// RUN: %sourcekitd-test -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -req-opts=reuseastcontext=0 -- %s | %FileCheck %s --check-prefix=DISABLED
+
+// DISABLED-NOT: key.reuseastcontext
+// DISABLED: key.results: [
+// DISABLED-NOT: key.reuseastcontext
+// DISABLED: key.results: [
+// DISABLED-NOT: key.reuseastcontext

--- a/test/SourceKit/TypeContextInfo/typecontext_basic.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_basic.swift
@@ -25,5 +25,5 @@ func test(obj: C) {
   let _ = obj.foo(x: 
 }
 
-// RUN: %sourcekitd-test -req=typecontextinfo -pos=25:22 %s -- %s > %t.response
+// RUN: %sourcekitd-test -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -- %s > %t.response
 // RUN: %diff -u %s.response %t.response

--- a/test/SourceKit/TypeContextInfo/typecontext_basic.swift.response
+++ b/test/SourceKit/TypeContextInfo/typecontext_basic.swift.response
@@ -58,3 +58,64 @@
     }
   ]
 }
+{
+  key.results: [
+    {
+      key.typename: "Direction",
+      key.typeusr: "$s17typecontext_basic9DirectionOD",
+      key.implicitmembers: [
+        {
+          key.name: "east",
+          key.sourcetext: "east",
+          key.description: "east"
+        },
+        {
+          key.name: "west",
+          key.sourcetext: "west",
+          key.description: "west"
+        },
+        {
+          key.name: "vector(x:y:)",
+          key.sourcetext: "vector(x: <#T##Int#>, y: <#T##Int#>)",
+          key.description: "vector(x: Int, y: Int)"
+        },
+        {
+          key.name: "distance(_:)",
+          key.sourcetext: "distance(<#T##Int#>)",
+          key.description: "distance(Int)"
+        }
+      ]
+    },
+    {
+      key.typename: "Target",
+      key.typeusr: "$s17typecontext_basic6TargetVD",
+      key.implicitmembers: [
+        {
+          key.name: "me",
+          key.sourcetext: "me",
+          key.description: "me",
+          key.doc.brief: "Mine."
+        },
+        {
+          key.name: "you",
+          key.sourcetext: "you",
+          key.description: "you",
+          key.doc.brief: "Yours."
+        },
+        {
+          key.name: "them",
+          key.sourcetext: "them",
+          key.description: "them",
+          key.doc.brief: "Theirs."
+        },
+        {
+          key.name: "all",
+          key.sourcetext: "all",
+          key.description: "all",
+          key.doc.brief: "One for all."
+        }
+      ]
+    }
+  ],
+  key.reusingastcontext: 1
+}

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -812,12 +812,14 @@ public:
 
   virtual void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf,
                                         unsigned Offset,
+                                        OptionsDictionary *options,
                                         ArrayRef<const char *> Args,
                                         TypeContextInfoConsumer &Consumer,
                                         Optional<VFSOptions> vfsOptions) = 0;
 
   virtual void getConformingMethodList(llvm::MemoryBuffer *inputBuf,
                                        unsigned Offset,
+                                       OptionsDictionary *options,
                                        ArrayRef<const char *> Args,
                                        ArrayRef<const char *> ExpectedTypes,
                                        ConformingMethodListConsumer &Consumer,

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -618,6 +618,7 @@ public:
 
   virtual void handleResult(const TypeContextInfoItem &Result) = 0;
   virtual void failed(StringRef ErrDescription) = 0;
+  virtual void setReusingASTContext(bool flag) = 0;
 };
 
 struct ConformingMethodListResult {
@@ -642,6 +643,7 @@ public:
   virtual ~ConformingMethodListConsumer() {}
 
   virtual void handleResult(const ConformingMethodListResult &Result) = 0;
+  virtual void setReusingASTContext(bool flag) = 0;
   virtual void failed(StringRef ErrDescription) = 0;
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -176,7 +176,7 @@ void SwiftLangSupport::getConformingMethodList(
 
   if (!swiftConformingMethodListImpl(*this, UnresolvedInputFile, Offset, Args,
                                      ExpectedTypeNames, Consumer, fileSystem,
-                                     /*EnableASTCaching=*/false, error)) {
+                                     /*EnableASTCaching=*/true, error)) {
     SKConsumer.failed(error);
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -44,6 +44,7 @@ static bool swiftConformingMethodListImpl(
 
         auto SF = CI.getCodeCompletionFile();
         performCodeCompletionSecondPass(*SF.get(), *callbacksFactory);
+        Consumer.setReusingASTContext(reusingASTContext);
       });
 }
 
@@ -68,7 +69,7 @@ void SwiftLangSupport::getConformingMethodList(
         : SKConsumer(SKConsumer) {}
 
     /// Convert an IDE result to a SK result and send it to \c SKConsumer .
-    void handleResult(const ide::ConformingMethodListResult &Result) {
+    void handleResult(const ide::ConformingMethodListResult &Result) override {
       SmallString<512> SS;
       llvm::raw_svector_ostream OS(SS);
 
@@ -171,6 +172,10 @@ void SwiftLangSupport::getConformingMethodList(
       SKResult.Members = SKMembers;
 
       SKConsumer.handleResult(SKResult);
+    }
+
+    void setReusingASTContext(bool flag) override {
+      SKConsumer.setReusingASTContext(flag);
     }
   } Consumer(SKConsumer);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -220,6 +220,18 @@ public:
 };
 } // end namespace CodeCompletion
 
+namespace TypeContextInfo {
+struct Options {
+  bool reuseASTContextIfPossible = true;
+};
+} // namespace TypeContextInfo
+
+namespace ConformingMethodList {
+struct Options {
+  bool reuseASTContextIfPossible = true;
+};
+} // namespace ConformingMethodList
+
 class SwiftInterfaceGenMap {
   llvm::StringMap<SwiftInterfaceGenContextRef> IFaceGens;
   mutable llvm::sys::Mutex Mtx;
@@ -596,11 +608,13 @@ public:
                std::function<void(const RequestResult<ArrayRef<StringRef>> &)> Receiver) override;
 
   void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf, unsigned Offset,
+                                OptionsDictionary *options,
                                 ArrayRef<const char *> Args,
                                 TypeContextInfoConsumer &Consumer,
                                 Optional<VFSOptions> vfsOptions) override;
 
   void getConformingMethodList(llvm::MemoryBuffer *inputBuf, unsigned Offset,
+                               OptionsDictionary *options,
                                ArrayRef<const char *> Args,
                                ArrayRef<const char *> ExpectedTypes,
                                ConformingMethodListConsumer &Consumer,

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -41,6 +41,7 @@ static bool swiftTypeContextInfoImpl(
 
         auto SF = CI.getCodeCompletionFile();
         performCodeCompletionSecondPass(*SF.get(), *callbacksFactory);
+        Consumer.setReusingASTContext(reusingASTContext);
       });
 }
 
@@ -144,9 +145,13 @@ void SwiftLangSupport::getExpressionContextInfo(
     Consumer(SourceKit::TypeContextInfoConsumer &SKConsumer)
         : SKConsumer(SKConsumer){};
 
-    void handleResults(ArrayRef<ide::TypeContextInfoItem> Results) {
+    void handleResults(ArrayRef<ide::TypeContextInfoItem> Results) override {
       for (auto &Item : Results)
         handleSingleResult(Item);
+    }
+
+    void setReusingASTContext(bool flag) override {
+      SKConsumer.setReusingASTContext(flag);
     }
   } Consumer(SKConsumer);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -151,7 +151,7 @@ void SwiftLangSupport::getExpressionContextInfo(
   } Consumer(SKConsumer);
 
   if (!swiftTypeContextInfoImpl(*this, UnresolvedInputFile, Offset, Consumer,
-                                Args, fileSystem, /*EnableASTCaching=*/false,
+                                Args, fileSystem, /*EnableASTCaching=*/true,
                                 error)) {
     SKConsumer.failed(error);
   }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2266,12 +2266,14 @@ static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
   ResponseBuilder RespBuilder;
 
   class Consumer : public TypeContextInfoConsumer {
+    ResponseBuilder RespBuilder;
     ResponseBuilder::Array SKResults;
     Optional<std::string> ErrorDescription;
 
   public:
     Consumer(ResponseBuilder Builder)
-        : SKResults(Builder.getDictionary().setArray(KeyResults)) {}
+        : RespBuilder(Builder),
+          SKResults(Builder.getDictionary().setArray(KeyResults)) {}
 
     void handleResult(const TypeContextInfoItem &Item) override {
       auto SKElem = SKResults.appendDictionary();
@@ -2286,6 +2288,11 @@ static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
         if (!member.DocBrief.empty())
           memberElem.set(KeyDocBrief, member.DocBrief);
       }
+    }
+
+    void setReusingASTContext(bool flag) override {
+      if (flag)
+        RespBuilder.getDictionary().setBool(KeyReusingASTContext, flag);
     }
 
     void failed(StringRef ErrDescription) override {
@@ -2339,6 +2346,11 @@ conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
         if (!member.DocBrief.empty())
           memberElem.set(KeyDocBrief, member.DocBrief);
       }
+    }
+
+    void setReusingASTContext(bool flag) override {
+      if (flag)
+        SKResult.setBool(KeyReusingASTContext, flag);
     }
 
     void failed(StringRef ErrDescription) override {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -176,11 +176,13 @@ static sourcekitd_response_t codeCompleteClose(StringRef name, int64_t Offset);
 
 static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
                                              int64_t Offset,
+                                             Optional<RequestDict> optionsDict,
                                              ArrayRef<const char *> Args,
                                              Optional<VFSOptions> vfsOptions);
 
 static sourcekitd_response_t
 conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
+                     Optional<RequestDict> optionsDict,
                      ArrayRef<const char *> Args,
                      ArrayRef<const char *> ExpectedTypes,
                      Optional<VFSOptions> vfsOptions);
@@ -993,7 +995,9 @@ static void handleSemanticRequest(
     int64_t Offset;
     if (Req.getInt64(KeyOffset, Offset, /*isOptional=*/false))
       return Rec(createErrorRequestInvalid("missing 'key.offset'"));
-    return Rec(typeContextInfo(InputBuf.get(), Offset, Args,
+    Optional<RequestDict> options =
+        Req.getDictionary(KeyTypeContextInfoOptions);
+    return Rec(typeContextInfo(InputBuf.get(), Offset, options, Args,
                                std::move(vfsOptions)));
   }
 
@@ -1008,9 +1012,11 @@ static void handleSemanticRequest(
     SmallVector<const char *, 8> ExpectedTypeNames;
     if (Req.getStringArray(KeyExpectedTypes, ExpectedTypeNames, true))
       return Rec(createErrorRequestInvalid("invalid 'key.expectedtypes'"));
+    Optional<RequestDict> options =
+        Req.getDictionary(KeyConformingMethodListOptions);
     return Rec(
-        conformingMethodList(InputBuf.get(), Offset, Args, ExpectedTypeNames,
-                             std::move(vfsOptions)));
+        conformingMethodList(InputBuf.get(), Offset, options, Args,
+                             ExpectedTypeNames, std::move(vfsOptions)));
   }
 
   if (!SourceFile.hasValue())
@@ -2261,6 +2267,7 @@ void SKGroupedCodeCompletionConsumer::setAnnotatedTypename(bool flag) {
 
 static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
                                              int64_t Offset,
+                                             Optional<RequestDict> optionsDict,
                                              ArrayRef<const char *> Args,
                                              Optional<VFSOptions> vfsOptions) {
   ResponseBuilder RespBuilder;
@@ -2305,8 +2312,12 @@ static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
     }
   } Consumer(RespBuilder);
 
+  std::unique_ptr<SKOptionsDictionary> options;
+  if (optionsDict)
+    options = std::make_unique<SKOptionsDictionary>(*optionsDict);
+
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.getExpressionContextInfo(InputBuf, Offset, Args, Consumer,
+  Lang.getExpressionContextInfo(InputBuf, Offset, options.get(), Args, Consumer,
                                 std::move(vfsOptions));
 
   if (Consumer.isError())
@@ -2320,6 +2331,7 @@ static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
 
 static sourcekitd_response_t
 conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
+                     Optional<RequestDict> optionsDict,
                      ArrayRef<const char *> Args,
                      ArrayRef<const char *> ExpectedTypes,
                      Optional<VFSOptions> vfsOptions) {
@@ -2363,9 +2375,13 @@ conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
     }
   } Consumer(RespBuilder);
 
+  std::unique_ptr<SKOptionsDictionary> options;
+  if (optionsDict)
+    options = std::make_unique<SKOptionsDictionary>(*optionsDict);
+
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.getConformingMethodList(InputBuf, Offset, Args, ExpectedTypes, Consumer,
-                               std::move(vfsOptions));
+  Lang.getConformingMethodList(InputBuf, Offset, options.get(), Args,
+                               ExpectedTypes, Consumer, std::move(vfsOptions));
 
   if (Consumer.isError())
     return createErrorRequestFailed(Consumer.getErrorDescription());

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -99,6 +99,8 @@ UID_KEYS = [
     KEY('EducationalNotePaths', 'key.educational_note_paths'),
     KEY('FormatOptions', 'key.editor.format.options'),
     KEY('CodeCompleteOptions', 'key.codecomplete.options'),
+    KEY('TypeContextInfoOptions', 'key.typecontextinfo.options'),
+    KEY('ConformingMethodListOptions', 'key.conformingmethods.options'),
     KEY('FilterRules', 'key.codecomplete.filterrules'),
     KEY('NextRequestStart', 'key.nextrequeststart'),
     KEY('Popular', 'key.popular'),


### PR DESCRIPTION
* **Explanation**: Enable ASTContext reusing by default in "type context info" and "conforming methods" requests in addition to "code completion". These requests shares a lot of logic with code completion, but ASTContext reusing hasn't been enabled. Since ASTContext reusing is stable enough in code completion, we can enable it by default in other completion-like request.
* **Scope**: "type context info" and "conforming methods"
* **Risk**: Low-Mid. Enabling pre-established functionality, but nevertheless it's a kind of big change
* **Testing**: Added regression test cases
* **Issue**: rdar://problem/64782333
* **Reviewer**: Ben Langmuir (@benlangmuir )
