### PR TITLE
Apply -debug-prefix-map to isysroot

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1782,7 +1782,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
       /* DWOId */ 0, /* SplitDebugInlining */ true,
       /* DebugInfoForProfiling */ false,
       llvm::DICompileUnit::DebugNameTableKind::Default,
-      /* RangesBaseAddress */ false, Sysroot, SDK);
+      /* RangesBaseAddress */ false, DebugPrefixMap.remapPath(Sysroot), SDK);
 
   // Because the swift compiler relies on Clang to setup the Module,
   // the clang CU is always created first.  Several dwarf-reading

--- a/test/DebugInfo/debug_prefix_map_sdk.swift
+++ b/test/DebugInfo/debug_prefix_map_sdk.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -sdk %t -g %s -emit-ir | %FileCheck -check-prefix=WITHOUT-PREFIX-MAP %s
-// RUN: %target-swift-frontend -sdk %t -g %s -emit-ir -debug-prefix-map %t=foo | %FileCheck -check-prefix=WITH-PREFIX-MAP %s
+// RUN: %target-swift-frontend -sdk %t/SOME_SDK -g %s -emit-ir | %FileCheck -check-prefix=WITHOUT-PREFIX-MAP %s
+// RUN: %target-swift-frontend -sdk %t/SOME_SDK -g %s -emit-ir -debug-prefix-map %t/SOME_SDK=foo | %FileCheck -check-prefix=WITH-PREFIX-MAP -implicit-check-not=SOME_SDK %s
 
 func foo() {}
 
-// WITHOUT-PREFIX-MAP: sysroot: "BUILD_DIR
+// WITHOUT-PREFIX-MAP: sysroot: "{{.*}}SOME_SDK
 // WITH-PREFIX-MAP: sysroot: "foo

--- a/test/DebugInfo/debug_prefix_map_sdk.swift
+++ b/test/DebugInfo/debug_prefix_map_sdk.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -sdk %t -g %s -emit-ir | %FileCheck -check-prefix=WITHOUT-PREFIX-MAP %s
+// RUN: %target-swift-frontend -sdk %t -g %s -emit-ir -debug-prefix-map %t=foo | %FileCheck -check-prefix=WITH-PREFIX-MAP %s
+
+func foo() {}
+
+// WITHOUT-PREFIX-MAP: sysroot: "BUILD_DIR
+// WITH-PREFIX-MAP: sysroot: "foo


### PR DESCRIPTION
Previously the absolute path to the sysroot, which could differ across
machines in remote build scenarios, was included in the debug info of
object files:

```
!11 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !12, producer: "Swift version 5.3-dev (LLVM 93caf26adb68d37, Swift 58b2ddc65afbd60)", isOptimized: false, runtimeVersion: 5, emissionKind: FullDebug, enums: !13, imports: !14, sysroot: "/Applications/Xcode-11.5.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", sdk: "MacOSX.sdk")
```

With this change these are included in the remapping done by
`-debug-prefix-map`.