### PR TITLE
Deterministically order class members for emission

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -101,7 +101,8 @@ public:
                            SymbolKind SKind = SymbolKind::Default);
 
   std::string mangleDestructorEntity(const DestructorDecl *decl,
-                                     bool isDeallocating, SymbolKind SKind);
+                                     bool isDeallocating,
+                                     SymbolKind SKind = SymbolKind::Default);
 
   std::string mangleConstructorEntity(const ConstructorDecl *ctor,
                                       bool isAllocating,
@@ -120,11 +121,11 @@ public:
 
   std::string mangleDefaultArgumentEntity(const DeclContext *func,
                                           unsigned index,
-                                          SymbolKind SKind);
+                                          SymbolKind SKind = SymbolKind::Default);
 
   std::string mangleInitializerEntity(const VarDecl *var, SymbolKind SKind);
   std::string mangleBackingInitializerEntity(const VarDecl *var,
-                                             SymbolKind SKind);
+                                             SymbolKind SKind = SymbolKind::Default);
 
   std::string mangleNominalType(const NominalTypeDecl *decl);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -535,16 +535,13 @@ protected:
     NumRequirementsInSignature : 16
   );
 
-  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+1+2+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+1+2+1+1+1+1+1,
     /// Whether this class inherits its superclass's convenience initializers.
     InheritsSuperclassInits : 1,
     ComputedInheritsSuperclassInits : 1,
 
     /// \see ClassDecl::ForeignKind
     RawForeignKind : 2,
-
-    /// \see ClassDecl::getEmittedMembers()
-    HasForcedEmittedMembers : 1,
 
     HasMissingDesignatedInitializers : 1,
     ComputedHasMissingDesignatedInitializers : 1,
@@ -3856,14 +3853,6 @@ class ClassDecl final : public NominalTypeDecl {
     llvm::PointerIntPair<Type, 1, bool> SuperclassType;
   } LazySemanticInfo;
 
-  bool hasForcedEmittedMembers() const {
-    return Bits.ClassDecl.HasForcedEmittedMembers;
-  }
-
-  void setHasForcedEmittedMembers() {
-    Bits.ClassDecl.HasForcedEmittedMembers = true;
-  }
-
   Optional<bool> getCachedInheritsSuperclassInitializers() const {
     if (Bits.ClassDecl.ComputedInheritsSuperclassInits)
       return Bits.ClassDecl.InheritsSuperclassInits;
@@ -4089,7 +4078,7 @@ public:
 
   /// Get all the members of this class, synthesizing any implicit members
   /// that appear in the vtable if needed.
-  DeclRange getEmittedMembers() const;
+  ArrayRef<Decl *> getEmittedMembers() const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1064,8 +1064,8 @@ public:
 
 class EmittedMembersRequest :
     public SimpleRequest<EmittedMembersRequest,
-                         DeclRange(ClassDecl *),
-                         RequestFlags::SeparatelyCached> {
+                         ArrayRef<Decl *>(ClassDecl *),
+                         RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -1073,14 +1073,11 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  DeclRange
+  ArrayRef<Decl *>
   evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
 
 public:
-  // Separate caching.
   bool isCached() const { return true; }
-  Optional<DeclRange> getCachedResult() const;
-  void cacheResult(DeclRange value) const;
 };
 
 class IsImplicitlyUnwrappedOptionalRequest :

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -65,8 +65,8 @@ SWIFT_REQUEST(TypeChecker, TypeEraserHasViableInitRequest,
 SWIFT_REQUEST(TypeChecker, DynamicallyReplacedDeclRequest,
               ValueDecl *(ValueDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, EmittedMembersRequest, DeclRange(ClassDecl *),
-              SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, EmittedMembersRequest, ArrayRef<Decl *>(ClassDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawValuesRequest,
               evaluator::SideEffect (EnumDecl *, TypeResolutionStage),
               SeparatelyCached, NoLocationInfo)

--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -192,9 +192,8 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
       // Mangle the sub-string up to the next word substitution (or to the end
       // of the identifier - that's why we added the dummy-word).
       // The first thing: we add the encoded sub-string length.
+      bool first = true;
       M.Buffer << (Repl.StringPos - Pos);
-      assert(!isDigit(ident[Pos]) &&
-             "first char of sub-string may not be a digit");
       do {
         // Update the start position of new added words, so that they refer to
         // the begin of the whole mangled Buffer.
@@ -203,9 +202,16 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
           M.Words[WordsInBuffer].start = M.getBufferStr().size();
           WordsInBuffer++;
         }
+        // Error recovery. We sometimes need to mangle identifiers coming
+        // from invalid code.
+        if (first && isDigit(ident[Pos]))
+          M.Buffer << 'X';
         // Add a literal character of the sub-string.
-        M.Buffer << ident[Pos];
+        else
+          M.Buffer << ident[Pos];
+
         Pos++;
+        first = false;
       } while (Pos < Repl.StringPos);
     }
     // Is it a "real" word substitution (and not the dummy-word)?

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -18,54 +18,10 @@
 #ifndef SWIFT_SIL_SILVTABLEVISITOR_H
 #define SWIFT_SIL_SILVTABLEVISITOR_H
 
-#include <string>
-
 #include "swift/AST/Decl.h"
 #include "swift/AST/Types.h"
-#include "swift/AST/ASTMangler.h"
 
 namespace swift {
-
-// Utility class for deterministically ordering vtable entries for
-// synthesized methods.
-struct SortedFuncList {
-  using Entry = std::pair<std::string, AbstractFunctionDecl *>;
-  SmallVector<Entry, 2> elts;
-  bool sorted = false;
-
-  void add(AbstractFunctionDecl *afd) {
-    Mangle::ASTMangler mangler;
-    std::string mangledName;
-    if (auto *cd = dyn_cast<ConstructorDecl>(afd))
-      mangledName = mangler.mangleConstructorEntity(cd, 0);
-    else
-      mangledName = mangler.mangleEntity(afd);
-
-    elts.push_back(std::make_pair(mangledName, afd));
-  }
-
-  bool empty() { return elts.empty(); }
-
-  void sort() {
-    assert(!sorted);
-    sorted = true;
-    std::sort(elts.begin(),
-              elts.end(),
-              [](const Entry &lhs, const Entry &rhs) -> bool {
-                return lhs.first < rhs.first;
-              });
-  }
-
-  decltype(elts)::const_iterator begin() const {
-    assert(sorted);
-    return elts.begin();
-  }
-
-  decltype(elts)::const_iterator end() const {
-    assert(sorted);
-    return elts.end();
-  }
-};
 
 /// A CRTP class for visiting virtually-dispatched methods of a class.
 ///
@@ -192,33 +148,8 @@ protected:
     if (!theClass->hasKnownSwiftImplementation())
       return;
 
-    // Note that while vtable order is not ABI, we still want it to be
-    // consistent between translation units.
-    //
-    // So, sort synthesized members by their mangled name, since they
-    // are added lazily during type checking, with the remaining ones
-    // forced at the end.
-    SortedFuncList synthesizedMembers;
-
-    for (auto member : theClass->getEmittedMembers()) {
-      if (auto *afd = dyn_cast<AbstractFunctionDecl>(member)) {
-        if (afd->isSynthesized()) {
-          synthesizedMembers.add(afd);
-          continue;
-        }
-      }
-
+    for (auto member : theClass->getEmittedMembers())
       maybeAddMember(member);
-    }
-
-    if (synthesizedMembers.empty())
-      return;
-
-    synthesizedMembers.sort();
-
-    for (const auto &pair : synthesizedMembers) {
-      maybeAddMember(pair.second);
-    }
   }
 };
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2741,7 +2741,7 @@ void ASTMangler::appendConstructorEntity(const ConstructorDecl *ctor,
 }
 
 void ASTMangler::appendDestructorEntity(const DestructorDecl *dtor,
-                                     bool isDeallocating) {
+                                        bool isDeallocating) {
   appendContextOf(dtor);
   appendOperator(isDeallocating ? "fD" : "fd");
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4318,6 +4318,10 @@ GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   if (ctx.LangOpts.EnableObjCInterop)
     CD->recordObjCMethod(DD, DD->getObjCSelector());
 
+  // Mark it as synthesized to make its location in getEmittedMembers()
+  // deterministic.
+  DD->setSynthesized(true);
+
   return DD;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4285,11 +4285,11 @@ DestructorDecl *ClassDecl::getDestructor() const {
                            nullptr);
 }
 
-DeclRange ClassDecl::getEmittedMembers() const {
+ArrayRef<Decl *> ClassDecl::getEmittedMembers() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
                            EmittedMembersRequest{const_cast<ClassDecl *>(this)},
-                           getMembers());
+                           ArrayRef<Decl *>());
 }
 
 /// Synthesizer callback for an empty implicit function body.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -784,23 +784,6 @@ void SynthesizeAccessorRequest::cacheResult(AccessorDecl *accessor) const {
 }
 
 //----------------------------------------------------------------------------//
-// EmittedMembersRequest computation.
-//----------------------------------------------------------------------------//
-
-Optional<DeclRange>
-EmittedMembersRequest::getCachedResult() const {
-  auto *classDecl = std::get<0>(getStorage());
-  if (classDecl->hasForcedEmittedMembers())
-    return classDecl->getMembers();
-  return None;
-}
-
-void EmittedMembersRequest::cacheResult(DeclRange result) const {
-  auto *classDecl = std::get<0>(getStorage());
-  classDecl->setHasForcedEmittedMembers();
-}
-
-//----------------------------------------------------------------------------//
 // IsImplicitlyUnwrappedOptionalRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2451,6 +2451,7 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
   forceConformance(Context.getProtocol(KnownProtocolKind::Decodable));
   forceConformance(Context.getProtocol(KnownProtocolKind::Encodable));
   forceConformance(Context.getProtocol(KnownProtocolKind::Hashable));
+  forceConformance(Context.getProtocol(KnownProtocolKind::Differentiable));
 
   // The projected storage wrapper ($foo) might have dynamically-dispatched
   // accessors, so force them to be synthesized.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2417,13 +2417,17 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
   return namingPattern;
 }
 
-DeclRange
+ArrayRef<Decl *>
 EmittedMembersRequest::evaluate(Evaluator &evaluator,
                                 ClassDecl *CD) const {
-  if (!CD->getParentSourceFile())
-    return CD->getMembers();
-
   auto &Context = CD->getASTContext();
+  SmallVector<Decl *, 8> result;
+
+  if (!CD->getParentSourceFile()) {
+    auto members = CD->getMembers();
+    result.append(members.begin(), members.end());
+    return Context.AllocateCopy(result);
+  }
 
   // We need to add implicit initializers because they
   // affect vtable layout.
@@ -2461,7 +2465,9 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
         (void) var->getPropertyWrapperBackingProperty();
   }
 
-  return CD->getMembers();
+  auto members = CD->getMembers();
+  result.append(members.begin(), members.end());
+  return Context.AllocateCopy(result);
 }
 
 bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,

--- a/test/SILGen/Inputs/deterministic-dtor-ordering-other.swift
+++ b/test/SILGen/Inputs/deterministic-dtor-ordering-other.swift
@@ -1,0 +1,3 @@
+public func makeAHorse() -> Horse {
+  return Horse()
+}

--- a/test/SILGen/deterministic-dtor-ordering.swift
+++ b/test/SILGen/deterministic-dtor-ordering.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-emit-silgen -module-name horse -primary-file %S/Inputs/deterministic-dtor-ordering-other.swift -primary-file %s -module-name horse | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name horse %S/Inputs/deterministic-dtor-ordering-other.swift -primary-file %s -module-name horse | %FileCheck %s
+
+public class Horse {}
+
+// CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s5horse5HorseCACycfC : $@convention(method) (@thick Horse.Type) -> @owned Horse {
+// CHECK-LABEL: sil hidden [ossa] @$s5horse5HorseCACycfc : $@convention(method) (@owned Horse) -> @owned Horse {
+// CHECK-LABEL: sil [ossa] @$s5horse5HorseCfd : $@convention(method) (@guaranteed Horse) -> @owned Builtin.NativeObject {
+// CHECK-LABEL: sil [ossa] @$s5horse5HorseCfD : $@convention(method) (@owned Horse) -> () {
+

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -454,12 +454,12 @@ class Wotsit<T> : Gizmo {
     return "Hello, world."
   }
 
-  // Ivar destroyer
-  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6WotsitCfETo
-
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6WotsitCACyxGSgycfcTo : $@convention(objc_method) <T> (@owned Wotsit<T>) -> @owned Optional<Wotsit<T>>
 
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6WotsitC7bellsOnACyxGSgSi_tcfcTo : $@convention(objc_method) <T> (Int, @owned Wotsit<T>) -> @owned Optional<Wotsit<T>>
+
+  // Ivar destroyer
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6WotsitCfETo
 
 }
 

--- a/validation-test/compiler_crashers_fixed/28809-isdigit-ident-pos-first-char-of-sub-string-may-not-be-a-digit.swift
+++ b/validation-test/compiler_crashers_fixed/28809-isdigit-ident-pos-first-char-of-sub-string-may-not-be-a-digit.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol 0{class TextOutputStream


### PR DESCRIPTION
We already did this for vtable entries, because its required for correctness; sink the ordering down into EmittedMembersRequest in service of reproducible builds as well.

This fixes an issue found by @davidungar where the driver's batching could flip the order of a class's default init() and deinit members, which tripped up our incremental build testing.

Along the way, I discovered that caching the emitted members list broke deriving the `Differentiable` conformance, because we might cache the member list before synthesizing the members; fixing this by forcing the conformance in `EmittedMembersRequest` in turn uncovered some order dependencies in conformance derivation, which I already addressed in https://github.com/apple/swift/pull/32578.