### PR TITLE
[SourceKit/CodeFormat] Fix multi-line array literal elements not indenting relative to their first line.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2342,8 +2342,17 @@ private:
         return None;
 
       ListAligner Aligner(SM, TargetLocation, L, L, R, true);
-      for (auto *Elem: AE->getElements())
-        Aligner.updateAlignment(Elem->getStartLoc(), Elem->getEndLoc(), Elem);
+      for (auto *Elem: AE->getElements()) {
+        SourceRange ElemRange = Elem->getSourceRange();
+        Aligner.updateAlignment(ElemRange, Elem);
+        if (isTargetContext(ElemRange)) {
+          Aligner.setAlignmentIfNeeded(CtxOverride);
+          return IndentContext {
+            ElemRange.Start,
+            !OutdentChecker::hasOutdent(SM, ElemRange, Elem)
+          };
+        }
+      }
       return Aligner.getContextAndSetAlignment(CtxOverride);
     }
 

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -1052,3 +1052,14 @@ struct <#name#> {
     <#fields#>
     func foo() {}
 }
+
+
+// Array literal elements should have their continuation lines indented relative to their first line.
+
+doStuffWithList([
+    baseThing()
+        .map { $0 }
+        .append(\.sdfsdf),
+    secondItem
+        .filter {$0 < 10}
+])


### PR DESCRIPTION
Previously each item in an array literal wasn't considered to be an indent context, so we under-indented their continuation lines as in the example below:
```
doStuffWithList([
    firstItem
    .map {$0}       // This line should be indented further.
    .append(\.foo),   // And so should this one.
    secondItem
    .filter {$0 > 5}
])
```

After this change, each item is an indent context so we get the below:
```
doStuffWithList([
    firstItem
        .map {$0}
        .append(\.foo),
    secondItem
        .filter {$0 > 5}
])
```

Resolves rdar://problem/64834040