### PR TITLE
[5.3][SourceKit/CodeFormat] Fix multi-line array literal elements not indenting relative to their first line.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2341,8 +2341,17 @@ private:
         return None;
 
       ListAligner Aligner(SM, TargetLocation, L, L, R, true);
-      for (auto *Elem: AE->getElements())
-        Aligner.updateAlignment(Elem->getStartLoc(), Elem->getEndLoc(), Elem);
+      for (auto *Elem: AE->getElements()) {
+        SourceRange ElemRange = Elem->getSourceRange();
+        Aligner.updateAlignment(ElemRange, Elem);
+        if (isTargetContext(ElemRange)) {
+          Aligner.setAlignmentIfNeeded(CtxOverride);
+          return IndentContext {
+            ElemRange.Start,
+            !OutdentChecker::hasOutdent(SM, ElemRange, Elem)
+          };
+        }
+      }
       return Aligner.getContextAndSetAlignment(CtxOverride);
     }
 

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -1052,3 +1052,14 @@ struct <#name#> {
     <#fields#>
     func foo() {}
 }
+
+
+// Array literal elements should have their continuation lines indented relative to their first line.
+
+doStuffWithList([
+    baseThing()
+        .map { $0 }
+        .append(\.sdfsdf),
+    secondItem
+        .filter {$0 < 10}
+])


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32582 for 5.3

- **Explanation**:
  Multi-line array literal elements were not indenting relative to their first line as they did before the indentation overhaul. Each item in an array literal wasn't being reported as an indent context, so we under-indented their continuation lines as in the example below:
  ```
  doStuffWithList([
      firstItem
      .map {$0}            // This line should be indented further.
      .append(\.foo),      // So should this one
      secondItem
      .filter {$0 > 5}.    // and this one.
  ])
  ```

  This change makes them an indent context giving the behavior below:
  ```
  doStuffWithList([
      firstItem
          .map {$0}
          .append(\.foo),
      secondItem
          .filter {$0 > 5}
  ])
  ```
- **Scope**: Affects the indentation of all multi-line expressions expression within array literals.
- **Risk**: Low. It's a small targeted fix that only affects sourcekitd's CodeFormat request. It has no impact on sourcekitd's other requests or the compiler.
- **Origination**: Since the indentation overhaul in 5.3.
- **Testing**: Added a regression test for this case and all existing tests pass.
- **Reviewer**: Ben Langmuir (@benlangmuir) on the [master PR](https://github.com/apple/swift/pull/32582)

Resolves rdar://problem/64834040