### PR TITLE
test: make `gen-output-file-map` Python 3 friendly

### DIFF
--- a/test/Incremental/Verifier/gen-output-file-map.py
+++ b/test/Incremental/Verifier/gen-output-file-map.py
@@ -74,7 +74,8 @@ def main(arguments):
         f.write(to_unicode(json.dumps(all_records, ensure_ascii=False)))
 
     if args.response_output_file is not None:
-        with io.open(args.response_output_file, 'w', encoding='utf-8', newline='\n') as f:
+        with io.open(args.response_output_file, 'w',
+                     encoding='utf-8', newline='\n') as f:
             for line in response_file_contents:
                 f.write(to_unicode(line + " "))
 

--- a/test/Incremental/Verifier/gen-output-file-map.py
+++ b/test/Incremental/Verifier/gen-output-file-map.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import argparse
+import io
 import json
 import os
 import sys
@@ -61,13 +62,21 @@ def main(arguments):
         'swift-dependencies': './main-buildrecord.swiftdeps'
     }
 
-    with open(output_path, 'wb') as f:
-        json.dump(all_records, f)
+    # TODO: this is for python 2 and python 3 compatibility.  Once Python 2 is
+    # removed, this function can be removed.
+    def to_unicode(r):
+        import sys
+        if sys.version_info[0] < 3:
+            return unicode(r)
+        return str(r)
+
+    with io.open(output_path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(to_unicode(json.dumps(all_records, ensure_ascii=False)))
 
     if args.response_output_file is not None:
-        with open(args.response_output_file, 'wb') as f:
+        with io.open(args.response_output_file, 'w', encoding='utf-8', newline='\n') as f:
             for line in response_file_contents:
-                f.write(line + " ")
+                f.write(to_unicode(line + " "))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adjust `gen-output-file-map.py` to be friendly to Python 3 by using
`io.open` instead of `open`.  This allow the use of `encoding` and
`newline` named parameters to write out files using UTF-8 encoded, UNIX
newline delimited files.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
