### PR TITLE
[SR-13088] Fix false positive downcast unrelated of types that cannot be statically known

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -786,6 +786,10 @@ public:
   
   /// Check if this is a nominal type defined at the top level of the Swift module
   bool isStdlibType();
+  
+  /// Check if this is either an Array, Set or Dictionary collection type defined
+  /// at the top level of the Swift module
+  bool isStdlibCollectionType();
 
   /// If this is a class type or a bound generic class type, returns the
   /// (possibly generic) class.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -789,7 +789,7 @@ public:
   
   /// Check if this is either an Array, Set or Dictionary collection type defined
   /// at the top level of the Swift module
-  bool isStdlibCollectionType();
+  bool isKnownStdlibCollectionType();
 
   /// If this is a class type or a bound generic class type, returns the
   /// (possibly generic) class.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -759,6 +759,18 @@ bool TypeBase::isStdlibType() {
   return false;
 }
 
+bool TypeBase::isStdlibCollectionType() {
+  if (auto *structType = getAs<BoundGenericStructType>()) {
+    auto &ctx = getASTContext();
+    auto *decl = structType->getDecl();
+    if (decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
+        decl == ctx.getSetDecl())
+      return true;
+  }
+
+  return false;
+}
+
 /// Remove argument labels from the function type.
 Type TypeBase::removeArgumentLabels(unsigned numArgumentLabels) {
   // If there is nothing to remove, don't.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -759,15 +759,13 @@ bool TypeBase::isStdlibType() {
   return false;
 }
 
-bool TypeBase::isStdlibCollectionType() {
+bool TypeBase::isKnownStdlibCollectionType() {
   if (auto *structType = getAs<BoundGenericStructType>()) {
     auto &ctx = getASTContext();
     auto *decl = structType->getDecl();
-    if (decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
-        decl == ctx.getSetDecl())
-      return true;
+    return decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
+           decl == ctx.getSetDecl();
   }
-
   return false;
 }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1035,7 +1035,7 @@ bool TypeVarBindingProducer::computeNext() {
     auto srcLocator = binding.getLocator();
     if (srcLocator &&
         srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() &&
-        !type->hasTypeVariable() && CS.isCollectionType(type)) {
+        !type->hasTypeVariable() && type->isKnownStdlibCollectionType()) {
       // If the type binding comes from the argument conversion, let's
       // instead of binding collection types directly, try to bind
       // using temporary type variables substituted for element

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3373,7 +3373,7 @@ bool MissingMemberFailure::diagnoseInLiteralCollectionContext() const {
 
   auto parentType = getType(parentExpr);
 
-  if (!isCollectionType(parentType) && !parentType->is<TupleType>())
+  if (!parentType->isKnownStdlibCollectionType() && !parentType->is<TupleType>())
     return false;
 
   if (isa<TupleExpr>(parentExpr)) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -208,11 +208,6 @@ protected:
       llvm::function_ref<void(GenericTypeParamType *, Type)> substitution =
           [](GenericTypeParamType *, Type) {});
 
-  bool isCollectionType(Type type) const {
-    auto &cs = getConstraintSystem();
-    return cs.isCollectionType(type);
-  }
-
   bool isArrayType(Type type) const {
     auto &cs = getConstraintSystem();
     return bool(cs.isArrayType(type));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3708,7 +3708,7 @@ bool ConstraintSystem::repairFailures(
     // func foo<T>(_: [T]) {}
     // foo(1) // expected '[Int]', got 'Int'
     // ```
-    if (isCollectionType(rhs)) {
+    if (rhs->isKnownStdlibCollectionType()) {
       std::function<Type(Type)> getArrayOrSetType = [&](Type type) -> Type {
         if (auto eltTy = isArrayType(type))
           return getArrayOrSetType(*eltTy);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -878,10 +878,6 @@ Optional<Type> ConstraintSystem::isSetType(Type type) {
   return None;
 }
 
-bool ConstraintSystem::isCollectionType(Type type) {
-  return type->isStdlibCollectionType();
-}
-
 bool ConstraintSystem::isAnyHashableType(Type type) {
   if (auto st = type->getAs<StructType>()) {
     auto &ctx = type->getASTContext();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -879,15 +879,7 @@ Optional<Type> ConstraintSystem::isSetType(Type type) {
 }
 
 bool ConstraintSystem::isCollectionType(Type type) {
-  if (auto *structType = type->getAs<BoundGenericStructType>()) {
-    auto &ctx = type->getASTContext();
-    auto *decl = structType->getDecl();
-    if (decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
-        decl == ctx.getSetDecl())
-      return true;
-  }
-
-  return false;
+  return type->isStdlibCollectionType();
 }
 
 bool ConstraintSystem::isAnyHashableType(Type type) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3348,9 +3348,6 @@ public:
   /// element type of the set.
   static Optional<Type> isSetType(Type t);
 
-  /// Determine if the type in question is one of the known collection types.
-  static bool isCollectionType(Type t);
-
   /// Determine if the type in question is AnyHashable.
   static bool isAnyHashableType(Type t);
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3250,7 +3250,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   auto checkElementCast = [&](Type fromElt, Type toElt,
                               CheckedCastKind castKind) -> CheckedCastKind {
     // Let's not emit diagnostic when the element type is erased because
-    // we can't statically known about if element is convertible.
+    // we can't statically known if element is convertible.
     if (fromElt->isAny() || toElt->isAny())
       return castKind;
     

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3648,9 +3648,9 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     return CheckedCastKind::ValueCast;
   }
 
-  // If the destination type can be a supertype of the source type, we are
-  // performing what looks like an upcast except it rebinds generic
-  // parameters.
+  // If it is possible to substitute the generic arguments of source type
+  // with the destination generic archetypes, we are performing what looks
+  // like an upcast except it rebinds generic parameters.
   if (toType->isBindableTo(fromType))
     return CheckedCastKind::ValueCast;
   

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3554,7 +3554,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       auto protocolDecl =
           dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
       // Checking for possible dynamic conformances because we cannot fail
-      // in thoses cases.
+      // in those cases.
       if (protocolDecl &&
           !couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
         return failed();
@@ -3620,11 +3620,11 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     return CheckedCastKind::ValueCast;
   }
 
-  // If it is possible to substitute the generic arguments of source type
-  // with the destination generic archetypes, we are performing what looks
-  // like an upcast except it rebinds generic parameters. Or substitute
-  // destination to source generic archetypes, where we are performing
-  // what looks like an downcast except it also rebinds generic parameters.
+  // We perform an upcast while rebinding generic parameters if it's possible
+  // to substitute the generic arguments of the source type with the generic
+  // archetypes of the destination type. Or, if it's possible to substitute
+  // the generic arguments of the destination type with the generic archetypes
+  // of the source type, we perform a downcast instead.
   if (toType->isBindableTo(fromType) || fromType->isBindableTo(toType))
     return CheckedCastKind::ValueCast;
   
@@ -3642,8 +3642,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     }
   }
 
-  // We can conditionally cast from NSError to an Error-conforming
-  // type.  This is handled in the runtime, so it doesn't need a special cast
+  // We can conditionally cast from NSError to an Error-conforming type.
+  // This is handled in the runtime, so it doesn't need a special cast
   // kind.
   if (Context.LangOpts.EnableObjCInterop) {
     auto nsObject = Context.getNSObjectType();

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3534,8 +3534,9 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         (toType->isAnyObject() || fromType->isAnyObject()))
       return CheckedCastKind::ValueCast;
 
-    // A cast from an existential type to a concrete type does not succeed. For
-    // example:
+    // If we have a cast from an existential type to a concrete type that we
+    // statically know doesn't conform to the protocol, mark the cast as always
+    // failing. For example:
     //
     // struct S {}
     // enum FooError: Error { case bar }
@@ -3548,12 +3549,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     //   }
     // }
     //
-    // But we check for conformance and possible dynamic conformances in which
-    // case we cannot fail because it is impossible to know then statically.
     if (auto *protocolDecl =
           dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal())) {
-      // Checking for possible dynamic conformances because we cannot fail
-      // in those cases.
       if (!couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
         return failed();
       }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3548,15 +3548,14 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     //   }
     // }
     //
+    // But we check for conformance and possible dynamic conformances in which
+    // case we cannot fail because it is impossible to know then statically.
     if (auto *protocolDecl =
-          dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal())){
-      if (!toExistential) {
-        // Checking for possible dynamic conformances because we cannot fail
-        // in those cases.
-        if (protocolDecl &&
-            !couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
-          return failed();
-        }
+          dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal())) {
+      // Checking for possible dynamic conformances because we cannot fail
+      // in those cases.
+      if (!couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
+        return failed();
       }
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3548,16 +3548,15 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     //   }
     // }
     //
-    // Except when the toType is a generic archetype, because then it may
-    // have protocol conformances we cannot know statically.
-    if (fromExistential && (!toExistential && !toArchetype)) {
-      auto protocolDecl =
-          dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
-      // Checking for possible dynamic conformances because we cannot fail
-      // in those cases.
-      if (protocolDecl &&
-          !couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
-        return failed();
+    if (auto *protocolDecl =
+          dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal())){
+      if (!toExistential) {
+        // Checking for possible dynamic conformances because we cannot fail
+        // in those cases.
+        if (protocolDecl &&
+            !couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
+          return failed();
+        }
       }
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3105,7 +3105,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       }
 
       // In the context of collection element we just return a value cast
-      // becasue there may be situation where this can be convertible
+      // because there may be situations where this can be convertible
       // at runtime. e.g.
       //
       // func f(a: [Any], b: [AnyObject]) {
@@ -3568,9 +3568,9 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     // non-final class because it's possible that we might have a subclass
     // that conforms to the protocol.
     //
-    //  Also, relax the restriction when toType is a stdlib collection type
+    //  Also, relax the restriction when toType is a stdlib collection
     //  (Array, Set, Dictionary) that could have conditional conformances
-    //  because of custom casting implemented for those types e.g.
+    //  because of custom casting mechanism implemented for those types e.g.
     //
     //  func encodable(_ value: Encodable) {
     //    _ = value as! [String : Encodable]
@@ -3651,8 +3651,10 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
 
   // If it is possible to substitute the generic arguments of source type
   // with the destination generic archetypes, we are performing what looks
-  // like an upcast except it rebinds generic parameters.
-  if (toType->isBindableTo(fromType))
+  // like an upcast except it rebinds generic parameters. Or substitute
+  // destination to source generic archetypes, where we are performing
+  // what looks like an downcast except it also rebinds generic parameters.
+  if (toType->isBindableTo(fromType) || fromType->isBindableTo(toType))
     return CheckedCastKind::ValueCast;
   
   // Objective-C metaclasses are subclasses of NSObject in the ObjC runtime,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3582,8 +3582,9 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
           auto protocolDecl =
               dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
           if (protocolDecl && !conformsToProtocol(toType, protocolDecl, dc) &&
-              !(toType->isStdlibCollectionType() &&
-                getStdlibModule(dc)->lookupConformance(toType, protocolDecl))) {
+              !(toType->isKnownStdlibCollectionType() &&
+                dc->getParentModule()->lookupConformance(toType,
+                                                         protocolDecl))) {
             return failed();
           }
         }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3250,7 +3250,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   auto checkElementCast = [&](Type fromElt, Type toElt,
                               CheckedCastKind castKind) -> CheckedCastKind {
     // Let's not emit diagnostic when the element type is erased because
-    // we can't statically known if element is convertible.
+    // we can't statically know if element is convertible.
     if (fromElt->isAny() || toElt->isAny())
       return castKind;
     
@@ -3362,8 +3362,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         const auto &fromElt = fromTuple->getElement(i);
         const auto &toElt = toTuple->getElement(i);
 
-        // We only should perform name validation if both element have name
-        // bacause unlabeled tuple elements can be converted to labeled ones
+        // We should only perform name validation if both element have a label,
+        // because unlabeled tuple elements can be converted to labeled ones
         // e.g.
         // 
         // let tup: (Any, Any) = (1, 1)

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3565,10 +3565,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         if (!toType->is<ClassType>() || NTD->isFinal()) {
           auto protocolDecl =
               dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
-          if (protocolDecl && !conformsToProtocol(toType, protocolDecl, dc) &&
-              !(toType->isKnownStdlibCollectionType() &&
-                dc->getParentModule()->lookupConformance(toType,
-                                                         protocolDecl))) {
+          if (protocolDecl && !couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
             return failed();
           }
         }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4473,19 +4473,17 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
 bool
 TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
                                                DeclContext *DC) {
-  // If the type we're checking is a non-final class because it's
-  // possible that we might have a subclass that conforms to the protocol.
-  //
-  // Or when type is a stdlib collection (Array, Set, Dictionary) that
-  // could have conditional conformances because of custom casting
-  // mechanism implemented for those types e.g.
+  // We may have types that can dynamically conform to a protocol, e.g. a non-final
+  // class which might have a subclass that conforms to the protocol, or standard
+  // library collection types such as Array, Set or Dictionary which have custom
+  // casting machinery implemented in situations like:
   //
   //  func encodable(_ value: Encodable) {
   //    _ = value as! [String : Encodable]
   //  }
   //
   if (auto *classDecl = type->getClassOrBoundGenericClass()) {
-    if (!classDecl->isFinal() || type->is<ArchetypeType>())
+    if (!classDecl->isFinal())
       return true;
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4473,6 +4473,11 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
 bool
 TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
                                                DeclContext *DC) {
+  // An existential may have an concrete underlying type that protocol conformances
+  // we cannot know statically.
+  if (type->isExistentialType())
+    return true;
+  
   // A generic archetype may have protocol conformances we cannot know
   // statically.
   if (type->is<ArchetypeType>())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4473,7 +4473,7 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
 bool
 TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
                                                DeclContext *DC) {
-  // An existential may have an concrete underlying type that protocol conformances
+  // An existential may have a concrete underlying type with protocol conformances
   // we cannot know statically.
   if (type->isExistentialType())
     return true;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4470,6 +4470,15 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
   return lookupResult;
 }
 
+bool
+TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
+                                                DeclContext *DC) {
+  ModuleDecl *M = DC->getParentModule();
+  return conformsToProtocol(type, Proto, DC) ||
+         (type->isKnownStdlibCollectionType() &&
+          M->lookupConformance(type, Proto));
+}
+
 /// Exposes TypeChecker functionality for querying protocol conformance.
 /// Returns a valid ProtocolConformanceRef only if all conditional
 /// requirements are successfully resolved.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -341,8 +341,6 @@ enum class CheckedCastContextKind {
   IsPattern,
   /// An enum-element pattern.
   EnumElementPattern,
-  /// A collection element type.
-  CollectionElement,
 };
 
 namespace TypeChecker {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -884,6 +884,16 @@ ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           DeclContext *DC,
                                           SourceLoc ComplainLoc = SourceLoc());
 
+/// Determine whether the given type could dynamically conform to the given protocol.
+/// Meaning it may have conditional requirements to the protocol.
+///
+/// \param DC The context in which to check conformance. This affects, for
+/// example, extension visibility.
+///
+///
+/// \returns True if \c T conforms to the protocol \c Proto, false otherwise.
+bool couldDynamicallyConformToProtocol(Type T, ProtocolDecl *Proto,
+                                        DeclContext *DC);
 /// Completely check the given conformance.
 void checkConformance(NormalProtocolConformance *conformance);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -885,8 +885,8 @@ ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           SourceLoc ComplainLoc = SourceLoc());
 
 /// This is similar to \c conformsToProtocol, but returns \c true for cases where
-/// the type  \p T could be dynamically cast to \p Proto protocol, such as a non-final
-/// class where a subclass conforms to.
+/// the type \p T could be dynamically cast to \p Proto protocol, such as a non-final
+/// class where a subclass conforms to \p Proto.
 ///
 /// \param DC The context in which to check conformance. This affects, for
 /// example, extension visibility.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -341,6 +341,8 @@ enum class CheckedCastContextKind {
   IsPattern,
   /// An enum-element pattern.
   EnumElementPattern,
+  /// A collection element type.
+  CollectionElement,
 };
 
 namespace TypeChecker {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -884,16 +884,17 @@ ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           DeclContext *DC,
                                           SourceLoc ComplainLoc = SourceLoc());
 
-/// Determine whether the given type could dynamically conform to the given protocol.
-/// Meaning it may have conditional requirements to the protocol.
+/// This is similar to \c conformsToProtocol, but returns \c true for cases where
+/// the type  \p T could be dynamically cast to \p Proto protocol, such as a non-final
+/// class where a subclass conforms to.
 ///
 /// \param DC The context in which to check conformance. This affects, for
 /// example, extension visibility.
 ///
 ///
-/// \returns True if \c T conforms to the protocol \c Proto, false otherwise.
+/// \returns True if \p T conforms to the protocol \p Proto, false otherwise.
 bool couldDynamicallyConformToProtocol(Type T, ProtocolDecl *Proto,
-                                        DeclContext *DC);
+                                       DeclContext *DC);
 /// Completely check the given conformance.
 void checkConformance(NormalProtocolConformance *conformance);
 

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -235,8 +235,8 @@ func test_tuple_casts_no_warn() {
   _ = arr as! [(Foo, Foo, Foo)] // expected-warning {{cast from '[(Any, Any)]' to unrelated type '[(Foo, Foo, Foo)]' always fails}}
   _ = tup as! (Foo, Foo, Foo) // expected-warning {{cast from '(Any, Any)' to unrelated type '(Foo, Foo, Foo)' always fails}}
 
-  _ = arr as! [(a: Foo, Foo)] // expected-warning {{cast from '[(Any, Any)]' to unrelated type '[(a: Foo, Foo)]' always fails}}
-  _ = tup as! (a: Foo, Foo) // expected-warning {{cast from '(Any, Any)' to unrelated type '(a: Foo, Foo)' always fails}}
+  _ = arr as! [(a: Foo, Foo)] // Ok
+  _ = tup as! (a: Foo, Foo) // Ok
 }
 
 infix operator ^^^
@@ -334,4 +334,73 @@ func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [Strin
 
   // The array can also be inferred to be [Any].
   _ = ([] ?? []) as Array // expected-warning {{left side of nil coalescing operator '??' has non-optional type '[Any]', so the right side is never used}}
+}
+
+// SR-13088
+protocol JSON { }
+protocol JSONLeaf: JSON {}
+extension Int: JSONLeaf { }
+extension Array: JSON where Element: JSON { }
+
+protocol SR13035Error: Error {}
+struct ChildError: SR13035Error {}
+
+protocol AnyC {
+  func foo()
+}
+
+protocol AnyEvent {}
+
+protocol A {
+  associatedtype C: AnyC
+}
+
+protocol EventA: A {
+  associatedtype Event
+}
+
+typealias Container<Namespace>
+  = (event: Namespace.Event, c: Namespace.C) where Namespace: EventA
+
+enum ConcreteA: EventA {
+  struct C: AnyC {
+    func foo() {}
+  }
+
+  enum Event: AnyEvent {
+    case test
+  }
+}
+
+func tests_SR13088_false_positive_always_fail_casts() {
+  // SR-13081
+  let x: JSON = [4] // [4]
+  _ = x as? [Any] // Ok
+
+  // SR-7187
+  let a: [Any] = [String?.some("hello") as Any, String?.none as Any]
+
+  _ = a is [String?] // Ok
+  _ = a as? [String?] // Ok
+
+  // SR-13035
+  func SR13035<SomeError: SR13035Error>(_ mockResult: Result<String, ChildError>, _: Result<String, SomeError>) {
+      let _ = mockResult as? Result<String, SomeError> // Ok
+  }
+
+  // SR-11434 and SR-12321
+  func encodable(_ value: Encodable) {
+    _ = value as! [String : Encodable] // Ok
+    _ = value as? [String: Encodable] // Ok
+  }   
+
+  // SR-13025
+  func coordinate(_ event: AnyEvent, from c: AnyC) {
+    switch (event, c) {
+    case let container as Container<ConcreteA>: // OK
+      container.c.foo()
+    default:
+      break
+    }
+  }
 }

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -379,9 +379,12 @@ func tests_SR13088_false_positive_always_fail_casts() {
 
   // SR-7187
   let a: [Any] = [String?.some("hello") as Any, String?.none as Any]
+  let b: [AnyObject] = [String?.some("hello") as AnyObject, String?.none as AnyObject]
 
   _ = a is [String?] // Ok
   _ = a as? [String?] // Ok
+  _ = b is [String?] // Ok
+  _ = b as? [String?] // Ok
 
   // SR-13035
   func SR13035<SomeError: SR13035Error>(_ mockResult: Result<String, ChildError>, _: Result<String, SomeError>) {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -343,7 +343,7 @@ extension Int: JSONLeaf { }
 extension Array: JSON where Element: JSON { }
 
 protocol SR13035Error: Error {}
-struct ChildError: SR13035Error {}
+class ChildError: SR13035Error {}
 
 protocol AnyC {
   func foo()
@@ -385,7 +385,11 @@ func tests_SR13088_false_positive_always_fail_casts() {
 
   // SR-13035
   func SR13035<SomeError: SR13035Error>(_ mockResult: Result<String, ChildError>, _: Result<String, SomeError>) {
-      let _ = mockResult as? Result<String, SomeError> // Ok
+    let _ = mockResult as? Result<String, SomeError> // Ok
+  }
+
+  func SR13035_1<SomeError: SR13035Error, Child: ChildError>(_ mockResult: Result<String, Child>, _: Result<String, SomeError>) {
+    let _ = mockResult as? Result<String, SomeError> // Ok
   }
 
   // SR-11434 and SR-12321

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -377,15 +377,6 @@ func tests_SR13088_false_positive_always_fail_casts() {
   let x: JSON = [4] // [4]
   _ = x as? [Any] // Ok
 
-  // SR-7187
-  let a: [Any] = [String?.some("hello") as Any, String?.none as Any]
-  let b: [AnyObject] = [String?.some("hello") as AnyObject, String?.none as AnyObject]
-
-  _ = a is [String?] // Ok
-  _ = a as? [String?] // Ok
-  _ = b is [String?] // Ok
-  _ = b as? [String?] // Ok
-
   // SR-13035
   func SR13035<SomeError: SR13035Error>(_ child: Result<String, ChildError>, _: Result<String, SomeError>) {
     let _ = child as? Result<String, SomeError> // Ok

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -387,12 +387,13 @@ func tests_SR13088_false_positive_always_fail_casts() {
   _ = b as? [String?] // Ok
 
   // SR-13035
-  func SR13035<SomeError: SR13035Error>(_ mockResult: Result<String, ChildError>, _: Result<String, SomeError>) {
-    let _ = mockResult as? Result<String, SomeError> // Ok
+  func SR13035<SomeError: SR13035Error>(_ child: Result<String, ChildError>, _: Result<String, SomeError>) {
+    let _ = child as? Result<String, SomeError> // Ok
   }
 
-  func SR13035_1<SomeError: SR13035Error, Child: ChildError>(_ mockResult: Result<String, Child>, _: Result<String, SomeError>) {
-    let _ = mockResult as? Result<String, SomeError> // Ok
+  func SR13035_1<SomeError: SR13035Error, Child: ChildError>(_ child: Result<String, Child>, parent: Result<String, SomeError>) {
+    _ = child as? Result<String, SomeError> // Ok
+    _ = parent as? Result<String, Child> // OK
   }
 
   // SR-11434 and SR-12321


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adjusts rules around the diagnostics on unrelated types of edge cases for types that are erased or involve existential which may have conditional conformances.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
It almost resolves SR-13088.

Resolves aggregates:
SR-13081
SR-13035
SR-11434 
SR-12321
SR-13025

TODO:
SR-7187, SR-6112

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
