### PR TITLE
SwiftPrivateThreadExtras: correct misuse of API

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -117,17 +117,18 @@ public func _stdlib_thread_join<Result>(
 ) -> (CInt, Result?) {
 #if os(Windows)
   let result = WaitForSingleObject(thread, INFINITE)
-  if result == WAIT_OBJECT_0 {
-    var threadResult: DWORD = 0
-    GetExitCodeThread(thread, &threadResult)
-    CloseHandle(thread)
+  guard result == WAIT_OBJECT_0 else { return (CInt(result), nil) }
 
-    return (CInt(result),
-            UnsafeMutablePointer<DWORD>(&threadResult)
-                .withMemoryRebound(to: Result.self, capacity: 1){ $0.pointee })
-  } else {
-    return (CInt(result), nil)
+  var dwResult: DWORD = 0
+  GetExitCodeThread(thread, &dwResult)
+  CloseHandle(thread)
+
+  let value: Result = withUnsafePointer(to: &dwResult) {
+    $0.withMemoryRebound(to: Result.self, capacity: 1) {
+      $0.pointee
+    }
   }
+  return (CInt(result), value)
 #else
   var threadResultRawPtr: UnsafeMutableRawPointer?
   let result = pthread_join(thread, &threadResultRawPtr)


### PR DESCRIPTION
Copy out the result rather than form a dangling pointer.  This fixes the
incorrect usage that the compiler flags.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
