### PR TITLE
test: make stdlib.NumericParsing Python 3 friendly

### DIFF
--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -17,6 +17,7 @@
 // RUN: %line-directive %t/NumericParsing.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 %{
+from __future__ import division
 from SwiftIntTypes import all_integer_types
 
 word_bits = int(CMAKE_SIZEOF_VOID_P)
@@ -36,7 +37,7 @@ Note: the third parameter, zero, is not for user consumption.
   else:
     r = n % radix
     digit = chr((ord('0') + r) if r < 10 else (ord('a') + r - 10))
-    return inRadix(radix, int(n / radix), '') + digit
+    return inRadix(radix, int(n // radix), '') + digit
 
 # The maximal legal radix
 max_radix = ord('z') - ord('a') + 1 + 10
@@ -96,7 +97,7 @@ tests.test("${Self}/success") {
   % for radix in radices_to_test:
   %   for n in required_values + list(range(
   %     minValue + 1, maxValue - 1,
-  %     int((maxValue - minValue - 2) / (number_of_values - len(required_values))))):
+  %     int((maxValue - minValue - 2) // (number_of_values - len(required_values))))):
   %     prefix = '+' if n > 0 and n % 2 == 0 else '' # leading '+'
   %     text = inRadix(radix, n)
   expectEqual(${n}, ${Self}("${prefix + text}", radix: ${radix}))


### PR DESCRIPTION
Use the proper division operation as the test otherwise generates
different patterns.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
