### PR TITLE
[stdlib] Fix removeLast(_:) performance for non-random-access collections

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -342,9 +342,12 @@ extension BidirectionalCollection where SubSequence == Self {
   public mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= k,
-      "Can't remove more items from a collection than it contains")
-    self = self[startIndex..<index(endIndex, offsetBy: -k)]
+    guard let end = index(endIndex, offsetBy: -k, limitedBy: startIndex)
+    else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
+    }
+    self = self[startIndex..<end]
   }
 }
 

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -959,7 +959,7 @@ where Self: BidirectionalCollection, SubSequence == Self {
       _preconditionFailure(
         "Can't remove more items from a collection than it contains")
     }
-    removeSubrange(index(end, offsetBy: -k)..<end)
+    removeSubrange(start..<end)
   }
 }
 

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -285,12 +285,17 @@ public protocol RangeReplaceableCollection: Collection
   /// Customization point for `removeLast()`.  Implement this function if you
   /// want to replace the default implementation.
   ///
+  /// The collection must not be empty.
+  ///
   /// - Returns: A non-nil value if the operation was performed.
   mutating func _customRemoveLast() -> Element?
 
   /// Customization point for `removeLast(_:)`.  Implement this function if you
   /// want to replace the default implementation.
   ///
+  /// - Parameter n: The number of elements to remove from the collection.
+  ///   `n` must be greater than or equal to zero and must not exceed the
+  ///   number of elements in the collection.
   /// - Returns: `true` if the operation was performed.
   mutating func _customRemoveLast(_ n: Int) -> Bool
 
@@ -802,7 +807,12 @@ extension RangeReplaceableCollection
 
   @inlinable
   public mutating func _customRemoveLast(_ n: Int) -> Bool {
-    self = self[startIndex..<index(endIndex, offsetBy: -n)]
+    guard let end = index(endIndex, offsetBy: -n, limitedBy: startIndex)
+    else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
+    }
+    self = self[startIndex..<end]
     return true
   }
 }
@@ -866,13 +876,17 @@ extension RangeReplaceableCollection where Self: BidirectionalCollection {
   public mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= k,
-      "Can't remove more items from a collection than it contains")
     if _customRemoveLast(k) {
       return
     }
     let end = endIndex
-    removeSubrange(index(end, offsetBy: -k)..<end)
+    guard let start = index(end, offsetBy: -k, limitedBy: startIndex)
+    else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
+    }
+
+    removeSubrange(start..<end)
   }
 }
 

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -950,12 +950,15 @@ where Self: BidirectionalCollection, SubSequence == Self {
   public mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    _precondition(count >= k,
-      "Can't remove more items from a collection than it contains")
     if _customRemoveLast(k) {
       return
     }
     let end = endIndex
+    guard let start = index(end, offsetBy: -k, limitedBy: startIndex)
+    else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
+    }
     removeSubrange(index(end, offsetBy: -k)..<end)
   }
 }


### PR DESCRIPTION
This replaces the `count` comparison precondition with a limited index offset, which converts the method from O(n) to O(k). This follows up on #32451.
