### PR TITLE
[CSGen] Handle incorrect patterns (e.g. referencing unknown types)

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2282,12 +2282,17 @@ namespace {
 
         return setType(ParenType::get(CS.getASTContext(), underlyingType));
       }
-      case PatternKind::Var:
+      case PatternKind::Var: {
+        auto *subPattern = cast<VarPattern>(pattern)->getSubPattern();
+        auto type = getTypeForPattern(subPattern, locator, externalPatternType,
+                                      bindPatternVarsOneWay);
+
+        if (!type)
+          return Type();
+
         // Var doesn't affect the type.
-        return setType(
-            getTypeForPattern(
-              cast<VarPattern>(pattern)->getSubPattern(), locator,
-              externalPatternType, bindPatternVarsOneWay));
+        return setType(type);
+      }
 
       case PatternKind::Any: {
         return setType(
@@ -3918,7 +3923,9 @@ static bool generateInitPatternConstraints(
       pattern, locator, target.shouldBindPatternVarsOneWay(),
       target.getInitializationPatternBindingDecl(),
       target.getInitializationPatternBindingIndex());
-  assert(patternType && "All patterns have a type");
+
+  if (!patternType)
+    return true;
 
   if (auto wrappedVar = target.getInitializationWrappedVar()) {
     Type propertyType = generateWrappedPropertyTypeConstraints(

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -507,3 +507,14 @@ func rdar63510989() {
     // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
   }
 }
+
+// rdar://problem/64157451 - compiler crash when using undefined type in pattern
+func rdar64157451() {
+  enum E {
+  case foo(Int)
+  }
+
+  func test(e: E) {
+    if case .foo(let v as DoeNotExist) = e {} // expected-error {{cannot find type 'DoeNotExist' in scope}}
+  }
+}


### PR DESCRIPTION
Currently `generateInitPatternConstraints` assumes that all
patterns have types but it's not the case for patterns that
e.g. reference unknown types or have other structural issues.

Let's fail `generateInitPatternConstraints` if constraint
generation fails.

Resolves: rdar://problem/64157451

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
