### PR TITLE
[5.3][SourceKit/CursorInfo] Still print implicit decls in cursorinfo to handle compiler synthesized decls

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_info_synthesized_refs.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_synthesized_refs.swift
@@ -1,0 +1,18 @@
+struct Foo {
+    let x: Int
+    let y: String
+    func perform(_ action: (Int, Int) -> ()) {}
+}
+
+func test() {
+    let x = Foo.init(x: 2, y: "hello")
+    x.perform {
+        print($0 + $1)
+    }
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=8:17 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
+// CHECK1: <Declaration>init(x: <Type usr="s:Si">Int</Type>, y: <Type usr="s:SS">String</Type>)</Declaration>
+
+// RUN: %sourcekitd-test -req=cursor -pos=10:15 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+// CHECK2: <Declaration>let $0: <Type usr="s:Si">Int</Type></Declaration>

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -415,14 +415,13 @@ static void printAnnotatedDeclaration(const ValueDecl *VD,
   while (VD->isImplicit() && VD->getOverriddenDecl())
     VD = VD->getOverriddenDecl();
 
-  // If this is a property wrapper backing property (_foo) or projected value
-  // ($foo) and the wrapped property is not implicit, still print it.
-  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
-    if (auto *Wrapped = VarD->getOriginalWrappedProperty()) {
-      if (!Wrapped->isImplicit())
-        PO.TreatAsExplicitDeclList.push_back(VD);
-    }
-  }
+  // VD may be a compiler synthesized member, constructor, or shorthand argument
+  // so always print it even if it's implicit.
+  //
+  // FIXME: Update PrintOptions::printQuickHelpDeclaration to print implicit
+  // decls by default. That causes issues due to newlines being printed before
+  // implicit OpaqueTypeDecls at time of writing.
+  PO.TreatAsExplicitDeclList.push_back(VD);
 
   // Wrap this up in XML, as that's what we'll use for documentation comments.
   OS<<"<Declaration>";
@@ -446,14 +445,14 @@ void SwiftLangSupport::printFullyAnnotatedDeclaration(const ValueDecl *VD,
   while (VD->isImplicit() && VD->getOverriddenDecl())
     VD = VD->getOverriddenDecl();
 
-  // If this is a property wrapper backing property (_foo) or projected value
-  // ($foo) and the wrapped property is not implicit, still print it.
-  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
-    if (auto *Wrapped = VarD->getOriginalWrappedProperty()) {
-      if (!Wrapped->isImplicit())
-        PO.TreatAsExplicitDeclList.push_back(VD);
-    }
-  }
+  // VD may be a compiler synthesized member, constructor, or shorthand argument
+  // so always print it even if it's implicit.
+  //
+  // FIXME: Update PrintOptions::printQuickHelpDeclaration to print implicit
+  // decls by default. That causes issues due to newlines being printed before
+  // implicit OpaqueTypeDecls at time of writing.
+  PO.TreatAsExplicitDeclList.push_back(VD);
+
   VD->print(Printer, PO);
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32575 for 5.3

- **Explanation**:
  We weren't printing implicit decls like member-wise inits and shorthand arguments (e.g. $0, $1) in the annotated decl and   fully-annotated decl fields of sourcekitd's cursor info response, leaving them empty. This meant IDE features relying on these fields, like Quick Help in Xcode, wouldn't work on references to such decls decls.
- **Scope**: Affects all decls marked as implicit in the AST that can still be referenced in source code (i.e. can be a cursor-info target). This includes compiler-synthesized decls like member-wise inits, shorthand closure arguments, 'oldValue' in didSet blocks, 'error' in catch blocks, etc.
- **Risk**: Low. This only affects sourcekitd's CursorInfo request. It has no impact on the other requests or the compiler.
- **Origination**: This seems to have regressed in the 5.1 release.
- **Testing**: Added a regression test covering this case and all existing tests pass.
- **Reviewer**: Ben Langmuir (@benlangmuir) on the [master PR](https://github.com/apple/swift/pull/32575).

Resolves rdar://problem/58929991