### PR TITLE
[5.3][Function Builders] Fix a function builder crash due to constraint generation failures

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -283,8 +283,10 @@ protected:
       auto target = SolutionApplicationTarget::forInitialization(
           patternBinding->getInit(index), dc, patternType, pattern,
           /*bindPatternVarsOneWay=*/true);
-      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
+      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+        hadError = true;
         continue;
+      }
 
       // Keep track of this binding entry.
       applied.patternBindingEntries.insert({{patternBinding, index}, target});

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -418,11 +418,14 @@ func testNonExhaustiveSwitch(e: E) {
 // rdar://problem/59856491
 struct TestConstraintGenerationErrors {
   @TupleBuilder var buildTupleFnBody: String {
+    let a = nil // expected-error {{'nil' requires a contextual type}}
     String(nothing) // expected-error {{cannot find 'nothing' in scope}}
   }
 
   func buildTupleClosure() {
-    tuplify(true) { _ in
+    // FIXME: suppress the ambiguity error
+    tuplify(true) { _ in // expected-error {{type of expression is ambiguous without more context}}
+      let a = nothing // expected-error {{cannot find 'nothing' in scope}}
       String(nothing) // expected-error {{cannot find 'nothing' in scope}}
     }
   }


### PR DESCRIPTION
This crash was fixed in a recent refactoring on master (#32221). This change takes one line from that refactoring which records whether or not there was an error when generating constraints for a pattern binding decl in a function builder.

Tests are cherry-picked from #32607

Resolves: rdar://problem/59856491
