### PR TITLE
PathSanitizingFIleCheck: tweak regex match

### DIFF
--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -80,7 +80,7 @@ constants.""")
         # Since we want to use pattern as a regex in some platforms, we need
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
-        stdin = re.sub(re.sub(b'\\\\/', slashes_re, re.escape(pattern)),
+        stdin = re.sub(re.sub(br'[/\\]', slashes_re, re.escape(pattern)),
                        replacement,
                        stdin)
 


### PR DESCRIPTION
Adjust the regex match to do a better job of sanitizing the paths.  This
improves the test coverage pass rate with Python 3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
