### PR TITLE
[stdlib] Use a direct initializer for typed to raw pointer conversion

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -472,7 +472,7 @@ private func getConstantTaggedCocoaContents(_ cocoaString: _CocoaString) ->
   )!
 
   guard _swift_stdlib_dyld_is_objc_constant_string(
-    unsafeBitCast(ivarPointer, to: UnsafeRawPointer.self)
+    UnsafeRawPointer(ivarPointer)
   ) == 1 else {
     return nil
   }


### PR DESCRIPTION
This resolves a trivial warning:

```
.../swift/stdlib/public/core/StringBridge.swift:475:5: warning: 'unsafeBitCast' from 'UnsafePointer<_swift_shims_builtin_CFString>' (aka 'UnsafePointer<__swift_shims_builtin_CFString>') to 'UnsafeRawPointer' can be replaced with 'UnsafeRawPointer' initializer
    unsafeBitCast(ivarPointer, to: UnsafeRawPointer.self)
    ^~~~~~~~~~~~~~           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```