### PR TITLE
[AutoDiff] Update manifesto status to indicate feature gate

### DIFF
--- a/docs/DifferentiableProgramming.md
+++ b/docs/DifferentiableProgramming.md
@@ -1,7 +1,7 @@
 # Differentiable Programming Manifesto
 
 *   Authors: [Richard Wei], [Dan Zheng], [Marc Rasi], [Bart Chrzaszcz]
-*   Status: Partially implemented
+*   Status: Partially implemented on master, feature gated under `import _Differentiation`
 
 ## Table of contents
 


### PR DESCRIPTION
Change status to "Partially implemented on master, feature gated under `import _Differentiation`".