### PR TITLE
test: exit properly with `swift_build_sdk_interface`

### DIFF
--- a/utils/swift_build_sdk_interfaces.py
+++ b/utils/swift_build_sdk_interfaces.py
@@ -416,6 +416,10 @@ def main():
     non_stdlib_module_files = (
         x for x in module_files if x.name != STDLIB_NAME)
     status = process_module_files(pool, non_stdlib_module_files)
+    if os.name == 'nt':
+        import ctypes
+        Kernel32 = ctypes.cdll.LoadLibrary("Kernel32.dll")
+        Kernel32.ExitProcess(ctypes.c_ulong(status))
     sys.exit(status)
 
 


### PR DESCRIPTION
`sys.exit` takes an integral value in the range of `0-127`.  Python 3 is
much more stringent about this and will convert the value if it is out
of the range to 1.  On Windows, explicitly use `ExitProcess` to ensure
that we get the correct value on the exit code which matters to `not`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
