### PR TITLE
Add explicit init from BinaryInteger to CGFloat

### DIFF
--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -61,9 +61,13 @@ public struct CGFloat {
 }
 
 extension CGFloat : SignedNumeric {
+  @_alwaysEmitIntoClient // availability
+  public init<T: BinaryInteger>(_ source: T) {
+    self.native = NativeType(source)
+  }
 
   @_transparent
-  public init?<T : BinaryInteger>(exactly source: T) {
+  public init?<T: BinaryInteger>(exactly source: T) {
     guard let native = NativeType(exactly: source) else { return nil }
     self.native = native
   }
@@ -72,7 +76,6 @@ extension CGFloat : SignedNumeric {
   public var magnitude: CGFloat {
     return CGFloat(native.magnitude)
   }
-
 }
 
 extension CGFloat : BinaryFloatingPoint {


### PR DESCRIPTION
We don't have a concrete implementation, which means that we currently fall back on the generic implementation; we should simply forward this to the NativeType implementation instead (rdar://problem/64544503).
