### PR TITLE
[Clang importer] Remove the OS_object objc_runtime_visible hack

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5021,27 +5021,6 @@ namespace {
       }
       result->setSuperclass(superclassType);
 
-      // Mark the class as runtime-only if it is named 'OS_object', even
-      // if it doesn't have the runtime-only Clang attribute. This is a
-      // targeted fix allowing IRGen to emit convenience initializers
-      // correctly.
-      //
-      // FIXME: Remove this once SILGen gets proper support for factory
-      // initializers.
-      if (decl->getName() == "OS_object" ||
-          decl->getName() == "OS_os_log") {
-        result->setForeignClassKind(ClassDecl::ForeignKind::RuntimeOnly);
-      }
-
-      // If the superclass is runtime-only, our class is also. This only
-      // matters in the case above.
-      if (superclassType) {
-        auto superclassDecl = cast<ClassDecl>(superclassType->getAnyNominal());
-        auto kind = superclassDecl->getForeignClassKind();
-        if (kind != ClassDecl::ForeignKind::Normal)
-          result->setForeignClassKind(kind);
-      }
-
       // Import protocols this class conforms to.
       importObjCProtocols(result, decl->getReferencedProtocols(),
                           inheritedTypes);

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1387,7 +1387,8 @@ BraceStmt *swift::applyFunctionBuilderTransform(
         captured.first, captured.second)));
 }
 
-/// Produce any additional syntactic diagnostics for the body of a
+/// Produce any additional syntactic diagnostics for the body of a function
+/// that had a function builder applied.
 static void performAddOnDiagnostics(BraceStmt *stmt, DeclContext *dc) {
   class AddOnDiagnosticWalker : public ASTWalker {
     SmallVector<DeclContext *, 4> dcStack;


### PR DESCRIPTION
The Clang importer has an old hack that makes OS_object and its subclasses
implicitly "objc_runtime_visible" (which maps to the "runtime" foreign
class kind in Swift). Now that the headers in the SDK all use the
appropriate annotation, remove the hack.

Fixes rdar://problem/64778416.