### PR TITLE
[5.3][CSGen] Handle incorrect patterns (e.g. referencing unknown types)

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -495,3 +495,14 @@ func rdar63510989() {
     // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
   }
 }
+
+// rdar://problem/64157451 - compiler crash when using undefined type in pattern
+func rdar64157451() {
+  enum E {
+  case foo(Int)
+  }
+
+  func test(e: E) {
+    if case .foo(let v as DoeNotExist) = e {} // expected-error {{cannot find type 'DoeNotExist' in scope}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32602

---

- Explanation:

Currently `generateInitPatternConstraints` assumes that all
patterns have types but it's not the case for patterns that
e.g. reference unknown types or have other structural issues.

Let's fail `generateInitPatternConstraints` if constraint
generation fails.

- Scope: Limited to `var` patterns with incorrect sub-patterns.

- Resolves: rdar://problem/64157451

- Risk: Very Low

- Testing: Added regression tests

- Reviewer: @DougGregor 

Resolves: rdar://problem/64157451
(cherry picked from commit caab4f4eadc6baf167cdcc0f7c5a247656d639e1)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
