### PR TITLE
test: improve Python3 compatibility for `swift_build_sdk_interfaces`

### DIFF
--- a/utils/swift_build_sdk_interfaces.py
+++ b/utils/swift_build_sdk_interfaces.py
@@ -105,7 +105,7 @@ def run_command(args, dry_run):
     try:
         out, err = proc.communicate()
         exitcode = proc.returncode
-        return (exitcode, out, err)
+        return (exitcode, out.decode('utf-8'), err.decode('utf-8'))
     except KeyboardInterrupt:
         proc.terminate()
         raise


### PR DESCRIPTION
Return a "unicode" "string" (UTF-8 decoded data) rather than a
bytes-like object as the rest of the script expects the normal unicode
string.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
