### PR TITLE
[generics] Add an option that causes the generic specializer to validate newly specialized functions earlier when we have more information that we can put into a pretty stack trace.

### DIFF
--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -45,12 +45,25 @@ public:
 
 /// Observe that we are doing some processing of a SIL function.
 class PrettyStackTraceSILFunction : public llvm::PrettyStackTraceEntry {
-  const SILFunction *TheFn;
-  const char *Action;
+  const SILFunction *func;
+
+  /// An inline buffer of characters used if we are passed a twine.
+  SmallString<256> data;
+
+  /// This points either at a user provided const char * string or points at the
+  /// inline message buffer that is initialized with data from a twine on
+  /// construction.
+  StringRef action;
+
 public:
-  PrettyStackTraceSILFunction(const char *action, const SILFunction *F)
-    : TheFn(F), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  PrettyStackTraceSILFunction(const char *action, const SILFunction *func)
+      : func(func), data(), action(action) {}
+
+  PrettyStackTraceSILFunction(llvm::Twine &&twine, const SILFunction *func)
+      : func(func), data(), action(twine.toNullTerminatedStringRef(data)) {}
+
+  virtual void print(llvm::raw_ostream &os) const;
+
 protected:
   void printFunctionInfo(llvm::raw_ostream &out) const;
 };

--- a/lib/SIL/Utils/PrettyStackTrace.cpp
+++ b/lib/SIL/Utils/PrettyStackTrace.cpp
@@ -75,8 +75,8 @@ void PrettyStackTraceSILLocation::print(llvm::raw_ostream &out) const {
 }
 
 void PrettyStackTraceSILFunction::print(llvm::raw_ostream &out) const {
-  out << "While " << Action << " SIL function ";
-  if (!TheFn) {
+  out << "While " << action << " SIL function ";
+  if (!func) {
     out << " <<null>>";
     return;
   }
@@ -86,16 +86,16 @@ void PrettyStackTraceSILFunction::print(llvm::raw_ostream &out) const {
 
 void PrettyStackTraceSILFunction::printFunctionInfo(llvm::raw_ostream &out) const {  
   out << "\"";
-  TheFn->printName(out);
+  func->printName(out);
   out << "\".\n";
 
-  if (!TheFn->getLocation().isNull()) {
+  if (!func->getLocation().isNull()) {
     out << " for ";
-    printSILLocationDescription(out, TheFn->getLocation(),
-                                TheFn->getModule().getASTContext());
+    printSILLocationDescription(out, func->getLocation(),
+                                func->getModule().getASTContext());
   }
   if (SILPrintOnError)
-    TheFn->print(out);
+    func->print(out);
 }
 
 void PrettyStackTraceSILNode::print(llvm::raw_ostream &out) const {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -13,21 +13,22 @@
 #define DEBUG_TYPE "generic-specializer"
 
 #include "swift/SILOptimizer/Utils/Generics.h"
-#include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/TypeMatcher.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/SemanticAttrs.h"
-#include "swift/Basic/Statistic.h"
 #include "swift/AST/TypeCheckRequests.h"
-#include "swift/Serialization/SerializedSILLoader.h"
+#include "swift/AST/TypeMatcher.h"
+#include "swift/Basic/Statistic.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/OptimizationRemark.h"
-#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SILOptimizer/Utils/GenericCloner.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
-#include "swift/Demangling/ManglingMacros.h"
+#include "swift/Serialization/SerializedSILLoader.h"
 #include "swift/Strings.h"
 
 using namespace swift;
@@ -57,6 +58,12 @@ llvm::cl::opt<bool> PrintGenericSpecializationLoops(
     "sil-print-generic-specialization-loops", llvm::cl::init(false),
     llvm::cl::desc("Print detected infinite generic specialization loops that "
                    "were prevented"));
+
+llvm::cl::opt<bool> VerifyFunctionsAfterSpecialization(
+    "sil-generic-verify-after-specialization", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Verify functions after they are specialized "
+        "'PrettyStackTraceFunction'-ing the original function if we fail."));
 
 static bool OptimizeGenericSubstitutions = false;
 
@@ -1871,6 +1878,15 @@ SILFunction *GenericFuncSpecializer::tryCreateSpecialization() {
   SpecializedF->setClassSubclassScope(SubclassScope::NotApplicable);
   SpecializedF->setSpecializationInfo(
       GenericSpecializationInformation::create(Caller, GenericFunc, Subs));
+
+  if (VerifyFunctionsAfterSpecialization) {
+    PrettyStackTraceSILFunction SILFunctionDumper(
+        llvm::Twine("Generic function: ") + GenericFunc->getName() +
+            ". Specialized Function: " + SpecializedF->getName(),
+        GenericFunc);
+    SpecializedF->verify();
+  }
+
   return SpecializedF;
 }
 
@@ -2443,6 +2459,20 @@ void swift::trySpecializeApplyOfGeneric(
            << NV("FuncType", OS.str());
   });
 
+  // Verify our function after we have finished fixing up call sites/etc. Dump
+  // the generic function if there is an assertion failure (or a crash) to make
+  // it easier to debug such problems since the original generic function is
+  // easily at hand.
+  SWIFT_DEFER {
+    if (VerifyFunctionsAfterSpecialization) {
+      PrettyStackTraceSILFunction SILFunctionDumper(
+          llvm::Twine("Generic function: ") + RefF->getName() +
+              ". Specialized Function: " + SpecializedF->getName(),
+          RefF);
+      SpecializedF->verify();
+    }
+  };
+
   assert(ReInfo.getSpecializedType()
          == SpecializedF->getLoweredFunctionType() &&
          "Previously specialized function does not match expected type.");
@@ -2457,6 +2487,13 @@ void swift::trySpecializeApplyOfGeneric(
     SILFunction *Thunk =
       ReabstractionThunkGenerator(FuncBuilder, ReInfo, PAI, SpecializedF)
         .createThunk();
+    if (VerifyFunctionsAfterSpecialization) {
+      PrettyStackTraceSILFunction SILFunctionDumper(
+          llvm::Twine("Thunk For Generic function: ") + RefF->getName() +
+              ". Specialized Function: " + SpecializedF->getName(),
+          RefF);
+      Thunk->verify();
+    }
     NewFunctions.push_back(Thunk);
     SILBuilderWithScope Builder(PAI);
     auto *FRI = Builder.createFunctionRef(PAI->getLoc(), Thunk);


### PR DESCRIPTION
I also added support for creating a PrettyStackTraceSILFunction from a twine.