### PR TITLE
[AutoDiff] Support differentiation of functions with multiple results in SIL.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Differentiation/PullbackEmitter.h
@@ -105,8 +105,8 @@ private:
   /// A set used to remember local allocations that were destroyed.
   llvm::SmallDenseSet<SILValue> destroyedLocalAllocations;
 
-  /// The seed argument in the pullback function.
-  SILArgument *seed = nullptr;
+  /// The seed arguments of the pullback function.
+  SmallVector<SILArgument *, 4> seeds;
 
   llvm::BumpPtrAllocator allocator;
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -315,15 +315,12 @@ getDifferentiabilityParameters(SILFunctionType *originalFnTy,
 /// Collects the semantic results of the given function type in
 /// `originalResults`. The semantic results are formal results followed by
 /// `inout` parameters, in type order.
-// TODO(TF-983): Generalize to support multiple `inout` parameters. The current
-// singular `inoutParam` and `isWrtInoutParameter` are hacky.
 static void
 getSemanticResults(SILFunctionType *functionType, IndexSubset *parameterIndices,
-                   Optional<SILParameterInfo> &inoutParam,
-                   bool &isWrtInoutParameter,
+                   IndexSubset *&inoutParameterIndices,
                    SmallVectorImpl<SILResultInfo> &originalResults) {
-  inoutParam = None;
-  isWrtInoutParameter = false;
+  auto &C = functionType->getASTContext();
+  SmallVector<unsigned, 4> inoutParamIndices;
   // Collect original formal results.
   originalResults.append(functionType->getResults().begin(),
                          functionType->getResults().end());
@@ -332,11 +329,12 @@ getSemanticResults(SILFunctionType *functionType, IndexSubset *parameterIndices,
     auto param = functionType->getParameters()[i];
     if (!param.isIndirectInOut())
       continue;
-    inoutParam = param;
-    isWrtInoutParameter = parameterIndices->contains(i);
+    inoutParamIndices.push_back(i);
     originalResults.push_back(
         SILResultInfo(param.getInterfaceType(), ResultConvention::Indirect));
   }
+  inoutParameterIndices =
+      IndexSubset::get(C, parameterIndices->getCapacity(), inoutParamIndices);
 }
 
 /// Returns the differential type for the given original function type,
@@ -402,11 +400,10 @@ static CanSILFunctionType getAutoDiffDifferentialType(
   SmallVector<Type, 4> substReplacements;
   SmallVector<ProtocolConformanceRef, 4> substConformances;
 
-  Optional<SILParameterInfo> inoutParam = None;
-  bool isWrtInoutParameter = false;
+  IndexSubset *inoutParamIndices;
   SmallVector<SILResultInfo, 2> originalResults;
-  getSemanticResults(originalFnTy, parameterIndices, inoutParam,
-                     isWrtInoutParameter, originalResults);
+  getSemanticResults(originalFnTy, parameterIndices, inoutParamIndices,
+                     originalResults);
 
   SmallVector<SILParameterInfo, 4> diffParams;
   getDifferentiabilityParameters(originalFnTy, parameterIndices, diffParams);
@@ -430,7 +427,7 @@ static CanSILFunctionType getAutoDiffDifferentialType(
     }
   }
   SmallVector<SILResultInfo, 1> differentialResults;
-  if (!inoutParam || !isWrtInoutParameter) {
+  if (inoutParamIndices->isEmpty()) {
     for (auto resultIndex : resultIndices->getIndices()) {
       auto &result = originalResults[resultIndex];
       auto resultTan =
@@ -480,11 +477,10 @@ static CanSILFunctionType getAutoDiffPullbackType(
   SmallVector<Type, 4> substReplacements;
   SmallVector<ProtocolConformanceRef, 4> substConformances;
 
-  Optional<SILParameterInfo> inoutParam = None;
-  bool isWrtInoutParameter = false;
+  IndexSubset *inoutParamIndices;
   SmallVector<SILResultInfo, 2> originalResults;
-  getSemanticResults(originalFnTy, parameterIndices, inoutParam,
-                     isWrtInoutParameter, originalResults);
+  getSemanticResults(originalFnTy, parameterIndices, inoutParamIndices,
+                     originalResults);
 
   // Given a type, returns its formal SIL parameter info.
   auto getTangentParameterConventionForOriginalResult =
@@ -551,27 +547,11 @@ static CanSILFunctionType getAutoDiffPullbackType(
     return conv;
   };
 
+  // Collect pullback parameters.
   SmallVector<SILParameterInfo, 1> pullbackParams;
-  if (inoutParam) {
-    auto paramTan = inoutParam->getInterfaceType()->getAutoDiffTangentSpace(
-        lookupConformance);
-    assert(paramTan && "Parameter type does not have a tangent space?");
-    auto paramTanConvention = isWrtInoutParameter
-                                  ? inoutParam->getConvention()
-                                  : ParameterConvention::Indirect_In_Guaranteed;
-    auto paramTanType = paramTan->getCanonicalType();
-    if (!paramTanType->hasArchetype() && !paramTanType->hasTypeParameter()) {
-      pullbackParams.push_back(
-          SILParameterInfo(paramTanType, paramTanConvention));
-    } else {
-      auto gpIndex = substGenericParams.size();
-      auto gpType = CanGenericTypeParamType::get(0, gpIndex, ctx);
-      substGenericParams.push_back(gpType);
-      substReplacements.push_back(paramTanType);
-      pullbackParams.push_back({gpType, paramTanConvention});
-    }
-  } else {
-    for (auto resultIndex : resultIndices->getIndices()) {
+  for (auto resultIndex : resultIndices->getIndices()) {
+    // Handle formal original result.
+    if (resultIndex < originalFnTy->getNumResults()) {
       auto &origRes = originalResults[resultIndex];
       auto resultTan = origRes.getInterfaceType()->getAutoDiffTangentSpace(
           lookupConformance);
@@ -590,12 +570,46 @@ static CanSILFunctionType getAutoDiffPullbackType(
         substReplacements.push_back(resultTanType);
         pullbackParams.push_back({gpType, paramTanConvention});
       }
+      continue;
+    }
+    // Handle original `inout` parameter.
+    auto inoutParamIndex = resultIndex - originalFnTy->getNumResults();
+    auto inoutParamIt = std::next(
+        originalFnTy->getIndirectMutatingParameters().begin(), inoutParamIndex);
+    auto paramIndex =
+        std::distance(originalFnTy->getParameters().begin(), &*inoutParamIt);
+    auto inoutParam = originalFnTy->getParameters()[paramIndex];
+    auto paramTan = inoutParam.getInterfaceType()->getAutoDiffTangentSpace(
+        lookupConformance);
+    assert(paramTan && "Parameter type does not have a tangent space?");
+    // The pullback parameter convention depends on whether the original `inout`
+    // paramater is a differentiability parameter.
+    // - If yes, the pullback parameter convention is `@inout`.
+    // - If no, the pullback parameter convention is `@in_guaranteed`.
+    bool isWrtInoutParameter = parameterIndices->contains(paramIndex);
+    auto paramTanConvention = isWrtInoutParameter
+                                  ? inoutParam.getConvention()
+                                  : ParameterConvention::Indirect_In_Guaranteed;
+    auto paramTanType = paramTan->getCanonicalType();
+    if (!paramTanType->hasArchetype() && !paramTanType->hasTypeParameter()) {
+      pullbackParams.push_back(
+          SILParameterInfo(paramTanType, paramTanConvention));
+    } else {
+      auto gpIndex = substGenericParams.size();
+      auto gpType = CanGenericTypeParamType::get(0, gpIndex, ctx);
+      substGenericParams.push_back(gpType);
+      substReplacements.push_back(paramTanType);
+      pullbackParams.push_back({gpType, paramTanConvention});
     }
   }
+
+  // Collect pullback results.
   SmallVector<SILParameterInfo, 4> diffParams;
   getDifferentiabilityParameters(originalFnTy, parameterIndices, diffParams);
   SmallVector<SILResultInfo, 8> pullbackResults;
   for (auto &param : diffParams) {
+    // Skip `inout` parameters, which semantically behave as original results
+    // and always appear as pullback parameters.
     if (param.isIndirectInOut())
       continue;
     auto paramTan =

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -346,12 +346,8 @@ func multipleResults(_ x: Float) -> (Float, Float) {
   return (x, x)
 }
 
-// TODO(TF-983): Support differentiation of multiple results.
-// expected-error @+2 {{function is not differentiable}}
-// expected-note @+2 {{when differentiating this function definition}}
 @differentiable
 func usesMultipleResults(_ x: Float) -> Float {
-  // expected-note @+1 {{cannot differentiate through multiple results}}
   let tuple = multipleResults(x)
   return tuple.0 + tuple.1
 }
@@ -440,27 +436,19 @@ func activeInoutParamMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) {
   nonactive = result.0
 }
 
-// TODO(TF-983): Support differentiation of multiple results.
 func twoInoutParameters(_ x: inout Float, _ y: inout Float) {}
-// expected-error @+2 {{function is not differentiable}}
-// expected-note @+2 {{when differentiating this function definition}}
 @differentiable
 func testTwoInoutParameters(_ x: Float, _ y: Float) -> Float {
   var x = x
   var y = y
-  // expected-note @+1 {{cannot differentiate through multiple results}}
   twoInoutParameters(&x, &y)
   return x
 }
 
-// TODO(TF-983): Support differentiation of multiple results.
 func inoutParameterAndFormalResult(_ x: inout Float) -> Float { x }
-// expected-error @+2 {{function is not differentiable}}
-// expected-note @+2 {{when differentiating this function definition}}
 @differentiable
 func testInoutParameterAndFormalResult(_ x: Float) -> Float {
   var x = x
-  // expected-note @+1 {{cannot differentiate through multiple results}}
   return inoutParameterAndFormalResult(&x)
 }
 


### PR DESCRIPTION
Reverse-mode differentiation now supports `apply` instructions with multiple
active "semantic results" (formal results or `inout` parameters).

The "cannot differentiate through multiple results" non-differentiability error
is lifted.

Resolves TF-983.

---

Follow-up:
- TF-1288: relax `@differentiable` and `@derivative` type-checking to allow
  original declarations with multiple semantic results.
- Add forward-mode differentiation support for `apply` instructions with multiple
  active "semantic results".

---

Example:

```swift
import _Differentiation

// Test function returning a tuple of active results.
func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
  return (x, y)
}
func multiply(_ x: Float, _ y: Float) -> Float {
  let z = tuple(x, y)
  // Note: both results (tuple elements) are active.
  return z.0 * z.1
}
print(valueWithGradient(at: 3, 4, in: multiply))
print(valueWithGradient(at: 5, 10, in: multiply))

// Test function with multiple `inout` parameters.
func swap<T>(_ x: inout T, _ y: inout T) {
  let tmp = x; x = y; y = tmp
}
func multiply_swap(_ x: Float, _ y: Float) -> Float {
  var tuple = (x, y)
  swap(&tuple.0, &tuple.1)
  return tuple.0 * tuple.1
}
print(valueWithGradient(at: 3, 4, in: multiply_swap))
print(valueWithGradient(at: 5, 10, in: multiply_swap))
```

Before:
```console
$ swift test.swift
test.swift:25:40: error: function is not differentiable
print(valueWithGradient(at: 5, 10, in: multiply_swap))
                                       ^~~~~~~~~~~~~
test.swift:21:3: note: cannot differentiate through multiple results
  swap(&tuple.0, &tuple.1)
  ^
test.swift:13:40: error: function is not differentiable
print(valueWithGradient(at: 5, 10, in: multiply))
                                       ^~~~~~~~
test.swift:8:11: note: cannot differentiate through multiple results
  let z = tuple(x, y)
          ^
```

After:
```console
$ swift test.swift
(value: 12.0, gradient: (4.0, 3.0))
(value: 50.0, gradient: (10.0, 5.0))
(value: 12.0, gradient: (4.0, 3.0))
(value: 50.0, gradient: (10.0, 5.0))
```