### PR TITLE
[CodeCompletion] Force apply a viable solution even if ambiguous

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1132,18 +1132,24 @@ namespace {
                                       TVO_CanBindToLValue |
                                       TVO_CanBindToNoEscape);
 
-      // Defaults to the type of the base expression if we have a base
-      // expression.
-      // FIXME: This is just to keep the old behavior where `foo(base.<HERE>)`
-      // the argument is type checked to the type of the 'base'. Ideally, code
-      // completion expression should be defauled to 'UnresolvedType'
-      // regardless of the existence of the base expression. But the constraint
-      // system is simply not ready for that.
       if (auto base = E->getBase()) {
+        // Defaults to the type of the base expression if we have a base
+        // expression.
+        // FIXME: This is just to keep the old behavior where `foo(base.<HERE>)`
+        // the argument is type checked to the type of the 'base'. Ideally, code
+        // completion expression should be defauled to 'UnresolvedType'
+        // regardless of the existence of the base expression. But the
+        // constraint system is simply not ready for that.
         CS.addConstraint(ConstraintKind::Defaultable, ty, CS.getType(base),
                          locator);
+
+        // Apply a viable solution even if it's ambiguous.
+        // FIXME: Remove this. This is a hack for code completion which only
+        // see solution applied AST. In future, code completion collects all
+        // viable solutions so we need to apply any solution at all.
+        CS.Options |= ConstraintSystemFlags::ForceApplyViableSolution;
       }
-      
+
       return ty;
     }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1328,6 +1328,12 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
     return bestIdx;
   }
 
+  // FIXME: Terrible hack for code completion. But applying a solution is better
+  // than just failing.
+  if (Options.contains(ConstraintSystemFlags::ForceApplyViableSolution)) {
+    return bestIdx;
+  }
+
   // If there is not a single "better" than others
   // solution, which probably means that solutions
   // were incomparable, let's just keep the original

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1207,6 +1207,10 @@ enum class ConstraintSystemFlags {
   /// for a pre-configured set of expressions on line numbers by setting
   /// \c DebugConstraintSolverOnLines.
   DebugConstraints = 0x10,
+
+  /// For apply a viable solution even if they are ambiguous. So that the client
+  /// get a solution.
+  ForceApplyViableSolution = 0x20,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/test/IDE/complete_builder_multiviable.swift
+++ b/test/IDE/complete_builder_multiviable.swift
@@ -1,0 +1,38 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE1 | %FileCheck %s --check-prefix=CHECK
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE1 | %FileCheck %s --check-prefix=CHECK
+
+@_functionBuilder
+struct Builder {
+  static func buildBlock<T1>(_ v1: T1) -> T1 { v1 }
+  static func buildBlock<T1, T2>(_ v1: T1, _ v2: T2) -> (T1, T2) { v1 }
+}
+
+struct MyValue {
+  var title: String
+  var id: Int
+  var value: Float
+}
+
+func build<T>(@Builder fn: (MyValue) -> T) {}
+
+struct Container {
+  init(x: Float) {}
+  init(x: Int) {}
+}
+
+func test(foo: Foo) {
+  build { val in
+    Container(x: val.#^COMPLETE1^#)
+  }
+  build { val in
+    1 + 2
+    Container(x: val.#^COMPLETE2^#)
+  }
+}
+
+// CHECK: Begin completions, 4 items
+// CHECK: Keyword[self]/CurrNominal:          self[#MyValue#]; name=self
+// CHECK: Decl[InstanceVar]/CurrNominal:      title[#String#]; name=title
+// CHECK: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: id[#Int#]; name=id
+// CHECK: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: value[#Float#]; name=value
+// CHECK: End completions


### PR DESCRIPTION
As a workaround for the issue where code completion fails to suggest member completions for function builder closure parameters.

Added ConstraintSystem flag to force apply a solution even if there are multiple viable solutions.

rdar://problem/64079439
