### PR TITLE
Dependencies Scanner: report compiled Swift module paths if they are available

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -716,8 +716,11 @@ public:
   ///                compiler.
   /// \param isDWARF \c true if this module loader can load Clang modules
   ///                from DWARF.
+  /// \param IsInterface \c true if this module loader can load Swift textual
+  ///                interface.
   void addModuleLoader(std::unique_ptr<ModuleLoader> loader,
-                       bool isClang = false, bool isDWARF = false);
+                       bool isClang = false, bool isDWARF = false,
+                       bool IsInterface = false);
 
   /// Retrieve the module dependencies for the module with the given name.
   ///
@@ -791,6 +794,8 @@ public:
   /// The loader is owned by the AST context.
   ClangModuleLoader *getDWARFModuleLoader() const;
 
+  /// Retrieve the module interface loader for this ASTContext.
+  ModuleLoader *getModuleInterfaceLoader() const;
 public:
   namelookup::ImportCache &getImportCache() const;
 

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -180,11 +180,11 @@ public:
   /// Describe the module dependencies for a Swift module that can be
   /// built from a Swift interface file (\c .swiftinterface).
   static ModuleDependencies forSwiftInterface(
-      const std::string &compiledModulePath,
       const std::string &swiftInterfaceFile,
       ArrayRef<StringRef> buildCommands,
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash) {
+    std::string compiledModulePath;
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
           compiledModulePath, swiftInterfaceFile, buildCommands,
@@ -201,9 +201,8 @@ public:
   }
 
   /// Describe the main Swift module.
-  static ModuleDependencies forMainSwiftModule(
-      const std::string &compiledModulePath,
-      ArrayRef<StringRef> extraPCMArgs) {
+  static ModuleDependencies forMainSwiftModule(ArrayRef<StringRef> extraPCMArgs) {
+    std::string compiledModulePath;
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
           compiledModulePath, None, ArrayRef<StringRef>(), extraPCMArgs,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -202,7 +202,6 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
 
   bool isCached(StringRef DepPath) override;
-
 public:
   static std::unique_ptr<ModuleInterfaceLoader>
   create(ASTContext &ctx, StringRef cacheDir, StringRef prebuiltCacheDir,
@@ -235,6 +234,9 @@ public:
     StringRef ModuleName, StringRef InPath, StringRef OutPath,
     bool SerializeDependencyHashes, bool TrackSystemDependencies,
     ModuleInterfaceLoaderOptions Opts);
+
+  std::string getUpToDateCompiledModuleForInterface(StringRef moduleName,
+                                                    StringRef interfacePath) override;
 };
 
 struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -445,12 +445,7 @@ public:
   }
 };
 
-Optional<StringRef>
-computePrebuiltModulePath(ASTContext &ctx,
-                          StringRef interfacePath,
-                          StringRef prebuiltCacheDir,
-                          StringRef moduleName,
-                          llvm::SmallString<256> &scratch);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -200,6 +200,11 @@ public:
   virtual Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
+
+  virtual std::string getUpToDateCompiledModuleForInterface(StringRef moduleName,
+                                                      StringRef interfacePath) {
+    return std::string();
+  }
 };
 
 /// Imports serialized Swift modules into an ASTContext.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -263,6 +263,9 @@ struct ASTContext::Implementation {
   /// The module loader used to load Clang modules from DWARF.
   ClangModuleLoader *TheDWARFModuleLoader = nullptr;
 
+  /// The module loader used to load Swift textual interface.
+  ModuleLoader *TheModuleInterfaceLoader = nullptr;
+
   /// Map from Swift declarations to raw comments.
   llvm::DenseMap<const Decl *, RawComment> RawComments;
 
@@ -1450,14 +1453,15 @@ void ASTContext::addSearchPath(StringRef searchPath, bool isFramework,
 }
 
 void ASTContext::addModuleLoader(std::unique_ptr<ModuleLoader> loader,
-                                 bool IsClang, bool IsDwarf) {
+                                 bool IsClang, bool IsDwarf, bool IsInterface) {
   if (IsClang && !IsDwarf && !getImpl().TheClangModuleLoader)
     getImpl().TheClangModuleLoader =
         static_cast<ClangModuleLoader *>(loader.get());
   if (IsClang && IsDwarf && !getImpl().TheDWARFModuleLoader)
     getImpl().TheDWARFModuleLoader =
         static_cast<ClangModuleLoader *>(loader.get());
-
+  if (IsInterface && !getImpl().TheModuleInterfaceLoader)
+    getImpl().TheModuleInterfaceLoader = loader.get();
   getImpl().ModuleLoaders.push_back(std::move(loader));
 }
 
@@ -1530,6 +1534,10 @@ ClangModuleLoader *ASTContext::getClangModuleLoader() const {
 
 ClangModuleLoader *ASTContext::getDWARFModuleLoader() const {
   return getImpl().TheDWARFModuleLoader;
+}
+
+ModuleLoader *ASTContext::getModuleInterfaceLoader() const {
+  return getImpl().TheModuleInterfaceLoader;
 }
 
 ModuleDecl *ASTContext::getLoadedModule(

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -504,7 +504,7 @@ bool CompilerInstance::setUpModuleLoaders() {
         getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
         LoaderOpts,
         IgnoreSourceInfoFile);
-    Context->addModuleLoader(std::move(PIML));
+    Context->addModuleLoader(std::move(PIML), false, false, true);
   }
 
   std::unique_ptr<SerializedModuleLoader> SML =

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -590,11 +590,9 @@ class ModuleInterfaceLoaderImpl {
     return path.startswith(resourceDir);
   }
 
-  /// Finds the most appropriate .swiftmodule, whose dependencies are up to
-  /// date, that we can load for the provided .swiftinterface file.
-  llvm::ErrorOr<DiscoveredModule> discoverUpToDateModuleForInterface(
-    StringRef modulePath, StringRef cachedOutputPath,
-    SmallVectorImpl<FileDependency> &deps) {
+  llvm::ErrorOr<DiscoveredModule>
+  discoverUpToDateCompiledModuleForInterface(SmallVectorImpl<FileDependency> &deps,
+                                             std::string &UsableModulePath) {
     auto notFoundError =
       std::make_error_code(std::errc::no_such_file_or_directory);
 
@@ -619,50 +617,6 @@ class ModuleInterfaceLoaderImpl {
     case ModuleLoadingMode::OnlySerialized:
       llvm_unreachable("module interface loader should not have been created");
     }
-
-
-    // First, check the cached module path. Whatever's in this cache represents
-    // the most up-to-date knowledge we have about the module.
-    if (auto cachedBufOrError = fs.getBufferForFile(cachedOutputPath)) {
-      auto buf = std::move(*cachedBufOrError);
-
-      // Check to see if the module is a serialized AST. If it's not, then we're
-      // probably dealing with a Forwarding Module, which is a YAML file.
-      bool isForwardingModule =
-        !serialization::isSerializedAST(buf->getBuffer());
-
-      // If it's a forwarding module, load the YAML file from disk and check
-      // if it's up-to-date.
-      if (isForwardingModule) {
-        if (auto forwardingModule = ForwardingModule::load(*buf)) {
-          std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
-          if (forwardingModuleIsUpToDate(cachedOutputPath,
-                                         *forwardingModule, deps,
-                                         moduleBuffer)) {
-            LLVM_DEBUG(llvm::dbgs() << "Found up-to-date forwarding module at "
-                                    << cachedOutputPath << "\n");
-            return DiscoveredModule::forwarded(
-              forwardingModule->underlyingModulePath, std::move(moduleBuffer));
-          }
-
-          LLVM_DEBUG(llvm::dbgs() << "Found out-of-date forwarding module at "
-                     << cachedOutputPath << "\n");
-          rebuildInfo.setModuleKind(cachedOutputPath,
-                                    ModuleRebuildInfo::ModuleKind::Forwarding);
-        }
-      // Otherwise, check if the AST buffer itself is up to date.
-      } else if (serializedASTBufferIsUpToDate(cachedOutputPath, *buf, deps)) {
-        LLVM_DEBUG(llvm::dbgs() << "Found up-to-date cached module at "
-                                << cachedOutputPath << "\n");
-        return DiscoveredModule::normal(cachedOutputPath, std::move(buf));
-      } else {
-        LLVM_DEBUG(llvm::dbgs() << "Found out-of-date cached module at "
-                   << cachedOutputPath << "\n");
-        rebuildInfo.setModuleKind(cachedOutputPath,
-                                  ModuleRebuildInfo::ModuleKind::Cached);
-      }
-    }
-
     // [Note: ModuleInterfaceLoader-defer-to-SerializedModuleLoader]
     // If there's a module adjacent to the .swiftinterface that we can
     // _likely_ load (it validates OK and is up to date), bail early with
@@ -680,6 +634,7 @@ class ModuleInterfaceLoaderImpl {
           LLVM_DEBUG(llvm::dbgs() << "Found up-to-date module at "
                                   << modulePath
                                   << "; deferring to serialized module loader\n");
+          UsableModulePath = modulePath.str();
           return std::make_error_code(std::errc::not_supported);
         } else if (isInResourceDir(modulePath) &&
                    loadMode == ModuleLoadingMode::PreferSerialized) {
@@ -725,6 +680,7 @@ class ModuleInterfaceLoaderImpl {
         if (swiftModuleIsUpToDate(*path, deps, moduleBuffer)) {
           LLVM_DEBUG(llvm::dbgs() << "Found up-to-date prebuilt module at "
                                   << path->str() << "\n");
+          UsableModulePath = path->str();
           return DiscoveredModule::prebuilt(*path, std::move(moduleBuffer));
         } else {
           LLVM_DEBUG(llvm::dbgs() << "Found out-of-date prebuilt module at "
@@ -738,6 +694,57 @@ class ModuleInterfaceLoaderImpl {
     // Couldn't find an up-to-date .swiftmodule, will need to build module from
     // interface.
     return notFoundError;
+  }
+
+  /// Finds the most appropriate .swiftmodule, whose dependencies are up to
+  /// date, that we can load for the provided .swiftinterface file.
+  llvm::ErrorOr<DiscoveredModule> discoverUpToDateModuleForInterface(
+    StringRef cachedOutputPath,
+    SmallVectorImpl<FileDependency> &deps) {
+
+    // First, check the cached module path. Whatever's in this cache represents
+    // the most up-to-date knowledge we have about the module.
+    if (auto cachedBufOrError = fs.getBufferForFile(cachedOutputPath)) {
+      auto buf = std::move(*cachedBufOrError);
+
+      // Check to see if the module is a serialized AST. If it's not, then we're
+      // probably dealing with a Forwarding Module, which is a YAML file.
+      bool isForwardingModule =
+        !serialization::isSerializedAST(buf->getBuffer());
+
+      // If it's a forwarding module, load the YAML file from disk and check
+      // if it's up-to-date.
+      if (isForwardingModule) {
+        if (auto forwardingModule = ForwardingModule::load(*buf)) {
+          std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
+          if (forwardingModuleIsUpToDate(cachedOutputPath,
+                                         *forwardingModule, deps,
+                                         moduleBuffer)) {
+            LLVM_DEBUG(llvm::dbgs() << "Found up-to-date forwarding module at "
+                                    << cachedOutputPath << "\n");
+            return DiscoveredModule::forwarded(
+              forwardingModule->underlyingModulePath, std::move(moduleBuffer));
+          }
+
+          LLVM_DEBUG(llvm::dbgs() << "Found out-of-date forwarding module at "
+                     << cachedOutputPath << "\n");
+          rebuildInfo.setModuleKind(cachedOutputPath,
+                                    ModuleRebuildInfo::ModuleKind::Forwarding);
+        }
+      // Otherwise, check if the AST buffer itself is up to date.
+      } else if (serializedASTBufferIsUpToDate(cachedOutputPath, *buf, deps)) {
+        LLVM_DEBUG(llvm::dbgs() << "Found up-to-date cached module at "
+                                << cachedOutputPath << "\n");
+        return DiscoveredModule::normal(cachedOutputPath, std::move(buf));
+      } else {
+        LLVM_DEBUG(llvm::dbgs() << "Found out-of-date cached module at "
+                   << cachedOutputPath << "\n");
+        rebuildInfo.setModuleKind(cachedOutputPath,
+                                  ModuleRebuildInfo::ModuleKind::Cached);
+      }
+    }
+    std::string usableModulePath;
+    return discoverUpToDateCompiledModuleForInterface(deps, usableModulePath);
   }
 
   /// Writes the "forwarding module" that will forward to a module in the
@@ -847,7 +854,7 @@ class ModuleInterfaceLoaderImpl {
     // in the cache, or in the prebuilt cache.
     SmallVector<FileDependency, 16> allDeps;
     auto moduleOrErr =
-      discoverUpToDateModuleForInterface(modulePath, cachedOutputPath, allDeps);
+      discoverUpToDateModuleForInterface(cachedOutputPath, allDeps);
 
     // If we errored with anything other than 'no such file or directory',
     // fail this load and let the other module loader diagnose it.
@@ -993,6 +1000,25 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   return std::error_code();
 }
 
+std::string
+ModuleInterfaceLoader::getUpToDateCompiledModuleForInterface(StringRef moduleName,
+                                                      StringRef interfacePath) {
+  // Derive .swiftmodule path from the .swiftinterface path.
+  auto newExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
+  llvm::SmallString<32> modulePath = interfacePath;
+  llvm::sys::path::replace_extension(modulePath, newExt);
+  ModuleInterfaceLoaderImpl Impl(
+                Ctx, modulePath, interfacePath, moduleName,
+                CacheDir, PrebuiltCacheDir, SourceLoc(),
+                Opts,
+                dependencyTracker,
+                llvm::is_contained(PreferInterfaceForModules, moduleName) ?
+                  ModuleLoadingMode::PreferInterface : LoadMode);
+  SmallVector<FileDependency, 16> allDeps;
+  std::string usableModulePath;
+  Impl.discoverUpToDateCompiledModuleForInterface(allDeps, usableModulePath);
+  return usableModulePath;
+}
 
 bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     SourceManager &SourceMgr, DiagnosticEngine &Diags,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -508,6 +508,82 @@ class ModuleInterfaceLoaderImpl {
     return true;
   }
 
+  Optional<StringRef>
+  computePrebuiltModulePath(llvm::SmallString<256> &scratch) {
+    namespace path = llvm::sys::path;
+    StringRef sdkPath = ctx.SearchPathOpts.SDKPath;
+
+    // Check if the interface file comes from the SDK
+    if (sdkPath.empty() || !hasPrefix(path::begin(interfacePath),
+                                      path::end(interfacePath),
+                                      path::begin(sdkPath),
+                                      path::end(sdkPath)))
+      return None;
+
+    // Assemble the expected path: $PREBUILT_CACHE/Foo.swiftmodule or
+    // $PREBUILT_CACHE/Foo.swiftmodule/arch.swiftmodule. Note that there's no
+    // cache key here.
+    scratch = prebuiltCacheDir;
+
+    // FIXME: Would it be possible to only have architecture-specific names
+    // here? Then we could skip this check.
+    StringRef inParentDirName =
+      path::filename(path::parent_path(interfacePath));
+    if (path::extension(inParentDirName) == ".swiftmodule") {
+      assert(path::stem(inParentDirName) == moduleName);
+      path::append(scratch, inParentDirName);
+    }
+    path::append(scratch, path::filename(modulePath));
+
+    // If there isn't a file at this location, skip returning a path.
+    if (!fs.exists(scratch))
+      return None;
+
+    return scratch.str();
+  }
+
+  /// Hack to deal with build systems (including the Swift standard library, at
+  /// the time of this comment) that aren't yet using target-specific names for
+  /// multi-target swiftmodules, in case the prebuilt cache is.
+  Optional<StringRef>
+  computeFallbackPrebuiltModulePath(llvm::SmallString<256> &scratch) {
+    namespace path = llvm::sys::path;
+    StringRef sdkPath = ctx.SearchPathOpts.SDKPath;
+
+    // Check if the interface file comes from the SDK
+    if (sdkPath.empty() || !hasPrefix(path::begin(interfacePath),
+                                      path::end(interfacePath),
+                                      path::begin(sdkPath),
+                                      path::end(sdkPath)))
+      return None;
+
+    // If the module isn't target-specific, there's no fallback path.
+    StringRef inParentDirName =
+        path::filename(path::parent_path(interfacePath));
+    if (path::extension(inParentDirName) != ".swiftmodule")
+      return None;
+
+    // If the interface is already using the target-specific name, there's
+    // nothing else to try.
+    auto normalizedTarget = getTargetSpecificModuleTriple(ctx.LangOpts.Target);
+    if (path::stem(modulePath) == normalizedTarget.str())
+      return None;
+
+    // Assemble the expected path:
+    // $PREBUILT_CACHE/Foo.swiftmodule/target.swiftmodule. Note that there's no
+    // cache key here.
+    scratch = prebuiltCacheDir;
+    path::append(scratch, inParentDirName);
+    path::append(scratch, normalizedTarget.str());
+    scratch += ".swiftmodule";
+
+    // If there isn't a file at this location, skip returning a path.
+    if (!fs.exists(scratch))
+      return None;
+
+    return scratch.str();
+  }
+
   bool isInResourceDir(StringRef path) {
     StringRef resourceDir = ctx.SearchPathOpts.RuntimeResourcePath;
     if (resourceDir.empty()) return false;
@@ -639,12 +715,12 @@ class ModuleInterfaceLoaderImpl {
     if (!prebuiltCacheDir.empty()) {
       llvm::SmallString<256> scratch;
       std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
-      Optional<StringRef> path = computePrebuiltModulePath(ctx,
-                                                           interfacePath,
-                                                           prebuiltCacheDir,
-                                                           moduleName,
-                                                           scratch);
-
+      Optional<StringRef> path = computePrebuiltModulePath(scratch);
+      if (!path) {
+        // Hack: deal with prebuilds of modules that still use the target-based
+        // names.
+        path = computeFallbackPrebuiltModulePath(scratch);
+      }
       if (path) {
         if (swiftModuleIsUpToDate(*path, deps, moduleBuffer)) {
           LLVM_DEBUG(llvm::dbgs() << "Found up-to-date prebuilt module at "

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -339,8 +339,12 @@ static void writeJSON(llvm::raw_ostream &out,
         }
         out.indent(5 * 2);
         out << "],\n";
+      } else if (!swiftDeps->compiledModulePath.empty()) {
+        writeJSONSingleField(
+            out, "compiledModulePath",
+            swiftDeps->compiledModulePath, 5,
+            /*trailingComma=*/false);
       }
-
       if (!swiftDeps->extraPCMArgs.empty()) {
         out.indent(5 * 2);
         out << "\"extraPcmArgs\": [\n";
@@ -354,7 +358,6 @@ static void writeJSON(llvm::raw_ostream &out,
         out.indent(5 * 2);
         out << (swiftDeps->bridgingHeaderFile.hasValue() ? "],\n" : "]\n");
       }
-
       /// Bridging header and its source file dependencies, if any.
       if (swiftDeps->bridgingHeaderFile) {
         out.indent(5 * 2);
@@ -431,7 +434,7 @@ bool swift::scanDependencies(CompilerInstance &instance) {
       .asAPINotesVersionString()).str();
   // Compute the dependencies of the main module.
   auto mainDependencies =
-    ModuleDependencies::forMainSwiftModule(mainModulePath.str().str(), {
+    ModuleDependencies::forMainSwiftModule({
       // ExtraPCMArgs
       "-Xcc", "-target", "-Xcc", instance.getASTContext().LangOpts.Target.str(),
       "-Xcc", apinotesVer

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/Platform.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticSuppression.h"
@@ -22,92 +21,6 @@ using namespace swift;
 using llvm::ErrorOr;
 
 namespace {
-static Optional<StringRef>
-computePrebuiltModulePathDefault(ASTContext &ctx,
-                                 StringRef interfacePath,
-                                 StringRef prebuiltCacheDir,
-                                 StringRef moduleName,
-                                 StringRef modulePath,
-                                 llvm::SmallString<256> &scratch) {
-  namespace path = llvm::sys::path;
-  StringRef sdkPath = ctx.SearchPathOpts.SDKPath;
-  auto &fs = *ctx.SourceMgr.getFileSystem();
-  // Check if the interface file comes from the SDK
-  if (sdkPath.empty() || !hasPrefix(path::begin(interfacePath),
-                                    path::end(interfacePath),
-                                    path::begin(sdkPath),
-                                    path::end(sdkPath)))
-    return None;
-
-  // Assemble the expected path: $PREBUILT_CACHE/Foo.swiftmodule or
-  // $PREBUILT_CACHE/Foo.swiftmodule/arch.swiftmodule. Note that there's no
-  // cache key here.
-  scratch = prebuiltCacheDir;
-
-  // FIXME: Would it be possible to only have architecture-specific names
-  // here? Then we could skip this check.
-  StringRef inParentDirName =
-    path::filename(path::parent_path(interfacePath));
-  if (path::extension(inParentDirName) == ".swiftmodule") {
-    assert(path::stem(inParentDirName) == moduleName);
-    path::append(scratch, inParentDirName);
-  }
-  path::append(scratch, path::filename(modulePath));
-
-  // If there isn't a file at this location, skip returning a path.
-  if (!fs.exists(scratch))
-    return None;
-
-  return scratch.str();
-}
-
-/// Hack to deal with build systems (including the Swift standard library, at
-/// the time of this comment) that aren't yet using target-specific names for
-/// multi-target swiftmodules, in case the prebuilt cache is.
-static Optional<StringRef>
-computeFallbackPrebuiltModulePath(ASTContext &ctx,
-                                  StringRef interfacePath,
-                                  StringRef prebuiltCacheDir,
-                                  StringRef moduleName,
-                                  StringRef modulePath,
-                                  llvm::SmallString<256> &scratch) {
-  namespace path = llvm::sys::path;
-  StringRef sdkPath = ctx.SearchPathOpts.SDKPath;
-  auto &fs = *ctx.SourceMgr.getFileSystem();
-
-  // Check if the interface file comes from the SDK
-  if (sdkPath.empty() || !hasPrefix(path::begin(interfacePath),
-                                    path::end(interfacePath),
-                                    path::begin(sdkPath),
-                                    path::end(sdkPath)))
-    return None;
-
-  // If the module isn't target-specific, there's no fallback path.
-  StringRef inParentDirName =
-      path::filename(path::parent_path(interfacePath));
-  if (path::extension(inParentDirName) != ".swiftmodule")
-    return None;
-
-  // If the interface is already using the target-specific name, there's
-  // nothing else to try.
-  auto normalizedTarget = getTargetSpecificModuleTriple(ctx.LangOpts.Target);
-  if (path::stem(modulePath) == normalizedTarget.str())
-    return None;
-
-  // Assemble the expected path:
-  // $PREBUILT_CACHE/Foo.swiftmodule/target.swiftmodule. Note that there's no
-  // cache key here.
-  scratch = prebuiltCacheDir;
-  path::append(scratch, inParentDirName);
-  path::append(scratch, normalizedTarget.str());
-  scratch += ".swiftmodule";
-
-  // If there isn't a file at this location, skip returning a path.
-  if (!fs.exists(scratch))
-    return None;
-
-  return scratch.str();
-}
 
 /// A module "loader" that looks for .swiftinterface and .swiftmodule files
 /// for the purpose of determining dependencies, but does not attempt to
@@ -179,28 +92,6 @@ public:
     llvm_unreachable("Not used");
   }
 };
-}
-
-Optional<StringRef>
-swift::computePrebuiltModulePath(ASTContext &ctx,
-                                 StringRef interfacePath,
-                                 StringRef prebuiltCacheDir,
-                                 StringRef moduleName,
-                                 llvm::SmallString<256> &scratch) {
-  llvm::SmallString<64> modulePath = llvm::sys::path::filename(interfacePath);
-  llvm::sys::path::replace_extension(modulePath,
-    file_types::getExtension(file_types::TY_SwiftModuleFile));
-  auto defaultPath =
-    computePrebuiltModulePathDefault(ctx, interfacePath, prebuiltCacheDir,
-                                     moduleName, modulePath, scratch);
-  if (defaultPath.hasValue())
-    return defaultPath;
-  else
-    return computeFallbackPrebuiltModulePath(ctx, interfacePath,
-                                             prebuiltCacheDir,
-                                             moduleName,
-                                             modulePath,
-                                             scratch);
 }
 
 ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -44,6 +44,16 @@ public:
                                    /*IgnoreSwiftSourceInfoFile=*/true),
         moduleName(moduleName), astDelegate(astDelegate) { }
 
+  std::string getCompiledModulePath(const SerializedModuleBaseName &BaseName) {
+    if (LoadMode == ModuleLoadingMode::OnlySerialized) {
+      return BaseName.getName(file_types::TY_SwiftModuleFile);
+    }
+    return static_cast<SerializedModuleLoaderBase*>(Ctx
+      .getModuleInterfaceLoader())->getUpToDateCompiledModuleForInterface(
+         moduleName.str(),
+         BaseName.getName(file_types::TY_SwiftModuleInterfaceFile));
+  }
+
   virtual std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID,
       const SerializedModuleBaseName &BaseName,
@@ -56,12 +66,9 @@ public:
     auto &fs = *Ctx.SourceMgr.getFileSystem();
 
     // Compute the full path of the module we're looking for.
-    auto ModPath = BaseName.getName(file_types::TY_SwiftModuleFile);
-    if (LoadMode == ModuleLoadingMode::OnlySerialized) {
-      // If there is no module file, there's nothing we can do.
-      if (!fs.exists(ModPath))
-        return std::make_error_code(std::errc::no_such_file_or_directory);
+    auto ModPath = getCompiledModulePath(BaseName);
 
+    if (fs.exists(ModPath)) {
       // The module file will be loaded directly.
       auto dependencies = scanModuleFile(ModPath);
       if (dependencies) {
@@ -110,8 +117,7 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
                                               SourceLoc(),
                 [&](ASTContext &Ctx, ArrayRef<StringRef> Args,
                     ArrayRef<StringRef> PCMArgs, StringRef Hash) {
-    Result = ModuleDependencies::forSwiftInterface(modulePath.str().str(),
-                                                   moduleInterfacePath.str(),
+    Result = ModuleDependencies::forSwiftInterface(moduleInterfacePath.str(),
                                                    Args,
                                                    PCMArgs,
                                                    Hash);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -366,13 +366,14 @@ llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
   // Load the module file without validation.
   std::unique_ptr<ModuleFile> loadedModuleFile;
   bool isFramework = false;
+  serialization::ExtendedValidationInfo extInfo;
   serialization::ValidationInfo loadInfo =
       ModuleFile::load(modulePath.str(),
                        std::move(moduleBuf.get()),
                        nullptr,
                        nullptr,
                        isFramework, loadedModuleFile,
-                       nullptr);
+                       &extInfo);
 
   // Map the set of dependencies over to the "module dependencies".
   auto dependencies = ModuleDependencies::forSwiftModule(modulePath.str());

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -63,6 +63,9 @@ struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
   var moduleInterfacePath: String?
 
+  /// The compiled Swift module to use.
+  var compiledModulePath: String?
+
   /// The bridging header, if any.
   var bridgingHeader: BridgingHeader?
 

--- a/test/ScanDependencies/compiled_swift_modules.swift
+++ b/test/ScanDependencies/compiled_swift_modules.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Foo.swiftmodule)
+// RUN: %empty-directory(%t/ResourceDir/%target-sdk-name/prebuilt-modules/Foo.swiftmodule)
+// RUN: echo "public func foo() {}" > %t/Foo.swift
+
+import Foo
+
+// HAS_COMPILED:        "compiledModulePath": "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
+// HAS_NO_COMPILED-NOT: "compiledModulePath": "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
+
+// Step 1: build swift interface and swift module side by side
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// Step 2: scan dependency should give us the binary module adjacent to the interface file.
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d
+// RUN: %FileCheck %s -check-prefix=HAS_COMPILED < %t/deps.json
+
+// Step 3: remove the adjacent module.
+// RUN: rm %t/Foo.swiftmodule/%target-swiftmodule-name
+
+// Step 4: scan dependency should give us the interface file.
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d
+// RUN: %FileCheck %s -check-prefix=HAS_NO_COMPILED < %t/deps.json
+
+// Step 4: build prebuilt module cache using the interface.
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -disable-interface-lock %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// Step 5: scan dependency now should give us the prebuilt module cache
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
+// RUN: %FileCheck %s -check-prefix=HAS_COMPILED < %t/deps.json
+
+// Step 6: update the interface file from where the prebuilt module cache was built.
+// RUN: touch %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// Step 4: scan dependency should give us the interface file.
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d
+// RUN: %FileCheck %s -check-prefix=HAS_NO_COMPILED < %t/deps.json

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -179,7 +179,6 @@ import SubE
 // CHECK-MAKE-DEPS: module_deps.swift
 // CHECK-MAKE-DEPS-SAME: A.swiftinterface
 // CHECK-MAKE-DEPS-SAME: G.swiftinterface
-// CHECK-MAKE-DEPS-SAME: Swift.swiftmodule
 // CHECK-MAKE-DEPS-SAME: B.h
 // CHECK-MAKE-DEPS-SAME: F.h
 // CHECK-MAKE-DEPS-SAME: Bridging.h


### PR DESCRIPTION
For the explicit module mode, swift-driver uses -compile-module-from-interface to
generate modules from interfaces found by the dependency scanner. However, we don't
need to build the binary module if up-to-date modules are available, either adjacent
to the interface file or in the prebuilt module cache directory. This patch teaches
dependencies scanner to report these ready-to-use binary modules.