### PR TITLE
NFC: silence some -Wrange-loop-analysis warnings.

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3524,7 +3524,7 @@ namespace {
       if (T->getParent())
         printRec("parent", T->getParent());
 
-      for (const auto arg : T->getDirectGenericArgs())
+      for (const auto &arg : T->getDirectGenericArgs())
         printRec(arg);
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -39,7 +39,7 @@ class Traversal : public TypeVisitor<Traversal, bool>
     if (auto parent = ty->getParent())
       if (doIt(parent)) return true;
 
-    for (const auto arg : ty->getDirectGenericArgs())
+    for (const auto &arg : ty->getDirectGenericArgs())
       if (doIt(arg))
         return true;
     


### PR DESCRIPTION
Silence warnings:
```
lib/AST/TypeWalker.cpp:42:21: warning: loop variable 'arg' of type 'const swift::Type' creates a copy from type 'const swift::Type' [-Wrange-loop-analysis]
    for (const auto arg : ty->getDirectGenericArgs())
                    ^
lib/AST/TypeWalker.cpp:42:10: note: use reference type 'const swift::Type &' to prevent copying
    for (const auto arg : ty->getDirectGenericArgs())
         ^~~~~~~~~~~~~~~~
                    &
1 warning generated.
```
```
lib/AST/ASTDumper.cpp:3527:23: warning: loop variable 'arg' of type 'const swift::Type' creates a copy from type 'const swift::Type' [-Wrange-loop-analysis]
      for (const auto arg : T->getDirectGenericArgs())
                      ^
lib/AST/ASTDumper.cpp:3527:12: note: use reference type 'const swift::Type &' to prevent copying
      for (const auto arg : T->getDirectGenericArgs())
           ^~~~~~~~~~~~~~~~
                      &
1 warning generated.
```