### PR TITLE
NFC: silence some -Wrange-loop-analysis warnings.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -622,7 +622,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
   FullArgs.clear();
 
   // First grab our basic arguments from our apply.
-  for (const auto &Arg : AI.getArguments())
+  for (SILValue Arg : AI.getArguments())
     FullArgs.push_back(Arg);
 
   // Then grab a first approximation of our apply by stripping off all copy

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -131,7 +131,7 @@ static bool hasOpaqueArchetypeOperand(TypeExpansionContext context,
 static bool hasOpaqueArchetypeResult(TypeExpansionContext context,
                                      SILInstruction &inst) {
   // Check the results for opaque types.
-  for (const auto &res : inst.getResults())
+  for (SILValue res : inst.getResults())
     if (opaqueArchetypeWouldChange(context, res->getType().getASTType()))
       return true;
   return false;


### PR DESCRIPTION
```
lib/SILOptimizer/Mandatory/MandatoryInlining.cpp:625:20: warning: loop variable 'Arg' is always a copy because the range of type 'swift::OperandValueArrayRef' (aka 'ArrayRefView<swift::Operand, swift::SILValue, getSILValueType>') does not return a reference [-Wrange-loop-analysis]
  for (const auto &Arg : AI.getArguments())
                   ^
lib/SILOptimizer/Mandatory/MandatoryInlining.cpp:625:8: note: use non-reference type 'swift::SILValue'
  for (const auto &Arg : AI.getArguments())
       ^~~~~~~~~~~~~~~~~
1 warning generated.
```
```
lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp:134:20: warning: loop variable 'res' is always a copy because the range of type 'swift::SILInstructionResultArray' does not return a reference [-Wrange-loop-analysis]
  for (const auto &res : inst.getResults())
                   ^
lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp:134:8: note: use non-reference type 'swift::SILValue'
  for (const auto &res : inst.getResults())
       ^~~~~~~~~~~~~~~~~
```