### PR TITLE
[AutoDiff] Fix protocol witness SILGen for `@differentiable` class methods.

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -309,7 +309,7 @@ struct SILDeclRef {
   /// function.
   SILDeclRef asAutoDiffDerivativeFunction(
       AutoDiffDerivativeFunctionIdentifier *derivativeId) const {
-    assert(!derivativeFunctionIdentifier);
+    assert(derivativeId);
     SILDeclRef declRef = *this;
     declRef.derivativeFunctionIdentifier = derivativeId;
     return declRef;

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4604,6 +4604,17 @@ getWitnessFunctionRef(SILGenFunction &SGF,
   }
   case WitnessDispatchKind::Class: {
     SILValue selfPtr = witnessParams.back().getValue();
+    // If `witness` is a derivative function `SILDeclRef`, replace the
+    // derivative function identifier's generic signature with the witness thunk
+    // substitution map's generic signature.
+    if (auto *derivativeId = witness.derivativeFunctionIdentifier) {
+      auto *newDerivativeId = AutoDiffDerivativeFunctionIdentifier::get(
+          derivativeId->getKind(), derivativeId->getParameterIndices(),
+          witnessSubs.getGenericSignature(), SGF.getASTContext());
+      return SGF.emitClassMethodRef(
+          loc, selfPtr, witness.asAutoDiffDerivativeFunction(newDerivativeId),
+          witnessFTy);
+    }
     return SGF.emitClassMethodRef(loc, selfPtr, witness, witnessFTy);
   }
   }

--- a/test/AutoDiff/compiler_crashers_fixed/tf1180-silgen-vtable-method-does-not-appear.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1180-silgen-vtable-method-does-not-appear.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-silgen %s
+
+// TF-1180: SIL verification error regarding `@differentiable` class method
+// witnesses for `@differentiable` protocol requirements.
+
+import _Differentiation
+
+protocol Protocol {
+  @differentiable
+  func method(_ x: Float) -> Float
+}
+
+class Class: Protocol {
+  @differentiable
+  public func method(_ x: Float) -> Float { x }
+}
+
+// Original error:
+// SIL verification failed: method does not appear in the class's vtable: VerifyClassMethodVisitor(member).Seen
+// Verifying instruction:
+//      %2 = load_borrow %1 : $*Class                // users: %8, %4, %3
+// ->   %3 = class_method %2 : $Class, #Class.method!jvp.SU.<Self where Self : Protocol> : (Class) -> (Float) -> Float, $@convention(method) (Float, @guaranteed Class) -> (Float, @owned @callee_guaranteed (Float) -> Float) // user: %4
+//      %4 = apply %3(%0, %2) : $@convention(method) (Float, @guaranteed Class) -> (Float, @owned @callee_guaranteed (Float) -> Float) // user: %5
+// In function:
+// // AD__$s4main5ClassCAA8ProtocolA2aDP6methodyS2fFTW_jvp_SU
+// sil private [transparent] [thunk] [ossa] @AD__$s4main5ClassCAA8ProtocolA2aDP6methodyS2fFTW_jvp_SU : $@convention(witness_method: Protocol) (Float, @in_guaranteed Class) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// // %0                                             // user: %4
+// // %1                                             // user: %2
+// bb0(%0 : $Float, %1 : $*Class):
+//   %2 = load_borrow %1 : $*Class                   // users: %8, %4, %3
+//   %3 = class_method %2 : $Class, #Class.method!jvp.SU.<Self where Self : Protocol> : (Class) -> (Float) -> Float, $@convention(method) (Float, @guaranteed Class) -> (Float, @owned @callee_guaranteed (Float) -> Float) // user: %4
+//   %4 = apply %3(%0, %2) : $@convention(method) (Float, @guaranteed Class) -> (Float, @owned @callee_guaranteed (Float) -> Float) // user: %5
+//   (%5, %6) = destructure_tuple %4 : $(Float, @callee_guaranteed (Float) -> Float) // users: %7, %7
+//   %7 = tuple (%5 : $Float, %6 : $@callee_guaranteed (Float) -> Float) // user: %9
+//   end_borrow %2 : $Class                          // id: %8
+//   return %7 : $(Float, @callee_guaranteed (Float) -> Float) // id: %9
+// } // end sil function 'AD__$s4main5ClassCAA8ProtocolA2aDP6methodyS2fFTW_jvp_SU'


### PR DESCRIPTION
During protocol witness SILGen for `@differentiable` class methods,
replace the `AutoDiffDerivativeFunctionIdentifier` generic signature
with the [witness thunk substitution map](https://github.com/apple/swift/blob/71dbe2b65c3e23be579dcef91668f0c000a1dd8e/include/swift/AST/Witness.h#L72-L89)'s generic signature.

Resolves TF-1180: vtable SIL verification error.

---

Example:
```swift
import _Differentiation

protocol Protocol {
  @differentiable
  func method<T: Differentiable>(_ x: T) -> Float
}

class Class: Protocol {
  @differentiable
  func method<T: Differentiable>(_ x: T) -> Float { return 0 }
}
```

SIL vtables and witness tables:

```
sil_vtable Class {
  #Class.method: <T where T : Differentiable> (Class) -> (T) -> Float : @$s4main5ClassC6methodySfx16_Differentiation14DifferentiableRzlF	// Class.method<A>(_:)
  #Class.method!jvp.SU.<T where T : Differentiable>: <T where T : Differentiable> (Class) -> (T) -> Float : @AD__$s4main5ClassC6methodySfx16_Differentiation14DifferentiableRzlF__jvp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk	// AD__$s4main5ClassC6methodySfx16_Differentiation14DifferentiableRzlF__jvp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk
  #Class.method!vjp.SU.<T where T : Differentiable>: <T where T : Differentiable> (Class) -> (T) -> Float : @AD__$s4main5ClassC6methodySfx16_Differentiation14DifferentiableRzlF__vjp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk	// AD__$s4main5ClassC6methodySfx16_Differentiation14DifferentiableRzlF__vjp_src_0_wrt_0_16_Differentiation14DifferentiableRzl_vtable_entry_thunk
  #Class.init!allocator: (Class.Type) -> () -> Class : @$s4main5ClassCACycfC	// Class.__allocating_init()
  #Class.deinit!deallocator: @$s4main5ClassCfD	// Class.__deallocating_deinit
}

sil_witness_table hidden Class: Protocol module main {
  method #Protocol.method: <Self where Self : Protocol><T where T : Differentiable> (Self) -> (T) -> Float : @$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW	// protocol witness for Protocol.method<A>(_:) in conformance Class
  method #Protocol.method!jvp.SU.<Self, T where Self : Protocol, T : Differentiable>: <Self where Self : Protocol><T where T : Differentiable> (Self) -> (T) -> Float : @AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_jvp_SU	// AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_jvp_SU
  method #Protocol.method!vjp.SU.<Self, T where Self : Protocol, T : Differentiable>: <Self where Self : Protocol><T where T : Differentiable> (Self) -> (T) -> Float : @AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_vjp_SU	// AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_vjp_SU
}
```

The fix is related to the protocol witnesses for `#Class.method!jvp.SU` and `#Class.method!vjp.SU`.

Before: error due to `class_method %2 : $Class, #Class.method!jvp.SU.<Self, T where Self : Protocol, T : Differentiable>`.
```
SIL verification failed: method does not appear in the class's vtable: VerifyClassMethodVisitor(member).Seen
Verifying instruction:
     %2 = load_borrow %1 : $*Class                // users: %8, %4, %3
->   %3 = class_method %2 : $Class, #Class.method!jvp.SU.<Self, T where Self : Protocol, T : Differentiable> : <T where T : Differentiable> (Class) -> (T) -> Float, $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, @guaranteed Class) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // user: %4
     %4 = apply %3<τ_0_0>(%0, %2) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, @guaranteed Class) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // user: %5
In function:
// AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_jvp_SU
sil private [transparent] [thunk] [ossa] @AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_jvp_SU : $@convention(witness_method: Protocol) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, @in_guaranteed Class) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) {
// %0                                             // user: %4
// %1                                             // user: %2
bb0(%0 : $*τ_0_0, %1 : $*Class):
  %2 = load_borrow %1 : $*Class                   // users: %8, %4, %3
  %3 = class_method %2 : $Class, #Class.method!jvp.SU.<Self, T where Self : Protocol, T : Differentiable> : <T where T : Differentiable> (Class) -> (T) -> Float, $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, @guaranteed Class) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // user: %4
  %4 = apply %3<τ_0_0>(%0, %2) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, @guaranteed Class) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // user: %5
  (%5, %6) = destructure_tuple %4 : $(Float, @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // users: %7, %7
  %7 = tuple (%5 : $Float, %6 : $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // user: %9
  end_borrow %2 : $Class                          // id: %8
  return %7 : $(Float, @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Float for <τ_0_0.TangentVector>) // id: %9
} // end sil function 'AD__$s4main5ClassCAA8ProtocolA2aDP6methodySfqd__16_Differentiation14DifferentiableRd__lFTW_jvp_SU'
```

After: `class_method %2 : $Class, #Class.method!jvp.SU.<T where T : Differentiable>`.