### PR TITLE
[lit] Detect lldb by checking both for lldb_build_root and that that root contains an lldb exec.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -100,6 +100,8 @@ def get_simulator_command(run_os, run_cpu, sdk_path):
 
 def get_lldb_python_path(lldb_build_root):
     lldb_path = os.path.join(lldb_build_root, 'bin', 'lldb')
+    if not os.access(lldb_path, os.F_OK):
+        return None
     return subprocess.check_output([lldb_path, "-P"]).rstrip()
 
 ###
@@ -1918,9 +1920,14 @@ config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 
 if config.lldb_build_root != "":
-    config.available_features.add('lldb')
     lldb_python_path = get_lldb_python_path(config.lldb_build_root)
-    config.substitutions.append(('%lldb-python-path', lldb_python_path))
+    if lldb_python_path == None:
+        lit_config.warning("""
+        Specified lldb_build_root, but could not find lldb in that build root
+        """)
+    else:
+        config.available_features.add('lldb')
+        config.substitutions.append(('%lldb-python-path', lldb_python_path))
 
 # Disable randomized hash seeding by default. Tests need to manually opt in to
 # random seeds by unsetting the SWIFT_DETERMINISTIC_HASHING environment


### PR DESCRIPTION
Otherwise, if one builds lldb with a specific build-script config and does not
fully build lldb, one will not be blocked from testing. With this change, one
instead gets a warning that we found a configured lldb dir, but not lldb exec.
