### PR TITLE
[WIP] Forward matching of trailing closure arguments.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -560,6 +560,11 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   100)
 
+DECL_ATTR(_trailingClosureMatching, TrailingClosureMatching,
+  OnAbstractFunction | OnSubscript | OnEnumElement | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  101)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -54,6 +54,7 @@ class GenericFunctionType;
 class LazyConformanceLoader;
 class LazyMemberLoader;
 class PatternBindingInitializer;
+enum class TrailingClosureMatching: uint8_t;
 class TrailingWhereClause;
 class TypeExpr;
 
@@ -2043,6 +2044,26 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Transpose;
+  }
+};
+
+/// Attribute that controls the matching of trailing closures.
+class TrailingClosureMatchingAttr final : public DeclAttribute {
+  TrailingClosureMatching matchingRule;
+
+public:
+  TrailingClosureMatchingAttr(SourceLoc atLoc, SourceRange range,
+                              TrailingClosureMatching matchingRule,
+                              bool implicit)
+    : DeclAttribute(DAK_TrailingClosureMatching, atLoc, range, implicit),
+      matchingRule(matchingRule) {}
+
+  TrailingClosureMatching getMatchingRule() const {
+    return matchingRule;
+  }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_TrailingClosureMatching;
   }
 };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1372,6 +1372,10 @@ ERROR(attr_only_at_non_local_scope, none,
 ERROR(projection_value_property_not_identifier,none,
       "@_projectedValueProperty name must be an identifier", ())
 
+ERROR(trailing_closure_matching_missing_dot_identifier,none,
+      "@_trailingClosureMatching parameter must be '.forward' or '.backward'",
+      ())
+
 // Access control
 ERROR(attr_access_expected_set,none,
       "expected 'set' as subject of '%0' modifier", (StringRef))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -271,6 +271,9 @@ namespace swift {
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;
 
+    /// Whether to default to the "forward" scan for trailing closure matching.
+    bool EnableForwardTrailingClosureMatching = false;
+
     /// Use Clang function types for computing canonical types.
     /// If this option is false, the clang function types will still be computed
     /// but will not be used for checking type equality.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -534,6 +534,11 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def enable_experimental_trailing_closure_matching : Flag<["-"],
+    "enable-experimental-trailing-closure-matching">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable the experimental 'forward' matching rule for trailing closures">;
+
 def enable_direct_intramodule_dependencies : Flag<["-"],
     "enable-direct-intramodule-dependencies">,
   Flags<[FrontendOption, HelpHidden]>,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1075,6 +1075,22 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_TrailingClosureMatching: {
+    Printer.printAttrName("@_trailingClosureMatching");
+    Printer << '(';
+    switch (cast<TrailingClosureMatchingAttr>(this)->getMatchingRule()) {
+    case TrailingClosureMatching::Backward:
+      Printer << ".backward";
+      break;
+
+    case TrailingClosureMatching::Forward:
+      Printer << ".forward";
+      break;
+    }
+    Printer << ')';
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -1217,6 +1233,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "derivative";
   case DAK_Transpose:
     return "transpose";
+  case DAK_TrailingClosureMatching:
+    return "_trailingClosureMatching";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -251,6 +251,9 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
+  inputArgs.AddLastArg(
+      arguments,
+      options::OPT_enable_experimental_trailing_closure_matching);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
   inputArgs.AddLastArg(arguments,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -546,6 +546,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
+  Opts.EnableForwardTrailingClosureMatching =
+      Args.hasArg(OPT_enable_experimental_trailing_closure_matching);
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1529,8 +1529,6 @@ namespace {
     /// \param callee The callee for the function being applied.
     /// \param apply The ApplyExpr that forms the call.
     /// \param argLabels The argument labels provided for the call.
-    /// \param hasTrailingClosure Whether the last argument is a trailing
-    /// closure.
     /// \param locator Locator used to describe where in this expression we are.
     ///
     /// \returns the coerced expression, which will have type \c ToType.
@@ -1538,7 +1536,6 @@ namespace {
     coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
                         ConcreteDeclRef callee, ApplyExpr *apply,
                         ArrayRef<Identifier> argLabels,
-                        bool hasTrailingClosure,
                         ConstraintLocatorBuilder locator);
 
     /// Coerce the given object argument (e.g., for the base of a
@@ -1749,7 +1746,7 @@ namespace {
       auto fullSubscriptTy = openedFullFnType->getResult()
                                   ->castTo<FunctionType>();
       index = coerceCallArguments(index, fullSubscriptTy, subscriptRef, nullptr,
-                                  argLabels, hasTrailingClosure,
+                                  argLabels,
                                   locator.withPathElement(
                                     ConstraintLocator::ApplyArgument));
       if (!index)
@@ -2574,7 +2571,6 @@ namespace {
       auto newArg = coerceCallArguments(
           expr->getArg(), fnType, witness,
           /*applyExpr=*/nullptr, expr->getArgumentLabels(),
-          expr->hasTrailingClosure(),
           cs.getConstraintLocator(expr, ConstraintLocator::ApplyArgument));
 
       expr->setInitializer(witness);
@@ -4919,7 +4915,7 @@ namespace {
       auto *newIndexExpr =
           coerceCallArguments(indexExpr, subscriptType, ref,
                               /*applyExpr*/ nullptr, labels,
-                              /*hasTrailingClosure*/ false, locator);
+                              locator);
 
       // We need to be able to hash the captured index values in order for
       // KeyPath itself to be hashable, so check that all of the subscript
@@ -5452,12 +5448,12 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
   return false;
 }
 
-Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
-                                        ConcreteDeclRef callee,
-                                        ApplyExpr *apply,
-                                        ArrayRef<Identifier> argLabels,
-                                        bool hasTrailingClosure,
-                                        ConstraintLocatorBuilder locator) {
+Expr *ExprRewriter::coerceCallArguments(
+    Expr *arg, AnyFunctionType *funcType,
+    ConcreteDeclRef callee,
+    ApplyExpr *apply,
+    ArrayRef<Identifier> argLabels,
+    ConstraintLocatorBuilder locator) {
   auto &ctx = getConstraintSystem().getASTContext();
   auto params = funcType->getParams();
 
@@ -5507,9 +5503,11 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
 
   MatchCallArgumentListener listener;
   SmallVector<ParamBinding, 4> parameterBindings;
+  auto unlabeledTrailingClosureIndex =
+      arg->getUnlabeledTrailingClosureIndexOfPackedArgument();
   bool failed = constraints::matchCallArguments(args, params,
                                                 paramInfo,
-                       arg->getUnlabeledTrailingClosureIndexOfPackedArgument(),
+                                                unlabeledTrailingClosureIndex,
                                                 /*allowFixes=*/false, listener,
                                                 parameterBindings);
 
@@ -5739,7 +5737,7 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
       (params[0].getValueOwnership() == ValueOwnership::Default ||
        params[0].getValueOwnership() == ValueOwnership::InOut)) {
     assert(newArgs.size() == 1);
-    assert(!hasTrailingClosure);
+    assert(!unlabeledTrailingClosureIndex);
     return newArgs[0];
   }
 
@@ -5752,8 +5750,9 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
       argParen->setSubExpr(newArgs[0]);
     } else {
       bool isImplicit = arg->isImplicit();
-      arg = new (ctx)
-          ParenExpr(lParenLoc, newArgs[0], rParenLoc, hasTrailingClosure);
+      arg = new (ctx) ParenExpr(
+          lParenLoc, newArgs[0], rParenLoc,
+          static_cast<bool>(unlabeledTrailingClosureIndex));
       arg->setImplicit(isImplicit);
     }
   } else {
@@ -5767,8 +5766,8 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
       }
     } else {
       // Build a new TupleExpr, re-using source location information.
-      arg = TupleExpr::create(ctx, lParenLoc, newArgs, newLabels, newLabelLocs,
-                              rParenLoc, hasTrailingClosure,
+      arg = TupleExpr::create(ctx, lParenLoc, rParenLoc, newArgs, newLabels,
+                              newLabelLocs, unlabeledTrailingClosureIndex,
                               /*implicit=*/arg->isImplicit());
     }
   }
@@ -7119,9 +7118,6 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   auto *arg = apply->getArg();
   auto *fn = apply->getFn();
 
-  bool hasTrailingClosure =
-    isa<CallExpr>(apply) && cast<CallExpr>(apply)->hasTrailingClosure();
-
   auto finishApplyOfDeclWithSpecialTypeCheckingSemantics
     = [&](ApplyExpr *apply,
           ConcreteDeclRef declRef,
@@ -7137,7 +7133,6 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         arg = coerceCallArguments(arg, fnType, declRef,
                                   apply,
                                   apply->getArgumentLabels(argLabelsScratch),
-                                  hasTrailingClosure,
                                   locator.withPathElement(
                                     ConstraintLocator::ApplyArgument));
         if (!arg) {
@@ -7341,7 +7336,6 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   if (auto fnType = cs.getType(fn)->getAs<FunctionType>()) {
     arg = coerceCallArguments(arg, fnType, callee, apply,
                               apply->getArgumentLabels(argLabelsScratch),
-                              hasTrailingClosure,
                               locator.withPathElement(
                                   ConstraintLocator::ApplyArgument));
     if (!arg) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1760,7 +1760,8 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
       newName = newNames[i];
 
     if (oldName == newName ||
-        (argList.hasTrailingClosure && i == argList.args.size()-1))
+        (argList.hasTrailingClosure && i == argList.args.size()-1 &&
+         (numMissing > 0 || numExtra > 0 || numWrong > 0)))
       continue;
 
     if (oldName.empty()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -117,6 +117,7 @@ public:
   IGNORED_ATTR(ReferenceOwnership)
   IGNORED_ATTR(OriginallyDefinedIn)
   IGNORED_ATTR(NoDerivative)
+  IGNORED_ATTR(TrailingClosureMatching)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1436,6 +1436,7 @@ namespace  {
     UNINTERESTING_ATTR(Convenience)
     UNINTERESTING_ATTR(Semantics)
     UNINTERESTING_ATTR(SetterAccess)
+    UNINTERESTING_ATTR(TrailingClosureMatching)
     UNINTERESTING_ATTR(TypeEraser)
     UNINTERESTING_ATTR(SPIAccessControl)
     UNINTERESTING_ATTR(HasStorage)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4446,6 +4446,18 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         break;
       }
 
+      case decls_block::TrailingClosureMatching_DECL_ATTR: {
+        bool isImplicit;
+        uint8_t matchingRule;
+        serialization::decls_block::TrailingClosureMatchingDeclAttrLayout
+            ::readRecord(scratch, isImplicit, matchingRule);
+
+        Attr = new (ctx) TrailingClosureMatchingAttr(
+             SourceLoc(), SourceRange(),
+             static_cast<TrailingClosureMatching>(matchingRule), isImplicit);
+        break;
+      }
+
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...) \
       case decls_block::CLASS##_DECL_ATTR: { \
         bool isImplicit; \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1705,6 +1705,12 @@ namespace decls_block {
     BCArray<IdentifierIDField>  // SPI names
   >;
 
+  using TrailingClosureMatchingDeclAttrLayout = BCRecordLayout<
+    TrailingClosureMatching_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCFixed<1>  // matching rule
+  >;
+
   using AlignmentDeclAttrLayout = BCRecordLayout<
     Alignment_DECL_ATTR,
     BCFixed<1>, // implicit flag

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2230,6 +2230,17 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_TrailingClosureMatching: {
+      auto theAttr = cast<TrailingClosureMatchingAttr>(DA);
+      auto abbrCode =
+          S.DeclTypeAbbrCodes[TrailingClosureMatchingDeclAttrLayout::Code];
+
+      TrailingClosureMatchingDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
+          static_cast<uint8_t>(theAttr->getMatchingRule()));
+      return;
+    }
+
     case DAK_Alignment: {
       auto *theAlignment = cast<AlignmentAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[AlignmentDeclAttrLayout::Code];

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,0 +1,86 @@
+// RUN: %target-typecheck-verify-swift
+
+@_trailingClosureMatching(.forward)
+func forwardMatch1(
+  a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,
+  numbers: Int..., closure2: ((Double) -> Double)? = nil,
+  closure3: (String) -> String = { $0 + "!" }
+) {
+}
+
+func testForwardMatch1(i: Int, d: Double, s: String) {
+  forwardMatch1()
+
+  // Matching closure1
+  forwardMatch1 { _ in i }
+  forwardMatch1 { _ in i } closure2: { d + $0 }
+  forwardMatch1 { _ in i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1 { _ in i } closure3: { $0 + ", " + s + "!" }
+
+  forwardMatch1(a: 5) { $0 + i }
+  forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 }
+  forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1(a: 5) { $0 + i } closure3: { $0 + ", " + s + "!" }
+
+  forwardMatch1(b: 1) { $0 + i }
+  forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 }
+  forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1(b: 1) { $0 + i } closure3: { $0 + ", " + s + "!" }
+
+  // Matching closure2
+  forwardMatch1(closure1: { $0 + i }) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } closure3: { $0 + ", " + s + "!" }
+
+  // Matching closure3
+  forwardMatch1(closure2: nil) { $0 + ", " + s + "!" }
+}
+
+@_trailingClosureMatching(.forward)
+func forwardMatchWithAutoclosure1(
+  a: String = "hello",
+  b: @autoclosure () -> Int = 17,
+  closure1: () -> String
+) { }
+
+func testForwardMatchWithAutoclosure1(i: Int, s: String) {
+  forwardMatchWithAutoclosure1 {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(a: s) {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(b: i) {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(a: s, b: i) {
+    print(s)
+    return s
+  }
+}
+
+@_trailingClosureMatching(.forward)
+func forwardMatchWithAutoclosure2(
+  a: String = "hello",
+  closure1: @autoclosure () -> (() -> String),
+  closure2: () -> Int = { 5 }
+) { }
+
+func testForwardMatchWithAutoclosure2(i: Int, s: String) {
+  forwardMatchWithAutoclosure2 {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure2(a: s) {
+    print(s)
+    return s
+  }
+
+  forwardMatchWithAutoclosure2(a: s, closure1: { s }) {
+    print(i)
+    return i
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-trailing-closure-matching
+
+func forwardMatchWithGeneric<T>( // expected-note{{'forwardMatchWithGeneric(closure1:closure2:)' declared here}}
+  closure1: T,
+  closure2: () -> Int = { 5 }
+) { }
+
+func testKnownSourceBreaks(i: Int) {
+  forwardMatchWithGeneric { i } // expected-error{{missing argument for parameter 'closure1' in call}}
+  let _: (() -> ()).Type = type { } // expected-error{{missing argument label 'of:' in call}}
+}
+
+func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
+  var arrayOfFuncs = [() -> Void]()
+  arrayOfFuncs.append { print("Hi") } // okay because the parameter is unlabeled?
+
+  fn { $0 + i} // okay because the parameter label is empty
+
+}


### PR DESCRIPTION
Introduce an experimental attribute and command-line flag to replace
the "backward" matching algorithm for unlabeled trailing closure
arguments with a simpler "forward" algorithm. In this new algorithm,
unlabeled trailing closure arguments match the next parameter in the
parameter list that can accept an unlabeled trailing closure.

The "can accept an unlabeled trailing closure" criteria looks at the
parameter itself. The parameter accepts an unlabeled trailing closure
if all of the following are true:

* The parameter is not variadic
* The parameter is not `inout`
* The adjusted type of the parameter (defined below) is a function type

The adjusted type of the parameter is the parameter's type as
declared, after performing two adjustments:

* If the parameter is an `@autoclosure`, use the result type of the
parameter's declared (function) type, before performing the second
adjustment.
* Remove all outer "optional" types.

For example, the following function illustrates both adjustments to
determine that the parameter "body" accepts an unlabeled trailing
closure:

    func doSomething(body: @autoclosure () -> (((Int) -> String)?))

This source-breaking change is accessible in one of two ways. The new attribute

    @_trailingClosureMatching(.forward)

can be applied to a function, initializer, or subscript to enable the
new forward matching algorithm for direct calls to that function. This
allows specific APIs to opt in to forward matching while leaving all
other calls unaffected.

The command-line parameter `-enable-experimental-trailing-closure-matching`
enables forward matching as the default algorithm. It is most useful
for experimenting with the source-compatibility effects of forward
matching.

Specific APIs can also explicitly request to use the current, backward
matching algorithm to maintain their existing behavior even under the
new command-line parameter, by using the other form of the new
trailing closure matching attribute:

    @_trailingClosureMatching(.backward)