### PR TITLE
[TBDGen] NFC: print duplicate symbol name before assertion.

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -70,7 +70,12 @@ void TBDGenVisitor::addSymbolInternal(StringRef name,
   if (StringSymbols && kind == SymbolKind::GlobalSymbol) {
     auto isNewValue = StringSymbols->insert(name).second;
     (void)isNewValue;
-    assert(isNewValue && "symbol appears twice");
+#ifndef NDEBUG
+    if (!isNewValue) {
+      llvm::dbgs() << "TBDGen duplicate symbol: " << name << '\n';
+      assert(false && "TBDGen symbol appears twice");
+    }
+#endif
   }
 }
 


### PR DESCRIPTION
This facilitates debugging.

Example:
```
TBDGen duplicate symbol: _$s4main5ClassC6methodyS2fFTq
Assertion failed: (false && "TBDGen symbol appears twice"), function addSymbolInternal, file swift/lib/TBDGen/TBDGen.cpp, line 76.
```