### PR TITLE
SIL: increase the module version number

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 561; // Initializers of globals.
+const uint16_t SWIFTMODULE_VERSION_MINOR = 562; // base_addr_for_offset instruction
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///


### PR DESCRIPTION
I forgot to do that in https://github.com/apple/swift/pull/32544, which introduces the new base_addr_for_offset instruction.
