### PR TITLE
PathSanitizingFileCheck: improve Python3 compatibility

### DIFF
--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -67,20 +67,21 @@ constants.""")
 
     if args.enable_windows_compatibility:
         if args.enable_yaml_compatibility:
-            slashes_re = b'(/|\\\\\\\\|\\\\\\\\\\\\\\\\)'
+            slashes_re = r'(/|\\\\|\\\\\\\\)'
         else:
-            slashes_re = b'(/|\\\\\\\\)'
+            slashes_re = r'(/|\\\\)'
     else:
-        slashes_re = b'/'
+        slashes_re = r'/'
 
-    stdin = io.open(sys.stdin.fileno(), 'rb').read()
+    stdin = io.open(sys.stdin.fileno(), 'r', encoding='utf-8', errors='ignore').read()
 
     for s in args.sanitize_strings:
-        replacement, pattern = s.encode(encoding="utf-8").split(b'=', 1)
+        replacement, pattern = s.split('=', 1)
         # Since we want to use pattern as a regex in some platforms, we need
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
-        stdin = re.sub(re.sub(b'\\\\/', slashes_re, re.escape(pattern)),
+        stdin = re.sub(re.sub('\\\\/' if sys.version_info[0] < 3 else r'[/\\]',
+                              slashes_re, re.escape(pattern)),
                        replacement,
                        stdin)
 
@@ -90,7 +91,7 @@ constants.""")
     else:
         p = subprocess.Popen(
             [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)
-        stdout, stderr = p.communicate(stdin)
+        stdout, stderr = p.communicate(stdin.encode('utf-8'))
         if stdout is not None:
             print(stdout)
         if stderr is not None:


### PR DESCRIPTION
Adjust the regex match to do a better job of sanitizing the paths.  This
improves the test coverage pass rate with Python 3.  Furthermore, handle
the unicode conversion properly that breaks with Python 3.  This further
improves the Python 3 test coverage pass rate.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
