### PR TITLE
[5.3] [sourcekit] Retain semantic annotations across queries

### DIFF
--- a/test/SourceKit/Sema/sema_annotations_saved.swift
+++ b/test/SourceKit/Sema/sema_annotations_saved.swift
@@ -1,0 +1,10 @@
+func foo() {}
+foo()
+
+// RUN: %sourcekitd-test -req=open %s -- %s \
+// RUN:    == -req=edit -offset=0 -replace="" -length=0 %s \
+// RUN:    == -req=edit -offset=0 -replace="" -length=0 %s \
+// RUN:    == -req=edit -pos=3:1 -replace="foo()" -length=0 %s \
+// RUN:    == -req=edit -offset=0 -replace="" -length=0 %s \
+// RUN:    == -req=edit -offset=0 -replace="" -length=0 %s > %t.response
+// RUN: diff -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_annotations_saved.swift
+++ b/test/SourceKit/Sema/sema_annotations_saved.swift
@@ -7,4 +7,4 @@ foo()
 // RUN:    == -req=edit -pos=3:1 -replace="foo()" -length=0 %s \
 // RUN:    == -req=edit -offset=0 -replace="" -length=0 %s \
 // RUN:    == -req=edit -offset=0 -replace="" -length=0 %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: %diff -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_annotations_saved.swift.response
+++ b/test/SourceKit/Sema/sema_annotations_saved.swift.response
@@ -1,0 +1,66 @@
+{
+  key.annotations: [
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 14,
+      key.length: 3
+    }
+  ],
+  key.diagnostic_stage: source.diagnostic.stage.swift.sema,
+  key.syntaxmap: [
+  ],
+  key.substructure: [
+  ]
+}
+{
+  key.annotations: [
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 14,
+      key.length: 3
+    }
+  ],
+  key.diagnostic_stage: source.diagnostic.stage.swift.sema,
+  key.syntaxmap: [
+  ],
+  key.substructure: [
+  ]
+}
+{
+  key.annotations: [
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 14,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 20,
+      key.length: 3
+    }
+  ],
+  key.diagnostic_stage: source.diagnostic.stage.swift.sema,
+  key.syntaxmap: [
+  ],
+  key.substructure: [
+  ]
+}
+{
+  key.annotations: [
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 14,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 20,
+      key.length: 3
+    }
+  ],
+  key.diagnostic_stage: source.diagnostic.stage.swift.sema,
+  key.syntaxmap: [
+  ],
+  key.substructure: [
+  ]
+}


### PR DESCRIPTION
* **Explanation**: Previously, when returning semantic highlighting tokens, we would remove the tokens and if the editor queried again it would receive no semantic tokens the second time. This was not a regression, but we found some cases where this happened in practice.  After this change we keep the tokens around so that the requests for highlighting are independent, making it more robust.
* **Scope**: Affects semantic highlighting in sourcekitd.
* **Risk**: Low. Makes repeated queries for semantic highlighting return the same result instead of dropping values. The logic for modifying the highlighting after an edit is unchanged.
* **Testing**: Regression tests added. Also tested manually in Xcode.
* **Issue**: rdar://64904029
* **Reviewer**: @akyrtzi 