### PR TITLE
Add -sil-inline-never-function flag

### DIFF
--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -19,6 +19,10 @@ llvm::cl::opt<std::string>
     SILInlineNeverFuns("sil-inline-never-functions", llvm::cl::init(""),
                        llvm::cl::desc("Never inline functions whose name "
                                       "includes this string."));
+llvm::cl::list<std::string>
+    SILInlineNeverFun("sil-inline-never-function", llvm::cl::CommaSeparated,
+                       llvm::cl::desc("Never inline functions whose name "
+                                      "is this string"));
 
 //===----------------------------------------------------------------------===//
 //                               ConstantTracker
@@ -696,6 +700,13 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   if (!SILInlineNeverFuns.empty()
       && Callee->getName().find(SILInlineNeverFuns, 0) != StringRef::npos)
     return nullptr;
+
+  if (!SILInlineNeverFun.empty() &&
+      SILInlineNeverFun.end() != std::find(SILInlineNeverFun.begin(),
+                                           SILInlineNeverFun.end(),
+                                           Callee->getName())) {
+    return nullptr;
+  }
 
   if (!Callee->shouldOptimize()) {
     return nullptr;

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil -Xllvm '-sil-inline-never-functions=$sSa6appendyy' %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil -Xllvm '-sil-inline-never-functions=$sSa6appendyy' -Xllvm -sil-inline-never-function='$sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lFSi_SaySiGTg5' %s | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // This is an end-to-end test of the Array.append(contentsOf:) ->


### PR DESCRIPTION
-sil-inline-never-functions already exists, but it does a substring match. This is not desired all the time. Add
-sil-inline-never-function flag that does a full string match and avoids inlining functions with that name

