### PR TITLE
Fix typo in 'KeyedEncodingContainer.superEncoder' documentation.

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -471,7 +471,7 @@ public protocol KeyedEncodingContainerProtocol {
     forKey key: Key
   ) -> UnkeyedEncodingContainer
 
-  /// Stores a new nested container for the default `super` key and returns A
+  /// Stores a new nested container for the default `super` key and returns a
   /// new encoder instance for encoding `super` into that container.
   ///
   /// Equivalent to calling `superEncoder(forKey:)` with
@@ -480,7 +480,7 @@ public protocol KeyedEncodingContainerProtocol {
   /// - returns: A new encoder to pass to `super.encode(to:)`.
   mutating func superEncoder() -> Encoder
 
-  /// Stores a new nested container for the given key and returns A new encoder
+  /// Stores a new nested container for the given key and returns a new encoder
   /// instance for encoding `super` into that container.
   ///
   /// - parameter key: The key to encode `super` for.
@@ -911,7 +911,7 @@ public struct KeyedEncodingContainer<K: CodingKey> :
     return _box.nestedUnkeyedContainer(forKey: key)
   }
 
-  /// Stores a new nested container for the default `super` key and returns A
+  /// Stores a new nested container for the default `super` key and returns a
   /// new encoder instance for encoding `super` into that container.
   ///
   /// Equivalent to calling `superEncoder(forKey:)` with
@@ -922,7 +922,7 @@ public struct KeyedEncodingContainer<K: CodingKey> :
     return _box.superEncoder()
   }
 
-  /// Stores a new nested container for the given key and returns A new encoder
+  /// Stores a new nested container for the given key and returns a new encoder
   /// instance for encoding `super` into that container.
   ///
   /// - parameter key: The key to encode `super` for.


### PR DESCRIPTION
Explanation: Cherry pick docs typo fix from #32252.  The published documentation comes from the in-source comments on the branch that corresponds to the current shipping Swift version, hence the need to cherry pick.

Scope: Correct 'A' to 'a' in the middle of a sentence.

Issue: <rdar://problem/64136400>

Risk: Low.  Changes to the  docs should have no impact on behavior.

Reviewer: @rxwei made the original change. @amartini51 reviewed on the original PR.