### PR TITLE
[5.3] Use Formal Access To Compute Override Elision Check

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -749,8 +749,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (auto *BD = VD->getOverriddenDecl()) {
         if (!BD->hasClangNode() &&
-            VD->isEffectiveLinkageMoreVisibleThan(BD))
+            !BD->getFormalAccessScope(VD->getDeclContext(),
+                                      /*treatUsableFromInlineAsPublic*/ true)
+                 .isPublic()) {
           return false;
+        }
       }
     }
     break;

--- a/test/ModuleInterface/skip-override-keyword.swift
+++ b/test/ModuleInterface/skip-override-keyword.swift
@@ -2,13 +2,23 @@
 // RUN: %target-swift-frontend -typecheck -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
 
+// RUN: %target-swift-frontend -typecheck -enable-testing -module-name FooWithTesting -emit-module-interface-path %t/FooWithTesting.swiftinterface %s
+// RUN: %target-swift-frontend -compile-module-from-interface %t/FooWithTesting.swiftinterface -o %t/FooWithTesting.swiftmodule
+
 public class BaseClass {
+  init() { }
   var property: Int { return 1 }
   func doSomething() { }
   subscript(index: Int) -> Int { get { return 0 } set(newValue) {} }
+  @usableFromInline func doSomethingInline() {}
+  @usableFromInline func doSomethingUsableFromInline() {}
 }
+
 public class DerivedClass: BaseClass {
+  public override init() { super.init() }
   public override var property : Int { return 0 }
   public override func doSomething() { }
   public override subscript(index: Int) -> Int { get {return 0} set(newValue) {} }
+  @inlinable public override func doSomethingInline() { super.doSomethingInline() }
+  @usableFromInline override func doSomethingUsableFromInline() { super.doSomethingUsableFromInline() }
 }


### PR DESCRIPTION
Cherry-pick of #32638 

The effective access of an overridden declaration is subject to
escalation by -enable-testing. When this flag is enabled, an
interface containing an internal-overriding-public declaration will
still print `override`. This is because the effective access of the base
of the override is formally internal but effectively public.

Instead, use the formal access scope of the overridden declaration to
compute its access relative to the override. While I'm here, catch the
case where the base declaration is `@usableFromInline` and therefore
*will* be printed in the interface. We treat these declarations as
effectively public for the purpose of printing `override`.

Resolves rdar://64969741
