### PR TITLE
[test] Add OpenBSD to stable ABI testing targets.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -699,7 +699,7 @@ if (run_os == 'maccatalyst'):
   target_os_abi = 'macosx'
   target_os_is_maccatalyst = "TRUE"
   config.available_features.add("OS=ios")
-if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android', 'linux-androideabi']):
+if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android', 'linux-androideabi']):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')
 config.substitutions.append(('%target-os-abi', target_os_abi))


### PR DESCRIPTION
See #30391, #30296. Neither IRGen/conditional_conformances.swift nor
IRGen/class_resilience.swift pass on OpenBSD unless
target_mandates_stable_abi = TRUE.

cc @kubamracek