### PR TITLE
[Gardening] Use os(..) checks instead of canImport(Darwin) in CTypes.swift

### DIFF
--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -14,9 +14,9 @@
 
 import Swift
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin.C.tgmath
-#elseif canImport(Glibc)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(Windows)
   import MSVCRT

--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
 @objc
 public enum MachErrorCode : Int32 {
@@ -202,4 +202,4 @@ public enum MachErrorCode : Int32 {
   /// The requested property cannot be changed at this time.
   case policyStatic             = 51
 }
-#endif // canImport(Darwin)
+#endif // os(macOS) || os(iOS) || os(tvOS) || os(watchOS)

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Enumeration describing POSIX error codes.
 @objc

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -17,7 +17,7 @@ import SwiftOverlayShims
 import ucrt
 #endif
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 //===----------------------------------------------------------------------===//
 // MacTypes.h
 //===----------------------------------------------------------------------===//
@@ -103,7 +103,7 @@ public var errno : Int32 {
 // stdio.h
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin) || os(FreeBSD) || os(PS4)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(PS4)
 public var stdin : UnsafeMutablePointer<FILE> {
   get {
     return __stdinp
@@ -248,7 +248,7 @@ public var S_IFBLK: mode_t  { return mode_t(0o060000) }
 public var S_IFREG: mode_t  { return mode_t(0o100000) }
 public var S_IFLNK: mode_t  { return mode_t(0o120000) }
 public var S_IFSOCK: mode_t { return mode_t(0o140000) }
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 public var S_IFWHT: mode_t  { return mode_t(0o160000) }
 #endif
 
@@ -271,7 +271,7 @@ public var S_ISUID: mode_t  { return mode_t(0o004000) }
 public var S_ISGID: mode_t  { return mode_t(0o002000) }
 public var S_ISVTX: mode_t  { return mode_t(0o001000) }
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 public var S_ISTXT: mode_t  { return S_ISVTX }
 public var S_IREAD: mode_t  { return S_IRUSR }
 public var S_IWRITE: mode_t { return S_IWUSR }
@@ -315,7 +315,7 @@ public func ioctl(
 // unistd.h
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 @available(*, unavailable, message: "Please use threads or posix_spawn*()")
 public func fork() -> Int32 {
   fatalError("unavailable function can't be called")
@@ -331,7 +331,7 @@ public func vfork() -> Int32 {
 // signal.h
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 public var SIG_DFL: sig_t? { return nil }
 public var SIG_IGN: sig_t { return unsafeBitCast(1, to: sig_t.self) }
 public var SIG_ERR: sig_t { return unsafeBitCast(-1, to: sig_t.self) }
@@ -395,10 +395,10 @@ public typealias Semaphore = UnsafeMutablePointer<sem_t>
 
 /// The value returned by `sem_open()` in the case of failure.
 public var SEM_FAILED: Semaphore? {
-#if canImport(Darwin)
-  // The value is ABI.  Value verified to be correct for macOS, iOS, watchOS, tvOS.
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  // The value is ABI.  Value verified to be correct for OS X, iOS, watchOS, tvOS.
   return Semaphore(bitPattern: -1)
-#elseif canImport(Glibc)
+#elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   // The value is ABI.  Value verified to be correct on Glibc.
   return Semaphore(bitPattern: 0)
 #else
@@ -429,7 +429,7 @@ public func sem_open(
 //===----------------------------------------------------------------------===//
 
 // Some platforms don't have `extern char** environ` imported from C.
-#if canImport(Darwin) || os(FreeBSD) || os(OpenBSD) || os(PS4)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(OpenBSD) || os(PS4)
 public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
   return _swift_stdlib_getEnviron()
 }

--- a/stdlib/public/Platform/TiocConstants.swift
+++ b/stdlib/public/Platform/TiocConstants.swift
@@ -13,7 +13,7 @@
 // Tty ioctl request constants, needed only on Darwin and FreeBSD.
 
 // Constants available on all platforms, also available on Linux.
-#if canImport(Darwin) || os(FreeBSD) || os(Haiku)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(FreeBSD) || os(Haiku)
 
 /// Set exclusive use of tty.
 public var TIOCEXCL: UInt { return 0x2000740d }
@@ -115,7 +115,7 @@ public var TIOCGLTC: UInt { return 0x40067474 }
 
 
 // Darwin only constants, also available on Linux.
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Get termios struct.
 public var TIOCGETA: UInt { return 0x40487413 }

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -234,7 +234,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 
 % end
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 // Unary intrinsic functions
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -24,7 +24,7 @@ public func _stdlib_isOSVersionAtLeast(
   _ minor: Builtin.Word,
   _ patch: Builtin.Word
 ) -> Builtin.Int1 {
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   if Int(major) == 9999 {
     return true._value
   }

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -67,7 +67,7 @@ public typealias CFloat = Float
 public typealias CDouble = Double
 
 /// The C 'long double' type.
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 // On Darwin, long double is Float80 on x86, and Double otherwise.
 #if arch(x86_64) || arch(i386)
 public typealias CLongDouble = Float80
@@ -231,7 +231,7 @@ extension UInt {
 }
 
 /// A wrapper around a C `va_list` pointer.
-#if arch(arm64) && !(canImport(Darwin) || os(Windows))
+#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 @frozen
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -590,7 +590,7 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_NFKC_CASEFOLDED)
   }
 
-#if canImport(Darwin)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   // FIXME: These properties were introduced in ICU 57, but Ubuntu 16.04 comes
   // with ICU 55 so the values won't be correct there. Exclude them on
   // non-Darwin platforms for now; bundling ICU with the toolchain would resolve

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -91,7 +91,7 @@ internal let _countGPRegisters = 16
 @usableFromInline
 internal let _registerSaveWords = _countGPRegisters
 
-#elseif arch(arm64) && !(canImport(Darwin) || os(Windows))
+#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 // ARM Procedure Call Standard for aarch64. (IHI0055B)
 // The va_list type may refer to any parameter in a parameter list may be in one
 // of three memory locations depending on its type and position in the argument
@@ -419,7 +419,7 @@ extension Float80: CVarArg, _CVarArgAligned {
 }
 #endif
 
-#if (arch(x86_64) && !os(Windows)) || arch(s390x) || (arch(arm64) && !(canImport(Darwin) || os(Windows)))
+#if (arch(x86_64) && !os(Windows)) || arch(s390x) || (arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows)))
 
 /// An object that can manage the lifetime of storage backing a
 /// `CVaListPointer`.


### PR DESCRIPTION
Reverts a small part of cddf73ecdbd79edf456fe17a7dba19a8adff9186.