### PR TITLE
[CS] Avoid checking RHS of one-way constraint for reactivation

### DIFF
--- a/test/Constraints/rdar64890308.swift
+++ b/test/Constraints/rdar64890308.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+
+// rdar://64890308: Make sure we don't leave one-way constraints unsolved.
+
+import Swift
+
+@_functionBuilder
+class ArrayBuilder<Element> {
+  static func buildBlock() -> [Element] { [] }
+  static func buildBlock(_ elt: Element) -> [Element] { [elt] }
+  static func buildBlock(_ elts: Element...) -> [Element] { elts }
+}
+
+func foo<T>(@ArrayBuilder<T> fn: () -> [T]) {}
+
+// FIXME(SR-13132): This should compile.
+foo { // expected-error {{type of expression is ambiguous without more context}}
+  ""
+}
+
+struct S<T> {
+  init(_: T.Type) {}
+  func overloaded() -> [T] { [] }
+  func overloaded(_ x: T) -> [T] { [x] }
+  func overloaded(_ x: T...) -> [T] { x }
+}
+
+func bar<T>(_ x: T, _ fn: (T, T.Type) -> [T]) {}
+bar("") { x, ty in
+  (Builtin.one_way(S(ty).overloaded(x)))
+}


### PR DESCRIPTION
Previously we would only gather one-way constraints if they were found through a type variable in their right hand side. However we would incorrectly check this against the type variable that we started the search at. This meant that if the constraint was found through a fixed binding, we would never return it, and could therefore fail to re-activate it, leaving it unsolved.

Fix this issue by simply removing the check for the RHS, and letting the constraint system handle it instead.

Resolves rdar://64890308.

