### PR TITLE
[build] Add LTO flag to link options

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -121,6 +121,7 @@ function(_add_host_variant_c_compile_link_flags name)
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
   if (_lto_flag_out)
     target_compile_options(${name} PRIVATE ${_lto_flag_out})
+    target_link_options(${name} PRIVATE ${_lto_flag_out})
   endif()
 endfunction()
 


### PR DESCRIPTION
After the refactoring in #31612, LTO flag is only added to compile
flags -- we need to pass this only when linking.

Addresses rdar://65037856