### PR TITLE
[Parser] Accept @_spi without an argument on imports

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1741,6 +1741,10 @@ ERROR(spi_attribute_on_protocol_requirement,none,
 ERROR(spi_attribute_on_frozen_stored_properties,none,
       "stored property %0 cannot be declared '@_spi' in a '@frozen' struct",
       (DeclName))
+ERROR(default_spi_attribute_on_non_import,none,
+      "%0 %1 needs an SPI identifier; "
+      "only import declarations can use an empty '@_spi'",
+      (DescriptiveDeclKind, DeclName))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -997,12 +997,11 @@ void PrintAST::printAttributes(const Decl *D) {
 
     // SPI groups
     if (Options.PrintSPIs) {
-      interleave(D->getSPIGroups(),
-             [&](Identifier spiName) {
-               Printer.printAttrName("_spi", true);
-               Printer << "(" << spiName << ") ";
-             },
-             [&] { Printer << ""; });
+      for (Identifier spiName: D->getSPIGroups()) {
+        Printer.printAttrName("_spi", true);
+        if (!spiName.empty())
+          Printer << "(" << spiName << ") ";
+      }
       Options.ExcludeAttrList.push_back(DAK_SPIAccessControl);
     }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -131,8 +131,12 @@ static void printImports(raw_ostream &out,
     if (Opts.PrintSPIs) {
       llvm::SmallSetVector<Identifier, 4> spis;
       M->lookupImportedSPIGroups(importedModule, spis);
-      for (auto spiName : spis)
-        out << "@_spi(" << spiName << ") ";
+      for (Identifier spiName : spis) {
+        out << "@_spi";
+        if (!spiName.empty())
+          out << "(" << spiName << ")";
+        out << " ";
+      }
     }
 
     out << "import ";

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1579,32 +1579,32 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   }
 
   case DAK_SPIAccessControl: {
+    SmallVector<Identifier, 1> spiGroups;
+
     if (!consumeIf(tok::l_paren)) {
-      diagnose(Loc, diag::attr_expected_lparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
-    }
+      // Default anonymous SPI group.
+      spiGroups.push_back(Identifier());
+      AttrRange = SourceRange(Loc);
+    } else {
+      if (!Tok.is(tok::identifier) ||
+          Tok.isContextualKeyword("set")) {
+        diagnose(getEndOfPreviousLoc(), diag::attr_access_expected_spi_name);
+        consumeToken();
+        consumeIf(tok::r_paren);
+        return false;
+      }
 
-    SmallVector<Identifier, 4> spiGroups;
-
-    if (!Tok.is(tok::identifier) ||
-        Tok.isContextualKeyword("set")) {
-      diagnose(getEndOfPreviousLoc(), diag::attr_access_expected_spi_name);
+      auto text = Tok.getText();
+      spiGroups.push_back(Context.getIdentifier(text));
       consumeToken();
-      consumeIf(tok::r_paren);
-      return false;
-    }
 
-    auto text = Tok.getText();
-    spiGroups.push_back(Context.getIdentifier(text));
-    consumeToken();
+      AttrRange = SourceRange(Loc, Tok.getLoc());
 
-    AttrRange = SourceRange(Loc, Tok.getLoc());
-
-    if (!consumeIf(tok::r_paren)) {
-      diagnose(Loc, diag::attr_expected_rparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
+      if (!consumeIf(tok::r_paren)) {
+        diagnose(Loc, diag::attr_expected_rparen, AttrName,
+                 DeclAttribute::isDeclModifier(DK));
+        return false;
+      }
     }
 
     Attributes.add(SPIAccessControlAttr::create(Context, AtLoc, AttrRange,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -917,6 +917,17 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
           diagnoseAndRemoveAttr(attr,
                                 diag::spi_attribute_on_frozen_stored_properties,
                                 VD->getName());
+
+    // Allow the default @_spi on imports only.
+    if (!isa<ImportDecl>(D)) {
+      for (Identifier spi : attr->getSPIGroups())
+        if (spi.empty()) {
+          diagnoseAndRemoveAttr(attr,
+                                diag::default_spi_attribute_on_non_import,
+                                VD->getDescriptiveKind(), VD->getName());
+          break;
+        }
+    }
   }
 }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2098,7 +2098,10 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc) {
     while (!spisStr.empty()) {
       StringRef nextComponent;
       std::tie(nextComponent, spisStr) = spisStr.split('\0');
-      dependency.spiGroups.push_back(ctx.getIdentifier(nextComponent));
+
+      Identifier id = nextComponent.empty() ? Identifier()
+                                            : ctx.getIdentifier(nextComponent);
+      dependency.spiGroups.push_back(id);
     }
 
     if (!module->hasResolvedImports()) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2221,7 +2221,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       SmallVector<IdentifierID, 4> spis;
       for (auto spi : theAttr->getSPIGroups()) {
-        assert(!spi.empty() && "Empty SPI name");
+        assert(!spi.empty() && "Empty SPI name on a non-import decl");
         spis.push_back(S.addDeclBaseNameRef(spi));
       }
 

--- a/test/SPI/Inputs/spi_helper.swift
+++ b/test/SPI/Inputs/spi_helper.swift
@@ -1,5 +1,8 @@
 /// Library defining SPI decls
 
+import Swift
+@_spi @_spi(ARandomSPI) import Swift
+
 public protocol PublicProto {
   associatedtype Assoc
 }

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -8,6 +8,7 @@
 @_spi(+) public func invalidSPIName() {} // expected-error {{expected an SPI identifier as subject of the '@_spi' attribute}}
 @_spi(🤔) public func emojiNamedSPI() {}
 @_spi() public func emptyParensSPI() {} // expected-error {{expected an SPI identifier as subject of the '@_spi' attribute}}
+@_spi public func defaultSPI() {} // expected-error {{global function 'defaultSPI()' needs an SPI identifier; only import declarations can use an empty '@_spi'}} {{1-7=}}
 @_spi(set) public func keywordSPI() {} // expected-error {{expected an SPI identifier as subject of the '@_spi' attribute}}
 
 @_spi(S) public class SPIClass {} // expected-note 2 {{type declared here}}

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -21,9 +21,12 @@
 // RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/merged.swiftinterface
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/merged.private.swiftinterface
 
-@_spi(HelperSPI) @_spi(OtherSPI) @_spi(OtherSPI) import SPIHelper
+@_spi(HelperSPI) @_spi(OtherSPI) @_spi(OtherSPI) @_spi import SPIHelper
 // CHECK-PUBLIC: import SPIHelper
-// CHECK-PRIVATE: @_spi(OtherSPI) @_spi(HelperSPI) import SPIHelper
+// CHECK-PUBLIC-NOT: OtherSPI
+// CHECK-PUBLIC-NOT: HelperSPI
+// CHECK-PUBLIC-NOT: @_spi
+// CHECK-PRIVATE: @_spi @_spi(OtherSPI) @_spi(HelperSPI) import SPIHelper
 
 public func foo() {}
 // CHECK-PUBLIC: foo()

--- a/test/SPI/spi_client.swift
+++ b/test/SPI/spi_client.swift
@@ -16,7 +16,7 @@
 // RUN: rm %t/SPIHelper.private.swiftinterface
 // RUN: not %target-swift-frontend -typecheck -I %t
 
-@_spi(HelperSPI) import SPIHelper
+@_spi(HelperSPI) @_spi import SPIHelper
 
 // Use as SPI
 publicFunc()


### PR DESCRIPTION
Accept `@_spi import Lib` to prepare for SPI imports to appear only in the private swiftinterface files. This attribute without an argument has no effect at this time.