### PR TITLE
test: migrate tests to Python3 by default

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -351,7 +351,7 @@ _Block_release(void) { }\n")
       endif()
 
       execute_process(COMMAND
-          $<TARGET_FILE:Python2::Interpreter> "-c" "import psutil"
+          $<TARGET_FILE:Python3::Interpreter> "-c" "import psutil"
           RESULT_VARIABLE python_psutil_status
           TIMEOUT 1 # second
           ERROR_QUIET)
@@ -415,7 +415,7 @@ _Block_release(void) { }\n")
             ${command_upload_swift_reflection_test}
             ${command_clean_test_results_dir}
             COMMAND
-              $<TARGET_FILE:Python2::Interpreter> "${LIT}"
+              $<TARGET_FILE:Python3::Interpreter> "${LIT}"
               ${LIT_ARGS}
               "--param" "swift_test_subset=${test_subset}"
               "--param" "swift_test_mode=${test_mode}"
@@ -434,7 +434,7 @@ _Block_release(void) { }\n")
             ${command_upload_swift_reflection_test}
             ${command_clean_test_results_dir}
             COMMAND
-              $<TARGET_FILE:Python2::Interpreter> "${LIT}"
+              $<TARGET_FILE:Python3::Interpreter> "${LIT}"
               ${LIT_ARGS}
               "--param" "swift_test_subset=${test_subset}"
               "--param" "swift_test_mode=${test_mode}"


### PR DESCRIPTION
This changes the python interpreter used to invoke the tests to Python3.
Python2 has been EOL'ed by the Python Software Foundation.  This
migration enables the Swift test suite to run with Python 3 instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
