### PR TITLE
Disable a RUN line in osx-targets.swift

### DIFF
--- a/test/IRGen/osx-targets.swift
+++ b/test/IRGen/osx-targets.swift
@@ -1,6 +1,8 @@
 // RUN: %swift %s -emit-ir | %FileCheck %s
 // RUN: %swift -target x86_64-apple-macosx10.51 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
-// RUN: %swift -target x86_64-apple-darwin55 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
+
+// disable this test until macOS 11 support lands in Swift.
+// : %swift -target x86_64-apple-darwin55 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
 
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
Darwin 55 is now translated to macOS 46 after the LLVM changes landed that added support for macOS 11. This change temporarily disables the RUN line in the test that uses the `darwin55` triple until the appropriate fix is upstreamed on the swift side.

(cherry picked from commit f1bba3e1bfbc85b1cd8864ebc69c1a429bc86490)
