### PR TITLE
test: make `validate_parse` more python3 friendly

### DIFF
--- a/utils/incrparse/validate_parse.py
+++ b/utils/incrparse/validate_parse.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import argparse
 import difflib
+import io
 import os
 import sys
 
@@ -108,8 +109,8 @@ def main():
         sys.exit(1)
 
     # Check if the two syntax trees are the same
-    lines = difflib.unified_diff(open(incremental_serialized_file).readlines(),
-                                 open(post_edit_serialized_file).readlines(),
+    lines = difflib.unified_diff(io.open(incremental_serialized_file, 'r', encoding='utf-8', errors='ignore').readlines(),
+                                 io.open(post_edit_serialized_file, 'r', encoding='utf-8', errors='ignore').readlines(),
                                  fromfile=incremental_serialized_file,
                                  tofile=post_edit_serialized_file)
     diff = '\n'.join(line for line in lines)

--- a/utils/incrparse/validate_parse.py
+++ b/utils/incrparse/validate_parse.py
@@ -109,8 +109,10 @@ def main():
         sys.exit(1)
 
     # Check if the two syntax trees are the same
-    lines = difflib.unified_diff(io.open(incremental_serialized_file, 'r', encoding='utf-8', errors='ignore').readlines(),
-                                 io.open(post_edit_serialized_file, 'r', encoding='utf-8', errors='ignore').readlines(),
+    lines = difflib.unified_diff(io.open(incremental_serialized_file, 'r',
+                                         encoding='utf-8', errors='ignore').readlines(),
+                                 io.open(post_edit_serialized_file, 'r',
+                                         encoding='utf-8', errors='ignore').readlines(),
                                  fromfile=incremental_serialized_file,
                                  tofile=post_edit_serialized_file)
     diff = '\n'.join(line for line in lines)


### PR DESCRIPTION
Use `io.open` to open the files with the correct encoding and to allow
proper newline specification.  This allows the script to be python 2 and
python 3 compatible.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
