### PR TITLE
[5.3] [CS] Avoid checking RHS of one-way constraint for reactivation

### DIFF
--- a/test/Constraints/rdar64890308.swift
+++ b/test/Constraints/rdar64890308.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+
+// rdar://64890308: Make sure we don't leave one-way constraints unsolved.
+
+import Swift
+
+@_functionBuilder
+class ArrayBuilder<Element> {
+  static func buildBlock() -> [Element] { [] }
+  static func buildBlock(_ elt: Element) -> [Element] { [elt] }
+  static func buildBlock(_ elts: Element...) -> [Element] { elts }
+}
+
+func foo<T>(@ArrayBuilder<T> fn: () -> [T]) {}
+foo {
+  ""
+}
+
+struct S<T> {
+  init(_: T.Type) {}
+  func overloaded() -> [T] { [] }
+  func overloaded(_ x: T) -> [T] { [x] }
+  func overloaded(_ x: T...) -> [T] { x }
+}
+
+func bar<T>(_ x: T, _ fn: (T, T.Type) -> [T]) {}
+bar("") { x, ty in
+  (Builtin.one_way(S(ty).overloaded(x)))
+}


### PR DESCRIPTION
5.3 cherry-pick of https://github.com/apple/swift/pull/32673.

---

- **Explanation**: Fixes a compiler crash that can potentially occur when using a function builder.

- **Scope**: Fixes a 5.3 regression with function builders.

- **Radar**: rdar://64890308

- **Risk**: Medium-low: The fix modifies constraint re-activation, but is isolated to one-way constraints that haven't split the constraint system, and will cause us to re-activate strictly more constraints.

- **Testing**: Added unit test.

- **Reviewer**: @xedin