### PR TITLE
Add bug reference to XFAIL operator tests

### DIFF
--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
 //
-// We can't yet call member functions correctly on Windows.
+// We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: OS=windows-msvc
 
 import MemberInline

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -2,7 +2,7 @@
 //
 // REQUIRES: executable_test
 //
-// We can't yet call member functions correctly on Windows.
+// We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: OS=windows-msvc
 
 import MemberInline


### PR DESCRIPTION
This addresses a review comment from https://github.com/apple/swift/pull/32293 that I missed.