### PR TITLE
test: adjust `PathSanitizingFileCheck` for Python 3

### DIFF
--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -81,7 +81,7 @@ constants.""")
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
         stdin = re.sub(re.sub('\\\\/' if sys.version_info[0] < 3 else r'[/\\]',
-                              slashes_re, re.escape(pattern)),
+                              slashes_re, pattern),
                        replacement,
                        stdin)
 


### PR DESCRIPTION
The `re.escape` will escape `-` which will result in a failure to match
paths if there is a `-` in the name.  This improves the path
sanitization to work with such a path.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
