### PR TITLE
test: make `test_util` more Python 3 friendly

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -183,6 +183,9 @@ def append_to_env_path(directory):
     config.environment['PATH'] = \
         os.path.pathsep.join((directory, config.environment['PATH']))
 
+if kIsWindows:
+    config.environment['PYTHONIOENCODING'] = 'UTF8'
+
 # Tweak the PATH to include the tools dir and the scripts dir.
 if swift_obj_root is not None:
     llvm_tools_dir = getattr(config, 'llvm_tools_dir', None)

--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -104,14 +104,19 @@ def parseLine(line, line_no, test_case, incremental_edit_args, reparse_args,
             # Nothing more to do
             line = ''
 
-    return (pre_edit_line.encode('utf-8'), post_edit_line.encode('utf-8'), current_reparse_start)
+    return (pre_edit_line.encode('utf-8'),
+            post_edit_line.encode('utf-8'),
+            current_reparse_start)
 
 
 def prepareForIncrParse(test_file, test_case, pre_edit_file, post_edit_file,
                         incremental_edit_args, reparse_args):
-    with io.open(test_file, mode='r', encoding='utf-8', newline='\n') as test_file_handle, \
-            io.open(pre_edit_file, mode='w+', encoding='utf-8', newline='\n') as pre_edit_file_handle, \
-            io.open(post_edit_file, mode='w+', encoding='utf-8', newline='\n') as post_edit_file_handle:
+    with io.open(test_file, mode='r', encoding='utf-8',
+                 newline='\n') as test_file_handle, \
+            io.open(pre_edit_file, mode='w+', encoding='utf-8',
+                    newline='\n') as pre_edit_file_handle, \
+            io.open(post_edit_file, mode='w+', encoding='utf-8',
+                    newline='\n') as post_edit_file_handle:
 
         current_reparse_start = None
 

--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import argparse
+import io
 import os
 import re
 import subprocess
@@ -21,6 +22,7 @@ def escapeCmdArg(arg):
 
 
 def run_command(cmd):
+    cmd = list(map(lambda s: s.encode('utf-8'), cmd))
     print(' '.join([escapeCmdArg(arg) for arg in cmd]))
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
@@ -56,7 +58,7 @@ def parseLine(line, line_no, test_case, incremental_edit_args, reparse_args,
                 # Compute the -incremental-edit argument for swift-syntax-test
                 column = len(pre_edit_line) + len(prefix) + 1
                 edit_arg = '%d:%d-%d:%d=%s' % \
-                    (line_no, column, line_no, column + len(pre_edit),
+                    (line_no, column, line_no, column + len(pre_edit.encode('utf-8')),
                      post_edit)
                 incremental_edit_args.append('-incremental-edit')
                 incremental_edit_args.append(edit_arg)
@@ -102,14 +104,14 @@ def parseLine(line, line_no, test_case, incremental_edit_args, reparse_args,
             # Nothing more to do
             line = ''
 
-    return (pre_edit_line, post_edit_line, current_reparse_start)
+    return (pre_edit_line.encode('utf-8'), post_edit_line.encode('utf-8'), current_reparse_start)
 
 
 def prepareForIncrParse(test_file, test_case, pre_edit_file, post_edit_file,
                         incremental_edit_args, reparse_args):
-    with open(test_file, mode='r') as test_file_handle, \
-            open(pre_edit_file, mode='w+b') as pre_edit_file_handle, \
-            open(post_edit_file, mode='w+b') as post_edit_file_handle:
+    with io.open(test_file, mode='r', encoding='utf-8', newline='\n') as test_file_handle, \
+            io.open(pre_edit_file, mode='w+', encoding='utf-8', newline='\n') as pre_edit_file_handle, \
+            io.open(post_edit_file, mode='w+', encoding='utf-8', newline='\n') as post_edit_file_handle:
 
         current_reparse_start = None
 
@@ -121,8 +123,8 @@ def prepareForIncrParse(test_file, test_case, pre_edit_file, post_edit_file,
             (pre_edit_line, post_edit_line, current_reparse_start) = \
                 parseLineRes
 
-            pre_edit_file_handle.write(pre_edit_line)
-            post_edit_file_handle.write(post_edit_line)
+            pre_edit_file_handle.write(pre_edit_line.decode('utf-8'))
+            post_edit_file_handle.write(post_edit_line.decode('utf-8'))
 
             line_no += 1
 
@@ -231,7 +233,7 @@ def serializeIncrParseMarkupFile(test_file, test_case, mode,
         if print_visual_reuse_info:
             print(output)
     except subprocess.CalledProcessError as e:
-        raise TestFailedError(e.output)
+        raise TestFailedError(e.output.decode('utf-8'))
 
 
 def main():


### PR DESCRIPTION
This uses `io.open` to allow `test_util` to open with the encoding and
newline handling across python 2 and python 3.  With this change, the
test suite failures are within the single digits locally.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
