### PR TITLE
[AutoDiff] Disallow differentiation of opaque-result-typed functions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3151,6 +3151,8 @@ ERROR(autodiff_attr_original_multiple_semantic_results,none,
 ERROR(autodiff_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
+ERROR(autodiff_attr_opaque_result_type_unsupported,none,
+      "cannot differentiate functions returning opaque result types", ())
 
 // differentiation `wrt` parameters clause
 ERROR(diff_function_no_parameters,none,

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend-typecheck -verify %s
+// RUN: %target-swift-frontend-typecheck -verify -disable-availability-checking %s
 
 import _Differentiation
 
@@ -1123,4 +1123,14 @@ extension Float {
   func jvpMethod() -> (value: Float, differential: (Float) -> Float) {
     fatalError()
   }
+}
+
+// Test original function with opaque result type.
+
+func opaqueResult(_ x: Float) -> some Differentiable { x }
+
+// expected-error @+1 {{could not find function 'opaqueResult' with expected type '(Float) -> Float'}}
+@derivative(of: opaqueResult)
+func vjpOpaqueResult(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
 }

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend-typecheck -verify %s
+// RUN: %target-swift-frontend-typecheck -verify -disable-availability-checking %s
 
 import _Differentiation
 
@@ -697,3 +697,7 @@ struct Accessors: Differentiable {
     _modify { yield &stored }
   }
 }
+
+// expected-error @+1 {{cannot differentiate functions returning opaque result types}}
+@differentiable
+func opaqueResult(_ x: Float) -> some Differentiable { x }

--- a/test/AutoDiff/compiler_crashers_fixed/sr12656-differentiation-opaque-result-type.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12656-differentiation-opaque-result-type.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -disable-availability-checking -emit-sil -verify %s
+// RUN: not %target-swift-frontend -disable-availability-checking -emit-sil -verify %s
 // REQUIRES: asserts
 
 // SR-12656: Differentiation transform crashes for original function with opaque


### PR DESCRIPTION
Reject `@differentiable` and `@derivative` attribute for original functions with opaque result types.

It is not possible to support derivative registration nor the differentiation transform for such functions.

There's no way to express the proper derivative type for functions returning `some Differentiable`:

```swift
func foo(_ x: Float) -> some Differentiable { x }

@derivative(of: foo)
// The expected JVP/VJP type isn't currently expressible:
func vjpFoo(_ x: Float) -> <T: Differentiable> (value: T, pullback: (T.TangentVector) -> TangentVector) { ... }
```

Aside from derivative registration, there's no principled way to "unpack" values of type `(some Differentiable).TangentVector` to get the underlying value, which would be necessary in the differentiation transform.

```
sil private [ossa] @AD__foo__pullback_src_0_wrt_0 : $@convention(thin) (@in_guaranteed @_opaqueReturnTypeOf("foo", 0) 🦸.TangentVector, @owned _AD__foo_bb0__PB__src_0_wrt_0) -> Float {
bb0(%0 : $*@_opaqueReturnTypeOf("foo", 0) 🦸.TangentVector, %1 : $_AD__foo_bb0__PB__src_0_wrt_0):
  // How to unpack `$*@_opaqueReturnTypeOf("foo", 0) 🦸.TangentVector` to the actual
  // underlying non-opaque type (e.g. `$*Float`)?
  //
  // We could perform some unsafe type coercion (`unchecked_addr_cast`), not sure about the full implications.
}
```

Resolves SR-12656: differentiation transform crash.