### PR TITLE
[cxx-interop] [nfc] Remove swift namespace from SwiftShims in C++ mode.

### DIFF
--- a/stdlib/public/SwiftShims/AssertionReporting.h
+++ b/stdlib/public/SwiftShims/AssertionReporting.h
@@ -21,7 +21,7 @@
 #endif
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 /// Report a fatal error to system console, stderr, and crash logs.
@@ -69,7 +69,7 @@ void _swift_stdlib_reportUnimplementedInitializer(
     __swift_uint32_t flags);
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #if __has_feature(nullability)

--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -23,7 +23,7 @@
 #include "Visibility.h"
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 #ifdef __OBJC2__
@@ -78,7 +78,7 @@ _swift_stdlib_dyld_is_objc_constant_string(const void * _Nonnull addr);
 #endif // __OBJC2__
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_COREFOUNDATIONSHIMS_H

--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -32,7 +32,7 @@
 #pragma clang assume_nonnull begin
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 typedef void (^__swift_shims_dispatch_block_t)(void);
@@ -251,7 +251,7 @@ static inline void _swift_dispatch_release(dispatch_object_t object) {
 }
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #pragma clang assume_nonnull end

--- a/stdlib/public/SwiftShims/FoundationShims.h
+++ b/stdlib/public/SwiftShims/FoundationShims.h
@@ -30,7 +30,7 @@
 #include "SwiftStdint.h"
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 typedef struct {
@@ -58,7 +58,7 @@ SWIFT_RUNTIME_STDLIB_API
 _SwiftNSOperatingSystemVersion _swift_stdlib_operatingSystemVersion() __attribute__((const));
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_FOUNDATIONSHIMS_H

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -29,7 +29,7 @@
 #endif
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 // This declaration might not be universally correct.
@@ -184,7 +184,7 @@ long double lgammal_r(long double x, int *psigngam);
 #endif // defined(__APPLE__)
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #if __has_feature(nullability)

--- a/stdlib/public/SwiftShims/Random.h
+++ b/stdlib/public/SwiftShims/Random.h
@@ -25,14 +25,14 @@
 #endif
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 SWIFT_RUNTIME_STDLIB_API
 void swift_stdlib_random(void *buf, __swift_size_t nbytes);
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #if __has_feature(nullability)

--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -23,7 +23,7 @@
 #include "Visibility.h"
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 /// Return an NSString to be used as the Mirror summary of the object
@@ -85,7 +85,7 @@ __swift_size_t _swift_stdlib_getHardwareConcurrency(void);
 #define _swift_MinAllocationAlignment (__swift_size_t) 16
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_RUNTIMESHIMS_H

--- a/stdlib/public/SwiftShims/RuntimeStubs.h
+++ b/stdlib/public/SwiftShims/RuntimeStubs.h
@@ -22,7 +22,7 @@
 #include "LibcShims.h"
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
@@ -42,7 +42,7 @@ _swift_stdlib_overrideUnsafeArgvArgc(char * _Nullable * _Nonnull argv, int argc)
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_RUNTIMESTUBS_H_

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+extern "C" {
 #endif
 
 SWIFT_RUNTIME_STDLIB_API
@@ -554,7 +554,7 @@ double __swift_stdlib_u_getNumericValue(__swift_stdlib_UChar32 c);
 
 
 #ifdef __cplusplus
-}} // extern "C", namespace swift
+} // extern "C"
 #endif
 
 #if __has_feature(nullability)

--- a/stdlib/public/runtime/BackDeployment.cpp
+++ b/stdlib/public/runtime/BackDeployment.cpp
@@ -30,7 +30,7 @@ _swift_classIsSwiftMask = computeIsSwiftMask();
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 #endif // SWIFT_CLASS_IS_SWIFT_MASK_GLOBAL_VARIABLE
 
-static swift::_SwiftNSOperatingSystemVersion swiftInOSVersion = {
+static _SwiftNSOperatingSystemVersion swiftInOSVersion = {
 #if __MAC_OS_X_VERSION_MIN_REQUIRED
   10, 14, 4
 // WatchOS also pretends to be iOS, so check it first.
@@ -43,8 +43,8 @@ static swift::_SwiftNSOperatingSystemVersion swiftInOSVersion = {
 #endif
 };
 
-static bool versionLessThan(swift::_SwiftNSOperatingSystemVersion lhs,
-                            swift::_SwiftNSOperatingSystemVersion rhs) {
+static bool versionLessThan(_SwiftNSOperatingSystemVersion lhs,
+                            _SwiftNSOperatingSystemVersion rhs) {
   if (lhs.majorVersion < rhs.majorVersion) return true;
   if (lhs.majorVersion > rhs.majorVersion) return false;
   
@@ -58,7 +58,7 @@ static bool versionLessThan(swift::_SwiftNSOperatingSystemVersion lhs,
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 int _swift_isBackDeploying() {
-  auto version = swift::_swift_stdlib_operatingSystemVersion();
+  auto version = _swift_stdlib_operatingSystemVersion();
   return versionLessThan(version, swiftInOSVersion);
 }
 #endif

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -39,7 +39,7 @@ static void logPrefixAndMessageToDebugger(
   free(debuggerMessage);
 }
 
-void swift::_swift_stdlib_reportFatalErrorInFile(
+void _swift_stdlib_reportFatalErrorInFile(
     const unsigned char *prefix, int prefixLength,
     const unsigned char *message, int messageLength,
     const unsigned char *file, int fileLength,
@@ -61,7 +61,7 @@ void swift::_swift_stdlib_reportFatalErrorInFile(
   logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
 }
 
-void swift::_swift_stdlib_reportFatalError(
+void _swift_stdlib_reportFatalError(
     const unsigned char *prefix, int prefixLength,
     const unsigned char *message, int messageLength,
     uint32_t flags
@@ -78,7 +78,7 @@ void swift::_swift_stdlib_reportFatalError(
   logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
 }
 
-void swift::_swift_stdlib_reportUnimplementedInitializerInFile(
+void _swift_stdlib_reportUnimplementedInitializerInFile(
     const unsigned char *className, int classNameLength,
     const unsigned char *initName, int initNameLength,
     const unsigned char *file, int fileLength,
@@ -99,7 +99,7 @@ void swift::_swift_stdlib_reportUnimplementedInitializerInFile(
   free(log);
 }
 
-void swift::_swift_stdlib_reportUnimplementedInitializer(
+void _swift_stdlib_reportUnimplementedInitializer(
     const unsigned char *className, int classNameLength,
     const unsigned char *initName, int initNameLength,
     uint32_t flags

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -47,7 +47,7 @@ using namespace swift;
 /// This is ABI and cannot be removed. Even though _stdlib_isOSVersionAtLeast()
 /// is no longer inlinable, is previously was and so calls to this method
 /// have been inlined into shipped apps.
-_SwiftNSOperatingSystemVersion swift::_swift_stdlib_operatingSystemVersion() {
+_SwiftNSOperatingSystemVersion _swift_stdlib_operatingSystemVersion() {
   os_system_version_s version = SWIFT_LAZY_CONSTANT(getOSVersion());
 
   return { (int)version.major, (int)version.minor, (int)version.patch };

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -66,26 +66,26 @@ static inline void initializeBridgingFunctions() {
 }
 
 __swift_uint8_t
-swift::_swift_stdlib_isNSString(id obj) {
+_swift_stdlib_isNSString(id obj) {
   initializeBridgingFunctions();
   return _CFGetTypeID((CFTypeRef)obj) == _CFStringTypeID ? 1 : 0;
 }
 
 _swift_shims_CFHashCode
-swift::_swift_stdlib_CFStringHashNSString(id _Nonnull obj) {
+_swift_stdlib_CFStringHashNSString(id _Nonnull obj) {
   initializeBridgingFunctions();
   return _CFStringHashNSString(obj);
 }
 
 _swift_shims_CFHashCode
-swift::_swift_stdlib_CFStringHashCString(const _swift_shims_UInt8 * _Nonnull bytes,
+_swift_stdlib_CFStringHashCString(const _swift_shims_UInt8 * _Nonnull bytes,
                                   _swift_shims_CFIndex length) {
   initializeBridgingFunctions();
   return _CFStringHashCString(bytes, length);
 }
 
 const __swift_uint8_t *
-swift::_swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
+_swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
                                                   unsigned long encoding) {
   typedef __swift_uint8_t * _Nullable (*cStrImplPtr)(id, SEL, unsigned long);
   cStrImplPtr imp = (cStrImplPtr)class_getMethodImplementation([obj superclass],
@@ -94,7 +94,7 @@ swift::_swift_stdlib_NSStringCStringUsingEncodingTrampoline(id _Nonnull obj,
 }
 
 __swift_uint8_t
-swift::_swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
+_swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
                                          _swift_shims_UInt8 *buffer,
                                          _swift_shims_CFIndex maxLength,
                                          unsigned long encoding) {
@@ -111,7 +111,7 @@ swift::_swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 }
 
 __swift_uint8_t
-swift::_swift_stdlib_dyld_is_objc_constant_string(const void *addr) {
+_swift_stdlib_dyld_is_objc_constant_string(const void *addr) {
   initializeBridgingFunctions();
   if (!dyld_is_objc_constant) return false;
   return dyld_is_objc_constant(dyld_objc_string_kind, addr) ? 1 : 0;

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -118,8 +118,8 @@ static swift::_SwiftHashingParameters initializeHashingParameters() {
     return { 0, 0, true };
   }
   __swift_uint64_t seed0 = 0, seed1 = 0;
-  swift::swift_stdlib_random(&seed0, sizeof(seed0));
-  swift::swift_stdlib_random(&seed1, sizeof(seed1));
+  swift_stdlib_random(&seed0, sizeof(seed0));
+  swift_stdlib_random(&seed1, sizeof(seed1));
   return { seed0, seed1, false };
 }
 

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -31,15 +31,13 @@
 
 #include "../SwiftShims/LibcShims.h"
 
-using namespace swift;
-
 #if !defined(_WIN32) || defined(__CYGWIN__)
-static_assert(std::is_same<mode_t, swift::__swift_mode_t>::value,
+static_assert(std::is_same<mode_t, __swift_mode_t>::value,
               "__swift_mode_t must be defined as equivalent to mode_t in LibcShims.h");
 #endif
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
-int swift::_swift_stdlib_putchar_unlocked(int c) {
+int _swift_stdlib_putchar_unlocked(int c) {
 #if defined(_WIN32)
   return _putc_nolock(c, stdout);
 #else
@@ -48,7 +46,7 @@ int swift::_swift_stdlib_putchar_unlocked(int c) {
 }
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
-__swift_size_t swift::_swift_stdlib_fwrite_stdout(const void *ptr,
+__swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr,
                                                   __swift_size_t size,
                                                   __swift_size_t nitems) {
     return fwrite(ptr, size, nitems, stdout);
@@ -56,7 +54,7 @@ __swift_size_t swift::_swift_stdlib_fwrite_stdout(const void *ptr,
 
 SWIFT_RUNTIME_STDLIB_SPI
 __swift_ssize_t
-swift::_swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte) {
+_swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte) {
 #if defined(_WIN32)
   return _read(fd, buf, nbyte);
 #else
@@ -66,7 +64,7 @@ swift::_swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte) {
 
 SWIFT_RUNTIME_STDLIB_SPI
 __swift_ssize_t
-swift::_swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte) {
+_swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte) {
 #if defined(_WIN32)
   return _write(fd, buf, nbyte);
 #else
@@ -75,7 +73,7 @@ swift::_swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte) {
 }
 
 SWIFT_RUNTIME_STDLIB_SPI
-int swift::_swift_stdlib_close(int fd) {
+int _swift_stdlib_close(int fd) {
 #if defined(_WIN32)
   return _close(fd);
 #else

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -44,10 +44,12 @@
 
 #include <algorithm> // required for std::min
 
+using namespace swift;
+
 #if defined(__APPLE__)
 
 SWIFT_RUNTIME_STDLIB_API
-void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
+void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   arc4random_buf(buf, nbytes);
 }
 
@@ -55,7 +57,7 @@ void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
 #warning TODO: Test swift_stdlib_random on Windows
 
 SWIFT_RUNTIME_STDLIB_API
-void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
+void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   if (nbytes > ULONG_MAX) {
     fatalError(0, "Fatal error: %zd exceeds ULONG_MAX\n", nbytes);
   }
@@ -79,7 +81,7 @@ void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
 }())
 
 SWIFT_RUNTIME_STDLIB_API
-void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
+void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   while (nbytes > 0) {
     __swift_ssize_t actual_nbytes = -1;
 

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -289,7 +289,7 @@ uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
 /// \returns Size of character data returned in \c LinePtr, or -1
 /// if an error occurred, or EOF was reached.
 __swift_ssize_t
-swift::swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
+swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
 #if defined(_WIN32)
   if (LinePtr == nullptr)
     return -1;
@@ -455,25 +455,25 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   return EndPtr;
 }
     
-const char *swift::_swift_stdlib_strtold_clocale(
+const char *_swift_stdlib_strtold_clocale(
   const char * nptr, void *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(
     nptr, static_cast<long double*>(outResult), HUGE_VALL, strtold_l);
 }
 
-const char *swift::_swift_stdlib_strtod_clocale(
+const char *_swift_stdlib_strtod_clocale(
     const char * nptr, double *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(
     nptr, outResult, HUGE_VAL, strtod_l);
 }
 
-const char *swift::_swift_stdlib_strtof_clocale(
+const char *_swift_stdlib_strtof_clocale(
     const char * nptr, float *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(
     nptr, outResult, HUGE_VALF, strtof_l);
 }
 
-const char *swift::_swift_stdlib_strtof16_clocale(
+const char *_swift_stdlib_strtof16_clocale(
     const char * nptr, __fp16 *outResult) {
   float tmp;
   const char *result = _swift_stdlib_strtof_clocale(nptr, &tmp);
@@ -481,7 +481,7 @@ const char *swift::_swift_stdlib_strtof16_clocale(
   return result;
 }
 
-void swift::_swift_stdlib_flockfile_stdout() {
+void _swift_stdlib_flockfile_stdout() {
 #if defined(_WIN32)
   _lock_file(stdout);
 #elif defined(__wasi__)
@@ -491,7 +491,7 @@ void swift::_swift_stdlib_flockfile_stdout() {
 #endif
 }
 
-void swift::_swift_stdlib_funlockfile_stdout() {
+void _swift_stdlib_funlockfile_stdout() {
 #if defined(_WIN32)
   _unlock_file(stdout);
 #elif defined(__wasi__)
@@ -501,10 +501,10 @@ void swift::_swift_stdlib_funlockfile_stdout() {
 #endif
 }
 
-int swift::_swift_stdlib_putc_stderr(int C) {
+int _swift_stdlib_putc_stderr(int C) {
   return putc(C, stderr);
 }
 
-size_t swift::_swift_stdlib_getHardwareConcurrency() {
+size_t _swift_stdlib_getHardwareConcurrency() {
   return std::thread::hardware_concurrency();
 }

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -33,7 +33,7 @@ typedef enum UCharNameChoice {} UCharNameChoice;
 typedef uint16_t UChar;
 typedef int32_t UChar32;
 typedef int8_t UBool;
-typedef swift::__swift_stdlib_UProperty UProperty;
+typedef __swift_stdlib_UProperty UProperty;
 
 #define U_MAX_VERSION_LENGTH 4
 typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
@@ -103,7 +103,7 @@ double u_getNumericValue(UChar32);
 /// 'DestinationCapacity' this function must be called again with a buffer of
 /// the required length to get an uppercase version of the string.
 int32_t
-swift::_swift_stdlib_unicode_strToUpper(uint16_t *Destination,
+_swift_stdlib_unicode_strToUpper(uint16_t *Destination,
                                         int32_t DestinationCapacity,
                                         const uint16_t *Source,
                                         int32_t SourceLength) {
@@ -124,7 +124,7 @@ swift::_swift_stdlib_unicode_strToUpper(uint16_t *Destination,
 /// 'DestinationCapacity' this function must be called again with a buffer of
 /// the required length to get a lowercase version of the string.
 int32_t
-swift::_swift_stdlib_unicode_strToLower(uint16_t *Destination,
+_swift_stdlib_unicode_strToLower(uint16_t *Destination,
                                         int32_t DestinationCapacity,
                                         const uint16_t *Source,
                                         int32_t SourceLength) {
@@ -150,49 +150,49 @@ template <typename T, typename U> const T *ptr_cast(const U *p) {
 }
 }
 
-void swift::__swift_stdlib_ubrk_close(
-    swift::__swift_stdlib_UBreakIterator *bi) {
+void __swift_stdlib_ubrk_close(
+    __swift_stdlib_UBreakIterator *bi) {
   ubrk_close(ptr_cast<UBreakIterator>(bi));
 }
 
-swift::__swift_stdlib_UBreakIterator *swift::__swift_stdlib_ubrk_open(
-    swift::__swift_stdlib_UBreakIteratorType type, const char *locale,
+__swift_stdlib_UBreakIterator *__swift_stdlib_ubrk_open(
+    __swift_stdlib_UBreakIteratorType type, const char *locale,
     const __swift_stdlib_UChar *text, int32_t textLength,
     __swift_stdlib_UErrorCode *status) {
-  return ptr_cast<swift::__swift_stdlib_UBreakIterator>(
+  return ptr_cast<__swift_stdlib_UBreakIterator>(
       ubrk_open(static_cast<UBreakIteratorType>(type), locale,
                 reinterpret_cast<const UChar *>(text), textLength,
                 ptr_cast<UErrorCode>(status)));
 }
 
 int32_t
-swift::__swift_stdlib_ubrk_preceding(swift::__swift_stdlib_UBreakIterator *bi,
+__swift_stdlib_ubrk_preceding(__swift_stdlib_UBreakIterator *bi,
                                      int32_t offset) {
   return ubrk_preceding(ptr_cast<UBreakIterator>(bi), offset);
 }
 
 int32_t
-swift::__swift_stdlib_ubrk_following(swift::__swift_stdlib_UBreakIterator *bi,
+__swift_stdlib_ubrk_following(__swift_stdlib_UBreakIterator *bi,
                                      int32_t offset) {
   return ubrk_following(ptr_cast<UBreakIterator>(bi), offset);
 }
 
-void swift::__swift_stdlib_ubrk_setText(
-    swift::__swift_stdlib_UBreakIterator *bi, const __swift_stdlib_UChar *text,
+void __swift_stdlib_ubrk_setText(
+    __swift_stdlib_UBreakIterator *bi, const __swift_stdlib_UChar *text,
     __swift_int32_t textLength, __swift_stdlib_UErrorCode *status) {
   return ubrk_setText(ptr_cast<UBreakIterator>(bi), ptr_cast<UChar>(text),
                       textLength, ptr_cast<UErrorCode>(status));
 }
 
-void swift::__swift_stdlib_ubrk_setUText(
-    swift::__swift_stdlib_UBreakIterator *bi, __swift_stdlib_UText *text,
+void __swift_stdlib_ubrk_setUText(
+    __swift_stdlib_UBreakIterator *bi, __swift_stdlib_UText *text,
     __swift_stdlib_UErrorCode *status) {
   return ubrk_setUText(ptr_cast<UBreakIterator>(bi), ptr_cast<UText>(text),
                        ptr_cast<UErrorCode>(status));
 }
 
-SWIFT_RUNTIME_STDLIB_API swift::__swift_stdlib_UText *
-swift::__swift_stdlib_utext_openUTF8(__swift_stdlib_UText *ut,
+SWIFT_RUNTIME_STDLIB_API __swift_stdlib_UText *
+__swift_stdlib_utext_openUTF8(__swift_stdlib_UText *ut,
                               const char *s, int64_t len,
                               __swift_stdlib_UErrorCode *status) {
   return ptr_cast<__swift_stdlib_UText>(
@@ -200,8 +200,8 @@ swift::__swift_stdlib_utext_openUTF8(__swift_stdlib_UText *ut,
                    ptr_cast<UErrorCode>(status)));
 }
 
-SWIFT_RUNTIME_STDLIB_API swift::__swift_stdlib_UText *
-swift::__swift_stdlib_utext_openUChars(__swift_stdlib_UText *ut,
+SWIFT_RUNTIME_STDLIB_API __swift_stdlib_UText *
+__swift_stdlib_utext_openUChars(__swift_stdlib_UText *ut,
                                        const __swift_stdlib_UChar *s,
                                        int64_t len,
                                        __swift_stdlib_UErrorCode *status) {
@@ -210,17 +210,17 @@ swift::__swift_stdlib_utext_openUChars(__swift_stdlib_UText *ut,
                      ptr_cast<UErrorCode>(status)));
 }
 
-swift::__swift_stdlib_UBool swift::__swift_stdlib_unorm2_hasBoundaryBefore(
+__swift_stdlib_UBool __swift_stdlib_unorm2_hasBoundaryBefore(
     const __swift_stdlib_UNormalizer2 *ptr, __swift_stdlib_UChar32 char32) {
   return unorm2_hasBoundaryBefore(ptr_cast<UNormalizer2>(ptr), char32);
 }
-const swift::__swift_stdlib_UNormalizer2 *
-swift::__swift_stdlib_unorm2_getNFCInstance(__swift_stdlib_UErrorCode *err) {
+const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getNFCInstance(__swift_stdlib_UErrorCode *err) {
   return ptr_cast<__swift_stdlib_UNormalizer2>(
       unorm2_getNFCInstance(ptr_cast<UErrorCode>(err)));
 }
 
-int32_t swift::__swift_stdlib_unorm2_normalize(
+int32_t __swift_stdlib_unorm2_normalize(
     const __swift_stdlib_UNormalizer2 *norm, const __swift_stdlib_UChar *src,
     __swift_int32_t len, __swift_stdlib_UChar *dst, __swift_int32_t capacity,
     __swift_stdlib_UErrorCode *err) {
@@ -236,7 +236,7 @@ int32_t swift::__swift_stdlib_unorm2_normalize(
 #endif
 }
 
-__swift_int32_t swift::__swift_stdlib_unorm2_spanQuickCheckYes(
+__swift_int32_t __swift_stdlib_unorm2_spanQuickCheckYes(
     const __swift_stdlib_UNormalizer2 *norm, const __swift_stdlib_UChar *ptr,
     __swift_int32_t len, __swift_stdlib_UErrorCode *err) {
   return unorm2_spanQuickCheckYes(ptr_cast<UNormalizer2>(norm),
@@ -244,25 +244,25 @@ __swift_int32_t swift::__swift_stdlib_unorm2_spanQuickCheckYes(
                                   ptr_cast<UErrorCode>(err));
 }
 
-swift::__swift_stdlib_UBool
-swift::__swift_stdlib_u_hasBinaryProperty(__swift_stdlib_UChar32 c,
+__swift_stdlib_UBool
+__swift_stdlib_u_hasBinaryProperty(__swift_stdlib_UChar32 c,
                                           __swift_stdlib_UProperty p) {
   return u_hasBinaryProperty(c, static_cast<UProperty>(p));
 }
 
 void
-swift::__swift_stdlib_u_charAge(__swift_stdlib_UChar32 c,
+__swift_stdlib_u_charAge(__swift_stdlib_UChar32 c,
                                 __swift_stdlib_UVersionInfo versionInfo) {
   return u_charAge(c, versionInfo);
 }
 
 __swift_int32_t
-swift::__swift_stdlib_u_getIntPropertyValue(__swift_stdlib_UChar32 c,
+__swift_stdlib_u_getIntPropertyValue(__swift_stdlib_UChar32 c,
                                             __swift_stdlib_UProperty p) {
   return u_getIntPropertyValue(c, static_cast<UProperty>(p));
 }
 
-__swift_int32_t swift::__swift_stdlib_u_charName(
+__swift_int32_t __swift_stdlib_u_charName(
     __swift_stdlib_UChar32 code, __swift_stdlib_UCharNameChoice nameChoice,
     char *buffer, __swift_int32_t bufferLength,
     __swift_stdlib_UErrorCode *pErrorCode) {
@@ -271,7 +271,7 @@ __swift_int32_t swift::__swift_stdlib_u_charName(
                     ptr_cast<UErrorCode>(pErrorCode));
 }
 
-__swift_int32_t swift::__swift_stdlib_u_strToLower(
+__swift_int32_t __swift_stdlib_u_strToLower(
     __swift_stdlib_UChar *dest, __swift_int32_t destCapacity,
     const __swift_stdlib_UChar *src, __swift_int32_t srcLength,
     const char *locale, __swift_stdlib_UErrorCode *pErrorCode) {
@@ -280,7 +280,7 @@ __swift_int32_t swift::__swift_stdlib_u_strToLower(
                       locale, ptr_cast<UErrorCode>(pErrorCode));
 }
 
-__swift_int32_t swift::__swift_stdlib_u_strToTitle(
+__swift_int32_t __swift_stdlib_u_strToTitle(
     __swift_stdlib_UChar *dest, __swift_int32_t destCapacity,
     const __swift_stdlib_UChar *src, __swift_int32_t srcLength,
     __swift_stdlib_UBreakIterator *titleIter, const char *locale,
@@ -291,7 +291,7 @@ __swift_int32_t swift::__swift_stdlib_u_strToTitle(
                       ptr_cast<UErrorCode>(pErrorCode));
 }
 
-__swift_int32_t swift::__swift_stdlib_u_strToUpper(
+__swift_int32_t __swift_stdlib_u_strToUpper(
     __swift_stdlib_UChar *dest, __swift_int32_t destCapacity,
     const __swift_stdlib_UChar *src, __swift_int32_t srcLength,
     const char *locale, __swift_stdlib_UErrorCode *pErrorCode) {
@@ -300,7 +300,7 @@ __swift_int32_t swift::__swift_stdlib_u_strToUpper(
                       locale, ptr_cast<UErrorCode>(pErrorCode));
 }
 
-double swift::__swift_stdlib_u_getNumericValue(__swift_stdlib_UChar32 c) {
+double __swift_stdlib_u_getNumericValue(__swift_stdlib_UChar32 c) {
   return u_getNumericValue(c);
 }
 


### PR DESCRIPTION
Most SwiftShims were put in the swift namespace in C++ mode which broke certain things when importing them in a swift file with C++ interop enabled. This was OK when they were only imported as part of the swift runtime but, now they are used in C++ mode both in the swift runtime and when C++ interop is enabled.