### PR TITLE
[SR-13088] Fixing remaining spurious cast to unrelated type warning involving collection elements

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -151,7 +151,7 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
     return nullptr;
 
   const auto castKind = TypeChecker::typeCheckCheckedCast(
-      fromType, toType, CheckedCastContextKind::None, cs.DC,
+      fromType, toType, CheckedCastContextKind::Coercion, cs.DC,
       SourceLoc(), coerceExpr->getSubExpr(), SourceRange());
 
   // Invalid cast.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3357,7 +3357,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         const auto &fromElt = fromTuple->getElement(i);
         const auto &toElt = toTuple->getElement(i);
 
-        // We should only perform name validation if both element have a label,
+        // We should only perform name validation if both elements have a label,
         // because unlabeled tuple elements can be converted to labeled ones
         // e.g.
         // 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4548,7 +4548,7 @@ TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
 
   ModuleDecl *M = DC->getParentModule();
   // For standard library collection types such as Array, Set or Dictionary
-  // which have custom casting machinery implemented in situations like:
+  // which have custom casting machinery implemented for situations like:
   //
   //  func encodable(_ value: Encodable) {
   //    _ = value as! [String : Encodable]

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -341,6 +341,9 @@ enum class CheckedCastContextKind {
   IsPattern,
   /// An enum-element pattern.
   EnumElementPattern,
+  /// Coerce to checked cast. Used when we verify if it is possible to
+  /// suggest to convert a coercion to a checked cast.
+  Coercion,
 };
 
 namespace TypeChecker {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -113,10 +113,10 @@ func protocol_concrete_casts(_ p1: P1, p2: P2, p12: P1 & P2) {
 
   _ = p2 as! S1 // expected-warning {{cast from 'P2' to unrelated type 'S1' always fails}}
 
-  _ = p12 as! S1
-  _ = p12 as! S2
+  _ = p12 as! S1 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S1' always fails}}
+  _ = p12 as! S2 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S2' always fails}}
   _ = p12 as! S12
-  _ = p12 as! S3
+  _ = p12 as! S3 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S3' always fails}}
 
   // Type queries.
   var _:Bool = p1 is S1
@@ -128,10 +128,10 @@ func protocol_concrete_casts(_ p1: P1, p2: P2, p12: P1 & P2) {
 
   var _:Bool = p2 is S1 // expected-warning {{cast from 'P2' to unrelated type 'S1' always fails}}
 
-  var _:Bool = p12 is S1
-  var _:Bool = p12 is S2
+  var _:Bool = p12 is S1 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S1' always fails}}
+  var _:Bool = p12 is S2 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S2' always fails}}
   var _:Bool = p12 is S12
-  var _:Bool = p12 is S3
+  var _:Bool = p12 is S3 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S3' always fails}}
 }
 
 func conditional_cast(_ b: B) -> D? {
@@ -372,6 +372,26 @@ enum ConcreteA: EventA {
   }
 }
 
+protocol ProtocolP1 {}
+protocol ProtocolQ1 {}
+typealias Composition = ProtocolP1 & ProtocolQ1
+
+protocol ProtocolP {}
+protocol ProtocolQ {}
+
+class ConcreteP: ProtocolP {}
+class ConcreteQ: ProtocolQ {}
+class ConcretePQ: ProtocolP, ProtocolQ {}
+class ConcreteCPQ: ConcreteP, ProtocolQ {}
+
+class ConcreteP1: ProtocolP1 {}
+class ConcretePQ1: ProtocolP1, ProtocolQ1 {}
+
+class ConcretePPQ1: ProtocolP, ProtocolP1, ProtocolQ1 {}
+class NotConforms {}
+struct StructNotComforms {}
+final class NotConformsFinal {}
+
 func tests_SR13088_false_positive_always_fail_casts() {
   // SR-13081
   let x: JSON = [4] // [4]
@@ -402,4 +422,21 @@ func tests_SR13088_false_positive_always_fail_casts() {
       break
     }
   }
+}
+
+// Protocol composition
+func protocol_composition(_ c: ProtocolP & ProtocolQ, _ c1: ProtocolP & Composition) {
+  _ = c as? ConcretePQ // Ok
+  _ = c as? ConcreteCPQ // Ok
+  _ = c as? ConcreteP // Ok
+  _ = c as? NotConforms // Ok
+  _ = c as? StructNotComforms // expected-warning {{cast from 'ProtocolP & ProtocolQ' to unrelated type 'StructNotComforms' always fails}}
+  _ = c as? NotConformsFinal // expected-warning {{cast from 'ProtocolP & ProtocolQ' to unrelated type 'NotConformsFinal' always fails}}
+  _ = c1 as? ConcreteP // Ok
+  _ = c1 as? ConcreteP1 // OK
+  _ = c1 as? ConcretePQ1 // OK
+  _ = c1 as? ConcretePPQ1 // Ok
+  _ = c1 as? NotConforms // Ok
+  _ = c1 as? StructNotComforms // expected-warning {{cast from 'ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'StructNotComforms' always fails}}
+  _ = c1 as? NotConformsFinal // expected-warning {{cast from 'ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'NotConformsFinal' always fails}}
 }

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -232,7 +232,7 @@ func test_tuple_casts_no_warn() {
   _ = arr as! [(Foo, Foo)] // Ok
   _ = tup as! (Foo, Foo) // Ok
 
-  _ = arr as! [(Foo, Foo, Foo)] // expected-warning {{cast from '[(Any, Any)]' to unrelated type '[(Foo, Foo, Foo)]' always fails}}
+  _ = arr as! [(Foo, Foo, Foo)] // Ok
   _ = tup as! (Foo, Foo, Foo) // expected-warning {{cast from '(Any, Any)' to unrelated type '(Foo, Foo, Foo)' always fails}}
 
   _ = arr as! [(a: Foo, Foo)] // Ok
@@ -422,6 +422,33 @@ func tests_SR13088_false_positive_always_fail_casts() {
       break
     }
   }
+
+  // SR-7187
+  let a: [Any] = [String?.some("hello") as Any, String?.none as Any]
+  let b: [AnyObject] = [String?.some("hello") as AnyObject, String?.none as AnyObject]
+
+  _ = a is [String?] // Ok
+  _ = a as? [String?] as Any // OK
+  _ = b is [String?] // Ok
+  _ = b as? [String?] as AnyObject // OK
+
+  // SR-6192
+  let items = [String]()
+  let dict = [String: Any]()
+  let set = Set<String>()
+
+  _ = items is [Int] // Ok
+  _ = items as? [Int] as Any // Ok
+  _ = items as! [Int] // Ok
+
+  _ = dict is [Int: Any] // Ok
+  _ = dict as? [Int: Any] as Any // Ok
+  _ = dict as! [Int: Any] as Any // Ok
+
+  _ = set is Set<Int> // Ok
+  _ = set as? Set<Int> as Any // Ok
+  _ = set as! Set<Int> // Ok
+
 }
 
 // Protocol composition

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -92,8 +92,8 @@ Double(1) as Double as String // expected-error{{cannot convert value of type 'D
 (1, 1.0, "a", [1, 23]) as (Int, Double, String, [String])
 // expected-error@-1 2 {{cannot convert value of type 'Int' to expected element type 'String'}}
 
-_ = [1] as! [String] // expected-warning{{cast from '[Int]' to unrelated type '[String]' always fails}}
-_ = [(1, (1, 1))] as! [(Int, (String, Int))] // expected-warning{{cast from '[(Int, (Int, Int))]' to unrelated type '[(Int, (String, Int))]' always fails}}
+_ = [1] as! [String] // OK
+_ = [(1, (1, 1))] as! [(Int, (String, Int))] // OK
 
 // <rdar://problem/19495253> Incorrect diagnostic for explicitly casting to the same type
 _ = "hello" as! String // expected-warning{{forced cast of 'String' to same type has no effect}} {{13-24=}}

--- a/test/expr/cast/dictionary_downcast.swift
+++ b/test/expr/cast/dictionary_downcast.swift
@@ -43,7 +43,7 @@ dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type '[C :
 // expected-note@-2 {{arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
 
 // Test dictionary conditional downcasts to unrelated types
-if let _ = dictCC as? Dictionary<D, U> { } // expected-warning{{cast from '[C : C]' to unrelated type 'Dictionary<D, U>' always fails}}
-if let _ = dictCC as? Dictionary<U, D> { } // expected-warning{{cast from '[C : C]' to unrelated type 'Dictionary<U, D>' always fails}}
-if let _ = dictCC as? Dictionary<U, U> { } // expected-warning{{cast from '[C : C]' to unrelated type 'Dictionary<U, U>' always fails}}
+if let _ = dictCC as? Dictionary<D, U> { } // Ok
+if let _ = dictCC as? Dictionary<U, D> { } // Ok
+if let _ = dictCC as? Dictionary<U, U> { } // Ok
 

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -94,7 +94,7 @@ func testConditionalDowncastBridge() {
   if let s = setB as? Set<Root> { _ = s } // expected-warning{{conditional cast from 'Set<BridgedToObjC>' to 'Set<Root>' always succeeds}}
   if let s = setB as? Set<ObjC> { _ = s } // expected-warning{{conditional cast from 'Set<BridgedToObjC>' to 'Set<ObjC>' always succeeds}}
   if let s = setB as? Set<DerivesObjC> { _ = s }
-  if let s = setB as? Set<Unrelated> { _ = s } // expected-warning {{cast from 'Set<BridgedToObjC>' to unrelated type 'Set<Unrelated>' always fails}}
+  if let s = setB as? Set<Unrelated> { _ = s } // OK
 
   _ = setR
   _ = setO

--- a/test/expr/cast/set_downcast.swift
+++ b/test/expr/cast/set_downcast.swift
@@ -30,7 +30,7 @@ setD = setC as! Set<D>
 if let _ = setC as? Set<D> { }
 
 // Test set downcasts to unrelated types.
-_ = setC as! Set<U> // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}
+_ = setC as! Set<U> // Ok
 
-// Test set conditional downcasts to unrelated types
-if let _ = setC as? Set<U> { } // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}
+// Test set conditional downcasts to unrelated types.
+if let _ = setC as? Set<U> { } // Ok


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a followup for resolution of SR-13088
This fixes SR-7187 and SR-6192 and possibly SR-7738
Also, this handles the unrelated warning for checked cast from protocol 
composition to unrelated non-existential. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves remaining issues on SR-13088.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
