### PR TITLE
Add tests for C++ out-of-line member operators

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -1,5 +1,5 @@
 #include "member-out-of-line.h"
 
-IntBox IntBox::operator+(IntBox rhs) {
+IntBox IntBox::operator+(IntBox rhs) const {
   return IntBox{.value = value + rhs.value};
 }

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -1,0 +1,5 @@
+#include "member-out-of-line.h"
+
+IntBox IntBox::operator+(IntBox rhs) {
+  return IntBox{.value = value + rhs.value};
+}

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -3,7 +3,7 @@
 
 struct IntBox {
   int value;
-  IntBox operator+(IntBox rhs);
+  IntBox operator+(IntBox rhs) const;
 };
 
 #endif

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -1,0 +1,9 @@
+#ifndef TEST_INTEROP_CXX_OPERATORS_INPUTS_MEMBER_OUT_OF_LINE_H
+#define TEST_INTEROP_CXX_OPERATORS_INPUTS_MEMBER_OUT_OF_LINE_H
+
+struct IntBox {
+  int value;
+  IntBox operator+(IntBox rhs);
+};
+
+#endif

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -2,6 +2,10 @@ module MemberInline {
   header "member-inline.h"
 }
 
+module MemberOutOfLine {
+  header "member-out-of-line.h"
+}
+
 module NonMemberInline {
   header "non-member-inline.h"
 }

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -7,5 +7,5 @@ import MemberOutOfLine
 
 public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
-// CHECK: call {{i32|i64}} [[NAME:@_ZNK6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64}} %{{[0-9]+}})
-// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox*, {{i32|\[1 x i32\]|i64}})
+// CHECK: call {{i32|i64}} [[NAME:@_ZNK6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval align 4}} %{{[0-9]+}})
+// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox*, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval\(%struct.IntBox\) align 4}})

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
+
+import MemberOutOfLine
+
+public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+
+// CHECK: call {{i32|i64}} [[NAME:@_ZN6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64}} %{{[0-9]+}})
+// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox*, {{i32|\[1 x i32\]|i64}})

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -7,5 +7,5 @@ import MemberOutOfLine
 
 public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
-// CHECK: call {{i32|i64}} [[NAME:@_ZN6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64}} %{{[0-9]+}})
+// CHECK: call {{i32|i64}} [[NAME:@_ZNK6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64}} %{{[0-9]+}})
 // CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox*, {{i32|\[1 x i32\]|i64}})

--- a/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
@@ -9,7 +9,7 @@ public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
 // CHECK: bb0([[LHS:%.*]] : $*IntBox, [[RHS:%.*]] : $IntBox):
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[LHS]] : $*IntBox
-// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZN6IntBoxplES_]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZNK6IntBoxplES_]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
 // CHECK:   apply [[FUNC]]([[ACCESS]], [[RHS]]) : $@convention(c) (@inout IntBox, IntBox) -> IntBox
 // CHECK:   end_access [[ACCESS]] : $*IntBox
 

--- a/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
+
+import MemberOutOfLine
+
+public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+
+// CHECK: bb0([[LHS:%.*]] : $*IntBox, [[RHS:%.*]] : $IntBox):
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[LHS]] : $*IntBox
+// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZN6IntBoxplES_]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK:   apply [[FUNC]]([[ACCESS]], [[RHS]]) : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK:   end_access [[ACCESS]] : $*IntBox
+
+// CHECK: sil [clang IntBox."+"] [[NAME]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o -std=c++17
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
+// RUN: %target-codesign %t/member-out-of-line
+// RUN: %target-run %t/member-out-of-line
+//
+// REQUIRES: executable_test
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
+
+import MemberOutOfLine
+import StdlibUnittest
+
+var OperatorsTestSuite = TestSuite("Operators")
+
+OperatorsTestSuite.test("plus") {
+  var lhs = IntBox(value: 42)
+  let rhs = IntBox(value: 23)
+
+  let result = lhs + rhs
+
+  expectEqual(65, result.value)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
+// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o -std=c++17
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line


### PR DESCRIPTION
This is part of SR-12748.