### PR TITLE
stdlib: make integer truncation a transparent function.

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3152,8 +3152,7 @@ extension FixedWidthInteger {
   ///     // 'y' has a binary representation of 11111111_11101011
   ///
   /// - Parameter source: An integer to convert to this type.
-  @inlinable // FIXME(inline-always)
-  @inline(__always)
+  @_transparent
   public init<T: BinaryInteger>(truncatingIfNeeded source: T) {
     if Self.bitWidth <= Int.bitWidth {
       self = Self(_truncatingBits: source._lowWord)

--- a/test/SILOptimizer/int_truncating_onone.swift
+++ b/test/SILOptimizer/int_truncating_onone.swift
@@ -1,0 +1,13 @@
+// RUN: %target-build-swift -Onone %s -module-name=test -emit-sil | %FileCheck %s
+
+// Make sure that integer truncation does not result in a generic function call,
+// even in -Onone.
+
+// CHECK-LABEL: sil @$s4test6testitys5Int32Vs5Int64VF : $@convention(thin) (Int64) -> Int32
+// CHECK-NOT: apply
+// CHECK:     builtin
+// CHECK-NOT: apply
+// CHECK: } // end sil function '$s4test6testitys5Int32Vs5Int64VF'
+public func testit(_ x: Int64) -> Int32 {
+  return Int32(truncatingIfNeeded: x)
+}


### PR DESCRIPTION
Integer truncation is a simple operation and should not need a ton of function calls including generation of metadata, even in Onone.
Making the corresponding initializer transparent dramatically improves performance of this operation with -Onone.
For optimized builds, there should be not much change, because originally, the initializer was inlinable + inline(always).

rdar://problem/64992353
