### PR TITLE
build: fix cross-compilation on Darwin platforms

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -354,16 +354,15 @@ def apply_default_arguments(toolchain, args):
 
     # Filter out any macOS stdlib deployment targets that are not supported
     # by the macOS SDK.
-    if platform.system() == "Darwin":
-        targets = StdlibDeploymentTarget.get_targets_by_name(
-            args.stdlib_deployment_targets)
-        args.stdlib_deployment_targets = [
-            target.name
-            for target in targets
-            if (target.platform.is_darwin and
-                target.platform.sdk_supports_architecture(
-                    target.arch, args.darwin_xcrun_toolchain))
-        ]
+    targets = StdlibDeploymentTarget.get_targets_by_name(
+        args.stdlib_deployment_targets)
+    args.stdlib_deployment_targets = [
+        target.name
+        for target in targets
+        if (not target.platform.is_darwin or
+            target.platform.sdk_supports_architecture(
+                target.arch, args.darwin_xcrun_toolchain))
+    ]
 
     # Include the Darwin module-only architectures in the CMake options.
     if args.swift_darwin_module_archs:


### PR DESCRIPTION
After https://github.com/apple/swift/pull/32705 was merged, cross-compiling stdlib from Darwin to other platforms (such as WebAssembly/WASI) fails. This is fixed by performing the condition check for Darwin targets within the `buil-script` loop.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

CC @kateinoigakukun 
