### PR TITLE
[cxx-interop] Add support for benchmarks with C++ interop.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -188,6 +188,7 @@ set(SWIFT_BENCH_MODULES
     single-source/Walsh
     single-source/WordCount
     single-source/XorLoop
+    cxx-source/CreateObjects
 )
 
 set(SWIFT_MULTISOURCE_SWIFT_BENCHES

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -478,6 +478,12 @@ function (swift_benchmark_compile_archopts)
       list(APPEND SWIFT_BENCH_OBJFILES "${objfile}")
       list(APPEND bench_library_swiftmodules "${swiftmodule}")
 
+      # Only set "enable-cxx-interop" for tests in the "cxx-source" directory.
+      set(cxx_options "")
+      if ("${module_name_path}" MATCHES ".*cxx-source/.*")
+        list(APPEND cxx_options "-Xfrontend" "-enable-cxx-interop" "-I" "${srcdir}/utils/CxxTests/")
+      endif()
+
       if ("${bench_flags}" MATCHES "-whole-module.*")
         set(output_option "-o" "${objfile}")
       else()
@@ -501,6 +507,7 @@ function (swift_benchmark_compile_archopts)
           "-module-name" "${module_name}"
           "-emit-module-path" "${swiftmodule}"
           "-I" "${objdir}"
+          ${cxx_options}
           ${output_option}
           "${source}")
       if (SWIFT_BENCHMARK_EMIT_SIB)
@@ -518,6 +525,7 @@ function (swift_benchmark_compile_archopts)
             ${SWIFT_BENCHMARK_EXTRA_FLAGS}
             "-module-name" "${module_name}"
             "-I" "${objdir}"
+            ${cxx_options}
             "-emit-sib"
             "-o" "${sibfile}"
             "${source}")
@@ -582,6 +590,8 @@ function (swift_benchmark_compile_archopts)
       "-whole-module-optimization"
       "-emit-module" "-module-name" "${module_name}"
       "-I" "${objdir}"
+      "-Xfrontend" "-enable-cxx-interop"
+      "-I" "${srcdir}/utils/CxxTests/"
       "-o" "${objdir}/${module_name}.o"
       "${source}")
   list(APPEND SWIFT_BENCH_OBJFILES "${objdir}/${module_name}.o")

--- a/benchmark/cxx-source/CreateObjects.swift
+++ b/benchmark/cxx-source/CreateObjects.swift
@@ -1,0 +1,31 @@
+//===--- CreateObjects.swift ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This is a simple test that creates thousands of C++ objects and does nothing
+// with them.
+
+import TestsUtils
+import CxxCreateObjects
+
+public let CreateObjects = BenchmarkInfo(
+  name: "CreateObjects",
+  runFunction: run_CreateObjects,
+  tags: [.validation, .bridging])
+
+@inline(never)
+public func run_CreateObjects(_ N: Int) {
+  for i in 0...(N * 10_000) {
+    let x = Int32(i)
+    let f = CxxLoadableIntWrapper(value: x)
+    blackHole(f)
+  }
+}

--- a/benchmark/utils/CxxTests/CreateObjects.h
+++ b/benchmark/utils/CxxTests/CreateObjects.h
@@ -1,0 +1,3 @@
+struct CxxLoadableIntWrapper {
+  int value;
+};

--- a/benchmark/utils/CxxTests/module.modulemap
+++ b/benchmark/utils/CxxTests/module.modulemap
@@ -1,0 +1,3 @@
+module CxxCreateObjects {
+  header "CreateObjects.h"
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -48,6 +48,7 @@ import Chars
 import ClassArrayGetter
 import Codable
 import Combos
+import CreateObjects
 import DataBenchmarks
 import DeadArray
 import DevirtualizeProtocolComposition
@@ -235,6 +236,7 @@ registerBenchmark(Chars)
 registerBenchmark(Codable)
 registerBenchmark(Combos)
 registerBenchmark(ClassArrayGetter)
+registerBenchmark(CreateObjects)
 registerBenchmark(DataBenchmarks)
 registerBenchmark(DeadArray)
 registerBenchmark(DevirtualizeProtocolComposition)


### PR DESCRIPTION
* Adds support for benchmarks that use C++ modules.
* Adds "CreateObjects" benchmark that creates C++ objects.

Based on #32715.