### PR TITLE
[5.3] [SR-12486] `T.self is Any.Protocol` is broken

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1189,13 +1189,6 @@ swift_dynamicCastMetatypeImpl(const Metadata *sourceType,
     }
     break;
 
-  case MetadataKind::Existential: {
-    auto targetTypeAsExistential = static_cast<const ExistentialTypeMetadata *>(targetType);
-    if (_conformsToProtocols(nullptr, sourceType, targetTypeAsExistential, nullptr))
-      return origSourceType;
-    return nullptr;
-  }
-
   default:
     return nullptr;
   }

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -16,8 +16,11 @@ enum PE: P {}
 class PC: P, PObjC {}
 class PCSub: PC {}
 
-func nongenericAnyIsPObjC(type: Any.Type) -> Bool {
+func nongenericAnyIsPObjCType(type: Any.Type) -> Bool {
   return type is PObjC.Type
+}
+func nongenericAnyIsPObjCProtocol(type: Any.Type) -> Bool {
+  return type is PObjC.Protocol
 }
 func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   // If we're testing against a runtime that doesn't have the fix this tests,
@@ -29,13 +32,23 @@ func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   }
 }
 
-// CHECK-LABEL: casting types to ObjC protocols with generics:
-print("casting types to ObjC protocols with generics:")
-print(nongenericAnyIsPObjC(type: PS.self)) // CHECK: false
-print(genericAnyIs(type: PS.self, to: PObjC.self, expected: false)) // CHECK: false
-print(nongenericAnyIsPObjC(type: PE.self)) // CHECK: false
-print(genericAnyIs(type: PE.self, to: PObjC.self, expected: false)) // CHECK: false
-print(nongenericAnyIsPObjC(type: PC.self)) // CHECK: true
-print(genericAnyIs(type: PC.self, to: PObjC.self, expected: true)) // CHECK-ONONE: true
-print(nongenericAnyIsPObjC(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: PObjC.self, expected: true)) // CHECK-ONONE: true
+// CHECK-LABEL: casting types to ObjC protocol existential metatype:
+print("casting types to ObjC protocol existential metatype:")
+print(#line, nongenericAnyIsPObjCType(type: PS.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCType(type: PE.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCType(type: PC.self)) // CHECK: [[@LINE]] true
+print(#line, nongenericAnyIsPObjCType(type: PCSub.self)) // CHECK: [[@LINE]] true
+
+// CHECK-LABEL: casting types to ObjC protocol metatype:
+print("casting types to ObjC protocol metatype:")
+print(#line, nongenericAnyIsPObjCProtocol(type: PS.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCProtocol(type: PE.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCProtocol(type: PC.self)) // CHECK: [[@LINE]] false
+print(#line, nongenericAnyIsPObjCProtocol(type: PCSub.self)) // CHECK: [[@LINE]] false
+
+// CHECK-LABEL: casting types to ObjC protocol metatype via generic:
+print("casting types to ObjC protocol metatype via generic:")
+print(#line, genericAnyIs(type: PS.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false
+print(#line, genericAnyIs(type: PE.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false
+print(#line, genericAnyIs(type: PC.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false
+print(#line, genericAnyIs(type: PCSub.self, to: PObjC.self, expected: false)) // CHECK: [[@LINE]] false

--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -21,6 +21,8 @@ import StdlibUnittest
 import Foundation
 #endif
 
+private func blackhole<T>(_ t: T) {}
+
 let CastsTests = TestSuite("Casts")
 
 // Test for SR-426: missing release for some types after failed conversion
@@ -160,5 +162,64 @@ CastsTests.test("Dynamic casts of CF types to protocol existentials")
   }
 }
 #endif
+
+CastsTests.test("Any.Protocol") {
+  class C {}
+  struct S {}
+  func isAnyProtocol<T>(_ type: T.Type) -> Bool {
+    let result = T.self is Any.Protocol
+		if result {
+			// `as!` should succeed if `is` does
+			blackhole(T.self as! Any.Protocol)
+		}
+    return result
+  }
+  func isAnyType<T>(_ type: T.Type) -> Bool {
+    return T.self is Any.Type
+  }
+  func isType<T,U>(_ type: T.Type, to: U.Type) -> Bool {
+    return T.self is U.Type
+  }
+
+  expectTrue(Int.self is Any.Type)
+  expectNotNil(Int.self as? Any.Type)
+  expectTrue(isAnyType(Int.self))
+  expectFalse(Int.self is Any.Protocol)
+  expectNil(Int.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(Int.self))
+  expectFalse(isType(Int.self, to: Any.self))
+
+  expectTrue(C.self is Any.Type)
+  expectNotNil(C.self as? Any.Type)
+  expectTrue(isAnyType(C.self))
+  expectFalse(C.self is Any.Protocol)
+  expectNil(C.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(C.self))
+  expectFalse(isType(C.self, to: Any.self))
+
+  expectTrue(S.self is Any.Type)
+  expectNotNil(S.self as? Any.Type)
+  expectTrue(isAnyType(S.self))
+  expectFalse(S.self is Any.Protocol)
+  expectNil(S.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(S.self))
+  expectFalse(isType(S.self, to: Any.self))
+
+  expectTrue(Any.self is Any.Type)
+  expectNotNil(Any.self as? Any.Type)
+  expectTrue(isAnyType(Any.self))
+  expectTrue(Any.self is Any.Protocol)
+  expectNotNil(Any.self as? Any.Protocol)
+  expectTrue(isAnyProtocol(Any.self))
+  expectTrue(isType(Any.self, to: Any.self))
+
+  expectTrue(Any?.self is Any.Type)
+  expectNotNil(Any?.self as? Any.Type)
+  expectTrue(isAnyType(Any?.self))
+  expectFalse(Any?.self is Any.Protocol)
+  expectNil(Any?.self as? Any.Protocol)
+  expectFalse(isAnyProtocol(Any?.self))
+  expectFalse(isType(Any?.self, to: Any.self))
+}
 
 runAllTests()


### PR DESCRIPTION
Merge PR #31662 into release/5.3 branch

# Description from original PR #31662 

This turned out to be fallout from https://github.com/apple/swift/pull/27572  which was in turn motivated by our confusing metatype syntax when generic variables are bound to protocols.
    
In particular, the earlier PR was an attempt to make the expression `x is T.Type` (where `T` is a generic type variable bound to a protocol `P`) behave the same as `x is P.Type` (where `P` is a protocol). Unfortunately, the generic `T.Type` actually binds to `P.Protocol` in this case (not `P.Type`), so the original motivation was flawed, and as it happens, `x is T.Type` already behaved the same as `x is P.Protocol` in this situation.
    
This PR reverts that earlier change and beefs up some of the tests around these behaviors.
    
Resolves SR-12486
    
Resolves rdar://62201613
    
Reverts PR#27572

# CCC Information

• Explanation: Reverts PR#27572 which broke several different runtime casts
• Scope of Issue: Restores the correct behavior from Swift 5.0
• Origination: PR#27572
• Risk: Some projects may have introduced dependencies on the Swift 5.1 or 5.2 behaviors (which were different from each other and different from the correct Swift 5.0 behavior)
• Reviewed By: Joe Groff, Mike Ash
• Automated Testing: Unit tests were augmented to clarify the correct behavior
• Impact: Runtime only
