### PR TITLE
[5.3][CSBindings] Open collection binding associated with @autoclosure argument

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1038,8 +1038,9 @@ bool TypeVarBindingProducer::computeNext() {
 
     auto srcLocator = binding.getLocator();
     if (srcLocator &&
-        srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() &&
-        !type->hasTypeVariable() && CS.isCollectionType(type)) {
+        (srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() ||
+         srcLocator->isLastElement<LocatorPathElt::AutoclosureResult>()) &&
+          !type->hasTypeVariable() && CS.isCollectionType(type)) {
       // If the type binding comes from the argument conversion, let's
       // instead of binding collection types directly, try to bind
       // using temporary type variables substituted for element

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -874,3 +874,19 @@ func generic_and_missing_label<T>(x: T) {}
 
 generic_and_missing_label(42)
 // expected-error@-1 {{missing argument label 'x:' in call}} {{27-27=x: }}
+
+// SR-13135: Type inference regression in Swift 5.3 - can't infer a type of @autoclosure result.
+func sr13135() {
+  struct Foo {
+    var bar: [Int] = []
+  }
+
+  let baz: Int? = nil
+
+  func foo<T: Equatable>(
+    _ a: @autoclosure () throws -> T,
+    _ b: @autoclosure () throws -> T
+  ) {}
+
+  foo(Foo().bar, [baz])
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32724

---

- Explanation:

To preserve subtype relationship between element types of a collection
passed as an argument to a parameter represented by another collection
type let's extend opening of the collection types to be done for arguments
to @autoclosure parameters as well because implicit closure is transparent
to the caller.

- Scope: Limited to `@autoclosure` arguments represented by a collection type.

- Resolves: rdar://problem/65088975

- Risk: Very Low

- Testing: Added regression tests

- Reviewer: @DougGregor, @hborla 

Resolves: [SR-13135](https://bugs.swift.org/browse/SR-13135)
Resolves: rdar://problem/65088975
(cherry picked from commit 739ba4bb3908f9dfb02ad3530744c608b6c5f49f)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
