### PR TITLE
docs: make Windows build instructions fully self-contained

### DIFF
--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -1,0 +1,132 @@
+set(LLVM_ENABLE_PROJECTS
+      clang
+      clang-tools-extra
+      lld
+      lldb
+    CACHE STRING "")
+
+set(LLVM_EXTERNAL_PROJECTS
+      cmark
+      swift
+    CACHE STRING "")
+
+# NOTE(compnerd) always enable assertions, the toolchain will not provide enough
+# context to resolve issues otherwise and may silently generate invalid output.
+set(LLVM_ENABLE_ASSERTIONS YES CACHE BOOL "")
+
+set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
+set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
+
+# Disable certain targets to reduce the configure time or to avoid configuration
+# differences (and in some cases weird build errors on a complete build).
+set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
+set(LLVM_BUILD_LLVM_DYLIB NO CACHE BOOL "")
+set(LLVM_BUILD_LLVM_C_DYLIB NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 NO CACHE BOOL "")
+set(LLVM_ENABLE_OCAMLDOC NO CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB NO CACHE BOOL "")
+set(LLVM_INCLUDE_BENCHMARKS NO CACHE BOOL "")
+set(LLVM_INCLUDE_DOCS NO CACHE BOOL "")
+set(LLVM_INCLUDE_EXAMPLES NO CACHE BOOL "")
+set(LLVM_INCLUDE_GO_TESTS NO CACHE BOOL "")
+set(LLVM_TOOL_GOLD_BUILD NO CACHE BOOL "")
+set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
+
+# Avoid swig dependency for lldb
+set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+
+# This requires perl which may not be available on Windows
+set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_STDLIB NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_SDK_OVERLAY NO CACHE BOOL "")
+
+set(LLVM_INSTALL_BINUTILS_SYMLINKS YES CACHE BOOL "")
+set(LLVM_INSTALL_TOOLCHAIN_ONLY YES CACHE BOOL "")
+set(LLVM_TOOLCHAIN_TOOLS
+      addr2line
+      ar
+      c++filt
+      dsymutil
+      dwp
+      # lipo
+      llvm-ar
+      llvm-cov
+      llvm-cvtres
+      llvm-cxxfilt
+      llvm-dlltool
+      llvm-dwarfdump
+      llvm-dwp
+      llvm-lib
+      llvm-lipo
+      llvm-mt
+      llvm-mt
+      llvm-nm
+      llvm-objcopy
+      llvm-objdump
+      llvm-pdbutil
+      llvm-profdata
+      llvm-ranlib
+      llvm-rc
+      llvm-readelf
+      llvm-readobj
+      llvm-size
+      llvm-strings
+      llvm-strip
+      llvm-symbolizer
+      llvm-undname
+      nm
+      objcopy
+      objdump
+      ranlib
+      readelf
+      size
+      strings
+    CACHE STRING "")
+
+set(CLANG_TOOLS
+      clang
+      clangd
+      clang-format
+      clang-resource-headers
+      clang-tidy
+    CACHE STRING "")
+
+set(LLD_TOOLS
+      lld
+    CACHE STRING "")
+
+set(LLDB_TOOLS
+      liblldb
+      lldb
+      lldb-argdumper
+      lldb-python-scripts
+      lldb-server
+      lldb-vscode
+      repl_swift
+    CACHE STRING "")
+
+set(SWIFT_INSTALL_COMPONENTS
+      autolink-driver
+      compiler
+      clang-builtin-headers
+      editor-integration
+      tools
+      sourcekit-inproc
+      swift-remote-mirror
+      swift-remote-mirror-headers
+    CACHE STRING "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS
+      IndexStore
+      libclang
+      libclang-headers
+      LTO
+      ${LLVM_TOOLCHAIN_TOOLS}
+      ${CLANG_TOOLS}
+      ${LLD_TOOLS}
+      ${LLDB_TOOLS}
+      ${SWIFT_INSTALL_COMPONENTS}
+    CACHE STRING "")

--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -52,7 +52,6 @@ From the settings application, go to `Update & Security`.  In the `For developer
 
 1. Clone `apple/llvm-project` into a directory for the toolchain
 2. Clone `apple/swift-cmark`, `apple/swift`, `apple/swift-corelibs-libdispatch`, `apple/swift-corelibs-foundation`, `apple/swift-corelibs-xctest`, `apple/swift-llbuild`, `apple/swift-package-manager` into the toolchain directory
-3. Clone `compnerd/swift-build` as a peer of the toolchain directory
 
 - Currently, other repositories in the Swift project have not been tested and may not be supported.
 
@@ -73,21 +72,12 @@ git clone https://github.com/apple/swift-corelibs-xctest swift-corelibs-xctest
 git clone https://github.com/apple/swift-llbuild llbuild
 git clone https://github.com/apple/swift-tools-support-core swift-tools-support-core
 git clone -c core.autocrlf=input https://github.com/apple/swift-package-manager swiftpm
-git clone https://github.com/compnerd/swift-build swift-build
 ```
 
-## Acquire ICU, SQLite3, curl, libxml2 and zlib
+## Dependencies (ICU, SQLite3, curl, libxml2 and zlib)
 
-```
-C:\Python27\python.exe -m pip install --user msrest azure-devops tabulate
-C:\Python27\python.exe swift-build\utilities\swift-build.py --build-id ICU --latest-artifacts --filter windows-x64 --download
-C:\Python27\python.exe swift-build\utilities\swift-build.py --build-id XML2 --latest-artifacts --filter windows-x64 --download
-C:\Python27\python.exe swift-build\utilities\swift-build.py --build-id CURL --latest-artifacts --filter windows-x64 --download
-C:\Python27\python.exe swift-build\utilities\swift-build.py --build-id zlib --latest-artifacts --filter windows-x64 --download
-C:\Python27\python.exe swift-build\utilities\swift-build.py --build-id SQLite --latest-artifacts --filter windows-x64 --download
-```
-
-Extract the zip files, ignoring the top level directory, into `S:/Library`. The directory structure should resemble:
+The instructions assume that the dependencies are in `S:/Library`. The directory
+structure should resemble:
 
 ```
 /Library
@@ -102,6 +92,10 @@ Extract the zip files, ignoring the top level directory, into `S:/Library`. The 
   ┕ zlib-1.2.11
       ┕ usr/...
 ```
+
+Note that only ICU is required for building the toolchain, and SQLite is only
+needed for building llbuild and onwards.  The ICU project provides binaries,
+alternatively, see the ICU project for details on building ICU from source.
 
 ## One-time Setup (re-run on Visual Studio upgrades)
 
@@ -126,26 +120,17 @@ Warning: Creating the above links usually requires administrator privileges. The
 
 ```cmd
 cmake -B "S:\b\toolchain" ^
-  -C S:\swift-build\cmake\caches\windows-x86_64.cmake ^
-  -C S:\swift-build\cmake\caches\org.compnerd.dt.cmake ^
+  -C S:\swift\cmake\caches\Windows-x86_64.cmake ^
   -D CMAKE_BUILD_TYPE=Release ^
-  -D LLVM_ENABLE_ASSERTIONS=YES ^
-  -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb;lld" ^
-  -D LLVM_EXTERNAL_PROJECTS="cmark;swift" ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=S:\swift-corelibs-libdispatch ^
   -D LLVM_ENABLE_PDB=YES ^
-  -D LLVM_ENABLE_LIBEDIT=NO ^
-  -D LLDB_ENABLE_PYTHON=YES ^
-  -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR="S:/swift" ^
-  -D LLVM_EXTERNAL_CMARK_SOURCE_DIR="S:/cmark" ^
-  -D SWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE="S:/Library/icu-67/usr/include" ^
-  -D SWIFT_WINDOWS_x86_64_ICU_UC="S:/Library/icu-67/usr/lib/icuuc67.lib" ^
-  -D SWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE="S:/Library/icu-67/usr/include" ^
-  -D SWIFT_WINDOWS_x86_64_ICU_I18N="S:/Library/icu-67/usr/lib/icuin67.lib" ^
-  -D CMAKE_INSTALL_PREFIX="C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr" ^
-  -D PYTHON_EXECUTABLE=C:\Python27\python.exe ^
-  -D SWIFT_BUILD_DYNAMIC_STDLIB=YES ^
-  -D SWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES ^
+  -D LLVM_EXTERNAL_SWIFT_SOURCE_DIR=S:\swift ^
+  -D LLVM_EXTERNAL_CMARK_SOURCE_DIR=S:\cmark ^
+  -D SWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=S:\Library\icu-67\usr\include ^
+  -D SWIFT_WINDOWS_x86_64_ICU_UC=S:\Library\icu-67\usr\lib\icuuc67.lib ^
+  -D SWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=S:\Library\icu-67\usr\include ^
+  -D SWIFT_WINDOWS_x86_64_ICU_I18N=S:\Library\icu-67\usr\lib\icuin67.lib ^
+  -D CMAKE_INSTALL_PREFIX=C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr ^
   -G Ninja ^
   -S S:\llvm-project\llvm
 


### PR DESCRIPTION
Remove the extra repository dependency for the single cache file.
Update the build examples to simplify the cmake invocation
appropriately.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
