### PR TITLE
Bump TSC to latest (0.1.8)

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -355,7 +355,7 @@
                 "swift": "tensorflow",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",
-                "swift-tools-support-core": "0.0.1",
+                "swift-tools-support-core": "0.1.8",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",
                 "swift-argument-parser": "0.2.0",
                 "swift-driver": "master",


### PR DESCRIPTION
<!-- What's in this pull request? -->
We are currently pulling in a very old version of swift-tools-support-core. This updates to the latest release (0.1.8).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves the following build errors after [apple/swift-driver#160](https://github.com/apple/swift-driver/commit/cad0d23ccd9b35e69894c5560f53a27f35780be3).
```
/swift-base/swift-driver/Sources/SwiftDriver/Utilities/VirtualPath.swift:110:29: error: value of type 'RelativePath' has no member 'appending'
      return .relative(path.appending(component: component))
                       ~~~~ ^~~~~~~~~
/swift-base/swift-driver/Sources/SwiftDriver/Utilities/VirtualPath.swift:112:30: error: value of type 'RelativePath' has no member 'appending'
      return .temporary(path.appending(component: component))
                        ~~~~ ^~~~~~~~~
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
