### PR TITLE
[Sema] Mark the direct callee as being a callee for all ApplyExprs not just CallExprs

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1157,7 +1157,7 @@ namespace {
       ExprStack.pop_back();
 
       // Mark the direct callee as being a callee.
-      if (auto *call = dyn_cast<CallExpr>(expr))
+      if (auto *call = dyn_cast<ApplyExpr>(expr))
         markDirectCallee(call->getFn());
 
       // Fold sequence expressions.

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -290,3 +290,9 @@ func rdar_62054241() {
     return arr.sorted(by: <) // expected-error {{no exact matches in reference to operator function '<'}}
   }
 }
+
+// SR-11399 - Operator returning IUO doesn't implicitly unwrap
+postfix operator ^^^
+postfix func ^^^ (lhs: Int) -> Int! { 0 }
+
+let x: Int = 1^^^


### PR DESCRIPTION
This pull request will mark the direct callee as being a callee if an `Expr` is any `ApplyExpr` instead of just for `CallExpr`s.

This was preventing the `FunctionRefKind` for an operator call to be `SingleApply`, which ultimately did not introduce a disjunction choice for an implicitly unwrapped return value.

Resolves: SR-11399.
Resolves: rdar://problem/55042628