### PR TITLE
[ModuleTrace] Track direct dependencies through #import and @_exported import

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3409,6 +3409,8 @@ void ClangModuleUnit::getImportedModules(
   if (filter.containsOnly(ModuleDecl::ImportFilterKind::ImplementationOnly))
     return;
 
+  // [Note: Pure-Clang-modules-privately-import-stdlib]:
+  // Needed for implicitly synthesized conformances.
   if (filter.contains(ModuleDecl::ImportFilterKind::Private))
     if (auto stdlib = owner.getStdlibModule())
       imports.push_back({ModuleDecl::AccessPathTy(), stdlib});

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -208,6 +208,8 @@ static void emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
       });
 }
 
+// MARK: - Module Trace
+
 namespace {
 struct SwiftModuleTraceInfo {
   Identifier Name;
@@ -262,6 +264,318 @@ template <> struct ObjectTraits<LoadedModuleTraceFormat> {
 }
 }
 
+static bool isClangOverlayOf(ModuleDecl *potentialOverlay,
+                             ModuleDecl *potentialUnderlying) {
+  return !potentialOverlay->isNonSwiftModule()
+      && potentialUnderlying->isNonSwiftModule()
+      && potentialOverlay->getName() == potentialUnderlying->getName();
+}
+
+// TODO: Delete this once changes from https://reviews.llvm.org/D83449 land on
+// apple/llvm-project's swift/master branch.
+template <typename SetLike, typename Item>
+static bool contains(const SetLike &setLike, Item item) {
+  return setLike.find(item) != setLike.end();
+}
+
+/// Get a set of modules imported by \p module.
+///
+/// By default, all imports are included.
+static void getImmediateImports(
+    ModuleDecl *module,
+    SmallPtrSetImpl<ModuleDecl *> &imports,
+    ModuleDecl::ImportFilter importFilter = {
+      ModuleDecl::ImportFilterKind::Public,
+      ModuleDecl::ImportFilterKind::Private,
+      ModuleDecl::ImportFilterKind::ImplementationOnly,
+      ModuleDecl::ImportFilterKind::SPIAccessControl,
+      ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay
+    }) {
+  SmallVector<ModuleDecl::ImportedModule, 8> importList;
+  module->getImportedModules(importList, importFilter);
+
+  for (ModuleDecl::ImportedModule &import : importList)
+    imports.insert(import.importedModule);
+}
+
+namespace {
+/// Helper type for computing (approximate) information about ABI-dependencies.
+///
+/// This misses out on details such as typealiases and more.
+/// See the "isImportedDirectly" field above for more details.
+class ABIDependencyEvaluator {
+  /// Map of ABIs exported by a particular module, excluding itself.
+  ///
+  /// For example, consider (primed letters represent Clang modules):
+  /// \code
+  /// - A is @_exported-imported by B
+  /// - B is #imported by C' (via a compiler-generated umbrella header)
+  /// - C' is @_exported-imported by C (Swift overlay)
+  /// - D' is #imported by E'
+  /// - D' is @_exported-imported by D (Swift overlay)
+  /// - E' is @_exported-imported by E (Swift overlay)
+  /// \endcode
+  ///
+  /// Then the \c abiExportMap will be
+  /// \code
+  /// { A: {}, B: {A}, C: {B}, C': {B}, D: {}, D': {}, E: {D}, E': {D'} }
+  /// \endcode
+  ///
+  /// \b WARNING: Use \c reexposeImportedABI instead of inserting directly.
+  llvm::DenseMap<ModuleDecl *, llvm::DenseSet<ModuleDecl *>> abiExportMap;
+
+  /// Stack for depth-first traversal.
+  SmallVector<ModuleDecl *, 32> searchStack;
+
+  llvm::DenseSet<ModuleDecl *> visited;
+
+  /// Helper function to handle invariant violations as crashes in debug mode.
+  void crashOnInvariantViolation(
+    llvm::function_ref<void (llvm::raw_string_ostream &)> f) const;
+
+  /// Computes the ABI exports for \p importedModule and adds them to
+  /// \p module's ABI exports.
+  ///
+  /// If \p includeImportedModule is true, also adds \p importedModule to
+  /// \p module's ABI exports.
+  ///
+  /// Correct way to add entries to \c abiExportMap.
+  void reexposeImportedABI(ModuleDecl *module, ModuleDecl *importedModule,
+                           bool includeImportedModule = true);
+
+  /// Recursive step in computing ABI dependencies.
+  ///
+  /// Use this method instead of using the \c forClangModule/\c forSwiftModule
+  /// methods.
+  void computeABIDependenciesForModule(ModuleDecl *module);
+  void computeABIDependenciesForSwiftModule(ModuleDecl *module);
+  void computeABIDependenciesForClangModule(ModuleDecl *module);
+
+  static void printModule(const ModuleDecl *module, llvm::raw_ostream &os);
+
+  template<typename SetLike>
+  static void printModuleSet(const SetLike &set, llvm::raw_ostream &os);
+
+public:
+  ABIDependencyEvaluator() = default;
+  ABIDependencyEvaluator(const ABIDependencyEvaluator &) = delete;
+  ABIDependencyEvaluator(ABIDependencyEvaluator &&) = default;
+
+  void getABIDependenciesForSwiftModule(
+    ModuleDecl *module, SmallPtrSetImpl<ModuleDecl *> &abiDependencies);
+
+  void printABIExportMap(llvm::raw_ostream &os) const;
+};
+} // end anonymous namespace
+
+// See [Note: Bailing-vs-crashing-in-trace-emission].
+// TODO: Use PrettyStackTrace instead?
+void ABIDependencyEvaluator::crashOnInvariantViolation(
+  llvm::function_ref<void (llvm::raw_string_ostream &)> f) const {
+#ifndef NDEBUG
+  std::string msg;
+  llvm::raw_string_ostream os(msg);
+  os << "error: invariant violation: ";
+  f(os);
+  llvm::report_fatal_error(os.str());
+#endif
+}
+
+// [Note: Trace-Clang-submodule-complexity]
+//
+// A Clang module may have zero or more submodules. In practice, when traversing
+// the imports of a module, we observe that different submodules of the same
+// top-level module (almost) freely import each other. Despite this, we still
+// need to conceptually traverse the tree formed by the submodule relationship
+// (with the top-level module being the root).
+//
+// This needs to be taken care of in two ways:
+// 1. We need to make sure we only go towards the leaves. It's okay if we "jump"
+//    branches, so long as we don't try to visit an ancestor when one of its
+//    descendants is still on the traversal stack, so that we don't end up with
+//    arbitrarily complex intra-module cycles.
+//    See also: [Note: Intra-module-leafwards-traversal].
+// 2. When adding entries to the ABI export map, we need to avoid marking
+//    dependencies within the same top-level module. This step is needed in
+//    addition to step 1 to avoid creating cycles like
+//    Overlay -> Underlying -> Submodule -> Overlay.
+
+void ABIDependencyEvaluator::reexposeImportedABI(
+    ModuleDecl *module, ModuleDecl *importedModule,
+    bool includeImportedModule) {
+  if (module == importedModule) {
+    crashOnInvariantViolation([&](llvm::raw_string_ostream &os) {
+      os << "module "; printModule(module, os); os << " imports itself!\n";
+    });
+    return;
+  }
+
+  auto addToABIExportMap = [this](ModuleDecl *module, ModuleDecl *reexport) {
+    if (module == reexport) {
+      crashOnInvariantViolation([&](llvm::raw_string_ostream &os){
+        os << "expected module "; printModule(reexport, os);
+        os << "  to not re-export itself\n";
+      });
+      return;
+    }
+    if (reexport->isNonSwiftModule()
+        && module->isNonSwiftModule()
+        && module->getTopLevelModule() == reexport->getTopLevelModule()) {
+      // Dependencies within the same top-level Clang module are not useful.
+      // See also: [Note: Trace-Clang-submodule-complexity].
+      return;
+    }
+
+    // We only care about dependencies across top-level modules and we want to
+    // avoid exploding abiExportMap with submodules. So we only insert entries
+    // after calling getTopLevelModule().
+
+    if (::isClangOverlayOf(module, reexport)) {
+      // For overlays, we need to have a dependency on the underlying module.
+      // Otherwise, we might accidentally create a Swift -> Swift cycle.
+      abiExportMap[module].insert(
+        reexport->getTopLevelModule(/*preferOverlay*/false));
+      return;
+    }
+    abiExportMap[module].insert(
+        reexport->getTopLevelModule(/*preferOverlay*/true));
+  };
+
+  computeABIDependenciesForModule(importedModule);
+  if (includeImportedModule) {
+    addToABIExportMap(module, importedModule);
+  }
+  // Force creation of default value if missing. This prevents abiExportMap from
+  // growing (and moving) when calling addToABIExportMap. If abiExportMap gets
+  // moved, then abiExportMap[importedModule] will be moved, forcing us to
+  // create a defensive copy to avoid iterator invalidation on move.
+  (void)abiExportMap[module];
+  for (auto reexportedModule: abiExportMap[importedModule])
+    addToABIExportMap(module, reexportedModule);
+}
+
+void ABIDependencyEvaluator::computeABIDependenciesForModule(
+    ModuleDecl *module) {
+  if (llvm::find(searchStack, module) != searchStack.end()) {
+    crashOnInvariantViolation([&](llvm::raw_string_ostream &os) {
+      os << "unexpected cycle in import graph!\n";
+      for (auto m: searchStack) {
+        printModule(m, os); os << "\ndepends on ";
+      }
+      printModule(module, os); os << '\n';
+    });
+    return;
+  }
+  if (::contains(visited, module))
+    return;
+  searchStack.push_back(module);
+  if (module->isNonSwiftModule())
+    computeABIDependenciesForClangModule(module);
+  else
+    computeABIDependenciesForSwiftModule(module);
+  searchStack.pop_back();
+  visited.insert(module);
+}
+
+void ABIDependencyEvaluator::computeABIDependenciesForSwiftModule(
+    ModuleDecl *module) {
+  SmallPtrSet<ModuleDecl *, 32> allImports;
+  ::getImmediateImports(module, allImports);
+  for (auto import: allImports) {
+    computeABIDependenciesForModule(import);
+    if (::isClangOverlayOf(module, import)) {
+      reexposeImportedABI(module, import,
+                          /*includeImportedModule=*/false);
+    }
+  }
+
+  SmallPtrSet<ModuleDecl *, 32> reexportedImports;
+  ::getImmediateImports(module, reexportedImports,
+                        {ModuleDecl::ImportFilterKind::Public});
+  for (auto reexportedImport: reexportedImports) {
+    reexposeImportedABI(module, reexportedImport);
+  }
+}
+
+void ABIDependencyEvaluator::computeABIDependenciesForClangModule(
+    ModuleDecl *module) {
+  SmallPtrSet<ModuleDecl *, 32> imports;
+  ::getImmediateImports(module, imports);
+  for (auto import: imports) {
+    // There are three cases here which can potentially create cycles:
+    //
+    // 1. Clang modules importing the stdlib.
+    //    See [Note: Pure-Clang-modules-privately-import-stdlib].
+    // 2. Overlay S @_exported-imports underlying module S' and another Clang
+    //    module C'. C' (transitively) #imports S' but it gets treated as if
+    //    C' imports S. This creates a cycle: S -> C' -> ... -> S.
+    //    In practice, this case is hit for
+    //      Darwin (Swift) -> SwiftOverlayShims (Clang) -> Darwin (Swift).
+    // 3. [Note: Intra-module-leafwards-traversal]
+    //    Cycles within the same top-level module.
+    //    These don't matter for us, since we only care about the dependency
+    //    graph at the granularity of top-level modules. So we ignore these
+    //    by only considering parent -> submodule dependencies.
+    //    See also [Note: Trace-Clang-submodule-complexity].
+    if (import->isStdlibModule()) {
+      continue;
+    }
+    if (!import->isNonSwiftModule()
+        && import->findUnderlyingClangModule() != nullptr
+        && llvm::find(searchStack, import) != searchStack.end()) {
+      continue;
+    }
+    if (import->isNonSwiftModule()
+        && module->getTopLevelModule() == import->getTopLevelModule()
+        && !import->findUnderlyingClangModule()
+                  ->isSubModuleOf(module->findUnderlyingClangModule())) {
+      continue;
+    }
+    computeABIDependenciesForModule(import);
+    reexposeImportedABI(module, import);
+  }
+}
+
+void ABIDependencyEvaluator::getABIDependenciesForSwiftModule(
+    ModuleDecl *module, SmallPtrSetImpl<ModuleDecl *> &abiDependencies) {
+  computeABIDependenciesForModule(module);
+  SmallPtrSet<ModuleDecl *, 32> allImports;
+  ::getImmediateImports(module, allImports);
+  for (auto directDependency: allImports) {
+    abiDependencies.insert(directDependency);
+    for (auto exposedDependency: abiExportMap[directDependency]) {
+      abiDependencies.insert(exposedDependency);
+    }
+  }
+}
+
+void ABIDependencyEvaluator::printModule(
+    const ModuleDecl *module, llvm::raw_ostream &os) {
+  module->getReverseFullModuleName().printForward(os);
+  os << (module->isNonSwiftModule() ? " (Clang)" : " (Swift)");
+  os << " @ " << llvm::format("0x%llx", reinterpret_cast<uintptr_t>(module));
+}
+
+template<typename SetLike>
+void ABIDependencyEvaluator::printModuleSet(
+    const SetLike &set, llvm::raw_ostream &os) {
+  os << "{ ";
+  for (auto module: set) {
+    printModule(module, os); os << ", ";
+  }
+  os << "}";
+}
+
+void ABIDependencyEvaluator::printABIExportMap(llvm::raw_ostream &os) const {
+  os << "ABI Export Map {{\n";
+  for (auto &entry: abiExportMap) {
+    printModule(entry.first, os); os << " : ";
+    printModuleSet(entry.second, os);
+    os << "\n";
+  }
+  os << "}}\n";
+}
+
 /// Compute the per-module information to be recorded in the trace file.
 //
 // The most interesting/tricky thing here is _which_ paths get recorded in
@@ -276,7 +590,7 @@ template <> struct ObjectTraits<LoadedModuleTraceFormat> {
 // FIXME: Use the VFS instead of handling paths directly. We are particularly
 // sloppy about handling relative paths in the dependency tracker.
 static void computeSwiftModuleTraceInfo(
-    const SmallPtrSetImpl<ModuleDecl *> &importedModules,
+    const SmallPtrSetImpl<ModuleDecl *> &abiDependencies,
     const llvm::DenseMap<StringRef, ModuleDecl *> &pathToModuleDecl,
     const DependencyTracker &depTracker,
     StringRef prebuiltCachePath,
@@ -337,6 +651,8 @@ static void computeSwiftModuleTraceInfo(
                              // this is good enough.
         : buffer.str();
 
+      bool isImportedDirectly = ::contains(abiDependencies, depMod);
+
       traceInfo.push_back(
           {/*Name=*/
            depMod->getName(),
@@ -347,8 +663,10 @@ static void computeSwiftModuleTraceInfo(
            // app/test using -import-objc-header, we should look at the direct
            // imports of the bridging modules, and mark those as our direct
            // imports.
+           // TODO: Add negative test cases for the comment above.
+           // TODO: Describe precise semantics of "isImportedDirectly".
            /*IsImportedDirectly=*/
-           importedModules.find(depMod) != importedModules.end(),
+           isImportedDirectly,
            /*SupportsLibraryEvolution=*/
            depMod->isResilient()});
       buffer.clear();
@@ -376,8 +694,7 @@ static void computeSwiftModuleTraceInfo(
     // be saved (not checked), so don't save the path to this swiftmodule.
     SmallString<256> moduleAdjacentInterfacePath(depPath);
     computeAdjacentInterfacePath(moduleAdjacentInterfacePath);
-    if (pathToModuleDecl.find(moduleAdjacentInterfacePath)
-        != pathToModuleDecl.end())
+    if (::contains(pathToModuleDecl, moduleAdjacentInterfacePath))
       continue;
 
     // FIXME: The behavior of fs::exists for relative paths is undocumented.
@@ -404,20 +721,18 @@ static void computeSwiftModuleTraceInfo(
   });
 }
 
-static void extractImportsForTrace(ModuleDecl *module,
-                                   SmallPtrSetImpl<ModuleDecl *> &imports) {
-  ModuleDecl::ImportFilter filter = ModuleDecl::ImportFilterKind::Public;
-  filter |= ModuleDecl::ImportFilterKind::Private;
-  filter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-  filter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
-  filter |= ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay;
-  SmallVector<ModuleDecl::ImportedModule, 8> importList;
-  module->getImportedModules(importList, filter);
-
-  for (ModuleDecl::ImportedModule &import : importList)
-    imports.insert(import.importedModule);
-}
-
+// [Note: Bailing-vs-crashing-in-trace-emission] There are certain edge cases
+// in trace emission where an invariant that you think should hold does not hold
+// in practice. For example, sometimes we have seen modules without any
+// corresponding filename.
+//
+// Since the trace is a supplementary output for build system consumption, it
+// it better to emit it on a best-effort basis instead of crashing and failing
+// the build.
+//
+// Moreover, going forward, it would be nice if trace emission were more robust
+// so we could emit the trace on a best-effort basis even if the dependency
+// graph is ill-formed, so that the trace can be used as a debugging aid.
 static bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
                                           DependencyTracker *depTracker,
                                           StringRef prebuiltCachePath,
@@ -438,8 +753,12 @@ static bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
     return true;
   }
 
-  SmallPtrSet<ModuleDecl *, 8> importedModules;
-  extractImportsForTrace(mainModule, importedModules);
+  SmallPtrSet<ModuleDecl *, 32> abiDependencies;
+  {
+    ABIDependencyEvaluator evaluator{};
+    evaluator.getABIDependenciesForSwiftModule(mainModule,
+                                               abiDependencies);
+  }
 
   llvm::DenseMap<StringRef, ModuleDecl *> pathToModuleDecl;
   for (const auto &module : ctxt.getLoadedModules()) {
@@ -463,7 +782,8 @@ static bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
   }
 
   std::vector<SwiftModuleTraceInfo> swiftModules;
-  computeSwiftModuleTraceInfo(importedModules, pathToModuleDecl, *depTracker,
+  computeSwiftModuleTraceInfo(abiDependencies,
+                              pathToModuleDecl, *depTracker,
                               prebuiltCachePath, swiftModules);
 
   LoadedModuleTraceFormat trace = {

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuel.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuel.h
@@ -1,0 +1,2 @@
+#include "CoreFuelHydrogen.h"
+#include "CoreFuelMethane.h"

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuel.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuel.h
@@ -1,2 +1,2 @@
-#include "CoreFuelHydrogen.h"
-#include "CoreFuelMethane.h"
+#import "CoreFuelHydrogen.h"
+#import "CoreFuelMethane.h"

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuelHydrogen.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuelHydrogen.h
@@ -1,0 +1,1 @@
+float hydrogenEnergyDensityInMJPerKg = 120.0;

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuelMethane.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuelMethane.h
@@ -1,0 +1,3 @@
+#include "CoreFuelHydrogen.h"
+
+float methaneEnergyDensityInMJPerKg = 55.7;

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuelMethane.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreFuel/CoreFuelMethane.h
@@ -1,3 +1,3 @@
-#include "CoreFuelHydrogen.h"
+#import "CoreFuelHydrogen.h"
 
 float methaneEnergyDensityInMJPerKg = 55.7;

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreShip.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/CoreShip.h
@@ -1,0 +1,5 @@
+struct Ship {
+  float mainFuelInKg;
+  float backupFuelInKg;
+  float oxygenInKg;
+};

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/FlightKit.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/FlightKit.h
@@ -1,0 +1,1 @@
+#include "CoreShip.h"

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/FlightKit.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/FlightKit.h
@@ -1,1 +1,1 @@
-#include "CoreShip.h"
+#import "CoreShip.h"

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/LaunchKit.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/LaunchKit.h
@@ -1,1 +1,1 @@
-#include "CoreFuel/CoreFuel.h"
+#import "CoreFuel/CoreFuel.h"

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/LaunchKit.h
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/LaunchKit.h
@@ -1,0 +1,1 @@
+#include "CoreFuel/CoreFuel.h"

--- a/test/Driver/Inputs/imported_modules/ComplexModuleGraph/module.modulemap
+++ b/test/Driver/Inputs/imported_modules/ComplexModuleGraph/module.modulemap
@@ -1,0 +1,22 @@
+module CoreShip {
+  header "CoreShip.h"
+  export *
+}
+
+module CoreFuel {
+  umbrella header "CoreFuel/CoreFuel.h"
+  explicit module CoreFuelHydrogen {
+    header "CoreFuel/CoreFuelHydrogen.h"
+    export *
+  }
+  explicit module CoreFuelMethane {
+    header "CoreFuel/CoreFuelMethane.h"
+    export *
+  }
+  export *
+}
+
+module LaunchKit {
+  header "LaunchKit.h"
+  export *
+}

--- a/test/Driver/loaded_module_trace_directness.swift
+++ b/test/Driver/loaded_module_trace_directness.swift
@@ -1,6 +1,10 @@
 // Check "isImportedDirectly" in trace for complex dependency graphs.
 // See also: rdar://64993153.
 
+// Unsupported on Windows because we are using #import in ObjC, which leads
+// to compiler errors on Windows.
+// UNSUPPORTED: OS=Windows
+
 // Dependency graph:
 
 // * CoreShip - ObjC module with overlay
@@ -55,8 +59,7 @@ public typealias Mission = (origin: Planet, destination: Planet)
 let _ = CoreFuel.hydrogenEnergyDensityInMJPerKg
 let _ = CoreFuel.totalEnergyInMJ
 
-// FIXME: rdar://64993153
-// LAUNCHKIT: {"name":"CoreFuel","path":"{{[^"]*}}CoreFuel.swiftmodule","isImportedDirectly":false,
+// LAUNCHKIT: {"name":"CoreFuel","path":"{{[^"]*}}CoreFuel.swiftmodule","isImportedDirectly":true,
 #endif
 
 
@@ -99,10 +102,8 @@ let _cassini: FlightKit.Mission = (origin: "Earth", destination: "Saturn")
 // SHIPUI: "swiftmodulesDetailedInfo":[
 // SHIPUI-DAG: {"name":"FlightKit","path":"{{[^"]*}}FlightKit.swiftmodule","isImportedDirectly":true,
 // SHIPUI-DAG: {"name":"LaunchKit","path":"{{[^"]*}}LaunchKit.swiftmodule","isImportedDirectly":true,
-// FIXME: rdar://64993153 - this should be direct
-// SHIPUI-DAG: {"name":"CoreFuel","path":"{{[^"]*}}CoreFuel.swiftmodule","isImportedDirectly":false,
+// SHIPUI-DAG: {"name":"CoreFuel","path":"{{[^"]*}}CoreFuel.swiftmodule","isImportedDirectly":true,
 // SHIPUI-DAG: {"name":"CoreShip","path":"{{[^"]*}}CoreShip.swiftmodule","isImportedDirectly":false,
-// FIXME: rdar://64993153 - this should be direct
-// SHIPUI-DAG: {"name":"CoreMission","path":"{{[^"]*}}CoreMission.swiftmodule","isImportedDirectly":false,
+// SHIPUI-DAG: {"name":"CoreMission","path":"{{[^"]*}}CoreMission.swiftmodule","isImportedDirectly":true,
 // SHIPUI: ]
 #endif

--- a/test/Driver/loaded_module_trace_directness.swift
+++ b/test/Driver/loaded_module_trace_directness.swift
@@ -1,0 +1,108 @@
+// Check "isImportedDirectly" in trace for complex dependency graphs.
+// See also: rdar://64993153.
+
+// Dependency graph:
+
+// * CoreShip - ObjC module with overlay
+// * CoreFuel - ObjC module with overlay
+// * CoreMission - Swift module
+// * LaunchKit - ObjC module with overlay, has #import <CoreFuel.h> but not import CoreFuel
+// * FlightKit - Swift module, has import CoreShip and @_exported import CoreMission
+// * ShipUI - Swift module, has import FlightKit and import LaunchKit
+
+// RUN: %empty-directory(%t)
+
+// 1. Create CoreShip module
+// RUN: %target-swift-frontend %s -DCoreShip -module-name CoreShip -emit-module -o %t/CoreShip.swiftmodule -I %S/Inputs/imported_modules/ComplexModuleGraph
+
+#if CoreShip
+@_exported import CoreShip
+#endif
+
+
+// 2. Create CoreFuel module
+// RUN: %target-swift-frontend %s -DCoreFuel -module-name CoreFuel -emit-module -o %t/CoreFuel.swiftmodule -I %S/Inputs/imported_modules/ComplexModuleGraph
+
+#if CoreFuel
+@_exported import CoreFuel
+public func totalEnergyInMJ(hydrogenInKg: Float, methaneInKg: Float) -> Float {
+  return hydrogenInKg * hydrogenEnergyDensityInMJPerKg
+       + methaneInKg * methaneEnergyDensityInMJPerKg
+}
+#endif
+
+
+// 3. Create CoreMission module
+// RUN: %target-swift-frontend %s -DCoreMission -module-name CoreMission -emit-module -o %t/CoreMission.swiftmodule
+
+#if CoreMission
+public typealias Planet = String
+public typealias Mission = (origin: Planet, destination: Planet)
+#endif
+
+
+// 4. Compile LaunchKit and check that its trace has:
+// - direct dependency on CoreFuel
+//
+// RUN: %target-swift-frontend %s -DLaunchKit -module-name LaunchKit -emit-module -o %t/LaunchKit.swiftmodule -I %S/Inputs/imported_modules/ComplexModuleGraph -I %t -emit-loaded-module-trace
+// RUN: %FileCheck %s --check-prefix=LAUNCHKIT < %t/LaunchKit.trace.json
+
+#if LaunchKit
+// CoreFuel is not imported explicitly, but it is automatically @_exported via ObjC #import
+@_exported import LaunchKit
+
+// Both ObjC and Swift parts of CoreFuel are directly accessible!
+let _ = CoreFuel.hydrogenEnergyDensityInMJPerKg
+let _ = CoreFuel.totalEnergyInMJ
+
+// FIXME: rdar://64993153
+// LAUNCHKIT: {"name":"CoreFuel","path":"{{[^"]*}}CoreFuel.swiftmodule","isImportedDirectly":false,
+#endif
+
+
+// 5. Compile FlightKit and check that trace has:
+// - direct dependency on CoreShip
+//
+// RUN: %target-swift-frontend %s -DFlightKit -module-name FlightKit -emit-module -o %t/FlightKit.swiftmodule -I %S/Inputs/imported_modules/ComplexModuleGraph -I %t -emit-loaded-module-trace
+// RUN: %FileCheck %s --check-prefix=FLIGHTKIT < %t/FlightKit.trace.json
+
+#if FlightKit
+import CoreShip
+@_exported import CoreMission
+
+// FLIGHTKIT: "swiftmodulesDetailedInfo":[
+// FLIGHTKIT-DAG: {"name":"CoreShip","path":"{{[^"]*}}CoreShip.swiftmodule","isImportedDirectly":true,
+// FLIGHTKIT-DAG: {"name":"CoreMission","path":"{{[^"]*}}CoreMission.swiftmodule","isImportedDirectly":true,
+// FLIGHTKIT: ]
+#endif
+
+// 6. Compile ShipUI and check that trace has:
+// - direct dependency on FlightKit and LaunchKit (due to imports)
+// - direct dependency on CoreFuel (via LaunchKit)
+// - indirect dependency on CoreShip (via FlightKit)
+// - direct dependency on CoreMission (via FlightKit)
+//
+// RUN: %target-swift-frontend %s -DShipUI -module-name ShipUI -emit-module -o %t/ShipUI.swiftmodule -I %S/Inputs/imported_modules/ComplexModuleGraph -I %t -emit-loaded-module-trace
+// RUN: %FileCheck %s --check-prefix=SHIPUI < %t/ShipUI.trace.json
+
+#if ShipUI
+import FlightKit
+import LaunchKit
+
+// Both ObjC and Swift parts of CoreFuel are accessible via LaunchKit
+let _ = LaunchKit.hydrogenEnergyDensityInMJPerKg
+let _ = LaunchKit.totalEnergyInMJ
+
+// CoreMission's types are accessible via FlightKit
+let _cassini: FlightKit.Mission = (origin: "Earth", destination: "Saturn")
+
+// SHIPUI: "swiftmodulesDetailedInfo":[
+// SHIPUI-DAG: {"name":"FlightKit","path":"{{[^"]*}}FlightKit.swiftmodule","isImportedDirectly":true,
+// SHIPUI-DAG: {"name":"LaunchKit","path":"{{[^"]*}}LaunchKit.swiftmodule","isImportedDirectly":true,
+// FIXME: rdar://64993153 - this should be direct
+// SHIPUI-DAG: {"name":"CoreFuel","path":"{{[^"]*}}CoreFuel.swiftmodule","isImportedDirectly":false,
+// SHIPUI-DAG: {"name":"CoreShip","path":"{{[^"]*}}CoreShip.swiftmodule","isImportedDirectly":false,
+// FIXME: rdar://64993153 - this should be direct
+// SHIPUI-DAG: {"name":"CoreMission","path":"{{[^"]*}}CoreMission.swiftmodule","isImportedDirectly":false,
+// SHIPUI: ]
+#endif


### PR DESCRIPTION
Still missing:

- [X] Test cases.
  - [x] Test case(s) for SPI (maybe SPI change should be a separate PR?)
  - [x] Test cases for overlay-overlay dependency hazards. (Current status: works on my machine)
  - [x] Test cases for import chains. I really wish unit-testing this part of the compiler were easier lolsob. (Current status: I think it should work?)
- [X] ~~Some need to break up last commit into smaller commits.~~ Seems difficult, a lot of things depend on each other.
- [X] ~~It's not clear that the depth-first traversal can be refactored out but maybe it's possible.~~ This is fine. We can refactor later. There's also a bunch of special cases, don't want to block landing the fix on an elegant design.
- [X] ~~It might be possible to factor out some of the logic in `getABIDependenciesForSwiftModule`.~~ Seems ok.

Just opening the PR to get initial feedback on whether the approach looks right.