### PR TITLE
Bump swiftpm to latest (temporarily)

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -356,7 +356,7 @@
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",
                 "swift-tools-support-core": "0.1.8",
-                "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",
+                "swiftpm": "3b56accc865173b0e0588b1df310e74f124c784b",
                 "swift-argument-parser": "0.2.0",
                 "swift-driver": "master",
                 "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2020-06-29-a",


### PR DESCRIPTION
<!-- What's in this pull request? -->
After #32735, we are still encountering build errors. Since SwiftPM contains its own version of TSC, pull in the latest changes. Created [TF-1291](https://bugs.swift.org/browse/TF-1291) to switch back to using the `swift-DEVELOPMENT-SNAPSHOT` tag.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves the following build errors after [apple/swift-package-manager#2802](https://github.com/apple/swift-package-manager/pull/2802)
```
/swift-base/swift-driver/Sources/SwiftDriver/Utilities/VirtualPath.swift:110:29: error: value of type 'RelativePath' has no member 'appending'
      return .relative(path.appending(component: component))
                       ~~~~ ^~~~~~~~~
/swift-base/swift-driver/Sources/SwiftDriver/Utilities/VirtualPath.swift:112:30: error: value of type 'RelativePath' has no member 'appending'
      return .temporary(path.appending(component: component))
                        ~~~~ ^~~~~~~~~
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
