### PR TITLE
[5.3][Sema] Mark the direct callee as being a callee for all ApplyExpr not just CallExpr

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1161,7 +1161,7 @@ namespace {
       ExprStack.pop_back();
 
       // Mark the direct callee as being a callee.
-      if (auto *call = dyn_cast<CallExpr>(expr))
+      if (auto *call = dyn_cast<ApplyExpr>(expr))
         markDirectCallee(call->getFn());
 
       // Fold sequence expressions.

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -290,3 +290,9 @@ func rdar_62054241() {
     return arr.sorted(by: <) // expected-error {{no exact matches in reference to operator function '<'}}
   }
 }
+
+// SR-11399 - Operator returning IUO doesn't implicitly unwrap
+postfix operator ^^^
+postfix func ^^^ (lhs: Int) -> Int! { 0 }
+
+let x: Int = 1^^^


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32737

---

- Explanation:

Fix inability to infer IUO as a result type on an operator application
by extending "direct callee" detection to work not only for calls
but for any type of function application.

- Scope: Limited to operators applications with IUO result types.

- Resolves: rdar://problem/55042628

- Risk: Very Low

- Testing: Added regression tests

- Reviewer: @xedin, @hborla 

Resolves: SR-11399.
Resolves: rdar://problem/55042628
(cherry picked from commit 7c5b6d796ce46d85d7c6abd4a59625d57ee62da5)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
