### PR TITLE
update-checkout: pin swift-driver to the original release revision

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -358,7 +358,7 @@
                 "swift-tools-support-core": "0.0.1",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-06-08-a",
                 "swift-argument-parser": "0.1.0",
-                "swift-driver": "master",
+                "swift-driver": "f44c66392e325d71d51f09cfa29c523f8a2e5256",
                 "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2020-06-08-a",
                 "swift-stress-tester": "swift-DEVELOPMENT-SNAPSHOT-2020-06-08-a",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2020-06-08-a",


### PR DESCRIPTION
swift-driver does not have the developer snapshot points.  Pin the
version to the release version.  This revision was retrieved from the
original build logs for the tensorflow 0.10 release.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
