### PR TITLE
[NFC] Remove __swift_mode_t.

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -32,26 +32,6 @@
 extern "C" {
 #endif
 
-// This declaration might not be universally correct.
-// We verify its correctness for the current platform in the runtime code.
-#if defined(__linux__)
-# if defined(__ANDROID__) && !(defined(__aarch64__) || defined(__x86_64__))
-typedef __swift_uint16_t __swift_mode_t;
-# else
-typedef __swift_uint32_t __swift_mode_t;
-# endif
-#elif defined(__APPLE__)
-typedef __swift_uint16_t __swift_mode_t;
-#elif defined(_WIN32)
-typedef __swift_int32_t __swift_mode_t;
-#elif defined(__wasi__)
-typedef __swift_uint32_t __swift_mode_t;
-#elif defined(__OpenBSD__)
-typedef __swift_uint32_t __swift_mode_t;
-#else  // just guessing
-typedef __swift_uint16_t __swift_mode_t;
-#endif
-
 
 // Input/output <stdio.h>
 SWIFT_RUNTIME_STDLIB_INTERNAL

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -31,11 +31,6 @@
 
 #include "../SwiftShims/LibcShims.h"
 
-#if !defined(_WIN32) || defined(__CYGWIN__)
-static_assert(std::is_same<mode_t, __swift_mode_t>::value,
-              "__swift_mode_t must be defined as equivalent to mode_t in LibcShims.h");
-#endif
-
 SWIFT_RUNTIME_STDLIB_INTERNAL
 int _swift_stdlib_putchar_unlocked(int c) {
 #if defined(_WIN32)


### PR DESCRIPTION
Removes the "__swift_mode_t" type from SwiftShims. This type is no longer used anywhere.
