### PR TITLE
[5.3][Index] Fast path for getting value member

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4693,6 +4693,13 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   if (LookupResult.ViableCandidates.empty())
     return Result;
 
+  // If there's only one viable member, that is the best one.
+  if (LookupResult.ViableCandidates.size() == 1) {
+    Result.Impl->BestIdx = Result.Impl->AllDecls.size();
+    Result.Impl->AllDecls.push_back(LookupResult.ViableCandidates[0].getDecl());
+    return Result;
+  }
+
   // Try to figure out the best overload.
   ConstraintLocator *Locator = CS.getConstraintLocator(nullptr);
   TypeVariableType *TV = CS.createTypeVariable(Locator,


### PR DESCRIPTION
Cherry-pick of #32748 into `release/5.3`

* **Explanation**: Avoid solving constraint system if there's only one viable overload. This should fix a crash we are seeing in `candidates.size() == 1` branch in the constraint system because the patch avoid the crashing code path.
* **Scope**: Index while building, module interface printing
* **Risk**: Very low. Just adding a fast path in obvious cases
* **Testing**: Passes current regression test cases. No tests added because we don't have a reproducer of the crash
* **Issue**: rdar://problem/64636688
* **Reviewer**: Pavel Yaskevich (@xedin)