### PR TITLE
[master-next] Update several clang Type::dump() calls to fix the build

### DIFF
--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -26,6 +26,7 @@
 
 namespace clang {
   class Type;
+  class ASTContext;
 }
 
 namespace swift {
@@ -141,11 +142,13 @@ public:
 /// PrettyStackTraceClangType - Observe that we are processing a
 /// specific Clang type.
 class PrettyStackTraceClangType : public llvm::PrettyStackTraceEntry {
+  const clang::ASTContext &Context;
   const clang::Type *TheType;
   const char *Action;
 public:
-  PrettyStackTraceClangType(const char *action, const clang::Type *type)
-    : TheType(type), Action(action) {}
+  PrettyStackTraceClangType(clang::ASTContext &ctx,
+                            const char *action, const clang::Type *type)
+    : Context(ctx), TheType(type), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 

--- a/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
@@ -24,7 +24,7 @@ class SILInstruction;
 class DominanceAnalysis : public FunctionAnalysisBase<DominanceInfo> {
 protected:
   virtual void verify(DominanceInfo *DI) const override {
-    if (DI->getRoots().empty())
+    if (DI->roots().empty())
       return;
     DI->verify();
   }
@@ -52,7 +52,7 @@ public:
 class PostDominanceAnalysis : public FunctionAnalysisBase<PostDominanceInfo> {
 protected:
   virtual void verify(PostDominanceInfo *PDI) const override {
-    if (PDI->getRoots().empty())
+    if (PDI->roots().empty())
       return;
     PDI->verify();
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3752,7 +3752,9 @@ namespace {
       if (auto *cty = T->getClangFunctionType()) {
         std::string s;
         llvm::raw_string_ostream os(s);
-        cty->dump(os);
+        auto &ctx = T->getASTContext().getClangModuleLoader()
+          ->getClangASTContext();
+        cty->dump(os, ctx);
         printField("clang_type", os.str());
       }
       printAnyFunctionParams(T->getParams(), "input");

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -217,7 +217,7 @@ void PrettyStackTraceClangType::print(llvm::raw_ostream &out) const {
     out << "NULL clang type!\n";
     return;
   }
-  TheType->dump(out);
+  TheType->dump(out, Context);
 }
 
 void PrettyStackTraceTypeRepr::print(llvm::raw_ostream &out) const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3388,8 +3388,8 @@ AnyFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
     SmallString<256> buf;
     llvm::raw_svector_ostream os(buf);
     os << "Expected a Clang function type wrapped in a pointer type or "
-       << "a block pointer type but found:\n";
-    type->dump(os);
+       << "a block pointer type but found:\n <TODO>";
+    // type->dump(os);
     llvm_unreachable(os.str().data());
   }
 #endif

--- a/lib/SIL/Utils/Dominance.cpp
+++ b/lib/SIL/Utils/Dominance.cpp
@@ -119,7 +119,7 @@ void PostDominanceInfo::verify() const {
   //
   // Even though at the SIL level we have "one" return function, we can have
   // multiple exits provided by no-return functions.
-  auto *F = getRoots()[0]->getParent();
+  auto *F = (*root_begin())->getParent();
   PostDominanceInfo OtherDT(F);
 
   // And compare.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -611,7 +611,8 @@ serialization::ClangTypeID Serializer::addClangTypeRef(const clang::Type *ty) {
     isSerializable = false;
   }
   if (!isSerializable) {
-    PrettyStackTraceClangType trace("staging a serialized reference to", ty);
+    PrettyStackTraceClangType trace(loader->getClangASTContext(),
+                                    "staging a serialized reference to", ty);
     llvm::report_fatal_error("Clang function type is not serializable");
   }
 
@@ -4396,7 +4397,8 @@ public:
 
 void Serializer::writeASTBlockEntity(const clang::Type *ty) {
   using namespace decls_block;
-  PrettyStackTraceClangType traceRAII("serializing clang type", ty);
+  auto &ctx = getASTContext().getClangModuleLoader()->getClangASTContext();
+  PrettyStackTraceClangType traceRAII(ctx, "serializing clang type", ty);
   assert(ClangTypesToSerialize.hasRef(ty));
 
   // Serialize the type as an opaque sequence of data.


### PR DESCRIPTION
It now requires an extra clang::ASTContext argument.
https://ci.swift.org/view/swift-master-next/job/oss-swift-incremental-RA-osx-master-next/7670/console:
```
/Volumes/swift-ci/jenkins/workspace/oss-swift-incremental-RA-osx-master-next/swift/lib/AST/ASTDumper.cpp:3755:14: error: no matching member function for call to 'dump'
01:55:26         cty->dump(os);
01:55:26         ~~~~~^~~~
01:55:26 /Volumes/swift-ci/jenkins/workspace/oss-swift-incremental-RA-osx-master-next/llvm-project/clang/include/clang/AST/Type.h:2617:8: note: candidate function not viable: requires 0 arguments, but 1 was provided
01:55:26   void dump() const;
01:55:26        ^
01:55:26 /Volumes/swift-ci/jenkins/workspace/oss-swift-incremental-RA-osx-master-next/llvm-project/clang/include/clang/AST/Type.h:2618:8: note: candidate function not viable: requires 2 arguments, but 1 was provided
01:55:26   void dump(llvm::raw_ostream &OS, const ASTContext &Context) const;
01:55:26        ^
01:55:26 1 error generated.
```

Also, fix up code using DominatorTreeBase::getRoots(), which was removed upstream, to use roots(), roots_being(), etc. instead.