### PR TITLE
test: repair windows builder after #32429

### DIFF
--- a/test/IRGen/autolink_merge_from_clangimporter.swift
+++ b/test/IRGen/autolink_merge_from_clangimporter.swift
@@ -15,5 +15,5 @@ func useLibrarySym() {
 }
 
 // CHECK-DAG: !llvm.linker.options = !{
-// CHECK-DAG: !{{[0-9]+}} = !{!"-lempty"}
+// CHECK-DAG: !{{[0-9]+}} = !{!{{"-lempty"|"/DEFAULTLIB:empty.lib"}}}
 // CHECK-DAG: !{{[0-9]+}} = !{!"-framework", !"LinkFramework"}


### PR DESCRIPTION
The test was overly strict in checking the IR, loosen the test
appropriately.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
