### PR TITLE
AssociatedTypeInference: Delay substitutions into abstract type witnesses until after they have been computed

### DIFF
--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -607,3 +607,90 @@ protocol SR_13172_P2 {
 enum SR_13172_E2: SR_13172_P2 {
   case bar // Okay
 }
+
+/** References to type parameters in type witnesses. */
+
+// Circular reference through a fixed type witness.
+protocol P35a {
+  associatedtype A = Array<B> // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'}}
+}
+protocol P35b: P35a where B == A {}
+// expected-error@+2 {{type 'S35' does not conform to protocol 'P35a'}}
+// expected-error@+1 {{type 'S35' does not conform to protocol 'P35b'}}
+struct S35: P35b {}
+
+// Circular reference through a value witness.
+protocol P36a {
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+
+  func foo(arg: A)
+}
+protocol P36b: P36a {
+  associatedtype B = (Self) -> A // expected-note {{protocol requires nested type 'B'}}
+}
+// expected-error@+2 {{type 'S36' does not conform to protocol 'P36a'}}
+// expected-error@+1 {{type 'S36' does not conform to protocol 'P36b'}}
+struct S36: P36b {
+  func foo(arg: Array<B>) {}
+}
+
+// Test that we can resolve abstract type witnesses that reference
+// other abstract type witnesses.
+protocol P37 {
+  associatedtype A = Array<B>
+  associatedtype B: Equatable = Never
+}
+struct S37: P37 {}
+
+protocol P38a {
+  associatedtype A = Never
+  associatedtype B: Equatable
+}
+protocol P38b: P38a where B == Array<A> {}
+struct S38: P38b {}
+
+protocol P39 where A: Sequence {
+  associatedtype A = Array<B>
+  associatedtype B
+}
+struct S39<B>: P39 {}
+
+// Test that we can handle an analogous complex case involving all kinds of
+// type witness resolution.
+protocol P40a {
+  associatedtype A
+  associatedtype B: P40a
+
+  func foo(arg: A)
+}
+protocol P40b: P40a {
+  associatedtype C = (A, B.A, D.D, E) -> Self
+  associatedtype D: P40b
+  associatedtype E: Equatable
+}
+protocol P40c: P40b where D == S40<Never> {}
+struct S40<E: Equatable>: P40c {
+  func foo(arg: Never) {}
+
+  typealias B = Self
+}
+
+// Self is not treated as a fixed type witness.
+protocol FIXME_P1a {
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+}
+protocol FIXME_P1b: FIXME_P1a where A == Self {}
+// expected-error@+2 {{type 'FIXME_S1' does not conform to protocol 'FIXME_P1a'}}
+// expected-error@+1 {{type 'FIXME_S1' does not conform to protocol 'FIXME_P1b'}}
+struct FIXME_S1: FIXME_P1b {}
+
+// Fails to find the fixed type witness B == FIXME_S2<A>.
+protocol FIXME_P2a {
+  associatedtype A: Equatable = Never // expected-note {{protocol requires nested type 'A'}}
+  associatedtype B: FIXME_P2a // expected-note {{protocol requires nested type 'B'}}
+}
+protocol FIXME_P2b: FIXME_P2a where B == FIXME_S2<A> {}
+// expected-error@+2 {{type 'FIXME_S2<T>' does not conform to protocol 'FIXME_P2a'}}
+// expected-error@+1 {{type 'FIXME_S2<T>' does not conform to protocol 'FIXME_P2b'}}
+struct FIXME_S2<T: Equatable>: FIXME_P2b {}


### PR DESCRIPTION
* We were trying to substitute into default type witnesses without considering other tentative abstract type witnesses we may need to compute later, resulting in conformance errors whenever a default type witness referenced other associated types that are destined to resolve to abstract type witnesses.
  ```swift
  protocol P {
    associatedtype A = [B]
    associatedtype B = Never
  }
  struct Foo: P {} // used to be a conformance error
  ```
* Bonus: fixed type witnesses are now getting substituted into as well and can finally reference other associated types without unconditional conformance errors.
  ```swift
  protocol P {
    associatedtype A = Never
    associatedtype B
  }
  protocol Q: P where B == [A] {}
  struct Foo: Q {} // used to be a conformance error
  ```