### PR TITLE
[AssociatedTypeInference] Strip 'self' parameter from function type of an enum case witness

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -546,9 +546,8 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
 
 /// Remove the 'self' type from the given type, if it's a method type.
 static Type removeSelfParam(ValueDecl *value, Type type) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
-    if (func->getDeclContext()->isTypeContext())
-      return type->castTo<AnyFunctionType>()->getResult();
+  if (value->hasCurriedSelf()) {
+    return type->castTo<AnyFunctionType>()->getResult();
   }
 
   return type;

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -588,3 +588,22 @@ extension SR_12707_P2 {
 struct SR_12707_Conform_P2: SR_12707_P2 {
   typealias A = Never
 }
+
+// SR-13172: Inference when witness is an enum case
+protocol SR_13172_P1 {
+  associatedtype Bar
+  static func bar(_ value: Bar) -> Self
+}
+
+enum SR_13172_E1: SR_13172_P1 {
+  case bar(String) // Okay
+}
+
+protocol SR_13172_P2 {
+  associatedtype Bar
+  static var bar: Bar { get }
+}
+
+enum SR_13172_E2: SR_13172_P2 {
+  case bar // Okay
+}


### PR DESCRIPTION
We weren't stripping off the `self` parameter from the function type of an enum case, causing associated type inference to fail.

Resolves SR-13172
Resolves rdar://problem/65248356