### PR TITLE
[Explicit Module Builds] Add canImport functionality to the ExplicitSwiftModuleLoader

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -141,6 +141,8 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
 
+  bool canImportModule(Located<Identifier> mID) override;
+
   bool isCached(StringRef DepPath) override { return false; };
 
   struct Implementation;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1514,6 +1514,17 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
   return std::error_code();
 }
 
+bool ExplicitSwiftModuleLoader::canImportModule(
+    Located<Identifier> mID) {
+  StringRef moduleName = mID.Item.str();
+  auto it = Impl.ExplicitModuleMap.find(moduleName);
+  // If no provided explicit module matches the name, then it cannot be imported.
+  if (it == Impl.ExplicitModuleMap.end()) {
+    return false;
+  }
+  return true;
+}
+
 void ExplicitSwiftModuleLoader::collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const {
   for (auto &entry: Impl.ExplicitModuleMap) {

--- a/test/ScanDependencies/can_import_with_map.swift
+++ b/test/ScanDependencies/can_import_with_map.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: echo "public func foo() {}" >> %t/foo.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules
+#if canImport(Foo)
+import Foo
+#endif


### PR DESCRIPTION
It needs to check against the provided ExplicitModuleMap instead of looking into search paths.