### PR TITLE
[Frontend] Improve -print-target-info

### DIFF
--- a/include/swift/Frontend/BackDeploymentLibs.def
+++ b/include/swift/Frontend/BackDeploymentLibs.def
@@ -1,0 +1,31 @@
+//===------ BackDeploymentLibs.def - Backward Deployment Libraries --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// Enumerates the backward deployment libraries that need to be linked
+// into Swift targets. Clients of this file must define the macro
+//
+//   BACK_DEPLOYMENT_LIB(Version, Filter, LibraryName)
+//
+// where:
+//   Version is a maximum Swift version written like a tuple, e.g., (5, 1)
+//   Filter is one of executable or all.
+//   LibraryName is the name of the library, e.g., "swiftCompatibility51"
+//===----------------------------------------------------------------------===//
+
+#ifndef BACK_DEPLOYMENT_LIB
+#  error "Must define BACK_DEPLOYMENT_LIB(Version, Filter, Library)"
+#endif
+
+BACK_DEPLOYMENT_LIB((5, 0), all, "swiftCompatibility50")
+BACK_DEPLOYMENT_LIB((5, 1), all, "swiftCompatibility51")
+BACK_DEPLOYMENT_LIB((5, 0), executable, "swiftCompatibilityDynamicReplacements")
+                    
+#undef BACK_DEPLOYMENT_LIB

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1985,6 +1985,12 @@ static void printTargetInfo(const CompilerInvocation &invocation,
                             llvm::raw_ostream &out) {
   out << "{\n";
 
+  // Compiler version, as produced by --version.
+  out << "  \"compilerVersion\": \"";
+  out.write_escaped(version::getSwiftFullVersion(
+                                                 version::Version::getCurrentLanguageVersion()));
+  out << "\",\n";
+
   // Target triple and target variant triple.
   auto &langOpts = invocation.getLangOptions();
   out << "  \"target\": ";

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1948,8 +1948,36 @@ createJSONFixItDiagnosticConsumerIfNeeded(
   });
 }
 
+/// Print information about a
+static void printCompatibilityLibrary(
+    llvm::VersionTuple runtimeVersion, llvm::VersionTuple maxVersion,
+    StringRef filter, StringRef libraryName, bool &printedAny,
+    llvm::raw_ostream &out) {
+  if (runtimeVersion > maxVersion)
+    return;
+
+  if (printedAny) {
+    out << ",";
+  }
+
+  out << "\n";
+  out << "      {\n";
+
+  out << "        \"libraryName\": \"";
+  out.write_escaped(libraryName);
+  out << "\",\n";
+
+  out << "        \"filter\": \"";
+  out.write_escaped(filter);
+  out << "\"\n";
+  out << "      }";
+
+  printedAny = true;
+}
+
 /// Print information about the target triple in JSON.
 static void printTripleInfo(const llvm::Triple &triple,
+                            llvm::Optional<llvm::VersionTuple> runtimeVersion,
                             llvm::raw_ostream &out) {
   out << "{\n";
 
@@ -1965,11 +1993,26 @@ static void printTripleInfo(const llvm::Triple &triple,
   out.write_escaped(getTargetSpecificModuleTriple(triple).getTriple());
   out << "\",\n";
 
-  if (auto runtimeVersion = getSwiftRuntimeCompatibilityVersionForTarget(
-          triple)) {
+  if (runtimeVersion) {
     out << "    \"swiftRuntimeCompatibilityVersion\": \"";
     out.write_escaped(runtimeVersion->getAsString());
     out << "\",\n";
+
+    // Compatibility libraries that need to be linked.
+    out << "    \"compatibilityLibraries\": [";
+    bool printedAnyCompatibilityLibrary = false;
+    #define BACK_DEPLOYMENT_LIB(Version, Filter, LibraryName)           \
+      printCompatibilityLibrary(                                        \
+        *runtimeVersion, llvm::VersionTuple Version, #Filter, LibraryName, \
+        printedAnyCompatibilityLibrary, out);
+    #include "swift/Frontend/BackDeploymentLibs.def"
+
+    if (printedAnyCompatibilityLibrary) {
+      out << "\n   ";
+    }
+    out << " ],\n";
+  } else {
+    out << "    \"compatibilityLibraries\": [ ],\n";
   }
 
   out << "    \"librariesRequireRPath\": "
@@ -1992,14 +2035,16 @@ static void printTargetInfo(const CompilerInvocation &invocation,
   out << "\",\n";
 
   // Target triple and target variant triple.
+  auto runtimeVersion =
+    invocation.getIRGenOptions().AutolinkRuntimeCompatibilityLibraryVersion;
   auto &langOpts = invocation.getLangOptions();
   out << "  \"target\": ";
-  printTripleInfo(langOpts.Target, out);
+  printTripleInfo(langOpts.Target, runtimeVersion, out);
   out << ",\n";
 
   if (auto &variant = langOpts.TargetVariant) {
     out << "  \"targetVariant\": ";
-    printTripleInfo(*variant, out);
+    printTripleInfo(*variant, runtimeVersion, out);
     out << ",\n";
   }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -471,28 +471,31 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
   // situations where it isn't useful, such as for dylibs, though this is
   // harmless aside from code size.
   if (!IRGen.Opts.UseJIT) {
-    if (auto compatibilityVersion
-          = IRGen.Opts.AutolinkRuntimeCompatibilityLibraryVersion) {
-      if (*compatibilityVersion <= llvm::VersionTuple(5, 0)) {
-        this->addLinkLibrary(LinkLibrary("swiftCompatibility50",
-                                         LibraryKind::Library,
-                                         /*forceLoad*/ true));
+    auto addBackDeployLib = [&](llvm::VersionTuple version,
+                                StringRef libraryName) {
+      Optional<llvm::VersionTuple> compatibilityVersion;
+      if (libraryName == "swiftCompatibilityDynamicReplacements") {
+        compatibilityVersion = IRGen.Opts.
+            AutolinkRuntimeCompatibilityDynamicReplacementLibraryVersion;
+      } else {
+        compatibilityVersion = IRGen.Opts.
+            AutolinkRuntimeCompatibilityLibraryVersion;
       }
-      if (*compatibilityVersion <= llvm::VersionTuple(5, 1)) {
-        this->addLinkLibrary(LinkLibrary("swiftCompatibility51",
-                                         LibraryKind::Library,
-                                         /*forceLoad*/ true));
-      }
-    }
 
-    if (auto compatibilityVersion =
-            IRGen.Opts.AutolinkRuntimeCompatibilityDynamicReplacementLibraryVersion) {
-      if (*compatibilityVersion <= llvm::VersionTuple(5, 0)) {
-        this->addLinkLibrary(LinkLibrary("swiftCompatibilityDynamicReplacements",
-                                         LibraryKind::Library,
-                                         /*forceLoad*/ true));
-      }
-    }
+      if (!compatibilityVersion)
+        return;
+
+      if (*compatibilityVersion > version)
+        return;
+
+      this->addLinkLibrary(LinkLibrary(libraryName,
+                                       LibraryKind::Library,
+                                       /*forceLoad*/ true));
+    };
+
+    #define BACK_DEPLOYMENT_LIB(Version, Filter, LibraryName)         \
+      addBackDeployLib(llvm::VersionTuple Version, LibraryName);
+    #include "swift/Frontend/BackDeploymentLibs.def"
   }
 }
 

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -36,7 +36,7 @@
 // CHECK-IOS:   }
 
 
-// CHECK-LINUX:   "compilerVersion": "Swift version
+// CHECK-LINUX:   "compilerVersion": "{{.*}}Swift version
 
 // CHECK-LINUX:   "target": {
 // CHECK-LINUX:     "triple": "x86_64-unknown-linux",

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -9,7 +9,7 @@
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
 
-// CHECK-IOS:   "compilerVersion": "Swift version
+// CHECK-IOS:   "compilerVersion": "{{.*}}Swift version
 
 // CHECK-IOS:   "target": {
 // CHECK-IOS:     "triple": "arm64-apple-ios12.0",

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -16,6 +16,12 @@
 // CHECK-IOS:     "unversionedTriple": "arm64-apple-ios",
 // CHECK-IOS:     "moduleTriple": "arm64-apple-ios",
 // CHECK-IOS:     "swiftRuntimeCompatibilityVersion": "5.0",
+// CHECK-IOS:     "compatibilityLibraries": [
+// CHECK-IOS:       "libraryName": "swiftCompatibility50",
+// CHECK-IOS:       "libraryName": "swiftCompatibility51",
+// CHECK-IOS:       "libraryName": "swiftCompatibilityDynamicReplacements"
+// CHECK-IOS:       "filter": "executable"
+// CHECK-IOS:     ],
 // CHECK-IOS:     "librariesRequireRPath": true
 // CHECK-IOS:   }
 

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -9,6 +9,8 @@
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
 
+// CHECK-IOS:   "compilerVersion": "Swift version
+
 // CHECK-IOS:   "target": {
 // CHECK-IOS:     "triple": "arm64-apple-ios12.0",
 // CHECK-IOS:     "unversionedTriple": "arm64-apple-ios",
@@ -27,6 +29,8 @@
 // CHECK-IOS:     "runtimeResourcePath": "{{.*}}lib{{(/|\\\\)}}swift"
 // CHECK-IOS:   }
 
+
+// CHECK-LINUX:   "compilerVersion": "Swift version
 
 // CHECK-LINUX:   "target": {
 // CHECK-LINUX:     "triple": "x86_64-unknown-linux",


### PR DESCRIPTION
Enhance `-print-target-info` in a few ways to benefit the driver (and eliminate code duplication):
* Add the Swift compiler version (so clients don't also have to invoke with `-version`
* Add the set of compatibility libraries that should be linked with the target

The latter involved some refactoring into a table of compatibility libraries, since we already had 2 copies of the logic in the source code, and I would have had to add a third for `-print-target-info`.