### PR TITLE
[5.3] [Runtime] Let existential types satisfy superclass requirements.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -869,6 +869,15 @@ bool swift::_checkGenericRequirements(
                                    substGenericParam, substWitnessTable).getMetadata();
       if (!baseType) return true;
 
+      // If the type which is constrained to a base class is an existential 
+      // type, and if that existential type includes a superclass constraint,
+      // just require that the superclass by which the existential is
+      // constrained is a subclass of the base class.
+      if (auto *existential = dyn_cast<ExistentialTypeMetadata>(subjectType)) {
+        if (auto *superclassConstraint = existential->getSuperclassConstraint())
+          subjectType = superclassConstraint;
+      }
+
       if (!isSubclass(subjectType, baseType))
         return true;
 

--- a/validation-test/Runtime/rdar64672291.swift
+++ b/validation-test/Runtime/rdar64672291.swift
@@ -1,0 +1,24 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: objc_interop
+
+import Foundation
+
+final class Storage<T: NSObject> {
+    weak var object: T?
+    init(object: T) {
+        self.object = object
+    }
+}
+
+
+@objc protocol MyProtocol {}
+typealias MyStorage = Storage<NSObject & MyProtocol>
+
+class Gadget: NSObject, MyProtocol {
+    func testit() {
+        _ = MyStorage(object: self)
+    }
+}
+
+let gadget = Gadget()
+gadget.testit()


### PR DESCRIPTION
Previously, when an attempt was made to instantiate a generic metadata whose argument was constrained to subclass a superclass Super with an existential type E that had a superclass constraint to a subclass Sub of that same superclass Super, the instantiation would fail at runtime, despite the fact that the generic instantiation was allowed to type-check.

The result was a runtime failure to instantiate generic metadata resulting eventually in a crash.

Here, handling for that situation is added.  When checking generic requirements at runtime, when a superclass requirement is encountered, an existential type is checked for.  If that existential type has a superclass constraint and if that superclass constraint is a subclass of the superclass requirement, the check is determined to be satisfactory.

rdar://problem/64672291

PR against master: https://github.com/apple/swift/pull/32695