### PR TITLE
Sema: Don't look through nested typealiases when checking for unsupported member reference

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -353,8 +353,7 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
     // underlying type is not dependent.
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
       if (!aliasDecl->isGeneric() &&
-          aliasDecl->getUnderlyingType()->getCanonicalType()
-            ->hasTypeParameter()) {
+          aliasDecl->getUnderlyingType()->hasTypeParameter()) {
         return true;
       }
     }

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -23,11 +23,12 @@ struct X1<T> : P1 {
   }
 }
 
-struct GenericStruct<T> { // expected-note 2{{generic type 'GenericStruct' declared here}}
+struct GenericStruct<T> { // expected-note 3{{generic type 'GenericStruct' declared here}}
   typealias Alias = T
   typealias MetaAlias = T.Type
 
   typealias Concrete = Int
+  typealias ReferencesConcrete = Concrete
 
   func methodOne() -> Alias.Type {}
   func methodTwo() -> MetaAlias {}
@@ -58,6 +59,9 @@ let _: GenericStruct.MetaAlias = metaFoo()
 // ... but if the typealias has a fully concrete underlying type,
 // we are OK.
 let _: GenericStruct.Concrete = foo()
+
+let _: GenericStruct.ReferencesConcrete = foo()
+// expected-error@-1 {{reference to generic type 'GenericStruct' requires arguments in <...>}}
 
 class SuperG<T, U> {
   typealias Composed = (T, U)


### PR DESCRIPTION
It appears that a long time ago, we didn't enforce that a member
reference to a typealias nested inside a generic type would supply
the generic arguments at all. To avoid breaking source compatibility,
we carved out some exceptions. Tighten up the exception to prohibit
the case where a typealias references another typealias, to fix a
crash.

While this worked in 5.1, it would crash in 5.2 and 5.3, and at
this point it's more trouble than it is worth to make it work
again, because of subtle representational issues. So let's just
ban it.

Fixes <rdar://problem/63535194>.
