### PR TITLE
[5.3] [Build System] Support host target prefix in symbols package

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1250,6 +1250,7 @@ def main_normal():
 
         if platform.system() == 'Darwin':
             prefix = targets.darwin_toolchain_prefix(args.install_prefix)
+            prefix = os.path.join(args.host_target, prefix.lstrip('/'))
         else:
             prefix = args.install_prefix
 


### PR DESCRIPTION
(cherry picked from commit 6c89aa052689444e27e725d077e58da0e4edce16)
