### PR TITLE
[NFC] AssociatedTypeInference: Improve dumping of an inference solution

### DIFF
--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -383,9 +383,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
       auto decl = overload.getDecl();
       decl->dumpRef(Out);
       Out << " : " << decl->getInterfaceType();
-      if (!sm || !decl->getLoc().isValid()) return;
-      Out << " at ";
-      decl->getLoc().print(Out, *sm);
     };
 
     switch (overload.getKind()) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -75,21 +75,26 @@ void InferredAssociatedTypesByWitness::dump(llvm::raw_ostream &out,
 }
 
 void InferredTypeWitnessesSolution::dump() const {
+  const auto numValueWitnesses = ValueWitnesses.size();
   llvm::errs() << "Type Witnesses:\n";
   for (auto &typeWitness : TypeWitnesses) {
     llvm::errs() << "  " << typeWitness.first->getName() << " := ";
     typeWitness.second.first->print(llvm::errs());
-    llvm::errs() << " value " << typeWitness.second.second << '\n';
+    if (typeWitness.second.second == numValueWitnesses) {
+      llvm::errs() << ", abstract";
+    } else {
+      llvm::errs() << ", inferred from $" << typeWitness.second.second;
+    }
+    llvm::errs() << '\n';
   }
   llvm::errs() << "Value Witnesses:\n";
   for (unsigned i : indices(ValueWitnesses)) {
-    auto &valueWitness = ValueWitnesses[i];
-    llvm::errs() << i << ":  " << (Decl*)valueWitness.first
-    << ' ' << valueWitness.first->getBaseName() << '\n';
-    valueWitness.first->getDeclContext()->printContext(llvm::errs());
-    llvm::errs() << "    for " << (Decl*)valueWitness.second
-    << ' ' << valueWitness.second->getBaseName() << '\n';
-    valueWitness.second->getDeclContext()->printContext(llvm::errs());
+    const auto &valueWitness = ValueWitnesses[i];
+    llvm::errs() << '$' << i << ":\n  ";
+    valueWitness.first->dumpRef(llvm::errs());
+    llvm::errs() << " ->\n  ";
+    valueWitness.second->dumpRef(llvm::errs());
+    llvm::errs() << '\n';
   }
 }
 


### PR DESCRIPTION
It was a challenge to read through those value witnesses previously.

Before: 
```
Type Witnesses:
  A := Int value 0
  B := Bool value 1
Value Witnesses:
0:  0x7f8e2a0c8ea8 foo
0x7f8e2a0c84d0 Module name=test
  0x7f8e2a0c86d0 FileUnit file="/Users/anthonylatsis/Desktop/test.swift"
    0x7f8e2a0c8b10 ProtocolDecl name=P
    for 0x7f8e2a0d26d0 foo
0x7f8e2a0c84d0 Module name=test
  0x7f8e2a0c86d0 FileUnit file="/Users/anthonylatsis/Desktop/test.swift"
    0x7f8e2a0d24a0 StructDecl name=Foo
1:  0x7f8e2a0d2020 bar
0x7f8e2a0c84d0 Module name=test
  0x7f8e2a0c86d0 FileUnit file="/Users/anthonylatsis/Desktop/test.swift"
    0x7f8e2a0c8b10 ProtocolDecl name=P
    for 0x7f8e2a0d2a38 bar
0x7f8e2a0c84d0 Module name=test
  0x7f8e2a0c86d0 FileUnit file="/Users/anthonylatsis/Desktop/test.swift"
    0x7f8e2a0d24a0 StructDecl name=Foo
```

After:
```
Type Witnesses:
  B := Bool value 1
  A := Int value 0
Value Witnesses:
0:
  test.(file).P.foo(arg:)@/Users/anthonylatsis/Desktop/test.swift:12:8 ->
  test.(file).Foo.foo(arg:)@/Users/anthonylatsis/Desktop/test.swift:20:8
1:
  test.(file).P.bar(arg:arg2:)@/Users/anthonylatsis/Desktop/test.swift:13:8 ->
  test.(file).Foo.bar(arg:arg2:)@/Users/anthonylatsis/Desktop/test.swift:21:8
```
