### PR TITLE
[5.3] [AssociatedTypeInference] Strip 'self' parameter from function type of an enum case witness

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -549,9 +549,8 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
 
 /// Remove the 'self' type from the given type, if it's a method type.
 static Type removeSelfParam(ValueDecl *value, Type type) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
-    if (func->getDeclContext()->isTypeContext())
-      return type->castTo<AnyFunctionType>()->getResult();
+  if (value->hasCurriedSelf()) {
+    return type->castTo<AnyFunctionType>()->getResult();
   }
 
   return type;

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -527,3 +527,22 @@ extension S30 {
     T.bar()
   }
 }
+
+// SR-13172: Inference when witness is an enum case
+protocol SR_13172_P1 {
+  associatedtype Bar
+  static func bar(_ value: Bar) -> Self
+}
+
+enum SR_13172_E1: SR_13172_P1 {
+  case bar(String) // Okay
+}
+
+protocol SR_13172_P2 {
+  associatedtype Bar
+  static var bar: Bar { get }
+}
+
+enum SR_13172_E2: SR_13172_P2 {
+  case bar // Okay
+}


### PR DESCRIPTION
Cherry-pick of #32753.

---

**Explanation**: We weren't stripping off the `self` parameter from the function type of an enum case, causing associated type inference to fail when an enum case was used to satisfy a protocol requirement.

**Scope**: Affects associated type inference when using an enum case as protocol witness (SE-0280).

**SR Issue**: SR-13172.

**Risk**: Low. This is a pretty simple change to a check which only considered abstract functions as a protocol witness candidate. The check has been expanded to include an enum case as well.

**Testing**: Added a test case.

**Reviewed by:** @slavapestov

Resolves rdar://problem/65248356