### PR TITLE
[AutoDiff] NFC: garden differentiation transform.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/JVPCloner.h
+++ b/include/swift/SILOptimizer/Differentiation/JVPCloner.h
@@ -1,4 +1,4 @@
-//===--- JVPEmitter.h - JVP Generation in Differentiation -----*- C++ -*---===//
+//===--- JVPCloner.h - JVP function generation ----------------*- C++ -*---===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPEMITTER_H
-#define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPEMITTER_H
+#ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPCLONER_H
+#define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPCLONER_H
 
 #include "swift/SILOptimizer/Differentiation/AdjointValue.h"
 #include "swift/SILOptimizer/Differentiation/DifferentiationInvoker.h"
@@ -40,8 +40,8 @@ namespace autodiff {
 
 class ADContext;
 
-class JVPEmitter final
-    : public TypeSubstCloner<JVPEmitter, SILOptFunctionBuilder> {
+class JVPCloner final
+    : public TypeSubstCloner<JVPCloner, SILOptFunctionBuilder> {
 private:
   /// The global context.
   ADContext &context;
@@ -368,9 +368,9 @@ private:
   void prepareForDifferentialGeneration();
 
 public:
-  explicit JVPEmitter(ADContext &context, SILFunction *original,
-                      SILDifferentiabilityWitness *witness, SILFunction *jvp,
-                      DifferentiationInvoker invoker);
+  explicit JVPCloner(ADContext &context, SILFunction *original,
+                     SILDifferentiabilityWitness *witness, SILFunction *jvp,
+                     DifferentiationInvoker invoker);
 
   static SILFunction *
   createEmptyDifferential(ADContext &context,
@@ -411,4 +411,4 @@ public:
 } // end namespace autodiff
 } // end namespace swift
 
-#endif // SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPEMITTER_H
+#endif // SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPCLONER_H

--- a/include/swift/SILOptimizer/Differentiation/VJPCloner.h
+++ b/include/swift/SILOptimizer/Differentiation/VJPCloner.h
@@ -1,4 +1,4 @@
-//===--- VJPEmitter.h - VJP Generation in differentiation -----*- C++ -*---===//
+//===--- VJPCloner.h - VJP function generation ----------------*- C++ -*---===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPEMITTER_H
-#define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPEMITTER_H
+#ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPCLONER_H
+#define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPCLONER_H
 
 #include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "swift/SILOptimizer/Differentiation/DifferentiationInvoker.h"
@@ -35,11 +35,11 @@ class SILInstruction;
 namespace autodiff {
 
 class ADContext;
-class PullbackEmitter;
+class PullbackCloner;
 
-class VJPEmitter final
-    : public TypeSubstCloner<VJPEmitter, SILOptFunctionBuilder> {
-  friend class PullbackEmitter;
+class VJPCloner final
+    : public TypeSubstCloner<VJPCloner, SILOptFunctionBuilder> {
+  friend class PullbackCloner;
 
 private:
   /// The global context.
@@ -90,9 +90,9 @@ private:
                   SILAutoDiffIndices indices, SILFunction *vjp);
 
 public:
-  explicit VJPEmitter(ADContext &context, SILFunction *original,
-                      SILDifferentiabilityWitness *witness, SILFunction *vjp,
-                      DifferentiationInvoker invoker);
+  explicit VJPCloner(ADContext &context, SILFunction *original,
+                     SILDifferentiabilityWitness *witness, SILFunction *vjp,
+                     DifferentiationInvoker invoker);
 
   SILFunction *createEmptyPullback();
 
@@ -170,4 +170,4 @@ public:
 } // end namespace autodiff
 } // end namespace swift
 
-#endif // SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPEMITTER_H
+#endif // SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_VJPCLONER_H

--- a/lib/SILOptimizer/Differentiation/CMakeLists.txt
+++ b/lib/SILOptimizer/Differentiation/CMakeLists.txt
@@ -2,8 +2,8 @@ target_sources(swiftSILOptimizer PRIVATE
   ADContext.cpp
   Common.cpp
   DifferentiationInvoker.cpp
-  JVPEmitter.cpp
+  JVPCloner.cpp
   LinearMapInfo.cpp
-  PullbackEmitter.cpp
+  PullbackCloner.cpp
   Thunk.cpp
-  VJPEmitter.cpp)
+  VJPCloner.cpp)

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -37,9 +37,9 @@
 #include "swift/SIL/TypeSubstCloner.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Differentiation/ADContext.h"
-#include "swift/SILOptimizer/Differentiation/JVPEmitter.h"
+#include "swift/SILOptimizer/Differentiation/JVPCloner.h"
 #include "swift/SILOptimizer/Differentiation/Thunk.h"
-#include "swift/SILOptimizer/Differentiation/VJPEmitter.h"
+#include "swift/SILOptimizer/Differentiation/VJPCloner.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
@@ -919,8 +919,8 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
         return true;
       }
       // Emit JVP function.
-      JVPEmitter emitter(context, original, witness, jvp, invoker);
-      if (emitter.run())
+      JVPCloner cloner(context, original, witness, jvp, invoker);
+      if (cloner.run())
         return true;
     } else {
       // If JVP generation is disabled or a user-defined custom VJP function
@@ -947,8 +947,8 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
     witness->setVJP(vjp);
     context.recordGeneratedFunction(vjp);
     // Emit VJP function.
-    VJPEmitter emitter(context, original, witness, vjp, invoker);
-    return emitter.run();
+    VJPCloner cloner(context, original, witness, vjp, invoker);
+    return cloner.run();
   }
   return false;
 }


### PR DESCRIPTION
Rename "emitters" to "cloners", for consistency with the rest of the codebase:
- `JVPEmitter` -> `JVPCloner`
- `VJPEmitter` -> `VJPCloner`
- `PullbackEmitter` -> `PullbackCloner`

Improve `PullbackCloner` documentation.
- Document previously undocumented methods.
- Update outdated documentation.
  - For adjoint value accumulation helpers: rename "buffer access" occurrences to
    "address". Pullback generation no longer uses buffer accesses (`begin_apply`).

---

Prep for SR-13182: using the pointer-to-impl pattern to minimize derivative function cloner
header files. It's nice to first finalize the header file locations.