### PR TITLE
Include SPI dependencies in module trace.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -427,6 +427,7 @@ static bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
   ModuleDecl::ImportFilter filter = ModuleDecl::ImportFilterKind::Public;
   filter |= ModuleDecl::ImportFilterKind::Private;
   filter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+  filter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
   filter |= ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay;
   SmallVector<ModuleDecl::ImportedModule, 8> imports;
   mainModule->getImportedModules(imports, filter);

--- a/test/Driver/loaded_module_trace_spi.swift
+++ b/test/Driver/loaded_module_trace_spi.swift
@@ -17,5 +17,4 @@ import Module0
 
 #endif
 
-// FIXME: SPI imports are marked indirect in trace.
-// CHECK: "name":"Module0","path":"{{[^"]*}}","isImportedDirectly":false
+// CHECK: "name":"Module0","path":"{{[^"]*}}","isImportedDirectly":true

--- a/test/Driver/loaded_module_trace_spi.swift
+++ b/test/Driver/loaded_module_trace_spi.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -emit-module -module-name Module0 -DSPI_DECLARING_MODULE -o %t/Module0.swiftmodule
+// RUN: %target-build-swift %s -module-name Module1 -DSPI_IMPORTING_MODULE -emit-loaded-module-trace -o %t/spi_import -I %t
+// RUN: %FileCheck %s < %t/Module1.trace.json
+
+#if SPI_DECLARING_MODULE
+
+@_spi(ForModule1)
+public func f() {}
+
+#endif
+
+#if SPI_IMPORTING_MODULE
+
+@_spi(ForModule1)
+import Module0
+
+#endif
+
+// FIXME: SPI imports are marked indirect in trace.
+// CHECK: "name":"Module0","path":"{{[^"]*}}","isImportedDirectly":false


### PR DESCRIPTION
SPI dependencies also need to be tracked as direct imports.