### PR TITLE
[Test] Un-XFAIL ParseableInterface/verify_all_overlays.py.

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -14,9 +14,6 @@
 
 # REQUIRES: nonexecutable_test
 
-# rdar://problem/50648519
-# XFAIL: asan
-
 # Expected failures by platform
 # -----------------------------
 # macosx: XCTest


### PR DESCRIPTION
The test is passing now--un-XFAIL it.

rdar://problem/50648519