### PR TITLE
[Test] Specialize Prototypes/BigInt.swift for Windows.

### DIFF
--- a/test/Prototypes/BigInt-windows.swift
+++ b/test/Prototypes/BigInt-windows.swift
@@ -1,0 +1,13 @@
+// This test is intentionally specialized on windows because `not --crash`
+// behaves differently there: the exit code from the crashing frontend
+// invocations is mapped to `-21` there, which lit's `not` along does not remap
+// correctly.
+// See rdar://problem/65251059
+// REQUIRES: OS=windows-msvc
+
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-build-swift -swift-version 4 -o %t/a.out %S/BigInt.swift
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+// REQUIRES: CPU=x86_64
+// XFAIL: asserts

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -11,12 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: %empty-directory(%t)
-// RUN: not --crash %target-build-swift -swift-version 4 -o %t/a.out %s
+// RUN: %target-build-swift -swift-version 4 -o %t/a.out %s
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: CPU=x86_64
 
-// REQUIRES: rdar65251059
+// See rdar://problem/65251059
+// UNSUPPORTED: windows
 // rdar://problem/65015626
 // XFAIL: asserts
 


### PR DESCRIPTION
Building the file with asserts crashes the compiler.  Building the file with no_asserts does *not* crash the compiler.

For non-Windows platforms, it is sufficient to `XFAIL: asserts`.

That does not work on Windows thanks to Python < 3: the crash is not handled by lit's `not` there as it is on other platforms.  To handle the expected crash on Windows when building with asserts, not --crash is required.  However on other platforms, not --crash breaks the test in no_asserts builds.

Here, a version of the test's run script specialized for Windows is broken out into a separate BigInt-windows.swift file.

rdar://problem/65251059