### PR TITLE
[gardening] Add a helper to SILFunctionConventions to retrieve if a function has a noreturn result.

### DIFF
--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -396,6 +396,9 @@ public:
   /// Return the SIL type of the apply/entry argument at the given index.
   SILType getSILArgumentType(unsigned index,
                              TypeExpansionContext context) const;
+
+  /// Returns true if this function does not return to the caller.
+  bool isNoReturn(TypeExpansionContext context) const;
 };
 
 struct SILFunctionConventions::SILResultTypeFunc {
@@ -462,6 +465,11 @@ SILFunctionConventions::getSILArgumentType(unsigned index,
   }
   return getSILType(
       funcTy->getParameters()[index - getNumIndirectSILResults()], context);
+}
+
+inline bool
+SILFunctionConventions::isNoReturn(TypeExpansionContext context) const {
+  return funcTy->isNoReturnFunction(silConv.getModule(), context);
 }
 
 inline SILFunctionConventions


### PR DESCRIPTION
Sometimes one just has a SILFunctionConvention instead of the underlying
SILFunctionType (that the SILFunctionConvention contains). This just shims in
that API onto the composition type.

----

NFC