### PR TITLE
Sema: Fix crash on circular reference in checkContextualRequirements()

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -619,6 +619,8 @@ static Type checkContextualRequirements(Type type,
     return type;
   }
 
+  auto &ctx = dc->getASTContext();
+
   SourceLoc noteLoc;
   {
     // We are interested in either a contextual where clause or
@@ -637,6 +639,13 @@ static Type checkContextualRequirements(Type type,
 
   const auto subMap = parentTy->getContextSubstitutions(decl->getDeclContext());
   const auto genericSig = decl->getGenericSignature();
+  if (!genericSig) {
+    ctx.Diags.diagnose(loc, diag::recursive_decl_reference,
+                       decl->getDescriptiveKind(), decl->getName());
+    decl->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
+    return ErrorType::get(ctx);
+  }
+
   const auto result =
     TypeChecker::checkGenericArguments(
         dc, loc, noteLoc, type,
@@ -647,7 +656,7 @@ static Type checkContextualRequirements(Type type,
   switch (result) {
   case RequirementCheckResult::Failure:
   case RequirementCheckResult::SubstitutionFailure:
-    return ErrorType::get(dc->getASTContext());
+    return ErrorType::get(ctx);
   case RequirementCheckResult::Success:
     return type;
   }

--- a/validation-test/compiler_crashers_2_fixed/rdar64759168.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar64759168.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public class Clazz {}
+
+public protocol SelectableFieldValueProtocol {}
+
+public protocol FieldProtocol {
+    associatedtype SelectableValue : SelectableFieldValueProtocol
+}
+
+public protocol SelectFieldValueCoordinatorDelegate  {
+    associatedtype Field : Clazz, FieldProtocol
+}
+
+public class SelectFieldValueCoordinator<Field, Delegate : SelectFieldValueCoordinatorDelegate> where Field == Delegate.Field {}

--- a/validation-test/compiler_crashers_2_fixed/rdar64992293.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar64992293.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+public protocol SomeProtocol {}
+
+public struct Impl<Param>: SomeProtocol where Param: SomeProtocol {}
+
+public struct Wrapper<Content> where Content: SomeProtocol {}
+
+public extension Wrapper where Content == Impl<WrapperParam> {
+  typealias WrapperParam = SomeProtocol
+}
+


### PR DESCRIPTION
The call to getGenericSignature() might return nullptr if we encounter
a circular reference.

Fixes <rdar://problem/64992293>.