### PR TITLE
Remove -sil-merge-partial-modules

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -554,10 +554,6 @@ def sil_unroll_threshold : Separate<["-"], "sil-unroll-threshold">,
   MetaVarName<"<250>">,
   HelpText<"Controls the aggressiveness of loop unrolling">;
 
-// FIXME: This option is now redundant and should eventually be removed.
-def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
-  Alias<merge_modules>;
-
 def sil_verify_all : Flag<["-"], "sil-verify-all">,
   HelpText<"Verify SIL after each transform">;
   

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -981,9 +981,6 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   // serialized ASTs.
   Arguments.push_back("-parse-as-library");
 
-  // Merge serialized SIL from partial modules.
-  Arguments.push_back("-sil-merge-partial-modules");
-
   // Disable SIL optimization passes; we've already optimized the code in each
   // partial mode.
   Arguments.push_back("-disable-diagnostic-passes");


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/32461, this is now the default behaviour for -merge-modules.