### PR TITLE
[PlaceholderExpansion] Omit return type in closure signature

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1016,10 +1016,6 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
       SmallString<32> buffer;
       llvm::raw_svector_ostream OS(buffer);
 
-      bool returnsVoid = AFT->getResult()->isVoid();
-      bool hasSignature = !returnsVoid || !AFT->getParams().empty();
-      if (hasSignature)
-        OS << "(";
       bool firstParam = true;
       for (const auto &param : AFT->getParams()) {
         if (!firstParam)
@@ -1038,12 +1034,8 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
           OS << "#>";
         }
       }
-      if (hasSignature)
-        OS << ")";
-      if (!returnsVoid)
-        OS << " -> " << AFT->getResult()->getString(PO);
 
-      if (hasSignature)
+      if (!firstParam)
         OS << " in";
 
       addChunkWithText(

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -24,11 +24,11 @@ func testGlobalFunc() {
     { 1 } #^GLOBALFUNC_SAMELINE^#
     #^GLOBALFUNC_NEWLINE^#
 // GLOBALFUNC_SAMELINE: Begin completions, 1 items
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
 // GLOBALFUNC_SAMELINE: End completions
 
 // GLOBALFUNC_NEWLINE: Begin completions, 1 items
-// GLOBALFUNC_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// GLOBALFUNC_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
 // GLOBALFUNC_NEWLINE: End completions
 
   globalFunc1()
@@ -53,14 +53,14 @@ func testMethod(value: MyStruct) {
   } #^METHOD_SAMELINE^#
   #^METHOD_NEWLINE^#
 // METHOD_SAMELINE: Begin completions, 4 items
-// METHOD_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#];
+// METHOD_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
 // METHOD_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#];
 // METHOD_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#];
 // METHOD_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#];
 // METHOD_SAMELINE: End completions
 
 // METHOD_NEWLINE: Begin completions
-// METHOD_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#];
+// METHOD_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
 // METHOD_NEWLINE-DAG: Keyword[class]/None:                class;
 // METHOD_NEWLINE-DAG: Keyword[if]/None:                   if;
 // METHOD_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -84,15 +84,15 @@ func testOverloadedInit() {
   #^INIT_OVERLOADED_NEWLINE^#
 
 // INIT_OVERLOADED_SAMELINE: Begin completions, 4 items
-// INIT_OVERLOADED_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
-// INIT_OVERLOADED_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_OVERLOADED_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OVERLOADED_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OVERLOADED_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_OVERLOADED_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct#];
 // INIT_OVERLOADED_SAMELINE: End completions
 
 // INIT_OVERLOADED_NEWLINE: Begin completions
-// INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
-// INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -111,15 +111,15 @@ func testOptionalInit() {
   #^INIT_OPTIONAL_NEWLINE^#
 
 // INIT_OPTIONAL_SAMELINE: Begin completions, 4 items
-// INIT_OPTIONAL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
-// INIT_OPTIONAL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_OPTIONAL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OPTIONAL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OPTIONAL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_OPTIONAL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct2#];
 // INIT_OPTIONAL_SAMELINE: End completions
 
 // INIT_OPTIONAL_NEWLINE: Begin completions
-// INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
-// INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -139,11 +139,11 @@ func testOptionalInit() {
   #^INIT_REQUIRED_NEWLINE_1^#
 
 // INIT_REQUIRED_SAMELINE_1: Begin completions, 1 items
-// INIT_REQUIRED_SAMELINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_REQUIRED_SAMELINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_1: End completions
 
 // INIT_REQUIRED_NEWLINE_1: Begin completions, 1 items
-// INIT_REQUIRED_NEWLINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_REQUIRED_NEWLINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_1: End completions
 
   // missing 'fn3'.
@@ -155,11 +155,11 @@ func testOptionalInit() {
   #^INIT_REQUIRED_NEWLINE_2^#
 
 // INIT_REQUIRED_SAMELINE_2: Begin completions, 1 items
-// INIT_REQUIRED_SAMELINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_REQUIRED_SAMELINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_2: End completions
 
 // INIT_REQUIRED_NEWLINE_2: Begin completions, 1 items
-// INIT_REQUIRED_NEWLINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_REQUIRED_NEWLINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_2: End completions
 
   // Call is completed.
@@ -218,14 +218,14 @@ struct TestNominalMember: P {
   #^MEMBERDECL_NEWLINE^#
 
 // MEMBERDECL_SAMELINE: Begin completions, 4 items
-// MEMBERDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// MEMBERDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#]; name=enumFunc()
 // MEMBERDECL_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#]; name=+ SimpleEnum
 // MEMBERDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#]; name=self
 // MEMBERDECL_SAMELINE: End completions
 
 // MEMBERDECL_NEWLINE: Begin completions
-// MEMBERDECL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// MEMBERDECL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_NEWLINE-DAG: Keyword[enum]/None:                 enum; name=enum
 // MEMBERDECL_NEWLINE-DAG: Keyword[func]/None:                 func; name=func
 // MEMBERDECL_NEWLINE-DAG: Keyword[private]/None:              private; name=private

--- a/test/IDE/complete_multiple_trailingclosure_signatures.swift
+++ b/test/IDE/complete_multiple_trailingclosure_signatures.swift
@@ -17,12 +17,12 @@ func test() {
 
 // GLOBALFUNC_SAMELINE: Begin completions
 // GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn2:  () -> Void {|}#}[#() -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn3:  (Int) -> Void {(<#Int#>) in|}#}[#(Int) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn4:  (Int, String) -> Void {(<#Int#>, <#String#>) in|}#}[#(Int, String) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn5:  (Int, String) -> Int {(<#Int#>, <#String#>) -> Int in|}#}[#(Int, String) -> Int#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn3:  (Int) -> Void {<#Int#> in|}#}[#(Int) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn4:  (Int, String) -> Void {<#Int#>, <#String#> in|}#}[#(Int, String) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn5:  (Int, String) -> Int {<#Int#>, <#String#> in|}#}[#(Int, String) -> Int#];
 // FIXME: recover names
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn6:  (Int, String) -> Int {(<#Int#>, <#String#>) -> Int in|}#}[#(Int, String) -> Int#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn7:  (inout Int) -> Void {(<#inout Int#>) in|}#}[#(inout Int) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn8:  (Int...) -> Void {(<#Int...#>) in|}#}[#(Int...) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn6:  (Int, String) -> Int {<#Int#>, <#String#> in|}#}[#(Int, String) -> Int#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn7:  (inout Int) -> Void {<#inout Int#> in|}#}[#(inout Int) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn8:  (Int...) -> Void {<#Int...#> in|}#}[#(Int...) -> Void#];
 // GLOBALFUNC_SAMELINE: End completions
 }

--- a/test/SourceKit/CodeComplete/multiple_trailing_closure_signatures.swift
+++ b/test/SourceKit/CodeComplete/multiple_trailing_closure_signatures.swift
@@ -19,11 +19,11 @@ func func1(
 
 // CHECK: key.results: [
 // CHECK-DAG: key.sourcetext: "fn2: {\n<#code#>\n}"
-// CHECK-DAG: key.sourcetext: "fn3: { (<#Int#>) in\n<#code#>\n}"
-// CHECK-DAG: key.sourcetext: "fn4: { (<#Int#>, <#String#>) in\n<#code#>\n}",
-// CHECK-DAG: key.sourcetext: "fn5: { (<#Int#>, <#String#>) -> Int in\n<#code#>\n}",
-// CHECK-DAG: key.sourcetext: "fn7: { (<#inout Int#>) in\n<#code#>\n}",
-// CHECK-DAG: key.sourcetext: "fn8: { (<#Int...#>) in\n<#code#>\n}",
+// CHECK-DAG: key.sourcetext: "fn3: { <#Int#> in\n<#code#>\n}"
+// CHECK-DAG: key.sourcetext: "fn4: { <#Int#>, <#String#> in\n<#code#>\n}",
+// CHECK-DAG: key.sourcetext: "fn5: { <#Int#>, <#String#> in\n<#code#>\n}",
+// CHECK-DAG: key.sourcetext: "fn7: { <#inout Int#> in\n<#code#>\n}",
+// CHECK-DAG: key.sourcetext: "fn8: { <#Int...#> in\n<#code#>\n}",
 // CHECK: ]
 
 // DESCRIPTION-NOT: key.description: "fn{{[0-9]*}}: {

--- a/test/SourceKit/CodeExpand/code-expand-multiple-trailing-closures.swift
+++ b/test/SourceKit/CodeExpand/code-expand-multiple-trailing-closures.swift
@@ -89,18 +89,18 @@ nonTrailingAndTrailing2(a: <#T##() -> ()#>, b: <#T##Int#> c: <#T##() -> ()#>)
 
 
 withTypesAndLabels1(a: <#T##(_ booly: Bool, inty: Int) -> ()#>, b: <#T##(solo: Xyz) -> ()#>)
-// CHECK:      withTypesAndLabels1 { (booly, inty) in
+// CHECK:      withTypesAndLabels1 { booly, inty in
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: } b: { (solo) in
+// CHECK-NEXT: } b: { solo in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
 func reset_parser1() {}
 
 withTypes1(a: <#T##(Bool, Int) -> ()#>, b: <#T##() -> Int#>)
-// CHECK:      withTypes1 { (<#Bool#>, <#Int#>) in
+// CHECK:      withTypes1 { <#Bool#>, <#Int#> in
 // CHECK-NEXT: <#code#>
-// CHECK-NEXT: } b: { () -> Int in
+// CHECK-NEXT: } b: {
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -11,23 +11,23 @@ foo(x: <#T##() -> Void#>, y: <#T##Int#>)
 // CHECK-NEXT: }, y: Int)
 
 anArr.indexOfObjectPassingTest(<#T##predicate: ((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?##((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?#>)
-// CHECK:      anArr.indexOfObjectPassingTest { (<#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#>) -> Bool in
+// CHECK:      anArr.indexOfObjectPassingTest { <#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#> in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
 anArr.indexOfObjectPassingTest(<#T##predicate: ((_ obj: AnyObject!, _ idx: Int, _ stop: UnsafePointer<ObjCBool>) -> Bool)?##((_ obj: AnyObject!, _ idx: Int, _ stop: UnsafePointer<ObjCBool>) -> Bool)?#>)
-// CHECK:      anArr.indexOfObjectPassingTest { (obj, idx, stop) -> Bool in
+// CHECK:      anArr.indexOfObjectPassingTest { obj, idx, stop in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
 anArr.indexOfObjectAtIndexes(<#T##s: NSIndexSet?##NSIndexSet?#>, options: <#T##NSEnumerationOptions#>, passingTest: <#T##((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?#>)
-// CHECK:      anArr.indexOfObjectAtIndexes(NSIndexSet?, options: NSEnumerationOptions) { (<#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#>) -> Bool in
+// CHECK:      anArr.indexOfObjectAtIndexes(NSIndexSet?, options: NSEnumerationOptions) { <#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#> in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
 if anArr.indexOfObjectPassingTest(<#T##predicate: ((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?##((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?#>) {
 }
-// CHECK:      if anArr.indexOfObjectPassingTest({ (<#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#>) -> Bool in
+// CHECK:      if anArr.indexOfObjectPassingTest({ <#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#> in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }) {
 // CHECK-NEXT: }
@@ -48,10 +48,10 @@ do {
 }
 
 foo(x: <#T##Self.SegueIdentifier -> Void#>)
-// CHECK:      foo { (<#Self.SegueIdentifier#>) in
+// CHECK:      foo { <#Self.SegueIdentifier#> in
 
 store.requestAccessToEntityType(<#T##entityType: EKEntityType##EKEntityType#>, completion: <#T##EKEventStoreRequestAccessCompletionHandler##EKEventStoreRequestAccessCompletionHandler##(Bool, NSError?) -> Void#>)
-// CHECK:      store.requestAccessToEntityType(EKEntityType) { (<#Bool#>, <#NSError?#>) in
+// CHECK:      store.requestAccessToEntityType(EKEntityType) { <#Bool#>, <#NSError?#> in
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 


### PR DESCRIPTION
Return type in the closure signatures are often redundant when expanding placeholders because the type of the closures are usually inferred from the context (i.e. calling function). Users don't need to write the return type explicitly.

They are not only redundant, but also sometimes harmful when the return type is a generic parameter or its requirement. Actually, there is no correct fixed spelling in such cases.

So omit the return type and the parentheses around the parameter clause.

```swift
// OLD
obj.call { () -> String in
  <#code#>
}

// NEW
obj.call {
  <#code#>
}
```

```swift
// OLD
obj.call { (<#Int#>, <#Int#>) -> Result in
  <#code#>
}

// NEW
obj.call { <#Int#>, <#Int#> in
  <#code#> 
}
``` 

rdar://problem/63607976
