### PR TITLE
test: make `test_util` more python 3 friendly

### DIFF
--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -22,7 +22,8 @@ def escapeCmdArg(arg):
 
 
 def run_command(cmd):
-    cmd = list(map(lambda s: s.encode('utf-8'), cmd))
+    if sys.version_info[0] < 3:
+      cmd = list(map(lambda s: s.encode('utf-8'), cmd))
     print(' '.join([escapeCmdArg(arg) for arg in cmd]))
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 

--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -23,7 +23,7 @@ def escapeCmdArg(arg):
 
 def run_command(cmd):
     if sys.version_info[0] < 3:
-      cmd = list(map(lambda s: s.encode('utf-8'), cmd))
+        cmd = list(map(lambda s: s.encode('utf-8'), cmd))
     print(' '.join([escapeCmdArg(arg) for arg in cmd]))
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 


### PR DESCRIPTION
The last set of changes to make it backwards compatible with Python 2
required converting the arguments.  That is not compatible on Python 3
unfortunately.  Only perform that on Python 2 to make the utility
compatible with 2 and 3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
