### PR TITLE
Fix typo in comparison in comments and help text

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -56,7 +56,7 @@ namespace driver {
 enum class OutputLevel {
   /// Indicates that normal output should be produced.
   Normal,
-  
+
   /// Indicates that only jobs should be printed and not run. (-###)
   PrintJobs,
 
@@ -83,7 +83,7 @@ public:
     const bool &EnableIncrementalBuild;
     const bool EnableSourceRangeDependencies;
 
-    /// If not empty, the path to use to log the comparision.
+    /// If not empty, the path to use to log the comparison.
     const StringRef CompareIncrementalSchemesPath;
 
     const unsigned SwiftInputCount;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -154,7 +154,7 @@ Flag<["-"], "enable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalB
 def disable_only_one_dependency_file :
 Flag<["-"], "disable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
  HelpText<"Disables incremental build optimization that only produces one dependencies file">;
- 
+
 
 def enable_source_range_dependencies :
 Flag<["-"], "enable-source-range-dependencies">, Flags<[]>,
@@ -167,7 +167,7 @@ HelpText<"Print a simple message comparing dependencies with source ranges (w/ f
 
 def driver_compare_incremental_schemes_path :
 Separate<["-"], "driver-compare-incremental-schemes-path">, Flags<[ArgumentIsPath,DoesNotAffectIncrementalBuild]>,
-HelpText<"Path to use for machine-readable comparision">,
+HelpText<"Path to use for machine-readable comparison">,
 MetaVarName<"<path>">;
 
 def driver_compare_incremental_schemes_path_EQ :

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -65,7 +65,7 @@ extension StringProtocol {
 }
 
 extension String: Equatable {
-  @inlinable @inline(__always) // For the bitwise comparision
+  @inlinable @inline(__always) // For the bitwise comparison
   @_effects(readonly)
   @_semantics("string.equals")
   public static func == (lhs: String, rhs: String) -> Bool {
@@ -74,7 +74,7 @@ extension String: Equatable {
 }
 
 extension String: Comparable {
-  @inlinable @inline(__always) // For the bitwise comparision
+  @inlinable @inline(__always) // For the bitwise comparison
   @_effects(readonly)
   public static func < (lhs: String, rhs: String) -> Bool {
     return _stringCompare(lhs._guts, rhs._guts, expecting: .less)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes a small typo in the word comparison (was comparis_i_on) in the `swift --help` argument help of `-driver-compare-incremental-schemes-path` as well as two comments in the stdlib and one in a swift header.
I've noticed the typo in the help text and found the other three while searching for it in the source code.

There are no functional changes in this PR.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
