### PR TITLE
Change ProjectionIndex for ref_tail_addr to UINT_MAX.

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -137,6 +137,8 @@ static inline bool isCastProjectionKind(ProjectionKind Kind) {
 ///
 /// This lightweight utility maps a SIL address projection to an index.
 struct ProjectionIndex {
+  static constexpr unsigned MaxIndex = ~0U;
+
   SILValue Aggregate;
   unsigned Index;
 
@@ -164,7 +166,7 @@ struct ProjectionIndex {
     }
     case ValueKind::RefTailAddrInst: {
       RefTailAddrInst *REA = cast<RefTailAddrInst>(V);
-      Index = 0;
+      Index = MaxIndex;
       Aggregate = REA->getOperand();
       break;
     }


### PR DESCRIPTION
This is necessary to disambiguate the tail elements from
ref_element_addr field zero.

In preparation for adding the AccessPath utility.