### PR TITLE
test: use `-log-path` for stderr access in ModuleInterface tests

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash-windows.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash-windows.test-sh
@@ -4,7 +4,9 @@
 # See rdar://59397376
 REQUIRES: OS=windows-msvc
 
-RUN: env SWIFT_EXEC=%swiftc_driver_plain not --crash %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler 2>&1 | %FileCheck %s
+RUN: %empty-directory(%t)
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not --crash %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler -log-path %t
+RUN: %FileCheck %s < %t/Flat-Flat-err.txt
 
 CHECK: Program arguments:
 CHECK-SAME: -debug-crash-immediately

--- a/test/ModuleInterface/swift_build_sdk_interfaces/xfails.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/xfails.test-sh
@@ -1,8 +1,8 @@
 RUN: %empty-directory(%t)
-RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output 2> %t/stderr.txt | %FileCheck %s
-RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
-RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -v -o %t/output 2> %t/stderr.txt | %FileCheck -check-prefix CHECK-VERBOSE %s
-RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t | %FileCheck %s
+RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/Bad-Bad-err.txt
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -log-path %t | %FileCheck -check-prefix CHECK-VERBOSE %s
+RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/Bad-Bad-err.txt
 
 CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-VERBOSE-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
@@ -13,10 +13,10 @@ HIDES-ERROR-NOT: cannot find 'garbage' in scope
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good"]' > %t/xfails-good.json
-RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
-RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -xfails %t/xfails-good.json -log-path %t | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
+RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/Bad-Bad-err.txt
 RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
-RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
+RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/Bad-Bad-err.txt
 
 CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-XFAIL-GOOD-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
@@ -25,8 +25,8 @@ RUN: %empty-directory(%t)
 RUN: echo '["Good", "Bad"]' > %t/xfails-good-and-bad.json
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -xfails %t/xfails-good-and-bad.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD-AND-BAD %s
 RUN: %FileCheck -check-prefix HIDES-ERROR -allow-empty %s < %t/stderr.txt
-RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good-and-bad.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD-AND-BAD %s
-RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
+RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good-and-bad.json -log-path %t | %FileCheck -check-prefix=CHECK-XFAIL-GOOD-AND-BAD %s
+RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/Bad-Bad-err.txt
 
 CHECK-XFAIL-GOOD-AND-BAD-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-XFAIL-GOOD-AND-BAD-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
@@ -35,8 +35,8 @@ RUN: %empty-directory(%t)
 RUN: echo '["Bad"]' > %t/xfails-bad.json
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -xfails %t/xfails-bad.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-BAD %s
 RUN: %FileCheck -check-prefix HIDES-ERROR -allow-empty %s < %t/stderr.txt
-RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-bad.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-BAD-VERBOSE %s
-RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
+RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-bad.json -log-path %t | %FileCheck -check-prefix=CHECK-XFAIL-BAD-VERBOSE %s
+RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/Bad-Bad-err.txt
 
 CHECK-XFAIL-BAD: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-XFAIL-BAD-VERBOSE-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface


### PR DESCRIPTION
The stderr handles seem to behave differently under Python 3.  Use the
`-log-path` option to capture the standard error output and validate the
output.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
