### PR TITLE
test: make `remote-run` Python 3 friendly

### DIFF
--- a/utils/remote-run
+++ b/utils/remote-run
@@ -89,7 +89,7 @@ class CommandRunner(object):
             print(concatenated_commands, file=sys.stderr)
         if self.dry_run:
             return
-        _, _ = sftp_proc.communicate(concatenated_commands)
+        _, _ = sftp_proc.communicate(concatenated_commands.encode('utf-8'))
         if sftp_proc.returncode:
             sys.exit(sftp_proc.returncode)
 


### PR DESCRIPTION
Without this the remote-run tests fail due to expecting a "bytes-like"
object rather than str.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
