### PR TITLE
[Sema] Only require a default implementation for SPI requirements in non-SPI protocols

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -873,44 +873,6 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
                             D->getDescriptiveKind());
     }
 
-    // If VD is a public protocol requirement it can be SPI only if there's
-    // a default implementation.
-    if (auto protocol = dyn_cast<ProtocolDecl>(D->getDeclContext())) {
-      auto implementations = TypeChecker::lookupMember(
-                                             D->getDeclContext(),
-                                             protocol->getDeclaredType(),
-                                             VD->createNameRef(),
-                                             NameLookupFlags::ProtocolMembers);
-      bool hasDefaultImplementation = llvm::any_of(implementations,
-        [&](const LookupResultEntry &entry) {
-          auto entryDecl = entry.getValueDecl();
-          auto DC = entryDecl->getDeclContext();
-          auto extension = dyn_cast<ExtensionDecl>(DC);
-
-          // The implementation must be defined in the same module in
-          // an unconstrained extension.
-          if (!extension ||
-              extension->getParentModule() != protocol->getParentModule() ||
-              extension->isConstrainedExtension())
-            return false;
-
-          // For computed properties and subscripts, check that the default
-          // implementation defines `set` if the protocol declares it.
-          if (auto protoStorage = dyn_cast<AbstractStorageDecl>(VD))
-            if (auto entryStorage = dyn_cast<AbstractStorageDecl>(entryDecl))
-              if (protoStorage->supportsMutation() &&
-                  !entryStorage->supportsMutation())
-                return false;
-
-          return true;
-        });
-
-      if (!hasDefaultImplementation)
-        diagnoseAndRemoveAttr(attr,
-                              diag::spi_attribute_on_protocol_requirement,
-                              VD->getName());
-    }
-
     // Forbid stored properties marked SPI in frozen types.
     if (auto property = dyn_cast<AbstractStorageDecl>(VD))
       if (auto DC = dyn_cast<NominalTypeDecl>(D->getDeclContext()))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5758,8 +5758,9 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     ResolveWitnessResult result = checker.resolveWitnessViaLookup(valueDecl);
 
     if (result == ResolveWitnessResult::Missing &&
-        requirement->isSPI()) {
-      // SPI requirements need a default value.
+        requirement->isSPI() &&
+        !proto->isSPI()) {
+      // SPI requirements need a default value, unless the protocol is SPI too.
       valueDecl->diagnose(diag::spi_attribute_on_protocol_requirement,
                           valueDecl->getName());
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5755,7 +5755,14 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     if (!valueDecl->isProtocolRequirement())
       continue;
 
-    checker.resolveWitnessViaLookup(valueDecl);
+    ResolveWitnessResult result = checker.resolveWitnessViaLookup(valueDecl);
+
+    if (result == ResolveWitnessResult::Missing &&
+        requirement->isSPI()) {
+      // SPI requirements need a default value.
+      valueDecl->diagnose(diag::spi_attribute_on_protocol_requirement,
+                          valueDecl->getName());
+    }
   }
 
   // Find defaults for any associated conformances rooted on defaulted

--- a/test/SPI/protocol_requirement.swift
+++ b/test/SPI/protocol_requirement.swift
@@ -1,23 +1,23 @@
 // Test limitations on SPI protocol requirements.
 
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-library-evolution
 
 // Reject SPI protocol requirements without a default implementation.
 public protocol PublicProtoRejected {
-  @_spi(Private) // expected-error{{protocol requirement 'reqWithoutDefault()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
-  func reqWithoutDefault()
+  @_spi(Private)
+  func reqWithoutDefault() // expected-error{{protocol requirement 'reqWithoutDefault()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
-  @_spi(Private) // expected-error{{protocol requirement 'property' cannot be declared '@_spi' without a default implementation in a protocol extension}}
-  var property: Int { get set }
+  @_spi(Private)
+  var property: Int { get set } // expected-error{{protocol requirement 'property' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
-  @_spi(Private) // expected-error{{protocol requirement 'propertyWithoutSetter' cannot be declared '@_spi' without a default implementation in a protocol extension}}
-  var propertyWithoutSetter: Int { get set }
+  @_spi(Private)
+  var propertyWithoutSetter: Int { get set } // expected-error{{protocol requirement 'propertyWithoutSetter' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
-  @_spi(Private) // expected-error{{protocol requirement 'subscript(_:)' cannot be declared '@_spi' without a default implementation in a protocol extension}}
-  subscript(index: Int) -> Int { get set }
+  @_spi(Private)
+  subscript(index: Int) -> Int { get set } // expected-error{{protocol requirement 'subscript(_:)' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
-  @_spi(Private) // expected-error{{protocol requirement 'init()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
-  init()
+  @_spi(Private)
+  init() // expected-error{{protocol requirement 'init()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
   @_spi(Private) // expected-error{{'@_spi' attribute cannot be applied to this declaration}}
   associatedtype T

--- a/test/SPI/protocol_requirement.swift
+++ b/test/SPI/protocol_requirement.swift
@@ -8,6 +8,9 @@ public protocol PublicProtoRejected {
   func reqWithoutDefault() // expected-error{{protocol requirement 'reqWithoutDefault()' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
   @_spi(Private)
+  func reqWithSharedName(_: Int) // expected-error{{protocol requirement 'reqWithSharedName' cannot be declared '@_spi' without a default implementation in a protocol extension}}
+
+  @_spi(Private)
   var property: Int { get set } // expected-error{{protocol requirement 'property' cannot be declared '@_spi' without a default implementation in a protocol extension}}
 
   @_spi(Private)
@@ -26,6 +29,9 @@ public protocol PublicProtoRejected {
 extension PublicProtoRejected {
   @_spi(Private)
   public var propertyWithoutSetter: Int { get { return 42 } }
+
+  @_spi(Private)
+  public func reqWithSharedName(_: String) {}
 }
 
 extension PublicProtoRejected where Self : Equatable {

--- a/test/SPI/protocol_requirement.swift
+++ b/test/SPI/protocol_requirement.swift
@@ -75,3 +75,24 @@ extension PublicProto {
   @_spi(Private)
   public init() { }
 }
+
+@_spi(Private)
+public protocol SPIProtocol {
+  @_spi(Private)
+  func reqWithoutDefault()
+
+  @_spi(Private)
+  var property: Int { get set }
+
+  @_spi(Private)
+  var propertyWithoutSetter: Int { get set }
+
+  @_spi(Private)
+  subscript(index: Int) -> Int { get set }
+
+  @_spi(Private)
+  init()
+
+  @_spi(Private)
+  static var staticProperty: Int { get }
+}


### PR DESCRIPTION
The check for SPI protocol requirements needing a default implementation should ignore requirements in a protocol that is SPI too. The protocol can’t be conformed to without knowing of the requirement.

rdar://65286171