### PR TITLE
test: make test syntactically compatible with Python3

### DIFF
--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -82,10 +82,11 @@ type_initializer_map = [
   ]
 
 import re
-def derive_name((type, val)):
+def derive_name(type, val):
   return (re.sub(r'[<> ,\.\?\(\)\[\]-]', '_', type), type, val)
 
-for name, type, val in map(derive_name, type_initializer_map):
+for (type, val) in type_initializer_map:
+  (name, type, val) = derive_name(type, val)
   generic = (type in ['T', 'U'])
   function = "->" in type
 }%


### PR DESCRIPTION
Python3 does not like the use of the unpacked tuple in the argument
list, change the function's arity and require the caller to expand the
tuple.

`map` now returns an iterator rather than a list, simplify the iteration
to unpack the elements in the list and use that to invoke the map'ed
method instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
