### PR TITLE
[swift-inspect] Add a command for dumping metadata cache nodes.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -850,6 +850,36 @@ public:
     }
   }
 
+  llvm::Optional<MetadataCacheNode<Runtime>>
+  metadataAllocationCacheNode(MetadataAllocation<Runtime> Allocation) {
+    switch (Allocation.Tag) {
+    case BoxesTag:
+    case ObjCClassWrappersTag:
+    case FunctionTypesTag:
+    case MetatypeTypesTag:
+    case ExistentialMetatypeValueWitnessTablesTag:
+    case ExistentialMetatypesTag:
+    case ExistentialTypesTag:
+    case OpaqueExistentialValueWitnessTablesTag:
+    case ClassExistentialValueWitnessTablesTag:
+    case ForeignWitnessTablesTag:
+    case TupleCacheTag:
+    case GenericMetadataCacheTag:
+    case ForeignMetadataCacheTag:
+    case GenericWitnessTableCacheTag: {
+      auto NodeBytes = getReader().readBytes(
+          RemoteAddress(Allocation.Ptr), sizeof(MetadataCacheNode<Runtime>));
+      auto Node =
+          reinterpret_cast<const MetadataCacheNode<Runtime> *>(NodeBytes.get());
+      if (!Node)
+        return llvm::None;
+      return *Node;
+    }
+    default:
+      return llvm::None;
+    }
+  }
+
   /// Iterate the metadata allocations in the target process, calling Call with
   /// each allocation found. Returns None on success, and a string describing
   /// the error on failure.

--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -41,6 +41,11 @@ struct MetadataAllocation {
   unsigned Size;
 };
 
+template <typename Runtime> struct MetadataCacheNode {
+  typename Runtime::StoredPointer Left;
+  typename Runtime::StoredPointer Right;
+};
+
 } // end namespace reflection
 } // end namespace swift
 

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -339,6 +339,12 @@ const char *
 swift_reflection_metadataAllocationTagName(SwiftReflectionContextRef ContextRef,
                                            swift_metadata_allocation_tag_t Tag);
 
+SWIFT_REMOTE_MIRROR_LINKAGE
+int swift_reflection_metadataAllocationCacheNode(
+    SwiftReflectionContextRef ContextRef,
+    swift_metadata_allocation_t Allocation,
+    swift_metadata_cache_node_t *OutNode);
+
 /// Backtrace iterator callback passed to
 /// swift_reflection_iterateMetadataAllocationBacktraces
 typedef void (*swift_metadataAllocationBacktraceIterator)(

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -162,6 +162,11 @@ typedef struct swift_metadata_allocation {
   unsigned Size;
 } swift_metadata_allocation_t;
 
+typedef struct swift_metadata_cache_node {
+  swift_reflection_ptr_t Left;
+  swift_reflection_ptr_t Right;
+} swift_metadata_cache_node_t;
+
 /// An opaque pointer to a context which maintains state and
 /// caching of reflection structure for heap instances.
 typedef struct SwiftReflectionContext *SwiftReflectionContextRef;

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -645,6 +645,25 @@ const char *swift_reflection_metadataAllocationTagName(
   return returnableCString(ContextRef, Result);
 }
 
+int swift_reflection_metadataAllocationCacheNode(
+    SwiftReflectionContextRef ContextRef,
+    swift_metadata_allocation_t Allocation,
+    swift_metadata_cache_node_t *OutNode) {
+  auto Context = ContextRef->nativeContext;
+  MetadataAllocation<Runtime> ConvertedAllocation;
+  ConvertedAllocation.Tag = Allocation.Tag;
+  ConvertedAllocation.Ptr = Allocation.Ptr;
+  ConvertedAllocation.Size = Allocation.Size;
+
+  auto Result = Context->metadataAllocationCacheNode(ConvertedAllocation);
+  if (!Result)
+    return 0;
+
+  OutNode->Left = Result->Left;
+  OutNode->Right = Result->Right;
+  return 1;
+}
+
 const char *swift_reflection_iterateMetadataAllocationBacktraces(
     SwiftReflectionContextRef ContextRef,
     swift_metadataAllocationBacktraceIterator Call, void *ContextPtr) {

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirrorExtensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirrorExtensions.swift
@@ -83,6 +83,23 @@ extension SwiftReflectionContextRef {
     swift_reflection_allocationMetadataPointer(self, allocation)
   }
 
+  func metadataTagName(_ tag: swift_metadata_allocation_tag_t) -> String? {
+    swift_reflection_metadataAllocationTagName(self, tag)
+      .map(String.init)
+  }
+
+  func metadataAllocationCacheNode(
+    _ allocation: swift_metadata_allocation_t
+  ) -> swift_metadata_cache_node_t? {
+    var node = swift_metadata_cache_node_t();
+    let success = swift_reflection_metadataAllocationCacheNode(
+      self, allocation, &node)
+    if success == 0 {
+      return nil
+    }
+    return node
+  }
+
   private func throwError(str: UnsafePointer<CChar>?) throws {
     if let str = str {
       throw Error(cString: str)

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -152,15 +152,34 @@ struct SwiftInspect: ParsableCommand {
     ])
 }
 
+struct UniversalOptions: ParsableArguments {
+  @Argument(help: "The pid or partial name of the target process")
+  var nameOrPid: String
+}
+
+struct BacktraceOptions: ParsableArguments {
+  @Flag(help: "Show the backtrace for each allocation")
+  var backtrace: Bool
+
+  @Flag(help: "Show a long-form backtrace for each allocation")
+  var backtraceLong: Bool
+
+  var style: Backtrace.Style? {
+    backtrace ? .oneLine :
+    backtraceLong ? .long :
+    nil
+  }
+}
+
 struct DumpConformanceCache: ParsableCommand {
   static let configuration = CommandConfiguration(
     abstract: "Print the contents of the target's protocol conformance cache.")
 
-  @Argument(help: "The pid or partial name of the target process")
-  var nameOrPid: String
+  @OptionGroup()
+  var options: UniversalOptions
 
   func run() throws {
-    try withReflectionContext(nameOrPid: nameOrPid) { context, _ in
+    try withReflectionContext(nameOrPid: options.nameOrPid) { context, _ in
       try dumpConformanceCache(context: context)
     }
   }
@@ -169,22 +188,18 @@ struct DumpConformanceCache: ParsableCommand {
 struct DumpRawMetadata: ParsableCommand {
   static let configuration = CommandConfiguration(
     abstract: "Print the target's metadata allocations.")
-  @Argument(help: "The pid or partial name of the target process")
 
-  var nameOrPid: String
+  @OptionGroup()
+  var universalOptions: UniversalOptions
 
-  @Flag(help: "Show the backtrace for each allocation")
-  var backtrace: Bool
-
-  @Flag(help: "Show a long-form backtrace for each allocation")
-  var backtraceLong: Bool
+  @OptionGroup()
+  var backtraceOptions: BacktraceOptions
 
   func run() throws {
-    let style = backtrace ? Backtrace.Style.oneLine :
-                backtraceLong ? Backtrace.Style.long :
-                nil
-    try withReflectionContext(nameOrPid: nameOrPid) {
-      try dumpRawMetadata(context: $0, inspector: $1, backtraceStyle: style)
+    try withReflectionContext(nameOrPid: universalOptions.nameOrPid) {
+      try dumpRawMetadata(context: $0,
+                          inspector: $1,
+                          backtraceStyle: backtraceOptions.style)
     }
   }
 }
@@ -193,23 +208,17 @@ struct DumpGenericMetadata: ParsableCommand {
   static let configuration = CommandConfiguration(
     abstract: "Print the target's generic metadata allocations.")
 
-  @Argument(help: "The pid or partial name of the target process")
-  var nameOrPid: String
+  @OptionGroup()
+  var universalOptions: UniversalOptions
 
-  @Flag(help: "Show the backtrace for each allocation")
-  var backtrace: Bool
-
-  @Flag(help: "Show a long-form backtrace for each allocation")
-  var backtraceLong: Bool
+  @OptionGroup()
+  var backtraceOptions: BacktraceOptions
 
   func run() throws {
-    let style = backtrace ? Backtrace.Style.oneLine :
-                backtraceLong ? Backtrace.Style.long :
-                nil
-    try withReflectionContext(nameOrPid: nameOrPid) {
+    try withReflectionContext(nameOrPid: universalOptions.nameOrPid) {
       try dumpGenericMetadata(context: $0,
                               inspector: $1,
-                              backtraceStyle: style)
+                              backtraceStyle: backtraceOptions.style)
     }
   }
 }
@@ -218,11 +227,11 @@ struct DumpCacheNodes: ParsableCommand {
   static let configuration = CommandConfiguration(
     abstract: "Print the target's metadata cache nodes.")
 
-  @Argument(help: "The pid or partial name of the target process")
-  var nameOrPid: String
+  @OptionGroup()
+  var options: UniversalOptions
 
   func run() throws {
-    try withReflectionContext(nameOrPid: nameOrPid) {
+    try withReflectionContext(nameOrPid: options.nameOrPid) {
       try dumpMetadataCacheNodes(context: $0,
                                  inspector: $1)
     }


### PR DESCRIPTION
Also, consolidate options that different commands have in common into OptionGroups that they can share.