### PR TITLE
[5.3][ModuleInterface] Don't print SPI attributes on unsupported decls

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -991,7 +991,9 @@ void PrintAST::printAttributes(const Decl *D) {
     }
 
     // SPI groups
-    if (Options.PrintSPIs) {
+    if (Options.PrintSPIs &&
+        DeclAttribute::canAttributeAppearOnDeclKind(
+          DAK_SPIAccessControl, D->getKind())) {
       interleave(D->getSPIGroups(),
              [&](Identifier spiName) {
                Printer.printAttrName("_spi", true);

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -88,6 +88,20 @@ private class PrivateClassLocal {}
   // CHECK-PUBLIC-NOT: extensionSPIMethod
 }
 
+@_spi(LocalSPI) public protocol SPIProto3 {
+// CHECK-PRIVATE: @_spi(LocalSPI) public protocol SPIProto3
+// CHECK-PUBLIC-NOT: SPIProto3
+
+  associatedtype AssociatedType
+  // CHECK-PRIVATE: associatedtype AssociatedType
+  // CHECK-PRIVATE-NOT: @_spi(LocalSPI) associatedtype AssociatedType
+  // CHECK-PUBLIC-NOT: AssociatedType
+
+  func implicitSPIMethod()
+  // CHECK-PRIVATE: @_spi(LocalSPI) func implicitSPIMethod()
+  // CHECK-PUBLIC-NOT: implicitSPIMethod
+}
+
 // Test the dummy conformance printed to replace private types used in
 // conditional conformances. rdar://problem/63352700
 

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -93,8 +93,7 @@ private class PrivateClassLocal {}
 // CHECK-PUBLIC-NOT: SPIProto3
 
   associatedtype AssociatedType
-  // CHECK-PRIVATE: associatedtype AssociatedType
-  // CHECK-PRIVATE-NOT: @_spi(LocalSPI) associatedtype AssociatedType
+  // CHECK-PRIVATE: {{^}}  associatedtype AssociatedType
   // CHECK-PUBLIC-NOT: AssociatedType
 
   func implicitSPIMethod()


### PR DESCRIPTION
In Swift 5.3 associated types can’t be explicitly declared SPI but they can inherit it from their context. This leads the compiler to generate invalid private textual interface files where implicit attribute are printed explicitly. As a narrow fix, don’t print SPI attributes on declarations that would not accept it explicitly.

Cherry-pick of #32211 and #32850

- Scope of Issue: The bug affects the private swiftinterface files of projects with associated types in SPI protocols.
- Origination: Introduction of the `@_spi` attribute.
- Risk: Very low, this only affects what is printed in private swiftinterface files.
- Resolves: rdar://64039069
- Reviewed by: @brentdax