### PR TITLE
[Typechecker] Emit specialized diagnostic notes on automatic synthesis failure to Comparable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2833,9 +2833,12 @@ NOTE(missing_member_type_conformance_prevents_synthesis, none,
      "protocol %2, preventing synthesized conformance "
      "of %3 to %2",
      (unsigned, Type, Type, Type))
-NOTE(classes_automatic_protocol_synthesis,none,
-    "automatic synthesis of '%0' is not supported for classes",
-    (StringRef))
+NOTE(automatic_protocol_synthesis_unsupported,none,
+    "automatic synthesis of '%0' is not supported for %select{classes|structs}1",
+    (StringRef, unsigned))
+NOTE(comparable_synthesis_raw_value_not_allowed, none,
+     "enum declares raw type %0, preventing synthesized conformance of %1 to %2", 
+     (Type, Type, Type))
 
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -130,8 +130,8 @@ void diagnoseFailedDerivation(DeclContext *DC, NominalTypeDecl *nominal,
 
   if (auto *classDecl = dyn_cast<ClassDecl>(nominal)) {
     ctx.Diags.diagnose(classDecl->getLoc(),
-                       diag::classes_automatic_protocol_synthesis,
-                       protocol->getName().str());
+                       diag::automatic_protocol_synthesis_unsupported,
+                       protocol->getName().str(), 0);
   }
 }
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -175,6 +175,10 @@ void DerivedConformance::tryDiagnoseFailedDerivation(DeclContext *DC,
   if (*knownProtocol == KnownProtocolKind::Hashable) {
     tryDiagnoseFailedHashableDerivation(DC, nominal);
   }
+
+  if (*knownProtocol == KnownProtocolKind::Comparable) {
+    tryDiagnoseFailedComparableDerivation(DC, nominal);
+  }
 }
 
 ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -169,6 +169,14 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveComparable(ValueDecl *requirement);
 
+  /// Diagnose problems, if any, preventing automatic derivation of Comparable
+  /// requirements
+  ///
+  /// \param nominal The nominal type for which we would like to diagnose
+  /// derivation failures
+  static void tryDiagnoseFailedComparableDerivation(DeclContext *DC,
+                                                    NominalTypeDecl *nominal);
+
   /// Determine if an Equatable requirement can be derived for a type.
   ///
   /// This is implemented for enums without associated values or all-Equatable

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -6701,9 +6701,13 @@
     %select{associated value|stored property}0 type %1 does not conform to
     protocol %2, preventing synthesized conformance of %3 to %2
 
-- id: classes_automatic_protocol_synthesis
+- id: automatic_protocol_synthesis_unsupported
   msg: >-
-    automatic synthesis of '%0' is not supported for classes
+    automatic synthesis of '%0' is not supported for %select{classes|structs}1
+
+- id: comparable_synthesis_raw_value_not_allowed
+  msg: >-
+    enum declares raw type %0, preventing synthesized conformance of %1 to %2
 
 - id: dynamic_self_non_method
   msg: >-

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -174,7 +174,7 @@ func genericNotHashable() {
 }
 
 // An enum with no cases should also derive conformance.
-enum NoCases: Hashable, Comparable {}
+enum NoCases: Hashable {}
 
 // rdar://19773050
 private enum Bar<T> {
@@ -327,47 +327,6 @@ enum ImpliedMain: ImplierMain {
 }
 extension ImpliedOther: ImplierMain {}
 
-// Comparable enum synthesis
-enum Angel: Comparable {
-  case lily, elsa, karlie 
-}
-
-func pit(_ a: Angel, against b: Angel) -> Bool {
-  return a < b
-}
-
-// enums with non-conforming payloads don’t get synthesized Comparable 
-enum Notice: Comparable { // expected-error{{type 'Notice' does not conform to protocol 'Comparable'}} expected-error{{type 'Notice' does not conform to protocol 'Equatable'}} 
-  case taylor((Int, Int)), taylornation(Int) // expected-note{{associated value type '(Int, Int)' does not conform to protocol 'Equatable', preventing synthesized conformance of 'Notice' to 'Equatable'}} 
-}
-
-// neither do enums with raw values 
-enum Track: Int, Comparable { // expected-error{{type 'Track' does not conform to protocol 'Comparable'}} 
-  case four = 4
-  case five = 5 
-  case six  = 6
-}
-
-// synthesized Comparable must be explicit 
-enum Publicist {
-  case thow, paine 
-}
-
-func miss(_ a: Publicist, outsold b: Publicist) -> Bool {
-  return b < a // expected-error{{binary operator '<' cannot be applied to two 'Publicist' operands}}
-}
-
-// can synthesize Comparable conformance through extension 
-enum Birthyear {
-  case eighties(Int)
-  case nineties(Int)
-  case twothousands(Int)
-}
-extension Birthyear: Comparable {
-}
-func canEatHotChip(_ birthyear:Birthyear) -> Bool {
-  return birthyear > .nineties(3)
-}
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '<T> (Generic<T>, Generic<T>) -> Bool'

--- a/test/decl/protocol/special/comparable/comparable_supported.swift
+++ b/test/decl/protocol/special/comparable/comparable_supported.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Comparable enum synthesis
+enum Angel: Comparable {
+  case lily, elsa, karlie 
+}
+
+func pit(_ a: Angel, against b: Angel) -> Bool {
+  return a < b // Okay
+}
+
+// An enum with no cases should also derive conformance to Comparable.
+
+enum NoCasesEnum: Comparable {} // Okay
+
+// Comparable enum conformance through extension 
+enum Birthyear {
+  case eighties(Int)
+  case nineties(Int)
+  case twothousands(Int)
+}
+
+extension Birthyear: Comparable {}
+
+func canEatHotChip(_ birthyear:Birthyear) -> Bool {
+  return birthyear > .nineties(3) // Okay
+}

--- a/test/decl/protocol/special/comparable/comparable_unsupported.swift
+++ b/test/decl/protocol/special/comparable/comparable_unsupported.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Automatic synthesis of Comparable is only supported for enums for now.
+
+struct NotComparableStruct: Comparable {
+  // expected-error@-1 {{type 'NotComparableStruct' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{automatic synthesis of 'Comparable' is not supported for structs}}
+  var value = 0
+}
+
+class NotComparableClass: Comparable {
+  // expected-error@-1 {{type 'NotComparableClass' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{automatic synthesis of 'Comparable' is not supported for classes}}
+  // expected-error@-3 {{type 'NotComparableClass' does not conform to protocol 'Equatable'}}
+  // expected-note@-4 {{automatic synthesis of 'Equatable' is not supported for classes}}
+  var value = 1
+}
+
+// Automatic synthesis of Comparable requires enum without raw type.
+
+enum NotComparableEnumOne: Int, Comparable {
+  // expected-error@-1 {{type 'NotComparableEnumOne' does not conform to protocol 'Comparable'}}
+  // expected-note@-2 {{enum declares raw type 'Int', preventing synthesized conformance of 'NotComparableEnumOne' to 'Comparable'}}
+  case value
+}
+
+// Automatic synthesis of Comparable requires associated values to be Comparable as well.
+
+enum NotComparableEnumTwo: Comparable {
+  // expected-error@-1 {{type 'NotComparableEnumTwo' does not conform to protocol 'Comparable'}}
+  struct NotComparable: Equatable {}
+  case value(NotComparable)
+  // expected-note@-1 {{associated value type 'NotComparableEnumTwo.NotComparable' does not conform to protocol 'Comparable', preventing synthesized conformance of 'NotComparableEnumTwo' to 'Comparable'}}
+}


### PR DESCRIPTION
Automatic synthesis of `Comparable` is only supported for `enum`s for now. So, if we have a `struct` or a `class` and a conformance failure to `Comparable`, emit a note just like we do for `Equatable` (on classes) for example, to let the user know that automatic synthesis is unsupported.

As a bonus, also emit a note when the `enum` has a raw type or if the associated values don't conform to `Comparable`.

Resolves SR-13148
rdar://problem/65116465