### PR TITLE
test: partially undo changes to `PathSanitizingFileCheck`

### DIFF
--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -80,10 +80,9 @@ constants.""")
         # Since we want to use pattern as a regex in some platforms, we need
         # to escape it first, and then replace the escaped slash
         # literal (r'\\/') for our platform-dependent slash regex.
-        stdin = re.sub(re.sub('\\\\/' if sys.version_info[0] < 3 else r'[/\\]',
+        stdin = re.sub(re.sub(r'\\/' if sys.version_info[0] < 3 else r'/',
                               slashes_re, re.escape(pattern)),
-                       replacement,
-                       stdin)
+                       replacement, stdin)
 
     if args.dry_run:
         print(stdin)


### PR DESCRIPTION
The regular expression engine escaped the strings differently across
python 2 and 3.  Using a raw string makes this simpler to understand
and obsoletes the comment.  This change also now properly allows the
replacement to occur in the same way on 2 and 3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
