### PR TITLE
[CMake] Copy localization files to `share/diagnostics`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1113,6 +1113,12 @@ add_subdirectory(utils)
 
 add_subdirectory(userdocs)
 
+file(GLOB LOCALIZATION_FILES
+  "include/swift/AST/diagnostics/*.yaml"
+)
+
+file(COPY ${LOCALIZATION_FILES} DESTINATION "share/diagnostics")
+
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   if(SWIFT_BUILD_PERF_TESTSUITE)
     add_subdirectory(benchmark)

--- a/include/swift/AST/CMakeLists.txt
+++ b/include/swift/AST/CMakeLists.txt
@@ -1,3 +1,0 @@
-swift_install_in_component(DIRECTORY diagnostics
-                           DESTINATION "share/swift/"
-                           COMPONENT compiler)


### PR DESCRIPTION
In this PR, I'm copying the YAML localization files to `share/diagnostics` regardless of whether it’s in toolchain or regular build. That way we won't need to use `-localization-path` flag each time.

The approach I'm taking with copying files with CMake *might* fail because of the limitation on Windows on the number of characters in a single command line, which is either 2047 or 8191 characters (as appropriate to the operating system). See [Microsoft's command-line string limitation](https://support.microsoft.com/en-gb/help/830473/command-prompt-cmd-exe-command-line-string-limitation). However, I don't think this will be an issue for now because the number of languages in [LocalizationLanguages](https://github.com/apple/swift/blob/master/include/swift/AST/LocalizationLanguages.def) is 184 languages and each code has a length of 2 characters and the extension of the localization files is `.yaml` so adding all of these up will be just 7 characters, multiplied by 184 is equal to 1288. Therefore, *I think* we will be safe with this method. WDYT?

cc @xedin, @owenv, @compnerd 