### PR TITLE
[build-script] Tie llvm, swift, and lldb to the same sysroot

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -705,6 +705,10 @@ function set_build_options_for_host() {
                 # in the compiler checks CMake performs
                 -DCMAKE_OSX_ARCHITECTURES="${architecture}"
             )
+
+            lldb_cmake_options+=(
+                -DCMAKE_OSX_SYSROOT:PATH="${cmake_os_sysroot}"
+            )
             ;;
     esac
 


### PR DESCRIPTION
This resolves build failures in lldb when building with Apple-internal SDKs.

rdar://62895058