### PR TITLE
[CodeCompletion] Safer getEquivalentDeclContextFromSourceFile()

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -89,6 +89,7 @@ template <typename Range> Decl *getElementAt(const Range &Decls, unsigned N) {
 ///        config block, this function returns \c false.
 static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
                                                            SourceFile *SF) {
+  PrettyStackTraceDeclContext trace("getting equivalent decl context for", DC);
   auto *newDC = DC;
   // NOTE: Shortcut for DC->getParentSourceFile() == SF case is not needed
   // because they should be always different.
@@ -115,13 +116,17 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
       D = storage;
     }
 
-    if (auto parentSF = dyn_cast<SourceFile>(parentDC))
+    if (auto parentSF = dyn_cast<SourceFile>(parentDC)) {
       N = findIndexInRange(D, parentSF->getTopLevelDecls());
-    else if (auto parentIDC =
-                 dyn_cast<IterableDeclContext>(parentDC->getAsDecl()))
+    } else if (auto parentIDC = dyn_cast_or_null<IterableDeclContext>(
+                   parentDC->getAsDecl())) {
       N = findIndexInRange(D, parentIDC->getMembers());
-    else
+    } else {
+#ifndef NDEBUG
       llvm_unreachable("invalid DC kind for finding equivalent DC (indexpath)");
+#endif
+      return nullptr;
+    }
 
     // Not found in the decl context tree.
     // FIXME: Probably DC is in an inactive #if block.


### PR DESCRIPTION
There seems to be case where `parentDC->getAsDecl()` returns `nullptr`. I haven't been able to find a reproducer though. 
Safe nullptr check in release build. Added pretty stack trace and assertion to see more info when it happens again.

rdar://problem/61765124
