### PR TITLE
Add -jit-build driver + frontend flag

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -79,6 +79,8 @@ WARNING(warning_unnecessary_repl_mode,none,
 ERROR(error_unsupported_option,none,
       "option '%0' is not supported by '%1'; did you mean to use '%2'?",
       (StringRef, StringRef, StringRef))
+ERROR(jit_build_unsupported,none,
+      "-jit-build is not supported by the integrated driver", ())
 
 WARNING(incremental_requires_output_file_map,none,
         "ignoring -incremental (currently requires an output file map)", ())

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -959,6 +959,12 @@ def deprecated_integrated_repl : Flag<["-"], "deprecated-integrated-repl">,
   Flags<[FrontendOption, NoBatchOption]>, ModeOpt;
 def i : Flag<["-"], "i">, ModeOpt; // only used to provide diagnostics.
 
+// A JIT compilation mode where a stub executable is created and a frontend
+// process will register itself as a "provider" that will be able to JIT code
+// for it.
+def jit_build : Flag<["-"], "jit-build">, HelpText<"JIT compilation mode">,
+  Flags<[NoInteractiveOption, HelpHidden]>, ModeOpt;
+
 def whole_module_optimization : Flag<["-"], "whole-module-optimization">,
   HelpText<"Optimize input files together instead of individually">,
   Flags<[FrontendOption, NoInteractiveOption]>;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1585,6 +1585,10 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerMode = OutputInfo::Mode::REPL;
       break;
 
+    case options::OPT_jit_build:
+      Diags.diagnose(SourceLoc(), diag::jit_build_unsupported);
+      break;
+
     default:
       llvm_unreachable("unknown mode");
     }


### PR DESCRIPTION
This will be used in both the new Swift driver and the frontend to implement a new JIT compilation mode where a stub executable is created and a frontend process will register itself as a "provider" that will be able to JIT code for it.
