### PR TITLE
[Test] Mark executable test appropriately.

### DIFF
--- a/validation-test/Runtime/rdar64672291.swift
+++ b/validation-test/Runtime/rdar64672291.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: objc_interop
+// REQUIRES: executable_test
 
 import Foundation
 


### PR DESCRIPTION
Missing annotation was causing a failure at https://ci.swift.org/view/Dashboard/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/138/ .