### PR TITLE
[cxx-interop] Temporarily disable emitting debug info for C++ types.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1586,6 +1586,13 @@ private:
 
   /// Determine if there exists a name mangling for the given type.
   static bool canMangle(TypeBase *Ty) {
+    // TODO: C++ types are not yet supported (SR-13223).
+    if (Ty->getStructOrBoundGenericStruct() &&
+        Ty->getStructOrBoundGenericStruct()->getClangDecl() &&
+        isa<clang::CXXRecordDecl>(
+            Ty->getStructOrBoundGenericStruct()->getClangDecl()))
+      return false;
+
     switch (Ty->getKind()) {
     case TypeKind::GenericFunction: // Not yet supported.
     case TypeKind::SILBlockStorage: // Not supported at all.
@@ -2377,6 +2384,17 @@ void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
     Optional<SILLocation> Loc) {
   if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::LineTables)
     return;
+
+  // TODO: fix demangling for C++ types (SR-13223).
+  if (swift::TypeBase *ty = DbgTy.getType()) {
+    if (MetatypeType *metaTy = dyn_cast<MetatypeType>(ty))
+      ty = metaTy->getInstanceType().getPointer();
+    if (ty->getStructOrBoundGenericStruct() &&
+        ty->getStructOrBoundGenericStruct()->getClangDecl() &&
+        isa<clang::CXXRecordDecl>(
+            ty->getStructOrBoundGenericStruct()->getClangDecl()))
+      return;
+  }
 
   llvm::DIType *DITy = getOrCreateType(DbgTy);
   VarDecl *VD = nullptr;

--- a/test/Interop/Cxx/class/Inputs/debug-info.h
+++ b/test/Interop/Cxx/class/Inputs/debug-info.h
@@ -1,0 +1,3 @@
+struct IntWrapper {
+  int value;
+};

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -25,3 +25,7 @@ module ProtocolConformance {
 module SynthesizedInitializers {
   header "synthesized-initializers.h"
 }
+
+module DebugInfo {
+  header "debug-info.h"
+}

--- a/test/Interop/Cxx/class/debug-info-irgen.swift
+++ b/test/Interop/Cxx/class/debug-info-irgen.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir -g | %FileCheck %s
+
+// Validate that we don't crash when trying to deserialize C++ type debug info.
+// Note, however, that the actual debug info is not generated, see SR-13223.
+
+import DebugInfo
+
+public func create(_ x: Int32) -> IntWrapper { IntWrapper(value: x) }
+
+public func getInt() -> Int32 { 0 }
+
+// CHECK-LABEL: define {{.*}}void @"$s4main4testyyF"
+// CHECK: [[I:%.*]] = call swiftcc i32 @"$s4main6getInts5Int32VyF"()
+// CHECK: call swiftcc i32 @"$s4main6createySo10IntWrapperVs5Int32VF"(i32 [[I]])
+// CHECK: ret void
+public func test() {
+  let f = create(getInt())
+}
+


### PR DESCRIPTION
When we try to emit debug info from C++ types we crash because we can't deserialize them. This is a temporary fix to circumnavigate the crash before a real fix can be created.

Refs #32721.

Edit: https://bugs.swift.org/browse/SR-13223