### PR TITLE
[swift-inspect] Support DLQ_GetPtrAuthMask.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -38,6 +38,8 @@
 #include <utility>
 #include <vector>
 
+#include <inttypes.h>
+
 namespace {
 
 template <unsigned PointerSize> struct MachOTraits;
@@ -958,7 +960,8 @@ public:
         // FIXME: std::stringstream would be better, but LLVM's standard library
         // introduces a vtable and we don't want that.
         char result[128];
-        std::snprintf(result, sizeof(result), "unable to read Next pointer %p",
+        std::snprintf(result, sizeof(result),
+            "unable to read Next pointer %#" PRIx64,
             BacktraceListNext.getAddressData());
         return std::string(result);
       }

--- a/tools/swift-inspect/Sources/SymbolicationShims/SymbolicationShims.h
+++ b/tools/swift-inspect/Sources/SymbolicationShims/SymbolicationShims.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <stdint.h>
+#include <ptrauth.h>
 
 struct CSTypeRef {
   uintptr_t a, b;
@@ -19,3 +20,11 @@ struct CSTypeRef {
 struct Range {
   uintptr_t location, length;
 };
+
+uintptr_t GetPtrauthMask(void) {
+#if __has_feature(ptrauth_calls)
+  return (uintptr_t)ptrauth_strip((void*)0x0007ffffffffffff, 0);
+#else
+  return (uintptr_t)~0ull;
+#endif
+}

--- a/tools/swift-inspect/Sources/swift-inspect/Inspector.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Inspector.swift
@@ -126,6 +126,10 @@ private func QueryDataLayoutFn(context: UnsafeMutableRawPointer?,
     let size = UInt8(MemoryLayout<UnsafeRawPointer>.stride)
     outBuffer!.storeBytes(of: size, toByteOffset: 0, as: UInt8.self)
     return 1
+  case DLQ_GetPtrAuthMask:
+    let mask = GetPtrauthMask()
+    outBuffer!.storeBytes(of: mask, toByteOffset: 0, as: UInt.self)
+    return 1
   default:
     return 0
   }


### PR DESCRIPTION
While we're in there, fix an snprintf warning in ReflectionContext.h.