### PR TITLE
[CSBindings] Split type variable binding inference into phases

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -81,6 +81,11 @@ void ConstraintSystem::inferTransitiveSupertypeBindings(
       bindings.addPotentialBinding(
           binding.withSameSource(type, AllowedBindingKind::Supertypes));
     }
+
+    // Infer transitive protocol requirements.
+    for (auto *protocol : relatedBindings->getSecond().Protocols) {
+      bindings.Protocols.push_back(protocol);
+    }
   }
 }
 
@@ -628,6 +633,10 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
       LLVM_FALLTHROUGH;
 
     case ConstraintKind::LiteralConformsTo: {
+      // Record constraint where protocol requirement originated
+      // this is useful to use for the binding later.
+      result.Protocols.push_back(constraint);
+
       // If there is a 'nil' literal constraint, we might need optional
       // supertype bindings.
       if (constraint->getProtocol()->isSpecificProtocol(

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -491,6 +491,16 @@ bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
   return !InvolvesTypeVariables;
 }
 
+ConstraintSystem::PotentialBindings
+ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar) {
+  auto bindings = getPotentialBindings(typeVar);
+
+  llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>
+      inferred;
+  bindings.finalize(*this, inferred);
+  return bindings;
+}
+
 Optional<ConstraintSystem::PotentialBinding>
 ConstraintSystem::getPotentialBindingForRelationalConstraint(
     PotentialBindings &result, Constraint *constraint,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -342,12 +342,14 @@ void ConstraintSystem::PotentialBindings::finalize(
   // it's always better to infer concrete type and erase it if required
   // by the context.
   if (Bindings.size() > 1) {
-    auto anyType = llvm::find_if(Bindings, [](const PotentialBinding &binding) {
-      return binding.BindingType->isAny() && !binding.isDefaultableBinding();
-    });
+    auto AnyTypePos =
+        llvm::find_if(Bindings, [](const PotentialBinding &binding) {
+          return binding.BindingType->isAny() &&
+                 !binding.isDefaultableBinding();
+        });
 
-    if (anyType != Bindings.end()) {
-      std::rotate(Bindings.begin(), anyType + 1, Bindings.end());
+    if (AnyTypePos != Bindings.end()) {
+      std::rotate(AnyTypePos, AnyTypePos + 1, Bindings.end());
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4224,6 +4224,12 @@ bool ConstraintSystem::repairFailures(
         if (hasFixFor(loc, FixKind::ContextualMismatch))
           return true;
 
+        if (contextualType->isVoid() &&
+            getContextualTypePurpose(anchor) == CTP_ReturnStmt) {
+          conversionsOrFixes.push_back(RemoveReturn::create(*this, lhs, loc));
+          break;
+        }
+
         conversionsOrFixes.push_back(
             ContextualMismatch::create(*this, lhs, rhs, loc));
         break;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2380,7 +2380,7 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
   if (typeVar->getImpl().getFixedType(nullptr))
     return;
 
-  auto bindings = cs.getPotentialBindings(typeVar);
+  auto bindings = cs.inferBindingsFor(typeVar);
   if (bindings.InvolvesTypeVariables || bindings.Bindings.size() != 1)
     return;
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1116,7 +1116,7 @@ bool ConstraintGraph::contractEdges() {
     // us enough information to decided on l-valueness.
     if (isParamBindingConstraint && tyvar1->getImpl().canBindToInOut()) {
       bool isNotContractable = true;
-      if (auto bindings = CS.getPotentialBindings(tyvar1)) {
+      if (auto bindings = CS.inferBindingsFor(tyvar1)) {
         // Holes can't be contracted.
         if (bindings.IsHole)
           continue;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4645,8 +4645,7 @@ private:
   getPotentialBindingForRelationalConstraint(
       PotentialBindings &result, Constraint *constraint,
       bool &hasDependentMemberRelationalConstraints,
-      bool &hasNonDependentMemberRelationalConstraints,
-      bool &addOptionalSupertypeBindings) const;
+      bool &hasNonDependentMemberRelationalConstraints) const;
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar) const;
 
 private:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4569,10 +4569,17 @@ private:
     /// \param inferredBindings The set of all bindings inferred for type
     /// variables in the workset.
     void inferTransitiveBindings(
-        ConstraintSystem &cs,
+        ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes,
         const llvm::SmallDenseMap<TypeVariableType *,
                                   ConstraintSystem::PotentialBindings>
             &inferredBindings);
+
+    /// Finalize binding computation for this type variable by
+    /// inferring bindings from context e.g. transitive bindings.
+    void finalize(ConstraintSystem &cs,
+                  const llvm::SmallDenseMap<TypeVariableType *,
+                                            ConstraintSystem::PotentialBindings>
+                      &inferredBindings);
 
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4649,6 +4649,12 @@ private:
 
   Optional<Type> checkTypeOfBinding(TypeVariableType *typeVar, Type type) const;
   Optional<PotentialBindings> determineBestBindings();
+
+  /// Infer bindings for the given type variable based on current
+  /// state of the constraint system.
+  PotentialBindings inferBindingsFor(TypeVariableType *typeVar);
+
+private:
   Optional<ConstraintSystem::PotentialBinding>
   getPotentialBindingForRelationalConstraint(
       PotentialBindings &result, Constraint *constraint,
@@ -4656,7 +4662,6 @@ private:
       bool &hasNonDependentMemberRelationalConstraints) const;
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar) const;
 
-private:
   /// Add a constraint to the constraint system.
   SolutionKind addConstraintImpl(ConstraintKind kind, Type first, Type second,
                                  ConstraintLocatorBuilder locator,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4420,6 +4420,9 @@ private:
     /// The set of potential bindings.
     SmallVector<PotentialBinding, 4> Bindings;
 
+    /// The set of protocol requirements placed on this type variable.
+    llvm::TinyPtrVector<Constraint *> Protocols;
+
     /// Whether these bindings should be delayed until the rest of the
     /// constraint system is considered "fully bound".
     bool FullyBound = false;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4557,6 +4557,23 @@ private:
     /// if it has only concrete types or would resolve a closure.
     bool favoredOverDisjunction(Constraint *disjunction) const;
 
+    /// Detect `subtype` relationship between two type variables and
+    /// attempt to infer supertype bindings transitively e.g.
+    ///
+    /// Given A <: T1 <: T2 transitively A <: T2
+    ///
+    /// Which gives us a new (superclass A) binding for T2 as well as T1.
+    ///
+    /// \param cs The constraint system this type variable is associated with.
+    ///
+    /// \param inferredBindings The set of all bindings inferred for type
+    /// variables in the workset.
+    void inferTransitiveBindings(
+        ConstraintSystem &cs,
+        const llvm::SmallDenseMap<TypeVariableType *,
+                                  ConstraintSystem::PotentialBindings>
+            &inferredBindings);
+
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {
       out.indent(indent);
@@ -4624,22 +4641,6 @@ private:
       bool &hasNonDependentMemberRelationalConstraints,
       bool &addOptionalSupertypeBindings) const;
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar) const;
-
-  /// Detect `subtype` relationship between two type variables and
-  /// attempt to infer supertype bindings transitively e.g.
-  ///
-  /// Given A <: T1 <: T2 transitively A <: T2
-  ///
-  /// Which gives us a new (superclass A) binding for T2 as well as T1.
-  ///
-  /// \param inferredBindings The set of all bindings inferred for type
-  /// variables in the workset.
-  /// \param bindings The type variable we aim to infer new supertype
-  /// bindings for.
-  void inferTransitiveSupertypeBindings(
-      const llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
-          &inferredBindings,
-      PotentialBindings &bindings);
 
 private:
   /// Add a constraint to the constraint system.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4423,6 +4423,9 @@ private:
     /// The set of protocol requirements placed on this type variable.
     llvm::TinyPtrVector<Constraint *> Protocols;
 
+    /// The set of constraints which would be used to infer default types.
+    llvm::TinyPtrVector<Constraint *> Defaults;
+
     /// Whether these bindings should be delayed until the rest of the
     /// constraint system is considered "fully bound".
     bool FullyBound = false;
@@ -4573,6 +4576,11 @@ private:
         const llvm::SmallDenseMap<TypeVariableType *,
                                   ConstraintSystem::PotentialBindings>
             &inferredBindings);
+
+    /// Infer bindings based on any protocol conformances that have default
+    /// types.
+    void inferDefaultTypes(ConstraintSystem &cs,
+                           llvm::SmallPtrSetImpl<CanType> &existingTypes);
 
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -50,7 +50,7 @@ useDoubleList([1.0,2,3])
 useDoubleList([1.0,2.0,3.0])
 
 useIntDict(["Niners" => 31, "Ravens" => 34])
-useIntDict(["Niners" => 31, "Ravens" => 34.0]) // expected-error{{cannot convert value of type 'Double' to expected argument type 'Int'}}
+useIntDict(["Niners" => 31, "Ravens" => 34.0]) // expected-error{{cannot convert value of type 'Double' to expected element type 'Int'}}
 // <rdar://problem/22333090> QoI: Propagate contextual information in a call to operands
 useDoubleDict(["Niners" => 31, "Ravens" => 34.0])
 useDoubleDict(["Niners" => 31.0, "Ravens" => 34])
@@ -328,7 +328,6 @@ protocol P { }
 struct PArray<T> { }
 
 extension PArray : ExpressibleByArrayLiteral where T: P {
-  // expected-note@-1 {{requirement from conditional conformance of 'PArray<String>' to 'ExpressibleByArrayLiteral'}}
   typealias ArrayLiteralElement = T
 
   init(arrayLiteral elements: T...) { }
@@ -338,7 +337,7 @@ extension Int: P { }
 
 func testConditional(i: Int, s: String) {
   let _: PArray<Int> = [i, i, i]
-  let _: PArray<String> = [s, s, s] // expected-error{{generic struct 'PArray' requires that 'String' conform to 'P'}}
+  let _: PArray<String> = [s, s, s] // expected-error{{cannot convert value of type '[String]' to specified type 'PArray<String>'}}
 }
 
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -456,13 +456,7 @@ extension Collection {
   }
 }
 func fn_r28909024(n: Int) {
-  // FIXME(diagnostics): Unfortunately there is no easy way to fix this diagnostic issue at the moment
-  // because the problem is related to ordering of the bindings - we'd attempt to bind result of the expression
-  // to contextual type of `Void` which prevents solver from discovering correct types for range - 0..<10
-  // (since both arguments are literal they are ranked lower than contextual type).
-  //
-  // Good diagnostic for this is - `unexpected non-void return value in void function`
-  return (0..<10).r28909024 { // expected-error {{type of expression is ambiguous without more context}}
+  return (0..<10).r28909024 { // expected-error {{unexpected non-void return value in void function}} // expected-note {{did you mean to add a return type?}}
     _ in true
   }
 }

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -254,3 +254,14 @@ func sr_10837() {
     }
   }
 }
+
+// To make sure that hack related to type variable bindings works as expected we need to test
+// that in the following case result of a call to `reduce` maintains optionality.
+func test_that_optionality_of_closure_result_is_preserved() {
+  struct S {}
+
+  let arr: [S?] = []
+  let _: [S]? = arr.reduce([], { (a: [S]?, s: S?) -> [S]? in
+    a.flatMap { (group: [S]) -> [S]? in s.map { group + [$0] } } // Ok
+  })
+}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -207,7 +207,7 @@ func r17020197(_ x : Int?, y : Int) {
 
 // <rdar://problem/20714480> QoI: Boolean expr not treated as Bool type when function return type is different
 func validateSaveButton(_ text: String) {
-  return (text.count > 0) ? true : false  // expected-error {{unexpected non-void return value in void function}}
+  return (text.count > 0) ? true : false  // expected-error {{unexpected non-void return value in void function}} expected-note {{did you mean to add a return type?}}
 }
 
 // <rdar://problem/20201968> QoI: poor diagnostic when calling a class method via a metatype

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -846,3 +846,15 @@ func test_dictionary_with_generic_mismatch_in_key_or_value() {
   let _: [S<Bool>: Int] = [S<Int>(): 42]
   // expected-error@-1 {{cannot convert value of type 'S<Int>' to expected dictionary key type 'S<Bool>'}}
 }
+
+
+// rdar://problem/56212087 - unable to infer type for generic parameter `T`
+func rdar56212087() {
+  func setValue(_: Any?, forKey: String) {}
+
+  func foo<T: ExpressibleByStringLiteral>(_: String, _: T) -> T {
+    fatalError()
+  }
+
+  setValue(foo("", ""), forKey: "") // Ok (T is inferred as a `String` instead of `Any?`)
+}

--- a/test/Parse/omit_return.swift
+++ b/test/Parse/omit_return.swift
@@ -1005,7 +1005,7 @@ var fvs_stubMyOwnFatalError: () {
 var fvs_forceTryExplicit: String {
     get { "ok" }
     set {
-        return try! failableIdentity("shucks") // expected-error {{cannot convert value of type 'String' to expected argument type '()'}}
+        return try! failableIdentity("shucks") // expected-error {{unexpected non-void return value in void function}}
     }
 }
 

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -663,14 +663,14 @@ struct FunctionConversionParameterSubstToOrigReabstractionTest {
   }
 }
 
-// CHECK: sil {{.*}} [ossa] @$sS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR
-// CHECK:  [[TUPLE:%.*]] = apply %4(%2, %3) : $@noescape @callee_guaranteed (@guaranteed String, @guaranteed String) -> (@owned String, @owned String)
-// CHECK:  ([[LHS:%.*]], [[RHS:%.*]]) = destructure_tuple [[TUPLE]]
-// CHECK:  [[ADDR:%.*]] = alloc_stack $String
-// CHECK:  store [[LHS]] to [init] [[ADDR]] : $*String
-// CHECK:  [[CVT:%.*]] = function_ref @$ss21_convertToAnyHashableys0cD0VxSHRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0) -> @out AnyHashable
-// CHECK:  apply [[CVT]]<String>(%0, [[ADDR]])
-// CHECK: } // end sil function '$sS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR'
+// CHECK: sil hidden [ossa] @$s19function_conversion9dontCrashyyF
+// CHECK: [[FORCE_CAST:%.*]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF
+// CHECK-NEXT: [[DOWNCAST_RESULT:%.*]] = apply [[FORCE_CAST]]<(String, String), (AnyHashable, Any)>({{.*}})
+// CHECK-NEXT: [[ADDR:%.*]] = alloc_stack $Array<(AnyHashable, Any)>
+// CHECK-NEXT: store [[DOWNCAST_RESULT]] to [init] [[ADDR]] : $*Array<(AnyHashable, Any)>
+// CHECK-NEXT: // function_ref Dictionary.init<A>(uniqueKeysWithValues:)
+// CHECK-NEXT: [[DICT_INIT:%.*]] = function_ref @$sSD20uniqueKeysWithValuesSDyxq_Gqd__n_tcSTRd__x_q_t7ElementRtd__lufC
+// CHECK-NEXT: apply [[DICT_INIT]]<AnyHashable, Any, [(AnyHashable, Any)]>([[ADDR]], [[TYPE:%.*]])
 
 func dontCrash() {
   let userInfo = ["hello": "world"]

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -600,7 +600,7 @@ func keypath_with_subscripts(_ arr: SubscriptLens<[Int]>,
 
 func keypath_with_incorrect_return_type(_ arr: Lens<Array<Int>>) {
   for idx in 0..<arr.count {
-    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'Lens<Int>'}}
+    // expected-error@-1 {{cannot convert value of type 'Lens<Int>' to expected argument type 'Int'}}
     let _ = arr[idx]
   }
 }

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -103,7 +103,7 @@ _ = A<String, Int>(a: "foo", // expected-error {{cannot convert value of type 'S
   b: 42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
 _ = B(a: 12, b: 42)
 _ = B(a: 12, b: 42 as Float)
-_ = B(a: "foo", b: 42)     // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+_ = B(a: "foo", b: 42)     // expected-error {{conflicting arguments to generic parameter 'T1' ('String' vs. 'Int')}}
 _ = C(a: "foo", b: 42)
 _ = C(a: 42,        // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
   b: 42)

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -790,7 +790,7 @@ func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
 
   // ?? should have lower precedence than range and arithmetic operators.
   let r1 = r ?? (0...42) // ok
-  let r2 = (r ?? 0)...42 // not ok: expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'ClosedRange<Int>'}}
+  let r2 = (r ?? 0)...42 // not ok: expected-error {{binary operator '??' cannot be applied to operands of type 'ClosedRange<Int>?' and 'Int'}}
   let r3 = r ?? 0...42 // parses as the first one, not the second.
   
   


### PR DESCRIPTION
Refactor `getPotentialBindings` and extract most of the logic to be performed in phased fashion:

Phases include (in order):

- Infer direct bindings (based on all of the constraints associated with the given type variable);
  - Record protocol requirements (both `ConformsTo` and `LiteralConformsTo` constraints)
  - Record `Defaultable` constraints
- Infer transitive bindings based on subtype/conversion relationships;
  - This also infers both protocol requirements and defaults
- Infer default types (if there are no bindings which already cover them);
- Introduce "holes" if necessary.

Resolves: rdar://problem/56212087

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
