### PR TITLE
Handle Boolean Patterns Matching Against Invalid Constructor Forms

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -412,6 +412,7 @@ namespace {
         PAIRCASE (SpaceKind::BooleanConstant, SpaceKind::BooleanConstant):
           return this->getBoolValue() == other.getBoolValue();
 
+        PAIRCASE (SpaceKind::BooleanConstant, SpaceKind::Constructor):
         PAIRCASE (SpaceKind::BooleanConstant, SpaceKind::UnknownCase):
           return false;
 

--- a/validation-test/compiler_crashers_2_fixed/rdar65229620.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar65229620.swift
@@ -1,0 +1,18 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+// N.B.: Requires a no-asserts build to reproduce, otherwise this hits an
+// assertion in type check pattern.
+// REQUIRES: no_asserts
+
+indirect enum BadOverload {
+case one(Bool, other: Void)
+case one(Bool?)
+}
+
+func crash(_ x: BadOverload) {
+  switch $0 {
+  case .one(false?):
+    break
+  }
+}
+


### PR DESCRIPTION
The Space Engine maintains as one of its invariants that the AST it is
handed must at least typecheck. When swift typechecks patterns, the only
case one is allowed to form a Boolean pattern is when a literal is
expected, and the corresponding type of the pattern clause is exactly
Bool. This precludes the use of other types, including
ExpressibleByBooleanLiteral types, from matching. Thus, this code path
was never hit. That is, until we accidentally lifted the restriction on
enum case base name overloading too early. Now, it is possible for the
space engine to see the same constructor head that has subspaces with
different argument types. The space engine is relatively tolerant of
this bizarre situation, but in this one narrow case it was not.

This patch has a narrow fix to add the missing case to the
space engine. In the long term, we need to actually finish SE-0155 which
will make this crash structurally impossible once again.

Resolves rdar://65229620