### PR TITLE
Sema: Force synthesis of the CodingKeys nested type in EmittedMembersRequest

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2523,6 +2523,14 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
   forceConformance(Context.getProtocol(KnownProtocolKind::Hashable));
   forceConformance(Context.getProtocol(KnownProtocolKind::Differentiable));
 
+  // If the class conforms to Encodable or Decodable, even via an extension,
+  // the CodingKeys enum is synthesized as a member of the type itself.
+  // Force it into existence.
+  (void) evaluateOrDefault(Context.evaluator,
+                           ResolveImplicitMemberRequest{CD,
+                                      ImplicitMemberAction::ResolveCodingKeys},
+                           {});
+
   // If the class has a @main attribute, we need to force synthesis of the
   // $main function.
   (void) evaluateOrDefault(Context.evaluator,

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -4,6 +4,7 @@ final class Final<T> {
     var x: T
     init(x: T) { self.x = x }
 }
+
 // CHECK-LABEL: final class Final<T> {
 // CHECK:   @_hasStorage final var x: T { get set }
 // CHECK:   init(x: T)
@@ -50,6 +51,16 @@ class Nonfinal<T> {
 // CHECK-LABEL: extension Nonfinal : Encodable where T : Encodable {
 // CHECK:   func encode(to encoder: Encoder) throws
 // CHECK: }
+
+// Make sure that CodingKeys members are actually emitted.
+
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}21__derived_enum_equalsySbAFyx_G_AHtFZ : $@convention(method) <T> (Final<T>.CodingKeys, Final<T>.CodingKeys, @thin Final<T>.CodingKeys.Type) -> Bool {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}9hashValueSivg : $@convention(method) <T> (Final<T>.CodingKeys) -> Int {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}4hash4intoys6HasherVz_tF : $@convention(method) <T> (@inout Hasher, Final<T>.CodingKeys) -> () {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}11stringValueSSvg : $@convention(method) <T> (Final<T>.CodingKeys) -> @owned String {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}11stringValueAFyx_GSgSS_tcfC : $@convention(method) <T> (@owned String, @thin Final<T>.CodingKeys.Type) -> Optional<Final<T>.CodingKeys> {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}8intValueSiSgvg : $@convention(method) <T> (Final<T>.CodingKeys) -> Optional<Int> {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}8intValueAFyx_GSgSi_tcfC : $@convention(method) <T> (Int, @thin Final<T>.CodingKeys.Type) -> Optional<Final<T>.CodingKeys> {
 
 extension Final: Encodable where T: Encodable {}
 // CHECK-LABEL: // Final<A>.encode(to:)


### PR DESCRIPTION
Even if the conformance to Encodable or Decodable is via an extension, the
nested type is synthesized as a member of the type itself, so that it can
be shared by both conformances. Make sure we force it to be synthesized in
this case.

This fixes a regression from https://github.com/apple/swift/pull/32581.