### PR TITLE
test: make `stdlib/Integer.swift.gyb` python 3 friendly

### DIFF
--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -19,7 +19,8 @@
 // REQUIRES: OS=macosx
 
 %{
-word_bits = int(WORD_BITS) / 2
+from __future__ import division
+word_bits = int(WORD_BITS) // 2
 from SwiftIntTypes import all_integer_types
 }%
 


### PR DESCRIPTION
Adjust the division operation to ensure that we get an integral value
back.  Without this, we would attempt to shift a floating point value
by bitwise operations which is not supported.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
