### PR TITLE
test: make `apply-fixit-edits` python3 friendly

### DIFF
--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -46,7 +46,7 @@ def apply_edits(path):
             text = ed.get("text", "")
             edits_per_file[fname].append((offset, length, text))
 
-    for fname, edits in edits_per_file.iteritems():
+    for fname, edits in edits_per_file.items():
         print('Updating', fname)
         edits.sort(reverse=True)
         with open(fname) as f:


### PR DESCRIPTION
`iteritems` was removed in Python 3, adjust for that.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
