### PR TITLE
test: adjust `SILGen/magic_identifier_file_conflicting.swift.gyb` for…

### DIFF
--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb -D TEMPDIR=%t %s > %t/magic_identifier_file_conflicting.swift
-// RUN: %{python} -c "import sys; t = open(sys.argv[1], 'rb').read().replace('\r\n', '\n'); open(sys.argv[1], 'wb').write(t)" %t/magic_identifier_file_conflicting.swift
+// RUN: %{python} -c "import io; import sys; t = io.open(sys.argv[1], 'r', encoding='utf-8').read().replace('\r\n', '\n'); io.open(sys.argv[1], 'w', encoding='utf-8', newline='\n').write(t)" %t/magic_identifier_file_conflicting.swift
 
 // We want to check both the diagnostics and the SIL output.
 // RUN: %target-swift-emit-silgen -verify -emit-sorted-sil -enable-experimental-concise-pound-file -module-name Foo %t/magic_identifier_file_conflicting.swift %S/Inputs/magic_identifier_file_conflicting_other.swift | %FileCheck %s


### PR DESCRIPTION
… python 3

This test has inline python which requires byte-to-text conversions.
Avoid that by using the `io` module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
