### PR TITLE
[5.3] Availability-related fixes with keypaths, _modify, and/or property wrappers

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6135,7 +6135,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
           // If this is an attempt to access read-only member via
           // writable key path, let's fail this choice early.
           auto &ctx = getASTContext();
-          if (isReadOnlyKeyPathComponent(storage) &&
+          if (isReadOnlyKeyPathComponent(storage, SourceLoc()) &&
               (keyPath == ctx.getWritableKeyPathDecl() ||
                keyPath == ctx.getReferenceWritableKeyPathDecl())) {
             result.addUnviable(
@@ -7850,7 +7850,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
       if (!storage)
         return SolutionKind::Error;
 
-      if (isReadOnlyKeyPathComponent(storage)) {
+      if (isReadOnlyKeyPathComponent(storage, component.getLoc())) {
         capability = ReadOnly;
         continue;
       }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1669,7 +1669,7 @@ synthesizeSetterBody(AccessorDecl *setter, ASTContext &ctx) {
   case WriteImplKind::Modify:
     return synthesizeModifyCoroutineSetterBody(setter, ctx);
   }
-  llvm_unreachable("bad ReadImplKind");
+  llvm_unreachable("bad WriteImplKind");
 }
 
 static std::pair<BraceStmt *, bool>
@@ -1950,7 +1950,75 @@ static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
 
   // All mutable storage requires a setter.
   assert(storage->requiresOpaqueAccessor(AccessorKind::Set));
+  
+  // Copy availability from the accessor we'll synthesize the setter from.
+  SmallVector<Decl *, 2> asAvailableAs;
+  
+  // That could be a property wrapper...
+  if (auto var = dyn_cast<VarDecl>(storage)) {
+    if (var->hasAttachedPropertyWrapper()) {
+      // The property wrapper info may not actually link back to a wrapper
+      // implementation, if there was a semantic error checking the wrapper.
+      auto info = var->getAttachedPropertyWrapperTypeInfo(0);
+      if (info.valueVar) {
+        if (auto setter = info.valueVar->getOpaqueAccessor(AccessorKind::Set)) {
+          asAvailableAs.push_back(setter);
+        }
+      }
+    } else if (auto wrapperSynthesizedKind
+                 = var->getPropertyWrapperSynthesizedPropertyKind()) {
+      switch (*wrapperSynthesizedKind) {
+      case PropertyWrapperSynthesizedPropertyKind::Backing:
+        break;
+    
+      case PropertyWrapperSynthesizedPropertyKind::StorageWrapper: {
+        if (auto origVar = var->getOriginalWrappedProperty(wrapperSynthesizedKind)) {
+          // The property wrapper info may not actually link back to a wrapper
+          // implementation, if there was a semantic error checking the wrapper.
+          auto info = origVar->getAttachedPropertyWrapperTypeInfo(0);
+          if (info.projectedValueVar) {
+            if (auto setter
+                = info.projectedValueVar->getOpaqueAccessor(AccessorKind::Set)){
+              asAvailableAs.push_back(setter);
+            }
+          }
+        }
+        break;
+      }
+      }
+    }
+  }
 
+
+  // ...or another accessor.
+  switch (storage->getWriteImpl()) {
+  case WriteImplKind::Immutable:
+    llvm_unreachable("synthesizing setter from immutable storage");
+  case WriteImplKind::Stored:
+  case WriteImplKind::StoredWithObservers:
+  case WriteImplKind::InheritedWithObservers:
+  case WriteImplKind::Set:
+    // Setter's availability shouldn't be externally influenced in these
+    // cases.
+    break;
+      
+  case WriteImplKind::MutableAddress:
+    if (auto addr = storage->getOpaqueAccessor(AccessorKind::MutableAddress)) {
+      asAvailableAs.push_back(addr);
+    }
+    break;
+  case WriteImplKind::Modify:
+    if (auto mod = storage->getOpaqueAccessor(AccessorKind::Modify)) {
+      asAvailableAs.push_back(mod);
+    }
+    break;
+  }
+  
+  if (!asAvailableAs.empty()) {
+    AvailabilityInference::applyInferredAvailableAttrs(
+        setter, asAvailableAs, ctx);
+  }
+  
   finishImplicitAccessor(setter, ctx);
 
   return setter;

--- a/test/Sema/generalized_accessors_availability.swift
+++ b/test/Sema/generalized_accessors_availability.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -typecheck -verify %s
+
+// REQUIRES: OS=macosx
+
+@propertyWrapper
+struct SetterConditionallyAvailable<T> {
+    var wrappedValue: T {
+        get { fatalError() }
+
+        @available(macOS 10.10, *)
+        set { fatalError() }
+    }
+
+    var projectedValue: T {
+        get { fatalError() }
+
+        @available(macOS 10.10, *)
+        set { fatalError() }
+    }
+}
+
+@propertyWrapper
+struct ModifyConditionallyAvailable<T> {
+    var wrappedValue: T {
+        get { fatalError() }
+
+        @available(macOS 10.10, *)
+        _modify { fatalError() }
+    }
+
+    var projectedValue: T {
+        get { fatalError() }
+
+        @available(macOS 10.10, *)
+        _modify { fatalError() }
+    }
+}
+
+struct Butt {
+    var modify_conditionally_available: Int {
+        get { fatalError() }
+
+        @available(macOS 10.10, *)
+        _modify { fatalError() }
+    }
+
+    @SetterConditionallyAvailable
+    var wrapped_setter_conditionally_available: Int
+
+    @ModifyConditionallyAvailable
+    var wrapped_modify_conditionally_available: Int
+}
+
+func butt(x: inout Butt) { // expected-note*{{}}
+    x.modify_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
+    x.wrapped_setter_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
+    x.wrapped_modify_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
+    x.$wrapped_setter_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
+    x.$wrapped_modify_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
+
+    if #available(macOS 10.10, *) {
+        x.modify_conditionally_available = 0
+        x.wrapped_setter_conditionally_available = 0
+        x.wrapped_modify_conditionally_available = 0
+        x.$wrapped_setter_conditionally_available = 0
+        x.$wrapped_modify_conditionally_available = 0
+    }
+}

--- a/test/expr/unary/keypath/keypath-availability.swift
+++ b/test/expr/unary/keypath/keypath-availability.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -typecheck -verify %s
+// REQUIRES: OS=macosx
+
+struct Butt {
+    var setter_conditionally_available: Int {
+        get { fatalError() }
+
+        @available(macOS 10.10, *)
+        set { fatalError() }
+    }
+}
+
+func assertExactType<T>(of _: inout T, is _: T.Type) {}
+
+@available(macOS 10.9, *)
+public func unavailableSetterContext() {
+    var kp = \Butt.setter_conditionally_available
+    assertExactType(of: &kp, is: KeyPath<Butt, Int>.self)
+}
+@available(macOS 10.10, *)
+public func availableSetterContext() {
+    var kp = \Butt.setter_conditionally_available
+    assertExactType(of: &kp, is: WritableKeyPath<Butt, Int>.self)
+}
+@available(macOS 10.9, *)
+public func conditionalAvailableSetterContext() {
+    if #available(macOS 10.10, *) {
+        var kp = \Butt.setter_conditionally_available
+        assertExactType(of: &kp, is: WritableKeyPath<Butt, Int>.self)
+    } else {
+        var kp = \Butt.setter_conditionally_available
+        assertExactType(of: &kp, is: KeyPath<Butt, Int>.self)
+    }
+}
+


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/32819. Fixes for rdar://problem/65152582:

- Key path literal type checking did not take into account the availability of the setter, allowing statically WritableKeyPaths to be formed in contexts where the setter is unavailable
- Synthesized opaque setter implementations did not inherit the availability of the declarations they get synthesized from, such as property wrapper implementations and/or _modify or addressor accessors

Reviewed by: @hborla 

Risk: Low. Shouldn't affect much existing code; it is a correctness fix for working with new APIs that added setters in this year's Apple OS

Issue: rdar://problem/65152582