### PR TITLE
Teach EscapeAnalysis to ignore end_access markers.

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -2079,6 +2079,10 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       return;
   }
 
+  // Incidental uses produce no values and have no effect on their operands.
+  if (isIncidentalUse(I))
+    return;
+
   // Instructions which return the address of non-writable memory cannot have
   // an effect on escaping.
   if (isNonWritableMemoryAddress(I))

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1915,7 +1915,7 @@ bb0(%0 : $*SomeData):
 
 // CHECK-LABEL: CG of testAccessMarker
 // CHECK-NEXT:   Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:   Con [ref] %0.1 Esc: G, Succ:
+// CHECK-NEXT:   Con [ref] %0.1 Esc: A, Succ:
 // CHECK-LABEL: End
 sil hidden @testAccessMarker : $@convention(thin) (@inout SomeData) -> () {
 bb0(%0 : $*SomeData):
@@ -1925,6 +1925,34 @@ bb0(%0 : $*SomeData):
   end_access %1 : $*SomeData
   %5 = tuple ()
   return %5 : $()
+}
+
+// Test that end_access does not cause its storage to escape.
+//
+// CHECK-LABEL: CG of testEndAccess
+// CHECK:   Val [ref] %0 Esc: , Succ: (%3)
+// CHECK:   Con [int] %3 Esc: , Succ: (%3.1)
+// CHECK:   Con [ref] %3.1 Esc: , Succ:
+// CHECK: End
+// CHECK: NoEscape:   %0 = alloc_ref $IntWrapper
+// CHECK:  to   set_deallocating %0 : $IntWrapper
+// CHECK: NoEscape:   %3 = ref_element_addr %0 : $IntWrapper, #IntWrapper.property
+// CHECK:  to   set_deallocating %0 : $IntWrapper
+// CHECK: MayEscape:   %4 = begin_access [modify] [dynamic] [no_nested_conflict] %3 : $*Int64
+// CHECK:  to   set_deallocating %0 : $IntWrapper
+sil @testEndAccess : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $IntWrapper
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int64 (%1 : $Builtin.Int64)
+  %3 = ref_element_addr %0 : $IntWrapper, #IntWrapper.property
+  %4 = begin_access [modify] [dynamic] [no_nested_conflict] %3 : $*Int64
+  store %2 to %4 : $*Int64
+  end_access %4 : $*Int64
+  set_deallocating %0 : $IntWrapper
+  dealloc_ref %0 : $IntWrapper
+  %9 = tuple ()
+  return %9 : $()
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The presence of end_access markers was causing object properties to
appear to escape globally. That's too conservative.