### PR TITLE
[AutoDiff][stdlib] Add JVPs to ArrayDifferentiation.swift

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -312,6 +312,27 @@ extension Array where Element: Differentiable {
     }
     return (value: values, pullback: pullback)
   }
+
+  @inlinable
+  @derivative(of: differentiableMap)
+  internal func _jvpDifferentiableMap<Result: Differentiable>(
+      _ body: @differentiable (Element) -> Result
+  ) -> (
+    value: [Result],
+    differential: (Array.TangentVector) -> Array<Result>.TangentVector
+  ) {
+    var values: [Result] = []
+    var differentials: [(Element.TangentVector) -> Result.TangentVector] = []
+    for x in self {
+      let (y, df) = valueWithDifferential(at: x, in: body)
+      values.append(y)
+      differentials.append(df)
+    }
+    func differential(_ tans: Array.TangentVector) -> Array<Result>.TangentVector {
+      .init(zip(tans.base, differentials).map { tan, df in df(tan) })
+    }
+    return (value: values, differential: differential)
+  }
 }
 
 extension Array where Element: Differentiable {

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -316,7 +316,7 @@ extension Array where Element: Differentiable {
   @inlinable
   @derivative(of: differentiableMap)
   internal func _jvpDifferentiableMap<Result: Differentiable>(
-      _ body: @differentiable (Element) -> Result
+    _ body: @differentiable (Element) -> Result
   ) -> (
     value: [Result],
     differential: (Array.TangentVector) -> Array<Result>.TangentVector

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1319,4 +1319,21 @@ ForwardModeTests.test("ForceUnwrapping") {
   expectEqual(5, forceUnwrap(Float(2)))
 }
 
+//===----------------------------------------------------------------------===//
+// Array methods from ArrayDifferentiation.swift
+//===----------------------------------------------------------------------===//
+ForwardModeTests.test("Array.differentiableMap") {
+  let a: Array<Float> = [1, 2, 3]
+
+  func multiplyMap(a: Array<Float>) -> Array<Float> {
+    return a.differentiableMap({x in 3 * x});
+  }
+  expectEqual([3, 3, 3], differential(at: [1, 1, 1], in: multiplyMap)(a))
+
+  func squareMap(a: Array<Float>) -> Array<Float> {
+    return a.differentiableMap({x in x * x});
+  }
+  expectEqual([2, 4, 6], differential(at: [1, 1, 1], in: squareMap)(a))
+}
+
 runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1322,16 +1322,17 @@ ForwardModeTests.test("ForceUnwrapping") {
 //===----------------------------------------------------------------------===//
 // Array methods from ArrayDifferentiation.swift
 //===----------------------------------------------------------------------===//
-ForwardModeTests.test("Array.differentiableMap") {
-  let a: Array<Float> = [1, 2, 3]
 
-  func multiplyMap(a: Array<Float>) -> Array<Float> {
-    return a.differentiableMap({x in 3 * x});
+ForwardModeTests.test("Array.differentiableMap") {
+  let a: [Float] = [1, 2, 3]
+
+  func multiplyMap(_ a: [Float]) -> [Float] {
+    return a.differentiableMap({ x in 3 * x })
   }
   expectEqual([3, 3, 3], differential(at: [1, 1, 1], in: multiplyMap)(a))
 
-  func squareMap(a: Array<Float>) -> Array<Float> {
-    return a.differentiableMap({x in x * x});
+  func squareMap(_ a: [Float]) -> [Float] {
+    return a.differentiableMap({ x in x * x })
   }
   expectEqual([2, 4, 6], differential(at: [1, 1, 1], in: squareMap)(a))
 }

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1324,18 +1324,18 @@ ForwardModeTests.test("ForceUnwrapping") {
 //===----------------------------------------------------------------------===//
 
 ForwardModeTests.test("Array.differentiableMap") {
-  let a: [Float] = [1, 2, 3]
-  let tan = Array<Float>.TangentVector.init(a)
+  let x: [Float] = [1, 2, 3]
+  let tan = Array<Float>.TangentVector([1, 1, 1])
 
   func multiplyMap(_ a: [Float]) -> [Float] {
     return a.differentiableMap({ x in 3 * x })
   }
-  expectEqual([3, 3, 3], differential(at: [1, 1, 1], in: multiplyMap)(tan))
+  expectEqual([3, 3, 3], differential(at: x, in: multiplyMap)(tan))
 
   func squareMap(_ a: [Float]) -> [Float] {
     return a.differentiableMap({ x in x * x })
   }
-  expectEqual([2, 4, 6], differential(at: [1, 1, 1], in: squareMap)(tan))
+  expectEqual([2, 4, 6], differential(at: x, in: squareMap)(tan))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1323,6 +1323,75 @@ ForwardModeTests.test("ForceUnwrapping") {
 // Array methods from ArrayDifferentiation.swift
 //===----------------------------------------------------------------------===//
 
+typealias FloatArrayTan = Array<Float>.TangentVector
+
+ForwardModeTests.test("Array.+") {
+  func sumFirstThreeConcatenating(_ a: [Float], _ b: [Float]) -> Float {
+    let c = a + b
+    return c[0] + c[1] + c[2]
+  }
+
+  expectEqual(3, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1]), .init([1, 1])))
+  expectEqual(0, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([0, 0]), .init([0, 1])))
+  expectEqual(1, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([0, 1]), .init([0, 1])))
+  expectEqual(1, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 0]), .init([0, 1])))
+  expectEqual(1, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([0, 0]), .init([1, 1])))
+  expectEqual(2, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1]), .init([0, 1])))
+
+  expectEqual(
+    3,
+    differential(at: [0, 0, 0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1, 1, 1]), .init([1, 1])))
+  expectEqual(
+    3,
+    differential(at: [0, 0, 0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1, 1, 0]), .init([0, 0])))
+  
+  expectEqual(
+    3,
+    differential(at: [], [0, 0, 0, 0], in: sumFirstThreeConcatenating)(.init([]), .init([1, 1, 1, 1])))
+  expectEqual(
+    0,
+    differential(at: [], [0, 0, 0, 0], in: sumFirstThreeConcatenating)(.init([]), .init([0, 0, 0, 1])))
+}
+
+ForwardModeTests.test("Array.init(repeating:count:)") {
+  @differentiable
+  func repeating(_ x: Float) -> [Float] {
+    Array(repeating: x, count: 10)
+  }
+  expectEqual(Float(10), derivative(at: .zero) { x in
+    repeating(x).differentiableReduce(0, {$0 + $1})
+  })
+  expectEqual(Float(20), differential(at: .zero, in: { x in
+    repeating(x).differentiableReduce(0, {$0 + $1})
+  })(2))
+}
+
+ForwardModeTests.test("Array.DifferentiableView.init") {
+  @differentiable
+  func constructView(_ x: [Float]) -> Array<Float>.DifferentiableView {
+    return Array<Float>.DifferentiableView(x)
+  }
+
+  let forward = differential(at: [5, 6, 7, 8], in: constructView)
+  expectEqual(
+    FloatArrayTan([1, 2, 3, 4]),
+    forward(FloatArrayTan([1, 2, 3, 4])))
+}
+
+ForwardModeTests.test("Array.DifferentiableView.base") {
+  @differentiable
+  func accessBase(_ x: Array<Float>.DifferentiableView) -> [Float] {
+    return x.base
+  }
+
+  let forward = differential(
+    at: Array<Float>.DifferentiableView([5, 6, 7, 8]),
+    in: accessBase)
+  expectEqual(
+    FloatArrayTan([1, 2, 3, 4]),
+    forward(FloatArrayTan([1, 2, 3, 4])))
+}
+
 ForwardModeTests.test("Array.differentiableMap") {
   let x: [Float] = [1, 2, 3]
   let tan = Array<Float>.TangentVector([1, 1, 1])
@@ -1336,6 +1405,26 @@ ForwardModeTests.test("Array.differentiableMap") {
     return a.differentiableMap({ x in x * x })
   }
   expectEqual([2, 4, 6], differential(at: x, in: squareMap)(tan))
+}
+
+ForwardModeTests.test("Array.differentiableReduce") {
+  let x: [Float] = [1, 2, 3]
+  let tan = Array<Float>.TangentVector([1, 1, 1])
+
+  func sumReduce(_ a: [Float]) -> Float {
+    return a.differentiableReduce(0, { $0 + $1 })
+  }
+  expectEqual(1 + 1 + 1, differential(at: x, in: sumReduce)(tan))
+
+  func productReduce(_ a: [Float]) -> Float {
+    return a.differentiableReduce(1, { $0 * $1 })
+  }
+  expectEqual(x[1] * x[2] + x[0] * x[2] + x[0] * x[1], differential(at: x, in: productReduce)(tan))
+
+  func sumOfSquaresReduce(_ a: [Float]) -> Float {
+    return a.differentiableReduce(0, { $0 + $1 * $1 })
+  }
+  expectEqual(2 * x[0] + 2 * x[1] + 2 * x[2], differential(at: x, in: sumOfSquaresReduce)(tan))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1325,16 +1325,17 @@ ForwardModeTests.test("ForceUnwrapping") {
 
 ForwardModeTests.test("Array.differentiableMap") {
   let a: [Float] = [1, 2, 3]
+  let tan = Array<Float>.TangentVector.init(a)
 
   func multiplyMap(_ a: [Float]) -> [Float] {
     return a.differentiableMap({ x in 3 * x })
   }
-  expectEqual([3, 3, 3], differential(at: [1, 1, 1], in: multiplyMap)(a))
+  expectEqual([3, 3, 3], differential(at: [1, 1, 1], in: multiplyMap)(tan))
 
   func squareMap(_ a: [Float]) -> [Float] {
     return a.differentiableMap({ x in x * x })
   }
-  expectEqual([2, 4, 6], differential(at: [1, 1, 1], in: squareMap)(a))
+  expectEqual([2, 4, 6], differential(at: [1, 1, 1], in: squareMap)(tan))
 }
 
 runAllTests()


### PR DESCRIPTION
Adds JVPs to `Array` and `Array.DifferentiableView`

`_jvpDifferentiableReduce` is taken from #29324