### PR TITLE
[SR-11184] Delay binding of key path application projected result value 

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -551,8 +551,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
       if (result.FullyBound)
         continue;
 
-      // If this variable is in the application projected result type, it is
-      // fully bound.
+      // If this variable is in the application projected result type, mark the
+      // result as `FullyBound` to ensure we delay binding until we've bound
+      // other type variables in the KeyPathApplication constraint. This ensures
+      // we try to bind the key path type first, which can allow us to discover
+      // additional bindings for the result type.
       SmallPtrSet<TypeVariableType *, 4> typeVars;
       findInferableTypeVars(simplifyType(constraint->getThirdType()), typeVars);
       if (typeVars.count(typeVar))

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -547,13 +547,25 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
       }
       break;
     }
+    case ConstraintKind::KeyPathApplication: {
+      if (result.FullyBound)
+        continue;
+
+      // If this variable is in the application projected result type, it is
+      // fully bound.
+      SmallPtrSet<TypeVariableType *, 4> typeVars;
+      findInferableTypeVars(simplifyType(constraint->getThirdType()), typeVars);
+      if (typeVars.count(typeVar))
+        result.FullyBound = true;
+
+      break;
+    }
 
     case ConstraintKind::BridgingConversion:
     case ConstraintKind::CheckedCast:
     case ConstraintKind::EscapableFunctionOf:
     case ConstraintKind::OpenedExistentialOf:
     case ConstraintKind::KeyPath:
-    case ConstraintKind::KeyPathApplication:
     case ConstraintKind::FunctionInput:
     case ConstraintKind::FunctionResult:
     case ConstraintKind::OpaqueUnderlyingType:

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -137,3 +137,18 @@ func test_mismatch_with_contextual_optional_result() {
   let _ = A(B(), keyPath: \.arr)
   // expected-error@-1 {{key path value type '[Int]' cannot be converted to contextual type '[Int]?'}}
 }
+
+// SR-11184
+class SR11184 {}
+
+func fSR11184(_ c: SR11184!, _ kp: ReferenceWritableKeyPath<SR11184, String?>, _ str: String) {
+  c[keyPath: kp] = str // OK
+  c![keyPath: kp] = str // OK
+  c?[keyPath: kp] = str // OK
+}
+
+func fSR11184_O(_ c: SR11184!, _ kp: ReferenceWritableKeyPath<SR11184, String?>, _ str: String?) {
+  c[keyPath: kp] = str // OK
+  c![keyPath: kp] = str // OK
+  c?[keyPath: kp] = str // OK
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Delay binding the projected result value binding of the key path application constraint until we've tried the key path type.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-11184.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
