### PR TITLE
Teach stripCasts (and getUnderlyingObject) about begin_access.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -50,8 +50,7 @@
 
 namespace swift {
 
-/// Get the base address of a formal access by stripping access markers and
-/// borrows.
+/// Get the base address of a formal access by stripping access markers.
 ///
 /// If \p v is an address, then the returned value is also an address
 /// (pointer-to-address is not stripped).

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -127,9 +127,10 @@ SILValue swift::stripCastsWithoutMarkDependence(SILValue V) {
     V = stripSinglePredecessorArgs(V);
 
     auto K = V->getKind();
-    if (isRCIdentityPreservingCast(K) ||
-        K == ValueKind::UncheckedTrivialBitCastInst ||
-        K == ValueKind::EndCOWMutationInst) {
+    if (isRCIdentityPreservingCast(K)
+        || K == ValueKind::UncheckedTrivialBitCastInst
+        || K == ValueKind::BeginAccessInst
+        || K == ValueKind::EndCOWMutationInst) {
       V = cast<SingleValueInstruction>(V)->getOperand(0);
       continue;
     }
@@ -145,7 +146,8 @@ SILValue swift::stripCasts(SILValue v) {
     auto k = v->getKind();
     if (isRCIdentityPreservingCast(k)
         || k == ValueKind::UncheckedTrivialBitCastInst
-        || k == ValueKind::MarkDependenceInst) {
+        || k == ValueKind::MarkDependenceInst
+        || k == ValueKind::BeginAccessInst) {
       v = cast<SingleValueInstruction>(v)->getOperand(0);
       continue;
     }

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -371,8 +371,13 @@ Optional<ProjectionPath> ProjectionPath::getProjectionPath(SILValue Start,
 
   auto Iter = End;
   while (Start != Iter) {
-    // end_cow_mutation is not a projection, but we want to "see through" it.
-    if (!isa<EndCOWMutationInst>(Iter)) {
+    // end_cow_mutation and begin_access are not projections, but we need to be
+    // able to form valid ProjectionPaths across them, otherwise optimization
+    // passes like RLE/DSE cannot recognize their locations.
+    //
+    // TODO: migrate users to getProjectionPath to the AccessPath utility to
+    // avoid this hack.
+    if (!isa<EndCOWMutationInst>(Iter) && !isa<BeginAccessInst>(Iter)) {
       Projection AP(Iter);
       if (!AP.isValid())
         break;

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1938,7 +1938,7 @@ bb0(%0 : $*SomeData):
 // CHECK:  to   set_deallocating %0 : $IntWrapper
 // CHECK: NoEscape:   %3 = ref_element_addr %0 : $IntWrapper, #IntWrapper.property
 // CHECK:  to   set_deallocating %0 : $IntWrapper
-// CHECK: MayEscape:   %4 = begin_access [modify] [dynamic] [no_nested_conflict] %3 : $*Int64
+// CHECK: NoEscape:   %4 = begin_access [modify] [dynamic] [no_nested_conflict] %3 : $*Int64
 // CHECK:  to   set_deallocating %0 : $IntWrapper
 sil @testEndAccess : $@convention(thin) () -> () {
 bb0:


### PR DESCRIPTION
This was blocking EscapeAnalysis and many other analyses from handling
access markers.