### PR TITLE
test: use the `o` octal specifier for python 3 compatibility

### DIFF
--- a/utils/scale-test
+++ b/utils/scale-test
@@ -62,7 +62,7 @@ def write_input_file(args, ast, d, n):
 
 def ensure_tmpdir(d):
     if d is not None and not os.path.exists(d):
-        os.makedirs(d, 0700)
+        os.makedirs(d, 0o700)
     return tempfile.mkdtemp(dir=d)
 
 
@@ -74,7 +74,7 @@ def supports_stats_output_dir(args):
     sd = os.path.join(d, "stats-probe")
 
     try:
-        os.makedirs(sd, 0700)
+        os.makedirs(sd, 0o700)
         # Write a trivial test program and try running with
         # -stats-output-dir
         testpath = os.path.join(sd, "test.swift")


### PR DESCRIPTION
This adjusts the permissions to use the octal specifier explicitly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
