### PR TITLE
validation: explicitly use integral division

### DIFF
--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -8,6 +8,7 @@ var FixedPoint = TestSuite("FixedPoint")
 
 %{
 
+from __future__ import division
 import gyb
 from SwiftIntTypes import all_integer_types
 
@@ -248,7 +249,7 @@ FixedPoint.test("${Self}.hash(into:)") {
 %     if self_ty.bits == 64:
     let expected = Hasher._hash(seed: 0, ${reference} as UInt64)
 %     else:
-    let expected = Hasher._hash(seed: 0, bytes: ${reference}, count: ${self_ty.bits / 8})
+    let expected = Hasher._hash(seed: 0, bytes: ${reference}, count: ${self_ty.bits // 8})
 %     end
     expectEqual(expected, output, "input: \(input)")
   }


### PR DESCRIPTION
Division behaviour changed between Python 2 and Python 3.  Explicitly
indicate that we wish to use integral division here.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
