### PR TITLE
validation: make UnsafeBufferPointer Python3 friendly

### DIFF
--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -425,7 +425,7 @@ for testIndex in (0..<bufCount) {
     defer { allocated.deallocate() }
 
     let buffer = ${Type}(start: allocated, count: bufCount)
-    ${'var' if mutable and action <> 'read' else 'let'} slice = buffer[sliceRange]
+    ${'var' if mutable and action != 'read' else 'let'} slice = buffer[sliceRange]
 
     if _isDebugAssertConfiguration(),
        testIndex < sliceRange.lowerBound ||
@@ -466,7 +466,7 @@ for testRange in testRanges {
     defer { allocated.deallocate() }
 
     let buffer = ${Type}(start: allocated, count: bufCount+2)
-    ${'var' if mutable and action <> 'read' else 'let'} slice = buffer[sliceRange]
+    ${'var' if mutable and action != 'read' else 'let'} slice = buffer[sliceRange]
 
     if _isDebugAssertConfiguration(),
       testRange.lowerBound < sliceRange.lowerBound ||


### PR DESCRIPTION
The `<>` operator does not work in Python 3.  Switch it out for `!=`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
