### PR TITLE
[ModuleInterface] Fix test for SPI attributes on unsupported decls

### DIFF
--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -93,8 +93,7 @@ private class PrivateClassLocal {}
 // CHECK-PUBLIC-NOT: SPIProto3
 
   associatedtype AssociatedType
-  // CHECK-PRIVATE: associatedtype AssociatedType
-  // CHECK-PRIVATE-NOT: @_spi(LocalSPI) associatedtype AssociatedType
+  // CHECK-PRIVATE: {{^}}  associatedtype AssociatedType
   // CHECK-PUBLIC-NOT: AssociatedType
 
   func implicitSPIMethod()


### PR DESCRIPTION
Fix test introduced by #32211. Thank you @brentdax for spotting this problem.