### PR TITLE
[Test] Disable Prototypes/BigInt.swift.

### DIFF
--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -16,6 +16,7 @@
 // REQUIRES: executable_test
 // REQUIRES: CPU=x86_64
 
+// REQUIRES: rdar65251059
 // rdar://problem/65015626
 // XFAIL: asserts
 


### PR DESCRIPTION
Disable the test while solving the problem in a way that doesn't break any platforms.

Most recent failure is here

https://ci.swift.org/view/Dashboard/job/oss-swift_tools-R_stdlib-RD_test-simulator/5173/consoleText

rdar://problem/65251059