### PR TITLE
[Test] Un-Xfail ParseableInterface/verify_all_overlays.py.

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -14,9 +14,6 @@
 
 # REQUIRES: nonexecutable_test
 
-# rdar://problem/50648519
-# XFAIL: asan
-
 # Expected failures by platform
 # -----------------------------
 # macosx: XCTest


### PR DESCRIPTION
The test is now passing with ASAN.  Most recent pass at

    https://ci.swift.org/view/Dashboard/job/oss-swift-5.3-incremental-ASAN-RA-osx/109/consoleText

rdar://problem/65358162