### PR TITLE
validation: make `line-directive` python 3.5 friendly

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -63,7 +63,7 @@ def _make_line_map(target_filename, stream=None):
     """
     >>> try:
     ...     from StringIO import StringIO # py2
-    ... except ModuleNotFoundError:
+    ... except ImportError:
     ...     from io import StringIO # py3
     >>> _make_line_map('box',
     ... StringIO('''// ###sourceLocation(file: "foo.bar", line: 3)


### PR DESCRIPTION
`ModuleNotFoundError` was introduced in python 3.6 as a child of
`ImportError`.  However, some of the CI hosts use python 3.5.  Use
`ImportError` as the filter type to be compatible with earlier python
versions.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
