### PR TITLE
validation: make test_shell Python3 friendly

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -137,7 +137,7 @@ def capture(command, stderr=None, env=None, dry_run=None, echo=True,
         return str(out.decode())
     except subprocess.CalledProcessError as e:
         if allow_non_zero_exit:
-            return e.output
+            return str(e.output.decode())
         if optional:
             return None
         _fatal_error(


### PR DESCRIPTION
It seems that the returned value is a byte string in Python 3 rather
than a text string.  Mark the expected literal as a byte string, which
allows this test to pass on Python 2 and Python 3.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
