### PR TITLE
[build] Fix --skip-build-llvm so that its minimal targets, like tblgen, are still built

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -848,8 +848,11 @@ class BuildScriptInvocation(object):
         impl_product_classes = []
         if self.args.build_cmark:
             impl_product_classes.append(products.CMark)
-        if self.args.build_llvm:
-            impl_product_classes.append(products.LLVM)
+
+        # If --skip-build-llvm is passed in, LLVM cannot be completely disabled, as
+        # Swift still needs a few LLVM targets like tblgen to be built for it to be
+        # configured. Instead, handle this in build-script-impl for now.
+        impl_product_classes.append(products.LLVM)
         if self.args.build_libcxx:
             impl_product_classes.append(products.LibCXX)
         if self.args.build_libicu:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1157,10 +1157,14 @@ LIBDISPATCH_STATIC_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 LIBCXX_SOURCE_DIR="${WORKSPACE}/llvm-project/libcxx"
 
+# We cannot currently apply the normal rules of skipping here for LLVM. Even if
+# we are skipping building LLVM, we still need to at least build a few tools
+# like tblgen that Swift relies on for building and testing. See the LLVM
+# configure rules.
+PRODUCTS=(llvm)
 [[ "${SKIP_BUILD_CMARK}" ]] || PRODUCTS+=(cmark)
 [[ "${SKIP_BUILD_LIBCXX}" ]] || PRODUCTS+=(libcxx)
 [[ "${SKIP_BUILD_LIBICU}" ]] || PRODUCTS+=(libicu)
-[[ "${SKIP_BUILD_LLVM}" ]] || PRODUCTS+=(llvm)
 [[ "${SKIP_BUILD_SWIFT}" ]] || PRODUCTS+=(swift)
 [[ "${SKIP_BUILD_LLDB}" ]] || PRODUCTS+=(lldb)
 [[ "${SKIP_BUILD_LIBDISPATCH}" ]] || PRODUCTS+=(libdispatch)
@@ -1550,7 +1554,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${BUILD_LLVM}" == "0" ] ; then
                     build_targets=(clean)
                 fi
-                if [ "${SKIP_BUILD}" ] ; then
+                if [[ "${SKIP_BUILD}" || "${SKIP_BUILD_LLVM}" ]] ; then
                     # We can't skip the build completely because the standalone
                     # build of Swift depend on these for building and testing.
                     build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)

--- a/validation-test/BuildSystem/skip_cmark_swift_llvm.test
+++ b/validation-test/BuildSystem/skip_cmark_swift_llvm.test
@@ -20,7 +20,7 @@
 # SKIP-CMARK-CHECK: --- Installing swift ---
 
 # SKIP-LLVM-CHECK: cmake --build {{.*}}cmark-
-# SKIP-LLVM-CHECK-NOT: cmake --build {{.*}}llvm-
+# SKIP-LLVM-CHECK: cmake --build {{.*}}llvm-tblgen
 # SKIP-LLVM-CHECK: cmake --build {{.*}}swift-
 # SKIP-LLVM-CHECK: --- Installing cmark ---
 # SKIP-LLVM-CHECK-NOT: --- Installing llvm ---


### PR DESCRIPTION
There have been some regressions this year that broke the way the three base products- cmark, llvm, and swift- are built if their `skip-build-*` flags are applied. For example, [building the standalone stdlib](https://github.com/apple/swift/blob/c03ea7ad44e417c2a52982411cc7432df1941c87/utils/build-presets.ini#L2302) no longer works after pulls #29373, #29500, and #32256. I just noticed this when trying to run this similar build-script command to build the Swift stdlib alone on linux with the latest July 12 source snapshot from trunk and matching prebuilt official compiler (I use [an extended version of this command when cross-compiling the stdlib for Android](https://github.com/termux/termux-packages/blob/b2c582bf9217b730a42058512c751f24a788bee9/packages/swift/build.sh#L107)):
```
./swift/utils/build-script -R --no-assertions --build-runtime-with-host-compiler --build-swift-tools=0 --native-swift-tools-path=/home/butta/712-swift/usr/bin/ --native-llvm-tools-path=/home/butta/712-swift/usr/bin/ --native-clang-tools-path=/home/butta/712-swift/usr/bin/ --skip-build-cmark --skip-build-llvm -j5
```
The three base products were always handled differently in the build scripts until this year, because they would usually be built and relied on each other. For example, LLVM has to be configured for the Swift product to be configured.

The way the build-script worked till January was that `--skip-build-*` meant the product was neither configured or built, with the exception of the base products: CMark, LLVM, and Swift. For those three, `--skip-build-swift` or the equivalent would mean that that product was configured, but not built (with one exception, [a few LLVM targets like tblgen would always be built even with `--skip-build-llvm` or `--skip-build` back then](https://github.com/apple/swift/pull/29500/files#diff-65b44eb6cb88af2161d8e1176231aad0L1439)).

Since January, the first two pulls above changed the base products to match all other products, ie `--skip-build-*` always means `don't configure and don't build` (with a strange exception of configuring and building the minimal LLVM targets only if the `--skip-build` flag was passed, likely a mistake). The way this worked was that `build-script-impl` was always run for each of the base products and the flags in that bash script would then disable both configuring and building the unwanted base products.

Finally, #32256 last month added another layer and [disabled even running `build-script-impl` if a `skip-build-*` flag was passed for a base product](https://github.com/apple/swift/pull/32256/files#diff-23cfac4b9c8ced6111824fa8012556e2L820). That made the logic from the first two pulls disabling those same base products in `build-script-impl` redundant.

This pull partially reverts those three pulls for the `--skip-build-llvm` flag alone, ~with the only difference from~changing it back to the way it worked last year ~that it will now configure the minimal LLVM targets but not build them~. This gets the above pasted command to build the standalone stdlib working again.

I'm not sure if more should be done, so I'm only offering this as a potential solution to spur discussion. @atrick and @gottesmm, let me know what you think these `--skip-build*` flags for the three base products should do, given the historical behavior and dependencies laid out above.