### PR TITLE
IRGen: Name the symbol for the private use area attached to protocol conformance descriptors.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -171,6 +171,8 @@ Globals
   global ::= entity 'Wvd'                // field offset
   global ::= entity 'WC'                 // resilient enum tag index
 
+  global ::= global 'MK'                 // instantiation cache associated with global
+
 A direct symbol resolves directly to the address of an object.  An
 indirect symbol resolves to the address of a pointer to the object.
 They are distinct manglings to make a certain class of bugs

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -291,5 +291,8 @@ CONTEXT_NODE(OpaqueReturnTypeOf)
 NODE(CanonicalSpecializedGenericMetaclass)
 NODE(CanonicalSpecializedGenericTypeMetadataAccessFunction)
 
+// Added in Swift 5.4
+NODE(MetadataInstantiationCache)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1911,6 +1911,9 @@ NodePointer Demangler::demangleMetatype() {
     case 'j':
       return createWithChild(Node::Kind::OpaqueTypeDescriptorAccessorKey,
                              popNode());
+    case 'K':
+      return createWithChild(Node::Kind::MetadataInstantiationCache,
+                             popNode());
     case 'k':
       return createWithChild(Node::Kind::OpaqueTypeDescriptorAccessorVar,
                              popNode());

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -454,6 +454,7 @@ private:
     case Node::Kind::PropertyDescriptor:
     case Node::Kind::ProtocolConformance:
     case Node::Kind::ProtocolConformanceDescriptor:
+    case Node::Kind::MetadataInstantiationCache:
     case Node::Kind::ProtocolDescriptor:
     case Node::Kind::ProtocolRequirementsBaseDescriptor:
     case Node::Kind::ProtocolSelfConformanceDescriptor:
@@ -2431,6 +2432,10 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return nullptr;
   case Node::Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
     Printer << "canonical specialized generic type metadata accessor for ";
+    print(Node->getChild(0));
+    return nullptr;
+  case Node::Kind::MetadataInstantiationCache:
+    Printer << "metadata instantiation cache for ";
     print(Node->getChild(0));
     return nullptr;
   }

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2132,6 +2132,9 @@ void Remangler::mangleOpaqueTypeDescriptorAccessorVar(Node *node) {
 void Remangler::mangleAccessorFunctionReference(Node *node) {
   unreachable("can't remangle");
 }
+void Remangler::mangleMetadataInstantiationCache(Node *node) {
+  unreachable("unsupported");
+}
 
 void Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node) {
   Buffer << "MM";

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2547,6 +2547,11 @@ void Remangler::mangleCanonicalSpecializedGenericTypeMetadataAccessFunction(
   Buffer << "Mb";
 }
 
+void Remangler::mangleMetadataInstantiationCache(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "MK";
+}
+
 } // anonymous namespace
 
 /// The top-level interface to the remangler.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1924,11 +1924,16 @@ namespace {
           llvm::ArrayType::get(IGM.Int8PtrTy,
                                swift::NumGenericMetadataPrivateDataWords);
         auto privateDataInit = llvm::Constant::getNullValue(privateDataTy);
+        
+        IRGenMangler mangler;
+        auto symbolName =
+          mangler.mangleProtocolConformanceInstantiationCache(Conformance);
+        
         auto privateData =
           new llvm::GlobalVariable(IGM.Module, privateDataTy,
                                    /*constant*/ false,
                                    llvm::GlobalVariable::InternalLinkage,
-                                   privateDataInit, "");
+                                   privateDataInit, symbolName);
         B.addRelativeAddress(privateData);
       }
     }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -143,6 +143,8 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
   });
 }
 
+
+
 std::string IRGenMangler::mangleProtocolConformanceDescriptor(
                                  const RootProtocolConformance *conformance) {
   beginMangling();
@@ -154,6 +156,21 @@ std::string IRGenMangler::mangleProtocolConformanceDescriptor(
     appendProtocolName(protocol);
     appendOperator("MS");
   }
+  return finalize();
+}
+
+std::string IRGenMangler::mangleProtocolConformanceInstantiationCache(
+                                 const RootProtocolConformance *conformance) {
+  beginMangling();
+  if (isa<NormalProtocolConformance>(conformance)) {
+    appendProtocolConformance(conformance);
+    appendOperator("Mc");
+  } else {
+    auto protocol = cast<SelfProtocolConformance>(conformance)->getProtocol();
+    appendProtocolName(protocol);
+    appendOperator("MS");
+  }
+  appendOperator("MK");
   return finalize();
 }
 

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -315,8 +315,10 @@ public:
   }
 
   std::string mangleProtocolConformanceDescriptor(
-                                   const RootProtocolConformance *conformance);
-  
+                                    const RootProtocolConformance *conformance);
+  std::string mangleProtocolConformanceInstantiationCache(
+                                    const RootProtocolConformance *conformance);
+
   std::string manglePropertyDescriptor(const AbstractStorageDecl *storage) {
     beginMangling();
     appendEntity(storage);

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -69,7 +69,7 @@ public struct Y { }
 // -- instantiator function
 // CHECK-USAGE-SAME: i32 0,
 // -- private data area
-// CHECK-USAGE-SAME: {{@[0-9]+}}
+// CHECK-USAGE-SAME: "$s31protocol_resilience_descriptors1YV010resilient_A022OtherResilientProtocolAAMcMK"
 // --
 // CHECK-USAGE-SAME: }
 extension Y: OtherResilientProtocol { }


### PR DESCRIPTION
Make it easier to track the memory usage of these symbols. rdar://problem/65559024
