### PR TITLE
Sink linker directive computation into IRGen

### DIFF
--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -184,7 +184,7 @@ public:
   ModuleDecl *getParentModule() const;
 
   /// Compute the linker directives to emit.
-  llvm::StringSet<> getLinkerDirectives() const;
+  std::vector<std::string> getLinkerDirectives() const;
 };
 
 /// Report that a request of the given kind is being evaluated, so it

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -78,7 +78,7 @@ void simple_display(llvm::raw_ostream &out, const TBDGenDescriptor &desc);
 SourceLoc extractNearestSourceLoc(const TBDGenDescriptor &desc);
 
 using TBDFileAndSymbols =
-    std::pair<llvm::MachO::InterfaceFile, llvm::StringSet<>>;
+    std::pair<llvm::MachO::InterfaceFile, std::vector<std::string>>;
 
 /// Computes the TBD file and public symbols for a given module or file.
 class GenerateTBDRequest

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -62,6 +62,7 @@ namespace swift {
   class SourceManager;
   class SyntaxParseActions;
   class SyntaxParsingCache;
+  struct TBDGenOptions;
   class Token;
   class TopLevelContext;
   class TypeCheckerOptions;
@@ -207,23 +208,23 @@ namespace swift {
   /// and return the generated LLVM IR module.
   /// If you set an outModuleHash, then you need to call performLLVM.
   GeneratedModule
-  performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
+  performIRGeneration(ModuleDecl *M, const IRGenOptions &Opts,
+                      const TBDGenOptions &TBDOpts,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                       ArrayRef<std::string> parallelOutputFilenames,
-                      llvm::GlobalVariable **outModuleHash = nullptr,
-                      llvm::StringSet<> *LinkerDirectives = nullptr);
+                      llvm::GlobalVariable **outModuleHash = nullptr);
 
   /// Turn the given Swift module into either LLVM IR or native code
   /// and return the generated LLVM IR module.
   /// If you set an outModuleHash, then you need to call performLLVM.
   GeneratedModule
-  performIRGeneration(const IRGenOptions &Opts, SourceFile &SF,
+  performIRGeneration(SourceFile &SF, const IRGenOptions &Opts, 
+                      const TBDGenOptions &TBDOpts,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                       StringRef PrivateDiscriminator,
-                      llvm::GlobalVariable **outModuleHash = nullptr,
-                      llvm::StringSet<> *LinkerDirectives = nullptr);
+                      llvm::GlobalVariable **outModuleHash = nullptr);
 
   /// Given an already created LLVM module, construct a pass pipeline and run
   /// the Swift LLVM Pipeline upon it. This does not cause the module to be

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -89,7 +89,7 @@ struct TBDGenOptions {
   }
 };
 
-llvm::StringSet<> getPublicSymbols(TBDGenDescriptor desc);
+std::vector<std::string> getPublicSymbols(TBDGenDescriptor desc);
 
 void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                   const TBDGenOptions &opts);

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -14,6 +14,7 @@
 
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringSet.h"
+#include "swift/AST/TBDGenRequests.h"
 #include "swift/Basic/Version.h"
 #include <vector>
 
@@ -88,10 +89,7 @@ struct TBDGenOptions {
   }
 };
 
-void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,
-                            const TBDGenOptions &opts);
-void enumeratePublicSymbols(ModuleDecl *module, llvm::StringSet<> &symbols,
-                            const TBDGenOptions &opts);
+llvm::StringSet<> getPublicSymbols(TBDGenDescriptor desc);
 
 void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                   const TBDGenOptions &opts);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1074,7 +1074,7 @@ static bool writeLdAddCFileIfNeeded(CompilerInstance &Instance) {
     llvm::raw_svector_ostream NameOS(NameBuffer);
     NameOS << "ldAdd_" << Idx;
     OS << "extern const char " << NameOS.str() << " __asm(\"" <<
-      changeToLdAdd(S.getKey()) << "\");\n";
+      changeToLdAdd(S) << "\");\n";
     OS << "const char " << NameOS.str() << " = 0;\n";
     ++ Idx;
   }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1054,9 +1054,9 @@ static bool writeLdAddCFileIfNeeded(CompilerInstance &Instance) {
   }
   auto tbdOpts = Invocation.getTBDGenOptions();
   tbdOpts.LinkerDirectivesOnly = true;
-  llvm::StringSet<> ldSymbols;
   auto *module = Instance.getMainModule();
-  enumeratePublicSymbols(module, ldSymbols, tbdOpts);
+  auto ldSymbols =
+      getPublicSymbols(TBDGenDescriptor::forModule(module, tbdOpts));
   std::error_code EC;
   llvm::raw_fd_ostream OS(Path, EC, llvm::sys::fs::F_None);
   if (EC) {
@@ -1663,15 +1663,17 @@ static bool generateCode(CompilerInstance &Instance, StringRef OutputFilename,
                      OutputFilename, Instance.getStatsReporter());
 }
 
-static void collectLinkerDirectives(const CompilerInvocation &Invocation,
-                                    ModuleOrSourceFile MSF,
-                                    llvm::StringSet<> &Symbols) {
+static llvm::StringSet<>
+collectLinkerDirectives(const CompilerInvocation &Invocation,
+                        ModuleOrSourceFile MSF) {
   auto tbdOpts = Invocation.getTBDGenOptions();
   tbdOpts.LinkerDirectivesOnly = true;
-  if (MSF.is<SourceFile*>())
-    enumeratePublicSymbols(MSF.get<SourceFile*>(), Symbols, tbdOpts);
-  else
-    enumeratePublicSymbols(MSF.get<ModuleDecl*>(), Symbols, tbdOpts);
+  if (auto *SF = MSF.dyn_cast<SourceFile *>()) {
+    return getPublicSymbols(TBDGenDescriptor::forFile(SF, tbdOpts));
+  } else {
+    return getPublicSymbols(
+        TBDGenDescriptor::forModule(MSF.get<ModuleDecl *>(), tbdOpts));
+  }
 }
 
 static bool performCompileStepsPostSILGen(CompilerInstance &Instance,

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -73,10 +73,13 @@ bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
   llvm_unreachable("unhandled kind");
 }
 
-static bool validateSymbolSet(DiagnosticEngine &diags,
-                              llvm::StringSet<> symbols,
-                              const llvm::Module &IRModule,
-                              bool diagnoseExtraSymbolsInTBD) {
+static bool validateSymbols(DiagnosticEngine &diags,
+                            const std::vector<std::string> &symbols,
+                            const llvm::Module &IRModule,
+                            bool diagnoseExtraSymbolsInTBD) {
+  llvm::StringSet<> symbolSet;
+  symbolSet.insert(symbols.begin(), symbols.end());
+
   auto error = false;
 
   // Diff the two sets of symbols, flagging anything outside their intersection.
@@ -101,13 +104,13 @@ static bool validateSymbolSet(DiagnosticEngine &diags,
           GV->hasExternalLinkage() && !GV->hasHiddenVisibility();
       if (!GV->isDeclaration() && externallyVisible) {
         // Is it listed?
-        if (!symbols.erase(name))
+        if (!symbolSet.erase(name))
           // Note: Add the unmangled name to the irNotTBD list, which is owned
           //       by the IRModule, instead of the mangled name.
           irNotTBD.push_back(unmangledName);
       }
     } else {
-      assert(symbols.find(name) == symbols.end() &&
+      assert(symbolSet.find(name) == symbolSet.end() &&
              "non-global value in value symbol table");
     }
   }
@@ -121,7 +124,7 @@ static bool validateSymbolSet(DiagnosticEngine &diags,
 
   if (diagnoseExtraSymbolsInTBD) {
     // Look for any extra symbols.
-    for (auto &name : sortSymbols(symbols)) {
+    for (auto &name : sortSymbols(symbolSet)) {
       diags.diagnose(SourceLoc(), diag::symbol_in_tbd_not_in_ir, name,
                      Demangle::demangleSymbolAsString(name));
       error = true;
@@ -140,8 +143,8 @@ bool swift::validateTBD(ModuleDecl *M,
                         const TBDGenOptions &opts,
                         bool diagnoseExtraSymbolsInTBD) {
   auto symbols = getPublicSymbols(TBDGenDescriptor::forModule(M, opts));
-  return validateSymbolSet(M->getASTContext().Diags, symbols, IRModule,
-                           diagnoseExtraSymbolsInTBD);
+  return validateSymbols(M->getASTContext().Diags, symbols, IRModule,
+                         diagnoseExtraSymbolsInTBD);
 }
 
 bool swift::validateTBD(FileUnit *file,
@@ -149,7 +152,6 @@ bool swift::validateTBD(FileUnit *file,
                         const TBDGenOptions &opts,
                         bool diagnoseExtraSymbolsInTBD) {
   auto symbols = getPublicSymbols(TBDGenDescriptor::forFile(file, opts));
-  return validateSymbolSet(file->getParentModule()->getASTContext().Diags,
-                           symbols, IRModule,
-                           diagnoseExtraSymbolsInTBD);
+  return validateSymbols(file->getParentModule()->getASTContext().Diags,
+                         symbols, IRModule, diagnoseExtraSymbolsInTBD);
 }

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -139,9 +139,7 @@ bool swift::validateTBD(ModuleDecl *M,
                         const llvm::Module &IRModule,
                         const TBDGenOptions &opts,
                         bool diagnoseExtraSymbolsInTBD) {
-  llvm::StringSet<> symbols;
-  enumeratePublicSymbols(M, symbols, opts);
-
+  auto symbols = getPublicSymbols(TBDGenDescriptor::forModule(M, opts));
   return validateSymbolSet(M->getASTContext().Diags, symbols, IRModule,
                            diagnoseExtraSymbolsInTBD);
 }
@@ -150,9 +148,7 @@ bool swift::validateTBD(FileUnit *file,
                         const llvm::Module &IRModule,
                         const TBDGenOptions &opts,
                         bool diagnoseExtraSymbolsInTBD) {
-  llvm::StringSet<> symbols;
-  enumeratePublicSymbols(file, symbols, opts);
-
+  auto symbols = getPublicSymbols(TBDGenDescriptor::forFile(file, opts));
   return validateSymbolSet(file->getParentModule()->getASTContext().Diags,
                            symbols, IRModule,
                            diagnoseExtraSymbolsInTBD);

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -69,4 +69,5 @@ target_link_libraries(swiftIRGen PRIVATE
   swiftLLVMPasses
   swiftSIL
   swiftSILGen
-  swiftSILOptimizer)
+  swiftSILOptimizer
+  swiftTBDGen)

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1030,7 +1030,8 @@ static bool hasCodeCoverageInstrumentation(SILFunction &f, SILModule &m) {
   return f.getProfiler() && m.getOptions().EmitProfileCoverageMapping;
 }
 
-void IRGenerator::emitGlobalTopLevel(llvm::StringSet<> *linkerDirectives) {
+void IRGenerator::emitGlobalTopLevel(
+    const llvm::StringSet<> &linkerDirectives) {
   // Generate order numbers for the functions in the SIL module that
   // correspond to definitions in the LLVM module.
   unsigned nextOrderNumber = 0;
@@ -1050,10 +1051,8 @@ void IRGenerator::emitGlobalTopLevel(llvm::StringSet<> *linkerDirectives) {
     CurrentIGMPtr IGM = getGenModule(wt.getProtocol()->getDeclContext());
     ensureRelativeSymbolCollocation(wt);
   }
-  if (linkerDirectives) {
-    for (auto &entry: *linkerDirectives) {
-      createLinkerDirectiveVariable(*PrimaryIGM, entry.getKey());
-    }
+  for (auto &entry: linkerDirectives) {
+    createLinkerDirectiveVariable(*PrimaryIGM, entry.getKey());
   }
   for (SILGlobalVariable &v : PrimaryIGM->getSILModule().getSILGlobals()) {
     Decl *decl = v.getDecl();

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1031,7 +1031,7 @@ static bool hasCodeCoverageInstrumentation(SILFunction &f, SILModule &m) {
 }
 
 void IRGenerator::emitGlobalTopLevel(
-    const llvm::StringSet<> &linkerDirectives) {
+    const std::vector<std::string> &linkerDirectives) {
   // Generate order numbers for the functions in the SIL module that
   // correspond to definitions in the LLVM module.
   unsigned nextOrderNumber = 0;
@@ -1051,8 +1051,8 @@ void IRGenerator::emitGlobalTopLevel(
     CurrentIGMPtr IGM = getGenModule(wt.getProtocol()->getDeclContext());
     ensureRelativeSymbolCollocation(wt);
   }
-  for (auto &entry: linkerDirectives) {
-    createLinkerDirectiveVariable(*PrimaryIGM, entry.getKey());
+  for (auto &directive: linkerDirectives) {
+    createLinkerDirectiveVariable(*PrimaryIGM, directive);
   }
   for (SILGlobalVariable &v : PrimaryIGM->getSILModule().getSILGlobals()) {
     Decl *decl = v.getDecl();

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1113,11 +1113,11 @@ struct LLVMCodeGenThreads {
 
 /// Generates LLVM IR, runs the LLVM passes and produces the output files.
 /// All this is done in multiple threads.
-static void performParallelIRGeneration(
-    const IRGenOptions &Opts, swift::ModuleDecl *M, std::unique_ptr<SILModule> SILMod,
-    StringRef ModuleName,
-    ArrayRef<std::string> outputFilenames,
-    llvm::StringSet<> *linkerDirectives) {
+static void performParallelIRGeneration(IRGenDescriptor desc) {
+  const auto &Opts = desc.Opts;
+  auto outputFilenames = desc.parallelOutputFilenames;
+  auto SILMod = std::unique_ptr<SILModule>(desc.SILMod);
+  auto *M = desc.getParentModule();
 
   IRGenerator irgen(Opts, *SILMod);
 
@@ -1158,7 +1158,7 @@ static void performParallelIRGeneration(
     // Create the IR emitter.
     IRGenModule *IGM =
         new IRGenModule(irgen, std::move(targetMachine), nextSF,
-                        ModuleName, *OutputIter++, nextSF->getFilename(),
+                        desc.ModuleName, *OutputIter++, nextSF->getFilename(),
                         nextSF->getPrivateDiscriminator().str());
     IGMcreated = true;
 
@@ -1178,7 +1178,7 @@ static void performParallelIRGeneration(
   }
 
   // Emit the module contents.
-  irgen.emitGlobalTopLevel(linkerDirectives);
+  irgen.emitGlobalTopLevel(desc.LinkerDirectives);
 
   for (auto *File : M->getFiles()) {
     if (auto *SF = dyn_cast<SourceFile>(File)) {
@@ -1311,18 +1311,17 @@ GeneratedModule swift::performIRGeneration(
     const PrimarySpecificPaths &PSPs,
     ArrayRef<std::string> parallelOutputFilenames,
     llvm::GlobalVariable **outModuleHash, llvm::StringSet<> *LinkerDirectives) {
+  auto desc = IRGenDescriptor::forWholeModule(
+      Opts, M, std::move(SILMod), ModuleName, PSPs, parallelOutputFilenames,
+      outModuleHash, LinkerDirectives);
+
   if (Opts.shouldPerformIRGenerationInParallel() &&
       !parallelOutputFilenames.empty()) {
-    ::performParallelIRGeneration(Opts, M, std::move(SILMod), ModuleName,
-                                  parallelOutputFilenames, LinkerDirectives);
+    ::performParallelIRGeneration(desc);
     // TODO: Parallel LLVM compilation cannot be used if a (single) module is
     // needed as return value.
     return GeneratedModule::null();
   }
-
-  auto desc = IRGenDescriptor::forWholeModule(
-      Opts, M, std::move(SILMod), ModuleName, PSPs, parallelOutputFilenames,
-      outModuleHash, LinkerDirectives);
   return llvm::cantFail(M->getASTContext().evaluator(IRGenRequest{desc}));
 }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -375,7 +375,7 @@ public:
   
   /// Emit functions, variables and tables which are needed anyway, e.g. because
   /// they are externally visible.
-  void emitGlobalTopLevel(llvm::StringSet<> *LinkerDirectives);
+  void emitGlobalTopLevel(const llvm::StringSet<> &LinkerDirectives);
 
   /// Emit references to each of the protocol descriptors defined in this
   /// IR module.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -375,7 +375,7 @@ public:
   
   /// Emit functions, variables and tables which are needed anyway, e.g. because
   /// they are externally visible.
-  void emitGlobalTopLevel(const llvm::StringSet<> &LinkerDirectives);
+  void emitGlobalTopLevel(const std::vector<std::string> &LinkerDirectives);
 
   /// Emit references to each of the protocol descriptors defined in this
   /// IR module.

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -76,7 +76,7 @@ ModuleDecl *IRGenDescriptor::getParentModule() const {
   return Ctx.get<ModuleDecl *>();
 }
 
-llvm::StringSet<> IRGenDescriptor::getLinkerDirectives() const {
+std::vector<std::string> IRGenDescriptor::getLinkerDirectives() const {
   auto opts = TBDOpts;
   opts.LinkerDirectivesOnly = true;
   if (auto *SF = Ctx.dyn_cast<SourceFile *>()) {

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/Subsystems.h"
+#include "swift/TBDGen/TBDGen.h"
 #include "llvm/IR/Module.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 
@@ -73,6 +74,17 @@ ModuleDecl *IRGenDescriptor::getParentModule() const {
   if (auto *SF = Ctx.dyn_cast<SourceFile *>())
     return SF->getParentModule();
   return Ctx.get<ModuleDecl *>();
+}
+
+llvm::StringSet<> IRGenDescriptor::getLinkerDirectives() const {
+  auto opts = TBDOpts;
+  opts.LinkerDirectivesOnly = true;
+  if (auto *SF = Ctx.dyn_cast<SourceFile *>()) {
+    return getPublicSymbols(TBDGenDescriptor::forFile(SF, opts));
+  } else {
+    auto *M = Ctx.get<ModuleDecl *>();
+    return getPublicSymbols(TBDGenDescriptor::forModule(M, opts));
+  }
 }
 
 evaluator::DependencySource IRGenRequest::readDependencySource(

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -201,9 +201,10 @@ int swift::RunImmediately(CompilerInstance &CI,
   // IRGen the main module.
   auto *swiftModule = CI.getMainModule();
   const auto PSPs = CI.getPrimarySpecificPathsForAtMostOnePrimary();
+  const auto &TBDOpts = CI.getInvocation().getTBDGenOptions();
   auto GenModule = performIRGeneration(
-      IRGenOpts, swiftModule, std::move(SM), swiftModule->getName().str(),
-      PSPs, ArrayRef<std::string>());
+      swiftModule, IRGenOpts, TBDOpts, std::move(SM),
+      swiftModule->getName().str(), PSPs, ArrayRef<std::string>());
 
   if (Context.hadError())
     return -1;

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1190,19 +1190,9 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
   return std::make_pair(std::move(file), std::move(symbols));
 }
 
-void swift::enumeratePublicSymbols(FileUnit *file, StringSet &symbols,
-                                   const TBDGenOptions &opts) {
-  assert(symbols.empty() && "Additive symbol enumeration not supported");
-  auto &evaluator = file->getASTContext().evaluator;
-  auto desc = TBDGenDescriptor::forFile(file, opts);
-  symbols = llvm::cantFail(evaluator(GenerateTBDRequest{desc})).second;
-}
-void swift::enumeratePublicSymbols(ModuleDecl *M, StringSet &symbols,
-                                   const TBDGenOptions &opts) {
-  assert(symbols.empty() && "Additive symbol enumeration not supported");
-  auto &evaluator = M->getASTContext().evaluator;
-  auto desc = TBDGenDescriptor::forModule(M, opts);
-  symbols = llvm::cantFail(evaluator(GenerateTBDRequest{desc})).second;
+StringSet swift::getPublicSymbols(TBDGenDescriptor desc) {
+  auto &evaluator = desc.getParentModule()->getASTContext().evaluator;
+  return llvm::cantFail(evaluator(GenerateTBDRequest{desc})).second;
 }
 void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                          const TBDGenOptions &opts) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -67,11 +67,10 @@ void TBDGenVisitor::addSymbolInternal(StringRef name,
   if (!isLinkerDirective && Opts.LinkerDirectivesOnly)
     return;
   Symbols.addSymbol(kind, name, Targets);
-  if (StringSymbols && kind == SymbolKind::GlobalSymbol) {
-    auto isNewValue = StringSymbols->insert(name).second;
-    (void)isNewValue;
+  if (kind == SymbolKind::GlobalSymbol) {
+    StringSymbols.push_back(name);
 #ifndef NDEBUG
-    if (!isNewValue) {
+    if (!DuplicateSymbolChecker.insert(name).second) {
       llvm::dbgs() << "TBDGen duplicate symbol: " << name << '\n';
       assert(false && "TBDGen symbol appears twice");
     }
@@ -1135,10 +1134,8 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
     llvm::MachO::Target targetVar(*ctx.LangOpts.TargetVariant);
     file.addTarget(targetVar);
   }
-  StringSet symbols;
   auto *clang = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-  TBDGenVisitor visitor(file, {target}, &symbols,
-                        clang->getTargetInfo().getDataLayout(),
+  TBDGenVisitor visitor(file, {target}, clang->getTargetInfo().getDataLayout(),
                         linkInfo, M, opts);
 
   auto visitFile = [&](FileUnit *file) {
@@ -1187,10 +1184,10 @@ GenerateTBDRequest::evaluate(Evaluator &evaluator,
     });
   }
 
-  return std::make_pair(std::move(file), std::move(symbols));
+  return std::make_pair(std::move(file), std::move(visitor.StringSymbols));
 }
 
-StringSet swift::getPublicSymbols(TBDGenDescriptor desc) {
+std::vector<std::string> swift::getPublicSymbols(TBDGenDescriptor desc) {
   auto &evaluator = desc.getParentModule()->getASTContext().evaluator;
   return llvm::cantFail(evaluator(GenerateTBDRequest{desc})).second;
 }

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -63,8 +63,13 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
 public:
   llvm::MachO::InterfaceFile &Symbols;
   llvm::MachO::TargetList Targets;
-  StringSet *StringSymbols;
+  std::vector<std::string> StringSymbols;
   const llvm::DataLayout &DataLayout;
+
+#ifndef NDEBUG
+  /// Tracks the symbols emitted to ensure we don't emit any duplicates.
+  llvm::StringSet<> DuplicateSymbolChecker;
+#endif
 
   const UniversalLinkageInfo &UniversalLinkInfo;
   ModuleDecl *SwiftModule;
@@ -136,13 +141,13 @@ private:
 
 public:
   TBDGenVisitor(llvm::MachO::InterfaceFile &symbols,
-                llvm::MachO::TargetList targets, StringSet *stringSymbols,
+                llvm::MachO::TargetList targets,
                 const llvm::DataLayout &dataLayout,
                 const UniversalLinkageInfo &universalLinkInfo,
                 ModuleDecl *swiftModule, const TBDGenOptions &opts)
-      : Symbols(symbols), Targets(targets), StringSymbols(stringSymbols),
-        DataLayout(dataLayout), UniversalLinkInfo(universalLinkInfo),
-        SwiftModule(swiftModule), Opts(opts),
+      : Symbols(symbols), Targets(targets), DataLayout(dataLayout),
+        UniversalLinkInfo(universalLinkInfo), SwiftModule(swiftModule),
+        Opts(opts),
         previousInstallNameMap(parsePreviousModuleInstallNameMap())  {}
   ~TBDGenVisitor() { assert(DeclStack.empty()); }
   void addMainIfNecessary(FileUnit *file) {

--- a/test/TBD/linker-directives.swift
+++ b/test/TBD/linker-directives.swift
@@ -21,5 +21,5 @@ public func toast() {}
 // RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/linker_directives.tbd -emit-ldadd-cfile-path %t/ldAdd.c -module-name AppKit
 // RUN: %FileCheck %s --check-prefix CHECK-C-SYMBOL < %t/ldAdd.c
 
-// CHECK-C-SYMBOL: $ld$add$os10.14$_$s10ToasterKit5toastyyF
 // CHECK-C-SYMBOL: $ld$add$os10.8$_$s10ToasterKit5toastyyF
+// CHECK-C-SYMBOL: $ld$add$os10.14$_$s10ToasterKit5toastyyF

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -196,7 +196,9 @@ int main(int argc, char **argv) {
   }
 
   const PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
-  auto Mod = performIRGeneration(Opts, CI.getMainModule(), std::move(SILMod),
+  auto Mod = performIRGeneration(CI.getMainModule(), Opts,
+                                 CI.getInvocation().getTBDGenOptions(),
+                                 std::move(SILMod),
                                  CI.getMainModule()->getName().str(), PSPs,
                                  ArrayRef<std::string>());
   return CI.getASTContext().hadError();


### PR DESCRIPTION
With an inverted pipeline, IRGen needs to be able to compute the linker directives itself, so sink it down such that it can be computed by the `IRGenDescriptor`.