### PR TITLE
Make Float16 unavailable on macOS and macCatalyst, as in Apple Swift

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -21,12 +21,15 @@ bits = self_type.bits
 
 def Availability(bits):
     if bits == 16:
-        return '@available(macOS 10.16, iOS 14.0, tvOS 14.0, watchOS 7.0, *)'
+        return '@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)'
     return ''
 }%
 
 % if bits == 80:
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+% end
+% if bits == 16:
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
 % end
 
 //===----------------------------------------------------------------------===//
@@ -253,7 +256,7 @@ extension ${Self} {
   }
 }
 
-% if bits == 80:
+% if bits == 80 or bits == 16:
 #endif
 % end
 % end

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -57,7 +57,9 @@ public typealias CLong = Int
 public typealias CLongLong = Int64
 
 /// The C '_Float16' type.
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 public typealias CFloat16 = Float16
 
 /// The C 'float' type.

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -4730,7 +4730,9 @@ extension RawRepresentable where RawValue == Float, Self: Decodable {
   }
 }
 
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 extension Float16: Codable {
   /// Creates a new instance by decoding from the given decoder.
   ///

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -46,7 +46,9 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 
 //===--- Parsing ----------------------------------------------------------===//
 %if bits == 16:
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 %end
 extension ${Self}: LosslessStringConvertible {
   /// Creates a new instance from the given string.

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -40,7 +40,7 @@ RawSignificand = 'UInt' + str(SignificandSize)
 
 def Availability(bits):
     if bits == 16:
-        return '@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)'
+        return '@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)\n@available(macOS, unavailable)\n@available(macCatalyst, unavailable)'
     return ''
 
 if Self == 'Float16':

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1152,7 +1152,9 @@ public struct ${Self}
   ///   `source` must be representable in this type after rounding toward
   ///   zero.
 %     if FloatType == 'Float16':
-  @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
 %     end
   @_transparent
   public init(_ source: ${FloatType}) {
@@ -1182,7 +1184,9 @@ public struct ${Self}
   ///
   /// - Parameter source: A floating-point value to convert to an integer.
 %     if FloatType == 'Float16':
-  @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
 %     end
   @_transparent
   public init?(exactly source: ${FloatType}) {

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -303,7 +303,9 @@ internal func _float16ToStringImpl(
   _ debug: Bool
 ) -> Int
 
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 internal func _float16ToString(
   _ value: Float16,
   debug: Bool

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -254,7 +254,9 @@ extension ${Self}: SIMDScalar {
 
 %for (Self, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
 %if bits == 16:
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 %end
 extension ${Self} : SIMDScalar {
 

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -72,7 +72,8 @@ func test_powl() {
 }
 #endif
 
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 func test_f16() {
   var x = Float16.zero
   f16ptrfunc(&x)
@@ -80,6 +81,7 @@ func test_f16() {
   f16func(x)
   #endif
 }
+#endif
 
 func test_puts(_ s: String) {
   _ = s.withCString { puts($0) + 32 };

--- a/test/stdlib/Inputs/FloatingPointConversion.swift.gyb
+++ b/test/stdlib/Inputs/FloatingPointConversion.swift.gyb
@@ -16,6 +16,9 @@ var FloatingPointConversionFailures = TestSuite("FloatingPointToFloatingPointCon
 %   SelfSignificandBits = self_type.bits
 %   Self = self_type.stdlib_name
 
+%  if Self == 'Float16':
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+%  end
 %  if Self == 'Float80':
 #if !os(Windows) && (arch(i386) || arch(x86_64))
 %  end
@@ -24,6 +27,9 @@ var FloatingPointConversionFailures = TestSuite("FloatingPointToFloatingPointCon
 %   OtherSignificandBits = other_type.bits
 %   OtherFloat = other_type.stdlib_name
 
+%   if OtherFloat == 'Float16':
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+%   end
 %   if OtherFloat == 'Float80':
 #if !os(Windows) && (arch(i386) || arch(x86_64))
 %   end
@@ -31,7 +37,7 @@ var FloatingPointConversionFailures = TestSuite("FloatingPointToFloatingPointCon
 %   if OtherSignificandBits <= SelfSignificandBits:
 
 %    if OtherFloat == 'Float16':
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 %    end
 FloatingPointConversionTruncations.test("${OtherFloat}To${Self}Conversion")
 
@@ -56,7 +62,7 @@ FloatingPointConversionTruncations.test("${OtherFloat}To${Self}Conversion")
 %   else:
 
 %    if Self == 'Float16':
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 %    end
 FloatingPointConversionTruncations.test("${OtherFloat}To${Self}Conversion")
   .forEach(in: [
@@ -77,7 +83,7 @@ FloatingPointConversionTruncations.test("${OtherFloat}To${Self}Conversion")
 %   end
 
 %    if 'Float16' in [Self, OtherFloat]:
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 %    end
 FloatingPointConversionTruncations.test("${OtherFloat}To${Self}Conversion/special") {
   expectEqual( 1.0 as ${Self},   ${Self}(exactly:  1.0 as ${OtherFloat}))
@@ -119,6 +125,9 @@ FloatingPointConversionFailures.test("${OtherFloat}To${Self}Conversion/AlwaysSuc
 }
 %    end
 
+%  if OtherFloat == 'Float16':
+#endif
+%  end
 %   if OtherFloat == 'Float80':
 #endif
 %   end
@@ -138,7 +147,8 @@ _UnimplementedError()
 
 extension ${OtherInt} {
   %    if Self == 'Float16':
-  @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(macOS, unavailable)
   %    end
   static var _test${Self}Conversion: [(${OtherInt}, ${OtherInt}, ${OtherInt}?)] {
     if bitWidth > ${Self}.significandBitCount + 1 {
@@ -165,7 +175,7 @@ extension ${OtherInt} {
 }
 
 %    if Self == 'Float16':
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 %    end
 FixedPointConversionTruncations.test("${OtherInt}to${Self}")
   .forEach(in: ${OtherInt}._test${Self}Conversion) {
@@ -187,6 +197,9 @@ FixedPointConversionTruncations.test("${OtherInt}to${Self}")
 
 %  end # for in int_types
 
+%  if Self == 'Float16':
+#endif
+%  end
 %  if Self == 'Float80':
 #endif
 %  end

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -345,7 +345,9 @@ let PrintTests = TestSuite("FloatingPointPrinting")
 
 % for FloatType in ['Float16', 'Float', 'Double', 'Float80']:
 % if FloatType == 'Float16':
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 % end
 % if FloatType == 'Float80':
 #if !os(Windows) && (arch(i386) || arch(x86_64))
@@ -383,7 +385,9 @@ fileprivate func expectDescription(_ expected: String, _ object: ${FloatType},
 //   that is closest (as an infinitely-precise real number) to the original
 //   binary float (interpreted as an infinitely-precise real number).
 % if FloatType == 'Float16':
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
 % end
 fileprivate func expectAccurateDescription(_ object: ${FloatType},
   _ message: @autoclosure () -> String = "",
@@ -584,7 +588,8 @@ PrintTests.test("Printable_CDouble") {
   expectDescription("-1.0", CDouble(-1.0))
 }
 
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 PrintTests.test("Printable_Float16") {
   func asFloat16(_ f: Float16) -> Float16 { return f }
 
@@ -727,6 +732,7 @@ PrintTests.test("Printable_Float16") {
   expectDescription("0.0", asFloat16(0.0000000125))
 }
 }
+#endif
 
 PrintTests.test("Printable_Float") {
   func asFloat32(_ f: Float32) -> Float32 { return f }


### PR DESCRIPTION
LLVM doesn't have a stable ABI for Float16 on x86 yet; I've asked Intel to take a look at that, but we don't want to make the type available on macOS until a stable ABI is actually available, because we'd break binaries compiled before any calling convention changes if we do.

Note that the calling conventions _are_ stable for Float16 on Apple Silicon. So the type should eventually be made available on macOS for Apple Silicon even if we never get stable calling conventions on x86, but it will simplify everything if we just mark the type unavailable in the short term on macOS.