### PR TITLE
Replace commit hash with tag for SwiftPM

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -356,7 +356,7 @@
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2020-07-04-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2020-07-04-a",
                 "swift-tools-support-core": "0.1.8",
-                "swiftpm": "3b56accc865173b0e0588b1df310e74f124c784b",
+                "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-07-12-a",
                 "swift-argument-parser": "0.2.0",
                 "swift-driver": "master",
                 "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2020-07-04-a",


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replaces the commit hash for SwiftPM with a nightly tag. The hash was temporarily in place to unblock toolchain builds by including [apple/swift-package-manager#2802](https://github.com/apple/swift-package-manager/pull/2802), since nightly tags were unavailable from 7/4 - 7/9.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [TF-1291](https://bugs.swift.org/browse/TF-1291).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
