### PR TITLE
[stdlib] Add _forEachField(of:options:body:) function

### DIFF
--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -212,6 +212,10 @@ struct ReflectionMirrorImpl {
   
   virtual char displayStyle() = 0;
   virtual intptr_t count() = 0;
+  virtual intptr_t childOffset(intptr_t index) = 0;
+  virtual const FieldType childMetadata(intptr_t index,
+                                        const char **outName,
+                                        void (**outFreeFunc)(const char *)) = 0;
   virtual AnyReturn subscript(intptr_t index, const char **outName,
                               void (**outFreeFunc)(const char *)) = 0;
   virtual const char *enumCaseName() { return nullptr; }
@@ -220,6 +224,22 @@ struct ReflectionMirrorImpl {
   virtual id quickLookObject() { return nil; }
 #endif
   
+  // For class types, traverse through superclasses when providing field
+  // information. The base implementations call through to their local-only
+  // counterparts.
+  virtual intptr_t recursiveCount() {
+    return count();
+  }
+  virtual intptr_t recursiveChildOffset(intptr_t index) {
+    return childOffset(index);
+  }
+  virtual const FieldType recursiveChildMetadata(intptr_t index,
+                                                 const char **outName,
+                                                 void (**outFreeFunc)(const char *))
+  {
+    return childMetadata(index, outName, outFreeFunc);
+  }
+
   virtual ~ReflectionMirrorImpl() {}
 };
 
@@ -235,8 +255,19 @@ struct TupleImpl : ReflectionMirrorImpl {
     return Tuple->NumElements;
   }
   
-  AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
+  intptr_t childOffset(intptr_t i) {
+    auto *Tuple = static_cast<const TupleTypeMetadata *>(type);
+
+    if (i < 0 || (size_t)i > Tuple->NumElements)
+      swift::crash("Swift mirror subscript bounds check failure");
+
+    // Get the nth element.
+    auto &elt = Tuple->getElement(i);
+    return elt.Offset;
+  }
+
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
     auto *Tuple = static_cast<const TupleTypeMetadata *>(type);
 
     if (i < 0 || (size_t)i > Tuple->NumElements)
@@ -269,12 +300,21 @@ struct TupleImpl : ReflectionMirrorImpl {
 
     // Get the nth element.
     auto &elt = Tuple->getElement(i);
+
+    return FieldType(elt.Type);
+  }
+
+  AnyReturn subscript(intptr_t i, const char **outName,
+                      void (**outFreeFunc)(const char *)) {
+    auto eltOffset = childOffset(i);
+    auto fieldType = childMetadata(i, outName, outFreeFunc);
+
     auto *bytes = reinterpret_cast<const char *>(value);
-    auto *eltData = reinterpret_cast<const OpaqueValue *>(bytes + elt.Offset);
+    auto *eltData = reinterpret_cast<const OpaqueValue *>(bytes + eltOffset);
 
     Any result;
 
-    result.Type = elt.Type;
+    result.Type = fieldType.getType();
     auto *opaqueValueAddr = result.Type->allocateBoxForExistentialIn(&result.Buffer);
     result.Type->vw_initializeWithCopy(opaqueValueAddr,
                                        const_cast<OpaqueValue *>(eltData));
@@ -408,17 +448,19 @@ struct StructImpl : ReflectionMirrorImpl {
     auto *Struct = static_cast<const StructMetadata *>(type);
     return Struct->getDescription()->NumFields;
   }
-  
-  AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
+
+  intptr_t childOffset(intptr_t i) {
     auto *Struct = static_cast<const StructMetadata *>(type);
 
     if (i < 0 || (size_t)i > Struct->getDescription()->NumFields)
       swift::crash("Swift mirror subscript bounds check failure");
 
     // Load the offset from its respective vector.
-    auto fieldOffset = Struct->getFieldOffsets()[i];
+    return Struct->getFieldOffsets()[i];
+  }
 
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
     StringRef name;
     FieldType fieldInfo;
     std::tie(name, fieldInfo) = getFieldAt(type, i);
@@ -427,9 +469,17 @@ struct StructImpl : ReflectionMirrorImpl {
     *outName = name.data();
     *outFreeFunc = nullptr;
     
+    return fieldInfo;
+  }
+
+  AnyReturn subscript(intptr_t i, const char **outName,
+                      void (**outFreeFunc)(const char *)) {
+    auto fieldInfo = childMetadata(i, outName, outFreeFunc);
+
     auto *bytes = reinterpret_cast<char*>(value);
+    auto fieldOffset = childOffset(i);
     auto *fieldData = reinterpret_cast<OpaqueValue *>(bytes + fieldOffset);
-    
+
     return copyFieldContents(fieldData, fieldInfo);
   }
 };
@@ -474,9 +524,23 @@ struct EnumImpl : ReflectionMirrorImpl {
       return 0;
     }
     
+    // No fields if reflecting the enumeration type instead of a case
+    if (!value) {
+      return 0;
+    }
+
     const Metadata *payloadType;
     getInfo(nullptr, &payloadType, nullptr);
     return (payloadType != nullptr) ? 1 : 0;
+  }
+
+  intptr_t childOffset(intptr_t i) {
+    return 0;
+  }
+
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
+    return FieldType();
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
@@ -546,21 +610,54 @@ struct ClassImpl : ReflectionMirrorImpl {
     return 'c';
   }
   
+  bool hasSuperclassMirror() {
+    auto *Clas = static_cast<const ClassMetadata*>(type);
+    auto description = Clas->getDescription();
+
+    return ((description->SuperclassType)
+            && (Clas->Superclass)
+            && (Clas->Superclass->isTypeMetadata()));
+  }
+
+  ClassImpl superclassMirror() {
+    auto *Clas = static_cast<const ClassMetadata*>(type);
+    auto description = Clas->getDescription();
+
+    if (description->SuperclassType) {
+      if (auto theSuperclass = Clas->Superclass) {
+        auto impl = ClassImpl();
+        impl.type = (Metadata *)theSuperclass;
+        impl.value = nullptr;
+        return impl;
+      }
+    }
+    swift::crash("No superclass mirror found");
+  }
+
   intptr_t count() {
     if (!isReflectable())
       return 0;
 
     auto *Clas = static_cast<const ClassMetadata*>(type);
-    auto count = Clas->getDescription()->NumFields;
+    auto description = Clas->getDescription();
+    auto count = description->NumFields;
 
     return count;
   }
-  
-  AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
-    auto *Clas = static_cast<const ClassMetadata*>(type);
 
-    if (i < 0 || (size_t)i > Clas->getDescription()->NumFields)
+  intptr_t recursiveCount() {
+    if (hasSuperclassMirror()) {
+      return superclassMirror().recursiveCount() + count();
+    }
+
+    return count();
+  }
+
+  intptr_t childOffset(intptr_t i) {
+    auto *Clas = static_cast<const ClassMetadata*>(type);
+    auto description = Clas->getDescription();
+
+    if (i < 0 || (size_t)i > description->NumFields)
       swift::crash("Swift mirror subscript bounds check failure");
 
     // FIXME: If the class has ObjC heritage, get the field offset using the ObjC
@@ -578,18 +675,63 @@ struct ClassImpl : ReflectionMirrorImpl {
       swift::crash("Object appears to be Objective-C, but no runtime.");
   #endif
     }
+    return (intptr_t)fieldOffset;
+  }
 
+  intptr_t recursiveChildOffset(intptr_t i) {
+    if (hasSuperclassMirror()) {
+      auto superMirror = superclassMirror();
+      auto superclassFieldCount = superMirror.recursiveCount();
+
+      if (i < superclassFieldCount) {
+        return superMirror.recursiveChildOffset(i);
+      } else {
+        i -= superclassFieldCount;
+      }
+    }
+
+    return childOffset(i);
+  }
+
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
     StringRef name;
     FieldType fieldInfo;
     std::tie(name, fieldInfo) = getFieldAt(type, i);
     assert(!fieldInfo.isIndirect() && "class indirect properties not implemented");
-    
-    auto *bytes = *reinterpret_cast<char * const *>(value);
-    auto *fieldData = reinterpret_cast<OpaqueValue *>(bytes + fieldOffset);
 
     *outName = name.data();
     *outFreeFunc = nullptr;
-  
+
+    return fieldInfo;
+  }
+
+  const FieldType recursiveChildMetadata(intptr_t i,
+                                         const char **outName,
+                                         void (**outFreeFunc)(const char *))
+  {
+    if (hasSuperclassMirror()) {
+      auto superMirror = superclassMirror();
+      auto superclassFieldCount = superMirror.recursiveCount();
+
+      if (i < superclassFieldCount) {
+        return superMirror.recursiveChildMetadata(i, outName, outFreeFunc);
+      } else {
+        i -= superclassFieldCount;
+      }
+    }
+
+    return childMetadata(i, outName, outFreeFunc);
+  }
+
+  AnyReturn subscript(intptr_t i, const char **outName,
+                      void (**outFreeFunc)(const char *)) {
+    auto fieldInfo = childMetadata(i, outName, outFreeFunc);
+
+    auto *bytes = *reinterpret_cast<char * const *>(value);
+    auto fieldOffset = childOffset(i);
+    auto *fieldData = reinterpret_cast<OpaqueValue *>(bytes + fieldOffset);
+
     return copyFieldContents(fieldData, fieldInfo);
   }
 
@@ -618,6 +760,15 @@ struct ObjCClassImpl : ClassImpl {
     return 0;
   }
   
+  intptr_t childOffset(intptr_t i) {
+    swift::crash("Cannot get children of Objective-C objects.");
+  }
+
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
+    swift::crash("Cannot get children of Objective-C objects.");
+  }
+
   AnyReturn subscript(intptr_t i, const char **outName,
                       void (**outFreeFunc)(const char *)) {
     swift::crash("Cannot get children of Objective-C objects.");
@@ -635,7 +786,16 @@ struct MetatypeImpl : ReflectionMirrorImpl {
   intptr_t count() {
     return 0;
   }
-  
+
+  intptr_t childOffset(intptr_t i) {
+    swift::crash("Metatypes have no children.");
+  }
+
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
+    swift::crash("Metatypes have no children.");
+  }
+
   AnyReturn subscript(intptr_t i, const char **outName,
                     void (**outFreeFunc)(const char *)) {
     swift::crash("Metatypes have no children.");
@@ -653,6 +813,15 @@ struct OpaqueImpl : ReflectionMirrorImpl {
     return 0;
   }
   
+  intptr_t childOffset(intptr_t i) {
+    swift::crash("Opaque types have no children.");
+  }
+
+  const FieldType childMetadata(intptr_t i, const char **outName,
+                                void (**outFreeFunc)(const char *)) {
+    swift::crash("Opaque types have no children.");
+  }
+
   AnyReturn subscript(intptr_t i, const char **outName,
                     void (**outFreeFunc)(const char *)) {
     swift::crash("Opaque types have no children.");
@@ -785,6 +954,12 @@ const Metadata *swift_reflectionMirror_normalizedType(OpaqueValue *value,
   return call(value, T, type, [](ReflectionMirrorImpl *impl) { return impl->type; });
 }
 
+// func _getMetadataKind(_ type: Any.Type) -> UInt
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+uintptr_t swift_getMetadataKind(const Metadata *type) {
+  return static_cast<uintptr_t>(type->getKind());
+}
+
 // func _getChildCount<T>(_: T, type: Any.Type) -> Int
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 intptr_t swift_reflectionMirror_count(OpaqueValue *value,
@@ -792,6 +967,44 @@ intptr_t swift_reflectionMirror_count(OpaqueValue *value,
                                       const Metadata *T) {
   return call(value, T, type, [](ReflectionMirrorImpl *impl) {
     return impl->count();
+  });
+}
+
+// func _getChildCount(_ type: Any.Type) -> Int
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+intptr_t swift_reflectionMirror_recursiveCount(const Metadata *type) {
+  return call(nullptr, type, type, [](ReflectionMirrorImpl *impl) {
+    return impl->recursiveCount();
+  });
+}
+
+// func _getChildMetadata(
+//   type: Any.Type,
+//   index: Int,
+//   outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
+//   outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
+// ) -> Any.Type
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+const Metadata *swift_reflectionMirror_recursiveChildMetadata(
+                                       const Metadata *type,
+                                       intptr_t index,
+                                       const char **outName,
+                                       void (**outFreeFunc)(const char *)) {
+  return call(nullptr, type, type, [&](ReflectionMirrorImpl *impl) {
+    return impl->recursiveChildMetadata(index, outName, outFreeFunc).getType();
+  });
+}
+
+// internal func _getChildOffset(
+//   type: Any.Type,
+//   index: Int
+// ) -> Int
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+intptr_t swift_reflectionMirror_recursiveChildOffset(
+                                       const Metadata *type,
+                                       intptr_t index) {
+  return call(nullptr, type, type, [&](ReflectionMirrorImpl *impl) {
+    return impl->recursiveChildOffset(index);
   });
 }
 

--- a/test/stdlib/ForEachField.swift
+++ b/test/stdlib/ForEachField.swift
@@ -1,0 +1,375 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+@_spi(Reflection) import Swift
+import StdlibUnittest
+import Foundation
+
+struct TestStruct {
+  var int = 0
+  var double = 0.0
+  var bool = false
+}
+
+struct GenericStruct<T> {
+  var int = 0
+  var first: T
+  var second: T
+}
+
+enum TestEnum {
+  case one
+  case two
+  case three(TestStruct)
+}
+
+class BaseClass {
+  var superInt = 0
+  init() {}
+}
+
+class TestClass: BaseClass {
+  var int = 0
+  var double = 0.0
+  var bool = false
+  override init() {}
+}
+
+class TestSubclass: TestClass {
+  var strings: [String] = []
+  override init() {}
+}
+
+class GenericClass<T, U>: BaseClass {
+  var first: T
+  var second: U
+
+  init(_ t: T, _ u: U) {
+    self.first = t
+    self.second = u
+  }
+}
+
+class GenericSubclass<V, W>: GenericClass<V, Bool> {
+  var third: W
+
+  init(_ v: V, _ w: W) {
+    self.third = w
+    super.init(v, false)
+  }
+}
+
+class OwnershipTestClass: BaseClass {
+  weak var test1: TestClass?
+  unowned var test2: TestClass
+  unowned(unsafe) var test3: TestClass
+  
+  init(_ t: TestClass) {
+    self.test1 = t
+    self.test2 = t
+    self.test3 = t
+  }
+}
+
+struct SimilarToNSPoint {
+  var x: Double
+  var y: Double
+}
+
+struct SimilarToNSSize {
+  var width: Double
+  var height: Double
+}
+
+struct SimilarToNSRect {
+  var origin: SimilarToNSPoint
+  var size: SimilarToNSSize
+}
+
+struct ContainsObject {
+  var obj: TestClass
+}
+
+class NSObjectSubclass: NSObject {
+  var point: (Double, Double)
+
+  init(x: Double, y: Double) {
+    self.point = (x, y)
+  }
+}
+
+class EmptyNSObject: NSObject {}
+
+@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+func checkFields<T>(
+  of type: T.Type,
+  options: _EachFieldOptions = [],
+  fields: [String: (Int, Any.Type)]
+) {
+  var count = 0
+
+  _forEachField(of: T.self, options: options) {
+    charPtr, offset, type, kind in
+    count += 1
+
+    let fieldName = String(cString: charPtr)
+    guard let (checkOffset, checkType) = fields[fieldName] else {
+      expectTrue(false, "Unexpected field '\(fieldName)'")
+      return true
+    }
+
+    expectEqual(checkOffset, offset)
+    expectEqual(checkType, type)
+    return true
+  }
+
+  expectEqual(fields.count, count)
+}
+
+protocol ExistentialProtocol {}
+
+extension TestStruct: ExistentialProtocol {}
+extension GenericStruct: ExistentialProtocol {}
+extension GenericSubclass: ExistentialProtocol {}
+
+@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+extension ExistentialProtocol {
+  static func doCheckFields(
+    options: _EachFieldOptions = [],
+    fields: [String: (Int, Any.Type)]
+  ) {
+    checkFields(of: Self.self, options: options, fields: fields)
+  }
+}
+
+@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+func checkFieldsAsExistential(
+  of type: ExistentialProtocol.Type,
+  options: _EachFieldOptions = [],
+  fields: [String: (Int, Any.Type)]
+) {
+  type.doCheckFields(options: options, fields: fields)
+}
+
+@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+func _withTypeEncodingCallback(encoding: inout String, name: UnsafePointer<CChar>, offset: Int, type: Any.Type, kind: _MetadataKind) -> Bool {
+  if type == Bool.self {
+    encoding += "B"
+    return true
+  } else if type == Int.self {
+    if MemoryLayout<Int>.size == MemoryLayout<Int64>.size {
+      encoding += "q"
+    } else if MemoryLayout<Int>.size == MemoryLayout<Int32>.size {
+      encoding += "l"
+    } else {
+      return false
+    }
+    return true
+  } else if type == Double.self {
+    encoding += "d"
+    return true
+  }
+  
+  switch kind {
+  case .struct:
+    encoding += "{"
+    defer { encoding += "}" }
+    _forEachField(of: type) { name, offset, type, kind in
+      _withTypeEncodingCallback(encoding: &encoding, name: name, offset: offset, type: type, kind: kind)
+    }
+  case .class:
+    encoding += "@"
+  default:
+    break
+  }
+  return true
+}
+
+@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+func getTypeEncoding<T>(_ type: T.Type) -> String? {
+  var encoding = ""
+  _ = _forEachField(of: type) { name, offset, type, kind in
+    _withTypeEncodingCallback(encoding: &encoding, name: name, offset: offset, type: type, kind: kind)
+  }
+  return "{\(encoding)}"
+}
+
+//===----------------------------------------------------------------------===//
+
+var tests = TestSuite("ForEachField")
+
+if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
+
+  tests.test("TestTuple") {
+    checkFields(
+      of: (Int, Bool).self,
+      fields: [".0": (0, Int.self), ".1": (MemoryLayout<Int>.stride, Bool.self)])
+
+    checkFields(
+      of: (a: Int, b: Bool).self,
+      fields: ["a": (0, Int.self), "b": (MemoryLayout<Int>.stride, Bool.self)])
+  }
+
+  tests.test("TestEnum") {
+    checkFields(of: TestEnum.self, fields: [:])
+  }
+
+  tests.test("TestStruct") {
+    checkFields(
+      of: TestStruct.self,
+      fields: [
+        "int": (0, Int.self),
+        "double": (MemoryLayout<Double>.stride, Double.self),
+        "bool": (MemoryLayout<Double>.stride * 2, Bool.self),
+    ])
+
+    checkFieldsAsExistential(
+      of: TestStruct.self,
+      fields: [
+        "int": (0, Int.self),
+        "double": (MemoryLayout<Double>.stride, Double.self),
+        "bool": (MemoryLayout<Double>.stride * 2, Bool.self),
+    ])
+
+    // Applying to struct type with .classType option fails
+    expectFalse(_forEachField(of: TestStruct.self, options: .classType) {
+      _, _, _, _ in true
+    })
+  }
+
+  func checkGenericStruct<T>(_: T.Type) {
+    let firstOffset = max(MemoryLayout<Int>.stride, MemoryLayout<T>.alignment)
+    
+    checkFields(
+      of: GenericStruct<T>.self,
+      fields: [
+        "int": (0, Int.self),
+        "first": (firstOffset, T.self),
+        "second": (firstOffset + MemoryLayout<T>.stride, T.self),
+    ])
+
+    checkFieldsAsExistential(
+      of: GenericStruct<T>.self,
+      fields: [
+        "int": (0, Int.self),
+        "first": (firstOffset, T.self),
+        "second": (firstOffset + MemoryLayout<T>.stride, T.self),
+    ])
+  }
+
+  tests.test("GenericStruct") {
+    checkGenericStruct(Bool.self)
+    checkGenericStruct(TestStruct.self)
+    checkGenericStruct((TestStruct, TestClass, Int, Int).self)
+  }
+
+  tests.test("TestClass") {
+    let classOffset = MemoryLayout<Int>.stride * 2
+    let doubleOffset = classOffset
+      + max(MemoryLayout<Int>.stride * 2, MemoryLayout<Double>.stride)
+
+    checkFields(
+      of: TestClass.self, options: .classType,
+      fields: [
+        "superInt": (classOffset, Int.self),
+        "int": (classOffset + MemoryLayout<Int>.stride, Int.self),
+        "double": (doubleOffset, Double.self),
+        "bool": (doubleOffset + MemoryLayout<Double>.stride, Bool.self),
+    ])
+
+    checkFields(
+      of: TestSubclass.self, options: .classType,
+      fields: [
+        "superInt": (classOffset, Int.self),
+        "int": (classOffset + MemoryLayout<Int>.stride, Int.self),
+        "double": (doubleOffset, Double.self),
+        "bool": (doubleOffset + MemoryLayout<Double>.stride, Bool.self),
+        "strings": (doubleOffset + MemoryLayout<Double>.stride + MemoryLayout<Array<String>>.stride, Array<String>.self),
+    ])
+
+    let firstOffset = classOffset
+      + max(MemoryLayout<Int>.stride, MemoryLayout<TestStruct>.alignment)
+    checkFields(
+      of: GenericSubclass<TestStruct, TestStruct>.self, options: .classType,
+      fields: [
+        "superInt": (classOffset, Int.self),
+        "first": (firstOffset, TestStruct.self),
+        "second": (firstOffset + MemoryLayout<TestStruct>.size, Bool.self),
+        "third": (firstOffset + MemoryLayout<TestStruct>.stride, TestStruct.self),
+    ])
+
+    checkFields(
+      of: GenericSubclass<Int, Never>.self, options: .classType,
+      fields: [
+        "superInt": (classOffset, Int.self),
+        "first": (classOffset + MemoryLayout<Int>.stride, Int.self),
+        "second": (classOffset + MemoryLayout<Int>.stride * 2, Bool.self),
+        "third": (0, Never.self),
+    ])
+
+    checkFieldsAsExistential(
+      of: GenericSubclass<TestStruct, TestStruct>.self, options: .classType,
+      fields: [
+        "superInt": (classOffset, Int.self),
+        "first": (firstOffset, TestStruct.self),
+        "second": (firstOffset + MemoryLayout<TestStruct>.size, Bool.self),
+        "third": (firstOffset + MemoryLayout<TestStruct>.stride, TestStruct.self),
+    ])
+
+    // Applying to class type without .classType option fails
+    expectFalse(_forEachField(of: TestClass.self) {
+      _, _, _, _ in true
+    })
+  }
+
+  tests.test("OwnershipTestClass") {
+    let classOffset = MemoryLayout<Int>.stride * 2
+
+    checkFields(
+      of: OwnershipTestClass.self, options: .classType,
+      fields: [
+        "superInt": (classOffset, Int.self),
+        "test1": (classOffset + MemoryLayout<Int>.stride, Optional<TestClass>.self),
+        "test2": (classOffset + MemoryLayout<Int>.stride * 2, TestClass.self),
+        "test3": (classOffset + MemoryLayout<Int>.stride * 3, TestClass.self),
+    ])
+  }
+
+  tests.test("NSObjectSubclass") {
+    expectTrue(_forEachField(of: NSObjectSubclass.self, options: .classType) {
+      charPtr, _, type, _ in
+
+      let fieldName = String(cString: charPtr)
+      return type == (Double, Double).self
+        && fieldName == "point"
+    })
+
+    expectTrue(_forEachField(of: EmptyNSObject.self, options: .classType) {
+      _, _, _, _ in true
+    })
+  }
+
+  tests.test("withTypeEncoding") {
+    expectEqual("{@}", getTypeEncoding(ContainsObject.self))
+    expectEqual("{{dd}{dd}}", getTypeEncoding(SimilarToNSRect.self))
+    
+    let testEncoding = getTypeEncoding(TestStruct.self)
+    expectTrue("{qdB}" == testEncoding || "{ldB}" == testEncoding)
+  }
+
+  runAllTests()
+} else {
+  runNoTests()
+}

--- a/test/stdlib/ForEachField.swift
+++ b/test/stdlib/ForEachField.swift
@@ -15,7 +15,6 @@
 
 @_spi(Reflection) import Swift
 import StdlibUnittest
-import Foundation
 
 struct TestStruct {
   var int = 0
@@ -102,6 +101,9 @@ struct ContainsObject {
   var obj: TestClass
 }
 
+#if _runtime(_ObjC)
+import Foundation
+
 class NSObjectSubclass: NSObject {
   var point: (Double, Double)
 
@@ -111,6 +113,7 @@ class NSObjectSubclass: NSObject {
 }
 
 class EmptyNSObject: NSObject {}
+#endif
 
 @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
 func checkFields<T>(
@@ -347,6 +350,7 @@ if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
     ])
   }
 
+  #if _runtime(_ObjC)
   tests.test("NSObjectSubclass") {
     expectTrue(_forEachField(of: NSObjectSubclass.self, options: .classType) {
       charPtr, _, type, _ in
@@ -360,6 +364,7 @@ if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
       _, _, _, _ in true
     })
   }
+  #endif
 
   tests.test("withTypeEncoding") {
     expectEqual("{@}", getTypeEncoding(ContainsObject.self))


### PR DESCRIPTION
This function walks all the fields of a struct, class, or tuple, and calls `body` with the name, offset, and type of each field. `body` can perform any required work or validation, returning `true` to continue walking fields or `false` to stop immediately.
