### PR TITLE
validation: make `scale-test` Python 3 friendly

### DIFF
--- a/utils/scale-test
+++ b/utils/scale-test
@@ -361,7 +361,7 @@ def fit_function_to_data_by_least_squares(objective, params, bounds, xs, ys):
     assert(len(ys) > 0)
     mean_y = sum(ys) / len(ys)
     ss_total = sum((y - mean_y) ** 2 for y in ys)
-    data = zip(xs, ys)
+    data = list(zip(xs, ys))
 
     def inner(ps):
         s = 0.0


### PR DESCRIPTION
`zip` will return a generator in Python 3 rather than the zipped list.
This results in the Nelder-Mead Simplex to fail as it does not actually
perform the optimization of the data.  Explicitly convert the data to a
form which can be consumed.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
