### PR TITLE
Improvements to Escape Analysis

### DIFF
--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -689,7 +689,7 @@ bool AliasAnalysis::canApplyDecrementRefCount(FullApplySite FAS, SILValue Ptr) {
     return true;
 
   /// If the pointer cannot escape to the function we are done.
-  if (!EA->canEscapeTo(Ptr, FAS))
+  if (!EA->canEscapeToRelease(Ptr, FAS))
     return false;
 
   FunctionSideEffects ApplyEffects;

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -335,7 +335,7 @@ MemBehavior MemoryBehaviorVisitor::visitBuiltinInst(BuiltinInst *BI) {
 MemBehavior MemoryBehaviorVisitor::visitTryApplyInst(TryApplyInst *AI) {
   MemBehavior Behavior = MemBehavior::MayHaveSideEffects;
   // Ask escape analysis.
-  if (!EA->canEscapeTo(V, AI))
+  if (!EA->canEscapeToRelease(V, AI))
     Behavior = MemBehavior::None;
 
   // Otherwise be conservative and return that we may have side effects.
@@ -396,7 +396,7 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
       Behavior = MemBehavior::MayRead;
 
     // Ask escape analysis.
-    if (!EA->canEscapeTo(V, AI))
+    if (!EA->canEscapeToRelease(V, AI))
       Behavior = MemBehavior::None;
   }
   LLVM_DEBUG(llvm::dbgs() << "  Found apply, returning " << Behavior << '\n');
@@ -405,22 +405,22 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
 
 MemBehavior
 MemoryBehaviorVisitor::visitStrongReleaseInst(StrongReleaseInst *SI) {
-  if (!EA->canEscapeTo(V, SI))
+  if (!EA->canEscapeToRelease(V, SI))
     return MemBehavior::None;
   return MemBehavior::MayHaveSideEffects;
 }
 
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-MemBehavior \
-MemoryBehaviorVisitor::visit##Name##ReleaseInst(Name##ReleaseInst *SI) { \
-  if (!EA->canEscapeTo(V, SI)) \
-    return MemBehavior::None; \
-  return MemBehavior::MayHaveSideEffects; \
-}
+#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
+  MemBehavior MemoryBehaviorVisitor::visit##Name##ReleaseInst(                 \
+      Name##ReleaseInst *SI) {                                                 \
+    if (!EA->canEscapeToRelease(V, SI))                                        \
+      return MemBehavior::None;                                                \
+    return MemBehavior::MayHaveSideEffects;                                    \
+  }
 #include "swift/AST/ReferenceStorage.def"
 
 MemBehavior MemoryBehaviorVisitor::visitReleaseValueInst(ReleaseValueInst *SI) {
-  if (!EA->canEscapeTo(V, SI))
+  if (!EA->canEscapeToRelease(V, SI))
     return MemBehavior::None;
   return MemBehavior::MayHaveSideEffects;
 }

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -118,16 +118,16 @@ bool StackPromotion::tryPromoteAlloc(AllocRefInst *ARI, EscapeAnalysis *EA,
 
   LLVM_DEBUG(llvm::dbgs() << "Promote " << *ARI);
 
-  // Collect all use-points of the allocation. These are refcount instructions
-  // and apply instructions.
-  llvm::SmallVector<SILInstruction *, 8> UsePoints;
-  ConGraph->getUsePoints(contentNode, UsePoints);
+  // Collect all release-points of the allocation. These are refcount
+  // instructions and apply instructions.
+  llvm::SmallVector<SILInstruction *, 8> ReleasePoints;
+  ConGraph->getReleasePoints(contentNode, ReleasePoints);
 
-  ValueLifetimeAnalysis VLA(ARI, UsePoints);
-  // Check if there is a use point before the allocation (this can happen e.g.
-  // if the allocated object is stored into another object, which is already
-  // alive at the allocation point).
-  // In such a case the value lifetime extends up to the function entry.
+  ValueLifetimeAnalysis VLA(ARI, ReleasePoints);
+  // Check if there is a release point before the allocation (this can happen
+  // e.g. if the allocated object is stored into another object, which is
+  // already alive at the allocation point). In such a case the value lifetime
+  // extends up to the function entry.
   if (VLA.isAliveAtBeginOfBlock(ARI->getFunction()->getEntryBlock())) {
     LLVM_DEBUG(llvm::dbgs() << "  use before allocation -> don't promote");
     return false;

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -73,8 +73,13 @@ class EscapeAnalysisDumper : public SILModuleTransform {
               for (unsigned i = 0, e = Values.size(); i != e; ++i) {
                 SILValue val = Values[i];
                 bool escape = EA->canEscapeToRelease(val, fas);
-                llvm::outs() << (escape ? "May" : "No") << "Escape: " << val
-                             << " to " << ii;
+                llvm::outs() << (escape ? "May" : "No")
+                             << "EscapeToRelease: " << val << " to " << ii;
+                if (!escape) {
+                  bool escape = EA->canEscapeToAccess(val, fas);
+                  llvm::outs() << (escape ? "May" : "No")
+                               << "EscapeToAccess: " << val << " to " << ii;
+                }
               }
             }
             if (RefCountingInst *rci = dyn_cast<RefCountingInst>(&ii)) {

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -72,7 +72,7 @@ class EscapeAnalysisDumper : public SILModuleTransform {
             if (auto fas = FullApplySite::isa(&ii)) {
               for (unsigned i = 0, e = Values.size(); i != e; ++i) {
                 SILValue val = Values[i];
-                bool escape = EA->canEscapeTo(val, fas);
+                bool escape = EA->canEscapeToRelease(val, fas);
                 llvm::outs() << (escape ? "May" : "No") << "Escape: " << val
                              << " to " << ii;
               }
@@ -80,7 +80,7 @@ class EscapeAnalysisDumper : public SILModuleTransform {
             if (RefCountingInst *rci = dyn_cast<RefCountingInst>(&ii)) {
               for (unsigned i = 0, e = Values.size(); i != e; ++i) {
                 SILValue val = Values[i];
-                bool escape = EA->canEscapeTo(val, rci);
+                bool escape = EA->canEscapeToRelease(val, rci);
                 llvm::outs() << (escape ? "May" : "No") << "Escape: " << val
                              << " to " << ii;
               }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1784,7 +1784,7 @@ bb10(%arg3 : $C):
 // CHECK-NEXT:   Val %1 Esc: , Succ: (%0.1)
 // CHECK-NEXT:   Val %5 Esc: , Succ: %0, %1
 // CHECK-LABEL: End
-// CHECK: MayEscape: %5 = argument of bb3 : $*Builtin.Int32
+// CHECK: MayEscapeToRelease: %5 = argument of bb3 : $*Builtin.Int32
 // CHECK-NEXT:  to   %{{.*}} = apply %{{.*}}(%0) : $@convention(thin) (@inout Builtin.Int32) -> ()
 sil @takeAdr : $@convention(thin) (@inout Builtin.Int32) -> ()
 

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1983,3 +1983,39 @@ bb4:
   %z = tuple ()
   return %z : $()
 }
+
+sil @guaranteed_call : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>, Builtin.Int32) -> () {
+bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $Builtin.Int32):
+  %proj = project_box %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  store  %1 to %proj : $*Builtin.Int32
+  %ret = tuple()
+  return %ret : $()
+}
+
+// Test to make sure guaranteed arg does not escape as release
+
+// CHECK-LABEL: CG of $test_guaranteed_arg
+// CHECK:   Val [ref] %1 Esc: , Succ: (%2)
+// CHECK:   Con [int] %2 Esc: %6,%7,%5, Succ: (%2.1)
+// CHECK:   Con %2.1 Esc: %6,%7,%5, Succ: (%2.2)
+// CHECK:   Con [int] %2.2 Esc: %6,%7,%5, Succ: (%2.3)
+// CHECK:   Con %2.3 Esc: %6,%7,%5, Succ: (%2.4)
+// CHECK:   Con %2.4 Esc: G, Succ: 
+// CHECK: End
+// CHECK: NoEscapeToRelease:   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+// CHECK:  to   %5 = apply %3(%1, %0) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>, Builtin.Int32) -> ()
+// CHECK: MayEscapeToAccess:   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+// CHECK:  to   %5 = apply %3(%1, %0) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>, Builtin.Int32) -> ()
+sil hidden [noinline] @$test_guaranteed_arg : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : $Builtin.Int32):
+  %box = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  %proj = project_box %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  %funcref = function_ref @guaranteed_call : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>, Builtin.Int32) -> ()
+  strong_retain %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  apply %funcref (%box, %0) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>, Builtin.Int32) -> ()
+  strong_release %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  strong_release %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  %tup = tuple ()
+  return %tup : $()
+}
+


### PR DESCRIPTION
This PR consists of improvements to EscapeAnalysis around guaranteed args

Escape analysis returns unnecessarily conservative results for guaranteed args which can limit ARC optimizations among others.

Example:

```
sil hidden [noinline] @$s4test3fooyyF : $@convention(thin) () -> () {
bb0:
  %box = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
  %proj = project_box %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
  %funcref = function_ref @userg : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
  strong_retain %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
  apply %funcref (%box) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> () // id: applyId
  strong_release %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
  strong_release %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
  %tup = tuple ()    
  return %tup : $()    
}
```

Here EscapeAnalysis::canEscapeTo returns true for %box and %applyId in spite of it not escaping. The current implementation depends on isUsePoint which is stricter than necessary. isUsePoint considers any apply arg as a use. guaranteed args cannot be released in an apply unless they have already escaped.

UsePoints used to compute EscapeAnalysis::canEscapeTo in turn get used in AliasAnalysis' mayReadFromMemory, mayWriteToMemory, canApplyDecrementRefCount, etc. The effectiveness of optimizations like RLE, ARCSequenceOpts, DSE depends on these queries.

With this change, "use points" are split into "release points" and "access points". ReleasePoints consists of release and consuming apply instructions. AccessPoints consists of guaranteed args passed to apply instructions. canEscapeTo is split into canEscapeToRelease and canEscapeToAccess.

With this apply's MemoryBehavior can be computed using both canEscapeToRelease and canEscapeToAccess. And queries like AliasAnalysis::canApplyDecrementRefCount is improved for guaranteed args.

