### PR TITLE
[Foundation] Work around name resolution wrinkle in Swift 5.3

### DIFF
--- a/stdlib/public/Darwin/Foundation/CheckClass.swift
+++ b/stdlib/public/Darwin/Foundation/CheckClass.swift
@@ -38,8 +38,7 @@ extension NSKeyedUnarchiver {
   /// - Returns: 0 if the given class is safe to archive, and non-zero if it
   ///     isn't.
   @objc(_swift_checkClassAndWarnForKeyedArchiving:operation:)
-  @usableFromInline
-  internal class func _swift_checkClassAndWarnForKeyedArchiving(
+  internal class func __swift_checkClassAndWarnForKeyedArchiving(
     _ theClass: AnyClass,
     operation: CInt
   ) -> CInt {


### PR DESCRIPTION
From #32809:

In 5.3, if an Objective-C method declared in a header shares the same name as an inaccessible Swift method, then the compiler considers the method to be inaccessible. As a workaround, rename the Swift method and stop emitting a symbol for it.

This is not a problem on the trunk, but there is no reason to expose this symbol there, either.
