### PR TITLE
[WIP] [NO-MERGE] Make "unique" flag more robust and update access enforcement opts to make use of it. 

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2238,6 +2238,7 @@ alloc_ref
 ::
 
   sil-instruction ::= 'alloc_ref'
+                        ('[' 'unique' ']')?
                         ('[' 'objc' ']')?
                         ('[' 'stack' ']')?
                         ('[' 'tail_elems' sil-type '*' sil-operand ']')*
@@ -2272,6 +2273,11 @@ The count-operand must be of a builtin integer type.
 The instructions ``ref_tail_addr`` and ``tail_addr`` can be used to project
 the tail elements.
 The ``objc`` attribute cannot be used together with ``tail_elems``.
+
+The optional ``unique`` attribute indicates that this is the only reference to
+the allocated object. In other words, the reference will not escape or be
+written to dynamically. This allows access of the object to be static instead
+of dynamic.
 
 alloc_ref_dynamic
 `````````````````

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -173,6 +173,8 @@ private:
 /// return SILValue().
 SILValue getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi);
 
+SILFunction *getDestructor(AllocRefInstBase *ari);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -175,6 +175,12 @@ SILValue getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi);
 
 SILFunction *getDestructor(AllocRefInstBase *ari);
 
+/// \returns None if \p ref is unique. Otherwise, returns an error message in
+/// the form of a string. If \p verbose is true, will print out diagnostics,
+/// such as the reason for failure. This is helpful when the funciton is being
+/// used by the SILVerifier.
+Optional<StringRef> isReferenceUnique(AllocRefInstBase *ref, bool verbose);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -362,6 +362,9 @@ public:
   bool isLetAccess(SILFunction *F) const;
   
   bool isUniquelyIdentified() const {
+    if (auto *ref = dyn_cast<AllocRefInst>(value))
+      return ref->isUniqueReference();
+
     switch (getKind()) {
     case Box:
     case Stack:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -421,17 +421,17 @@ public:
                                          Var, hasDynamicLifetime));
   }
 
-  AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,
-                               bool objc, bool canAllocOnStack,
+  AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType, bool objc,
+                               bool canAllocOnStack, bool isUnique,
                                ArrayRef<SILType> ElementTypes,
                                ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefInsts expand to function calls and can therefore not be
     // counted towards the function prologue.
     assert(!Loc.isInPrologue());
-    return insert(AllocRefInst::create(getSILDebugLocation(Loc), getFunction(),
-                                       ObjectType, objc, canAllocOnStack,
-                                       ElementTypes, ElementCountOperands,
-                                       C.OpenedArchetypes));
+    return insert(AllocRefInst::create(
+        getSILDebugLocation(Loc), getFunction(), ObjectType, objc,
+        canAllocOnStack, isUnique, ElementTypes, ElementCountOperands,
+        C.OpenedArchetypes));
   }
 
   AllocRefDynamicInst *createAllocRefDynamic(SILLocation Loc, SILValue operand,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -817,10 +817,9 @@ SILCloner<ImplClass>::visitAllocRefInst(AllocRefInst *Inst) {
   for (SILType OrigElemType : Inst->getTailAllocatedTypes()) {
     ElemTypes.push_back(getOpType(OrigElemType));
   }
-  auto *NewInst = getBuilder().createAllocRef(getOpLocation(Inst->getLoc()),
-                                      getOpType(Inst->getType()),
-                                      Inst->isObjC(), Inst->canAllocOnStack(),
-                                      ElemTypes, CountArgs);
+  auto *NewInst = getBuilder().createAllocRef(
+      getOpLocation(Inst->getLoc()), getOpType(Inst->getType()), Inst->isObjC(),
+      Inst->canAllocOnStack(), Inst->isUniqueReference(), ElemTypes, CountArgs);
   recordClonedInstruction(Inst, NewInst);
 }
 

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -201,12 +201,11 @@ protected:
     NumOperands : 32-NumAllocationInstBits,
     VarInfo : 32
   );
-  IBWTO_BITFIELD(AllocRefInstBase, AllocationInst, 32-NumAllocationInstBits,
-    ObjC : 1,
-    OnStack : 1,
-    NumTailTypes : 32-1-1-NumAllocationInstBits
-  );
-  static_assert(32-1-1-NumAllocationInstBits >= 16, "Reconsider bitfield use?");
+  IBWTO_BITFIELD(AllocRefInstBase, AllocationInst, 32 - NumAllocationInstBits,
+                 ObjC : 1, OnStack : 1, uniqueReference : 1,
+                 NumTailTypes : 32 - 1 - 1 - 1 - NumAllocationInstBits);
+  static_assert(32 - 1 - 1 - 1 - NumAllocationInstBits >= 16,
+                "Reconsider bitfield use?");
 
   UIWTDOB_BITFIELD_EMPTY(AllocValueBufferInst, AllocationInst);
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -279,6 +279,8 @@ IRGEN_PASS(LoadableByAddress, "loadable-address",
      "SIL Large Loadable type by-address lowering.")
 PASS(MandatorySILLinker, "mandatory-linker",
      "Deserialize all referenced SIL functions that are shared or transparent")
+PASS(MarkReferenceUnique, "mark-reference-unique",
+     "If possible, mark alloc_ref instruction with 'unique' flag")
 PASS(PerformanceSILLinker, "performance-linker",
      "Deserialize all referenced SIL functions")
 PASS(RawSILInstLowering, "raw-sil-inst-lowering",

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -200,13 +200,13 @@ DeallocStackInst *AllocStackInst::getSingleDeallocStack() const {
 }
 
 AllocRefInstBase::AllocRefInstBase(SILInstructionKind Kind,
-                                   SILDebugLocation Loc,
-                                   SILType ObjectType,
-                                   bool objc, bool canBeOnStack,
+                                   SILDebugLocation Loc, SILType ObjectType,
+                                   bool objc, bool canBeOnStack, bool isUnique,
                                    ArrayRef<SILType> ElementTypes)
     : AllocationInst(Kind, Loc, ObjectType) {
   SILInstruction::Bits.AllocRefInstBase.ObjC = objc;
   SILInstruction::Bits.AllocRefInstBase.OnStack = canBeOnStack;
+  SILInstruction::Bits.AllocRefInstBase.uniqueReference = isUnique;
   SILInstruction::Bits.AllocRefInstBase.NumTailTypes = ElementTypes.size();
   assert(SILInstruction::Bits.AllocRefInstBase.NumTailTypes ==
          ElementTypes.size() && "Truncation");
@@ -214,8 +214,8 @@ AllocRefInstBase::AllocRefInstBase(SILInstructionKind Kind,
 }
 
 AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILFunction &F,
-                                   SILType ObjectType,
-                                   bool objc, bool canBeOnStack,
+                                   SILType ObjectType, bool objc,
+                                   bool canBeOnStack, bool isUnique,
                                    ArrayRef<SILType> ElementTypes,
                                    ArrayRef<SILValue> ElementCountOperands,
                                    SILOpenedArchetypesState &OpenedArchetypes) {
@@ -233,7 +233,7 @@ AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILFunction &F,
                                                         ElementTypes.size());
   auto Buffer = F.getModule().allocateInst(Size, alignof(AllocRefInst));
   return ::new (Buffer) AllocRefInst(Loc, F, ObjectType, objc, canBeOnStack,
-                                     ElementTypes, AllOperands);
+                                     isUnique, ElementTypes, AllOperands);
 }
 
 AllocRefDynamicInst *

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1153,6 +1153,8 @@ public:
       *this << "[objc] ";
     if (ARI->canAllocOnStack())
       *this << "[stack] ";
+    if (ARI->isUniqueReference())
+      *this << "[unique] ";
     auto Types = ARI->getTailAllocatedTypes();
     auto Counts = ARI->getTailAllocatedCounts();
     for (unsigned Idx = 0, NumTypes = Types.size(); Idx < NumTypes; ++Idx) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3862,6 +3862,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::AllocRefDynamicInst: {
     bool IsObjC = false;
     bool OnStack = false;
+    bool isUnique = false;
     SmallVector<SILType, 2> ElementTypes;
     SmallVector<SILValue, 2> ElementCounts;
     while (P.consumeIf(tok::l_square)) {
@@ -3872,6 +3873,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         IsObjC = true;
       } else if (Optional == "stack") {
         OnStack = true;
+      } else if (Optional == "unique") {
+        isUnique = true;
       } else if (Optional == "tail_elems") {
         SILType ElemTy;
         if (parseSILType(ElemTy) || !P.Tok.isAnyOperator() ||
@@ -3916,7 +3919,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
                                           ElementTypes, ElementCounts);
     } else {
       ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack,
-                                   ElementTypes, ElementCounts);
+                                   isUnique, ElementTypes, ElementCounts);
     }
     break;
   }

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -758,7 +758,8 @@ Optional<StringRef> swift::isReferenceUnique(AllocRefInstBase *ref,
       continue;
     }
 
-    if (isa<BeginAccessInst>(user) || isa<RefElementAddrInst>(user)) {
+    if (isa<BeginAccessInst>(user) || isa<RefElementAddrInst>(user) ||
+        isa<StructElementAddrInst>(user) || isa<TupleElementAddrInst>(user)) {
       auto *userVal = cast<SingleValueInstruction>(user);
       usesToCheck.append(userVal->use_begin(), userVal->use_end());
       continue;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1303,7 +1303,17 @@ public:
         auto *use = usesToCheck.pop_back_val();
         auto *user = use->getUser();
 
-        // TODO: Phi arguments.
+        if (auto br = dyn_cast<BranchInst>(user)) {
+          unsigned i = 0;
+          for (auto arg : br->getArgs()) {
+            if (arg == use->get())
+              break;
+            i++;
+          }
+          auto arg = br->getDestBB()->getArgument(i);
+          usesToCheck.append(arg->use_begin(), arg->use_end());
+          continue;
+        }
 
         // These instructions are OK.
         if (isa<LoadInst>(user) || isa<DeallocRefInst>(user) ||

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1296,78 +1296,11 @@ public:
     // reference does not escape but, the SILVerifier doesn't know about it,
     // then the right thing to do is fail.
     if (ARI->isUniqueReference()) {
-      SmallVector<Operand *, 8> usesToCheck;
-      usesToCheck.append(ARI->use_begin(), ARI->use_end());
-
-      while (!usesToCheck.empty()) {
-        auto *use = usesToCheck.pop_back_val();
-        auto *user = use->getUser();
-
-        if (auto br = dyn_cast<BranchInst>(user)) {
-          unsigned i = 0;
-          for (auto arg : br->getArgs()) {
-            if (arg == use->get())
-              break;
-            i++;
-          }
-          auto arg = br->getDestBB()->getArgument(i);
-          usesToCheck.append(arg->use_begin(), arg->use_end());
-          continue;
-        }
-        
-        if (auto apply = FullApplySite::isa(user)) {
-          if (!apply.getReferencedFunctionOrNull()) {
-            llvm::dbgs()
-                << "Could not find the referenced function of the following full apply site: \n";
-            apply.getInstruction()->print(llvm::dbgs());
-            require(false, "Found unkown use of unique reference.");
-          }
-
-          auto referencedFn = apply.getReferencedFunctionOrNull();
-          unsigned i = 0;
-          for (auto arg : apply.getArguments()) {
-            if (arg == use->get())
-              break;
-            i++;
-          }
-          auto arg = referencedFn->getArgument(i);
-          usesToCheck.append(arg->use_begin(), arg->use_end());
-          continue;
-        }
-        
-        if (isa<StrongReleaseInst>(user)) {
-          auto *destructor = getDestructor(ARI);
-          require(destructor, "Cannot find destructor for reference type while checking strong_release does not escape the unique reference.");
-          auto *selfInDestructor = destructor->begin()->getArgument(0);
-          usesToCheck.append(selfInDestructor->use_begin(),
-                             selfInDestructor->use_end());
-          continue;
-        }
-
-        // These instructions are OK.
-        if (isa<LoadInst>(user) || isa<DeallocRefInst>(user) ||
-            isa<EndAccessInst>(user) || isa<SetDeallocatingInst>(user) ||
-            isa<DebugValueInst>(user) || isa<DebugValueAddrInst>(user) ||
-            isa<ClassMethodInst>(user) || isa<StrongRetainInst>(user))
-          continue;
-
-        if (auto *store = dyn_cast<StoreInst>(user)) {
-          require(store->getDest() == use->get(),
-                  "Store escapes address. Store instruction must store into "
-                  "the unique reference.");
-          continue;
-        }
-
-        if (isa<BeginAccessInst>(user) || isa<RefElementAddrInst>(user)) {
-          auto *userVal = cast<SingleValueInstruction>(user);
-          usesToCheck.append(userVal->use_begin(), userVal->use_end());
-          continue;
-        }
-
-        llvm::dbgs()
-            << "The following instruction may escape the reference: \n";
-        user->print(llvm::dbgs());
-        require(false, "Found unkown use of unique reference.");
+      Optional<StringRef> isNotUnique =
+          isReferenceUnique(ARI, /*verbose=*/true);
+      if (isNotUnique) {
+        llvm::dbgs() << isNotUnique.getValue();
+        require(false, "Failing due to above error.");
       }
     }
   }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -208,7 +208,7 @@ SILGenBuilder::createGuaranteedTransformingTerminatorArgument(SILType type) {
 
 ManagedValue SILGenBuilder::createAllocRef(
     SILLocation loc, SILType refType, bool objc, bool canAllocOnStack,
-    ArrayRef<SILType> inputElementTypes,
+    bool isUnique, ArrayRef<SILType> inputElementTypes,
     ArrayRef<ManagedValue> inputElementCountOperands) {
   llvm::SmallVector<SILType, 8> elementTypes(inputElementTypes.begin(),
                                              inputElementTypes.end());
@@ -217,8 +217,9 @@ ManagedValue SILGenBuilder::createAllocRef(
                   std::back_inserter(elementCountOperands),
                   [](ManagedValue mv) -> SILValue { return mv.getValue(); });
 
-  AllocRefInst *i = createAllocRef(loc, refType, objc, canAllocOnStack,
-                                   elementTypes, elementCountOperands);
+  AllocRefInst *i =
+      createAllocRef(loc, refType, objc, canAllocOnStack, isUnique,
+                     elementTypes, elementCountOperands);
   return SGF.emitManagedRValueWithCleanup(i);
 }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -143,7 +143,7 @@ public:
 
   using SILBuilder::createAllocRef;
   ManagedValue createAllocRef(SILLocation loc, SILType refType, bool objc,
-                              bool canAllocOnStack,
+                              bool canAllocOnStack, bool isUnique,
                               ArrayRef<SILType> elementTypes,
                               ArrayRef<ManagedValue> elementCountOperands);
   using SILBuilder::createAllocRefDynamic;

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1001,8 +1001,8 @@ static ManagedValue emitBuiltinAllocWithTailElems(SILGenFunction &SGF,
     assert(InstanceType == RefType.getASTType() &&
            "substituted type does not match operand metatype");
     (void) InstanceType;
-    return SGF.B.createAllocRef(loc, RefType, false, false,
-                                ElemTypes, Counts);
+    return SGF.B.createAllocRef(loc, RefType, false, false, false, ElemTypes,
+                                Counts);
   } else {
     return SGF.B.createAllocRefDynamic(loc, Metatype, RefType, false,
                                        ElemTypes, Counts);

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -601,7 +601,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     // allocated is the type of the class that defines the designated
     // initializer.
     F.setIsExactSelfClass(IsExactSelfClass);
-    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false,
+    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false, false,
                                  ArrayRef<SILType>(), ArrayRef<SILValue>());
   }
   args.push_back(selfValue);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -508,6 +508,10 @@ static void addHighLevelModulePipeline(SILPassPipelinePlan &P) {
 
   P.addGlobalOpt();
   P.addLetPropertiesOpt();
+
+  P.addAccessEnforcementOpts();
+  P.addAccessEnforcementWMO();
+  // P.addAccessMarkerElimination();
 }
 
 static void addSerializePipeline(SILPassPipelinePlan &P) {
@@ -630,8 +634,6 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   // Sometimes stack promotion can catch cases only at this late stage of the
   // pipeline, after FunctionSignatureOpts.
   P.addStackPromotion();
-
-  P.addMarkReferenceUnique();
 
   // Optimize overflow checks.
   P.addRedundantOverflowCheckRemoval();

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -355,6 +355,8 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   //  Do a round of CFG simplification, followed by peepholes, then
   //  more CFG simplification.
 
+  P.addMarkReferenceUnique();
+
   // Jump threading can expose opportunity for SILCombine (enum -> is_enum_tag->
   // cond_br).
   P.addJumpThreadSimplifyCFG();
@@ -628,6 +630,8 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   // Sometimes stack promotion can catch cases only at this late stage of the
   // pipeline, after FunctionSignatureOpts.
   P.addStackPromotion();
+
+  P.addMarkReferenceUnique();
 
   // Optimize overflow checks.
   P.addRedundantOverflowCheckRemoval();

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1888,10 +1888,9 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     if (!SILInstanceTy.getClassOrBoundGenericClass())
       return nullptr;
 
-    NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
-                                     ARDI->isObjC(), false,
-                                     ARDI->getTailAllocatedTypes(),
-                                     getCounts(ARDI));
+    NewInst = Builder.createAllocRef(
+        ARDI->getLoc(), SILInstanceTy, ARDI->isObjC(), false, false,
+        ARDI->getTailAllocatedTypes(), getCounts(ARDI));
 
   } else if (isa<SILArgument>(MDVal)) {
 
@@ -1913,10 +1912,9 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
       auto SILInstanceTy = SILType::getPrimitiveObjectType(InstanceTy);
       if (!SILInstanceTy.getClassOrBoundGenericClass())
         return nullptr;
-      NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
-                                       ARDI->isObjC(), false,
-                                       ARDI->getTailAllocatedTypes(),
-                                       getCounts(ARDI));
+      NewInst = Builder.createAllocRef(
+          ARDI->getLoc(), SILInstanceTy, ARDI->isObjC(), false, false,
+          ARDI->getTailAllocatedTypes(), getCounts(ARDI));
     }
   }
   if (NewInst && NewInst->getType() != ARDI->getType()) {

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(swiftSILOptimizer PRIVATE
   Devirtualizer.cpp
   DifferentiabilityWitnessDevirtualizer.cpp
   GenericSpecializer.cpp
+  MarkReferenceUnique.cpp
   MergeCondFail.cpp
   Outliner.cpp
   ObjectOutliner.cpp

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -61,42 +61,6 @@ STATISTIC(DeadAllocApplyEliminated,
 
 using UserList = llvm::SmallSetVector<SILInstruction *, 16>;
 
-// Analyzing the body of this class destructor is valid because the object is
-// dead. This means that the object is never passed to objc_setAssociatedObject,
-// so its destructor cannot be extended at runtime.
-static SILFunction *getDestructor(AllocRefInst *ARI) {
-  // We only support classes.
-  ClassDecl *ClsDecl = ARI->getType().getClassOrBoundGenericClass();
-  if (!ClsDecl)
-    return nullptr;
-
-  // Look up the destructor of ClsDecl.
-  DestructorDecl *Destructor = ClsDecl->getDestructor();
-  assert(Destructor && "getDestructor() should never return a nullptr.");
-
-  // Find the destructor name via SILDeclRef.
-  // FIXME: When destructors get moved into vtables, update this to use the
-  // vtable for the class.
-  SILDeclRef Ref(Destructor);
-  SILFunction *Fn = ARI->getModule().lookUpFunction(Ref);
-  if (!Fn || Fn->empty()) {
-    LLVM_DEBUG(llvm::dbgs() << "    Could not find destructor.\n");
-    return nullptr;
-  }
-
-  LLVM_DEBUG(llvm::dbgs() << "    Found destructor!\n");
-
-  // If the destructor has an objc_method calling convention, we cannot
-  // analyze it since it could be swapped out from under us at runtime.
-  if (Fn->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod) {
-    LLVM_DEBUG(llvm::dbgs() << "        Found Objective-C destructor. Can't "
-               "analyze!\n");
-    return nullptr;
-  }
-
-  return Fn;
-}
-
 /// Analyze the destructor for the class of ARI to see if any instructions in it
 /// could have side effects on the program outside the destructor. If it does
 /// not, then we can eliminate the destructor.

--- a/lib/SILOptimizer/Transforms/MarkReferenceUnique.cpp
+++ b/lib/SILOptimizer/Transforms/MarkReferenceUnique.cpp
@@ -1,0 +1,63 @@
+//===---- MarkReferenceUnique.cpp - Mark references as unique -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+//                            MarkReferenceUnique
+//===----------------------------------------------------------------------===//
+
+struct MarkReferenceUnique : public SILFunctionTransform {
+  MarkReferenceUnique() = default;
+
+  /// The entry point to the transformation.
+  void run() override {
+    auto *func = getFunction();
+
+    bool madeChange = false;
+    for (auto &block : *func) {
+      for (auto &inst : block) {
+        if (auto *ref = dyn_cast<AllocRefInst>(&inst)) {
+          // No point in doing exra work.
+          if (ref->isUniqueReference())
+            continue;
+
+          // The result of isReferenceUnique is an error message. If there's no
+          // message, then this is a unique reference.
+          bool isUnique =
+              isReferenceUnique(ref, /*verbose*/ false).hasValue() == false;
+          if (isUnique) {
+            madeChange = true;
+            ref->setUniqueReference();
+          }
+        }
+      }
+    }
+
+    if (madeChange)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createMarkReferenceUnique() {
+  return new MarkReferenceUnique();
+}

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1418,6 +1418,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned Flags = ListOfValues[0];
     bool isObjC = (bool)(Flags & 1);
     bool canAllocOnStack = (bool)((Flags >> 1) & 1);
+    bool isUnique = (bool)((Flags >> 2) & 1);
     SILType ClassTy =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     SmallVector<SILValue, 4> Counts;
@@ -1443,7 +1444,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     } else {
       assert(i == NumVals);
       ResultVal = Builder.createAllocRef(Loc, ClassTy, isObjC, canAllocOnStack,
-                                         TailTypes, Counts);
+                                         isUnique, TailTypes, Counts);
     }
     break;
   }

--- a/test/SIL/unique-reference-verifier-escape-with-apply.sil
+++ b/test/SIL/unique-reference-verifier-escape-with-apply.sil
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class MyClass {
+  @_hasStorage @_hasInitialValue var i: Int { get set }
+  deinit
+  init()
+}
+
+sil @user : $@convention(thin) (MyClass) -> ()
+
+// CHECK: The following instruction may escape the reference:
+// CHECK:   %{{[0-9]+}} = apply %{{[0-9]+}}(%{{[0-9]+}}) : $@convention(thin) (MyClass) -> ()
+// CHECK: SIL verification failed: Found unkown use of unique reference.
+sil @simple : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] [unique] $MyClass
+  %fn = function_ref @user : $@convention(thin) (MyClass) -> ()
+  apply %fn(%0) : $@convention(thin) (MyClass) -> ()
+  set_deallocating %0 : $MyClass
+  dealloc_ref %0 : $MyClass
+  dealloc_ref [stack] %0 : $MyClass
+  %14 = tuple ()
+  return %14 : $()
+}

--- a/test/SIL/unique-reference-verifier-escape-with-store.sil
+++ b/test/SIL/unique-reference-verifier-escape-with-store.sil
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class MyClass {
+  @_hasStorage @_hasInitialValue var i: Int { get set }
+  deinit
+  init()
+}
+
+// CHECK: SIL verification failed: Store escapes address. Store instruction must store into the unique reference.: store->getDest() == use->get()
+sil @simple : $@convention(thin) () -> () {
+bb0:
+  %arg = alloc_stack $MyClass
+  %0 = alloc_ref [stack] [unique] $MyClass
+  store %0 to %arg : $*MyClass
+  set_deallocating %0 : $MyClass
+  dealloc_ref %0 : $MyClass
+  dealloc_ref [stack] %0 : $MyClass
+  dealloc_stack %arg : $*MyClass
+  %14 = tuple ()
+  return %14 : $()
+}

--- a/test/SIL/unique-reference-verifier-escape-with-strong-release.sil
+++ b/test/SIL/unique-reference-verifier-escape-with-strong-release.sil
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class MyClass {
+  @_hasStorage @_hasInitialValue var i: Int { get set }
+  deinit
+  init()
+}
+
+// CHECK: The following instruction may escape the reference:
+// CHECK:   strong_release %{{[0-9]+}} : $MyClass
+// CHECK: SIL verification failed: Found unkown use of unique reference.
+sil @simple : $@convention(thin) () -> () {
+bb0:
+  %arg = alloc_stack $MyClass
+  %0 = alloc_ref [stack] [unique] $MyClass
+  strong_release %0 : $MyClass
+  set_deallocating %0 : $MyClass
+  dealloc_ref %0 : $MyClass
+  dealloc_ref [stack] %0 : $MyClass
+  dealloc_stack %arg : $*MyClass
+  %14 = tuple ()
+  return %14 : $()
+}

--- a/test/SIL/unique-reference-verifier-escape-with-unkown.sil
+++ b/test/SIL/unique-reference-verifier-escape-with-unkown.sil
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class MyClass {
+  @_hasStorage @_hasInitialValue var i: Int { get set }
+  deinit
+  init()
+}
+
+public class MyOtherClass {
+  @_hasStorage @_hasInitialValue var i: Int { get set }
+  deinit
+  init()
+}
+
+// CHECK: The following instruction may escape the reference:
+// CHECK:   %{{[0-9]+}} = unchecked_ref_cast %{{[0-9]+}} : $MyClass to $MyOtherClass
+// CHECK: SIL verification failed: Found unkown use of unique reference.
+sil @simple : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] [unique] $MyClass
+  // An "unkown" instruction.
+  %1 = unchecked_ref_cast %0 : $MyClass to $MyOtherClass
+  set_deallocating %0 : $MyClass
+  dealloc_ref %0 : $MyClass
+  dealloc_ref [stack] %0 : $MyClass
+  %14 = tuple ()
+  return %14 : $()
+}

--- a/test/SIL/unique-reference-verifier.sil
+++ b/test/SIL/unique-reference-verifier.sil
@@ -93,3 +93,54 @@ bb3(%20 : $Int):
   return %20 : $Int
 }
 
+// CHECK-LABEL: sil @test_multiblock_with_branch
+// CHECK: alloc_ref [stack] [unique] $MyClass
+// CHECK-LABEL: end sil function 'test_multiblock_with_branch'
+sil @test_multiblock_with_branch : $@convention(thin) (Bool, Bool) -> Int {
+bb0(%0 : $Bool, %1 : $Bool):
+  %4 = alloc_ref [stack] [unique] $Foo
+  %6 = integer_literal $Builtin.Int64, 0
+  %7 = struct $Int (%6 : $Builtin.Int64)
+  %8 = ref_element_addr %4 : $Foo, #Foo.x
+  %9 = begin_access [modify] [dynamic] [no_nested_conflict] %8 : $*Int
+  store %7 to %9 : $*Int
+  end_access %9 : $*Int
+  %12 = struct_extract %0 : $Bool, #Bool._value
+  cond_br %12, bb2, bb1
+
+bb1:
+  br bb3
+
+bb2:
+  %15 = integer_literal $Builtin.Int64, 1
+  %16 = struct $Int (%15 : $Builtin.Int64)
+  %19 = begin_access [modify] [static] [no_nested_conflict] %8 : $*Int
+  store %16 to %19 : $*Int
+  end_access %19 : $*Int
+  br bb3
+
+bb3:
+  %23 = struct_extract %1 : $Bool, #Bool._value
+  cond_br %23, bb4, bb5
+
+bb4:
+  %25 = alloc_ref $Foo
+  %27 = ref_element_addr %25 : $Foo, #Foo.x
+  %28 = begin_access [modify] [dynamic] [no_nested_conflict] %27 : $*Int
+  store %7 to %28 : $*Int
+  end_access %28 : $*Int
+  // strong_release %4 : $Foo
+  br bb6(%25 : $Foo)
+
+bb5:
+  br bb6(%4 : $Foo)
+
+bb6(%34 : $Foo):
+  %36 = ref_element_addr %34 : $Foo, #Foo.x
+  %37 = begin_access [read] [dynamic] [no_nested_conflict] %36 : $*Int
+  %38 = load %37 : $*Int
+  end_access %37 : $*Int
+  // strong_release %34 : $Foo
+  dealloc_ref [stack] %4 : $Foo
+  return %38 : $Int
+}

--- a/test/SIL/unique-reference-verifier.sil
+++ b/test/SIL/unique-reference-verifier.sil
@@ -144,3 +144,31 @@ bb6(%34 : $Foo):
   dealloc_ref [stack] %4 : $Foo
   return %38 : $Int
 }
+
+sil [noinline] @user : $@convention(thin) (@guaranteed Foo) -> Int {
+bb0(%0 : $Foo):
+  %2 = ref_element_addr %0 : $Foo, #Foo.x
+  %3 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Int
+  %4 = load %3 : $*Int
+  end_access %3 : $*Int
+  return %4 : $Int
+}
+
+// CHECK-LABEL: sil @test_apply
+// CHECK: alloc_ref [stack] [unique] $MyClass
+// CHECK-LABEL: end sil function 'test_apply'
+sil @test_apply : $@convention(thin) (Bool, Bool) -> Int {
+bb0(%0 : $Bool, %1 : $Bool):
+  %2 = alloc_ref [unique] $Foo
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = struct $Int (%4 : $Builtin.Int64)
+  %6 = ref_element_addr %2 : $Foo, #Foo.x
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %6 : $*Int
+  store %5 to %7 : $*Int
+  end_access %7 : $*Int
+  // function_ref user(_:)
+  %10 = function_ref @user : $@convention(thin) (@guaranteed Foo) -> Int
+  %11 = apply %10(%2) : $@convention(thin) (@guaranteed Foo) -> Int
+  // strong_release %2 : $Foo
+  return %11 : $Int
+}

--- a/test/SIL/unique-reference-verifier.sil
+++ b/test/SIL/unique-reference-verifier.sil
@@ -1,0 +1,95 @@
+// RUN: %swift %s -emit-sil -module-name run | %FileCheck %s
+
+// The main thing here is to make sure that we can read in an `alloc_ref` with
+// the `[unique]` flag and print it back out without triggering SILVerifier
+// errors.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class MyClass {
+  @_hasStorage @_hasInitialValue var i: Int { get set }
+  deinit
+  init()
+}
+
+// CHECK-LABEL: sil @simple
+// CHECK: alloc_ref [stack] [unique] $MyClass
+// CHECK-LABEL: end sil function 'simple'
+sil @simple : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] [unique] $MyClass
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = ref_element_addr %0 : $MyClass, #MyClass.i
+  %5 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int
+  store %3 to %5 : $*Int
+  end_access %5 : $*Int
+  set_deallocating %0 : $MyClass
+  dealloc_ref %0 : $MyClass
+  dealloc_ref [stack] %0 : $MyClass
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil @store_then_load
+// CHECK: alloc_ref [stack] [unique] $MyClass
+// CHECK-LABEL: end sil function 'store_then_load'
+sil @store_then_load : $@convention(thin) () -> Int {
+bb0:
+  %0 = alloc_ref [unique] [stack] $MyClass
+  debug_value %0 : $MyClass, let, name "self", argno 1
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  %4 = ref_element_addr %0 : $MyClass, #MyClass.i
+  %5 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int
+  store %3 to %5 : $*Int
+  end_access %5 : $*Int
+  debug_value %0 : $MyClass, let, name "x"
+  debug_value %0 : $MyClass, let, name "self", argno 1
+  %10 = begin_access [read] [static] [no_nested_conflict] %4 : $*Int
+  %11 = load %10 : $*Int
+  end_access %10 : $*Int
+  set_deallocating %0 : $MyClass
+  debug_value %0 : $MyClass, let, name "self", argno 1
+  debug_value %0 : $MyClass, let, name "self", argno 1
+  dealloc_ref %0 : $MyClass
+  dealloc_ref [stack] %0 : $MyClass
+  return %11 : $Int
+}
+
+// CHECK-LABEL: sil @multi_block
+// CHECK: alloc_ref [stack] [unique] $MyClass
+// CHECK-LABEL: end sil function 'multi_block'
+sil @multi_block : $@convention(thin) (Bool) -> Int {
+bb0(%0 : $Bool):
+  %2 = alloc_ref [unique] [stack] $MyClass
+  debug_value %2 : $MyClass, let, name "self", argno 1
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = struct $Int (%4 : $Builtin.Int64)
+  %6 = ref_element_addr %2 : $MyClass, #MyClass.i
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %6 : $*Int
+  store %5 to %7 : $*Int
+  end_access %7 : $*Int
+  %10 = struct_extract %0 : $Bool, #Bool._value
+  cond_br %10, bb1, bb2
+
+bb1:
+  %13 = begin_access [read] [static] [no_nested_conflict] %6 : $*Int
+  %14 = load %13 : $*Int
+  end_access %13 : $*Int
+  br bb3(%14 : $Int)
+
+bb2:
+  br bb3(%5 : $Int)
+
+bb3(%20 : $Int):
+  set_deallocating %2 : $MyClass
+  dealloc_ref %2 : $MyClass
+  dealloc_ref [stack] %2 : $MyClass
+  return %20 : $Int
+}
+

--- a/test/SIL/unique-reference-verifier.sil
+++ b/test/SIL/unique-reference-verifier.sil
@@ -1,4 +1,4 @@
-// RUN: %swift %s -emit-sil -module-name run | %FileCheck %s
+// RUN: %swift %s -emit-sil -module-name test | %FileCheck %s
 
 // The main thing here is to make sure that we can read in an `alloc_ref` with
 // the `[unique]` flag and print it back out without triggering SILVerifier
@@ -171,4 +171,39 @@ bb0(%0 : $Bool, %1 : $Bool):
   %11 = apply %10(%2) : $@convention(thin) (@guaranteed Foo) -> Int
   // strong_release %2 : $Foo
   return %11 : $Int
+}
+
+// Foo.deinit
+sil @$s4test3FooCfd : $@convention(method) (@guaranteed Foo) -> @owned Builtin.NativeObject {
+// %0 "self"                                      // users: %2, %1
+bb0(%0 : $Foo):
+  debug_value %0 : $Foo, let, name "self", argno 1 // id: %1
+  %2 = unchecked_ref_cast %0 : $Foo to $Builtin.NativeObject // user: %3
+  return %2 : $Builtin.NativeObject               // id: %3
+} // end sil function '$s4test3FooCfd'
+
+// Foo.__deallocating_deinit
+sil @$s4test3FooCfD : $@convention(method) (@owned Foo) -> () {
+// %0 "self"                                      // users: %3, %2, %1
+bb0(%0 : $Foo):
+  debug_value %0 : $Foo, let, name "self", argno 1 // id: %1
+  debug_value %0 : $Foo, let, name "self", argno 1 // id: %2
+  dealloc_ref %0 : $Foo                           // id: %3
+  %4 = tuple ()                                   // user: %5
+  return %4 : $()                                 // id: %5
+} // end sil function '$s4test3FooCfD'
+
+// CHECK-LABEL: sil @test_strong_release
+// CHECK: alloc_ref [stack] [unique] $MyClass
+// CHECK-LABEL: end sil function 'test_strong_release'
+sil @test_strong_release : $@convention(thin) (Bool, Bool) -> () {
+bb0(%0 : $Bool, %1 : $Bool):
+  %2 = alloc_ref [unique] $Foo
+  strong_release %2 : $Foo
+  %t = tuple ()
+  return %t : $()
+}
+
+sil_vtable Foo {
+  #Foo.deinit!deallocator: @$s4test3FooCfD      // Foo.__deallocating_deinit
 }

--- a/test/SILOptimizer/access_enforcement_opts.sil
+++ b/test/SILOptimizer/access_enforcement_opts.sil
@@ -1737,3 +1737,31 @@ bb0(%0 : ${ var Int64 }):
   end_access %access : $*Int64
   return %val : $Int64
 }
+
+// CHECK-LABEL: sil @promote_unique_class_to_static
+// CHECK: begin_access [modify] [static] [no_nested_conflict]
+// CHECK: begin_access [read] [static] [no_nested_conflict]
+// CHECK-LABEL: end sil function 'promote_unique_class_to_static'
+sil @promote_unique_class_to_static : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 0
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %4 = alloc_ref [stack] [unique] $RefElemClass
+  
+  %8 = ref_element_addr %4 : $RefElemClass, #RefElemClass.y
+  %9 = begin_access [modify] [dynamic] [no_nested_conflict] %8 : $*Int32
+  store %1 to %9 : $*Int32
+  end_access %9 : $*Int32
+  
+  %17 = begin_access [read] [dynamic] [no_nested_conflict] %8 : $*Int32
+  %18 = struct_element_addr %17 : $*Int32, #Int32._value
+  %19 = load %18 : $*Builtin.Int32
+  end_access %17 : $*Int32
+
+  set_deallocating %4 : $RefElemClass
+  dealloc_ref %4 : $RefElemClass
+  dealloc_ref [stack] %4 : $RefElemClass
+  
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
This is a WIP PR to get a benchmark of the performance improvements of access enforcement opts when it promotes uniquely identified storage accesses to statically enforced accesses. 

I'm not sure to what degree `AccessedStorage::isUniquelyIdentified` is used throughout the optimizer. I wouldn't be supprised if this PR doesn't have any meaningful performance gains. I think another pass that just updated accesses of "unique" references might be much more beneficial (performance-wise). We'll see. 

Later, I'll clean up these individual commits and break each one into its own PR. The tests do not currently pass, this PR is just for benchmarking. 

Refs (and based on) #32844. [Related forum post](https://forums.swift.org/t/adding-a-unique-flag-to-alloc-ref/38398).