### PR TITLE
[NO-MERGE] Add access enforcement opts and access marker elimination to addHighLevelModulePipeline.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -506,6 +506,10 @@ static void addHighLevelModulePipeline(SILPassPipelinePlan &P) {
 
   P.addGlobalOpt();
   P.addLetPropertiesOpt();
+
+  P.addAccessEnforcementOpts();
+  P.addAccessEnforcementWMO();
+  P.addAccessMarkerElimination();
 }
 
 static void addSerializePipeline(SILPassPipelinePlan &P) {


### PR DESCRIPTION
I want to see the performance gains of removing access markers in the middle of the pass pipeline. I think this could be the source of the performance improvements in #31423. After the benchmarks run, I'll close this PR.