### PR TITLE
[IRGen] Check if VTable isn't a nullptr.

### DIFF
--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -171,7 +171,7 @@ private:
   friend SILVTableVisitor<Impl>;
   void addMethod(SILDeclRef declRef) {
     // Does this method require a reified runtime vtable entry?
-    if (methodRequiresReifiedVTableEntry(IGM, VTable, declRef)) {
+    if (!VTable || methodRequiresReifiedVTableEntry(IGM, VTable, declRef)) {
       asImpl().addReifiedVTableEntry(declRef);
     }
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1440,7 +1440,7 @@ namespace {
     }
 
     void addMethod(SILDeclRef fn) {
-      if (methodRequiresReifiedVTableEntry(IGM, VTable, fn)) {
+      if (!VTable || methodRequiresReifiedVTableEntry(IGM, VTable, fn)) {
         VTableEntries.push_back(fn);
       } else if (getType()->getEffectiveAccess() >= AccessLevel::Public) {
         // Emit a stub method descriptor and lookup function for nonoverridden


### PR DESCRIPTION
Fixes a ubsan error on the lldb bots

runtime error: member call on null pointer of type 'swift::SILVTable'
undefined-behavior lib/IRGen/GenMeta.cpp:5107:24

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
