### PR TITLE
[NFC] Refactor DerivedConformances code to reduce diagnostics code duplication

### DIFF
--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -343,28 +343,10 @@ void DerivedConformance::tryDiagnoseFailedComparableDerivation(
     DeclContext *DC, NominalTypeDecl *nominal) {
   auto &ctx = DC->getASTContext();
   auto *comparableProto = ctx.getProtocol(KnownProtocolKind::Comparable);
-  if (!isa<EnumDecl>(nominal)) {
-    auto contextDecl = DC->getAsDecl();
-    ctx.Diags.diagnose(
-        contextDecl->getLoc(), diag::automatic_protocol_synthesis_unsupported,
-        comparableProto->getName().str(), isa<StructDecl>(contextDecl));
-  }
+  diagnoseAnyNonConformingMemberTypes(DC, nominal, comparableProto);
+  diagnoseIfSynthesisUnsupportedForDecl(nominal, comparableProto);
 
-  if (auto *enumDecl = dyn_cast<EnumDecl>(nominal)) {
-    auto nonconformingAssociatedTypes =
-        DerivedConformance::associatedValuesNotConformingToProtocol(
-            DC, enumDecl, comparableProto);
-    for (auto *typeToDiagnose : nonconformingAssociatedTypes) {
-      SourceLoc reprLoc;
-      if (auto *repr = typeToDiagnose->getTypeRepr())
-        reprLoc = repr->getStartLoc();
-      ctx.Diags.diagnose(
-          reprLoc, diag::missing_member_type_conformance_prevents_synthesis, 0,
-          typeToDiagnose->getInterfaceType(),
-          comparableProto->getDeclaredType(),
-          nominal->getDeclaredInterfaceType());
-    }
-
+  if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
     if (enumDecl->hasRawType() && !enumDecl->getRawType()->is<ErrorType>()) {
       auto rawType = enumDecl->getRawType();
       auto rawTypeLoc = enumDecl->getInherited()[0].getSourceRange().Start;

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -50,6 +50,14 @@ public:
   /// Get the declared type of the protocol that this is conformance is for.
   Type getProtocolType() const;
 
+  /// Returns the VarDecl of each stored property in the given struct whose type
+  /// does not conform to a protocol.
+  /// \p theStruct The struct whose stored properties should be checked.
+  /// \p protocol The protocol being requested.
+  /// \return The VarDecl of each stored property whose type does not conform.
+  static SmallVector<VarDecl *, 3> storedPropertiesNotConformingToProtocol(
+      DeclContext *DC, StructDecl *theStruct, ProtocolDecl *protocol);
+
   /// True if the type can implicitly derive a conformance for the given
   /// protocol.
   ///
@@ -79,6 +87,30 @@ public:
   static void tryDiagnoseFailedDerivation(DeclContext *DC,
                                           NominalTypeDecl *nominal,
                                           ProtocolDecl *protocol);
+
+  /// Diagnose any members which do not conform to the protocol for which
+  /// we were trying to synthesize the conformance to.
+  ///
+  /// \param nominal The nominal type for which we would like to diagnose
+  /// derivation failures
+  ///
+  /// \param protocol The protocol with requirements we would like to diagnose
+  /// derivation failures for
+  static void diagnoseAnyNonConformingMemberTypes(DeclContext *DC,
+                                                  NominalTypeDecl *nominal,
+                                                  ProtocolDecl *protocol);
+
+  /// Diagnose the declaration for which we were trying to synthesize
+  /// the conformance for, if the synthesis is not supported for that
+  /// declaration.
+  ///
+  /// \param nominal The nominal type for which we would like to diagnose
+  /// derivation failures
+  ///
+  /// \param protocol The protocol with requirements we would like to diagnose
+  /// derivation failures for
+  static void diagnoseIfSynthesisUnsupportedForDecl(NominalTypeDecl *nominal,
+                                                    ProtocolDecl *protocol);
 
   /// Determine the derivable requirement that would satisfy the given
   /// requirement, if there is one.


### PR DESCRIPTION
This is a follow-up to #32797.

There was some code duplication for emitting new diagnostic notes for `Comparable` synthesis failures, so I have pulled the common code out for diagnosing derived conformance failures into separate functions which can be reused to emit the diagnostics.

1. `diagnoseAnyNonConformingMemberTypes` diagnoses any members of the conforming type that does not conform to the protocol we were trying to synthesise the conformance to. For example, `Comparable` synthesis requires the members of the conforming type to also be `Comparable` and using this method we can diagnose any members which does not conform to `Comparable`.

2. `diagnoseIfSynthesisUnsupportedForDecl` diagnoses the conforming type if we do not support derived conformances for that type. For example, `Equatable` synthesis is not supported for classes and using this method we can diagnose a given class type.

3. `storedPropertiesNotConformingToProtocol` returns any stored properties of a struct which do not conform to a given protocol. For example, `diagnoseNonConformingMemberTypes` uses this method to find the struct members which do not conform to the type for which we're trying to synthesise the conformance to. It is also used in `canDeriveConformance` to figure out if we can synthesise `Equatable` or `Hashable` for a struct.