### PR TITLE
[ownership] Update LowerAggregateInstrs for Ownership

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -725,6 +725,27 @@ public:
     return lowering.emitLoad(*this, Loc, LV, Qualifier);
   }
 
+  /// Convenience function for calling emitLoad on the type lowering for
+  /// non-address values.
+  SILValue emitLoweredLoadValueOperation(
+      SILLocation Loc, SILValue LV, LoadOwnershipQualifier Qualifier,
+      Lowering::TypeLowering::TypeExpansionKind ExpansionKind) {
+    assert(isLoadableOrOpaque(LV->getType()));
+    const auto &lowering = getTypeLowering(LV->getType());
+    return lowering.emitLoweredLoad(*this, Loc, LV, Qualifier, ExpansionKind);
+  }
+
+  /// Convenience function for calling emitLoweredStore on the type lowering for
+  /// non-address values.
+  void emitLoweredStoreValueOperation(
+      SILLocation Loc, SILValue Value, SILValue Addr,
+      StoreOwnershipQualifier Qual,
+      Lowering::TypeLowering::TypeExpansionKind ExpansionKind) {
+    assert(isLoadableOrOpaque(Value->getType()));
+    const auto &lowering = getTypeLowering(Value->getType());
+    lowering.emitLoweredStore(*this, Loc, Value, Addr, Qual, ExpansionKind);
+  }
+
   LoadBorrowInst *createLoadBorrow(SILLocation Loc, SILValue LV) {
     assert(isLoadableOrOpaque(LV->getType()) &&
            !LV->getType().isTrivial(getFunction()));
@@ -2186,6 +2207,16 @@ public:
     return lowering.emitCopyValue(*this, Loc, v);
   }
 
+  /// Convenience function for calling emitCopy on the type lowering
+  /// for the non-address value.
+  SILValue emitLoweredCopyValueOperation(
+      SILLocation Loc, SILValue v,
+      Lowering::TypeLowering::TypeExpansionKind expansionKind) {
+    assert(!v->getType().isAddress());
+    auto &lowering = getTypeLowering(v->getType());
+    return lowering.emitLoweredCopyValue(*this, Loc, v, expansionKind);
+  }
+
   /// Convenience function for calling TypeLowering.emitDestroy on the type
   /// lowering for the non-address value.
   void emitDestroyValueOperation(SILLocation Loc, SILValue v) {
@@ -2194,6 +2225,18 @@ public:
       return;
     auto &lowering = getTypeLowering(v->getType());
     lowering.emitDestroyValue(*this, Loc, v);
+  }
+
+  /// Convenience function for calling TypeLowering.emitDestroy on the type
+  /// lowering for the non-address value.
+  void emitLoweredDestroyValueOperation(
+      SILLocation Loc, SILValue v,
+      Lowering::TypeLowering::TypeExpansionKind expansionKind) {
+    assert(!v->getType().isAddress());
+    if (F->hasOwnership() && v.getOwnershipKind() == ValueOwnershipKind::None)
+      return;
+    auto &lowering = getTypeLowering(v->getType());
+    lowering.emitLoweredDestroyValue(*this, Loc, v, expansionKind);
   }
 
   /// Convenience function for destroying objects and addresses.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -390,6 +390,28 @@ public:
                             ///> types.
   };
 
+  /// Emit a load from \p addr given the LoadOwnershipQualifier \p qual.
+  ///
+  /// This abstracts over the differences in between trivial and non-trivial
+  /// types and lets one specify an expansion kind that gets passed to any
+  /// copy_value that we create.
+  virtual SILValue emitLoweredLoad(
+      SILBuilder &B, SILLocation loc, SILValue addr,
+      LoadOwnershipQualifier qual,
+      Lowering::TypeLowering::TypeExpansionKind expansionKind) const = 0;
+
+  /// Emit a store of \p value into \p addr given the StoreOwnershipQualifier
+  /// qual.
+  ///
+  /// This abstracts over the differences in between trivial and non-trivial
+  /// types and allows for one to specify an expansion kind that is passed to
+  /// any destroy operations we create if we are asked to assign in non-ossa
+  /// code.
+  virtual void emitLoweredStore(
+      SILBuilder &B, SILLocation loc, SILValue value, SILValue addr,
+      StoreOwnershipQualifier qual,
+      Lowering::TypeLowering::TypeExpansionKind expansionKind) const = 0;
+
   //===--------------------------------------------------------------------===//
   // DestroyValue
   //===--------------------------------------------------------------------===//

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SIL/SILInstruction.h"
 #define DEBUG_TYPE "libsil"
 #include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/ASTContext.h"
@@ -668,6 +669,26 @@ namespace {
       return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
     }
 
+    SILValue emitLoweredLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                             LoadOwnershipQualifier qual,
+                             TypeExpansionKind) const override {
+      if (B.getFunction().hasOwnership())
+        return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
+      return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+    }
+
+    void emitLoweredStore(SILBuilder &B, SILLocation loc, SILValue value,
+                          SILValue addr, StoreOwnershipQualifier qual,
+                          Lowering::TypeLowering::TypeExpansionKind
+                              expansionKind) const override {
+      auto storeQual = [&]() -> StoreOwnershipQualifier {
+        if (B.getFunction().hasOwnership())
+          return StoreOwnershipQualifier::Trivial;
+        return StoreOwnershipQualifier::Unqualified;
+      }();
+      B.createStore(loc, value, addr, storeQual);
+    }
+
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
                             SILValue addr) const override {
       // Trivial
@@ -762,6 +783,40 @@ namespace {
       // Otherwise, emit the copy value operation.
       return B.emitCopyValueOperation(loc, loadValue);
     }
+
+    SILValue emitLoweredLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                             LoadOwnershipQualifier qual,
+                             TypeExpansionKind expansionKind) const override {
+      if (B.getFunction().hasOwnership())
+        return B.createLoad(loc, addr, qual);
+
+      SILValue loadValue =
+          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+
+      // If we do not have a copy, just return the value...
+      if (qual != LoadOwnershipQualifier::Copy)
+        return loadValue;
+
+      // Otherwise, emit the copy value operation.
+      return B.emitLoweredCopyValueOperation(loc, loadValue, expansionKind);
+    }
+
+    void emitLoweredStore(SILBuilder &B, SILLocation loc, SILValue value,
+                          SILValue addr, StoreOwnershipQualifier qual,
+                          Lowering::TypeLowering::TypeExpansionKind
+                              expansionKind) const override {
+      if (B.getFunction().hasOwnership()) {
+        B.createStore(loc, value, addr, qual);
+        return;
+      }
+
+      if (qual == StoreOwnershipQualifier::Assign) {
+        SILValue oldValue = B.emitLoadValueOperation(
+            loc, addr, LoadOwnershipQualifier::Unqualified);
+        B.emitLoweredDestroyValueOperation(loc, oldValue, expansionKind);
+      }
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
+    }
   };
 
   /// A CRTP helper class for loadable but non-trivial aggregate types.
@@ -802,6 +857,32 @@ namespace {
                                        forExpansion) {
     }
 
+    /// CRTP Default implementation of destructuring an aggregate value.
+    ///
+    /// Uses getChildren() and emitRValueProject() to create projections for
+    /// each child. Subclasses should override this to customize on how
+    /// destructuring is done.
+    ///
+    /// NOTE: Due to the CRTP, this must always be called as
+    /// asImpl().destructureAggregate() to ensure that one gets the proper
+    /// implementation!
+    void destructureAggregate(
+        SILBuilder &B, SILLocation loc, SILValue aggValue, bool skipTrivial,
+        function_ref<void(unsigned, SILValue, const TypeLowering &)> visitor)
+        const {
+      for (auto pair : llvm::enumerate(getChildren(B.getModule().Types))) {
+        auto &child = pair.value();
+        auto &childLowering = child.getLowering();
+        // Skip trivial children.
+        if (skipTrivial && childLowering.isTrivial())
+          continue;
+        auto childIndex = child.getIndex();
+        auto childValue = asImpl().emitRValueProject(B, loc, aggValue,
+                                                     childIndex, childLowering);
+        visitor(pair.index(), childValue, childLowering);
+      }
+    }
+
     virtual SILValue rebuildAggregate(SILBuilder &B, SILLocation loc,
                                       ArrayRef<SILValue> values) const = 0;
 
@@ -820,16 +901,12 @@ namespace {
     void forEachNonTrivialChild(SILBuilder &B, SILLocation loc,
                                 SILValue aggValue,
                                 const T &operation) const {
-      for (auto &child : getChildren(B.getModule().Types)) {
-        auto &childLowering = child.getLowering();
-        // Skip trivial children.
-        if (childLowering.isTrivial())
-          continue;
-        auto childIndex = child.getIndex();
-        auto childValue = asImpl().emitRValueProject(B, loc, aggValue,
-                                                   childIndex, childLowering);
-        operation(B, loc, childIndex, childValue, childLowering);
-      }
+      asImpl().destructureAggregate(B, loc, aggValue, true /*skipTrivial*/,
+                                    [&](unsigned, SILValue childValue,
+                                        const TypeLowering &childLowering) {
+                                      operation(B, loc, childValue,
+                                                childLowering);
+                                    });
     }
 
     using SimpleOperationTy = void (TypeLowering::*)(SILBuilder &B,
@@ -839,10 +916,11 @@ namespace {
                                 SILValue aggValue,
                                 SimpleOperationTy operation) const {
       forEachNonTrivialChild(B, loc, aggValue,
-        [operation](SILBuilder &B, SILLocation loc, IndexType index,
-                     SILValue childValue, const TypeLowering &childLowering) {
-          (childLowering.*operation)(B, loc, childValue);
-        });
+                             [operation](SILBuilder &B, SILLocation loc,
+                                         SILValue childValue,
+                                         const TypeLowering &childLowering) {
+                               (childLowering.*operation)(B, loc, childValue);
+                             });
     }
 
     SILValue emitCopyValue(SILBuilder &B, SILLocation loc,
@@ -860,20 +938,16 @@ namespace {
         return emitCopyValue(B, loc, aggValue);
       }
 
-      llvm::SmallVector<SILValue, 8> loweredChildValues;
-      for (auto &child : getChildren(B.getModule().Types)) {
-        auto &childLowering = child.getLowering();
-        SILValue childValue = asImpl().emitRValueProject(B, loc, aggValue,
-                                                         child.getIndex(),
-                                                         childLowering);
-        if (!childLowering.isTrivial()) {
-          SILValue loweredChildValue = childLowering.emitLoweredCopyChildValue(
-              B, loc, childValue, style);
-          loweredChildValues.push_back(loweredChildValue);
-        } else {
-          loweredChildValues.push_back(childValue);
-        }
-      }
+      SmallVector<SILValue, 8> loweredChildValues;
+      asImpl().destructureAggregate(
+          B, loc, aggValue, false /*skipTrivial*/,
+          [&](unsigned childIndex, SILValue childValue,
+              const TypeLowering &childLowering) {
+            if (!childLowering.isTrivial())
+              childValue = childLowering.emitLoweredCopyChildValue(
+                  B, loc, childValue, style);
+            loweredChildValues.push_back(childValue);
+          });
 
       return rebuildAggregate(B, loc, loweredChildValues);
     }
@@ -911,6 +985,8 @@ namespace {
   /// A lowering for loadable but non-trivial tuple types.
   class LoadableTupleTypeLowering final
       : public LoadableAggTypeLowering<LoadableTupleTypeLowering, unsigned> {
+    using Super = LoadableAggTypeLowering<LoadableTupleTypeLowering, unsigned>;
+
   public:
     LoadableTupleTypeLowering(CanType type, RecursiveProperties properties,
                               TypeExpansionContext forExpansion)
@@ -919,8 +995,33 @@ namespace {
     SILValue emitRValueProject(SILBuilder &B, SILLocation loc,
                                SILValue tupleValue, unsigned index,
                                const TypeLowering &eltLowering) const {
+      assert(!B.hasOwnership() &&
+             "Shouldn't call this when ownership is enabled?! Destructure "
+             "non-trivial tuples instead");
       return B.createTupleExtract(loc, tupleValue, index,
                                   eltLowering.getLoweredType());
+    }
+
+    void destructureAggregate(
+        SILBuilder &B, SILLocation loc, SILValue aggValue, bool skipTrivial,
+        function_ref<void(unsigned childIndex, SILValue childValue,
+                          const TypeLowering &childLowering)>
+            visitor) const {
+      // Without ownership, use our parent.
+      if (!B.hasOwnership())
+        return Super::destructureAggregate(B, loc, aggValue, skipTrivial,
+                                           visitor);
+
+      // Otherwise, emit a destructure tuple and do the loop.
+      auto *dti = B.createDestructureTuple(loc, aggValue);
+      for (auto pair : llvm::enumerate(dti->getResults())) {
+        SILValue childValue = pair.value();
+        auto &childLowering =
+            B.getFunction().getTypeLowering(childValue->getType());
+        if (skipTrivial && childLowering.isTrivial())
+          continue;
+        visitor(pair.index(), childValue, childLowering);
+      }
     }
 
     SILValue rebuildAggregate(SILBuilder &B, SILLocation loc,
@@ -947,7 +1048,10 @@ namespace {
 
   /// A lowering for loadable but non-trivial struct types.
   class LoadableStructTypeLowering final
-      : public LoadableAggTypeLowering<LoadableStructTypeLowering, VarDecl*> {
+      : public LoadableAggTypeLowering<LoadableStructTypeLowering, VarDecl *> {
+    using Super =
+        LoadableAggTypeLowering<LoadableStructTypeLowering, VarDecl *>;
+
   public:
     LoadableStructTypeLowering(CanType type, RecursiveProperties properties,
                                TypeExpansionContext forExpansion)
@@ -958,6 +1062,26 @@ namespace {
                                const TypeLowering &fieldLowering) const {
       return B.createStructExtract(loc, structValue, field,
                                    fieldLowering.getLoweredType());
+    }
+
+    void destructureAggregate(
+        SILBuilder &B, SILLocation loc, SILValue aggValue, bool skipTrivial,
+        function_ref<void(unsigned childIndex, SILValue childValue,
+                          const TypeLowering &childLowering)>
+            visitor) const {
+      if (!B.hasOwnership())
+        return Super::destructureAggregate(B, loc, aggValue, skipTrivial,
+                                           visitor);
+
+      auto *dsi = B.createDestructureStruct(loc, aggValue);
+      for (auto pair : llvm::enumerate(dsi->getResults())) {
+        SILValue childValue = pair.value();
+        auto &childLowering =
+            B.getFunction().getTypeLowering(childValue->getType());
+        if (skipTrivial && childLowering.isTrivial())
+          continue;
+        visitor(pair.index(), childValue, childLowering);
+      }
     }
 
     SILValue rebuildAggregate(SILBuilder &B, SILLocation loc,
@@ -979,7 +1103,7 @@ namespace {
       }
     }
   };
-  
+
   /// A lowering for loadable but non-trivial enum types.
   class LoadableEnumTypeLowering final : public NonTrivialLoadableTypeLowering {
   public:
@@ -1239,6 +1363,20 @@ namespace {
     SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
                       LoadOwnershipQualifier qual) const override {
       llvm_unreachable("calling emitLoad on non-loadable type");
+    }
+
+    SILValue emitLoweredLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                             LoadOwnershipQualifier qual,
+                             Lowering::TypeLowering::TypeExpansionKind
+                                 expansionKind) const override {
+      llvm_unreachable("calling emitLoweredLoad on non-loadable type?!");
+    }
+
+    void emitLoweredStore(SILBuilder &B, SILLocation loc, SILValue value,
+                          SILValue addr, StoreOwnershipQualifier qual,
+                          Lowering::TypeLowering::TypeExpansionKind
+                              expansionKind) const override {
+      llvm_unreachable("calling emitLoweredStore on non-loadable type?!");
     }
 
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,

--- a/test/SILOptimizer/loweraggregateinstrs.sil
+++ b/test/SILOptimizer/loweraggregateinstrs.sil
@@ -64,8 +64,8 @@ struct LargeStruct {
 // CHECK:   release_value [[ARG0]]
 // CHECK:   [[ALLOC_STACK:%.*]] = alloc_stack $LargeStruct
 // CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
-// CHECK:   [[LOADED_OLD_VAL:%.*]] = load [[ALLOC_STACK]]
 // CHECK:   retain_value [[LOADED_ARG1]]
+// CHECK:   [[LOADED_OLD_VAL:%.*]] = load [[ALLOC_STACK]]
 // CHECK:   release_value [[LOADED_OLD_VAL]]
 // CHECK:   store [[LOADED_ARG1]] to [[ALLOC_STACK]]
 // CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
@@ -97,11 +97,12 @@ bb0(%0 : $LargeStruct, %1 : $*LargeStruct):
 //
 // CHECK:   [[ALLOC_STACK:%.*]] = alloc_stack $S2
 // CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
-// CHECK:   [[LOADED_OLDVALUE:%.*]] = load [[ALLOC_STACK]]
 // CHECK:   [[LOADED_ARG1cls1:%.*]] = struct_extract [[LOADED_ARG1]] : $S2, #S2.cls1
 // CHECK:   strong_retain [[LOADED_ARG1cls1]] : $C1
 // CHECK:   [[LOADED_ARG1cls2:%.*]] = struct_extract [[LOADED_ARG1]] : $S2, #S2.cls2
 // CHECK:   strong_retain [[LOADED_ARG1cls2]] : $C2
+
+// CHECK:   [[LOADED_OLDVALUE:%.*]] = load [[ALLOC_STACK]]
 // CHECK:   [[LOADED_OLDVALUEcls1:%.*]] = struct_extract [[LOADED_OLDVALUE]] : $S2, #S2.cls1
 // CHECK:   strong_release [[LOADED_OLDVALUEcls1]] : $C1
 // CHECK:   [[LOADED_OLDVALUEcls2:%.*]] = struct_extract [[LOADED_OLDVALUE]] : $S2, #S2.cls2

--- a/test/SILOptimizer/loweraggregateinstrs_expandall.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_expandall.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-expand-all %s -lower-aggregate-instrs | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-expand-all -sil-lower-agg-instrs-expand-all -lower-aggregate-instrs %s | %FileCheck %s
 
 // This file makes sure that the mechanics of expanding aggregate instructions
 // work. With that in mind, we expand all structs here ignoring code-size
@@ -115,14 +115,16 @@ bb0(%0 : $*(S, S2, C1)):
 }
 
 // Do not do anything.
-/*
+//
+// CHECK-LABEL: sil @expand_destroy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
+// CHECK: destroy_addr
+// CHECK: } // end sil function 'expand_destroy_addr_addressonly'
 sil @expand_destroy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
 bb0(%0 : $*T):
   destroy_addr %0 : $*T
   %1 = tuple()
   return %1 : $()
 }
-*/
 
 // CHECK-LABEL: sil @expand_destroy_addr_reference
 // CHECK: bb0
@@ -180,8 +182,7 @@ bb0(%0 : $*S, %1 : $*S):
 // CHECK: strong_retain [[innerstructIN12]] : $C2
 // CHECK: [[innerstructtrivial:%[0-9]+]] = struct_extract [[innerstruct]] : $S2, #S2.trivial
 // CHECK: store [[IN1]] to [[IN2PTR]]
-// CHECK: tuple
-// CHECK: return
+// CHECK: } // end sil function 'expand_copy_addr_init'
 sil @expand_copy_addr_init : $@convention(thin) (@inout S, @inout S) -> () {
 bb0(%0 : $*S, %1 : $*S):
   copy_addr %0 to [initialization] %1 : $*S
@@ -226,19 +227,21 @@ bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
   return %2 : $()
 }
 
-// CHECK-LABEL: sil @expand_copy_addr_aggstructnontrivial
+// CHECK-LABEL: sil @expand_copy_addr_aggstructnontrivial :
 // CHECK: bb0([[IN1PTR:%[0-9]+]] : $*S, [[IN2PTR:%[0-9]+]] : $*S):
 // CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*S
-// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*S
 // CHECK: [[IN1trivial:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.trivial
 // CHECK: [[IN1cls:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.cls
 // CHECK: strong_retain [[IN1cls]] : $C3
+//
 // CHECK: [[IN1innerstruct:%[0-9]+]] = struct_extract [[IN1]] : $S, #S.inner_struct
 // CHECK: [[IN1innerstructcls1:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.cls1
 // CHECK: strong_retain [[IN1innerstructcls1]] : $C1
 // CHECK: [[IN1innerstructcls2:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.cls2
 // CHECK: strong_retain [[IN1innerstructcls2]] : $C2
+//
 // CHECK: [[IN1innerstructtrivial:%[0-9]+]] = struct_extract [[IN1innerstruct]] : $S2, #S2.trivial
+// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*S
 // CHECK: [[IN2cls:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.cls
 // CHECK: strong_release [[IN2cls]] : $C3
 // CHECK: [[IN2innerstruct:%[0-9]+]] = struct_extract [[IN2]] : $S, #S.inner_struct
@@ -247,8 +250,7 @@ bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
 // CHECK: [[IN2innerstructcls2:%[0-9]+]] = struct_extract [[IN2innerstruct]] : $S2, #S2.cls2
 // CHECK: strong_release [[IN2innerstructcls2]]
 // CHECK: store [[IN1]] to [[IN2PTR]]
-// CHECK: tuple
-// CHECK: return
+// CHECK: } // end sil function 'expand_copy_addr_aggstructnontrivial'
 sil @expand_copy_addr_aggstructnontrivial : $@convention(thin) (@inout S, @inout S) -> () {
 bb0(%0 : $*S, %1 : $*S):
   copy_addr %0 to %1 : $*S
@@ -256,10 +258,13 @@ bb0(%0 : $*S, %1 : $*S):
   return %2 : $()
 }
 
-// CHECK-LABEL: sil @expand_copy_addr_aggtuplenontrivial
+// CHECK-LABEL: sil @expand_copy_addr_aggtuplenontrivial :
 // CHECK: bb0([[IN1PTR:%[0-9]+]] : $*(S, S2, C1, E), [[IN2PTR:%[0-9]+]] : $*(S, S2, C1, E)):
+//
+// -- Begin IN1ELT
 // CHECK: [[IN1:%[0-9]+]] = load [[IN1PTR]] : $*(S, S2, C1, E)
-// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*(S, S2, C1, E)
+//
+// -- IN1ELT0
 // CHECK: [[IN1ELT0:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 0
 // CHECK: [[IN1ELT0trivial:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.trivial
 // CHECK: [[IN1ELT0cls:%[0-9]+]] = struct_extract [[IN1ELT0]] : $S, #S.cls
@@ -270,16 +275,27 @@ bb0(%0 : $*S, %1 : $*S):
 // CHECK: [[IN1ELT0innerstructcls2:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.cls2
 // CHECK: strong_retain [[IN1ELT0innerstructcls2]]
 // CHECK: [[IN1ELT0innerstructtrivial:%[0-9]+]] = struct_extract [[IN1ELT0innerstruct]] : $S2, #S2.trivial
+//
+// -- IN1ELT1
 // CHECK: [[IN1ELT1:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 1
 // CHECK: [[IN1ELT1cls1:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.cls1
 // CHECK: strong_retain [[IN1ELT1cls1]] : $C1
 // CHECK: [[IN1ELT1cls2:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.cls2
 // CHECK: strong_retain [[IN1ELT1cls2]] : $C2
 // CHECK: [[IN1ELT1trivial:%[0-9]+]] = struct_extract [[IN1ELT1]] : $S2, #S2.trivial
+//
+// -- IN1ELT2
 // CHECK: [[IN1ELT2:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 2
 // CHECK: strong_retain [[IN1ELT2]]
+//
+// -- IN1ELT3
 // CHECK: [[IN1ELT3:%[0-9]+]] = tuple_extract [[IN1]] : $(S, S2, C1, E), 3
 // CHECK: retain_value [[IN1ELT3]] : $E
+//
+// -- Finish IN1ELT
+//
+// -- IN2
+// CHECK: [[IN2:%[0-9]+]] = load [[IN2PTR]] : $*(S, S2, C1, E)
 // CHECK: [[IN2ELT0:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 0
 // CHECK: [[IN2ELT0cls:%[0-9]+]] = struct_extract [[IN2ELT0]] : $S, #S.cls
 // CHECK: strong_release [[IN2ELT0cls]] : $C3
@@ -297,11 +313,9 @@ bb0(%0 : $*S, %1 : $*S):
 // CHECK: strong_release [[IN2ELT2]]
 // CHECK: [[IN2ELT3:%[0-9]+]] = tuple_extract [[IN2]] : $(S, S2, C1, E), 3
 // CHECK: release_value [[IN2ELT3]] : $E
+//
 // CHECK: store [[IN1]] to [[IN2PTR]] : $*(S, S2, C1, E)
-// CHECK: tuple ()
-// CHECK: return
-
-
+// CHECK: } // end sil function 'expand_copy_addr_aggtuplenontrivial'
 sil @expand_copy_addr_aggtuplenontrivial : $@convention(thin) (@inout (S, S2, C1, E), @inout (S, S2, C1, E)) -> () {
 bb0(%0 : $*(S, S2, C1, E), %1 : $*(S, S2, C1, E)):
   copy_addr %0 to %1 : $*(S, S2, C1, E)
@@ -310,25 +324,27 @@ bb0(%0 : $*(S, S2, C1, E), %1 : $*(S, S2, C1, E)):
 }
 
 // Do not do anything.
-/*
+//
+// CHECK-LABEL: sil @expand_copy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
+// CHECK: copy_addr
+// CHECK: } // end sil function 'expand_copy_addr_addressonly'
 sil @expand_copy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
 bb0(%0 : $*T):
-  copy_addr %0 : $*T
+  copy_addr [take] %0 to [initialization] %0 : $*T
   %1 = tuple()
   return %1 : $()
 }
-*/
 
 // Just turn into a load + strong_release.
-// CHECK-LABEL: sil @expand_copy_addr_reference
+//
+// CHECK-LABEL: sil @expand_copy_addr_reference :
 // CHECK: bb0([[IN1:%[0-9]+]] : $*C1, [[IN2:%[0-9]+]] : $*C1):
 // CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*C1
-// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*C1
 // CHECK: strong_retain [[LOAD1]]
+// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*C1
 // CHECK: strong_release [[LOAD2]]
 // CHECK: store [[LOAD1]] to [[IN2]]
-// CHECK: tuple
-// CHECK: return
+// CHECK: } // end sil function 'expand_copy_addr_reference'
 sil @expand_copy_addr_reference : $@convention(thin) (@inout C1, @inout C1) -> () {
 bb0(%0 : $*C1, %1 : $*C1):
   copy_addr %0 to %1 : $*C1
@@ -336,15 +352,14 @@ bb0(%0 : $*C1, %1 : $*C1):
   return %2 : $()
 }
 
-// CHECK-LABEL: sil @expand_copy_addr_enum
+// CHECK-LABEL: sil @expand_copy_addr_enum :
 // CHECK: bb0([[IN1:%[0-9]+]] : $*E, [[IN2:%[0-9]+]] : $*E):
 // CHECK: [[LOAD1:%[0-9]+]] = load [[IN1]] : $*E
-// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*E
 // CHECK: retain_value [[LOAD1]]
+// CHECK: [[LOAD2:%[0-9]+]] = load [[IN2]] : $*E
 // CHECK: release_value [[LOAD2]]
 // CHECK: store [[LOAD1]] to [[IN2]]
-// CHECK: tuple
-// CHECK: return
+// CHECK: } // end sil function 'expand_copy_addr_enum'
 sil @expand_copy_addr_enum : $@convention(thin) (@inout E, @inout E) -> () {
 bb0(%0 : $*E, %1 : $*E):
   copy_addr %0 to %1 : $*E

--- a/test/SILOptimizer/loweraggregateinstrs_expandall_ossa.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_expandall_ossa.sil
@@ -1,0 +1,357 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-expand-all -sil-lower-agg-instrs-expand-all -lower-aggregate-instrs %s | %FileCheck %s
+
+// This file makes sure that the mechanics of expanding aggregate instructions
+// work. With that in mind, we expand all structs here ignoring code-size
+// trade-offs.
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+class C1 {
+  var data : Builtin.Int64
+  init()
+}
+
+class C2 {
+  var data : Builtin.FPIEEE32
+  init()
+}
+
+class C3 {
+  var data : Builtin.FPIEEE64
+  init()
+}
+
+struct S2 {
+  var cls1 : C1
+  var cls2 : C2
+  var trivial : Builtin.FPIEEE32
+}
+
+struct S {
+  var trivial : Builtin.Int64
+  var cls : C3
+  var inner_struct : S2
+}
+
+enum E {
+  case NoElement(Void)
+  case TrivialElement(Builtin.Int64)
+  case ReferenceElement(C1)
+  case StructNonTrivialElt(S)
+  case TupleNonTrivialElt((Builtin.Int64, S, C3))
+}
+
+// A struct for testing that aggregate rebuilding works.
+struct S3 {
+  var trivial1 : Builtin.Int64
+  var cls : S
+  var trivial2 : Builtin.Int64
+  var e : E
+  var trivial3 : Builtin.Int64
+}
+
+//////////////////
+// Destroy Addr //
+//////////////////
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_addr_trivial
+// CHECK: bb0
+// CHECK: tuple ()
+// CHECK: return
+sil [ossa] @expand_destroy_addr_trivial : $@convention(thin) (@in Builtin.Int64) -> () {
+bb0(%0 : $*Builtin.Int64):
+  destroy_addr %0 : $*Builtin.Int64
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_addr_aggstructnontrivial :
+// CHECK: bb0([[INPTR:%[0-9]+]] : $*S):
+// CHECK: [[IN:%[0-9]+]] = load [take] [[INPTR]] : $*S
+// CHECK: ({{%.*}}, [[cls:%.*]], [[innerstruct:%.*]]) = destructure_struct [[IN]]
+// CHECK: destroy_value [[cls]] : $C3
+// CHECK: ([[innerstruct_cls1:%.*]], [[innerstruct_cls2:%.*]], {{%.*}}) = destructure_struct [[innerstruct]]
+// CHECK: destroy_value [[innerstruct_cls1]] : $C1
+// CHECK: destroy_value [[innerstruct_cls2]] : $C2
+// CHECK: } // end sil function 'expand_destroy_addr_aggstructnontrivial'
+sil [ossa] @expand_destroy_addr_aggstructnontrivial : $@convention(thin) (@in S) -> () {
+bb0(%0 : $*S):
+  destroy_addr %0 : $*S
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_addr_aggtuplenontrivial :
+// CHECK: bb0([[INPTR:%[0-9]+]] : $*(S, S2, C1)):
+// CHECK: [[IN:%[0-9]+]] = load [take] [[INPTR]] : $*(S, S2, C1)
+// CHECK: ([[ELT0:%.*]], [[ELT1:%.*]], [[ELT2:%.*]]) = destructure_tuple [[IN]]
+// CHECK: ({{%[0-9]+}}, [[ELT0cls:%[0-9]+]], [[ELT0innerstruct:%[0-9]+]]) = destructure_struct [[ELT0]]
+// CHECK: destroy_value [[ELT0cls]]
+// CHECK: ([[ELT0innerstructcls1:%[0-9]+]], [[ELT0innerstructcls2:%[0-9]+]], {{%[0-9]+}}) = destructure_struct [[ELT0innerstruct]]
+// CHECK: destroy_value [[ELT0innerstructcls1]]
+// CHECK: destroy_value [[ELT0innerstructcls2]]
+// CHECK: ([[ELT1cls1:%[0-9]+]], [[ELT1cls2:%[0-9]+]], {{%.*}}) = destructure_struct [[ELT1]]
+// CHECK: destroy_value [[ELT1cls1]] : $C1
+// CHECK: destroy_value [[ELT1cls2]] : $C2
+// CHECK: destroy_value [[ELT2]]
+// CHECK: } // end sil function 'expand_destroy_addr_aggtuplenontrivial'
+sil [ossa] @expand_destroy_addr_aggtuplenontrivial : $@convention(thin) (@in (S, S2, C1)) -> () {
+bb0(%0 : $*(S, S2, C1)):
+  destroy_addr %0 : $*(S, S2, C1)
+  %1 = tuple()
+  return %1 : $()
+}
+
+// Do not do anything.
+sil [ossa] @expand_destroy_addr_addressonly : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $*T):
+  destroy_addr %0 : $*T
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_addr_reference :
+// CHECK: bb0
+// CHECK: load
+// CHECK: destroy_value
+// CHECK: tuple
+// CHECK: } // end sil function 'expand_destroy_addr_reference'
+sil [ossa] @expand_destroy_addr_reference : $@convention(thin) (@in C1) -> () {
+bb0(%0 : $*C1):
+  destroy_addr %0 : $*C1
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_addr_enum :
+// CHECK: bb0
+// CHECK: load
+// CHECK: destroy_value
+// CHECK: } // end sil function 'expand_destroy_addr_enum'
+sil [ossa] @expand_destroy_addr_enum : $@convention(thin) (@in E) -> () {
+bb0(%0 : $*E):
+  destroy_addr %0 : $*E
+  %1 = tuple()
+  return %1 : $()
+}
+
+///////////////
+// Copy Addr //
+///////////////
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_takeinit :
+// CHECK: bb0([[OUT:%[0-9]+]] : $*S, [[IN:%[0-9]+]] : $*S):
+// CHECK: [[LOAD:%[0-9]+]] = load [take] [[IN]]
+// CHECK: store [[LOAD]] to [init] [[OUT]]
+// CHECK: } // end sil function 'expand_copy_addr_takeinit'
+sil [ossa] @expand_copy_addr_takeinit : $@convention(thin) (@in S) -> @out S {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr [take] %1 to [initialization] %0 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_init :
+// CHECK: bb0([[OUT:%[0-9]+]] : $*S, [[IN:%[0-9]+]] : $*S):
+// CHECK: [[LOADED_IN:%[0-9]+]] = load [copy] [[IN]] : $*S
+// CHECK: store [[LOADED_IN]] to [init] [[OUT]]
+// CHECK: } // end sil function 'expand_copy_addr_init'
+sil [ossa] @expand_copy_addr_init : $@convention(thin) (@in_guaranteed S) -> @out S {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr %1 to [initialization] %0 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_take :
+// CHECK: bb0([[IN_ARG:%[0-9]+]] : $*S, [[INOUT_ARG:%[0-9]+]] : $*S):
+// CHECK: [[LOADED_IN_ARG:%[0-9]+]] = load [take] [[IN_ARG]]
+// CHECK: store [[LOADED_IN_ARG]] to [assign] [[INOUT_ARG]]
+// CHECK: } // end sil function 'expand_copy_addr_take'
+sil [ossa] @expand_copy_addr_take : $@convention(thin) (@in S, @inout S) -> () {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr [take] %0 to %1 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// Test expansions for various types (these will become more
+// interesting when I introduce the actual chopping work).
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_trivial :
+// CHECK: bb0
+// CHECK: load [trivial]
+// CHECK: store
+// CHECK: } // end sil function 'expand_copy_addr_trivial'
+sil [ossa] @expand_copy_addr_trivial : $@convention(thin) (@inout Builtin.Int64, @inout Builtin.Int64) -> () {
+bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
+  copy_addr %0 to %1 : $*Builtin.Int64
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_aggstructnontrivial :
+// CHECK: bb0([[INOUT_ARG1:%[0-9]+]] : $*S, [[INOUT_ARG2:%[0-9]+]] : $*S):
+// CHECK: [[INOUT_ARG1_LOADED:%[0-9]+]] = load [copy] [[INOUT_ARG1]]
+// CHECK: store [[INOUT_ARG1_LOADED]] to [assign] [[INOUT_ARG2]]
+// CHECK: } // end sil function 'expand_copy_addr_aggstructnontrivial'
+sil [ossa] @expand_copy_addr_aggstructnontrivial : $@convention(thin) (@inout S, @inout S) -> () {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr %0 to %1 : $*S
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_aggtuplenontrivial :
+// CHECK: bb0([[INOUT_1:%[0-9]+]] : $*(S, S2, C1, E), [[INOUT_2:%[0-9]+]] : $*(S, S2, C1, E)):
+// CHECK: [[INOUT_1_LOADED:%[0-9]+]] = load [copy] [[INOUT_1]] : $*(S, S2, C1, E)
+// CHECK: store [[INOUT_1_LOADED]] to [assign] [[INOUT_2]] : $*(S, S2, C1, E)
+// CHECK: tuple ()
+// CHECK: return
+
+
+sil [ossa] @expand_copy_addr_aggtuplenontrivial : $@convention(thin) (@inout (S, S2, C1, E), @inout (S, S2, C1, E)) -> () {
+bb0(%0 : $*(S, S2, C1, E), %1 : $*(S, S2, C1, E)):
+  copy_addr %0 to %1 : $*(S, S2, C1, E)
+  %2 = tuple()
+  return %2 : $()
+}
+
+// Do not do anything.
+//
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_addressonly : $@convention(thin) <T> (@in T, @inout T) -> () {
+// CHECK: copy_addr
+// CHECK: } // end sil function 'expand_copy_addr_addressonly'
+sil [ossa] @expand_copy_addr_addressonly : $@convention(thin) <T> (@in T, @inout T) -> () {
+bb0(%0 : $*T, %1 : $*T):
+  copy_addr [take] %0 to %1 : $*T
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Just turn into a load + destroy_value.
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_reference :
+// CHECK: bb0([[INOUT_1:%[0-9]+]] : $*C1, [[INOUT_2:%[0-9]+]] : $*C1):
+// CHECK: [[LOAD1:%[0-9]+]] = load [copy] [[INOUT_1]] : $*C1
+// CHECK: store [[LOAD1]] to [assign] [[INOUT_2]]
+// CHECK: } // end sil function 'expand_copy_addr_reference'
+sil [ossa] @expand_copy_addr_reference : $@convention(thin) (@inout C1, @inout C1) -> () {
+bb0(%0 : $*C1, %1 : $*C1):
+  copy_addr %0 to %1 : $*C1
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_addr_enum :
+// CHECK: bb0([[IN1:%[0-9]+]] : $*E, [[IN2:%[0-9]+]] : $*E):
+// CHECK: [[LOAD1:%[0-9]+]] = load [copy] [[IN1]] : $*E
+// CHECK: store [[LOAD1]] to [assign] [[IN2]]
+// CHECK: } // end sil function 'expand_copy_addr_enum'
+sil [ossa] @expand_copy_addr_enum : $@convention(thin) (@inout E, @inout E) -> () {
+bb0(%0 : $*E, %1 : $*E):
+  copy_addr %0 to %1 : $*E
+  %2 = tuple()
+  return %2 : $()
+}
+
+///////////////////
+// Destroy Value //
+///////////////////
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_value_aggstructnontrivial :
+// CHECK: bb0([[IN:%[0-9]+]] : @owned $S):
+// CHECK: destroy_value [[IN]]
+// CHECK: } // end sil function 'expand_destroy_value_aggstructnontrivial'
+sil [ossa] @expand_destroy_value_aggstructnontrivial : $@convention(thin) (@owned S) -> () {
+bb0(%0 : @owned $S):
+  destroy_value %0 : $S
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_value_aggtuplenontrivial :
+// CHECK: bb0([[IN:%[0-9]+]] : @owned $(S, S2, C1, E)):
+// CHECK:   destroy_value [[IN]]
+// CHECK: } // end sil function 'expand_destroy_value_aggtuplenontrivial'
+sil [ossa] @expand_destroy_value_aggtuplenontrivial : $@convention(thin) (@owned (S, S2, C1, E)) -> () {
+bb0(%0 : @owned $(S, S2, C1, E)):
+  destroy_value %0 : $(S, S2, C1, E)
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_value_reference :
+// CHECK: bb0([[IN:%[0-9]+]] : @owned $C1):
+// CHECK: destroy_value [[IN]]
+// CHECK: } // end sil function 'expand_destroy_value_reference'
+sil [ossa] @expand_destroy_value_reference : $@convention(thin) (@owned C1) -> () {
+bb0(%0 : @owned $C1):
+  destroy_value %0 : $C1
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_destroy_value_enum :
+// CHECK: bb0([[IN1:%[0-9]+]] : @owned $E):
+// CHECK: destroy_value
+// CHECK: } // end sil function 'expand_destroy_value_enum'
+sil [ossa] @expand_destroy_value_enum : $@convention(thin) (@owned E) -> () {
+bb0(%0 : @owned $E):
+  destroy_value %0 : $E
+  %1 = tuple()
+  return %1 : $()
+}
+
+
+////////////////
+// Copy Value //
+////////////////
+
+// CHECK-LABEL: sil [ossa] @expand_copy_value_aggstructnontrivial :
+// CHECK: bb0([[IN:%[0-9]+]] : @guaranteed $S3):
+// CHECK:   [[COPY:%.*]] = copy_value [[IN]]
+// CHECK:   return [[COPY]] : $S3
+// CHECK: } // end sil function 'expand_copy_value_aggstructnontrivial'
+sil [ossa] @expand_copy_value_aggstructnontrivial : $@convention(thin) (@guaranteed S3) -> @owned S3 {
+bb0(%0 : @guaranteed $S3):
+  %1 = copy_value %0 : $S3
+  return %1 : $S3
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_value_aggtuplenontrivial :
+// CHECK: bb0([[IN:%[0-9]+]] : @guaranteed $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)):
+// CHECK: [[OUT:%.*]] = copy_value [[IN]]
+// CHECK: return [[OUT]]
+// CHECK: } // end sil function 'expand_copy_value_aggtuplenontrivial'
+
+sil [ossa] @expand_copy_value_aggtuplenontrivial : $@convention(thin) (@guaranteed (S, Builtin.Int64, S2, C1, Builtin.Int64, E)) -> @owned (S, Builtin.Int64, S2, C1, Builtin.Int64, E) {
+bb0(%0 : @guaranteed $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)):
+  %1 = copy_value %0 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)
+  return %1 : $(S, Builtin.Int64, S2, C1, Builtin.Int64, E)
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_value_reference :
+// CHECK: bb0([[IN:%[0-9]+]] : @guaranteed $C1):
+// CHECK:  [[OUT:%.*]] = copy_value [[IN]]
+// CHECK:   return [[OUT]]
+// CHECK: } // end sil function 'expand_copy_value_reference'
+sil [ossa] @expand_copy_value_reference : $@convention(thin) (@guaranteed C1) -> @owned C1 {
+bb0(%0 : @guaranteed $C1):
+  %1 = copy_value %0 : $C1
+  return %1 : $C1
+}
+
+// CHECK-LABEL: sil [ossa] @expand_copy_value_enum :
+// CHECK: bb0([[IN:%[0-9]+]] : @guaranteed $E):
+// CHECK: [[OUT:%.*]] = copy_value [[IN]]
+// CHECk: return [[OUT]]
+// CHECK: } // end sil function 'expand_copy_value_enum'
+sil [ossa] @expand_copy_value_enum : $@convention(thin) (@guaranteed E) -> @owned E {
+bb0(%0 : @guaranteed $E):
+  %1 = copy_value %0 : $E
+  return %1 : $E
+}
+

--- a/test/SILOptimizer/loweraggregateinstrs_ossa.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_ossa.sil
@@ -1,0 +1,117 @@
+// RUN: %target-sil-opt -sil-print-on-error -enable-sil-verify-all %s -lower-aggregate-instrs | %FileCheck %s
+
+// This file makes sure that given the current code-size metric we properly
+// expand operations for small structs and not for large structs in a consistent
+// way for all operations we expand.
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+class C1 {
+  var data : Builtin.Int64
+  init()
+}
+
+class C2 {
+  var data : Builtin.FPIEEE32
+  init()
+}
+
+class C3 {
+  var data : Builtin.FPIEEE64
+  init()
+}
+
+struct S2 {
+  var cls1 : C1
+  var cls2 : C2
+  var trivial : Builtin.FPIEEE32
+}
+
+struct S {
+  var trivial : Builtin.Int64
+  var cls : C3
+  var inner_struct : S2
+}
+
+enum E {
+  case NoElement
+  case TrivialElement(Builtin.Int64)
+  case ReferenceElement(C1)
+  case StructNonTrivialElt(S)
+  case TupleNonTrivialElt((Builtin.Int64, S, C3))
+}
+
+// This struct is larger than our current code-size limit (> 6 leaf nodes).
+struct LargeStruct {
+  var trivial1 : Builtin.Int64
+  var cls : S
+  var trivial2 : Builtin.Int64
+  var trivial3 : Builtin.Int64
+}
+
+///////////
+// Tests //
+///////////
+
+// This test makes sure that we /do not/ expand copy_value, destroy_value and
+// promote copy_addr/destroy_value to non-expanded copy_value, destroy_value.
+// CHECK-LABEL: sil [ossa] @large_struct_test : $@convention(thin) (@owned LargeStruct, @in LargeStruct) -> () {
+// CHECK: bb0([[ARG0:%.*]] : @owned $LargeStruct, [[ARG1:%.*]] : $*LargeStruct):
+// CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
+// CHECK:   destroy_value [[ARG0]]
+// CHECK:   [[ALLOC_STACK:%.*]] = alloc_stack $LargeStruct
+// CHECK:   [[LOADED_ARG1:%.*]] = load [copy] [[ARG1]]
+// CHECK:   store [[LOADED_ARG1]] to [init] [[ALLOC_STACK]]
+// CHECK:   [[LOADED_OLD_VAL:%.*]] = load [take] [[ARG1]]
+// CHECK:   destroy_value [[LOADED_OLD_VAL]]
+// CHECK:   [[LOADED_ARG1:%.*]] = load [take] [[ALLOC_STACK]]
+// CHECK:   destroy_value [[LOADED_ARG1]]
+// CHECK:   dealloc_stack [[ALLOC_STACK]]
+// CHECK:   destroy_value [[ARG0_COPY]]
+// CHECK: } // end sil function 'large_struct_test'
+sil [ossa] @large_struct_test : $@convention(thin) (@owned LargeStruct, @in LargeStruct) -> () {
+bb0(%0 : @owned $LargeStruct, %1 : $*LargeStruct):
+  %0a = copy_value %0 : $LargeStruct
+  destroy_value %0 : $LargeStruct
+  %2 = alloc_stack $LargeStruct
+  copy_addr %1 to [initialization] %2 : $*LargeStruct
+  destroy_addr %1 : $*LargeStruct
+  destroy_addr %2 : $*LargeStruct
+  dealloc_stack %2 : $*LargeStruct
+  destroy_value %0a : $LargeStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// In OSSA, we do not blow up copy_value, destroy_value today, but we do promote
+// copy_addr, destroy_addr of loadable types to their deep variants.
+//
+// CHECK-LABEL: sil [ossa] @small_struct_test : $@convention(thin) (@guaranteed S2, @in S2) -> () {
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $S2, [[ARG1:%.*]] : $*S2):
+// CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
+// CHECK:   destroy_value [[ARG0_COPY]]
+// CHECK:   [[ALLOC_STACK:%.*]] = alloc_stack $S2
+// CHECK:   [[LOADED_ARG1:%.*]] = load [copy] [[ARG1]]
+// CHECK:   store [[LOADED_ARG1]] to [init] [[ALLOC_STACK]]
+//
+// CHECK:   [[LOADED_OLDVALUE:%.*]] = load [take] [[ARG1]]
+// CHECK:   destroy_value [[LOADED_OLDVALUE]]
+//
+// CHECK:   [[RELOADED_ARG1:%.*]] = load [take] [[ALLOC_STACK]]
+// CHECK:   destroy_value [[RELOADED_ARG1]]
+// CHECK: } // end sil function 'small_struct_test'
+sil [ossa] @small_struct_test : $@convention(thin) (@guaranteed S2, @in S2) -> () {
+bb0(%0 : @guaranteed $S2, %1 : $*S2):
+  %0a = copy_value %0 : $S2
+  destroy_value %0a : $S2
+  %2 = alloc_stack $S2
+  copy_addr %1 to [initialization] %2 : $*S2
+  destroy_addr %1 : $*S2
+  destroy_addr %2 : $*S2
+  dealloc_stack %2 : $*S2
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
There are two different PRs here:

1. There are parts of lower aggregate inserts where I need to use emit{Load,Store}ValueOperation to emit code in both ossa/non-ossa mode but for which in non-ossa mode, we need to use the emitLowered* APIs. I exposed these on SILBuilder so we can keep the old codegen in non-ossa mode.

2. In the second commit I update for OSSA. The main difference is that we do not explode anything today: instead we just promote loadable typed copy_addr, destroy_addr to value operations. The reason why I am doing this is that originally the exploding was done to make it easier for the low level ARC optimizer to optimize (since aggregates with multiple-nontrivial mess with its usage of the concept of "RC Identity"). The high level ARC optimizer doesn't care about this and in fact it is just noise that gets in the way of optimizing and makes its job harder. Additionally since this is a function pass, after we lower ownership we will re-run lower aggregate instrs ensuring that the low level arc optimizer still sees what it is looking for.

