### PR TITLE
Remove uniqueness assertion in job sorting.

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -2060,10 +2060,7 @@ void Compilation::sortJobsToMatchCompilationInputs(
     if (const CompileJobAction *CJA =
             dyn_cast<CompileJobAction>(&J->getSource())) {
       const InputAction *IA = CJA->findSingleSwiftInput();
-      auto R =
-          jobsByInput.insert(std::make_pair(IA->getInputArg().getValue(), J));
-      assert(R.second);
-      (void)R;
+      jobsByInput.insert(std::make_pair(IA->getInputArg().getValue(), J));
     } else
       sortedJobs.push_back(J);
   }

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -196,6 +196,8 @@ std::vector<StringRef> ModuleDepGraph::getExternalDependencies() const {
 }
 
 // Add every (swiftdeps) use of the external dependency to foundJobs.
+// Can return duplicates, but it doesn't break anything, and they will be
+// canonicalized later.
 std::vector<const Job *> ModuleDepGraph::findExternallyDependentUntracedJobs(
     StringRef externalDependency) {
   FrontendStatsTracer tracer(

--- a/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
+++ b/unittests/Driver/TypeBodyFingerprintsDependencyGraphTests.cpp
@@ -13,6 +13,8 @@
 // would be excluded in the coarse-grained graph. But since these will be jobs
 // that have already been scheduled, downstream mechanisms will filter them out.
 
+// \c \c findExternallyDependentUntracedJobs may also return duplicates
+
 // To debug a test, create the \c ModuleDepGraph and pass true as the second
 // argument to the constructor, then find the dot files in the directory
 // where the tests run,


### PR DESCRIPTION
When finding externally dependent jobs, the traversal can find the same job twice. The duplicates are filtered out later, so no harm is done. But when -driver-show-incremental is specified, these jobs are sorted, and the sort has an assertion that trips if there are duplicates. Remove that assertion.