### PR TITLE
AST: Allow @_fixed_layout protocols

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -244,7 +244,7 @@ SIMPLE_DECL_ATTR(nonobjc, NonObjC,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   30)
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
-  OnVar | OnClass | OnStruct |
+  OnVar | OnClass | OnStruct | OnProtocol |
   UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove |
   APIStableToAdd | APIStableToRemove,
   31)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -612,7 +612,7 @@ namespace {
     ProtocolDescriptorBuilder(IRGenModule &IGM, ProtocolDecl *Proto,
                                      SILDefaultWitnessTable *defaultWitnesses)
       : super(IGM), Proto(Proto), DefaultWitnesses(defaultWitnesses),
-        Resilient(IGM.isResilient(Proto, ResilienceExpansion::Minimal)) {}
+        Resilient(IGM.getSwiftModule()->isResilient()) {}
 
     void layout() {
       super::layout();

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -968,13 +968,14 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
     struct WitnessVisitor : public SILWitnessVisitor<WitnessVisitor> {
       TBDGenVisitor &TBD;
       ProtocolDecl *PD;
+      bool Resilient;
 
     public:
       WitnessVisitor(TBDGenVisitor &TBD, ProtocolDecl *PD)
-          : TBD(TBD), PD(PD) {}
+          : TBD(TBD), PD(PD), Resilient(PD->getParentModule()->isResilient()) {}
 
       void addMethod(SILDeclRef declRef) {
-        if (PD->isResilient()) {
+        if (Resilient) {
           TBD.addDispatchThunk(declRef);
           TBD.addMethodDescriptor(declRef);
         }

--- a/test/IRGen/frozen_protocols.swift
+++ b/test/IRGen/frozen_protocols.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution -O %s
+
+import resilient_protocol
+
+@_fixed_layout public protocol FrozenProtocol {
+  func protocolMethod()
+}
+
+public func callOtherProtocolMethod<T : OtherFrozenProtocol>(_ t: T) {
+  t.protocolMethod()
+}
+
+public struct ConformsToFrozenProtocol : FrozenProtocol {
+  public func protocolMethod() {}
+}
+
+// CHECK-LABEL: @"$s16frozen_protocols24ConformsToFrozenProtocolVAA0eF0AAMc" = {{(dllexport )?}}{{(protected )?}}constant %swift.protocol_conformance_descriptor
+
+// -- the protocol
+// CHECK-SAME: @"$s16frozen_protocols14FrozenProtocolMp"
+
+// -- the conforming type
+// CHECK-SAME: @"$s16frozen_protocols24ConformsToFrozenProtocolVMn"
+
+// -- the witness table
+// CHECK-SAME: @"$s16frozen_protocols24ConformsToFrozenProtocolVAA0eF0AAWP"
+
+// -- flags
+// CHECK-SAME: i32 0
+// CHECK-SAME: }
+
+// @_fixed_layout protocols still emit protocol requirement descriptors though,
+// which allows for a protocol to be retroactively declared as @_fixed_layout
+// CHECK-LABEL: @"$s16frozen_protocols14FrozenProtocolP14protocolMethodyyFTq" = {{(dllexport )?}}{{(protected )?}}alias %swift.protocol_requirement
+
+// Requirements in @_fixed_layout protocols are called by direct witness
+// table lookup
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16frozen_protocols23callOtherProtocolMethodyyx18resilient_protocol0d6FrozenE0RzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T, i8** %T.OtherFrozenProtocol)
+// CHECK: [[ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.OtherFrozenProtocol, i32 1
+// CHECK: [[FN:%.*]] = load i8*, i8** [[ADDR]]
+// CHECK: [[CAST:%.*]] = bitcast i8* [[FN]] to void (%swift.opaque*, %swift.type*, i8**)*
+// CHECK: call swiftcc void %3(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %T, i8** %T.OtherFrozenProtocol)
+// CHECK: ret void
+
+// @_fixed_layout protocols still emit method dispatch thunks though, which
+// allows for a protocol to be retroactively declared as @_fixed_layout
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16frozen_protocols14FrozenProtocolP14protocolMethodyyFTj"(
+

--- a/test/Inputs/resilient_protocol.swift
+++ b/test/Inputs/resilient_protocol.swift
@@ -40,3 +40,7 @@ public protocol ProtocolWithAssocTypeDefaults {
 public protocol ResilientSelfDefault : ResilientBaseProtocol {
   associatedtype AssocType: ResilientBaseProtocol = Self
 }
+
+@_fixed_layout public protocol OtherFrozenProtocol {
+  func protocolMethod()
+}


### PR DESCRIPTION
A @_fixed_layout protocol exposes its witness table layout to
clients, which prevents re-ordering of requirements or adding
new requiremenst with a default.

When library evolution is enabled, we still emit method
descriptors even for @_fixed_layout protocols; this allows a
previously-resilient protocol to become @_fixed_layout as long
as the published layout matches the resilient layout in all
previously-shipped versions of the library.