### PR TITLE
[Test] Disable two tests that hang asan bots.

### DIFF
--- a/validation-test/compiler_crashers_2/0207-sr7371.swift
+++ b/validation-test/compiler_crashers_2/0207-sr7371.swift
@@ -1,4 +1,6 @@
 // RUN: not --crash %target-swift-frontend -emit-ir %s
+// rdar://problem/65571199
+// UNSUPPORTED: asan
 
 public protocol TypedParserResultTransferType {
     // Remove type constraint

--- a/validation-test/compiler_crashers_2/0208-sr8751.swift
+++ b/validation-test/compiler_crashers_2/0208-sr8751.swift
@@ -1,4 +1,6 @@
 // RUN: not --crash %target-swift-frontend -emit-ir %s
+// rdar://problem/65571199
+// UNSUPPORTED: asan
 
 protocol TreeProtocol {
 


### PR DESCRIPTION
The following tests are disabled here:

    compiler_crashers_2/0208-sr8751.swift
    compiler_crashers_2/0207-sr7371.swift

rdar://problem/65571199