### PR TITLE
[SE-0286] Forward matching of trailing closure arguments

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -55,6 +55,7 @@ class GenericFunctionType;
 class LazyConformanceLoader;
 class LazyMemberLoader;
 class PatternBindingInitializer;
+enum class TrailingClosureMatching: uint8_t;
 class TrailingWhereClause;
 class TypeExpr;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1186,6 +1186,18 @@ ERROR(extra_trailing_closure_in_call,none,
 ERROR(trailing_closure_bad_param,none,
       "trailing closure passed to parameter of type %0 that does not "
       "accept a closure", (Type))
+WARNING(unlabeled_trailing_closure_changed_behavior,none,
+        "since Swift 5.3, unlabeled trailing closure argument matches parameter %0 rather than parameter %1",
+        (Identifier, Identifier))
+WARNING(unlabeled_trailing_closure_changed_behavior_same_param_name,none,
+        "since Swift 5.3, unlabeled trailing closure argument matches earlier parameter %0 rather than later parameter with the same name",
+        (Identifier))
+NOTE(trailing_closure_select_parameter,none,
+     "label the argument with %0 to %select{retain the pre-Swift 5.3 behavior|silence this warning for Swift 5.3 and newer}1",
+     (Identifier, unsigned))
+NOTE(decl_multiple_defaulted_closure_parameters,none,
+     "%0 contains defaulted closure parameters %1 and %2",
+     (DeclName, Identifier, Identifier))
 NOTE(candidate_with_extraneous_args,none,
       "candidate %0 requires %1 argument%s1, "
       "but %2 %select{were|was}3 %select{provided|used in closure body}4",

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3499,6 +3499,7 @@ END_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
 /// has a default argument.
 struct ParameterListInfo {
   SmallBitVector defaultArguments;
+  SmallBitVector acceptsUnlabeledTrailingClosures;
 
 public:
   ParameterListInfo() { }
@@ -3508,6 +3509,10 @@ public:
 
   /// Whether the parameter at the given index has a default argument.
   bool hasDefaultArgument(unsigned paramIdx) const;
+
+  /// Whether the parameter accepts an unlabeled trailing closure argument
+  /// according to the "forward-scan" rule.
+  bool acceptsUnlabeledTrailingClosureArgument(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -271,6 +271,14 @@ namespace swift {
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;
 
+    /// Whether to enable the "fuzzy" forward-scanning behavior for trailing
+    /// closure matching, which skips over defaulted closure parameters
+    /// to match later (non-defaulted) closure parameters
+    ///
+    /// This is a backward-compatibility hack for unlabeled trailing closures,
+    /// to be disabled in Swift 6+.
+    bool EnableFuzzyForwardScanTrailingClosureMatching = true;
+
     /// Use Clang function types for computing canonical types.
     /// If this option is false, the clang function types will still be computed
     /// but will not be used for checking type equality.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -546,6 +546,16 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def disable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
+    "disable-fuzzy-forward-scan-trailing-closure-matching">,
+  Flags<[FrontendOption]>,
+  HelpText<"Disable fuzzy forward-scan trailing closure matching">;
+
+def enable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
+    "enable-fuzzy-forward-scan-trailing-closure-matching">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable fuzzy forward-scan trailing closure matching">;
+
 def enable_direct_intramodule_dependencies : Flag<["-"],
     "enable-direct-intramodule-dependencies">,
   Flags<[FrontendOption, HelpHidden]>,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -839,8 +839,9 @@ static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
   if (param->isInOut())
     return false;
 
-  Type paramType =
-      param->getInterfaceType()->getRValueType()->lookThroughAllOptionalTypes();
+  Type paramType = param->isVariadic() ? param->getVarargBaseTy()
+                                       : param->getInterfaceType();
+  paramType = paramType->getRValueType()->lookThroughAllOptionalTypes();
 
   // For autoclosure parameters, look through the autoclosure result type
   // to get the actual argument type.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -832,16 +832,42 @@ Type TypeBase::replaceCovariantResultType(Type newResultType,
   return FunctionType::get(inputType, resultType, fnType->getExtInfo());
 }
 
+/// Whether this parameter accepts an unlabeled trailing closure argument
+/// using the more-restrictive forward-scan rule.
+static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
+  // inout parameters never allow an unlabeled trailing closure.
+  if (param->isInOut())
+    return false;
+
+  Type paramType =
+      param->getInterfaceType()->getRValueType()->lookThroughAllOptionalTypes();
+
+  // For autoclosure parameters, look through the autoclosure result type
+  // to get the actual argument type.
+  if (param->isAutoClosure()) {
+    auto fnType = paramType->getAs<AnyFunctionType>();
+    if (!fnType)
+      return false;
+
+    paramType = fnType->getResult()->lookThroughAllOptionalTypes();
+  }
+
+  // After lookup through all optional types, this parameter allows an
+  // unlabeled trailing closure if it is (structurally) a function type.
+  return paramType->is<AnyFunctionType>();
+}
+
 ParameterListInfo::ParameterListInfo(
     ArrayRef<AnyFunctionType::Param> params,
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
+  acceptsUnlabeledTrailingClosures.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
   //
-  // FIXME: We ought to not request default argument info in this case.
+  // FIXME: We ought to not request paramer list info in this case.
   if (!paramOwner)
     return;
 
@@ -875,11 +901,16 @@ ParameterListInfo::ParameterListInfo(
   if (params.size() != paramList->size())
     return;
 
-  // Note which parameters have default arguments and/or function builders.
+  // Note which parameters have default arguments and/or accept unlabeled
+  // trailing closure arguments with the forward-scan rule.
   for (auto i : range(0, params.size())) {
     auto param = paramList->get(i);
     if (param->isDefaultArgument()) {
       defaultArguments.set(i);
+    }
+
+    if (allowsUnlabeledTrailingClosureParameter(param)) {
+      acceptsUnlabeledTrailingClosures.set(i);
     }
   }
 }
@@ -887,6 +918,12 @@ ParameterListInfo::ParameterListInfo(
 bool ParameterListInfo::hasDefaultArgument(unsigned paramIdx) const {
   return paramIdx < defaultArguments.size() ? defaultArguments[paramIdx]
       : false;
+}
+
+bool ParameterListInfo::acceptsUnlabeledTrailingClosureArgument(
+    unsigned paramIdx) const {
+  return paramIdx < acceptsUnlabeledTrailingClosures.size() &&
+      acceptsUnlabeledTrailingClosures[paramIdx];
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -863,7 +863,6 @@ ParameterListInfo::ParameterListInfo(
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
-  acceptsUnlabeledTrailingClosures.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -902,6 +901,10 @@ ParameterListInfo::ParameterListInfo(
   if (params.size() != paramList->size())
     return;
 
+  // Now we have enough information to determine which parameters accept
+  // unlabled trailing closures.
+  acceptsUnlabeledTrailingClosures.resize(params.size());
+
   // Note which parameters have default arguments and/or accept unlabeled
   // trailing closure arguments with the forward-scan rule.
   for (auto i : range(0, params.size())) {
@@ -923,7 +926,7 @@ bool ParameterListInfo::hasDefaultArgument(unsigned paramIdx) const {
 
 bool ParameterListInfo::acceptsUnlabeledTrailingClosureArgument(
     unsigned paramIdx) const {
-  return paramIdx < acceptsUnlabeledTrailingClosures.size() &&
+  return paramIdx >= acceptsUnlabeledTrailingClosures.size() ||
       acceptsUnlabeledTrailingClosures[paramIdx];
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -264,6 +264,10 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
+  inputArgs.AddLastArg(
+      arguments,
+      options::OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
+      options::OPT_disable_fuzzy_forward_scan_trailing_closure_matching);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
   inputArgs.AddLastArg(arguments,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -572,6 +572,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
+  Opts.EnableFuzzyForwardScanTrailingClosureMatching =
+      Args.hasFlag(OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
+                   OPT_disable_fuzzy_forward_scan_trailing_closure_matching,
+                   !Opts.EffectiveLanguageVersion.isVersionAtLeast(6));
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -575,7 +575,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableFuzzyForwardScanTrailingClosureMatching =
       Args.hasFlag(OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
                    OPT_disable_fuzzy_forward_scan_trailing_closure_matching,
-                   !Opts.EffectiveLanguageVersion.isVersionAtLeast(6));
+                   true);
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5715,7 +5715,7 @@ Expr *ExprRewriter::coerceCallArguments(
   // Warn if there was a recent change in trailing closure binding semantics
   // that might have lead to a silent change in behavior.
   maybeWarnAboutTrailingClosureBindingChange(
-      callee, apply->getFn(), arg, args, params, paramInfo,
+      callee, apply ? apply->getFn() : nullptr, arg, args, params, paramInfo,
       unlabeledTrailingClosureIndex, parameterBindings);
 
   SourceLoc lParenLoc, rParenLoc;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5554,17 +5554,7 @@ static void maybeWarnAboutTrailingClosureBindingChange(
         decl->getName(), paramName, backwardParamName);
 
     // Dig out the parameter declarations so we can highlight them.
-    // FIXME: There should be a utility for this.
-    const ParameterList *paramList = nullptr;
-    if (auto *func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      paramList = func->getParameters();
-    } else if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
-      paramList = subscript->getIndices();
-    } else if (auto *enumElement = dyn_cast<EnumElementDecl>(decl)) {
-      paramList = enumElement->getParameterList();
-    }
-
-    if (paramList) {
+    if (const ParameterList *paramList = getParameterList(decl)) {
       diag.highlight(paramList->get(paramIdx)->getLoc());
       diag.highlight(paramList->get(*matchingBackwardParamIdx)->getLoc());
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5888,19 +5888,6 @@ bool ExtraneousCallFailure::diagnoseAsError() {
   return true;
 }
 
-bool InvalidUseOfTrailingClosure::diagnoseAsError() {
-  emitDiagnostic(diag::trailing_closure_bad_param, getToType())
-      .highlight(getSourceRange());
-
-  if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
-    if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
-    }
-  }
-
-  return true;
-}
-
 void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   auto getPointerKind = [](Type ty) -> PointerTypeKind {
     PointerTypeKind pointerKind;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3915,9 +3915,9 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   Expr *fnExpr = nullptr;
   Expr *argExpr = nullptr;
   unsigned numArguments = 0;
-  bool hasTrailingClosure = false;
+  Optional<unsigned> firstTrailingClosure = None;
 
-  std::tie(fnExpr, argExpr, numArguments, hasTrailingClosure) =
+  std::tie(fnExpr, argExpr, numArguments, firstTrailingClosure) =
       getCallInfo(getRawAnchor());
 
   // TODO(diagnostics): We should be able to suggest this fix-it
@@ -3980,46 +3980,66 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   auto position = argument.first;
   auto label = argument.second.getLabel();
 
+  Expr *fnExpr = nullptr;
+  Expr *argExpr = nullptr;
+  unsigned numArgs = 0;
+  Optional<unsigned> firstTrailingClosure = None;
+
+  std::tie(fnExpr, argExpr, numArgs, firstTrailingClosure) =
+      getCallInfo(anchor);
+
+  if (!argExpr) {
+    return false;
+  }
+
+  // Will the parameter accept a trailing closure?
+  Type paramType = resolveType(argument.second.getPlainType());
+  bool paramAcceptsTrailingClosure = paramType
+      ->lookThroughAllOptionalTypes()->is<AnyFunctionType>();
+
+  // Determine whether we're inserting as a trailing closure.
+  bool insertingTrailingClosure =
+    firstTrailingClosure && position > *firstTrailingClosure;
+
   SmallString<32> insertBuf;
   llvm::raw_svector_ostream insertText(insertBuf);
 
-  if (position != 0)
+  if (insertingTrailingClosure)
+    insertText << " ";
+  else if (position != 0)
     insertText << ", ";
 
   forFixIt(insertText, argument.second);
 
-  Expr *fnExpr = nullptr;
-  Expr *argExpr = nullptr;
-  unsigned insertableEndIdx = 0;
-  bool hasTrailingClosure = false;
-
-  std::tie(fnExpr, argExpr, insertableEndIdx, hasTrailingClosure) =
-      getCallInfo(anchor);
-
-  if (!argExpr)
-    return false;
-
-  if (hasTrailingClosure)
-    insertableEndIdx -= 1;
-
-  if (position == 0 && insertableEndIdx != 0)
+  if (position == 0 && numArgs > 0 &&
+      (!firstTrailingClosure || position < *firstTrailingClosure))
     insertText << ", ";
 
   SourceLoc insertLoc;
-  if (auto *TE = dyn_cast<TupleExpr>(argExpr)) {
-    // fn():
-    //   fn([argMissing])
+
+  if (position >= numArgs && insertingTrailingClosure) {
+    // Add a trailing closure to the end.
+
+    // fn { closure }:
+    //   fn {closure} label: [argMissing]
+    // fn() { closure }:
+    //   fn() {closure} label: [argMissing]
+    // fn(argX) { closure }:
+    //   fn(argX) { closure } label: [argMissing]
+    insertLoc = Lexer::getLocForEndOfToken(
+        ctx.SourceMgr, argExpr->getEndLoc());
+  } else if (auto *TE = dyn_cast<TupleExpr>(argExpr)) {
     // fn(argX, argY):
     //   fn([argMissing, ]argX, argY)
     //   fn(argX[, argMissing], argY)
-    //   fn(argX, argY[, argMissing])
     // fn(argX) { closure }:
     //   fn([argMissing, ]argX) { closure }
     //   fn(argX[, argMissing]) { closure }
-    //   fn(argX[, closureLabel: ]{closure}[, argMissing)] // Not impl.
-    if (insertableEndIdx == 0)
+    // fn(argX, argY):
+    //   fn(argX, argY[, argMissing])
+    if (numArgs == 0) {
       insertLoc = TE->getRParenLoc();
-    else if (position != 0) {
+    } else if (position != 0) {
       auto argPos = std::min(TE->getNumElements(), position) - 1;
       insertLoc = Lexer::getLocForEndOfToken(
           ctx.SourceMgr, TE->getElement(argPos)->getEndLoc());
@@ -4031,25 +4051,25 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   } else {
     auto *PE = cast<ParenExpr>(argExpr);
     if (PE->getRParenLoc().isValid()) {
+      // fn():
+      //   fn([argMissing])
       // fn(argX):
-      //   fn([argMissing, ]argX)
       //   fn(argX[, argMissing])
+      //   fn([argMissing, ]argX)
       // fn() { closure }:
       //   fn([argMissing]) {closure}
-      //   fn([closureLabel: ]{closure}[, argMissing]) // Not impl.
-      if (insertableEndIdx == 0)
-        insertLoc = PE->getRParenLoc();
-      else if (position == 0)
-        insertLoc = PE->getSubExpr()->getStartLoc();
-      else
+      if (position == 0) {
         insertLoc = Lexer::getLocForEndOfToken(ctx.SourceMgr,
-                                               PE->getSubExpr()->getEndLoc());
+                                               PE->getLParenLoc());
+      } else {
+        insertLoc = Lexer::getLocForEndOfToken(
+            ctx.SourceMgr, PE->getSubExpr()->getEndLoc());
+      }
     } else {
       // fn { closure }:
       //   fn[(argMissing)] { closure }
-      //   fn[(closureLabel:] { closure }[, missingArg)]  // Not impl.
       assert(!isExpr<SubscriptExpr>(anchor) && "bracket less subscript");
-      assert(PE->hasTrailingClosure() &&
+      assert(firstTrailingClosure &&
              "paren less ParenExpr without trailing closure");
       insertBuf.insert(insertBuf.begin(), '(');
       insertBuf.insert(insertBuf.end(), ')');
@@ -4061,16 +4081,28 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   if (insertLoc.isInvalid())
     return false;
 
+  // If we are trying to insert a trailing closure but the parameter
+  // corresponding to the missing argument doesn't support a trailing closure,
+  // don't provide a Fix-It.
+  // FIXME: It's possible to parenthesize and relabel the argument list to
+  // accomodate this, but it's tricky.
+  bool shouldEmitFixIt =
+    !(insertingTrailingClosure && !paramAcceptsTrailingClosure);
+
   if (label.empty()) {
-    emitDiagnosticAt(insertLoc, diag::missing_argument_positional, position + 1)
-        .fixItInsert(insertLoc, insertText.str());
+    auto diag = emitDiagnosticAt(
+        insertLoc, diag::missing_argument_positional, position + 1);
+    if (shouldEmitFixIt)
+      diag.fixItInsert(insertLoc, insertText.str());
   } else if (isPropertyWrapperInitialization()) {
     auto *TE = cast<TypeExpr>(fnExpr);
     emitDiagnosticAt(TE->getLoc(), diag::property_wrapper_missing_arg_init,
                      label, resolveType(TE->getInstanceType())->getString());
   } else {
-    emitDiagnosticAt(insertLoc, diag::missing_argument_named, label)
-        .fixItInsert(insertLoc, insertText.str());
+    auto diag = emitDiagnosticAt(
+        insertLoc, diag::missing_argument_named, label);
+    if (shouldEmitFixIt)
+      diag.fixItInsert(insertLoc, insertText.str());
   }
 
   if (auto selectedOverload =
@@ -4298,23 +4330,24 @@ bool MissingArgumentsFailure::isMisplacedMissingArgument(
   return TypeChecker::isConvertibleTo(argType, paramType, solution.getDC());
 }
 
-std::tuple<Expr *, Expr *, unsigned, bool>
+std::tuple<Expr *, Expr *, unsigned, Optional<unsigned>>
 MissingArgumentsFailure::getCallInfo(ASTNode anchor) const {
   if (auto *call = getAsExpr<CallExpr>(anchor)) {
     return std::make_tuple(call->getFn(), call->getArg(),
-                           call->getNumArguments(), call->hasTrailingClosure());
+                           call->getNumArguments(),
+                           call->getUnlabeledTrailingClosureIndex());
   } else if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor)) {
     return std::make_tuple(UME, UME->getArgument(), UME->getNumArguments(),
-                           UME->hasTrailingClosure());
+                           UME->getUnlabeledTrailingClosureIndex());
   } else if (auto *SE = getAsExpr<SubscriptExpr>(anchor)) {
     return std::make_tuple(SE, SE->getIndex(), SE->getNumArguments(),
-                           SE->hasTrailingClosure());
+                           SE->getUnlabeledTrailingClosureIndex());
   } else if (auto *OLE = getAsExpr<ObjectLiteralExpr>(anchor)) {
     return std::make_tuple(OLE, OLE->getArg(), OLE->getNumArguments(),
-                           OLE->hasTrailingClosure());
+                           OLE->getUnlabeledTrailingClosureIndex());
   }
 
-  return std::make_tuple(nullptr, nullptr, 0, false);
+  return std::make_tuple(nullptr, nullptr, 0, None);
 }
 
 void MissingArgumentsFailure::forFixIt(
@@ -5509,6 +5542,9 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
   if (diagnosePropertyWrapperMismatch())
     return true;
 
+  if (diagnoseTrailingClosureMismatch())
+    return true;
+
   auto argType = getFromType();
   auto paramType = getToType();
 
@@ -5740,6 +5776,26 @@ bool ArgumentMismatchFailure::diagnosePropertyWrapperMismatch() const {
     return true;
 
   emitDiagnostic(diag::cannot_convert_initializer_value, argType, paramType);
+  return true;
+}
+
+bool ArgumentMismatchFailure::diagnoseTrailingClosureMismatch() const {
+  if (!Info.isTrailingClosure())
+    return false;
+
+  auto paramType = getToType();
+  if (paramType->lookThroughAllOptionalTypes()->is<AnyFunctionType>())
+    return false;
+
+  emitDiagnostic(diag::trailing_closure_bad_param, paramType)
+      .highlight(getSourceRange());
+
+  if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
+    if (auto *decl = overload->choice.getDeclOrNull()) {
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+    }
+  }
+
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1293,9 +1293,10 @@ private:
   bool isPropertyWrapperInitialization() const;
 
   /// Gather information associated with expression that represents
-  /// a call - function, arguments, # of arguments and whether it has
-  /// a trailing closure.
-  std::tuple<Expr *, Expr *, unsigned, bool> getCallInfo(ASTNode anchor) const;
+  /// a call - function, arguments, # of arguments and the position of
+  /// the first trailing closure.
+  std::tuple<Expr *, Expr *, unsigned, Optional<unsigned>>
+      getCallInfo(ASTNode anchor) const;
 
   /// Transform given argument into format suitable for a fix-it
   /// text e.g. `[<label>:]? <#<type#>`
@@ -1814,6 +1815,10 @@ public:
   /// property wrapper initialization via implicit `init(wrappedValue:)`
   /// or now deprecated `init(initialValue:)`.
   bool diagnosePropertyWrapperMismatch() const;
+
+  /// Tailored diagnostics for argument mismatches associated with trailing
+  /// closures being passed to non-closure parameters.
+  bool diagnoseTrailingClosureMismatch() const;
 
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1317,21 +1317,6 @@ RemoveInvalidCall *RemoveInvalidCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) RemoveInvalidCall(cs, locator);
 }
 
-bool AllowInvalidUseOfTrailingClosure::diagnose(const Solution &solution,
-                                                bool asNote) const {
-  InvalidUseOfTrailingClosure failure(solution, getFromType(), getToType(),
-                                      getLocator());
-  return failure.diagnose(asNote);
-}
-
-AllowInvalidUseOfTrailingClosure *
-AllowInvalidUseOfTrailingClosure::create(ConstraintSystem &cs, Type argType,
-                                         Type paramType,
-                                         ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      AllowInvalidUseOfTrailingClosure(cs, argType, paramType, locator);
-}
-
 bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
   NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -225,8 +225,6 @@ enum class FixKind : uint8_t {
   /// a variable, a property etc.
   RemoveCall,
 
-  AllowInvalidUseOfTrailingClosure,
-
   /// Allow an ephemeral argument conversion for a parameter marked as being
   /// non-ephemeral.
   TreatEphemeralAsNonEphemeral,
@@ -1713,24 +1711,6 @@ public:
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
-};
-
-class AllowInvalidUseOfTrailingClosure final : public AllowArgumentMismatch {
-  AllowInvalidUseOfTrailingClosure(ConstraintSystem &cs, Type argType,
-                                   Type paramType, ConstraintLocator *locator)
-      : AllowArgumentMismatch(cs, FixKind::AllowInvalidUseOfTrailingClosure,
-                              argType, paramType, locator) {}
-
-public:
-  std::string getName() const {
-    return "allow invalid use of trailing closure";
-  }
-
-  bool diagnose(const Solution &solution, bool asNote = false) const;
-
-  static AllowInvalidUseOfTrailingClosure *create(ConstraintSystem &cs,
-                                                  Type argType, Type paramType,
-                                                  ConstraintLocator *locator);
 };
 
 class TreatEphemeralAsNonEphemeral final : public AllowArgumentMismatch {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -200,21 +200,6 @@ static ConstraintSystem::TypeMatchOptions getDefaultDecompositionOptions(
   return flags | ConstraintSystem::TMF_GenerateConstraints;
 }
 
-/// Determine whether the given parameter can accept a trailing closure.
-static bool acceptsTrailingClosure(const AnyFunctionType::Param &param) {
-  Type paramTy = param.getPlainType();
-  if (!paramTy)
-    return true;
-
-  paramTy = paramTy->lookThroughAllOptionalTypes();
-  return paramTy->isTypeParameter() ||
-      paramTy->is<ArchetypeType>() ||
-      paramTy->is<AnyFunctionType>() ||
-      paramTy->isTypeVariableOrMember() ||
-      paramTy->is<UnresolvedType>() ||
-      paramTy->isAny();
-}
-
 // FIXME: This should return ConstraintSystem::TypeMatchResult instead
 //        to give more information to the solver about the failure.
 bool constraints::
@@ -285,6 +270,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
   auto skipClaimedArgs = [&](unsigned &nextArgIdx) {
     while (nextArgIdx != numArgs && claimedArgs[nextArgIdx])
       ++nextArgIdx;
+    return nextArgIdx;
   };
 
   // Local function that retrieves the next unclaimed argument with the given
@@ -297,6 +283,13 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
     // If we've claimed all of the arguments, there's nothing more to do.
     if (numClaimedArgs == numArgs)
+      return None;
+
+    // If we're claiming variadic arguments, do not claim an unlabeled trailing
+    // closure argument.
+    if (forVariadic &&
+        unlabeledTrailingClosureArgIndex &&
+        nextArgIdx == *unlabeledTrailingClosureArgIndex)
       return None;
 
     // Go hunting for an unclaimed argument whose name does match.
@@ -387,12 +380,45 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
   auto bindNextParameter = [&](unsigned paramIdx, unsigned &nextArgIdx,
                                bool ignoreNameMismatch) {
     const auto &param = params[paramIdx];
+    Identifier paramLabel = param.getLabel();
+
+    // If we have the trailing closure argument and are performing a forward
+    // match, look for the matching parameter.
+    if (unlabeledTrailingClosureArgIndex &&
+        skipClaimedArgs(nextArgIdx) == *unlabeledTrailingClosureArgIndex) {
+
+      // If the parameter we are looking at does not support the (unlabeled)
+      // trailing closure argument, this parameter is unfulfilled.
+      if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx)) {
+        haveUnfulfilledParams = true;
+        return;
+      }
+
+      // If there is only one trailing closure argument, consider applying
+      // a "fuzzy" match rule that skips this parameter if it is defaulted but
+      // later parameters require an argument.
+      if (nextArgIdx + 1 == numArgs &&
+          paramInfo.hasDefaultArgument(paramIdx) &&
+          param.getPlainType()->getASTContext().LangOpts
+              .EnableFuzzyForwardScanTrailingClosureMatching &&
+          llvm::any_of(range(paramIdx + 1, params.size()), [&](unsigned idx) {
+            return !paramInfo.hasDefaultArgument(idx)
+              && !params[idx].isVariadic();
+          })) {
+        haveUnfulfilledParams = true;
+        return;
+      }
+
+      // The argument is unlabeled, so mark the parameter as unlabeled as
+      // well.
+      paramLabel = Identifier();
+    }
 
     // Handle variadic parameters.
     if (param.isVariadic()) {
       // Claim the next argument with the name of this parameter.
       auto claimed =
-          claimNextNamed(nextArgIdx, param.getLabel(), ignoreNameMismatch);
+          claimNextNamed(nextArgIdx, paramLabel, ignoreNameMismatch);
 
       // If there was no such argument, leave the parameter unfulfilled.
       if (!claimed) {
@@ -425,7 +451,7 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
     // Try to claim an argument for this parameter.
     if (auto claimed =
-            claimNextNamed(nextArgIdx, param.getLabel(), ignoreNameMismatch)) {
+            claimNextNamed(nextArgIdx, paramLabel, ignoreNameMismatch)) {
       parameterBindings[paramIdx].push_back(*claimed);
       return;
     }
@@ -433,125 +459,6 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
     // There was no argument to claim. Leave the argument unfulfilled.
     haveUnfulfilledParams = true;
   };
-
-  // If we have an unlabeled trailing closure, we match trailing closure
-  // labels from the end, then match the trailing closure arg.
-  if (unlabeledTrailingClosureArgIndex) {
-    unsigned unlabeledArgIdx = *unlabeledTrailingClosureArgIndex;
-
-    // One past the next parameter index to look at.
-    unsigned prevParamIdx = numParams;
-
-    // Scan backwards to match any labeled trailing closures.
-    for (unsigned argIdx = numArgs - 1; argIdx != unlabeledArgIdx; --argIdx) {
-      bool claimed = false;
-
-      // We do this scan on a copy of prevParamIdx so that, if it fails,
-      // we'll restart at this same point for the next trailing closure.
-      unsigned prevParamIdxForArg = prevParamIdx;
-      while (prevParamIdxForArg > 0) {
-        prevParamIdxForArg -= 1;
-        unsigned paramIdx = prevParamIdxForArg;
-
-        // Check for an exact label match.
-        const auto &param = params[paramIdx];
-        if (param.getLabel() == args[argIdx].getLabel()) {
-          parameterBindings[paramIdx].push_back(argIdx);
-          claim(param.getLabel(), argIdx);
-
-          // Future arguments should search prior to this parameter.
-          prevParamIdx = prevParamIdxForArg;
-          claimed = true;
-          break;
-        }
-      }
-
-      // If we ran out of parameters, there's no match for this argument.
-      // TODO: somehow fall through to report out-of-order arguments?
-      if (!claimed) {
-        if (listener.extraArgument(argIdx))
-          return true;
-      }
-    }
-
-    // Okay, we've matched all the labeled closures; scan backwards from
-    // there to match the unlabeled trailing closure.
-    Optional<unsigned> unlabeledParamIdx;
-    if (prevParamIdx > 0) {
-      unsigned paramIdx = prevParamIdx - 1;
-
-      bool lastAcceptsTrailingClosure =
-          acceptsTrailingClosure(params[paramIdx]);
-
-      // If the last parameter is defaulted, this might be
-      // an attempt to use a trailing closure with previous
-      // parameter that accepts a function type e.g.
-      //
-      // func foo(_: () -> Int, _ x: Int = 0) {}
-      // foo { 42 }
-      //
-      // FIXME: shouldn't this skip multiple arguments and look for
-      // something that acceptsTrailingClosure rather than just something
-      // with a function type?
-      if (!lastAcceptsTrailingClosure && paramIdx > 0 &&
-          paramInfo.hasDefaultArgument(paramIdx)) {
-        auto paramType = params[paramIdx - 1].getPlainType();
-        // If the parameter before defaulted last accepts.
-        if (paramType->is<AnyFunctionType>()) {
-          lastAcceptsTrailingClosure = true;
-          paramIdx -= 1;
-        }
-      }
-
-      if (lastAcceptsTrailingClosure)
-        unlabeledParamIdx = paramIdx;
-    }
-
-    // If there's no suitable last parameter to accept the trailing closure,
-    // notify the listener and bail if we need to.
-    if (!unlabeledParamIdx) {
-      // Try to use a specialized diagnostic for an extra closure.
-      bool isExtraClosure = false;
-      if (prevParamIdx == 0) {
-        isExtraClosure = true;
-      } else if (unlabeledArgIdx > 0) {
-        // Argument before the trailing closure.
-        unsigned prevArg = unlabeledArgIdx - 1;
-        auto &arg = args[prevArg];
-        // If the argument before trailing closure matches
-        // last parameter, this is just a special case of
-        // an extraneous argument.
-        const auto param = params[prevParamIdx - 1];
-        if (param.hasLabel() && param.getLabel() == arg.getLabel()) {
-          isExtraClosure = true;
-        }
-      }
-
-      if (isExtraClosure) {
-        if (listener.extraArgument(unlabeledArgIdx))
-          return true;
-      } else {
-        if (listener.trailingClosureMismatch(prevParamIdx - 1,
-                                             unlabeledArgIdx))
-          return true;
-      }
-
-      if (isExtraClosure) {
-        // Claim the unlabeled trailing closure without an associated
-        // parameter to suppress further complaints about it.
-        claim(Identifier(), unlabeledArgIdx, /*ignoreNameClash=*/true);
-      } else {
-        unlabeledParamIdx = prevParamIdx - 1;
-      }
-    }
-
-    if (unlabeledParamIdx) {
-      // Claim the parameter/argument pair.
-      claim(params[*unlabeledParamIdx].getLabel(), unlabeledArgIdx,
-            /*ignoreNameClash=*/true);
-      parameterBindings[*unlabeledParamIdx].push_back(unlabeledArgIdx);
-    }
-  }
 
   {
     unsigned nextArgIdx = 0;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -421,7 +421,8 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
       // If the parameter we are looking at does not support the (unlabeled)
       // trailing closure argument, this parameter is unfulfilled.
-      if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx)) {
+      if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx) &&
+          !ignoreNameMismatch) {
         haveUnfulfilledParams = true;
         return;
       }
@@ -739,7 +740,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         // one argument requires label and another one doesn't, but caller
         // doesn't provide either, problem is going to be identified as
         // out-of-order argument instead of label mismatch.
-        const auto expectedLabel = params[paramIdx].getLabel();
+        const auto expectedLabel =
+          fromArgIdx == unlabeledTrailingClosureArgIndex
+            ? Identifier()
+            : params[paramIdx].getLabel();
         const auto argumentLabel = args[fromArgIdx].getLabel();
 
         if (argumentLabel != expectedLabel) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -196,7 +196,7 @@ static ConstraintSystem::TypeMatchOptions getDefaultDecompositionOptions(
 }
 
 /// Whether the given parameter requires an argument.
-static bool parameterRequiresArgument(
+bool swift::parameterRequiresArgument(
     ArrayRef<AnyFunctionType::Param> params,
     const ParameterListInfo &paramInfo,
     unsigned paramIdx) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -61,11 +61,6 @@ bool MatchCallArgumentListener::relabelArguments(ArrayRef<Identifier> newNames){
   return true;
 }
 
-bool MatchCallArgumentListener::trailingClosureMismatch(
-    unsigned paramIdx, unsigned argIdx) {
-  return true;
-}
-
 /// Produce a score (smaller is better) comparing a parameter name and
 /// potentially-typo'd argument name.
 ///
@@ -948,37 +943,6 @@ public:
     auto impact = 1 + numOutOfOrder + numExtraneous * 2 + numRenames * 3 +
                   MissingArguments.size() * 2;
     return CS.recordFix(fix, impact);
-  }
-
-  bool trailingClosureMismatch(unsigned paramIdx, unsigned argIdx) override {
-    if (!CS.shouldAttemptFixes())
-      return true;
-
-    const auto &param = Parameters[paramIdx];
-
-    auto *argLoc = CS.getConstraintLocator(
-        Locator.withPathElement(LocatorPathElt::ApplyArgToParam(
-            argIdx, paramIdx, param.getParameterFlags())));
-
-    // TODO(diagnostics): This fix should be attempted later
-    // when the argument is matched to a parameter. Doing that
-    // would not require special handling of the closure type.
-    Type argType;
-    if (auto *closure =
-            getAsExpr<ClosureExpr>(simplifyLocatorToAnchor(argLoc))) {
-      argType = CS.getClosureType(closure);
-    } else {
-      argType = Arguments[argIdx].getPlainType();
-    }
-
-    argType.visit([&](Type type) {
-      if (auto *typeVar = type->getAs<TypeVariableType>())
-        CS.recordPotentialHole(typeVar);
-    });
-
-    auto *fix = AllowInvalidUseOfTrailingClosure::create(
-        CS, argType, param.getPlainType(), argLoc);
-    return CS.recordFix(fix, /*impact=*/3);
   }
 
   ArrayRef<std::pair<unsigned, AnyFunctionType::Param>>
@@ -3467,9 +3431,6 @@ bool ConstraintSystem::repairFailures(
 
   case ConstraintLocator::ApplyArgToParam: {
     auto loc = getConstraintLocator(locator);
-
-    if (hasFixFor(loc, FixKind::AllowInvalidUseOfTrailingClosure))
-      return true;
 
     // Don't attempt to fix an argument being passed to a
     // _OptionalNilComparisonType parameter. Such an overload should only take
@@ -9811,7 +9772,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::GenericArgumentsMismatch:
   case FixKind::AllowMutatingMemberOnRValueBase:
   case FixKind::AllowTupleSplatForSingleParameter:
-  case FixKind::AllowInvalidUseOfTrailingClosure:
   case FixKind::AllowNonClassTypeToConvertToAnyObject:
   case FixKind::SpecifyClosureParameterType:
   case FixKind::SpecifyClosureReturnType:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5742,6 +5742,12 @@ bool shouldTypeCheckInEnclosingExpression(ClosureExpr *expr);
 void forEachExprInConstraintSystem(
     Expr *expr, llvm::function_ref<Expr *(Expr *)> callback);
 
+/// Whether the given parameter requires an argument.
+bool parameterRequiresArgument(
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    unsigned paramIdx);
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5200,13 +5200,6 @@ public:
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
   virtual bool relabelArguments(ArrayRef<Identifier> newNames);
-
-  /// Indicates that the trailing closure argument at the given \c argIdx
-  /// cannot be passed to the last parameter at \c paramIdx.
-  ///
-  /// \returns true to indicate that this should cause a failure, false
-  /// otherwise.
-  virtual bool trailingClosureMismatch(unsigned paramIdx, unsigned argIdx);
 };
 
 /// Match the call arguments (as described by the given argument type) to

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -595,6 +595,15 @@ public:
     return StringRef(scratch.data(), scratch.size());
   }
 
+  /// Whether the argument is a trailing closure.
+  bool isTrailingClosure() const {
+    if (auto trailingClosureArg =
+            ArgListExpr->getUnlabeledTrailingClosureIndexOfPackedArgument())
+      return ArgIdx >= *trailingClosureArg;
+
+    return false;
+  }
+
   /// \returns The interface type for the function being applied. Note that this
   /// may not a function type, for example it could be a generic parameter.
   Type getFnInterfaceType() const { return FnInterfaceType; }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1798,7 +1798,8 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
       newName = newNames[i];
 
     if (oldName == newName ||
-        (argList.hasTrailingClosure && i == argList.args.size()-1))
+        (argList.hasTrailingClosure && i == argList.args.size()-1 &&
+         (numMissing > 0 || numExtra > 0 || numWrong > 0)))
       continue;
 
     if (oldName.empty()) {

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1418,7 +1418,7 @@ struct RelabelAndTrailingClosure {
   func f2(aa: Int, bb: Int, _ cc: () -> Void = {}) {}
 
   func test() {
-    f1(aax: 1, bbx: 2) {} // expected-error {{incorrect argument labels in call (have 'aax:bbx:_:', expected 'aa:bb:cc:')}} {{8-11=aa}} {{16-19=bb}} {{none}}
+    f1(aax: 1, bbx: 2) {} // expected-error {{incorrect argument labels in call (have 'aax:bbx:_:', expected 'aa:bb:_:')}} {{8-11=aa}} {{16-19=bb}} {{none}}
     f2(aax: 1, bbx: 2) {} // expected-error {{incorrect argument labels in call (have 'aax:bbx:_:', expected 'aa:bb:_:')}} {{8-11=aa}} {{16-19=bb}} {{none}}
 
     f1(aax: 1, bbx: 2) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{8-11=aa}} {{16-19=bb}} {{none}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -999,11 +999,13 @@ func rdar52204414() {
   // expected-error@-1 {{declared closure result 'Int' is incompatible with contextual type 'Void'}}
 }
 
-// SR-12291 - trailing closure is used as an argument to the last (positionally) parameter
-func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {}
-func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {}
+// SR-12291 - trailing closure is used as an argument to the last (positionally) parameter.
+// Note that this was accepted prior to Swift 5.3. SE-0286 changed the
+// order of argument resolution and made it ambiguous.
+func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note{{found this candidate}}
+func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note{{found this candidate}}
 
-overloaded_with_default { 0 } // Ok (could be ambiguous if trailing was allowed to match `a:` in first overload)
+overloaded_with_default { 0 } // expected-error{{ambiguous use of 'overloaded_with_default'}}
 
 func overloaded_with_default_and_autoclosure<T>(_ a: @autoclosure () -> T, b: Int = 0) {}
 func overloaded_with_default_and_autoclosure<T>(b: Int = 0, c: @escaping () -> T?) {}

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -35,11 +35,9 @@ trailingClosureSingle1() { 1 } // expected-error {{missing argument for paramete
 
 func trailingClosureSingle2(x: () -> Int, y: Int) {} // expected-note * {{here}}
 trailingClosureSingle2 { 1 }
-// expected-error@-1 {{missing argument for parameter 'x' in call}} {{23-23=(x: <#() -> Int#>)}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing argument for parameter 'y' in call}} {{none}}
 trailingClosureSingle2() { 1 }
-// expected-error@-1 {{missing argument for parameter 'x' in call}} {{24-24=x: <#() -> Int#>}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing argument for parameter 'y' in call}} {{none}}
 
 func trailingClosureMulti1(x: Int, y: Int, z: () -> Int) {} // expected-note * {{here}}
 trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#Int#>, }}
@@ -48,14 +46,17 @@ trailingClosureMulti1(x: 1, y: 1) // expected-error {{missing argument for param
 
 func trailingClosureMulti2(x: Int, y: () -> Int, z: Int) {} // expected-note * {{here}}
 trailingClosureMulti2 { 1 }
-// expected-error@-1 {{missing arguments for parameters 'x', 'y' in call}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing arguments for parameters 'x', 'z' in call}}
 trailingClosureMulti2() { 1 }
-// expected-error@-1 {{missing arguments for parameters 'x', 'y' in call}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing arguments for parameters 'x', 'z' in call}}
 trailingClosureMulti2(x: 1) { 1 }
-// expected-error@-1 {{missing argument for parameter 'y' in call}} {{27-27=, y: <#() -> Int#>}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing argument for parameter 'z' in call}} {{none}}
+
+func trailingClosureMulti3(x: (Int) -> Int, y: (Int) -> Int, z: (Int) -> Int) {} // expected-note 2 {{declared here}}
+trailingClosureMulti3 { $0 } y: { $0 } // expected-error{{missing argument for parameter 'z' in call}}{{39-39= z: <#(Int) -> Int#>}}
+
+trailingClosureMulti3 { $0 } z: { $0 } // expected-error{{missing argument for parameter 'y' in call}}{{29-29= y: <#(Int) -> Int#>}}
+
 
 func param2Func(x: Int, y: Int) {} // expected-note * {{here}}
 param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1101,8 +1101,9 @@ func rdar17170728() {
     // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
-  let _ = [i, j, k].reduce(0 as Int?) { // expected-note{{found candidate with type '(__owned @escaping (Bool, Bool) -> Bool?, (inout @escaping (Bool, Bool) -> Bool?, Int?) throws -> ()) throws -> (Bool, Bool) -> Bool?'}}
-    // expected-error@-1{{no exact matches in call to instance method 'reduce'}}
+  let _ = [i, j, k].reduce(0 as Int?) {
+    // expected-error@-1{{missing argument label 'into:' in call}}
+    // expected-error@-2{{cannot convert value of type 'Int?' to expected argument type}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
     // expected-error@-1{{binary operator '+' cannot be applied to two 'Bool' operands}}
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1101,14 +1101,10 @@ func rdar17170728() {
     // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
-  let _ = [i, j, k].reduce(0 as Int?) {
-    // expected-error@-1 3 {{cannot convert value of type 'Int?' to expected element type 'Int'}}
+  let _ = [i, j, k].reduce(0 as Int?) { // expected-note{{found candidate with type '(__owned @escaping (Bool, Bool) -> Bool?, (inout @escaping (Bool, Bool) -> Bool?, Int?) throws -> ()) throws -> (Bool, Bool) -> Bool?'}}
+    // expected-error@-1{{no exact matches in call to instance method 'reduce'}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 2 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-    // expected-error@-2   {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-    // expected-error@-3 2 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
-    // expected-note@-4:16 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-    // expected-note@-5:16 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-error@-1{{binary operator '+' cannot be applied to two 'Bool' operands}}
   }
 }
 

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -38,14 +38,3 @@ func testUnresolvedMember(i: Int) -> X {
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
   return .init(i, i)
 }
-
-func trailing(x: Int = 0, y: () -> Void) { }
-func trailing(x: Int = 0, z: Float) { }
-
-func testTrailing() {
-  // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).trailing(x:z:)
-  trailing() { }
-
-  // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).trailing(x:z:)
-  trailing(x: 5) { }
-}

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -68,12 +68,14 @@ func bar(_ s: S) {
   }
 }
 
-func multiple_trailing_with_defaults(
+func multiple_trailing_with_defaults( // expected-note{{contains defaulted closure parameters 'animations' and 'completion'}}
   duration: Int,
   animations: (() -> Void)? = nil,
   completion: (() -> Void)? = nil) {}
 
-multiple_trailing_with_defaults(duration: 42) {}
+multiple_trailing_with_defaults(duration: 42) {} // expected-warning{{unlabeled trailing closure argument matches}}
+// expected-note@-1{{'completion' to retain}}
+// expected-note@-2{{'animations' to silence this}}
 
 multiple_trailing_with_defaults(duration: 42) {} completion: {}
 

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -82,7 +82,7 @@ func test_multiple_trailing_syntax_without_labels() {
 
   fn {} g: {} // Ok
 
-  fn {} _: {} // expected-error {{extra argument in call}}
+  fn {} _: {} // expected-error {{missing argument labels 'f:g:' in call}}
 
   fn {} g: <#T##() -> Void#> // expected-error {{editor placeholder in source file}}
 
@@ -90,16 +90,15 @@ func test_multiple_trailing_syntax_without_labels() {
 
   multiple {} _: { }
 
-  func mixed_args_1(a: () -> Void, _: () -> Void) {} // expected-note {{'mixed_args_1(a:_:)' declared here}}
-  func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} // expected-note 2 {{'mixed_args_2(_:a:_:)' declared here}}
+  func mixed_args_1(a: () -> Void, _: () -> Void) {}
+  func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} // expected-note {{'mixed_args_2(_:a:_:)' declared here}}
 
   mixed_args_1
     {}
     _: {}
 
-  // FIXME: not a good diagnostic
   mixed_args_1
-    {}  // expected-error {{extra argument in call}} expected-error {{missing argument for parameter #2 in call}}
+    {}  // expected-error {{incorrect argument labels in call (have '_:a:', expected 'a:_:')}}
     a: {}
 
   mixed_args_2
@@ -107,14 +106,13 @@ func test_multiple_trailing_syntax_without_labels() {
     a: {}
     _: {}
 
-  // FIXME: not a good diagnostic
   mixed_args_2
-    {} // expected-error {{missing argument for parameter #1 in call}}
+    {} // expected-error {{missing argument for parameter 'a' in call}}
     _: {}
 
   // FIXME: not a good diagnostic
   mixed_args_2
-    {}  // expected-error {{extra argument in call}} expected-error {{missing argument for parameter 'a' in call}}
+    {}  // expected-error {{missing argument label 'a:' in call}}
     _: {}
     _: {}
 }
@@ -123,5 +121,5 @@ func produce(fn: () -> Int?, default d: () -> Int) -> Int { // expected-note {{d
   return fn() ?? d()
 }
 // TODO: The diagnostics here are perhaps a little overboard.
-_ = produce { 0 } default: { 1 } // expected-error {{missing argument for parameter 'fn' in call}} expected-error {{consecutive statements}} expected-error {{'default' label can only appear inside a 'switch' statement}} expected-error {{top-level statement cannot begin with a closure expression}} expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}}
+_ = produce { 0 } default: { 1 } // expected-error {{missing argument for parameter 'default' in call}} expected-error {{consecutive statements}} expected-error {{'default' label can only appear inside a 'switch' statement}} expected-error {{top-level statement cannot begin with a closure expression}} expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}}
 _ = produce { 2 } `default`: { 3 }

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -5,7 +5,7 @@ func takeFunc(_ f: (Int) -> Int) -> Int {}
 func takeValueAndFunc(_ value: Int, _ f: (Int) -> Int) {}
 func takeTwoFuncs(_ f: (Int) -> Int, _ g: (Int) -> Int) {}
 func takeFuncWithDefault(f : ((Int) -> Int)? = nil) {}
-func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {}
+func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {} // expected-note{{contains defaulted closure parameters 'f1' and 'f2'}}
 
 struct X {
   func takeFunc(_ f: (Int) -> Int) {}
@@ -94,8 +94,6 @@ var c3 = C().map // expected-note{{callee is here}}
 func multiTrailingClosure(_ a : () -> (), b : () -> ()) {  // expected-note {{'multiTrailingClosure(_:b:)' declared here}}
   multiTrailingClosure({}) {} // ok
   multiTrailingClosure {} {}   // expected-error {{missing argument for parameter 'b' in call}} expected-error {{consecutive statements on a line must be separated by ';'}} {{26-26=;}} expected-error {{closure expression is unused}} expected-note{{did you mean to use a 'do' statement?}} {{27-27=do }}
-  
-  
 }
 
 func labeledArgumentAndTrailingClosure() {
@@ -108,7 +106,8 @@ func labeledArgumentAndTrailingClosure() {
 
   // Trailing closure binds to first parameter.
  takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
-  takeTwoFuncsWithDefaults { $0 + 1 }
+  takeTwoFuncsWithDefaults { $0 + 1 } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })
 }
 

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -93,7 +93,7 @@ var c3 = C().map // expected-note{{callee is here}}
 // <rdar://problem/16835718> Ban multiple trailing closures
 func multiTrailingClosure(_ a : () -> (), b : () -> ()) {  // expected-note {{'multiTrailingClosure(_:b:)' declared here}}
   multiTrailingClosure({}) {} // ok
-  multiTrailingClosure {} {}   // expected-error {{missing argument for parameter #1 in call}} expected-error {{consecutive statements on a line must be separated by ';'}} {{26-26=;}} expected-error {{closure expression is unused}} expected-note{{did you mean to use a 'do' statement?}} {{27-27=do }}
+  multiTrailingClosure {} {}   // expected-error {{missing argument for parameter 'b' in call}} expected-error {{consecutive statements on a line must be separated by ';'}} {{26-26=;}} expected-error {{closure expression is unused}} expected-note{{did you mean to use a 'do' statement?}} {{27-27=do }}
   
   
 }
@@ -106,9 +106,9 @@ func labeledArgumentAndTrailingClosure() {
   takeFuncWithDefault({ $0 + 1 }) // expected-error {{missing argument label 'f:' in call}} {{23-23=f: }}
   takeFuncWithDefault(f: { $0 + 1 })
 
-  // Trailing closure binds to last parameter, always.
- takeTwoFuncsWithDefaults { "Hello, " + $0 }
-  takeTwoFuncsWithDefaults { $0 + 1 } // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  // Trailing closure binds to first parameter.
+ takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
+  takeTwoFuncsWithDefaults { $0 + 1 }
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })
 }
 
@@ -420,11 +420,11 @@ func variadicAndNonOverloadLabel(b: (() -> Void)...) -> Int { return 0 }
 func testVariadic() {
   variadic {}
   variadic() {}
-  variadic({}) {} // expected-error {{extra argument in call}}
+  variadic({}) {}
 
   variadicLabel {}
   variadicLabel() {}
-  variadicLabel(closures: {}) {} // expected-error {{extra argument 'closures' in call}}
+  variadicLabel(closures: {}) {}
 
   let a1 = variadicOverloadMismatch {}
   _ = a1 as String // expected-error {{cannot convert value of type 'Bool' to type 'String'}}

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,0 +1,83 @@
+// RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
+
+func forwardMatch1(
+  a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,
+  numbers: Int..., closure2: ((Double) -> Double)? = nil,
+  closure3: (String) -> String = { $0 + "!" }
+) {
+}
+
+func testForwardMatch1(i: Int, d: Double, s: String) {
+  forwardMatch1()
+
+  // Matching closure1
+  forwardMatch1 { _ in i }
+  forwardMatch1 { _ in i } closure2: { d + $0 }
+  forwardMatch1 { _ in i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1 { _ in i } closure3: { $0 + ", " + s + "!" }
+
+  forwardMatch1(a: 5) { $0 + i }
+  forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 }
+  forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1(a: 5) { $0 + i } closure3: { $0 + ", " + s + "!" }
+
+  forwardMatch1(b: 1) { $0 + i }
+  forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 }
+  forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1(b: 1) { $0 + i } closure3: { $0 + ", " + s + "!" }
+
+  // Matching closure2
+  forwardMatch1(closure1: { $0 + i }) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } closure3: { $0 + ", " + s + "!" }
+
+  // Matching closure3
+  forwardMatch1(closure2: nil) { $0 + ", " + s + "!" }
+}
+
+func forwardMatchWithAutoclosure1(
+  a: String = "hello",
+  b: @autoclosure () -> Int = 17,
+  closure1: () -> String
+) { }
+
+func testForwardMatchWithAutoclosure1(i: Int, s: String) {
+  forwardMatchWithAutoclosure1 {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(a: s) {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(b: i) {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(a: s, b: i) {
+    print(s)
+    return s
+  }
+}
+
+func forwardMatchWithAutoclosure2(
+  a: String = "hello",
+  closure1: @autoclosure () -> (() -> String),
+  closure2: () -> Int = { 5 }
+) { }
+
+func testForwardMatchWithAutoclosure2(i: Int, s: String) {
+  forwardMatchWithAutoclosure2 {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure2(a: s) {
+    print(s)
+    return s
+  }
+
+  forwardMatchWithAutoclosure2(a: s, closure1: { s }) {
+    print(i)
+    return i
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
 
-func forwardMatch1(
+func forwardMatch1( // expected-note 5 {{contains defaulted}}
   a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,
   numbers: Int..., closure2: ((Double) -> Double)? = nil,
   closure3: (String) -> String = { $0 + "!" }
@@ -11,24 +11,29 @@ func testForwardMatch1(i: Int, d: Double, s: String) {
   forwardMatch1()
 
   // Matching closure1
-  forwardMatch1 { _ in i }
+  forwardMatch1 { _ in i } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1 { _ in i } closure2: { d + $0 }
   forwardMatch1 { _ in i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1 { _ in i } closure3: { $0 + ", " + s + "!" }
 
-  forwardMatch1(a: 5) { $0 + i }
+  forwardMatch1(a: 5) { $0 + i } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 }
   forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1(a: 5) { $0 + i } closure3: { $0 + ", " + s + "!" }
 
-  forwardMatch1(b: 1) { $0 + i }
+  forwardMatch1(b: 1) { $0 + i } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 }
   forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1(b: 1) { $0 + i } closure3: { $0 + ", " + s + "!" }
 
   // Matching closure2
-  forwardMatch1(closure1: { $0 + i }) { d + $0 }
-  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }) { d + $0 } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } closure3: { $0 + ", " + s + "!" }
 
   // Matching closure3

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -81,3 +81,13 @@ func testForwardMatchWithAutoclosure2(i: Int, s: String) {
     return i
   }
 }
+
+// Match a closure parameter to a variadic parameter.
+func acceptsVariadicClosureParameter(closures: ((Int, Int) -> Int)...) {
+}
+
+func testVariadicClosureParameter() {
+  acceptsVariadicClosureParameter { x, y in x % y }
+  acceptsVariadicClosureParameter() { x, y in x % y }
+  acceptsVariadicClosureParameter(closures: +, -, *, /) { x, y in x % y }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
@@ -1,0 +1,102 @@
+// RUN: %target-typecheck-verify-swift
+
+// Ambiguity when calling.
+func ambiguous1( // expected-note 3 {{'ambiguous1(x:a:y:b:z:c:)' contains defaulted closure parameters '}}
+
+  x: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  z: (Int) -> Int = { $0 },
+  c: Int = 5
+) {}
+
+func testAmbiguous1() {
+  ambiguous1 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter 'z'}}
+    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{13-13=(z: }}{{20-20=)}}
+    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{13-13=(x: }}{{20-20=)}}
+
+  ambiguous1() { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter 'z'}}
+    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{14-15=z: }}{{22-22=)}}
+    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{14-15=x: }}{{22-22=)}}
+
+  ambiguous1(a: 3) { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'y' rather than parameter 'z'}}
+    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{18-19=, z: }}{{26-26=)}}
+    // expected-note@-2{{label the argument with 'y' to silence this warning for Swift 5.3 and newer}}{{18-19=, y: }}{{26-26=)}}
+
+  // No warning; this is matching the last parameter.
+  ambiguous1(b: 3) { $0 }
+}
+
+// Ambiguity with two unlabeled arguments.
+func ambiguous2( // expected-note{{'ambiguous2(_:a:y:b:_:x:)' contains defaulted closure parameters '_' and '_'}}
+  _: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  x: Int = 5
+) {}
+
+func testAmbiguous2() {
+    ambiguous2 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches earlier parameter '_' rather than later parameter with the same name}}
+}
+
+// Ambiguity with one unlabeled argument.
+func ambiguous3( // expected-note{{'ambiguous3(x:a:y:b:_:c:)' contains defaulted closure parameters 'x' and '_'}}
+  x: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  c: Int = 5
+) {}
+
+func testAmbiguous3() {
+  ambiguous3 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter '_'}}
+    // expected-note@-1{{label the argument with '_' to retain the pre-Swift 5.3 behavior}}{{13-13=(}}{{20-20=)}}
+    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{13-13=(x: }}{{20-20=)}}
+}
+
+// Not ambiguous because of an arity mismatch that would lead to different
+// type-checks.
+func notAmbiguous1(
+  x: (Int, Int) -> Int = { $0 + $1 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  c: Int = 5
+) { }
+
+func testNotAmbiguous1() {
+  notAmbiguous1 { $0 / $1 }
+}
+
+// Not ambiguous because of a missing default argument.
+func notAmbiguous2(
+  x: (Int) -> Int,
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  c: Int = 5
+) { }
+
+func testNotAmbiguous2() {
+  notAmbiguous2 { $0 }
+}
+
+// Not ambiguous because of a missing default argument.
+func notAmbiguous3(
+  x: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int ,
+  c: Int = 5
+) { }
+
+func testNotAmbiguous3() {
+  notAmbiguous3 { $0 }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
+
+func forwardMatchWithGeneric<T>( // expected-note{{'forwardMatchWithGeneric(closure1:closure2:)' declared here}}
+  closure1: T,
+  closure2: () -> Int = { 5 }
+) { }
+
+func testKnownSourceBreaks(i: Int) {
+  forwardMatchWithGeneric { i } // expected-error{{missing argument for parameter 'closure1' in call}}
+  let _: (() -> ()).Type = type { } // expected-error{{missing argument label 'of:' in call}}
+}
+
+func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
+  var arrayOfFuncs = [() -> Void]()
+  arrayOfFuncs.append { print("Hi") } // okay because the parameter is unlabeled?
+
+  fn { $0 + i} // okay because the parameter label is empty
+}
+
+// When "fuzzy matching is disabled, this will fail.
+func forwardMatchFailure( // expected-note{{declared here}}
+  onError: ((Error) -> Void)? = nil,
+  onCompletion: (Int) -> Void
+) { }
+
+func testForwardMatchFailure() {
+  forwardMatchFailure { x in // expected-error{{missing argument for parameter 'onCompletion' in call}}
+    print(x)
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -7,7 +7,7 @@ func forwardMatchWithGeneric<T>( // expected-note{{'forwardMatchWithGeneric(clos
 
 func testKnownSourceBreaks(i: Int) {
   forwardMatchWithGeneric { i } // expected-error{{missing argument for parameter 'closure1' in call}}
-  let _: (() -> ()).Type = type { } // expected-error{{missing argument label 'of:' in call}}
+  let _: (() -> ()).Type = type { }
 }
 
 func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
@@ -24,7 +24,7 @@ func forwardMatchFailure( // expected-note{{declared here}}
 ) { }
 
 func testForwardMatchFailure() {
-  forwardMatchFailure { x in // expected-error{{missing argument for parameter 'onCompletion' in call}}
+  forwardMatchFailure { x in
     print(x)
-  }
+  } // expected-error{{missing argument for parameter 'onCompletion' in call}}{{4-4= onCompletion: <#(Int) -> Void#>}}
 }

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+func doSomething(onError: ((Error) -> Void)? = nil, onCompletion: (Int) -> Void) { }
+
+func testDoSomething() {
+  doSomething { x in
+    print(x)
+  }
+
+  doSomething(onError: nil) { x in
+    print(x)
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -10,4 +10,21 @@ func testDoSomething() {
   doSomething(onError: nil) { x in
     print(x)
   }
+
+  doSomething { e in
+    print(e)
+  } onCompletion: { x in
+    print(x)
+  }
+}
+
+func trailingClosures(
+  arg1: () -> Void = {},
+  arg2: () -> Void,
+  arg3: () -> Void = {}
+) {}
+
+func testTrailingClosures() {
+  trailingClosures { print("Hello!") }
+  trailingClosures { print("Hello,") } arg3: { print("world!") }
 }


### PR DESCRIPTION
Introduce a new "forward" algorithm for trailing closures where
the unlabeled trailing closure argument matches the next parameter in
the parameter list that can accept an unlabeled trailing closure. This
feature is described by SE-0286.