### PR TITLE
[Explicit Module Builds] Prevent SerializedModuleLoader from running in Explicit Module Build mode.

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -64,9 +64,11 @@ protected:
   ASTContext &Ctx;
   ModuleLoadingMode LoadMode;
   bool IgnoreSwiftSourceInfoFile;
+  bool ImplicitModulesDisabled;
   SerializedModuleLoaderBase(ASTContext &ctx, DependencyTracker *tracker,
                              ModuleLoadingMode LoadMode,
-                             bool IgnoreSwiftSourceInfoFile);
+                             bool IgnoreSwiftSourceInfoFile,
+                             bool ImplicitModulesDisabled = false);
 
   void collectVisibleTopLevelModuleNamesImpl(SmallVectorImpl<Identifier> &names,
                                              StringRef extension) const;
@@ -211,8 +213,11 @@ public:
 class SerializedModuleLoader : public SerializedModuleLoaderBase {
 
   SerializedModuleLoader(ASTContext &ctx, DependencyTracker *tracker,
-                         ModuleLoadingMode loadMode, bool IgnoreSwiftSourceInfo)
-    : SerializedModuleLoaderBase(ctx, tracker, loadMode, IgnoreSwiftSourceInfo)
+                         ModuleLoadingMode loadMode, bool IgnoreSwiftSourceInfo,
+                         bool DisableImplicitSwiftModule,
+                         bool ImplicitModulesDisabled)
+    : SerializedModuleLoaderBase(ctx, tracker, loadMode, IgnoreSwiftSourceInfo,
+                                 ImplicitModulesDisabled)
   {}
 
   std::error_code findModuleFilesInDirectory(
@@ -241,9 +246,11 @@ public:
   static std::unique_ptr<SerializedModuleLoader>
   create(ASTContext &ctx, DependencyTracker *tracker = nullptr,
          ModuleLoadingMode loadMode = ModuleLoadingMode::PreferSerialized,
-         bool IgnoreSwiftSourceInfo = false) {
+         bool IgnoreSwiftSourceInfo = false, bool ImplicitModulesDisabled = false) {
     return std::unique_ptr<SerializedModuleLoader>{
-      new SerializedModuleLoader(ctx, tracker, loadMode, IgnoreSwiftSourceInfo)
+      new SerializedModuleLoader(ctx, tracker, loadMode, IgnoreSwiftSourceInfo,
+                                 /* IgnoreSwiftSourceInfo */ false,
+                                 ImplicitModulesDisabled)
     };
   }
 };

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -484,7 +484,8 @@ bool CompilerInstance::setUpModuleLoaders() {
 
   // If implicit modules are disabled, we need to install an explicit module
   // loader.
-  if (Invocation.getFrontendOptions().DisableImplicitModules) {
+  bool ImplicitModulesDisabled = Invocation.getFrontendOptions().DisableImplicitModules;
+  if (ImplicitModulesDisabled) {
     auto ESML = ExplicitSwiftModuleLoader::create(
         *Context,
         getDependencyTracker(), MLM,
@@ -509,7 +510,7 @@ bool CompilerInstance::setUpModuleLoaders() {
 
   std::unique_ptr<SerializedModuleLoader> SML =
     SerializedModuleLoader::create(*Context, getDependencyTracker(), MLM,
-                                   IgnoreSourceInfoFile);
+                                   IgnoreSourceInfoFile, ImplicitModulesDisabled);
   this->SML = SML.get();
   Context->addModuleLoader(std::move(SML));
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -110,9 +110,10 @@ Optional<bool> forEachModuleSearchPath(
 // Defined out-of-line so that we can see ~ModuleFile.
 SerializedModuleLoaderBase::SerializedModuleLoaderBase(
     ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
-    bool IgnoreSwiftSourceInfoFile)
+    bool IgnoreSwiftSourceInfoFile, bool ImplicitModulesDisabled)
     : ModuleLoader(tracker), Ctx(ctx), LoadMode(loadMode),
-      IgnoreSwiftSourceInfoFile(IgnoreSwiftSourceInfoFile) {}
+      IgnoreSwiftSourceInfoFile(IgnoreSwiftSourceInfoFile),
+      ImplicitModulesDisabled(ImplicitModulesDisabled) {}
 
 SerializedModuleLoaderBase::~SerializedModuleLoaderBase() = default;
 SerializedModuleLoader::~SerializedModuleLoader() = default;
@@ -409,6 +410,9 @@ std::error_code SerializedModuleLoader::findModuleFilesInDirectory(
          "Module and Module Doc buffer must both be initialized or NULL");
 
   if (LoadMode == ModuleLoadingMode::OnlyInterface)
+    return std::make_error_code(std::errc::not_supported);
+
+  if (ImplicitModulesDisabled)
     return std::make_error_code(std::errc::not_supported);
 
   auto ModuleErr = openModuleFile(ModuleID, BaseName, ModuleBuffer);

--- a/test/ScanDependencies/explicit-module-map.swift
+++ b/test/ScanDependencies/explicit-module-map.swift
@@ -5,11 +5,20 @@
 // RUN: echo "public func foo() {}" >> %t/foo.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
 
+// RUN: touch %t/inputs/Swift.swiftmodule
 // RUN: echo "[{" > %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
 // RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%stdlib_dir/SwiftOnoneSupport.swiftmodule/%module-target-triple.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -enable-swiftsourceinfo -source-filename %s -explicit-swift-module-map-file %t/inputs/map.json | %FileCheck %s

--- a/test/ScanDependencies/module_not_found.swift
+++ b/test/ScanDependencies/module_not_found.swift
@@ -5,13 +5,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
 
 // RUN: touch %t/inputs/Swift.swiftmodule
-// RUN: echo "[{" > %/t/inputs/map.json
-// RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
-// RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
-// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"" >> %/t/inputs/map.json
-// RUN: echo "}," >> %/t/inputs/map.json
-// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "[{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
@@ -20,7 +14,8 @@
 // RUN: echo "\"modulePath\": \"%stdlib_dir/SwiftOnoneSupport.swiftmodule/%module-target-triple.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
-// RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules
-#if canImport(Foo)
+// Add the -I search path to ensure we do not accidentally implicitly load Foo.swiftmodule
+// RUN: not %target-swift-frontend -typecheck %s -I %t/inputs -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules
 import Foo
-#endif
+// CHECK: error: no such module 'Foo'
+

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1439,6 +1439,9 @@ config.substitutions.append(('%module-target-future', target_future))
 # Add 'target-sdk-name' as the name for platform-specific directories
 config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 
+# Add 'stdlib_dir' as the path to the stdlib resource directory
+config.substitutions.append(('%stdlib_dir', config.swiftlib_dir + "/" + run_os))
+
 # Different OS's require different prefixes for the environment variables to be
 # propagated to the calling contexts.
 # In order to make tests OS-agnostic, names of environment variables should be


### PR DESCRIPTION
And update the tests to explicitly import stdlib. 