### PR TITLE
Fix a Source Break With Function Builders

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1472,6 +1472,13 @@ namespace {
         type = CS.getInstanceType(CS.cacheType(E));
         assert(type && "Implicit type expr must have type set!");
         type = CS.openUnboundGenericTypes(type, locator);
+      } else if (CS.hasType(E)) {
+        // If there's a type already set into the constraint system, honor it.
+        // FIXME: This supports the function builder transform, which sneakily
+        // stashes a type in the constraint system through a TypeExpr in order
+        // to pass it down to the rest of CSGen. This is a terribly
+        // unprincipled thing to do.
+        return CS.getType(E);
       } else {
         auto *repr = E->getTypeRepr();
         assert(repr && "Explicit node has no type repr!");

--- a/test/Constraints/rdar64890308.swift
+++ b/test/Constraints/rdar64890308.swift
@@ -13,8 +13,7 @@ class ArrayBuilder<Element> {
 
 func foo<T>(@ArrayBuilder<T> fn: () -> [T]) {}
 
-// FIXME(SR-13132): This should compile.
-foo { // expected-error {{type of expression is ambiguous without more context}}
+foo {
   ""
 }
 
@@ -28,4 +27,21 @@ struct S<T> {
 func bar<T>(_ x: T, _ fn: (T, T.Type) -> [T]) {}
 bar("") { x, ty in
   (Builtin.one_way(S(ty).overloaded(x)))
+}
+
+protocol P {}
+extension String : P {}
+
+@_functionBuilder
+struct FooBuilder<T> {}
+
+extension FooBuilder where T : P {
+  static func buildBlock(_ x: Int, _ y: Int) -> String { "" }
+}
+
+func foo<T : P>(@FooBuilder<T> fn: () -> T) {}
+
+foo {
+  0
+  0
 }


### PR DESCRIPTION
Before 09db2902d21107165225f3397ac45e0e7c9fb018, the function builder
transform used to try to detect when the builder type wasn't fully
resolved. In such a case, rather than fail the solution set as we do
currently, it would construct a null TypeLoc, then stash the type-
variable-laden builder type inside of a TypeExpr and rely on CSGen
to reinterpret that as a request to read the stashed type as it was
constructing the rest of the system. This used to rely on the ability to construct
an implicit TypeExpr node with a null type but now such a thing is
banned by the TypeExpr interface.

Instead, we have to detect this case and construct an *explicit*
TypeExpr node pointing to all the usual fake data. This node's type will
be used to resolve the build* member, but the final applied type of the
node will be the builder type we stashed earlier - hopefully with
outstanding type variables solved.

rdar://65116204, SR-13132
