### PR TITLE
[opt-remark] Add a pass called Opt Remark Generator that implements small opt remarks that do not result from large dataflow checks.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -345,6 +345,8 @@ PASS(MandatoryCombine, "mandatory-combine",
     "Perform mandatory peephole combines")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
+PASS(OptRemarkGenerator, "sil-opt-remark-generator",
+     "Emit small peephole opt remarks that do not use large analyses")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(swiftSILOptimizer PRIVATE
   MergeCondFail.cpp
   Outliner.cpp
   ObjectOutliner.cpp
+  OptRemarkGenerator.cpp
   PerformanceInliner.cpp
   PhiArgumentOptimizations.cpp
   PruneVTables.cpp

--- a/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
+++ b/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
@@ -1,0 +1,108 @@
+//===--- OptRemarkGenerator.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-opt-remark-gen"
+
+#include "swift/SIL/OptimizationRemark.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                        Opt Remark Generator Visitor
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct OptRemarkGeneratorInstructionVisitor
+    : public SILInstructionVisitor<OptRemarkGeneratorInstructionVisitor> {
+  SILModule &mod;
+  OptRemark::Emitter ORE;
+
+  OptRemarkGeneratorInstructionVisitor(SILModule &mod)
+      : mod(mod), ORE(DEBUG_TYPE, mod) {}
+
+  void visitStrongRetainInst(StrongRetainInst *sri);
+  void visitStrongReleaseInst(StrongReleaseInst *sri);
+  void visitRetainValueInst(RetainValueInst *rvi);
+  void visitReleaseValueInst(ReleaseValueInst *rvi);
+  void visitSILInstruction(SILInstruction *) {}
+};
+
+} // anonymous namespace
+
+void OptRemarkGeneratorInstructionVisitor::visitStrongRetainInst(
+    StrongRetainInst *sri) {
+  ORE.emit([&]() {
+    using namespace OptRemark;
+    return RemarkMissed("memory-management", *sri)
+           << "Unable to remove ARC operation";
+  });
+}
+
+void OptRemarkGeneratorInstructionVisitor::visitStrongReleaseInst(
+    StrongReleaseInst *sri) {
+  ORE.emit([&]() {
+    using namespace OptRemark;
+    return RemarkMissed("memory-management", *sri)
+           << "Unable to remove ARC operation";
+  });
+}
+
+void OptRemarkGeneratorInstructionVisitor::visitRetainValueInst(
+    RetainValueInst *rvi) {
+  ORE.emit([&]() {
+    using namespace OptRemark;
+    return RemarkMissed("memory-management", *rvi)
+           << "Unable to remove ARC operation";
+  });
+}
+
+void OptRemarkGeneratorInstructionVisitor::visitReleaseValueInst(
+    ReleaseValueInst *rvi) {
+  ORE.emit([&]() {
+    using namespace OptRemark;
+    return RemarkMissed("memory-management", *rvi)
+           << "Unable to remove ARC operation";
+  });
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class OptRemarkGenerator : public SILFunctionTransform {
+  ~OptRemarkGenerator() override {}
+
+  /// The entry point to the transformation.
+  void run() override {
+    OptRemarkGeneratorInstructionVisitor visitor(getFunction()->getModule());
+    for (auto &block : *getFunction()) {
+      for (auto &inst : block) {
+        visitor.visit(&inst);
+      }
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createOptRemarkGenerator() {
+  return new OptRemarkGenerator();
+}

--- a/test/SILOptimizer/opt-remark-generator.sil
+++ b/test/SILOptimizer/opt-remark-generator.sil
@@ -1,0 +1,24 @@
+// RUN: %target-sil-opt -sil-opt-remark-generator -sil-remarks-missed=sil-opt-remark-gen %s -o /dev/null 2>&1 | %FileCheck %s
+
+// CHECK: {{.*}}opt-remark-generator.sil:18:3: remark: Unable to remove ARC operation
+// CHECK-NEXT: strong_retain
+// CHECK: {{.*}}opt-remark-generator.sil:19:3: remark: Unable to remove ARC operation
+// CHECK-NEXT: retain_value
+// CHECK: {{.*}}opt-remark-generator.sil:20:3: remark: Unable to remove ARC operation
+// CHECK-NEXT: strong_release
+// CHECK: {{.*}}opt-remark-generator.sil:21:3: remark: Unable to remove ARC operation
+// CHECK-NEXT: release_value
+
+sil_stage canonical
+
+import Builtin
+
+sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  retain_value %0 : $Builtin.NativeObject
+  strong_release %0 : $Builtin.NativeObject
+  release_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
We do allow for limited def-use traversal to do things like find debug_value.
But nothing like a full data flow pass. As a proof of concept I just emit
opt-remarks when we see retains, releases. Eventually I would like to also print
out which lvalue the retain is from but that is more than I want to do with this
proof of concept.
