### PR TITLE
runtime: correct the `asprintf` shim for Windows

### DIFF
--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -56,6 +56,7 @@ int asprintf(char **strp, const char *fmt, ...) {
     return -1;
 
   length = _vsnprintf(*strp, length, fmt, argp1);
+  (*strp)[length] = '\0';
 
   va_end(argp0);
   va_end(argp1);


### PR DESCRIPTION
Ensure that the string that is formed from the `asprintf` call is
null-terminated.  The `_vsnprintf` call will not null-terminate the
string if the length is not sufficient.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
