### PR TITLE
[NFC] Make StringRef to std::string conversions explicit.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -98,11 +98,12 @@ void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
     llvm::sys::path::append(defaultPrebuiltPathWithSDKVer, ver->getAsString());
     // If the versioned prebuilt module cache exists in the disk, use it.
     if (llvm::sys::fs::exists(defaultPrebuiltPathWithSDKVer)) {
-      FrontendOpts.PrebuiltModuleCachePath = defaultPrebuiltPathWithSDKVer.str();
+      FrontendOpts.PrebuiltModuleCachePath =
+        std::string(defaultPrebuiltPathWithSDKVer.str());
       return;
     }
   }
-  FrontendOpts.PrebuiltModuleCachePath = defaultPrebuiltPath.str();
+  FrontendOpts.PrebuiltModuleCachePath = std::string(defaultPrebuiltPath.str());
 }
 
 static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1162,7 +1162,7 @@ bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(
 
   if (CompRe.match(SB, &CompMatches)) {
     assert(CompMatches.size() == 2);
-    CompilerVersion = ArgSaver.save(CompMatches[1]);
+    CompilerVersion = std::string(ArgSaver.save(CompMatches[1]));
   }
   else {
     // Don't diagnose; handwritten module interfaces don't include this field.
@@ -1196,7 +1196,7 @@ bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(
 }
 
 void InterfaceSubContextDelegateImpl::addExtraClangArg(StringRef arg) {
-  subInvocation.getClangImporterOptions().ExtraArgs.push_back(arg);
+  subInvocation.getClangImporterOptions().ExtraArgs.push_back(std::string(arg));
   GenericArgs.push_back("-Xcc");
   GenericArgs.push_back(ArgSaver.save(arg));
 }
@@ -1254,7 +1254,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // FIXME: we shouldn't need this. Remove it?
   StringRef explictSwiftModuleMap = searchPathOpts.ExplicitSwiftModuleMap;
   subInvocation.getSearchPathOptions().ExplicitSwiftModuleMap =
-    explictSwiftModuleMap;
+    std::string(explictSwiftModuleMap);
   if (!explictSwiftModuleMap.empty()) {
     GenericArgs.push_back("-explicit-swift-module-map-file");
     GenericArgs.push_back(explictSwiftModuleMap);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -179,14 +179,16 @@ static bool emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
     reversePathSortedFilenames(opts.InputsAndOutputs.getInputFilenames());
   for (auto const &path : inputPaths) {
     dependencyString.push_back(' ');
-    dependencyString.append(frontend::utils::escapeForMake(path, buffer));
+    dependencyString.append(
+      std::string(frontend::utils::escapeForMake(path, buffer)));
   }
   // Then print dependencies we've picked up during compilation.
   auto dependencyPaths =
     reversePathSortedFilenames(depTracker->getDependencies());
   for (auto const &path : dependencyPaths) {
     dependencyString.push_back(' ');
-    dependencyString.append(frontend::utils::escapeForMake(path, buffer));
+    dependencyString.append(
+      std::string(frontend::utils::escapeForMake(path, buffer)));
   }
   
   // FIXME: Xcode can't currently handle multiple targets in a single
@@ -1183,7 +1185,7 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
         llvm::SmallString<32> Buffer(*opts.BridgingHeaderDirForPrint);
         llvm::sys::path::append(Buffer,
           llvm::sys::path::filename(opts.ImplicitObjCHeaderPath));
-        BridgingHeaderPathForPrint = Buffer.str();
+        BridgingHeaderPathForPrint = std::string(Buffer.str());
       } else {
         // By default, include the given bridging header path directly.
         BridgingHeaderPathForPrint = opts.ImplicitObjCHeaderPath;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -359,7 +359,7 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
                       /*isFramework*/isFramework, loadedModuleFile,
                       &ExtInfo);
 
-  Name = loadedModuleFile->Name;
+  Name = std::string(loadedModuleFile->Name);
   return std::move(moduleBuf.get());
 }
 

--- a/lib/Serialization/ModuleFileCoreTableInfo.h
+++ b/lib/Serialization/ModuleFileCoreTableInfo.h
@@ -457,7 +457,7 @@ public:
       int32_t nameLength = endian::readNext<int32_t, little, unaligned>(data);
       StringRef mangledName(reinterpret_cast<const char *>(data), nameLength);
       data += nameLength;
-      result.push_back({mangledName, genSigId});
+      result.push_back({std::string(mangledName), genSigId});
     }
     return result;
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5151,7 +5151,8 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
       for (auto config : entry.second) {
         auto paramIndices = config.first.str();
         auto genSigID = addGenericSignatureRef(config.second);
-        derivativeConfigs[entry.first].push_back({paramIndices, genSigID});
+        derivativeConfigs[entry.first].push_back(
+          {std::string(paramIndices), genSigID});
       }
     }
     index_block::DerivativeFunctionConfigTableLayout DerivativeConfigTable(Out);

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -68,7 +68,7 @@ void TBDGenVisitor::addSymbolInternal(StringRef name,
     return;
   Symbols.addSymbol(kind, name, Targets);
   if (kind == SymbolKind::GlobalSymbol) {
-    StringSymbols.push_back(name);
+    StringSymbols.push_back(std::string(name));
 #ifndef NDEBUG
     if (!DuplicateSymbolChecker.insert(name).second) {
       llvm::dbgs() << "TBDGen duplicate symbol: " << name << '\n';

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -274,7 +274,7 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
   llvm::SmallString<128> LibPath(SKCtx.getRuntimeLibPath());
   llvm::sys::path::append(LibPath, "swift");
   RuntimeResourcePath = std::string(LibPath.str());
-  DiagnosticDocumentationPath = SKCtx.getDiagnosticDocumentationPath();
+  DiagnosticDocumentationPath = std::string(SKCtx.getDiagnosticDocumentationPath());
 
   Stats = std::make_shared<SwiftStatistics>();
   EditorDocuments = std::make_shared<SwiftEditorDocumentFileMap>();

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2805,7 +2805,7 @@ static std::string getJsonOutputFilePath(llvm::Triple Triple, bool ABI) {
       exit(1);
     }
     llvm::sys::path::append(OutputPath, getBaselineFilename(Triple));
-    return OutputPath.str();
+    return std::string(OutputPath.str());
   }
   llvm::errs() << "Unable to decide output file path\n";
   exit(1);


### PR DESCRIPTION
Upstream LLVM made these conversions explicit a few months back, however, the changes didn't make it into LLVM swift/master yet. That required some Swift-side changes and as well as a bunch of changes to LLDB and the sanitizers. So we do a paired PR here.

This should reduce the headache induced by conflicts when merging Swift's master into Swift's master-next.