### PR TITLE
[Test] Disable stdlib/DefaultIndices when use_os_stdlib.

### DIFF
--- a/test/stdlib/DefaultIndices.swift
+++ b/test/stdlib/DefaultIndices.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
+// rdar://problem/65605593
+// UNSUPPORTED: use_os_stdlib
 
 import StdlibUnittest
 


### PR DESCRIPTION
rdar://problem/65605593