### PR TITLE
[5.3][ModuleInterface] Print some implementation-only imports in the private interface

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -43,6 +43,10 @@ struct ModuleInterfaceOptions {
 
   // Print SPI decls and attributes.
   bool PrintSPIs = false;
+
+  /// Print imports with both @_implementationOnly and @_spi, only applies
+  /// when PrintSPIs is true.
+  bool ExperimentalSPIImports = false;
 };
 
 extern version::Version InterfaceFormatVersion;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -627,6 +627,10 @@ def module_interface_preserve_types_as_written :
   HelpText<"When emitting a module interface, preserve types as they were "
            "written in the source">;
 
+def experimental_spi_imports :
+  Flag<["-"], "experimental-spi-imports">,
+  HelpText<"Enable experimental support for SPI imports">;
+
 def experimental_print_full_convention :
  Flag<["-"], "experimental-print-full-convention">,
  HelpText<"When emitting a module interface, emit additional @convention "

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -289,6 +289,8 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasArg(OPT_module_interface_preserve_types_as_written);
   Opts.PrintFullConvention |=
     Args.hasArg(OPT_experimental_print_full_convention);
+  Opts.ExperimentalSPIImports |=
+    Args.hasArg(OPT_experimental_spi_imports);
 }
 
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running

--- a/test/SPI/experimental_spi_imports_swiftinterface.swift
+++ b/test/SPI/experimental_spi_imports_swiftinterface.swift
@@ -1,0 +1,26 @@
+/// Test the textual interfaces generated with -experimental-spi-imports.
+
+// RUN: %empty-directory(%t)
+
+/// Generate 3 empty modules.
+// RUN: touch %t/empty.swift
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name ExperimentalImported -emit-module-path %t/ExperimentalImported.swiftmodule -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name IOIImported -emit-module-path %t/IOIImported.swiftmodule -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name SPIImported -emit-module-path %t/SPIImported.swiftmodule -swift-version 5 -enable-library-evolution
+
+/// Test the generated swiftinterface.
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -emit-private-module-interface-path %t/main.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t -experimental-spi-imports
+// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/main.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/main.private.swiftinterface
+
+@_spi(dummy) @_implementationOnly import ExperimentalImported
+// CHECK-PUBLIC-NOT: import ExperimentalImported
+// CHECK-PRIVATE: @_implementationOnly @_spi{{.*}} import ExperimentalImported
+
+@_implementationOnly import IOIImported
+// CHECK-PUBLIC-NOT: IOIImported
+// CHECK-PRIVATE-NOT: IOIImported
+
+@_spi(dummy) import SPIImported
+// CHECK-PUBLIC: {{^}}import SPIImported
+// CHECK-PRIVATE: @_spi{{.*}} import SPIImported

--- a/test/SPI/experimental_spi_imports_type_check.swift
+++ b/test/SPI/experimental_spi_imports_type_check.swift
@@ -1,0 +1,50 @@
+/// Test the use of implementation-only types with -experimental-spi-imports.
+
+/// Build LibCore an internal module and LibPublic a public module using LibCore.
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -DLIB_CORE %s -module-name LibCore -emit-module-path %t/LibCore.swiftmodule -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module -DLIB_PUBLIC %s -module-name LibPublic -emit-module-path %t/LibPublic.swiftmodule -I %t -emit-module-interface-path %t/LibPublic.swiftinterface -emit-private-module-interface-path %t/LibPublic.private.swiftinterface -enable-library-evolution -swift-version 5 -experimental-spi-imports
+
+/// Test with the swiftmodule file, the compiler raises an error only when
+/// LibCore isn't loaded by the client.
+// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
+// RUN: %target-swift-frontend -typecheck %s -DCLIENT -DCLIENT_LOAD_CORE -I %t
+
+/// Test with the private swiftinterface file, the compiler raises an error
+/// only when LibCore isn't loaded by the client.
+// RUN: rm %t/LibPublic.swiftmodule
+// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
+// RUN: %target-swift-frontend -typecheck %s -DCLIENT -DCLIENT_LOAD_CORE -I %t
+
+/// Test with the public swiftinterface file, the SPI is unknown.
+// RUN: rm %t/LibPublic.private.swiftinterface
+// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
+// RUN: %target-typecheck-verify-swift -DCLIENT -DCLIENT_LOAD_CORE -I %t
+
+#if LIB_CORE
+
+public struct CoreStruct {
+  public init() {}
+  public func coreMethod() {}
+}
+
+
+#elseif LIB_PUBLIC
+
+@_spi(dummy) @_implementationOnly import LibCore
+
+@_spi(A) public func SPIFunc() -> CoreStruct { return CoreStruct() }
+
+
+#elseif CLIENT
+
+@_spi(A) import LibPublic
+
+#if CLIENT_LOAD_CORE
+import LibCore
+#endif
+
+let x = SPIFunc() // expected-error {{cannot find 'SPIFunc' in scope}}
+x.coreMethod()
+
+#endif


### PR DESCRIPTION
Introduce an experimental feature to print implementation-only imports that include SPIs in the private swiftinterface, e.g. `@_implementationOnly @_spi(Private) import A`. This allows projects to export types from implementation-only imports in local SPI and aligns the behavior of compiling against binary interfaces with the use of private textual interfaces.

This is a temporary solution behind the frontend flag `-experimental-spi-imports`.

- Scope of Issue: This is affecting the private swiftinterface of projects exporting implementation-only imported types in SPI.
- Origination: The introduction of the @_spi attribute.
- Risk: Very low, this feature is hidden behind a feature flag.
- Resolves: rdar://65696882