### PR TITLE
[5.3][CodeCompletion] Fix a crash in CCExprRemover

### DIFF
--- a/validation-test/IDE/crashers_2_fixed/rdar65556791.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar65556791.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=B -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=C -source-filename=%s
+
+func myFunc(_: Int, _: Undefined) {}
+
+undefined {
+  myFunc($0, undefined)
+} #^A^#
+
+undefined(x: 1) {
+  myFunc($0, undefined)
+} #^B^#
+
+undefined(1, 2) {
+  myFunc { 1 }
+} #^C^#


### PR DESCRIPTION
Cherry-pick of #32900 into `release/5.3`

* **Explanation**: Fix a crash in `CCExprRemover` introduced in #32415 . There was no consideration for `getArgumentLabelLocs().size() == 0` cases. Also, added some guards to minimize the risk of this function.
* **Scope**: Code completion right after trailing closures
* **Risk**: Low
* **Testing**: Added regression test cases
* **Issue**: rdar://problem/65556791
* **Reviewer**: Ben Langmuir (@benlangmuir)