### PR TITLE
Rework a couple of benchmarks to work with both Python2 and Python3

### DIFF
--- a/benchmark/single-source/DropFirst.swift.gyb
+++ b/benchmark/single-source/DropFirst.swift.gyb
@@ -38,7 +38,7 @@ Sequences = [
   ('AnyCollection', 'AnyCollection(0..<sequenceCount)'),
   ('Array', 'array'),
 ]
-def lazy ((Name, Expr)) : return (Name + 'Lazy', '(' + Expr + ').lazy')
+def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
 Sequences = Sequences + map(lazy, Sequences)
 }%

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -38,7 +38,7 @@ Sequences = [
   ('AnyCollection', 'AnyCollection(0..<sequenceCount)'),
   ('Array', 'array'),
 ]
-def lazy ((Name, Expr)) : return (Name + 'Lazy', '(' + Expr + ').lazy')
+def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
 Sequences = Sequences + map(lazy, Sequences)
 }%

--- a/benchmark/single-source/DropWhile.swift.gyb
+++ b/benchmark/single-source/DropWhile.swift.gyb
@@ -38,7 +38,7 @@ Sequences = [
   ('AnyCollection', 'AnyCollection(0..<sequenceCount)'),
   ('Array', 'array'),
 ]
-def lazy ((Name, Expr)) : return (Name + 'Lazy', '(' + Expr + ').lazy')
+def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
 Sequences = Sequences + map(lazy, Sequences)
 }%

--- a/benchmark/single-source/Prefix.swift.gyb
+++ b/benchmark/single-source/Prefix.swift.gyb
@@ -37,7 +37,7 @@ Sequences = [
   ('AnyCollection', 'AnyCollection(0..<sequenceCount)'),
   ('Array', 'array'),
 ]
-def lazy ((Name, Expr)) : return (Name + 'Lazy', '(' + Expr + ').lazy')
+def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
 Sequences = Sequences + map(lazy, Sequences)
 }%

--- a/benchmark/single-source/PrefixWhile.swift.gyb
+++ b/benchmark/single-source/PrefixWhile.swift.gyb
@@ -37,7 +37,7 @@ Sequences = [
   ('AnyCollection', 'AnyCollection(0..<sequenceCount)'),
   ('Array', 'array'),
 ]
-def lazy ((Name, Expr)) : return (Name + 'Lazy', '(' + Expr + ').lazy')
+def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
 Sequences = Sequences + map(lazy, Sequences)
 }%

--- a/benchmark/single-source/Suffix.swift.gyb
+++ b/benchmark/single-source/Suffix.swift.gyb
@@ -37,7 +37,7 @@ Sequences = [
   ('AnyCollection', 'AnyCollection(0..<sequenceCount)'),
   ('Array', 'array'),
 ]
-def lazy ((Name, Expr)) : return (Name + 'Lazy', '(' + Expr + ').lazy')
+def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
 Sequences = Sequences + map(lazy, Sequences)
 }%


### PR DESCRIPTION
Python3 doesn't support implicit tuple deconstruction in arguments as Python2 used to.  So this just changes the function to access tuple components directly.