### PR TITLE
[ConstraintSystem] Preserve l-valueness of the result after implicit …

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5398,7 +5398,7 @@ Expr *ExprRewriter::coerceOptionalToOptional(Expr *expr, Type toType,
 
 Expr *ExprRewriter::coerceImplicitlyUnwrappedOptionalToValue(Expr *expr, Type objTy) {
   auto optTy = cs.getType(expr);
-  // Coerce to an r-value.
+  // Preserve l-valueness of the result.
   if (optTy->is<LValueType>())
     objTy = LValueType::get(objTy);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3966,8 +3966,13 @@ public:
     auto resultTy = fnTy->getResult();
     if (auto *resultFnTy = resultTy->getAs<AnyFunctionType>())
       resultTy = replaceFinalResultTypeWithUnderlying(resultFnTy);
-    else
-      resultTy = resultTy->getWithoutSpecifierType()->getOptionalObjectType();
+    else {
+      auto objType =
+          resultTy->getWithoutSpecifierType()->getOptionalObjectType();
+      // Preserve l-value through force operation.
+      resultTy =
+          resultTy->is<LValueType>() ? LValueType::get(objType) : objType;
+    }
 
     assert(resultTy);
 

--- a/test/Constraints/iuo_objc.swift
+++ b/test/Constraints/iuo_objc.swift
@@ -56,3 +56,10 @@ extension X where Self : OptionalRequirements {
     let _ = self.name
   }
 }
+
+func rdar61337704() {
+  func setColor(v: ColorDescriptor) { }
+
+  let descriptor = PaletteDescriptor()
+  setColor(v: descriptor.colors[0]) // Ok
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1181,3 +1181,15 @@ void takeNullableId(_Nullable id);
 @interface IUOProperty
 @property (readonly) id<OptionalRequirements> iuo;
 @end
+
+@interface ColorDescriptor : NSObject <NSCopying>
+@end
+
+@interface ColorArray : NSObject
+- (ColorDescriptor *)objectAtIndexedSubscript:(NSUInteger)attachmentIndex;
+- (void)setObject:(nullable ColorDescriptor *)attachment atIndexedSubscript:(NSUInteger)attachmentIndex;
+@end
+
+@interface PaletteDescriptor : NSObject <NSCopying>
+@property (readonly, nonnull) ColorArray *colors;
+@end


### PR DESCRIPTION
…IUO unwrap

Detect that result type of the overload choice is l-value and preserve
that information through the forced unwrap operation so it's possible
to load the value implicitly during solution application.

Resolves: rdar://problem/61337704

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
