### PR TITLE
[Sema][os_log] Allow wrapping os_log strings within constant evaluable functions

### DIFF
--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -155,3 +155,32 @@ func testNonConstantLogObjectLevel(
   osLogWithLevel(level, log: log, message)
     // expected-error@-1 {{argument must be a string interpolation}}
 }
+
+// Test that log messages can be wrapped in constant_evaluable functions.
+
+// A function similar to the one used by SwiftUI preview to wrap string
+// literals.
+@_semantics("constant_evaluable")
+public func __designTimeStringStub(
+  _ key: String,
+  fallback: OSLogMessage
+) -> OSLogMessage {
+  fallback
+}
+
+func testSwiftUIPreviewWrapping() {
+  // This should not produce any diagnostics.
+  _osLogTestHelper(__designTimeStringStub("key", fallback: "A literal message"))
+}
+
+public func nonConstantFunction(
+  _ key: String,
+  fallback: OSLogMessage
+) -> OSLogMessage {
+  fallback
+}
+
+func testLogMessageWrappingDiagnostics() {
+  _osLogTestHelper(nonConstantFunction("key", fallback: "A literal message"))
+    // expected-error@-1{{argument must be a string interpolation}}
+}


### PR DESCRIPTION
As of now, the sema checks for os_log allow only string interpolations to be passed to the log calls. E.g. `logger.log(foo("message"))` would not be allowed. This PR relaxes this requirement and allows it as long as `foo` is annotated as `@_semantics("constant_evaluable")`.

However, as a special case, this PR still prevents calling the initializer of `OSLogMessage`, which is annotated constant_evaluable, to create the log message. E.g. `logger.log(OSLogMessage(stringLiteral: "message"))` would still be prevented. This is done to ensure that users who are new to the APIs do not reach out for the `OSLogMessage` initializer to construct a message (by looking at the type of the argument). `OSLogMessage` should be automatically created when passing string interpolations.  So this condition is checked for and a diagnostic is emitted. 

<rdar://problem/65842243>