### PR TITLE
[master-next][build-script-impl] Make libcxx build step a no-op

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1575,19 +1575,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
 
             libcxx)
-                build_targets=(cxx-headers)
+                build_targets=()
                 cmake_options=(
                     "${cmake_options[@]}"
-                    -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
-                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
-                    -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
-                    -DLLVM_INCLUDE_DOCS:BOOL=TRUE
-                    -DLLVM_CONFIG_PATH="$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-config"
                     "${llvm_cmake_options[@]}"
                 )
-
                 ;;
 
             swift)
@@ -2215,6 +2207,10 @@ for host in "${ALL_HOSTS[@]}"; do
             fi
             with_pushd "${build_dir}" \
                 call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
+        fi
+
+        if [[ "${product}" == "libcxx" ]]; then
+            continue
         fi
 
         # When we are building LLVM create symlinks to the c++ headers. We need


### PR DESCRIPTION
Attempting to fix `ninja: error: unknown target 'cxx-headers'` after an upstream change removing that target. The install step is using 'install-cxx-headers' to copy to the headers, so the build step doesn't seem to be needed.

Resolves rdar://problem/65579363