### PR TITLE
[IRGen] Introduce OptimizedIRRequest

### DIFF
--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -123,7 +123,7 @@ public:
 };
 
 struct IRGenDescriptor {
-  llvm::PointerUnion<ModuleDecl *, SourceFile *> Ctx;
+  llvm::PointerUnion<FileUnit *, ModuleDecl *> Ctx;
 
   const IRGenOptions &Opts;
   const TBDGenOptions &TBDOpts;
@@ -151,12 +151,12 @@ struct IRGenDescriptor {
 
 public:
   static IRGenDescriptor
-  forFile(SourceFile &SF, const IRGenOptions &Opts,
+  forFile(FileUnit *file, const IRGenOptions &Opts,
           const TBDGenOptions &TBDOpts, std::unique_ptr<SILModule> &&SILMod,
           StringRef ModuleName, const PrimarySpecificPaths &PSPs,
           StringRef PrivateDiscriminator,
           llvm::GlobalVariable **outModuleHash) {
-    return IRGenDescriptor{&SF,
+    return IRGenDescriptor{file,
                            Opts,
                            TBDOpts,
                            SILMod.release(),

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -160,7 +160,7 @@ public:
           Lowering::TypeConverter &Conv, std::unique_ptr<SILModule> &&SILMod,
           StringRef ModuleName, const PrimarySpecificPaths &PSPs,
           StringRef PrivateDiscriminator,
-          llvm::GlobalVariable **outModuleHash) {
+          llvm::GlobalVariable **outModuleHash = nullptr) {
     return IRGenDescriptor{file,
                            Opts,
                            TBDOpts,
@@ -180,8 +180,8 @@ public:
                  Lowering::TypeConverter &Conv,
                  std::unique_ptr<SILModule> &&SILMod, StringRef ModuleName,
                  const PrimarySpecificPaths &PSPs,
-                 ArrayRef<std::string> parallelOutputFilenames,
-                 llvm::GlobalVariable **outModuleHash) {
+                 ArrayRef<std::string> parallelOutputFilenames = {},
+                 llvm::GlobalVariable **outModuleHash = nullptr) {
     return IRGenDescriptor{M,
                            Opts,
                            TBDOpts,

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -22,6 +22,7 @@
 #include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/PrimarySpecificPaths.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Target/TargetMachine.h"
 
 namespace swift {
 class SourceFile;
@@ -39,6 +40,7 @@ namespace llvm {
 class GlobalVariable;
 class LLVMContext;
 class Module;
+class TargetMachine;
 
 namespace orc {
 class ThreadSafeModule;
@@ -58,8 +60,9 @@ class GeneratedModule final {
 private:
   std::unique_ptr<llvm::LLVMContext> Context;
   std::unique_ptr<llvm::Module> Module;
+  std::unique_ptr<llvm::TargetMachine> Target;
 
-  GeneratedModule() : Context(nullptr), Module(nullptr) {}
+  GeneratedModule() : Context(nullptr), Module(nullptr), Target(nullptr) {}
 
   GeneratedModule(GeneratedModule const &) = delete;
   GeneratedModule &operator=(GeneratedModule const &) = delete;
@@ -70,10 +73,13 @@ public:
   /// The given pointers must not be null. If a null \c GeneratedModule is
   /// needed, use \c GeneratedModule::null() instead.
   explicit GeneratedModule(std::unique_ptr<llvm::LLVMContext> &&Context,
-                           std::unique_ptr<llvm::Module> &&Module)
-    : Context(std::move(Context)), Module(std::move(Module)) {
+                           std::unique_ptr<llvm::Module> &&Module,
+                           std::unique_ptr<llvm::TargetMachine> &&Target)
+    : Context(std::move(Context)), Module(std::move(Module)),
+      Target(std::move(Target)) {
       assert(getModule() && "Use GeneratedModule::null() instead");
       assert(getContext() && "Use GeneratedModule::null() instead");
+      assert(getTargetMachine() && "Use GeneratedModule::null() instead");
     }
 
   GeneratedModule(GeneratedModule &&) = default;
@@ -96,6 +102,9 @@ public:
 
   const llvm::LLVMContext *getContext() const { return Context.get(); }
   llvm::LLVMContext *getContext() { return Context.get(); }
+
+  const llvm::TargetMachine *getTargetMachine() const { return Target.get(); }
+  llvm::TargetMachine *getTargetMachine() { return Target.get(); }
 
 public:
   /// Release ownership of the context and module to the caller, consuming

--- a/include/swift/AST/IRGenTypeIDZone.def
+++ b/include/swift/AST/IRGenTypeIDZone.def
@@ -17,3 +17,6 @@
 SWIFT_REQUEST(IRGen, IRGenRequest,
               GeneratedModule(IRGenDescriptor),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(IRGen, OptimizedIRRequest,
+              GeneratedModule(IRGenDescriptor),
+              Uncached, NoLocationInfo)

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -251,7 +251,6 @@ namespace swift {
   ///                   was already compiled, may be null if not desired.
   /// \param Module LLVM module to code gen, required.
   /// \param TargetMachine target of code gen, required.
-  /// \param effectiveLanguageVersion version of the language, effectively.
   /// \param OutputFilename Filename for output.
   bool performLLVM(const IRGenOptions &Opts,
                    DiagnosticEngine &Diags,
@@ -259,7 +258,6 @@ namespace swift {
                    llvm::GlobalVariable *HashGlobal,
                    llvm::Module *Module,
                    llvm::TargetMachine *TargetMachine,
-                   const version::Version &effectiveLanguageVersion,
                    StringRef OutputFilename,
                    UnifiedStatsReporter *Stats);
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -215,11 +215,11 @@ namespace swift {
                       ArrayRef<std::string> parallelOutputFilenames,
                       llvm::GlobalVariable **outModuleHash = nullptr);
 
-  /// Turn the given Swift module into either LLVM IR or native code
+  /// Turn the given Swift file into either LLVM IR or native code
   /// and return the generated LLVM IR module.
   /// If you set an outModuleHash, then you need to call performLLVM.
   GeneratedModule
-  performIRGeneration(SourceFile &SF, const IRGenOptions &Opts, 
+  performIRGeneration(FileUnit *file, const IRGenOptions &Opts, 
                       const TBDGenOptions &TBDOpts,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -204,9 +204,8 @@ namespace swift {
              std::string>
   getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx);
 
-  /// Turn the given Swift module into either LLVM IR or native code
-  /// and return the generated LLVM IR module.
-  /// If you set an outModuleHash, then you need to call performLLVM.
+  /// Turn the given Swift module into LLVM IR and return the generated module.
+  /// To compile and output the generated code, call \c performLLVM.
   GeneratedModule
   performIRGeneration(ModuleDecl *M, const IRGenOptions &Opts,
                       const TBDGenOptions &TBDOpts,
@@ -215,9 +214,8 @@ namespace swift {
                       ArrayRef<std::string> parallelOutputFilenames,
                       llvm::GlobalVariable **outModuleHash = nullptr);
 
-  /// Turn the given Swift file into either LLVM IR or native code
-  /// and return the generated LLVM IR module.
-  /// If you set an outModuleHash, then you need to call performLLVM.
+  /// Turn the given Swift file into LLVM IR and return the generated module.
+  /// To compile and output the generated code, call \c performLLVM.
   GeneratedModule
   performIRGeneration(FileUnit *file, const IRGenOptions &Opts, 
                       const TBDGenOptions &TBDOpts,

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -232,6 +232,15 @@ namespace swift {
   void performLLVMOptimizations(const IRGenOptions &Opts, llvm::Module *Module,
                                 llvm::TargetMachine *TargetMachine);
 
+  /// Compiles and writes the given LLVM module into an output stream in the
+  /// format specified in the \c IRGenOptions.
+  bool compileAndWriteLLVM(llvm::Module *module,
+                           llvm::TargetMachine *targetMachine,
+                           const IRGenOptions &opts,
+                           UnifiedStatsReporter *stats, DiagnosticEngine &diags,
+                           llvm::raw_pwrite_stream &out,
+                           llvm::sys::Mutex *diagMutex = nullptr);
+
   /// Wrap a serialized module inside a swift AST section in an object file.
   void createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
                                    StringRef OutputPath);

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -405,7 +405,7 @@ std::string getSwiftFullVersion(Version effectiveVersion) {
   OS << "-dev";
 #endif
 
-  if (!(effectiveVersion == Version::getCurrentLanguageVersion())) {
+  if (effectiveVersion != Version::getCurrentLanguageVersion()) {
     OS << " effective-" << effectiveVersion;
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1648,16 +1648,14 @@ static bool generateCode(CompilerInstance &Instance, StringRef OutputFilename,
   const auto &opts = Instance.getInvocation().getIRGenOptions();
   std::unique_ptr<llvm::TargetMachine> TargetMachine =
       createTargetMachine(opts, Instance.getASTContext());
-  version::Version EffectiveLanguageVersion =
-      Instance.getASTContext().LangOpts.EffectiveLanguageVersion;
 
   // Free up some compiler resources now that we have an IRModule.
   freeASTContextIfPossible(Instance);
 
   // Now that we have a single IR Module, hand it over to performLLVM.
   return performLLVM(opts, Instance.getDiags(), nullptr, HashGlobal, IRModule,
-                     TargetMachine.get(), EffectiveLanguageVersion,
-                     OutputFilename, Instance.getStatsReporter());
+                     TargetMachine.get(), OutputFilename,
+                     Instance.getStatsReporter());
 }
 
 static bool performCompileStepsPostSILGen(CompilerInstance &Instance,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1508,7 +1508,7 @@ generateIR(const IRGenOptions &IRGenOpts, const TBDGenOptions &TBDOpts,
            llvm::GlobalVariable *&HashGlobal,
            ArrayRef<std::string> parallelOutputFilenames) {
   if (auto *SF = MSF.dyn_cast<SourceFile *>()) {
-    return performIRGeneration(*SF, IRGenOpts, TBDOpts,
+    return performIRGeneration(SF, IRGenOpts, TBDOpts,
                                std::move(SM), OutputFilename, PSPs,
                                SF->getPrivateDiscriminator().str(),
                                &HashGlobal);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -907,7 +907,8 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
   auto SILMod = std::unique_ptr<SILModule>(desc.SILMod);
   auto *M = desc.getParentModule();
   auto filesToEmit = desc.getFiles();
-  auto *primaryFile = desc.Ctx.dyn_cast<SourceFile *>();
+  auto *primaryFile =
+      dyn_cast_or_null<SourceFile>(desc.Ctx.dyn_cast<FileUnit *>());
 
   auto &Ctx = M->getASTContext();
   assert(!Ctx.hadError());
@@ -1326,16 +1327,16 @@ GeneratedModule swift::performIRGeneration(
 }
 
 GeneratedModule swift::
-performIRGeneration(SourceFile &SF, const IRGenOptions &Opts,
+performIRGeneration(FileUnit *file, const IRGenOptions &Opts,
                     const TBDGenOptions &TBDOpts,
                     std::unique_ptr<SILModule> SILMod,
                     StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                     StringRef PrivateDiscriminator,
                     llvm::GlobalVariable **outModuleHash) {
-  auto desc = IRGenDescriptor::forFile(SF, Opts, TBDOpts, std::move(SILMod),
+  auto desc = IRGenDescriptor::forFile(file, Opts, TBDOpts, std::move(SILMod),
                                        ModuleName, PSPs, PrivateDiscriminator,
                                        outModuleHash);
-  return llvm::cantFail(SF.getASTContext().evaluator(IRGenRequest{desc}));
+  return llvm::cantFail(file->getASTContext().evaluator(IRGenRequest{desc}));
 }
 
 void

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -934,6 +934,7 @@ GeneratedModule IRGenModule::intoGeneratedModule() && {
   return GeneratedModule{
     std::move(LLVMContext),
     std::unique_ptr<llvm::Module>{ClangCodeGen->ReleaseModule()},
+    std::move(TargetMachine)
   };
 }
 

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -39,13 +39,12 @@ llvm::orc::ThreadSafeModule GeneratedModule::intoThreadSafeContext() && {
 void swift::simple_display(llvm::raw_ostream &out,
                            const IRGenDescriptor &desc) {
   auto *MD = desc.Ctx.dyn_cast<ModuleDecl *>();
-  auto *SF = desc.Ctx.dyn_cast<SourceFile *>();
   if (MD) {
     out << "IR Generation for module " << MD->getName();
   } else {
-    assert(SF);
+    auto *file = desc.Ctx.get<FileUnit *>();
     out << "IR Generation for file ";
-    out << '\"' << SF->getFilename() << '\"';
+    simple_display(out, file);
   }
 }
 
@@ -58,29 +57,30 @@ TinyPtrVector<FileUnit *> IRGenDescriptor::getFiles() const {
   if (auto *mod = Ctx.dyn_cast<ModuleDecl *>())
     return TinyPtrVector<FileUnit *>(mod->getFiles());
 
-  // For a primary source file, we emit IR for both it and potentially its
+  // For a primary file, we emit IR for both it and potentially its
   // SynthesizedFileUnit.
-  auto *SF = Ctx.get<SourceFile *>();
+  auto *primary = Ctx.get<FileUnit *>();
   TinyPtrVector<FileUnit *> files;
-  files.push_back(SF);
+  files.push_back(primary);
 
-  if (auto *synthesizedFile = SF->getSynthesizedFile())
-    files.push_back(synthesizedFile);
-
+  if (auto *SF = dyn_cast<SourceFile>(primary)) {
+    if (auto *synthesizedFile = SF->getSynthesizedFile())
+      files.push_back(synthesizedFile);
+  }
   return files;
 }
 
 ModuleDecl *IRGenDescriptor::getParentModule() const {
-  if (auto *SF = Ctx.dyn_cast<SourceFile *>())
-    return SF->getParentModule();
+  if (auto *file = Ctx.dyn_cast<FileUnit *>())
+    return file->getParentModule();
   return Ctx.get<ModuleDecl *>();
 }
 
 std::vector<std::string> IRGenDescriptor::getLinkerDirectives() const {
   auto opts = TBDOpts;
   opts.LinkerDirectivesOnly = true;
-  if (auto *SF = Ctx.dyn_cast<SourceFile *>()) {
-    return getPublicSymbols(TBDGenDescriptor::forFile(SF, opts));
+  if (auto *file = Ctx.dyn_cast<FileUnit *>()) {
+    return getPublicSymbols(TBDGenDescriptor::forFile(file, opts));
   } else {
     auto *M = Ctx.get<ModuleDecl *>();
     return getPublicSymbols(TBDGenDescriptor::forModule(M, opts));
@@ -96,8 +96,8 @@ evaluator::DependencySource IRGenRequest::readDependencySource(
     return {nullptr, e.getActiveSourceScope()};
   }
 
-  auto *SF = desc.Ctx.get<SourceFile *>();
-  return {SF, evaluator::DependencyScope::Cascading};
+  auto *primary = desc.Ctx.get<FileUnit *>();
+  return {dyn_cast<SourceFile>(primary), evaluator::DependencyScope::Cascading};
 }
 
 // Define request evaluation functions for each of the IRGen requests.

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -196,6 +196,7 @@ int swift::RunImmediately(CompilerInstance &CI,
                           const IRGenOptions &IRGenOpts,
                           const SILOptions &SILOpts,
                           std::unique_ptr<SILModule> &&SM) {
+  // TODO: Use OptimizedIRRequest for this.
   ASTContext &Context = CI.getASTContext();
   
   // IRGen the main module.
@@ -210,6 +211,13 @@ int swift::RunImmediately(CompilerInstance &CI,
     return -1;
 
   assert(GenModule && "Emitted no diagnostics but IR generation failed?");
+
+  performLLVM(IRGenOpts, Context.Diags, /*diagMutex*/ nullptr, /*hash*/ nullptr,
+              GenModule.getModule(), GenModule.getTargetMachine(),
+              PSPs.OutputFilename, Context.Stats);
+
+  if (Context.hadError())
+    return -1;
 
   // Load libSwiftCore to setup process arguments.
   //

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -201,5 +201,11 @@ int main(int argc, char **argv) {
                                  std::move(SILMod),
                                  CI.getMainModule()->getName().str(), PSPs,
                                  ArrayRef<std::string>());
+  if (!Mod)
+    return 1;
+
+  performLLVM(Opts, CI.getDiags(), /*diagMutex*/ nullptr, /*hash*/ nullptr,
+              Mod.getModule(), Mod.getTargetMachine(), OutputFilename,
+              CI.getASTContext().Stats);
   return CI.getASTContext().hadError();
 }

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -178,34 +178,42 @@ int main(int argc, char **argv) {
   if (CI.setup(Invocation))
     return 1;
 
-  CI.performSema();
-
-  // If parsing produced an error, don't run any passes.
-  if (CI.getASTContext().hadError())
+  std::error_code EC;
+  llvm::raw_fd_ostream outStream(OutputFilename, EC, llvm::sys::fs::F_None);
+  if (outStream.has_error() || EC) {
+    CI.getDiags().diagnose(SourceLoc(), diag::error_opening_output,
+                           OutputFilename, EC.message());
+    outStream.clear_error();
     return 1;
+  }
 
   auto *mod = CI.getMainModule();
   assert(mod->getFiles().size() == 1);
 
-  std::unique_ptr<SILModule> SILMod;
-  if (PerformWMO) {
-    SILMod = performASTLowering(mod, CI.getSILTypes(), CI.getSILOptions());
-  } else {
-    SILMod = performASTLowering(*mod->getFiles()[0], CI.getSILTypes(),
-                                CI.getSILOptions());
-  }
+  auto getDescriptor = [&]() -> IRGenDescriptor {
+    const auto &TBDOpts = Invocation.getTBDGenOptions();
+    const auto &SILOpts = Invocation.getSILOptions();
+    auto &SILTypes = CI.getSILTypes();
+    auto moduleName = CI.getMainModule()->getName().str();
+    const PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
 
-  const PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
-  auto Mod = performIRGeneration(CI.getMainModule(), Opts,
-                                 CI.getInvocation().getTBDGenOptions(),
-                                 std::move(SILMod),
-                                 CI.getMainModule()->getName().str(), PSPs,
-                                 ArrayRef<std::string>());
-  if (!Mod)
+    if (PerformWMO) {
+      return IRGenDescriptor::forWholeModule(
+          mod, Opts, TBDOpts, SILOpts, SILTypes,
+          /*SILMod*/ nullptr, moduleName, PSPs);
+    } else {
+      return IRGenDescriptor::forFile(mod->getFiles()[0], Opts, TBDOpts,
+                                      SILOpts, SILTypes, /*SILMod*/ nullptr,
+                                      moduleName, PSPs, /*discriminator*/ "");
+    }
+  };
+
+  auto &eval = CI.getASTContext().evaluator;
+  auto generatedMod = llvm::cantFail(eval(OptimizedIRRequest{getDescriptor()}));
+  if (!generatedMod)
     return 1;
 
-  performLLVM(Opts, CI.getDiags(), /*diagMutex*/ nullptr, /*hash*/ nullptr,
-              Mod.getModule(), Mod.getTargetMachine(), OutputFilename,
-              CI.getASTContext().Stats);
-  return CI.getASTContext().hadError();
+  return compileAndWriteLLVM(generatedMod.getModule(),
+                             generatedMod.getTargetMachine(), Opts,
+                             CI.getStatsReporter(), CI.getDiags(), outStream);
 }


### PR DESCRIPTION
Introduce a request that returns the optimized IR for a whole-module or file, and use it in SILLLVMGen. For now this manually wraps the entire compiler pipeline, but eventually will be able to just call into IRGen. 