### PR TITLE
[stdlib] Make _convertConstStringToUTF8PointerArgument transparent

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -359,6 +359,7 @@ func _convertMutableArrayToPointerArgument<
 }
 
 /// Derive a UTF-8 pointer argument from a value string parameter.
+@_transparent
 public // COMPILER_INTRINSIC
 func _convertConstStringToUTF8PointerArgument<
   ToPointer: _Pointer


### PR DESCRIPTION
This function not being inlinable prevents optimizing it away, and it doesn't actually access any string internals.