### PR TITLE
[build-script-impl] Simplify libcxx build step

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1661,19 +1661,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
 
             libcxx)
-                build_targets=(cxx-headers)
+                build_targets=()
                 cmake_options=(
                     "${cmake_options[@]}"
-                    -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
-                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
-                    -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
-                    -DLLVM_INCLUDE_DOCS:BOOL=TRUE
-                    -DLLVM_CONFIG_PATH="$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-config"
                     "${llvm_cmake_options[@]}"
                 )
-
                 ;;
 
             swift)
@@ -2301,6 +2293,10 @@ for host in "${ALL_HOSTS[@]}"; do
             fi
             with_pushd "${build_dir}" \
                 call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
+        fi
+
+        if [[ "${product}" == "libcxx" ]]; then
+            continue
         fi
 
         # When we are building LLVM create symlinks to the c++ headers. We need


### PR DESCRIPTION
Cherry-pick from https://github.com/apple/swift/pull/32909
Fixes `ninja: error: unknown target 'cxx-headers'` on master-next after that target was removed upstream, so trying this change out on master as well.