### PR TITLE
[Test] Disabled rdar64672291.swift when appropriate.

### DIFF
--- a/validation-test/Runtime/rdar64672291.swift
+++ b/validation-test/Runtime/rdar64672291.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: objc_interop
+// REQUIRES: executable_test 
+// UNSUPPORTED: use_os_stdlib
 
 import Foundation
 


### PR DESCRIPTION
The test requires execution and to be run with the just-built stdlib.  These fixes were already made on master.