### PR TITLE
[build] extend support for building with a prebuilt toolchain to the corelibs and llbuild

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1518,6 +1518,18 @@ for host in "${ALL_HOSTS[@]}"; do
         )
     fi
 
+    if [[ "${NATIVE_CLANG_TOOLS_PATH}" ]] ; then
+        CLANG_BIN="${NATIVE_CLANG_TOOLS_PATH}"
+    else
+        CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
+    fi
+
+    if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
+        SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
+    else
+        SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+    fi
+
     for product in "${PRODUCTS[@]}"; do
         [[ $(should_execute_action "${host}-${product/_static}-build") ]] || continue
 
@@ -1954,7 +1966,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
-                    -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
+                    -DLLDB_SWIFTC:PATH=${SWIFTC_BIN}
                     -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
                     -DLLDB_FRAMEWORK_INSTALL_DIR="$(get_host_install_prefix ${host})../System/Library/PrivateFrameworks"
@@ -2004,15 +2016,17 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
 
                     -DCMAKE_BUILD_TYPE:STRING="${LLBUILD_BUILD_TYPE}"
+                    -DCMAKE_C_COMPILER:PATH="${CLANG_BIN}/clang"
+                    -DCMAKE_CXX_COMPILER:PATH="${CLANG_BIN}/clang++"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
-                    -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                    -DCMAKE_Swift_COMPILER:PATH=${SWIFTC_BIN}
 
                     -DLLBUILD_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLBUILD_ENABLE_ASSERTIONS}")
                     -DLLBUILD_SUPPORT_BINDINGS:=Swift
 
                     -DLIT_EXECUTABLE:PATH="${LLVM_SOURCE_DIR}/utils/lit/lit.py"
                     -DFILECHECK_EXECUTABLE:PATH="$(build_directory_bin ${LOCAL_HOST} llvm)/FileCheck"
-                    -DSWIFTC_EXECUTABLE:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                    -DSWIFTC_EXECUTABLE:PATH=${SWIFTC_BIN}
                     -DFOUNDATION_BUILD_DIR:PATH="$(build_directory ${host} foundation)"
                     -DLIBDISPATCH_BUILD_DIR:PATH="$(build_directory ${host} libdispatch)"
                     -DLIBDISPATCH_SOURCE_DIR:PATH="${LIBDISPATCH_SOURCE_DIR}"
@@ -2035,7 +2049,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 ;;
             xctest)
-                SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
                 SWIFT_BUILD_DIR=$(build_directory ${host} swift)
@@ -2073,14 +2086,12 @@ for host in "${ALL_HOSTS[@]}"; do
                   echo "Cleaning the XCTest build directory"
                   call rm -rf "${XCTEST_BUILD_DIR}"
 
-                  LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
-
                   cmake_options=(
                     ${cmake_options[@]}
                     -DCMAKE_BUILD_TYPE:STRING="${XCTEST_BUILD_TYPE}"
-                    -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
-                    -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
-                    -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                    -DCMAKE_C_COMPILER:PATH="${CLANG_BIN}/clang"
+                    -DCMAKE_CXX_COMPILER:PATH="${CLANG_BIN}/clang++"
+                    -DCMAKE_Swift_COMPILER:PATH=${SWIFTC_BIN}
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
 
@@ -2091,7 +2102,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}
                     -DXCTEST_PATH_TO_LIBDISPATCH_BUILD:PATH=$(build_directory ${host} libdispatch)
                     -DXCTEST_PATH_TO_FOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}
-                    -DCMAKE_SWIFT_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                    -DCMAKE_SWIFT_COMPILER:PATH=${SWIFTC_BIN}
                     -DCMAKE_PREFIX_PATH:PATH=$(build_directory ${host} llvm)
 
                     -DENABLE_TESTING=YES
@@ -2105,9 +2116,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 # location for building and running the tests. Note that XCTest
                 # is not yet built at this point.
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-
-                SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
-                LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
                 if [[ ${host} == "macosx"* ]]; then
                     echo "Skipping Foundation on OS X -- use the Xcode project instead"
@@ -2148,8 +2156,8 @@ for host in "${ALL_HOSTS[@]}"; do
                 cmake_options=(
                   ${cmake_options[@]}
                   -DCMAKE_BUILD_TYPE:STRING=${FOUNDATION_BUILD_TYPE}
-                  -DCMAKE_C_COMPILER:PATH=${LLVM_BIN}/clang
-                  -DCMAKE_CXX_COMPILER:PATH=${LLVM_BIN}/clang++
+                  -DCMAKE_C_COMPILER:PATH=${CLANG_BIN}/clang
+                  -DCMAKE_CXX_COMPILER:PATH=${CLANG_BIN}/clang++
                   -DCMAKE_SWIFT_COMPILER:PATH=${SWIFTC_BIN}
                   -DCMAKE_Swift_COMPILER:PATH=${SWIFTC_BIN}
                   -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
@@ -2171,8 +2179,6 @@ for host in "${ALL_HOSTS[@]}"; do
             libdispatch|libdispatch_static)
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                 SWIFT_BUILD_PATH="$(build_directory ${host} swift)"
-                SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
-                LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
                 case "${host}" in
                 macosx-*)
@@ -2191,8 +2197,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DENABLE_SWIFT=YES
                     ${cmake_options[@]}
                     -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
-                    -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
-                    -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
+                    -DCMAKE_C_COMPILER:PATH="${CLANG_BIN}/clang"
+                    -DCMAKE_CXX_COMPILER:PATH="${CLANG_BIN}/clang++"
                     -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
                     -DCMAKE_Swift_COMPILER:PATH="${SWIFTC_BIN}"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
@@ -2399,6 +2405,18 @@ for host in "${ALL_HOSTS[@]}"; do
 
     set_build_options_for_host $host
 
+    if [[ "${NATIVE_CLANG_TOOLS_PATH}" ]] ; then
+        CLANG_BIN="${NATIVE_CLANG_TOOLS_PATH}"
+    else
+        CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
+    fi
+
+    if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
+        SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
+    else
+        SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+    fi
+
     # Run the tests for each product
     for product in "${PRODUCTS[@]}"; do
         # Check if we should perform this action.
@@ -2530,7 +2548,6 @@ for host in "${ALL_HOSTS[@]}"; do
                   fi
 
                   echo "--- Running tests for ${product} ---"
-                  SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                   FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
                   XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                   call "${XCTEST_SOURCE_DIR}"/build_script.py test \
@@ -2583,16 +2600,12 @@ for host in "${ALL_HOSTS[@]}"; do
                     LIBICU_BUILD_ARGS=()
                 fi
 
-
-                SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
-                LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
-
                 # NOTE(compnerd) the time has come to enable tests now
                 cmake_options=(
                   ${cmake_options[@]}
                   -DCMAKE_BUILD_TYPE:STRING=${FOUNDATION_BUILD_TYPE}
-                  -DCMAKE_C_COMPILER:PATH=${LLVM_BIN}/clang
-                  -DCMAKE_CXX_COMPILER:PATH=${LLVM_BIN}/clang++
+                  -DCMAKE_C_COMPILER:PATH=${CLANG_BIN}/clang
+                  -DCMAKE_CXX_COMPILER:PATH=${CLANG_BIN}/clang++
                   -DCMAKE_Swift_COMPILER:PATH=${SWIFTC_BIN}
                   -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
 
@@ -2635,10 +2648,6 @@ for host in "${ALL_HOSTS[@]}"; do
                   continue
                 ;;
                 *)
-                  cmake_options=(
-                    ${cmake_options[@]}
-                    -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
-                  )
                   results_targets=( "test" )
                   executable_target=""
                 ;;


### PR DESCRIPTION
The flags `--native-{swift,clang,llvm}-tools-path`, for building the Swift stdlib with a prebuilt Swift and clang compiler, have been around since the beginning, so might as well use them to quickly build other Swift repos too. This is useful when iterating on the Swift corelibs, so you don't have to build the most recent compilers from scratch each time.

The following commands will set up, build, and run the tests for libdispatch for the most recent trunk snapshot for which there's an official prebuilt compiler, with this pull merged:
```
wget https://swift.org/builds/development/ubuntu2004/swift-DEVELOPMENT-SNAPSHOT-2020-07-15-a/swift-DEVELOPMENT-SNAPSHOT-2020-07-15-a-ubuntu20.04.tar.gz
tar xf swift-DEVELOPMENT-SNAPSHOT-2020-07-15-a-ubuntu20.04.tar.gz
mv swift-DEVELOPMENT-SNAPSHOT-2020-07-15-a-ubuntu20.04 swift-715
rm /home/butta/swift-715/usr/lib/swift/dispatch/module.modulemap

cd swift
git checkout swift-DEVELOPMENT-SNAPSHOT-2020-07-15-a
cd ../swift-corelibs-dispatch
git checkout swift-DEVELOPMENT-SNAPSHOT-2020-07-15-a
cd ..

./swift/utils/build-script -R --no-assertions --native-swift-tools-path=/home/butta/swift-715/usr/bin/ --native-clang-tools-path=/home/butta/swift-715/usr/bin/ --skip-build-cmark --skip-build-llvm --skip-build-swift --libdispatch -T -j9
``` 
This is obviously much quicker than rebuilding the Swift and clang compilers every time you checkout a trunk snapshot. Replacing `--libdispatch` with `--xctest -b` in that last command, I was able to build and test all the corelibs and llbuild on linux, though I had to remove the CoreFoundation module.map too (`rm /home/butta/swift-715/usr/lib/swift/CoreFoundation/module.map`), as those module maps that come with the prebuilt toolchain conflict with the freshly built ones (the tests already pass `LD_LIBRARY_PATH` where necessary to link and test the freshly built corelibs), and XCTest and llbuild needed my recent pull #32860 for testing to work (otherwise, lit and some other testing utilities couldn't be found).

@shahmishal, this could also be used on the CI to greatly reduce testing times for these corelibs, by caching the build of the latest merged commit in this compiler repo and reusing it for the CI for the corelibs and other repos. A few projects like libdispatch couldn't be run this way, as [it's a dependency of SourceKit and is built as part of this repo too](https://github.com/apple/swift/blob/8461047ae6499cea00b8e1e4022a3b7dbabaaa9e/CMakeLists.txt#L941), but the rest of these Swift repos' CI could be run a lot faster, saving a lot of wasted builds.

This pull is based on [my patch to cross-compile the corelibs and SPM for Android AArch64](https://github.com/termux/termux-packages/blob/master/packages/swift/swift-build-script.patch#L215), which is used [to distribute a Swift toolchain that runs on Android AArch64 devices](https://forums.swift.org/t/swift-for-android-call-for-the-community/32766/13).