### PR TITLE
stdlib: enable COW sanity checks with an environment variable

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -12,6 +12,20 @@
 
 import SwiftShims
 
+#if INTERNAL_CHECKS_ENABLED
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@_silgen_name("swift_COWSanityChecksEnabled")
+public func _COWSanityChecksEnabled() -> Bool
+
+@_alwaysEmitIntoClient
+internal func doCOWSanityChecks() -> Bool {
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    return _COWSanityChecksEnabled()
+  }
+  return false
+}
+#endif
+
 /// Class used whose sole instance is used as storage for empty
 /// arrays.  The instance is defined in the runtime and statically
 /// initialized.  See stdlib/runtime/GlobalObjects.cpp for details.
@@ -454,13 +468,13 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @_alwaysEmitIntoClient
   internal var isImmutable: Bool {
     get {
-      if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+      if doCOWSanityChecks() {
         return capacity == 0 || _swift_isImmutableCOWBuffer(_storage)
       }
       return true
     }
     nonmutating set {
-      if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+      if doCOWSanityChecks() {
         if newValue {
           if capacity > 0 {
             let wasImmutable = _swift_setImmutableCOWBuffer(_storage, true)
@@ -480,7 +494,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   
   @_alwaysEmitIntoClient
   internal var isMutable: Bool {
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if doCOWSanityChecks() {
       return !_swift_isImmutableCOWBuffer(_storage)
     }
     return true

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -188,3 +188,9 @@ void swift::runtime::environment::initialize(void *context) {
               "will not be flagged.");
 }
 #endif
+
+SWIFT_RUNTIME_EXPORT
+bool swift_COWSanityChecksEnabled() {
+  return runtime::environment::SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS();
+}
+

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -44,4 +44,7 @@ VARIABLE(SWIFT_ENABLE_MANGLED_NAME_VERIFICATION, bool, false,
 VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, bool, false,
          "Scribble on runtime allocations such as metadata allocations.")
 
+VARIABLE(SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS, bool, false,
+         "Enable sanity checks for copy-on-write operations.")
+
 #undef VARIABLE

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1940,6 +1940,9 @@ config.environment[TARGET_ENV_PREFIX + 'SWIFT_DETERMINISTIC_HASHING'] = '1'
 # Enable malloc scribble during tests by default.
 config.environment[TARGET_ENV_PREFIX + 'SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE'] = 'YES'
 
+# Enable COW sanity checks in the swift runtime by default.
+config.environment['SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS'] = 'true'
+
 # Run lsb_release on the target to be tested and return the results.
 def linux_get_lsb_release():
     lsb_release_path = '/usr/bin/lsb_release'


### PR DESCRIPTION
Instead of doing the sanity checks by default (with an assert-build of the stdlib), only do the checks if the environment variable SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS is set to true.

The checks can give false alarms in case a binary is built against a no-assert stdlib but run with an assert-stdlib.
Therefore only do the checks if it's explicitly enabled at runtime, which is done when running the lit tests.

rdar://problem/65475776