### PR TITLE
[SIL] Fix a regression with optional class-constrained unowned property

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -392,7 +392,8 @@ namespace {
     } \
     RetTy visit##Name##StorageType(Can##Name##StorageType type, \
                                    AbstractionPattern origType) { \
-      auto referentType = type->getReferentType(); \
+      auto referentType = \
+        type->getReferentType()->lookThroughSingleOptionalType(); \
       auto concreteType = getConcreteReferenceStorageReferent(referentType); \
       if (Name##StorageType::get(concreteType, TC.Context) \
             ->isLoadable(Expansion.getResilienceExpansion())) { \

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -161,8 +161,13 @@ func takesUnownedStruct(_ z: Unowned<C>) {}
 // Make sure we don't crash here
 struct UnownedGenericCapture<T : AnyObject> {
   var object: T
+  var optionalObject: T?
 
   func f() -> () -> () {
     return { [unowned object] in _ = object }
+  }
+
+  func g() -> () -> () {
+    return { [unowned optionalObject] in _ = optionalObject }
   }
 }


### PR DESCRIPTION
When we have a class-constrained optional unowned property (i.e. `T? where T: AnyObject`), we need to strip off the optional before handing it off to `getConcreteReferenceStorageReferent`. Otherwise, it will return the optional back, which won't be handled by `getReferenceCounting` (via `UnownedStorageType::isLoadable`) due to the generic type parameter.

Resolves SR-13227.