### PR TITLE
[5.3][stdlib] Make _convertConstStringToUTF8PointerArgument transparent

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -359,6 +359,7 @@ func _convertMutableArrayToPointerArgument<
 }
 
 /// Derive a UTF-8 pointer argument from a value string parameter.
+@_transparent
 public // COMPILER_INTRINSIC
 func _convertConstStringToUTF8PointerArgument<
   ToPointer: _Pointer


### PR DESCRIPTION
This function was not marked as inlineable, which prevents specialization and caused code using it to add resilient caches for the `_Pointer` protocol into the DATA segment. The unspecialized code is also less efficient.

Cherry-pick of #32915 
Scope of Issue: This is causing unspecialized code on pointer manipulation, which dirties memory and bloats code size.
Origination: This has been like this since the standard library became resilient
Risk: Extremely low, this is just exposing trivial code to the inline
Test: use is covered by several existing tests
Reviewed by: @lorentey 
Resolves: rdar://65640613