### PR TITLE
IRGen: Simplify logic for locating the legacy type info YAML file

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1355,23 +1355,7 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
     if (!doesPlatformUseLegacyLayouts(platformName, archName))
       return;
 
-    // Find the first runtime library path that exists.
-    bool found = false;
-    for (auto &RuntimeLibraryPath
-         : IGM.Context.SearchPathOpts.RuntimeLibraryPaths) {
-      if (fs->exists(RuntimeLibraryPath)) {
-        defaultPath.append(RuntimeLibraryPath);
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      auto joined = llvm::join(IGM.Context.SearchPathOpts.RuntimeLibraryPaths,
-                               "', '");
-      llvm::report_fatal_error("Unable to find a runtime library path at '"
-                               + joined + "'");
-    }
-
+    defaultPath = IGM.Context.SearchPathOpts.RuntimeLibraryPaths[0];
     llvm::sys::path::append(defaultPath, "layouts-");
     defaultPath.append(archName);
     defaultPath.append(".yaml");


### PR DESCRIPTION
This will eliminate the unhelpful "Cannot read ‘/usr/lib/swift/layouts-x86_64.yaml’"
error message, and actually print the location where the file was supposed to be
found.