### PR TITLE
[5.3][Sema] SPI info on a wrapped property should propagate to the backing storage

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2249,7 +2249,15 @@ SPIGroupsRequest::evaluate(Evaluator &evaluator, const Decl *decl) const {
     for (auto spi : attr->getSPIGroups())
       spiGroups.insert(spi);
 
-  auto &ctx = decl->getASTContext();
+  // Backing storage for a wrapped property gets the SPI groups from the
+  // original property.
+  if (auto varDecl = dyn_cast<VarDecl>(decl))
+    if (auto originalDecl = varDecl->getOriginalWrappedProperty()) {
+      auto originalSPIs = originalDecl->getSPIGroups();
+      spiGroups.insert(originalSPIs.begin(), originalSPIs.end());
+    }
+
+  // If there is no local SPI information, look at the context.
   if (spiGroups.empty()) {
 
     // Then in the extended nominal type.
@@ -2269,6 +2277,7 @@ SPIGroupsRequest::evaluate(Evaluator &evaluator, const Decl *decl) const {
     }
   }
 
+  auto &ctx = decl->getASTContext();
   return ctx.AllocateCopy(spiGroups.getArrayRef());
 }
 

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -88,6 +88,45 @@ private class PrivateClassLocal {}
   // CHECK-PUBLIC-NOT: extensionSPIMethod
 }
 
+@propertyWrapper
+public struct Wrapper<T> {
+  public var value: T
+
+  public var wrappedValue: T {
+    get { value }
+    set { value = newValue }
+  }
+}
+
+@propertyWrapper
+public struct WrapperWithInitialValue<T> {
+  private var value: T
+
+  public var wrappedValue: T {
+    get { value }
+    set { value = newValue }
+  }
+
+  public var projectedValue: Wrapper<T> {
+    get { Wrapper(value: value) }
+    set { value = newValue.value }
+  }
+}
+
+public class SomeClass {
+}
+
+public struct PublicStruct {
+  @_spi(S) @Wrapper public var spiWrappedSimple: SomeClass
+  // CHECK-PRIVATE: @_spi(S) @{{.*}}.Wrapper public var spiWrappedSimple: {{.*}}.SomeClass
+  // CHECK-PUBLIC-NOT: spiWrappedSimple
+
+  @_spi(S) @WrapperWithInitialValue public var spiWrappedDefault: SomeClass
+  // CHECK-PRIVATE: @_spi(S) @{{.*}}.WrapperWithInitialValue @_projectedValueProperty($spiWrappedDefault) public var spiWrappedDefault: {{.*}}.SomeClass
+  // CHECK-PRIVATE: @_spi(S) public var $spiWrappedDefault: {{.*}}.Wrapper<{{.*}}.SomeClass>
+  // CHECK-PUBLIC-NOT: spiWrappedDefault
+}
+
 @_spi(LocalSPI) public protocol SPIProto3 {
 // CHECK-PRIVATE: @_spi(LocalSPI) public protocol SPIProto3
 // CHECK-PUBLIC-NOT: SPIProto3


### PR DESCRIPTION
The SPI information for the backing storage of wrapped properties wasn't correctly infered, which made the compiler consider the storage API and print it in the public swiftinterface file. The backing storage for a wrapped property should be SPI if the original property is SPI.

Cherry-pick of #32910.

- Scope of Issue: This affects the public swiftinterface generated for projects using @_spi on a property wrapped by a property  wrapper with a default value.
- Origination: The introduction of the @_spi attribute.
- Risk: Very low, this only affects the use of property wrappers on SPI properties.
- Resolves: rdar://problem/65690805