### PR TITLE
[ast] Rename VarPattern -> BindingPattern.

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -73,7 +73,7 @@ protected:
     Value : 1
   );
 
-  SWIFT_INLINE_BITFIELD(VarPattern, Pattern, 1,
+  SWIFT_INLINE_BITFIELD(BindingPattern, Pattern, 1,
     /// True if this is a let pattern, false if a var pattern.
     IsLet : 1
   );
@@ -113,7 +113,7 @@ public:
   /// Find the smallest subpattern which obeys the property that matching it is
   /// equivalent to matching this pattern.
   ///
-  /// Looks through ParenPattern, VarPattern, and TypedPattern.
+  /// Looks through ParenPattern, BindingPattern, and TypedPattern.
   Pattern *getSemanticsProvidingPattern();
   const Pattern *getSemanticsProvidingPattern() const {
     return const_cast<Pattern*>(this)->getSemanticsProvidingPattern();
@@ -692,22 +692,23 @@ public:
 /// semantics of its own, but has a syntactic effect on the subpattern. Bare
 /// identifiers in the subpattern create new variable bindings instead of being
 /// parsed as expressions referencing existing entities.
-class VarPattern : public Pattern {
+class BindingPattern : public Pattern {
   SourceLoc VarLoc;
   Pattern *SubPattern;
 public:
-  VarPattern(SourceLoc loc, bool isLet, Pattern *sub)
-      : Pattern(PatternKind::Var), VarLoc(loc), SubPattern(sub) {
-    Bits.VarPattern.IsLet = isLet;
+  BindingPattern(SourceLoc loc, bool isLet, Pattern *sub)
+      : Pattern(PatternKind::Binding), VarLoc(loc), SubPattern(sub) {
+    Bits.BindingPattern.IsLet = isLet;
   }
 
-  static VarPattern *createImplicit(ASTContext &Ctx, bool isLet, Pattern *sub) {
-    auto *VP = new (Ctx) VarPattern(SourceLoc(), isLet, sub);
+  static BindingPattern *createImplicit(ASTContext &Ctx, bool isLet,
+                                        Pattern *sub) {
+    auto *VP = new (Ctx) BindingPattern(SourceLoc(), isLet, sub);
     VP->setImplicit();
     return VP;
   }
 
-  bool isLet() const { return Bits.VarPattern.IsLet; }
+  bool isLet() const { return Bits.BindingPattern.IsLet; }
 
   SourceLoc getLoc() const { return VarLoc; }
   SourceRange getSourceRange() const {
@@ -722,17 +723,16 @@ public:
   void setSubPattern(Pattern *p) { SubPattern = p; }
 
   static bool classof(const Pattern *P) {
-    return P->getKind() == PatternKind::Var;
+    return P->getKind() == PatternKind::Binding;
   }
 };
-
 
 inline Pattern *Pattern::getSemanticsProvidingPattern() {
   if (auto *pp = dyn_cast<ParenPattern>(this))
     return pp->getSubPattern()->getSemanticsProvidingPattern();
   if (auto *tp = dyn_cast<TypedPattern>(this))
     return tp->getSubPattern()->getSemanticsProvidingPattern();
-  if (auto *vp = dyn_cast<VarPattern>(this))
+  if (auto *vp = dyn_cast<BindingPattern>(this))
     return vp->getSubPattern()->getSemanticsProvidingPattern();
   return this;
 }

--- a/include/swift/AST/PatternNodes.def
+++ b/include/swift/AST/PatternNodes.def
@@ -32,13 +32,13 @@
 #define LAST_PATTERN(Id)
 #endif
 
-// Metavars: x (variable), pat (pattern), e (expression)
-PATTERN(Paren, Pattern) // (pat)
-PATTERN(Tuple, Pattern) // (pat1, ..., patN), N >= 1
-PATTERN(Named, Pattern) // let pat, var pat
-PATTERN(Any, Pattern)   // _
-PATTERN(Typed, Pattern) // pat : type
-PATTERN(Var, Pattern)   // x
+// Metavars: x (variable binding), pat (pattern), e (expression)
+PATTERN(Paren, Pattern)   // (pat)
+PATTERN(Tuple, Pattern)   // (pat1, ..., patN), N >= 1
+PATTERN(Named, Pattern)   // let pat, var pat
+PATTERN(Any, Pattern)     // _
+PATTERN(Typed, Pattern)   // pat : type
+PATTERN(Binding, Pattern) // x
 REFUTABLE_PATTERN(Is, Pattern)           // x is myclass
 REFUTABLE_PATTERN(EnumElement, Pattern)  // .mycase(pat1, ..., patN)
                                          // MyType.mycase(pat1, ..., patN)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -507,7 +507,7 @@ namespace {
         printRec(P->getSubExpr());
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
-    void visitVarPattern(VarPattern *P) {
+    void visitBindingPattern(BindingPattern *P) {
       printCommon(P, P->isLet() ? "pattern_let" : "pattern_var");
       OS << '\n';
       printRec(P->getSubPattern());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1834,7 +1834,7 @@ namespace {
     VarDecl *visitParenPattern(ParenPattern *P) {
       return visit(P->getSubPattern());
     }
-    VarDecl *visitVarPattern(VarPattern *P) {
+    VarDecl *visitBindingPattern(BindingPattern *P) {
       return visit(P->getSubPattern());
     }
     VarDecl *visitTypedPattern(TypedPattern *P) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1192,12 +1192,12 @@ void PrintAST::printPattern(const Pattern *pattern) {
     // FIXME: Print expr.
     break;
 
-  case PatternKind::Var:
+  case PatternKind::Binding:
     if (!Options.SkipIntroducerKeywords)
-      Printer << (cast<VarPattern>(pattern)->isLet() ? tok::kw_let
-                                                     : tok::kw_var)
+      Printer << (cast<BindingPattern>(pattern)->isLet() ? tok::kw_let
+                                                         : tok::kw_var)
               << " ";
-    printPattern(cast<VarPattern>(pattern)->getSubPattern());
+    printPattern(cast<BindingPattern>(pattern)->getSubPattern());
   }
 }
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1738,7 +1738,7 @@ Pattern *Traversal::visitExprPattern(ExprPattern *P) {
   return nullptr;
 }
 
-Pattern *Traversal::visitVarPattern(VarPattern *P) {
+Pattern *Traversal::visitBindingPattern(BindingPattern *P) {
   if (Pattern *newSub = doIt(P->getSubPattern())) {
     P->setSubPattern(newSub);
     return P;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5601,7 +5601,7 @@ SourceRange VarDecl::getTypeSourceRangeForDiagnostics() const {
   if (!Pat || Pat->isImplicit())
     return SourceRange();
 
-  if (auto *VP = dyn_cast<VarPattern>(Pat))
+  if (auto *VP = dyn_cast<BindingPattern>(Pat))
     Pat = VP->getSubPattern();
   if (auto *TP = dyn_cast<TypedPattern>(Pat))
     if (auto typeRepr = TP->getTypeRepr())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2451,7 +2451,7 @@ void FindLocalVal::checkPattern(const Pattern *Pat, DeclVisibilityKind Reason) {
     return;
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return checkPattern(Pat->getSemanticsProvidingPattern(), Reason);
   case PatternKind::Named:
     return checkValueDecl(cast<NamedPattern>(Pat)->getDecl(), Reason);

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -48,7 +48,7 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS, PatternKind kind) {
     return OS << "prefix 'is' pattern";
   case PatternKind::Expr:
     return OS << "expression pattern";
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return OS << "'var' binding pattern";
   case PatternKind::EnumElement:
     return OS << "enum case matching pattern";
@@ -214,7 +214,7 @@ void Pattern::forEachVariable(llvm::function_ref<void(VarDecl *)> fn) const {
 
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return getSemanticsProvidingPattern()->forEachVariable(fn);
 
   case PatternKind::Tuple:
@@ -262,8 +262,8 @@ void Pattern::forEachNode(llvm::function_ref<void(Pattern*)> f) {
     return cast<ParenPattern>(this)->getSubPattern()->forEachNode(f);
   case PatternKind::Typed:
     return cast<TypedPattern>(this)->getSubPattern()->forEachNode(f);
-  case PatternKind::Var:
-    return cast<VarPattern>(this)->getSubPattern()->forEachNode(f);
+  case PatternKind::Binding:
+    return cast<BindingPattern>(this)->getSubPattern()->forEachNode(f);
 
   case PatternKind::Tuple:
     for (auto elt : cast<TuplePattern>(this)->getElements())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1634,10 +1634,10 @@ static void makeStructRawValuedWithBridge(
   makeComputed(computedVar, computedVarGetter, nullptr);
 
   // Create a pattern binding to describe the variable.
-  Pattern *computedVarPattern = createTypedNamedPattern(computedVar);
+  Pattern *computedBindingPattern = createTypedNamedPattern(computedVar);
   auto *computedPatternBinding = PatternBindingDecl::createImplicit(
-      ctx, StaticSpellingKind::None, computedVarPattern, /*InitExpr*/ nullptr,
-      structDecl);
+      ctx, StaticSpellingKind::None, computedBindingPattern,
+      /*InitExpr*/ nullptr, structDecl);
 
   auto init = createRawValueBridgingConstructor(Impl, structDecl, computedVar,
                                                 storedVar,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5720,7 +5720,7 @@ Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
       } else if (auto paren = dyn_cast<ParenPattern>(cur)) {
         primaryVarIsWellFormed = false;
         cur = paren->getSubPattern();
-      } else if (auto var = dyn_cast<VarPattern>(cur)) {
+      } else if (auto var = dyn_cast<BindingPattern>(cur)) {
         primaryVarIsWellFormed = false;
         cur = var->getSubPattern();
       } else {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1022,8 +1022,8 @@ ParserResult<Pattern> Parser::parsePattern() {
       return makeParserCodeCompletionResult<Pattern>();
     if (subPattern.isNull())
       return nullptr;
-    return makeParserResult(new (Context) VarPattern(varLoc, isLet,
-                                                     subPattern.get()));
+    return makeParserResult(
+        new (Context) BindingPattern(varLoc, isLet, subPattern.get()));
   }
       
   default:
@@ -1233,7 +1233,7 @@ ParserResult<Pattern> Parser::parseMatchingPatternAsLetOrVar(bool isLet,
   ParserResult<Pattern> subPattern = parseMatchingPattern(isExprBasic);
   if (subPattern.isNull())
     return nullptr;
-  auto *varP = new (Context) VarPattern(varLoc, isLet, subPattern.get());
+  auto *varP = new (Context) BindingPattern(varLoc, isLet, subPattern.get());
   return makeParserResult(ParserStatus(subPattern), varP);
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1092,8 +1092,8 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
                                        P.CurDeclContext);
     var->setImplicit();
     auto namePattern = new (P.Context) NamedPattern(var);
-    auto varPattern = new (P.Context) VarPattern(loc, /*isLet*/true,
-                                                 namePattern);
+    auto varPattern =
+        new (P.Context) BindingPattern(loc, /*isLet*/ true, namePattern);
     varPattern->setImplicit();
     patternResult = makeParserResult(varPattern);
   }
@@ -1485,8 +1485,8 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     ThePattern = parseMatchingPattern(/*isExprBasic*/ true);
     
     if (ThePattern.isNonNull()) {
-      auto *P = new (Context) VarPattern(IntroducerLoc, wasLet,
-                                          ThePattern.get());
+      auto *P =
+          new (Context) BindingPattern(IntroducerLoc, wasLet, ThePattern.get());
       ThePattern = makeParserResult(Status, P);
     }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -937,9 +937,9 @@ static void emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl,
                           cast<TypedPattern>(pattern)->getSubPattern(),
                           std::move(src));
 
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return emitMemberInit(SGF, selfDecl,
-                          cast<VarPattern>(pattern)->getSubPattern(),
+                          cast<BindingPattern>(pattern)->getSubPattern(),
                           std::move(src));
 
 #define PATTERN(Name, Parent)

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1041,7 +1041,7 @@ struct InitializationForPattern
   InitializationPtr visitTypedPattern(TypedPattern *P) {
     return visit(P->getSubPattern());
   }
-  InitializationPtr visitVarPattern(VarPattern *P) {
+  InitializationPtr visitBindingPattern(BindingPattern *P) {
     return visit(P->getSubPattern());
   }
 

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -141,7 +141,7 @@ struct GenGlobalAccessors : public PatternVisitor<GenGlobalAccessors>
   void visitTypedPattern(TypedPattern *P) {
     return visit(P->getSubPattern());
   }
-  void visitVarPattern(VarPattern *P) {
+  void visitBindingPattern(BindingPattern *P) {
     return visit(P->getSubPattern());
   }
   void visitTuplePattern(TuplePattern *P) {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -99,7 +99,7 @@ static void dumpPattern(const Pattern *p, llvm::raw_ostream &os) {
 
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     llvm_unreachable("not semantic");
   }
 }
@@ -129,7 +129,7 @@ static bool isDirectlyRefutablePattern(const Pattern *p) {
   // Recur into simple wrapping patterns.
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return isDirectlyRefutablePattern(p->getSemanticsProvidingPattern());
   }  
   llvm_unreachable("bad pattern");
@@ -190,7 +190,7 @@ static unsigned getNumSpecializationsRecursive(const Pattern *p, unsigned n) {
   // Recur into simple wrapping patterns.
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return getNumSpecializationsRecursive(p->getSemanticsProvidingPattern(), n);
   }  
   llvm_unreachable("bad pattern");
@@ -231,7 +231,7 @@ static bool isWildcardPattern(const Pattern *p) {
   // Recur into simple wrapping patterns.
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return isWildcardPattern(p->getSemanticsProvidingPattern());
   }
 
@@ -293,7 +293,7 @@ static Pattern *getSimilarSpecializingPattern(Pattern *p, Pattern *first) {
   }
     
   case PatternKind::Paren:
-  case PatternKind::Var:
+  case PatternKind::Binding:
   case PatternKind::Typed:
     llvm_unreachable("not semantic");
   }
@@ -1348,7 +1348,7 @@ void PatternMatchEmission::emitSpecializedDispatch(ClauseMatrix &clauses,
 
   case PatternKind::Paren:
   case PatternKind::Typed:
-  case PatternKind::Var:
+  case PatternKind::Binding:
     llvm_unreachable("non-semantic pattern kind!");
   
   case PatternKind::Tuple:

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5458,7 +5458,7 @@ void InOutConversionFailure::fixItChangeArgumentType() const {
   SourceLoc startLoc; // Left invalid if we're inserting
 
   auto isSimpleTypelessPattern = [](Pattern *P) -> bool {
-    if (auto VP = dyn_cast_or_null<VarPattern>(P))
+    if (auto VP = dyn_cast_or_null<BindingPattern>(P))
       P = VP->getSubPattern();
     return P && isa<NamedPattern>(P);
   };

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2293,8 +2293,8 @@ namespace {
 
         return setType(ParenType::get(CS.getASTContext(), underlyingType));
       }
-      case PatternKind::Var: {
-        auto *subPattern = cast<VarPattern>(pattern)->getSubPattern();
+      case PatternKind::Binding: {
+        auto *subPattern = cast<BindingPattern>(pattern)->getSubPattern();
         auto type = getTypeForPattern(subPattern, locator, externalPatternType,
                                       bindPatternVarsOneWay);
 
@@ -2304,7 +2304,6 @@ namespace {
         // Var doesn't affect the type.
         return setType(type);
       }
-
       case PatternKind::Any: {
         return setType(
             externalPatternType

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -737,8 +737,8 @@ DerivedConformance::enumElementPayloadSubpattern(EnumElementDecl *enumElementDec
 
       auto namedPattern = new (C) NamedPattern(payloadVar);
       namedPattern->setImplicit();
-      auto letPattern = VarPattern::createImplicit(C, /*isLet*/ true,
-                                                   namedPattern);
+      auto letPattern =
+          BindingPattern::createImplicit(C, /*isLet*/ true, namedPattern);
       elementPatterns.push_back(TuplePatternElt(tupleElement.getName(),
                                                 SourceLoc(), letPattern));
     }
@@ -757,8 +757,8 @@ DerivedConformance::enumElementPayloadSubpattern(EnumElementDecl *enumElementDec
 
   auto namedPattern = new (C) NamedPattern(payloadVar);
   namedPattern->setImplicit();
-  auto letPattern = new (C) VarPattern(SourceLoc(), /*isLet*/ true,
-                                       namedPattern);
+  auto letPattern =
+      new (C) BindingPattern(SourceLoc(), /*isLet*/ true, namedPattern);
   return ParenPattern::createImplicit(C, letPattern);
 }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2733,7 +2733,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         if (SC->getCond().size() == 1) {
           auto pattern = SC->getCond()[0].getPattern();
           if (auto OSP = dyn_cast<OptionalSomePattern>(pattern))
-            if (auto LP = dyn_cast<VarPattern>(OSP->getSubPattern()))
+            if (auto LP = dyn_cast<BindingPattern>(OSP->getSubPattern()))
               if (isa<NamedPattern>(LP->getSubPattern())) {
                 auto initExpr = SC->getCond()[0].getInitializer();
                 if (initExpr->getStartLoc().isValid()) {
@@ -2801,13 +2801,13 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         if (PBD->getSingleVar() == var)
           FixItLoc = PBD->getLoc();
       } else if (auto *pattern = var->getParentPattern()) {
-        VarPattern *foundVP = nullptr;
+        BindingPattern *foundVP = nullptr;
         pattern->forEachNode([&](Pattern *P) {
-          if (auto *VP = dyn_cast<VarPattern>(P))
+          if (auto *VP = dyn_cast<BindingPattern>(P))
             if (VP->getSingleVar() == var)
               foundVP = VP;
         });
-        
+
         if (foundVP && !foundVP->isLet())
           FixItLoc = foundVP->getLoc();
       }
@@ -3734,7 +3734,7 @@ static void diagDeprecatedObjCSelectors(const DeclContext *dc,
 static Pattern *skipNonTypeSyntacticPatterns(Pattern *pattern) {
   if (auto *pp = dyn_cast<ParenPattern>(pattern))
     return skipNonTypeSyntacticPatterns(pp->getSubPattern());
-  if (auto *vp = dyn_cast<VarPattern>(pattern))
+  if (auto *vp = dyn_cast<BindingPattern>(pattern))
     return skipNonTypeSyntacticPatterns(vp->getSubPattern());
   return pattern;
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1039,9 +1039,9 @@ static Optional<std::string> buildDefaultInitializerString(DeclContext *dc,
     return buildDefaultInitializerString(
         dc, cast<TypedPattern>(pattern)->getSubPattern());
 
-  case PatternKind::Var:
+  case PatternKind::Binding:
     return buildDefaultInitializerString(
-        dc, cast<VarPattern>(pattern)->getSubPattern());
+        dc, cast<BindingPattern>(pattern)->getSubPattern());
   }
 
   llvm_unreachable("Unhandled PatternKind in switch.");

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -992,9 +992,9 @@ public:
         auto diag = vd->diagnose(diag::mutability_mismatch_multiple_pattern_list,
                                  vd->isLet(), initialCaseVarDecl->isLet());
 
-        VarPattern *foundVP = nullptr;
+        BindingPattern *foundVP = nullptr;
         vd->getParentPattern()->forEachNode([&](Pattern *P) {
-          if (auto *VP = dyn_cast<VarPattern>(P))
+          if (auto *VP = dyn_cast<BindingPattern>(P))
             if (VP->getSingleVar() == vd)
               foundVP = VP;
         });
@@ -2061,9 +2061,9 @@ void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
         auto diag = var->diagnose(diag::mutability_mismatch_multiple_pattern_list,
                                   var->isLet(), initialCaseVarDecl->isLet());
 
-        VarPattern *foundVP = nullptr;
+        BindingPattern *foundVP = nullptr;
         var->getParentPattern()->forEachNode([&](Pattern *P) {
-          if (auto *VP = dyn_cast<VarPattern>(P))
+          if (auto *VP = dyn_cast<BindingPattern>(P))
             if (VP->getSingleVar() == var)
               foundVP = VP;
         });

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1257,7 +1257,7 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
 
   auto *Named = NamedPattern::createImplicit(Ctx, Tmp1VD);
   Named->setType(Tmp1VD->getType());
-  auto *Let = VarPattern::createImplicit(Ctx, /*let*/true, Named);
+  auto *Let = BindingPattern::createImplicit(Ctx, /*let*/ true, Named);
   Let->setType(Named->getType());
   auto *Some = new (Ctx) OptionalSomePattern(Let, SourceLoc());
   Some->setImplicit();

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1417,8 +1417,8 @@ namespace {
         llvm_unreachable("cannot appear in case patterns");
       case PatternKind::Expr:
         return Space();
-      case PatternKind::Var: {
-        auto *VP = cast<VarPattern>(item);
+      case PatternKind::Binding: {
+        auto *VP = cast<BindingPattern>(item);
         return projectPattern(VP->getSubPattern());
       }
       case PatternKind::Paren: {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -399,11 +399,12 @@ Expected<Pattern *> ModuleFile::readPattern(DeclContext *owningDC) {
   }
   case decls_block::VAR_PATTERN: {
     bool isLet;
-    VarPatternLayout::readRecord(scratch, isLet);
+    BindingPatternLayout::readRecord(scratch, isLet);
 
     Pattern *subPattern = readPatternUnchecked(owningDC);
 
-    auto result = VarPattern::createImplicit(getContext(), isLet, subPattern);
+    auto result =
+        BindingPattern::createImplicit(getContext(), isLet, subPattern);
     if (Type interfaceType = subPattern->getDelayedInterfaceType())
       result->setDelayedInterfaceType(interfaceType, owningDC);
     else

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1510,7 +1510,7 @@ namespace decls_block {
     // The sub-pattern trails the record.
   >;
 
-  using VarPatternLayout = BCRecordLayout<
+  using BindingPatternLayout = BCRecordLayout<
     VAR_PATTERN,
     BCFixed<1>  // isLet?
     // The sub-pattern trails the record.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2722,12 +2722,12 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case PatternKind::Expr:
       llvm_unreachable("Refutable patterns cannot be serialized");
 
-    case PatternKind::Var: {
-      auto var = cast<VarPattern>(pattern);
+    case PatternKind::Binding: {
+      auto var = cast<BindingPattern>(pattern);
 
-      unsigned abbrCode = S.DeclTypeAbbrCodes[VarPatternLayout::Code];
-      VarPatternLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                   var->isLet());
+      unsigned abbrCode = S.DeclTypeAbbrCodes[BindingPatternLayout::Code];
+      BindingPatternLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                       var->isLet());
       writePattern(var->getSubPattern());
       break;
     }
@@ -4488,7 +4488,7 @@ void Serializer::writeAllDeclsAndTypes() {
   registerDeclTypeAbbr<TuplePatternLayout>();
   registerDeclTypeAbbr<TuplePatternEltLayout>();
   registerDeclTypeAbbr<NamedPatternLayout>();
-  registerDeclTypeAbbr<VarPatternLayout>();
+  registerDeclTypeAbbr<BindingPatternLayout>();
   registerDeclTypeAbbr<AnyPatternLayout>();
   registerDeclTypeAbbr<TypedPatternLayout>();
   registerDeclTypeAbbr<InlinableBodyTextLayout>();


### PR DESCRIPTION
VarPattern is today used to implement both 'let' and 'var' pattern bindings, so
today is already misleading. The reason why the name Var was chosen was done b/c
it is meant to represent a pattern that performs 'variable binding'. Given that
I am going to add a new 'inout' pattern binding to this, it makes sense to
give it now a better fitting name before I make things more confusing.
