### PR TITLE
GSB: Fix use-after-free error when vending ResolvedType

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -743,12 +743,6 @@ private:
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
-  /// Realize a potential archetype for the given type.
-  ///
-  /// The resolved archetype will be written back into the unresolved type,
-  /// to make the next resolution more efficient.
-  PotentialArchetype *realizePotentialArchetype(UnresolvedType &type);
-
 public:
   /// Try to resolve the equivalence class of the given type.
   ///

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3677,19 +3677,7 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
       if (!nestedPA)
         return ResolvedType::forUnresolved(baseEquivClass);
 
-      // If base resolved to the anchor, then the nested potential archetype
-      // we found is the resolved potential archetype. Return it directly,
-      // so it doesn't need to be resolved again.
-      if (basePA == resolvedBase.getPotentialArchetypeIfKnown())
-        return ResolvedType(nestedPA);
-
-      // Compute the resolved dependent type to return.
-      Type resolvedBaseType = resolvedBase.getDependentType(*this);
-      Type resolvedMemberType =
-          DependentMemberType::get(resolvedBaseType, assocType);
-
-      return ResolvedType(resolvedMemberType,
-                          nestedPA->getOrCreateEquivalenceClass(*this));
+      return ResolvedType(nestedPA);
     } else {
       auto *concreteDecl =
           baseEquivClass->lookupNestedType(*this, depMemTy->getName());

--- a/lib/AST/GenericSignatureBuilderImpl.h
+++ b/lib/AST/GenericSignatureBuilderImpl.h
@@ -24,7 +24,7 @@ class GenericSignatureBuilder::ResolvedType {
 public:
   /// A specific resolved potential archetype.
   ResolvedType(PotentialArchetype *pa)
-    : type(pa), equivClass(pa->getEquivalenceClassIfPresent()) { }
+    : type(pa), equivClass(nullptr) { }
 
   /// A resolved type within the given equivalence class.
   ResolvedType(Type type, EquivalenceClass *equivClass)

--- a/lib/AST/GenericSignatureBuilderImpl.h
+++ b/lib/AST/GenericSignatureBuilderImpl.h
@@ -21,17 +21,16 @@ class GenericSignatureBuilder::ResolvedType {
   ResolvedType(EquivalenceClass *equivClass)
     : type(), equivClass(equivClass) { }
 
+  /// A concrete resolved type .
+  ResolvedType(Type type) : type(type), equivClass(nullptr) {
+    assert(!type->isTypeParameter());
+  }
+
 public:
   /// A specific resolved potential archetype.
   ResolvedType(PotentialArchetype *pa)
     : type(pa), equivClass(nullptr) { }
 
-  /// A resolved type within the given equivalence class.
-  ResolvedType(Type type, EquivalenceClass *equivClass)
-      : type(type), equivClass(equivClass) {
-    assert(type->isTypeParameter() == static_cast<bool>(equivClass) &&
-           "type parameters must have equivalence classes");
-  }
 
   /// Return an unresolved result, which could be resolved when we
   /// learn more information about the given equivalence class.
@@ -41,7 +40,7 @@ public:
 
   /// Return a result for a concrete type.
   static ResolvedType forConcrete(Type concreteType) {
-    return ResolvedType(concreteType, nullptr);
+    return ResolvedType(concreteType);
   }
 
   /// Determine whether this result was resolved.

--- a/lib/AST/GenericSignatureBuilderImpl.h
+++ b/lib/AST/GenericSignatureBuilderImpl.h
@@ -13,24 +13,20 @@
 namespace swift {
 
 class GenericSignatureBuilder::ResolvedType {
-  llvm::PointerUnion<PotentialArchetype *, Type> type;
-  EquivalenceClass *equivClass;
+  llvm::PointerUnion<PotentialArchetype *, Type, EquivalenceClass *> storage;
 
   /// For a type that could not be resolved further unless the given
   /// equivalence class changes.
-  ResolvedType(EquivalenceClass *equivClass)
-    : type(), equivClass(equivClass) { }
+  ResolvedType(EquivalenceClass *equivClass) : storage(equivClass) { }
 
-  /// A concrete resolved type .
-  ResolvedType(Type type) : type(type), equivClass(nullptr) {
+  /// A concrete resolved type.
+  ResolvedType(Type type) : storage(type) {
     assert(!type->isTypeParameter());
   }
 
 public:
   /// A specific resolved potential archetype.
-  ResolvedType(PotentialArchetype *pa)
-    : type(pa), equivClass(nullptr) { }
-
+  ResolvedType(PotentialArchetype *pa) : storage(pa) { }
 
   /// Return an unresolved result, which could be resolved when we
   /// learn more information about the given equivalence class.
@@ -44,7 +40,9 @@ public:
   }
 
   /// Determine whether this result was resolved.
-  explicit operator bool() const { return !type.isNull(); }
+  explicit operator bool() const {
+    return storage.is<PotentialArchetype *>() || storage.is<Type>();
+  }
 
   /// Retrieve the dependent type.
   Type getDependentType(GenericSignatureBuilder &builder) const;
@@ -53,51 +51,38 @@ public:
   /// a concrete type.
   Type getAsConcreteType() const {
     assert(*this && "Doesn't contain any result");
-    if (equivClass) return Type();
-    return type.dyn_cast<Type>();
+    return storage.dyn_cast<Type>();
   }
-
-  /// Realize a potential archetype for this type parameter.
-  PotentialArchetype *realizePotentialArchetype(
-                                            GenericSignatureBuilder &builder);
 
   /// Retrieve the potential archetype, if already known.
   PotentialArchetype *getPotentialArchetypeIfKnown() const {
-    return type.dyn_cast<PotentialArchetype *>();
+    return storage.dyn_cast<PotentialArchetype *>();
   }
 
   /// Retrieve the equivalence class into which a resolved type refers.
   EquivalenceClass *getEquivalenceClass(
                      GenericSignatureBuilder &builder) const {
-    assert(*this && "Only for resolved types");
-    if (equivClass) return equivClass;
-
-    // Create the equivalence class now.
-    return type.get<PotentialArchetype *>()
+    return storage.get<PotentialArchetype *>()
              ->getOrCreateEquivalenceClass(builder);
   }
 
   /// Retrieve the equivalence class into which a resolved type refers.
   EquivalenceClass *getEquivalenceClassIfPresent() const {
-    assert(*this && "Only for resolved types");
-    if (equivClass) return equivClass;
-
-    // Create the equivalence class now.
-    return type.get<PotentialArchetype *>()->getEquivalenceClassIfPresent();
+    return storage.get<PotentialArchetype *>()
+            ->getEquivalenceClassIfPresent();
   }
 
   /// Retrieve the unresolved result.
   EquivalenceClass *getUnresolvedEquivClass() const {
-    assert(!*this);
-    return equivClass;
+    return storage.dyn_cast<EquivalenceClass *>();
   }
 
   /// Return an unresolved type.
-  ///
-  /// This loses equivalence-class information that could be useful, which
-  /// is unfortunate.
   UnresolvedType getUnresolvedType() const {
-    return type;
+    assert(!storage.is<EquivalenceClass *>());
+    if (storage.is<PotentialArchetype *>())
+      return storage.get<PotentialArchetype *>();
+    return storage.get<Type>();
   }
 };
 

--- a/validation-test/compiler_crashers_2_fixed/rdar65040635.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar65040635.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol P1 {
+  associatedtype Value
+}
+
+public protocol P2 {
+  associatedtype Value
+}
+
+public class Class2<V> : P2 {
+  public typealias Value = V
+}
+
+public class Superclass<T1, T2> where T1 : P1, T2 : P2, T2.Value == T1.Value {
+}
+
+public class Subclass<T1, T2> : Superclass<T1, T2> where T1 : P1, T2 : Class2<T1.Value> {
+}

--- a/validation-test/compiler_crashers_2_fixed/sr12812.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12812.swift
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol DefaultInitializable {
+  init()
+}
+
+public protocol AdjacencyEdge_ {
+  associatedtype VertexID: Equatable
+  associatedtype Properties
+
+  var destination: VertexID { get set }
+  var properties: Properties { get set }
+}
+
+public struct AdjacencyEdge<VertexID: Equatable, Properties>: AdjacencyEdge_ {
+  public var destination: VertexID
+  public var properties: Properties
+}
+
+public protocol AdjacencyVertex_ {
+  associatedtype Edges: Collection where Edges.Element: AdjacencyEdge_
+  associatedtype Properties
+
+  var edges: Edges { get set }
+  var properties: Properties { get set }
+}
+
+public struct AdjacencyVertex<Edges: Collection, Properties> : AdjacencyVertex_
+  where Edges.Element: AdjacencyEdge_
+{
+  public var edges: Edges
+  public var properties: Properties
+}
+
+public protocol BinaryFunction {
+  associatedtype Parameter0
+  associatedtype Parameter1
+  associatedtype Result
+
+  func callAsFunction(_: Parameter0, _: Parameter1) -> Result
+}
+
+public struct GeneralAdjacencyList<
+  Spine: Collection, VertexIDToIndex: BinaryFunction
+>
+  where Spine.Element : AdjacencyVertex_,
+        VertexIDToIndex.Parameter0 == Spine,
+        VertexIDToIndex.Parameter1 == Spine.Element.Edges.Element.VertexID,
+        VertexIDToIndex.Result == Spine.Index
+{
+  public let vertexIDToIndex: VertexIDToIndex
+  public var spine: Spine
+}
+
+public struct IdentityVertexIDToIndex<Spine: Collection>: BinaryFunction
+  where Spine.Element : AdjacencyVertex_,
+        Spine.Element.Edges.Element.VertexID == Spine.Index
+{
+  public func callAsFunction(_: Spine, _ id: Spine.Index) -> Spine.Index {
+    return id
+  }
+}
+
+public extension GeneralAdjacencyList {
+  typealias VertexID = VertexIDToIndex.Parameter1
+  typealias VertexProperties = Spine.Element.Properties
+  typealias EdgeProperties = Spine.Element.Edges.Element.Properties
+
+  struct EdgeID: Equatable {
+    /// The source vertex.
+    let source: VertexIDToIndex.Parameter1
+    /// The position of the edge in `source`'s list of edges.
+    let targetIndex: Spine.Index
+  }
+}
+
+public extension GeneralAdjacencyList
+  where VertexIDToIndex == IdentityVertexIDToIndex<Spine>,
+        Spine: RangeReplaceableCollection,
+        Spine.Element.Edges: RangeReplaceableCollection
+          & BidirectionalCollection // Because https://bugs.swift.org/browse/SR-12810
+{
+  func addVertex(storing properties: VertexProperties) -> VertexID {
+    return spine.indices.first!
+  }
+}
+


### PR DESCRIPTION
The maybeResolveEquivalenceClass() method can deallocate equivalence
classes, because it calls updateNestedTypeForConformance(), which
calls addSameTypeRequirement().

Therefore, the EquivalenceClass stored inside a ResolvedType could
become invalid across calls to maybeResolveEquivalenceClass().

This was a problem in one place in particular, when adding a new
same-type constraint between two type parameters.

Fix this by not caching the equivalence class of a PotentialArchetype
in the ResolvedType implementation. The only time an equivalence class
is now stored is when returning an unresolved type, which is acted
upon immediately.

Fixes <https://bugs.swift.org/browse/SR-12812>, <rdar://problem/63422600>.