### PR TITLE
GSB: Fix use-after-free error when vending ResolvedType [5.3]

### DIFF
--- a/lib/AST/GenericSignatureBuilderImpl.h
+++ b/lib/AST/GenericSignatureBuilderImpl.h
@@ -24,7 +24,7 @@ class GenericSignatureBuilder::ResolvedType {
 public:
   /// A specific resolved potential archetype.
   ResolvedType(PotentialArchetype *pa)
-    : type(pa), equivClass(pa->getEquivalenceClassIfPresent()) { }
+    : type(pa), equivClass(nullptr) { }
 
   /// A resolved type within the given equivalence class.
   ResolvedType(Type type, EquivalenceClass *equivClass)

--- a/validation-test/compiler_crashers_2_fixed/rdar65040635.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar65040635.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol P1 {
+  associatedtype Value
+}
+
+public protocol P2 {
+  associatedtype Value
+}
+
+public class Class2<V> : P2 {
+  public typealias Value = V
+}
+
+public class Superclass<T1, T2> where T1 : P1, T2 : P2, T2.Value == T1.Value {
+}
+
+public class Subclass<T1, T2> : Superclass<T1, T2> where T1 : P1, T2 : Class2<T1.Value> {
+}

--- a/validation-test/compiler_crashers_2_fixed/sr12812.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12812.swift
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol DefaultInitializable {
+  init()
+}
+
+public protocol AdjacencyEdge_ {
+  associatedtype VertexID: Equatable
+  associatedtype Properties
+
+  var destination: VertexID { get set }
+  var properties: Properties { get set }
+}
+
+public struct AdjacencyEdge<VertexID: Equatable, Properties>: AdjacencyEdge_ {
+  public var destination: VertexID
+  public var properties: Properties
+}
+
+public protocol AdjacencyVertex_ {
+  associatedtype Edges: Collection where Edges.Element: AdjacencyEdge_
+  associatedtype Properties
+
+  var edges: Edges { get set }
+  var properties: Properties { get set }
+}
+
+public struct AdjacencyVertex<Edges: Collection, Properties> : AdjacencyVertex_
+  where Edges.Element: AdjacencyEdge_
+{
+  public var edges: Edges
+  public var properties: Properties
+}
+
+public protocol BinaryFunction {
+  associatedtype Parameter0
+  associatedtype Parameter1
+  associatedtype Result
+
+  func callAsFunction(_: Parameter0, _: Parameter1) -> Result
+}
+
+public struct GeneralAdjacencyList<
+  Spine: Collection, VertexIDToIndex: BinaryFunction
+>
+  where Spine.Element : AdjacencyVertex_,
+        VertexIDToIndex.Parameter0 == Spine,
+        VertexIDToIndex.Parameter1 == Spine.Element.Edges.Element.VertexID,
+        VertexIDToIndex.Result == Spine.Index
+{
+  public let vertexIDToIndex: VertexIDToIndex
+  public var spine: Spine
+}
+
+public struct IdentityVertexIDToIndex<Spine: Collection>: BinaryFunction
+  where Spine.Element : AdjacencyVertex_,
+        Spine.Element.Edges.Element.VertexID == Spine.Index
+{
+  public func callAsFunction(_: Spine, _ id: Spine.Index) -> Spine.Index {
+    return id
+  }
+}
+
+public extension GeneralAdjacencyList {
+  typealias VertexID = VertexIDToIndex.Parameter1
+  typealias VertexProperties = Spine.Element.Properties
+  typealias EdgeProperties = Spine.Element.Edges.Element.Properties
+
+  struct EdgeID: Equatable {
+    /// The source vertex.
+    let source: VertexIDToIndex.Parameter1
+    /// The position of the edge in `source`'s list of edges.
+    let targetIndex: Spine.Index
+  }
+}
+
+public extension GeneralAdjacencyList
+  where VertexIDToIndex == IdentityVertexIDToIndex<Spine>,
+        Spine: RangeReplaceableCollection,
+        Spine.Element.Edges: RangeReplaceableCollection
+          & BidirectionalCollection // Because https://bugs.swift.org/browse/SR-12810
+{
+  func addVertex(storing properties: VertexProperties) -> VertexID {
+    return spine.indices.first!
+  }
+}
+


### PR DESCRIPTION
The maybeResolveEquivalenceClass() method can deallocate equivalence
classes, because it calls updateNestedTypeForConformance(), which
calls addSameTypeRequirement().

Therefore, the EquivalenceClass stored inside a ResolvedType could
become invalid across calls to maybeResolveEquivalenceClass().

This was a problem in one place in particular, when adding a new
same-type constraint between two type parameters.

Fix this by not caching the equivalence class of a PotentialArchetype
in the ResolvedType implementation. The only time an equivalence class
is now stored is when returning an unresolved type, which is acted
upon immediately.

Fixes <https://bugs.swift.org/browse/SR-12812>, <rdar://problem/63422600>.