### PR TITLE
[CodeCompletion] Fast completion inside function builder function

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1353,6 +1353,13 @@ class PoundAssertStmt : public Stmt {
   }
 };
 
+inline void simple_display(llvm::raw_ostream &out, Stmt *S) {
+  if (S)
+    out << Stmt::getKindName(S->getKind());
+  else
+    out << "(null)";
+};
+
 } // end namespace swift
 
 #endif // SWIFT_AST_STMT_H

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1836,7 +1836,8 @@ enum class FunctionBuilderBodyPreCheck : uint8_t {
 
 class PreCheckFunctionBuilderRequest
     : public SimpleRequest<PreCheckFunctionBuilderRequest,
-                           FunctionBuilderBodyPreCheck(AnyFunctionRef),
+                           FunctionBuilderBodyPreCheck(AnyFunctionRef,
+                                                       BraceStmt *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1845,8 +1846,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  FunctionBuilderBodyPreCheck
-  evaluate(Evaluator &evaluator, AnyFunctionRef fn) const;
+  FunctionBuilderBodyPreCheck evaluate(Evaluator &evaluator, AnyFunctionRef fn,
+                                       BraceStmt *body) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -231,7 +231,7 @@ SWIFT_REQUEST(TypeChecker, HasUserDefinedDesignatedInitRequest,
 SWIFT_REQUEST(TypeChecker, HasMemberwiseInitRequest,
               bool(StructDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PreCheckFunctionBuilderRequest,
-              FunctionBuilderClosurePreCheck(AnyFunctionRef),
+              FunctionBuilderClosurePreCheck(AnyFunctionRef, BraceStmt *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),

--- a/test/SourceKit/CodeComplete/complete_sequence_builderfunc.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_builderfunc.swift
@@ -1,0 +1,51 @@
+protocol Entity {}
+struct Empty: Entity {
+    var value: Void = ()
+}
+
+@_functionBuilder
+struct Builder {
+  static func buildBlock() ->  { Empty() }
+  static func buildBlock<T: Entity>(_ t: T) -> T { t }
+}
+
+struct MyValue {
+    var id: Int
+    var title: String
+}
+
+func build(_ arg: (MyValue) -> String) -> Empty { Empty() }
+
+struct MyStruct {
+  @Builder var body: some Entity {
+    build { value in
+      value./*HERE * 2*/
+    } /*HERE*/
+  }
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=22:13 %s -- %s == \
+// RUN:   -req=complete -pos=22:13 %s -- %s == \
+// RUN:   -req=complete -pos=23:7 %s -- %s \
+// RUN: | tee %t.result | %FileCheck %s
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.description: "id"
+// CHECK-DAG: key.description: "title"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1 
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.description: "id"
+// CHECK-DAG: key.description: "title"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1 
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.description: "value"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1 
+


### PR DESCRIPTION
`PreCheckFunctionBuilderRequest` applies `PreCheckExpression` to the expressions inside the function body. Previously it used to receive only `AnyFunctionRef` (`FunctionDecl` or `ClosureExpr`) as the parameter. However, when fast-completion kicks-in, it replaces the body of the function, then tries to call `PreCheckFunctionBuilderRequest` again, with the same function decl as before. It used to return cached "Success" result, but it didn't actually apply `PreCheckExpression`. So any `UnresolvedDeclRefExpr` remained unresolved.

In this patch, make `PreCheckFunctionBuilderRequest` receive "body" of the function as well, so it doesn't return the cached result for the *previous* body.

rdar://problem/65692922
