### PR TITLE
[5.3] [SIL] Fix a regression with optional class-constrained unowned property

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -390,7 +390,8 @@ namespace {
     } \
     RetTy visit##Name##StorageType(Can##Name##StorageType type, \
                                    AbstractionPattern origType) { \
-      auto referentType = type->getReferentType(); \
+      auto referentType = \
+        type->getReferentType()->lookThroughSingleOptionalType(); \
       auto concreteType = getConcreteReferenceStorageReferent(referentType); \
       if (Name##StorageType::get(concreteType, TC.Context) \
             ->isLoadable(Expansion.getResilienceExpansion())) { \

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -161,8 +161,13 @@ func takesUnownedStruct(_ z: Unowned<C>) {}
 // Make sure we don't crash here
 struct UnownedGenericCapture<T : AnyObject> {
   var object: T
+  var optionalObject: T?
 
   func f() -> () -> () {
     return { [unowned object] in _ = object }
+  }
+
+  func g() -> () -> () {
+    return { [unowned optionalObject] in _ = optionalObject }
   }
 }


### PR DESCRIPTION
Cherry-pick of #32927. 

---

**Explanation**: Use of `unowned` with optional type (`T? where T: AnyObject`), was crashing during SILGen because we weren't stripping off the optional from the type before checking whether the type is loadable.

**Scope**: Affects use of `unowned`.

**SR Issue**: SR-13227.

**Risk**: Low. It's a simple change that strips off one level of optionality before we try to determine whether the type is loadable.

**Testing**: Added a test case.

**Reviewed by:** @slavapestov 

**Resolves:** rdar://65751793