### PR TITLE
Fix a bunch of python lint errors

### DIFF
--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -551,9 +551,9 @@ class TestComparator(object):
 
         comparisons = list(map(compare, comparable_tests))
 
-        def partition(l, p):
+        def partition(items, p):
             return functools.reduce(
-                lambda x, y: x[not p(y)].append(y) or x, l, ([], [])
+                lambda x, y: x[not p(y)].append(y) or x, items, ([], [])
             )
 
         decreased, not_decreased = partition(

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -130,8 +130,8 @@ class BenchmarkDriver(object):
         print("testing driver at path: %s" % binary)
         names = []
         output = subprocess.check_output([binary, "--list"], universal_newlines=True)
-        for l in output.split("\n")[1:]:
-            m = BENCHMARK_OUTPUT_RE.match(l)
+        for line in output.split("\n")[1:]:
+            m = BENCHMARK_OUTPUT_RE.match(line)
             if m is None:
                 continue
             names.append(m.group(1))

--- a/test/Inputs/not.py
+++ b/test/Inputs/not.py
@@ -10,5 +10,5 @@ try:
     isPosix = (sys.platform != "win32")
     subprocess.check_call(shlex.split(sys.argv[1], posix=isPosix))
     sys.exit(1)
-except subprocess.CalledProcessError as e:
+except subprocess.CalledProcessError:
     sys.exit(0)

--- a/unittests/Reflection/RemoteMirrorInterop/test.py
+++ b/unittests/Reflection/RemoteMirrorInterop/test.py
@@ -56,9 +56,9 @@ for i, (swiftc, swiftlib) in enumerate(zip(swiftcs, swiftlibs)):
 for i in range(len(swiftcs) + 1):
     for localMirrorlibs in itertools.combinations(mirrorlibs, i):
         for i, arg in enumerate(absoluteArgs):
-            print 'Testing', arg, 'with mirror libs:'
-            for l in localMirrorlibs:
-                print '\t', l
+            print('Testing', arg, 'with mirror libs:')
+            for lib in localMirrorlibs:
+                print('\t', lib)
             callArgs = ['/tmp/test']
             dylibPath = os.path.join('/tmp', 'libtest' + str(i) + '.dylib')
             callArgs.append(dylibPath)

--- a/utils/bug_reducer/bug_reducer/list_reducer.py
+++ b/utils/bug_reducer/bug_reducer/list_reducer.py
@@ -12,8 +12,8 @@ TESTRESULTS = set([TESTRESULT_NOFAILURE, TESTRESULT_KEEPSUFFIX,
 class ListReducer(object):
     """Reduce lists of objects. Inspired by llvm bugpoint"""
 
-    def __init__(self, l):
-        self.target_list = l
+    def __init__(self, lst):
+        self.target_list = lst
         # Maximal number of allowed splitting iterations,
         # before the elements are randomly shuffled.
         self.max_iters_without_progress = 3

--- a/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
@@ -16,8 +16,8 @@ import swift_tools
 
 class ReduceMiscompilingPasses(list_reducer.ListReducer):
 
-    def __init__(self, l, invoker):
-        list_reducer.ListReducer.__init__(self, l)
+    def __init__(self, lst, invoker):
+        list_reducer.ListReducer.__init__(self, lst)
         self.invoker = invoker
 
     def run_test(self, prefix, suffix):

--- a/utils/bug_reducer/bug_reducer/swift_tools.py
+++ b/utils/bug_reducer/bug_reducer/swift_tools.py
@@ -236,7 +236,7 @@ class SILNMInvoker(SILToolInvoker):
         cmdline = self.base_args(emit_sib=False)
         cmdline.append(input_file)
         output = subprocess.check_output(cmdline)
-        for l in output.split("\n")[:-1]:
-            t = tuple(l.split(" "))
+        for line in output.split("\n")[:-1]:
+            t = tuple(line.split(" "))
             assert(len(t) == 2)
             yield t

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -714,8 +714,8 @@ def run():
                 break
             output = input
 
-            def decode_match(p, l):
-                m = p.match(l)
+            def decode_match(p, line):
+                m = p.match(line)
                 if m is None:
                     return ()
                 file, line_num = map_line_to_source_file(

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -186,8 +186,8 @@ for node in sorted(graph.keys()):
               else ''
 
     label = node if len(requirements + generics) == 0 else (
-        '\n<TABLE BORDER="0">\n<TR><TD>\n%s\n</TD></TR><HR/>' +
-        '\n%s%s%s</TABLE>\n' % (
+        ('\n<TABLE BORDER="0">\n<TR><TD>\n%s\n</TD></TR><HR/>' +
+        '\n%s%s%s</TABLE>\n') % (
             node,
             '\n'.join('<TR><TD>%s</TD></TR>' % r for r in requirements),
             divider,

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -187,7 +187,7 @@ for node in sorted(graph.keys()):
 
     label = node if len(requirements + generics) == 0 else (
         ('\n<TABLE BORDER="0">\n<TR><TD>\n%s\n</TD></TR><HR/>' +
-        '\n%s%s%s</TABLE>\n') % (
+            '\n%s%s%s</TABLE>\n') % (
             node,
             '\n'.join('<TR><TD>%s</TD></TR>' % r for r in requirements),
             divider,

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -37,9 +37,9 @@ def run_parallel(fn, pool_args, n_processes=0):
     parallel implementation.
     """
 
-    def init(l):
+    def init(lck):
         global lock
-        lock = l
+        lock = lck
 
     if n_processes == 0:
         n_processes = cpu_count() * 2


### PR DESCRIPTION
Python 3 lint seems to catch a lot more issues than Python 2 lint.

This PR contains fixes for a number of them.  The issues include:
* Use of `l` as a variable name.  This is easily confused with `1` or `I`.  (Python_lint also complains about `O` as a variable name for the same reason.)
* Unused variable names.
* Missing parentheses in `print()` statements (these are required in python 3)
