### PR TITLE
Generalize the MemAccessUtils API for use outside of access enforcement

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -36,8 +36,13 @@ bool isExclusiveArgument(SILValue V);
 /// does not look through init/open_existential_addr.
 bool pointsToLocalObject(SILValue V);
 
-/// Returns true if \p V is a uniquely identified address or reference. It may
-/// be any of:
+/// Returns true if \p V is a uniquely identified address or reference. Two
+/// uniquely identified pointers with distinct roots cannot alias. However, a
+/// uniquely identified pointer may alias with unidentified pointers. For
+/// example, the uniquely identified pointer may escape to a call that returns an
+/// alias of that pointer.
+///
+/// It may be any of:
 ///
 /// - an address projection based on a locally allocated address with no
 /// indirection

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1948,20 +1948,20 @@ public:
     // also requires that Unidentified access fit a whitelist on known
     // non-internal globals or class properties.
     //
-    // First check that findAccessedStorage returns without asserting. For
+    // First check that identifyFormalAccess returns without asserting. For
     // Unsafe enforcement, that is sufficient. For any other enforcement
     // level also require that it returns a valid AccessedStorage object.
     // Unsafe enforcement is used for some unrecognizable access patterns,
     // like debugger variables. The compiler never cares about the source of
     // those accesses.
-    findAccessedStorage(BAI->getSource());
+    identifyFormalAccess(BAI);
     // FIXME: rdar://57291811 - the following check for valid storage will be
     // reenabled shortly. A fix is planned. In the meantime, the possiblity that
     // a real miscompilation could be caused by this failure is insignificant.
     // I will probably enable a much broader SILVerification of address-type
     // block arguments first to ensure we never hit this check again.
     /*
-    AccessedStorage storage = findAccessedStorage(BAI->getSource());
+    AccessedStorage storage = identifyFormalAccess(BAI);
     if (BAI->getEnforcement() != SILAccessEnforcement::Unsafe)
       require(storage, "Unknown formal access pattern");
     */
@@ -2000,8 +2000,8 @@ public:
       break;
     }
 
-    // First check that findAccessedStorage never asserts.
-    AccessedStorage storage = findAccessedStorage(BUAI->getSource());
+    // First check that identifyFormalAccess never asserts.
+    AccessedStorage storage = identifyFormalAccess(BUAI);
     // Only allow Unsafe and Builtin access to have invalid storage.
     if (BUAI->getEnforcement() != SILAccessEnforcement::Unsafe
         && !BUAI->isFromBuiltin()) {

--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -253,7 +253,7 @@ transformCalleeStorage(const StorageAccessInfo &storage,
     SILValue argVal = getCallerArg(fullApply, storage.getParamIndex());
     if (argVal) {
       // Remap the argument source value and inherit the old storage info.
-      auto calleeStorage = findAccessedStorageNonNested(argVal);
+      auto calleeStorage = findAccessedStorage(argVal);
       if (calleeStorage)
         return StorageAccessInfo(calleeStorage, storage);
     }
@@ -262,7 +262,7 @@ transformCalleeStorage(const StorageAccessInfo &storage,
     //
     // This is an untested bailout. It is only reachable if the call graph
     // contains an edge that getCallerArg is unable to analyze OR if
-    // findAccessedStorageNonNested returns an invalid SILValue, which won't
+    // findAccessedStorage returns an invalid SILValue, which won't
     // pass SIL verification.
     //
     // FIXME: In case argVal is invalid, support Unidentified access for invalid
@@ -299,7 +299,7 @@ void AccessedStorageResult::visitBeginAccess(B *beginAccess) {
     return;
 
   const AccessedStorage &storage =
-      findAccessedStorageNonNested(beginAccess->getSource());
+      findAccessedStorage(beginAccess->getSource());
 
   if (storage.getKind() == AccessedStorage::Unidentified) {
     // This also catches invalid storage.

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -700,19 +700,18 @@ static bool analyzeBeginAccess(BeginAccessInst *BI,
                                InstSet &SideEffectInsts,
                                AccessedStorageAnalysis *ASA,
                                DominanceInfo *DT) {
-  const AccessedStorage &storage =
-      findAccessedStorageNonNested(BI->getSource());
+  const AccessedStorage &storage = findAccessedStorage(BI->getSource());
   if (!storage) {
     return false;
   }
 
-  auto BIAccessedStorageNonNested = findAccessedStorageNonNested(BI);
+  auto BIAccessedStorageNonNested = findAccessedStorage(BI);
   auto safeBeginPred = [&](BeginAccessInst *OtherBI) {
     if (BI == OtherBI) {
       return true;
     }
     return BIAccessedStorageNonNested.isDistinctFrom(
-        findAccessedStorageNonNested(OtherBI));
+        findAccessedStorage(OtherBI));
   };
 
   if (!std::all_of(BeginAccesses.begin(), BeginAccesses.end(), safeBeginPred))

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -583,16 +583,6 @@ static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
       .highlight(NoteAccess.getAccessLoc().getSourceRange());
 }
 
-/// Look through a value to find the underlying storage accessed.
-static AccessedStorage findValidAccessedStorage(SILValue Source) {
-  const AccessedStorage &Storage = findAccessedStorage(Source);
-  if (!Storage) {
-    llvm::dbgs() << "Bad memory access source: " << Source;
-    llvm_unreachable("Unexpected access source.");
-  }
-  return Storage;
-}
-
 /// Returns true when the apply calls the Standard Library swap().
 /// Used for fix-its to suggest replacing with Collection.swapAt()
 /// on exclusivity violations.
@@ -700,7 +690,7 @@ struct AccessState {
 
 // Find conflicting access on each argument using AccessSummaryAnalysis.
 static void
-checkCaptureAccess(ApplySite Apply, AccessState &State,
+checkAccessSummary(ApplySite Apply, AccessState &State,
                    const AccessSummaryAnalysis::FunctionSummary &FS) {
   for (unsigned ArgumentIndex : range(Apply.getNumArguments())) {
 
@@ -721,7 +711,7 @@ checkCaptureAccess(ApplySite Apply, AccessState &State,
 
     // A valid AccessedStorage should always be found because Unsafe accesses
     // are not tracked by AccessSummaryAnalysis.
-    const AccessedStorage &Storage = findValidAccessedStorage(Argument);
+    const AccessedStorage &Storage = identifyCapturedStorage(Argument);
     auto AccessIt = State.Accesses->find(Storage);
 
     // Are there any accesses in progress at the time of the call?
@@ -743,7 +733,7 @@ static void checkCaptureAccess(ApplySite Apply, AccessState &State) {
   // dynamically replaceable.
   SILFunction *Callee = Apply.getCalleeFunction();
   if (Callee && !Callee->empty()) {
-    checkCaptureAccess(Apply, State, State.ASA->getOrCreateSummary(Callee));
+    checkAccessSummary(Apply, State, State.ASA->getOrCreateSummary(Callee));
     return;
   }
   // In the absence of AccessSummaryAnalysis, conservatively assume by-address
@@ -755,7 +745,7 @@ static void checkCaptureAccess(ApplySite Apply, AccessState &State) {
 
     // A valid AccessedStorage should always be found because Unsafe accesses
     // are not tracked by AccessSummaryAnalysis.
-    const AccessedStorage &Storage = findValidAccessedStorage(argOper.get());
+    const AccessedStorage &Storage = identifyCapturedStorage(argOper.get());
 
     // Are there any accesses in progress at the time of the call?
     auto AccessIt = State.Accesses->find(Storage);
@@ -845,8 +835,8 @@ static void checkForViolationsAtInstruction(SILInstruction &I,
       return;
 
     SILAccessKind Kind = BAI->getAccessKind();
-    const AccessedStorage &Storage =
-      findValidAccessedStorage(BAI->getSource());
+    const AccessedStorage &Storage = identifyFormalAccess(BAI);
+    assert(Storage && "unidentified formal access");
     // Storage may be associated with a nested access where the outer access is
     // "unsafe". That's ok because the outer access can itself be treated like a
     // valid source, as long as we don't ask for its source.
@@ -862,14 +852,15 @@ static void checkForViolationsAtInstruction(SILInstruction &I,
   }
 
   if (auto *EAI = dyn_cast<EndAccessInst>(&I)) {
-    if (EAI->getBeginAccess()->getEnforcement() == SILAccessEnforcement::Unsafe)
+    BeginAccessInst *BAI = EAI->getBeginAccess();
+    if (BAI->getEnforcement() == SILAccessEnforcement::Unsafe)
       return;
 
-    auto It =
-      State.Accesses->find(findValidAccessedStorage(EAI->getSource()));
+    const AccessedStorage &Storage = identifyFormalAccess(BAI);
+    assert(Storage && "unidentified formal access");
+    auto It = State.Accesses->find(identifyFormalAccess(BAI));
     AccessInfo &Info = It->getSecond();
 
-    BeginAccessInst *BAI = EAI->getBeginAccess();
     const IndexTrieNode *SubPath = State.ASA->findSubPathAccessed(BAI);
     Info.endAccess(EAI, SubPath);
 
@@ -973,7 +964,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
 // Check that the given address-type operand is guarded by begin/end access
 // markers.
 static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
-  SILValue address = memOper->get();
+  SILValue address = getAddressAccess(memOper->get());
   SILInstruction *memInst = memOper->getUser();
 
   auto error = [address, memInst]() {
@@ -984,6 +975,21 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
     memInst->getFunction()->print(llvm::dbgs());
     abort();
   };
+
+  // Check if this address is guarded by an access.
+  if (auto *BAI = dyn_cast<BeginAccessInst>(address)) {
+    if (BAI->getEnforcement() == SILAccessEnforcement::Unsafe)
+      return;
+
+    const AccessedStorage &Storage = identifyFormalAccess(BAI);
+    assert(Storage && "unidentified formal access");
+    AccessInfo &Info = Accesses[Storage];
+    if (Info.hasAccessesInProgress())
+      return;
+
+    error();
+  }
+  // --- This address is not guarded by a begin_access.
 
   // If the memory instruction is only used for initialization, it doesn't need
   // an access marker.
@@ -1011,7 +1017,6 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
       return;
   }
 
-  // Strip off address projections, but not ref_element_addr.
   const AccessedStorage &storage = findAccessedStorage(address);
   // findAccessedStorage may return an invalid storage object if the address
   // producer is not recognized by its whitelist. For the purpose of
@@ -1040,18 +1045,6 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
     return;
   }
 
-  // Otherwise, the address base should be an in-scope begin_access.
-  if (storage.getKind() == AccessedStorage::Nested) {
-    auto *BAI = cast<BeginAccessInst>(storage.getValue());
-    if (BAI->getEnforcement() == SILAccessEnforcement::Unsafe)
-      return;
-
-    const AccessedStorage &Storage = findValidAccessedStorage(BAI->getSource());
-    AccessInfo &Info = Accesses[Storage];
-    if (!Info.hasAccessesInProgress())
-      error();
-    return;
-  }
   error();
 }
 

--- a/lib/SILOptimizer/Transforms/AccessEnforcementDom.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementDom.cpp
@@ -251,7 +251,7 @@ void DominatedAccessAnalysis::analyzeAccess(BeginAccessInst *BAI,
   // Only track dynamic access in the result. Static accesses still need to be
   // tracked by data flow, but they can't be optimized as "dominating".
   if (BAI->getEnforcement() == SILAccessEnforcement::Dynamic) {
-    AccessedStorage storage = findAccessedStorageNonNested(BAI->getSource());
+    AccessedStorage storage = findAccessedStorage(BAI->getSource());
     // Copy the AccessStorage into DomAccessedStorage. All pass-specific bits
     // are initialized to zero.
     domStorage = DomAccessedStorage(storage);
@@ -381,7 +381,7 @@ void DominatedAccessRemoval::visitBeginAccess(BeginAccessInst *BAI) {
     return;
 
   // Only track "identifiable" storage.
-  if (currDomStorage.isUniquelyIdentifiedOrClass()) {
+  if (currDomStorage.isFormalAccessBase()) {
     if (checkDominatedAccess(BAI, currDomStorage))
       return;
   }
@@ -569,7 +569,7 @@ void DominatedAccessRemoval::tryInsertLoopPreheaderAccess(
 
   // Insert the new dominating instruction in both DominatedAccessAnalysis and
   // storageToDomMap if it has uniquely identifiable storage.
-  if (!currAccessInfo.isUniquelyIdentifiedOrClass())
+  if (!currAccessInfo.isFormalAccessBase())
     return;
 
   AccessedStorage storage = static_cast<AccessedStorage>(currAccessInfo);

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -566,8 +566,7 @@ bool AccessConflictAndMergeAnalysis::identifyBeginAccesses() {
       // now, since this optimization runs at the end of the pipeline, we
       // gracefully ignore unrecognized source address patterns, which show up
       // here as an invalid `storage` value.
-      AccessedStorage storage =
-          findAccessedStorageNonNested(beginAccess->getSource());
+      AccessedStorage storage = findAccessedStorage(beginAccess->getSource());
 
       auto iterAndInserted = storageSet.insert(storage);
 

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -42,7 +42,7 @@
 ///
 /// Warning: This is only sound when unidentified accesses can never alias with
 /// Class/Global access. To enforce this, the SILVerifier calls
-/// findAccessedStorage() for every access, which asserts that any Unidentified
+/// identifyFormalAccess() for every access, which asserts that any Unidentified
 /// access belongs to a know pattern that cannot originate from Class or Global
 /// accesses.
 ///
@@ -70,7 +70,7 @@ using llvm::SmallDenseSet;
 // AccessedStorage. Returns nullptr for any storage that can't be partitioned
 // into a disjoint location.
 //
-// findAccessedStorage may only return Unidentified storage for a global
+// identifyFormalAccess may only return Unidentified storage for a global
 // variable access if the global is defined in a different module.
 //
 // WARNING: Retrieving VarDecl for Class access is not constant time.
@@ -103,7 +103,7 @@ namespace {
 //
 // The existence of unidentified access complicates this problem. For this
 // optimization to be valid, Global and Class property access must always be
-// identifiable. findAccessedStorage() in MemAccessUtils enforces a short list
+// identifiable. identifyFormalAccess() in MemAccessUtils enforces a short list
 // of unidentified producers (non-address PhiArgument, PointerToAddress, Undef,
 // & local-init). We cannot allow the address of a global variable or class
 // property to be exposed via one of these instructions, unless the declaration
@@ -168,13 +168,13 @@ void GlobalAccessRemoval::perform() {
 
 void GlobalAccessRemoval::visitInstruction(SILInstruction *I) {
   if (auto *BAI = dyn_cast<BeginAccessInst>(I)) {
-    AccessedStorage storage = findAccessedStorageNonNested(BAI->getSource());
+    AccessedStorage storage = findAccessedStorage(BAI->getSource());
     const VarDecl *decl = getDisjointAccessLocation(storage);
     recordAccess(BAI, decl, storage.getKind(), BAI->hasNoNestedConflict());
     return;
   }
   if (auto *BUAI = dyn_cast<BeginUnpairedAccessInst>(I)) {
-    AccessedStorage storage = findAccessedStorageNonNested(BUAI->getSource());
+    AccessedStorage storage = findAccessedStorage(BUAI->getSource());
     const VarDecl *decl = getDisjointAccessLocation(storage);
     recordAccess(BUAI, decl, storage.getKind(), BUAI->hasNoNestedConflict());
     return;

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -432,11 +432,8 @@ bool SILPerformanceInliner::isProfitableToInline(
           // The access is dynamic and has no nested conflict
           // See if the storage location is considered by
           // access enforcement optimizations
-          AccessedStorage storage =
-              findAccessedStorageNonNested(BAI->getSource());
-          if (BAI->hasNoNestedConflict() &&
-              (storage.isUniquelyIdentified() ||
-               storage.getKind() == AccessedStorage::Class)) {
+          AccessedStorage storage = findAccessedStorage(BAI->getSource());
+          if (BAI->hasNoNestedConflict() && (storage.isFormalAccessBase())) {
             BlockW.updateBenefit(ExclusivityBenefitWeight,
                                  ExclusivityBenefitBase);
           } else {

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -627,7 +627,7 @@ bb3(%result : $Int):
   return %result : $Int
 }
 
-// Make sure findAccessedStorage returns a valid storage object for an address-phi
+// Make sure identifyFormalAccess returns a valid storage object for an address-phi
 // that feeds ref_element_addr instructions. The ref_element_addr's need to have the
 // same base object and same field id.
 // <rdar://problem/46114512> SIL verification failed: Unknown formal access pattern: storage

--- a/test/SILOptimizer/verifier.sil
+++ b/test/SILOptimizer/verifier.sil
@@ -83,7 +83,7 @@ bb4:
   return %10 : $()
 }
 
-// Verify that findAccessedStorage handles cyclic phis.
+// Verify that identifyFormalAccess handles cyclic phis.
 // <rdar://47059671> swiftc crashes
 class AClass {
   var aStoredProp: Builtin.Int32


### PR DESCRIPTION
Also paves the way for adding an AccessPath utility.

I think the API comments are now much more helpful to people looking at this for the first time.