### PR TITLE
DependenciesScanner: include compiled module candidates for textual module interface in JSON output

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -69,6 +69,9 @@ public:
   /// The Swift interface file, if it can be used to generate the module file.
   const Optional<std::string> swiftInterfaceFile;
 
+  /// Potentially ready-to-use compiled modules for the interface file.
+  const std::vector<std::string> compiledModuleCandidates;
+
   /// The Swift frontend invocation arguments to build the Swift module from the
   /// interface.
   const std::vector<std::string> buildCommandLine;
@@ -96,11 +99,14 @@ public:
   SwiftModuleDependenciesStorage(
       const std::string &compiledModulePath,
       const Optional<std::string> &swiftInterfaceFile,
+      ArrayRef<std::string> compiledModuleCandidates,
       ArrayRef<StringRef> buildCommandLine,
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash
   ) : ModuleDependenciesStorageBase(/*isSwiftModule=*/true, compiledModulePath),
       swiftInterfaceFile(swiftInterfaceFile),
+      compiledModuleCandidates(compiledModuleCandidates.begin(),
+                               compiledModuleCandidates.end()),
       buildCommandLine(buildCommandLine.begin(), buildCommandLine.end()),
       extraPCMArgs(extraPCMArgs.begin(), extraPCMArgs.end()),
       contextHash(contextHash) { }
@@ -181,13 +187,14 @@ public:
   /// built from a Swift interface file (\c .swiftinterface).
   static ModuleDependencies forSwiftInterface(
       const std::string &swiftInterfaceFile,
+      ArrayRef<std::string> compiledCandidates,
       ArrayRef<StringRef> buildCommands,
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash) {
     std::string compiledModulePath;
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, swiftInterfaceFile, buildCommands,
+          compiledModulePath, swiftInterfaceFile, compiledCandidates, buildCommands,
           extraPCMArgs, contextHash));
   }
 
@@ -196,7 +203,7 @@ public:
       const std::string &compiledModulePath) {
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, None, ArrayRef<StringRef>(),
+          compiledModulePath, None, ArrayRef<std::string>(), ArrayRef<StringRef>(),
           ArrayRef<StringRef>(), StringRef()));
   }
 
@@ -205,8 +212,8 @@ public:
     std::string compiledModulePath;
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, None, ArrayRef<StringRef>(), extraPCMArgs,
-          StringRef()));
+          compiledModulePath, None, ArrayRef<std::string>(),
+          ArrayRef<StringRef>(), extraPCMArgs, StringRef()));
   }
 
   /// Describe the module dependencies for a Clang module that can be

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -237,8 +237,9 @@ public:
     bool SerializeDependencyHashes, bool TrackSystemDependencies,
     ModuleInterfaceLoaderOptions Opts);
 
-  std::string getUpToDateCompiledModuleForInterface(StringRef moduleName,
-                                                    StringRef interfacePath) override;
+  std::vector<std::string>
+  getCompiledModuleCandidatesForInterface(StringRef moduleName,
+                                          StringRef interfacePath) override;
 };
 
 struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -201,9 +201,10 @@ public:
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
 
-  virtual std::string getUpToDateCompiledModuleForInterface(StringRef moduleName,
-                                                      StringRef interfacePath) {
-    return std::string();
+  virtual std::vector<std::string>
+  getCompiledModuleCandidatesForInterface(StringRef moduleName,
+                                          StringRef interfacePath) {
+    return std::vector<std::string>();
   }
 };
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1015,9 +1015,9 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   return std::error_code();
 }
 
-std::string
-ModuleInterfaceLoader::getUpToDateCompiledModuleForInterface(StringRef moduleName,
-                                                      StringRef interfacePath) {
+std::vector<std::string>
+ModuleInterfaceLoader::getCompiledModuleCandidatesForInterface(StringRef moduleName,
+                                                               StringRef interfacePath) {
   // Derive .swiftmodule path from the .swiftinterface path.
   auto newExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
   llvm::SmallString<32> modulePath = interfacePath;
@@ -1030,9 +1030,14 @@ ModuleInterfaceLoader::getUpToDateCompiledModuleForInterface(StringRef moduleNam
                 llvm::is_contained(PreferInterfaceForModules, moduleName) ?
                   ModuleLoadingMode::PreferInterface : LoadMode);
   SmallVector<FileDependency, 16> allDeps;
-  std::string usableModulePath;
-  Impl.discoverUpToDateCompiledModuleForInterface(allDeps, usableModulePath);
-  return usableModulePath;
+  std::vector<std::string> results;
+  auto pair = Impl.getCompiledModuleCandidates();
+  // Add compiled module candidates only when they are non-empty.
+  if (!pair.first.empty())
+    results.push_back(pair.first);
+  if (!pair.second.empty())
+    results.push_back(pair.second);
+  return results;
 }
 
 bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -339,6 +339,17 @@ static void writeJSON(llvm::raw_ostream &out,
         }
         out.indent(5 * 2);
         out << "],\n";
+        out.indent(5 * 2);
+        out << "\"compiledModuleCandidates\": [\n";
+        for (auto &candidate: swiftDeps->compiledModuleCandidates) {
+          out.indent(6 * 2);
+          out << "\"" << candidate << "\"";
+          if (&candidate != &swiftDeps->compiledModuleCandidates.back())
+            out << ",";
+          out << "\n";
+        }
+        out.indent(5 * 2);
+        out << "],\n";
       } else if (!swiftDeps->compiledModulePath.empty()) {
         writeJSONSingleField(
             out, "compiledModulePath",

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -63,6 +63,9 @@ struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
   var moduleInterfacePath: String?
 
+  /// The paths of potentially ready-to-use compiled modules for the interface.
+  var compiledModuleCandidates: [String]?
+
   /// The compiled Swift module to use.
   var compiledModulePath: String?
 

--- a/test/ScanDependencies/compiled_swift_modules.swift
+++ b/test/ScanDependencies/compiled_swift_modules.swift
@@ -5,8 +5,10 @@
 
 import Foo
 
-// HAS_COMPILED:        "compiledModulePath": "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
-// HAS_NO_COMPILED-NOT: "compiledModulePath": "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
+// HAS_COMPILED: "compiledModuleCandidates": [
+// HAS_COMPILED-NEXT: "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
+
+// HAS_NO_COMPILED-NOT: "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
 
 // Step 1: build swift interface and swift module side by side
 // RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name
@@ -32,6 +34,6 @@ import Foo
 // Step 6: update the interface file from where the prebuilt module cache was built.
 // RUN: touch %t/Foo.swiftmodule/%target-swiftinterface-name
 
-// Step 4: scan dependency should give us the interface file.
-// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d
-// RUN: %FileCheck %s -check-prefix=HAS_NO_COMPILED < %t/deps.json
+// Step 7: scan dependency should give us the prebuilt module file even though it's out-of-date.
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
+// RUN: %FileCheck %s -check-prefix=HAS_COMPILED < %t/deps.json


### PR DESCRIPTION
Instead of replacing an interface file with its up-to-date compile module,
the dep-scanner should report potentially up-to-date module candidates either adjacent to
the interface file or in the prebuilt module cache. swift-driver should later pass down
these candidates to -compile-module-from-interface invocation and the front-end job
will check if one of the candidates is ready to use. The front-end job then either emits a forwarding
module to an up-to-date candidate or creates a binary module.