### PR TITLE
[Lexer] Handle UTF8 characters in dollar identifier

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -921,15 +921,15 @@ void Lexer::lexDollarIdent() {
     return formToken(tok::sil_dollar, tokStart);
 
   bool isAllDigits = true;
-  for (;; ++CurPtr) {
+  while (true) {
     if (isDigit(*CurPtr)) {
-      // continue
-    } else if (clang::isIdentifierHead(*CurPtr, /*dollar*/true)) {
+      ++CurPtr;
+      continue;
+    } else if (advanceIfValidContinuationOfIdentifier(CurPtr, BufferEnd)) {
       isAllDigits = false;
-      // continue
-    } else {
-      break;
+      continue;
     }
+    break;
   }
 
   if (CurPtr == tokStart + 1) {

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -70,3 +70,16 @@ func $declareWithDollar() { // expected-error{{cannot declare entity named '$dec
     $a: Int, // expected-error{{cannot declare entity named '$a'}}
     $b c: Int) { } // expected-error{{cannot declare entity named '$b'}}
 }
+
+// SR-13232
+@propertyWrapper
+struct Wrapper {
+  var wrappedValue: Int
+  var projectedValue: String { String(wrappedValue) }
+}
+
+struct S {
+  @Wrapper var café = 42
+}
+
+let _ = S().$café // Okay


### PR DESCRIPTION
When lexing a dollar identifier, we don't handle UTF-8 characters. This leads to failure when accessing the `projectedValue` of a property wrapper (which is synthesised as `$<property_name>`) if the property name contains UTF-8 characters, such as `é`.

Resolves SR-13232