### PR TITLE
[AutoDiff] [stdlib] Fix a bug in `_jvpMultiply` in SIMDDifferentiation.swift.gyb

### DIFF
--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -176,7 +176,7 @@ where
     )
   {
     return (lhs * rhs, { ltan, rtan in
-      return lhs * ltan + rtan * rhs
+      return lhs * rtan + ltan * rhs
     })
   }
 

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1537,15 +1537,17 @@ ForwardModeTests.test("Subtraction") {
 
 ForwardModeTests.test("Multiplication") {
   let a = SIMD4<Float>(1, 2, 3, 4)
+  let a2 = SIMD4<Float>(4, 3, 2, 1)
   let g = SIMD4<Float>(1, 1, 1, 1)
+  let g2 = SIMD4<Float>(0, 2, 1, 3)
 
   // SIMD * SIMD
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x * y
   }
-  let (val1, df1) = valueWithDifferential(at: a, a, in: foo1)
-  expectEqual(a * a, val1)
-  expectEqual(a * g + g * a, df1(g, g))
+  let (val1, df1) = valueWithDifferential(at: a, b, in: foo1)
+  expectEqual(a * b, val1)
+  expectEqual(a * g2 + g * b, df1(g, g2))
 
   // SIMD * Scalar
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1599,6 +1599,9 @@ ForwardModeTests.test("Generics") {
 
   // FIXME(SR-13210): Fix forward-mode SIL verification error.
   /*
+  let a = SIMD3<Double>(1, 2, 3)
+  let g = SIMD3<Double>(1, 1, 1)
+
   func testInit<Scalar, SIMDType: SIMD>(x: Scalar) -> SIMDType
     where SIMDType.Scalar == Scalar,
           SIMDType : Differentiable,

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1599,9 +1599,6 @@ ForwardModeTests.test("Generics") {
 
   // FIXME(SR-13210): Fix forward-mode SIL verification error.
   /*
-  let a = SIMD3<Double>(1, 2, 3)
-  let g = SIMD3<Double>(1, 1, 1)
-
   func testInit<Scalar, SIMDType: SIMD>(x: Scalar) -> SIMDType
     where SIMDType.Scalar == Scalar,
           SIMDType : Differentiable,

--- a/test/AutoDiff/validation-test/forward_mode.swift
+++ b/test/AutoDiff/validation-test/forward_mode.swift
@@ -1545,9 +1545,9 @@ ForwardModeTests.test("Multiplication") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x * y
   }
-  let (val1, df1) = valueWithDifferential(at: a, b, in: foo1)
-  expectEqual(a * b, val1)
-  expectEqual(a * g2 + g * b, df1(g, g2))
+  let (val1, df1) = valueWithDifferential(at: a, a2, in: foo1)
+  expectEqual(a * a2, val1)
+  expectEqual(a * g2 + g * a2, df1(g, g2))
 
   // SIMD * Scalar
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {


### PR DESCRIPTION
A recently merged PR (https://github.com/apple/swift/pull/32854/) had a bug in it, fixing here.