### PR TITLE
[ClangImporter] Update clang invocation to use the marketing names of CPUs

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -730,22 +730,22 @@ importer::addCommonInvocationArguments(
 
   } else if (triple.isOSDarwin()) {
     // Special case CPU based on known deployments:
-    //   - arm64 deploys to cyclone
+    //   - arm64 deploys to apple-a7
     //   - arm64 on macOS
     //   - arm64 for iOS/tvOS/watchOS simulators
-    //   - arm64e deploys to vortex
-    // and arm64e (everywhere) and arm64e macOS defaults to the "vortex" CPU
+    //   - arm64e deploys to apple-a12
+    // and arm64e (everywhere) and arm64e macOS defaults to the "apple-a12" CPU
     // for Darwin, but Clang only detects this if we use -arch.
     if (triple.getArchName() == "arm64e")
-      invocationArgStrs.push_back("-mcpu=vortex");
+      invocationArgStrs.push_back("-mcpu=apple-a12");
     else if (triple.isAArch64() && triple.isMacOSX())
-      invocationArgStrs.push_back("-mcpu=vortex");
+      invocationArgStrs.push_back("-mcpu=apple-a12");
     else if (triple.isAArch64() && triple.isSimulatorEnvironment() &&
              (triple.isiOS() || triple.isWatchOS()))
-      invocationArgStrs.push_back("-mcpu=vortex");
+      invocationArgStrs.push_back("-mcpu=apple-a12");
     else if (triple.getArch() == llvm::Triple::aarch64 ||
              triple.getArch() == llvm::Triple::aarch64_be) {
-      invocationArgStrs.push_back("-mcpu=cyclone");
+      invocationArgStrs.push_back("-mcpu=apple-a7");
     }
   } else if (triple.getArch() == llvm::Triple::systemz) {
     invocationArgStrs.push_back("-march=z13");

--- a/test/ClangImporter/invocation-mcpu.swift
+++ b/test/ClangImporter/invocation-mcpu.swift
@@ -1,0 +1,7 @@
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-ios13.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A12 %s
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-macos11.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A12 %s
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-ios13.0-simulator 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A12 %s
+// CHECK-APPLE-A12: '-mcpu=apple-a12'
+
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64-apple-ios13.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A7 %s
+// CHECK-APPLE-A7: '-mcpu=apple-a7'

--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -1,8 +1,8 @@
 // RUN: not %swift -typecheck -target arm64-apple-ios7 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=TARGETCPU1 %s
-// TARGETCPU1: "-target-cpu" "cyclone"
+// TARGETCPU1: "-target-cpu" "apple-a7"
 
 // RUN: not %swift -typecheck -target arm64-apple-tvos9 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=APPLETVTARGETCPU1 %s
-// APPLETVTARGETCPU1: "-target-cpu" "cyclone"
+// APPLETVTARGETCPU1: "-target-cpu" "apple-a7"
 
 // RUN: not %swift -typecheck -target armv7s-apple-tvos9 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=APPLETVTARGETCPU2 %s
 // APPLETVTARGETCPU2: "-target-cpu" "swift"
@@ -14,7 +14,7 @@
 // WATCHTARGETCPU1: "-target-cpu" "cortex-a7"
 
 // RUN: not %swift -typecheck -target arm64-apple-watchos2 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=WATCHTARGETCPU2 %s
-// WATCHTARGETCPU2: "-target-cpu" "cyclone"
+// WATCHTARGETCPU2: "-target-cpu" "apple-a7"
 
 // RUN: not %swift -typecheck -target armv7s-apple-ios7 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=TARGETCPU2 %s
 // TARGETCPU2: "-target-cpu" "swift"


### PR DESCRIPTION
Update the clang invocation to use the marketing name of Apple CPUs and reflect recent changes in clang.

rdar://problem/64918604