### PR TITLE
More Python3 lint fixes

### DIFF
--- a/unittests/Reflection/RemoteMirrorInterop/test.py
+++ b/unittests/Reflection/RemoteMirrorInterop/test.py
@@ -7,6 +7,8 @@
 #
 # Invoke by passing the various Swift build directories as parameters.
 
+from __future__ import print_function
+
 import itertools
 import os
 import subprocess
@@ -14,9 +16,9 @@ import sys
 
 args = sys.argv[1:]
 if len(args) == 0:
-    print >> sys.stderr, "Usage:", sys.argv[0], "swift-build-dirs..."
-    print >> sys.stderr, ("Note: pass paths to the swift-macosx-x86_64"
-                          " directories, or /usr to test the OS.")
+    print("Usage:", sys.argv[0], "swift-build-dirs...", file=sys.stderr)
+    print(("Note: pass paths to the swift-macosx-x86_64"
+           " directories, or /usr to test the OS."), file=sys.stderr)
     sys.exit(1)
 
 absoluteArgs = [os.path.abspath(arg) for arg in args]
@@ -63,8 +65,8 @@ for i in range(len(swiftcs) + 1):
             dylibPath = os.path.join('/tmp', 'libtest' + str(i) + '.dylib')
             callArgs.append(dylibPath)
             callArgs += list(localMirrorlibs)
-            print ' '.join(callArgs)
+            print(' '.join(callArgs))
             subprocess.call(callArgs)
-            print 'DONE'
-            print ''
-        print localMirrorlibs
+            print('DONE')
+            print('')
+        print(localMirrorlibs)

--- a/utils/api_checker/sdk-module-lists/infer-imports.py
+++ b/utils/api_checker/sdk-module-lists/infer-imports.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python -u
 
+from __future__ import print_function
+
 import os
 import sys
 
@@ -63,14 +65,17 @@ def get_frameworks(sdk_path, swift_frameworks_only):
 
             if not os.path.exists(header_dir_path):
                 if os.path.exists(module_dir_path):
-                    print >>sys.stderr, header_dir_path, \
-                        " non-existent while 'Modules' exists"
+                    print(header_dir_path,
+                          " non-existent while 'Modules' exists",
+                          file=sys.stderr)
                 if os.path.exists(old_modulemap_path):
-                    print >>sys.stderr, header_dir_path, \
-                        " non-existent while 'module.map' exists"
+                    print(header_dir_path,
+                          " non-existent while 'module.map' exists",
+                          file=sys.stderr)
                 if os.path.exists(old_modulemap_private_path):
-                    print >>sys.stderr, header_dir_path, \
-                        " non-existent while 'module_private.map' exists"
+                    print(header_dir_path,
+                          " non-existent while 'module_private.map' exists",
+                          file=sys.stderr)
                 continue
 
             if should_exclude_framework(frameworks_path + '/' + frame):
@@ -110,14 +115,14 @@ def should_exclude_framework(frame_path):
 def print_clang_imports(frames, use_hash):
     for name in frames:
         if use_hash:
-            print "#import <" + name + "/" + name + ".h>"
+            print("#import <" + name + "/" + name + ".h>")
         else:
-            print "@import " + name + ";"
+            print("@import " + name + ";")
 
 
 def print_swift_imports(frames):
     for name in frames:
-        print "import " + name
+        print("import " + name)
 
 
 def main():
@@ -161,14 +166,14 @@ def main():
             frames = get_frameworks(opts.sdk, opts.swift_frameworks_only)
     if opts.v:
         for name in frames:
-            print >>sys.stderr, 'Including: ', name
+            print('Including: ', name, file=sys.stderr)
     if opts.out_mode == "clang-import":
         print_clang_imports(frames, opts.use_hash)
     elif opts.out_mode == "swift-import":
         print_swift_imports(frames)
     elif opts.out_mode == "list":
         for name in frames:
-            print name
+            print(name)
     else:
         parser.error(
             "output mode not found: 'clang-import'/'swift-import'/'list'")

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -342,7 +342,7 @@ class TestDriverArgumentParser(unittest.TestCase):
         try:
             return migration.parse_args(self.parser, args)
         except (SystemExit, ValueError) as e:
-            raise ParserError('failed to parse arguments: {}'.format(
+            raise ParserError('failed to parse arguments: {} {}'.format(
                 six.text_type(args), e))
 
     def _check_impl_args(self, namespace):
@@ -353,7 +353,7 @@ class TestDriverArgumentParser(unittest.TestCase):
                 constants.BUILD_SCRIPT_IMPL_PATH,
                 namespace.build_script_impl_args)
         except (SystemExit, ValueError) as e:
-            raise ParserError('failed to parse impl arguments: {}'.format(
+            raise ParserError('failed to parse impl arguments: {} {}'.format(
                 six.text_type(namespace.build_script_impl_args), e))
 
     def parse_args_and_unknown_args(self, args, namespace=None):
@@ -369,7 +369,7 @@ class TestDriverArgumentParser(unittest.TestCase):
                     migration._process_disambiguation_arguments(
                         namespace, unknown_args))
             except (SystemExit, argparse.ArgumentError) as e:
-                raise ParserError('failed to parse arguments: {}'.format(
+                raise ParserError('failed to parse arguments: {} {}'.format(
                     six.text_type(args), e))
 
         return namespace, unknown_args

--- a/utils/lldb/lldbCheckExpect.py
+++ b/utils/lldb/lldbCheckExpect.py
@@ -21,6 +21,7 @@ this, e.g:
       Expected value  : 98
       Actual value    : ...
 '''
+from __future__ import print_function
 
 
 def unwrap(s):
@@ -55,7 +56,7 @@ def unwrap(s):
 def on_check_expect(frame, bp_loc, session):
     parent_frame = frame.get_parent_frame()
     parent_name = parent_frame.GetFunctionName()
-    print "Evaluating check-expect in", parent_name
+    print("Evaluating check-expect in", parent_name)
 
     # Note: If we fail to stringify the arguments in the check-expect frame,
     # the standard library has probably not been compiled with debug info.
@@ -69,25 +70,25 @@ def on_check_expect(frame, bp_loc, session):
     expr_result = parent_frame.FindVariable(var_name).GetObjectDescription()
     eval_result = unwrap(str(expr_result))
 
-    print "  Checked variable:", var_name
-    print "  Expected value  :", expected_value
-    print "  Actual value    :", eval_result
+    print("  Checked variable:", var_name)
+    print("  Expected value  :", expected_value)
+    print("  Actual value    :", eval_result)
 
     if eval_result == expected_value:
         # Do not stop execution.
         return False
 
-    print "Found a possible expression evaluation failure."
+    print("Found a possible expression evaluation failure.")
 
     for i, (c1, c2) in enumerate(zip(expected_value, eval_result)):
         if c1 == c2:
             continue
-        print " -> Character difference at index", i
-        print " -> Expected", c1, "but found", c2
+        print(" -> Character difference at index", i)
+        print(" -> Expected", c1, "but found", c2)
         break
     else:
-        print " -> Expected string has length", len(expected_value)
-        print " -> Actual string has length", len(eval_result)
+        print(" -> Expected string has length", len(expected_value))
+        print(" -> Actual string has length", len(eval_result))
     return True
 
 

--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -6,6 +6,7 @@ Load into LLDB with 'command script import /path/to/lldbToolBox.py'
 This will also import LLVM data formatters as well, assuming that llvm is next
 to the swift checkout.
 """
+from __future__ import print_function
 
 import argparse
 import os
@@ -108,7 +109,7 @@ def sequence(debugger, command, exec_ctx, result, internal_dict):
         ret = lldb.SBCommandReturnObject()
         interpreter.HandleCommand(subcommand, exec_ctx, ret)
         if ret.GetOutput():
-            print >>result, ret.GetOutput().strip()
+            print(ret.GetOutput().strip(), file=result)
 
         if not ret.Succeeded():
             result.SetError(ret.GetError())

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -281,7 +281,7 @@ def Nelder_Mead_simplex(objective, params, bounds, epsilon=1.0e-6):
     locs = [tuple(random.uniform(*b) for b in bounds)
             for _ in range(ndim + 1)]
     SimplexPoint = namedtuple("SimplexPoint", ["loc", "val"])
-    simplex = [SimplexPoint(loc=l, val=f(l)) for l in locs]
+    simplex = [SimplexPoint(loc=L, val=f(L)) for L in locs]
 
     # Algorithm parameters
     alpha = 1.0
@@ -337,8 +337,8 @@ def Nelder_Mead_simplex(objective, params, bounds, epsilon=1.0e-6):
 
         # 6. Shrink
         simplex = (simplex[:1] +
-                   [SimplexPoint(loc=l, val=f(l))
-                    for l in [tup_add(xb, tup_mul(sigma, tup_sub(p.loc, xb)))
+                   [SimplexPoint(loc=L, val=f(L))
+                    for L in [tup_add(xb, tup_mul(sigma, tup_sub(p.loc, xb)))
                               for p in simplex[1:]]])
 
 

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -281,7 +281,7 @@ def Nelder_Mead_simplex(objective, params, bounds, epsilon=1.0e-6):
     locs = [tuple(random.uniform(*b) for b in bounds)
             for _ in range(ndim + 1)]
     SimplexPoint = namedtuple("SimplexPoint", ["loc", "val"])
-    simplex = [SimplexPoint(loc=L, val=f(L)) for L in locs]
+    simplex = [SimplexPoint(loc=loc, val=f(loc)) for loc in locs]
 
     # Algorithm parameters
     alpha = 1.0

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -161,8 +161,11 @@ def print_command(cmd, outfile=""):
 # Dump the API for the given module.
 
 
-def dump_module_api((cmd, extra_dump_args, output_dir, module, quiet,
-                     verbose)):
+def dump_module_api_star(pack):
+    dump_module_api(*pack)
+
+
+def dump_module_api(cmd, extra_dump_args, output_dir, module, quiet, verbose):
     # Collect the submodules
     submodules = collect_submodules(cmd, module)
 
@@ -341,7 +344,7 @@ def main():
 
     # Execute the API dumps
     pool = multiprocessing.Pool(processes=args.jobs)
-    pool.map(dump_module_api, jobs)
+    pool.map(dump_module_api_star, jobs)
 
     # Remove the .swift file we fed into swift-ide-test
     subprocess.call(['rm', '-f', source_filename])

--- a/utils/type-layout-fuzzer.py
+++ b/utils/type-layout-fuzzer.py
@@ -35,7 +35,7 @@ if objcInterop:
 def randomTypeList(depth):
     count = random.randint(0, maxMembers)
     result = "("
-    for i in xrange(count):
+    for i in range(count):
         if i > 0:
             result += ", "
         result += randomTypeReference(depth + 1)
@@ -81,7 +81,7 @@ def randomTypeReference(depth):
 
 def defineRandomFields(depth, basename):
     numMembers = random.randint(0, maxMembers)
-    for i in xrange(numMembers):
+    for i in range(numMembers):
         print("  var " + basename + str(i) + ": " +
               randomTypeReference(depth + 1))
 
@@ -141,7 +141,7 @@ def defineRandomNominalType(name, depth=0):
         print("enum " + name + " {")
 
         numCases = random.randint(0, maxMembers)
-        for i in xrange(numCases):
+        for i in range(numCases):
             print("  case x" + str(i) + randomTypeList(depth + 1))
 
         print("}")


### PR DESCRIPTION
Some of the issues addressed include:
* Don't use `l` as a variable name (confusable with `1` or `I`)
* `print` statement does not exist in Py3, use `print` function instead
* Implicit tuple deconstruction in function args is no longer supported,
  use explicit splat `*` at the call site instead
* `xrange` does not exist in Py3, use `range` instead