### PR TITLE
[CSBindings] Make sure that transitive bindings aren't inferred on it…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -47,7 +47,7 @@ void ConstraintSystem::PotentialBindings::inferTransitiveBindings(
   for (auto *constraint : conversions) {
     auto *tv =
         cs.simplifyType(constraint->getFirstType())->getAs<TypeVariableType>();
-    if (!tv)
+    if (!tv || tv == TypeVar)
       continue;
 
     auto relatedBindings = inferredBindings.find(tv);


### PR DESCRIPTION
…self

It's possible to find current type variable while trying to infer
transitive bindings (because sources are gathered from multiple
different type variables and current type variable could be a
representative of an equivalence class), let's make sure we don't
attempt to use constraints which refer to current type variable
on the left-hand side.

Resolves: rdar://problem/65724310

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
