### PR TITLE
[SILGen] Fix handling of dynamic Self in key paths (SR-12428)

### DIFF
--- a/test/SILGen/keypath_dynamic_self.swift
+++ b/test/SILGen/keypath_dynamic_self.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -sil-verify-all -o %t/a.out %s
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+class Foo {
+  var a: Int = 0
+  
+  var dynamicSelf: Self {
+    return self
+  }
+  
+  subscript() -> Self {
+    get {
+      return self
+    }
+  }
+  
+  init() {
+    print(\Self.a)
+  }
+  
+  // self is dynamic in a convenience init
+  convenience init(a: Int) {
+    self.init()
+    self[keyPath: \.a] = a
+    print(self[keyPath: \.dynamicSelf.a])
+  }
+}
+
+class Bar: Foo { var b: Int = 0 }
+
+let foo = Foo(a: 1)
+let bar = Bar()
+
+print(foo[keyPath: \Foo.dynamicSelf])
+print(foo[keyPath: \.dynamicSelf[].a])
+print(bar[keyPath: \Bar[].dynamicSelf.b])


### PR DESCRIPTION
<!-- What's in this pull request? -->

`emitKeyPath*` did not handle key paths involving covariant Self types (where either the root or a computed property is of type Self); we would just emit key path instructions involving @dynamic_self types. This led to various crashes at both compile-time [and at runtime](https://stackoverflow.com/q/61137449/3476191), since the rest of the compiler and standard library do not expect the dynamic Self type to show up in key paths. The type system does not make it possible to declare a key path whose leaf type is a dynamic Self, so it seems sensible to just get rid of dynamic self types in SILGen.

Handling key paths where the root is a dynamic Self is easy: if the root type is `@dynamic_self Foo`, then the key path can only access properties on `Foo` -- the dynamic Self attribute has no effect and can simply be removed (in `visitKeyPathExpr`).

Key paths with a computed property returning Self is only slightly more complicated. If we have a dynamic Self property on class `Foo`, and we access that property through a key path on an object of `class Bar: Foo`, then we need to downcast the getter result to `Bar` before we can remove the dynamic Self attribute. I've done that by detecting that case in `emitKeyPathComponentForDecl` and passing an extra parameter to `getOrCreateKeyPathGetter` informing it that we want the key path getter to downcast the result before returning it. `getOrCreateKeyPathGetter` was already using `emitSubstToOrigValue` to reabstract the result; changing the call to the more general `emitTransformedValue` allows us to easily downcast the result as well.

I have also added a test case and SILVerifier checks that catch all the crashes I am aware of.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-12428](https://bugs.swift.org/browse/SR-12428).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
