### PR TITLE
[swift-driver-compatibility] Reorder entries in Sanitizers.def

### DIFF
--- a/include/swift/Basic/Sanitizers.def
+++ b/include/swift/Basic/Sanitizers.def
@@ -21,9 +21,9 @@
 // SANITIZER(enum_bit, kind, name, file)
 
 SANITIZER(0, Address,   address,    asan)
-SANITIZER(1, Thread,    thread,     tsan)
-SANITIZER(2, Undefined, undefined,  ubsan)
-SANITIZER(3, Fuzzer,    fuzzer,     fuzzer)
-SANITIZER(4, Scudo,     scudo,      scudo)
+SANITIZER(1, Fuzzer,    fuzzer,     fuzzer)
+SANITIZER(2, Scudo,     scudo,      scudo)
+SANITIZER(3, Thread,    thread,     tsan)
+SANITIZER(4, Undefined, undefined,  ubsan)
 
 #undef SANITIZER

--- a/test/Driver/sanitize_scudo.swift
+++ b/test/Driver/sanitize_scudo.swift
@@ -34,7 +34,7 @@
 
 // SCUDO_ASAN: argument '-sanitize=scudo' is not allowed with '-sanitize=address'
 // SCUDO_TSAN: argument '-sanitize=scudo' is not allowed with '-sanitize=thread'
-// SCUDO_UBSAN_LINUX: -fsanitize=undefined,scudo
+// SCUDO_UBSAN_LINUX: -fsanitize=scudo,undefined
 // SCUDO_LIBRARY_LINUX: bin{{/|\\\\}}clang
 // SCUDO_LIBRARY_LINUX-NOT: -fsanitize=scudo
 

--- a/test/Driver/sanitizers.swift
+++ b/test/Driver/sanitizers.swift
@@ -42,7 +42,7 @@
 /*
  * Multiple Sanitizers At Once
  */
-// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,undefined,fuzzer -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MULTIPLE_SAN_LINUX %s
+// RUN: %swiftc_driver -sdk "" -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=address,fuzzer,undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=MULTIPLE_SAN_LINUX %s
 
 /*
  * Bad Argument Tests
@@ -106,7 +106,7 @@
 
 // UBSAN: -rpath @executable_path
 
-// MULTIPLE_SAN_LINUX: -fsanitize=address,undefined,fuzzer
+// MULTIPLE_SAN_LINUX: -fsanitize=address,fuzzer,undefined
 
 // BADARG: unsupported argument 'unknown' to option '-sanitize='
 // INCOMPATIBLESANITIZERS: argument '-sanitize=address' is not allowed with '-sanitize=thread'


### PR DESCRIPTION
This impacts the order in which they're listed using -fsanitize. This change increases compatibility with swift-driver.
