### PR TITLE
[NFC] Cleanup some code to use 'swift::getParameterList' to fetch parameter lists

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -735,23 +735,12 @@ static bool getUnnamedParamIndex(const ParameterList *ParamList,
 }
 
 static unsigned getUnnamedParamIndex(const ParamDecl *D) {
-  if (auto SD = dyn_cast<SubscriptDecl>(D->getDeclContext())) {
-    unsigned UnnamedIndex = 0;
-    auto *ParamList = SD->getIndices();
-    if (getUnnamedParamIndex(ParamList, D, UnnamedIndex))
-      return UnnamedIndex;
-    llvm_unreachable("param not found");
-  }
-
   ParameterList *ParamList;
-
-  if (auto AFD = dyn_cast<AbstractFunctionDecl>(D->getDeclContext())) {
-    ParamList = AFD->getParameters();
-  } else if (auto EED = dyn_cast<EnumElementDecl>(D->getDeclContext())) {
-    ParamList = EED->getParameterList();
+  auto *DC = D->getDeclContext();
+  if (isa<AbstractClosureExpr>(DC)) {
+    ParamList = cast<AbstractClosureExpr>(DC)->getParameters();
   } else {
-    auto ACE = cast<AbstractClosureExpr>(D->getDeclContext());
-    ParamList = ACE->getParameters();
+    ParamList = getParameterList(cast<ValueDecl>(DC->getAsDecl()));
   }
 
   unsigned UnnamedIndex = 0;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -723,16 +723,13 @@ bool ParameterList::hasInternalParameter(StringRef Prefix) const {
 
 bool Decl::hasUnderscoredNaming() const {
   const Decl *D = this;
-  if (const auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-    // If it's a function with a parameter with leading underscore, it's a
-    // private function.
-    if (AFD->getParameters()->hasInternalParameter("_")) {
-      return true;
-    }
-  }
 
-  if (const auto SubscriptD = dyn_cast<SubscriptDecl>(D)) {
-    if (SubscriptD->getIndices()->hasInternalParameter("_")) {
+  // If it's a function or subscript with a parameter with leading
+  // underscore, it's a private function or subscript.
+  if (isa<AbstractFunctionDecl>(D) || isa<SubscriptDecl>(D)) {
+    const auto VD = cast<ValueDecl>(D);
+    if (getParameterList(const_cast<ValueDecl *>(VD))
+            ->hasInternalParameter("_")) {
       return true;
     }
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -850,14 +850,8 @@ ParameterListInfo::ParameterListInfo(
     return;
 
   // Find the corresponding parameter list.
-  const ParameterList *paramList = nullptr;
-  if (auto *func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
-    paramList = func->getParameters();
-  } else if (auto *subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
-    paramList = subscript->getIndices();
-  } else if (auto *enumElement = dyn_cast<EnumElementDecl>(paramOwner)) {
-    paramList = enumElement->getParameterList();
-  }
+  const ParameterList *paramList =
+      getParameterList(const_cast<ValueDecl *>(paramOwner));
 
   // No parameter list means no default arguments - hand back the zeroed
   // bitvector.

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -739,10 +739,7 @@ class ExprContextAnalyzer {
         auto Params = typeAndDecl.Type->getParams();
         ParameterList *paramList = nullptr;
         if (auto VD = typeAndDecl.Decl) {
-          if (auto FD = dyn_cast<AbstractFunctionDecl>(VD))
-            paramList = FD->getParameters();
-          else if (auto SD = dyn_cast<SubscriptDecl>(VD))
-            paramList = SD->getIndices();
+          paramList = getParameterList(VD);
           if (paramList && paramList->size() != Params.size())
             paramList = nullptr;
         }

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -501,18 +501,14 @@ private:
     } else if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (!handleBraces(VD->getBracesRange(), VD->getNameLoc()))
         return Stop;
-    } else if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-      if (auto *PL = AFD->getParameters()) {
-        if (!handleParens(PL->getLParenLoc(), PL->getRParenLoc(), ContextLoc))
+    } else if (isa<AbstractFunctionDecl>(D) || isa<SubscriptDecl>(D)) {
+      if (isa<SubscriptDecl>(D)) {
+        if (!handleBraces(cast<SubscriptDecl>(D)->getBracesRange(), ContextLoc))
           return Stop;
       }
-    } else if (auto *SD = dyn_cast<SubscriptDecl>(D)) {
-      if (!handleBraces(SD->getBracesRange(), ContextLoc))
+      auto *PL = getParameterList(cast<ValueDecl>(D));
+      if (!handleParens(PL->getLParenLoc(), PL->getRParenLoc(), ContextLoc))
         return Stop;
-      if (auto *PL = SD->getIndices()) {
-        if (!handleParens(PL->getLParenLoc(), PL->getRParenLoc(), ContextLoc))
-          return Stop;
-      }
     } else if (auto *PGD = dyn_cast<PrecedenceGroupDecl>(D)) {
       SourceRange Braces(PGD->getLBraceLoc(), PGD->getRBraceLoc());
       if (!handleBraces(Braces, ContextLoc))

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -140,12 +140,9 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
       return false;
     };
 
-    if (auto AF = dyn_cast<AbstractFunctionDecl>(VD)) {
-      if (ReportParamList(AF->getParameters()))
-        return false;
-    }
-    if (auto SD = dyn_cast<SubscriptDecl>(VD)) {
-      if (ReportParamList(SD->getIndices()))
+    if (isa<AbstractFunctionDecl>(VD) || isa<SubscriptDecl>(VD)) {
+      auto ParamList = getParameterList(VD);
+      if (ReportParamList(ParamList))
         return false;
     }
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -536,20 +536,17 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
 static bool parameterTypesMatch(const ValueDecl *derivedDecl,
                                 const ValueDecl *baseDecl,
                                 TypeMatchOptions matchMode) {
-  const ParameterList *derivedParams;
-  const ParameterList *baseParams;
-  if (auto *derived = dyn_cast<AbstractFunctionDecl>(derivedDecl)) {
-    auto *base = dyn_cast<AbstractFunctionDecl>(baseDecl);
-    if (!base)
-      return false;
-    baseParams = base->getParameters();
-    derivedParams = derived->getParameters();
-  } else {
-    auto *base = dyn_cast<SubscriptDecl>(baseDecl);
-    if (!base)
-      return false;
-    baseParams = base->getIndices();
-    derivedParams = cast<SubscriptDecl>(derivedDecl)->getIndices();
+  const ParameterList *derivedParams = nullptr;
+  const ParameterList *baseParams = nullptr;
+  if ((isa<AbstractFunctionDecl>(derivedDecl) &&
+       isa<AbstractFunctionDecl>(baseDecl)) ||
+      isa<SubscriptDecl>(baseDecl)) {
+    derivedParams = getParameterList(const_cast<ValueDecl *>(derivedDecl));
+    baseParams = getParameterList(const_cast<ValueDecl *>(baseDecl));
+  }
+
+  if (!derivedParams && !baseParams) {
+    return false;
   }
 
   if (baseParams->size() != derivedParams->size())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2076,10 +2076,8 @@ SourceLoc OptionalAdjustment::getOptionalityLoc(ValueDecl *witness) const {
 
   // For parameter adjustments, dig out the pattern.
   ParameterList *params = nullptr;
-  if (auto func = dyn_cast<AbstractFunctionDecl>(witness)) {
-    params = func->getParameters();
-  } else if (auto subscript = dyn_cast<SubscriptDecl>(witness)) {
-    params = subscript->getIndices();
+  if (isa<AbstractFunctionDecl>(witness) || isa<SubscriptDecl>(witness)) {
+    params = getParameterList(witness);
   } else {
     return SourceLoc();
   }
@@ -4793,12 +4791,11 @@ static bool isGeneric(ValueDecl *decl) {
 /// Determine whether this is an unlabeled initializer or subscript.
 static bool isUnlabeledInitializerOrSubscript(ValueDecl *value) {
   ParameterList *paramList = nullptr;
-  if (auto constructor = dyn_cast<ConstructorDecl>(value))
-    paramList = constructor->getParameters();
-  else if (auto subscript = dyn_cast<SubscriptDecl>(value))
-    paramList = subscript->getIndices();
-  else
+  if (isa<ConstructorDecl>(value) || isa<SubscriptDecl>(value)) {
+    paramList = getParameterList(value);
+  } else {
     return false;
+  }
 
   for (auto param : *paramList) {
     if (!param->getArgumentName().empty()) return false;

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -313,17 +313,13 @@ static bool hasDoubleUnderscore(Decl *D) {
   // base names.
   static StringRef Prefix = "__";
 
-  if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-    // If it's a function with a parameter with leading double underscore,
-    // it's a private function.
-    if (AFD->getParameters()->hasInternalParameter(Prefix))
+  // If it's a function or subscript with a parameter with leading
+  // double underscore, it's a private function or subscript.
+  if (isa<AbstractFunctionDecl>(D) || isa<SubscriptDecl>(D)) {
+    if (getParameterList(cast<ValueDecl>(D))->hasInternalParameter(Prefix))
       return true;
   }
 
-  if (auto SubscriptD = dyn_cast<SubscriptDecl>(D)) {
-    if (SubscriptD->getIndices()->hasInternalParameter(Prefix))
-      return true;
-  }
   if (auto *VD = dyn_cast<ValueDecl>(D)) {
     auto Name = VD->getBaseName();
     if (!Name.isSpecial() &&

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -915,12 +915,10 @@ void SwiftLangSupport::printMemberDeclDescription(const swift::ValueDecl *VD,
     }
     OS << ')';
   };
-  if (auto EED = dyn_cast<EnumElementDecl>(VD)) {
-    if (auto params = EED->getParameterList())
-      printParams(params);
-  } else if (auto *FD = dyn_cast<FuncDecl>(VD)) {
-    if (auto params = FD->getParameters())
-      printParams(params);
+  if (isa<EnumElementDecl>(VD) || isa<FuncDecl>(VD)) {
+    if (const auto ParamList = getParameterList(const_cast<ValueDecl *>(VD))) {
+      printParams(ParamList);
+    }
   } else if (isa<VarDecl>(VD)) {
     // Var decl doesn't have parameters.
   } else {


### PR DESCRIPTION
We have a convenience function called `getParameterList` which takes a `ValueDecl *` and returns the parameters if they exist. Let's use it wherever possible instead of manually checking the types and then extracting the parameters for each.