### PR TITLE
SR-13098 Diagnostic improvement: encountering an unexpected statement at type scope

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -217,7 +217,6 @@ ERROR(let_cannot_be_addressed_property,none,
 ERROR(disallowed_var_multiple_getset,none,
       "'var' declarations with multiple variables cannot have explicit"
       " getters/setters", ())
-NOTE(found_unexpected_stmt,none, "found an unexpected statement here", ())
 
 ERROR(disallowed_init,none,
       "initial value is not allowed here", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -217,6 +217,7 @@ ERROR(let_cannot_be_addressed_property,none,
 ERROR(disallowed_var_multiple_getset,none,
       "'var' declarations with multiple variables cannot have explicit"
       " getters/setters", ())
+NOTE(found_unexpected_stmt,none, "found an unexpected statement here", ())
 
 ERROR(disallowed_init,none,
       "initial value is not allowed here", ())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3890,6 +3890,16 @@ Parser::parseDecl(ParseDeclOptions Flags,
     if (Flags.contains(PD_HasContainerType) &&
         IsAtStartOfLineOrPreviousHadSemi) {
 
+      // Fail fast if we have something that starts with an identifier
+      // but cannot be a var or func declaration.
+      const bool NotAVarOrFuncDecl = Tok.isIdentifierOrUnderscore() &&
+        peekToken().isAny(tok::period);
+
+      if (NotAVarOrFuncDecl) {
+          diagnose(Tok, diag::expected_decl);
+          break;
+      }
+
       // Emit diagnostics if we meet an identifier/operator where a declaration
       // is expected, perhaps the user forgot the 'func' or 'var' keyword.
       //
@@ -3927,8 +3937,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
       }
 
       const bool IsProbablyFuncDecl =
-          (Tok.isIdentifierOrUnderscore() && peekToken().isAny(tok::l_paren, tok::l_angle)) || 
-          (Tok.isAnyOperator() && peekToken().isAny(tok::l_paren, tok::l_angle));
+          Tok.isIdentifierOrUnderscore() || Tok.isAnyOperator();
 
       if (IsProbablyFuncDecl) {
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3903,6 +3903,15 @@ Parser::parseDecl(ParseDeclOptions Flags,
       const bool IsProbablyTupleDecl =
           Tok.is(tok::l_paren) && peekToken().isIdentifierOrUnderscore();
 
+      const bool IsProbablyStatement =
+          Tok.isIdentifierOrUnderscore() &&
+          peekToken().isAny(tok::period);
+
+      if (IsProbablyStatement) {
+        diagnose(Tok.getLoc(), diag::found_unexpected_stmt);
+        break;
+      }
+
       if (IsProbablyVarDecl || IsProbablyTupleDecl) {
 
         DescriptiveDeclKind DescriptiveKind;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3901,8 +3901,12 @@ Parser::parseDecl(ParseDeclOptions Flags,
         // diagnostic first before parseExpr moves the cursor
         diagnose(Tok, diag::expected_decl);
         // parse the rest of the expression to get past the problem.
+        // return it so that parsing continues at the end of the expr.
         parseExpr(diag::expected_expr);
-        // we did not parse a Decl here so we need to report an error 
+        // note that makeParserError will cause the parser to
+        // skip to the next right brace. So anything after this will
+        // not be parsed at all. It does not seem to be possible to
+        // recover even if the code after the expr is valid.
         return makeParserError();
       }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3898,13 +3898,12 @@ Parser::parseDecl(ParseDeclOptions Flags,
         peekToken().isAny(tok::period);
 
       if (IdentifierPeriod) {
-        ParserResult<Expr> ResultExpr = parseExpr(diag::expected_expr);
-        // parse the rest of the expression to get past the problem.
-        if (ResultExpr.isNonNull()) {
-          auto Result = ResultExpr.get();
-        }
+        // diagnostic first before parseExpr moves the cursor
         diagnose(Tok, diag::expected_decl);
-        break;
+        // parse the rest of the expression to get past the problem.
+        parseExpr(diag::expected_expr);
+        // we did not parse a Decl here so we need to report an error 
+        return makeParserError();
       }
 
       // Emit diagnostics if we meet an identifier/operator where a declaration

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3891,13 +3891,20 @@ Parser::parseDecl(ParseDeclOptions Flags,
         IsAtStartOfLineOrPreviousHadSemi) {
 
       // Fail fast if we have something that starts with an identifier
-      // but cannot be a var or func declaration.
-      const bool NotAVarOrFuncDecl = Tok.isIdentifierOrUnderscore() &&
+      // and a period, but cannot be a var or func declaration.
+      // we try to parse from here as an expression to pass over
+      // the tokens and reach a safe place to keep parsing.
+      const bool IdentifierPeriod = Tok.isIdentifierOrUnderscore() &&
         peekToken().isAny(tok::period);
 
-      if (NotAVarOrFuncDecl) {
-          diagnose(Tok, diag::expected_decl);
-          break;
+      if (IdentifierPeriod) {
+        ParserResult<Expr> ResultExpr = parseExpr(diag::expected_expr);
+        // parse the rest of the expression to get past the problem.
+        if (ResultExpr.isNonNull()) {
+          auto Result = ResultExpr.get();
+        }
+        diagnose(Tok, diag::expected_decl);
+        break;
       }
 
       // Emit diagnostics if we meet an identifier/operator where a declaration

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3903,15 +3903,6 @@ Parser::parseDecl(ParseDeclOptions Flags,
       const bool IsProbablyTupleDecl =
           Tok.is(tok::l_paren) && peekToken().isIdentifierOrUnderscore();
 
-      const bool IsProbablyStatement =
-          Tok.isIdentifierOrUnderscore() &&
-          peekToken().isAny(tok::period);
-
-      if (IsProbablyStatement) {
-        diagnose(Tok.getLoc(), diag::found_unexpected_stmt);
-        break;
-      }
-
       if (IsProbablyVarDecl || IsProbablyTupleDecl) {
 
         DescriptiveDeclKind DescriptiveKind;
@@ -3936,7 +3927,8 @@ Parser::parseDecl(ParseDeclOptions Flags,
       }
 
       const bool IsProbablyFuncDecl =
-          Tok.isIdentifierOrUnderscore() || Tok.isAnyOperator();
+          (Tok.isIdentifierOrUnderscore() && peekToken().isAny(tok::l_paren, tok::l_angle)) || 
+          (Tok.isAnyOperator() && peekToken().isAny(tok::l_paren, tok::l_angle));
 
       if (IsProbablyFuncDecl) {
 

--- a/test/Parse/diagnostic_call_at_type_level.swift
+++ b/test/Parse/diagnostic_call_at_type_level.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Bar { // expected-note {{in declaration of 'Bar'}}
+ var fisr = 0x5F3759DF
+ var a: Int
+
+ // ensure that the id.id pattern is not interpreted as a function
+ a.foo = 345 // expected-error {{expected declaration}}
+ // ensure that the id.id pattern generating an expected declaration
+ // diagnostic does not block further diagnostics.
+ fisr.bar = 345
+}

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -44,7 +44,7 @@ struct Bar {
   a.foo = 345 // expected-error {{expected declaration}}
   // ensure that the id.id pattern generating an expected declaration
   // diagnostic does not block further diagnostics.
-  fisr.bar = 345 // expected-error {{expected declaration}}
+  fisr.bar = 345
 
 }
 

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -38,6 +38,7 @@ struct Bar {
 
   (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
   
+  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 }
 
 struct Faz {

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -27,9 +27,9 @@ infix operator %%
 struct Bar {
   fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected declaration}}
-
-
+  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
+                                      // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
+                                      // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
     lhs + lhs + rhs + rhs
   }
 
@@ -38,14 +38,12 @@ struct Bar {
 
   (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
   
-  a, b: Int // expected-error {{expected declaration}}
-}
+  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-struct Faz {
-  abc : Int = 10 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
-  def.ber : Float = 1.0 // expected-error {{expected declaration}}
+  a.qux = 345 // expected-error {{expected declaration}}
+  
+  fisr.qux = 345 // expected-error {{expected declaration}}
 
-  x + 3 // expected-error {{expected declaration}}
 }
 
 class Baz {

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -25,27 +25,20 @@ protocol Brew { // expected-note {{in declaration of 'Brew'}}
 infix operator %%
 
 struct Bar {
-  fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+ fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
-                                      // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
-                                      // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
-    lhs + lhs + rhs + rhs
-  }
+ %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
+                                     // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
+                                     // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
+   lhs + lhs + rhs + rhs
+ }
 
-  _: Int = 42 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
-              // expected-error @-1 {{property declaration does not bind any variables}}
+ _: Int = 42 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+             // expected-error @-1 {{property declaration does not bind any variables}}
 
-  (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
-  
-  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+ (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  // ensure that the id.id pattern is not interpreted as a function
-  a.foo = 345 // expected-error {{expected declaration}}
-  // ensure that the id.id pattern generating an expected declaration
-  // diagnostic does not block further diagnostics.
-  fisr.bar = 345
-
+ a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 }
 
 class Baz {

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -38,7 +38,11 @@ struct Bar {
 
   (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
   
-  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+}
+
+struct Faz {
+  abc : Int = 10 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  def.ber : Float = 1.0 // expected-note {{found an unexpected statement here}}
 }
 
 class Baz {

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -25,20 +25,20 @@ protocol Brew { // expected-note {{in declaration of 'Brew'}}
 infix operator %%
 
 struct Bar {
- fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
- %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
-                                     // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
-                                     // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
-   lhs + lhs + rhs + rhs
- }
+  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
+                                      // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
+                                      // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
+    lhs + lhs + rhs + rhs
+  }
 
- _: Int = 42 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  _: Int = 42 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
              // expected-error @-1 {{property declaration does not bind any variables}}
 
- (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
- a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 }
 
 class Baz {

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -40,9 +40,11 @@ struct Bar {
   
   a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  a.qux = 345 // expected-error {{expected declaration}}
-  
-  fisr.qux = 345 // expected-error {{expected declaration}}
+  // ensure that the id.id pattern is not interpreted as a function
+  a.foo = 345 // expected-error {{expected declaration}}
+  // ensure that the id.id pattern generating an expected declaration
+  // diagnostic does not block further diagnostics.
+  fisr.bar = 345 // expected-error {{expected declaration}}
 
 }
 

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -27,9 +27,9 @@ infix operator %%
 struct Bar {
   fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
-                                      // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
-                                      // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
+  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected declaration}}
+
+
     lhs + lhs + rhs + rhs
   }
 
@@ -38,12 +38,14 @@ struct Bar {
 
   (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
   
-  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  a, b: Int // expected-error {{expected declaration}}
 }
 
 struct Faz {
   abc : Int = 10 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
-  def.ber : Float = 1.0 // expected-note {{found an unexpected statement here}}
+  def.ber : Float = 1.0 // expected-error {{expected declaration}}
+
+  x + 3 // expected-error {{expected declaration}}
 }
 
 class Baz {

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -24,13 +24,6 @@ x x // expected-error{{consecutive statements}} {{2-2=;}}
 
 // rdar://19582475
 public struct S { // expected-note{{in declaration of 'S'}}
-// expected-error@+8{{expected 'func' keyword in operator function declaration}}
-// expected-error@+7{{operator '/' declared in type 'S' must be 'static'}}
-// expected-error@+6{{expected '(' in argument list of function declaration}}
-// expected-error@+5{{operators must have one or two arguments}}
-// expected-error@+4{{member operator '/()' must have at least one argument of type 'S'}}
-// expected-error@+3{{expected '{' in body of function declaration}}
-// expected-error@+2{{consecutive declarations on a line must be separated by ';}}
 // expected-error@+1{{expected declaration}}
 / ###line 25 "line-directive.swift"
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds logic and a note to identify a statement in the sequence of declarations in a struct or class declaration. The previous version was generating multiple diagnostics that were not directly relevant. 

This only applies to statements like `identifier.identifier` for a member or property access, where there's a period after an identifier at the beginning of a line or after a semicolon. There was already logic to identify other cases where none of the valid beginning-of-context keywords like `func`, `var` or `let` appear. 

@varungandhi-apple helped me with this. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13098.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
