### PR TITLE
ModuleInterface: teach -compile-module-from-interface to emit forwarding module

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -85,6 +85,9 @@ public:
   /// The paths to a set of explicitly built modules from interfaces.
   std::vector<std::string> ExplicitSwiftModules;
 
+  /// A set of compiled modules that may be ready to use.
+  std::vector<std::string> CandidateCompiledModules;
+
   /// A map of explict Swift module information.
   std::string ExplicitSwiftModuleMap;
 private:

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -240,6 +240,14 @@ public:
   std::vector<std::string>
   getCompiledModuleCandidatesForInterface(StringRef moduleName,
                                           StringRef interfacePath) override;
+
+  /// Given a list of potential ready-to-use compiled modules for \p interfacePath,
+  /// check if any one of them is up-to-date. If so, emit a forwarding module
+  /// to the candidate binary module to \p outPath.
+  bool tryEmitForwardingModule(StringRef moduleName,
+                               StringRef interfacePath,
+                               ArrayRef<std::string> candidates,
+                               StringRef outPath) override;
 };
 
 struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -719,4 +719,8 @@ def target_variant_sdk_version : Separate<["-"], "target-variant-sdk-version">,
 
 def extra_clang_options_only : Flag<["-"], "only-use-extra-clang-opts">,
   HelpText<"Options passed via -Xcc are sufficient for Clang configuration">;
+
+def candidate_module_file
+  : Separate<["-"], "candidate-module-file">, MetaVarName<"<path>">,
+    HelpText<"Specify Swift module may be ready to use for an interface">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -206,6 +206,12 @@ public:
                                           StringRef interfacePath) {
     return std::vector<std::string>();
   }
+  virtual bool tryEmitForwardingModule(StringRef moduleName,
+                                       StringRef interfacePath,
+                                       ArrayRef<std::string> candidates,
+                                       StringRef outPath) {
+    return false;
+  }
 };
 
 /// Imports serialized Swift modules into an ASTContext.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -900,6 +900,10 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   }
   if (const Arg *A = Args.getLastArg(OPT_explict_swift_module_map))
     Opts.ExplicitSwiftModuleMap = A->getValue();
+  for (auto A: Args.filtered(OPT_candidate_module_file)) {
+    Opts.CandidateCompiledModules.push_back(resolveSearchPath(A->getValue()));
+  }
+
   // Opts.RuntimeIncludePath is set by calls to
   // setRuntimeIncludePath() or setMainExecutablePath().
   // Opts.RuntimeImportPath is set by calls to

--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -85,7 +85,8 @@ private:
       bool IsHashBased);
 
   bool buildSwiftModuleInternal(StringRef OutPath, bool ShouldSerializeDeps,
-                                std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer);
+                                std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+                                ArrayRef<std::string> CandidateModules);
 public:
   ModuleInterfaceBuilder(SourceManager &sourceMgr, DiagnosticEngine &diags,
                             InterfaceSubContextDelegate &subASTDelegate,
@@ -111,7 +112,8 @@ public:
 
   bool buildSwiftModule(StringRef OutPath, bool ShouldSerializeDeps,
                         std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-                        llvm::function_ref<void()> RemarkRebuild = nullptr);
+                        llvm::function_ref<void()> RemarkRebuild = nullptr,
+                        ArrayRef<std::string> CandidateModules = {});
 };
 
 } // end namespace swift

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1029,7 +1029,6 @@ ModuleInterfaceLoader::getCompiledModuleCandidatesForInterface(StringRef moduleN
                 dependencyTracker,
                 llvm::is_contained(PreferInterfaceForModules, moduleName) ?
                   ModuleLoadingMode::PreferInterface : LoadMode);
-  SmallVector<FileDependency, 16> allDeps;
   std::vector<std::string> results;
   auto pair = Impl.getCompiledModuleCandidates();
   // Add compiled module candidates only when they are non-empty.
@@ -1038,6 +1037,41 @@ ModuleInterfaceLoader::getCompiledModuleCandidatesForInterface(StringRef moduleN
   if (!pair.second.empty())
     results.push_back(pair.second);
   return results;
+}
+
+bool ModuleInterfaceLoader::tryEmitForwardingModule(StringRef moduleName,
+                                                    StringRef interfacePath,
+                                                    ArrayRef<std::string> candidates,
+                                                    StringRef outputPath) {
+  // Derive .swiftmodule path from the .swiftinterface path.
+  auto newExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
+  llvm::SmallString<32> modulePath = interfacePath;
+  llvm::sys::path::replace_extension(modulePath, newExt);
+  ModuleInterfaceLoaderImpl Impl(
+                Ctx, modulePath, interfacePath, moduleName,
+                CacheDir, PrebuiltCacheDir, SourceLoc(),
+                Opts,
+                dependencyTracker,
+                llvm::is_contained(PreferInterfaceForModules, moduleName) ?
+                  ModuleLoadingMode::PreferInterface : LoadMode);
+  SmallVector<FileDependency, 16> deps;
+  std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
+  for (auto mod: candidates) {
+    // Check if the candidate compiled module is still up-to-date.
+    if (Impl.swiftModuleIsUpToDate(mod, deps, moduleBuffer)) {
+      // If so, emit a forwarding module to the candidate.
+      ForwardingModule FM(mod);
+      auto hadError = withOutputFile(Ctx.Diags, outputPath,
+        [&](llvm::raw_pwrite_stream &out) {
+          llvm::yaml::Output yamlWriter(out);
+          yamlWriter << FM;
+          return false;
+        });
+      if (!hadError)
+        return true;
+    }
+  }
+  return false;
 }
 
 bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
@@ -1069,7 +1103,8 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
   // FIXME: We really only want to serialize 'important' dependencies here, if
   //        we want to ship the built swiftmodules to another machine.
   return builder.buildSwiftModule(OutPath, /*shouldSerializeDeps*/true,
-                                  /*ModuleBuffer*/nullptr);
+                                  /*ModuleBuffer*/nullptr, nullptr,
+                                  SearchPathOpts.CandidateCompiledModules);
 }
 
 void ModuleInterfaceLoader::collectVisibleTopLevelModuleNames(

--- a/test/ModuleInterface/emit-forward-modules.swift
+++ b/test/ModuleInterface/emit-forward-modules.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Foo.swiftmodule)
+// RUN: %empty-directory(%t/ResourceDir/%target-sdk-name/prebuilt-modules/Foo.swiftmodule)
+// RUN: echo "public func foo() {}" > %t/Foo.swift
+
+import Foo
+
+// Step 1: build swift interface from the source
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// Step 2: building a module from the interface, and the module should not be a forwarding module.
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftmodule/%target-swiftinterface-name -o %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo
+
+// RUN: not %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/Foo.swiftmodule/%target-swiftmodule-name
+
+// Step 3: given the adjacent binary module as a candidate, building a module from the interface should give us a forwarding module
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftmodule/%target-swiftinterface-name -o %t/Foo-from-interface.swiftmodule -module-name Foo -candidate-module-file %t/Foo.swiftmodule/%target-swiftmodule-name
+
+// RUN: %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/Foo-from-interface.swiftmodule
+
+// Step 4: given the stale adjacent binary module as a candidate, building a module from the interface should give us a binary module
+// RUN: touch %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftmodule/%target-swiftinterface-name -o %t/Foo-from-interface.swiftmodule -module-name Foo -candidate-module-file %t/Foo.swiftmodule/%target-swiftmodule-name
+
+// RUN: not %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/Foo-from-interface.swiftmodule


### PR DESCRIPTION
-compile-module-from-interface action now takes arguments of -candidate-module-file.
If one of the candidate module files is up-to-date, the action emits a forwarding
module pointing to the candidate module instead of building a binary module.