### PR TITLE
[opt-remark] Add support for emitting opt-remark-generator remarks when compiling with optimization.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -660,6 +660,9 @@ static void addLastChanceOptPassPipeline(SILPassPipelinePlan &P) {
 
   // Only has an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();
+
+  // Only has an effect if opt-remark is enabled.
+  P.addOptRemarkGenerator();
 }
 
 static void addSILDebugInfoGeneratorPipeline(SILPassPipelinePlan &P) {

--- a/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
+++ b/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
@@ -49,8 +49,10 @@ void OptRemarkGeneratorInstructionVisitor::visitStrongRetainInst(
     StrongRetainInst *sri) {
   ORE.emit([&]() {
     using namespace OptRemark;
-    return RemarkMissed("memory-management", *sri)
-           << "Unable to remove ARC operation";
+    // Retains begin a lifetime scope so we infer scan forward.
+    return RemarkMissed("memory-management", *sri,
+                        SourceLocInferenceBehavior::ForwardScanOnly)
+           << "Unable to remove retain";
   });
 }
 
@@ -58,8 +60,10 @@ void OptRemarkGeneratorInstructionVisitor::visitStrongReleaseInst(
     StrongReleaseInst *sri) {
   ORE.emit([&]() {
     using namespace OptRemark;
-    return RemarkMissed("memory-management", *sri)
-           << "Unable to remove ARC operation";
+    // Releases end a lifetime scope so we infer scan backward.
+    return RemarkMissed("memory-management", *sri,
+                        SourceLocInferenceBehavior::BackwardScanOnly)
+           << "Unable to remove release";
   });
 }
 
@@ -67,8 +71,10 @@ void OptRemarkGeneratorInstructionVisitor::visitRetainValueInst(
     RetainValueInst *rvi) {
   ORE.emit([&]() {
     using namespace OptRemark;
-    return RemarkMissed("memory-management", *rvi)
-           << "Unable to remove ARC operation";
+    // Retains begin a lifetime scope, so we infer scan forwards.
+    return RemarkMissed("memory-management", *rvi,
+                        SourceLocInferenceBehavior::ForwardScanOnly)
+           << "Unable to remove retain";
   });
 }
 
@@ -76,8 +82,10 @@ void OptRemarkGeneratorInstructionVisitor::visitReleaseValueInst(
     ReleaseValueInst *rvi) {
   ORE.emit([&]() {
     using namespace OptRemark;
-    return RemarkMissed("memory-management", *rvi)
-           << "Unable to remove ARC operation";
+    // Releases end a lifetime scope so we infer scan backward.
+    return RemarkMissed("memory-management", *rvi,
+                        SourceLocInferenceBehavior::BackwardScanOnly)
+           << "Unable to remove release";
   });
 }
 
@@ -90,10 +98,22 @@ namespace {
 class OptRemarkGenerator : public SILFunctionTransform {
   ~OptRemarkGenerator() override {}
 
+  bool isOptRemarksEnabled() {
+    // TODO: Put this on LangOpts as a helper.
+    auto &langOpts = getFunction()->getASTContext().LangOpts;
+    return bool(langOpts.OptimizationRemarkMissedPattern) ||
+           bool(langOpts.OptimizationRemarkPassedPattern);
+  }
+
   /// The entry point to the transformation.
   void run() override {
-    OptRemarkGeneratorInstructionVisitor visitor(getFunction()->getModule());
-    for (auto &block : *getFunction()) {
+    if (!isOptRemarksEnabled())
+      return;
+
+    auto *fn = getFunction();
+    LLVM_DEBUG(llvm::dbgs() << "Visiting: " << fn->getName() << "\n");
+    OptRemarkGeneratorInstructionVisitor visitor(fn->getModule());
+    for (auto &block : *fn) {
       for (auto &inst : block) {
         visitor.visit(&inst);
       }

--- a/test/SILOptimizer/opt-remark-generator.sil
+++ b/test/SILOptimizer/opt-remark-generator.sil
@@ -1,12 +1,12 @@
 // RUN: %target-sil-opt -sil-opt-remark-generator -sil-remarks-missed=sil-opt-remark-gen %s -o /dev/null 2>&1 | %FileCheck %s
 
-// CHECK: {{.*}}opt-remark-generator.sil:18:3: remark: Unable to remove ARC operation
+// CHECK: {{.*}}opt-remark-generator.sil:18:3: remark: Unable to remove retain
 // CHECK-NEXT: strong_retain
-// CHECK: {{.*}}opt-remark-generator.sil:19:3: remark: Unable to remove ARC operation
+// CHECK: {{.*}}opt-remark-generator.sil:19:3: remark: Unable to remove retain
 // CHECK-NEXT: retain_value
-// CHECK: {{.*}}opt-remark-generator.sil:20:3: remark: Unable to remove ARC operation
+// CHECK: {{.*}}opt-remark-generator.sil:20:3: remark: Unable to remove release
 // CHECK-NEXT: strong_release
-// CHECK: {{.*}}opt-remark-generator.sil:21:3: remark: Unable to remove ARC operation
+// CHECK: {{.*}}opt-remark-generator.sil:21:3: remark: Unable to remove release
 // CHECK-NEXT: release_value
 
 sil_stage canonical

--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swiftc_driver -O -Rpass-missed=sil-opt-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
+
+public class Klass {}
+
+public var global = Klass()
+
+@inline(never)
+public func getGlobal() -> Klass {
+    return global // expected-remark @:5 {{Unable to remove retain}}
+}
+
+public func useGlobal() {
+    let x = getGlobal()
+    // Make sure that the retain msg is at the beginning of the print and the
+    // releases are the end of the print.
+    print(x) // expected-remark @:5 {{Unable to remove retain}}
+    // expected-remark @-1:12 {{Unable to remove release}}
+    // expected-remark @-2:12 {{Unable to remove release}}
+}


### PR DESCRIPTION
In order to test this, I implemented a small source loc inference routine for
instructions without valid SILLocations. This is an optional nob that the
opt-remark writer can optionally enable on a per remark basis. The current
behaviors are just forward/backward scans in the same basic block. If we scan
forwards, if we find a valid SourceLoc, we just use ethat. If we are scanning
backwards, instead we grab the SourceRange and if it is valid use the end source
range of the given instruction. This seems to give a good result for retain
(forward scan) and release (backward scan).

The specific reason that I did that is that my test case for this are
retain/release operations. Often times these operations due to code-motion are
moved around (and rightly to prevent user confusion) given by optimizations auto
generated SIL locations. Since that is the test case I am using, to test this I
needed said engine.
