### PR TITLE
[Sema] Warn about unexpected `.self` behavior with metatypes 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4098,6 +4098,11 @@ WARNING(class_super_not_usable_from_inline_warn,none,
         "should be '@usableFromInline' or public",
         (bool))
 
+WARNING(metatype_self,none,
+        "self expression applied to a metatype results in a meta-metatype, "
+        "which may be unexpected", ())
+NOTE(metatype_self_silence,none,
+     "add parentheses to silence this warning", ())
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))
 ERROR(tuple_single_element,none,

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -8396,6 +8396,15 @@
     %select{type referenced from |}0the superclass of a '@usableFromInline'
     class should be '@usableFromInline' or public
 
+- id: metatype_self
+  msg: >-
+    self expression applied to a metatype results in a meta-metatype,
+    which may be unexpected
+
+- id: metatype_self_silence
+  msg: >-
+    add parentheses to silence this warning
+
 - id: dot_protocol_on_non_existential
   msg: >-
     cannot use 'Protocol' with non-protocol type %0

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -610,7 +610,7 @@ extension TestSuite {
       return makeCollectionOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     //===------------------------------------------------------------------===//
     // generate()
@@ -1311,7 +1311,7 @@ extension TestSuite {
       return makeCollectionOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     // FIXME: swift-3-indexing-model - add tests for the follow?
     //          index(before: of i: Index) -> Index
@@ -1756,7 +1756,7 @@ extension TestSuite {
     outOfBoundsSubscriptOffset: outOfBoundsSubscriptOffset,
     collectionIsBidirectional: collectionIsBidirectional)
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     func makeWrappedCollection(_ elements: [OpaqueValue<Int>]) -> C {
       return makeCollection(elements.map(wrapValue))

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -156,7 +156,7 @@ extension TestSuite {
       return makeCollectionOfComparable(elements.map(wrapValueIntoComparable))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
 //===----------------------------------------------------------------------===//
 // subscript(_: Index)
@@ -907,7 +907,7 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
 //===----------------------------------------------------------------------===//
 // subscript(_: Index)
@@ -1055,7 +1055,7 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
       return makeCollectionOfComparable(elements.map(wrapValueIntoComparable))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
 //===----------------------------------------------------------------------===//
 // sort()

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -489,7 +489,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
 //===----------------------------------------------------------------------===//
 // init()
@@ -1215,7 +1215,7 @@ self.test("\(testNamePrefix).OperatorPlus") {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
 //===----------------------------------------------------------------------===//
 // removeLast()
@@ -1329,7 +1329,7 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
       resiliencyChecks: resiliencyChecks,
       outOfBoundsIndexOffset: outOfBoundsIndexOffset)
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     // No extra checks for collections with random access traversal so far.
   } // addRangeReplaceableRandomAccessCollectionTests

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -62,7 +62,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     //===------------------------------------------------------------------===//
     // removeFirst()
@@ -204,7 +204,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     //===------------------------------------------------------------------===//
     // removeLast()
@@ -342,7 +342,7 @@ extension TestSuite {
       resiliencyChecks: resiliencyChecks,
       outOfBoundsIndexOffset: outOfBoundsIndexOffset)
 
-    testNamePrefix += String(describing: C.Type.self)
+    testNamePrefix += String(describing: C.self)
 
     // No tests yet.
   } // addRangeReplaceableRandomAccessSliceTests

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1641,7 +1641,7 @@ extension TestSuite {
       return makeSequenceOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(describing: S.Type.self)
+    testNamePrefix += String(describing: S.self)
 
     // FIXME: swift-3-indexing-model: add tests for `underestimatedCount`
     // Check that it is non-negative, and an underestimate of the actual

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -45,14 +45,14 @@ class WashingMachine : Toaster {}
 class Dryer : WashingMachine {}
 class HairDryer {}
 
-let a: Toaster.Type.Protocol = Toaster.Type.self
-let b: Any.Type.Type = Toaster.Type.self // expected-error {{cannot convert value of type 'Toaster.Type.Protocol' to specified type 'Any.Type.Type'}}
-let c: Any.Type.Protocol = Toaster.Type.self // expected-error {{cannot convert value of type 'Toaster.Type.Protocol' to specified type 'Any.Type.Protocol'}}
-let d: Toaster.Type.Type = WashingMachine.Type.self
-let e: Any.Type.Type = WashingMachine.Type.self
-let f: Toaster.Type.Type = Dryer.Type.self
-let g: Toaster.Type.Type = HairDryer.Type.self // expected-error {{cannot convert value of type 'HairDryer.Type.Type' to specified type 'Toaster.Type.Type'}}
-let h: WashingMachine.Type.Type = Dryer.Type.self // expected-error {{cannot convert value of type 'Dryer.Type.Type' to specified type 'WashingMachine.Type.Type'}}
+let a: Toaster.Type.Protocol = (Toaster.Type).self
+let b: Any.Type.Type = (Toaster.Type).self // expected-error {{cannot convert value of type '(Toaster.Type).Protocol' to specified type 'Any.Type.Type'}}
+let c: Any.Type.Protocol = (Toaster.Type).self // expected-error {{cannot convert value of type '(Toaster.Type).Protocol' to specified type 'Any.Type.Protocol'}}
+let d: Toaster.Type.Type = (WashingMachine.Type).self
+let e: Any.Type.Type = (WashingMachine.Type).self
+let f: Toaster.Type.Type = (Dryer.Type).self
+let g: Toaster.Type.Type = (HairDryer.Type).self // expected-error {{cannot convert value of type '(HairDryer.Type).Type' to specified type 'Toaster.Type.Type'}}
+let h: WashingMachine.Type.Type = (Dryer.Type).self // expected-error {{cannot convert value of type '(Dryer.Type).Type' to specified type 'WashingMachine.Type.Type'}}
 
 func generic<T : WashingMachine>(_ t: T.Type) {
   let _: Toaster.Type.Type = type(of: t)

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -78,8 +78,8 @@ func qualifiedType() {
 
 // We allow '.Type' in expr context
 func metaType() {
-  let _ = Foo.Type.self
-  let _ = Foo.Type.self
+  let _ = Foo.Type.self // expected-warning{{self expression applied to a metatype results in a meta-metatype, which may be unexpected}} {{15-19=}}
+  // expected-note@-1 {{add parentheses to silence this warning}}
 
   let _ = Foo.Type // expected-error{{expected member name or constructor call after type name}}
   // expected-note@-1 {{use '.self' to reference the type object}}
@@ -194,11 +194,14 @@ protocol P {}
 
 func meta_metatypes() {
   let _: P.Protocol = P.self
-  _ = P.Type.self
-  _ = P.Protocol.self
+  _ = P.Type.self // expected-warning{{self expression applied to a metatype results in a meta-metatype, which may be unexpected}} {{9-13=}}
+  // expected-note@-1 {{add parentheses to silence this warning}}
+  _ = P.Protocol.self // expected-warning{{self expression applied to a metatype results in a meta-metatype, which may be unexpected}} {{9-17=}}
+  // expected-note@-1 {{add parentheses to silence this warning}}
   _ = P.Protocol.Protocol.self // expected-error{{cannot use 'Protocol' with non-protocol type 'P.Protocol'}}
-  _ = P.Protocol.Type.self
-  _ = B.Type.self
+  _ = P.Protocol.Type.self // expected-warning{{self expression applied to a metatype results in a meta-metatype, which may be unexpected}} {{18-22=}}
+  // expected-note@-1 {{add parentheses to silence this warning}}
+  _ = (B.Type).self
 }
 
 class E {


### PR DESCRIPTION
When `Foo` is a type, programmers often type `Foo.Type.self` in an expression context when they mean `Foo.self`. Let's warn them.

Feedback would be appreciated about what a "good" warning message would look like.

Also, are there any good real-world reasons for programmers to work with meta-metatypes? How much effort should we go to let programmers suppress these two warnings?