### PR TITLE
[Sema] Remove a leftover CSDiag hack

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2578,7 +2578,6 @@ private:
                                                         Type builderType);
   friend Optional<SolutionApplicationTarget>
   swift::TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
-                                          bool &unresolvedTypeExprs,
                                           TypeCheckExprOptions options);
 
   /// Emit the fixes computed as part of the solution, returning true if we were

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -678,7 +678,6 @@ Type typeCheckExpression(Expr *&expr, DeclContext *dc,
 
 Optional<constraints::SolutionApplicationTarget>
 typeCheckExpression(constraints::SolutionApplicationTarget &target,
-                    bool &unresolvedTypeExprs,
                     TypeCheckExprOptions options = TypeCheckExprOptions());
 
 /// Return the type of operator function for specified LHS, or a null


### PR DESCRIPTION
Now that CSDiag is gone, it looks like this hack isn't needed anymore.

I was looking into removing `AllowUnresolvedTypeVariables` too but it looks like we still need it for code completion :/
