### PR TITLE
Verify OSSA address phis.

### DIFF
--- a/test/SIL/verifier-fail-address-phi-ossa.sil
+++ b/test/SIL/verifier-fail-address-phi-ossa.sil
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+class Klass {}
+
+struct MyStruct {
+  @_hasStorage var k: Klass
+}
+
+// The SIL verifier must crash on address phis.
+//
+// CHECK: SIL verification failed: Block arguments cannot be addresses: !arg->getType().isAddress()
+sil [ossa] @handle_phi_address_nodes : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack $MyStruct
+  %2 = struct_element_addr %1 : $*MyStruct, #MyStruct.k
+  store %0 to [init] %2 : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%1 : $*MyStruct)
+
+bb2:
+  br bb3(%1 : $*MyStruct)
+
+bb3(%7 : $*MyStruct):
+  destroy_addr %7 : $*MyStruct
+  dealloc_stack %1 : $*MyStruct
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/semantic-arc-opts-canonical.sil
+++ b/test/SILOptimizer/semantic-arc-opts-canonical.sil
@@ -394,43 +394,6 @@ bb0(%0 : @guaranteed $(Klass, MyInt)):
   return %4 : $Builtin.Int32
 }
 
-// Make sure that we do not optimize this case.
-//
-// CHECK-LABEL: sil [ossa] @handle_phi_address_nodes : $@convention(thin) (@guaranteed Klass) -> () {
-// CHECK: load [copy]
-// CHECK: } // end sil function 'handle_phi_address_nodes'
-sil [ossa] @handle_phi_address_nodes : $@convention(thin) (@guaranteed Klass) -> () {
-bb0(%0 : @guaranteed $Klass):
-  %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
-  %2 = copy_value %1 : $FakeOptional<Klass>
-  %3 = copy_value %1 : $FakeOptional<Klass>
-
-  %4 = alloc_stack $FakeOptional<Klass>
-  store %2 to [init] %4 : $*FakeOptional<Klass>
-  %5 = alloc_stack $FakeOptional<Klass>
-  store %3 to [init] %5 : $*FakeOptional<Klass>
-
-  cond_br undef, bb1, bb2
-
-bb1:
-  br bb3(%4 : $*FakeOptional<Klass>)
-
-bb2:
-  br bb3(%5 : $*FakeOptional<Klass>)
-
-bb3(%6 : $*FakeOptional<Klass>):
-  %7 = load [copy] %6 : $*FakeOptional<Klass>
-  %8 = function_ref @fakeoptional_guaranteed_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
-  apply %8(%7) : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
-  destroy_value %7 : $FakeOptional<Klass>
-  destroy_addr %5 : $*FakeOptional<Klass>
-  dealloc_stack %5 : $*FakeOptional<Klass>
-  destroy_addr %4 : $*FakeOptional<Klass>
-  dealloc_stack %4 : $*FakeOptional<Klass>
-  %9999 = tuple()
-  return %9999 : $()
-}
-
 // CHECK-LABEL: sil [ossa] @switch_enum_test_loadcopy_no_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
 // CHECK-NOT: load [copy]
 // CHECK: load_borrow


### PR DESCRIPTION
Verify that address phis are prohibited in all OSSA passes.

Eventually they should be prohibited in all passes. This at least
allows preserving access markers in OSSA passes.
