### PR TITLE
Refine AccessUseDefChainVisitor.

### DIFF
--- a/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Transforms/SemanticARCOpts.cpp
@@ -2090,11 +2090,16 @@ public:
   void visitNonAccess(SILValue addr) {
     return answer(true);
   }
-  
-  void visitIncomplete(SILValue projectedAddr, SILValue parentAddr) {
-    return next(parentAddr);
+
+  void visitCast(SingleValueInstruction *cast, Operand *parentAddr) {
+    return next(parentAddr->get());
   }
-  
+
+  void visitPathComponent(SingleValueInstruction *projectedAddr,
+                          Operand *parentAddr) {
+    return next(parentAddr->get());
+  }
+
   void visitPhi(SILPhiArgument *phi) {
     // We shouldn't have address phis in OSSA SIL, so we don't need to recur
     // through the predecessors here.


### PR DESCRIPTION
Prepare to reuse this visitor for an AccessPath utility.

Remove visitIncomplete. Add visitCast and visitPathComponent.

Handle phis in a separate visitor. This simplifies the main
visitor. In the long-term, we may be able to eliminate the pointer-phi
visitor entirely. For now, this lets us enforce that all phi paths
follow the same access path.
