### PR TITLE
[Test] Add a regression test for SR-13258

### DIFF
--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -238,3 +238,9 @@ class UsesPayload {
     }
   }
 }
+
+func sr_13258() {
+  let a = 1
+  let b = Int?.none
+  if let c = b ?? a { _ = c } // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
+}


### PR DESCRIPTION
We regressed in Swift 5.3 (Xcode 12 beta 1 & 2) and accepted the following ill-formed code, but we don't do that anymore on master. So, add a regression test to make sure it doesn't happen again.

```swift
let a = 1
let b = Int?.none
if let c = b ?? a { _ = c } // no error in 5.3
```
