### PR TITLE
[Serialization] Load swiftmodule files as volatile to avoid mmap

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -351,6 +351,16 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   // Use the default arguments except for IsVolatile. Force avoiding the use of
   // mmap to workaround issues on NFS when the swiftmodule file loaded changes
   // on disk while it's in use.
+  //
+  // In practice, a swiftmodule file can chane when a client uses a
+  // swiftmodule file from a framework while the framework is recompiled and
+  // installed over existing files. Or when many processes rebuild the same
+  // module interface.
+  //
+  // We have seen these scenarios leading to deserialization errors that on
+  // the surface look like memory corruption.
+  //
+  // rdar://63755989
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleOrErr =
       FS.getBufferForFile(ModulePath,
                           /*FileSize=*/-1,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -347,8 +347,15 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   }
 
   // Actually load the file and error out if necessary.
+  //
+  // Use the default arguments except for IsVolatile. Force avoiding the use of
+  // mmap to workaround issues on NFS when the swiftmodule file loaded changes
+  // on disk while it's in use.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleOrErr =
-      FS.getBufferForFile(ModulePath);
+      FS.getBufferForFile(ModulePath,
+                          /*FileSize=*/-1,
+                          /*RequiresNullTerminator=*/true,
+                          /*IsVolatile=*/true);
   if (!ModuleOrErr)
     return ModuleOrErr.getError();
 


### PR DESCRIPTION
Avoid mmaping swiftmodule files to hopefully fix issues seen when building Swift projects in parallel on NFS. This change only affects loading ModuleFile, it doesn't affect scanning swiftmodule for dependencies which are still handled as non-volatile.

Let's try always avoid mmap at first to confirm if this was the issue. However, this will likely affect memory usage so we may need a way to restrict this further if it causes issues on memory-constrained systems.