### PR TITLE
[CS] Connect arg-to-param constraint to function builder

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -208,9 +208,6 @@ public:
                         DeclContext *dc, Type builderType,
                         Type bodyResultType)
       : cs(cs), dc(dc), ctx(ctx), builderType(builderType) {
-    assert((cs || !builderType->hasTypeVariable()) &&
-           "cannot handle builder type with type variables without "
-           "constraint system");
     builder = builderType->getAnyNominal();
     applied.builderType = builderType;
     applied.bodyResultType = bodyResultType;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1635,22 +1635,6 @@ ConstraintSystem::matchFunctionBuilder(
     }
   }
 
-  // If the builder type has a type parameter, substitute in the type
-  // variables.
-  if (builderType->hasTypeParameter()) {
-    // Find the opened type for this callee and substitute in the type
-    // parametes.
-    for (const auto &opened : OpenedTypes) {
-      if (opened.first == calleeLocator) {
-        OpenedTypeMap replacements(opened.second.begin(),
-                                   opened.second.end());
-        builderType = openType(builderType, replacements);
-        break;
-      }
-    }
-    assert(!builderType->hasTypeParameter());
-  }
-
   BuilderClosureVisitor visitor(getASTContext(), this, dc, builderType,
                                 bodyResultType);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4686,6 +4686,13 @@ private:
                                  ConstraintLocatorBuilder locator,
                                  bool isFavored);
 
+  /// Adds a constraint for the conversion of an argument to a parameter. Do not
+  /// call directly, use \c addConstraint instead.
+  SolutionKind
+  addArgumentConversionConstraintImpl(ConstraintKind kind, Type first,
+                                      Type second,
+                                      ConstraintLocatorBuilder locator);
+
   /// Collect the current inactive disjunction constraints.
   void collectDisjunctions(SmallVectorImpl<Constraint *> &disjunctions);
 

--- a/test/Constraints/sr13183.swift
+++ b/test/Constraints/sr13183.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-13183: Make sure we don't incorrectly split the constraint system without
+// considering that a function builder type var may connect the inside of a
+// closure body with the enclosing expression.
+
+struct New<Value> {
+  init(value: Value, @ScopeBuilder<Value> scope: () -> Component) { }
+}
+
+struct Component {}
+
+struct Map<Value, Transformed> {
+  let transform: (Value) -> Transformed
+}
+
+@_functionBuilder
+struct ScopeBuilder<Value> {
+  static func buildExpression<T>(_ map: Map<Value, T>) -> Component {
+    Component()
+  }
+
+  static func buildBlock(_ components: Component...) -> Component {
+    Component()
+  }
+}
+
+let new1 = New(value: 42) {
+  Map { $0.description }
+}
+
+let new2 = New<Int>(value: 42) {
+  Map { $0.description }
+}


### PR DESCRIPTION
Previously we could inadvertently split the constraint system without realizing that a function builder with a generic argument may allow the closure body to reference a type variable that connects it to the enclosing expression.

Fix this issue by checking for an unresolved closure argument and forming an unresolved argument conversion constraint that includes any type variables from the function builder type.

Resolves SR-13183
Resolves rdar://problem/65695054