### PR TITLE
[Draft: Do Not Merge]  Make Python3 required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,14 +889,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endif()
 endif()
 
-find_package(Python2 COMPONENTS Interpreter REQUIRED)
-find_package(Python3 COMPONENTS Interpreter)
-if(NOT Python3_Interpreter_FOUND)
-  message(WARNING "Python3 not found, using python2 as a fallback")
-  add_executable(Python3::Interpreter IMPORTED)
-  set_target_properties(Python3::Interpreter PROPERTIES
-    IMPORTED_LOCATION ${Python2_EXECUTABLE})
-endif()
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 #
 # Find optional dependencies.

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -115,14 +115,7 @@ include(SwiftConfigureSDK)
 include(SwiftComponents)
 include(DarwinSDKs)
 
-find_package(Python2 COMPONENTS Interpreter REQUIRED)
-find_package(Python3 COMPONENTS Interpreter)
-if(NOT Python3_Interpreter_FOUND)
-  message(WARNING "Python3 not found, using python2 as a fallback")
-  add_executable(Python3::Interpreter IMPORTED)
-  set_target_properties(Python3::Interpreter PROPERTIES
-    IMPORTED_LOCATION ${Python2_EXECUTABLE})
-endif()
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Without this line, installing components is broken. This needs refactoring.
 swift_configure_components()


### PR DESCRIPTION
Note that many there are many places where we explicitly
use Python2 to run particular scripts.

This does not change any of those.  It only changes the
CMake configuration process so it will fail if Python3
is not found (instead of silently switching Python2 for
Python3).

Putting this up as a draft for now in order to see what impact this has on CI.