### PR TITLE
[5.3] Reflection Library crash inspecting certain BoundGeneric types (#32983)

### DIFF
--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -728,11 +728,15 @@ bool TypeRef::isConcreteAfterSubstitutions(
 
 unsigned NominalTypeTrait::getDepth() const {
   if (auto P = Parent) {
-    if (auto *Nominal = dyn_cast<NominalTypeRef>(P))
-      return 1 + Nominal->getDepth();
-    return 1 + cast<BoundGenericTypeRef>(P)->getDepth();
+    switch (P->getKind()) {
+    case TypeRefKind::Nominal:
+      return 1 + cast<NominalTypeRef>(P)->getDepth();
+    case TypeRefKind::BoundGeneric:
+      return 1 + cast<BoundGenericTypeRef>(P)->getDepth();
+    default:
+      break;
+    }
   }
-
   return 0;
 }
 


### PR DESCRIPTION
Propose merging #32983 to release/5.3

# Original Description

If the parent of a BoundGeneric type is not a NominalType (for example, if the
Parent was an ObjCClass type) the `getDepth()` method would end up reading a
Parent reference from uninitialized memory.  The resulting garbage pointer
would cause a crash in the tool that was using the reflection library
(leaks, instruments, etc.)

Of course, this does not always result in a crash, since the memory in question
is frequently zeroed, resulting in a nil pointer that is safely detected.

Resolves rdar://54173375

# CCC Info

Risk: Low.  Adds a missing type check to avoid a crash.
