### PR TITLE
[Constant Evaluator] Add new test for skipping TSAN instrumentation

### DIFF
--- a/test/SILOptimizer/OSLogConstantEvaluableTsanTest.swift
+++ b/test/SILOptimizer/OSLogConstantEvaluableTsanTest.swift
@@ -1,0 +1,12 @@
+// REQUIRES: tsan_runtime
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -sanitize=thread -swift-version 5 -emit-silgen -primary-file %S/Inputs/OSLogConstantEvaluable.swift -o %t/OSLogConstantEvaluableTsanTest_silgen.sil
+//
+// Run the (mandatory) passes on which constant evaluator depends, and run the
+// constant evaluator on the SIL produced after the dependent passes are run.
+//
+// RUN: %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 3072 -test-constant-evaluable-subset %t/OSLogConstantEvaluableTsanTest_silgen.sil > %t/OSLogConstantEvaluableTsanTest.sil 2> %t/error-output
+//
+// RUN: %FileCheck %S/Inputs/OSLogConstantEvaluable.swift < %t/error-output
+//
+// REQUIRES: VENDOR=apple

--- a/test/SILOptimizer/constant_evaluable_tsan_test.swift
+++ b/test/SILOptimizer/constant_evaluable_tsan_test.swift
@@ -1,0 +1,10 @@
+// REQUIRES: tsan_runtime
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -sanitize=thread -emit-silgen -primary-file %S/Inputs/constant_evaluable.swift -o %t/constant_evaluable_tsan_test_silgen.sil
+//
+// Run the (mandatory) passes on which constant evaluator depends, and test the
+// constant evaluator on the SIL produced after the dependent passes are run.
+//
+// RUN: not %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 3000 -test-constant-evaluable-subset %t/constant_evaluable_tsan_test_silgen.sil > %t/constant_evaluable_tsan_test.sil 2> %t/error-output
+//
+// RUN: %FileCheck %S/Inputs/constant_evaluable.swift < %t/error-output


### PR DESCRIPTION
This change adds tests to ensure that that the constant evaluator continues to properly skip instructions from Thread Sanitizer instrumentation. It takes advantage of the recent refactor of constant evaluator tests. 
