### PR TITLE
 Add AccessedStorage::Tail access kind and remove more exclusivity checks.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -68,8 +68,10 @@ PASS(CrossModuleSerializationSetup, "cross-module-serialization-setup",
      "Setup serialization flags for cross-module optimization")
 PASS(AccessSummaryDumper, "access-summary-dump",
      "Dump Address Parameter Access Summary")
+PASS(AccessedStorageAnalysisDumper, "accessed-storage-analysis-dump",
+     "Dump Accessed Storage Analysis Summaries")
 PASS(AccessedStorageDumper, "accessed-storage-dump",
-     "Dump Accessed Storage Summary")
+     "Dump Accessed Storage Information")
 PASS(AccessMarkerElimination, "access-marker-elim",
      "Access Marker Elimination.")
 PASS(AddressLowering, "address-lowering",

--- a/lib/SIL/Verifier/LoadBorrowInvalidationChecker.cpp
+++ b/lib/SIL/Verifier/LoadBorrowInvalidationChecker.cpp
@@ -486,6 +486,11 @@ bool LoadBorrowNeverInvalidatedAnalysis::isNeverInvalidated(
   // validate that all uses of the project_box are not writes that overlap with
   // our load_borrow's result. These are things that may not be a formal access
   // base.
+  //
+  // FIXME: we don't seem to verify anywhere that a pointer_to_address cannot
+  // itself be derived from another address that is accessible in the same
+  // function, either because it was returned from a call or directly
+  // address_to_pointer'd.
   if (isa<PointerToAddressInst>(address)) {
     return doesAddressHaveWriteThatInvalidatesLoadBorrow(lbi, endBorrowUses,
                                                          address);
@@ -525,6 +530,9 @@ bool LoadBorrowNeverInvalidatedAnalysis::isNeverInvalidated(
   }
   case AccessedStorage::Yield: {
     // For now, do this. Otherwise, check for in_guaranteed, etc.
+    //
+    // FIXME: The yielded address could overlap with another address in this
+    // function.
     return true;
   }
   case AccessedStorage::Box: {
@@ -534,8 +542,17 @@ bool LoadBorrowNeverInvalidatedAnalysis::isNeverInvalidated(
   case AccessedStorage::Class: {
     // Check that the write to the class's memory doesn't overlap with our
     // load_borrow.
+    //
+    // FIXME: how do we know that other projections of the same object don't
+    // occur within the same function?
     return doesAddressHaveWriteThatInvalidatesLoadBorrow(lbi, endBorrowUses,
                                                          address);
+  }
+  case AccessedStorage::Tail: {
+    // This should be as strong as the Class address case, but to handle it we
+    // need to find all aliases of the object and all tail projections within
+    // that object.
+    return false;
   }
   case AccessedStorage::Global: {
     // Check that the write to the class's memory doesn't overlap with our

--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -230,14 +230,17 @@ transformCalleeStorage(const StorageAccessInfo &storage,
   case AccessedStorage::Global:
     // Global accesses is universal.
     return storage;
-  case AccessedStorage::Class: {
+  case AccessedStorage::Class:
+  case AccessedStorage::Tail: {
     // If the object's value is an argument, translate it into a value on the
     // caller side.
     SILValue obj = storage.getObject();
     if (auto *arg = dyn_cast<SILFunctionArgument>(obj)) {
       SILValue argVal = getCallerArg(fullApply, arg->getIndex());
       if (argVal) {
-        unsigned idx = storage.getPropertyIndex();
+        unsigned idx = (storage.getKind() == AccessedStorage::Class)
+                           ? storage.getPropertyIndex()
+                           : AccessedStorage::TailIndex;
         // Remap this storage info. The argument source value is now the new
         // object. The old storage info is inherited.
         return StorageAccessInfo(AccessedStorage::forClass(argVal, idx),

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -743,6 +743,7 @@ void AccessConflictAndMergeAnalysis::visitMayRelease(SILInstruction *instr,
   // accesses can be affected by a deinitializer.
   auto isHeapAccess = [](AccessedStorage::Kind accessKind) {
     return accessKind == AccessedStorage::Class
+           || accessKind == AccessedStorage::Class
            || accessKind == AccessedStorage::Global;
   };
   // Mark the in-scope accesses as having a nested conflict

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -85,6 +85,7 @@ const VarDecl *getDisjointAccessLocation(const AccessedStorage &storage) {
   }
   case AccessedStorage::Box:
   case AccessedStorage::Stack:
+  case AccessedStorage::Tail:
   case AccessedStorage::Argument:
   case AccessedStorage::Yield:
   case AccessedStorage::Unidentified:

--- a/lib/SILOptimizer/UtilityPasses/AccessedStorageAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessedStorageAnalysisDumper.cpp
@@ -1,4 +1,4 @@
-//===--- AccessedStorageDumper.cpp - Dump accessed storage for functions ---===//
+//===--- AccessedStorageAnalysisDumper.cpp - accessed storage anlaysis ----===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,51 +10,40 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "sil-accessed-storage-dumper"
-#include "swift/SIL/MemAccessUtils.h"
+#define DEBUG_TYPE "sil-accessed-storage-analysys-dumper"
+#include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
 
-static void dumpAccessedStorage(SILInstruction *inst) {
-  visitAccessedAddress(
-    inst,
-    [&](Operand *operand) {
-      inst->print(llvm::outs());
-      findAccessedStorage(operand->get()).print(llvm::outs());
-    }
-  );
-}
-
 namespace {
 
-/// Dumps sorage information for each access.
-class AccessedStorageDumper : public SILModuleTransform {
+/// Dumps per-function information on dynamically enforced formal accesses.
+class AccessedStorageAnalysisDumper : public SILModuleTransform {
 
   void run() override {
+    auto *analysis = PM->getAnalysis<AccessedStorageAnalysis>();
+
     for (auto &fn : *getModule()) {
       llvm::outs() << "@" << fn.getName() << "\n";
       if (fn.empty()) {
         llvm::outs() << "<unknown>\n";
         continue;
       }
-      for (auto &bb : fn) {
-        for (auto &inst : bb) {
-          if (inst.mayReadOrWriteMemory())
-            dumpAccessedStorage(&inst);
-        }
-      }
+      const FunctionAccessedStorage &summary = analysis->getEffects(&fn);
+      summary.print(llvm::outs());
     }
   }
 };
 
 } // end anonymous namespace
 
-SILTransform *swift::createAccessedStorageDumper() {
-  return new AccessedStorageDumper();
+SILTransform *swift::createAccessedStorageAnalysisDumper() {
+  return new AccessedStorageAnalysisDumper();
 }

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(swiftSILOptimizer PRIVATE
   AADumper.cpp
   AccessSummaryDumper.cpp
+  AccessedStorageAnalysisDumper.cpp
   AccessedStorageDumper.cpp
   BasicCalleePrinter.cpp
   BasicInstructionPropertyDumper.cpp

--- a/test/SILOptimizer/accessed_storage.sil
+++ b/test/SILOptimizer/accessed_storage.sil
@@ -123,9 +123,9 @@ struct MyArray<T> {
 
 // CHECK-LABEL: @arrayValue
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
-// CHECK: Unidentified  %{{.*}} = ref_tail_addr [immutable] [[REF:%[0-9]+]] : $__ContiguousArrayStorageBase, $Int64
+// CHECK: Tail  %{{.*}} = unchecked_ref_cast [[REF:%[0-9]+]] : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
-// CHECK: Unidentified  %{{.*}} = ref_tail_addr [immutable] [[REF]] : $__ContiguousArrayStorageBase, $Int64
+// CHECK: Tail  %{{.*}} = unchecked_ref_cast [[REF:%[0-9]+]] : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
 sil [ossa] @arrayValue : $@convention(thin) (@guaranteed MyArray<Int64>) -> Int64 {
 bb0(%0 : @guaranteed $MyArray<Int64>):
   %1 = integer_literal $Builtin.Word, 3

--- a/test/SILOptimizer/accessed_storage.sil
+++ b/test/SILOptimizer/accessed_storage.sil
@@ -1,0 +1,151 @@
+// RUN: %target-sil-opt %s -accessed-storage-dump -enable-sil-verify-all -o /dev/null | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct MyStruct {
+  @_hasStorage @_hasInitialValue var i: Int64 { get set }
+  @_hasStorage @_hasInitialValue var j: Int64 { get set }
+}
+
+// CHECK-LABEL: @testStructPhiCommon
+// CHECK: store
+// CHECK: Argument %0 = argument of bb0 : $*MyStruct
+sil hidden @testStructPhiCommon : $@convention(thin) (@inout MyStruct) -> () {
+bb0(%0 : $*MyStruct):
+  %2 = struct_element_addr %0 : $*MyStruct, #MyStruct.i
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
+  br bb3(%3 : $Builtin.RawPointer)
+
+bb2:
+  %5 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
+  br bb3(%5 : $Builtin.RawPointer)
+
+bb3(%6 : $Builtin.RawPointer) :
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int64
+  %8 = integer_literal $Builtin.Int64, 2
+  %9 = struct $Int64 (%8 : $Builtin.Int64)
+  store %9 to %7 : $*Int64
+  %22 = tuple ()
+  return %22 : $()
+}
+
+// A pointer phi leading to different access paths should be
+// considered illegal, but we don't have a way to verify it yet.
+//
+// CHECK-LABEL: @testStructPhiDivergent
+// CHECK: store
+// CHECK: INVALID
+sil hidden @testStructPhiDivergent : $@convention(thin) (@inout MyStruct) -> () {
+bb0(%0 : $*MyStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = struct_element_addr %0 : $*MyStruct, #MyStruct.i
+  %3 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
+  br bb3(%3 : $Builtin.RawPointer)
+
+bb2:
+  %4 = struct_element_addr %0 : $*MyStruct, #MyStruct.j
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  br bb3(%5 : $Builtin.RawPointer)
+
+bb3(%6 : $Builtin.RawPointer) :
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int64
+  %8 = integer_literal $Builtin.Int64, 2
+  %9 = struct $Int64 (%8 : $Builtin.Int64)
+  store %9 to %7 : $*Int64
+  %22 = tuple ()
+  return %22 : $()
+}
+
+// Test FindPhiStorageVisitor with a combination of
+// - valid storage for address_to_pointer %1
+// - invalid common definition between #MyStruct.i and #MyStruct.j
+//
+// Make sure that visiting the invalid common definition also
+// invalidates storage.
+//
+// CHECK-LABEL: @testStructPhiChained
+// CHECK:   store
+// CHECK: INVALID
+sil hidden @testStructPhiChained : $@convention(thin) (@inout MyStruct, @inout Int64) -> () {
+bb0(%0 : $*MyStruct, %1 : $*Int64):
+  cond_br undef, bb1, bb5
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %2 = address_to_pointer %1 : $*Int64 to $Builtin.RawPointer
+  br bb4(%2 : $Builtin.RawPointer)
+
+bb3:
+  %3 = struct_element_addr %0 : $*MyStruct, #MyStruct.i
+  %4 = address_to_pointer %3 : $*Int64 to $Builtin.RawPointer
+  br bb4(%4 : $Builtin.RawPointer)
+
+bb4(%6 : $Builtin.RawPointer) :
+  br bb6(%6 : $Builtin.RawPointer)
+
+bb5:
+  %7 = struct_element_addr %0 : $*MyStruct, #MyStruct.j
+  %8 = address_to_pointer %7 : $*Int64 to $Builtin.RawPointer
+  br bb6(%8 : $Builtin.RawPointer)
+
+bb6(%9 : $Builtin.RawPointer) :
+  %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64
+  %11 = integer_literal $Builtin.Int64, 2
+  %12 = struct $Int64 (%11 : $Builtin.Int64)
+  store %12 to %10 : $*Int64
+  %22 = tuple ()
+  return %22 : $()
+}
+
+struct _MyBridgeStorage {
+  @_hasStorage var rawValue : Builtin.BridgeObject
+}
+
+struct _MyArrayBuffer<T> {
+  @_hasStorage var _storage : _MyBridgeStorage
+}
+
+
+struct MyArray<T> {
+  @_hasStorage var _buffer : _MyArrayBuffer<T>
+}
+
+// CHECK-LABEL: @arrayValue
+// CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
+// CHECK: Unidentified  %{{.*}} = ref_tail_addr [immutable] [[REF:%[0-9]+]] : $__ContiguousArrayStorageBase, $Int64
+// CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
+// CHECK: Unidentified  %{{.*}} = ref_tail_addr [immutable] [[REF]] : $__ContiguousArrayStorageBase, $Int64
+sil [ossa] @arrayValue : $@convention(thin) (@guaranteed MyArray<Int64>) -> Int64 {
+bb0(%0 : @guaranteed $MyArray<Int64>):
+  %1 = integer_literal $Builtin.Word, 3
+  %2 = integer_literal $Builtin.Word, 4
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = struct_extract %0 : $MyArray<Int64>, #MyArray._buffer
+  %5 = struct_extract %4 : $_MyArrayBuffer<Int64>, #_MyArrayBuffer._storage
+  %6 = struct_extract %5 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
+  %7 = unchecked_ref_cast %6 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %8 = ref_tail_addr [immutable] %7 : $__ContiguousArrayStorageBase, $Int64
+  %9 = index_addr %8 : $*Int64, %1 : $Builtin.Word
+  %10 = struct_element_addr %9 : $*Int64, #Int64._value
+  %11 = load [trivial] %10 : $*Builtin.Int64
+  %12 = index_addr %8 : $*Int64, %2 : $Builtin.Word
+  %13 = struct_element_addr %12 : $*Int64, #Int64._value
+  %14 = load [trivial] %13 : $*Builtin.Int64
+  %15 = builtin "sadd_with_overflow_Int64"(%11 : $Builtin.Int64, %14 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %16 = tuple_extract %15 : $(Builtin.Int64, Builtin.Int1), 0
+  %17 = tuple_extract %15 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %17 : $Builtin.Int1, "arithmetic overflow"
+  %19 = struct $Int64 (%16 : $Builtin.Int64)
+  return %19 : $Int64
+}

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -accessed-storage-dump -enable-sil-verify-all -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -accessed-storage-analysis-dump -enable-sil-verify-all -o /dev/null | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -561,7 +561,7 @@ func testGetOptionalForceClass(_ s: SimpleClass) -> Int {
 // CHECK-LABEL: sil {{.*}}testGetComplex
 // opt
 // CHECK: [[E1:%[0-9]+]] = ref_element_addr
-// CHECK: [[B1:%[0-9]+]] = begin_access [read] [dynamic] [[E1]]
+// CHECK: [[B1:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E1]]
 // !
 // CHECK: [[F:%[0-9]+]] = select_enum [[O:%[0-9]+]]
 // CHECK: cond_fail [[F]]


### PR DESCRIPTION
    Distinguish ref_tail_addr storage from the other storage classes.

    We didn't have this originally because be don't expect a begin_access
    to directly operate on tail storage. It could occur after inlining, at
    least with static access markers. More importantly it helps ditinguish
    regular formal accesses from other unidentified access, so we probably
    should have always had this.

    At any rate, it's particularly important when AccessedStorage is
    generalized to arbitrary memory access.

    The immediate motivation is to add an AccessPath utility, which will
    need to distinguish tail storage.

    In the process, rewrite AccessedStorage::isDistinct. This could have a
    large positive impact on exclusivity performance.