### PR TITLE
[opt-remark] Teach opt-remark how to emit back notes to retain/released variables in simple cases.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -536,6 +536,7 @@ ERROR(non_borrowed_indirect_addressof,none,
 
 REMARK(opt_remark_passed, none, "%0", (StringRef))
 REMARK(opt_remark_missed, none, "%0", (StringRef))
+NOTE(opt_remark_note, none, "%0", (StringRef))
 
 // Float-point to integer conversions
 ERROR(float_to_int_overflow, none,

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -41,6 +41,15 @@ struct ArgumentKeyKind {
     // diagnostic when emitting diagnostics. Do nothing special
     // along the backend path.
     Note,
+
+    // Assume that this is a note that should be emitted as a separate
+    // diagnostic but that doesn't have its own source loc: we should reuse the
+    // one for the original remark.
+    //
+    // This is intended to be used in situations where one needs to emit a
+    // "note" warning due to us not being able to infer a part of our
+    // opt-remark.
+    ParentLocNote,
   };
 
   InnerTy innerValue;
@@ -60,6 +69,7 @@ struct ArgumentKeyKind {
     case InnerTy::Default:
       return false;
     case InnerTy::Note:
+    case InnerTy::ParentLocNote:
       return true;
     }
 

--- a/include/swift/SIL/SILRemarkStreamer.h
+++ b/include/swift/SIL/SILRemarkStreamer.h
@@ -111,7 +111,7 @@ llvm::remarks::Remark SILRemarkStreamer::toLLVMRemark(
 
   for (const OptRemark::Argument &arg : optRemark.getArgs()) {
     llvmRemark.Args.emplace_back();
-    llvmRemark.Args.back().Key = arg.key;
+    llvmRemark.Args.back().Key = arg.key.data;
     llvmRemark.Args.back().Val = arg.val;
     llvmRemark.Args.back().Loc =
         toRemarkLocation(arg.loc, getASTContext().SourceMgr);

--- a/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
+++ b/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
@@ -17,6 +17,7 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 
@@ -31,10 +32,12 @@ namespace {
 struct OptRemarkGeneratorInstructionVisitor
     : public SILInstructionVisitor<OptRemarkGeneratorInstructionVisitor> {
   SILModule &mod;
+  RCIdentityFunctionInfo &rcfi;
   OptRemark::Emitter ORE;
 
-  OptRemarkGeneratorInstructionVisitor(SILModule &mod)
-      : mod(mod), ORE(DEBUG_TYPE, mod) {}
+  OptRemarkGeneratorInstructionVisitor(SILModule &mod,
+                                       RCIdentityFunctionInfo &rcfi)
+      : mod(mod), rcfi(rcfi), ORE(DEBUG_TYPE, mod) {}
 
   void visitStrongRetainInst(StrongRetainInst *sri);
   void visitStrongReleaseInst(StrongReleaseInst *sri);
@@ -49,10 +52,28 @@ void OptRemarkGeneratorInstructionVisitor::visitStrongRetainInst(
     StrongRetainInst *sri) {
   ORE.emit([&]() {
     using namespace OptRemark;
+    SILValue root = rcfi.getRCIdentityRoot(sri->getOperand());
+    SmallVector<Argument, 8> inferredArgs;
+    bool foundArgs = Argument::inferArgumentsForValue(
+        ArgumentKeyKind::Note, "on value:", root, [&](Argument arg) {
+          inferredArgs.push_back(arg);
+          return true;
+        });
+    (void)foundArgs;
+
     // Retains begin a lifetime scope so we infer scan forward.
-    return RemarkMissed("memory-management", *sri,
-                        SourceLocInferenceBehavior::ForwardScanOnly)
-           << "Unable to remove retain";
+    auto remark = RemarkMissed("memory-management", *sri,
+                               SourceLocInferenceBehavior::ForwardScanOnly)
+                  << "Found retain:";
+    if (inferredArgs.empty()) {
+      remark << Argument({ArgumentKeyKind::ParentLocNote, "InferValueFailure"},
+                         "Unable to infer any values being retained.");
+    } else {
+      for (auto arg : inferredArgs) {
+        remark << arg;
+      }
+    }
+    return remark;
   });
 }
 
@@ -61,9 +82,26 @@ void OptRemarkGeneratorInstructionVisitor::visitStrongReleaseInst(
   ORE.emit([&]() {
     using namespace OptRemark;
     // Releases end a lifetime scope so we infer scan backward.
-    return RemarkMissed("memory-management", *sri,
-                        SourceLocInferenceBehavior::BackwardScanOnly)
-           << "Unable to remove release";
+    SILValue root = rcfi.getRCIdentityRoot(sri->getOperand());
+    SmallVector<Argument, 8> inferredArgs;
+    bool foundArgs = Argument::inferArgumentsForValue(
+        ArgumentKeyKind::Note, "on value:", root, [&](Argument arg) {
+          inferredArgs.push_back(arg);
+          return true;
+        });
+    (void)foundArgs;
+    auto remark = RemarkMissed("memory-management", *sri,
+                               SourceLocInferenceBehavior::BackwardScanOnly)
+                  << "Found release:";
+    if (inferredArgs.empty()) {
+      remark << Argument({ArgumentKeyKind::ParentLocNote, "InferValueFailure"},
+                         "Unable to infer any values being released.");
+    } else {
+      for (auto arg : inferredArgs) {
+        remark << arg;
+      }
+    }
+    return remark;
   });
 }
 
@@ -71,10 +109,28 @@ void OptRemarkGeneratorInstructionVisitor::visitRetainValueInst(
     RetainValueInst *rvi) {
   ORE.emit([&]() {
     using namespace OptRemark;
+    SILValue root = rcfi.getRCIdentityRoot(rvi->getOperand());
+    SmallVector<Argument, 8> inferredArgs;
+    bool foundArgs = Argument::inferArgumentsForValue(
+        ArgumentKeyKind::Note, "on value:", root, [&](Argument arg) {
+          inferredArgs.push_back(arg);
+          return true;
+        });
+    (void)foundArgs;
+
     // Retains begin a lifetime scope, so we infer scan forwards.
-    return RemarkMissed("memory-management", *rvi,
-                        SourceLocInferenceBehavior::ForwardScanOnly)
-           << "Unable to remove retain";
+    auto remark = RemarkMissed("memory-management", *rvi,
+                               SourceLocInferenceBehavior::ForwardScanOnly)
+                  << "Found retain:";
+    if (inferredArgs.empty()) {
+      remark << Argument({ArgumentKeyKind::ParentLocNote, "InferValueFailure"},
+                         "Unable to infer any values being retained.");
+    } else {
+      for (auto arg : inferredArgs) {
+        remark << arg;
+      }
+    }
+    return remark;
   });
 }
 
@@ -82,10 +138,29 @@ void OptRemarkGeneratorInstructionVisitor::visitReleaseValueInst(
     ReleaseValueInst *rvi) {
   ORE.emit([&]() {
     using namespace OptRemark;
+    SILValue root = rcfi.getRCIdentityRoot(rvi->getOperand());
+    SmallVector<Argument, 8> inferredArgs;
+    bool foundArgs = Argument::inferArgumentsForValue(
+        ArgumentKeyKind::Note, "on value:", root, [&](Argument arg) {
+          inferredArgs.push_back(arg);
+          return true;
+        });
+    (void)foundArgs;
+
     // Releases end a lifetime scope so we infer scan backward.
-    return RemarkMissed("memory-management", *rvi,
-                        SourceLocInferenceBehavior::BackwardScanOnly)
-           << "Unable to remove release";
+    auto remark = RemarkMissed("memory-management", *rvi,
+                               SourceLocInferenceBehavior::BackwardScanOnly)
+                  << "Found release:";
+    if (inferredArgs.empty()) {
+      remark << Argument({ArgumentKeyKind::ParentLocNote, "InferValueFailure"},
+                         "Unable to infer any values being released.");
+    } else {
+      for (auto arg : inferredArgs) {
+        remark << arg;
+      }
+    }
+
+    return remark;
   });
 }
 
@@ -115,7 +190,8 @@ class OptRemarkGenerator : public SILFunctionTransform {
 
     auto *fn = getFunction();
     LLVM_DEBUG(llvm::dbgs() << "Visiting: " << fn->getName() << "\n");
-    OptRemarkGeneratorInstructionVisitor visitor(fn->getModule());
+    auto &rcfi = *getAnalysis<RCIdentityAnalysis>()->get(fn);
+    OptRemarkGeneratorInstructionVisitor visitor(fn->getModule(), rcfi);
     for (auto &block : *fn) {
       for (auto &inst : block) {
         visitor.visit(&inst);

--- a/test/SILOptimizer/opt-remark-generator.sil
+++ b/test/SILOptimizer/opt-remark-generator.sil
@@ -1,13 +1,4 @@
-// RUN: %target-sil-opt -sil-opt-remark-generator -sil-remarks-missed=sil-opt-remark-gen %s -o /dev/null 2>&1 | %FileCheck %s
-
-// CHECK: {{.*}}opt-remark-generator.sil:18:3: remark: Unable to remove retain
-// CHECK-NEXT: strong_retain
-// CHECK: {{.*}}opt-remark-generator.sil:19:3: remark: Unable to remove retain
-// CHECK-NEXT: retain_value
-// CHECK: {{.*}}opt-remark-generator.sil:20:3: remark: Unable to remove release
-// CHECK-NEXT: strong_release
-// CHECK: {{.*}}opt-remark-generator.sil:21:3: remark: Unable to remove release
-// CHECK-NEXT: release_value
+// RUN: %target-sil-opt -sil-opt-remark-generator -sil-remarks-missed=sil-opt-remark-gen -verify %s -o /dev/null
 
 sil_stage canonical
 
@@ -15,10 +6,14 @@ import Builtin
 
 sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
-  strong_retain %0 : $Builtin.NativeObject
-  retain_value %0 : $Builtin.NativeObject
-  strong_release %0 : $Builtin.NativeObject
-  release_value %0 : $Builtin.NativeObject
+  strong_retain %0 : $Builtin.NativeObject // expected-remark {{Found retain:}}
+                                           // expected-note @-1 {{Unable to infer any values being retained.}}
+  retain_value %0 : $Builtin.NativeObject  // expected-remark {{Found retain:}}
+                                           // expected-note @-1 {{Unable to infer any values being retained.}}
+  strong_release %0 : $Builtin.NativeObject // expected-remark {{Found release:}}
+                                            // expected-note @-1 {{Unable to infer any values being released.}}
+  release_value %0 : $Builtin.NativeObject // expected-remark {{Found release:}}
+                                           // expected-note @-1 {{Unable to infer any values being released.}}
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -7,37 +7,45 @@
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
 // CHECK-NEXT: Name:            sil.memory-management
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 49, Column: 5 }
+// CHECK-NEXT:                    Line: 57, Column: 5 }
 // CHECK-NEXT: Function:        'getGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          Unable to remove retain
+// CHECK-NEXT:   - String:          'Found retain:'
+// CHECK-NEXT:   - InferValueFailure: Unable to infer any values being retained.
 // CHECK-NEXT: ...
 // CHECK-NEXT: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
 // CHECK-NEXT: Name:            sil.memory-management
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 56, Column: 5 }
+// CHECK-NEXT:                    Line: 65, Column: 5 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          Unable to remove retain
+// CHECK-NEXT:   - String:          'Found retain:'
+// CHECK-NEXT:   - InferredValue:   'on value:'
+// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+// CHECK-NEXT:                        Line: 62, Column: 9 }
 // CHECK-NEXT: ...
 // CHECK-NEXT: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
 // CHECK-NEXT: Name:            sil.memory-management
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 56, Column: 12 }
+// CHECK-NEXT:                    Line: 65, Column: 12 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          Unable to remove release
+// CHECK-NEXT:   - String:          'Found release:'
+// CHECK-NEXT:   - InferValueFailure: Unable to infer any values being released.
 // CHECK-NEXT: ...
 // CHECK-NEXT: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
 // CHECK-NEXT: Name:            sil.memory-management
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 56, Column: 12 }
+// CHECK-NEXT:                    Line: 65, Column: 12 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          Unable to remove release
+// CHECK-NEXT:   - String:          'Found release:'
+// CHECK-NEXT:   - InferredValue:   'on value:'
+// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+// CHECK-NEXT:                        Line: 62, Column: 9 }
 // CHECK-NEXT: ...
 
 public class Klass {}
@@ -46,14 +54,18 @@ public var global = Klass()
 
 @inline(never)
 public func getGlobal() -> Klass {
-    return global // expected-remark @:5 {{Unable to remove retain}}
+    return global // expected-remark @:5 {{Found retain:}}
+                  // expected-note @-1:5 {{Unable to infer any values being retained.}}
 }
 
 public func useGlobal() {
     let x = getGlobal()
     // Make sure that the retain msg is at the beginning of the print and the
     // releases are the end of the print.
-    print(x) // expected-remark @:5 {{Unable to remove retain}}
-    // expected-remark @-1:12 {{Unable to remove release}}
-    // expected-remark @-2:12 {{Unable to remove release}}
+    print(x) // expected-remark @:5 {{Found retain:}}
+             // expected-note @-4:9 {{on value:}}
+             // expected-remark @-2:12 {{Found release:}}
+             // expected-note @-3:12 {{Unable to infer any values being released.}}
+             // expected-remark @-4:12 {{Found release:}}
+             // expected-note @-8:9 {{on value:}}
 }


### PR DESCRIPTION
This implements a note functionality that when emitting Swift diagnostics causes us to emit NOTE back to the values being retained, released but that when we emit to the bitstream are emitted like normal remark arguments. I also emit a NOTE if we fail to infer any values so that the user isn't surprised.

When we emit the NOTES, we use the emitDiagnosticAndNotes so it should show up nicely in IDEs.