### PR TITLE
[Property Wrappers] Fix property wrapper initialization type checking when `wrappedValue` is an optional of a generic parameter.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3907,8 +3907,9 @@ static Expr *generateConstraintsFor(ConstraintSystem &cs, Expr *expr,
 /// initializes the underlying storage variable.
 /// \param wrappedVar The property that has a property wrapper.
 /// \returns the type of the property.
-static Type generateWrappedPropertyTypeConstraints(
-   ConstraintSystem &cs, Type initializerType, VarDecl *wrappedVar) {
+static bool generateWrappedPropertyTypeConstraints(
+   ConstraintSystem &cs, Type initializerType, VarDecl *wrappedVar,
+   Type propertyType) {
   auto dc = wrappedVar->getInnermostDeclContext();
 
   Type wrapperType = LValueType::get(initializerType);
@@ -3922,7 +3923,7 @@ static Type generateWrappedPropertyTypeConstraints(
     Type rawWrapperType = wrappedVar->getAttachedPropertyWrapperType(i);
     auto wrapperInfo = wrappedVar->getAttachedPropertyWrapperTypeInfo(i);
     if (rawWrapperType->hasError() || !wrapperInfo)
-      return Type();
+      return true;
 
     // The former wrappedValue type must be equal to the current wrapper type
     if (wrappedValueType) {
@@ -3940,12 +3941,12 @@ static Type generateWrappedPropertyTypeConstraints(
         dc->getParentModule(), wrapperInfo.valueVar);
   }
 
-  // Set up an equality constraint to drop the lvalue-ness of the value
-  // type we produced.
-  auto locator = cs.getConstraintLocator(wrappedVar);
-  Type propertyType = cs.createTypeVariable(locator, 0);
-  cs.addConstraint(ConstraintKind::Equal, propertyType, wrappedValueType, locator);
-  return propertyType;
+  // The property type must be equal to the wrapped value type
+  cs.addConstraint(ConstraintKind::Equal, propertyType, wrappedValueType,
+      cs.getConstraintLocator(wrappedVar, LocatorPathElt::ContextualType()));
+  cs.setContextualType(wrappedVar, TypeLoc::withoutLoc(wrappedValueType),
+                       CTP_WrappedProperty);
+  return false;
 }
 
 /// Generate additional constraints for the pattern of an initialization.
@@ -3962,17 +3963,11 @@ static bool generateInitPatternConstraints(
   if (!patternType)
     return true;
 
-  if (auto wrappedVar = target.getInitializationWrappedVar()) {
-    Type propertyType = generateWrappedPropertyTypeConstraints(
-        cs, cs.getType(target.getAsExpr()), wrappedVar);
-    if (!propertyType)
-      return true;
+  if (auto wrappedVar = target.getInitializationWrappedVar())
+    return generateWrappedPropertyTypeConstraints(
+        cs, cs.getType(target.getAsExpr()), wrappedVar, patternType);
 
-    // Add an equal constraint between the pattern type and the
-    // property wrapper's "value" type.
-    cs.addConstraint(ConstraintKind::Equal, patternType,
-                     propertyType, locator, /*isFavored*/ true);
-  } else if (!patternType->is<OpaqueTypeArchetypeType>()) {
+  if (!patternType->is<OpaqueTypeArchetypeType>()) {
     // Add a conversion constraint between the types.
     cs.addConstraint(ConstraintKind::Conversion, cs.getType(target.getAsExpr()),
                      patternType, locator, /*isFavored*/true);
@@ -4216,17 +4211,12 @@ bool ConstraintSystem::generateConstraints(
                                                getConstraintLocator(typeRepr));
     setType(typeRepr, backingType);
 
-    auto wrappedValueType =
-        generateWrappedPropertyTypeConstraints(*this, backingType, wrappedVar);
-    Type propertyType = wrappedVar->getType();
-    if (!wrappedValueType || propertyType->hasError())
+    auto propertyType = wrappedVar->getType();
+    if (propertyType->hasError())
       return true;
 
-    addConstraint(ConstraintKind::Equal, propertyType, wrappedValueType,
-        getConstraintLocator(wrappedVar, LocatorPathElt::ContextualType()));
-    setContextualType(wrappedVar, TypeLoc::withoutLoc(wrappedValueType),
-                      CTP_WrappedProperty);
-    return false;
+    return generateWrappedPropertyTypeConstraints(
+        *this, backingType, wrappedVar, propertyType);
   }
   }
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2958,7 +2958,7 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
   std::tie(fromObjectType, fromUnwraps) = getObjectTypeAndUnwraps(fromType);
   std::tie(toObjectType, toUnwraps) = getObjectTypeAndUnwraps(toType);
 
-  // Since equality is symmetric and it decays into a `Bind` eagerly
+  // Since equality is symmetric and it decays into a `Bind`, eagerly
   // unwrapping optionals from either side might be incorrect since
   // there is not enough information about what is expected e.g.
   // `Int?? equal T0?` just like `T0? equal Int??` allows `T0` to be

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -2021,3 +2021,13 @@ public struct NonVisibleImplicitInit {
     return false
   }
 }
+
+@propertyWrapper
+struct OptionalWrapper<T> {
+  init() {}
+  var wrappedValue: T? { nil }
+}
+
+struct UseOptionalWrapper {
+  @OptionalWrapper var p: Int?? // Okay
+}


### PR DESCRIPTION
* Make `repairViaOptionalUnwrap` less eager
* Don't anchor the equality constraint between the property type and `wrappedValue` type at the initialization expression. Failure to solve this constraint should be diagnosed at the wrapped property itself 

Resolves: rdar://problem/65802331
