### PR TITLE
[5.3][build] Fix --skip-build-llvm so that its minimal targets, like tblgen, are still built

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -199,6 +199,11 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 swift_obj_root = getattr(config, 'swift_obj_root', None)
 
+# cmake. The path to the cmake executable we used to configure swift.
+assert(config.cmake)
+config.substitutions.append( ('%cmake',  config.cmake) )
+lit_config.note('Using cmake: ' + config.cmake)
+
 # Set llvm_{src,obj}_root for use by others.
 config.llvm_src_root = getattr(config, 'llvm_src_root', None)
 config.llvm_obj_root = getattr(config, 'llvm_obj_root', None)

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -14,6 +14,7 @@ import os
 import platform
 import sys
 
+config.cmake = "@CMAKE_COMMAND@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1141,10 +1141,14 @@ LIBDISPATCH_STATIC_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 LIBCXX_SOURCE_DIR="${WORKSPACE}/llvm-project/libcxx"
 
+# We cannot currently apply the normal rules of skipping here for LLVM. Even if
+# we are skipping building LLVM, we still need to at least build a few tools
+# like tblgen that Swift relies on for building and testing. See the LLVM
+# configure rules.
+PRODUCTS=(llvm)
 [[ "${SKIP_BUILD_CMARK}" ]] || PRODUCTS+=(cmark)
 [[ "${SKIP_BUILD_LIBCXX}" ]] || PRODUCTS+=(libcxx)
 [[ "${SKIP_BUILD_LIBICU}" ]] || PRODUCTS+=(libicu)
-[[ "${SKIP_BUILD_LLVM}" ]] || PRODUCTS+=(llvm)
 [[ "${SKIP_BUILD_SWIFT}" ]] || PRODUCTS+=(swift)
 [[ "${SKIP_BUILD_LLDB}" ]] || PRODUCTS+=(lldb)
 [[ "${SKIP_BUILD_LIBDISPATCH}" ]] || PRODUCTS+=(libdispatch)
@@ -1534,7 +1538,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${BUILD_LLVM}" == "0" ] ; then
                     build_targets=(clean)
                 fi
-                if [ "${SKIP_BUILD}" ] ; then
+                if [[ "${SKIP_BUILD}" || "${SKIP_BUILD_LLVM}" ]] ; then
                     # We can't skip the build completely because the standalone
                     # build of Swift depend on these for building and testing.
                     build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -272,7 +272,7 @@ class CMake(object):
             cmake_binary = 'cmake'
 
         installed_ver = self.installed_cmake_version(cmake_binary)
-        if installed_ver > self.cmake_source_version(cmake_source_dir):
+        if installed_ver >= self.cmake_source_version(cmake_source_dir):
             return
         else:
             # Build CMake from source and return the path to the executable.

--- a/validation-test/BuildSystem/skip_cmark_swift_llvm.test-sh
+++ b/validation-test/BuildSystem/skip_cmark_swift_llvm.test-sh
@@ -1,0 +1,24 @@
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --skip-build-cmark 2>&1 | %FileCheck --check-prefix=SKIP-CMARK-CHECK %s
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --skip-build-llvm 2>&1 | %FileCheck --check-prefix=SKIP-LLVM-CHECK %s
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --skip-build-swift 2>&1 | %FileCheck --check-prefix=SKIP-SWIFT-CHECK %s
+
+# SKIP-CMARK-CHECK-NOT: cmake --build {{.*}}cmark-
+# SKIP-CMARK-CHECK: cmake --build {{.*}}llvm-
+# SKIP-CMARK-CHECK: cmake --build {{.*}}swift-
+
+# SKIP-LLVM-CHECK: cmake --build {{.*}}cmark-
+# SKIP-LLVM-CHECK-NOT: cmake --build {{.*}}llvm-
+# SKIP-LLVM-CHECK: cmake --build {{.*}}swift-
+
+# SKIP-SWIFT-CHECK: cmake --build {{.*}}cmark-
+# SKIP-SWIFT-CHECK: cmake --build {{.*}}llvm-
+# SKIP-SWIFT-CHECK-NOT: cmake --build {{.*}}swift-
+

--- a/validation-test/BuildSystem/skip_cmark_swift_llvm.test-sh
+++ b/validation-test/BuildSystem/skip_cmark_swift_llvm.test-sh
@@ -15,7 +15,7 @@
 # SKIP-CMARK-CHECK: cmake --build {{.*}}swift-
 
 # SKIP-LLVM-CHECK: cmake --build {{.*}}cmark-
-# SKIP-LLVM-CHECK-NOT: cmake --build {{.*}}llvm-
+# SKIP-LLVM-CHECK: cmake --build {{.*}}llvm-tblgen
 # SKIP-LLVM-CHECK: cmake --build {{.*}}swift-
 
 # SKIP-SWIFT-CHECK: cmake --build {{.*}}cmark-

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -13,6 +13,7 @@
 import sys
 import platform
 
+config.cmake = "@CMAKE_COMMAND@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"


### PR DESCRIPTION
The Swift compiler and stdlib builds always [need a few LLVM targets like tblgen built](https://github.com/apple/swift/blob/release/5.3/utils/build-script-impl#L1538), even if skipping building a full LLVM. This was just corrected in the main branch with #32860, backporting to the 5.3 branch so there's no regression for this flag when Swift 5.3 is released. For example, [I use this flag when cross-compiling the Swift stdlib for Android](https://github.com/termux/termux-packages/blob/b2c582bf9217b730a42058512c751f24a788bee9/packages/swift/build.sh#L109), others may be using it too.

Ping @atrick.