### PR TITLE
Correct some typos

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -14,7 +14,7 @@ types. For non-generic nominal types, these metadata records are generated
 statically by the compiler. For instances of generic types, and for intrinsic
 types such as tuples, functions, protocol compositions, etc., metadata records
 are lazily created by the runtime as required. Every type has a unique metadata
-record; two **metadata pointer** values are equal iff the types are equivalent.
+record; two **metadata pointer** values are equal if the types are equivalent.
 
 In the layout descriptions below, offsets are given relative to the
 metadata pointer as an index into an array of pointers. On a 32-bit platform,


### PR DESCRIPTION
17 record; two **metadata pointer** values are equal iff the types are equivalent > 17 record; two **metadata pointer** values are equal if the types are equivalent
