### PR TITLE
[Parse] Fix excessive skipping of '}'

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -660,7 +660,7 @@ public:
   /// \returns true if there is an instance of \c T1 on the current line (this
   /// avoids the foot-gun of not considering T1 starting the next line for a
   /// plain Tok.is(T1) check).
-  bool skipUntilTokenOrEndOfLine(tok T1);
+  bool skipUntilTokenOrEndOfLine(tok T1, tok T2 = tok::NUM_TOKENS);
 
   /// Skip a braced block (e.g. function body). The current token must be '{'.
   /// Returns \c true if the parser hit the eof before finding matched '}'.

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -658,7 +658,8 @@ ParserResult<BraceStmt> Parser::parseBraceItemList(Diag<> ID) {
     diagnose(Tok, ID);
 
     // Attempt to recover by looking for a left brace on the same line
-    if (!skipUntilTokenOrEndOfLine(tok::l_brace))
+    if (!skipUntilTokenOrEndOfLine(tok::l_brace, tok::r_brace) ||
+        !Tok.is(tok::l_brace))
       return nullptr;
   }
   SyntaxParsingContext LocalContext(SyntaxContext, SyntaxKind::CodeBlock);
@@ -1699,7 +1700,8 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
       // got a problem. If the last bit is 'else ... {' on one line, let's
       // assume they've forgotten the 'if'.
       BacktrackingScope backtrack(*this);
-      implicitlyInsertIf = skipUntilTokenOrEndOfLine(tok::l_brace);
+      if (skipUntilTokenOrEndOfLine(tok::l_brace, tok::r_brace))
+        implicitlyInsertIf = Tok.is(tok::l_brace);
     }
 
     if (Tok.is(tok::kw_if) || implicitlyInsertIf) {

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -660,7 +660,7 @@ void Parser::skipSingle() {
   switch (Tok.getKind()) {
   case tok::l_paren:
     consumeToken();
-    skipUntil(tok::r_paren);
+    skipUntil(tok::r_paren, tok::r_brace);
     consumeIf(tok::r_paren);
     break;
   case tok::l_brace:
@@ -670,7 +670,7 @@ void Parser::skipSingle() {
     break;
   case tok::l_square:
     consumeToken();
-    skipUntil(tok::r_square);
+    skipUntil(tok::r_square, tok::r_brace);
     consumeIf(tok::r_square);
     break;
   case tok::pound_if:
@@ -825,11 +825,11 @@ void Parser::skipUntilConditionalBlockClose() {
   }
 }
 
-bool Parser::skipUntilTokenOrEndOfLine(tok T1) {
-  while (Tok.isNot(tok::eof, T1) && !Tok.isAtStartOfLine())
+bool Parser::skipUntilTokenOrEndOfLine(tok T1, tok T2) {
+  while (Tok.isNot(tok::eof, T1, T2) && !Tok.isAtStartOfLine())
     skipSingle();
 
-  return Tok.is(T1) && !Tok.isAtStartOfLine();
+  return Tok.isAny(T1, T2) && !Tok.isAtStartOfLine();
 }
 
 bool Parser::loadCurrentSyntaxNodeFromCache() {

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -679,12 +679,13 @@ func a(s: S[{{g) -> Int {} // expected-note {{to match this opening '['}}
 }}} // expected-error {{expected ']' in array type}}
 #endif
   
-  
-  
 // rdar://19605567
-// expected-error@+3{{expected '(' for initializer parameters}}
-// expected-error@+2{{initializers may only be declared within a type}}
-// expected-error@+1{{expected an identifier to name generic parameter}}
+// expected-error@+6{{expected '(' for initializer parameters}}
+// expected-error@+5{{initializers may only be declared within a type}}
+// expected-error@+4{{expected an identifier to name generic parameter}}
+// expected-error@+3{{consecutive statements on a line must be separated by ';'}}
+// expected-error@+2{{expected expression}}
+// expected-error@+1{{extraneous '}' at top level}}
 func F() { init<( } )} // expected-note 2{{did you mean 'F'?}}
 
 struct InitializerWithName {
@@ -859,3 +860,16 @@ func SR11006(a: Int == 0) {}
 // rdar://38225184
 extension Collection where Element == Int && Index == Int {}
 // expected-error@-1 {{expected ',' to separate the requirements of this 'where' clause}} {{43-45=,}}
+
+func testSkipUnbalancedParen() {
+  ?( // expected-error {{expected expression}}
+}
+func testSkipToFindOpenBrace1() {
+  // expected-error@+3 {{expected pattern}}
+  // expected-error@+2 {{variable binding in a condition requires an initializer}}
+  // expected-error@+1 {{expected '{' after 'if' condition}}
+  do { if case }
+}
+func testSkipToFindOpenBrace2() {
+  do { if true {} else false } // expected-error {{expected '{' or 'if' after 'else'}}
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1013,7 +1013,7 @@ func testMemberAccessOnOptionalKeyPathComponent() {
   // expected-error@-1 {{value of optional type 'String?' must be unwrapped to refer to member 'count' of wrapped base type 'String'}}
 }
 
-func testSyntaxErrors() { // expected-note{{}}
+func testSyntaxErrors() {
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;
   _ = \[a ;
@@ -1045,4 +1045,4 @@ func testSyntaxErrors() { // expected-note{{}}
   _ = \A[a];
   _ = \A.a?;
   _ = \A.a!;
-} // expected-error@+1{{}}
+}


### PR DESCRIPTION
* Don't skip `}` in parentheses or square brackets.
  When skipping `foo ( bar [ baz } qux ...`, we should stop at `}` because braces are probably "stronger" than parentheses and square brackets.
  
* Don't skip `}` when finding `{` on the same line. Similar but in a different function (`skipUntilTokenOrEndOfLine`).

rdar://problem/65891507
