### PR TITLE
[Mangling] Add a new mangling for opaque return type to use when mangling an ObjC runtime name

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -654,6 +654,11 @@ implementation details of a function type.
     opaque-type-decl-name ::= entity 'QO' // opaque result type of specified decl
   #endif
 
+  #if SWIFT_VERSION >= 5.4
+    type ::= 'Qu'                         // opaque result type (of current decl)
+                                          // used for ObjC class runtime name purposes.
+  #endif
+
 Opaque return types have a special short representation in the mangling of
 their defining entity. In structural position, opaque types are fully qualified
 by mangling the defining entity for the opaque declaration and the substitutions

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2010,6 +2010,10 @@ private:
       }
     }
     if (c == 'Q') {
+      if (Mangled.nextIf('u')) {
+        // Special mangling for opaque return type.
+        return Factory.createNode(Node::Kind::OpaqueReturnType);
+      }
       return demangleArchetypeType();
     }
     if (c == 'q') {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2106,7 +2106,7 @@ void Remangler::mangleSugaredParen(Node *node) {
 }
 
 void Remangler::mangleOpaqueReturnType(Node *node) {
-  unreachable("unsupported");
+  Buffer << "Qu";
 }
 void Remangler::mangleOpaqueReturnTypeOf(Node *node, EntityContext &ctx) {
   unreachable("unsupported");

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -329,6 +329,7 @@ _$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
 _$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
 _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
+_TtCF4test11doNotCrash1FT_QuL_8MyClass1 ---> MyClass1 #1 in test.doNotCrash1() -> some
 $s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1>
 $s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0
 $S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A>

--- a/validation-test/compiler_crashers_2_fixed/sr13203.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13203.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+protocol MyProtocol {}
+
+func doNotCrash1() -> some MyProtocol {
+  class MyClass1: MyProtocol {}
+  return MyClass1()
+}
+
+var doNotCrash2: some MyProtocol {
+  class MyClass2: MyProtocol {}
+  return MyClass2()
+}

--- a/validation-test/compiler_crashers_2_fixed/sr13203.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13203.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null %s
 
 protocol MyProtocol {}
 


### PR DESCRIPTION
The old remangler does not handle opaque result types and can crash when mangling an ObjC runtime name for a class that is in a local context that returns an opaque type, for example:

```swift
func opaqueTypeFunc() -> some MyProtocol {
  class Foo: MyProtocol { ... }
  return Foo()
}

var opaqueTypeVar: some MyProtocol {
  class Bar: MyProtocol { ... }
  return Bar()
}
```

Introduce a new `Qu` mangling to represent the opaque return type in old mangling.

Resolves SR-13203