### PR TITLE
[CS] Emit syntactic diagnostics for for loop where clauses

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1453,64 +1453,6 @@ BraceStmt *swift::applyFunctionBuilderTransform(
         captured.first, captured.second)));
 }
 
-/// Produce any additional syntactic diagnostics for the body of a function
-/// that had a function builder applied.
-static void performAddOnDiagnostics(BraceStmt *stmt, DeclContext *dc) {
-  class AddOnDiagnosticWalker : public ASTWalker {
-    SmallVector<DeclContext *, 4> dcStack;
-
-  public:
-    AddOnDiagnosticWalker(DeclContext *dc) {
-      dcStack.push_back(dc);
-    }
-
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
-      performSyntacticExprDiagnostics(
-          expr, dcStack.back(), /*isExprStmt=*/false);
-
-      if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-        if (closure->wasSeparatelyTypeChecked()) {
-          dcStack.push_back(closure);
-          return { true, expr };
-        }
-      }
-
-      return { false, expr };
-    }
-
-    Expr *walkToExprPost(Expr *expr) override {
-      if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-        if (closure->wasSeparatelyTypeChecked()) {
-          assert(dcStack.back() == closure);
-          dcStack.pop_back();
-        }
-      }
-
-      return expr;
-    }
-
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
-      performStmtDiagnostics(dcStack.back()->getASTContext(), stmt);
-      return { true, stmt };
-    }
-
-    std::pair<bool, Pattern*> walkToPatternPre(Pattern *pattern) override {
-      return { false, pattern };
-    }
-
-    bool walkToTypeLocPre(TypeLoc &typeLoc) override { return false; }
-
-    bool walkToTypeReprPre(TypeRepr *typeRepr) override { return false; }
-
-    bool walkToParameterListPre(ParameterList *params) override {
-      return false;
-    }
-  };
-
-  AddOnDiagnosticWalker walker(dc);
-  stmt->walk(walker);
-}
-
 Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
     FuncDecl *func, Type builderType) {
   // Pre-check the body: pre-check any expressions in it and look
@@ -1629,7 +1571,7 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   if (auto result = cs.applySolution(
           solutions.front(),
           SolutionApplicationTarget(func))) {
-    performAddOnDiagnostics(result->getFunctionBody(), func);
+    performSyntacticDiagnosticsForTarget(*result, /*isExprStmt*/ false);
     return result->getFunctionBody();
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5596,6 +5596,11 @@ bool isKnownKeyPathDecl(ASTContext &ctx, ValueDecl *decl);
 /// statements that could produce non-void result.
 bool hasExplicitResult(ClosureExpr *closure);
 
+/// Emit diagnostics for syntactic restrictions within a given solution
+/// application target.
+void performSyntacticDiagnosticsForTarget(
+    const SolutionApplicationTarget &target, bool isExprStmt);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1603,6 +1603,12 @@ public:
   /// For a pattern initialization target, retrieve the contextual pattern.
   ContextualPattern getContextualPattern() const;
 
+  /// Whether this target is for a for-in statement.
+  bool isForEachStmt() const {
+    return kind == Kind::expression &&
+           getExprContextualTypePurpose() == CTP_ForEachStmt;
+  }
+
   /// Whether this is an initialization for an Optional.Some pattern.
   bool isOptionalSomePatternInit() const {
     return kind == Kind::expression &&
@@ -1659,14 +1665,12 @@ public:
   }
 
   const ForEachStmtInfo &getForEachStmtInfo() const {
-    assert(kind == Kind::expression);
-    assert(expression.contextualPurpose == CTP_ForEachStmt);
+    assert(isForEachStmt());
     return expression.forEachStmt;
   }
 
   ForEachStmtInfo &getForEachStmtInfo() {
-    assert(kind == Kind::expression);
-    assert(expression.contextualPurpose == CTP_ForEachStmt);
+    assert(isForEachStmt());
     return expression.forEachStmt;
   }
 

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -34,3 +34,12 @@ func test_contextual_member_with_availability() {
 
   _ = Test(.foo) // Ok
 }
+
+@available(*, unavailable)
+func unavailableFunction(_ x: Int) -> Bool { true } // expected-note {{'unavailableFunction' has been explicitly marked unavailable here}}
+
+// SR-13260: Availability checking not working in the where clause of a for
+// loop.
+func sr13260(_ arr: [Int]) {
+  for x in arr where unavailableFunction(x) {} // expected-error {{'unavailableFunction' is unavailable}}
+}

--- a/test/decl/var/function_builders_availability.swift
+++ b/test/decl/var/function_builders_availability.swift
@@ -84,3 +84,16 @@ tuplify(true) { x in
   Option.best // expected-error{{'best' is only available in macOS 10.15.4 or newer}}
   // expected-note@-1{{add 'if #available' version check}}
 }
+
+@available(*, unavailable)
+func unavailableFunc(_ x: Bool) -> Bool {} // expected-note {{'unavailableFunc' has been explicitly marked unavailable here}}
+
+// SR-13260: Availability checking not working in the where clause of a for
+// loop.
+tuplify(true) { b in
+  for x in [b] where unavailableFunc(x) { // expected-error {{'unavailableFunc' is unavailable}}
+    ""
+    Option.best // expected-error{{'best' is only available in macOS 10.15.4 or newer}}
+    // expected-note@-1{{add 'if #available' version check}}
+  }
+}


### PR DESCRIPTION
When moving the type-checking of for-in loops into the constraint system, we inadvertently stopped running the syntactic expression diagnostics for the where clause. Re-enable this diagnostic logic.

Resolves SR-13260
Resolves rdar://65903005