### PR TITLE
[CodeCompletion] Don't throw away parsed return type for function decls

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -839,13 +839,10 @@ Parser::parseFunctionSignature(Identifier SimpleName,
 
     ParserResult<TypeRepr> ResultType =
         parseDeclResultType(diag::expected_type_function_result);
-    if (ResultType.hasCodeCompletion())
-      return ResultType;
     retType = ResultType.getPtrOrNull();
-    if (!retType) {
-      Status.setIsParseError();
+    Status |= ResultType;
+    if (Status.isError())
       return Status;
-    }
   } else {
     // Otherwise, we leave retType null.
     retType = nullptr;


### PR DESCRIPTION
Parsed type should be in the result AST to maintain the source range of the decl.

(No observable behavior change at this point)

rdar://problem/65906026