### PR TITLE
Python3 compatibility for Benchmarks

### DIFF
--- a/benchmark/single-source/CharacterProperties.swift
+++ b/benchmark/single-source/CharacterProperties.swift
@@ -53,180 +53,100 @@ extension Character {
 
 
 // Fetch the CharacterSet for every call
-func isControl(_ c: Character) -> Bool {
-  return CharacterSet.controlCharacters.contains(c.firstScalar)
-}
 func isAlphanumeric(_ c: Character) -> Bool {
   return CharacterSet.alphanumerics.contains(c.firstScalar)
-}
-func isLowercase(_ c: Character) -> Bool {
-  return CharacterSet.lowercaseLetters.contains(c.firstScalar)
-}
-func isPunctuation(_ c: Character) -> Bool {
-  return CharacterSet.punctuationCharacters.contains(c.firstScalar)
-}
-func isWhitespace(_ c: Character) -> Bool {
-  return CharacterSet.whitespaces.contains(c.firstScalar)
-}
-func isLetter(_ c: Character) -> Bool {
-  return CharacterSet.letters.contains(c.firstScalar)
-}
-func isUppercase(_ c: Character) -> Bool {
-  return CharacterSet.uppercaseLetters.contains(c.firstScalar)
-}
-func isDecimal(_ c: Character) -> Bool {
-  return CharacterSet.decimalDigits.contains(c.firstScalar)
-}
-func isNewline(_ c: Character) -> Bool {
-  return CharacterSet.newlines.contains(c.firstScalar)
 }
 func isCapitalized(_ c: Character) -> Bool {
   return CharacterSet.capitalizedLetters.contains(c.firstScalar)
 }
+func isControl(_ c: Character) -> Bool {
+  return CharacterSet.controlCharacters.contains(c.firstScalar)
+}
+func isDecimal(_ c: Character) -> Bool {
+  return CharacterSet.decimalDigits.contains(c.firstScalar)
+}
+func isLetter(_ c: Character) -> Bool {
+  return CharacterSet.letters.contains(c.firstScalar)
+}
+func isLowercase(_ c: Character) -> Bool {
+  return CharacterSet.lowercaseLetters.contains(c.firstScalar)
+}
+func isUppercase(_ c: Character) -> Bool {
+  return CharacterSet.uppercaseLetters.contains(c.firstScalar)
+}
+func isNewline(_ c: Character) -> Bool {
+  return CharacterSet.newlines.contains(c.firstScalar)
+}
+func isWhitespace(_ c: Character) -> Bool {
+  return CharacterSet.whitespaces.contains(c.firstScalar)
+}
+func isPunctuation(_ c: Character) -> Bool {
+  return CharacterSet.punctuationCharacters.contains(c.firstScalar)
+}
 
 // Stash the set
-let controlCharacters = CharacterSet.controlCharacters
-func isControlStashed(_ c: Character) -> Bool {
-  return controlCharacters.contains(c.firstScalar)
-}
 let alphanumerics = CharacterSet.alphanumerics
 func isAlphanumericStashed(_ c: Character) -> Bool {
   return alphanumerics.contains(c.firstScalar)
-}
-let lowercaseLetters = CharacterSet.lowercaseLetters
-func isLowercaseStashed(_ c: Character) -> Bool {
-  return lowercaseLetters.contains(c.firstScalar)
-}
-let punctuationCharacters = CharacterSet.punctuationCharacters
-func isPunctuationStashed(_ c: Character) -> Bool {
-  return punctuationCharacters.contains(c.firstScalar)
-}
-let whitespaces = CharacterSet.whitespaces
-func isWhitespaceStashed(_ c: Character) -> Bool {
-  return whitespaces.contains(c.firstScalar)
-}
-let letters = CharacterSet.letters
-func isLetterStashed(_ c: Character) -> Bool {
-  return letters.contains(c.firstScalar)
-}
-let uppercaseLetters = CharacterSet.uppercaseLetters
-func isUppercaseStashed(_ c: Character) -> Bool {
-  return uppercaseLetters.contains(c.firstScalar)
-}
-let decimalDigits = CharacterSet.decimalDigits
-func isDecimalStashed(_ c: Character) -> Bool {
-  return decimalDigits.contains(c.firstScalar)
-}
-let newlines = CharacterSet.newlines
-func isNewlineStashed(_ c: Character) -> Bool {
-  return newlines.contains(c.firstScalar)
 }
 let capitalizedLetters = CharacterSet.capitalizedLetters
 func isCapitalizedStashed(_ c: Character) -> Bool {
   return capitalizedLetters.contains(c.firstScalar)
 }
+let controlCharacters = CharacterSet.controlCharacters
+func isControlStashed(_ c: Character) -> Bool {
+  return controlCharacters.contains(c.firstScalar)
+}
+let decimalDigits = CharacterSet.decimalDigits
+func isDecimalStashed(_ c: Character) -> Bool {
+  return decimalDigits.contains(c.firstScalar)
+}
+let letters = CharacterSet.letters
+func isLetterStashed(_ c: Character) -> Bool {
+  return letters.contains(c.firstScalar)
+}
+let lowercaseLetters = CharacterSet.lowercaseLetters
+func isLowercaseStashed(_ c: Character) -> Bool {
+  return lowercaseLetters.contains(c.firstScalar)
+}
+let uppercaseLetters = CharacterSet.uppercaseLetters
+func isUppercaseStashed(_ c: Character) -> Bool {
+  return uppercaseLetters.contains(c.firstScalar)
+}
+let newlines = CharacterSet.newlines
+func isNewlineStashed(_ c: Character) -> Bool {
+  return newlines.contains(c.firstScalar)
+}
+let whitespaces = CharacterSet.whitespaces
+func isWhitespaceStashed(_ c: Character) -> Bool {
+  return whitespaces.contains(c.firstScalar)
+}
+let punctuationCharacters = CharacterSet.punctuationCharacters
+func isPunctuationStashed(_ c: Character) -> Bool {
+  return punctuationCharacters.contains(c.firstScalar)
+}
 
 func setupStash() {
   blackHole(workload)
-    blackHole(controlCharacters)
     blackHole(alphanumerics)
-    blackHole(lowercaseLetters)
-    blackHole(punctuationCharacters)
-    blackHole(whitespaces)
-    blackHole(letters)
-    blackHole(uppercaseLetters)
-    blackHole(decimalDigits)
-    blackHole(newlines)
     blackHole(capitalizedLetters)
+    blackHole(controlCharacters)
+    blackHole(decimalDigits)
+    blackHole(letters)
+    blackHole(lowercaseLetters)
+    blackHole(uppercaseLetters)
+    blackHole(newlines)
+    blackHole(whitespaces)
+    blackHole(punctuationCharacters)
 }
 
 // Memoize the stashed set
-var controlCharactersMemo = Set<UInt32>()
-func isControlStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if controlCharactersMemo.contains(scalar.value) { return true }
-  if controlCharacters.contains(scalar) {
-    controlCharactersMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
 var alphanumericsMemo = Set<UInt32>()
 func isAlphanumericStashedMemo(_ c: Character) -> Bool {
   let scalar = c.firstScalar
   if alphanumericsMemo.contains(scalar.value) { return true }
   if alphanumerics.contains(scalar) {
     alphanumericsMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var lowercaseLettersMemo = Set<UInt32>()
-func isLowercaseStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if lowercaseLettersMemo.contains(scalar.value) { return true }
-  if lowercaseLetters.contains(scalar) {
-    lowercaseLettersMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var punctuationCharactersMemo = Set<UInt32>()
-func isPunctuationStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if punctuationCharactersMemo.contains(scalar.value) { return true }
-  if punctuationCharacters.contains(scalar) {
-    punctuationCharactersMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var whitespacesMemo = Set<UInt32>()
-func isWhitespaceStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if whitespacesMemo.contains(scalar.value) { return true }
-  if whitespaces.contains(scalar) {
-    whitespacesMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var lettersMemo = Set<UInt32>()
-func isLetterStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if lettersMemo.contains(scalar.value) { return true }
-  if letters.contains(scalar) {
-    lettersMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var uppercaseLettersMemo = Set<UInt32>()
-func isUppercaseStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if uppercaseLettersMemo.contains(scalar.value) { return true }
-  if uppercaseLetters.contains(scalar) {
-    uppercaseLettersMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var decimalDigitsMemo = Set<UInt32>()
-func isDecimalStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if decimalDigitsMemo.contains(scalar.value) { return true }
-  if decimalDigits.contains(scalar) {
-    decimalDigitsMemo.insert(scalar.value)
-    return true
-  }
-  return false
-}
-var newlinesMemo = Set<UInt32>()
-func isNewlineStashedMemo(_ c: Character) -> Bool {
-  let scalar = c.firstScalar
-  if newlinesMemo.contains(scalar.value) { return true }
-  if newlines.contains(scalar) {
-    newlinesMemo.insert(scalar.value)
     return true
   }
   return false
@@ -241,19 +161,99 @@ func isCapitalizedStashedMemo(_ c: Character) -> Bool {
   }
   return false
 }
+var controlCharactersMemo = Set<UInt32>()
+func isControlStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if controlCharactersMemo.contains(scalar.value) { return true }
+  if controlCharacters.contains(scalar) {
+    controlCharactersMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var decimalDigitsMemo = Set<UInt32>()
+func isDecimalStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if decimalDigitsMemo.contains(scalar.value) { return true }
+  if decimalDigits.contains(scalar) {
+    decimalDigitsMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var lettersMemo = Set<UInt32>()
+func isLetterStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if lettersMemo.contains(scalar.value) { return true }
+  if letters.contains(scalar) {
+    lettersMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var lowercaseLettersMemo = Set<UInt32>()
+func isLowercaseStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if lowercaseLettersMemo.contains(scalar.value) { return true }
+  if lowercaseLetters.contains(scalar) {
+    lowercaseLettersMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var uppercaseLettersMemo = Set<UInt32>()
+func isUppercaseStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if uppercaseLettersMemo.contains(scalar.value) { return true }
+  if uppercaseLetters.contains(scalar) {
+    uppercaseLettersMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var newlinesMemo = Set<UInt32>()
+func isNewlineStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if newlinesMemo.contains(scalar.value) { return true }
+  if newlines.contains(scalar) {
+    newlinesMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var whitespacesMemo = Set<UInt32>()
+func isWhitespaceStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if whitespacesMemo.contains(scalar.value) { return true }
+  if whitespaces.contains(scalar) {
+    whitespacesMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
+var punctuationCharactersMemo = Set<UInt32>()
+func isPunctuationStashedMemo(_ c: Character) -> Bool {
+  let scalar = c.firstScalar
+  if punctuationCharactersMemo.contains(scalar.value) { return true }
+  if punctuationCharacters.contains(scalar) {
+    punctuationCharactersMemo.insert(scalar.value)
+    return true
+  }
+  return false
+}
 
 func setupMemo() {
   blackHole(workload)
-    blackHole(controlCharactersMemo)
     blackHole(alphanumericsMemo)
-    blackHole(lowercaseLettersMemo)
-    blackHole(punctuationCharactersMemo)
-    blackHole(whitespacesMemo)
-    blackHole(lettersMemo)
-    blackHole(uppercaseLettersMemo)
-    blackHole(decimalDigitsMemo)
-    blackHole(newlinesMemo)
     blackHole(capitalizedLettersMemo)
+    blackHole(controlCharactersMemo)
+    blackHole(decimalDigitsMemo)
+    blackHole(lettersMemo)
+    blackHole(lowercaseLettersMemo)
+    blackHole(uppercaseLettersMemo)
+    blackHole(newlinesMemo)
+    blackHole(whitespacesMemo)
+    blackHole(punctuationCharactersMemo)
 }
 
 // Precompute whole scalar set
@@ -271,69 +271,69 @@ func precompute(_ charSet: CharacterSet, capacity: Int) -> Set<UInt32> {
   }
   return result
 }
-var controlCharactersPrecomputed: Set<UInt32> =
-  precompute(controlCharacters, capacity: 24951)
-func isControlPrecomputed(_ c: Character) -> Bool {
-  return controlCharactersPrecomputed.contains(c.firstScalar.value)
-}
 var alphanumericsPrecomputed: Set<UInt32> =
   precompute(alphanumerics, capacity: 122647)
 func isAlphanumericPrecomputed(_ c: Character) -> Bool {
   return alphanumericsPrecomputed.contains(c.firstScalar.value)
-}
-var lowercaseLettersPrecomputed: Set<UInt32> =
-  precompute(lowercaseLetters, capacity: 2063)
-func isLowercasePrecomputed(_ c: Character) -> Bool {
-  return lowercaseLettersPrecomputed.contains(c.firstScalar.value)
-}
-var punctuationCharactersPrecomputed: Set<UInt32> =
-  precompute(punctuationCharacters, capacity: 770)
-func isPunctuationPrecomputed(_ c: Character) -> Bool {
-  return punctuationCharactersPrecomputed.contains(c.firstScalar.value)
-}
-var whitespacesPrecomputed: Set<UInt32> =
-  precompute(whitespaces, capacity: 19)
-func isWhitespacePrecomputed(_ c: Character) -> Bool {
-  return whitespacesPrecomputed.contains(c.firstScalar.value)
-}
-var lettersPrecomputed: Set<UInt32> =
-  precompute(letters, capacity: 121145)
-func isLetterPrecomputed(_ c: Character) -> Bool {
-  return lettersPrecomputed.contains(c.firstScalar.value)
-}
-var uppercaseLettersPrecomputed: Set<UInt32> =
-  precompute(uppercaseLetters, capacity: 1733)
-func isUppercasePrecomputed(_ c: Character) -> Bool {
-  return uppercaseLettersPrecomputed.contains(c.firstScalar.value)
-}
-var decimalDigitsPrecomputed: Set<UInt32> =
-  precompute(decimalDigits, capacity: 590)
-func isDecimalPrecomputed(_ c: Character) -> Bool {
-  return decimalDigitsPrecomputed.contains(c.firstScalar.value)
-}
-var newlinesPrecomputed: Set<UInt32> =
-  precompute(newlines, capacity: 7)
-func isNewlinePrecomputed(_ c: Character) -> Bool {
-  return newlinesPrecomputed.contains(c.firstScalar.value)
 }
 var capitalizedLettersPrecomputed: Set<UInt32> =
   precompute(capitalizedLetters, capacity: 31)
 func isCapitalizedPrecomputed(_ c: Character) -> Bool {
   return capitalizedLettersPrecomputed.contains(c.firstScalar.value)
 }
+var controlCharactersPrecomputed: Set<UInt32> =
+  precompute(controlCharacters, capacity: 24951)
+func isControlPrecomputed(_ c: Character) -> Bool {
+  return controlCharactersPrecomputed.contains(c.firstScalar.value)
+}
+var decimalDigitsPrecomputed: Set<UInt32> =
+  precompute(decimalDigits, capacity: 590)
+func isDecimalPrecomputed(_ c: Character) -> Bool {
+  return decimalDigitsPrecomputed.contains(c.firstScalar.value)
+}
+var lettersPrecomputed: Set<UInt32> =
+  precompute(letters, capacity: 121145)
+func isLetterPrecomputed(_ c: Character) -> Bool {
+  return lettersPrecomputed.contains(c.firstScalar.value)
+}
+var lowercaseLettersPrecomputed: Set<UInt32> =
+  precompute(lowercaseLetters, capacity: 2063)
+func isLowercasePrecomputed(_ c: Character) -> Bool {
+  return lowercaseLettersPrecomputed.contains(c.firstScalar.value)
+}
+var uppercaseLettersPrecomputed: Set<UInt32> =
+  precompute(uppercaseLetters, capacity: 1733)
+func isUppercasePrecomputed(_ c: Character) -> Bool {
+  return uppercaseLettersPrecomputed.contains(c.firstScalar.value)
+}
+var newlinesPrecomputed: Set<UInt32> =
+  precompute(newlines, capacity: 7)
+func isNewlinePrecomputed(_ c: Character) -> Bool {
+  return newlinesPrecomputed.contains(c.firstScalar.value)
+}
+var whitespacesPrecomputed: Set<UInt32> =
+  precompute(whitespaces, capacity: 19)
+func isWhitespacePrecomputed(_ c: Character) -> Bool {
+  return whitespacesPrecomputed.contains(c.firstScalar.value)
+}
+var punctuationCharactersPrecomputed: Set<UInt32> =
+  precompute(punctuationCharacters, capacity: 770)
+func isPunctuationPrecomputed(_ c: Character) -> Bool {
+  return punctuationCharactersPrecomputed.contains(c.firstScalar.value)
+}
 
 func setupPrecomputed() {
   blackHole(workload)
-    blackHole(controlCharactersPrecomputed)
     blackHole(alphanumericsPrecomputed)
-    blackHole(lowercaseLettersPrecomputed)
-    blackHole(punctuationCharactersPrecomputed)
-    blackHole(whitespacesPrecomputed)
-    blackHole(lettersPrecomputed)
-    blackHole(uppercaseLettersPrecomputed)
-    blackHole(decimalDigitsPrecomputed)
-    blackHole(newlinesPrecomputed)
     blackHole(capitalizedLettersPrecomputed)
+    blackHole(controlCharactersPrecomputed)
+    blackHole(decimalDigitsPrecomputed)
+    blackHole(lettersPrecomputed)
+    blackHole(lowercaseLettersPrecomputed)
+    blackHole(uppercaseLettersPrecomputed)
+    blackHole(newlinesPrecomputed)
+    blackHole(whitespacesPrecomputed)
+    blackHole(punctuationCharactersPrecomputed)
 }
 
 // Compute on the fly
@@ -361,16 +361,16 @@ let workload = """
 public func run_CharacterPropertiesFetch(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-        blackHole(isControl(c))
         blackHole(isAlphanumeric(c))
-        blackHole(isLowercase(c))
-        blackHole(isPunctuation(c))
-        blackHole(isWhitespace(c))
-        blackHole(isLetter(c))
-        blackHole(isUppercase(c))
-        blackHole(isDecimal(c))
-        blackHole(isNewline(c))
         blackHole(isCapitalized(c))
+        blackHole(isControl(c))
+        blackHole(isDecimal(c))
+        blackHole(isLetter(c))
+        blackHole(isLowercase(c))
+        blackHole(isUppercase(c))
+        blackHole(isNewline(c))
+        blackHole(isWhitespace(c))
+        blackHole(isPunctuation(c))
     }
   }
 }
@@ -379,16 +379,16 @@ public func run_CharacterPropertiesFetch(_ N: Int) {
 public func run_CharacterPropertiesStashed(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-        blackHole(isControlStashed(c))
         blackHole(isAlphanumericStashed(c))
-        blackHole(isLowercaseStashed(c))
-        blackHole(isPunctuationStashed(c))
-        blackHole(isWhitespaceStashed(c))
-        blackHole(isLetterStashed(c))
-        blackHole(isUppercaseStashed(c))
-        blackHole(isDecimalStashed(c))
-        blackHole(isNewlineStashed(c))
         blackHole(isCapitalizedStashed(c))
+        blackHole(isControlStashed(c))
+        blackHole(isDecimalStashed(c))
+        blackHole(isLetterStashed(c))
+        blackHole(isLowercaseStashed(c))
+        blackHole(isUppercaseStashed(c))
+        blackHole(isNewlineStashed(c))
+        blackHole(isWhitespaceStashed(c))
+        blackHole(isPunctuationStashed(c))
     }
   }
 }
@@ -397,16 +397,16 @@ public func run_CharacterPropertiesStashed(_ N: Int) {
 public func run_CharacterPropertiesStashedMemo(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-        blackHole(isControlStashedMemo(c))
         blackHole(isAlphanumericStashedMemo(c))
-        blackHole(isLowercaseStashedMemo(c))
-        blackHole(isPunctuationStashedMemo(c))
-        blackHole(isWhitespaceStashedMemo(c))
-        blackHole(isLetterStashedMemo(c))
-        blackHole(isUppercaseStashedMemo(c))
-        blackHole(isDecimalStashedMemo(c))
-        blackHole(isNewlineStashedMemo(c))
         blackHole(isCapitalizedStashedMemo(c))
+        blackHole(isControlStashedMemo(c))
+        blackHole(isDecimalStashedMemo(c))
+        blackHole(isLetterStashedMemo(c))
+        blackHole(isLowercaseStashedMemo(c))
+        blackHole(isUppercaseStashedMemo(c))
+        blackHole(isNewlineStashedMemo(c))
+        blackHole(isWhitespaceStashedMemo(c))
+        blackHole(isPunctuationStashedMemo(c))
     }
   }
 }
@@ -415,16 +415,16 @@ public func run_CharacterPropertiesStashedMemo(_ N: Int) {
 public func run_CharacterPropertiesPrecomputed(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-        blackHole(isControlPrecomputed(c))
         blackHole(isAlphanumericPrecomputed(c))
-        blackHole(isLowercasePrecomputed(c))
-        blackHole(isPunctuationPrecomputed(c))
-        blackHole(isWhitespacePrecomputed(c))
-        blackHole(isLetterPrecomputed(c))
-        blackHole(isUppercasePrecomputed(c))
-        blackHole(isDecimalPrecomputed(c))
-        blackHole(isNewlinePrecomputed(c))
         blackHole(isCapitalizedPrecomputed(c))
+        blackHole(isControlPrecomputed(c))
+        blackHole(isDecimalPrecomputed(c))
+        blackHole(isLetterPrecomputed(c))
+        blackHole(isLowercasePrecomputed(c))
+        blackHole(isUppercasePrecomputed(c))
+        blackHole(isNewlinePrecomputed(c))
+        blackHole(isWhitespacePrecomputed(c))
+        blackHole(isPunctuationPrecomputed(c))
     }
   }
 }

--- a/benchmark/single-source/CharacterProperties.swift.gyb
+++ b/benchmark/single-source/CharacterProperties.swift.gyb
@@ -52,27 +52,27 @@ extension Character {
   var firstScalar: UnicodeScalar { return unicodeScalars.first! }
 }
 
-% Properties = { "Alphanumeric": "alphanumerics", \
-%              "Capitalized": "capitalizedLetters", \
-%              "Control": "controlCharacters", \
-%              "Decimal": "decimalDigits", \
-%              "Letter": "letters", \
-%              "Lowercase": "lowercaseLetters", \
-%              "Uppercase": "uppercaseLetters", \
-%              "Newline": "newlines", \
-%              "Whitespace": "whitespaces", \
-%              "Punctuation": "punctuationCharacters" \
-%              }
+% Properties = [ ( "Alphanumeric", "alphanumerics"),
+%                ( "Capitalized", "capitalizedLetters"),
+%                ( "Control", "controlCharacters"),
+%                ( "Decimal", "decimalDigits"),
+%                ( "Letter", "letters"),
+%                ( "Lowercase", "lowercaseLetters"),
+%                ( "Uppercase", "uppercaseLetters"),
+%                ( "Newline", "newlines"),
+%                ( "Whitespace", "whitespaces"),
+%                ( "Punctuation", "punctuationCharacters")
+%              ]
 
 // Fetch the CharacterSet for every call
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
 func is${Property}(_ c: Character) -> Bool {
   return CharacterSet.${Set}.contains(c.firstScalar)
 }
 % end
 
 // Stash the set
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
 let ${Set} = CharacterSet.${Set}
 func is${Property}Stashed(_ c: Character) -> Bool {
   return ${Set}.contains(c.firstScalar)
@@ -81,13 +81,13 @@ func is${Property}Stashed(_ c: Character) -> Bool {
 
 func setupStash() {
   blackHole(workload)
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
     blackHole(${Set})
 % end
 }
 
 // Memoize the stashed set
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
 var ${Set}Memo = Set<UInt32>()
 func is${Property}StashedMemo(_ c: Character) -> Bool {
   let scalar = c.firstScalar
@@ -102,7 +102,7 @@ func is${Property}StashedMemo(_ c: Character) -> Bool {
 
 func setupMemo() {
   blackHole(workload)
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
     blackHole(${Set}Memo)
 % end
 }
@@ -130,7 +130,7 @@ func precompute(_ charSet: CharacterSet, capacity: Int) -> Set<UInt32> {
     capitalizedLetters=31
   )
 }%
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
 var ${Set}Precomputed: Set<UInt32> =
   precompute(${Set}, capacity: ${precomputed_capacity[Set]})
 func is${Property}Precomputed(_ c: Character) -> Bool {
@@ -140,7 +140,7 @@ func is${Property}Precomputed(_ c: Character) -> Bool {
 
 func setupPrecomputed() {
   blackHole(workload)
-% for Property, Set in Properties.items():
+% for Property, Set in Properties:
     blackHole(${Set}Precomputed)
 %#//    print("${Set}: \(${Set}Precomputed.count)")
 % end
@@ -171,7 +171,7 @@ let workload = """
 public func run_CharacterPropertiesFetch(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-    % for Property, Set in Properties.items():
+    % for Property, Set in Properties:
         blackHole(is${Property}(c))
     % end
     }
@@ -182,7 +182,7 @@ public func run_CharacterPropertiesFetch(_ N: Int) {
 public func run_CharacterPropertiesStashed(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-    % for Property, Set in Properties.items():
+    % for Property, Set in Properties:
         blackHole(is${Property}Stashed(c))
     % end
     }
@@ -193,7 +193,7 @@ public func run_CharacterPropertiesStashed(_ N: Int) {
 public func run_CharacterPropertiesStashedMemo(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-    % for Property, Set in Properties.items():
+    % for Property, Set in Properties:
         blackHole(is${Property}StashedMemo(c))
     % end
     }
@@ -204,7 +204,7 @@ public func run_CharacterPropertiesStashedMemo(_ N: Int) {
 public func run_CharacterPropertiesPrecomputed(_ N: Int) {
   for _ in 1...N {
     for c in workload {
-    % for Property, Set in Properties.items():
+    % for Property, Set in Properties:
         blackHole(is${Property}Precomputed(c))
     % end
     }

--- a/benchmark/single-source/DropFirst.swift.gyb
+++ b/benchmark/single-source/DropFirst.swift.gyb
@@ -40,7 +40,7 @@ Sequences = [
 ]
 def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
-Sequences = Sequences + map(lazy, Sequences)
+Sequences = Sequences + list(map(lazy, Sequences))
 }%
 
 public let DropFirst = [

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -40,7 +40,7 @@ Sequences = [
 ]
 def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
-Sequences = Sequences + map(lazy, Sequences)
+Sequences = Sequences + list(map(lazy, Sequences))
 }%
 
 public let DropLast = [

--- a/benchmark/single-source/DropWhile.swift.gyb
+++ b/benchmark/single-source/DropWhile.swift.gyb
@@ -40,7 +40,7 @@ Sequences = [
 ]
 def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
-Sequences = Sequences + map(lazy, Sequences)
+Sequences = Sequences + list(map(lazy, Sequences))
 }%
 
 public let DropWhile = [

--- a/benchmark/single-source/ExistentialPerformance.swift.gyb
+++ b/benchmark/single-source/ExistentialPerformance.swift.gyb
@@ -169,7 +169,7 @@ func next(_ x: inout Int, upto mod: Int) {
   x = (x + 1) % (mod + 1)
 }
 
-% for (V, i) in [(v, int(filter(str.isdigit, v))) for v in Vals]:
+% for (V, i) in [(v, int(''.join(filter(str.isdigit, v)))) for v in Vals]:
 struct ${V} : Existential {${
   ''.join(['\n	var f{0}: Int = {1}'.format(vi, v)
               for (vi, v) in Vars[0:i]]) +
@@ -208,7 +208,7 @@ class Klazz { // body same as Val2
 	}
 }
 
-% for (V, i) in [(v, int(filter(str.isdigit, v))) for v in Refs]:
+% for (V, i) in [(v, int(''.join(filter(str.isdigit, v)))) for v in Refs]:
 struct ${V} : Existential {
 	${'\n	'.join([('var f{0}: Klazz = Klazz()'.format(vi) if vi < 3 else
                  'var f3: Int = 0') for (vi, _) in Vars[0:i]])}

--- a/benchmark/single-source/Prefix.swift.gyb
+++ b/benchmark/single-source/Prefix.swift.gyb
@@ -39,7 +39,7 @@ Sequences = [
 ]
 def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
-Sequences = Sequences + map(lazy, Sequences)
+Sequences = Sequences + list(map(lazy, Sequences))
 }%
 
 public let Prefix = [

--- a/benchmark/single-source/PrefixWhile.swift.gyb
+++ b/benchmark/single-source/PrefixWhile.swift.gyb
@@ -39,7 +39,7 @@ Sequences = [
 ]
 def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
-Sequences = Sequences + map(lazy, Sequences)
+Sequences = Sequences + list(map(lazy, Sequences))
 }%
 
 public let PrefixWhile = [

--- a/benchmark/single-source/Suffix.swift.gyb
+++ b/benchmark/single-source/Suffix.swift.gyb
@@ -39,7 +39,7 @@ Sequences = [
 ]
 def lazy (NameExpr) : return (NameExpr[0] + 'Lazy', '(' + NameExpr[1] + ').lazy')
 
-Sequences = Sequences + map(lazy, Sequences)
+Sequences = Sequences + list(map(lazy, Sequences))
 }%
 
 public let Suffix = [


### PR DESCRIPTION
Three issues addressed here:

1. Dependency on dictionary iteration order

 CharacterProperties.swift.gyb iterated a dictionary to produce its output.
 Changed this to a list of tuples to ensure the order is predictable.
 Regenerated CharacterProperties.swift to match the new order.

2. Python3 `map` returns an iterator, not a list

 Changed a bunch of `map` calls to `list(map(...))` to ensure the result is a list

3. Python3 `int()` expects a string, won't accept a list of characters

 Added a concatenation step that is effectively a no-op on Python2
