### PR TITLE
gyb: special case list for conversion

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -737,7 +737,7 @@ class Code(ASTNode):
             result_string = None
             if isinstance(result, Number) and not isinstance(result, Integral):
                 result_string = repr(result)
-            elif isinstance(result, Integral):
+            elif isinstance(result, Integral) or isinstance(result, list):
                 result_string = str(result)
             else:
                 result_string = StringIO(result).read()


### PR DESCRIPTION
In order to deal with encoding conversions for Python 2 and Python 3,
the string had to be passed through CStringIO for Python 2.  On Python
3, the strings are unicode.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
