### PR TITLE
CXX_SUPPORTS_WE4062 ONLY for MSVC

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -269,7 +269,7 @@ macro(swift_common_cxx_warnings)
     check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_WERROR_SWITCH_FLAG)
     append_if(CXX_SUPPORTS_WERROR_SWITCH_FLAG "-Werror=switch" CMAKE_CXX_FLAGS)
 
-    if(MSVC)
+    IF (CMAKE_SYSTEM_NAME MATCHES "Windows")
       check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
       append_if(CXX_SUPPORTS_WE4062 "/we4062" CMAKE_CXX_FLAGS)
     endif()

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -269,8 +269,10 @@ macro(swift_common_cxx_warnings)
     check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_WERROR_SWITCH_FLAG)
     append_if(CXX_SUPPORTS_WERROR_SWITCH_FLAG "-Werror=switch" CMAKE_CXX_FLAGS)
 
-    check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
-    append_if(CXX_SUPPORTS_WE4062 "/we4062" CMAKE_CXX_FLAGS)
+    if(MSVC)
+      check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
+      append_if(CXX_SUPPORTS_WE4062 "/we4062" CMAKE_CXX_FLAGS)
+    endif()
   endif()
 
   check_cxx_compiler_flag("-Werror -Wdocumentation" CXX_SUPPORTS_DOCUMENTATION_FLAG)

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -269,7 +269,7 @@ macro(swift_common_cxx_warnings)
     check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_WERROR_SWITCH_FLAG)
     append_if(CXX_SUPPORTS_WERROR_SWITCH_FLAG "-Werror=switch" CMAKE_CXX_FLAGS)
 
-    IF (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    if(CMAKE_SYSTEM_NAME MATCHES "Windows")
       check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
       append_if(CXX_SUPPORTS_WE4062 "/we4062" CMAKE_CXX_FLAGS)
     endif()


### PR DESCRIPTION
it breaks MacOS Swift Toolchain build: 
    $ ./swift/utils/build-toolchain com.abael

surrounding as:
if(MSVC)
    CXX_SUPPORTS_WE4062 case ...
endif()

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
