### PR TITLE
[opt-remark] Teach opt-remark how to identify temporary arrays used for varargs.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -21,8 +21,10 @@
 #ifndef SWIFT_SIL_APPLYSITE_H
 #define SWIFT_SIL_APPLYSITE_H
 
+#include "swift/AST/Types.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -409,6 +411,14 @@ public:
     case ApplySiteKind::PartialApplyInst:
       llvm_unreachable("Unhandled case");
     }
+  }
+
+  bool isVariadic(Operand &op) {
+    unsigned calleeArgIdx =
+        getCalleeArgIndexOfFirstAppliedArg() + getAppliedArgIndex(op);
+    auto isVarArg =
+        getSubstCalleeConv().getParamInfoForSILArg(calleeArgIdx).isVariadic();
+    return SILParameterIsVariadic::Yes == isVarArg;
   }
 
   static ApplySite getFromOpaqueValue(void *p) { return ApplySite(p); }

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -120,6 +120,9 @@ struct Argument {
   Argument(ArgumentKey key, StringRef msg, const ValueDecl *decl)
       : key(key), val(msg), loc(decl->getLoc()) {}
 
+  Argument(ArgumentKey key, llvm::Twine &&twine, const SILInstruction *i)
+      : key(key), val(twine.str()), loc(i->getLoc().getSourceLoc()) {}
+
   /// Given a value, call \p funcPassedInferredArgs for each associated
   /// ValueDecl that is associated with \p value. All created Arguments are
   /// passed the same StringRef. To stop iteration, return false in \p

--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -3,71 +3,75 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil -save-optimization-record=yaml  -save-optimization-record-path %t/note.yaml %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
 
-// CHECK: --- !Missed
-// CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
-// CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 59, Column: 5 }
-// CHECK-NEXT: Function:        'getGlobal()'
-// CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found retain:'
-// CHECK-NEXT:   - InferredValue:   'on value:'
-// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
-// CHECK-NEXT:                        Line: 55, Column: 12 }
-// CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
-// CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
-// CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 67, Column: 5 }
-// CHECK-NEXT: Function:        'useGlobal()'
-// CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found retain:'
-// CHECK-NEXT:   - InferredValue:   'on value:'
-// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
-// CHECK-NEXT:                        Line: 64, Column: 9 }
-// CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
-// CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
-// CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 67, Column: 12 }
-// CHECK-NEXT: Function:        'useGlobal()'
-// CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found release:'
-// CHECK-NEXT:   - InferValueFailure: Unable to infer any values being released.
-// CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
-// CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
-// CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
-// CHECK-NEXT:                    Line: 67, Column: 12 }
-// CHECK-NEXT: Function:        'useGlobal()'
-// CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found release:'
-// CHECK-NEXT:   - InferredValue:   'on value:'
-// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
-// CHECK-NEXT:                        Line: 64, Column: 9 }
-// CHECK-NEXT: ...
-
 public class Klass {}
 
 public var global = Klass()
 
 @inline(never)
 public func getGlobal() -> Klass {
+
+    // CHECK: --- !Missed
+    // CHECK-NEXT: Pass:            sil-opt-remark-gen
+    // CHECK-NEXT: Name:            sil.memory-management
+    // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                    Line: [[#@LINE+8]], Column: 5 }
+    // CHECK-NEXT: Function:        'getGlobal()'
+    // CHECK-NEXT: Args:
+    // CHECK-NEXT:   - String:          'Found retain:'
+    // CHECK-NEXT:   - InferredValue:   'on value:'
+    // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                        Line: [[#@LINE-15]], Column: 12 }
+    // CHECK-NEXT: ...
     return global // expected-remark @:5 {{Found retain:}}
-                  // expected-note @-5:12 {{on value:}}
+                  // expected-note @-18:12 {{on value:}}
 }
 
 public func useGlobal() {
     let x = getGlobal()
+
+    // CHECK-NEXT: --- !Missed
+    // CHECK-NEXT: Pass:            sil-opt-remark-gen
+    // CHECK-NEXT: Name:            sil.memory-management
+    // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                    Line: [[# @LINE + 35]], Column: 5 }
+    // CHECK-NEXT: Function:        'useGlobal()'
+    // CHECK-NEXT: Args:
+    // CHECK-NEXT:   - String:          'Found retain:'
+    // CHECK-NEXT:   - InferredValue:   'on value:'
+    // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                        Line: [[# @LINE - 12]], Column: 9 }
+    // CHECK-NEXT: ...
+    // CHECK-NEXT: --- !Missed
+    // CHECK-NEXT: Pass:            sil-opt-remark-gen
+    // CHECK-NEXT: Name:            sil.memory-management
+    // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                    Line: [[# @LINE + 23]], Column: 12 }
+    // CHECK-NEXT: Function:        'useGlobal()'
+    // CHECK-NEXT: Args:
+    // CHECK-NEXT:   - String:          'Found release:'
+    // CHECK-NEXT:   - InferredValue:   'on variadic argument array for argument 0:'
+    // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                        Line: [[# @LINE + 17]], Column: 5 }
+    // CHECK-NEXT: ...
+    // CHECK-NEXT: --- !Missed
+    // CHECK-NEXT: Pass:            sil-opt-remark-gen
+    // CHECK-NEXT: Name:            sil.memory-management
+    // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                    Line: [[# @LINE + 11]], Column: 12 }
+    // CHECK-NEXT: Function:        'useGlobal()'
+    // CHECK-NEXT: Args:
+    // CHECK-NEXT:   - String:          'Found release:'
+    // CHECK-NEXT:   - InferredValue:   'on value:'
+    // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
+    // CHECK-NEXT:                        Line: [[# @LINE - 36]], Column: 9 }
+    // CHECK-NEXT: ...
+    //
     // Make sure that the retain msg is at the beginning of the print and the
     // releases are the end of the print.
     print(x) // expected-remark @:5 {{Found retain:}}
-             // expected-note @-4:9 {{on value:}}
+             // expected-note @-42:9 {{on value:}}
              // expected-remark @-2:12 {{Found release:}}
-             // expected-note @-3:12 {{Unable to infer any values being released.}}
+             // expected-note @-3:5 {{on variadic argument array for argument 0:}}
              // expected-remark @-4:12 {{Found release:}}
-             // expected-note @-8:9 {{on value:}}
+             // expected-note @-46:9 {{on value:}}
 }


### PR DESCRIPTION
The first commit repurposes a padding bit from SILParameterInfo and uses that bit to stash in TypeLowering if an Array parameter was originally a Variadic parameter.

Then the second commit teaches opt-remark how to emit a nice note on any releases of such a variadic parameter instead of an ugly... I don't know what is being released.