### PR TITLE
[NFC] Stash Syntactic Information in EnumIsCaseExpr

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4704,7 +4704,7 @@ public:
 
 /// Represents an explicit conditional checked cast, which converts
 /// from a type to some subtype and produces an Optional value, which will be
-/// .Some(x) if the cast succeeds, or .None if the cast fails.
+/// .some(x) if the cast succeeds, or .none if the cast fails.
 /// Spelled 'a as? T' and produces a value of type 'T?'.
 class ConditionalCheckedCastExpr final : public CheckedCastExpr {
   SourceLoc QuestionLoc;
@@ -4721,9 +4721,6 @@ public:
 
   static ConditionalCheckedCastExpr *createImplicit(ASTContext &ctx, Expr *sub,
                                                     Type castTy);
-
-  static ConditionalCheckedCastExpr *
-  createImplicit(ASTContext &ctx, Expr *sub, TypeRepr *tyRepr, Type castTy);
 
   /// Retrieve the location of the '?' that follows 'as'.
   SourceLoc getQuestionLoc() const { return QuestionLoc; }
@@ -4911,20 +4908,21 @@ public:
 /// a particular case.
 class EnumIsCaseExpr : public Expr {
   Expr *SubExpr;
+  TypeRepr *CaseRepr;
   EnumElementDecl *Element;
   
 public:
-  EnumIsCaseExpr(Expr *SubExpr, EnumElementDecl *Element)
-    : Expr(ExprKind::EnumIsCase, /*implicit*/ true),
-      SubExpr(SubExpr), Element(Element)
-  {}
-  
+  EnumIsCaseExpr(Expr *SubExpr, TypeRepr *CaseRepr, EnumElementDecl *Element)
+      : Expr(ExprKind::EnumIsCase, /*implicit*/ true), SubExpr(SubExpr),
+        CaseRepr(CaseRepr), Element(Element) {}
+
   Expr *getSubExpr() const { return SubExpr; }
   void setSubExpr(Expr *e) { SubExpr = e; }
-  
+
+  TypeRepr *getCaseTypeRepr() const { return CaseRepr; }
+
   EnumElementDecl *getEnumElement() const { return Element; }
-  void setEnumElement(EnumElementDecl *elt) { Element = elt; }
-  
+
   SourceLoc getLoc() const { return SubExpr->getLoc(); }
   SourceLoc getStartLoc() const { return SubExpr->getStartLoc(); }
   SourceLoc getEndLoc() const { return SubExpr->getEndLoc(); }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -951,7 +951,11 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         return nullptr;
       E->setSubExpr(Sub);
     }
-    
+
+    if (auto *typerepr = E->getCaseTypeRepr())
+      if (doIt(typerepr))
+        return nullptr;
+
     return E;
   }
   

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1808,17 +1808,6 @@ ConditionalCheckedCastExpr::createImplicit(ASTContext &ctx, Expr *sub,
   return expr;
 }
 
-ConditionalCheckedCastExpr *
-ConditionalCheckedCastExpr::createImplicit(ASTContext &ctx, Expr *sub,
-                                           TypeRepr *tyRepr, Type castTy) {
-  auto *const expr = new (ctx) ConditionalCheckedCastExpr(
-      sub, SourceLoc(), SourceLoc(), new (ctx) TypeExpr(tyRepr));
-  expr->setType(OptionalType::get(castTy));
-  expr->setImplicit();
-  expr->setCastType(castTy);
-  return expr;
-}
-
 IsExpr *IsExpr::create(ASTContext &ctx, SourceLoc isLoc, TypeRepr *tyRepr) {
   return new (ctx) IsExpr(nullptr, isLoc, new (ctx) TypeExpr(tyRepr));
 }


### PR DESCRIPTION
After the TypeLocs were removed here, the TypeRepr from the IsExpr was
the only thing providing access to syntactic information from the parent
IsExpr. In order to support this, it was possible to construct a bizarre
ConditionalCheckedCastExpr that contained both semantic and syntactic
information. This doesn't comport with the rest of the casting nodes,
which force you to pick one or the other.

Since we're rewriting an IsExpr into a EnumIsCaseExpr, let's just stash
the syntactic information there. This unblocks a bit of cleanup.