### PR TITLE
[Serialization] Move loading swiftmodule files as volatile behind a flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -372,6 +372,9 @@ namespace swift {
     /// Enable verification when every SubstitutionMap is constructed.
     bool VerifyAllSubstitutionMaps = false;
 
+    /// Load swiftmodule files in memory as volatile and avoid mmap.
+    bool EnableVolatileModules = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -457,6 +457,9 @@ def warn_long_expression_type_checking_EQ : Joined<["-"], "warn-long-expression-
 def Rmodule_interface_rebuild : Flag<["-"], "Rmodule-interface-rebuild">,
   HelpText<"Emits a remark if an imported module needs to be re-compiled from its module interface">;
 
+def enable_volatile_modules : Flag<["-"], "enable-volatile-modules">,
+  HelpText<"Load Swift modules in memory">;
+
 def solver_expression_time_threshold_EQ : Joined<["-"], "solver-expression-time-threshold=">;
 
 def solver_disable_shrink :

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -599,6 +599,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.VerifyAllSubstitutionMaps |= Args.hasArg(OPT_verify_all_substitution_maps);
 
+  Opts.EnableVolatileModules |= Args.hasArg(OPT_enable_volatile_modules);
+
   Opts.UseDarwinPreStableABIBit =
     (Target.isMacOSX() && Target.isMacOSXVersionLT(10, 14, 4)) ||
     (Target.isiOS() && Target.isOSVersionLT(12, 2)) ||

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -348,7 +348,8 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
 
   // Actually load the file and error out if necessary.
   //
-  // Use the default arguments except for IsVolatile. Force avoiding the use of
+  // Use the default arguments except for IsVolatile that is set by the
+  // frontend option -enable-volatile-modules. If set, we avoid the use of
   // mmap to workaround issues on NFS when the swiftmodule file loaded changes
   // on disk while it's in use.
   //
@@ -361,11 +362,12 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   // the surface look like memory corruption.
   //
   // rdar://63755989
+  bool enableVolatileModules = Ctx.LangOpts.EnableVolatileModules;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleOrErr =
       FS.getBufferForFile(ModulePath,
                           /*FileSize=*/-1,
                           /*RequiresNullTerminator=*/true,
-                          /*IsVolatile=*/true);
+                          /*IsVolatile=*/enableVolatileModules);
   if (!ModuleOrErr)
     return ModuleOrErr.getError();
 


### PR DESCRIPTION
Introduce a new frontend flag `-enable-volatile-modules` to trigger loading swiftmodule files as volatile and avoid using mmap. Revert the default behavior to using mmap.