### PR TITLE
[cxx-interop] Support function templates.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -23,11 +23,12 @@
 #include "swift/AST/Import.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/Type.h"
-#include "swift/AST/Types.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/Malloc.h"
+#include "clang/AST/DeclTemplate.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -627,6 +628,13 @@ public:
   getCanonicalClangFunctionType(
     ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
     SILFunctionType::Representation trueRep);
+
+  /// Instantiates "Impl.Converter" if needed, then calls
+  /// ClangTypeConverter::getClangTemplateArguments.
+  std::unique_ptr<TemplateInstantiationError> getClangTemplateArguments(
+      const clang::TemplateParameterList *templateParams,
+      ArrayRef<Type> genericArgs,
+      SmallVectorImpl<clang::TemplateArgument> &templateArgs);
 
   /// Get the Swift declaration that a Clang declaration was exported from,
   /// if applicable.

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -14,7 +14,9 @@
 #define SWIFT_AST_CLANG_MODULE_LOADER_H
 
 #include "swift/AST/ModuleLoader.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/TaggedUnion.h"
+#include "clang/AST/DeclTemplate.h"
 
 namespace clang {
 class ASTContext;
@@ -219,6 +221,18 @@ public:
   /// based on subtleties like the target module interface format.
   virtual bool isSerializable(const clang::Type *type,
                               bool checkCanonical) const = 0;
+
+  virtual clang::FunctionDecl *
+  instantiateCXXFunctionTemplate(ASTContext &ctx,
+                                 clang::FunctionTemplateDecl *func,
+                                 SubstitutionMap subst) = 0;
+};
+
+/// Used to describe a template instantiation error.
+struct TemplateInstantiationError {
+  /// Generic types that could not be converted to QualTypes using the
+  /// ClangTypeConverter.
+  SmallVector<Type, 4> failedTypes;
 };
 
 } // namespace swift

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5960,9 +5960,10 @@ public:
                                   DeclContext *Parent);
 
   static FuncDecl *createImported(ASTContext &Context, SourceLoc FuncLoc,
-                                  DeclName Name, SourceLoc NameLoc,
-                                  bool Async, bool Throws,
-                                  ParameterList *BodyParams, Type FnRetType,
+                                  DeclName Name, SourceLoc NameLoc, bool Async,
+                                  bool Throws, ParameterList *BodyParams,
+                                  Type FnRetType,
+                                  GenericParamList *GenericParams,
                                   DeclContext *Parent, ClangNode ClangN);
 
   bool isStatic() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1674,6 +1674,11 @@ ERROR(where_nongeneric_ctx,none,
 ERROR(where_nongeneric_toplevel,none,
       "'where' clause cannot be applied to a non-generic top-level "
       "declaration", ())
+ERROR(unable_to_convert_generic_swift_types,none,
+      "could not generate C++ types from the generic Swift types provided. "
+      "The following Swift type(s) provided to '%0' were unable to be "
+      "converted: %1.",
+      (StringRef, StringRef))
 
 // Type aliases
 ERROR(type_alias_underlying_type_access,none,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -472,6 +472,11 @@ public:
 
   bool isSerializable(const clang::Type *type,
                       bool checkCanonical) const override;
+
+  clang::FunctionDecl *
+  instantiateCXXFunctionTemplate(ASTContext &ctx,
+                                 clang::FunctionTemplateDecl *func,
+                                 SubstitutionMap subst) override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -807,3 +807,33 @@ Decl *ClangTypeConverter::getSwiftDeclForExportedClangDecl(
   auto it = ReversedExportMap.find(decl);
   return (it != ReversedExportMap.end() ? it->second : nullptr);
 }
+
+std::unique_ptr<TemplateInstantiationError>
+ClangTypeConverter::getClangTemplateArguments(
+    const clang::TemplateParameterList *templateParams,
+    ArrayRef<Type> genericArgs,
+    SmallVectorImpl<clang::TemplateArgument> &templateArgs) {
+  // Keep track of the types we failed to convert so we can return a useful
+  // error.
+  SmallVector<Type, 2> failedTypes;
+  for (clang::NamedDecl *param : *templateParams) {
+    // Note: all template parameters must be template type parameters. This is
+    // verified when we import the clang decl.
+    auto templateParam = cast<clang::TemplateTypeParmDecl>(param);
+    auto replacement = genericArgs[templateParam->getIndex()];
+    auto qualType = convert(replacement);
+    if (qualType.isNull()) {
+      failedTypes.push_back(replacement);
+      // Find all the types we can't convert.
+      continue;
+    }
+    templateArgs.push_back(clang::TemplateArgument(qualType));
+  }
+  if (failedTypes.empty())
+    return nullptr;
+  auto errorInfo = std::make_unique<TemplateInstantiationError>();
+  llvm::for_each(failedTypes, [&errorInfo](auto type) {
+    errorInfo->failedTypes.push_back(type);
+  });
+  return errorInfo;
+}

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -84,8 +84,18 @@ public:
   /// Swift declaration.
   Decl *getSwiftDeclForExportedClangDecl(const clang::Decl *decl) const;
 
+  /// Translate Swift generic arguments to template arguments.
+  ///
+  /// \returns nullptr if successful. If an error occors, returns a unique_ptr
+  /// to a `TemplateInstantiationError` with a list of the failed types.
+  std::unique_ptr<TemplateInstantiationError> getClangTemplateArguments(
+      const clang::TemplateParameterList *templateParams,
+      ArrayRef<Type> genericArgs,
+      SmallVectorImpl<clang::TemplateArgument> &templateArgs);
+
 private:
   clang::QualType convert(Type type);
+
   clang::QualType convertMemberType(NominalTypeDecl *DC,
                                     StringRef memberName);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7227,16 +7227,15 @@ FuncDecl *FuncDecl::createImplicit(ASTContext &Context,
 }
 
 FuncDecl *FuncDecl::createImported(ASTContext &Context, SourceLoc FuncLoc,
-                                   DeclName Name, SourceLoc NameLoc,
-                                   bool Async, bool Throws,
-                                   ParameterList *BodyParams,
-                                   Type FnRetType, DeclContext *Parent,
-                                   ClangNode ClangN) {
+                                   DeclName Name, SourceLoc NameLoc, bool Async,
+                                   bool Throws, ParameterList *BodyParams,
+                                   Type FnRetType,
+                                   GenericParamList *GenericParams,
+                                   DeclContext *Parent, ClangNode ClangN) {
   assert(ClangN && FnRetType);
   auto *const FD = FuncDecl::createImpl(
       Context, SourceLoc(), StaticSpellingKind::None, FuncLoc, Name, NameLoc,
-      Async, SourceLoc(), Throws, SourceLoc(),
-      /*GenericParams=*/nullptr, Parent, ClangN);
+      Async, SourceLoc(), Throws, SourceLoc(), GenericParams, Parent, ClangN);
   FD->setParameters(BodyParams);
   FD->setResultInterfaceType(FnRetType);
   return FD;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -17,6 +17,7 @@
 #include "CFTypeInfo.h"
 #include "ImporterImpl.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Builtins.h"
@@ -51,7 +52,6 @@
 #include "clang/AST/DeclObjCCommon.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/Basic/CharInfo.h"
-#include "swift/Basic/Statistic.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/Preprocessor.h"
@@ -161,27 +161,22 @@ createVarWithPattern(ASTContext &ctx, DeclContext *dc, Identifier name, Type ty,
 static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                                       Optional<AccessorInfo> accessorInfo,
                                       DeclName name, SourceLoc nameLoc,
-                                      ParameterList *bodyParams,
-                                      Type resultTy,
-                                      bool async,
-                                      bool throws,
-                                      DeclContext *dc,
+                                      GenericParamList *genericParams,
+                                      ParameterList *bodyParams, Type resultTy,
+                                      bool async, bool throws, DeclContext *dc,
                                       ClangNode clangNode) {
   if (accessorInfo) {
     return AccessorDecl::create(ctx, funcLoc,
                                 /*accessorKeywordLoc*/ SourceLoc(),
-                                accessorInfo->Kind,
-                                accessorInfo->Storage,
-                                /*StaticLoc*/SourceLoc(),
-                                StaticSpellingKind::None,
-                                throws,
-                                /*ThrowsLoc=*/SourceLoc(),
-                                /*GenericParams=*/nullptr,
-                                bodyParams,
-                                resultTy, dc, clangNode);
+                                accessorInfo->Kind, accessorInfo->Storage,
+                                /*StaticLoc*/ SourceLoc(),
+                                StaticSpellingKind::None, throws,
+                                /*ThrowsLoc=*/SourceLoc(), genericParams,
+                                bodyParams, resultTy, dc, clangNode);
   } else {
     return FuncDecl::createImported(ctx, funcLoc, name, nameLoc, async, throws,
-                                    bodyParams, resultTy, dc, clangNode);
+                                    bodyParams, resultTy, genericParams, dc,
+                                    clangNode);
   }
 }
 
@@ -3736,9 +3731,9 @@ namespace {
           continue;
         nonSelfParams.push_back(decl->getParamDecl(i));
       }
-      return Impl.importFunctionParameterList(dc, decl, nonSelfParams,
-                                              decl->isVariadic(),
-                                              allowNSUIntegerAsInt, argNames);
+      return Impl.importFunctionParameterList(
+          dc, decl, nonSelfParams, decl->isVariadic(), allowNSUIntegerAsInt,
+          argNames, /*genericParams=*/{});
     }
 
     Decl *importGlobalAsInitializer(const clang::FunctionDecl *decl,
@@ -3783,10 +3778,11 @@ namespace {
       return importFunctionDecl(decl, importedName, correctSwiftName, None);
     }
 
-    Decl *importFunctionDecl(const clang::FunctionDecl *decl,
-                             ImportedName importedName,
-                             Optional<ImportedName> correctSwiftName,
-                             Optional<AccessorInfo> accessorInfo) {
+    Decl *importFunctionDecl(
+        const clang::FunctionDecl *decl, ImportedName importedName,
+        Optional<ImportedName> correctSwiftName,
+        Optional<AccessorInfo> accessorInfo,
+        const clang::FunctionTemplateDecl *funcTemplate = nullptr) {
       if (decl->isDeleted())
         return nullptr;
 
@@ -3801,6 +3797,22 @@ namespace {
       ImportedType importedType;
       bool selfIsInOut = false;
       ParameterList *bodyParams = nullptr;
+      GenericParamList *genericParams = nullptr;
+      SmallVector<GenericTypeParamDecl *, 4> templateParams;
+      if (funcTemplate) {
+        unsigned i = 0;
+        for (auto param : *funcTemplate->getTemplateParameters()) {
+          auto *typeParam = Impl.createDeclWithClangNode<GenericTypeParamDecl>(
+              param, AccessLevel::Public, dc,
+              Impl.SwiftContext.getIdentifier(param->getName()), SourceLoc(), 0,
+              i);
+          templateParams.push_back(typeParam);
+          (void)++i;
+        }
+        genericParams = GenericParamList::create(Impl.SwiftContext, SourceLoc(),
+                                                 templateParams, SourceLoc());
+      }
+
       if (!dc->isModuleScopeContext() && !isa<clang::CXXMethodDecl>(decl)) {
         // Handle initializers.
         if (name.getBaseName() == DeclBaseName::createConstructor()) {
@@ -3868,7 +3880,8 @@ namespace {
         // names get into the resulting function type.
         importedType = Impl.importFunctionParamsAndReturnType(
             dc, decl, {decl->param_begin(), decl->param_size()},
-            decl->isVariadic(), isInSystemModule(dc), name, bodyParams);
+            decl->isVariadic(), isInSystemModule(dc), name, bodyParams,
+            templateParams);
 
         if (auto *mdecl = dyn_cast<clang::CXXMethodDecl>(decl)) {
           if (mdecl->isStatic() ||
@@ -3901,6 +3914,10 @@ namespace {
 
       auto loc = Impl.importSourceLoc(decl->getLocation());
 
+      ClangNode clangNode = decl;
+      if (funcTemplate)
+        clangNode = funcTemplate;
+
       // FIXME: Poor location info.
       auto nameLoc = Impl.importSourceLoc(decl->getLocation());
 
@@ -3914,17 +3931,17 @@ namespace {
         DeclName ctorName(Impl.SwiftContext, DeclBaseName::createConstructor(),
                           bodyParams);
         result = Impl.createDeclWithClangNode<ConstructorDecl>(
-            decl, AccessLevel::Public, ctorName, loc, /*failable=*/false,
+            clangNode, AccessLevel::Public, ctorName, loc, /*failable=*/false,
             /*FailabilityLoc=*/SourceLoc(), /*Throws=*/false,
-            /*ThrowsLoc=*/SourceLoc(), bodyParams, /*GenericParams=*/nullptr,
-            dc);
+            /*ThrowsLoc=*/SourceLoc(), bodyParams, genericParams, dc);
       } else {
         auto resultTy = importedType.getType();
 
         FuncDecl *func =
             createFuncOrAccessor(Impl.SwiftContext, loc, accessorInfo, name,
-                                 nameLoc, bodyParams, resultTy,
-                                 /*async=*/false, /*throws=*/false, dc, decl);
+                                 nameLoc, genericParams, bodyParams, resultTy,
+                                 /*async=*/false, /*throws=*/false, dc,
+                                 clangNode);
         result = func;
 
         if (!dc->isModuleScopeContext()) {
@@ -4156,6 +4173,21 @@ namespace {
     Decl *VisitTemplateDecl(const clang::TemplateDecl *decl) {
       // Note: templates are not imported.
       return nullptr;
+    }
+
+    Decl *VisitFunctionTemplateDecl(const clang::FunctionTemplateDecl *decl) {
+      Optional<ImportedName> correctSwiftName;
+      auto importedName =
+          importFullName(decl->getAsFunction(), correctSwiftName);
+      if (!importedName)
+        return nullptr;
+      // All template parameters must be template type parameters.
+      if (!llvm::all_of(*decl->getTemplateParameters(), [](auto param) {
+            return isa<clang::TemplateTypeParmDecl>(param);
+          }))
+        return nullptr;
+      return importFunctionDecl(decl->getAsFunction(), importedName,
+                                correctSwiftName, None, decl);
     }
 
     Decl *VisitUsingDecl(const clang::UsingDecl *decl) {
@@ -4530,12 +4562,11 @@ namespace {
       }
 
       auto result = createFuncOrAccessor(Impl.SwiftContext,
-                                         /*funcLoc*/SourceLoc(),
-                                         accessorInfo,
+                                         /*funcLoc*/ SourceLoc(), accessorInfo,
                                          importedName.getDeclName(),
-                                         /*nameLoc*/SourceLoc(),
-                                         bodyParams, resultTy,
-                                         async, throws, dc, decl);
+                                         /*nameLoc*/ SourceLoc(),
+                                         /*genericParams=*/nullptr, bodyParams,
+                                         resultTy, async, throws, dc, decl);
 
       result->setAccess(getOverridableAccessLevel(dc));
 
@@ -6045,7 +6076,7 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
   } else {
     parameterList = Impl.importFunctionParameterList(
         dc, decl, {decl->param_begin(), decl->param_end()}, decl->isVariadic(),
-        allowNSUIntegerAsInt, argNames);
+        allowNSUIntegerAsInt, argNames, /*genericParams=*/{});
   }
   if (!parameterList)
     return nullptr;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1077,13 +1077,11 @@ public:
   ///   to system APIs.
   /// \param name The name of the function.
   /// \param[out] parameterList The parameters visible inside the function body.
-  ImportedType
-  importFunctionParamsAndReturnType(DeclContext *dc,
-                                    const clang::FunctionDecl *clangDecl,
-                                    ArrayRef<const clang::ParmVarDecl *> params,
-                                    bool isVariadic, bool isFromSystemModule,
-                                    DeclName name,
-                                    ParameterList *&parameterList);
+  ImportedType importFunctionParamsAndReturnType(
+      DeclContext *dc, const clang::FunctionDecl *clangDecl,
+      ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
+      bool isFromSystemModule, DeclName name, ParameterList *&parameterList,
+      ArrayRef<GenericTypeParamDecl *> genericParams);
 
   /// Import the given function return type.
   ///
@@ -1110,12 +1108,11 @@ public:
   /// \param argNames The argument names
   ///
   /// \returns The imported parameter list on success, or null on failure
-  ParameterList *
-  importFunctionParameterList(DeclContext *dc,
-                              const clang::FunctionDecl *clangDecl,
-                              ArrayRef<const clang::ParmVarDecl *> params,
-                              bool isVariadic, bool allowNSUIntegerAsInt,
-                              ArrayRef<Identifier> argNames);
+  ParameterList *importFunctionParameterList(
+      DeclContext *dc, const clang::FunctionDecl *clangDecl,
+      ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
+      bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
+      ArrayRef<GenericTypeParamDecl *> genericParams);
 
   ImportedType importPropertyType(const clang::ObjCPropertyDecl *clangDecl,
                                   bool isFromSystemModule);

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -201,6 +201,7 @@ public:
       DC = nsDecl->getCanonicalDecl();
     } else {
       assert(isa<clang::TranslationUnitDecl>(dc) ||
+             isa<clang::LinkageSpecDecl>(dc) ||
              isa<clang::ObjCContainerDecl>(dc) &&
                  "No other kinds of effective Clang contexts");
       DC = dc;

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -1,0 +1,22 @@
+template <class T> T add(T a, T b) { return a + b; }
+
+template <class A, class B> A addTwoTemplates(A a, B b) { return a + b; }
+
+template <class T> T passThrough(T value) { return value; }
+
+template <class T> const T passThroughConst(const T value) { return value; }
+
+void takesString(const char *) {}
+template <class T> void expectsString(T str) { takesString(str); }
+
+template <long x> void integerTemplate() {}
+template <long x = 0> void defaultIntegerTemplate() {}
+
+// We cannot yet use this in swift but, make sure we don't crash when parsing
+// it.
+template <class R, class T, class U> R returns_template(T a, U b) {
+  return a + b;
+}
+
+// Same here:
+template <class T> void cannot_infer_template() {}

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -22,6 +22,10 @@ module ExplicitClassSpecialization {
   header "explicit-class-specialization.h"
 }
 
+module FunctionTemplates {
+  header "function-templates.h"
+}
+
 module UsingDirective {
   header "using-directive.h"
 }

--- a/test/Interop/Cxx/templates/function-template-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-errors.swift
@@ -1,0 +1,39 @@
+// RUN: not %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+
+// README: If you just added support for protocol composition to the
+// ClangTypeConverter, please update this test to use a different type that we
+// don't support so the error messages here are still tested.
+
+
+import FunctionTemplates
+
+// Use protocol composition to create a type that we cannot (yet) turn into a clang::QualType.
+protocol A { }
+protocol B { }
+protocol C { }
+
+// CHECK: error: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'passThrough' were unable to be converted: A & B.
+public func caller1(x: A & B) -> A & B {
+  return passThrough(x)
+}
+
+// CHECK: error: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'addTwoTemplates' were unable to be converted: A & B, A & C.
+public func caller2(x: A & B, y: A & C) -> A & B {
+  return addTwoTemplates(x, y)
+}
+
+// Make sure we emit an error and don't crash when failing to instantiate a function.
+// CHECK: error: no matching function for call to 'takesString'
+// CHECK: note: in instantiation of function template specialization 'expectsString<int>' requested here
+// CHECK: note: candidate function not viable: no known conversion from 'int' to 'const char *' for 1st argument
+public func callExpectsString() {
+  expectsString(0 as Int32)
+}
+
+// Make sure we don't import non-type template parameters.
+// CHECK: error: cannot find 'integerTemplate' in scope
+// CHECK: error: cannot find 'defaultIntegerTemplate' in scope
+public func callIntegerTemplates() {
+  integerTemplate()
+  defaultIntegerTemplate()
+}

--- a/test/Interop/Cxx/templates/function-template-irgen-objc.swift
+++ b/test/Interop/Cxx/templates/function-template-irgen-objc.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+// TODO: This needs to be fixed in the SwiftTypeConverter.
+// Currently "Any" is imported as an Objective-C "id".
+// That doesn't work unless we have Objective-C interop.
+// Once that's done, this test can be merged with "template-irgen".
+// REQUIRES: objc_interop
+
+import FunctionTemplates
+
+// CHECK-LABEL: define {{.*}}void @"$s4main18testPassThroughAny1xypyp_tF"(%Any* noalias nocapture sret %0, %Any* noalias nocapture dereferenceable({{32|16}}) %1)
+// CHECK: call i8* @_Z11passThroughIP11objc_objectET_S2_(i8*
+// CHECK: ret void
+public func testPassThroughAny(x: Any) -> Any {
+  return passThrough(x)
+}
+

--- a/test/Interop/Cxx/templates/function-template-irgen.swift
+++ b/test/Interop/Cxx/templates/function-template-irgen.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import FunctionTemplates
+
+// CHECK-LABEL: define {{.*}}i32 @"$s4main20testPassThroughConst1xs5Int32VAE_tF"(i32 %0)
+// CHECK: [[RET_VAL:%.*]] = call i32 @{{_Z16passThroughConstIiEKT_S0_|"\?\?\$passThroughConst@H@@YA\?BHH@Z"}}(i32 %0)
+// CHECK: ret i32 [[RET_VAL]]
+
+// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z16passThroughConstIiEKT_S0_|"\?\?\$passThroughConst@H@@YA\?BHH@Z"}}(i32 %value)
+public func testPassThroughConst(x: Int32) -> Int32 {
+  return passThroughConst(x)
+}
+
+// CHECK-LABEL: define {{.*}}i32 @"$s4main15testPassThrough1xs5Int32VAE_tF"(i32 %0)
+// CHECK: [[RET_VAL:%.*]] = call i32 @{{_Z11passThroughIiET_S0_|"\?\?\$passThrough@H@@YAHH@Z"}}(i32 %0)
+// CHECK: ret i32 [[RET_VAL]]
+
+// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z11passThroughIiET_S0_|"\?\?\$passThrough@H@@YAHH@Z"}}(i32 %value)
+public func testPassThrough(x: Int32) -> Int32 {
+  return passThrough(x)
+}
+
+// CHECK-LABEL: define {{.*}}i32 @"$s4main19testAddTwoTemplates1xs5Int32VAE_tF"(i32 %0)
+// CHECK: [[OUT_VAL:%.*]] = call i32 @{{_Z15addTwoTemplatesIiiET_S0_T0_|"\?\?\$addTwoTemplates@HH@@YAHHH@Z"}}(i32 %0, i32 %0)
+// CHECK: ret i32 [[OUT_VAL]]
+
+// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z15addTwoTemplatesIiiET_S0_T0_|"\?\?\$addTwoTemplates@HH@@YAHHH@Z"}}(i32 %a, i32 %b)
+public func testAddTwoTemplates(x: Int32) -> Int32 {
+  return addTwoTemplates(x, x)
+}
+
+// CHECK-LABEL: define {{.*}}i32 @"$s4main7testAdd1xs5Int32VAE_tF"(i32 %0)
+// CHECK: [[OUT_VAL:%.*]] = call i32 @{{_Z3addIiET_S0_S0_|"\?\?\$add@H@@YAHHH@Z"}}(i32 %0, i32 %0)
+// CHECK: ret i32 [[OUT_VAL]]
+
+// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z3addIiET_S0_S0_|"\?\?\$add@H@@YAHHH@Z"}}(i32 %a, i32 %b)
+public func testAdd(x: Int32) -> Int32 {
+  return add(x, x)
+}

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=FunctionTemplates -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: func add<T>(_ a: T, _ b: T) -> T
+// CHECK: func addTwoTemplates<A, B>(_ a: A, _ b: B) -> A
+// CHECK: func passThrough<T>(_ value: T) -> T
+// CHECK: func passThroughConst<T>(_ value: T) -> T
+// CHECK: func returns_template<R, T, U>(_ a: T, _ b: U) -> R
+// CHECK: func cannot_infer_template<T>()

--- a/test/Interop/Cxx/templates/function-template-silgen.swift
+++ b/test/Interop/Cxx/templates/function-template-silgen.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import FunctionTemplates
+
+// CHECK-LABEL: sil @$s4main4test1xs5Int32VAE_tF
+
+// CHECK: bb0(%0 : $Int32):
+// CHECK:   [[IL_ZERO:%.*]] = integer_literal $Builtin.Int32, 0
+// CHECK:   [[ZERO:%.*]] = struct $Int32 ([[IL_ZERO]] : $Builtin.Int32)
+// CHECK:   [[PASS_THROUGH_CONST_FN:%.*]] = function_ref @{{_Z16passThroughConstIiEKT_S0_|\?\?\$passThroughConst@H@@YA\?BHH@Z}} : $@convention(c) (Int32) -> Int32
+// CHECK:   [[A:%.*]] = apply [[PASS_THROUGH_CONST_FN]]([[ZERO]]) : $@convention(c) (Int32) -> Int32
+
+// CHECK:   [[PASS_THROUGH_FN:%.*]] = function_ref @{{_Z11passThroughIiET_S0_|\?\?\$passThrough@H@@YAHH@Z}} : $@convention(c) (Int32) -> Int32
+// CHECK:   [[B:%.*]] = apply [[PASS_THROUGH_FN]](%0) : $@convention(c) (Int32) -> Int32
+
+// CHECK:   [[ADD_TWO_FN:%.*]] = function_ref @{{_Z15addTwoTemplatesIiiET_S0_T0_|\?\?\$addTwoTemplates@HH@@YAHHH@Z}} : $@convention(c) (Int32, Int32) -> Int32
+// CHECK:   [[C:%.*]] = apply [[ADD_TWO_FN]]([[A]], [[B]]) : $@convention(c) (Int32, Int32) -> Int32
+
+// CHECK:   [[C_32_ADDR:%.*]] = alloc_stack $Int32
+// CHECK:   [[C_32:%.*]] = load [[C_32_ADDR]] : $*Int32
+// CHECK:   [[ADD_FN:%.*]] = function_ref @{{_Z3addIiET_S0_S0_|\?\?\$add@H@@YAHHH@Z}} : $@convention(c) (Int32, Int32) -> Int32
+// CHECK:   [[OUT:%.*]] = apply [[ADD_FN]]([[B]], [[C_32]]) : $@convention(c) (Int32, Int32) -> Int32
+// CHECK:   return [[OUT]] : $Int32
+
+// CHECK-LABEL: end sil function '$s4main4test1xs5Int32VAE_tF'
+public func test(x: Int32) -> Int32 {
+  let a = passThroughConst(Int32(0))
+  let b = passThrough(x)
+  let c = addTwoTemplates(a, b)
+  return add(b, Int32(c))
+}

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import FunctionTemplates
+import StdlibUnittest
+
+var FunctionTemplateTestSuite = TestSuite("Function Templates")
+
+FunctionTemplateTestSuite.test("passThrough<T> where T == Int") {
+  let result = passThrough(42)
+  expectEqual(42, result)
+}
+
+FunctionTemplateTestSuite.test("add<T> where T == Int") {
+  let result = add(42, 23)
+  expectEqual(65, result)
+}
+
+FunctionTemplateTestSuite.test("add<T, U> where T, U == Int") {
+  let result = addTwoTemplates(42, 23)
+  expectEqual(65, result)
+}
+
+// TODO: currently "Any" is imported as an Objective-C "id".
+// This doesn't work without the Objective-C runtime. 
+#if _runtime(_ObjC)
+FunctionTemplateTestSuite.test("passThrough<T> where T == Any") {
+  let result = passThrough(42 as Any)
+  expectEqual(42, result as! Int)
+}
+#endif
+
+// TODO: Generics, Any, and Protocols should be tested here but need to be
+// better supported in ClangTypeConverter first.
+
+runAllTests()


### PR DESCRIPTION
This patch adds rudimentary support for C++ template functions in swift. There's still a lot lacking but, that mostly has to do with the clang type converter which can be updated with incremental follow up patches.

Unfortunately, there's some ugliness and unconventional logic in this patch. First, we have to generate and define the specialization in the SILGen phase (instead of when we import the function) so we have access to the argument types and substitution map. Similarly, in IRGen, we can't get the function pointer while visiting the `function_ref` instruction because we also need the substitution map to find the correct specialization of the template (this also means there may be problems when the compiler can't find the corresponding `function_ref`, i.e. if the function was passed as an argument). 