### PR TITLE
[5.3][fso] Do not try to specialize pseudo-generic functions today.

### DIFF
--- a/test/SILOptimizer/funcsig_pseudogenerics.sil
+++ b/test/SILOptimizer/funcsig_pseudogenerics.sil
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+// RUN: %target-sil-opt(mock-sdk: %clang-importer-sdk-nosource -I %t) -function-signature-opts -sil-fso-optimize-if-not-called %s | %FileCheck %s
+
+// Make sure that we do not try to specialize pseudo-generics with FSO.
+
+// REQUIRES: objc_interop
+
+sil_stage canonical
+
+import Swift
+import Foundation
+import objc_generics
+
+// CHECK: sil [signature_optimized_thunk] [always_inline] @non_pseudo_method :
+sil @non_pseudo_method : $@convention(thin) <T: AnyObject> (Int64) -> () {
+entry(%0 : $Int64):
+  return undef : $()
+}
+
+// CHECK: sil @method :
+sil @method : $@convention(method) @pseudogeneric <T: AnyObject> (Int64, @guaranteed GenericClass<T>) -> () {
+entry(%0 : $Int64, %1 : $GenericClass<T>):
+  return undef : $()
+}
+
+// CHECK: sil @objcMethod :
+sil @objcMethod : $@convention(objc_method) @pseudogeneric <T: AnyObject> (Int64, @guaranteed GenericClass<T>) -> () {
+entry(%0 : $Int64, %1 : $GenericClass<T>):
+  return undef : $()
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1001,6 +1001,11 @@ if run_vendor == 'apple':
     config.target_sil_opt = (
         "%s %s %s %s" %
         (xcrun_prefix, config.sil_opt, target_options, config.sil_test_options))
+    subst_target_sil_opt_mock_sdk = (
+        "%s %s" %
+        (config.sil_opt, target_options_for_mock_sdk))
+    subst_target_sil_opt_mock_sdk_after = \
+        target_options_for_mock_sdk_after
     config.target_swift_symbolgraph_extract = (
         "%s %s %s" %
         (xcrun_prefix, config.swift_symbolgraph_extract, target_options))
@@ -1080,6 +1085,8 @@ elif run_os in ['windows-msvc']:
             ('%r -target %s %s %s %s' % (config.sil_opt, config.variant_triple,  \
                                          resource_dir_opt, mcp_opt,              \
                                          config.sil_test_options))
+    subst_target_sil_opt_mock_sdk = config.target_sil_opt
+    subst_target_sil_opt_mock_sdk_after = ''
     config.target_swift_symbolgraph_extract =                                    \
             ('%r -target %s %s' % (config.swift_symbolgraph_extract,             \
                                          config.variant_triple,                  \
@@ -1183,6 +1190,8 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     config.target_sil_opt = (
         '%s -target %s %s %s %s' %
         (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
+    subst_target_sil_opt_mock_sdk = config.target_sil_opt
+    subst_target_sil_opt_mock_sdk_after = ""
     config.target_swift_symbolgraph_extract = (
         '%s -target %s %s' %
         (config.swift_symbolgraph_extract, config.variant_triple, mcp_opt))
@@ -1303,6 +1312,8 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-target', config.variant_triple,
         android_include_paths_opt,
         resource_dir_opt, mcp_opt, config.sil_test_options])
+    subst_target_sil_opt_mock_sdk = config.target_sil_opt
+    subst_target_sil_opt_mock_sdk_after = ""
     config.target_swift_symbolgraph_extract = ' '.join([
         config.swift_symbolgraph_extract,
         '-target', config.variant_triple,
@@ -1754,7 +1765,13 @@ config.substitutions.append(('%scale-test',
 config.substitutions.append(('%empty-directory\(([^)]+)\)',
                              SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
 
+config.substitutions.append(('%target-sil-opt\(mock-sdk:([^)]+)\)',
+                             SubstituteCaptures(r'%s \1 %s' % (subst_target_sil_opt_mock_sdk,
+                                                               subst_target_sil_opt_mock_sdk_after))))
+# NOTE: This needs to be appended after the mock-sdk expansion to ensure that we
+# first expand the mock-sdk when lit is processing.
 config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
+
 config.substitutions.append(('%target-sil-func-extractor', config.target_sil_func_extractor))
 config.substitutions.append(('%target-sil-llvm-gen', config.target_sil_llvm_gen))
 config.substitutions.append(('%target-sil-nm', config.target_sil_nm))


### PR DESCRIPTION
This is just fixing an assert violation. I also needed to add support for
target-sil-opt(mock-sdk: ...) so I added support to lit for that here.

<rdar://problem/62262811>

(cherry picked from commit 6049ce629cdce9851f3c3106f5e11560b5a233e8)

----

Explanation: This pass was never updated to handle pseudo-generic types (ObjC generics imported into Swift). The pass as a result breaks invariants in SILFunctionTypes around generic signatures/generics (our assertions caught this). Rather than fix it now, this just causes the pass to skip any SILFunctions that are marked as "pseudo-generic".

Scope: Just causes this pass to not run on SILFunction's if the SILFunction's SILFunctionType is "pseudo-generic" meaning that part of its type refers to an ObjC generic that was imported into swift.

Radar: rdar://62262811

Risk: Low, we just bail early if we see such a function.

Testing: I added a test that exercises this specific code path against the mock-sdk by using imported pseudo-generic types

Reviewer: @atrick