### PR TITLE
[AutoDiff] Start `linear_function` canonicalization skeleton

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Differentiation/ADContext.h
@@ -73,12 +73,21 @@ private:
   llvm::SmallVector<DifferentiableFunctionInst *, 32>
       differentiableFunctionInsts;
 
+  /// The worklist (stack) of `linear_function` instructions to be processed.
+  llvm::SmallVector<LinearFunctionInst *, 32> linearFunctionInsts;
+
   /// The set of `differentiable_function` instructions that have been
   /// processed. Used to avoid reprocessing invalidated instructions.
   /// NOTE(TF-784): if we use `CanonicalizeInstruction` subclass to replace
   /// `ADContext::processDifferentiableFunctionInst`, this field may be removed.
   llvm::SmallPtrSet<DifferentiableFunctionInst *, 32>
       processedDifferentiableFunctionInsts;
+
+  /// The set of `linear_function` instructions that have been processed. Used
+  /// to avoid reprocessing invalidated instructions.
+  /// NOTE(TF-784): if we use `CanonicalizeInstruction` subclass to replace
+  /// `ADContext::processLinearFunctionInst`, this field may be removed.
+  llvm::SmallPtrSet<LinearFunctionInst *, 32> processedLinearFunctionInsts;
 
   /// Mapping from witnesses to invokers.
   /// `SmallMapVector` is used for deterministic insertion order iteration.
@@ -121,30 +130,19 @@ public:
   SILPassManager &getPassManager() const { return passManager; }
   Lowering::TypeConverter &getTypeConverter() { return module.Types; }
 
+  llvm::SmallVectorImpl<DifferentiableFunctionInst *> &
+  getDifferentiableFunctionInstWorklist() {
+    return differentiableFunctionInsts;
+  }
+
+  llvm::SmallVectorImpl<LinearFunctionInst *> &getLinearFunctionInstWorklist() {
+    return linearFunctionInsts;
+  }
+
   /// Get or create the synthesized file for the given `SILFunction`.
   /// Used by `LinearMapInfo` for adding generated linear map struct and
   /// branching trace enum declarations.
   SynthesizedFileUnit &getOrCreateSynthesizedFile(SILFunction *original);
-
-  /// Returns true if the `differentiable_function` instruction worklist is
-  /// empty.
-  bool isDifferentiableFunctionInstsWorklistEmpty() const {
-    return differentiableFunctionInsts.empty();
-  }
-
-  /// Pops and returns a `differentiable_function` instruction from the
-  /// worklist. Returns nullptr if the worklist is empty.
-  DifferentiableFunctionInst *popDifferentiableFunctionInstFromWorklist() {
-    if (differentiableFunctionInsts.empty())
-      return nullptr;
-    return differentiableFunctionInsts.pop_back_val();
-  }
-
-  /// Adds the given `differentiable_function` instruction to the worklist.
-  void
-  addDifferentiableFunctionInstToWorklist(DifferentiableFunctionInst *dfi) {
-    differentiableFunctionInsts.push_back(dfi);
-  }
 
   /// Returns true if the given `differentiable_function` instruction has
   /// already been processed.
@@ -157,6 +155,17 @@ public:
   void
   markDifferentiableFunctionInstAsProcessed(DifferentiableFunctionInst *dfi) {
     processedDifferentiableFunctionInsts.insert(dfi);
+  }
+
+  /// Returns true if the given `linear_function` instruction has already been
+  /// processed.
+  bool isLinearFunctionInstProcessed(LinearFunctionInst *lfi) const {
+    return processedLinearFunctionInsts.count(lfi);
+  }
+
+  /// Adds the given `linear_function` instruction to the worklist.
+  void markLinearFunctionInstAsProcessed(LinearFunctionInst *lfi) {
+    processedLinearFunctionInsts.insert(lfi);
   }
 
   const llvm::SmallMapVector<SILDifferentiabilityWitness *,
@@ -204,11 +213,26 @@ public:
       IndexSubset *resultIndices, SILValue original,
       Optional<std::pair<SILValue, SILValue>> derivativeFunctions = None);
 
-  // Given an `differentiable_function` instruction, finds the corresponding
+  /// Creates a `linear_function` instruction using the given builder
+  /// and arguments. Erase the newly created instruction from the processed set,
+  /// if it exists - it may exist in the processed set if it has the same
+  /// pointer value as a previously processed and deleted instruction.
+  LinearFunctionInst *
+  createLinearFunction(SILBuilder &builder, SILLocation loc,
+                       IndexSubset *parameterIndices,
+                       IndexSubset *resultIndices, SILValue original,
+                       Optional<SILValue> transposeFunction = None);
+
+  // Given a `differentiable_function` instruction, finds the corresponding
   // differential operator used in the AST. If no differential operator is
   // found, return nullptr.
   DifferentiableFunctionExpr *
   findDifferentialOperator(DifferentiableFunctionInst *inst);
+
+  // Given a `linear_function` instruction, finds the corresponding differential
+  // operator used in the AST. If no differential operator is found, return
+  // nullptr.
+  LinearFunctionExpr *findDifferentialOperator(LinearFunctionInst *inst);
 
   template <typename... T, typename... U>
   InFlightDiagnostic diagnose(SourceLoc loc, Diag<T...> diag,
@@ -291,6 +315,21 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
   // non-differentiation operation.
   case DifferentiationInvoker::Kind::DifferentiableFunctionInst: {
     auto *inst = invoker.getDifferentiableFunctionInst();
+    if (auto *expr = findDifferentialOperator(inst)) {
+      diagnose(expr->getLoc(), diag::autodiff_function_not_differentiable_error)
+          .highlight(expr->getSubExpr()->getSourceRange());
+      return diagnose(loc, diag, std::forward<U>(args)...);
+    }
+    diagnose(loc, diag::autodiff_expression_not_differentiable_error);
+    return diagnose(loc, diag, std::forward<U>(args)...);
+  }
+
+  // For `linear_function` instructions: if the `linear_function` instruction
+  // comes from a differential operator, emit an error on the expression and a
+  // note on the non-differentiable operation. Otherwise, emit both an error and
+  // note on the non-differentiation operation.
+  case DifferentiationInvoker::Kind::LinearFunctionInst: {
+    auto *inst = invoker.getLinearFunctionInst();
     if (auto *expr = findDifferentialOperator(inst)) {
       diagnose(expr->getLoc(), diag::autodiff_function_not_differentiable_error)
           .highlight(expr->getSubExpr()->getSourceRange());

--- a/include/swift/SILOptimizer/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Differentiation/ADContext.h
@@ -219,8 +219,7 @@ public:
   /// pointer value as a previously processed and deleted instruction.
   LinearFunctionInst *
   createLinearFunction(SILBuilder &builder, SILLocation loc,
-                       IndexSubset *parameterIndices,
-                       IndexSubset *resultIndices, SILValue original,
+                       IndexSubset *parameterIndices, SILValue original,
                        Optional<SILValue> transposeFunction = None);
 
   // Given a `differentiable_function` instruction, finds the corresponding

--- a/include/swift/SILOptimizer/Differentiation/DifferentiationInvoker.h
+++ b/include/swift/SILOptimizer/Differentiation/DifferentiationInvoker.h
@@ -25,6 +25,7 @@ namespace swift {
 
 class ApplyInst;
 class DifferentiableFunctionInst;
+class LinearFunctionInst;
 class SILDifferentiabilityWitness;
 
 namespace autodiff {
@@ -41,6 +42,10 @@ public:
     // be linked to a Swift AST node (e.g. an `DifferentiableFunctionExpr`
     // expression).
     DifferentiableFunctionInst,
+
+    // Invoked by an `linear_function` instruction, which may or may not
+    // be linked to a Swift AST node (e.g. an `LinearFunctionExpr` expression).
+    LinearFunctionInst,
 
     // Invoked by the indirect application of differentiation. This case has an
     // associated original `apply` instruction and
@@ -59,6 +64,10 @@ private:
     /// The instruction associated with the `DifferentiableFunctionInst` case.
     DifferentiableFunctionInst *diffFuncInst;
     Value(DifferentiableFunctionInst *inst) : diffFuncInst(inst) {}
+
+    /// The instruction associated with the `LinearFunctionInst` case.
+    LinearFunctionInst *linearFuncInst;
+    Value(LinearFunctionInst *inst) : linearFuncInst(inst) {}
 
     /// The parent `apply` instruction and the witness associated with the
     /// `IndirectDifferentiation` case.
@@ -79,6 +88,8 @@ private:
 public:
   DifferentiationInvoker(DifferentiableFunctionInst *inst)
       : kind(Kind::DifferentiableFunctionInst), value(inst) {}
+  DifferentiationInvoker(LinearFunctionInst *inst)
+      : kind(Kind::LinearFunctionInst), value(inst) {}
   DifferentiationInvoker(ApplyInst *applyInst,
                          SILDifferentiabilityWitness *witness)
       : kind(Kind::IndirectDifferentiation), value({applyInst, witness}) {}
@@ -90,6 +101,11 @@ public:
   DifferentiableFunctionInst *getDifferentiableFunctionInst() const {
     assert(kind == Kind::DifferentiableFunctionInst);
     return value.diffFuncInst;
+  }
+
+  LinearFunctionInst *getLinearFunctionInst() const {
+    assert(kind == Kind::LinearFunctionInst);
+    return value.linearFuncInst;
   }
 
   std::pair<ApplyInst *, SILDifferentiabilityWitness *>

--- a/lib/SILOptimizer/Differentiation/ADContext.cpp
+++ b/lib/SILOptimizer/Differentiation/ADContext.cpp
@@ -128,5 +128,10 @@ ADContext::findDifferentialOperator(DifferentiableFunctionInst *inst) {
   return inst->getLoc().getAsASTNode<DifferentiableFunctionExpr>();
 }
 
+LinearFunctionExpr *
+ADContext::findDifferentialOperator(LinearFunctionInst *inst) {
+  return inst->getLoc().getAsASTNode<LinearFunctionExpr>();
+}
+
 } // end namespace autodiff
 } // end namespace swift

--- a/lib/SILOptimizer/Differentiation/ADContext.cpp
+++ b/lib/SILOptimizer/Differentiation/ADContext.cpp
@@ -123,6 +123,15 @@ DifferentiableFunctionInst *ADContext::createDifferentiableFunction(
   return dfi;
 }
 
+LinearFunctionInst *ADContext::createLinearFunction(
+    SILBuilder &builder, SILLocation loc, IndexSubset *parameterIndices,
+    SILValue original, Optional<SILValue> transposeFunction) {
+  auto *lfi = builder.createLinearFunction(loc, parameterIndices, original,
+                                           transposeFunction);
+  processedLinearFunctionInsts.erase(lfi);
+  return lfi;
+}
+
 DifferentiableFunctionExpr *
 ADContext::findDifferentialOperator(DifferentiableFunctionInst *inst) {
   return inst->getLoc().getAsASTNode<DifferentiableFunctionExpr>();

--- a/lib/SILOptimizer/Differentiation/DifferentiationInvoker.cpp
+++ b/lib/SILOptimizer/Differentiation/DifferentiationInvoker.cpp
@@ -28,6 +28,8 @@ SourceLoc DifferentiationInvoker::getLocation() const {
   switch (kind) {
   case Kind::DifferentiableFunctionInst:
     return getDifferentiableFunctionInst()->getLoc().getSourceLoc();
+  case Kind::LinearFunctionInst:
+    return getLinearFunctionInst()->getLoc().getSourceLoc();
   case Kind::IndirectDifferentiation:
     return getIndirectDifferentiation().first->getLoc().getSourceLoc();
   case Kind::SILDifferentiabilityWitnessInvoker:
@@ -45,6 +47,9 @@ void DifferentiationInvoker::print(llvm::raw_ostream &os) const {
   case Kind::DifferentiableFunctionInst:
     os << "differentiable_function_inst=(" << *getDifferentiableFunctionInst()
        << ")";
+    break;
+  case Kind::LinearFunctionInst:
+    os << "linear_function_inst=(" << *getLinearFunctionInst() << ")";
     break;
   case Kind::IndirectDifferentiation: {
     auto indDiff = getIndirectDifferentiation();

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -601,7 +601,7 @@ public:
           builder, loc, indices.parameters, indices.results, origCallee);
 
       // Record the `differentiable_function` instruction.
-      context.addDifferentiableFunctionInstToWorklist(diffFuncInst);
+      context.getDifferentiableFunctionInstWorklist().push_back(diffFuncInst);
 
       auto borrowedADFunc = builder.emitBeginBorrowOperation(loc, diffFuncInst);
       auto extractedJVP = builder.createDifferentiableFunctionExtract(
@@ -749,7 +749,15 @@ public:
     // instruction to the `differentiable_function` worklist.
     TypeSubstCloner::visitDifferentiableFunctionInst(dfi);
     auto *newDFI = cast<DifferentiableFunctionInst>(getOpValue(dfi));
-    context.addDifferentiableFunctionInstToWorklist(newDFI);
+    context.getDifferentiableFunctionInstWorklist().push_back(newDFI);
+  }
+
+  void visitLinearFunctionInst(LinearFunctionInst *lfi) {
+    // Clone `linear_function` from original to JVP, then add the cloned
+    // instruction to the `linear_function` worklist.
+    TypeSubstCloner::visitLinearFunctionInst(lfi);
+    auto *newLFI = cast<LinearFunctionInst>(getOpValue(lfi));
+    context.getLinearFunctionInstWorklist().push_back(newLFI);
   }
 
   //--------------------------------------------------------------------------//

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -529,7 +529,7 @@ public:
           getBuilder(), loc, indices.parameters, indices.results, origCallee);
 
       // Record the `differentiable_function` instruction.
-      context.addDifferentiableFunctionInstToWorklist(diffFuncInst);
+      context.getDifferentiableFunctionInstWorklist().push_back(diffFuncInst);
 
       auto borrowedADFunc = builder.emitBeginBorrowOperation(loc, diffFuncInst);
       auto extractedVJP = getBuilder().createDifferentiableFunctionExtract(
@@ -623,7 +623,15 @@ public:
     // instruction to the `differentiable_function` worklist.
     TypeSubstCloner::visitDifferentiableFunctionInst(dfi);
     auto *newDFI = cast<DifferentiableFunctionInst>(getOpValue(dfi));
-    context.addDifferentiableFunctionInstToWorklist(newDFI);
+    context.getDifferentiableFunctionInstWorklist().push_back(newDFI);
+  }
+
+  void visitLinearFunctionInst(LinearFunctionInst *lfi) {
+    // Clone `linear_function` from original to VJP, then add the cloned
+    // instruction to the `linear_function` worklist.
+    TypeSubstCloner::visitLinearFunctionInst(lfi);
+    auto *newLFI = cast<LinearFunctionInst>(getOpValue(lfi));
+    context.getLinearFunctionInstWorklist().push_back(newLFI);
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1334,7 +1334,7 @@ bool DifferentiationTransformer::processLinearFunctionInst(
     lfi->printInContext(s);
   });
 
-  // If `lfi` already has derivative functions, do not process.
+  // If `lfi` already has a transpose function, do not process.
   if (lfi->hasTransposeFunction())
     return false;
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -89,6 +89,12 @@ private:
                                            SILBuilder &builder, SILLocation loc,
                                            DifferentiationInvoker invoker);
 
+  /// Given a `linear_function` instruction that is missing a transpose operand,
+  /// return a new `linear_function` instruction with the transpose filled in.
+  SILValue promoteToLinearFunction(LinearFunctionInst *inst,
+                                   SILBuilder &builder, SILLocation loc,
+                                   DifferentiationInvoker invoker);
+
 public:
   /// Construct an `DifferentiationTransformer` for the given module.
   explicit DifferentiationTransformer(SILModuleTransform &transform)
@@ -112,6 +118,10 @@ public:
   /// Process the given `differentiable_function` instruction, filling in
   /// missing derivative functions if necessary.
   bool processDifferentiableFunctionInst(DifferentiableFunctionInst *dfi);
+
+  /// Process the given `linear_function` instruction, filling in the missing
+  /// transpose function if necessary.
+  bool processLinearFunctionInst(LinearFunctionInst *lfi);
 
   /// Fold `differentiable_function_extract` users of the given
   /// `differentiable_function` instruction, directly replacing them with
@@ -408,7 +418,7 @@ static SILValue reapplyFunctionConversion(
              "one argument");
       auto *dfi = context.createDifferentiableFunction(
           builder, loc, parameterIndices, resultIndices, newArgs.back());
-      context.addDifferentiableFunctionInstToWorklist(dfi);
+      context.getDifferentiableFunctionInstWorklist().push_back(dfi);
       newArgs.back() = dfi;
     }
     // Compute substitution map for reapplying `partial_apply`.
@@ -745,6 +755,19 @@ emitDerivativeFunctionReference(
   return None;
 }
 
+/// Emits a reference to the transpose function of `originalFunction`,
+/// differentiated with respect to exactly `desiredIndices`. Returns the
+/// transpose function `SILValue`.
+///
+/// Returns `None` on failure, signifying that a diagnostic has been emitted
+/// using `invoker`.
+static Optional<SILValue> emitTransposeFunctionReference(
+    DifferentiationTransformer &transformer, SILBuilder &builder,
+    SILAutoDiffIndices desiredIndices, SILValue originalFunction,
+    DifferentiationInvoker invoker) {
+  // TODO: Fill in.
+}
+
 //===----------------------------------------------------------------------===//
 // `SILDifferentiabilityWitness` processing
 //===----------------------------------------------------------------------===//
@@ -1046,7 +1069,7 @@ static SILValue promoteCurryThunkApplicationToDifferentiableFunction(
     retInst->eraseFromParent();
 
     context.recordGeneratedFunction(newThunk);
-    context.addDifferentiableFunctionInstToWorklist(dfi);
+    context.getDifferentiableFunctionInstWorklist().push_back(dfi);
     if (dt.processDifferentiableFunctionInst(dfi))
       return nullptr;
   }
@@ -1198,8 +1221,18 @@ SILValue DifferentiationTransformer::promoteToDifferentiableFunction(
   auto *newDiffFn = context.createDifferentiableFunction(
       builder, loc, parameterIndices, resultIndices, origFnCopy,
       std::make_pair(derivativeFns[0], derivativeFns[1]));
-  context.addDifferentiableFunctionInstToWorklist(dfi);
+  context.getDifferentiableFunctionInstWorklist().push_back(dfi);
   return newDiffFn;
+}
+
+SILValue DifferentiationTransformer::promoteToLinearFunction(
+    LinearFunctionInst *inst, SILBuilder &builder, SILLocation loc,
+    DifferentiationInvoker invoker) {
+  // TODO: Fill in. Copy code from above.
+  // For now, create a new `linear_function` instruction with an undef
+  // transpose.
+  // Eventually, use `emitTransposeFunctionReference` to fill in legitimately.
+  return inst;
 }
 
 /// Fold `differentiable_function_extract` users of the given
@@ -1288,6 +1321,39 @@ bool DifferentiationTransformer::processDifferentiableFunctionInst(
   return false;
 }
 
+bool DifferentiationTransformer::processLinearFunctionInst(
+    LinearFunctionInst *lfi) {
+  PrettyStackTraceSILNode dfiTrace("canonicalizing `linear_function`",
+                                   cast<SILInstruction>(lfi));
+  PrettyStackTraceSILFunction fnTrace("...in", lfi->getFunction());
+  LLVM_DEBUG({
+    auto &s = getADDebugStream() << "Processing LinearFunctoinInst:\n";
+    lfi->printInContext(s);
+  });
+
+  // If `lfi` already has derivative functions, do not process.
+  if (lfi->hasTransposeFunction())
+    return false;
+
+  SILFunction *parent = lfi->getFunction();
+  auto loc = lfi->getLoc();
+  SILBuilderWithScope builder(lfi);
+  auto linearFnValue = promoteToLinearFunction(lfi, builder, loc, lfi);
+  // Mark `lfi` as processed so that it won't be reprocessed after deletion.
+  context.markLinearFunctionInstAsProcessed(lfi);
+  if (!linearFnValue)
+    return true;
+  // Replace all uses of `lfi`.
+  lfi->replaceAllUsesWith(linearFnValue);
+  // Destroy the original operand.
+  builder.emitDestroyValueOperation(loc, lfi->getOriginalFunction());
+  lfi->eraseFromParent();
+
+  transform.invalidateAnalysis(parent,
+                               SILAnalysis::InvalidationKind::FunctionBody);
+  return false;
+}
+
 /// Automatic differentiation transform entry.
 void Differentiation::run() {
   auto &module = *getModule();
@@ -1308,22 +1374,15 @@ void Differentiation::run() {
     context.addInvoker(&witness);
   }
 
-  // Register all the `differentiable_function` instructions in the module that
-  // trigger differentiation.
+  // Register all the `differentiable_function` and `linear_function`
+  // instructions in the module that trigger differentiation.
   for (SILFunction &f : module) {
     for (SILBasicBlock &bb : f) {
       for (SILInstruction &i : bb) {
-        if (auto *dfi = dyn_cast<DifferentiableFunctionInst>(&i))
-          context.addDifferentiableFunctionInstToWorklist(dfi);
-        // Reject uncanonical `linear_function` instructions.
-        // FIXME(SR-11850): Add support for linear map transposition.
-        else if (auto *lfi = dyn_cast<LinearFunctionInst>(&i)) {
-          if (!lfi->hasTransposeFunction()) {
-            astCtx.Diags.diagnose(
-                lfi->getLoc().getSourceLoc(),
-                diag::autodiff_conversion_to_linear_function_not_supported);
-            errorOccurred = true;
-          }
+        if (auto *dfi = dyn_cast<DifferentiableFunctionInst>(&i)) {
+          context.getDifferentiableFunctionInstWorklist().push_back(dfi);
+        } else if (auto *lfi = dyn_cast<LinearFunctionInst>(&i)) {
+          context.getLinearFunctionInstWorklist().push_back(lfi);
         }
       }
     }
@@ -1331,7 +1390,7 @@ void Differentiation::run() {
 
   // If nothing has triggered differentiation, there's nothing to do.
   if (context.getInvokers().empty() &&
-      context.isDifferentiableFunctionInstsWorklistEmpty())
+      context.getDifferentiableFunctionInstWorklist().empty())
     return;
 
   // Differentiation relies on the stdlib (the Swift module).
@@ -1346,8 +1405,9 @@ void Differentiation::run() {
     if (!context.getInvokers().empty()) {
       loc = context.getInvokers().front().second.getLocation();
     } else {
-      assert(!context.isDifferentiableFunctionInstsWorklistEmpty());
-      loc = context.popDifferentiableFunctionInstFromWorklist()
+      assert(!context.getDifferentiableFunctionInstWorklist().empty());
+      loc = context.getDifferentiableFunctionInstWorklist()
+                .pop_back_val()
                 ->getLoc()
                 .getSourceLoc();
     }
@@ -1368,11 +1428,21 @@ void Differentiation::run() {
   }
 
   // Iteratively process `differentiable_function` instruction worklist.
-  while (auto *dfi = context.popDifferentiableFunctionInstFromWorklist()) {
+  while (!context.getDifferentiableFunctionInstWorklist().empty()) {
+    auto *dfi = context.getDifferentiableFunctionInstWorklist().pop_back_val();
     // Skip instructions that have been already been processed.
     if (context.isDifferentiableFunctionInstProcessed(dfi))
       continue;
     errorOccurred |= transformer.processDifferentiableFunctionInst(dfi);
+  }
+
+  // Iteratively process `linear_function` instruction worklist.
+  while (!context.getLinearFunctionInstWorklist().empty()) {
+    auto *lfi = context.getLinearFunctionInstWorklist().pop_back_val();
+    // Skip instructions that have been already been processed.
+    if (context.isLinearFunctionInstProcessed(lfi))
+      continue;
+    errorOccurred |= transformer.processLinearFunctionInst(lfi);
   }
 
   // If any error occurred while processing witnesses or

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1220,10 +1220,9 @@ SILValue DifferentiationTransformer::promoteToDifferentiableFunction(
 SILValue DifferentiationTransformer::promoteToLinearFunction(
     LinearFunctionInst *lfi, SILBuilder &builder, SILLocation loc,
     DifferentiationInvoker invoker) {
-  // TODO: Fill in. Copy code from above.
-  // For now, create a new `linear_function` instruction with an undef
-  // transpose.
-  // Eventually, use `emitTransposeFunctionReference` to fill in legitimately.
+  // Note: for now, this function creates a new `linear_function` instruction
+  // with an undef transpose function operand. Eventually, a legitimate
+  // transpose function operand should be created and used.
   auto origFnOperand = lfi->getOriginalFunction();
   auto origFnCopy = builder.emitCopyValueOperation(loc, origFnOperand);
   auto *parameterIndices = lfi->getParameterIndices();

--- a/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
@@ -1,0 +1,28 @@
+// RUN: %target-sil-opt -differentiation %s | %FileCheck %s
+
+sil_stage raw
+
+import Swift
+import Builtin
+
+import _Differentiation
+
+sil hidden @foo : $@convention(thin) (Float, Float, Float) -> Float {
+bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+  return %2 : $Float
+}
+
+sil @make_linear_func : $@convention(thin) () -> () {
+bb0:
+  %orig = function_ref @foo : $@convention(thin) (Float, Float, Float) -> Float
+  %linear_fn_0 = linear_function [parameters 0] %orig : $@convention(thin) (Float, Float, Float) -> Float
+  %linear_fn_1 = linear_function [parameters 0 2] %orig : $@convention(thin) (Float, Float, Float) -> Float
+  return undef : $()
+}
+
+// CHECK-LABEL: sil @make_linear_func
+// CHECK: bb0:
+// CHECK:   [[ORIG_FN:%.*]] = function_ref @foo : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK:   linear_function [parameters 0] %0 : $@convention(thin) (Float, Float, Float) -> Float with_transpose undef : $@convention(thin) (Float, Float, Float) -> Float
+// CHECK:   linear_function [parameters 0 2] %0 : $@convention(thin) (Float, Float, Float) -> Float with_transpose undef : $@convention(thin) (Float, Float) -> (Float, Float)
+// CHECK: }

--- a/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/linear_function_canonicalization.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -differentiation %s | %FileCheck %s
+// RUN: %target-sil-opt -differentiation -enable-experimental-linear-map-transposition %s | %FileCheck %s
 
 sil_stage raw
 


### PR DESCRIPTION
Start `linear_function` canonicalization skeleton copying from `differentiable_function` canonicalization. For now, transpose function operands are filled in with `undef`.