### PR TITLE
[test] Invert stdlib_dir conditional sense.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1441,10 +1441,10 @@ config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 
 # Add 'stdlib_dir' as the path to the stdlib resource directory
 stdlib_dir = os.path.join(config.swift_lib_dir, "swift")
-if platform.system() == 'Linux' or platform.system() == 'Windows':
-    stdlib_dir = os.path.join(stdlib_dir, config.target_sdk_name, run_cpu)
-else:
+if platform.system() == 'Darwin':
     stdlib_dir = os.path.join(stdlib_dir, config.target_sdk_name)
+else:
+    stdlib_dir = os.path.join(stdlib_dir, config.target_sdk_name, target_arch)
 config.substitutions.append(('%stdlib_dir', stdlib_dir))
 
 # Add 'stdlib_module' as the path to the stdlib .swiftmodule file


### PR DESCRIPTION
In #32903, a substitution pseudovariable was introduced to refer to the
path containing Swift.swiftmodule. Since builds on Linux put this file
in a path with a subdirectory named after the architecture name -- and
presumably builds on mac OS do not, a conditional was required to
distinguish these two cases.

However, builds on OpenBSD for example also put Swift.swiftmodule in a
similar subdirectory like Linux. Thus, invert the sense of this
conditional: if mac OS, refer to the path without architecture name,
otherwise in all other cases (and therefore all other platforms), refer
to the architecture name subdirectory.
