### PR TITLE
Fix stdlib builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1111,9 +1111,9 @@ if(SWIFT_INCLUDE_TOOLS)
   # Refer to the large comment above the add_subdirectory(stdlib) call.
   # https://bugs.swift.org/browse/SR-5975
   add_subdirectory(tools)
-endif()
 
-add_subdirectory(localization)
+  add_subdirectory(localization)
+endif()
 
 add_subdirectory(utils)
 


### PR DESCRIPTION
This PR resolves localization targets only if the frontend is being built.

In https://github.com/apple/swift/blob/master/localization/CMakeLists.txt#L9, there's an inherent dependency on the frontend. If another target, like only stdlib, is built, "swift-frontend" doesn't seem to resolve.

Attempt to fix by just moving the include into where "tools" is resolved, which I think also implies "swift-frontend".

EDIT @edymtt: Addresses rdar://65993232