### PR TITLE
[SR-13240][Sema] Removing repairFailures logic that did not allow more than one argument fix

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9824,9 +9824,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   }
 
   case FixKind::AllowArgumentTypeMismatch: {
-    increaseScore(SK_Fix);
-    
-    auto impact = 1;
+    auto impact = 2;
     // If there are any other argument mismatches already detected for this
     // call, we increase the score even higher so more argument fixes means
     // less viable is the overload.
@@ -9836,7 +9834,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
                      ? fixLocator->getAnchor() == locator.getAnchor()
                      : false;
         }))
-      impact = 2;
+      impact += 3;
 
     return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3653,22 +3653,6 @@ bool ConstraintSystem::repairFailures(
     if (rhs->isAny())
       break;
 
-    // If there are any other argument mismatches already detected
-    // for this call, we can consider overload unrelated.
-    if (llvm::any_of(getFixes(), [&](const ConstraintFix *fix) {
-          auto *locator = fix->getLocator();
-          // Since arguments to @dynamicCallable form either an array
-          // or a dictionary and all have to match the same element type,
-          // let's allow multiple invalid arguments.
-          if (locator->findFirst<LocatorPathElt::DynamicCallable>())
-            return false;
-
-          return locator->findLast<LocatorPathElt::ApplyArgToParam>()
-                     ? locator->getAnchor() == anchor
-                     : false;
-        }))
-      break;
-
     // If there are any restrictions here we need to wait and let
     // `simplifyRestrictedConstraintImpl` handle them.
     if (llvm::any_of(conversionsOrFixes,
@@ -9841,7 +9825,20 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
 
   case FixKind::AllowArgumentTypeMismatch: {
     increaseScore(SK_Fix);
-    return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+    
+    auto impact = 1;
+    // If there are any other argument mismatches already detected for this
+    // call, we increase the score even higher so more argument fixes means
+    // less viable is the overload.
+    if (llvm::any_of(getFixes(), [&](const ConstraintFix *fix) {
+          auto *fixLocator = fix->getLocator();
+          return fixLocator->findLast<LocatorPathElt::ApplyArgToParam>()
+                     ? fixLocator->getAnchor() == locator.getAnchor()
+                     : false;
+        }))
+      impact = 2;
+
+    return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
   case FixKind::ContextualMismatch: {

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1623,3 +1623,18 @@ func sr13135() {
 
   foo(Foo().bar, [baz])
 }
+
+// SR-13240
+func twoargs(_ x: String, _ y: String) {}
+
+func test() {
+  let x = 1
+  twoargs(x, x) // expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+}
+
+infix operator ---
+
+func --- (_ lhs: String, _ rhs: String) -> Bool { true }
+
+let x = 1
+x --- x // expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'String'}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1101,14 +1101,16 @@ func rdar17170728() {
     // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
+  // expected-error@+4 {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
+  // expected-error@+3 {{missing argument label 'into:' in call}}
+  // expected-note@+2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@+1 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
   let _ = [i, j, k].reduce(0 as Int?) {
-    // expected-error@-1 3 {{cannot convert value of type 'Int?' to expected element type 'Int'}}
+    // expected-error@-1 3 {{cannot convert value of type 'Int?' to expected element type 'Bool'}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
     // expected-error@-1 2 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-    // expected-error@-2   {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-    // expected-error@-3 2 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
-    // expected-note@-4:16 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-    // expected-note@-5:16 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-error@-2 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
+    // expected-error@-3 {{result values in '? :' expression have mismatching types 'Bool' and 'Int?'}}
   }
 }
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -358,5 +358,5 @@ func testKeyPathSubscriptArgFixes(_ fn: @escaping () -> Int) {
 
 func sr12426(a: Any, _ str: String?) {
   a == str // expected-error {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
-  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (String, String)}}
+  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (CodingUserInfoKey, CodingUserInfoKey), (String, String)}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -423,8 +423,8 @@ func test_force_unwrap_not_being_too_eager() {
 
 // rdar://problem/57097401
 func invalidOptionalChaining(a: Any) {
-  a == "="? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}
-  // expected-error@-1 {{cannot convert value of type 'Any' to expected argument type 'Any.Type?'}}
+  a == "="? // expected-error {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
+  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (CodingUserInfoKey, CodingUserInfoKey), (FloatingPointSign, FloatingPointSign), (String, String), (Unicode.CanonicalCombiningClass, Unicode.CanonicalCombiningClass)}}
 }
 
 // SR-12309 - Force unwrapping 'nil' compiles without warning

--- a/test/Parse/operators.swift
+++ b/test/Parse/operators.swift
@@ -88,10 +88,9 @@ postfix func ^ (x: Man) -> () -> God {
   return { return God() }
 }
 
-// TODO(diagnostics): This is ambiguous operator use because if solver attempted postfix version of the operator `^`
-// it could have found a solution, with infix one nothing matches - neither argument nor contextual type. It should
-// be possible to find a way to diagnose operator use here instead of type ambiguity...
-var _ : God = Man()^() // expected-error{{type of expression is ambiguous without more context}}
+var _ : God = Man()^() // expected-error{{cannot convert value of type 'Man' to expected argument type 'TheDevil'}}
+// expected-error@-1 {{cannot convert value of type '()' to expected argument type 'God'}}
+// expected-error@-2 {{cannot convert value of type 'Man' to specified type 'God'}}
 
 func &(x : Man, y : Man) -> Man { return x } // forgive amp_prefix token
 

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -266,6 +266,7 @@ protocol P3 {}
 func compositionType() {
   _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}}
+  // expected-note@-1 {{overloads for '&' exist with these partially matching parameter lists: (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
   _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(P2, P3)' cannot be used within a protocol-constrained type}}

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -266,7 +266,6 @@ protocol P3 {}
 func compositionType() {
   _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}}
-  // expected-note@-1 {{overloads for '&' exist with these partially matching parameter lists: (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
   _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(P2, P3)' cannot be used within a protocol-constrained type}}

--- a/test/stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/stdlib/UnicodeScalarDiagnostics.swift
@@ -8,9 +8,12 @@ func isString(_ s: inout String) {}
 func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
   var a1 = "a" + "b" // OK
   isString(&a1)
-  let a2 = "a" - "b" // expected-error {{binary operator '-' cannot be applied to two 'String' operands}} expected-note {{}}
-  let a3 = "a" * "b" // expected-error {{binary operator '*' cannot be applied to two 'String' operands}} expected-note {{}}
-  let a4 = "a" / "b" // expected-error {{binary operator '/' cannot be applied to two 'String' operands}} expected-note {{}}
+  let a2 = "a" - "b" // expected-error {{binary operator '-' cannot be applied to two 'String' operands}}
+  // expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists: (Double, Double), (Float, Float), (Float16, Float16), (Float80, Float80), (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
+  let a3 = "a" * "b" // expected-error {{binary operator '*' cannot be applied to two 'String' operands}}
+  // expected-note@-1 {{overloads for '*' exist with these partially matching parameter lists: (Double, Double), (Float, Float), (Float16, Float16), (Float80, Float80), (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
+  let a4 = "a" / "b" // expected-error {{binary operator '/' cannot be applied to two 'String' operands}}
+  // expected-note@-1 {{overloads for '/' exist with these partially matching parameter lists: (Double, Double), (Float, Float), (Float16, Float16), (Float80, Float80), (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
 
   let b1 = us + us // expected-error {{binary operator '+' cannot be applied to two 'UnicodeScalar' (aka 'Unicode.Scalar') operands}}
   let b2 = us - us // expected-error {{binary operator '-' cannot be applied to two 'UnicodeScalar' (aka 'Unicode.Scalar') operands}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removing `repairFailures` logic that did not allow more than one argument fix per call because in some situations with more than one arg to param constraint failures where only one was diagnosed it could let the solver in a state where it is unable to form a solution for that, therefore leading to an ambiguous diagnostic.
So always recording fixes but actually increase the score even high if there is a fix already.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13240.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
