### PR TITLE
[NFC] Fix incorrect comment in ExtInfo's constructor.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3013,7 +3013,7 @@ public:
     static void assertIsFunctionType(const clang::Type *);
 
     ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {
-      // TODO: [store-sil-clang-function-type] Once we start serializing
+      // TODO: [clang-function-type-serialization] Once we start serializing
       // the Clang type, we should also assert that the pointer is non-null.
       auto Rep = Representation(Bits & RepresentationMask);
       if ((Rep == Representation::CFunctionPointer) && Other.ClangFunctionType)


### PR DESCRIPTION
It was referring to the wrong milestone.