### PR TITLE
[Update Checkout] Fall back to revision if branch checkout fails.

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -119,6 +119,8 @@ def setup_mock_remote(base_dir):
     with open(get_config_path(base_dir), 'w') as f:
         json.dump(base_config, f)
 
+    return (LOCAL_PATH, REMOTE_PATH)
+
 
 BASEDIR_ENV_VAR = 'UPDATECHECKOUT_TEST_WORKSPACE_DIR'
 CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -147,7 +149,7 @@ class SchemeMockTestCase(unittest.TestCase):
 
     def setUp(self):
         create_dir(self.source_root)
-        setup_mock_remote(self.workspace)
+        (self.local_path, self.remote_path) = setup_mock_remote(self.workspace)
 
     def tearDown(self):
         teardown_mock_remote(self.workspace)

--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -1,0 +1,65 @@
+# ===--- test_clone.py ----------------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https:#swift.org/LICENSE.txt for license information
+# See https:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+import os
+
+from scheme_mock import call_quietly
+
+from . import scheme_mock
+
+WORKTREE_NAME = "feature"
+
+
+def path_for_worktree(workspace_path, worktree_name):
+    return os.path.join(workspace_path, worktree_name)
+
+
+def setup_worktree(workspace_path, local_path, worktree_name):
+    worktree_path = path_for_worktree(workspace_path, worktree_name)
+    os.makedirs(worktree_path)
+    for project in os.listdir(local_path):
+        local_project_path = os.path.join(local_path, project)
+        worktree_project_path = os.path.join(worktree_path, project)
+        call_quietly(['git', 
+                      '-C', local_project_path, 
+                      'worktree', 'add', worktree_project_path])
+
+
+def teardown_worktree(workspace_path, local_path, worktree_name):
+    worktree_path = path_for_worktree(workspace_path, worktree_name)
+    for project in os.listdir(local_path):
+        local_project_path = os.path.join(local_path, project)
+        worktree_project_path = os.path.join(worktree_path, project)
+        call_quietly(['git', 
+                      '-C', local_project_path, 
+                      'worktree', 'remove', worktree_project_path])
+
+
+class WorktreeTestCase(scheme_mock.SchemeMockTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(WorktreeTestCase, self).__init__(*args, **kwargs)
+
+    def test_worktree(self):
+        self.call([self.update_checkout_path,
+                   '--config', self.config_path,
+                   '--source-root', self.worktree_path,
+                   '--scheme', 'master'])
+
+    def setUp(self):
+        super(WorktreeTestCase, self).setUp()
+        self.worktree_path = os.path.join(self.workspace, WORKTREE_NAME)
+        setup_worktree(self.workspace, self.local_path, WORKTREE_NAME)
+
+    def tearDown(self):
+        teardown_worktree(self.workspace, self.local_path, WORKTREE_NAME)
+        super(WorktreeTestCase, self).tearDown()

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -158,7 +158,15 @@ def update_single_repository(pool_args):
             if checkout_target:
                 shell.run(['git', 'status', '--porcelain', '-uno'],
                           echo=False)
-                shell.run(['git', 'checkout', checkout_target], echo=True)
+                try:
+                    shell.run(['git', 'checkout', checkout_target], echo=True)
+                except Exception as originalException:
+                    try:
+                        result = shell.run(['git', 'rev-parse', checkout_target])
+                        revision = result[0].strip()
+                        shell.run(['git', 'checkout', revision], echo=True)
+                    except Exception as e:
+                        raise originalException
 
             # It's important that we checkout, fetch, and rebase, in order.
             # .git/FETCH_HEAD updates the not-for-merge attributes based on


### PR DESCRIPTION
In workflows featuring git worktrees, it is common for the same branch to be in use by multiple multiple checkouts.  For example, at the moment, the `master` branches of `swift-format`, `swift-tensorflow-apis`, and `pythonkit` (and the `release` branch of ninja) are indicated, in `update-checkout-config.json`, by both `master` and `release/5.3`.  If one
has a workflow featuring git worktrees, that means that when one runs `update_checkout --scheme master` in one's `mainline` directory and `update_checkout --scheme release/5.3` in one's `release53` directory, the latter will encounter failures for each of those four projects because the branch `master` (and `release` for ninja) will have already been checked out in the `mainline` directory's worktrees and so it cannot be checked out in the `release53`'s directory's worktrees.  The error looks something like:

```
/path/to/swift-container/release53/swift-format failed
(ret=128): ['git', 'checkout', u'master']
fatal: 'master' is already checked out at
'/path/to/swift-container/mainline/swift-format'

/path/to/swift-container/release53/tensorflow-swift-apis failed
(ret=128): ['git', 'checkout', u'master']
fatal: 'master' is already checked out at
'/path/to/swift-container/mainline/tensorflow-swift-apis'

/path/to/swift-container/release53/pythonkit failed (ret=128):
['git', 'checkout', u'master']
fatal: 'master' is already checked out at
'/path/to/swift-container/mainline/pythonkit'

/path/to/swift-container/release53/ninja failed (ret=128):
['git', 'checkout', u'release']
fatal: 'release' is already checked out at
'/path/to/swift-container/mainline/ninja'
```

Here, that workflow is enabled.  If `git checkout branch_name` fails for one of the projects, `update_checkout` falls back to getting the SHA for the indicated branch via `git rev-parse branch_name` and then checking out the SHA directly.

If anything goes wrong with the fallback approach, the exception originally encountered when trying to checkout the branch is raised.