### PR TITLE
Correct and expand doc comments

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -866,7 +866,7 @@ extension Dictionary {
   ///     }
   ///     // letterCounts == ["H": 1, "e": 2, "l": 4, "o": 1, ...]
   ///
-  /// When `letterCounts[letter, defaultValue: 0] += 1` is executed with a
+  /// When `letterCounts[letter, default: 0] += 1` is executed with a
   /// value of `letter` that isn't already a key in `letterCounts`, the
   /// specified default value (`0`) is returned from the subscript,
   /// incremented, and then added to the dictionary under that key.

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -90,6 +90,12 @@ public struct ${Self} {
 ${Availability(bits)}
 extension ${Self}: CustomStringConvertible {
   /// A textual representation of the value.
+  ///
+  /// For all  finite values, the value of this property is a string that can
+  /// be converted back to an instance of ${Self} without rounding errors.
+  /// That is, if `x` in a `${Self}`, then `${Self}(x.description) == x` is
+  /// always true.  For any NaN value, the property's value is "nan", and for
+  /// positive and negative infinity its value is "inf" and "-inf".
   public var description: String {
     if isNaN {
       return "nan"
@@ -106,6 +112,9 @@ extension ${Self}: CustomStringConvertible {
 ${Availability(bits)}
 extension ${Self}: CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
+  ///
+  /// This property has the same value as the `description` propyrty, except
+  /// that NaN values are printed in an extended format.
   public var debugDescription: String {
     var (buffer, length) = _float${bits}ToString(self, debug: true)
     return buffer.withBytes { (bufferPtr) in

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -91,11 +91,11 @@ ${Availability(bits)}
 extension ${Self}: CustomStringConvertible {
   /// A textual representation of the value.
   ///
-  /// For all  finite values, the value of this property is a string that can
-  /// be converted back to an instance of ${Self} without rounding errors.
-  /// That is, if `x` in a `${Self}`, then `${Self}(x.description) == x` is
-  /// always true.  For any NaN value, the property's value is "nan", and for
-  /// positive and negative infinity its value is "inf" and "-inf".
+  /// For all finite values, the value of this property is a string that can be
+  /// converted back to an instance of ${Self} without rounding errors.  That
+  /// is, if `x` in a `${Self}`, then `${Self}(x.description) == x` is always
+  /// true.  For any NaN value, the property's value is "nan", and for positive
+  /// and negative infinity its value is "inf" and "-inf".
   public var description: String {
     if isNaN {
       return "nan"
@@ -113,7 +113,7 @@ ${Availability(bits)}
 extension ${Self}: CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
   ///
-  /// This property has the same value as the `description` propyrty, except
+  /// This property has the same value as the `description` property, except
   /// that NaN values are printed in an extended format.
   public var debugDescription: String {
     var (buffer, length) = _float${bits}ToString(self, debug: true)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -93,9 +93,9 @@ extension ${Self}: CustomStringConvertible {
   ///
   /// For all finite values, the value of this property is a string that can be
   /// converted back to an instance of ${Self} without rounding errors.  That
-  /// is, if `x` in a `${Self}`, then `${Self}(x.description) == x` is always
-  /// true.  For any NaN value, the property's value is "nan", and for positive
-  /// and negative infinity its value is "inf" and "-inf".
+  /// is, if `x` is an instance of `${Self}`, then `${Self}(x.description) ==
+  /// x` is always true.  For any NaN value, the property's value is "nan", and
+  /// for positive and negative infinity its value is "inf" and "-inf".
   public var description: String {
     if isNaN {
       return "nan"

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -92,7 +92,7 @@ extension ${Self}: CustomStringConvertible {
   /// A textual representation of the value.
   ///
   /// For all finite values, the value of this property is a string that can be
-  /// converted back to an instance of ${Self} without rounding errors.  That
+  /// converted back to an instance of `${Self}` without rounding errors.  That
   /// is, if `x` is an instance of `${Self}`, then `${Self}(x.description) ==
   /// x` is always true.  For any NaN value, the property's value is "nan", and
   /// for positive and negative infinity its value is "inf" and "-inf".

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -30,10 +30,10 @@ internal func _abstract(
 // The two must coexist, so it was renamed. The old name must not be
 // used in the new runtime. _TtCs11_AnyKeyPath is the mangled name for
 // Swift._AnyKeyPath.
-@_objcRuntimeName(_TtCs11_AnyKeyPath)
 
 /// A type-erased key path, from any root type to any resulting value
 /// type.
+@_objcRuntimeName(_TtCs11_AnyKeyPath)
 public class AnyKeyPath: Hashable, _AppendKeyPath {
   /// The root type for this key path.
   @inlinable

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -770,7 +770,7 @@ extension SIMD where Scalar: FixedWidthInteger {
   /// Returns the sum of the scalars in the vector, computed with wrapping
   /// addition.
   ///
-  /// Equivalent to indices.reduce(into: 0) { $0 &+= self[$1] }.
+  /// Equivalent to `indices.reduce(into: 0) { $0 &+= self[$1] }`.
   @_alwaysEmitIntoClient
   public func wrappedSum() -> Scalar {
     return indices.reduce(into: 0) { $0 &+= self[$1] }


### PR DESCRIPTION
Add information to floating point types, per Tim Kientzle's comments.

Don't separate attribute from the rest of a declaration, which prevents proper parsing of doc comments.

Put code example in code voice.

Fixes <rdar://problem/58716408&65609221&51409021>.
