### PR TITLE
[CodeCompletion] Use TypeContextInfo to get expected return types

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6241,7 +6241,9 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
   case CompletionKind::ReturnStmtExpr : {
     SourceLoc Loc = P.Context.SourceMgr.getCodeCompletionLoc();
-    Lookup.setExpectedTypes(getReturnTypeFromContext(CurDeclContext),
+    SmallVector<Type, 2> possibleReturnTypes;
+    collectPossibleReturnTypesFromContext(CurDeclContext, possibleReturnTypes);
+    Lookup.setExpectedTypes(possibleReturnTypes,
                             /*isSingleExpressionBody*/ false);
     Lookup.getValueCompletionsInDeclContext(Loc);
     break;

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -41,9 +41,10 @@ Expr *findParsedExpr(const DeclContext *DC, SourceRange TargetRange);
 ///       position.
 bool removeCodeCompletionExpr(ASTContext &Ctx, Expr *&expr);
 
-/// Returns expected return type of the given decl context.
+/// Collects possible expected return types of the given decl context.
 /// \p DC should be an \c AbstractFunctionDecl or an \c AbstractClosureExpr.
-Type getReturnTypeFromContext(const DeclContext *DC);
+void collectPossibleReturnTypesFromContext(DeclContext *DC,
+                                           SmallVectorImpl<Type> &candidates);
 
 struct FunctionTypeAndDecl {
   AnyFunctionType *Type;

--- a/test/IDE/complete_sr13271.swift
+++ b/test/IDE/complete_sr13271.swift
@@ -1,0 +1,66 @@
+// RUN: %swift-ide-test -code-completion -source-filename=%s -code-completion-token=A | %FileCheck %s --check-prefix=A
+// RUN: %swift-ide-test -code-completion -source-filename=%s -code-completion-token=B | %FileCheck %s --check-prefix=B
+// RUN: %swift-ide-test -code-completion -source-filename=%s -code-completion-token=D | %FileCheck %s --check-prefix=D
+
+// https://bugs.swift.org/browse/SR-13271
+// https://forums.swift.org/t/code-completion-enhancement-request/38677
+
+enum AIdentifier {
+  case a
+}
+
+enum BIdentifier {
+  case b
+}
+
+struct X { }
+struct Y { }
+
+struct A <T> {
+  private init(){}
+  static func foo (arg: Bool) -> A<X> { A<X>() }
+  static func bar (arg: Int) -> A<Y> { A<Y>() }
+}
+
+struct B {
+  static var baz: B { B() }
+}
+
+func C<T>(_ identifier: AIdentifier, _ a: ()->A<T>) -> D<T> { }
+func C(_ identifier: BIdentifier, _ b: ()->B) { }
+
+struct D <T> {
+    func sink (_ handler: @escaping (T)->()) { }
+}
+
+func test() {
+  C(.a) {
+    .#^A^#
+  }
+// A: Begin completions, 2 items
+// A-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: foo({#arg: Bool#})[#A<X>#];
+// A-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: bar({#arg: Int#})[#A<Y>#];
+// A: End completions
+}
+
+func test() {
+  C(.b) {
+    .#^B^#
+  }
+// B: Begin completions, 2 items
+// B-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: baz[#B#]; name=baz
+// B-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#B#]; name=init()
+// B: End completions
+}
+
+func test() {
+  C(.a) {
+    .foo(arg: true)
+  }
+  .sink { value in
+    value.#^D^#
+  }
+// D: Begin completions, 1 items
+// D-DAG: Keyword[self]/CurrNominal:          self[#X#];
+// D: End completions
+}

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -122,6 +122,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_5 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_6 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_CONDITION | %FileCheck %s -check-prefix=TERNARY_CONDITION
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOADED_CLOSURE_RETURN | %FileCheck %s -check-prefix=OVERLOADED_CLOSURE_RETURN
 
 enum SomeEnum1 {
   case South
@@ -782,4 +783,18 @@ func testTernaryOperator2(cond: Bool) {
 // TERNARY_CONDITION: Begin completions
 // TERNARY_CONDITION-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init()[#Bool#]; name=init()
 // TERNARY_CONDITION: End completions
+}
+
+func overloadedClosureRcv(_: () -> SomeEnum1) {}
+func overloadedClosureRcv(_: () -> SomeEnum2) {}
+func testClosureReturnTypeForOverloaded() {
+  overloadedClosureRcv {
+    .#^OVERLOADED_CLOSURE_RETURN^#
+  }
+// OVERLOADED_CLOSURE_RETURN: Begin completions, 4 items
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: South[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: North[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: East[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: West[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN: End completions
 }


### PR DESCRIPTION
If the type checked return type from the context has unresolved types, it can't be used for checking convertibility. Fallback to get `TypeContextInfo` of the closure position.

https://bugs.swift.org/browse/SR-13271 / rdar://problem/66002497