### PR TITLE
[NFC] Add a test case for SR-12365

### DIFF
--- a/test/Constraints/sr12365.swift
+++ b/test/Constraints/sr12365.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+public protocol MyProtocol {}
+
+public struct MyProtocolImpl: MyProtocol {}
+
+public func != (lhs: MyProtocol, rhs: MyProtocol) -> MyProtocolImpl {
+  return MyProtocolImpl()
+}
+
+public func && (lhs: MyProtocol, rhs: MyProtocol) -> MyProtocolImpl {
+  return MyProtocolImpl()
+}
+
+func check(a: Double, b: Int64) -> Bool {
+  return a != 0 && b != 0 // Okay
+}
+
+func check() {
+  let x: Int = 1
+  let _ = UInt(1) << x - 1 // Okay
+  let _ = UInt(1) << (x + 1) - 1 // Okay
+}


### PR DESCRIPTION
This was recently fixed with https://github.com/apple/swift/pull/33060

Resolves: [SR-12365](https://bugs.swift.org/browse/SR-12365), [SR-9572](https://bugs.swift.org/browse/SR-9572)