### PR TITLE
[CSGen] Add a null check to prevent using invalid superclass type

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2994,6 +2994,9 @@ namespace {
         typeContext->getDeclaredInterfaceType());
       auto superclassTy = selfTy->getSuperclass();
 
+      if (!superclassTy)
+        return Type();
+
       if (selfDecl->getInterfaceType()->is<MetatypeType>())
         superclassTy = MetatypeType::get(superclassTy);
 

--- a/test/Constraints/super_method.swift
+++ b/test/Constraints/super_method.swift
@@ -59,3 +59,12 @@ func use_d(_ d: D) -> Int {
 func not_method() {
   super.foo() // expected-error{{'super' cannot be used outside of class members}}
 }
+
+// rdar://problem/50819554 - inability to properly resolve superclass shouldn't crash the solver
+func test_that_invalid_supertype_ref_doesnt_crash() {
+  final class Node: ManagedBuffer<AnyObject, Undefined> { // expected-error {{cannot find type 'Undefined' in scope}}
+    static func create() {
+      super.create()
+    }
+  }
+}


### PR DESCRIPTION
While generating constraints for `SuperRefExpr` generator has to figure out
a type of superclass associated with a current reference. Doing so might
produce an empty type (aka `Type()`) when resolution fails, so `getSuperType`
needs to check whether type is valid before attempting to wrap it into `MetatypeType`.

Resolves: rdar://problem/50819554


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
