### PR TITLE
[Sema] Delay 'explicit self required' check until closure has valid type (SR-13273)

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1491,10 +1491,15 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
     /// use or capture of "self." for qualification of member references.
     static bool isClosureRequiringSelfQualification(
                   const AbstractClosureExpr *CE) {
+      auto closureTy = CE->getType();
+      // If we don't have a type for this closure yet (or the closure has error
+      // type), don't offer diagnostics for required 'self'. We will have
+      // another chance when (if) the closure successfully typechecks.
+      if (!closureTy || closureTy->hasError())
+        return false;
       // If the closure's type was inferred to be noescape, then it doesn't
       // need qualification.
-      return !AnyFunctionRef(const_cast<AbstractClosureExpr *>(CE))
-               .isKnownNoEscape();
+      return !closureTy->castTo<AnyFunctionType>()->isNoEscape();
     }
 
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -523,3 +523,18 @@ class SR3186 {
     print("\(v)")
   }
 }
+
+// SR-13273
+class SR13273 {
+  var y: Int = 0
+
+  func foo() {
+    bar {
+      bar { [y] in // OK
+        print(y)
+      }
+    }
+  }
+
+  func bar(_: () -> Void) {}
+}


### PR DESCRIPTION
Avoid diagnosing "explicit self required" errors before we have the
type for a closure, since such closures will never be known-noescape.

Resolves SR-13273.
