### PR TITLE
[NFC] Const-Qualify Some Logically-Const Data

### DIFF
--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -104,7 +104,7 @@ public:
 
   /// If this initializes a single @lazy variable, lazily create a self
   /// declaration for it to refer to.
-  ParamDecl *getImplicitSelfDecl();
+  ParamDecl *getImplicitSelfDecl() const;
 
   static bool classof(const DeclContext *DC) {
     if (auto init = dyn_cast<Initializer>(DC))

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -519,9 +519,8 @@ void recordLookupOfTopLevelName(DeclContext *topLevelContext, DeclName name,
 /// Add anything we find to the \c result vector. If we come across the
 /// AnyObject type, set \c anyObject true.
 void getDirectlyInheritedNominalTypeDecls(
-    llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-    unsigned i,
-    llvm::SmallVectorImpl<Located<NominalTypeDecl *>> &result,
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+    unsigned i, llvm::SmallVectorImpl<Located<NominalTypeDecl *>> &result,
     bool &anyObject);
 
 /// Retrieve the set of nominal type declarations that are directly
@@ -529,26 +528,25 @@ void getDirectlyInheritedNominalTypeDecls(
 /// and splitting out the components of compositions.
 ///
 /// If we come across the AnyObject type, set \c anyObject true.
-SmallVector<Located<NominalTypeDecl *>, 4>
-getDirectlyInheritedNominalTypeDecls(
-                      llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                      bool &anyObject);
+SmallVector<Located<NominalTypeDecl *>, 4> getDirectlyInheritedNominalTypeDecls(
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+    bool &anyObject);
 
 /// Retrieve the set of nominal type declarations that appear as the
 /// constraint type of any "Self" constraints in the where clause of the
 /// given protocol or protocol extension.
 SelfBounds getSelfBoundsFromWhereClause(
-    llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl);
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl);
 
 /// Retrieve the TypeLoc at the given \c index from among the set of
 /// type declarations that are directly "inherited" by the given declaration.
-inline TypeLoc &
-getInheritedTypeLocAtIndex(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                           unsigned index) {
-  if (auto typeDecl = decl.dyn_cast<TypeDecl *>())
+inline const TypeLoc &getInheritedTypeLocAtIndex(
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+    unsigned index) {
+  if (auto typeDecl = decl.dyn_cast<const TypeDecl *>())
     return typeDecl->getInherited()[index];
 
-  return decl.get<ExtensionDecl *>()->getInherited()[index];
+  return decl.get<const ExtensionDecl *>()->getInherited()[index];
 }
 
 namespace namelookup {

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -51,8 +51,8 @@ enum class ResolutionKind;
 
 /// Display a nominal type or extension thereof.
 void simple_display(
-       llvm::raw_ostream &out,
-       const llvm::PointerUnion<TypeDecl *, ExtensionDecl *> &value);
+    llvm::raw_ostream &out,
+    const llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> &value);
 
 /// Describes a set of type declarations that are "direct" referenced by
 /// a particular type in the AST.
@@ -76,12 +76,13 @@ using DirectlyReferencedTypeDecls = llvm::TinyPtrVector<TypeDecl *>;
 ///
 /// The inherited declaration of \c D at index 0 is the class declaration C.
 /// The inherited declaration of \c D at index 1 is the typealias Alias.
-class InheritedDeclsReferencedRequest :
-  public SimpleRequest<InheritedDeclsReferencedRequest,
-                       DirectlyReferencedTypeDecls(
-                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
-                         unsigned),
-                       RequestFlags::Uncached> // FIXME: Cache these
+class InheritedDeclsReferencedRequest
+    : public SimpleRequest<
+          InheritedDeclsReferencedRequest,
+          DirectlyReferencedTypeDecls(
+              llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *>,
+              unsigned),
+          RequestFlags::Uncached> // FIXME: Cache these
 {
 public:
   using SimpleRequest::SimpleRequest;
@@ -90,10 +91,10 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  DirectlyReferencedTypeDecls evaluate(
-      Evaluator &evaluator,
-      llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-      unsigned index) const;
+  DirectlyReferencedTypeDecls
+  evaluate(Evaluator &evaluator,
+           llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+           unsigned index) const;
 
 public:
   // Caching
@@ -251,11 +252,11 @@ struct SelfBounds {
 
 /// Request the nominal types that occur as the right-hand side of "Self: Foo"
 /// constraints in the "where" clause of a protocol extension.
-class SelfBoundsFromWhereClauseRequest :
-    public SimpleRequest<SelfBoundsFromWhereClauseRequest,
-                         SelfBounds(llvm::PointerUnion<TypeDecl *,
-                                                       ExtensionDecl *>),
-                         RequestFlags::Uncached> {
+class SelfBoundsFromWhereClauseRequest
+    : public SimpleRequest<SelfBoundsFromWhereClauseRequest,
+                           SelfBounds(llvm::PointerUnion<
+                                      const TypeDecl *, const ExtensionDecl *>),
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -263,10 +264,10 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  SelfBounds evaluate(Evaluator &evaluator,
-                      llvm::PointerUnion<TypeDecl *, ExtensionDecl *>) const;
+  SelfBounds
+  evaluate(Evaluator &evaluator,
+           llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *>) const;
 };
-
 
 /// Request all type aliases and nominal types that appear in the "where"
 /// clause of an extension.

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -45,7 +45,8 @@ SWIFT_REQUEST(NameLookup, GetDestructorRequest, DestructorDecl *(ClassDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, InheritedDeclsReferencedRequest,
               DirectlyReferencedTypeDecls(
-                  llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned),
+                  llvm::PointerUnion<const TypeDecl *,
+                                     const ExtensionDecl *>, unsigned),
               Uncached, HasNearestLocation)
 SWIFT_REQUEST(NameLookup, InheritedProtocolsRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), SeparatelyCached,
@@ -68,7 +69,8 @@ SWIFT_REQUEST(NameLookup, QualifiedLookupRequest,
                   DeclNameRef, NLOptions),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, SelfBoundsFromWhereClauseRequest,
-              SelfBounds(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>),
+              SelfBounds(llvm::PointerUnion<const TypeDecl *,
+                                            const ExtensionDecl *>),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, SuperclassDeclRequest, ClassDecl *(NominalTypeDecl *),
               SeparatelyCached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -58,18 +58,17 @@ class StorageImplInfo;
 
 /// Display a nominal type or extension thereof.
 void simple_display(
-       llvm::raw_ostream &out,
-       const llvm::PointerUnion<TypeDecl *, ExtensionDecl *> &value);
+    llvm::raw_ostream &out,
+    const llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> &value);
 
 /// Request the type from the ith entry in the inheritance clause for the
 /// given declaration.
-class InheritedTypeRequest :
-    public SimpleRequest<InheritedTypeRequest,
-                         Type(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
-                              unsigned,
-                              TypeResolutionStage),
-                         RequestFlags::SeparatelyCached>
-{
+class InheritedTypeRequest
+    : public SimpleRequest<
+          InheritedTypeRequest,
+          Type(llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *>,
+               unsigned, TypeResolutionStage),
+          RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -79,9 +78,8 @@ private:
   // Evaluation.
   Type
   evaluate(Evaluator &evaluator,
-           llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-           unsigned index,
-           TypeResolutionStage stage) const;
+           llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+           unsigned index, TypeResolutionStage stage) const;
 
 public:
   // Source location

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -105,8 +105,8 @@ SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
                                  SmallVector<TypeLoc, 2>, bool),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InheritedTypeRequest,
-              Type(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned,
-                   TypeResolutionStage),
+              Type(llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *>,
+                   unsigned, TypeResolutionStage),
               SeparatelyCached, HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, InheritsSuperclassInitializersRequest,
               bool(ClassDecl *), SeparatelyCached, NoLocationInfo)

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -464,8 +464,8 @@ bool ConformanceLookupTable::addProtocol(ProtocolDecl *protocol, SourceLoc loc,
 }
 
 void ConformanceLookupTable::addInheritedProtocols(
-                          llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                          ConformanceSource source) {
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+    ConformanceSource source) {
   // Find all of the protocols in the inheritance list.
   bool anyObject = false;
   for (const auto &found :

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -327,8 +327,8 @@ class ConformanceLookupTable {
 
   /// Add the protocols from the given list.
   void addInheritedProtocols(
-                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                         ConformanceSource source);
+      llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+      ConformanceSource source);
 
   /// Expand the implied conformances for the given DeclContext.
   void expandImpliedConformances(NominalTypeDecl *nominal, DeclContext *dc);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1543,7 +1543,7 @@ PatternBindingDecl *PatternBindingDecl::createDeserialized(
   return PBD;
 }
 
-ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() {
+ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() const {
   if (SelfParam)
     return SelfParam;
 
@@ -1555,12 +1555,14 @@ ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() {
                         : ParamSpecifier::InOut);
 
       ASTContext &C = DC->getASTContext();
-      SelfParam = new (C) ParamDecl(SourceLoc(), SourceLoc(),
+      auto *mutableThis = const_cast<PatternBindingInitializer *>(this);
+      auto *LazySelfParam = new (C) ParamDecl(SourceLoc(), SourceLoc(),
                                     Identifier(), singleVar->getLoc(),
-                                    C.Id_self, this);
-      SelfParam->setImplicit();
-      SelfParam->setSpecifier(specifier);
-      SelfParam->setInterfaceType(DC->getSelfInterfaceType());
+                                    C.Id_self, mutableThis);
+      LazySelfParam->setImplicit();
+      LazySelfParam->setSpecifier(specifier);
+      LazySelfParam->setInterfaceType(DC->getSelfInterfaceType());
+      mutableThis->SelfParam = LazySelfParam;
     }
   }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3768,8 +3768,8 @@ void GenericSignatureBuilder::addGenericParameter(GenericTypeParamType *GenericP
 /// Visit all of the types that show up in the list of inherited
 /// types.
 static ConstraintResult visitInherited(
-         llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-         llvm::function_ref<ConstraintResult(Type, const TypeRepr *)> visitType) {
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+    llvm::function_ref<ConstraintResult(Type, const TypeRepr *)> visitType) {
   // Local function that (recursively) adds inherited types.
   ConstraintResult result = ConstraintResult::Resolved;
   std::function<void(Type, const TypeRepr *)> visitInherited;
@@ -3795,8 +3795,8 @@ static ConstraintResult visitInherited(
   };
 
   // Visit all of the inherited types.
-  auto typeDecl = decl.dyn_cast<TypeDecl *>();
-  auto extDecl = decl.dyn_cast<ExtensionDecl *>();
+  auto typeDecl = decl.dyn_cast<const TypeDecl *>();
+  auto extDecl = decl.dyn_cast<const ExtensionDecl *>();
   ASTContext &ctx = typeDecl ? typeDecl->getASTContext()
                              : extDecl->getASTContext();
   auto &evaluator = ctx.evaluator;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -37,14 +37,14 @@ namespace swift {
 }
 
 void swift::simple_display(
-       llvm::raw_ostream &out,
-       const llvm::PointerUnion<TypeDecl *, ExtensionDecl *> &value) {
-  if (auto type = value.dyn_cast<TypeDecl *>()) {
+    llvm::raw_ostream &out,
+    const llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> &value) {
+  if (auto type = value.dyn_cast<const TypeDecl *>()) {
     type->dumpRef(out);
     return;
   }
 
-  auto ext = value.get<ExtensionDecl *>();
+  auto ext = value.get<const ExtensionDecl *>();
   simple_display(out, ext);
 }
 
@@ -116,7 +116,7 @@ void InheritedTypeRequest::cacheResult(Type value) const {
   const auto &storage = getStorage();
   auto &typeLoc = getInheritedTypeLocAtIndex(std::get<0>(storage),
                                              std::get<1>(storage));
-  typeLoc.setType(value);
+  const_cast<TypeLoc &>(typeLoc).setType(value);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -70,13 +70,13 @@ using namespace swift;
 /// given type or extension. It need only be called within the primary source
 /// file.
 static void checkInheritanceClause(
-                    llvm::PointerUnion<TypeDecl *, ExtensionDecl *> declUnion) {
-  DeclContext *DC;
-  MutableArrayRef<TypeLoc> inheritedClause;
-  ExtensionDecl *ext = nullptr;
-  TypeDecl *typeDecl = nullptr;
-  Decl *decl;
-  if ((ext = declUnion.dyn_cast<ExtensionDecl *>())) {
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> declUnion) {
+  const DeclContext *DC;
+  ArrayRef<TypeLoc> inheritedClause;
+  const ExtensionDecl *ext = nullptr;
+  const TypeDecl *typeDecl = nullptr;
+  const Decl *decl;
+  if ((ext = declUnion.dyn_cast<const ExtensionDecl *>())) {
     decl = ext;
     DC = ext;
 
@@ -93,7 +93,7 @@ static void checkInheritanceClause(
       }
     }
   } else {
-    typeDecl = declUnion.get<TypeDecl *>();
+    typeDecl = declUnion.get<const TypeDecl *>();
     decl = typeDecl;
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
       DC = nominal;

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -25,24 +25,23 @@
 
 using namespace swift;
 
-Type
-InheritedTypeRequest::evaluate(
-    Evaluator &evaluator, llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-    unsigned index,
-    TypeResolutionStage stage) const {
+Type InheritedTypeRequest::evaluate(
+    Evaluator &evaluator,
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
+    unsigned index, TypeResolutionStage stage) const {
   // Figure out how to resolve types.
   TypeResolutionOptions options = None;
   DeclContext *dc;
-  if (auto typeDecl = decl.dyn_cast<TypeDecl *>()) {
+  if (auto typeDecl = decl.dyn_cast<const TypeDecl *>()) {
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
-      dc = nominal;
+      dc = (DeclContext *)nominal;
 
       options |= TypeResolutionFlags::AllowUnavailableProtocol;
     } else {
       dc = typeDecl->getDeclContext();
     }
   } else {
-    dc = decl.get<ExtensionDecl *>();
+    dc = (DeclContext *)decl.get<const ExtensionDecl *>();
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   }
 
@@ -70,7 +69,7 @@ InheritedTypeRequest::evaluate(
   }
   }
 
-  TypeLoc &typeLoc = getInheritedTypeLocAtIndex(decl, index);
+  const TypeLoc &typeLoc = getInheritedTypeLocAtIndex(decl, index);
 
   Type inheritedType;
   if (typeLoc.getTypeRepr())


### PR DESCRIPTION
* Mark `PatternBindingInitializer::getImplicitSelfDecl` const as it is a logically const operation.
* Swap `llvm::PointerUnion<TypeDecl *, ExtensionDecl *>` for its const cousin. The only operation in the stack that needed to mutate something is the caching part of a request which is itself logically const.