### PR TITLE
[5.3] [SE-0286] Trailing closure forward scan

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -55,6 +55,7 @@ class GenericFunctionType;
 class LazyConformanceLoader;
 class LazyMemberLoader;
 class PatternBindingInitializer;
+enum class TrailingClosureMatching: uint8_t;
 class TrailingWhereClause;
 
 /// TypeAttributes - These are attributes that may be applied to types.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -55,7 +55,6 @@ class GenericFunctionType;
 class LazyConformanceLoader;
 class LazyMemberLoader;
 class PatternBindingInitializer;
-enum class TrailingClosureMatching: uint8_t;
 class TrailingWhereClause;
 
 /// TypeAttributes - These are attributes that may be applied to types.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1174,15 +1174,6 @@ ERROR(extra_trailing_closure_in_call,none,
 ERROR(trailing_closure_bad_param,none,
       "trailing closure passed to parameter of type %0 that does not "
       "accept a closure", (Type))
-WARNING(unlabeled_trailing_closure_changed_behavior,none,
-        "since Swift 5.3, unlabeled trailing closure argument matches parameter %0 rather than parameter %1",
-        (Identifier, Identifier))
-WARNING(unlabeled_trailing_closure_changed_behavior_same_param_name,none,
-        "since Swift 5.3, unlabeled trailing closure argument matches earlier parameter %0 rather than later parameter with the same name",
-        (Identifier))
-NOTE(trailing_closure_select_parameter,none,
-     "label the argument with %0 to %select{retain the pre-Swift 5.3 behavior|silence this warning for Swift 5.3 and newer}1",
-     (Identifier, unsigned))
 WARNING(unlabeled_trailing_closure_deprecated,none,
         "backward matching of the unlabeled trailing closure is deprecated; label the argument with %0 to suppress this warning",
         (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1174,6 +1174,18 @@ ERROR(extra_trailing_closure_in_call,none,
 ERROR(trailing_closure_bad_param,none,
       "trailing closure passed to parameter of type %0 that does not "
       "accept a closure", (Type))
+WARNING(unlabeled_trailing_closure_changed_behavior,none,
+        "since Swift 5.3, unlabeled trailing closure argument matches parameter %0 rather than parameter %1",
+        (Identifier, Identifier))
+WARNING(unlabeled_trailing_closure_changed_behavior_same_param_name,none,
+        "since Swift 5.3, unlabeled trailing closure argument matches earlier parameter %0 rather than later parameter with the same name",
+        (Identifier))
+NOTE(trailing_closure_select_parameter,none,
+     "label the argument with %0 to %select{retain the pre-Swift 5.3 behavior|silence this warning for Swift 5.3 and newer}1",
+     (Identifier, unsigned))
+NOTE(decl_multiple_defaulted_closure_parameters,none,
+     "%0 contains defaulted closure parameters %1 and %2",
+     (DeclName, Identifier, Identifier))
 NOTE(candidate_with_extraneous_args,none,
       "candidate %0 requires %1 argument%s1, "
       "but %2 %select{were|was}3 %select{provided|used in closure body}4",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1183,6 +1183,9 @@ WARNING(unlabeled_trailing_closure_changed_behavior_same_param_name,none,
 NOTE(trailing_closure_select_parameter,none,
      "label the argument with %0 to %select{retain the pre-Swift 5.3 behavior|silence this warning for Swift 5.3 and newer}1",
      (Identifier, unsigned))
+WARNING(unlabeled_trailing_closure_deprecated,none,
+        "backward matching of the unlabeled trailing closure is deprecated; label the argument with %0 to suppress this warning",
+        (Identifier))
 NOTE(decl_multiple_defaulted_closure_parameters,none,
      "%0 contains defaulted closure parameters %1 and %2",
      (DeclName, Identifier, Identifier))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3484,6 +3484,7 @@ END_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
 /// has a default argument.
 struct ParameterListInfo {
   SmallBitVector defaultArguments;
+  SmallBitVector acceptsUnlabeledTrailingClosures;
 
 public:
   ParameterListInfo() { }
@@ -3493,6 +3494,10 @@ public:
 
   /// Whether the parameter at the given index has a default argument.
   bool hasDefaultArgument(unsigned paramIdx) const;
+
+  /// Whether the parameter accepts an unlabeled trailing closure argument
+  /// according to the "forward-scan" rule.
+  bool acceptsUnlabeledTrailingClosureArgument(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -250,6 +250,14 @@ namespace swift {
     /// Build the ASTScope tree lazily
     bool LazyASTScopes = true;
 
+    /// Whether to enable the "fuzzy" forward-scanning behavior for trailing
+    /// closure matching, which skips over defaulted closure parameters
+    /// to match later (non-defaulted) closure parameters
+    ///
+    /// This is a backward-compatibility hack for unlabeled trailing closures,
+    /// to be disabled in Swift 6+.
+    bool EnableFuzzyForwardScanTrailingClosureMatching = true;
+
     /// Use Clang function types for computing canonical types.
     /// If this option is false, the clang function types will still be computed
     /// but will not be used for checking type equality.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -519,6 +519,16 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def disable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
+    "disable-fuzzy-forward-scan-trailing-closure-matching">,
+  Flags<[FrontendOption]>,
+  HelpText<"Disable fuzzy forward-scan trailing closure matching">;
+
+def enable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
+    "enable-fuzzy-forward-scan-trailing-closure-matching">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable fuzzy forward-scan trailing closure matching">;
+
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
   Flags<[FrontendOption]>,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -829,8 +829,9 @@ static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
   if (param->isInOut())
     return false;
 
-  Type paramType =
-      param->getInterfaceType()->getRValueType()->lookThroughAllOptionalTypes();
+  Type paramType = param->isVariadic() ? param->getVarargBaseTy()
+                                       : param->getInterfaceType();
+  paramType = paramType->getRValueType()->lookThroughAllOptionalTypes();
 
   // For autoclosure parameters, look through the autoclosure result type
   // to get the actual argument type.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -822,16 +822,42 @@ Type TypeBase::replaceCovariantResultType(Type newResultType,
   return FunctionType::get(inputType, resultType, fnType->getExtInfo());
 }
 
+/// Whether this parameter accepts an unlabeled trailing closure argument
+/// using the more-restrictive forward-scan rule.
+static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
+  // inout parameters never allow an unlabeled trailing closure.
+  if (param->isInOut())
+    return false;
+
+  Type paramType =
+      param->getInterfaceType()->getRValueType()->lookThroughAllOptionalTypes();
+
+  // For autoclosure parameters, look through the autoclosure result type
+  // to get the actual argument type.
+  if (param->isAutoClosure()) {
+    auto fnType = paramType->getAs<AnyFunctionType>();
+    if (!fnType)
+      return false;
+
+    paramType = fnType->getResult()->lookThroughAllOptionalTypes();
+  }
+
+  // After lookup through all optional types, this parameter allows an
+  // unlabeled trailing closure if it is (structurally) a function type.
+  return paramType->is<AnyFunctionType>();
+}
+
 ParameterListInfo::ParameterListInfo(
     ArrayRef<AnyFunctionType::Param> params,
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
+  acceptsUnlabeledTrailingClosures.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
   //
-  // FIXME: We ought to not request default argument info in this case.
+  // FIXME: We ought to not request paramer list info in this case.
   if (!paramOwner)
     return;
 
@@ -865,11 +891,16 @@ ParameterListInfo::ParameterListInfo(
   if (params.size() != paramList->size())
     return;
 
-  // Note which parameters have default arguments and/or function builders.
+  // Note which parameters have default arguments and/or accept unlabeled
+  // trailing closure arguments with the forward-scan rule.
   for (auto i : range(0, params.size())) {
     auto param = paramList->get(i);
     if (param->isDefaultArgument()) {
       defaultArguments.set(i);
+    }
+
+    if (allowsUnlabeledTrailingClosureParameter(param)) {
+      acceptsUnlabeledTrailingClosures.set(i);
     }
   }
 }
@@ -877,6 +908,12 @@ ParameterListInfo::ParameterListInfo(
 bool ParameterListInfo::hasDefaultArgument(unsigned paramIdx) const {
   return paramIdx < defaultArguments.size() ? defaultArguments[paramIdx]
       : false;
+}
+
+bool ParameterListInfo::acceptsUnlabeledTrailingClosureArgument(
+    unsigned paramIdx) const {
+  return paramIdx < acceptsUnlabeledTrailingClosures.size() &&
+      acceptsUnlabeledTrailingClosures[paramIdx];
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -853,7 +853,6 @@ ParameterListInfo::ParameterListInfo(
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
-  acceptsUnlabeledTrailingClosures.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -892,6 +891,10 @@ ParameterListInfo::ParameterListInfo(
   if (params.size() != paramList->size())
     return;
 
+  // Now we have enough information to determine which parameters accept
+  // unlabled trailing closures.
+  acceptsUnlabeledTrailingClosures.resize(params.size());
+
   // Note which parameters have default arguments and/or accept unlabeled
   // trailing closure arguments with the forward-scan rule.
   for (auto i : range(0, params.size())) {
@@ -913,7 +916,7 @@ bool ParameterListInfo::hasDefaultArgument(unsigned paramIdx) const {
 
 bool ParameterListInfo::acceptsUnlabeledTrailingClosureArgument(
     unsigned paramIdx) const {
-  return paramIdx < acceptsUnlabeledTrailingClosures.size() &&
+  return paramIdx >= acceptsUnlabeledTrailingClosures.size() ||
       acceptsUnlabeledTrailingClosures[paramIdx];
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -252,6 +252,10 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
+  inputArgs.AddLastArg(
+      arguments,
+      options::OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
+      options::OPT_disable_fuzzy_forward_scan_trailing_closure_matching);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
   

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -562,7 +562,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableFuzzyForwardScanTrailingClosureMatching =
       Args.hasFlag(OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
                    OPT_disable_fuzzy_forward_scan_trailing_closure_matching,
-                   !Opts.EffectiveLanguageVersion.isVersionAtLeast(6));
+                   true);
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -559,6 +559,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
+  Opts.EnableFuzzyForwardScanTrailingClosureMatching =
+      Args.hasFlag(OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
+                   OPT_disable_fuzzy_forward_scan_trailing_closure_matching,
+                   !Opts.EffectiveLanguageVersion.isVersionAtLeast(6));
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5628,17 +5628,7 @@ static void maybeWarnAboutTrailingClosureBindingChange(
         decl->getName(), paramName, backwardParamName);
 
     // Dig out the parameter declarations so we can highlight them.
-    // FIXME: There should be a utility for this.
-    const ParameterList *paramList = nullptr;
-    if (auto *func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      paramList = func->getParameters();
-    } else if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
-      paramList = subscript->getIndices();
-    } else if (auto *enumElement = dyn_cast<EnumElementDecl>(decl)) {
-      paramList = enumElement->getParameterList();
-    }
-
-    if (paramList) {
+    if (const ParameterList *paramList = getParameterList(decl)) {
       diag.highlight(paramList->get(paramIdx)->getLoc());
       diag.highlight(paramList->get(*matchingBackwardParamIdx)->getLoc());
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5754,18 +5754,33 @@ Expr *ExprRewriter::coerceCallArguments(
   AnyFunctionType::relabelParams(args, argLabels);
 
   MatchCallArgumentListener listener;
-  SmallVector<ParamBinding, 4> parameterBindings;
   auto unlabeledTrailingClosureIndex =
       arg->getUnlabeledTrailingClosureIndexOfPackedArgument();
-  bool failed = constraints::matchCallArguments(args, params,
-                                                paramInfo,
-                                                unlabeledTrailingClosureIndex,
-                                                /*allowFixes=*/false, listener,
-                                                parameterBindings);
 
-  assert((matchCanFail || !failed) && "Call arguments did not match up?");
-  (void)failed;
+  // Determine the trailing closure matching rule that was applied. This
+  // is only relevant for explicit calls and subscripts.
+  auto trailingClosureMatching = TrailingClosureMatching::Forward;
+  {
+    SmallVector<LocatorPathElt, 4> path;
+    auto anchor = locator.getLocatorParts(path);
+    if (!path.empty() && path.back().is<LocatorPathElt::ApplyArgument>() &&
+        (anchor.isExpr(ExprKind::Call) || anchor.isExpr(ExprKind::Subscript))) {
+      auto locatorPtr = cs.getConstraintLocator(locator);
+      assert(solution.trailingClosureMatchingChoices.count(locatorPtr) == 1);
+      trailingClosureMatching = solution.trailingClosureMatchingChoices.find(
+          locatorPtr)->second;
+    }
+  }
+
+  auto callArgumentMatch = constraints::matchCallArguments(
+      args, params, paramInfo, unlabeledTrailingClosureIndex,
+      /*allowFixes=*/false, listener, trailingClosureMatching);
+
+  assert((matchCanFail || callArgumentMatch) &&
+         "Call arguments did not match up?");
   (void)matchCanFail;
+
+  auto parameterBindings = std::move(callArgumentMatch->parameterBindings);
 
   // We should either have parentheses or a tuple.
   auto *argTuple = dyn_cast<TupleExpr>(arg);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5703,7 +5703,7 @@ Expr *ExprRewriter::coerceCallArguments(
     SmallVector<LocatorPathElt, 4> path;
     auto anchor = locator.getLocatorParts(path);
     if (!path.empty() && path.back().is<LocatorPathElt::ApplyArgument>() &&
-        (anchor.isExpr(ExprKind::Call) || anchor.isExpr(ExprKind::Subscript))) {
+        (isa<CallExpr>(anchor) || isa<SubscriptExpr>(anchor))) {
       auto locatorPtr = cs.getConstraintLocator(locator);
       assert(solution.trailingClosureMatchingChoices.count(locatorPtr) == 1);
       trailingClosureMatching = solution.trailingClosureMatchingChoices.find(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5537,6 +5537,96 @@ static unsigned functionParameterArity(AnyFunctionType::Param param) {
   return paramType->castTo<AnyFunctionType>()->getNumParams();
 }
 
+/// Attach a Fix-It to the given diagnostic to give the trailing closure
+/// argument a label.
+static void labelTrailingClosureArgument(
+    ASTContext &ctx, Expr *fn, Expr *arg, Identifier paramName,
+    Expr *trailingClosure, InFlightDiagnostic &diag) {
+  // Dig out source locations.
+  SourceLoc existingRParenLoc;
+  SourceLoc leadingCommaLoc;
+  if (auto tupleExpr = dyn_cast<TupleExpr>(arg)) {
+    existingRParenLoc = tupleExpr->getRParenLoc();
+    assert(tupleExpr->getNumElements() >= 2 && "Should be a ParenExpr?");
+    leadingCommaLoc = Lexer::getLocForEndOfToken(
+        ctx.SourceMgr,
+        tupleExpr->getElements()[tupleExpr->getNumElements()-2]->getEndLoc());
+  } else {
+    auto parenExpr = cast<ParenExpr>(arg);
+    existingRParenLoc = parenExpr->getRParenLoc();
+  }
+
+  // Figure out the text to be inserted before the trailing closure.
+  SmallString<16> insertionText;
+  SourceLoc insertionLoc;
+  if (leadingCommaLoc.isValid()) {
+    insertionText += ", ";
+    assert(existingRParenLoc.isValid());
+    insertionLoc = leadingCommaLoc;
+  } else if (existingRParenLoc.isInvalid()) {
+    insertionText += "(";
+    insertionLoc = Lexer::getLocForEndOfToken(
+        ctx.SourceMgr, fn->getEndLoc());
+  } else {
+    insertionLoc = existingRParenLoc;
+  }
+
+  // Add the label, if there is one.
+  if (!paramName.empty()) {
+    insertionText += paramName.str();
+    insertionText += ": ";
+  }
+
+  // If there is an existing right parentheses, remove it while we
+  // insert the new text.
+  if (existingRParenLoc.isValid()) {
+    SourceLoc afterExistingRParenLoc = Lexer::getLocForEndOfToken(
+        ctx.SourceMgr, existingRParenLoc);
+    diag.fixItReplaceChars(
+        insertionLoc, afterExistingRParenLoc, insertionText);
+  } else {
+    // Insert the appropriate prefix.
+    diag.fixItInsert(insertionLoc, insertionText);
+  }
+
+  // Insert a right parenthesis after the closing '}' of the trailing closure;
+  SourceLoc newRParenLoc = Lexer::getLocForEndOfToken(
+      ctx.SourceMgr, trailingClosure->getEndLoc());
+  diag.fixItInsert(newRParenLoc, ")");
+}
+
+/// Find the trailing closure argument of a tuple or parenthesized expression.
+///
+/// Due to a quirk of the backward scan that could allow reordering of
+/// arguments in the presence of a trailing closure, it might not be the last
+/// argument in the tuple.
+static Expr *findTrailingClosureArgument(Expr *arg) {
+  if (auto parenExpr = dyn_cast<ParenExpr>(arg)) {
+    return parenExpr->getSubExpr();
+  }
+
+  auto tupleExpr = cast<TupleExpr>(arg);
+  SourceLoc endLoc = tupleExpr->getEndLoc();
+  for (Expr *elt : llvm::reverse(tupleExpr->getElements())) {
+    if (elt->getEndLoc() == endLoc)
+      return elt;
+  }
+
+  return tupleExpr->getElements().back();
+}
+
+/// Find the index of the parameter that binds the given argument.
+static unsigned findParamBindingArgument(
+    ArrayRef<ParamBinding> parameterBindings, unsigned argIndex) {
+  for (unsigned paramIdx : indices(parameterBindings)) {
+    if (llvm::find(parameterBindings[paramIdx], argIndex)
+          != parameterBindings[paramIdx].end())
+      return paramIdx;
+  }
+
+  llvm_unreachable("No parameter binds the argument?");
+}
+
 /// SE-0286 changed the direction in which the unlabeled trailing closure
 /// argument is matched to a parameter, from backward (the pre-Swift 5.3
 /// semantics) to forward (after SE-0286). Identify cases where this may
@@ -5558,13 +5648,8 @@ static void maybeWarnAboutTrailingClosureBindingChange(
     return;
 
   // Find the parameter that bound the unlabeled trailing closure argument.
-  unsigned paramIdx;
-  for (paramIdx = 0; paramIdx != parameterBindings.size(); ++paramIdx) {
-    if (llvm::find(parameterBindings[paramIdx], *unlabeledTrailingClosureIndex)
-          != parameterBindings[paramIdx].end())
-      break;
-  }
-  assert(paramIdx != parameterBindings.size() && "Unbound trailing closure!");
+  unsigned paramIdx = findParamBindingArgument(
+      parameterBindings, *unlabeledTrailingClosureIndex);
 
   // If this parameter requires an argument, it would have been unfilled
   // prior to SE-2086; there is nothing to diagnose.
@@ -5594,23 +5679,8 @@ static void maybeWarnAboutTrailingClosureBindingChange(
         functionParameterArity(params[*matchingBackwardParamIdx]))
     return;
 
-  // Compute the various source locations where diagnostics will occur.
-  ASTContext &ctx = params[paramIdx].getPlainType()->getASTContext();
-  Expr *trailingClosure;
-  SourceLoc existingRParenLoc;
-  SourceLoc leadingCommaLoc;
-  if (auto tupleExpr = dyn_cast<TupleExpr>(arg)) {
-    trailingClosure = tupleExpr->getElements().back();
-    existingRParenLoc = tupleExpr->getRParenLoc();
-    assert(tupleExpr->getNumElements() >= 2 && "Should be a ParenExpr?");
-    leadingCommaLoc = Lexer::getLocForEndOfToken(
-        ctx.SourceMgr,
-        tupleExpr->getElements()[tupleExpr->getNumElements()-2]->getEndLoc());
-  } else {
-    auto parenExpr = cast<ParenExpr>(arg);
-    trailingClosure = parenExpr->getSubExpr();
-    existingRParenLoc = parenExpr->getRParenLoc();
-  }
+  // Dig out the trailing closure.
+  Expr *trailingClosure = findTrailingClosureArgument(arg);
 
   // Determine the names of the parameters that would be matched by the
   // forward and backward scans.
@@ -5618,6 +5688,7 @@ static void maybeWarnAboutTrailingClosureBindingChange(
   Identifier backwardParamName = params[*matchingBackwardParamIdx].getLabel();
 
   // Produce a diagnostic referencing the callee.
+  ASTContext &ctx = params[paramIdx].getPlainType()->getASTContext();
   auto noteCallee = [&] {
     auto decl = callee.getDecl();
     if (!decl)
@@ -5653,51 +5724,42 @@ static void maybeWarnAboutTrailingClosureBindingChange(
     auto diag = ctx.Diags.diagnose(
         trailingClosure->getStartLoc(), diag::trailing_closure_select_parameter,
         paramName, which);
-
-    // Figure out the text to be inserted before the trailing closure.
-    SmallString<16> insertionText;
-    SourceLoc insertionLoc;
-    if (leadingCommaLoc.isValid()) {
-      insertionText += ", ";
-      assert(existingRParenLoc.isValid());
-      insertionLoc = leadingCommaLoc;
-    } else if (existingRParenLoc.isInvalid()) {
-      insertionText += "(";
-      insertionLoc = Lexer::getLocForEndOfToken(
-          ctx.SourceMgr, fn->getEndLoc());
-    } else {
-      insertionLoc = existingRParenLoc;
-    }
-
-    // Add the label, if there is one.
-    if (!paramName.empty()) {
-      insertionText += paramName.str();
-      insertionText += ": ";
-    }
-
-    // If there is an existing right parentheses, remove it while we
-    // insert the new text.
-    if (existingRParenLoc.isValid()) {
-      SourceLoc afterExistingRParenLoc = Lexer::getLocForEndOfToken(
-          ctx.SourceMgr, existingRParenLoc);
-      diag.fixItReplaceChars(
-          insertionLoc, afterExistingRParenLoc, insertionText);
-    } else {
-      // Insert the appropriate prefix.
-      diag.fixItInsert(insertionLoc, insertionText);
-    }
-
-
-    // Insert a right parenthesis after the closing '}' of the trailing closure;
-    SourceLoc newRParenLoc = Lexer::getLocForEndOfToken(
-        ctx.SourceMgr, trailingClosure->getEndLoc());
-    diag.fixItInsert(newRParenLoc, ")");
+    labelTrailingClosureArgument(
+        ctx, fn, arg, paramName, trailingClosure, diag);
   };
 
   diagResolution(backwardParamName, 0);
   diagResolution(paramName, 1);
 
   noteCallee();
+}
+
+/// Warn about the use of the deprecated "backward" scan for matching the
+/// unlabeled trailing closure. It was needed to properly type check, but
+/// this code will break with a future version of Swift.
+static void warnAboutTrailingClosureBackwardScan(
+    ConcreteDeclRef callee, Expr *fn, Expr *arg,
+    ArrayRef<AnyFunctionType::Param> params,
+    Optional<unsigned> unlabeledTrailingClosureIndex,
+    ArrayRef<ParamBinding> parameterBindings) {
+
+  Expr *trailingClosure = findTrailingClosureArgument(arg);
+  unsigned paramIdx = findParamBindingArgument(
+      parameterBindings, *unlabeledTrailingClosureIndex);
+  ASTContext &ctx = params[paramIdx].getPlainType()->getASTContext();
+  Identifier paramName = params[paramIdx].getLabel();
+
+  {
+    auto diag = ctx.Diags.diagnose(
+        trailingClosure->getStartLoc(),
+        diag::unlabeled_trailing_closure_deprecated, paramName);
+    labelTrailingClosureArgument(
+        ctx, fn, arg, paramName, trailingClosure, diag);
+  }
+
+  if (auto decl = callee.getDecl()) {
+    ctx.Diags.diagnose(decl, diag::decl_declared_here, decl->getName());
+  }
 }
 
 Expr *ExprRewriter::coerceCallArguments(
@@ -5790,9 +5852,15 @@ Expr *ExprRewriter::coerceCallArguments(
 
   // Warn if there was a recent change in trailing closure binding semantics
   // that might have lead to a silent change in behavior.
-  maybeWarnAboutTrailingClosureBindingChange(
-      callee, apply ? apply->getFn() : nullptr, arg, args, params, paramInfo,
-      unlabeledTrailingClosureIndex, parameterBindings);
+  if (trailingClosureMatching == TrailingClosureMatching::Forward) {
+    maybeWarnAboutTrailingClosureBindingChange(
+        callee, apply ? apply->getFn() : nullptr, arg, args, params, paramInfo,
+        unlabeledTrailingClosureIndex, parameterBindings);
+  } else {
+    warnAboutTrailingClosureBackwardScan(
+        callee, apply ? apply->getFn() : nullptr, arg, params,
+        unlabeledTrailingClosureIndex, parameterBindings);
+  }
 
   SourceLoc lParenLoc, rParenLoc;
   if (argTuple) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5786,7 +5786,7 @@ Expr *ExprRewriter::coerceCallArguments(
   // Warn if there was a recent change in trailing closure binding semantics
   // that might have lead to a silent change in behavior.
   maybeWarnAboutTrailingClosureBindingChange(
-      callee, apply->getFn(), arg, args, params, paramInfo,
+      callee, apply ? apply->getFn() : nullptr, arg, args, params, paramInfo,
       unlabeledTrailingClosureIndex, parameterBindings);
 
   SourceLoc lParenLoc, rParenLoc;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5521,6 +5521,195 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
   return false;
 }
 
+/// Determine the arity of the given parameter of function type.
+static unsigned functionParameterArity(AnyFunctionType::Param param) {
+  Type paramType = param.getPlainType();
+  if (param.isVariadic())
+    paramType = ParamDecl::getVarargBaseTy(paramType);
+
+  paramType = paramType->lookThroughAllOptionalTypes();
+
+  if (param.isAutoClosure()) {
+    paramType = paramType->castTo<AnyFunctionType>()->getResult();
+    paramType = paramType->lookThroughAllOptionalTypes();
+  }
+
+  return paramType->castTo<AnyFunctionType>()->getNumParams();
+}
+
+/// SE-0286 changed the direction in which the unlabeled trailing closure
+/// argument is matched to a parameter, from backward (the pre-Swift 5.3
+/// semantics) to forward (after SE-0286). Identify cases where this may
+/// have resulted in a silent change in behavior.
+static void maybeWarnAboutTrailingClosureBindingChange(
+    ConcreteDeclRef callee,
+    Expr *fn,
+    Expr *arg,
+    ArrayRef<AnyFunctionType::Param> args,
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    Optional<unsigned> unlabeledTrailingClosureIndex,
+    ArrayRef<ParamBinding> parameterBindings) {
+
+  if (!unlabeledTrailingClosureIndex)
+    return;
+
+  if (*unlabeledTrailingClosureIndex != args.size() - 1)
+    return;
+
+  // Find the parameter that bound the unlabeled trailing closure argument.
+  unsigned paramIdx;
+  for (paramIdx = 0; paramIdx != parameterBindings.size(); ++paramIdx) {
+    if (llvm::find(parameterBindings[paramIdx], *unlabeledTrailingClosureIndex)
+          != parameterBindings[paramIdx].end())
+      break;
+  }
+  assert(paramIdx != parameterBindings.size() && "Unbound trailing closure!");
+
+  // If this parameter requires an argument, it would have been unfilled
+  // prior to SE-2086; there is nothing to diagnose.
+  if (parameterRequiresArgument(params, paramInfo, paramIdx))
+    return;
+
+  // Look for a later parameter that could match a trailing closure; the
+  // last one of these would have been picked prior to SE-0286.
+  Optional<unsigned> matchingBackwardParamIdx;
+  for (unsigned backwardParamIdx :
+           range(paramIdx + 1, parameterBindings.size())) {
+    if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(backwardParamIdx))
+      continue;
+
+    matchingBackwardParamIdx = backwardParamIdx;
+  }
+
+  // If there is no other parameter that could match the unlabeled trailing
+  // closure, there is nothing to diagnose.
+  if (!matchingBackwardParamIdx)
+    return;
+
+  // Do a simple arity check; if the matched parameter and backward-matched
+  // parameter accept functions with different arity, this would not have
+  // type-checked with the backward scan, so there is nothing to report.
+  if (functionParameterArity(params[paramIdx]) !=
+        functionParameterArity(params[*matchingBackwardParamIdx]))
+    return;
+
+  // Compute the various source locations where diagnostics will occur.
+  ASTContext &ctx = params[paramIdx].getPlainType()->getASTContext();
+  Expr *trailingClosure;
+  SourceLoc existingRParenLoc;
+  SourceLoc leadingCommaLoc;
+  if (auto tupleExpr = dyn_cast<TupleExpr>(arg)) {
+    trailingClosure = tupleExpr->getElements().back();
+    existingRParenLoc = tupleExpr->getRParenLoc();
+    assert(tupleExpr->getNumElements() >= 2 && "Should be a ParenExpr?");
+    leadingCommaLoc = Lexer::getLocForEndOfToken(
+        ctx.SourceMgr,
+        tupleExpr->getElements()[tupleExpr->getNumElements()-2]->getEndLoc());
+  } else {
+    auto parenExpr = cast<ParenExpr>(arg);
+    trailingClosure = parenExpr->getSubExpr();
+    existingRParenLoc = parenExpr->getRParenLoc();
+  }
+
+  // Determine the names of the parameters that would be matched by the
+  // forward and backward scans.
+  Identifier paramName = params[paramIdx].getLabel();
+  Identifier backwardParamName = params[*matchingBackwardParamIdx].getLabel();
+
+  // Produce a diagnostic referencing the callee.
+  auto noteCallee = [&] {
+    auto decl = callee.getDecl();
+    if (!decl)
+      return;
+
+    auto diag = ctx.Diags.diagnose(
+        decl, diag::decl_multiple_defaulted_closure_parameters,
+        decl->getName(), paramName, backwardParamName);
+
+    // Dig out the parameter declarations so we can highlight them.
+    // FIXME: There should be a utility for this.
+    const ParameterList *paramList = nullptr;
+    if (auto *func = dyn_cast<AbstractFunctionDecl>(decl)) {
+      paramList = func->getParameters();
+    } else if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
+      paramList = subscript->getIndices();
+    } else if (auto *enumElement = dyn_cast<EnumElementDecl>(decl)) {
+      paramList = enumElement->getParameterList();
+    }
+
+    if (paramList) {
+      diag.highlight(paramList->get(paramIdx)->getLoc());
+      diag.highlight(paramList->get(*matchingBackwardParamIdx)->getLoc());
+    }
+  };
+
+  // If the parameters have the same name, provide a custom diagnostic and then
+  // bail out early; there are no useful notes we can provide here.
+  if (paramName == backwardParamName) {
+    ctx.Diags.diagnose(trailingClosure->getStartLoc(), diag::unlabeled_trailing_closure_changed_behavior_same_param_name,
+        paramName);
+    noteCallee();
+    return;
+  }
+
+  // Produce the diagnostic.
+  ctx.Diags.diagnose(trailingClosure->getStartLoc(), diag::unlabeled_trailing_closure_changed_behavior, paramName,
+      backwardParamName);
+
+  // Produce a note with a Fix-It describing how to resolve the ambiguity.
+  auto diagResolution = [&](Identifier paramName, unsigned which) {
+    // Emit the note.
+    auto diag = ctx.Diags.diagnose(
+        trailingClosure->getStartLoc(), diag::trailing_closure_select_parameter,
+        paramName, which);
+
+    // Figure out the text to be inserted before the trailing closure.
+    SmallString<16> insertionText;
+    SourceLoc insertionLoc;
+    if (leadingCommaLoc.isValid()) {
+      insertionText += ", ";
+      assert(existingRParenLoc.isValid());
+      insertionLoc = leadingCommaLoc;
+    } else if (existingRParenLoc.isInvalid()) {
+      insertionText += "(";
+      insertionLoc = Lexer::getLocForEndOfToken(
+          ctx.SourceMgr, fn->getEndLoc());
+    } else {
+      insertionLoc = existingRParenLoc;
+    }
+
+    // Add the label, if there is one.
+    if (!paramName.empty()) {
+      insertionText += paramName.str();
+      insertionText += ": ";
+    }
+
+    // If there is an existing right parentheses, remove it while we
+    // insert the new text.
+    if (existingRParenLoc.isValid()) {
+      SourceLoc afterExistingRParenLoc = Lexer::getLocForEndOfToken(
+          ctx.SourceMgr, existingRParenLoc);
+      diag.fixItReplaceChars(
+          insertionLoc, afterExistingRParenLoc, insertionText);
+    } else {
+      // Insert the appropriate prefix.
+      diag.fixItInsert(insertionLoc, insertionText);
+    }
+
+
+    // Insert a right parenthesis after the closing '}' of the trailing closure;
+    SourceLoc newRParenLoc = Lexer::getLocForEndOfToken(
+        ctx.SourceMgr, trailingClosure->getEndLoc());
+    diag.fixItInsert(newRParenLoc, ")");
+  };
+
+  diagResolution(backwardParamName, 0);
+  diagResolution(paramName, 1);
+
+  noteCallee();
+}
+
 Expr *ExprRewriter::coerceCallArguments(
     Expr *arg, AnyFunctionType *funcType,
     ConcreteDeclRef callee,
@@ -5593,6 +5782,12 @@ Expr *ExprRewriter::coerceCallArguments(
   auto *argParen = dyn_cast<ParenExpr>(arg);
   // FIXME: Eventually, we want to enforce that we have either argTuple or
   // argParen here.
+
+  // Warn if there was a recent change in trailing closure binding semantics
+  // that might have lead to a silent change in behavior.
+  maybeWarnAboutTrailingClosureBindingChange(
+      callee, apply->getFn(), arg, args, params, paramInfo,
+      unlabeledTrailingClosureIndex, parameterBindings);
 
   SourceLoc lParenLoc, rParenLoc;
   if (argTuple) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5905,19 +5905,6 @@ bool ExtraneousCallFailure::diagnoseAsError() {
   return true;
 }
 
-bool InvalidUseOfTrailingClosure::diagnoseAsError() {
-  emitDiagnostic(diag::trailing_closure_bad_param, getToType())
-      .highlight(getSourceRange());
-
-  if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
-    if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
-    }
-  }
-
-  return true;
-}
-
 void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   auto getPointerKind = [](Type ty) -> PointerTypeKind {
     PointerTypeKind pointerKind;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1283,10 +1283,10 @@ private:
   bool isPropertyWrapperInitialization() const;
 
   /// Gather information associated with expression that represents
-  /// a call - function, arguments, # of arguments and whether it has
-  /// a trailing closure.
-  std::tuple<Expr *, Expr *, unsigned, bool>
-  getCallInfo(TypedNode anchor) const;
+  /// a call - function, arguments, # of arguments and the position of
+  /// the first trailing closure.
+  std::tuple<Expr *, Expr *, unsigned, Optional<unsigned>>
+      getCallInfo(TypedNode anchor) const;
 
   /// Transform given argument into format suitable for a fix-it
   /// text e.g. `[<label>:]? <#<type#>`
@@ -1805,6 +1805,10 @@ public:
   /// property wrapper initialization via implicit `init(wrappedValue:)`
   /// or now deprecated `init(initialValue:)`.
   bool diagnosePropertyWrapperMismatch() const;
+
+  /// Tailored diagnostics for argument mismatches associated with trailing
+  /// closures being passed to non-closure parameters.
+  bool diagnoseTrailingClosureMismatch() const;
 
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1187,21 +1187,6 @@ RemoveInvalidCall *RemoveInvalidCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) RemoveInvalidCall(cs, locator);
 }
 
-bool AllowInvalidUseOfTrailingClosure::diagnose(const Solution &solution,
-                                                bool asNote) const {
-  InvalidUseOfTrailingClosure failure(solution, getFromType(), getToType(),
-                                      getLocator());
-  return failure.diagnose(asNote);
-}
-
-AllowInvalidUseOfTrailingClosure *
-AllowInvalidUseOfTrailingClosure::create(ConstraintSystem &cs, Type argType,
-                                         Type paramType,
-                                         ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      AllowInvalidUseOfTrailingClosure(cs, argType, paramType, locator);
-}
-
 bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
   NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -222,8 +222,6 @@ enum class FixKind : uint8_t {
   /// a variable, a property etc.
   RemoveCall,
 
-  AllowInvalidUseOfTrailingClosure,
-
   /// Allow an ephemeral argument conversion for a parameter marked as being
   /// non-ephemeral.
   TreatEphemeralAsNonEphemeral,
@@ -1654,24 +1652,6 @@ public:
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
-};
-
-class AllowInvalidUseOfTrailingClosure final : public AllowArgumentMismatch {
-  AllowInvalidUseOfTrailingClosure(ConstraintSystem &cs, Type argType,
-                                   Type paramType, ConstraintLocator *locator)
-      : AllowArgumentMismatch(cs, FixKind::AllowInvalidUseOfTrailingClosure,
-                              argType, paramType, locator) {}
-
-public:
-  std::string getName() const {
-    return "allow invalid use of trailing closure";
-  }
-
-  bool diagnose(const Solution &solution, bool asNote = false) const;
-
-  static AllowInvalidUseOfTrailingClosure *create(ConstraintSystem &cs,
-                                                  Type argType, Type paramType,
-                                                  ConstraintLocator *locator);
 };
 
 class TreatEphemeralAsNonEphemeral final : public AllowArgumentMismatch {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1409,7 +1409,8 @@ namespace {
       auto funcType = constr->getMethodInterfaceType()->castTo<FunctionType>();
       ::matchCallArguments(
           CS, funcType, args, params, ConstraintKind::ArgumentConversion,
-          CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument));
+          CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument),
+          TrailingClosureMatching::Forward);
 
       Type result = tv;
       if (constr->isFailable())

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -49,8 +49,8 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
       log << "use of an unavailable declaration";
       break;
 
-    case SK_BackwardTrailingClosure:
-      llvm::errs() << "backward scan when matching a trailing closure";
+    case SK_ForwardTrailingClosure:
+      llvm::errs() << "forward scan when matching a trailing closure";
       break;
 
     case SK_Fix:

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -49,6 +49,10 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
       log << "use of an unavailable declaration";
       break;
 
+    case SK_BackwardTrailingClosure:
+      llvm::errs() << "backward scan when matching a trailing closure";
+      break;
+
     case SK_Fix:
       log << "attempting to fix the source";
       break;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -199,6 +199,15 @@ static ConstraintSystem::TypeMatchOptions getDefaultDecompositionOptions(
   return flags | ConstraintSystem::TMF_GenerateConstraints;
 }
 
+/// Whether the given parameter requires an argument.
+static bool parameterRequiresArgument(
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    unsigned paramIdx) {
+  return !paramInfo.hasDefaultArgument(paramIdx)
+      && !params[paramIdx].isVariadic();
+}
+
 /// Determine whether any parameter from the given index up until the end
 /// requires an argument to be provided.
 ///
@@ -221,8 +230,7 @@ static bool anyParameterRequiresArgument(
       break;
 
     // If this parameter requires an argument, tell the caller.
-    if (!paramInfo.hasDefaultArgument(paramIdx)
-        && !params[paramIdx].isVariadic())
+    if (parameterRequiresArgument(params, paramInfo, paramIdx))
       return true;
   }
 
@@ -313,13 +321,6 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
     // If we've claimed all of the arguments, there's nothing more to do.
     if (numClaimedArgs == numArgs)
-      return None;
-
-    // If we're claiming variadic arguments, do not claim an unlabeled trailing
-    // closure argument.
-    if (forVariadic &&
-        unlabeledTrailingClosureArgIndex &&
-        nextArgIdx == *unlabeledTrailingClosureArgIndex)
       return None;
 
     // Go hunting for an unclaimed argument whose name does match.
@@ -424,10 +425,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         return;
       }
 
-      // If this parameter has a default argument, consider applying a "fuzzy"
-      // match rule that skips this parameter if doing so is the only way to
-      // satisfy
-      if (paramInfo.hasDefaultArgument(paramIdx) &&
+      // If this parameter does not require an argument, consider applying a
+      // "fuzzy" match rule that skips this parameter if doing so is the only
+      // way to successfully match arguments to parameters.
+      if (!parameterRequiresArgument(params, paramInfo, paramIdx) &&
           param.getPlainType()->getASTContext().LangOpts
               .EnableFuzzyForwardScanTrailingClosureMatching &&
           anyParameterRequiresArgument(
@@ -468,10 +469,21 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
       auto currentNextArgIdx = nextArgIdx;
       {
         nextArgIdx = *claimed;
+
         // Claim any additional unnamed arguments.
-        while (
-            (claimed = claimNextNamed(nextArgIdx, Identifier(), false, true))) {
-          parameterBindings[paramIdx].push_back(*claimed);
+        while (true) {
+          // If the next argument is the unlabeled trailing closure and the
+          // variadic parameter does not accept the unlabeled trailing closure
+          // argument, we're done.
+          if (unlabeledTrailingClosureArgIndex &&
+              skipClaimedArgs(nextArgIdx) == *unlabeledTrailingClosureArgIndex &&
+              !paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx))
+            break;
+
+          if ((claimed = claimNextNamed(nextArgIdx, Identifier(), false, true)))
+            parameterBindings[paramIdx].push_back(*claimed);
+          else
+            break;
         }
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -420,7 +420,8 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
       // If the parameter we are looking at does not support the (unlabeled)
       // trailing closure argument, this parameter is unfulfilled.
-      if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx)) {
+      if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx) &&
+          !ignoreNameMismatch) {
         haveUnfulfilledParams = true;
         return;
       }
@@ -738,7 +739,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         // one argument requires label and another one doesn't, but caller
         // doesn't provide either, problem is going to be identified as
         // out-of-order argument instead of label mismatch.
-        const auto expectedLabel = params[paramIdx].getLabel();
+        const auto expectedLabel =
+          fromArgIdx == unlabeledTrailingClosureArgIndex
+            ? Identifier()
+            : params[paramIdx].getLabel();
         const auto argumentLabel = args[fromArgIdx].getLabel();
 
         if (argumentLabel != expectedLabel) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -195,7 +195,7 @@ static ConstraintSystem::TypeMatchOptions getDefaultDecompositionOptions(
 }
 
 /// Whether the given parameter requires an argument.
-static bool parameterRequiresArgument(
+bool swift::parameterRequiresArgument(
     ArrayRef<AnyFunctionType::Param> params,
     const ParameterListInfo &paramInfo,
     unsigned paramIdx) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1228,13 +1228,13 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
         cs.getConstraintLocator(locator),
         callArgumentMatch->trailingClosureMatching);
 
-    // If we matched with the backward rule, increase the score for backward
-    // matches.
-    // FIXME: We shouldn't want this? Wait until later so we can diagnose
-    // appropriately.
-    if (callArgumentMatch->trailingClosureMatching
-            == TrailingClosureMatching::Backward)
-      cs.increaseScore(SK_BackwardTrailingClosure);
+    // If there was a disjunction because both forward and backward were
+    // possible, increase the score for forward matches to bias toward the
+    // (source-compatible) backward matches. The compiler will produce a
+    // warning for such code.
+    if (trailingClosureMatching &&
+        *trailingClosureMatching == TrailingClosureMatching::Forward)
+      cs.increaseScore(SK_ForwardTrailingClosure);
 
     // Take the parameter bindings we selected.
     parameterBindings = std::move(callArgumentMatch->parameterBindings);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -51,8 +51,8 @@ bool MatchCallArgumentListener::incorrectLabel(unsigned paramIdx) {
   return true;
 }
 
-bool MatchCallArgumentListener::outOfOrderArgument(unsigned argIdx,
-                                                   unsigned prevArgIdx) {
+bool MatchCallArgumentListener::outOfOrderArgument(
+    unsigned argIdx, unsigned prevArgIdx, ArrayRef<ParamBinding> bindings) {
   return true;
 }
 
@@ -160,12 +160,10 @@ static bool areConservativelyCompatibleArgumentLabels(
   ParameterListInfo paramInfo(params, decl, hasAppliedSelf);
 
   MatchCallArgumentListener listener;
-  SmallVector<ParamBinding, 8> unusedParamBindings;
-
-  return !matchCallArguments(args, params, paramInfo,
-                             unlabeledTrailingClosureArgIndex,
-                             /*allow fixes*/ false, listener,
-                             unusedParamBindings);
+  return matchCallArguments(args, params, paramInfo,
+                            unlabeledTrailingClosureArgIndex,
+                            /*allow fixes*/ false, listener,
+                            None).hasValue();
 }
 
 Expr *constraints::getArgumentLabelTargetExpr(Expr *fn) {
@@ -203,46 +201,32 @@ bool swift::parameterRequiresArgument(
       && !params[paramIdx].isVariadic();
 }
 
-/// Determine whether any parameter from the given index up until the end
-/// requires an argument to be provided.
-///
-/// \param params The parameters themselves.
-/// \param paramInfo Declaration-provided information about the parameters.
-/// \param firstParamIdx The first parameter to examine to determine whether any
-/// parameter in the range \c [paramIdx, params.size()) requires an argument.
-/// \param beforeLabel If non-empty, stop examining parameters when we reach
-/// a parameter with this label.
-static bool anyParameterRequiresArgument(
-    ArrayRef<AnyFunctionType::Param> params,
-    const ParameterListInfo &paramInfo,
-    unsigned firstParamIdx,
-    Optional<Identifier> beforeLabel) {
-  for (unsigned paramIdx : range(firstParamIdx, params.size())) {
-    // If have been asked to stop when we reach a parameter with a particular
-    // label, and we see a parameter with that label, we're done: no parameter
-    // requires an argument.
-    if (beforeLabel && *beforeLabel == params[paramIdx].getLabel())
-      break;
+/// Determine whether the given parameter can accept a trailing closure for the
+/// "backward" logic.
+static bool backwardScanAcceptsTrailingClosure(
+    const AnyFunctionType::Param &param) {
+  Type paramTy = param.getPlainType();
+  if (!paramTy)
+    return true;
 
-    // If this parameter requires an argument, tell the caller.
-    if (parameterRequiresArgument(params, paramInfo, paramIdx))
-      return true;
-  }
-
-  // No parameters required arguments.
-  return false;
+  paramTy = paramTy->lookThroughAllOptionalTypes();
+  return paramTy->isTypeParameter() ||
+      paramTy->is<ArchetypeType>() ||
+      paramTy->is<AnyFunctionType>() ||
+      paramTy->isTypeVariableOrMember() ||
+      paramTy->is<UnresolvedType>() ||
+      paramTy->isAny();
 }
 
-// FIXME: This should return ConstraintSystem::TypeMatchResult instead
-//        to give more information to the solver about the failure.
-bool constraints::
-matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
-                   ArrayRef<AnyFunctionType::Param> params,
-                   const ParameterListInfo &paramInfo,
-                   Optional<unsigned> unlabeledTrailingClosureArgIndex,
-                   bool allowFixes,
-                   MatchCallArgumentListener &listener,
-                   SmallVectorImpl<ParamBinding> &parameterBindings) {
+static bool matchCallArgumentsImpl(
+    SmallVectorImpl<AnyFunctionType::Param> &args,
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    Optional<unsigned> unlabeledTrailingClosureArgIndex,
+    bool allowFixes,
+    TrailingClosureMatching trailingClosureMatching,
+    MatchCallArgumentListener &listener,
+    SmallVectorImpl<ParamBinding> &parameterBindings) {
   assert(params.size() == paramInfo.size() && "Default map does not match");
   assert(!unlabeledTrailingClosureArgIndex ||
          *unlabeledTrailingClosureArgIndex < args.size());
@@ -410,28 +394,13 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
 
     // If we have the trailing closure argument and are performing a forward
     // match, look for the matching parameter.
-    if (unlabeledTrailingClosureArgIndex &&
+    if (trailingClosureMatching == TrailingClosureMatching::Forward &&
+        unlabeledTrailingClosureArgIndex &&
         skipClaimedArgs(nextArgIdx) == *unlabeledTrailingClosureArgIndex) {
-
       // If the parameter we are looking at does not support the (unlabeled)
       // trailing closure argument, this parameter is unfulfilled.
       if (!paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx) &&
           !ignoreNameMismatch) {
-        haveUnfulfilledParams = true;
-        return;
-      }
-
-      // If this parameter does not require an argument, consider applying a
-      // "fuzzy" match rule that skips this parameter if doing so is the only
-      // way to successfully match arguments to parameters.
-      if (!parameterRequiresArgument(params, paramInfo, paramIdx) &&
-          param.getPlainType()->getASTContext().LangOpts
-              .EnableFuzzyForwardScanTrailingClosureMatching &&
-          anyParameterRequiresArgument(
-              params, paramInfo, paramIdx + 1,
-              nextArgIdx + 1 < numArgs
-                ? Optional<Identifier>(args[nextArgIdx + 1].getLabel())
-                : Optional<Identifier>(None))) {
         haveUnfulfilledParams = true;
         return;
       }
@@ -471,8 +440,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
           // If the next argument is the unlabeled trailing closure and the
           // variadic parameter does not accept the unlabeled trailing closure
           // argument, we're done.
-          if (unlabeledTrailingClosureArgIndex &&
-              skipClaimedArgs(nextArgIdx) == *unlabeledTrailingClosureArgIndex &&
+          if (trailingClosureMatching == TrailingClosureMatching::Forward &&
+              unlabeledTrailingClosureArgIndex &&
+              skipClaimedArgs(nextArgIdx)
+                  == *unlabeledTrailingClosureArgIndex &&
               !paramInfo.acceptsUnlabeledTrailingClosureArgument(paramIdx))
             break;
 
@@ -497,6 +468,57 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
     // There was no argument to claim. Leave the argument unfulfilled.
     haveUnfulfilledParams = true;
   };
+
+  // If we have an unlabeled trailing closure and are matching backward, match
+  // the trailing closure argument near the end.
+  if (unlabeledTrailingClosureArgIndex &&
+      trailingClosureMatching == TrailingClosureMatching::Backward) {
+    assert(!claimedArgs[*unlabeledTrailingClosureArgIndex]);
+
+    // One past the next parameter index to look at.
+    unsigned prevParamIdx = numParams;
+
+    // Scan backwards from the end to match the unlabeled trailing closure.
+    Optional<unsigned> unlabeledParamIdx;
+    if (prevParamIdx > 0) {
+      unsigned paramIdx = prevParamIdx - 1;
+
+      bool lastAcceptsTrailingClosure =
+          backwardScanAcceptsTrailingClosure(params[paramIdx]);
+
+      // If the last parameter is defaulted, this might be
+      // an attempt to use a trailing closure with previous
+      // parameter that accepts a function type e.g.
+      //
+      // func foo(_: () -> Int, _ x: Int = 0) {}
+      // foo { 42 }
+      if (!lastAcceptsTrailingClosure && paramIdx > 0 &&
+          paramInfo.hasDefaultArgument(paramIdx)) {
+        auto paramType = params[paramIdx - 1].getPlainType();
+        // If the parameter before defaulted last accepts.
+        if (paramType->is<AnyFunctionType>()) {
+          lastAcceptsTrailingClosure = true;
+          paramIdx -= 1;
+        }
+      }
+
+      if (lastAcceptsTrailingClosure)
+        unlabeledParamIdx = paramIdx;
+    }
+
+    // Trailing closure argument couldn't be matched to anything. Fail fast.
+    if (!unlabeledParamIdx) {
+      return true;
+    }
+
+    // Claim the parameter/argument pair.
+    claim(
+        params[*unlabeledParamIdx].getLabel(),
+        *unlabeledTrailingClosureArgIndex,
+        /*ignoreNameClash=*/true);
+    parameterBindings[*unlabeledParamIdx].push_back(
+        *unlabeledTrailingClosureArgIndex);
+  }
 
   {
     unsigned nextArgIdx = 0;
@@ -770,8 +792,10 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         // to say exactly without considering other factors, because it
         // could be invalid labeling too.
         if (!hadLabelMismatch &&
-            isOutOfOrderArgument(paramIdx, fromArgIdx, toArgIdx))
-          return listener.outOfOrderArgument(fromArgIdx, toArgIdx);
+            isOutOfOrderArgument(paramIdx, fromArgIdx, toArgIdx)) {
+          return listener.outOfOrderArgument(
+              fromArgIdx, toArgIdx, parameterBindings);
+        }
 
         SmallVector<Identifier, 8> expectedLabels;
         llvm::transform(params, std::back_inserter(expectedLabels),
@@ -792,11 +816,128 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
   return listener.relabelArguments(actualArgNames);
 }
 
+/// Determine whether call-argument matching requires us to try both the
+/// forward and backward scanning directions to succeed.
+static bool requiresBothTrailingClosureDirections(
+    ArrayRef<AnyFunctionType::Param> args,
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    Optional<unsigned> unlabeledTrailingClosureArgIndex) {
+  // If there's no unlabeled trailing closure, direction doesn't matter.
+  if (!unlabeledTrailingClosureArgIndex)
+    return false;
+
+  // If there are labeled trailing closure arguments, only scan forward.
+  if (*unlabeledTrailingClosureArgIndex < args.size() - 1)
+    return false;
+
+  // If there are no parameters, it doesn't matter; only scan forward.
+  if (params.empty())
+    return false;
+
+  // If "fuzzy" matching is disabled, only scan forward.
+  ASTContext &ctx = params.front().getPlainType()->getASTContext();
+  if (!ctx.LangOpts.EnableFuzzyForwardScanTrailingClosureMatching)
+    return false;
+
+  // If there are at least two parameters that meet the backward scan's
+  // definition of "accepts trailing closure", or there is one such parameter
+  // with a defaulted parameter after it, we'll need to do the scan
+  // in both directions.
+  bool sawAnyTrailingClosureParam = false;
+  for (unsigned paramIdx : indices(params)) {
+    const auto &param = params[paramIdx];
+    if (backwardScanAcceptsTrailingClosure(param)) {
+      if (sawAnyTrailingClosureParam)
+        return true;
+
+      sawAnyTrailingClosureParam = true;
+      continue;
+    }
+
+    if (sawAnyTrailingClosureParam && paramInfo.hasDefaultArgument(paramIdx))
+      return true;
+  }
+
+  // Only one parameter can match the trailing closure anyway, so don't bother
+  // scanning twice.
+  return false;
+}
+
+Optional<MatchCallArgumentResult>
+constraints::matchCallArguments(
+    SmallVectorImpl<AnyFunctionType::Param> &args,
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    Optional<unsigned> unlabeledTrailingClosureArgIndex,
+    bool allowFixes,
+    MatchCallArgumentListener &listener,
+    Optional<TrailingClosureMatching> trailingClosureMatching) {
+
+  /// Perform a single call to the implementation of matchCallArguments,
+  /// invoking the listener and using the results from that match.
+  auto singleMatchCall = [&](TrailingClosureMatching scanDirection)
+      -> Optional<MatchCallArgumentResult> {
+    SmallVector<ParamBinding, 4> paramBindings;
+    if (matchCallArgumentsImpl(
+            args, params, paramInfo, unlabeledTrailingClosureArgIndex,
+            allowFixes, scanDirection, listener, paramBindings))
+      return None;
+
+    return MatchCallArgumentResult{
+        scanDirection, std::move(paramBindings), None};
+  };
+
+  // If we know that we won't have to perform both forward and backward
+  // scanning for trailing closures, fast-path by performing just the
+  // appropriate scan.
+  if (trailingClosureMatching ||
+      !requiresBothTrailingClosureDirections(
+          args, params, paramInfo, unlabeledTrailingClosureArgIndex)) {
+    return singleMatchCall(
+        trailingClosureMatching.getValueOr(TrailingClosureMatching::Forward));
+  }
+
+  MatchCallArgumentListener noOpListener;
+
+  // Try the forward direction first.
+  SmallVector<ParamBinding, 4> forwardParamBindings;
+  bool forwardFailed = matchCallArgumentsImpl(
+      args, params, paramInfo, unlabeledTrailingClosureArgIndex, allowFixes,
+      TrailingClosureMatching::Forward, noOpListener, forwardParamBindings);
+
+  // Try the backward direction.
+  SmallVector<ParamBinding, 4> backwardParamBindings;
+  bool backwardFailed = matchCallArgumentsImpl(
+      args, params, paramInfo, unlabeledTrailingClosureArgIndex, allowFixes,
+      TrailingClosureMatching::Backward, noOpListener, backwardParamBindings);
+
+  // If at least one of them failed, or they produced the same results, run
+  // call argument matching again with the real visitor.
+  if (forwardFailed || backwardFailed ||
+      forwardParamBindings == backwardParamBindings) {
+    // Run the forward scan unless the backward scan is the only one that
+    // succeeded.
+    auto scanDirection = backwardFailed || !forwardFailed
+        ? TrailingClosureMatching::Forward
+        : TrailingClosureMatching::Backward;
+    return singleMatchCall(scanDirection);
+  }
+
+  // Both forward and backward succeeded, and produced different results.
+  // Bundle them up and return both---without invoking the listener---so the
+  // solver can choose.
+  return MatchCallArgumentResult{
+      TrailingClosureMatching::Forward,
+      std::move(forwardParamBindings),
+      std::move(backwardParamBindings)
+  };
+}
+
 class ArgumentFailureTracker : public MatchCallArgumentListener {
   ConstraintSystem &CS;
   SmallVectorImpl<AnyFunctionType::Param> &Arguments;
   ArrayRef<AnyFunctionType::Param> Parameters;
-  SmallVectorImpl<ParamBinding> &Bindings;
   ConstraintLocatorBuilder Locator;
 
   SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> MissingArguments;
@@ -806,10 +947,8 @@ public:
   ArgumentFailureTracker(ConstraintSystem &cs,
                          SmallVectorImpl<AnyFunctionType::Param> &args,
                          ArrayRef<AnyFunctionType::Param> params,
-                         SmallVectorImpl<ParamBinding> &bindings,
                          ConstraintLocatorBuilder locator)
-      : CS(cs), Arguments(args), Parameters(params), Bindings(bindings),
-        Locator(locator) {}
+      : CS(cs), Arguments(args), Parameters(params), Locator(locator) {}
 
   ~ArgumentFailureTracker() override {
     if (!MissingArguments.empty()) {
@@ -865,7 +1004,9 @@ public:
     return !CS.shouldAttemptFixes();
   }
 
-  bool outOfOrderArgument(unsigned argIdx, unsigned prevArgIdx) override {
+  bool outOfOrderArgument(
+      unsigned argIdx, unsigned prevArgIdx,
+      ArrayRef<ParamBinding> bindings) override {
     if (CS.shouldAttemptFixes()) {
       // If some of the arguments are missing/extraneous, no reason to
       // record a fix for this, increase the score so there is a way
@@ -877,7 +1018,7 @@ public:
       }
 
       auto *fix = MoveOutOfOrderArgument::create(
-          CS, argIdx, prevArgIdx, Bindings, CS.getConstraintLocator(Locator));
+          CS, argIdx, prevArgIdx, bindings, CS.getConstraintLocator(Locator));
       return CS.recordFix(fix);
     }
 
@@ -955,7 +1096,8 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
     ConstraintSystem &cs, FunctionType *contextualType,
     ArrayRef<AnyFunctionType::Param> args,
     ArrayRef<AnyFunctionType::Param> params, ConstraintKind subKind,
-    ConstraintLocatorBuilder locator) {
+    ConstraintLocatorBuilder locator,
+    Optional<TrailingClosureMatching> trailingClosureMatching) {
   auto *loc = cs.getConstraintLocator(locator);
   assert(loc->isLastElement<LocatorPathElt::ApplyArgument>());
 
@@ -1021,13 +1163,36 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
   // Match up the call arguments to the parameters.
   SmallVector<ParamBinding, 4> parameterBindings;
   {
-    ArgumentFailureTracker listener(cs, argsWithLabels, params,
-                                    parameterBindings, locator);
-    if (constraints::matchCallArguments(
-            argsWithLabels, params, paramInfo,
-            argInfo->UnlabeledTrailingClosureIndex,
-            cs.shouldAttemptFixes(), listener, parameterBindings))
+    ArgumentFailureTracker listener(cs, argsWithLabels, params, locator);
+    auto callArgumentMatch = constraints::matchCallArguments(
+        argsWithLabels, params, paramInfo,
+        argInfo->UnlabeledTrailingClosureIndex,
+        cs.shouldAttemptFixes(), listener, trailingClosureMatching);
+    if (!callArgumentMatch)
       return cs.getTypeMatchFailure(locator);
+
+    // If there are different results for both the forward and backward
+    // scans, return an ambiguity: the caller will need to build a
+    // disjunction.
+    if (callArgumentMatch->backwardParameterBindings) {
+      return cs.getTypeMatchAmbiguous();
+    }
+
+    // Record the direction of matching used for this call.
+    cs.recordTrailingClosureMatch(
+        cs.getConstraintLocator(locator),
+        callArgumentMatch->trailingClosureMatching);
+
+    // If we matched with the backward rule, increase the score for backward
+    // matches.
+    // FIXME: We shouldn't want this? Wait until later so we can diagnose
+    // appropriately.
+    if (callArgumentMatch->trailingClosureMatching
+            == TrailingClosureMatching::Backward)
+      cs.increaseScore(SK_BackwardTrailingClosure);
+
+    // Take the parameter bindings we selected.
+    parameterBindings = std::move(callArgumentMatch->parameterBindings);
 
     auto extraArguments = listener.getExtraneousArguments();
     if (!extraArguments.empty()) {
@@ -8189,10 +8354,10 @@ bool ConstraintSystem::simplifyAppliedOverloads(
 
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyApplicableFnConstraint(
-                                           Type type1,
-                                           Type type2,
-                                           TypeMatchOptions flags,
-                                           ConstraintLocatorBuilder locator) {
+    Type type1, Type type2,
+    Optional<TrailingClosureMatching> trailingClosureMatching,
+    TypeMatchOptions flags,
+    ConstraintLocatorBuilder locator) {
   auto &ctx = getASTContext();
 
   // By construction, the left hand side is a type that looks like the
@@ -8252,8 +8417,9 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   auto formUnsolved = [&] {
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
-        Constraint::create(*this, ConstraintKind::ApplicableFunction, type1,
-                           type2, getConstraintLocator(locator)));
+        Constraint::createApplicableFunction(
+          *this, type1, type2, trailingClosureMatching,
+          getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
     
@@ -8341,11 +8507,37 @@ ConstraintSystem::simplifyApplicableFnConstraint(
                               : ConstraintKind::ArgumentConversion);
 
     // The argument type must be convertible to the input type.
-    if (::matchCallArguments(
-            *this, func2, func1->getParams(), func2->getParams(), subKind,
-            outerLocator.withPathElement(ConstraintLocator::ApplyArgument))
-            .isFailure())
+    auto matchCallResult = ::matchCallArguments(
+        *this, func2, func1->getParams(), func2->getParams(), subKind,
+        outerLocator.withPathElement(ConstraintLocator::ApplyArgument),
+        trailingClosureMatching);
+
+    switch (matchCallResult) {
+    case SolutionKind::Error:
       return SolutionKind::Error;
+
+    case SolutionKind::Unsolved: {
+      // Only occurs when there is an ambiguity between forward scanning and
+      // backward scanning for the unlabeled trailing closure. Create a
+      // disjunction so that we explore both paths, and can diagnose
+      // ambiguities later.
+      assert(!trailingClosureMatching.hasValue());
+
+      auto applyLocator = getConstraintLocator(locator);
+      auto forwardConstraint = Constraint::createApplicableFunction(
+          *this, type1, type2, TrailingClosureMatching::Forward, applyLocator);
+      auto backwardConstraint = Constraint::createApplicableFunction(
+          *this, type1, type2, TrailingClosureMatching::Backward,
+          applyLocator);
+      addDisjunctionConstraint(
+          { forwardConstraint, backwardConstraint}, applyLocator);
+      break;
+    }
+
+    case SolutionKind::Solved:
+      // Keep going.
+      break;
+    }
 
     // The result types are equivalent.
     if (matchTypes(func1->getResult(),
@@ -9605,7 +9797,8 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
                                  locator)) {
       return SolutionKind::Error;
     }
-    return simplifyApplicableFnConstraint(first, second, subflags, locator);
+    return simplifyApplicableFnConstraint(
+        first, second, None, subflags, locator);
   }
   case ConstraintKind::DynamicCallableApplicableFunction:
     return simplifyDynamicCallableApplicableFnConstraint(first, second,
@@ -10014,9 +10207,9 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
                                       None, constraint.getLocator());
 
   case ConstraintKind::ApplicableFunction:
-    return simplifyApplicableFnConstraint(constraint.getFirstType(),
-                                          constraint.getSecondType(),
-                                          None, constraint.getLocator());
+    return simplifyApplicableFnConstraint(
+        constraint.getFirstType(), constraint.getSecondType(),
+        constraint.getTrailingClosureMatching(), None, constraint.getLocator());
 
   case ConstraintKind::DynamicCallableApplicableFunction:
     return simplifyDynamicCallableApplicableFnConstraint(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -199,6 +199,37 @@ static ConstraintSystem::TypeMatchOptions getDefaultDecompositionOptions(
   return flags | ConstraintSystem::TMF_GenerateConstraints;
 }
 
+/// Determine whether any parameter from the given index up until the end
+/// requires an argument to be provided.
+///
+/// \param params The parameters themselves.
+/// \param paramInfo Declaration-provided information about the parameters.
+/// \param firstParamIdx The first parameter to examine to determine whether any
+/// parameter in the range \c [paramIdx, params.size()) requires an argument.
+/// \param beforeLabel If non-empty, stop examining parameters when we reach
+/// a parameter with this label.
+static bool anyParameterRequiresArgument(
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    unsigned firstParamIdx,
+    Optional<Identifier> beforeLabel) {
+  for (unsigned paramIdx : range(firstParamIdx, params.size())) {
+    // If have been asked to stop when we reach a parameter with a particular
+    // label, and we see a parameter with that label, we're done: no parameter
+    // requires an argument.
+    if (beforeLabel && *beforeLabel == params[paramIdx].getLabel())
+      break;
+
+    // If this parameter requires an argument, tell the caller.
+    if (!paramInfo.hasDefaultArgument(paramIdx)
+        && !params[paramIdx].isVariadic())
+      return true;
+  }
+
+  // No parameters required arguments.
+  return false;
+}
+
 // FIXME: This should return ConstraintSystem::TypeMatchResult instead
 //        to give more information to the solver about the failure.
 bool constraints::
@@ -393,17 +424,17 @@ matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
         return;
       }
 
-      // If there is only one trailing closure argument, consider applying
-      // a "fuzzy" match rule that skips this parameter if it is defaulted but
-      // later parameters require an argument.
-      if (nextArgIdx + 1 == numArgs &&
-          paramInfo.hasDefaultArgument(paramIdx) &&
+      // If this parameter has a default argument, consider applying a "fuzzy"
+      // match rule that skips this parameter if doing so is the only way to
+      // satisfy
+      if (paramInfo.hasDefaultArgument(paramIdx) &&
           param.getPlainType()->getASTContext().LangOpts
               .EnableFuzzyForwardScanTrailingClosureMatching &&
-          llvm::any_of(range(paramIdx + 1, params.size()), [&](unsigned idx) {
-            return !paramInfo.hasDefaultArgument(idx)
-              && !params[idx].isVariadic();
-          })) {
+          anyParameterRequiresArgument(
+              params, paramInfo, paramIdx + 1,
+              nextArgIdx + 1 < numArgs
+                ? Optional<Identifier>(args[nextArgIdx + 1].getLabel())
+                : Optional<Identifier>(None))) {
         haveUnfulfilledParams = true;
         return;
       }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -134,6 +134,15 @@ Solution ConstraintSystem::finalize() {
     solution.DisjunctionChoices.insert(choice);
   }
 
+  // Remember all of the trailing closure matching choices we made.
+  for (auto &trailingClosureMatch : trailingClosureMatchingChoices) {
+    auto inserted = solution.trailingClosureMatchingChoices.insert(
+        trailingClosureMatch);
+    assert((inserted.second ||
+            inserted.first->second == trailingClosureMatch.second));
+    (void)inserted;
+  }
+
   // Remember the opened types.
   for (const auto &opened : OpenedTypes) {
     // We shouldn't ever register opened types multiple times,
@@ -214,6 +223,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the solution's disjunction choices.
   for (auto &choice : solution.DisjunctionChoices) {
     DisjunctionChoices.push_back(choice);
+  }
+
+  // Remember all of the trailing closure matching choices we made.
+  for (auto &trailingClosureMatch : solution.trailingClosureMatchingChoices) {
+    trailingClosureMatchingChoices.push_back(trailingClosureMatch);
   }
 
   // Register the solution's opened types.
@@ -464,6 +478,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numFixes = cs.Fixes.size();
   numFixedRequirements = cs.FixedRequirements.size();
   numDisjunctionChoices = cs.DisjunctionChoices.size();
+  numTrailingClosureMatchingChoices = cs.trailingClosureMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
@@ -517,6 +532,10 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any disjunction choices.
   truncate(cs.DisjunctionChoices, numDisjunctionChoices);
+
+  // Remove any trailing closure matching choices;
+  truncate(
+      cs.trailingClosureMatchingChoices, numTrailingClosureMatchingChoices);
 
   // Remove any opened types.
   truncate(cs.OpenedTypes, numOpenedTypes);

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -45,6 +45,7 @@ namespace constraints {
 
 class ConstraintLocator;
 class ConstraintSystem;
+enum class TrailingClosureMatching;
 
 /// Describes the kind of constraint placed on one or more types.
 enum class ConstraintKind : char {
@@ -316,6 +317,10 @@ class Constraint final : public llvm::ilist_node<Constraint>,
   /// The kind of function reference, for member references.
   unsigned TheFunctionRefKind : 2;
 
+  /// The trailing closure matching for an applicable function constraint,
+  /// if any. 0 = None, 1 = Forward, 2 = Backward.
+  unsigned trailingClosureMatching : 2;
+
   union {
     struct {
       /// The first type.
@@ -481,6 +486,12 @@ public:
                                        ConstraintLocator *locator,
                                        RememberChoice_t shouldRememberChoice
                                          = ForgetChoice);
+
+  /// Create a new Applicable Function constraint.
+  static Constraint *createApplicableFunction(
+      ConstraintSystem &cs, Type argumentFnType, Type calleeType,
+      Optional<TrailingClosureMatching> trailingClosureMatching,
+      ConstraintLocator *locator);
 
   /// Determine the kind of constraint.
   ConstraintKind getKind() const { return Kind; }
@@ -699,6 +710,10 @@ public:
            Kind == ConstraintKind::ValueWitness);
     return Member.UseDC;
   }
+
+  /// For an applicable function constraint, retrieve the trailing closure
+  /// matching rule.
+  Optional<TrailingClosureMatching> getTrailingClosureMatching() const;
 
   /// Retrieve the locator for this constraint.
   ConstraintLocator *getLocator() const { return Locator; }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5439,6 +5439,12 @@ BraceStmt *applyFunctionBuilderTransform(
           constraints::SolutionApplicationTarget)>
             rewriteTarget);
 
+/// Whether the given parameter requires an argument.
+bool parameterRequiresArgument(
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    unsigned paramIdx);
+
 } // end namespace swift
 
 #endif // LLVM_SWIFT_SEMA_CONSTRAINT_SYSTEM_H

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -574,6 +574,15 @@ public:
     return StringRef(scratch.data(), scratch.size());
   }
 
+  /// Whether the argument is a trailing closure.
+  bool isTrailingClosure() const {
+    if (auto trailingClosureArg =
+            ArgListExpr->getUnlabeledTrailingClosureIndexOfPackedArgument())
+      return ArgIdx >= *trailingClosureArg;
+
+    return false;
+  }
+
   /// \returns The interface type for the function being applied. Note that this
   /// may not a function type, for example it could be a generic parameter.
   Type getFnInterfaceType() const { return FnInterfaceType; }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -660,8 +660,8 @@ enum ScoreKind {
   SK_Hole,
   /// A reference to an @unavailable declaration.
   SK_Unavailable,
-  /// A use of the "backward" scanning heuristic for trailing closures.
-  SK_BackwardTrailingClosure,
+  /// A use of the "forward" scan for trailing closures.
+  SK_ForwardTrailingClosure,
   /// A use of a disfavored overload.
   SK_DisfavoredOverload,
   /// An implicit force of an implicitly unwrapped optional value.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4907,13 +4907,6 @@ public:
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
   virtual bool relabelArguments(ArrayRef<Identifier> newNames);
-
-  /// Indicates that the trailing closure argument at the given \c argIdx
-  /// cannot be passed to the last parameter at \c paramIdx.
-  ///
-  /// \returns true to indicate that this should cause a failure, false
-  /// otherwise.
-  virtual bool trailingClosureMismatch(unsigned paramIdx, unsigned argIdx);
 };
 
 /// Match the call arguments (as described by the given argument type) to

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -68,6 +68,15 @@ namespace swift {
 
 namespace constraints {
 
+/// Describes the algorithm to use for trailing closure matching.
+enum class TrailingClosureMatching {
+  /// Match a trailing closure to the first parameter that appears to work.
+  Forward,
+
+  /// Match a trailing closure to the last parameter.
+  Backward,
+};
+
 /// A handle that holds the saved state of a type variable, which
 /// can be restored.
 class SavedTypeVariableBinding {
@@ -651,6 +660,8 @@ enum ScoreKind {
   SK_Hole,
   /// A reference to an @unavailable declaration.
   SK_Unavailable,
+  /// A use of the "backward" scanning heuristic for trailing closures.
+  SK_BackwardTrailingClosure,
   /// A use of a disfavored overload.
   SK_DisfavoredOverload,
   /// An implicit force of an implicitly unwrapped optional value.
@@ -895,6 +906,11 @@ public:
   /// The list of fixes that need to be applied to the initial expression
   /// to make the solution work.
   llvm::SmallVector<ConstraintFix *, 4> Fixes;
+
+  /// For locators associated with call expressions, the trailing closure
+  /// matching rule that was applied.
+  llvm::SmallMapVector<ConstraintLocator*, TrailingClosureMatching, 4>
+    trailingClosureMatchingChoices;
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.
@@ -1753,6 +1769,11 @@ private:
   std::vector<std::pair<ConstraintLocator*, unsigned>>
       DisjunctionChoices;
 
+  /// For locators associated with call expressions, the trailing closure
+  /// matching rule that was applied.
+  std::vector<std::pair<ConstraintLocator*, TrailingClosureMatching>>
+      trailingClosureMatchingChoices;
+
   /// The worklist of "active" constraints that should be revisited
   /// due to a change.
   ConstraintList ActiveConstraints;
@@ -2267,6 +2288,9 @@ public:
     /// The length of \c DisjunctionChoices.
     unsigned numDisjunctionChoices;
 
+    /// The length of \c trailingClosureMatchingChoices;
+    unsigned numTrailingClosureMatchingChoices;
+
     /// The length of \c OpenedTypes.
     unsigned numOpenedTypes;
 
@@ -2769,6 +2793,12 @@ public:
 
   void recordPotentialHole(TypeVariableType *typeVar);
   void recordPotentialHole(FunctionType *fnType);
+
+  void recordTrailingClosureMatch(
+      ConstraintLocator *locator,
+      TrailingClosureMatching trailingClosureMatch) {
+    trailingClosureMatchingChoices.push_back({locator, trailingClosureMatch});
+  }
 
   /// Determine whether constraint system already has a fix recorded
   /// for a particular location.
@@ -4023,10 +4053,9 @@ private:
 
   /// Attempt to simplify the ApplicableFunction constraint.
   SolutionKind simplifyApplicableFnConstraint(
-                                      Type type1,
-                                      Type type2,
-                                      TypeMatchOptions flags,
-                                      ConstraintLocatorBuilder locator);
+      Type type1, Type type2,
+      Optional<TrailingClosureMatching> trailingClosureMatching,
+      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the DynamicCallableApplicableFunction constraint.
   SolutionKind simplifyDynamicCallableApplicableFnConstraint(
@@ -4900,13 +4929,28 @@ public:
   ///
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
-  virtual bool outOfOrderArgument(unsigned argIdx, unsigned prevArgIdx);
+  virtual bool outOfOrderArgument(
+      unsigned argIdx, unsigned prevArgIdx, ArrayRef<ParamBinding> bindings);
 
   /// Indicates that the arguments need to be relabeled to match the parameters.
   ///
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
   virtual bool relabelArguments(ArrayRef<Identifier> newNames);
+};
+
+/// The result of calling matchCallArguments().
+struct MatchCallArgumentResult {
+  /// The direction of trailing closure matching that was performed.
+  TrailingClosureMatching trailingClosureMatching;
+
+  /// The parameter bindings determined by the match.
+  SmallVector<ParamBinding, 4> parameterBindings;
+
+  /// When present, the forward and backward scans each produced a result,
+  /// and the parameter bindings are different. The primary result will be
+  /// forwarding, and this represents the backward binding.
+  Optional<SmallVector<ParamBinding, 4>> backwardParameterBindings;
 };
 
 /// Match the call arguments (as described by the given argument type) to
@@ -4922,16 +4966,21 @@ public:
 /// \param listener Listener that will be notified when certain problems occur,
 /// e.g., to produce a diagnostic.
 ///
-/// \param parameterBindings Will be populated with the arguments that are
-/// bound to each of the parameters.
-/// \returns true if the call arguments could not be matched to the parameters.
-bool matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
-                        ArrayRef<AnyFunctionType::Param> params,
-                        const ParameterListInfo &paramInfo,
-                        Optional<unsigned> unlabeledTrailingClosureIndex,
-                        bool allowFixes,
-                        MatchCallArgumentListener &listener,
-                        SmallVectorImpl<ParamBinding> &parameterBindings);
+/// \param trailingClosureMatching If specified, the trailing closure matching
+/// direction to use. Otherwise, the matching direction will be determined
+/// based on language mode.
+///
+/// \returns the bindings produced by performing this matching, or \c None if
+/// the match failed.
+Optional<MatchCallArgumentResult>
+matchCallArguments(
+    SmallVectorImpl<AnyFunctionType::Param> &args,
+    ArrayRef<AnyFunctionType::Param> params,
+    const ParameterListInfo &paramInfo,
+    Optional<unsigned> unlabeledTrailingClosureIndex,
+    bool allowFixes,
+    MatchCallArgumentListener &listener,
+    Optional<TrailingClosureMatching> trailingClosureMatching);
 
 ConstraintSystem::TypeMatchResult
 matchCallArguments(ConstraintSystem &cs,
@@ -4939,7 +4988,8 @@ matchCallArguments(ConstraintSystem &cs,
                    ArrayRef<AnyFunctionType::Param> args,
                    ArrayRef<AnyFunctionType::Param> params,
                    ConstraintKind subKind,
-                   ConstraintLocatorBuilder locator);
+                   ConstraintLocatorBuilder locator,
+                   Optional<TrailingClosureMatching> trailingClosureMatching);
 
 /// Given an expression that is the target of argument labels (for a call,
 /// subscript, etc.), find the underlying target expression.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1798,7 +1798,8 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
       newName = newNames[i];
 
     if (oldName == newName ||
-        (argList.hasTrailingClosure && i == argList.args.size()-1))
+        (argList.hasTrailingClosure && i == argList.args.size()-1 &&
+         (numMissing > 0 || numExtra > 0 || numWrong > 0)))
       continue;
 
     if (oldName.empty()) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3011,6 +3011,22 @@ void Solution::dump(raw_ostream &out) const {
                   << " is " << getName(restriction.second) << "\n";
   }
 
+  out << "\n";
+  out << "Trailing closure matching:\n";
+  for (auto &trailingClosureMatching : trailingClosureMatchingChoices) {
+    out.indent(2);
+    trailingClosureMatching.first->dump(sm, out);
+    switch (trailingClosureMatching.second) {
+    case TrailingClosureMatching::Forward:
+      out << ": forward\n";
+      break;
+
+    case TrailingClosureMatching::Backward:
+      out << ": backward\n";
+      break;
+    }
+  }
+
   out << "\nDisjunction choices:\n";
   for (auto &choice : DisjunctionChoices) {
     out.indent(2);

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1006,11 +1006,13 @@ func rdar52204414() {
   // expected-error@-1 {{declared closure result 'Int' is incompatible with contextual type 'Void'}}
 }
 
-// SR-12291 - trailing closure is used as an argument to the last (positionally) parameter
-func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {}
-func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {}
+// SR-12291 - trailing closure is used as an argument to the last (positionally) parameter.
+// Note that this was accepted prior to Swift 5.3. SE-0286 changed the
+// order of argument resolution and made it ambiguous.
+func overloaded_with_default(a: () -> Int, b: Int = 0, c: Int = 0) {} // expected-note{{found this candidate}}
+func overloaded_with_default(b: Int = 0, c: Int = 0, a: () -> Int) {} // expected-note{{found this candidate}}
 
-overloaded_with_default { 0 } // Ok (could be ambiguous if trailing was allowed to match `a:` in first overload)
+overloaded_with_default { 0 } // expected-error{{ambiguous use of 'overloaded_with_default'}}
 
 func overloaded_with_default_and_autoclosure<T>(_ a: @autoclosure () -> T, b: Int = 0) {}
 func overloaded_with_default_and_autoclosure<T>(b: Int = 0, c: @escaping () -> T?) {}

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -35,11 +35,9 @@ trailingClosureSingle1() { 1 } // expected-error {{missing argument for paramete
 
 func trailingClosureSingle2(x: () -> Int, y: Int) {} // expected-note * {{here}}
 trailingClosureSingle2 { 1 }
-// expected-error@-1 {{missing argument for parameter 'x' in call}} {{23-23=(x: <#() -> Int#>)}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing argument for parameter 'y' in call}} {{none}}
 trailingClosureSingle2() { 1 }
-// expected-error@-1 {{missing argument for parameter 'x' in call}} {{24-24=x: <#() -> Int#>}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing argument for parameter 'y' in call}} {{none}}
 
 func trailingClosureMulti1(x: Int, y: Int, z: () -> Int) {} // expected-note * {{here}}
 trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#Int#>, }}
@@ -48,14 +46,17 @@ trailingClosureMulti1(x: 1, y: 1) // expected-error {{missing argument for param
 
 func trailingClosureMulti2(x: Int, y: () -> Int, z: Int) {} // expected-note * {{here}}
 trailingClosureMulti2 { 1 }
-// expected-error@-1 {{missing arguments for parameters 'x', 'y' in call}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing arguments for parameters 'x', 'z' in call}}
 trailingClosureMulti2() { 1 }
-// expected-error@-1 {{missing arguments for parameters 'x', 'y' in call}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing arguments for parameters 'x', 'z' in call}}
 trailingClosureMulti2(x: 1) { 1 }
-// expected-error@-1 {{missing argument for parameter 'y' in call}} {{27-27=, y: <#() -> Int#>}}
-// expected-error@-2 {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+// expected-error@-1 {{missing argument for parameter 'z' in call}} {{none}}
+
+func trailingClosureMulti3(x: (Int) -> Int, y: (Int) -> Int, z: (Int) -> Int) {} // expected-note 2 {{declared here}}
+trailingClosureMulti3 { $0 } y: { $0 } // expected-error{{missing argument for parameter 'z' in call}}{{39-39= z: <#(Int) -> Int#>}}
+
+trailingClosureMulti3 { $0 } z: { $0 } // expected-error{{missing argument for parameter 'y' in call}}{{29-29= y: <#(Int) -> Int#>}}
+
 
 func param2Func(x: Int, y: Int) {} // expected-note * {{here}}
 param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1259,8 +1259,11 @@ func rdar17170728() {
   }
 
   let _ = [i, j, k].reduce(0 as Int?) {
+    // expected-error@-1 {{missing argument label 'into:' in call}}
+    // expected-error@-2 {{cannot convert value of type 'Int?' to expected argument type '(inout @escaping (Bool, Bool) -> Bool, Int?) throws -> ()'}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
     // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
+    // expected-error@-2 {{'nil' cannot be used in context expecting type 'Bool'}}
   }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1260,8 +1260,7 @@ func rdar17170728() {
 
   let _ = [i, j, k].reduce(0 as Int?) {
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Int?' operands}}
-    // expected-error@-2 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
   }
 }
 

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -38,9 +38,9 @@ func testTernaryOneWayOverload(b: Bool) {
 
   // CHECK: solving component #1
   // CHECK: Initial bindings: $T11 := Int8
-  // CHECK: found solution 0 0 0 0 0 0 0 2 0 0 0 0 0
+  // CHECK: found solution 0 0 0 0 0 0 0 0 2 0 0 0 0 0
 
-  // CHECK: composed solution 0 0 0 0 0 0 0 2 0 0 0 0 0
-  // CHECK-NOT: composed solution 0 0 0 0 0 0 0 2 0 0 0 0 0
+  // CHECK: composed solution 0 0 0 0 0 0 0 0 2 0 0 0 0 0
+  // CHECK-NOT: composed solution 0 0 0 0 0 0 0 0 2 0 0 0 0 0
   let _: Int8 = b ? Builtin.one_way(int8Or16(17)) : Builtin.one_way(int8Or16(42))
 }

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -38,14 +38,3 @@ func testUnresolvedMember(i: Int) -> X {
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
   return .init(i, i)
 }
-
-func trailing(x: Int = 0, y: () -> Void) { }
-func trailing(x: Int = 0, z: Float) { }
-
-func testTrailing() {
-  // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).trailing(x:z:)
-  trailing() { }
-
-  // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).trailing(x:z:)
-  trailing(x: 5) { }
-}

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -68,12 +68,14 @@ func bar(_ s: S) {
   }
 }
 
-func multiple_trailing_with_defaults(
+func multiple_trailing_with_defaults( // expected-note{{contains defaulted closure parameters 'animations' and 'completion'}}
   duration: Int,
   animations: (() -> Void)? = nil,
   completion: (() -> Void)? = nil) {}
 
-multiple_trailing_with_defaults(duration: 42) {}
+multiple_trailing_with_defaults(duration: 42) {} // expected-warning{{unlabeled trailing closure argument matches}}
+// expected-note@-1{{'completion' to retain}}
+// expected-note@-2{{'animations' to silence this}}
 
 multiple_trailing_with_defaults(duration: 42) {} completion: {}
 

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -82,7 +82,7 @@ func test_multiple_trailing_syntax_without_labels() {
 
   fn {} g: {} // Ok
 
-  fn {} _: {} // expected-error {{extra argument in call}}
+  fn {} _: {} // expected-error {{missing argument labels 'f:g:' in call}}
 
   fn {} g: <#T##() -> Void#> // expected-error {{editor placeholder in source file}}
 
@@ -90,16 +90,15 @@ func test_multiple_trailing_syntax_without_labels() {
 
   multiple {} _: { }
 
-  func mixed_args_1(a: () -> Void, _: () -> Void) {} // expected-note {{'mixed_args_1(a:_:)' declared here}}
-  func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} // expected-note 2 {{'mixed_args_2(_:a:_:)' declared here}}
+  func mixed_args_1(a: () -> Void, _: () -> Void) {}
+  func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} // expected-note {{'mixed_args_2(_:a:_:)' declared here}}
 
   mixed_args_1
     {}
     _: {}
 
-  // FIXME: not a good diagnostic
   mixed_args_1
-    {}  // expected-error {{extra argument in call}} expected-error {{missing argument for parameter #2 in call}}
+    {}  // expected-error {{incorrect argument labels in call (have '_:a:', expected 'a:_:')}}
     a: {}
 
   mixed_args_2
@@ -107,14 +106,13 @@ func test_multiple_trailing_syntax_without_labels() {
     a: {}
     _: {}
 
-  // FIXME: not a good diagnostic
   mixed_args_2
-    {} // expected-error {{missing argument for parameter #1 in call}}
+    {} // expected-error {{missing argument for parameter 'a' in call}}
     _: {}
 
   // FIXME: not a good diagnostic
   mixed_args_2
-    {}  // expected-error {{extra argument in call}} expected-error {{missing argument for parameter 'a' in call}}
+    {}  // expected-error {{missing argument label 'a:' in call}}
     _: {}
     _: {}
 }
@@ -123,5 +121,5 @@ func produce(fn: () -> Int?, default d: () -> Int) -> Int { // expected-note {{d
   return fn() ?? d()
 }
 // TODO: The diagnostics here are perhaps a little overboard.
-_ = produce { 0 } default: { 1 } // expected-error {{missing argument for parameter 'fn' in call}} expected-error {{consecutive statements}} expected-error {{'default' label can only appear inside a 'switch' statement}} expected-error {{top-level statement cannot begin with a closure expression}} expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}}
+_ = produce { 0 } default: { 1 } // expected-error {{missing argument for parameter 'default' in call}} expected-error {{consecutive statements}} expected-error {{'default' label can only appear inside a 'switch' statement}} expected-error {{top-level statement cannot begin with a closure expression}} expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}}
 _ = produce { 2 } `default`: { 3 }

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -68,14 +68,12 @@ func bar(_ s: S) {
   }
 }
 
-func multiple_trailing_with_defaults( // expected-note{{contains defaulted closure parameters 'animations' and 'completion'}}
+func multiple_trailing_with_defaults( // expected-note{{declared here}}
   duration: Int,
   animations: (() -> Void)? = nil,
   completion: (() -> Void)? = nil) {}
 
-multiple_trailing_with_defaults(duration: 42) {} // expected-warning{{unlabeled trailing closure argument matches}}
-// expected-note@-1{{'completion' to retain}}
-// expected-note@-2{{'animations' to silence this}}
+multiple_trailing_with_defaults(duration: 42) {} // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'completion' to suppress this warning}}
 
 multiple_trailing_with_defaults(duration: 42) {} completion: {}
 

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -5,7 +5,7 @@ func takeFunc(_ f: (Int) -> Int) -> Int {}
 func takeValueAndFunc(_ value: Int, _ f: (Int) -> Int) {}
 func takeTwoFuncs(_ f: (Int) -> Int, _ g: (Int) -> Int) {}
 func takeFuncWithDefault(f : ((Int) -> Int)? = nil) {}
-func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {} // expected-note{{contains defaulted closure parameters 'f1' and 'f2'}}
+func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {}
 // expected-note@-1{{'takeTwoFuncsWithDefaults(f1:f2:)' declared here}}
 
 struct X {
@@ -107,8 +107,7 @@ func labeledArgumentAndTrailingClosure() {
 
   // Trailing closure binds to first parameter... unless only the second matches.
  takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'f2' to suppress this warning}}
- takeTwoFuncsWithDefaults { $0 + 1 } // expected-warning{{rather than}}
-  // expected-note@-1 2{{label the argument}}
+ takeTwoFuncsWithDefaults { $0 + 1 }
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })
 }
 

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -6,6 +6,7 @@ func takeValueAndFunc(_ value: Int, _ f: (Int) -> Int) {}
 func takeTwoFuncs(_ f: (Int) -> Int, _ g: (Int) -> Int) {}
 func takeFuncWithDefault(f : ((Int) -> Int)? = nil) {}
 func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {} // expected-note{{contains defaulted closure parameters 'f1' and 'f2'}}
+// expected-note@-1{{'takeTwoFuncsWithDefaults(f1:f2:)' declared here}}
 
 struct X {
   func takeFunc(_ f: (Int) -> Int) {}
@@ -105,8 +106,8 @@ func labeledArgumentAndTrailingClosure() {
   takeFuncWithDefault(f: { $0 + 1 })
 
   // Trailing closure binds to first parameter... unless only the second matches.
- takeTwoFuncsWithDefaults { "Hello, " + $0 }
-  takeTwoFuncsWithDefaults { $0 + 1 } // expected-warning{{rather than}}
+ takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'f2' to suppress this warning}}
+ takeTwoFuncsWithDefaults { $0 + 1 } // expected-warning{{rather than}}
   // expected-note@-1 2{{label the argument}}
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })
 }

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -5,7 +5,7 @@ func takeFunc(_ f: (Int) -> Int) -> Int {}
 func takeValueAndFunc(_ value: Int, _ f: (Int) -> Int) {}
 func takeTwoFuncs(_ f: (Int) -> Int, _ g: (Int) -> Int) {}
 func takeFuncWithDefault(f : ((Int) -> Int)? = nil) {}
-func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {}
+func takeTwoFuncsWithDefaults(f1 : ((Int) -> Int)? = nil, f2 : ((String) -> String)? = nil) {} // expected-note{{contains defaulted closure parameters 'f1' and 'f2'}}
 
 struct X {
   func takeFunc(_ f: (Int) -> Int) {}
@@ -94,8 +94,6 @@ var c3 = C().map // expected-note{{callee is here}}
 func multiTrailingClosure(_ a : () -> (), b : () -> ()) {  // expected-note {{'multiTrailingClosure(_:b:)' declared here}}
   multiTrailingClosure({}) {} // ok
   multiTrailingClosure {} {}   // expected-error {{missing argument for parameter 'b' in call}} expected-error {{consecutive statements on a line must be separated by ';'}} {{26-26=;}} expected-error {{closure expression is unused}} expected-note{{did you mean to use a 'do' statement?}} {{27-27=do }}
-  
-  
 }
 
 func labeledArgumentAndTrailingClosure() {
@@ -108,7 +106,8 @@ func labeledArgumentAndTrailingClosure() {
 
   // Trailing closure binds to first parameter.
  takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
-  takeTwoFuncsWithDefaults { $0 + 1 }
+  takeTwoFuncsWithDefaults { $0 + 1 } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })
 }
 

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -93,7 +93,7 @@ var c3 = C().map // expected-note{{callee is here}}
 // <rdar://problem/16835718> Ban multiple trailing closures
 func multiTrailingClosure(_ a : () -> (), b : () -> ()) {  // expected-note {{'multiTrailingClosure(_:b:)' declared here}}
   multiTrailingClosure({}) {} // ok
-  multiTrailingClosure {} {}   // expected-error {{missing argument for parameter #1 in call}} expected-error {{consecutive statements on a line must be separated by ';'}} {{26-26=;}} expected-error {{closure expression is unused}} expected-note{{did you mean to use a 'do' statement?}} {{27-27=do }}
+  multiTrailingClosure {} {}   // expected-error {{missing argument for parameter 'b' in call}} expected-error {{consecutive statements on a line must be separated by ';'}} {{26-26=;}} expected-error {{closure expression is unused}} expected-note{{did you mean to use a 'do' statement?}} {{27-27=do }}
   
   
 }
@@ -106,9 +106,9 @@ func labeledArgumentAndTrailingClosure() {
   takeFuncWithDefault({ $0 + 1 }) // expected-error {{missing argument label 'f:' in call}} {{23-23=f: }}
   takeFuncWithDefault(f: { $0 + 1 })
 
-  // Trailing closure binds to last parameter, always.
- takeTwoFuncsWithDefaults { "Hello, " + $0 }
-  takeTwoFuncsWithDefaults { $0 + 1 } // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  // Trailing closure binds to first parameter.
+ takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
+  takeTwoFuncsWithDefaults { $0 + 1 }
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })
 }
 
@@ -420,11 +420,11 @@ func variadicAndNonOverloadLabel(b: (() -> Void)...) -> Int { return 0 }
 func testVariadic() {
   variadic {}
   variadic() {}
-  variadic({}) {} // expected-error {{extra argument in call}}
+  variadic({}) {}
 
   variadicLabel {}
   variadicLabel() {}
-  variadicLabel(closures: {}) {} // expected-error {{extra argument 'closures' in call}}
+  variadicLabel(closures: {}) {}
 
   let a1 = variadicOverloadMismatch {}
   _ = a1 as String // expected-error {{cannot convert value of type 'Bool' to type 'String'}}

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -104,8 +104,8 @@ func labeledArgumentAndTrailingClosure() {
   takeFuncWithDefault({ $0 + 1 }) // expected-error {{missing argument label 'f:' in call}} {{23-23=f: }}
   takeFuncWithDefault(f: { $0 + 1 })
 
-  // Trailing closure binds to first parameter.
- takeTwoFuncsWithDefaults { "Hello, " + $0 } // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
+  // Trailing closure binds to first parameter... unless only the second matches.
+ takeTwoFuncsWithDefaults { "Hello, " + $0 }
   takeTwoFuncsWithDefaults { $0 + 1 } // expected-warning{{rather than}}
   // expected-note@-1 2{{label the argument}}
   takeTwoFuncsWithDefaults(f1: {$0 + 1 })

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,0 +1,83 @@
+// RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
+
+func forwardMatch1(
+  a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,
+  numbers: Int..., closure2: ((Double) -> Double)? = nil,
+  closure3: (String) -> String = { $0 + "!" }
+) {
+}
+
+func testForwardMatch1(i: Int, d: Double, s: String) {
+  forwardMatch1()
+
+  // Matching closure1
+  forwardMatch1 { _ in i }
+  forwardMatch1 { _ in i } closure2: { d + $0 }
+  forwardMatch1 { _ in i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1 { _ in i } closure3: { $0 + ", " + s + "!" }
+
+  forwardMatch1(a: 5) { $0 + i }
+  forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 }
+  forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1(a: 5) { $0 + i } closure3: { $0 + ", " + s + "!" }
+
+  forwardMatch1(b: 1) { $0 + i }
+  forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 }
+  forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
+  forwardMatch1(b: 1) { $0 + i } closure3: { $0 + ", " + s + "!" }
+
+  // Matching closure2
+  forwardMatch1(closure1: { $0 + i }) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } closure3: { $0 + ", " + s + "!" }
+
+  // Matching closure3
+  forwardMatch1(closure2: nil) { $0 + ", " + s + "!" }
+}
+
+func forwardMatchWithAutoclosure1(
+  a: String = "hello",
+  b: @autoclosure () -> Int = 17,
+  closure1: () -> String
+) { }
+
+func testForwardMatchWithAutoclosure1(i: Int, s: String) {
+  forwardMatchWithAutoclosure1 {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(a: s) {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(b: i) {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure1(a: s, b: i) {
+    print(s)
+    return s
+  }
+}
+
+func forwardMatchWithAutoclosure2(
+  a: String = "hello",
+  closure1: @autoclosure () -> (() -> String),
+  closure2: () -> Int = { 5 }
+) { }
+
+func testForwardMatchWithAutoclosure2(i: Int, s: String) {
+  forwardMatchWithAutoclosure2 {
+    print(s)
+    return s
+  }
+  forwardMatchWithAutoclosure2(a: s) {
+    print(s)
+    return s
+  }
+
+  forwardMatchWithAutoclosure2(a: s, closure1: { s }) {
+    print(i)
+    return i
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
 
-func forwardMatch1(
+func forwardMatch1( // expected-note 5 {{contains defaulted}}
   a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,
   numbers: Int..., closure2: ((Double) -> Double)? = nil,
   closure3: (String) -> String = { $0 + "!" }
@@ -11,24 +11,29 @@ func testForwardMatch1(i: Int, d: Double, s: String) {
   forwardMatch1()
 
   // Matching closure1
-  forwardMatch1 { _ in i }
+  forwardMatch1 { _ in i } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1 { _ in i } closure2: { d + $0 }
   forwardMatch1 { _ in i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1 { _ in i } closure3: { $0 + ", " + s + "!" }
 
-  forwardMatch1(a: 5) { $0 + i }
+  forwardMatch1(a: 5) { $0 + i } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 }
   forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1(a: 5) { $0 + i } closure3: { $0 + ", " + s + "!" }
 
-  forwardMatch1(b: 1) { $0 + i }
+  forwardMatch1(b: 1) { $0 + i } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 }
   forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1(b: 1) { $0 + i } closure3: { $0 + ", " + s + "!" }
 
   // Matching closure2
-  forwardMatch1(closure1: { $0 + i }) { d + $0 }
-  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }) { d + $0 } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } // expected-warning{{rather than}}
+  // expected-note@-1 2{{label the argument}}
   forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } closure3: { $0 + ", " + s + "!" }
 
   // Matching closure3

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
 
-func forwardMatch1( // expected-note 5 {{contains defaulted}}
+func forwardMatch1(
   a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,
   numbers: Int..., closure2: ((Double) -> Double)? = nil,
   closure3: (String) -> String = { $0 + "!" }
@@ -11,29 +11,24 @@ func testForwardMatch1(i: Int, d: Double, s: String) {
   forwardMatch1()
 
   // Matching closure1
-  forwardMatch1 { _ in i } // expected-warning{{rather than}}
-  // expected-note@-1 2{{label the argument}}
+  forwardMatch1 { _ in i }
   forwardMatch1 { _ in i } closure2: { d + $0 }
   forwardMatch1 { _ in i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1 { _ in i } closure3: { $0 + ", " + s + "!" }
 
-  forwardMatch1(a: 5) { $0 + i } // expected-warning{{rather than}}
-  // expected-note@-1 2{{label the argument}}
+  forwardMatch1(a: 5) { $0 + i }
   forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 }
   forwardMatch1(a: 5) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1(a: 5) { $0 + i } closure3: { $0 + ", " + s + "!" }
 
-  forwardMatch1(b: 1) { $0 + i } // expected-warning{{rather than}}
-  // expected-note@-1 2{{label the argument}}
+  forwardMatch1(b: 1) { $0 + i }
   forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 }
   forwardMatch1(b: 1) { $0 + i } closure2: { d + $0 } closure3: { $0 + ", " + s + "!" }
   forwardMatch1(b: 1) { $0 + i } closure3: { $0 + ", " + s + "!" }
 
   // Matching closure2
-  forwardMatch1(closure1: { $0 + i }) { d + $0 } // expected-warning{{rather than}}
-  // expected-note@-1 2{{label the argument}}
-  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } // expected-warning{{rather than}}
-  // expected-note@-1 2{{label the argument}}
+  forwardMatch1(closure1: { $0 + i }) { d + $0 }
+  forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 }
   forwardMatch1(closure1: { $0 + i }, numbers: 1, 2, 3) { d + $0 } closure3: { $0 + ", " + s + "!" }
 
   // Matching closure3

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -81,3 +81,13 @@ func testForwardMatchWithAutoclosure2(i: Int, s: String) {
     return i
   }
 }
+
+// Match a closure parameter to a variadic parameter.
+func acceptsVariadicClosureParameter(closures: ((Int, Int) -> Int)...) {
+}
+
+func testVariadicClosureParameter() {
+  acceptsVariadicClosureParameter { x, y in x % y }
+  acceptsVariadicClosureParameter() { x, y in x % y }
+  acceptsVariadicClosureParameter(closures: +, -, *, /) { x, y in x % y }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
@@ -88,7 +88,7 @@ func testNotAmbiguous2() {
 }
 
 // Not ambiguous because of a missing default argument.
-func notAmbiguous3(
+func notAmbiguous3( // expected-note{{'notAmbiguous3(x:a:y:b:_:c:)' declared here}}
   x: (Int) -> Int = { $0 },
   a: Int = 5,
   y: (Int) -> Int = { $0 },
@@ -98,5 +98,5 @@ func notAmbiguous3(
 ) { }
 
 func testNotAmbiguous3() {
-  notAmbiguous3 { $0 }
+  notAmbiguous3 { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with '_' to suppress this warning}}
 }

--- a/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // Ambiguity when calling.
-func ambiguous1( // expected-note 3 {{'ambiguous1(x:a:y:b:z:c:)' contains defaulted closure parameters '}}
+func ambiguous1( // expected-note 3 {{declared here}}
 
   x: (Int) -> Int = { $0 },
   a: Int = 5,
@@ -12,24 +12,18 @@ func ambiguous1( // expected-note 3 {{'ambiguous1(x:a:y:b:z:c:)' contains defaul
 ) {}
 
 func testAmbiguous1() {
-  ambiguous1 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter 'z'}}
-    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{13-13=(z: }}{{20-20=)}}
-    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{13-13=(x: }}{{20-20=)}}
+  ambiguous1 { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'z' to suppress this warning}}{{13-13=(z: }}{{20-20=)}}
 
-  ambiguous1() { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter 'z'}}
-    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{14-15=z: }}{{22-22=)}}
-    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{14-15=x: }}{{22-22=)}}
+  ambiguous1() { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'z' to suppress this warning}}{{14-15=z: }}{{22-22=)}}
 
-  ambiguous1(a: 3) { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'y' rather than parameter 'z'}}
-    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{18-19=, z: }}{{26-26=)}}
-    // expected-note@-2{{label the argument with 'y' to silence this warning for Swift 5.3 and newer}}{{18-19=, y: }}{{26-26=)}}
+  ambiguous1(a: 3) { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'z' to suppress this warning}}{{18-19=, z: }}{{26-26=)}}
 
   // No warning; this is matching the last parameter.
   ambiguous1(b: 3) { $0 }
 }
 
 // Ambiguity with two unlabeled arguments.
-func ambiguous2( // expected-note{{'ambiguous2(_:a:y:b:_:x:)' contains defaulted closure parameters '_' and '_'}}
+func ambiguous2( // expected-note{{declared here}}
   _: (Int) -> Int = { $0 },
   a: Int = 5,
   y: (Int) -> Int = { $0 },
@@ -39,11 +33,11 @@ func ambiguous2( // expected-note{{'ambiguous2(_:a:y:b:_:x:)' contains defaulted
 ) {}
 
 func testAmbiguous2() {
-    ambiguous2 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches earlier parameter '_' rather than later parameter with the same name}}
+    ambiguous2 { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with '_' to suppress this warning}}{{15-15=(}}{{22-22=)}}
 }
 
 // Ambiguity with one unlabeled argument.
-func ambiguous3( // expected-note{{'ambiguous3(x:a:y:b:_:c:)' contains defaulted closure parameters 'x' and '_'}}
+func ambiguous3( // expected-note{{declared here}}
   x: (Int) -> Int = { $0 },
   a: Int = 5,
   y: (Int) -> Int = { $0 },
@@ -53,9 +47,7 @@ func ambiguous3( // expected-note{{'ambiguous3(x:a:y:b:_:c:)' contains defaulted
 ) {}
 
 func testAmbiguous3() {
-  ambiguous3 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter '_'}}
-    // expected-note@-1{{label the argument with '_' to retain the pre-Swift 5.3 behavior}}{{13-13=(}}{{20-20=)}}
-    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{13-13=(x: }}{{20-20=)}}
+  ambiguous3 { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with '_' to suppress this warning}}{{13-13=(}}{{20-20=)}}
 }
 
 // Not ambiguous because of an arity mismatch that would lead to different

--- a/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
@@ -88,7 +88,7 @@ func testNotAmbiguous2() {
 }
 
 // Not ambiguous because of a missing default argument.
-func notAmbiguous3( // expected-note{{'notAmbiguous3(x:a:y:b:_:c:)' declared here}}
+func notAmbiguous3(
   x: (Int) -> Int = { $0 },
   a: Int = 5,
   y: (Int) -> Int = { $0 },
@@ -98,5 +98,5 @@ func notAmbiguous3( // expected-note{{'notAmbiguous3(x:a:y:b:_:c:)' declared her
 ) { }
 
 func testNotAmbiguous3() {
-  notAmbiguous3 { $0 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with '_' to suppress this warning}}
+  notAmbiguous3 { $0 }
 }

--- a/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
@@ -1,0 +1,102 @@
+// RUN: %target-typecheck-verify-swift
+
+// Ambiguity when calling.
+func ambiguous1( // expected-note 3 {{'ambiguous1(x:a:y:b:z:c:)' contains defaulted closure parameters '}}
+
+  x: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  z: (Int) -> Int = { $0 },
+  c: Int = 5
+) {}
+
+func testAmbiguous1() {
+  ambiguous1 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter 'z'}}
+    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{13-13=(z: }}{{20-20=)}}
+    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{13-13=(x: }}{{20-20=)}}
+
+  ambiguous1() { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter 'z'}}
+    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{14-15=z: }}{{22-22=)}}
+    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{14-15=x: }}{{22-22=)}}
+
+  ambiguous1(a: 3) { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'y' rather than parameter 'z'}}
+    // expected-note@-1{{label the argument with 'z' to retain the pre-Swift 5.3 behavior}}{{18-19=, z: }}{{26-26=)}}
+    // expected-note@-2{{label the argument with 'y' to silence this warning for Swift 5.3 and newer}}{{18-19=, y: }}{{26-26=)}}
+
+  // No warning; this is matching the last parameter.
+  ambiguous1(b: 3) { $0 }
+}
+
+// Ambiguity with two unlabeled arguments.
+func ambiguous2( // expected-note{{'ambiguous2(_:a:y:b:_:x:)' contains defaulted closure parameters '_' and '_'}}
+  _: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  x: Int = 5
+) {}
+
+func testAmbiguous2() {
+    ambiguous2 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches earlier parameter '_' rather than later parameter with the same name}}
+}
+
+// Ambiguity with one unlabeled argument.
+func ambiguous3( // expected-note{{'ambiguous3(x:a:y:b:_:c:)' contains defaulted closure parameters 'x' and '_'}}
+  x: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  c: Int = 5
+) {}
+
+func testAmbiguous3() {
+  ambiguous3 { $0 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'x' rather than parameter '_'}}
+    // expected-note@-1{{label the argument with '_' to retain the pre-Swift 5.3 behavior}}{{13-13=(}}{{20-20=)}}
+    // expected-note@-2{{label the argument with 'x' to silence this warning for Swift 5.3 and newer}}{{13-13=(x: }}{{20-20=)}}
+}
+
+// Not ambiguous because of an arity mismatch that would lead to different
+// type-checks.
+func notAmbiguous1(
+  x: (Int, Int) -> Int = { $0 + $1 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  c: Int = 5
+) { }
+
+func testNotAmbiguous1() {
+  notAmbiguous1 { $0 / $1 }
+}
+
+// Not ambiguous because of a missing default argument.
+func notAmbiguous2(
+  x: (Int) -> Int,
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int = { $0 },
+  c: Int = 5
+) { }
+
+func testNotAmbiguous2() {
+  notAmbiguous2 { $0 }
+}
+
+// Not ambiguous because of a missing default argument.
+func notAmbiguous3(
+  x: (Int) -> Int = { $0 },
+  a: Int = 5,
+  y: (Int) -> Int = { $0 },
+  b: Int = 5,
+  _: (Int) -> Int ,
+  c: Int = 5
+) { }
+
+func testNotAmbiguous3() {
+  notAmbiguous3 { $0 }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
+
+func forwardMatchWithGeneric<T>( // expected-note{{'forwardMatchWithGeneric(closure1:closure2:)' declared here}}
+  closure1: T,
+  closure2: () -> Int = { 5 }
+) { }
+
+func testKnownSourceBreaks(i: Int) {
+  forwardMatchWithGeneric { i } // expected-error{{missing argument for parameter 'closure1' in call}}
+  let _: (() -> ()).Type = type { } // expected-error{{missing argument label 'of:' in call}}
+}
+
+func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
+  var arrayOfFuncs = [() -> Void]()
+  arrayOfFuncs.append { print("Hi") } // okay because the parameter is unlabeled?
+
+  fn { $0 + i} // okay because the parameter label is empty
+}
+
+// When "fuzzy matching is disabled, this will fail.
+func forwardMatchFailure( // expected-note{{declared here}}
+  onError: ((Error) -> Void)? = nil,
+  onCompletion: (Int) -> Void
+) { }
+
+func testForwardMatchFailure() {
+  forwardMatchFailure { x in // expected-error{{missing argument for parameter 'onCompletion' in call}}
+    print(x)
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -7,7 +7,7 @@ func forwardMatchWithGeneric<T>( // expected-note{{'forwardMatchWithGeneric(clos
 
 func testKnownSourceBreaks(i: Int) {
   forwardMatchWithGeneric { i } // expected-error{{missing argument for parameter 'closure1' in call}}
-  let _: (() -> ()).Type = type { } // expected-error{{missing argument label 'of:' in call}}
+  let _: (() -> ()).Type = type { }
 }
 
 func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
@@ -24,7 +24,7 @@ func forwardMatchFailure( // expected-note{{declared here}}
 ) { }
 
 func testForwardMatchFailure() {
-  forwardMatchFailure { x in // expected-error{{missing argument for parameter 'onCompletion' in call}}
+  forwardMatchFailure { x in
     print(x)
-  }
+  } // expected-error{{missing argument for parameter 'onCompletion' in call}}{{4-4= onCompletion: <#(Int) -> Void#>}}
 }

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -42,13 +42,11 @@ func testTrailingClosureEitherDirection() {
 }
 
 // Check that we resolve ambiguities when both directions can be matched.
-// expected-note@+1{{'trailingClosureBothDirections(f:g:)' contains defaulted closure parameters 'f' and 'g'}}
+// expected-note@+1{{declared here}}
 func trailingClosureBothDirections(
   f: (Int, Int) -> Int = { $0 + $1 }, g: (Int, Int) -> Int = { $0 - $1 }
 ) { }
-trailingClosureBothDirections { $0 * $1 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'f' rather than parameter 'g'}}
-// expected-note@-1{{label the argument with 'g' to retain the pre-Swift 5.3 behavior}}
-// expected-note@-2{{label the argument with 'f' to silence this warning for Swift 5.3 and newer}}
+trailingClosureBothDirections { $0 * $1 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'g' to suppress this warning}}
 
 // Check an amusing quirk of the "backward" rule that allows the order of
 // arguments to be swapped.

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+func doSomething(onError: ((Error) -> Void)? = nil, onCompletion: (Int) -> Void) { }
+
+func testDoSomething() {
+  doSomething { x in
+    print(x)
+  }
+
+  doSomething(onError: nil) { x in
+    print(x)
+  }
+}

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -10,4 +10,21 @@ func testDoSomething() {
   doSomething(onError: nil) { x in
     print(x)
   }
+
+  doSomething { e in
+    print(e)
+  } onCompletion: { x in
+    print(x)
+  }
+}
+
+func trailingClosures(
+  arg1: () -> Void = {},
+  arg2: () -> Void,
+  arg3: () -> Void = {}
+) {}
+
+func testTrailingClosures() {
+  trailingClosures { print("Hello!") }
+  trailingClosures { print("Hello,") } arg3: { print("world!") }
 }

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -1,9 +1,9 @@
 // RUN: %target-typecheck-verify-swift
 
-func doSomething(onError: ((Error) -> Void)? = nil, onCompletion: (Int) -> Void) { }
+func doSomething(onError: ((Error) -> Void)? = nil, onCompletion: (Int) -> Void) { } // expected-note{{'doSomething(onError:onCompletion:)' declared here}}
 
 func testDoSomething() {
-  doSomething { x in
+  doSomething { x in // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'onCompletion' to suppress this warning}}
     print(x)
   }
 
@@ -31,13 +31,13 @@ func testTrailingClosures() {
 
 // Ensure that we can match either with the forward or the backward rule,
 // depending on additional type check information.
-func trailingClosureEitherDirection(
+func trailingClosureEitherDirection( // expected-note{{'trailingClosureEitherDirection(f:g:)' declared here}}
   f: (Int) -> Int = { $0 }, g: (Int, Int) -> Int = { $0 + $1 }
 ) { }
 
 func testTrailingClosureEitherDirection() {
   trailingClosureEitherDirection { -$0 }
-  trailingClosureEitherDirection { $0 * $1 }
+  trailingClosureEitherDirection { $0 * $1 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'g' to suppress this warning}}{{33-33=(g: }}{{45-45=)}}
 }
 
 // Check that we resolve ambiguities when both directions can be matched.
@@ -51,11 +51,11 @@ trailingClosureBothDirections { $0 * $1 } // expected-warning{{since Swift 5.3, 
 
 // Check an amusing quirk of the "backward" rule that allows the order of
 // arguments to be swapped.
-struct AccidentalReorder {
+struct AccidentalReorder { // expected-note{{'init(content:optionalInt:)' declared here}}
   let content: () -> Int
   var optionalInt: Int?
 }
 
 func testAccidentalReorder() {
-  _ = AccidentalReorder(optionalInt: 17) { 42 }
+  _ = AccidentalReorder(optionalInt: 17) { 42 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'content' to suppress this warning}}
 }

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -1,9 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
-func doSomething(onError: ((Error) -> Void)? = nil, onCompletion: (Int) -> Void) { } // expected-note{{'doSomething(onError:onCompletion:)' declared here}}
+func doSomething(onError: ((Error) -> Void)? = nil, onCompletion: (Int) -> Void) { }
 
 func testDoSomething() {
-  doSomething { x in // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'onCompletion' to suppress this warning}}
+  // Okay because we skip the onError.
+  doSomething { x in
     print(x)
   }
 

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -19,12 +19,43 @@ func testDoSomething() {
 }
 
 func trailingClosures(
-  arg1: () -> Void = {},
-  arg2: () -> Void,
+  arg1: () -> Void,
+  arg2: () -> Void = {},
   arg3: () -> Void = {}
 ) {}
 
 func testTrailingClosures() {
   trailingClosures { print("Hello!") }
   trailingClosures { print("Hello,") } arg3: { print("world!") }
+}
+
+// Ensure that we can match either with the forward or the backward rule,
+// depending on additional type check information.
+func trailingClosureEitherDirection(
+  f: (Int) -> Int = { $0 }, g: (Int, Int) -> Int = { $0 + $1 }
+) { }
+
+func testTrailingClosureEitherDirection() {
+  trailingClosureEitherDirection { -$0 }
+  trailingClosureEitherDirection { $0 * $1 }
+}
+
+// Check that we resolve ambiguities when both directions can be matched.
+// expected-note@+1{{'trailingClosureBothDirections(f:g:)' contains defaulted closure parameters 'f' and 'g'}}
+func trailingClosureBothDirections(
+  f: (Int, Int) -> Int = { $0 + $1 }, g: (Int, Int) -> Int = { $0 - $1 }
+) { }
+trailingClosureBothDirections { $0 * $1 } // expected-warning{{since Swift 5.3, unlabeled trailing closure argument matches parameter 'f' rather than parameter 'g'}}
+// expected-note@-1{{label the argument with 'g' to retain the pre-Swift 5.3 behavior}}
+// expected-note@-2{{label the argument with 'f' to silence this warning for Swift 5.3 and newer}}
+
+// Check an amusing quirk of the "backward" rule that allows the order of
+// arguments to be swapped.
+struct AccidentalReorder {
+  let content: () -> Int
+  var optionalInt: Int?
+}
+
+func testAccidentalReorder() {
+  _ = AccidentalReorder(optionalInt: 17) { 42 }
 }


### PR DESCRIPTION
Implementation of SE-0286 with the dual-scan source-compatibility trick and biasing toward maintaining existing behavior with the backward scan.

Implements rdar://problem/65615074