### PR TITLE
[SR-13240][tests] Fixing pattern match of note available overload lists diagnostic

### DIFF
--- a/test/stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/stdlib/UnicodeScalarDiagnostics.swift
@@ -8,12 +8,13 @@ func isString(_ s: inout String) {}
 func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
   var a1 = "a" + "b" // OK
   isString(&a1)
+  // We don't check for the overload choices list on the overload note match because they may change on different platforms. 
   let a2 = "a" - "b" // expected-error {{binary operator '-' cannot be applied to two 'String' operands}}
-  // expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists: (Double, Double), (Float, Float), (Float16, Float16), (Float80, Float80), (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
+  // expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists:}}
   let a3 = "a" * "b" // expected-error {{binary operator '*' cannot be applied to two 'String' operands}}
-  // expected-note@-1 {{overloads for '*' exist with these partially matching parameter lists: (Double, Double), (Float, Float), (Float16, Float16), (Float80, Float80), (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
+  // expected-note@-1 {{overloads for '*' exist with these partially matching parameter lists:}}
   let a4 = "a" / "b" // expected-error {{binary operator '/' cannot be applied to two 'String' operands}}
-  // expected-note@-1 {{overloads for '/' exist with these partially matching parameter lists: (Double, Double), (Float, Float), (Float16, Float16), (Float80, Float80), (Int, Int), (Int16, Int16), (Int32, Int32), (Int64, Int64), (Int8, Int8), (UInt, UInt), (UInt16, UInt16), (UInt32, UInt32), (UInt64, UInt64), (UInt8, UInt8)}}
+  // expected-note@-1 {{overloads for '/' exist with these partially matching parameter lists:}}
 
   let b1 = us + us // expected-error {{binary operator '+' cannot be applied to two 'UnicodeScalar' (aka 'Unicode.Scalar') operands}}
   let b2 = us - us // expected-error {{binary operator '-' cannot be applied to two 'UnicodeScalar' (aka 'Unicode.Scalar') operands}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixing pattern matching on overload note message for Unicode diagnostics as Windows we more possible choices. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
