### PR TITLE
[Diagnostics] Update diagnostic message for invalid overrides

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2439,14 +2439,14 @@ ERROR(override_of_non_open,none,
       (DescriptiveDeclKind))
 
 ERROR(method_does_not_override,none,
-      "method does not override any method from its superclass", ())
+      "method does not override any method from its %select{parent protocol|superclass}0", (bool))
 ERROR(property_does_not_override,none,
-      "property does not override any property from its superclass", ())
+      "property does not override any property from its %select{parent protocol|superclass}0", (bool))
 ERROR(subscript_does_not_override,none,
-      "subscript does not override any subscript from its superclass", ())
+      "subscript does not override any subscript from its %select{parent protocol|superclass}0", (bool))
 ERROR(initializer_does_not_override,none,
       "initializer does not override a designated initializer from its "
-      "superclass", ())
+      "%select{parent protocol|superclass}0", (bool))
 ERROR(failable_initializer_override,none,
       "failable initializer %0 cannot override a non-failable initializer",
       (DeclName))

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -503,16 +503,18 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
     break;
   case OverrideCheckingAttempt::MismatchedOptional:
   case OverrideCheckingAttempt::MismatchedTypes:
-  case OverrideCheckingAttempt::BaseNameWithMismatchedOptional:
+  case OverrideCheckingAttempt::BaseNameWithMismatchedOptional: {
+    auto isClassContext = decl->getDeclContext()->getSelfClassDecl() != nullptr;
+    auto diag = diag::method_does_not_override;
     if (isa<ConstructorDecl>(decl))
-      diags.diagnose(decl, diag::initializer_does_not_override);
+      diag = diag::initializer_does_not_override;
     else if (isa<SubscriptDecl>(decl))
-      diags.diagnose(decl, diag::subscript_does_not_override);
+      diag = diag::subscript_does_not_override;
     else if (isa<VarDecl>(decl))
-      diags.diagnose(decl, diag::property_does_not_override);
-    else
-      diags.diagnose(decl, diag::method_does_not_override);
+      diag = diag::property_does_not_override;
+    diags.diagnose(decl, diag, isClassContext);
     break;
+  }
   case OverrideCheckingAttempt::Final:
     llvm_unreachable("should have exited already");
   }
@@ -1124,6 +1126,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
   // If this is an exact type match, we're successful!
   Type declTy = getDeclComparisonType();
   Type owningTy = dc->getDeclaredInterfaceType();
+  auto isClassContext = classDecl != nullptr;
   if (declIUOAttr == matchDeclIUOAttr && declTy->isEqual(baseTy)) {
     // Nothing to do.
 
@@ -1132,7 +1135,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
       auto diagKind = diag::method_does_not_override;
       if (isa<ConstructorDecl>(method))
         diagKind = diag::initializer_does_not_override;
-      diags.diagnose(decl, diagKind);
+      diags.diagnose(decl, diagKind, isClassContext);
       noteFixableMismatchedTypes(decl, baseDecl);
       diags.diagnose(baseDecl, diag::overridden_near_match_here,
                      baseDecl->getDescriptiveKind(),
@@ -1164,7 +1167,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     }
 
     if (attempt == OverrideCheckingAttempt::MismatchedTypes) {
-      diags.diagnose(decl, diag::subscript_does_not_override);
+      diags.diagnose(decl, diag::subscript_does_not_override, isClassContext);
       noteFixableMismatchedTypes(decl, baseDecl);
       diags.diagnose(baseDecl, diag::overridden_near_match_here,
                      baseDecl->getDescriptiveKind(),

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1452,7 +1452,9 @@ public:
       auto overridden = VD->getOverriddenDecl();
       if (auto *OA = VD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!overridden) {
-          VD->diagnose(diag::property_does_not_override)
+          auto isClassContext =
+              VD->getDeclContext()->getSelfClassDecl() != nullptr;
+          VD->diagnose(diag::property_does_not_override, isClassContext)
               .highlight(OA->getLocation());
           OA->setInvalid();
         }
@@ -1659,7 +1661,9 @@ public:
       // anything, complain.
       if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!SD->getOverriddenDecl()) {
-          SD->diagnose(diag::subscript_does_not_override)
+          auto isClassContext =
+              SD->getDeclContext()->getSelfClassDecl() != nullptr;
+          SD->diagnose(diag::subscript_does_not_override, isClassContext)
               .highlight(OA->getLocation());
           OA->setInvalid();
         }
@@ -2236,7 +2240,8 @@ public:
       // override anything, complain.
       if (auto *OA = FD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!FD->getOverriddenDecl()) {
-          FD->diagnose(diag::method_does_not_override)
+          auto isClassContext = FD->getSelfClassDecl() != nullptr;
+          FD->diagnose(diag::method_does_not_override, isClassContext)
               .highlight(OA->getLocation());
           OA->setInvalid();
         }
@@ -2482,13 +2487,14 @@ public:
     // Check whether this initializer overrides an initializer in its
     // superclass.
     if (!checkOverrides(CD)) {
+      auto isClassContext = CD->getSelfClassDecl() != nullptr;
       // If an initializer has an override attribute but does not override
       // anything or overrides something that doesn't need an 'override'
       // keyword (e.g., a convenience initializer), complain.
       // anything, or overrides something that complain.
       if (auto *attr = CD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!CD->getOverriddenDecl()) {
-          CD->diagnose(diag::initializer_does_not_override)
+          CD->diagnose(diag::initializer_does_not_override, isClassContext)
               .highlight(attr->getLocation());
           attr->setInvalid();
         } else if (attr->isImplicit()) {
@@ -2513,7 +2519,7 @@ public:
             reqInit->diagnose(diag::overridden_required_initializer_here);
           } else {
             // We tried to override a convenience initializer.
-            CD->diagnose(diag::initializer_does_not_override)
+            CD->diagnose(diag::initializer_does_not_override, isClassContext)
                 .highlight(attr->getLocation());
             CD->getOverriddenDecl()->diagnose(
                 diag::convenience_init_override_here);

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -6104,20 +6104,20 @@
 
 - id: method_does_not_override
   msg: >-
-    method does not override any method from its superclass
+    method does not override any method from its %select{parent protocol|superclass}0
 
 - id: property_does_not_override
   msg: >-
-    property does not override any property from its superclass
+    property does not override any property from its %select{parent protocol|superclass}0
 
 - id: subscript_does_not_override
   msg: >-
-    subscript does not override any subscript from its superclass
+    subscript does not override any subscript from its %select{parent protocol|superclass}0
 
 - id: initializer_does_not_override
   msg: >-
     initializer does not override a designated initializer from its
-    superclass
+    %select{parent protocol|superclass}0
 
 - id: failable_initializer_override
   msg: >-

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -147,7 +147,7 @@ struct S {
   override func f() { } // expected-error{{'override' can only be specified on class members}} {{3-12=}}
 }
 extension S {
-  override func ef() {} // expected-error{{method does not override any method from its superclass}}
+  override func ef() {} // expected-error{{'override' can only be specified on class members}} {{3-12=}}
 }
 
 enum E {
@@ -155,7 +155,7 @@ enum E {
 }
 
 protocol P {
-  override func f() // FIXME wording: expected-error{{method does not override any method from its superclass}}
+  override func f() // expected-error{{method does not override any method from its parent protocol}}
 }
 
 override func f() { } // expected-error{{'override' can only be specified on class members}} {{1-10=}}

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -211,7 +211,7 @@ struct S {
   override func f() { } // expected-error{{'override' can only be specified on class members}} {{3-12=}}
 }
 extension S {
-  override func ef() {} // expected-error{{method does not override any method from its superclass}}
+  override func ef() {} // expected-error{{'override' can only be specified on class members}} {{3-12=}}
 }
 
 enum E {

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -219,7 +219,10 @@ enum E {
 }
 
 protocol P {
-  override func f() // FIXME wording: expected-error{{method does not override any method from its superclass}}
+  override func f() // expected-error{{method does not override any method from its parent protocol}}
+  override var g: Int { get } // expected-error{{property does not override any property from its parent protocol}}
+  override subscript(h: Int) -> Bool { get } // expected-error{{subscript does not override any subscript from its parent protocol}}
+  override init(i: Int) // expected-error{{initializer does not override a designated initializer from its parent protocol}}
 }
 
 override func f() { } // expected-error{{'override' can only be specified on class members}} {{1-10=}}

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -97,7 +97,7 @@ protocol P6: P0 {
 
 // Complain if 'override' is present but there is no overridden declaration.
 protocol P7: P0 {
-  // expected-error@+1{{method does not override any method from its superclass}}
+  // expected-error@+1{{method does not override any method from its parent protocol}}
   override func foo() -> Int
 
   // expected-error@+1{{property 'prop' with type 'Int' cannot override a property with type 'Self.A'}}


### PR DESCRIPTION
When we diagnose an override of a protocol requirement which doesn't actually override anything from the base declaration, the diagnostic mentions "superclass". So, adjust the diagnostic to say "parent protocol" instead.

Before:
```swift
protocol P {
  override var foo: Int { get } // property does not override any property from its superclass
}
```

After:
```swift
protocol P {
  override var foo: Int { get } // property does not override any property from its parent protocol
}
```

Also, reuse the existing `override_nonclass_decl` diagnostic in more places, for example:

Before:
```swift
struct S {}

extension S {
  override func foo() {} // method does not override any method from its superclass
}
```

After:
```swift
struct S {}

extension S {
  override func foo() {} // 'override' can only be specified on class members
}
```