### PR TITLE
Pass architecture into Benchmark_Driver to fix `build-script -B`

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -742,15 +742,18 @@ function(swift_benchmark_compile)
       add_custom_target("check-${executable_target}"
           COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
                   "-o" "O" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
+                  "--architecture" "${arch}"
                   "--swift-repo" "${SWIFT_SOURCE_DIR}"
                   "--independent-samples" "${SWIFT_BENCHMARK_NUM_O_ITERATIONS}"
           COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
                   "-o" "Onone" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
                   "--swift-repo" "${SWIFT_SOURCE_DIR}"
+                  "--architecture" "${arch}"
                   "--independent-samples" "${SWIFT_BENCHMARK_NUM_ONONE_ITERATIONS}"
           COMMAND "${swift-bin-dir}/Benchmark_Driver" "compare"
                   "--log-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
                   "--swift-repo" "${SWIFT_SOURCE_DIR}"
+                  "--architecture" "${arch}"
                   "--compare-script"
                   "${SWIFT_SOURCE_DIR}/benchmark/scripts/compare_perf_tests.py")
     endif()

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -753,7 +753,6 @@ function(swift_benchmark_compile)
           COMMAND "${swift-bin-dir}/Benchmark_Driver" "compare"
                   "--log-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
                   "--swift-repo" "${SWIFT_SOURCE_DIR}"
-                  "--architecture" "${arch}"
                   "--compare-script"
                   "${SWIFT_SOURCE_DIR}/benchmark/scripts/compare_perf_tests.py")
     endif()

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -919,6 +919,12 @@ def parse_args(args):
         help="optimization level to use: {O,Onone,Osize}, (default: O)",
         default="O",
     )
+    shared_benchmarks_parser.add_argument(
+        "--architecture",
+        metavar="architecture",
+        help="current architecture (e.g., x86_64, arm64, etc)",
+        default=None,
+    )
 
     run_parser = subparsers.add_parser(
         "run",


### PR DESCRIPTION
Recent changes to integrate Apple Silicon support modified how Benchmark drivers are invoked.  Specifically, the generated benchmarking program now includes the target architecture as part of the executable name.

This PR passes the target architecture information into `Benchmark_Driver` so that `build-script -B` will work again.

Related to: #32923