### PR TITLE
[IRGen] Catch Clang's new matrix types.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -785,6 +785,10 @@ namespace {
                              args...);
         return;
 
+      case clang::Type::ConstantMatrix:
+      case clang::Type::DependentSizedMatrix:
+        llvm_unreachable("matrix type in ABI lowering not supported");
+
       case clang::Type::Pointer:
       case clang::Type::BlockPointer:
       case clang::Type::ObjCObjectPointer:


### PR DESCRIPTION
For now, make sure no matrix types reach here. This is for completeness and an additional safeguard.