### PR TITLE
Sema: Desugar non-generic typealiases with an unbound generic underlying type

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3029,7 +3029,15 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
     // preserving sugar.
     llvm::SaveAndRestore<const GenericSignatureImpl *> setGenericSig(
         Options.GenericSig, decl->getGenericSignature().getPointer());
-    printTypeLoc(TypeLoc(decl->getUnderlyingTypeRepr(), Ty));
+
+    // Don't print the TypeRepr if we desugared an unbound generic type as
+    // the underlying type of the type alias.
+    auto *typeRepr = decl->getUnderlyingTypeRepr();
+    if (decl->getParsedGenericParams() == nullptr &&
+        decl->getGenericParams() != nullptr)
+      typeRepr = nullptr;
+
+    printTypeLoc(TypeLoc(typeRepr, Ty));
     printDeclGenericRequirements(decl);
   }
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -951,36 +951,3 @@ RequirementRequest::evaluate(Evaluator &evaluator,
   }
   llvm_unreachable("unhandled kind");
 }
-
-Type StructuralTypeRequest::evaluate(Evaluator &evaluator,
-                                     TypeAliasDecl *typeAlias) const {  
-  TypeResolutionOptions options((typeAlias->getGenericParams()
-                                     ? TypeResolverContext::GenericTypeAliasDecl
-                                     : TypeResolverContext::TypeAliasDecl));
-
-  // This can happen when code completion is attempted inside
-  // of typealias underlying type e.g. `typealias F = () -> Int#^TOK^#`
-  auto &ctx = typeAlias->getASTContext();
-  auto underlyingTypeRepr = typeAlias->getUnderlyingTypeRepr();
-  if (!underlyingTypeRepr) {
-    typeAlias->setInvalid();
-    return ErrorType::get(ctx);
-  }
-
-  const auto type =
-      TypeResolution::forStructural(typeAlias, options,
-                                    /*unboundTyOpener*/ nullptr,
-                                    /*placeholderHandler*/ nullptr)
-          .resolveType(underlyingTypeRepr);
-
-  auto genericSig = typeAlias->getGenericSignature();
-  SubstitutionMap subs;
-  if (genericSig)
-    subs = genericSig->getIdentitySubstitutionMap();
-
-  Type parent;
-  auto parentDC = typeAlias->getDeclContext();
-  if (parentDC->isTypeContext())
-    parent = parentDC->getSelfInterfaceType();
-  return TypeAliasType::get(typeAlias, parent, subs, type);
-}

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4417,11 +4417,6 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
         skipRequirementCheck = true;
     }
 
-    // Skip typealiases with an unbound generic type as their underlying type.
-    if (auto *typeAliasDecl = dyn_cast<TypeAliasDecl>(typeDecl))
-      if (typeAliasDecl->getDeclaredInterfaceType()->is<UnboundGenericType>())
-        continue;
-
     // Skip dependent protocol typealiases.
     //
     // FIXME: This should not be necessary.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -885,7 +885,8 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
 /// Apply generic arguments to the given type.
 Type TypeResolution::applyUnboundGenericArguments(
     GenericTypeDecl *decl, Type parentTy, SourceLoc loc,
-    ArrayRef<Type> genericArgs) const {
+    ArrayRef<Type> genericArgs,
+    bool skipRequirementsCheck) const {
   assert(genericArgs.size() == decl->getGenericParams()->size() &&
          "invalid arguments, use applyGenericArguments for diagnostic emitting");
 
@@ -898,11 +899,6 @@ Type TypeResolution::applyUnboundGenericArguments(
   // type parameters that appear inside this type with the provided
   // generic arguments.
   auto resultType = decl->getDeclaredInterfaceType();
-
-  // If types involved in requirements check have either type variables
-  // or unbound generics, let's skip the check here, and let the solver
-  // do it when missing types are deduced.
-  bool skipRequirementsCheck = false;
 
   // Get the substitutions for outer generic parameters from the parent
   // type.
@@ -943,6 +939,9 @@ Type TypeResolution::applyUnboundGenericArguments(
     subs[origTy->getCanonicalType()->castTo<GenericTypeParamType>()] =
       substTy;
 
+    // If types involved in requirements check have either type variables
+    // or unbound generics, let's skip the check here, and let the solver
+    // do it when missing types are deduced.
     skipRequirementsCheck |=
         substTy->hasTypeVariable() || substTy->hasUnboundGenericType();
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -445,7 +445,8 @@ public:
   /// \see applyGenericArguments
   Type applyUnboundGenericArguments(GenericTypeDecl *decl, Type parentTy,
                                     SourceLoc loc,
-                                    ArrayRef<Type> genericArgs) const;
+                                    ArrayRef<Type> genericArgs,
+                                    bool skipRequirementCheck=false) const;
 };
 
 } // end namespace swift

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -99,7 +99,7 @@ protocol Initable {
   init()
 }
 
-protocol P : Initable {
+protocol P : Initable { // expected-note {{required by referencing type alias 'G' on 'P' where 'Self' = 'P'}}
   func bar(_ x: Int)
   mutating func mut(_ x: Int)
   static func tum()
@@ -138,6 +138,9 @@ func generic<T: P>(_ t: T) {
 
   _ = t.mut // expected-error{{partial application of 'mutating' method is not allowed}}
   _ = t.tum // expected-error{{static member 'tum' cannot be used on instance of type 'T'}}
+
+  // Make sure that we open generics
+  let _: [Int].Type = T.G.self
 }
 
 func genericClassP<T: ClassP>(_ t: T) {
@@ -227,6 +230,7 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
 
   // Make sure that we open generics
   let _: [Int].Type = p.G.self
+  // expected-error@-1 {{protocol 'P' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 protocol StaticP {

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -24,7 +24,7 @@ public class A<X> {
   public func f11<T, U>(x: X, y: T) {} //expected-error{{generic parameter 'U' is not used in function signature}}
 }
 
-struct G<T> {} // expected-note {{generic type 'G' declared here}}
+struct G<T> {}
 
 struct GG<T, U> {}
 
@@ -32,7 +32,7 @@ protocol P {
   associatedtype A
   typealias B = Int
   typealias C<T> = T
-  typealias D = G
+  typealias D = G // expected-note {{generic type 'D' declared here}}
   typealias E<T> = GG<T, T>
 }
 
@@ -44,7 +44,7 @@ func f14<T : P>(x: T) -> T.C<Int> {}
 
 func f15<T : P>(x: T) -> T.D<Int> {}
 
-func f16<T : P>(x: T) -> T.D {} // expected-error {{reference to generic type 'T.D' (aka 'G') requires arguments in <...>}}
+func f16<T : P>(x: T) -> T.D {} // expected-error {{reference to generic type 'T.D' requires arguments in <...>}}
 
 func f17<T : P>(x: T) -> T.E<Int> {}
 

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -67,6 +67,7 @@ class X {
 struct SomeStruct<A> {
   typealias A = A // this is OK now -- the underlying type is the generic parameter 'A'
   typealias B = B // expected-error {{type alias 'B' references itself}} expected-note {{while resolving type 'B'}}
+  // expected-error@-1 {{circular reference}}
 }
 
 // <rdar://problem/27680407> Infinite recursion when using fully-qualified associatedtype name that has not been defined with typealias

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -100,7 +100,7 @@ func takesSomeClassArchetype<T : SomeClass>(_ t: T) {
 }
 
 // Typo correction of unqualified lookup from generic context.
-struct Generic<T> { // expected-note {{'T' declared as parameter to type 'Generic'}}
+struct Generic<T> {
   func match1() {}
   // expected-note@-1 {{'match1' declared here}}
 
@@ -112,9 +112,10 @@ struct Generic<T> { // expected-note {{'T' declared as parameter to type 'Generi
   }
 }
 
-protocol P { // expected-note {{'P' previously declared here}}
+protocol P { // expected-note {{required by referencing type alias 'a' on 'P' where 'Self' = 'P'}}
   // expected-note@-1 2{{did you mean 'P'?}}
   // expected-note@-2 {{'P' declared here}}
+  // expected-note@-3 {{'P' previously declared here}}
   typealias a = Generic
 }
 
@@ -125,6 +126,8 @@ protocol P {} // expected-error {{invalid redeclaration of 'P'}}
 func hasTypo() {
   _ = P.a.a // expected-error {{type 'Generic<T>' has no member 'a'}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{instance member 'a' cannot be used on type 'P'}}
+  // expected-error@-3 {{protocol 'P' as a type cannot conform to the protocol itself; only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 // Typo correction with AnyObject.

--- a/test/SourceKit/CursorInfo/rdar_34348776.swift
+++ b/test/SourceKit/CursorInfo/rdar_34348776.swift
@@ -12,3 +12,7 @@ public typealias Aliased = Alias
 // CHECK-NEXT: $s13rdar_343487765AliasamD
 // CHECK-NEXT: <Declaration>public typealias Aliased = <Type usr="s:13rdar_343487765Aliasa">Alias</Type></Declaration>
 // CHECK-NEXT: <decl.typealias><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Aliased</decl.name> = <ref.typealias usr="s:13rdar_343487765Aliasa">Alias</ref.typealias></decl.typealias>
+// CHECK-NEXT: Alias.Type
+// CHECK-NEXT: $s13rdar_343487765AliasamD
+// CHECK-NEXT: <Declaration>public typealias Aliased = <Type usr="s:13rdar_343487765Aliasa">Alias</Type></Declaration>
+// CHECK-NEXT: <decl.typealias><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Aliased</decl.name> = <ref.typealias usr="s:13rdar_343487765Aliasa">Alias</ref.typealias></decl.typealias>

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -11,6 +11,7 @@ class C {
 }
 
 typealias t = t // expected-error {{type alias 't' references itself}} expected-note {{while resolving type 't'}} expected-note {{through reference here}}
+// expected-error@-1 {{circular reference}}
 
 extension Foo {
   convenience init() {} // expected-error{{invalid redeclaration of synthesized 'init()'}}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -6,28 +6,6 @@ struct MyType<TyA, TyB> { // expected-note {{generic type 'MyType' declared here
   var a : TyA, b : TyB
 }
 
-//
-// Type aliases that reference unbound generic types -- not really generic,
-// but they behave as such, in the sense that you can apply generic
-// arguments to them.
-//
-
-typealias OurType = MyType
-
-typealias YourType = Swift.Optional
-
-struct Container {
-  typealias YourType = Swift.Optional
-}
-
-let _: OurType<Int, String>
-let _: YourType<Int>
-let _: Container.YourType<Int>
-
-//
-// Bona-fide generic type aliases
-//
-
 typealias DS<T> = MyType<String, T>
 
 typealias BadA<T : Int> = MyType<String, T>  // expected-error {{type 'T' constrained to non-protocol, non-class type 'Int'}}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -147,10 +147,12 @@ protocol Circular {
   typealias Y = Self.Y // expected-error {{type alias 'Y' references itself}} expected-note {{while resolving type 'Self.Y'}}
 
   typealias Y2 = Y2 // expected-error {{type alias 'Y2' references itself}} expected-note {{while resolving type 'Y2'}}
+  // expected-error@-1 {{circular reference}}
 
   typealias Y3 = Y4 // expected-error {{type alias 'Y3' references itself}} expected-note {{while resolving type 'Y4'}}
+  // expected-error@-1 {{circular reference}}
 
-  typealias Y4 = Y3 // expected-note {{through reference here}} expected-note {{while resolving type 'Y3'}}
+  typealias Y4 = Y3 // expected-note 2{{through reference here}} expected-note {{while resolving type 'Y3'}}
 }
 
 // Qualified and unqualified references to protocol typealiases from concrete type

--- a/test/decl/typealias/unbound.swift
+++ b/test/decl/typealias/unbound.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift
+
+//
+// Type aliases that reference unbound generic types -- not really generic,
+// but they behave as such, in the sense that you can apply generic
+// arguments to them.
+//
+
+struct MyType<TyA, TyB> {
+  var a : TyA, b : TyB
+}
+
+typealias OurType = MyType
+
+typealias YourType = Swift.Optional
+
+struct Container {
+  typealias YourType = Swift.Optional
+}
+
+let _: OurType<Int, String>
+let _: YourType<Int>
+let _: Container.YourType<Int>
+
+typealias WeirdType = Array where Element : Equatable
+// expected-error@-1 {{'where' clause cannot be applied to a non-generic top-level declaration}}
+// expected-error@-2 {{reference to generic type 'Array' requires arguments in <...>}}
+
+struct Generic<T> {
+  typealias WeirdType = Array where Element : Equatable
+  // expected-error@-1 {{cannot find type 'Element' in scope}}
+  // expected-error@-2 {{type '<<error type>>' in conformance requirement does not refer to a generic parameter or associated type}}
+  // expected-error@-3 {{reference to generic type 'Array' requires arguments in <...>}}
+
+  typealias WeirdestType = Array where T : Equatable
+  // expected-error@-1 {{reference to generic type 'Array' requires arguments in <...>}}
+
+  typealias SelfType = Generic
+}
+
+struct NotEquatable {}
+
+let _: Generic<NotEquatable>.WeirdestType = [1, 2, 3]
+// expected-error@-1 {{type 'NotEquatable' does not conform to protocol 'Equatable'}}
+
+// FIXME: Diagnose this
+let _: Generic<NotEquatable>.WeirdestType<Int> = [1, 2, 3]
+
+let _: Generic<Int>.SelfType = Generic<Int>()

--- a/test/decl/typealias/unbound_extension.swift
+++ b/test/decl/typealias/unbound_extension.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+extension UnboundAlias {}
+
+typealias UnboundAlias = GenericType
+
+struct GenericType<T> {}


### PR DESCRIPTION
We let you write this:

```
  typealias Foo = Array
```

This had the same exact interpretation, but a different representation than,
the generic equivalent:

```
  typealias Foo<Element> = Array<Element>
```

Now, we desugar the former to the latter by lazily synthesizing a
GenericParamList as needed for a typealias of this kind, followed by
implicitly applying the generic arguments in UnderlyingTypeRequest.