### PR TITLE
[5.3][Diagnostics] Record a fix for every argument type mismatch

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3523,22 +3523,6 @@ bool ConstraintSystem::repairFailures(
     if (rhs->isAny())
       break;
 
-    // If there are any other argument mismatches already detected
-    // for this call, we can consider overload unrelated.
-    if (llvm::any_of(getFixes(), [&](const ConstraintFix *fix) {
-          auto *locator = fix->getLocator();
-          // Since arguments to @dynamicCallable form either an array
-          // or a dictionary and all have to match the same element type,
-          // let's allow multiple invalid arguments.
-          if (locator->findFirst<LocatorPathElt::DynamicCallable>())
-            return false;
-
-          return locator->findLast<LocatorPathElt::ApplyArgToParam>()
-                     ? locator->getAnchor() == anchor
-                     : false;
-        }))
-      break;
-
     // If there are any restrictions here we need to wait and let
     // `simplifyRestrictedConstraintImpl` handle them.
     if (llvm::any_of(conversionsOrFixes,
@@ -9578,8 +9562,19 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   }
 
   case FixKind::AllowArgumentTypeMismatch: {
-    increaseScore(SK_Fix);
-    return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+    auto impact = 2;
+    // If there are any other argument mismatches already detected for this
+    // call, we increase the score even higher so more argument fixes means
+    // less viable is the overload.
+    if (llvm::any_of(getFixes(), [&](const ConstraintFix *fix) {
+          auto *fixLocator = fix->getLocator();
+          return fixLocator->findLast<LocatorPathElt::ApplyArgToParam>()
+                     ? fixLocator->getAnchor() == locator.getAnchor()
+                     : false;
+        }))
+      impact += 3;
+
+    return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
   case FixKind::ContextualMismatch: {

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -462,7 +462,12 @@ func fn_r28909024(n: Int) {
   // (since both arguments are literal they are ranked lower than contextual type).
   //
   // Good diagnostic for this is - `unexpected non-void return value in void function`
-  return (0..<10).r28909024 { // expected-error {{type of expression is ambiguous without more context}}
+  return (0..<10).r28909024 { // expected-error 2 {{cannot convert value of type 'Int' to expected argument type '()'}}
+    // expected-error@-1 {{type '()' cannot conform to 'Strideable'; only struct/enum/class types can conform to protocols}}
+    // expected-error@-2 {{type '()' cannot conform to 'Comparable'; only struct/enum/class types can conform to protocols}}
+    // expected-note@-3 {{required by referencing operator function '..<' on 'Comparable' where 'Self' = '()'}}
+    // expected-note@-4 {{requirement from conditional conformance of 'Range<()>' to 'Collection'}}
+    // expected-error@-5 {{referencing instance method 'r28909024' on 'Range' requires that '().Stride' conform to 'SignedInteger'}}
     _ in true
   }
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1258,10 +1258,13 @@ func rdar17170728() {
     // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
+  // expected-error@+2 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil'}}
+  // expected-error@+1 {{missing argument label 'into:' in call}}
   let _ = [i, j, k].reduce(0 as Int?) {
+    // expected-error@-1 3 {{cannot convert value of type 'Int?' to expected element type 'Bool'}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Int?' operands}}
-    // expected-error@-2 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+    // expected-error@-1 {{'nil' cannot be used in context expecting type 'Bool'}}
+    // expected-error@-2 {{binary operator '+' cannot be applied to two 'Bool' operands}}
   }
 }
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -358,8 +358,6 @@ func testKeyPathSubscriptArgFixes(_ fn: @escaping () -> Int) {
 }
 
 func sr12426(a: Any, _ str: String?) {
-  a == str // expected-error {{cannot convert value of type 'Any' to expected argument type 'String'}}
-  // expected-error@-1 {{value of optional type 'String?' must be unwrapped to a value of type 'String'}}
-  // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  a == str // expected-error {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
+  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (CodingUserInfoKey, CodingUserInfoKey), (String, String)}}
 }

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -890,3 +890,18 @@ func sr13135() {
 
   foo(Foo().bar, [baz])
 }
+
+// SR-13240
+func twoargs(_ x: String, _ y: String) {}
+
+func test() {
+  let x = 1
+  twoargs(x, x) // expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+}
+
+infix operator ---
+
+func --- (_ lhs: String, _ rhs: String) -> Bool { true }
+
+let x = 1
+x --- x // expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'String'}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -423,9 +423,8 @@ func test_force_unwrap_not_being_too_eager() {
 
 // rdar://problem/57097401
 func invalidOptionalChaining(a: Any) {
-  a == "="? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}
-  // expected-error@-1 {{value of protocol type 'Any' cannot conform to 'Equatable'; only struct/enum/class types can conform to protocols}}
-  // expected-note@-2 {{requirement from conditional conformance of 'Any?' to 'Equatable'}}
+  a == "="? // expected-error {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
+  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (CodingUserInfoKey, CodingUserInfoKey), (FloatingPointSign, FloatingPointSign), (String, String), (Unicode.CanonicalCombiningClass, Unicode.CanonicalCombiningClass)}}
 }
 
 // SR-12309 - Force unwrapping 'nil' compiles without warning

--- a/test/Parse/operators.swift
+++ b/test/Parse/operators.swift
@@ -88,10 +88,9 @@ postfix func ^ (x: Man) -> () -> God {
   return { return God() }
 }
 
-// TODO(diagnostics): This is ambiguous operator use because if solver attempted postfix version of the operator `^`
-// it could have found a solution, with infix one nothing matches - neither argument nor contextual type. It should
-// be possible to find a way to diagnose operator use here instead of type ambiguity...
-var _ : God = Man()^() // expected-error{{type of expression is ambiguous without more context}}
+var _ : God = Man()^() // expected-error{{cannot convert value of type 'Man' to expected argument type 'TheDevil'}}
+// expected-error@-1 {{cannot convert value of type '()' to expected argument type 'God'}}
+// expected-error@-2 {{cannot convert value of type 'Man' to specified type 'God'}}
 
 func &(x : Man, y : Man) -> Man { return x } // forgive amp_prefix token
 

--- a/test/stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/stdlib/UnicodeScalarDiagnostics.swift
@@ -9,12 +9,13 @@ func isString(_ s: inout String) {}
 func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
   var a1 = "a" + "b" // OK
   isString(&a1)
+  // We don't check for the overload choices list on the overload note match because they may change on different platforms. 
   let a2 = "a" - "b" // expected-error {{binary operator '-' cannot be applied to two 'String' operands}}
-  // expected-note @-1 {{overloads for '-' exist with these partially matching parameter lists:}}
+  // expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists:}}
   let a3 = "a" * "b" // expected-error {{binary operator '*' cannot be applied to two 'String' operands}}
-  // expected-note @-1 {{overloads for '*' exist with these partially matching parameter lists:}}
+  // expected-note@-1 {{overloads for '*' exist with these partially matching parameter lists:}}
   let a4 = "a" / "b" // expected-error {{binary operator '/' cannot be applied to two 'String' operands}}
-  // expected-note @-1 {{overloads for '/' exist with these partially matching parameter lists:}}
+  // expected-note@-1 {{overloads for '/' exist with these partially matching parameter lists:}}
 
   let b1 = us + us // expected-error {{binary operator '+' cannot be applied to two 'UnicodeScalar' operands}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/33068
and its follow-up PR to adjust notes.

Previously solver would just skip any argument mismatches after
the first one has been recorded, let's change that and instead
record fixes for all of the mismatches and adjust score accordingly.

Resolves: rdar://problem/65718419
Resolves: rdar://problem/65842034
Resolves: rdar://problem/65515039
Resolves: rdar://problem/65774807
Resolves: rdar://problem/65273656
Resolves: rdar://problem/65237711

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
