### PR TITLE
[TBDGen] Split off symbol collection from TBD file generation

### DIFF
--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -21,6 +21,10 @@
 #include "swift/AST/SimpleRequest.h"
 
 namespace llvm {
+
+class DataLayout;
+class Triple;
+
 namespace MachO {
 class InterfaceFile;
 } // end namespace MachO
@@ -59,6 +63,9 @@ public:
   /// Returns the TBDGen options.
   const TBDGenOptions &getOptions() const { return Opts; }
 
+  const llvm::DataLayout &getDataLayout() const;
+  const llvm::Triple &getTarget() const;
+
   bool operator==(const TBDGenDescriptor &other) const;
   bool operator!=(const TBDGenDescriptor &other) const {
     return !(*this == other);
@@ -77,13 +84,12 @@ llvm::hash_code hash_value(const TBDGenDescriptor &desc);
 void simple_display(llvm::raw_ostream &out, const TBDGenDescriptor &desc);
 SourceLoc extractNearestSourceLoc(const TBDGenDescriptor &desc);
 
-using TBDFileAndSymbols =
-    std::pair<llvm::MachO::InterfaceFile, std::vector<std::string>>;
+using TBDFile = llvm::MachO::InterfaceFile;
 
-/// Computes the TBD file and public symbols for a given module or file.
+/// Computes the TBD file for a given Swift module or file.
 class GenerateTBDRequest
     : public SimpleRequest<GenerateTBDRequest,
-                           TBDFileAndSymbols(TBDGenDescriptor),
+                           TBDFile(TBDGenDescriptor),
                            RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -92,7 +98,23 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  TBDFileAndSymbols evaluate(Evaluator &evaluator, TBDGenDescriptor desc) const;
+  TBDFile evaluate(Evaluator &evaluator, TBDGenDescriptor desc) const;
+};
+
+/// Retrieve the public symbols for a file or module.
+class PublicSymbolsRequest
+    : public SimpleRequest<PublicSymbolsRequest,
+                           std::vector<std::string>(TBDGenDescriptor),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  std::vector<std::string>
+  evaluate(Evaluator &evaluator, TBDGenDescriptor desc) const;
 };
 
 /// Report that a request of the given kind is being evaluated, so it

--- a/include/swift/AST/TBDGenTypeIDZone.def
+++ b/include/swift/AST/TBDGenTypeIDZone.def
@@ -14,5 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(TBDGen, GenerateTBDRequest, TBDFileAndSymbols(TBDGenDescriptor),
+SWIFT_REQUEST(TBDGen, GenerateTBDRequest, TBDFile(TBDGenDescriptor),
+              Uncached, NoLocationInfo)
+SWIFT_REQUEST(TBDGen, PublicSymbolsRequest,
+              std::vector<std::string>(TBDGenDescriptor),
               Uncached, NoLocationInfo)

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1651,6 +1651,10 @@ static bool generateCode(CompilerInstance &Instance, StringRef OutputFilename,
   // Free up some compiler resources now that we have an IRModule.
   freeASTContextIfPossible(Instance);
 
+  // If we emitted any errors while perfoming the end-of-pipeline actions, bail.
+  if (Instance.getDiags().hadAnyError())
+    return true;
+
   // Now that we have a single IR Module, hand it over to performLLVM.
   return performLLVM(opts, Instance.getDiags(), nullptr, HashGlobal, IRModule,
                      TargetMachine.get(), OutputFilename,
@@ -1772,21 +1776,17 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
       IRGenOpts, Invocation.getTBDGenOptions(), std::move(SM), PSPs,
       OutputFilename, MSF, HashGlobal, ParallelOutputFilenames);
 
-  // Just because we had an AST error it doesn't mean we can't performLLVM.
-  bool HadError = Instance.getASTContext().hadError();
-
-  // If the AST Context has no errors but no IRModule is available,
-  // parallelIRGen happened correctly, since parallel IRGen produces multiple
-  // modules.
+  // If no IRModule is available, bail. This can either happen if IR generation
+  // fails, or if parallelIRGen happened correctly (in which case it would have
+  // already performed LLVM).
   if (!IRModule)
-    return HadError;
+    return Instance.getDiags().hadAnyError();
 
   if (validateTBDIfNeeded(Invocation, MSF, *IRModule.getModule()))
     return true;
 
   return generateCode(Instance, OutputFilename, IRModule.getModule(),
-                      HashGlobal) ||
-         HadError;
+                      HashGlobal);
 }
 
 static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,

--- a/lib/TBDGen/TBDGenRequests.cpp
+++ b/lib/TBDGen/TBDGenRequests.cpp
@@ -11,11 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/TBDGenRequests.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/Module.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Subsystems.h"
 #include "swift/TBDGen/TBDGen.h"
+#include "clang/Basic/TargetInfo.h"
 #include "llvm/TextAPI/MachO/InterfaceFile.h"
 
 using namespace swift;
@@ -41,6 +44,16 @@ ModuleDecl *TBDGenDescriptor::getParentModule() const {
   if (auto *module = Input.dyn_cast<ModuleDecl *>())
     return module;
   return Input.get<FileUnit *>()->getParentModule();
+}
+
+const llvm::DataLayout &TBDGenDescriptor::getDataLayout() const {
+  auto &ctx = getParentModule()->getASTContext();
+  auto *clang = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+  return clang->getTargetInfo().getDataLayout();
+}
+
+const llvm::Triple &TBDGenDescriptor::getTarget() const {
+  return getParentModule()->getASTContext().LangOpts.Target;
 }
 
 bool TBDGenDescriptor::operator==(const TBDGenDescriptor &other) const {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -40,6 +40,7 @@ class DataLayout;
 
 namespace swift {
 
+class TBDGenDescriptor;
 struct TBDGenOptions;
 
 namespace tbdgen {
@@ -195,6 +196,12 @@ public:
   void visitDecl(Decl *D) {}
 
   void visit(Decl *D);
+
+  /// Visit the symbols in a given file unit.
+  void visitFile(FileUnit *file);
+
+  /// Visit the files specified by a given TBDGenDescriptor.
+  void visit(const TBDGenDescriptor &desc);
 };
 } // end namespace tbdgen
 } // end namespace swift


### PR DESCRIPTION
Refactor `TBDGenVisitor` to accept a callback for when it discovers a symbol, and split off public symbol gathering into `PublicSymbolsRequest` such that we don't need to unnecessarily also build a TBD file which we immediately throw away.