### PR TITLE
[ModuleTrace] Mark test unsupported for windows-msvc.

### DIFF
--- a/test/Driver/loaded_module_trace_directness.swift
+++ b/test/Driver/loaded_module_trace_directness.swift
@@ -3,7 +3,7 @@
 
 // Unsupported on Windows because we are using #import in ObjC, which leads
 // to compiler errors on Windows.
-// UNSUPPORTED: OS=Windows
+// UNSUPPORTED: OS=windows-msvc
 
 // Dependency graph:
 


### PR DESCRIPTION
Made a mistake earlier.