### PR TITLE
[master-next][cmake] Fix zlib cmake issue: Target <X> links to target "ZLIB::ZLIB" but the target was not found

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -97,6 +97,10 @@ macro(swift_common_standalone_build_config_llvm product)
     endif()
   endif()
 
+  if(LLVM_ENABLE_ZLIB)
+   find_package(ZLIB REQUIRED)
+  endif()
+
   include(AddLLVM)
   include(AddSwiftTableGen) # This imports TableGen from LLVM.
   include(HandleLLVMOptions)


### PR DESCRIPTION
...after the changes in https://reviews.llvm.org/D79219.

Resolves rdar://problem/66057385