### PR TITLE
SILCloner: fix critical edge handling; remove previous workarounds

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -144,8 +144,9 @@ public:
                   SILFunction &From,
                   SubstitutionMap ApplySubs,
                   SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+                  DominanceInfo *DT = nullptr,
                   bool Inlining = false)
-    : SILClonerWithScopes<ImplClass>(To, OpenedArchetypesTracker, Inlining),
+    : SILClonerWithScopes<ImplClass>(To, OpenedArchetypesTracker, DT, Inlining),
       SwiftMod(From.getModule().getSwiftModule()),
       SubsMap(ApplySubs),
       Original(From),

--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -136,9 +136,9 @@ public:
 /// block's branch to jump to the newly cloned block, call cloneBranchTarget
 /// instead.
 ///
-/// After cloning, call splitCriticalEdges, then updateSSAAfterCloning. This is
-/// decoupled from cloning becaused some clients perform CFG edges updates after
-/// cloning but before splitting CFG edges.
+/// After cloning, call updateSSAAfterCloning. This is decoupled from cloning
+/// becaused some clients perform CFG edges updates after cloning but before
+/// splitting CFG edges.
 class BasicBlockCloner : public SILCloner<BasicBlockCloner> {
   using SuperTy = SILCloner<BasicBlockCloner>;
   friend class SILCloner<BasicBlockCloner>;
@@ -225,12 +225,7 @@ public:
 
   bool wasCloned() { return isBlockCloned(origBB); }
 
-  /// Call this after processing all instructions to fix the control flow
-  /// graph. The branch cloner may have left critical edges.
-  bool splitCriticalEdges(DominanceInfo *domInfo, SILLoopInfo *loopInfo);
-
-  /// Helper function to perform SSA updates after calling both
-  /// cloneBranchTarget and splitCriticalEdges.
+  /// Helper function to perform SSA updates after calling cloneBranchTarget.
   void updateSSAAfterCloning();
 
 protected:

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -409,10 +409,13 @@ bool swift::rotateLoop(SILLoop *loop, DominanceInfo *domInfo,
   header->moveAfter(latch);
 
   // Merge the old latch with the old header if possible.
-  mergeBasicBlockWithSuccessor(latch, domInfo, loopInfo);
+  if (mergeBasicBlockWithSuccessor(latch, domInfo, loopInfo))
+    newHeader = latch; // The old Header is gone. Latch is now the Header.
 
-  // Create a new preheader.
-  splitIfCriticalEdge(preheader, newHeader, domInfo, loopInfo);
+  // Cloning the header into the preheader created critical edges from the
+  // preheader and original header to both the new header and loop exit.
+  splitCriticalEdgesFrom(preheader, domInfo, loopInfo);
+  splitCriticalEdgesFrom(newHeader, domInfo, loopInfo);
 
   if (shouldVerify) {
     domInfo->verify();

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -74,7 +74,8 @@ void LoopCloner::cloneLoop() {
   Loop->getExitBlocks(ExitBlocks);
 
   // Clone the entire loop.
-  cloneReachableBlocks(Loop->getHeader(), ExitBlocks);
+  cloneReachableBlocks(Loop->getHeader(), ExitBlocks,
+                       /*insertAfter*/Loop->getLoopLatch());
 }
 
 /// Determine the number of iterations the loop is at most executed. The loop
@@ -93,7 +94,7 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
   if (!Loop->isLoopExiting(Latch))
     return None;
 
-  // Get the loop exit condition.
+ // Get the loop exit condition.
   auto *CondBr = dyn_cast<CondBranchInst>(Latch->getTerminator());
   if (!CondBr)
     return None;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2834,9 +2834,6 @@ bool SimplifyCFG::tailDuplicateObjCMethodCallSuccessorBlocks() {
       continue;
 
     Cloner.cloneBranchTarget(Branch);
-
-    // Does not currently update DominanceInfo.
-    Cloner.splitCriticalEdges(nullptr, nullptr);
     Cloner.updateSSAAfterCloning();
 
     Changed = true;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1109,8 +1109,6 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
   // Duplicate the destination block into this one, rewriting uses of the BBArgs
   // to use the branch arguments as we go.
   Cloner.cloneBranchTarget(BI);
-  // Does not currently update DominanceInfo.
-  Cloner.splitCriticalEdges(nullptr, nullptr);
   Cloner.updateSSAAfterCloning();
 
   // Once all the instructions are copied, we can nuke BI itself.  We also add

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -134,28 +134,6 @@ void BasicBlockCloner::updateSSAAfterCloning() {
   }
 }
 
-// FIXME: Remove this. SILCloner should not create critical edges.
-bool BasicBlockCloner::splitCriticalEdges(DominanceInfo *domInfo,
-                                          SILLoopInfo *loopInfo) {
-  bool changed = false;
-  // Remove any critical edges that the EdgeThreadingCloner may have
-  // accidentally created.
-  for (unsigned succIdx = 0, succEnd = origBB->getSuccessors().size();
-       succIdx != succEnd; ++succIdx) {
-    if (nullptr
-        != splitCriticalEdge(origBB->getTerminator(), succIdx, domInfo,
-                             loopInfo))
-      changed |= true;
-  }
-  for (unsigned succIdx = 0, succEnd = getNewBB()->getSuccessors().size();
-       succIdx != succEnd; ++succIdx) {
-    auto *newBB = splitCriticalEdge(getNewBB()->getTerminator(), succIdx,
-                                    domInfo, loopInfo);
-    changed |= (newBB != nullptr);
-  }
-  return changed;
-}
-
 void BasicBlockCloner::sinkAddressProjections() {
   // Because the address projections chains will be disjoint (an instruction
   // in one chain cannot use the result of an instruction in another chain),

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -374,7 +374,7 @@ SILInlineCloner::SILInlineCloner(
     SILOpenedArchetypesTracker &openedArchetypesTracker,
     SILInliner::DeletionFuncTy deletionCallback)
     : SuperTy(*apply.getFunction(), *calleeFunction, applySubs,
-              openedArchetypesTracker, /*Inlining=*/true),
+              openedArchetypesTracker, /*DT=*/nullptr, /*Inlining=*/true),
       FuncBuilder(funcBuilder), IKind(inlineKind), Apply(apply),
       DeletionCallback(deletionCallback) {
 

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -609,17 +609,15 @@ bb2:
 
 // HOIST-LABEL: sil @hoist_rangechecked
 // HOIST: bb0
-// HOIST:  cond_br {{.*}}, bb1{{.*}}, bb2
+// HOIST:  cond_br {{.*}}, bb2, bb1
 // HOIST: bb1:
-// HOIST: br bb6
-// HOIST: bb2:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
 // HOIST:   br bb3{{.*}}
 // HOIST: bb3{{.*}}:
 // HOIST-NOT: function_ref @checkbounds
 // HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5{{.*}}, bb4{{.*}}
+// HOIST:   cond_br {{.*}}, bb5, bb4
 // HOIST: bb4
 // HOIST:   br bb3
 // HOIST: bb5
@@ -671,17 +669,15 @@ bb3:
 
 // HOIST-LABEL: sil @hoist_rangechecked_ref_tail_addr
 // HOIST: bb0
-// HOIST:  cond_br {{.*}}, bb1{{.*}}, bb2
+// HOIST:  cond_br {{.*}}, bb2, bb1
 // HOIST: bb1:
-// HOIST: br bb6
-// HOIST: bb2:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
 // HOIST:   br bb3{{.*}}
 // HOIST: bb3{{.*}}:
 // HOIST-NOT: function_ref @checkbounds
 // HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5{{.*}}, bb4{{.*}}
+// HOIST:   cond_br {{.*}}, bb5, bb4
 // HOIST: bb4
 // HOIST:   br bb3
 // HOIST: bb5
@@ -818,17 +814,15 @@ bb2:
 
 // HOIST-LABEL: sil @hoist_rangechecked_addr_proj_store
 // HOIST: bb0
-// HOIST:  cond_br {{.*}}, bb1{{.*}}, bb2
+// HOIST:  cond_br {{.*}}, bb2, bb1
 // HOIST: bb1:
-// HOIST:  br bb6
-// HOIST: bb2:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
 // HOIST:   br bb3{{.*}}
 // HOIST: bb3{{.*}}:
 // HOIST-NOT: function_ref @checkbounds
 // HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5{{.*}}, bb4{{.*}}
+// HOIST:   cond_br {{.*}}, bb5, bb4
 // HOIST: bb4
 // HOIST:   br bb3
 // HOIST: bb5
@@ -882,17 +876,15 @@ bb3:
 
 // HOIST-LABEL: hoist_inclusive_rangechecked
 // HOIST: bb0
-// HOIST:  cond_br {{.*}}, bb1{{.*}}, bb2
+// HOIST:  cond_br {{.*}}, bb2, bb1
 // HOIST: bb1:
-// HOIST:  br bb6
-// HOIST: bb2:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:    apply [[CB]]
 // HOIST:   br bb3{{.*}}
 // HOIST: bb3{{.*}}:
 // HOIST-NOT: function_ref @checkbounds
 // HOIST-NOT:    apply [[CB]]
-// HOIST:   cond_br {{.*}}, bb5{{.*}}, bb4{{.*}}
+// HOIST:   cond_br {{.*}}, bb5, bb4
 // HOIST: bb4:
 // HOIST:  br bb3
 // HOIST: bb5:
@@ -944,16 +936,15 @@ bb3:
 /// Don't hoist arrays that are variant.
 // HOIST-LABEL: dont_hoist_variant_array
 // HOIST: bb0
-// HOIST:  cond_br {{.*}}, bb1{{.*}}, bb2
+// HOIST:  cond_br {{.*}}, bb2, bb1
 // HOIST: bb1:
-// HOIST:  br bb6
+// HOIST-NEXT:  br bb3
 // HOIST: bb2:
-// HOIST-NOT:   function_ref @checkbounds
-// HOIST:   br bb3{{.*}}
+// HOIST-NEXT:  br bb6
 // HOIST: bb3{{.*}}:
 // HOIST:   [[CB:%[0-9]+]] = function_ref @checkbounds
 // HOIST:  apply [[CB]]
-// HOIST:  cond_br {{.*}}, bb5{{.*}}, bb4{{.*}}
+// HOIST:  cond_br {{.*}}, bb5, bb4
 // HOIST: bb4:
 // HOIST:  br bb3
 // HOIST: bb5:

--- a/test/SILOptimizer/arcsequenceopts_knownsafebugs_loop.sil
+++ b/test/SILOptimizer/arcsequenceopts_knownsafebugs_loop.sil
@@ -202,10 +202,10 @@ bb2:
 // CHECK-LABEL: sil hidden @$unmatched_rr_loop_early_exit :
 // CHECK: bb1
 // CHECK:   strong_release %0 : $Cls
-// CHECK:   cond_br undef, bb3, bb2
-// CHECK: bb3:
+// CHECK:   cond_br undef, bb2, bb3
+// CHECK: bb2:
 // CHECK:   strong_retain %0 : $Cls
-// CHECK:   cond_br undef, bb1, bb4
+// CHECK:   cond_br undef, bb1, bb3
 // CHECK-LABEL: } // end sil function '$unmatched_rr_loop_early_exit'
 sil hidden @$unmatched_rr_loop_early_exit : $@convention(thin) (@owned Cls) -> () {
 bb0(%0 : $Cls):
@@ -233,10 +233,10 @@ bb3:
 // CHECK-LABEL: sil hidden @$matched_rr_loop_early_exit :
 // CHECK: bb1
 // CHECK:   strong_retain %0 : $Cls
-// CHECK:   cond_br undef, bb3, bb2
-// CHECK: bb3:
+// CHECK:   cond_br undef, bb2, bb3
+// CHECK: bb2:
 // CHECK:   strong_release %0 : $Cls
-// CHECK:   cond_br undef, bb1, bb4
+// CHECK:   cond_br undef, bb1, bb3
 // CHECK-LABEL: } // end sil function '$matched_rr_loop_early_exit'
 sil hidden @$matched_rr_loop_early_exit : $@convention(thin) (@owned Cls) -> () {
 bb0(%0 : $Cls):

--- a/test/SILOptimizer/arcsequenceopts_loops.sil
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil
@@ -21,9 +21,12 @@ bb0(%0 : $Builtin.NativeObject):
   br bb1
 
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -39,9 +42,12 @@ bb0(%0 : $Builtin.NativeObject):
 
 bb1:
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -57,9 +63,12 @@ bb0(%0 : $Builtin.NativeObject):
 
 bb1:
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -75,9 +84,12 @@ bb0(%0 : $Builtin.NativeObject):
 bb1:
   strong_retain %0 : $Builtin.NativeObject
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -99,9 +111,12 @@ bb1:
   strong_retain %0 : $Builtin.NativeObject
   apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -120,9 +135,12 @@ bb1:
   strong_retain %0 : $Builtin.NativeObject
   apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
@@ -149,9 +167,12 @@ bb0(%0 : $Builtin.NativeObject):
 bb1:
   strong_retain %0 : $Builtin.NativeObject
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -173,9 +194,12 @@ bb0(%0 : $Builtin.NativeObject):
 bb1:
   strong_retain %0 : $Builtin.NativeObject
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
   apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
   strong_release %0 : $Builtin.NativeObject
@@ -204,9 +228,12 @@ bb0(%0 : $Builtin.NativeObject):
 bb1:
   strong_retain %0 : $Builtin.NativeObject
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
@@ -224,12 +251,18 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb3, bb4
 
 bb3:
-  cond_br undef, bb1, bb4
+  br bb2
 
 bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -248,12 +281,18 @@ bb1:
 
 bb2:
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb2, bb3
+  cond_br undef, bb3, bb4
 
 bb3:
-  cond_br undef, bb1, bb4
+  br bb2
 
 bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -272,12 +311,18 @@ bb1:
 
 bb2:
   strong_retain %0 : $Builtin.NativeObject
-  cond_br undef, bb2, bb3
+  cond_br undef, bb3, bb4
 
 bb3:
-  cond_br undef, bb1, bb4
+  br bb2
 
 bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -295,18 +340,27 @@ bb1:
   cond_br undef, bb2, bb3
 
 bb2:
-  cond_br undef, bb1, bb4
+  br bb1
 
 bb3:
-  cond_br undef, bb1, bb5
+  cond_br undef, bb4, bb5
 
 bb4:
-  br bb6
+  br bb1
 
 bb5:
-  br bb6
+  cond_br undef, bb6, bb7
 
 bb6:
+  br bb1
+
+bb7:
+  br bb8
+
+bb8:
+  br bb9
+
+bb9:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -314,23 +368,12 @@ bb6:
 // CHECK-LABEL: sil @loop_multiple_exits_multiple_insertion_points : $@convention(thin) (Builtin.NativeObject) -> () {
 // CHECK: bb0
 // CHECK: strong_retain
-// CHECK-NOT: strong_release
-// CHECK: bb1
 // CHECK-NOT: strong_retain
-// CHECK-NOT: strong_release
-// CHECK: bb2
-// CHECK-NOT: strong_retain
-// CHECK-NOT: strong_release
-// CHECK: bb3
-// CHECK-NOT: strong_retain
-// CHECK-NOT: strong_release
-// CHECK: bb4
-// CHECK: strong_release
-// CHECK: bb5
 // CHECK-NOT: strong_release
 // CHECK: bb6
+// CHECK: strong_release
 // CHECK-NOT: strong_release
-// CHECK: bb7
+// CHECK: bb8
 // CHECK: strong_release
 sil @loop_multiple_exits_multiple_insertion_points : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
@@ -338,22 +381,28 @@ bb0(%0 : $Builtin.NativeObject):
   br bb1
 
 bb1:
-  cond_br undef, bb2, bb3
+  cond_br undef, bb2, bb4
 
 bb2:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb3, bb6
 
 bb3:
-  strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb5
+  br bb1
 
 bb4:
-  br bb6
+  strong_release %0 : $Builtin.NativeObject
+  cond_br undef, bb5, bb7
 
 bb5:
-  br bb6
+  br bb1
 
 bb6:
+  br bb8
+
+bb7:
+  br bb8
+
+bb8:
   strong_release %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -378,13 +427,20 @@ bb0(%0 : $Builtin.NativeObject):
 bb1:
   cond_br undef, bb2, bb3
 
+
 bb2:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb2a, bb4
+
+bb2a:
+  br bb1
 
 bb3:
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb5
+  cond_br undef, bb3a, bb5
 
+bb3a:
+  br bb1
+  
 bb4:
   strong_retain %0 : $Builtin.NativeObject
   br bb6
@@ -449,7 +505,10 @@ bb2:
 
 bb3:
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb1, bb4
+  cond_br undef, bb3a, bb4
+
+bb3a:
+  br bb1
 
 bb4:
   strong_release %0 : $Builtin.NativeObject
@@ -477,10 +536,16 @@ bb3:
 
 bb4:
   strong_release %0 : $Builtin.NativeObject
-  cond_br undef, bb2, bb5
+  cond_br undef, bb4a, bb5
+
+bb4a:
+  br bb2
 
 bb5:
-  cond_br undef, bb1, bb6
+  cond_br undef, bb5a, bb6
+
+bb5a:
+  br bb1
 
 bb6:
   strong_release %0 : $Builtin.NativeObject

--- a/test/SILOptimizer/arcsequenceopts_loops.sil.gyb
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil.gyb
@@ -52,10 +52,12 @@ bb1:
   strong_release %0 : $Builtin.NativeObject
 % end
 // CHECK-NEXT: cond_br
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
-// CHECK: bb2:
 bb2:
+  br bb1
+// CHECK: bb3:
+bb3:
 % if i & 8:
 // CHECK-NEXT: strong_release
   strong_release %0 : $Builtin.NativeObject
@@ -109,10 +111,13 @@ bb2:
 // CHECK-NEXT: strong_release
   strong_release %0 : $Builtin.NativeObject
 % end
-  cond_br undef, bb1, bb3
+  cond_br undef, bb3, bb4
 
-// CHECK: bb3:
 bb3:
+  br bb1
+
+// CHECK: bb4:
+bb4:
 % if i & 2:
 // CHECK-NEXT: strong_release
   strong_release %0 : $Builtin.NativeObject

--- a/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
+++ b/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
@@ -320,9 +320,12 @@ bb2:
   br bb3(%1 : $FakeOptional<Builtin.NativeObject>)
 
 bb3(%2 : $FakeOptional<Builtin.NativeObject>):
-  cond_br undef, bb3(%2 : $FakeOptional<Builtin.NativeObject>), bb4
+  cond_br undef, bb4(%2 : $FakeOptional<Builtin.NativeObject>), bb5
 
-bb4:
+bb4(%3 : $FakeOptional<Builtin.NativeObject>):
+  br bb3(%3 : $FakeOptional<Builtin.NativeObject>)
+
+bb5:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
   release_value %2 : $FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
@@ -347,12 +350,24 @@ bb2:
   br bb3(%1 : $FakeOptional<Builtin.NativeObject>)
 
 bb3(%2 : $FakeOptional<Builtin.NativeObject>):
-  cond_br undef, bb4, bb5
+  cond_br undef, bb4, bb7
 
 bb4:
-  cond_br undef, bb4, bb5
+  br bb5
 
 bb5:
+  cond_br undef, bb6, bb8
+
+bb6:
+  br bb5
+
+bb7:
+  br bb9
+
+bb8:
+  br bb9
+
+bb9:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>
   release_value %2 : $FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
@@ -422,11 +437,14 @@ bb1(%1 : $FakeOptional<Cls>):
   retain_value %2 : $Cls
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb1(%3 : $FakeOptional<Cls>), bb2
+  cond_br undef, bb2(%3 : $FakeOptional<Cls>), bb3
 
-bb2:
-  %4 = tuple()
-  return %4 : $()
+bb2(%4 : $FakeOptional<Cls>):
+  br bb1(%4 : $FakeOptional<Cls>)
+
+bb3:
+  %5 = tuple()
+  return %5 : $()
 }
 
 // CHECK-LABEL: sil @dont_strip_phi_nodes_over_backedges_multibb1 : $@convention(thin) () -> () {
@@ -448,11 +466,14 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb1(%3 : $FakeOptional<Cls>), bb4
+  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
 
-bb4:
-  %4 = tuple()
-  return %4 : $()
+bb4(%4 : $FakeOptional<Cls>):
+  br bb1(%4 : $FakeOptional<Cls>)
+
+bb5:
+  %5 = tuple()
+  return %5 : $()
 }
 
 // CHECK-LABEL: sil @dont_strip_phi_nodes_over_backedges_multibb2 : $@convention(thin) () -> () {
@@ -474,11 +495,14 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb1(%3 : $FakeOptional<Cls>), bb4
+  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
 
-bb4:
-  %4 = tuple()
-  return %4 : $()
+bb4(%4 : $FakeOptional<Cls>):
+  br bb1(%4 : $FakeOptional<Cls>)
+
+bb5:
+  %5 = tuple()
+  return %5 : $()
 }
 
 // CHECK-LABEL: sil @dont_strip_phi_nodes_over_backedges_multibb3 : $@convention(thin) () -> () {
@@ -500,11 +524,14 @@ bb2:
 bb3:
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb1(%3 : $FakeOptional<Cls>), bb4
+  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
 
-bb4:
-  %4 = tuple()
-  return %4 : $()
+bb4(%4 : $FakeOptional<Cls>):
+  br bb1(%4 : $FakeOptional<Cls>)
+
+bb5:
+  %5 = tuple()
+  return %5 : $()
 }
 
 // CHECK-LABEL: sil @dont_strip_phi_nodes_over_backedges_multibb4 : $@convention(thin) () -> () {
@@ -526,11 +553,14 @@ bb3:
   retain_value %2 : $Cls
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb1(%3 : $FakeOptional<Cls>), bb4
+  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
 
-bb4:
-  %4 = tuple()
-  return %4 : $()
+bb4(%4 : $FakeOptional<Cls>):
+  br bb1(%4 : $FakeOptional<Cls>)
+
+bb5:
+  %5 = tuple()
+  return %5 : $()
 }
 
 // CHECK-LABEL: sil @dont_strip_phi_nodes_over_backedges_multibb5 : $@convention(thin) () -> () {
@@ -552,11 +582,14 @@ bb2:
 bb3:
   release_value %1 : $FakeOptional<Cls>
   %3 = enum $FakeOptional<Cls>, #FakeOptional.some!enumelt, %2 : $Cls
-  cond_br undef, bb1(%3 : $FakeOptional<Cls>), bb4
+  cond_br undef, bb4(%3 : $FakeOptional<Cls>), bb5
 
-bb4:
-  %4 = tuple()
-  return %4 : $()
+bb4(%4 : $FakeOptional<Cls>):
+  br bb1(%4 : $FakeOptional<Cls>)
+
+bb5:
+  %5 = tuple()
+  return %5 : $()
 }
 
 // CHECK-LABEL: sil @strip_off_structs_tuples_tuple_extracts : $@convention(thin) (Builtin.NativeObject, (Builtin.Int32, Builtin.NativeObject, Builtin.Int32)) -> () {

--- a/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
+++ b/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
@@ -51,10 +51,13 @@ bb3:
   return %273 : $()
 
 bb4:
-  br bb5
+  br bb6
+
+bb5:
+  br bb6
 
 // CHECK-NOT: strong_release
-bb5:
+bb6:
   strong_release %0 : $MD5
   br bb1(%13 : $Builtin.Int32)
 

--- a/test/SILOptimizer/array_specialize.sil
+++ b/test/SILOptimizer/array_specialize.sil
@@ -33,16 +33,22 @@ bb1:
   %4 = load %1 : $*MyBool
   retain_value %3 : $MyArray<MyClass>
   %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
-  switch_enum %4 : $MyBool, case #MyBool.False!enumelt: bb3, case #MyBool.True!enumelt: bb2
+  switch_enum %4 : $MyBool, case #MyBool.False!enumelt: bb5, case #MyBool.True!enumelt: bb2
 
 bb2:
  %6 = integer_literal $Builtin.Int1, -1
- cond_br %6, bb1, bb4
+ cond_br %6, bb3, bb4
 
 bb3:
- br bb4
+  br bb1
 
 bb4:
+ br bb6
+
+bb5:
+ br bb6
+
+bb6:
   return %4 : $MyBool
 }
 
@@ -60,16 +66,22 @@ bb1:
   retain_value %3 : $MyArray<MyClass>
   %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
   %11 = open_existential_ref %10 : $AProtocol to $@opened("B538073C-2428-11E5-AC93-C82A1428F987") AProtocol
-  switch_enum %4 : $MyBool, case #MyBool.False!enumelt: bb3, case #MyBool.True!enumelt: bb2
+  switch_enum %4 : $MyBool, case #MyBool.False!enumelt: bb5, case #MyBool.True!enumelt: bb2
 
 bb2:
  %6 = integer_literal $Builtin.Int1, -1
- cond_br %6, bb1, bb4
+ cond_br %6, bb3, bb4
 
 bb3:
- br bb4
+  br bb1
 
 bb4:
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
   release_value %11 : $@opened("B538073C-2428-11E5-AC93-C82A1428F987") AProtocol
   return %4 : $MyBool
 }
@@ -94,19 +106,19 @@ bb1:
   retain_value %3 : $MyArray<MyClass>
   %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
   %7 = function_ref @throwing_fun : $@convention(thin) () -> (MyBool, @error Error)
-  try_apply %7() : $@convention(thin) () -> (MyBool, @error Error), normal bb2, error bb5
+  try_apply %7() : $@convention(thin) () -> (MyBool, @error Error), normal bb2, error bb6
 
 bb2(%8 : $MyBool):
  %6 = integer_literal $Builtin.Int1, -1
- cond_br %6, bb1, bb4
+ cond_br %6, bb3, bb5
 
 bb3:
- br bb4
+  br bb1
 
-bb4:
+bb5:
   return %4 : $MyBool
 
-bb5(%9 : $Error):
+bb6(%9 : $Error):
   throw %9 : $Error
 }
 
@@ -120,25 +132,34 @@ bb1:
   %4 = load %1 : $*Builtin.Int1
   retain_value %3 : $MyArray<MyClass>
   %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
-  cond_br %4, bb2, bb4
+  cond_br %4, bb2, bb7
 
 bb2:
- cond_br undef, bb3, bb5
+  cond_br undef, bb3, bb6
 
 bb3:
- %6 = integer_literal $Builtin.Int1, -1
- cond_br %6, bb1, bb7
+  %6 = integer_literal $Builtin.Int1, -1
+  cond_br %6, bb4, bb5
 
-bb4: // Exit block; b1 dom b4
- cond_br undef, bb5, bb6
+bb4:
+  br bb1
 
-bb5: // Exit Block; b1 dom b4
- br bb6
+bb5:
+  br bb10
 
-bb6: // Non-exit Dominated by bb1
- br bb7
+bb6: // Exit block; b1 dom b4
+  br bb10
 
-bb7:
+bb7: // Exit block; b1 dom b4
+  cond_br undef, bb8, bb9
+
+bb8:
+  br bb10
+
+bb9:
+  br bb10
+
+bb10:
   return %4 : $Builtin.Int1
 }
 
@@ -152,27 +173,36 @@ bb1:
   %4 = load %1 : $*Builtin.Int1
   retain_value %3 : $MyArray<MyClass>
   %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
-  cond_br %4, bb2, bb4
+  cond_br %4, bb2, bb5
 
 bb2:
- cond_br undef, bb3, bb5
+ cond_br undef, bb3, bb9
 
 bb3:
  %6 = integer_literal $Builtin.Int1, -1
- cond_br %6, bb1, bb7
+ cond_br %6, bb4, bb10
 
-bb4: // Exit block; b1 dom b4
- cond_br undef, bb5, bb6
+bb4:
+  br bb1
 
-bb5: // Exit Block; b1 dom b4
- br bb6
+bb5: // Exit block; b1 dom b4
+ cond_br undef, bb6, bb7
 
-bb6: // Non-exit Dominated by bb1
+bb6: // Exit Block; b1 dom b4
  br bb8
 
-bb7: // Exit dominated by bb3
- br bb8
+bb7:
+  br bb8
 
-bb8: // Non-exit dominated by bb1
+bb8: // Non-exit Dominated by bb1
+ br bb11
+
+bb9: // Exit dominated by bb3
+ br bb11
+
+bb10: // Exit dominated by bb3
+ br bb11
+
+bb11: // Non-exit dominated by bb1
   return %4 : $Builtin.Int1
 }

--- a/test/SILOptimizer/conditionforwarding.sil
+++ b/test/SILOptimizer/conditionforwarding.sil
@@ -244,7 +244,7 @@ bb6:
 // CHECK:   return
 sil @no_forwarding_bad_control_flow : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  cond_br %0, bb1, bb2
+  cond_br %0, bb9, bb2
 
 bb1:
   %1 = enum $E, #E.A!enumelt
@@ -260,14 +260,26 @@ bb3(%14 : $E):
   switch_enum %14 : $E, case #E.A!enumelt: bb4, case #E.B!enumelt: bb5
 
 bb4:
-  br bb6
+  br bb7
 
 bb5:
-  cond_br undef, bb1, bb6
+  cond_br undef, bb6, bb10
 
 bb6:
+  br bb1
+
+bb7:
+  br bb8
+
+bb8:
   %r = tuple ()
   return %r : $()
+
+bb9:
+  br bb1
+
+bb10:
+  br bb7
 }
 
 // CHECK-LABEL: sil @no_forwarding_multiple_block_args

--- a/test/SILOptimizer/cropoverflow.sil
+++ b/test/SILOptimizer/cropoverflow.sil
@@ -40,9 +40,12 @@ bb1:                                              // Preds: bb0
   %18 = tuple_extract %17 : $(Builtin.Int64, Builtin.Int1), 1 // user: %19
   cond_fail %18 : $Builtin.Int1                   // id: %19
   %20 = apply %10() : $@convention(thin) () -> ()
-  br bb2                                          // id: %21
+  br bb3                                          // id: %21
 
-bb2:                                              // Preds: bb0 bb1
+bb2:
+  br bb3
+
+bb3:
   %22 = tuple ()                                  // user: %23
 // CHECK: return
   return %22 : $()                                // id: %23
@@ -75,9 +78,12 @@ bb1:                                              // Preds: bb0
   %18 = tuple_extract %17 : $(Builtin.Int64, Builtin.Int1), 1 // user: %19
   cond_fail %13 : $Builtin.Int1                   // id: %19
   %20 = apply %10() : $@convention(thin) () -> ()
-  br bb2                                          // id: %21
+  br bb3                                          // id: %21
 
-bb2:                                              // Preds: bb0 bb1
+bb2:
+  br bb3
+
+bb3:
   %22 = tuple ()                                  // user: %23
   return %22 : $()                                // id: %23
 }
@@ -109,9 +115,12 @@ bb1:                                              // Preds: bb0
   %18 = tuple_extract %17 : $(Builtin.Int64, Builtin.Int1), 1 // user: %19
   cond_fail %13 : $Builtin.Int1                   // id: %19
   %20 = apply %10() : $@convention(thin) () -> ()
-  br bb2                                          // id: %21
+  br bb3                                          // id: %21
 
-bb2:                                              // Preds: bb0 bb1
+bb2:
+  br bb3
+
+bb3:                                              // Preds: bb0 bb1
   %22 = tuple ()                                  // user: %23
   return %22 : $()                                // id: %23
 }
@@ -143,9 +152,12 @@ bb1:                                              // Preds: bb0
   %18 = tuple_extract %17 : $(Builtin.Int64, Builtin.Int1), 1 // user: %19
   cond_fail %13 : $Builtin.Int1                   // id: %19
   %20 = apply %10() : $@convention(thin) () -> ()
-  br bb2                                          // id: %21
+  br bb3                                          // id: %21
 
 bb2:                                              // Preds: bb0 bb1
+  br bb3
+
+bb3:
   %22 = tuple ()                                  // user: %23
   return %22 : $()                                // id: %23
 }
@@ -341,9 +353,12 @@ bb1:                                              // Preds: bb0
   %15 = tuple_extract %14 : $(Builtin.Int64, Builtin.Int1), 1 // user: %16
   cond_fail %9 : $Builtin.Int1                   // id: %16
   %17 = apply %11() : $@convention(thin) () -> ()
-  br bb2                                          // id: %18
+  br bb3                                          // id: %18
 
-bb2:                                              // Preds: bb0 bb1
+bb2:
+  br bb3
+
+bb3:
   %19 = tuple ()                                  // user: %20
   return %19 : $()                                // id: %20
 }
@@ -371,9 +386,12 @@ bb1:                                              // Preds: bb0
   %15 = tuple_extract %14 : $(Builtin.Int64, Builtin.Int1), 1 // user: %16
   cond_fail %9 : $Builtin.Int1                   // id: %16
   %17 = apply %11() : $@convention(thin) () -> ()
-  br bb2                                          // id: %18
+  br bb3                                          // id: %18
 
-bb2:                                              // Preds: bb0 bb1
+bb2:
+  br bb3
+
+bb3:
   %19 = tuple ()                                  // user: %20
   return %19 : $()                                // id: %20
 }

--- a/test/SILOptimizer/epilogue_arc_dumper.sil
+++ b/test/SILOptimizer/epilogue_arc_dumper.sil
@@ -74,9 +74,12 @@ bb0(%0 : $foo):
 
 bb1:
   strong_release %0 : $foo
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %3 = tuple ()
   return %3 : $()
 }
@@ -92,9 +95,12 @@ bb0(%0 : $foo):
   br bb1
 
 bb1:
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %3 = tuple ()
   return %3 : $()
 }

--- a/test/SILOptimizer/high_level_licm.sil
+++ b/test/SILOptimizer/high_level_licm.sil
@@ -28,9 +28,12 @@ bb1:
   %f2 = function_ref @user : $@convention(thin) (Int) -> ()
   %c1 = apply %f1(%0) : $@convention(method) (@guaranteed Array<Int>) -> Int
   %c2 = apply %f2(%c1) : $@convention(thin) (Int) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %r1 = tuple ()
   return %r1 : $()
 }
@@ -56,9 +59,12 @@ bb1:
   %f2 = function_ref @user : $@convention(thin) (Int) -> ()
   %c1 = apply %f1(%a1) : $@convention(method) (@guaranteed Array<Int>) -> Int
   %c2 = apply %f2(%c1) : $@convention(thin) (Int) -> ()
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %r1 = tuple ()
   return %r1 : $()
 }

--- a/test/SILOptimizer/inliner_spa.sil
+++ b/test/SILOptimizer/inliner_spa.sil
@@ -44,7 +44,8 @@ bb3:
 // CHECK-LABEL: SPA @test_simple_loop
 // CHECK-NEXT:    bb0: length=0+0, d-entry=0, d-exit=33
 // CHECK-NEXT:    bb1: length=3+30, d-entry=0, d-exit=33
-// CHECK-NEXT:    bb2: length=0+0, d-entry=33, d-exit=0
+// CHECK-NEXT:    bb2: length=0+0, d-entry=33, d-exit=33
+// CHECK-NEXT:    bb3: length=0+0, d-entry=33, d-exit=0
 // CHECK-NEXT:  Loop bb1:
 // CHECK-NEXT:    bb1: length=3+0, d-entry=0, d-exit=3
 
@@ -55,25 +56,30 @@ bb0:
 bb1:
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %4 = tuple ()
   return %4 : $()
 }
 
 // CHECK-LABEL: SPA @test_loop_with_bypass_edge
-// CHECK-NEXT:    bb0: length=1+30, d-entry=0, d-exit=31
-// CHECK-NEXT:    bb1: length=0+0, d-entry=31, d-exit=3
-// CHECK-NEXT:    bb2: length=3+0, d-entry=31, d-exit=3
-// CHECK-NEXT:    bb3: length=0+0, d-entry=34, d-exit=0
-// CHECK-NEXT:    bb4: length=0+0, d-entry=31, d-exit=0
+// CHECK-NEXT:    bb0: length=1+0, d-entry=0, d-exit=1
+// CHECK-NEXT:    bb1: length=0+0, d-entry=1, d-exit=33
+// CHECK-NEXT:    bb2: length=3+30, d-entry=1, d-exit=33
+// CHECK-NEXT:    bb3: length=0+0, d-entry=34, d-exit=33
+// CHECK-NEXT:    bb4: length=0+0, d-entry=34, d-exit=0
+// CHECK-NEXT:    bb5: length=0+0, d-entry=1, d-exit=0
+// CHECK-NEXT:    bb6: length=0+0, d-entry=1, d-exit=0
 // CHECK-NEXT:  Loop bb2:
 // CHECK-NEXT:    bb2: length=3+0, d-entry=0, d-exit=3
 
 sil @test_loop_with_bypass_edge : $@convention(thin) () -> () {
 bb0:
-  cond_br undef, bb1, bb4
+  cond_br undef, bb1, bb5
 
 bb1:
   br bb2
@@ -81,62 +87,100 @@ bb1:
 bb2:
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
-  cond_br undef, bb2, bb3
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb2
+
+bb4:
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %4 = tuple ()
+  return %4 : $()
+}
+
+
+
+// CHECK-LABEL: SPA @test_nested_loops
+// CHECK-NEXT:    bb0: length=1+0, d-entry=0, d-exit=1
+// CHECK-NEXT:    bb1: length=0+0, d-entry=1, d-exit=44
+// CHECK-NEXT:    bb2: length=1+40, d-entry=1, d-exit=44
+// CHECK-NEXT:    bb3: length=0+0, d-entry=42, d-exit=4
+// CHECK-NEXT:    bb4: length=3+0, d-entry=42, d-exit=4
+// CHECK-NEXT:    bb5: length=0+0, d-entry=45, d-exit=4
+// CHECK-NEXT:    bb6: length=0+0, d-entry=45, d-exit=1
+// CHECK-NEXT:    bb7: length=2+0, d-entry=42, d-exit=3
+// CHECK-NEXT:    bb8: length=1+0, d-entry=44, d-exit=1
+// CHECK-NEXT:    bb9: length=0+0, d-entry=45, d-exit=44
+// CHECK-NEXT:    bb10: length=0+0, d-entry=45, d-exit=0
+// CHECK-NEXT:    bb11: length=0+0, d-entry=1, d-exit=0
+// CHECK-NEXT:    bb12: length=0+0, d-entry=1, d-exit=0
+// CHECK-NEXT:  Loop bb2:
+// CHECK-NEXT:    bb2: length=1+0, d-entry=0, d-exit=4
+// CHECK-NEXT:    bb7: length=2+0, d-entry=1, d-exit=3
+// CHECK-NEXT:    bb3: length=0+0, d-entry=1, d-exit=3
+// CHECK-NEXT:    bb4: length=3+30, d-entry=1, d-exit=34
+// CHECK-NEXT:    bb6: length=0+0, d-entry=34, d-exit=1
+// CHECK-NEXT:    bb8: length=1+0, d-entry=3, d-exit=1
+// CHECK-NEXT:    bb9: length=0+0, d-entry=4, d-exit=0
+// CHECK-NEXT:    bb5: length=0+0, d-entry=34, d-exit=34
+// CHECK-NEXT:  Loop bb4:
+// CHECK-NEXT:    bb4: length=3+0, d-entry=0, d-exit=3
+// CHECK-NEXT:    bb5: length=0+0, d-entry=3, d-exit=0
+
+sil @test_nested_loops : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb11
+
+bb1:
+  br bb2
+
+bb2:
+  cond_br undef, bb3, bb7
 
 bb3:
   br bb4
 
 bb4:
-  %4 = tuple ()
-  return %4 : $()
-}
-
-// CHECK-LABEL: SPA @test_nested_loops
-// CHECK-NEXT:    bb0: length=1+40, d-entry=0, d-exit=41
-// CHECK-NEXT:    bb1: length=0+0, d-entry=41, d-exit=4
-// CHECK-NEXT:    bb2: length=1+0, d-entry=41, d-exit=4
-// CHECK-NEXT:    bb3: length=3+0, d-entry=42, d-exit=4
-// CHECK-NEXT:    bb4: length=2+0, d-entry=42, d-exit=3
-// CHECK-NEXT:    bb5: length=1+0, d-entry=44, d-exit=1
-// CHECK-NEXT:    bb6: length=0+0, d-entry=45, d-exit=0
-// CHECK-NEXT:    bb7: length=0+0, d-entry=41, d-exit=0
-// CHECK-NEXT:  Loop bb2:
-// CHECK-NEXT:    bb2: length=1+0, d-entry=0, d-exit=4
-// CHECK-NEXT:    bb4: length=2+0, d-entry=1, d-exit=3
-// CHECK-NEXT:    bb3: length=3+30, d-entry=1, d-exit=34
-// CHECK-NEXT:    bb5: length=1+0, d-entry=3, d-exit=1
-// CHECK-NEXT:  Loop bb3:
-// CHECK-NEXT:    bb3: length=3+0, d-entry=0, d-exit=3
-
-sil @test_nested_loops : $@convention(thin) () -> () {
-bb0:
-  cond_br undef, bb1, bb7
-
-bb1:
-  br bb2
-
-bb2:
-  cond_br undef, bb3, bb4
-
-bb3:
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
-  cond_br undef, bb3, bb5
-
-bb4:
-  %c3 = builtin "assert_configuration"() : $Builtin.Int32
-  br bb5
+  cond_br undef, bb5, bb6
 
 bb5:
-  cond_br undef, bb2, bb6
+  br bb4
 
 bb6:
-  br bb7
+  br bb8
 
 bb7:
+  %c3 = builtin "assert_configuration"() : $Builtin.Int32
+  br bb8
+
+bb8:
+  cond_br undef, bb9, bb10
+
+bb9:
+  br bb2
+
+bb10:
+  br bb12
+
+bb11:
+  br bb12
+
+bb12:
   %4 = tuple ()
   return %4 : $()
 }
+
+
+
+
+
 
 // CHECK-LABEL: SPA @noreturn_func
 // CHECK-NEXT:    bb0: length=0+0, d-entry=0, d-exit=536870912
@@ -148,7 +192,8 @@ bb0:
 // CHECK-LABEL: SPA @test_call_of_noreturn_in_loop
 // CHECK-NEXT:    bb0: length=0+0, d-entry=0, d-exit=132
 // CHECK-NEXT:    bb1: length=12+120, d-entry=0, d-exit=132
-// CHECK-NEXT:    bb2: length=0+0, d-entry=132, d-exit=0
+// CHECK-NEXT:    bb2: length=0+0, d-entry=132, d-exit=132
+// CHECK-NEXT:    bb3: length=0+0, d-entry=132, d-exit=0
 // CHECK-NEXT:  Loop bb1:
 // CHECK-NEXT:    bb1: length=12+0, d-entry=0, d-exit=12
 sil @test_call_of_noreturn_in_loop : $@convention(thin) () -> () {
@@ -159,9 +204,12 @@ bb1:
   %f = function_ref @noreturn_func : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+  
+bb3:
   %4 = tuple ()
   return %4 : $()
 }

--- a/test/SILOptimizer/iv_info_printer.sil
+++ b/test/SILOptimizer/iv_info_printer.sil
@@ -94,7 +94,7 @@ bb0(%0 : $Int32, %1 : $Int32):
 bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32):
   %8 = struct_extract %1 : $Int32, #Int32._value
   %9 = builtin "cmp_ne_Int32"(%6 : $Builtin.Int32, %8 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %9, bb2, bb4
+  cond_br %9, bb2, bb6
 
 bb2:
   %11 = integer_literal $Builtin.Int32, 1
@@ -108,12 +108,18 @@ bb2:
   %21 = tuple_extract %19 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %21 : $Builtin.Int1
   %24 = builtin "cmp_eq_Int32"(%5 : $Builtin.Int32, %20 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %24, bb4, bb3
+  cond_br %24, bb5, bb3
 
 bb3:
   br bb1(%20 : $Builtin.Int32, %15 : $Builtin.Int32)
 
-bb4:
+bb5:
+  br bb7
+
+bb6:
+  br bb7
+
+bb7:
   %27 = tuple ()
   return %27 : $()
 }

--- a/test/SILOptimizer/licm_apply.sil
+++ b/test/SILOptimizer/licm_apply.sil
@@ -47,9 +47,12 @@ bb1:
 
   // This store does _not_ alias with the read in @read_from_param
   store %28 to %1 : $*Int64
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+  
+bb3:
   %15 = tuple ()
   dealloc_stack %2 : $*Int64
   return %15 : $()
@@ -80,9 +83,12 @@ bb1:
 
   // This store does alias with the read in @read_from_param
   store %28 to %2 : $*Int64
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %15 = tuple ()
   dealloc_stack %2 : $*Int64
   return %15 : $()
@@ -114,9 +120,12 @@ bb0(%0 : $Int64, %1 : $*Int64):
 bb1:
   %21 = apply %9() : $@convention(thin) () -> @owned X
   strong_release %21 : $X
-  cond_br undef, bb1, bb2
+  cond_br undef, bb2, bb3
 
 bb2:
+  br bb1
+
+bb3:
   %15 = tuple ()
   return %15 : $()
 }

--- a/test/SILOptimizer/loop_canonicalizer.sil
+++ b/test/SILOptimizer/loop_canonicalizer.sil
@@ -4,162 +4,17 @@ sil_stage canonical
 
 import Builtin
 
-// CHECK-LABEL: sil @insert_preheader_1 : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK: cond_br undef, bb1, bb4
-// CHECK: bb1:
-// CHECK: br bb2
-// CHECK: bb2:
-// CHECK: cond_br undef, bb2, bb3
-// CHECK: bb3:
-// CHECK: br bb4
-// CHECK: bb4:
-// CHECK: return undef
-sil @insert_preheader_1 : $@convention(thin) () -> () {
-bb0:
-  cond_br undef, bb1, bb3
-
-// A bb will be inserted along the edge from bb0 -> bb1.
-bb1:
-  cond_br undef, bb1, bb2
-
-// This is the exit block of the loop on bb1. We do this so this test *only*
-// tests the preheader insertion vs the exit block canonicalization.
-bb2:
-  br bb3
-
-bb3:
-  return undef : $()
-}
-
-// Make sure that we insert the pre-header correctly given a header with
-// multiple predecessors.
-//
-// CHECK-LABEL: sil @insert_preheader_2 : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK: cond_br undef, bb1, [[PREHEADER:bb[0-9]+]]
-// CHECK: bb1:
-// CHECK: br [[PREHEADER]]
-// CHECK: [[PREHEADER]]:
-// CHECK: br bb3
-// CHECK: bb3:
-// CHECK: cond_br undef, bb3, bb4
-// CHECK: return undef : $()
-sil @insert_preheader_2 : $@convention(thin) () -> () {
-bb0:
-  cond_br undef, bb1, bb2
-
-bb1:
-  br bb2
-
-bb2:
-  cond_br undef, bb2, bb3
-
-bb3:
-  return undef : $()
-}
-
-// Make sure that we can handle pre-header insertion for loops in sequence
-// (i.e. where one loop branches into another loop) correctly in terms of
-// updating loop info.
-//
-// CHECK-LABEL: sil @insert_preheader_3 : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK: cond_br undef, bb1, bb4
-// CHECK: bb1:
-// CHECK: br bb2
-// CHECK: bb2:
-// CHECK: cond_br undef, bb2, bb3
-// CHECK: bb3:
-// CHECK: br bb7
-// CHECK: bb4:
-// CHECK: br bb5
-// CHECK: bb5:
-// CHECK: cond_br undef, bb5, bb6
-// CHECK: bb6:
-// CHECK: br bb7
-// CHECK: bb7
-// CHECK: br bb8
-// CHECK: bb8:
-// CHECK: cond_br undef, bb8, bb9
-// CHECK: bb9:
-// CHECK: return undef
-sil @insert_preheader_3 : $@convention(thin) () -> () {
-bb0:
-  cond_br undef, bb1, bb2
-
-bb1:
-  cond_br undef, bb1, bb3
-
-bb2:
-  cond_br undef, bb2, bb3
-
-bb3:
-  cond_br undef, bb3, bb4
-
-bb4:
-  return undef : $()
-}
-
-// Make sure that we insert pre-headers correctly for nested loops I am using
-// patterns in more places than I need to, to make the test case more obvious to
-// the reader.
-//
-// CHECK-LABEL: sil @insert_preheader_4 : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK: br bb1
-// CHECK: bb1:
-// CHECK: cond_br undef, bb2, [[PREHEADER_1:bb[0-9]+]]
-// CHECK: bb2:
-// CHECK: br [[PREHEADER_1]]
-// First pre-header
-// CHECK: [[PREHEADER_1]]:
-// CHECK: br bb4
-// CHECK: bb4:
-// CHECK: cond_br undef, bb8, [[PREHEADER_2:bb[0-9]+]]
-// CHECK: [[PREHEADER_2]]:
-// CHECK: br bb6
-// CHECK: bb6:
-// CHECK: cond_br undef, bb6, bb7
-// This is an exit bb for bb6.
-// CHECK: bb7:
-// CHECK: cond_br undef, bb8, bb9
-// CHECK: bb8:
-// CHECK: br bb4
-// CHECK: bb9:
-// CHECK: return undef
-sil @insert_preheader_4 : $@convention(thin) () -> () {
-bb0:
-  br bb1
-
-bb1:
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb3
-
-bb3:
-  cond_br undef, bb3, bb4
-
-bb4:
-  cond_br undef, bb4, bb5
-
-bb5:
-  cond_br undef, bb3, bb6
-
-bb6:
-  return undef : $()
-}
-
 // Test insertBackedgeBlock.
 //
 // CHECK-LABEL: insert_backedge_block
 // CHECK: bb2:
-// CHECK: cond_br undef, bb3, bb4
-// CHECK: bb3:
-// CHECK: br bb1
-// CHECK: bb4:
 // CHECK: cond_br undef, bb3, bb5
+// CHECK: bb3:
+// CHECK: br bb4
+// CHECK: bb5:
+// CHECK: cond_br undef, bb6, bb7
+// CHECK: bb6:
+// CHECK: br bb4
 sil @insert_backedge_block : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -168,12 +23,18 @@ bb1:
   br bb2
 
 bb2:
-  cond_br undef, bb1, bb3
+  cond_br undef, bb3, bb4
 
 bb3:
-  cond_br undef, bb1, bb4
+  br bb1
 
 bb4:
+  cond_br undef, bb5, bb7
+
+bb5:
+  br bb1
+
+bb7:
   return undef : $()
 }
 
@@ -183,14 +44,20 @@ bb4:
 // CHECK: bb2:
 // CHECK: br bb3
 // CHECK: bb3:
-// CHECK: cond_br undef, bb4, bb5
-// CHECK: bb4:
-// CHECK: br bb2
-// CHECK: bb5:
 // CHECK: cond_br undef, bb4, bb6
+// CHECK: bb4:
+// CHECK: br bb5
+// CHECK: bb5:
+// CHECK: br bb2
 // CHECK: bb6:
-// CHECK: cond_br undef, bb1, bb7
+// CHECK: cond_br undef, bb7, bb8
 // CHECK: bb7:
+// CHECK: br bb5
+// CHECK: bb8:
+// CHECK: cond_br undef, bb9, bb10
+// CHECK: bb9:
+// CHECK: br bb1
+// CHECK: bb10:
 // CHECK: return undef
 sil @insert_backedge_block_inner_loop : $@convention(thin) () -> () {
 bb0:
@@ -203,41 +70,23 @@ bb2:
   br bb3
 
 bb3:
-  cond_br undef, bb2, bb4
+  cond_br undef, bb4, bb5
 
 bb4:
-  cond_br undef, bb2, bb5
-
-bb5:
-  cond_br undef, bb1, bb6
-
-bb6:
-  return undef : $()
-}
-
-// CHECK-LABEL: sil @exit_blocks_should_only_have_exiting_blocks_as_predecessors : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK: cond_br undef, bb1, bb4
-// CHECK: bb1:
-// CHECK: br bb2
-// CHECK: bb2:
-// CHECK: cond_br undef, bb2, bb3
-// CHECK: bb3:
-// CHECK: br bb4
-// CHECK: bb4:
-// CHECK: return undef
-sil @exit_blocks_should_only_have_exiting_blocks_as_predecessors : $@convention(thin) () -> () {
-bb0:
-  cond_br undef, bb1, bb3
-
-// Header
-bb1:
   br bb2
 
-bb2:
-  cond_br undef, bb2, bb3
+bb5:
+  cond_br undef, bb6, bb7
 
-// Exit with multiple predecessors. The edge from bb2 -> bb3 will be split.
-bb3:
+bb6:
+  br bb2
+
+bb7:
+  cond_br undef, bb8, bb9
+
+bb8:
+  br bb1
+
+bb9:
   return undef : $()
 }

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -10,11 +10,17 @@ import Builtin
 // CHECK: bb1
 // CHECK:  builtin "sadd_with_overflow_Int64
 // CHECK:  cond_br {{.*}}, bb2, bb3
-// CHECK: bb2:
-// CHECK:  return
+// CHECK: bb2
+// CHECK:  br bb7
 // CHECK: bb3
+// CHECK:  br bb4
+// CHECK: bb4
 // CHECK:  builtin "sadd_with_overflow_Int64
-// CHECK:  br bb2
+// CHECK:  br bb5
+// CHECK: bb5
+// CHECK:  br bb7
+// CHECK: bb7:
+// CHECK:  return
 
 sil @loop_unroll_1 : $@convention(thin) () -> () {
 bb0:
@@ -28,11 +34,14 @@ bb1(%4 : $Builtin.Int64):
   %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
   %7 = builtin "cmp_eq_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %7, bb2, bb1(%6 : $Builtin.Int64)
+  cond_br %7, bb3, bb2
 
 bb2:
- %8 = tuple()
- return %8 : $()
+  br bb1(%6 : $Builtin.Int64)
+
+bb3:
+ %9 = tuple()
+ return %9 : $()
 }
 
 // CHECK-LABEL: sil @loop_unroll_2
@@ -40,14 +49,18 @@ bb2:
 // CHECK:  br bb1
 // CHECK: bb1
 // CHECK:  = builtin "sadd_with_overflow_Int64
-// CHECK:  cond_br {{.*}}, bb3, bb2
+// CHECK:  cond_br {{.*}}, bb2, bb3
 // CHECK: bb2:
-// CHECK:  br bb4
+// CHECK:  br bb7
 // CHECK: bb3:
-// CHECK:  return
+// CHECK:  br bb4
 // CHECK: bb4
 // CHECK:  = builtin "sadd_with_overflow_Int64
-// CHECK:  br bb3
+// CHECK:  br bb5
+// CHECK: bb5:
+// CHECK:  br bb7
+// CHECK: bb7:
+// CHECK:  return
 
 sil @loop_unroll_2 : $@convention(thin) () -> () {
 bb0:
@@ -76,14 +89,18 @@ bb3:
 // CHECK:  br bb1
 // CHECK: bb1
 // CHECK:  = builtin "sadd_with_overflow_Int64
-// CHECK:  cond_br {{.*}}, bb3, bb2
+// CHECK:  cond_br {{.*}}, bb2, bb3
 // CHECK: bb2:
-// CHECK:  br bb4
+// CHECK:  br bb7
 // CHECK: bb3:
-// CHECK:  return
+// CHECK:  br bb4
 // CHECK: bb4
 // CHECK:  = builtin "sadd_with_overflow_Int64
-// CHECK:  br bb3
+// CHECK:  br bb5
+// CHECK: bb5:
+// CHECK:  br bb7
+// CHECK: bb7:
+// CHECK:  return
 
 sil @loop_unroll_3 : $@convention(thin) () -> () {
 bb0:
@@ -112,14 +129,18 @@ bb3:
 // CHECK:  br bb1
 // CHECK: bb1
 // CHECK:  = builtin "sadd_with_overflow_Int64
-// CHECK:  cond_br {{.*}}, bb3, bb2
+// CHECK:  cond_br {{.*}}, bb2, bb3
 // CHECK: bb2:
-// CHECK:  br bb4
+// CHECK:  br bb7
 // CHECK: bb3:
-// CHECK:  return
+// CHECK:  br bb4
 // CHECK: bb4
 // CHECK:  = builtin "sadd_with_overflow_Int64
-// CHECK:  br bb3
+// CHECK:  br bb5
+// CHECK: bb5:
+// CHECK:  br bb7
+// CHECK: bb7:
+// CHECK:  return
 
 sil @loop_unroll_4 : $@convention(thin) () -> () {
 bb0:
@@ -146,7 +167,12 @@ bb3:
 // CHECK-LABEL: sil @loop_unroll_5
 // CHECK:      bb5:
 // CHECK-NEXT:   br bb4
-// CHECK-NEXT: }
+// CHECK: bb6:
+// CHECK-NEXT:  br bb7
+// CHECK: bb7:
+// CHECK-NEXT:  tuple ()
+// CHECK-NEXT:  return
+// CHECK-NEXT: } // end sil function 'loop_unroll_5'
 
 sil @loop_unroll_5 : $@convention(thin) () -> () {
 bb0:
@@ -173,8 +199,12 @@ bb3:
 // CHECK-LABEL: sil @loop_unroll_6
 // CHECK:      bb5:
 // CHECK-NEXT:   br bb4
-// CHECK-NEXT: }
-
+// CHECK: bb6:
+// CHECK-NEXT:  br bb7
+// CHECK: bb7:
+// CHECK-NEXT:  tuple ()
+// CHECK-NEXT:  return
+// CHECK-NEXT: } // end sil function 'loop_unroll_6'
 sil @loop_unroll_6 : $@convention(thin) () -> () {
 bb0:
  %0 = integer_literal $Builtin.Int64, 0
@@ -200,8 +230,12 @@ bb3:
 // CHECK-LABEL: sil @loop_unroll_7
 // CHECK:      bb5:
 // CHECK-NEXT:   br bb4
-// CHECK-NEXT: }
-
+// CHECK: bb6:
+// CHECK-NEXT:  br bb7
+// CHECK: bb7:
+// CHECK-NEXT:  tuple ()
+// CHECK-NEXT:  return
+// CHECK-NEXT: } // end sil function 'loop_unroll_7'
 sil @loop_unroll_7 : $@convention(thin) () -> () {
 bb0:
  %0 = integer_literal $Builtin.Int64, 0
@@ -226,13 +260,19 @@ bb3:
 
 // CHECK-LABEL: sil @unroll_with_exit_block_arg_1
 // CHECK: bb1({{.*}}):
-// CHECK:   cond_br {{.*}}, bb3{{.*}}, bb2({{.*}})
-// CHECK: bb2({{.*}}):
-// CHECK:   return
+// CHECK:   cond_br {{.*}}, bb4, bb2
+// CHECK: bb2:
+// CHECK:   br bb3({{.*}})
 // CHECK: bb3({{.*}}):
-// CHECK:   cond_br {{.*}}, bb4{{.*}}, bb2({{.*}})
-// CHECK: bb4({{.*}}):
-// CHECK:   br bb2({{.*}})
+// CHECK:   br bb11({{.*}})
+// CHECK: bb4:
+// CHECK:   br bb8({{.*}})
+// CHECK: bb8({{.*}}):
+// CHECK:   cond_br {{.*}}, bb9, bb10
+// CHECK: bb10:
+// CHECK:   br bb11({{.*}})
+// CHECK: bb11({{.*}}):
+// CHECK:   return
 // CHECK: }
 sil @unroll_with_exit_block_arg_1 : $@convention(thin) () -> () {
 bb0:
@@ -247,7 +287,10 @@ bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
   %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
   %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %70, bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64), bb6(%61 : $Builtin.Int64)
+  cond_br %70, bb5, bb6(%61 : $Builtin.Int64)
+
+bb5:
+  br bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64)
 
 bb6(%72 : $Builtin.Int64):
   %401 = tuple ()
@@ -256,17 +299,19 @@ bb6(%72 : $Builtin.Int64):
 
 // CHECK-LABEL: sil @unroll_with_exit_block_arg_2
 // CHECK: bb1({{.*}}):
-// CHECK:   cond_br {{.*}}, bb2, bb3({{.*}})
+// CHECK:   cond_br {{.*}}, bb4, bb2
 // CHECK: bb2:
-// CHECK:   br bb4{{.*}}
+// CHECK:   br bb3{{.*}}
 // CHECK: bb3({{.*}}):
+// CHECK:   br bb11{{.*}}
+// CHECK: bb4:
+// CHECK:   br bb8{{.*}}
+// CHECK: bb8({{.*}}):
+// CHECK:   cond_br {{.*}}, bb9, bb10
+// CHECK: bb10:
+// CHECK:   br bb11({{.*}})
+// CHECK: bb11({{.*}}):
 // CHECK:   return
-// CHECK: bb4({{.*}}):
-// CHECK:   cond_br {{.*}}, bb5, bb3({{.*}})
-// CHECK: bb5:
-// CHECK:   br bb6{{.*}}
-// CHECK: bb6({{.*}}):
-// CHECK:   br bb3({{.*}})
 // CHECK: }
 sil @unroll_with_exit_block_arg_2 : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -32,17 +32,20 @@ sil_vtable Bar {
 // CHECK: bb0(%0 : $Int32, %1 : $Bar):
 // CHECK:   class_method
 // CHECK:   apply
-// CHECK:   cond_br {{.*}}, bb3({{.*}} : $Builtin.Int32), bb1
+// CHECK:   cond_br {{.*}}, bb2, bb1
 
 // CHECK: bb1:
-// CHECK:   br bb2({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}}: $Int32)
+// CHECK-NEXT:   br bb3({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}}: $Int32)
 
-// CHECK: bb2({{.*}}: $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32):
+// CHECK: bb3({{.*}}: $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32):
 // CHECK:   class_method
 // CHECK:   apply
-// CHECK:   cond_br {{%.*}}, bb3({{.*}} : $Builtin.Int32), bb2({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Int32)
+// CHECK:   cond_br {{%.*}}, bb5, bb4
 
-// CHECK: bb3({{.*}} : $Builtin.Int32):
+// CHECK: bb5:
+// CHECK-NEXT:   br bb6({{.*}} : $Builtin.Int32)
+
+// CHECK: bb6({{.*}} : $Builtin.Int32):
 // CHECK:   [[STRUCT:%.*]] = struct $Int32 ({{%.*}} : $Builtin.Int32)
 // CHECK:   return [[STRUCT]] : $Int32
 // CHECK: } // end sil function 'looprotate'
@@ -339,12 +342,12 @@ bb0(%a0 : $Int32):
 // CHECK: bb0:
 // CHECK:  cond_br
 // CHECK: bb1:
-// CHECK:  br bb2
-// CHECK: bb2({{%.*}} : $Builtin.Int32, [[WORD:%.*]] : $Builtin.Int32
+// CHECK:  br bb3
+// CHECK: bb3({{%.*}} : $Builtin.Int32, [[WORD:%.*]] : $Builtin.Int32
 // CHECK:  [[STRUCT:%[0-9]+]] = struct $Int32 ([[WORD]]
 // CHECK:  apply {{.*}}([[STRUCT]])
 // CHECK:  cond_br
-// CHECK: bb3({{.*}}):
+// CHECK: bb6({{.*}}):
 // CHECK:  return
 sil @struct_arg : $@convention(thin) () -> () {
 bb0:
@@ -383,18 +386,18 @@ bb2:
 // CHECK:   cond_br
 // Loop Header
 // CHECK: bb1:
-// CHECK-NEXT: br bb2
-// CHECK: bb2:
-// CHECK:   cond_br %{{.*}}, bb3, bb5
+// CHECK-NEXT: br bb3
 // CHECK: bb3:
+// CHECK:   cond_br %{{.*}}, bb4, bb8
+// CHECK: bb4:
 // CHECK:   apply
-// CHECK:   br bb4(
-// CHECK: bb4(%[[ARG:[0-9]*]]
-// CHECK-NEXT: cond_br %{{.*}}, bb6, bb2
-// CHECK: bb5:
+// CHECK:   br bb5(
+// CHECK: bb5(%[[ARG:[0-9]*]]
+// CHECK-NEXT: cond_br %{{.*}}, bb7, bb6
+// CHECK: bb8:
 // CHECK:   apply
-// CHECK:   br bb4(%
-// CHECK: bb6
+// CHECK:   br bb5(%
+// CHECK: bb9
 // CHECK:   return
 sil @insert_backedge_block : $@convention(thin) (@owned @callee_owned () -> Builtin.Int32) -> () {
 bb0(%0 : $@callee_owned () -> Builtin.Int32):

--- a/test/SILOptimizer/mem2reg_liveness.sil
+++ b/test/SILOptimizer/mem2reg_liveness.sil
@@ -52,11 +52,14 @@ bb4:                                              // Preds: bb3 bb2
   cond_fail %33 : $Builtin.Int1                   // id: %35
   %36 = apply %25(%34) : $@convention(thin) (Int64) -> ()
   dealloc_stack %8 : $*Int64     // id: %37
-  br bb5                                          // id: %38
+  br bb6                                          // id: %38
+
+bb5:
+  br bb6
 
 // We don't need a PHI node here because the value is dead!
-// CHECK: bb5:
-bb5:                                              // Preds: bb4 bb0
+// CHECK: bb6:
+bb6:
   dealloc_stack %1 : $*Int64     // id: %39
   %40 = tuple ()                                  // user: %41
 // CHECK: return


### PR DESCRIPTION
There are multiple reasons this is needed.

    1. Most passes do not perform CFG transformations. However, we often
    need to split critical edges and remember to invalidate all SIL
    analyses at the end of virtually every pass. This is very innefficient
    and highly bug prone.

    2. Many SIL analysis algorithms needs to reason about CFG
    edges. Avoiding critical edges leads to far simpler and more efficient
    designs when edges can be identified by blocks.

    3. Handling block arguments on conditional branches create complexity
    at the lowest level of the SIL interface. This complexity is difficult
    to abstract over and bleeds until any algorithm that needs to reason
    about phi operands. It's far easier to work with phis if we can easily
    recover the phi operand with only a reference to the predecessor
    block.

    4. Attempting to preserve critical edges in high-level and mid-level IR
    prevents optimization that otherwise have no business optimizing
    branches. Branch optimization should always be defered to machine
    level IR where the most relevant heuristics are employed to remove
    unconditional branches. If code didn't need to be placed on a critical
    edges, then a branch optimization can easily remove that code from the
    critical edge.
