### PR TITLE
Verify that just-emitted module interfaces parse and typecheck

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -701,12 +701,12 @@ ERROR(sema_opening_import,Fatal,
 ERROR(serialization_load_failed,Fatal,
       "failed to load module '%0'", (StringRef))
 ERROR(module_interface_build_failed,Fatal,
-      "failed to build module '%0' from its module interface; "
-      "%select{the compiler that produced it, '%2', may have used features "
-      "that aren't supported by this compiler, '%3'"
-      "|it may have been damaged or it may have triggered a bug in the Swift "
-      "compiler when it was produced}1",
-      (StringRef, bool, StringRef, StringRef))
+      "failed to %select{build module '%1' from its module interface|verify "
+      "module interface of '%1'}0; %select{the compiler that produced it, "
+      "'%3', may have used features that aren't supported by this compiler, "
+      "'%4'|it may have been damaged or it may have triggered a bug in the "
+      "Swift compiler when it was produced}2",
+      (bool, StringRef, bool, StringRef, StringRef))
 ERROR(serialization_malformed_module,Fatal,
       "malformed compiled module: %0", (StringRef))
 ERROR(serialization_module_too_new,Fatal,

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -51,9 +51,10 @@ public:
     GenerateDSYMJob,
     VerifyDebugInfoJob,
     GeneratePCHJob,
+    VerifyModuleInterfaceJob,
 
     JobFirst = CompileJob,
-    JobLast = GeneratePCHJob
+    JobLast = VerifyModuleInterfaceJob
   };
 
   static const char *getClassName(Kind AC);
@@ -354,6 +355,26 @@ public:
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::StaticLinkJob;
+  }
+};
+
+class VerifyModuleInterfaceJobAction : public JobAction {
+  virtual void anchor();
+  file_types::ID inputType;
+
+public:
+  VerifyModuleInterfaceJobAction(const Action * ModuleEmitter,
+                                 file_types::ID inputType)
+    : JobAction(Action::Kind::VerifyModuleInterfaceJob, { ModuleEmitter },
+                file_types::TY_Nothing), inputType(inputType) {
+    assert(inputType == file_types::TY_SwiftModuleInterfaceFile ||
+           inputType == file_types::TY_PrivateSwiftModuleInterfaceFile);
+  }
+
+  file_types::ID getInputType() const { return inputType; }
+
+  static bool classof(const Action *A) {
+    return A->getKind() == Action::Kind::VerifyModuleInterfaceJob;
   }
 };
 

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -162,6 +162,9 @@ protected:
   virtual InvocationInfo
   constructInvocation(const VerifyDebugInfoJobAction &job,
                       const JobContext &context) const;
+  virtual InvocationInfo
+  constructInvocation(const VerifyModuleInterfaceJobAction &job,
+                      const JobContext &context) const;
   virtual InvocationInfo constructInvocation(const GeneratePCHJobAction &job,
                                              const JobContext &context) const;
   virtual InvocationInfo

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -116,6 +116,8 @@ public:
 
     /// Build from a swiftinterface, as close to `import` as possible
     CompileModuleFromInterface,
+    /// Same as CompileModuleFromInterface, but stopping after typechecking
+    TypecheckModuleFromInterface,
 
     EmitSIBGen, ///< Emit serialized AST + raw SIL
     EmitSIB,    ///< Emit serialized AST + canonical SIL

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -263,6 +263,8 @@ private:
 };
 
 struct ModuleInterfaceLoaderOptions {
+  FrontendOptions::ActionType requestedAction =
+      FrontendOptions::ActionType::EmitModuleOnly;
   bool remarkOnRebuildFromInterface = false;
   bool disableInterfaceLock = false;
   bool disableImplicitSwiftModule = false;
@@ -271,7 +273,17 @@ struct ModuleInterfaceLoaderOptions {
     remarkOnRebuildFromInterface(Opts.RemarkOnRebuildFromModuleInterface),
     disableInterfaceLock(Opts.DisableInterfaceFileLock),
     disableImplicitSwiftModule(Opts.DisableImplicitModules),
-    mainExecutablePath(Opts.MainExecutablePath) {}
+    mainExecutablePath(Opts.MainExecutablePath)
+  {
+    switch (Opts.RequestedAction) {
+    case FrontendOptions::ActionType::TypecheckModuleFromInterface:
+      requestedAction = FrontendOptions::ActionType::Typecheck;
+      break;
+    default:
+      requestedAction = FrontendOptions::ActionType::EmitModuleOnly;
+      break;
+    }
+  }
   ModuleInterfaceLoaderOptions() = default;
 };
 

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -41,12 +41,15 @@ struct ModuleInterfaceOptions {
   /// back .swiftinterface and reconstructing .swiftmodule.
   std::string Flags;
 
-  // Print SPI decls and attributes.
+  /// Print SPI decls and attributes.
   bool PrintSPIs = false;
 
   /// Print imports with both @_implementationOnly and @_spi, only applies
   /// when PrintSPIs is true.
   bool ExperimentalSPIImports = false;
+
+  /// Intentionally print invalid syntax into the file.
+  bool DebugPrintInvalidSyntax = false;
 };
 
 extern version::Version InterfaceFormatVersion;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -641,6 +641,11 @@ def build_module_from_parseable_interface :
   Alias<compile_module_from_interface>,
   ModeOpt;
 
+def typecheck_module_from_interface :
+  Flag<["-"], "typecheck-module-from-interface">,
+  HelpText<"Treat the (single) input as a swiftinterface and typecheck it">,
+  ModeOpt;
+
 def module_interface_preserve_types_as_written :
   Flag<["-"], "module-interface-preserve-types-as-written">,
   HelpText<"When emitting a module interface, preserve types as they were "

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -256,6 +256,9 @@ def debug_forbid_typecheck_prefix : Separate<["-"], "debug-forbid-typecheck-pref
   HelpText<"Triggers llvm fatal_error if typechecker tries to typecheck a decl "
            "with the provided prefix name">;
 
+def debug_emit_invalid_swiftinterface_syntax : Flag<["-"], "debug-emit-invalid-swiftinterface-syntax">,
+  HelpText<"Write an invalid declaration into swiftinterface files">;
+
 def debug_cycles : Flag<["-"], "debug-cycles">,
   HelpText<"Print out debug dumps when cycles are detected in evaluation">;
 def build_request_dependency_graph : Flag<["-"], "build-request-dependency-graph">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -460,6 +460,15 @@ def emit_private_module_interface_path :
          DoesNotAffectIncrementalBuild, ArgumentIsPath, SupplementaryOutput]>,
   MetaVarName<"<path>">, HelpText<"Output private module interface file to <path>">;
 
+def verify_emitted_module_interface :
+  Flag<["-"], "verify-emitted-module-interface">,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Check that module interfaces emitted during compilation typecheck">;
+def no_verify_emitted_module_interface :
+  Flag<["-"], "no-verify-emitted-module-interface">,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Don't check that module interfaces emitted during compilation typecheck">;
+
 def avoid_emit_module_source_info :
   Flag<["-"], "avoid-emit-module-source-info">,
   Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -33,6 +33,7 @@ const char *Action::getClassName(Kind AC) {
   case Kind::GenerateDSYMJob:  return "generate-dSYM";
   case Kind::VerifyDebugInfoJob:  return "verify-debug-info";
   case Kind::GeneratePCHJob:  return "generate-pch";
+  case Kind::VerifyModuleInterfaceJob: return "verify-module-interface";
   }
 
   llvm_unreachable("invalid class");
@@ -65,3 +66,5 @@ void GenerateDSYMJobAction::anchor() {}
 void VerifyDebugInfoJobAction::anchor() {}
 
 void GeneratePCHJobAction::anchor() {}
+
+void VerifyModuleInterfaceJobAction::anchor() {}

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2208,6 +2208,26 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       TopLevelActions.push_back(MergeModuleAction);
     TopLevelActions.append(AllLinkerInputs.begin(), AllLinkerInputs.end());
   }
+
+  bool verifyInterfacesByDefault = false;
+
+  if (MergeModuleAction
+      && Args.hasFlag(options::OPT_verify_emitted_module_interface,
+                      options::OPT_no_verify_emitted_module_interface,
+                      verifyInterfacesByDefault)) {
+    if (Args.hasArgNoClaim(options::OPT_emit_module_interface,
+                           options::OPT_emit_module_interface_path)) {
+      TopLevelActions.push_back(
+          C.createAction<VerifyModuleInterfaceJobAction>(MergeModuleAction,
+              file_types::TY_SwiftModuleInterfaceFile));
+    }
+
+    if (Args.hasArgNoClaim(options::OPT_emit_private_module_interface_path)) {
+      TopLevelActions.push_back(
+          C.createAction<VerifyModuleInterfaceJobAction>(MergeModuleAction,
+              file_types::TY_PrivateSwiftModuleInterfaceFile));
+    }
+  }
 }
 
 bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2209,7 +2209,11 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     TopLevelActions.append(AllLinkerInputs.begin(), AllLinkerInputs.end());
   }
 
+#ifdef NDEBUG
   bool verifyInterfacesByDefault = false;
+#else
+  bool verifyInterfacesByDefault = true;
+#endif
 
   if (MergeModuleAction
       && Args.hasFlag(options::OPT_verify_emitted_module_interface,

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -111,6 +111,7 @@ std::unique_ptr<Job> ToolChain::constructJob(
       CASE(GeneratePCHJob)
       CASE(AutolinkExtractJob)
       CASE(REPLJob)
+      CASE(VerifyModuleInterfaceJob)
 #undef CASE
     case Action::Kind::Input:
       llvm_unreachable("not a JobAction");

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1048,6 +1048,41 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
 }
 
 ToolChain::InvocationInfo
+ToolChain::constructInvocation(const VerifyModuleInterfaceJobAction &job,
+                               const JobContext &context) const {
+  InvocationInfo II{SWIFT_EXECUTABLE_NAME};
+  ArgStringList &Arguments = II.Arguments;
+  II.allowsResponseFiles = true;
+
+  for (auto &s : getDriver().getSwiftProgramArgs())
+    Arguments.push_back(s.c_str());
+  Arguments.push_back("-frontend");
+
+  Arguments.push_back("-typecheck-module-from-interface");
+
+  size_t sizeBefore = Arguments.size();
+  addInputsOfType(Arguments, context.Inputs, context.Args, job.getInputType());
+
+  (void)sizeBefore;
+  assert(Arguments.size() - sizeBefore == 1 &&
+         "should verify exactly one module interface per job");
+
+  addCommonFrontendArgs(context.OI, context.Output, context.Args, Arguments);
+  addRuntimeLibraryFlags(context.OI, Arguments);
+
+  addOutputsOfType(Arguments, context.Output, context.Args,
+                   file_types::TY_SerializedDiagnostics,
+                   "-serialize-diagnostics-path");
+
+  context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);
+
+  Arguments.push_back("-module-name");
+  Arguments.push_back(context.Args.MakeArgString(context.OI.ModuleName));
+
+  return II;
+}
+
+ToolChain::InvocationInfo
 ToolChain::constructInvocation(const ModuleWrapJobAction &job,
                                const JobContext &context) const {
   InvocationInfo II{SWIFT_EXECUTABLE_NAME};

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -147,7 +147,8 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.RequestedAction = determineRequestedAction(Args);
   }
 
-  if (Opts.RequestedAction == FrontendOptions::ActionType::CompileModuleFromInterface) {
+  if (Opts.RequestedAction == FrontendOptions::ActionType::CompileModuleFromInterface ||
+      Opts.RequestedAction == FrontendOptions::ActionType::TypecheckModuleFromInterface) {
     // The situations where we use this action, e.g. explicit module building and
     // generating prebuilt module cache, don't need synchronization. We should avoid
     // using lock files for them.
@@ -389,6 +390,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::Immediate;
   if (Opt.matches(OPT_compile_module_from_interface))
     return FrontendOptions::ActionType::CompileModuleFromInterface;
+  if (Opt.matches(OPT_typecheck_module_from_interface))
+    return FrontendOptions::ActionType::TypecheckModuleFromInterface;
 
   llvm_unreachable("Unhandled mode option");
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -325,6 +325,8 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasArg(OPT_experimental_print_full_convention);
   Opts.ExperimentalSPIImports |=
     Args.hasArg(OPT_experimental_spi_imports);
+  Opts.DebugPrintInvalidSyntax |=
+    Args.hasArg(OPT_debug_emit_invalid_swiftinterface_syntax);
 }
 
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -192,7 +192,9 @@ void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
 
 bool CompilerInstance::setUpASTContextIfNeeded() {
   if (Invocation.getFrontendOptions().RequestedAction ==
-      FrontendOptions::ActionType::CompileModuleFromInterface) {
+          FrontendOptions::ActionType::CompileModuleFromInterface ||
+      Invocation.getFrontendOptions().RequestedAction ==
+          FrontendOptions::ActionType::TypecheckModuleFromInterface) {
     // Compiling a module interface from source uses its own CompilerInstance
     // with options read from the input file. Don't bother setting up an
     // ASTContext at this level.

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -51,6 +51,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::EmitModuleOnly:
   case ActionType::MergeModules:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
     return true;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -118,6 +119,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::Parse:
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -192,6 +194,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::DumpPCM:
@@ -232,6 +235,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitPCM:
@@ -280,6 +284,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitPCM:
@@ -317,6 +322,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitPCM:
@@ -360,6 +366,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::EmitSILGen:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitPCM:
@@ -404,6 +411,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitPCM:
@@ -450,6 +458,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::MergeModules:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
@@ -484,6 +493,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::Parse:
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -521,6 +531,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
@@ -557,6 +568,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::Typecheck:
   case ActionType::ResolveImports:
   case ActionType::MergeModules:

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -200,9 +200,9 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
             getSwiftInterfaceCompilerVersionForCurrentCompiler(
                 SubInstance.getASTContext());
         StringRef emittedByCompiler = info.CompilerVersion;
-        diagnose(diag::module_interface_build_failed, moduleName,
-                 emittedByCompiler == builtByCompiler, emittedByCompiler,
-                 builtByCompiler);
+        diagnose(diag::module_interface_build_failed, isTypeChecking,
+                 moduleName, emittedByCompiler == builtByCompiler,
+                 emittedByCompiler, builtByCompiler);
       }
     };
 

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -176,6 +176,8 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
       return false;
     }
     FrontendOptions &FEOpts = subInvocation.getFrontendOptions();
+    bool isTypeChecking =
+        (FEOpts.RequestedAction == FrontendOptions::ActionType::Typecheck);
     const auto &InputInfo = FEOpts.InputsAndOutputs.firstInput();
     StringRef InPath = InputInfo.file();
     const auto &OutputInfo =
@@ -242,6 +244,9 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     if (ShouldSerializeDeps)
       SerializationOpts.Dependencies = Deps;
     SILMod->setSerializeSILAction([&]() {
+      if (isTypeChecking)
+        return;
+
       // We don't want to serialize module docs in the cache -- they
       // will be serialized beside the interface file.
       serializeToBuffers(Mod, SerializationOpts, ModuleBuffer,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1259,7 +1259,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   inheritOptionsForBuildingInterface(searchPathOpts, langOpts);
   // Configure front-end input.
   auto &SubFEOpts = genericSubInvocation.getFrontendOptions();
-  SubFEOpts.RequestedAction = FrontendOptions::ActionType::EmitModuleOnly;
+  SubFEOpts.RequestedAction = LoaderOpts.requestedAction;
   if (!moduleCachePath.empty()) {
     genericSubInvocation.setClangModuleCachePath(moduleCachePath);
   }
@@ -1442,7 +1442,10 @@ bool InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleN
   std::vector<std::string> outputFiles{"/<unused>"};
   std::vector<SupplementaryOutputPaths> ModuleOutputPaths;
   ModuleOutputPaths.emplace_back();
-  ModuleOutputPaths.back().ModuleOutputPath = outputPath.str();
+  if (subInvocation.getFrontendOptions().RequestedAction ==
+          FrontendOptions::ActionType::EmitModuleOnly) {
+    ModuleOutputPaths.back().ModuleOutputPath = outputPath.str();
+  }
   assert(subInvocation.getFrontendOptions().InputsAndOutputs.isWholeModule());
   subInvocation.getFrontendOptions().InputsAndOutputs
     .setMainAndSupplementaryOutputs(outputFiles, ModuleOutputPaths);

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -551,5 +551,8 @@ bool swift::emitSwiftInterface(raw_ostream &out,
   if (needDummyProtocolDeclaration)
     InheritedProtocolCollector::printDummyProtocolDeclaration(out);
 
+  if (Opts.DebugPrintInvalidSyntax)
+    out << "#__debug_emit_invalid_swiftinterface_syntax__\n";
+
   return false;
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1711,7 +1711,8 @@ static bool performCompile(CompilerInstance &Instance,
       << Invocation.getLangOptions().Target.str() << '\n';
     return false;
   }
-  if (Action == FrontendOptions::ActionType::CompileModuleFromInterface)
+  if (Action == FrontendOptions::ActionType::CompileModuleFromInterface ||
+      Action == FrontendOptions::ActionType::TypecheckModuleFromInterface)
     return buildModuleFromInterface(Instance);
 
   if (Invocation.getInputKind() == InputFileKind::LLVM)

--- a/test/ModuleInterface/unbuildable.swift
+++ b/test/ModuleInterface/unbuildable.swift
@@ -14,8 +14,15 @@
 //
 // And finally, test:
 //
-// RUN: not %target-swift-frontend -typecheck %s -I %t -DCURRENT 2>&1 | %FileCheck -check-prefix=CURRENT %s
-// RUN: not %target-swift-frontend -typecheck %s -I %t -DFUTURE 2>&1 | %FileCheck -check-prefix=FUTURE %s
+// RUN: not %target-swift-frontend -typecheck %s -I %t -DCURRENT 2>&1 | %FileCheck -check-prefixes=ALL,CURRENT %s
+// RUN: not %target-swift-frontend -typecheck %s -I %t -DFUTURE 2>&1 | %FileCheck -check-prefixes=ALL,FUTURE %s
+//
+// Test that we get the same results when typechecking the interface:
+//
+// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableCurrent.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,CURRENT-PREBUILD %s
+// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableFuture.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,FUTURE-PREBUILD %s
+
+// ALL: Unbuildable{{[^.]+}}.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: use of unknown directive '#somethingYouveNeverHeardOf'
 
 #if CURRENT
 import UnbuildableCurrent
@@ -25,3 +32,5 @@ import UnbuildableFuture
 // FUTURE: unbuildable.swift:[[@LINE-1]]:8: error: failed to build module 'UnbuildableFuture' from its module interface; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'
 #endif
 
+// CURRENT-PREBUILD: UnbuildableCurrent.swiftinterface:1:1: error: failed to build module 'UnbuildableCurrent' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// FUTURE-PREBUILD: UnbuildableFuture.swiftinterface:1:1: error: failed to build module 'UnbuildableFuture' from its module interface; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'

--- a/test/ModuleInterface/unbuildable.swift
+++ b/test/ModuleInterface/unbuildable.swift
@@ -19,8 +19,8 @@
 //
 // Test that we get the same results when typechecking the interface:
 //
-// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableCurrent.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,CURRENT-PREBUILD %s
-// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableFuture.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,FUTURE-PREBUILD %s
+// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableCurrent.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,CURRENT-VERIFY %s
+// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableFuture.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,FUTURE-VERIFY %s
 
 // ALL: Unbuildable{{[^.]+}}.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: use of unknown directive '#somethingYouveNeverHeardOf'
 
@@ -32,5 +32,5 @@ import UnbuildableFuture
 // FUTURE: unbuildable.swift:[[@LINE-1]]:8: error: failed to build module 'UnbuildableFuture' from its module interface; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'
 #endif
 
-// CURRENT-PREBUILD: UnbuildableCurrent.swiftinterface:1:1: error: failed to build module 'UnbuildableCurrent' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
-// FUTURE-PREBUILD: UnbuildableFuture.swiftinterface:1:1: error: failed to build module 'UnbuildableFuture' from its module interface; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'
+// CURRENT-VERIFY: UnbuildableCurrent.swiftinterface:1:1: error: failed to verify module interface of 'UnbuildableCurrent'; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// FUTURE-VERIFY: UnbuildableFuture.swiftinterface:1:1: error: failed to verify module interface of 'UnbuildableFuture'; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'

--- a/test/ModuleInterface/verify-module-interfaces.swift
+++ b/test/ModuleInterface/verify-module-interfaces.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// Check that verification won't reject a valid interface:
+// RUN: %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/MyModule.o -verify-emitted-module-interface -module-name MyModule %s
+
+// Check that verification will reject an invalid interface:
+// RUN: not %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/MyModule.o -verify-emitted-module-interface -module-name MyModule -Xfrontend -debug-emit-invalid-swiftinterface-syntax %s 2>&1 | %FileCheck %s
+
+// ...but not if verification is off.
+// RUN: %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/MyModule.o -no-verify-emitted-module-interface -module-name MyModule -Xfrontend -debug-emit-invalid-swiftinterface-syntax %s
+
+public struct MyStruct {}
+
+// CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: use of unknown directive '#__debug_emit_invalid_swiftinterface_syntax__'
+// CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: failed to build module 'MyModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced

--- a/test/ModuleInterface/verify-module-interfaces.swift
+++ b/test/ModuleInterface/verify-module-interfaces.swift
@@ -12,4 +12,4 @@
 public struct MyStruct {}
 
 // CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: use of unknown directive '#__debug_emit_invalid_swiftinterface_syntax__'
-// CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: failed to build module 'MyModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: failed to verify module interface of 'MyModule'; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -140,14 +140,15 @@ static int run_driver(StringRef ExecName,
                                                 argv.data()+argv.size()),
                              argv[0], (void *)(intptr_t)getExecutablePath);
     }
-  }
 
-  // Run the integrated Swift frontend when called as "swift-frontend" but
-  // without a leading "-frontend".
-  if (ExecName == "swift-frontend") {
-    return performFrontend(llvm::makeArrayRef(argv.data()+1,
-                                              argv.data()+argv.size()),
-                           argv[0], (void *)(intptr_t)getExecutablePath);
+    // Run the integrated Swift frontend when called as "swift-frontend" but
+    // without a leading "-frontend".
+    if (!FirstArg.startswith("--driver-mode=")
+        && ExecName == "swift-frontend") {
+      return performFrontend(llvm::makeArrayRef(argv.data()+1,
+                                                argv.data()+argv.size()),
+                             argv[0], (void *)(intptr_t)getExecutablePath);
+    }
   }
 
   std::string Path = getExecutablePath(argv[0]);


### PR DESCRIPTION
This PR makes Swift verify module interfaces and private module interfaces after emitting them. To do this, it adds a new frontend mode, `-typecheck-module-from-interface`, and modifies the driver to optionally schedule a typechecking job for each emitted module interface after merge-modules.

~~This is currently done unconditionally, but I'll probably add some kind of flag later on to turn it on only when requested.~~ This extra verification step is enabled by default in assert compilers, but can be enabled in any compiler by passing the `-verify-emitted-module-interface` flag to the driver.

Fixes rdar://66710563.