### PR TITLE
[Constraint solver] Type check captures as part of the constraint system

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -229,6 +229,11 @@ public:
   /// TapExpr.
   virtual bool shouldWalkIntoTapExpression() { return true; }
 
+  /// This method configures whether the walker should visit the capture
+  /// initializer expressions within a capture list directly, rather than
+  /// walking the declarations.
+  virtual bool shouldWalkCaptureInitializerExpressions() { return false; }
+
   /// This method configures whether the walker should exhibit the legacy
   /// behavior where accessors appear as peers of their storage, rather
   /// than children nested inside of it.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1968,8 +1968,15 @@ bool ClosureExpr::hasEmptyBody() const {
 }
 
 bool ClosureExpr::capturesSelfEnablingImplictSelf() const {
-  if (auto *VD = getCapturedSelfDecl())
-    return VD->isSelfParamCapture() && !VD->getType()->is<WeakStorageType>();
+  if (auto *VD = getCapturedSelfDecl()) {
+    if (!VD->isSelfParamCapture())
+      return false;
+
+    if (auto *attr = VD->getAttrs().getAttribute<ReferenceOwnershipAttr>())
+      return attr->get() != ReferenceOwnership::Weak;
+
+    return true;
+  }
   return false;
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7649,6 +7649,13 @@ namespace {
         TapsToTypeCheck.push_back(std::make_pair(tap, Rewriter.dc));
       }
 
+      if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
+        // Rewrite captures.
+        for (const auto &capture : captureList->getCaptureList()) {
+          (void)rewriteTarget(SolutionApplicationTarget(capture.Init));
+        }
+      }
+
       Rewriter.walkToExprPre(expr);
       return { true, expr };
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2783,6 +2783,8 @@ namespace {
 
         CollectVarRefs(ConstraintSystem &cs) : cs(cs) { }
 
+        bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
         std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
           // If there are any error expressions in this closure
           // it wouldn't be possible to infer its type.
@@ -3723,6 +3725,16 @@ namespace {
         if (keyPath->isObjC()) {
           auto &cs = CG.getConstraintSystem();
           (void)TypeChecker::checkObjCKeyPathExpr(cs.DC, keyPath);
+        }
+      }
+
+      // Generate constraints for each of the entries in the capture list.
+      if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
+        auto &CS = CG.getConstraintSystem();
+        for (const auto &capture : captureList->getCaptureList()) {
+          SolutionApplicationTarget target(capture.Init);
+          if (CS.generateConstraints(target, FreeTypeVariableBinding::Disallow))
+            return {false, nullptr};
         }
       }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -96,6 +96,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       return false;
     }
 
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
     bool shouldWalkIntoTapExpression() override { return false; }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -1332,6 +1334,8 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
       return false;
     }
 
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
     bool shouldWalkIntoTapExpression() override { return false; }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -1505,6 +1509,8 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       return false;
     }
 
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
     bool shouldWalkIntoTapExpression() override { return false; }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -1514,7 +1520,6 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         if (isClosureRequiringSelfQualification(CE))
           Closures.push_back(CE);
       }
-
 
       // If we aren't in a closure, no diagnostics will be produced.
       if (Closures.size() == 0)
@@ -3332,6 +3337,8 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
       return false;
     }
 
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
     bool shouldWalkIntoTapExpression() override { return false; }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -3481,6 +3488,8 @@ public:
   bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
     return false;
   }
+
+  bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
   bool shouldWalkIntoTapExpression() override { return false; }
 
@@ -4222,6 +4231,8 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       return false;
     }
 
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
     bool shouldWalkIntoTapExpression() override { return false; }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -4297,6 +4308,8 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
     bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
       return false;
     }
+
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
     bool shouldWalkIntoTapExpression() override { return false; }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -504,3 +504,22 @@ var qux1: (() -> Void)? = {}
 
 SR9839(qux1!)
 SR9839(forceUnwrap(qux1))
+
+// rdar://problem/65155671 - crash referencing parameter of outer closure
+func rdar65155671(x: Int) {
+    { a in
+      _ = { [a] in a }
+    }(x)
+}
+
+func sr3186<T, U>(_ f: (@escaping (@escaping (T) -> U) -> ((T) -> U))) -> ((T) -> U) {
+    return { x in return f(sr3186(f))(x) }
+}
+
+class SR3186 {
+  init() {
+    // expected-warning@+1{{capture 'self' was never used}}
+    let v = sr3186 { f in { [unowned self, f] x in x != 1000 ? f(x + 1) : "success" } }(0)
+    print("\(v)")
+  }
+}


### PR DESCRIPTION
Rather than type-checking captures as separate declarations during
pre-check, generate constraints and apply solutions to captures in
the same manner as other pattern bindings within a constraint
system.

Fixes SR-3186 / rdar://problem/64647232.