### PR TITLE
[NFC] Rename ExtInfo::Uncommon to ExtInfo::ClangTypeInfo.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -342,7 +342,7 @@ protected:
     /// Extra information which affects how the function is called, like
     /// regparm and the calling convention.
     ExtInfoBits : NumAFTExtInfoBits,
-    HasUncommonInfo : 1,
+    HasClangTypeInfo : 1,
     : NumPadBits,
     NumParams : 16
   );
@@ -365,7 +365,7 @@ protected:
 
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+3+1+2+1+1,
     ExtInfoBits : NumSILExtInfoBits,
-    HasUncommonInfo : 1,
+    HasClangTypeInfo : 1,
     CalleeConvention : 3,
     HasErrorResult : 1,
     CoroutineKind : 2,
@@ -2987,7 +2987,7 @@ public:
     unsigned Bits; // Naturally sized for speed.
 
   public:
-    class Uncommon {
+    class ClangTypeInfo {
       friend ExtInfo;
       friend class AnyFunctionType;
       friend class FunctionType;
@@ -2996,27 +2996,26 @@ public:
       // 2. The actual type being stored is [ignoring sugar] either a
       //    clang::PointerType, a clang::BlockPointerType, or a
       //    clang::ReferenceType which points to a clang::FunctionType.
-      const clang::Type *ClangFunctionType;
+      const clang::Type *type;
 
-      bool empty() const { return !ClangFunctionType; }
-      Uncommon(const clang::Type *type) : ClangFunctionType(type) {}
+      bool empty() const { return !type; }
+      ClangTypeInfo(const clang::Type *type) : type(type) {}
 
     public:
       /// Use the ClangModuleLoader to print the Clang type as a string.
-      void printClangFunctionType(ClangModuleLoader *cml,
-                                  llvm::raw_ostream &os);
+      void printType(ClangModuleLoader *cml, llvm::raw_ostream &os) const;
     };
 
   private:
-    Uncommon Other;
+    ClangTypeInfo Other;
 
     static void assertIsFunctionType(const clang::Type *);
 
-    ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {
+      ExtInfo(unsigned Bits, ClangTypeInfo Other) : Bits(Bits), Other(Other) {
       // [TODO: Clang-type-plumbing] Assert that the pointer is non-null.
       auto Rep = Representation(Bits & RepresentationMask);
-      if ((Rep == Representation::CFunctionPointer) && Other.ClangFunctionType)
-        assertIsFunctionType(Other.ClangFunctionType);
+      if ((Rep == Representation::CFunctionPointer) && Other.type)
+        assertIsFunctionType(Other.type);
     }
 
     friend AnyFunctionType;
@@ -3045,7 +3044,7 @@ public:
                   | (Throws ? ThrowsMask : 0)
                   | (((unsigned)DiffKind << DifferentiabilityMaskOffset)
                      & DifferentiabilityMask),
-                Uncommon(type)) {
+                ClangTypeInfo(type)) {
     }
 
     bool isNoEscape() const { return Bits & NoEscapeMask; }
@@ -3065,9 +3064,9 @@ public:
       return Representation(rawRep);
     }
 
-    /// Return the underlying Uncommon value if it is not the default value.
-    Optional<Uncommon> getUncommonInfo() const {
-      return Other.empty() ? Optional<Uncommon>() : Other;
+    /// Get the underlying ClangTypeInfo value if it is not the default value.
+    Optional<ClangTypeInfo> getClangTypeInfo() const {
+      return Other.empty() ? Optional<ClangTypeInfo>() : Other;
     }
 
     bool hasSelfParam() const {
@@ -3124,7 +3123,7 @@ public:
     }
     LLVM_NODISCARD
     ExtInfo withClangFunctionType(const clang::Type *type) const {
-      return ExtInfo(Bits, Uncommon(type));
+      return ExtInfo(Bits, ClangTypeInfo(type));
     }
     LLVM_NODISCARD
     ExtInfo
@@ -3136,7 +3135,7 @@ public:
     }
 
     std::pair<unsigned, const void *> getFuncAttrKey() const {
-      return std::make_pair(Bits, Other.ClangFunctionType);
+      return std::make_pair(Bits, Other.type);
     }
     
     /// Put a SIL representation in the ExtInfo.
@@ -3166,13 +3165,13 @@ protected:
   /// Create an AnyFunctionType.
   ///
   /// Subclasses are responsible for storing and retrieving the
-  /// ExtInfo::Uncommon value if one is present.
+  /// ExtInfo::ClangTypeInfo value if one is present.
   AnyFunctionType(TypeKind Kind, const ASTContext *CanTypeContext,
                   Type Output, RecursiveTypeProperties properties,
                   unsigned NumParams, ExtInfo Info)
   : TypeBase(Kind, CanTypeContext, properties), Output(Output) {
     Bits.AnyFunctionType.ExtInfoBits = Info.Bits;
-    Bits.AnyFunctionType.HasUncommonInfo = Info.getUncommonInfo().hasValue();
+    Bits.AnyFunctionType.HasClangTypeInfo = Info.getClangTypeInfo().hasValue();
     Bits.AnyFunctionType.NumParams = NumParams;
     assert(Bits.AnyFunctionType.NumParams == NumParams && "Params dropped!");
     // The use of both assert() and static_assert() is intentional.
@@ -3216,7 +3215,7 @@ public:
   GenericSignature getOptGenericSignature() const;
   
   bool hasClangFunctionType() const {
-    return Bits.AnyFunctionType.HasUncommonInfo;
+    return Bits.AnyFunctionType.HasClangTypeInfo;
   }
 
   const clang::Type *getClangFunctionType() const;
@@ -3435,7 +3434,7 @@ inline AnyFunctionType::CanYield AnyFunctionType::Yield::getCanonical() const {
 class FunctionType final : public AnyFunctionType,
     public llvm::FoldingSetNode,
     private llvm::TrailingObjects<FunctionType, AnyFunctionType::Param,
-                                  AnyFunctionType::ExtInfo::Uncommon> {
+                                  AnyFunctionType::ExtInfo::ClangTypeInfo> {
   friend TrailingObjects;
       
 
@@ -3443,7 +3442,7 @@ class FunctionType final : public AnyFunctionType,
     return getNumParams();
   }
 
-  size_t numTrailingObjects(OverloadToken<ExtInfo::Uncommon>) const {
+  size_t numTrailingObjects(OverloadToken<ExtInfo::ClangTypeInfo>) const {
     return hasClangFunctionType() ? 1 : 0;
   }
 
@@ -3460,7 +3459,7 @@ public:
   const clang::Type *getClangFunctionType() const {
     if (!hasClangFunctionType())
       return nullptr;
-    auto *type = getTrailingObjects<ExtInfo::Uncommon>()->ClangFunctionType;
+    auto *type = getTrailingObjects<ExtInfo::ClangTypeInfo>()->type;
     assert(type && "If the pointer was null, we shouldn't have stored it.");
     return type;
   }
@@ -4218,7 +4217,7 @@ public:
 
     unsigned Bits; // Naturally sized for speed.
 
-    class Uncommon {
+    class ClangTypeInfo {
       friend ExtInfo;
       friend class SILFunctionType;
 
@@ -4228,22 +4227,21 @@ public:
       const clang::FunctionType *ClangFunctionType;
 
       bool empty() const { return !ClangFunctionType; }
-      Uncommon(const clang::FunctionType *type) : ClangFunctionType(type) {}
+      ClangTypeInfo(const clang::FunctionType *type) : ClangFunctionType(type) {}
 
     public:
-      /// Analog of AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType.
-      void printClangFunctionType(ClangModuleLoader *cml,
-                                  llvm::raw_ostream &os) const;
+      /// Analog of AnyFunctionType::ExtInfo::ClangTypeInfo::printType.
+      void printType(ClangModuleLoader *cml, llvm::raw_ostream &os) const;
     };
 
-    Uncommon Other;
+    ClangTypeInfo Other;
 
-    ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {}
+    ExtInfo(unsigned Bits, ClangTypeInfo Other) : Bits(Bits), Other(Other) {}
 
     friend class SILFunctionType;
   public:
     // Constructor with all defaults.
-    ExtInfo() : Bits(0), Other(Uncommon(nullptr)) { }
+    ExtInfo() : Bits(0), Other(ClangTypeInfo(nullptr)) { }
 
     // Constructor for polymorphic type.
     ExtInfo(Representation rep, bool isPseudogeneric, bool isNoEscape,
@@ -4254,7 +4252,7 @@ public:
                   | (isNoEscape ? NoEscapeMask : 0)
                   | (((unsigned)diffKind << DifferentiabilityMaskOffset)
                      & DifferentiabilityMask),
-                Uncommon(type)) {
+                ClangTypeInfo(type)) {
     }
 
     static ExtInfo getThin() {
@@ -4287,9 +4285,9 @@ public:
       return getSILFunctionLanguage(getRepresentation());
     }
 
-    /// Return the underlying Uncommon value if it is not the default value.
-    Optional<Uncommon> getUncommonInfo() const {
-      return Other.empty() ? Optional<Uncommon>() : Other;
+    /// Get the underlying ClangTypeInfo value if it is not the default value.
+    Optional<ClangTypeInfo> getClangTypeInfo() const {
+      return Other.empty() ? Optional<ClangTypeInfo>() : Other;
     }
 
     bool hasSelfParam() const {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3082,17 +3082,17 @@ FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,
     return funcTy;
   }
 
-  Optional<ExtInfo::Uncommon> uncommon = info.getUncommonInfo();
+  Optional<ExtInfo::ClangTypeInfo> clangTypeInfo = info.getClangTypeInfo();
 
   size_t allocSize =
-    totalSizeToAlloc<AnyFunctionType::Param, ExtInfo::Uncommon>(
-      params.size(), uncommon.hasValue() ? 1 : 0);
+    totalSizeToAlloc<AnyFunctionType::Param, ExtInfo::ClangTypeInfo>(
+      params.size(), clangTypeInfo.hasValue() ? 1 : 0);
   void *mem = ctx.Allocate(allocSize, alignof(FunctionType), arena);
 
   bool isCanonical = isFunctionTypeCanonical(params, result);
-  if (uncommon.hasValue()) {
+  if (clangTypeInfo.hasValue()) {
     if (ctx.LangOpts.UseClangFunctionTypes)
-      isCanonical &= uncommon->ClangFunctionType->isCanonicalUnqualified();
+      isCanonical &= clangTypeInfo->type->isCanonicalUnqualified();
     else
       isCanonical = false;
   }
@@ -3113,9 +3113,9 @@ FunctionType::FunctionType(ArrayRef<AnyFunctionType::Param> params,
                       output, properties, params.size(), info) {
   std::uninitialized_copy(params.begin(), params.end(),
                           getTrailingObjects<AnyFunctionType::Param>());
-  Optional<ExtInfo::Uncommon> uncommon = info.getUncommonInfo();
-  if (uncommon.hasValue())
-    *getTrailingObjects<ExtInfo::Uncommon>() = uncommon.getValue();
+  auto clangTypeInfo = info.getClangTypeInfo();
+  if (clangTypeInfo.hasValue())
+    *getTrailingObjects<ExtInfo::ClangTypeInfo>() = clangTypeInfo.getValue();
 }
 
 void GenericFunctionType::Profile(llvm::FoldingSetNodeID &ID,
@@ -3208,7 +3208,7 @@ ArrayRef<Requirement> GenericFunctionType::getRequirements() const {
   return Signature->getRequirements();
 }
 
-void SILFunctionType::ExtInfo::Uncommon::printClangFunctionType(
+void SILFunctionType::ExtInfo::ClangTypeInfo::printType(
     ClangModuleLoader *cml, llvm::raw_ostream &os) const {
   cml->printClangType(ClangFunctionType, os);
 }
@@ -3272,7 +3272,7 @@ SILFunctionType::SILFunctionType(
 
   Bits.SILFunctionType.HasErrorResult = errorResult.hasValue();
   Bits.SILFunctionType.ExtInfoBits = ext.Bits;
-  Bits.SILFunctionType.HasUncommonInfo = false;
+  Bits.SILFunctionType.HasClangTypeInfo = false;
   Bits.SILFunctionType.HasPatternSubs = (bool) patternSubs;
   Bits.SILFunctionType.HasInvocationSubs = (bool) invocationSubs;
   // The use of both assert() and static_assert() below is intentional.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3598,7 +3598,7 @@ void printCType(ASTContext &Ctx, ASTPrinter &Printer, ExtInfo &info) {
   auto *cml = Ctx.getClangModuleLoader();
   SmallString<64> buf;
   llvm::raw_svector_ostream os(buf);
-  info.getUncommonInfo().getValue().printClangFunctionType(cml, os);
+  info.getClangTypeInfo().getValue().printType(cml, os);
   Printer << ", cType: " << QuotedString(os.str());
 }
 
@@ -4020,7 +4020,7 @@ public:
       case SILFunctionType::Representation::CFunctionPointer:
         Printer << "c";
         // [TODO: Clang-type-plumbing] Remove the second check.
-        if (printNameOnly || !info.getUncommonInfo().hasValue())
+        if (printNameOnly || !info.getClangTypeInfo().hasValue())
           break;
         printCType(Ctx, Printer, info);
         break;
@@ -4086,7 +4086,7 @@ public:
       case SILFunctionType::Representation::CFunctionPointer:
         Printer << "c";
         // [TODO: Clang-type-plumbing] Remove the second check.
-        if (printNameOnly || !info.getUncommonInfo().hasValue())
+        if (printNameOnly || !info.getClangTypeInfo().hasValue())
           break;
         printCType(Ctx, Printer, info);
         break;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3369,9 +3369,9 @@ Type ProtocolCompositionType::get(const ASTContext &C,
   return build(C, CanTypes, HasExplicitAnyObject);
 }
 
-void AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType(
-    ClangModuleLoader *cml, llvm::raw_ostream &os) {
-  cml->printClangType(ClangFunctionType, os);
+void AnyFunctionType::ExtInfo::ClangTypeInfo::printType(
+    ClangModuleLoader *cml, llvm::raw_ostream &os) const {
+  cml->printClangType(type, os);
 }
 
 void


### PR DESCRIPTION
The previous name was poorly chosen (by me). Time to fix that.

I broke off this commit out of the ExtInfo builder-pattern refactoring (that one's pretty large, like 1k+, 1k-).