### PR TITLE
Refactor ExtInfo to use the builder pattern for construction.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -590,13 +590,9 @@ public:
   ///
   /// \param params The function parameters.
   /// \param resultTy The Swift result type.
-  /// \param incompleteExtInfo Used to convey escaping and throwing
-  ///                          information, in case it is needed.
   /// \param trueRep The actual calling convention, which must be C-compatible.
-  ///                The calling convention in \p incompleteExtInfo is ignored.
   const clang::Type *
   getClangFunctionType(ArrayRef<AnyFunctionType::Param> params, Type resultTy,
-                       const FunctionType::ExtInfo incompleteExtInfo,
                        FunctionTypeRepresentation trueRep);
 
   /// Get the Swift declaration that a Clang declaration was exported from,

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -1,0 +1,711 @@
+//===--- ExtInfo.h - Extended information for function types ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the ASTExtInfo and SILExtInfo classes, which are used to store
+// the calling convention and related information for function types in the AST
+// and SIL respectively. These types are lightweight and immutable; they are
+// constructed using builder-pattern style APIs to enforce invariants.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_EXTINFO_H
+#define SWIFT_EXTINFO_H
+
+#include "swift/AST/AutoDiff.h"
+#include "swift/AST/ClangModuleLoader.h"
+
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <utility>
+
+namespace clang {
+class Type;
+} // namespace clang
+
+namespace swift {
+class AnyFunctionType;
+class ASTExtInfo;
+class ASTExtInfoBuilder;
+class FunctionType;
+class SILExtInfo;
+class SILExtInfoBuilder;
+class SILFunctionType;
+} // namespace swift
+
+namespace swift {
+
+// MARK: - ClangTypeInfo
+/// Wrapper class for storing a clang::Type in an (AST|SIL)ExtInfo.
+class ClangTypeInfo {
+  friend AnyFunctionType;
+  friend FunctionType;
+  friend SILFunctionType;
+  friend ASTExtInfoBuilder;
+  friend SILExtInfoBuilder;
+
+  // We preserve a full clang::Type *, not a clang::FunctionType * as:
+  // 1. We need to keep sugar in case we need to present an error to the user
+  //    (for AnyFunctionType).
+  // 2. The actual type being stored is [ignoring sugar] either a
+  //    clang::PointerType, a clang::BlockPointerType, or a
+  //    clang::ReferenceType which points to a clang::FunctionType.
+  //
+  // When used as a part of SILFunctionType, the type is canonical.
+  const clang::Type *type;
+
+  constexpr ClangTypeInfo() : type(nullptr) {}
+  constexpr ClangTypeInfo(const clang::Type *type) : type(type) {}
+
+  ClangTypeInfo getCanonical() const;
+
+public:
+  constexpr const clang::Type *getType() const { return type; }
+
+  constexpr bool empty() const { return !type; }
+
+  /// Use the ClangModuleLoader to print the Clang type as a string.
+  void printType(ClangModuleLoader *cml, llvm::raw_ostream &os) const;
+
+  void dump(llvm::raw_ostream &os) const;
+};
+
+// MARK: - FunctionTypeRepresentation
+/// The representation form of a function.
+enum class FunctionTypeRepresentation : uint8_t {
+  /// A "thick" function that carries a context pointer to reference captured
+  /// state. The default native function representation.
+  Swift = 0,
+
+  /// A thick function that is represented as an Objective-C block.
+  Block,
+
+  /// A "thin" function that needs no context.
+  Thin,
+
+  /// A C function pointer (or reference), which is thin and also uses the C
+  /// calling convention.
+  CFunctionPointer,
+
+  /// The value of the greatest AST function representation.
+  Last = CFunctionPointer,
+};
+
+// MARK: - SILFunctionTypeRepresentation
+
+/// The representation form of a SIL function.
+///
+/// This is a superset of FunctionTypeRepresentation. The common representations
+/// must share an enum value.
+///
+/// TODO: The overlap of SILFunctionTypeRepresentation and
+/// FunctionTypeRepresentation is a total hack necessitated by the way SIL
+/// TypeLowering is currently written. We ought to refactor TypeLowering so that
+/// it is not necessary to distinguish these cases.
+enum class SILFunctionTypeRepresentation : uint8_t {
+  /// A freestanding thick function.
+  Thick = uint8_t(FunctionTypeRepresentation::Swift),
+
+  /// A thick function that is represented as an Objective-C block.
+  Block = uint8_t(FunctionTypeRepresentation::Block),
+
+  /// A freestanding thin function that needs no context.
+  Thin = uint8_t(FunctionTypeRepresentation::Thin),
+
+  /// A C function pointer, which is thin and also uses the C calling
+  /// convention.
+  CFunctionPointer = uint8_t(FunctionTypeRepresentation::CFunctionPointer),
+
+  /// The value of the greatest AST function representation.
+  LastAST = CFunctionPointer,
+
+  /// The value of the least SIL-only function representation.
+  FirstSIL = 8,
+
+  /// A Swift instance method.
+  Method = FirstSIL,
+
+  /// An Objective-C method.
+  ObjCMethod,
+
+  /// A Swift protocol witness.
+  WitnessMethod,
+
+  /// A closure invocation function that has not been bound to a context.
+  Closure,
+};
+
+/// Can this calling convention result in a function being called indirectly
+/// through the runtime.
+constexpr bool canBeCalledIndirectly(SILFunctionTypeRepresentation rep) {
+  switch (rep) {
+  case SILFunctionTypeRepresentation::Thick:
+  case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+  case SILFunctionTypeRepresentation::Block:
+  case SILFunctionTypeRepresentation::Closure:
+    return false;
+  case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::Method:
+  case SILFunctionTypeRepresentation::WitnessMethod:
+    return true;
+  }
+
+  llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
+}
+
+// MARK: - ASTExtInfoBuilder
+/// A builder type for creating an \c ASTExtInfo.
+///
+/// The main API public includes the \c withXYZ and \p build() methods.
+class ASTExtInfoBuilder {
+  friend AnyFunctionType;
+  friend ASTExtInfo;
+
+  // If bits are added or removed, then TypeBase::AnyFunctionTypeBits
+  // and NumMaskBits must be updated, and they must match.
+  //
+  //   |representation|noEscape|async|throws|differentiability|
+  //   |    0 .. 3    |    4   |  5  |   6  |      7 .. 8     |
+  //
+  enum : unsigned {
+    RepresentationMask = 0xF << 0,
+    NoEscapeMask = 1 << 4,
+    AsyncMask = 1 << 5,
+    ThrowsMask = 1 << 6,
+    DifferentiabilityMaskOffset = 7,
+    DifferentiabilityMask = 0x3 << DifferentiabilityMaskOffset,
+    NumMaskBits = 9
+  };
+
+  unsigned bits; // Naturally sized for speed.
+
+  ClangTypeInfo clangTypeInfo;
+
+  using Representation = FunctionTypeRepresentation;
+
+  static void assertIsFunctionType(const clang::Type *);
+
+  ASTExtInfoBuilder(unsigned bits, ClangTypeInfo clangTypeInfo)
+      : bits(bits), clangTypeInfo(clangTypeInfo) {
+    // TODO: [clang-function-type-serialization] Once we start serializing
+    // the Clang type, we should also assert that the pointer is non-null.
+    auto Rep = Representation(bits & RepresentationMask);
+    if ((Rep == Representation::CFunctionPointer) && clangTypeInfo.type)
+      assertIsFunctionType(clangTypeInfo.type);
+  }
+
+public:
+  // Constructor with all defaults.
+  ASTExtInfoBuilder()
+      : ASTExtInfoBuilder(Representation::Swift, false, false,
+                          DifferentiabilityKind::NonDifferentiable, nullptr) {}
+
+  // Constructor for polymorphic type.
+  ASTExtInfoBuilder(Representation rep, bool throws)
+      : ASTExtInfoBuilder(rep, false, throws,
+                          DifferentiabilityKind::NonDifferentiable, nullptr) {}
+
+  // Constructor with no defaults.
+  ASTExtInfoBuilder(Representation rep, bool isNoEscape, bool throws,
+                    DifferentiabilityKind diffKind, const clang::Type *type)
+      : ASTExtInfoBuilder(
+            ((unsigned)rep) | (isNoEscape ? NoEscapeMask : 0) |
+                (throws ? ThrowsMask : 0) |
+                (((unsigned)diffKind << DifferentiabilityMaskOffset) &
+                 DifferentiabilityMask),
+            ClangTypeInfo(type)) {}
+
+  void checkInvariants() const;
+
+  /// Check if \c this is well-formed and create an ExtInfo.
+  ASTExtInfo build() const;
+
+  constexpr Representation getRepresentation() const {
+    unsigned rawRep = bits & RepresentationMask;
+    assert(rawRep <= unsigned(Representation::Last) &&
+           "unexpected SIL representation");
+    return Representation(rawRep);
+  }
+
+  constexpr bool isNoEscape() const { return bits & NoEscapeMask; }
+
+  constexpr bool async() const { return bits & AsyncMask; }
+
+  constexpr bool throws() const { return bits & ThrowsMask; }
+
+  constexpr DifferentiabilityKind getDifferentiabilityKind() const {
+    return DifferentiabilityKind((bits & DifferentiabilityMask) >>
+                                 DifferentiabilityMaskOffset);
+  }
+
+  constexpr bool isDifferentiable() const {
+    return getDifferentiabilityKind() >
+           DifferentiabilityKind::NonDifferentiable;
+  }
+
+  /// Get the underlying ClangTypeInfo value if it is not the default value.
+  Optional<ClangTypeInfo> getClangTypeInfo() const {
+    return clangTypeInfo.empty() ? Optional<ClangTypeInfo>() : clangTypeInfo;
+  }
+
+  constexpr SILFunctionTypeRepresentation getSILRepresentation() const {
+    unsigned rawRep = bits & RepresentationMask;
+    return SILFunctionTypeRepresentation(rawRep);
+  }
+
+  constexpr bool hasSelfParam() const {
+    switch (getSILRepresentation()) {
+    case SILFunctionTypeRepresentation::Thick:
+    case SILFunctionTypeRepresentation::Block:
+    case SILFunctionTypeRepresentation::Thin:
+    case SILFunctionTypeRepresentation::CFunctionPointer:
+    case SILFunctionTypeRepresentation::Closure:
+      return false;
+    case SILFunctionTypeRepresentation::ObjCMethod:
+    case SILFunctionTypeRepresentation::Method:
+    case SILFunctionTypeRepresentation::WitnessMethod:
+      return true;
+    }
+    llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
+  }
+
+  /// True if the function representation carries context.
+  constexpr bool hasContext() const {
+    switch (getSILRepresentation()) {
+    case SILFunctionTypeRepresentation::Thick:
+    case SILFunctionTypeRepresentation::Block:
+      return true;
+    case SILFunctionTypeRepresentation::Thin:
+    case SILFunctionTypeRepresentation::Method:
+    case SILFunctionTypeRepresentation::ObjCMethod:
+    case SILFunctionTypeRepresentation::WitnessMethod:
+    case SILFunctionTypeRepresentation::CFunctionPointer:
+    case SILFunctionTypeRepresentation::Closure:
+      return false;
+    }
+    llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
+  }
+
+  // Note that we don't have setters. That is by design, use
+  // the following with methods instead of mutating these objects.
+  LLVM_NODISCARD
+  ASTExtInfoBuilder withRepresentation(Representation rep) const {
+    return ASTExtInfoBuilder((bits & ~RepresentationMask) | (unsigned)rep,
+                             clangTypeInfo);
+  }
+  LLVM_NODISCARD
+  ASTExtInfoBuilder withNoEscape(bool noEscape = true) const {
+    return ASTExtInfoBuilder(noEscape ? (bits | NoEscapeMask)
+                                      : (bits & ~NoEscapeMask),
+                             clangTypeInfo);
+  }
+  LLVM_NODISCARD
+  ASTExtInfoBuilder withAsync(bool async = true) const {
+    return ASTExtInfoBuilder(async ? (bits | AsyncMask)
+                                   : (bits & ~AsyncMask),
+                             clangTypeInfo);
+  }
+  LLVM_NODISCARD
+  ASTExtInfoBuilder withThrows(bool throws = true) const {
+    return ASTExtInfoBuilder(
+        throws ? (bits | ThrowsMask) : (bits & ~ThrowsMask), clangTypeInfo);
+  }
+  LLVM_NODISCARD
+  ASTExtInfoBuilder
+  withDifferentiabilityKind(DifferentiabilityKind differentiability) const {
+    return ASTExtInfoBuilder(
+        (bits & ~DifferentiabilityMask) |
+            ((unsigned)differentiability << DifferentiabilityMaskOffset),
+        clangTypeInfo);
+  }
+  LLVM_NODISCARD
+  ASTExtInfoBuilder withClangFunctionType(const clang::Type *type) const {
+    return ASTExtInfoBuilder(bits, ClangTypeInfo(type));
+  }
+
+  /// Put a SIL representation in the ExtInfo.
+  ///
+  /// SIL type lowering transiently generates AST function types with SIL
+  /// representations. However, they shouldn't persist in the AST, and
+  /// don't need to be parsed, printed, or serialized.
+  LLVM_NODISCARD
+  ASTExtInfoBuilder
+  withSILRepresentation(SILFunctionTypeRepresentation rep) const {
+    return ASTExtInfoBuilder((bits & ~RepresentationMask) | (unsigned)rep,
+                             clangTypeInfo);
+  }
+
+  std::pair<unsigned, const void *> getFuncAttrKey() const {
+    return std::make_pair(bits, clangTypeInfo.getType());
+  }
+}; // end ASTExtInfoBuilder
+
+// MARK: - ASTExtInfo
+/// Calling convention and related information for AnyFunctionType + subclasses.
+///
+/// New instances can be made from existing instances via \c ASTExtInfoBuilder,
+/// typically using a code pattern like:
+/// \code
+/// extInfo.intoBuilder().withX(x).withY(y).build()
+/// \endcode
+class ASTExtInfo {
+  friend ASTExtInfoBuilder;
+  friend AnyFunctionType;
+
+  ASTExtInfoBuilder builder;
+
+  ASTExtInfo(ASTExtInfoBuilder builder) : builder(builder) {}
+  ASTExtInfo(unsigned bits, ClangTypeInfo clangTypeInfo)
+      : builder(bits, clangTypeInfo){};
+
+public:
+  ASTExtInfo() : builder(){};
+
+  /// Create a builder with the same state as \c this.
+  ASTExtInfoBuilder intoBuilder() const { return builder; }
+
+private:
+  constexpr unsigned getBits() const { return builder.bits; }
+
+public:
+  constexpr FunctionTypeRepresentation getRepresentation() const {
+    return builder.getRepresentation();
+  }
+
+  constexpr SILFunctionTypeRepresentation getSILRepresentation() const {
+    return builder.getSILRepresentation();
+  }
+
+  constexpr bool isNoEscape() const { return builder.isNoEscape(); }
+
+  constexpr bool async() const { return builder.async(); }
+
+  constexpr bool throws() const { return builder.throws(); }
+
+  constexpr DifferentiabilityKind getDifferentiabilityKind() const {
+    return builder.getDifferentiabilityKind();
+  }
+
+  constexpr bool isDifferentiable() const { return builder.isDifferentiable(); }
+
+  Optional<ClangTypeInfo> getClangTypeInfo() const {
+    return builder.getClangTypeInfo();
+  }
+
+  constexpr bool hasSelfParam() const { return builder.hasSelfParam(); }
+
+  constexpr bool hasContext() const { return builder.hasContext(); }
+
+  /// Helper method for changing the representation.
+  ///
+  /// Prefer using \c ASTExtInfoBuilder::withRepresentation for chaining.
+  LLVM_NODISCARD
+  ASTExtInfo withRepresentation(ASTExtInfoBuilder::Representation rep) const {
+    return builder.withRepresentation(rep).build();
+  }
+
+  /// Helper method for changing only the noEscape field.
+  ///
+  /// Prefer using \c ASTExtInfoBuilder::withNoEscape for chaining.
+  LLVM_NODISCARD
+  ASTExtInfo withNoEscape(bool noEscape = true) const {
+    return builder.withNoEscape(noEscape).build();
+  }
+
+  /// Helper method for changing only the throws field.
+  ///
+  /// Prefer using \c ASTExtInfoBuilder::withThrows for chaining.
+  LLVM_NODISCARD
+  ASTExtInfo withThrows(bool throws = true) const {
+    return builder.withThrows(throws).build();
+  }
+
+  bool operator==(ASTExtInfo other) const {
+    return builder.bits == other.builder.bits;
+  }
+  bool operator!=(ASTExtInfo other) const {
+    return builder.bits != other.builder.bits;
+  }
+
+  constexpr std::pair<unsigned, const void *> getFuncAttrKey() const {
+    return builder.getFuncAttrKey();
+  }
+}; // end ASTExtInfo
+
+// MARK: - SILFunctionLanguage
+
+/// A language-level calling convention.
+enum class SILFunctionLanguage : uint8_t {
+  /// A variation of the Swift calling convention.
+  Swift = 0,
+
+  /// A variation of the C calling convention.
+  C,
+};
+
+/// Map a SIL function representation to the base language calling convention
+/// it uses.
+constexpr
+SILFunctionLanguage getSILFunctionLanguage(SILFunctionTypeRepresentation rep) {
+  switch (rep) {
+  case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+  case SILFunctionTypeRepresentation::Block:
+    return SILFunctionLanguage::C;
+  case SILFunctionTypeRepresentation::Thick:
+  case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::Method:
+  case SILFunctionTypeRepresentation::WitnessMethod:
+  case SILFunctionTypeRepresentation::Closure:
+    return SILFunctionLanguage::Swift;
+  }
+
+  llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
+}
+
+// MARK: - SILExtInfoBuilder
+/// A builder type for creating an \c SILExtInfo.
+///
+/// The main API public includes the \c withXYZ and \p build() methods.
+class SILExtInfoBuilder {
+  friend SILExtInfo;
+  friend SILFunctionType;
+
+  // If bits are added or removed, then TypeBase::SILFunctionTypeBits
+  // and NumMaskBits must be updated, and they must match.
+
+  //   |representation|pseudogeneric| noescape |differentiability|
+  //   |    0 .. 3    |      4      |     5    |      6 .. 7     |
+  //
+  enum : unsigned {
+    RepresentationMask = 0xF << 0,
+    PseudogenericMask = 1 << 4,
+    NoEscapeMask = 1 << 5,
+    DifferentiabilityMaskOffset = 6,
+    DifferentiabilityMask = 0x3 << DifferentiabilityMaskOffset,
+    NumMaskBits = 8
+  };
+
+  unsigned bits; // Naturally sized for speed.
+
+  ClangTypeInfo clangTypeInfo;
+
+  using Language = SILFunctionLanguage;
+  using Representation = SILFunctionTypeRepresentation;
+
+  SILExtInfoBuilder(unsigned bits, ClangTypeInfo clangTypeInfo)
+      : bits(bits), clangTypeInfo(clangTypeInfo) {}
+
+public:
+  // Constructor with all defaults.
+  SILExtInfoBuilder() : bits(0), clangTypeInfo(ClangTypeInfo(nullptr)) {}
+
+  // Constructor for polymorphic type.
+  SILExtInfoBuilder(Representation rep, bool isPseudogeneric, bool isNoEscape,
+                    DifferentiabilityKind diffKind, const clang::Type *type)
+      : SILExtInfoBuilder(
+            ((unsigned)rep) | (isPseudogeneric ? PseudogenericMask : 0) |
+                (isNoEscape ? NoEscapeMask : 0) |
+                (((unsigned)diffKind << DifferentiabilityMaskOffset) &
+                 DifferentiabilityMask),
+            ClangTypeInfo(type)) {}
+
+  void checkInvariants() const;
+
+  /// Check if \c this is well-formed and create an ExtInfo.
+  SILExtInfo build() const;
+
+  /// What is the abstract representation of this function value?
+  constexpr Representation getRepresentation() const {
+    return Representation(bits & RepresentationMask);
+  }
+
+  constexpr Language getLanguage() const {
+    return getSILFunctionLanguage(getRepresentation());
+  }
+
+  /// Is this function pseudo-generic?  A pseudo-generic function
+  /// is not permitted to dynamically depend on its type arguments.
+  constexpr bool isPseudogeneric() const { return bits & PseudogenericMask; }
+
+  // Is this function guaranteed to be no-escape by the type system?
+  constexpr bool isNoEscape() const { return bits & NoEscapeMask; }
+
+  constexpr DifferentiabilityKind getDifferentiabilityKind() const {
+    return DifferentiabilityKind((bits & DifferentiabilityMask) >>
+                                 DifferentiabilityMaskOffset);
+  }
+
+  constexpr bool isDifferentiable() const {
+    return getDifferentiabilityKind() !=
+           DifferentiabilityKind::NonDifferentiable;
+  }
+
+  /// Get the underlying ClangTypeInfo value if it is not the default value.
+  Optional<ClangTypeInfo> getClangTypeInfo() const {
+    return clangTypeInfo.empty() ? Optional<ClangTypeInfo>() : clangTypeInfo;
+  }
+
+  constexpr bool hasSelfParam() const {
+    switch (getRepresentation()) {
+    case Representation::Thick:
+    case Representation::Block:
+    case Representation::Thin:
+    case Representation::CFunctionPointer:
+    case Representation::Closure:
+      return false;
+    case Representation::ObjCMethod:
+    case Representation::Method:
+    case Representation::WitnessMethod:
+      return true;
+    }
+    llvm_unreachable("Unhandled Representation in switch.");
+  }
+
+  /// True if the function representation carries context.
+  constexpr bool hasContext() const {
+    switch (getRepresentation()) {
+    case Representation::Thick:
+    case Representation::Block:
+      return true;
+    case Representation::Thin:
+    case Representation::CFunctionPointer:
+    case Representation::ObjCMethod:
+    case Representation::Method:
+    case Representation::WitnessMethod:
+    case Representation::Closure:
+      return false;
+    }
+    llvm_unreachable("Unhandled Representation in switch.");
+  }
+
+  // Note that we don't have setters. That is by design, use
+  // the following with methods instead of mutating these objects.
+  SILExtInfoBuilder withRepresentation(Representation rep) const {
+    return SILExtInfoBuilder((bits & ~RepresentationMask) | (unsigned)rep,
+                             clangTypeInfo);
+  }
+  SILExtInfoBuilder withIsPseudogeneric(bool isPseudogeneric = true) const {
+    return SILExtInfoBuilder(isPseudogeneric ? (bits | PseudogenericMask)
+                                             : (bits & ~PseudogenericMask),
+                             clangTypeInfo);
+  }
+  SILExtInfoBuilder withNoEscape(bool noEscape = true) const {
+    return SILExtInfoBuilder(noEscape ? (bits | NoEscapeMask)
+                                      : (bits & ~NoEscapeMask),
+                             clangTypeInfo);
+  }
+  SILExtInfoBuilder
+  withDifferentiabilityKind(DifferentiabilityKind differentiability) const {
+    return SILExtInfoBuilder(
+        (bits & ~DifferentiabilityMask) |
+            ((unsigned)differentiability << DifferentiabilityMaskOffset),
+        clangTypeInfo);
+  }
+
+  std::pair<unsigned, const void *> getFuncAttrKey() const {
+    return std::make_pair(bits, clangTypeInfo.getType());
+  }
+}; // end SILExtInfoBuilder
+
+// MARK: - SILExtInfo
+/// Calling convention information for SILFunctionType.
+///
+/// New instances can be made from existing instances via \c SILExtInfoBuilder,
+/// typically using a code pattern like:
+/// \code
+/// extInfo.intoBuilder().withX(x).withY(y).build()
+/// \endcode
+class SILExtInfo {
+  friend SILExtInfoBuilder;
+  friend SILFunctionType;
+
+  SILExtInfoBuilder builder;
+
+  SILExtInfo(SILExtInfoBuilder builder) : builder(builder) {}
+  SILExtInfo(unsigned bits, ClangTypeInfo clangTypeInfo)
+      : builder(bits, clangTypeInfo){};
+
+public:
+  SILExtInfo() : builder(){};
+
+  static SILExtInfo getThin() {
+    return SILExtInfoBuilder(SILExtInfoBuilder::Representation::Thin, false,
+                             false, DifferentiabilityKind::NonDifferentiable,
+                             nullptr)
+        .build();
+  }
+
+  /// Create a builder with the same state as \c this.
+  SILExtInfoBuilder intoBuilder() const { return builder; }
+
+private:
+  constexpr unsigned getBits() const { return builder.bits; }
+
+public:
+  constexpr SILFunctionTypeRepresentation getRepresentation() const {
+    return builder.getRepresentation();
+  }
+
+  constexpr SILFunctionLanguage getLanguage() const {
+    return builder.getLanguage();
+  }
+
+  constexpr bool isPseudogeneric() const { return builder.isPseudogeneric(); }
+
+  constexpr bool isNoEscape() const { return builder.isNoEscape(); }
+
+  constexpr DifferentiabilityKind getDifferentiabilityKind() const {
+    return builder.getDifferentiabilityKind();
+  }
+
+  constexpr bool isDifferentiable() const { return builder.isDifferentiable(); }
+
+  Optional<ClangTypeInfo> getClangTypeInfo() const {
+    return builder.getClangTypeInfo();
+  }
+
+  constexpr bool hasSelfParam() const { return builder.hasSelfParam(); }
+
+  constexpr bool hasContext() const { return builder.hasContext(); }
+
+  /// Helper method for changing the Representation.
+  ///
+  /// Prefer using \c SILExtInfoBuilder::withRepresentation for chaining.
+  SILExtInfo withRepresentation(SILExtInfoBuilder::Representation rep) const {
+    return builder.withRepresentation(rep).build();
+  }
+
+  /// Helper method for changing only the NoEscape field.
+  ///
+  /// Prefer using \c SILExtInfoBuilder::withNoEscape for chaining.
+  SILExtInfo withNoEscape(bool noEscape = true) const {
+    return builder.withNoEscape(noEscape).build();
+  }
+
+  bool operator==(SILExtInfo other) const {
+    return builder.bits == other.builder.bits;
+  }
+  bool operator!=(SILExtInfo other) const {
+    return builder.bits != other.builder.bits;
+  }
+
+
+  constexpr std::pair<unsigned, const void *> getFuncAttrKey() const {
+    return builder.getFuncAttrKey();
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_EXTINFO_H

--- a/include/swift/AST/TypeDifferenceVisitor.h
+++ b/include/swift/AST/TypeDifferenceVisitor.h
@@ -214,7 +214,7 @@ public:
 
   bool visitAnyFunctionType(CanAnyFunctionType type1,
                             CanAnyFunctionType type2) {
-    if (type1->getExtInfo() != type2->getExtInfo())
+    if (!type1->hasSameExtInfoAs(type2))
       return asImpl().visitDifferentTypeStructure(type1, type2);
 
     if (asImpl().visit(type1.getResult(), type2.getResult()))
@@ -242,10 +242,10 @@ public:
 
   bool visitSILFunctionTypeStructure(CanSILFunctionType type1,
                                      CanSILFunctionType type2) {
-    if (type1->getExtInfo() != type2->getExtInfo() ||
+    if (!type1->hasSameExtInfoAs(type2) ||
         type1->getCoroutineKind() != type2->getCoroutineKind() ||
-        type1->getInvocationGenericSignature()
-          != type2->getInvocationGenericSignature())
+        type1->getInvocationGenericSignature() !=
+            type2->getInvocationGenericSignature())
       return asImpl().visitDifferentTypeStructure(type1, type2);
     return false;
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2932,6 +2932,8 @@ public:
                                         : ClangTypeInfo());
   }
 
+  bool hasSameExtInfoAs(const AnyFunctionType *otherFn);
+
   /// Get the representation of the function type.
   Representation getRepresentation() const {
     return getExtInfo().getRepresentation();
@@ -4294,6 +4296,8 @@ public:
   }
 
   ClangTypeInfo getClangTypeInfo() const;
+
+  bool hasSameExtInfoAs(const SILFunctionType *otherFn);
 
   /// Given that `this` is a `@differentiable` or `@differentiable(linear)`
   /// function type, returns an `IndexSubset` corresponding to the

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/DeclContext.h"
+#include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Ownership.h"
@@ -42,11 +43,6 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TrailingObjects.h"
-
-namespace clang {
-class Type;
-class FunctionType;
-} // namespace clang
 
 namespace llvm {
 struct fltSemantics;
@@ -2688,116 +2684,6 @@ BEGIN_CAN_TYPE_WRAPPER(DynamicSelfType, Type)
   }
 END_CAN_TYPE_WRAPPER(DynamicSelfType, Type)
 
-/// A language-level calling convention.
-enum class SILFunctionLanguage : uint8_t {
-  /// A variation of the Swift calling convention.
-  Swift = 0,
-
-  /// A variation of the C calling convention.
-  C,
-};
-
-/// The representation form of a function.
-enum class FunctionTypeRepresentation : uint8_t {
-  /// A "thick" function that carries a context pointer to reference captured
-  /// state. The default native function representation.
-  Swift = 0,
-  
-  /// A thick function that is represented as an Objective-C block.
-  Block,
-  
-  /// A "thin" function that needs no context.
-  Thin,
-  
-  /// A C function pointer (or reference), which is thin and also uses the C
-  /// calling convention.
-  CFunctionPointer,
-
-  /// The value of the greatest AST function representation.
-  Last = CFunctionPointer,
-};
-
-/// The representation form of a SIL function.
-///
-/// This is a superset of FunctionTypeRepresentation. The common representations
-/// must share an enum value.
-///
-/// TODO: The overlap of SILFunctionTypeRepresentation and
-/// FunctionTypeRepresentation is a total hack necessitated by the way SIL
-/// TypeLowering is currently written. We ought to refactor TypeLowering so that
-/// it is not necessary to distinguish these cases.
-enum class SILFunctionTypeRepresentation : uint8_t {
-  /// A freestanding thick function.
-  Thick = uint8_t(FunctionTypeRepresentation::Swift),
-  
-  /// A thick function that is represented as an Objective-C block.
-  Block = uint8_t(FunctionTypeRepresentation::Block),
-  
-  /// A freestanding thin function that needs no context.
-  Thin = uint8_t(FunctionTypeRepresentation::Thin),
-  
-  /// A C function pointer, which is thin and also uses the C calling
-  /// convention.
-  CFunctionPointer = uint8_t(FunctionTypeRepresentation::CFunctionPointer),
-  
-  /// The value of the greatest AST function representation.
-  LastAST = CFunctionPointer,
-
-  /// The value of the least SIL-only function representation.
-  FirstSIL = 8,
-  
-  /// A Swift instance method.
-  Method = FirstSIL,
-  
-  /// An Objective-C method.
-  ObjCMethod,
-  
-  /// A Swift protocol witness.
-  WitnessMethod,
-  
-  /// A closure invocation function that has not been bound to a context.
-  Closure,
-};
-
-/// Can this calling convention result in a function being called indirectly
-/// through the runtime.
-inline bool canBeCalledIndirectly(SILFunctionTypeRepresentation rep) {
-  switch (rep) {
-  case SILFunctionTypeRepresentation::Thick:
-  case SILFunctionTypeRepresentation::Thin:
-  case SILFunctionTypeRepresentation::CFunctionPointer:
-  case SILFunctionTypeRepresentation::Block:
-  case SILFunctionTypeRepresentation::Closure:
-    return false;
-  case SILFunctionTypeRepresentation::ObjCMethod:
-  case SILFunctionTypeRepresentation::Method:
-  case SILFunctionTypeRepresentation::WitnessMethod:
-    return true;
-  }
-
-  llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
-}
-
-/// Map a SIL function representation to the base language calling convention
-/// it uses.
-inline SILFunctionLanguage
-getSILFunctionLanguage(SILFunctionTypeRepresentation rep) {
-  switch (rep) {
-  case SILFunctionTypeRepresentation::ObjCMethod:
-  case SILFunctionTypeRepresentation::CFunctionPointer:
-  case SILFunctionTypeRepresentation::Block:
-    return SILFunctionLanguage::C;
-  case SILFunctionTypeRepresentation::Thick:
-  case SILFunctionTypeRepresentation::Thin:
-  case SILFunctionTypeRepresentation::Method:
-  case SILFunctionTypeRepresentation::WitnessMethod:
-  case SILFunctionTypeRepresentation::Closure:
-    return SILFunctionLanguage::Swift;
-  }
-
-  llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
-}
-
 /// AnyFunctionType - A function type has zero or more input parameters and a
 /// single result. The result type may be a tuple. For example:
 ///   "(int) -> int" or "(a : int, b : int) -> (int, int)".
@@ -2914,6 +2800,8 @@ public:
     }
   };
 
+  using ExtInfo = swift::ASTExtInfo;
+  using ExtInfoBuilder = swift::ASTExtInfoBuilder;
   using CanParamArrayRef =
     ArrayRefView<Param,CanParam,CanParam::getFromParam,/*AccessOriginal*/true>;
   
@@ -2969,226 +2857,25 @@ public:
     }
   };
 
-  /// A class which abstracts out some details necessary for
-  /// making a call.
-  class ExtInfo {
-    // If bits are added or removed, then TypeBase::NumAFTExtInfoBits
-    // and NumMaskBits must be updated, and they must match.
-    //
-    //   |representation|noEscape|throws|differentiability|
-    //   |    0 .. 3    |    4   |   5  |      6 .. 7     |
-    //
-    enum : unsigned {
-      RepresentationMask          = 0xF << 0,
-      NoEscapeMask                = 1 << 4,
-      AsyncMask                   = 1 << 5,
-      ThrowsMask                  = 1 << 6,
-      DifferentiabilityMaskOffset = 7,
-      DifferentiabilityMask       = 0x3 << DifferentiabilityMaskOffset,
-      NumMaskBits                 = 9
-    };
-
-    unsigned Bits; // Naturally sized for speed.
-
-  public:
-    class ClangTypeInfo {
-      friend ExtInfo;
-      friend class AnyFunctionType;
-      friend class FunctionType;
-      // We preserve a full clang::Type *, not a clang::FunctionType * as:
-      // 1. We need to keep sugar in case we need to present an error to the user.
-      // 2. The actual type being stored is [ignoring sugar] either a
-      //    clang::PointerType, a clang::BlockPointerType, or a
-      //    clang::ReferenceType which points to a clang::FunctionType.
-      const clang::Type *type;
-
-      bool empty() const { return !type; }
-      ClangTypeInfo(const clang::Type *type) : type(type) {}
-
-    public:
-      /// Use the ClangModuleLoader to print the Clang type as a string.
-      void printType(ClangModuleLoader *cml, llvm::raw_ostream &os) const;
-    };
-
-  private:
-    ClangTypeInfo Other;
-
-    static void assertIsFunctionType(const clang::Type *);
-
-      ExtInfo(unsigned Bits, ClangTypeInfo Other) : Bits(Bits), Other(Other) {
-      // [TODO: Clang-type-plumbing] Assert that the pointer is non-null.
-      auto Rep = Representation(Bits & RepresentationMask);
-      if ((Rep == Representation::CFunctionPointer) && Other.type)
-        assertIsFunctionType(Other.type);
-    }
-
-    friend AnyFunctionType;
-    friend class FunctionType;
-
-  public:
-    // Constructor with all defaults.
-    ExtInfo()
-      : ExtInfo(Representation::Swift, false, false,
-                DifferentiabilityKind::NonDifferentiable,
-                nullptr) {
-    }
-
-    // Constructor for polymorphic type.
-    ExtInfo(Representation Rep, bool Throws)
-      : ExtInfo(Rep, false, Throws, DifferentiabilityKind::NonDifferentiable,
-                nullptr) {
-    }
-
-    // Constructor with no defaults.
-    ExtInfo(Representation Rep, bool IsNoEscape, bool Throws,
-            DifferentiabilityKind DiffKind,
-            const clang::Type *type)
-      : ExtInfo(((unsigned) Rep)
-                  | (IsNoEscape ? NoEscapeMask : 0)
-                  | (Throws ? ThrowsMask : 0)
-                  | (((unsigned)DiffKind << DifferentiabilityMaskOffset)
-                     & DifferentiabilityMask),
-                ClangTypeInfo(type)) {
-    }
-
-    bool isNoEscape() const { return Bits & NoEscapeMask; }
-    bool async() const { return Bits & AsyncMask; }
-    bool throws() const { return Bits & ThrowsMask; }
-    bool isDifferentiable() const {
-      return getDifferentiabilityKind() >
-             DifferentiabilityKind::NonDifferentiable;
-    }
-    DifferentiabilityKind getDifferentiabilityKind() const {
-      return DifferentiabilityKind((Bits & DifferentiabilityMask) >>
-                                   DifferentiabilityMaskOffset);
-    }
-    Representation getRepresentation() const {
-      unsigned rawRep = Bits & RepresentationMask;
-      assert(rawRep <= unsigned(Representation::Last)
-             && "unexpected SIL representation");
-      return Representation(rawRep);
-    }
-
-    /// Get the underlying ClangTypeInfo value if it is not the default value.
-    Optional<ClangTypeInfo> getClangTypeInfo() const {
-      return Other.empty() ? Optional<ClangTypeInfo>() : Other;
-    }
-
-    bool hasSelfParam() const {
-      switch (getSILRepresentation()) {
-      case SILFunctionTypeRepresentation::Thick:
-      case SILFunctionTypeRepresentation::Block:
-      case SILFunctionTypeRepresentation::Thin:
-      case SILFunctionTypeRepresentation::CFunctionPointer:
-      case SILFunctionTypeRepresentation::Closure:
-        return false;
-      case SILFunctionTypeRepresentation::ObjCMethod:
-      case SILFunctionTypeRepresentation::Method:
-      case SILFunctionTypeRepresentation::WitnessMethod:
-        return true;
-      }
-
-      llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
-    }
-
-    /// True if the function representation carries context.
-    bool hasContext() const {
-      switch (getSILRepresentation()) {
-      case SILFunctionTypeRepresentation::Thick:
-      case SILFunctionTypeRepresentation::Block:
-        return true;
-      case SILFunctionTypeRepresentation::Thin:
-      case SILFunctionTypeRepresentation::Method:
-      case SILFunctionTypeRepresentation::ObjCMethod:
-      case SILFunctionTypeRepresentation::WitnessMethod:
-      case SILFunctionTypeRepresentation::CFunctionPointer:
-      case SILFunctionTypeRepresentation::Closure:
-        return false;
-      }
-
-      llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
-    }
-    
-    // Note that we don't have setters. That is by design, use
-    // the following with methods instead of mutating these objects.
-    LLVM_NODISCARD
-    ExtInfo withRepresentation(Representation Rep) const {
-      return ExtInfo((Bits & ~RepresentationMask)
-                     | (unsigned)Rep, Other);
-    }
-    LLVM_NODISCARD
-    ExtInfo withNoEscape(bool NoEscape = true) const {
-      return ExtInfo(NoEscape ? (Bits | NoEscapeMask) : (Bits & ~NoEscapeMask),
-                     Other);
-    }
-    LLVM_NODISCARD
-    ExtInfo withAsync(bool Async = true) const {
-      return ExtInfo(Async ? (Bits | AsyncMask) : (Bits & ~AsyncMask),
-                     Other);
-    }
-    LLVM_NODISCARD
-    ExtInfo withThrows(bool Throws = true) const {
-      return ExtInfo(Throws ? (Bits | ThrowsMask) : (Bits & ~ThrowsMask),
-                     Other);
-    }
-    LLVM_NODISCARD
-    ExtInfo withClangFunctionType(const clang::Type *type) const {
-      return ExtInfo(Bits, ClangTypeInfo(type));
-    }
-    LLVM_NODISCARD
-    ExtInfo
-    withDifferentiabilityKind(DifferentiabilityKind differentiability) const {
-      return ExtInfo(
-          (Bits & ~DifferentiabilityMask) |
-              ((unsigned)differentiability << DifferentiabilityMaskOffset),
-          Other);
-    }
-
-    std::pair<unsigned, const void *> getFuncAttrKey() const {
-      return std::make_pair(Bits, Other.type);
-    }
-    
-    /// Put a SIL representation in the ExtInfo.
-    ///
-    /// SIL type lowering transiently generates AST function types with SIL
-    /// representations. However, they shouldn't persist in the AST, and
-    /// don't need to be parsed, printed, or serialized.
-    ExtInfo withSILRepresentation(SILFunctionTypeRepresentation Rep) const {
-      return ExtInfo((Bits & ~RepresentationMask)
-                     | (unsigned)Rep, Other);
-    }
-    
-    SILFunctionTypeRepresentation getSILRepresentation() const {
-      unsigned rawRep = Bits & RepresentationMask;
-      return SILFunctionTypeRepresentation(rawRep);
-    }
-
-    bool operator==(ExtInfo Other) const {
-      return Bits == Other.Bits;
-    }
-    bool operator!=(ExtInfo Other) const {
-      return Bits != Other.Bits;
-    }
-  };
-
 protected:
   /// Create an AnyFunctionType.
   ///
   /// Subclasses are responsible for storing and retrieving the
-  /// ExtInfo::ClangTypeInfo value if one is present.
+  /// ClangTypeInfo value if one is present.
   AnyFunctionType(TypeKind Kind, const ASTContext *CanTypeContext,
                   Type Output, RecursiveTypeProperties properties,
                   unsigned NumParams, ExtInfo Info)
   : TypeBase(Kind, CanTypeContext, properties), Output(Output) {
-    Bits.AnyFunctionType.ExtInfoBits = Info.Bits;
+    Bits.AnyFunctionType.ExtInfoBits = Info.getBits();
     Bits.AnyFunctionType.HasClangTypeInfo = Info.getClangTypeInfo().hasValue();
     Bits.AnyFunctionType.NumParams = NumParams;
     assert(Bits.AnyFunctionType.NumParams == NumParams && "Params dropped!");
     // The use of both assert() and static_assert() is intentional.
-    assert(Bits.AnyFunctionType.ExtInfoBits == Info.Bits
-           && "Bits were dropped!");
-    static_assert(ExtInfo::NumMaskBits == NumAFTExtInfoBits,
-                 "ExtInfo and AnyFunctionTypeBitfields must agree on bit size");
+    assert(Bits.AnyFunctionType.ExtInfoBits == Info.getBits() &&
+           "Bits were dropped!");
+    static_assert(
+        ASTExtInfoBuilder::NumMaskBits == NumAFTExtInfoBits,
+        "ExtInfo and AnyFunctionTypeBitfields must agree on bit size");
   }
 
 public:
@@ -3224,15 +2911,15 @@ public:
 
   GenericSignature getOptGenericSignature() const;
   
-  bool hasClangFunctionType() const {
+  bool hasClangTypeInfo() const {
     return Bits.AnyFunctionType.HasClangTypeInfo;
   }
 
-  const clang::Type *getClangFunctionType() const;
-  const clang::Type *getCanonicalClangFunctionType() const;
+  ClangTypeInfo getClangTypeInfo() const;
+  ClangTypeInfo getCanonicalClangTypeInfo() const;
 
   ExtInfo getExtInfo() const {
-    return ExtInfo(Bits.AnyFunctionType.ExtInfoBits, getClangFunctionType());
+    return ExtInfo(Bits.AnyFunctionType.ExtInfoBits, getClangTypeInfo());
   }
 
   /// Get the canonical ExtInfo for the function type.
@@ -3241,8 +2928,8 @@ public:
   /// In the future, we will always use the canonical clang function type.
   ExtInfo getCanonicalExtInfo(bool useClangFunctionType) const {
     return ExtInfo(Bits.AnyFunctionType.ExtInfoBits,
-                   useClangFunctionType ? getCanonicalClangFunctionType()
-                                        : nullptr);
+                   useClangFunctionType ? getCanonicalClangTypeInfo()
+                                        : ClangTypeInfo());
   }
 
   /// Get the representation of the function type.
@@ -3418,6 +3105,7 @@ public:
 };
 BEGIN_CAN_TYPE_WRAPPER(AnyFunctionType, Type)
   using ExtInfo = AnyFunctionType::ExtInfo;
+  using ExtInfoBuilder = AnyFunctionType::ExtInfoBuilder;
   using CanParamArrayRef = AnyFunctionType::CanParamArrayRef;
 
   static CanAnyFunctionType get(CanGenericSignature signature,
@@ -3445,19 +3133,20 @@ inline AnyFunctionType::CanYield AnyFunctionType::Yield::getCanonical() const {
 ///
 /// For example:
 ///   let x : (Float, Int) -> Int
-class FunctionType final : public AnyFunctionType,
-    public llvm::FoldingSetNode,
-    private llvm::TrailingObjects<FunctionType, AnyFunctionType::Param,
-                                  AnyFunctionType::ExtInfo::ClangTypeInfo> {
+class FunctionType final
+    : public AnyFunctionType,
+      public llvm::FoldingSetNode,
+      private llvm::TrailingObjects<FunctionType, AnyFunctionType::Param,
+                                    ClangTypeInfo> {
   friend TrailingObjects;
-      
+
 
   size_t numTrailingObjects(OverloadToken<AnyFunctionType::Param>) const {
     return getNumParams();
   }
 
-  size_t numTrailingObjects(OverloadToken<ExtInfo::ClangTypeInfo>) const {
-    return hasClangFunctionType() ? 1 : 0;
+  size_t numTrailingObjects(OverloadToken<ClangTypeInfo>) const {
+    return hasClangTypeInfo() ? 1 : 0;
   }
 
 public:
@@ -3470,12 +3159,13 @@ public:
     return {getTrailingObjects<Param>(), getNumParams()};
   }
 
-  const clang::Type *getClangFunctionType() const {
-    if (!hasClangFunctionType())
-      return nullptr;
-    auto *type = getTrailingObjects<ExtInfo::ClangTypeInfo>()->type;
-    assert(type && "If the pointer was null, we shouldn't have stored it.");
-    return type;
+  ClangTypeInfo getClangTypeInfo() const {
+    if (!hasClangTypeInfo())
+      return ClangTypeInfo();
+    auto *info = getTrailingObjects<ClangTypeInfo>();
+    assert(!info->empty() &&
+           "If the ClangTypeInfo was empty, we shouldn't have stored it.");
+    return *info;
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
@@ -4185,10 +3875,12 @@ namespace Lowering {
 /// This type is defined by the AST library because it must be capable
 /// of appearing in secondary positions, e.g. within tuple and
 /// function parameter and result types.
-class SILFunctionType final : public TypeBase, public llvm::FoldingSetNode,
-    private llvm::TrailingObjects<SILFunctionType, SILParameterInfo,
-                                  SILResultInfo, SILYieldInfo,
-                                  SubstitutionMap, CanType> {
+class SILFunctionType final
+    : public TypeBase,
+      public llvm::FoldingSetNode,
+      private llvm::TrailingObjects<SILFunctionType, SILParameterInfo,
+                                    SILResultInfo, SILYieldInfo,
+                                    SubstitutionMap, CanType> {
   friend TrailingObjects;
 
   size_t numTrailingObjects(OverloadToken<SILParameterInfo>) const {
@@ -4208,177 +3900,15 @@ class SILFunctionType final : public TypeBase, public llvm::FoldingSetNode,
   }
 
   size_t numTrailingObjects(OverloadToken<SubstitutionMap>) const {
-    return size_t(hasPatternSubstitutions())
-         + size_t(hasInvocationSubstitutions());
+    return size_t(hasPatternSubstitutions()) +
+           size_t(hasInvocationSubstitutions());
   }
 
 public:
-  using Language = SILFunctionLanguage;
-  using Representation = SILFunctionTypeRepresentation;
-
-  /// A class which abstracts out some details necessary for
-  /// making a call.
-  class ExtInfo {
-    // If bits are added or removed, then TypeBase::SILFunctionTypeBits
-    // and NumMaskBits must be updated, and they must match.
-
-    //   |representation|pseudogeneric|noescape|differentiability|
-    //   |    0 .. 3    |      4      |     5    |      6 .. 7     |
-    //
-    enum : unsigned {
-      RepresentationMask = 0xF << 0,
-      PseudogenericMask  = 1 << 4,
-      NoEscapeMask       = 1 << 5,
-      DifferentiabilityMaskOffset = 6,
-      DifferentiabilityMask       = 0x3 << DifferentiabilityMaskOffset,
-      NumMaskBits                 = 8
-    };
-
-    unsigned Bits; // Naturally sized for speed.
-
-    class ClangTypeInfo {
-      friend ExtInfo;
-      friend class SILFunctionType;
-
-      // Invariant: The FunctionType is canonical.
-      // We store a clang::FunctionType * instead of a clang::CanQualType to
-      // avoid depending on the Clang AST in this header.
-      const clang::FunctionType *ClangFunctionType;
-
-      bool empty() const { return !ClangFunctionType; }
-      ClangTypeInfo(const clang::FunctionType *type) : ClangFunctionType(type) {}
-
-    public:
-      /// Analog of AnyFunctionType::ExtInfo::ClangTypeInfo::printType.
-      void printType(ClangModuleLoader *cml, llvm::raw_ostream &os) const;
-    };
-
-    ClangTypeInfo Other;
-
-    ExtInfo(unsigned Bits, ClangTypeInfo Other) : Bits(Bits), Other(Other) {}
-
-    friend class SILFunctionType;
-  public:
-    // Constructor with all defaults.
-    ExtInfo() : Bits(0), Other(ClangTypeInfo(nullptr)) { }
-
-    // Constructor for polymorphic type.
-    ExtInfo(Representation rep, bool isPseudogeneric, bool isNoEscape,
-            DifferentiabilityKind diffKind,
-            const clang::FunctionType *type)
-      : ExtInfo(((unsigned) rep)
-                  | (isPseudogeneric ? PseudogenericMask : 0)
-                  | (isNoEscape ? NoEscapeMask : 0)
-                  | (((unsigned)diffKind << DifferentiabilityMaskOffset)
-                     & DifferentiabilityMask),
-                ClangTypeInfo(type)) {
-    }
-
-    static ExtInfo getThin() {
-      return ExtInfo(Representation::Thin, false, false,
-                     DifferentiabilityKind::NonDifferentiable, nullptr);
-    }
-
-    /// Is this function pseudo-generic?  A pseudo-generic function
-    /// is not permitted to dynamically depend on its type arguments.
-    bool isPseudogeneric() const { return Bits & PseudogenericMask; }
-
-    // Is this function guaranteed to be no-escape by the type system?
-    bool isNoEscape() const { return Bits & NoEscapeMask; }
-
-    bool isDifferentiable() const {
-      return getDifferentiabilityKind() !=
-             DifferentiabilityKind::NonDifferentiable;
-    }
-
-    DifferentiabilityKind getDifferentiabilityKind() const {
-      return DifferentiabilityKind((Bits & DifferentiabilityMask) >>
-                                   DifferentiabilityMaskOffset);
-    }
-
-    /// What is the abstract representation of this function value?
-    Representation getRepresentation() const {
-      return Representation(Bits & RepresentationMask);
-    }
-    Language getLanguage() const {
-      return getSILFunctionLanguage(getRepresentation());
-    }
-
-    /// Get the underlying ClangTypeInfo value if it is not the default value.
-    Optional<ClangTypeInfo> getClangTypeInfo() const {
-      return Other.empty() ? Optional<ClangTypeInfo>() : Other;
-    }
-
-    bool hasSelfParam() const {
-      switch (getRepresentation()) {
-      case Representation::Thick:
-      case Representation::Block:
-      case Representation::Thin:
-      case Representation::CFunctionPointer:
-      case Representation::Closure:
-        return false;
-      case Representation::ObjCMethod:
-      case Representation::Method:
-      case Representation::WitnessMethod:
-        return true;
-      }
-
-      llvm_unreachable("Unhandled Representation in switch.");
-    }
-
-    /// True if the function representation carries context.
-    bool hasContext() const {
-      switch (getRepresentation()) {
-      case Representation::Thick:
-      case Representation::Block:
-        return true;
-      case Representation::Thin:
-      case Representation::CFunctionPointer:
-      case Representation::ObjCMethod:
-      case Representation::Method:
-      case Representation::WitnessMethod:
-      case Representation::Closure:
-        return false;
-      }
-
-      llvm_unreachable("Unhandled Representation in switch.");
-    }
-    
-    // Note that we don't have setters. That is by design, use
-    // the following with methods instead of mutating these objects.
-    ExtInfo withRepresentation(Representation Rep) const {
-      return ExtInfo((Bits & ~RepresentationMask)
-                     | (unsigned)Rep, Other);
-    }
-    ExtInfo withIsPseudogeneric(bool isPseudogeneric = true) const {
-      return ExtInfo(isPseudogeneric
-                     ? (Bits | PseudogenericMask)
-                     : (Bits & ~PseudogenericMask),
-                     Other);
-    }
-    ExtInfo withNoEscape(bool NoEscape = true) const {
-      return ExtInfo(NoEscape ? (Bits | NoEscapeMask) : (Bits & ~NoEscapeMask),
-                     Other);
-    }
-    ExtInfo
-    withDifferentiabilityKind(DifferentiabilityKind differentiability) const {
-      return ExtInfo(
-          (Bits & ~DifferentiabilityMask) |
-              ((unsigned)differentiability << DifferentiabilityMaskOffset),
-          Other);
-    }
-
-    std::pair<unsigned, const void *> getFuncAttrKey() const {
-      return std::make_pair(Bits, Other.ClangFunctionType);
-    }
-
-    bool operator==(ExtInfo Other) const {
-      return Bits == Other.Bits;
-    }
-    bool operator!=(ExtInfo Other) const {
-      return Bits != Other.Bits;
-    }
-  };
+  using ExtInfo = SILExtInfo;
+  using ExtInfoBuilder = SILExtInfoBuilder;
+  using Language = SILExtInfoBuilder::Language;
+  using Representation = SILExtInfoBuilder::Representation;
 
 private:
   unsigned NumParameters;
@@ -4763,7 +4293,7 @@ public:
     return WitnessMethodConformance;
   }
 
-  const clang::FunctionType *getClangFunctionType() const;
+  ClangTypeInfo getClangTypeInfo() const;
 
   /// Given that `this` is a `@differentiable` or `@differentiable(linear)`
   /// function type, returns an `IndexSubset` corresponding to the
@@ -4911,7 +4441,7 @@ public:
       CanGenericSignature transposeFunctionGenericSignature = nullptr);
 
   ExtInfo getExtInfo() const {
-    return ExtInfo(Bits.SILFunctionType.ExtInfoBits, getClangFunctionType());
+    return ExtInfo(Bits.SILFunctionType.ExtInfoBits, getClangTypeInfo());
   }
 
   /// Returns the language-level calling convention of the function.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -57,7 +57,8 @@ CanAnyFunctionType adjustFunctionType(CanAnyFunctionType type,
 /// Change the given function type's representation.
 inline CanAnyFunctionType adjustFunctionType(CanAnyFunctionType t,
                                           SILFunctionType::Representation rep) {
-  auto extInfo = t->getExtInfo().withSILRepresentation(rep);
+  auto extInfo =
+      t->getExtInfo().intoBuilder().withSILRepresentation(rep).build();
   return adjustFunctionType(t, extInfo);  
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4446,7 +4446,6 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
 const clang::Type *
 ASTContext::getClangFunctionType(ArrayRef<AnyFunctionType::Param> params,
                                  Type resultTy,
-                                 FunctionType::ExtInfo incompleteExtInfo,
                                  FunctionTypeRepresentation trueRep) {
   auto &impl = getImpl();
   if (!impl.Converter) {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -400,18 +400,16 @@ Type ASTBuilder::createFunctionType(
      || representation == FunctionTypeRepresentation::Block)
     && !flags.isEscaping();
 
-  FunctionType::ExtInfo incompleteExtInfo(
-    FunctionTypeRepresentation::Swift,
-    noescape, flags.throws(), diffKind, /*clangFunctionType*/nullptr);
-
   const clang::Type *clangFunctionType = nullptr;
   if (representation == FunctionTypeRepresentation::CFunctionPointer)
     clangFunctionType = Ctx.getClangFunctionType(funcParams, output,
                                                  representation);
 
-  auto einfo = incompleteExtInfo.withRepresentation(representation)
-                                .withAsync(flags.async())
-                                .withClangFunctionType(clangFunctionType);
+  auto einfo =
+      FunctionType::ExtInfoBuilder(representation, noescape, flags.throws(),
+                                   diffKind, clangFunctionType)
+          .withAsync(flags.async())
+          .build();
 
   return FunctionType::get(funcParams, output, einfo);
 }
@@ -531,9 +529,10 @@ Type ASTBuilder::createImplFunctionType(
   }
 
   // [TODO: Store-SIL-Clang-type]
-  auto einfo = SILFunctionType::ExtInfo(representation, flags.isPseudogeneric(),
-                                        !flags.isEscaping(), diffKind,
-                                        /*clangFunctionType*/ nullptr);
+  auto einfo = SILExtInfoBuilder(representation, flags.isPseudogeneric(),
+                                 !flags.isEscaping(), diffKind,
+                                 /*clangFunctionType*/ nullptr)
+                   .build();
 
   llvm::SmallVector<SILParameterInfo, 8> funcParams;
   llvm::SmallVector<SILYieldInfo, 8> funcYields;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -407,7 +407,6 @@ Type ASTBuilder::createFunctionType(
   const clang::Type *clangFunctionType = nullptr;
   if (representation == FunctionTypeRepresentation::CFunctionPointer)
     clangFunctionType = Ctx.getClangFunctionType(funcParams, output,
-                                                 incompleteExtInfo,
                                                  representation);
 
   auto einfo = incompleteExtInfo.withRepresentation(representation)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3760,10 +3760,10 @@ namespace {
 
       OS << "\n";
       Indent += 2;
-      if (auto *cty = T->getClangFunctionType()) {
+      if (!T->getClangTypeInfo().empty()) {
         std::string s;
         llvm::raw_string_ostream os(s);
-        cty->dump(os);
+        T->getClangTypeInfo().dump(os);
         printField("clang_type", os.str());
       }
       printAnyFunctionParams(T->getParams(), "input");

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -44,6 +44,7 @@ add_swift_host_library(swiftAST STATIC
   DocComment.cpp
   Evaluator.cpp
   Expr.cpp
+  ExtInfo.cpp
   FineGrainedDependencies.cpp
   FineGrainedDependencyFormat.cpp
   FrontendSourceFileDepGraphFactory.cpp

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -572,7 +572,7 @@ clang::QualType ClangTypeConverter::visitEnumType(EnumType *type) {
 
 clang::QualType ClangTypeConverter::visitFunctionType(FunctionType *type) {
   // We must've already computed it before if applicable.
-  return clang::QualType(type->getClangFunctionType(), 0);
+  return clang::QualType(type->getClangTypeInfo().getType(), 0);
 }
 
 clang::QualType ClangTypeConverter::visitSILFunctionType(SILFunctionType *type) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2576,10 +2576,11 @@ mapSignatureExtInfo(AnyFunctionType::ExtInfo info,
                     bool topLevelFunction) {
   if (topLevelFunction)
     return AnyFunctionType::ExtInfo();
-  return AnyFunctionType::ExtInfo()
+  return AnyFunctionType::ExtInfoBuilder()
       .withRepresentation(info.getRepresentation())
       .withAsync(info.async())
-      .withThrows(info.throws());
+      .withThrows(info.throws())
+      .build();
 }
 
 /// Map a function's type to the type used for computing signatures,

--- a/lib/AST/ExtInfo.cpp
+++ b/lib/AST/ExtInfo.cpp
@@ -23,6 +23,15 @@ namespace swift {
 
 // MARK: - ClangTypeInfo
 
+bool operator==(ClangTypeInfo lhs, ClangTypeInfo rhs) {
+  if (lhs.type == rhs.type)
+    return true;
+  if (lhs.type && rhs.type)
+    return lhs.type->getCanonicalTypeInternal() ==
+           rhs.type->getCanonicalTypeInternal();
+  return false;
+}
+
 ClangTypeInfo ClangTypeInfo::getCanonical() const {
   if (!type)
     return ClangTypeInfo();

--- a/lib/AST/ExtInfo.cpp
+++ b/lib/AST/ExtInfo.cpp
@@ -1,0 +1,84 @@
+//===--- ExtInfo.cpp - Extended information for function types ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements ASTExtInfo, SILExtInfo and related classes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/ExtInfo.h"
+
+#include "clang/AST/Type.h"
+
+namespace swift {
+
+// MARK: - ClangTypeInfo
+
+ClangTypeInfo ClangTypeInfo::getCanonical() const {
+  if (!type)
+    return ClangTypeInfo();
+  return ClangTypeInfo(type->getCanonicalTypeInternal().getTypePtr());
+}
+
+void ClangTypeInfo::printType(ClangModuleLoader *cml,
+                              llvm::raw_ostream &os) const {
+  cml->printClangType(type, os);
+}
+
+void ClangTypeInfo::dump(llvm::raw_ostream &os) const {
+  if (type) {
+    type->dump(os);
+  } else {
+    os << "<nullptr>";
+  }
+}
+
+// MARK: - ASTExtInfoBuilder
+
+void ASTExtInfoBuilder::assertIsFunctionType(const clang::Type *type) {
+#ifndef NDEBUG
+  if (!(type->isFunctionPointerType() || type->isBlockPointerType() ||
+        type->isFunctionReferenceType())) {
+    SmallString<256> buf;
+    llvm::raw_svector_ostream os(buf);
+    os << "Expected a Clang function type wrapped in a pointer type or "
+       << "a block pointer type but found:\n";
+    type->dump(os);
+    llvm_unreachable(os.str().data());
+  }
+#endif
+  return;
+}
+
+void ASTExtInfoBuilder::checkInvariants() const {
+  // TODO: Add validation checks here while making sure things don't blow up.
+}
+
+// MARK: - ASTExtInfo
+
+ASTExtInfo ASTExtInfoBuilder::build() const {
+  checkInvariants();
+  return ASTExtInfo(*this);
+}
+
+// MARK: - SILExtInfoBuilder
+
+void SILExtInfoBuilder::checkInvariants() const {
+  // TODO: Add validation checks here while making sure things don't blow up.
+}
+
+SILExtInfo SILExtInfoBuilder::build() const {
+  checkInvariants();
+  return SILExtInfo(*this);
+}
+
+} // end namespace swift

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -314,7 +314,7 @@ CanType TypeJoin::visitFunctionType(CanType second) {
   auto secondExtInfo = secondFnTy->getExtInfo();
 
   // FIXME: Properly handle these attributes.
-  if (firstExtInfo != secondExtInfo)
+  if (!firstExtInfo.isEqualTo(secondExtInfo, useClangTypes(First)))
     return Unimplemented;
 
   if (!AnyFunctionType::equalParams(firstFnTy->getParams(),

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -167,11 +167,13 @@ namespace {
     return {FunctionType::get(
                 funcTy->getParams(), funcTy->getResult(),
                 funcTy->getExtInfo()
+                    .intoBuilder()
                     .withRepresentation(
                         AnyFunctionType::Representation::CFunctionPointer)
-                    .withClangFunctionType(&type)),
+                    .withClangFunctionType(&type)
+                    .build()),
             type.isReferenceType() ? ImportHint::None
-                                    : ImportHint::CFunctionPointer};
+                                   : ImportHint::CFunctionPointer};
   }
 
   static ImportResult importOverAlignedFunctionPointerLikeType(

--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -205,9 +205,12 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
                                bridging,
                                /*non-optional*/false);
 
-      return FunctionType::get(newParams, newResult,
-                               funTy->getExtInfo().withSILRepresentation(
-                                       SILFunctionType::Representation::Block));
+      return FunctionType::get(
+          newParams, newResult,
+          funTy->getExtInfo()
+              .intoBuilder()
+              .withSILRepresentation(SILFunctionType::Representation::Block)
+              .build());
     }
     }
   }

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -62,11 +62,14 @@ SILType SILBuilder::getPartialApplyResultType(
   auto params = FTI->getParameters();
   auto newParams = params.slice(0, params.size() - argCount);
 
-  auto extInfo = FTI->getExtInfo()
-    .withRepresentation(SILFunctionType::Representation::Thick)
-    .withIsPseudogeneric(false);
+  auto extInfoBuilder =
+      FTI->getExtInfo()
+          .intoBuilder()
+          .withRepresentation(SILFunctionType::Representation::Thick)
+          .withIsPseudogeneric(false);
   if (onStack)
-    extInfo = extInfo.withNoEscape();
+    extInfoBuilder = extInfoBuilder.withNoEscape();
+  auto extInfo = extInfoBuilder.build();
 
   // If the original method has an @unowned_inner_pointer return, the partial
   // application thunk will lifetime-extend 'self' for us, converting the

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -932,7 +932,7 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
 CanAnyFunctionType
 Lowering::adjustFunctionType(CanAnyFunctionType t,
                              AnyFunctionType::ExtInfo extInfo) {
-  if (t->getExtInfo() == extInfo)
+  if (t->getExtInfo().isEqualTo(extInfo, useClangTypes(t)))
     return t;
   return CanAnyFunctionType(t->withExtInfo(extInfo));
 }
@@ -943,7 +943,8 @@ Lowering::adjustFunctionType(CanSILFunctionType type,
                              SILFunctionType::ExtInfo extInfo,
                              ParameterConvention callee,
                              ProtocolConformanceRef witnessMethodConformance) {
-  if (type->getExtInfo() == extInfo && type->getCalleeConvention() == callee &&
+  if (type->getExtInfo().isEqualTo(extInfo, useClangTypes(type)) &&
+      type->getCalleeConvention() == callee &&
       type->getWitnessMethodConformanceOrInvalid() == witnessMethodConformance)
     return type;
 
@@ -965,7 +966,7 @@ SILFunctionType::getWithRepresentation(Representation repr) {
 
 CanSILFunctionType SILFunctionType::getWithExtInfo(ExtInfo newExt) {
   auto oldExt = getExtInfo();
-  if (newExt == oldExt)
+  if (newExt.isEqualTo(oldExt, useClangTypes(this)))
     return CanSILFunctionType(this);
 
   auto calleeConvention =
@@ -3968,7 +3969,7 @@ TypeConverter::getBridgedFunctionType(AbstractionPattern pattern,
   case SILFunctionTypeRepresentation::Closure:
   case SILFunctionTypeRepresentation::WitnessMethod: {
     // No bridging needed for native functions.
-    if (t->getExtInfo() == extInfo)
+    if (t->getExtInfo().isEqualTo(extInfo, useClangTypes(t)))
       return t;
     return CanAnyFunctionType::get(genericSig, t.getParams(), t.getResult(),
                                    extInfo);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3718,8 +3718,10 @@ public:
             .withRepresentation(SILFunctionType::Representation::Thick)
             .withNoEscape(resFTy->isNoEscape())
             .build();
-    require(adjustedOperandExtInfo == resFTy->getExtInfo(),
-            "operand and result of thin_to_think_function must agree in particulars");
+    require(adjustedOperandExtInfo.isEqualTo(resFTy->getExtInfo(),
+                                             useClangTypes(opFTy)),
+            "operand and result of thin_to_think_function must agree in "
+            "particulars");
   }
 
   void checkThickToObjCMetatypeInst(ThickToObjCMetatypeInst *TTOCI) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3714,8 +3714,10 @@ public:
 
     auto adjustedOperandExtInfo =
         opFTy->getExtInfo()
+            .intoBuilder()
             .withRepresentation(SILFunctionType::Representation::Thick)
-            .withNoEscape(resFTy->isNoEscape());
+            .withNoEscape(resFTy->isNoEscape())
+            .build();
     require(adjustedOperandExtInfo == resFTy->getExtInfo(),
             "operand and result of thin_to_think_function must agree in particulars");
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -411,12 +411,13 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
                     : ParameterConvention::Indirect_In_Guaranteed },
   };
 
-  auto extInfo = SILFunctionType::ExtInfo(
-      SILFunctionTypeRepresentation::Thin,
-      /*pseudogeneric*/ false,
-      /*non-escaping*/ false,
-      DifferentiabilityKind::NonDifferentiable,
-      /*clangFunctionType*/ nullptr);
+  auto extInfo =
+      SILFunctionType::ExtInfoBuilder(SILFunctionTypeRepresentation::Thin,
+                                      /*pseudogeneric*/ false,
+                                      /*non-escaping*/ false,
+                                      DifferentiabilityKind::NonDifferentiable,
+                                      /*clangFunctionType*/ nullptr)
+          .build();
 
   auto functionTy = SILFunctionType::get(sig, extInfo,
                                          SILCoroutineKind::YieldOnce,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -131,8 +131,11 @@ getDynamicMethodLoweredType(SILModule &M,
                             SILDeclRef constant,
                             CanAnyFunctionType substMemberTy) {
   assert(constant.isForeign);
-  auto objcFormalTy = substMemberTy.withExtInfo(substMemberTy->getExtInfo()
-             .withSILRepresentation(SILFunctionTypeRepresentation::ObjCMethod));
+  auto objcFormalTy = substMemberTy.withExtInfo(
+      substMemberTy->getExtInfo()
+          .intoBuilder()
+          .withSILRepresentation(SILFunctionTypeRepresentation::ObjCMethod)
+          .build());
   return SILType::getPrimitiveObjectType(
       M.Types.getUncachedSILFunctionTypeForConstant(
           TypeExpansionContext::minimal(), constant, objcFormalTy));

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -574,7 +574,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
     // context. Currently we don't capture anything directly into a block but a
     // Swift closure, but that's totally dumb.
     if (genericSig)
-      extInfo = extInfo.withIsPseudogeneric();
+      extInfo = extInfo.intoBuilder().withIsPseudogeneric().build();
   }
 
   auto invokeTy = SILFunctionType::get(

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -690,20 +690,18 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
       SILParameterInfo(argv->getType().getASTType(),
                        ParameterConvention::Direct_Unowned),
     };
-    auto NSApplicationMainType = SILFunctionType::get(nullptr,
-                  SILFunctionType::ExtInfo()
-                    // Should be C calling convention, but NSApplicationMain
-                    // has an overlay to fix the type of argv.
-                    .withRepresentation(SILFunctionType::Representation::Thin),
-                  SILCoroutineKind::None,
-                  ParameterConvention::Direct_Unowned,
-                  argTypes,
-                  /*yields*/ {},
-                  SILResultInfo(argc->getType().getASTType(),
-                                ResultConvention::Unowned),
-                  /*error result*/ None,
-                  SubstitutionMap(), SubstitutionMap(),
-                  getASTContext());
+    auto NSApplicationMainType = SILFunctionType::get(
+        nullptr,
+        SILFunctionType::ExtInfoBuilder()
+            // Should be C calling convention, but NSApplicationMain
+            // has an overlay to fix the type of argv.
+            .withRepresentation(SILFunctionType::Representation::Thin)
+            .build(),
+        SILCoroutineKind::None, ParameterConvention::Direct_Unowned, argTypes,
+        /*yields*/ {},
+        SILResultInfo(argc->getType().getASTType(), ResultConvention::Unowned),
+        /*error result*/ None, SubstitutionMap(), SubstitutionMap(),
+        getASTContext());
 
     SILGenFunctionBuilder builder(SGM);
     auto NSApplicationMainFn = builder.getOrCreateFunction(

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3476,8 +3476,9 @@ static CanSILFunctionType buildWithoutActuallyEscapingThunkType(
     CanSILFunctionType &escapingType, GenericEnvironment *&genericEnv,
     SubstitutionMap &interfaceSubs, CanType &dynamicSelfType) {
 
-  assert(escapingType->getExtInfo() ==
-         noEscapingType->getExtInfo().withNoEscape(false));
+  assert(escapingType->getExtInfo().isEqualTo(
+      noEscapingType->getExtInfo().withNoEscape(false),
+      useClangTypes(escapingType)));
 
   CanType inputSubstType, outputSubstType;
   auto type = SGF.buildThunkType(noEscapingType, escapingType,
@@ -3539,8 +3540,9 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   auto noEscapingFnSubstTy = noEscapingFunctionValue.getType()
     .castTo<SILFunctionType>();
   // TODO: maybe this should use a more explicit instruction.
-  assert(escapingFnSubstTy->getExtInfo() == noEscapingFnSubstTy->getExtInfo()
-                                                         .withNoEscape(false));
+  assert(escapingFnSubstTy->getExtInfo().isEqualTo(
+      noEscapingFnSubstTy->getExtInfo().withNoEscape(false),
+      useClangTypes(escapingFnSubstTy)));
 
   // Apply function type substitutions, since the code sequence for a thunk
   // doesn't vary with function representation.

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -129,13 +129,14 @@ CanSILFunctionType buildThunkType(SILFunction *fn,
   // - Building a reabstraction thunk type.
   // - Building an index subset thunk type, where the expected type has context
   //   (i.e. is `@convention(thick)`).
-  auto extInfo = expectedType->getExtInfo();
+  auto extInfoBuilder = expectedType->getExtInfo().intoBuilder();
   if (thunkKind == DifferentiationThunkKind::Reabstraction ||
-      extInfo.hasContext()) {
-    extInfo = extInfo.withRepresentation(SILFunctionType::Representation::Thin);
+      extInfoBuilder.hasContext()) {
+    extInfoBuilder = extInfoBuilder.withRepresentation(
+        SILFunctionType::Representation::Thin);
   }
   if (withoutActuallyEscaping)
-    extInfo = extInfo.withNoEscape(false);
+    extInfoBuilder = extInfoBuilder.withNoEscape(false);
 
   // Does the thunk type involve archetypes other than opened existentials?
   bool hasArchetypes = false;
@@ -191,7 +192,7 @@ CanSILFunctionType buildThunkType(SILFunction *fn,
   // pseudogeneric, since we have no way to pass generic parameters.
   if (genericSig)
     if (fn->getLoweredFunctionType()->isPseudogeneric())
-      extInfo = extInfo.withIsPseudogeneric();
+      extInfoBuilder = extInfoBuilder.withIsPseudogeneric();
 
   // Add the function type as the parameter.
   auto contextConvention =
@@ -241,7 +242,7 @@ CanSILFunctionType buildThunkType(SILFunction *fn,
 
   // The type of the thunk function.
   return SILFunctionType::get(
-      genericSig, extInfo, expectedType->getCoroutineKind(),
+      genericSig, extInfoBuilder.build(), expectedType->getCoroutineKind(),
       ParameterConvention::Direct_Unowned, interfaceParams, interfaceYields,
       interfaceResults, interfaceErrorResult,
       expectedType->getPatternSubstitutions(), SubstitutionMap(),

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -872,9 +872,7 @@ static void emitFatalError(ADContext &context, SILFunction *f,
                     ResultConvention::Unowned);
   // Fatal error function must have type `@convention(thin) () -> Never`.
   auto fatalErrorFnType = SILFunctionType::get(
-      /*genericSig*/ nullptr,
-      SILFunctionType::ExtInfo().withRepresentation(
-          SILFunctionTypeRepresentation::Thin),
+      /*genericSig*/ nullptr, SILFunctionType::ExtInfo::getThin(),
       SILCoroutineKind::None, ParameterConvention::Direct_Unowned, {},
       /*interfaceYields*/ {}, neverResultInfo,
       /*interfaceErrorResults*/ None, {}, {}, context.getASTContext());
@@ -1020,8 +1018,10 @@ static SILValue promoteCurryThunkApplicationToDifferentiableFunction(
   // Construct new curry thunk type with `@differentiable` function
   // result.
   auto diffResultFnTy = resultFnTy->getWithExtInfo(
-      resultFnTy->getExtInfo().withDifferentiabilityKind(
-          DifferentiabilityKind::Normal));
+      resultFnTy->getExtInfo()
+          .intoBuilder()
+          .withDifferentiabilityKind(DifferentiabilityKind::Normal)
+          .build());
   auto newThunkResult = thunkResult.getWithInterfaceType(diffResultFnTy);
   auto thunkType = SILFunctionType::get(
       thunkTy->getSubstGenericSignature(), thunkTy->getExtInfo(),

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -295,11 +295,12 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
   Results.push_back(SILResultInfo(
                       switchInfo.Br->getArg(0)->getType().getASTType(),
                       ResultConvention::Owned));
-  auto ExtInfo =
-      SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
-                               /*pseudogeneric*/ false, /*noescape*/ false,
-                               DifferentiabilityKind::NonDifferentiable,
-                               /*clangFunctionType*/ nullptr);
+  auto ExtInfo = SILFunctionType::ExtInfoBuilder(
+                     SILFunctionType::Representation::Thin,
+                     /*pseudogeneric*/ false, /*noescape*/ false,
+                     DifferentiabilityKind::NonDifferentiable,
+                     /*clangFunctionType*/ nullptr)
+                     .build();
   auto FunctionType = SILFunctionType::get(
       nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, /*yields*/ {},
@@ -1176,12 +1177,13 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
     ++OrigSigIdx;
   }
 
-  auto ExtInfo = SILFunctionType::ExtInfo(
-      SILFunctionType::Representation::Thin,
-      /*pseudogeneric*/ false,
-      /*noescape*/ false,
-      DifferentiabilityKind::NonDifferentiable,
-      /*clangFunctionType*/ nullptr);
+  auto ExtInfo =
+      SILFunctionType::ExtInfoBuilder(SILFunctionType::Representation::Thin,
+                                      /*pseudogeneric*/ false,
+                                      /*noescape*/ false,
+                                      DifferentiabilityKind::NonDifferentiable,
+                                      /*clangFunctionType*/ nullptr)
+          .build();
 
   SmallVector<SILResultInfo, 4> Results;
   // If we don't have a bridged return we changed from @autoreleased to @owned

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -84,10 +84,11 @@ class BugReducerTester : public SILFunctionTransform {
         SILResultInfo(EmptyTupleCanType, ResultConvention::Unowned));
     auto FuncType = SILFunctionType::get(
         nullptr,
-        SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
-                                 false /*isPseudoGeneric*/, false /*noescape*/,
-                                 DifferentiabilityKind::NonDifferentiable,
-                                 nullptr /*clangFunctionType*/),
+        SILFunctionType::ExtInfoBuilder(
+            SILFunctionType::Representation::Thin, false /*isPseudoGeneric*/,
+            false /*noescape*/, DifferentiabilityKind::NonDifferentiable,
+            nullptr /*clangFunctionType*/)
+            .build(),
         SILCoroutineKind::None, ParameterConvention::Direct_Unowned,
         ArrayRef<SILParameterInfo>(), ArrayRef<SILYieldInfo>(), ResultInfoArray,
         None, SubstitutionMap(), SubstitutionMap(),

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6732,7 +6732,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       maybeDiagnoseUnsupportedDifferentiableConversion(cs, expr, toFunc);
       if (!isFromDifferentiable && isToDifferentiable) {
         auto newEI =
-            fromEI.withDifferentiabilityKind(toEI.getDifferentiabilityKind());
+            fromEI.intoBuilder()
+                .withDifferentiabilityKind(toEI.getDifferentiabilityKind())
+                .build();
         fromFunc = FunctionType::get(toFunc->getParams(), fromFunc->getResult())
             ->withExtInfo(newEI)
             ->castTo<FunctionType>();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1906,23 +1906,27 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionResult),
         TVO_CanBindToNoEscape);
     FunctionType::Param arg(escapeClosure);
-    auto bodyClosure = FunctionType::get(arg, result,
-        FunctionType::ExtInfo(FunctionType::Representation::Swift,
-                              /*noescape*/ true,
-                              /*throws*/ true,
-                              DifferentiabilityKind::NonDifferentiable,
-                              /*clangFunctionType*/ nullptr));
+    auto bodyClosure = FunctionType::get(
+        arg, result,
+        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
+                                     /*noescape*/ true,
+                                     /*throws*/ true,
+                                     DifferentiabilityKind::NonDifferentiable,
+                                     /*clangFunctionType*/ nullptr)
+            .build());
     FunctionType::Param args[] = {
       FunctionType::Param(noescapeClosure),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
     };
 
-    auto refType = FunctionType::get(args, result,
-      FunctionType::ExtInfo(FunctionType::Representation::Swift,
-                            /*noescape*/ false,
-                            /*throws*/ true,
-                            DifferentiabilityKind::NonDifferentiable,
-                            /*clangFunctionType*/ nullptr));
+    auto refType = FunctionType::get(
+        args, result,
+        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
+                                     /*noescape*/ false,
+                                     /*throws*/ true,
+                                     DifferentiabilityKind::NonDifferentiable,
+                                     /*clangFunctionType*/ nullptr)
+            .build());
     return {refType, refType};
   }
   case DeclTypeCheckingSemantics::OpenExistential: {
@@ -1941,22 +1945,26 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionResult),
         TVO_CanBindToNoEscape);
     FunctionType::Param bodyArgs[] = {FunctionType::Param(openedTy)};
-    auto bodyClosure = FunctionType::get(bodyArgs, result,
-        FunctionType::ExtInfo(FunctionType::Representation::Swift,
-                              /*noescape*/ true,
-                              /*throws*/ true,
-                              DifferentiabilityKind::NonDifferentiable,
-                              /*clangFunctionType*/ nullptr));
+    auto bodyClosure = FunctionType::get(
+        bodyArgs, result,
+        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
+                                     /*noescape*/ true,
+                                     /*throws*/ true,
+                                     DifferentiabilityKind::NonDifferentiable,
+                                     /*clangFunctionType*/ nullptr)
+            .build());
     FunctionType::Param args[] = {
       FunctionType::Param(existentialTy),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
     };
-    auto refType = FunctionType::get(args, result,
-      FunctionType::ExtInfo(FunctionType::Representation::Swift,
-                            /*noescape*/ false,
-                            /*throws*/ true,
-                            DifferentiabilityKind::NonDifferentiable,
-                            /*clangFunctionType*/ nullptr));
+    auto refType = FunctionType::get(
+        args, result,
+        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
+                                     /*noescape*/ false,
+                                     /*throws*/ true,
+                                     DifferentiabilityKind::NonDifferentiable,
+                                     /*clangFunctionType*/ nullptr)
+            .build());
     return {refType, refType};
   }
   }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1585,7 +1585,7 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
       // types first.
       Action walkToTypePost(Type T) override {
         if (auto fnType = T->getAs<AnyFunctionType>()) {
-          if (auto clangType = fnType->getClangFunctionType()) {
+          if (auto clangType = fnType->getClangTypeInfo().getType()) {
             auto loader = T->getASTContext().getClangModuleLoader();
             // Serialization will serialize the sugared type if it can,
             // but we need the canonical type to be serializable or else

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2277,7 +2277,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     auto sig = AFD->getGenericSignature();
     bool hasSelf = AFD->hasImplicitSelfDecl();
 
-    AnyFunctionType::ExtInfo info;
+    AnyFunctionType::ExtInfoBuilder infoBuilder;
 
     // Result
     Type resultTy;
@@ -2297,12 +2297,13 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       SmallVector<AnyFunctionType::Param, 4> argTy;
       AFD->getParameters()->getParams(argTy);
 
-      info = info.withAsync(AFD->hasAsync());
+      infoBuilder = infoBuilder.withAsync(AFD->hasAsync());
       // 'throws' only applies to the innermost function.
-      info = info.withThrows(AFD->hasThrows());
+      infoBuilder = infoBuilder.withThrows(AFD->hasThrows());
       // Defer bodies must not escape.
       if (auto fd = dyn_cast<FuncDecl>(D))
-        info = info.withNoEscape(fd->isDeferBody());
+        infoBuilder = infoBuilder.withNoEscape(fd->isDeferBody());
+      auto info = infoBuilder.build();
 
       if (sig && !hasSelf) {
         funcTy = GenericFunctionType::get(sig, argTy, resultTy, info);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -35,7 +35,7 @@ static void adjustFunctionTypeForOverride(Type &type) {
   auto fnType = type->castTo<AnyFunctionType>();
   auto extInfo = fnType->getExtInfo();
   extInfo = extInfo.withThrows(false);
-  if (fnType->getExtInfo() != extInfo)
+  if (!fnType->getExtInfo().isEqualTo(extInfo, useClangTypes(fnType)))
     type = fnType->withExtInfo(extInfo);
 }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2680,8 +2680,7 @@ Type TypeResolver::resolveASTFunctionType(
   if (representation == AnyFunctionType::Representation::CFunctionPointer
       && !clangFnType)
     clangFnType = Context.getClangFunctionType(
-      params, outputTy, incompleteExtInfo,
-      AnyFunctionType::Representation::CFunctionPointer);
+        params, outputTy, AnyFunctionType::Representation::CFunctionPointer);
 
   auto extInfo = incompleteExtInfo.withRepresentation(representation)
                                   .withAsync(repr->async())

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5026,9 +5026,10 @@ public:
       clangFunctionType = loadedClangType.get();
     }
 
-    auto info = FunctionType::ExtInfo(*representation, noescape, throws,
-                                      *diffKind, clangFunctionType)
-                  .withAsync(async);
+    auto info = FunctionType::ExtInfoBuilder(*representation, noescape, throws,
+                                             *diffKind, clangFunctionType)
+                    .withAsync(async)
+                    .build();
 
     auto resultTy = MF.getTypeChecked(resultID);
     if (!resultTy)
@@ -5413,8 +5414,10 @@ public:
         MF.fatal();
     }
 
-    SILFunctionType::ExtInfo extInfo(*representation, pseudogeneric, noescape,
-                                     *diffKind, clangFunctionType);
+    auto extInfo =
+        SILFunctionType::ExtInfoBuilder(*representation, pseudogeneric,
+                                        noescape, *diffKind, clangFunctionType)
+            .build();
 
     // Process the coroutine kind.
     auto coroutineKind = getActualSILCoroutineKind(rawCoroutineKind);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4128,7 +4128,7 @@ public:
     using namespace decls_block;
 
     auto resultType = S.addTypeRef(fnTy->getResult());
-    auto clangType = S.addClangTypeRef(fnTy->getClangFunctionType());
+    auto clangType = S.addClangTypeRef(fnTy->getClangTypeInfo().getType());
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[FunctionTypeLayout::Code];
     FunctionTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -4216,7 +4216,7 @@ public:
       S.addSubstitutionMapRef(fnTy->getInvocationSubstitutions());
     auto patternSubstMapID =
       S.addSubstitutionMapRef(fnTy->getPatternSubstitutions());
-    auto clangTypeID = S.addClangTypeRef(fnTy->getClangFunctionType());
+    auto clangTypeID = S.addClangTypeRef(fnTy->getClangTypeInfo().getType());
 
     auto stableCoroutineKind =
       getRawStableSILCoroutineKind(fnTy->getCoroutineKind());


### PR DESCRIPTION
- ~~We could probably reduce some of the duplication with more helper methods that call `intoBuilder()` and `build()`~~.
- I don't feel particularly strongly about the method names.
- `git-clang-format` had a bit of a field day with reformatting the surrounding code, so that's a bit unfortunate...
- ~~The first commit in present in a separate PR. https://github.com/apple/swift/pull/33117~~
- The non-introduction of invariant checking is deliberate. I imagine something or the other is going to blow up when we introduce more checks, so we can do that one-by-one and refactor small amounts of code, instead of introducing the invariant checks and doing the refactoring in this PR (which is already somewhat big).