### PR TITLE
Add an AccessPath abstraction and formalize memory access

### DIFF
--- a/docs/SILProgrammersManual.md
+++ b/docs/SILProgrammersManual.md
@@ -159,6 +159,401 @@ rules out PartialApplies is no excuse to conflate applied arguments
 with function arguments. Also, without consistent use of common
 idioms, it becomes overly burdensome to evolve these APIs over time.
 
+## `AccessedStorage` and `AccessPath`
+
+The `AccessedStorage` and `AccessPath` types formalize memory access
+in SIL. Given an address-typed SIL value, it must be possible to
+reliably identify the storage location of the accessed
+memory. `AccessedStorage` identifies an accessed storage
+location. `AccessPath` contains both a storage location and the
+"access path" within that memory object. The relevant API details are
+documented in MemAccessUtils.h
+
+### Formal access
+
+SIL preserves the language semantics of formal variable access in the
+form of access markers. `begin_access` identifies the address of the
+formal access and `end_access` delimits the scope of the access. At
+the language level, a formal access is an access to a local variable
+or class property. For details, see
+[SE-0176: Enforce Exclusive Access to Memory](https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md)
+
+Access markers are preserved in SIL to:
+
+1. verify exclusivity enforcement
+
+2. continue optimizing exclusivity checks following other transforms
+
+3. simplify and strengthen general analyses of memory access. For
+example, `begin_access [read] %address` indicates that the accessed
+address is immutable for the duration of its access scope
+
+### Access path def-use relationship
+
+Computing `AccessedStorage` and `AccessPath` for any given SIL address
+involves a use-def traversal to determine the origin of the
+address. It may traverse operations on address, pointer, box, and
+reference types. The logic that formalizes which SIL operations may be
+involved in the def-use chain is encapsulated with the
+`AccessUseDefChainVisitor`. The traversal can be customized by
+implementing this visitor. Customization is not expected to change the
+meaning of AccessedStorage or AccessPath. Rather, it is intended for
+additional pass-specific book-keeping or for higher-level convenience
+APIs that operate on the use-def chain bypassing AccessedStorage
+completely.
+
+Access def-use chains are divided by three points: the "root", the
+formal access "base", and the address of a memory operation. For
+example:
+```
+  struct S {
+    var field: Int64
+  }
+  class C {
+    var prop: S
+  }
+
+  %root    = alloc_ref $C
+  %base    = ref_element_addr %root : $C, #C.prop
+  %access  = begin_access [read] [static] %base : $*S
+  %memaddr = struct_element_addr %access : $*S, #.field
+  %value   = load [trivial] %memaddr : $*Int64
+  end_access %access : $*S
+```
+
+#### Reference root
+
+The first part of the def-use chain computes the formal access base
+from the root of the object (e.g. `alloc_ref ->
+ref_element_addr`). Only reference types or Builtin.BridgeObject types
+are only allowed in this part. The reference root is the greatest
+common ancestor in the def-use graph that can identify an object by a
+single SILValue. If the root as an `alloc_ref`, then it is *uniquely
+identified*. The def-use chain from the root to the base may contain
+reference casts (`isRCIdentityPreservingCast`) and phis.
+
+This example has an identifiable def-use chain from `%root` to `%base`:
+```
+class A {
+  var prop0: Int64
+}
+class B : A {
+}
+
+bb0:
+  %root = alloc_ref $B
+  cond_br _, bb1, bb2
+
+bb1:
+  %a1 = upcast %root : $B to $A
+  br bb3(%a1 : $A)
+
+bb2:
+  %a2 = upcast %root : $B to $A
+  br bb3(%a2 : $A)
+
+bb3(%a : $A):
+  %bridge = ref_to_bridge_object %a : $A, %bits : $Builtin.Word
+  %ref = bridge_object_to_ref %bridge : $Builtin.BridgeObject to $A
+  %base = ref_element_addr %ref : $A, #A.prop0
+```
+
+Each object property and its tail storage is considered a separate
+formal access base. The reference root is only one component of an
+`AccessedStorage` location, its property index is another.
+
+#### Access base
+
+The access base is the address that directly identifies the kind of
+storage being accessed, such as `alloc_box`, `alloc_stack`,
+`global_addr`, `ref_element_addr`, and function arguments (see
+`AccessedStorage::Kind`).
+
+Typically, the base is the address-type source operand of a
+`begin_access`. However, the path from the access base to the
+`begin_access` may include *storage casts* (see
+`isAccessedStorageCast`). It may involve address, pointer, and box
+types, and may traverse phis. For some kinds of storage, the base may
+itself even be a non-address pointer. For phis that cannot be uniquely
+resolved, the base may even be a box type.
+
+This example has an identifiable def-use chain from `%base` to `%access`:
+```
+bb0:
+  %base = alloc_box $Int { var Int }
+  %boxadr = project_box %base : ${ var Int }
+  %p0 = address_to_pointer %boxadr : $*Int to $Builtin.RawPointer
+  cond_br _, bb1, bb2
+
+bb1:
+  %p1 = copy_value %p0 : $Builtin.RawPointer
+  br bb3(%p1 : $Builtin.RawPointer)
+
+bb2:
+  br bb3(%p0 : $Builtin.RawPointer)
+
+bb3(%ptr : $Builtin.RawPointer):
+  %adr = pointer_to_address %ptr : $Builtin.RawPointer to $*Int
+  %access = begin_access [read] [static] %adr : $*Int
+```
+
+Note that address-type phis are illegal (full enforcement
+pending). This is important for simplicity and efficiency, but also
+allows for a class of storage optimizations, such as bitfields, in
+which address storage is always uniquely determined. Currently, if a
+(non-address) phi on the access path from `base` to `access` does not
+have a common base, then it is considered an invalid access (the
+AccessedStorage object is not valid). SIL verification ensures that a
+formal access always has valid AccessedStorage (WIP). In other words, the
+source of a `begin_access` marker must be a single, non-phi base. In
+the future, for further simplicity, we may generally disallow box and
+pointer phis unless they have a common base.
+
+Not all SIL memory access is part of a formal access, but the
+`AccessedStorage` and `AccessPath` abstractions are universally
+applicable. Non-formal access still has an access base, even though
+the use-def search does not begin at a `begin_access` marker. For
+non-formal access, SIL verification is not as strict. An invalid
+access is allowed, but handled conservatively. This is safe as long as
+those non-formal accesses can never alias with class and global
+storage. Class and global access is always guarded by formal access
+markers--at least until static markers are stripped from SIL.
+
+#### Nested access
+
+Nested access occurs when an access base is a function argument. The
+caller always checks `@inout` arguments for exclusivity. However, the
+argument itself is a variable with its own formal access. Conflicts
+may occur in the callee which were not evident in the caller:
+
+```
+sil @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+
+sil @hasNestedAccess : $@convention(thin) (@inout Int) -> () {
+bb0(%0 : $*Int):
+  %innerAccess  = begin_access [modify] %0 : $*Int
+  %conflicting  = begin_access [modify] %0 : $*Int
+  %f = function_ref @takesTwoInouts
+  apply %f(%innerAccess, %conflicting)
+    : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %conflicting : $*Int
+  end_access %innerAccess : $*Int
+  //...
+}
+
+%var = alloc_stack $Int
+%outerAccess  = begin_access [modify] %var : $*Int
+%f = function_ref @hasNestedAccess
+apply %f(%outerAccess) : $@convention(thin) (@inout Int) -> () {
+end_access %outerAccess : $*Int
+```
+
+Nested accesses become part if the def-use chain after inlining.
+
+TODO: Nested static accesses that result from inlining could
+potentially be removed, as long as DiagnoseStaticExclusivity has
+already run.
+
+#### Access projections
+
+On the def-use chain between a formal access and a memory operation,
+*access projections* identify subobjects laid out within the formally
+accessed variable. The sequence of access projections between the base
+and the memory address correspond to an access path.
+
+For example, struct fields are not directly accessed, unless a nested
+access has been inlined. Instead, they are addressed using a
+`struct_element_addr` within the access scope:
+
+```
+%access  = begin_access [read] [static] %base : $*S
+%memaddr = struct_element_addr %access : $*S, #.field
+%value   = load [trivial] %memaddr : $*Int64
+end_access %access : $*S
+```
+
+Access projections are address projections--they take an address at
+operand zero and produce a single address result. Other
+straightforward access projections include `tuple_element_addr`,
+`index_addr`, and `tail_addr` (an aligned form of `index_addr`).
+
+Enum payload extraction (`unchecked_take_enum_data_addr`) is also an
+access projection, but it has no effect on the access path.
+
+Indirect enum payload extraction is a special two-instruction form of
+address projection (`load : ${ var } -> project_box`). For simplicity,
+and to avoid the appearance of box types on the access path, this
+should eventually be encapsulated in a single SIL instruction.
+
+For example, the following complex def-use chain from `%base` to
+`%load` actually has an empty access path:
+```
+%boxadr = unchecked_take_enum_data_addr %base : $*Enum<T>, #Enum.int!enumelt
+%box = load [take] %boxadr : $*<τ_0_0> { var Int } <T>
+%valadr = project_box %box : $<τ_0_0> { var Int } <T>, 0
+%load = load [trivial] %valadr : $*Int
+```
+
+Storage casts may also occur within an access. This typically results
+from accessors, which perform address-to-pointer
+conversion. Pointer-to-address conversion performs a type cast, and
+could lead to different subobject types corresponding to the same base
+and access path. Access paths still uniquely identify a memory
+location because it is illegal to cast memory to non-layout-compatible
+types on same execution path (without an intervening `bind_memory`).
+
+Address-type phis are prohibited, but because pointer and box types
+may be on the def-use chain, phis may also occur on an access path. A
+phi is only a valid part of an access path if it has no affect on the
+path components. This means that pointer casting and unboxing may
+occur on distinct phi paths, but index offsets and subobject
+projections may not. These rules are currently enforced to a limited
+extent, so it's possible for invalid access path to occur under
+certain conditions.
+
+For example, the following is a valid def-use access chain, with an
+access base defined in `b0`, a memory operation in `b3` and an
+`index_addr` and `struct_element_addr` on the access path:
+
+```
+class A {}
+
+struct S {
+  var field0: Int64
+  var field1: Int64
+}
+
+bb0:
+  %base    = ref_tail_addr %ref : $A, $S
+  %idxproj = index_addr %tail : $*S, %idx : $Builtin.Word
+  %p0 = address_to_pointer %idxproj : $*S to $Builtin.RawPointer
+  cond_br _, bb1, bb2
+
+bb1:
+  %pcopy = copy_value %p0 : $Builtin.RawPointer
+  %adr1  = pointer_to_address [strict] %pcopy : $Builtin.RawPointer to $*S
+  %p1    = address_to_pointer %adr1 : $*S to $Builtin.RawPointer
+  br bb3(%p1 : $Builtin.RawPointer)
+
+bb2:
+  br bb3(%p0 : $Builtin.RawPointer)
+
+bb3(%p3 : $Builtin.RawPointer):
+  %adr3 = pointer_to_address [strict] %p3 : $Builtin.RawPointer to $*S
+  %field = struct_element_addr %adr3 : $*S, $S.field0
+  load %field : $*Int64
+```
+
+### AccessedStorage
+
+`AccessedStorage` identifies an accessed storage location, be it a
+box, stack location, class property, global variable, or argument. It
+is implemented as a value object that requires no compile-time memory
+allocation and can be used as the hash key for that location. Extra
+bits are also available for information specific to a particular
+optimization pass. Its API provides the kind of location being
+accessed and information about the location's uniqueness or whether it
+is distinct from other storage.
+
+Two __uniquely identified__ storage locations may only alias if their
+AccessedStorage objects are identical.
+
+`AccessedStorage` records the "root" SILValue of the access. The root is
+the same as the access base for all storage kinds except global and
+class storage. For class properties, the storage root is the reference
+root of the object, not the base of the property. Multiple
+`ref_element_addr` projections may exist for the same property. Global
+variable storage is always uniquely identified, but it is impossible
+to find all uses from the def-use chain alone. Multiple `global_addr`
+instructions may reference the same variable. To find all global uses,
+the client must independently find all global variable references
+within the function. Clients that need to know which SILValue base was
+discovered during use-def traversal in all cases can make use of
+`AccessedStorageWithBase` or `AccessPathWithBase`. 
+
+### AccessPath
+
+`AccessPath` extends `AccessedStorage` to include the path components
+that determine the address of a subobject within the access base. The
+access path is a string of index offsets and subobject projection
+indices.
+
+```
+struct S {
+  var field0: Int64
+  var field1: Int64
+}
+
+%eltadr = struct_element_addr %access : $*S, #.field1
+
+Path: (#1)
+```
+
+```
+class A {}
+
+%tail  = ref_tail_addr %ref : $A, $S
+%one   = integer_literal $Builtin.Word, 1
+%elt   = index_addr %tail : $*S, %one : $Builtin.Word
+%field = struct_element_addr %elt : $*S, $S.field0
+
+Path: (@1, #0)
+```
+
+Note that a projection from a reference type to the object's property
+or tail storage is not part of the access path because it is already
+identified by the storage location.
+
+Offset indices are all folded into a single index at the head of the
+path (a missing offset implies offset zero). Offsets that are not
+static constants are still valid but are labeled "@Unknown". Indexing
+within a subobject is an ill-formed access, but is handled
+conservatively since this rule cannot be fully enforced.
+
+For example, the following is an invalid access path, which just
+happens to point to field1:
+```
+%field0 = struct_element_addr %base : $*S, #field0
+%field1 = index_addr %elt : $*Int64, %one : $Builtin.Word
+
+Path: (INVALID)
+```
+
+The following APIs determine whether an access path contains another
+or may overlap with another.
+
+`AccessPath::contains(AccessPath subPath)`
+
+`AccessPath::mayOverlap(AccessPath otherPath)`
+
+These are extremely light-weight APIs that, in the worst case, require
+a trivial linked list traversal with single pointer comparison for the
+length of subPath or otherPath.
+
+Subobjects are both contained with and overlap with their parent
+storage. An unknown offset does not contain any known offsets but
+overlaps with all offsets.
+
+### Access path uses
+
+For any accessed storage location and base, it must also be possible
+to reliably identify all uses of that storage location within the
+function for a particular access base. If the storage is uniquely
+identified, then that also implies that all uses of that storage
+within the function have been discovered.
+
+The `AccessPath::collectUses()` API does this. It is possible to ask
+for only the uses contained by the current path, or for all
+potentially overlapping uses. It is guaranteed to return a complete
+use set unless the client specifies a limit on the number of uses.
+
+The `AccessPathVerification` pass runs at key points in the pipeline
+to ensure that all address uses are identified and have consistent
+access paths. This pass ensures that the implementations of AccessPath
+is internally consistent for all SIL patterns. Enforcing the validity
+of the SIL itself, such as which operations are allowed on an access
+def-use chain, is handled within the SIL verifier instead.
+
 ## SILGen
 
 TBD: Possibly link to a separate document explaining the architecture of SILGen.

--- a/include/swift/Basic/IndexTrie.h
+++ b/include/swift/Basic/IndexTrie.h
@@ -22,15 +22,18 @@ namespace swift {
 
 // Trie node representing a sequence of unsigned integer indices.
 class IndexTrieNode {
-  static const unsigned RootIdx = ~0U;
-  unsigned Index;
+public:
+  static const int RootIndex = std::numeric_limits<int>::min();
+
+private:
+  int Index;
   llvm::SmallVector<IndexTrieNode*, 8> Children;
   IndexTrieNode *Parent;
 
 public:
-  IndexTrieNode(): Index(RootIdx), Parent(nullptr) {}
+  IndexTrieNode() : Index(RootIndex), Parent(nullptr) {}
 
-  explicit IndexTrieNode(unsigned V, IndexTrieNode *P): Index(V), Parent(P) {}
+  explicit IndexTrieNode(int V, IndexTrieNode *P) : Index(V), Parent(P) {}
 
   IndexTrieNode(IndexTrieNode &) =delete;
   IndexTrieNode &operator=(const IndexTrieNode&) =delete;
@@ -40,19 +43,18 @@ public:
       delete N;
   }
 
-  bool isRoot() const { return Index == RootIdx; }
+  bool isRoot() const { return Index == RootIndex; }
 
   bool isLeaf() const { return Children.empty(); }
 
-  unsigned getIndex() const { return Index; }
+  int getIndex() const { return Index; }
 
-  IndexTrieNode *getChild(unsigned Idx) {
-    assert(Idx != RootIdx);
+  IndexTrieNode *getChild(int Idx) {
+    assert(Idx != RootIndex);
 
-    auto I = std::lower_bound(Children.begin(), Children.end(), Idx,
-                              [](IndexTrieNode *a, unsigned i) {
-                                return a->Index < i;
-                              });
+    auto I =
+        std::lower_bound(Children.begin(), Children.end(), Idx,
+                         [](IndexTrieNode *a, int i) { return a->Index < i; });
     if (I != Children.end() && (*I)->Index == Idx)
       return *I;
     auto *N = new IndexTrieNode(Idx, this);

--- a/include/swift/Basic/IndexTrie.h
+++ b/include/swift/Basic/IndexTrie.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_INDEXTREE_H
 #define SWIFT_SILOPTIMIZER_UTILS_INDEXTREE_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include <algorithm>

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -844,6 +844,8 @@ public:
 
   int getOffset() const { return offset; }
 
+  bool hasUnknownOffset() const { return offset == UnknownOffset; }
+
   /// Return true if this path contains \p subPath.
   bool contains(AccessPath subPath) const;
 

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// These utilities model the storage locations of memory access.
+/// These utilities model the storage locations of memory access. See
+/// ProgrammersGuide.md for high-level design.
 ///
 /// All memory operations that are part of a formal access, as defined by
 /// exclusivity rules, are marked by begin_access and end_access instructions.

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -668,6 +668,16 @@ using BuiltinApplyTy = typename Apply_match<BuiltinValueKind, Tys...>::Ty;
 // Define matchers for most of builtin instructions.
 #include "swift/AST/Builtins.def"
 
+#undef BUILTIN_UNARY_OP_MATCH_WITH_ARG_MATCHER
+#undef BUILTIN_BINARY_OP_MATCH_WITH_ARG_MATCHER
+#undef BUILTIN_VARARGS_OP_MATCH_WITH_ARG_MATCHER
+#undef BUILTIN_CAST_OPERATION
+#undef BUILTIN_CAST_OR_BITCAST_OPERATION
+#undef BUILTIN_BINARY_OPERATION_ALL
+#undef BUILTIN_BINARY_PREDICATE
+#undef BUILTIN_MISC_OPERATION
+#undef BUILTIN
+
 //===
 // Convenience compound builtin instructions matchers that succeed
 // if any of the sub-matchers succeed.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Builtins.h"
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/SILOptions.h"
+#include "swift/Basic/IndexTrie.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/Basic/Range.h"
@@ -255,6 +256,10 @@ private:
 
   /// The indexed profile data to be used for PGO, or nullptr.
   std::unique_ptr<llvm::IndexedInstrProfReader> PGOReader;
+
+  /// A trie of integer indices that gives pointer identity to a path of
+  /// projections, shared between all functions in the module.
+  std::unique_ptr<IndexTrieNode> indexTrieRoot;
 
   /// The options passed into this SILModule.
   const SILOptions &Options;
@@ -654,6 +659,8 @@ public:
   void setPGOReader(std::unique_ptr<llvm::IndexedInstrProfReader> IPR) {
     PGOReader = std::move(IPR);
   }
+
+  IndexTrieNode *getIndexTrieRoot() { return indexTrieRoot.get(); }
 
   /// Can value operations (copies and destroys) on the given lowered type
   /// be performed in this module?

--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -19,10 +19,10 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ACCESS_SUMMARY_ANALYSIS_H_
 #define SWIFT_SILOPTIMIZER_ANALYSIS_ACCESS_SUMMARY_ANALYSIS_H_
 
+#include "swift/Basic/IndexTrie.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h"
-#include "swift/SILOptimizer/Utils/IndexTrie.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -173,21 +173,12 @@ private:
 
   llvm::SpecificBumpPtrAllocator<FunctionInfo> Allocator;
 
-  /// A trie of integer indices that gives pointer identity to a path of
-  /// projections. This is shared between all functions in the module.
-  std::unique_ptr<IndexTrieNode> SubPathTrie;
-
 public:
-  AccessSummaryAnalysis() : BottomUpIPAnalysis(SILAnalysisKind::AccessSummary) {
-    SubPathTrie.reset(new IndexTrieNode());
-  }
+  AccessSummaryAnalysis()
+      : BottomUpIPAnalysis(SILAnalysisKind::AccessSummary) {}
 
   /// Returns a summary of the accesses performed by the given function.
   const FunctionSummary &getOrCreateSummary(SILFunction *Fn);
-
-  IndexTrieNode *getSubPathTrieRoot() {
-    return SubPathTrie.get();
-  }
 
   /// Returns an IndexTrieNode that represents the single subpath accessed from
   /// BAI or the root if no such node exists.

--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -39,8 +39,8 @@ bool pointsToLocalObject(SILValue V);
 /// Returns true if \p V is a uniquely identified address or reference. Two
 /// uniquely identified pointers with distinct roots cannot alias. However, a
 /// uniquely identified pointer may alias with unidentified pointers. For
-/// example, the uniquely identified pointer may escape to a call that returns an
-/// alias of that pointer.
+/// example, the uniquely identified pointer may escape to a call that returns
+/// an alias of that pointer.
 ///
 /// It may be any of:
 ///
@@ -53,6 +53,9 @@ bool pointsToLocalObject(SILValue V);
 ///
 /// - an address projection based on an exclusive argument with no levels of
 /// indirection (e.g. ref_element_addr, project_box, etc.).
+///
+/// TODO: Fold this into the AccessedStorage API. pointsToLocalObject should be
+/// performed by AccessedStorage::isUniquelyIdentified.
 inline bool isUniquelyIdentified(SILValue V) {
   SILValue objectRef = V;
   if (V->getType().isAddress()) {
@@ -60,7 +63,7 @@ inline bool isUniquelyIdentified(SILValue V) {
     if (!storage)
       return false;
 
-    if (storage.isUniquelyIdentifiedAfterEnforcement())
+    if (storage.isUniquelyIdentified())
       return true;
 
     if (!storage.isObjectAccess())

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -70,6 +70,8 @@ PASS(AccessSummaryDumper, "access-summary-dump",
      "Dump Address Parameter Access Summary")
 PASS(AccessedStorageAnalysisDumper, "accessed-storage-analysis-dump",
      "Dump Accessed Storage Analysis Summaries")
+PASS(AccessPathVerification, "access-path-verification",
+     "Verify Access Paths (and Accessed Storage)")
 PASS(AccessedStorageDumper, "accessed-storage-dump",
      "Dump Accessed Storage Information")
 PASS(AccessMarkerElimination, "access-marker-elim",

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3849,7 +3849,7 @@ void IRGenSILFunction::visitRefTailAddrInst(RefTailAddrInst *i) {
 }
 
 static bool isInvariantAddress(SILValue v) {
-  SILValue accessedAddress = getAccessedAddress(v);
+  SILValue accessedAddress = getAccessAddress(v);
   if (auto *ptrRoot = dyn_cast<PointerToAddressInst>(accessedAddress)) {
     return ptrRoot->isInvariant();
   }

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -94,7 +94,8 @@ class SILModule::SerializationCallback final
 
 SILModule::SILModule(llvm::PointerUnion<FileUnit *, ModuleDecl *> context,
                      Lowering::TypeConverter &TC, const SILOptions &Options)
-    : Stage(SILStage::Raw), Options(Options), serialized(false),
+    : Stage(SILStage::Raw), indexTrieRoot(new IndexTrieNode()),
+      Options(Options), serialized(false),
       regDeserializationNotificationHandlerForNonTransparentFuncOME(false),
       regDeserializationNotificationHandlerForAllFuncOME(false),
       SerializeSILAction(), Types(TC) {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1274,7 +1274,7 @@ void AccessPath::Index::print(raw_ostream &os) const {
     os << '#' << getSubObjectIndex();
   else {
     os << '@';
-    if (getOffset() == AccessPath::UnknownOffset)
+    if (isUnknownOffset())
       os << "Unknown";
     else
       os << getOffset();

--- a/lib/SIL/Verifier/VerifierPrivate.h
+++ b/lib/SIL/Verifier/VerifierPrivate.h
@@ -41,6 +41,9 @@ private:
       LoadBorrowInst *lbi, ArrayRef<Operand *> endBorrowUses, SILValue address);
   bool doesBoxHaveWritesThatInvalidateLoadBorrow(
       LoadBorrowInst *lbi, ArrayRef<Operand *> endBorrowUses, SILValue box);
+  bool isUnidentifiedBorrowInvalidated(LoadBorrowInst *lbi,
+                                       ArrayRef<Operand *> endBorrowUses,
+                                       SILValue pointerBase);
 };
 
 } // namespace silverifier

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -49,9 +49,9 @@ void AccessSummaryAnalysis::processFunction(FunctionInfo *info,
 /// started by a begin_access and any flows of the arguments to other
 /// functions.
 void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
-                                             SILFunctionArgument *argument,
-                                             ArgumentSummary &summary,
-                                             FunctionOrder &order) {
+                                            SILFunctionArgument *argument,
+                                            ArgumentSummary &summary,
+                                            FunctionOrder &order) {
   unsigned argumentIndex = argument->getIndex();
 
   // Use a worklist to track argument uses to be processed.
@@ -77,7 +77,7 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
       // call.
       if (!callee || callee->empty()) {
         summary.mergeWith(SILAccessKind::Modify, apply.getLoc(),
-                          getSubPathTrieRoot());
+                          apply.getModule().getIndexTrieRoot());
         continue;
       }
       unsigned operandNumber = operand->getOperandNumber();
@@ -468,7 +468,6 @@ AccessSummaryAnalysis::getOrCreateSummary(SILFunction *fn) {
 void AccessSummaryAnalysis::AccessSummaryAnalysis::invalidate() {
   FunctionInfos.clear();
   Allocator.DestroyAll();
-  SubPathTrie.reset(new IndexTrieNode());
 }
 
 void AccessSummaryAnalysis::invalidate(SILFunction *F, InvalidationKind K) {
@@ -526,7 +525,7 @@ getSingleAddressProjectionUser(SingleValueInstruction *I) {
 
 const IndexTrieNode *
 AccessSummaryAnalysis::findSubPathAccessed(BeginAccessInst *BAI) {
-  IndexTrieNode *SubPath = getSubPathTrieRoot();
+  IndexTrieNode *SubPath = BAI->getModule().getIndexTrieRoot();
 
   // For each single-user projection of BAI, construct or get a node
   // from the trie representing the index of the field or tuple element

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -334,7 +334,7 @@ static bool isAccessedAddressTBAASafe(SILValue V) {
   if (!V->getType().isAddress())
     return false;
 
-  SILValue accessedAddress = getAccessedAddress(V);
+  SILValue accessedAddress = getAccessAddress(V);
   if (isa<SILFunctionArgument>(accessedAddress))
     return true;
 

--- a/lib/SILOptimizer/LoopTransforms/ArrayOpt.h
+++ b/lib/SILOptimizer/LoopTransforms/ArrayOpt.h
@@ -63,7 +63,7 @@ public:
   /// Do not form a path with an IndexAddrInst because we have no way to
   /// distinguish between indexing and subelement access. The same index could
   /// either refer to the next element (indexed) or a subelement.
-  static SILValue getAccessPath(SILValue V, SmallVectorImpl<unsigned>& Path) {
+  static SILValue getAccessPath(SILValue V, SmallVectorImpl<int> &Path) {
     V = stripCasts(V);
     if (auto *IA = dyn_cast<IndexAddrInst>(V)) {
       // Don't include index_addr projections in the access path. We could if
@@ -89,7 +89,7 @@ public:
   VisitedSet Visited;
 
   /// Collect all uses of the value at the given address.
-  void collectUses(ValueBase *V, ArrayRef<unsigned> AccessPath) {
+  void collectUses(ValueBase *V, ArrayRef<int> AccessPath) {
     // Save our old indent and increment.
     // Collect all users of the address and loads.
     collectAddressUses(V, AccessPath, nullptr);
@@ -142,7 +142,7 @@ protected:
   /// StructVal is invalid, then the value is the address of the Struct. If
   /// StructVal is valid, the value is the address of an element within the
   /// Struct.
-  void collectAddressUses(ValueBase *V, ArrayRef<unsigned> AccessPathSuffix,
+  void collectAddressUses(ValueBase *V, ArrayRef<int> AccessPathSuffix,
                           Operand *StructVal) {
     for (auto *UI : V->getUses()) {
       // Keep the operand, not the instruction in the visited set. The same

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -402,7 +402,7 @@ private:
     if (!Call.canHoist(Preheader->getTerminator(), DomTree))
       return false;
 
-    SmallVector<unsigned, 4> AccessPath;
+    SmallVector<int, 4> AccessPath;
     SILValue ArrayContainer =
       StructUseCollector::getAccessPath(Arr, AccessPath);
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -843,7 +843,7 @@ bool COWArrayOpt::hoistMakeMutable(ArraySemanticsCall MakeMutable,
     return false;
   }
 
-  SmallVector<unsigned, 4> AccessPath;
+  SmallVector<int, 4> AccessPath;
   SILValue ArrayContainer =
     StructUseCollector::getAccessPath(CurrentArrayAddr, AccessPath);
   bool arrayContainerIsUnique = checkUniqueArrayContainer(ArrayContainer);

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -711,7 +711,7 @@ static bool analyzeBeginAccess(BeginAccessInst *BI,
       return true;
     }
     return BIAccessedStorageNonNested.isDistinctFrom(
-        findAccessedStorage(OtherBI));
+      findAccessedStorage(OtherBI));
   };
 
   if (!std::all_of(BeginAccesses.begin(), BeginAccesses.end(), safeBeginPred))

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -754,7 +754,7 @@ static void checkCaptureAccess(ApplySite Apply, AccessState &State) {
 
     // The unknown argument access is considered a modify of the root subpath.
     auto argAccess = RecordedAccess(SILAccessKind::Modify, Apply.getLoc(),
-                                    State.ASA->getSubPathTrieRoot());
+                                    Apply.getModule().getIndexTrieRoot());
 
     // Construct a conflicting RecordedAccess if one doesn't already exist.
     const AccessInfo &info = AccessIt->getSecond();

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -422,6 +422,11 @@ static void addPerfDebugSerializationPipeline(SILPassPipelinePlan &P) {
 static void addPrepareOptimizationsPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("PrepareOptimizationPasses");
 
+  // Verify AccessedStorage once in OSSA before optimizing.
+#ifndef NDEBUG
+  P.addAccessPathVerification();
+#endif
+
   P.addForEachLoopUnroll();
   P.addMandatoryCombine();
   P.addAccessMarkerElimination();
@@ -668,6 +673,11 @@ static void addLastChanceOptPassPipeline(SILPassPipelinePlan &P) {
   // addAccessEnforcementDom might provide potential for LICM:
   // A loop might have only one dynamic access now, i.e. hoistable
   P.addLICM();
+
+  // Verify AccessedStorage once again after optimizing and lowering OSSA.
+#ifndef NDEBUG
+  P.addAccessPathVerification();
+#endif
 
   // Only has an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();

--- a/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
@@ -266,8 +266,13 @@ public:
     return next(parentAddr->get());
   }
 
-  void visitPathComponent(SingleValueInstruction *projectedAddr,
-                          Operand *parentAddr) {
+  void visitStorageCast(SingleValueInstruction *projectedAddr,
+                        Operand *parentAddr) {
+    return next(parentAddr->get());
+  }
+
+  void visitAccessProjection(SingleValueInstruction *projectedAddr,
+                             Operand *parentAddr) {
     return next(parentAddr->get());
   }
 

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -123,12 +123,12 @@
 /// ===----------------------------------------------------------------------===
 
 #define DEBUG_TYPE "copy-propagation"
+#include "swift/Basic/IndexTrie.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
-#include "swift/SILOptimizer/Utils/IndexTrie.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Statistic.h"

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -24,6 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "dead-object-elim"
+#include "swift/Basic/IndexTrie.h"
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/DebugUtils.h"
@@ -38,7 +39,6 @@
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/IndexTrie.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
 #include "swift/SILOptimizer/Utils/ValueLifetime.h"

--- a/lib/SILOptimizer/UtilityPasses/AccessPathVerification.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessPathVerification.cpp
@@ -1,0 +1,135 @@
+//===--- AccessPathVerification.cpp - verify access paths and storage -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Verify AccessPath computation. For the address of every memory operation in
+/// the module, compute the access path, compute all the users of that path,
+/// then verify that all users have the same access path.
+///
+/// This is potentially expensive, so there is a fast mode that limits the
+/// number of uses visited per path.
+///
+/// During full verification, also check that all addresses that share an
+/// AccessPath are covered when computed the use list of that AccessPath. This
+/// is important because optimizations may assume that the use list is
+/// complete.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "access-path-verification"
+#include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Verify access path and uses of each access.
+class AccessPathVerification : public SILModuleTransform {
+  llvm::DenseMap<Operand *, AccessPath> useToPathMap;
+
+  // Transient uses
+  llvm::SmallVector<Operand *, 64> uses;
+
+public:
+  void verifyAccessPath(Operand *operand) {
+    auto pathAndBase = AccessPathWithBase::compute(operand->get());
+    auto accessPath = pathAndBase.accessPath;
+    if (!accessPath.isValid())
+      return;
+
+    auto iterAndInserted = useToPathMap.try_emplace(operand, accessPath);
+    // If this use was already computed from a previously visited path, make
+    // sure the path we just computed matches.
+    if (!iterAndInserted.second) {
+      auto collectedFromPath = iterAndInserted.first->second;
+      if (collectedFromPath != accessPath) {
+        llvm::errs() << "Address use: " << *operand->getUser()
+                     << "  collected from path\n  ";
+        collectedFromPath.dump();
+        llvm::errs() << "  has different path\n  ";
+        accessPath.dump();
+        operand->getUser()->getFunction()->dump();
+        assert(false && "computed path does not match collected path");
+      }
+      return;
+    }
+    // This is a new path, so map all its uses.
+    assert(uses.empty());
+    pathAndBase.collectUses(uses, /*collectContainingUses*/ false);
+    bool foundOperandUse = false;
+    for (Operand *use : uses) {
+      if (use == operand) {
+        foundOperandUse = true;
+        continue;
+      }
+      // (live) subobject projections within an access will be mapped later as a
+      // separate path.
+      switch (use->getUser()->getKind()) {
+      default:
+        break;
+      case SILInstructionKind::StructElementAddrInst:
+      case SILInstructionKind::TupleElementAddrInst:
+      case SILInstructionKind::IndexAddrInst:
+        continue;
+      }
+      auto iterAndInserted = useToPathMap.try_emplace(use, accessPath);
+      if (!iterAndInserted.second) {
+        llvm::errs() << "Address use: " << *operand->getUser()
+                     << "  with path...\n";
+        pathAndBase.dump();
+        llvm::errs() << "  was not collected for: " << *use->getUser();
+        llvm::errs() << "  with path...\n";
+        auto computedPath = iterAndInserted.first->second;
+        computedPath.dump();
+        use->getUser()->getFunction()->dump();
+        assert(false && "missing collected use");
+      }
+    }
+    if (!foundOperandUse && !accessPath.hasUnknownOffset()) {
+      llvm::errs() << "Address use: " << *operand->getUser()
+                   << "  is not a use of path\n  ";
+      accessPath.dump();
+      assert(false && "not a user of its own computed path ");
+    }
+    uses.clear();
+  }
+
+  void run() override {
+    for (auto &fn : *getModule()) {
+      if (fn.empty())
+        continue;
+
+      PrettyStackTraceSILFunction functionDumper("...", &fn);
+      for (auto &bb : fn) {
+        for (auto &inst : bb) {
+          if (inst.mayReadOrWriteMemory())
+            visitAccessedAddress(&inst, [this](Operand *operand) {
+              return verifyAccessPath(operand);
+            });
+        }
+      }
+      useToPathMap.clear();
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createAccessPathVerification() {
+  return new AccessPathVerification();
+}

--- a/lib/SILOptimizer/UtilityPasses/AccessedStorageDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessedStorageDumper.cpp
@@ -1,8 +1,8 @@
-//===--- AccessedStorageDumper.cpp - Dump accessed storage for functions ---===//
+//===--- AccessedStorageDumper.cpp - Dump accessed storage ----------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -17,24 +17,52 @@
 #include "swift/SIL/SILValue.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
 
-static void dumpAccessedStorage(SILInstruction *inst) {
-  visitAccessedAddress(
-    inst,
-    [&](Operand *operand) {
-      inst->print(llvm::outs());
-      findAccessedStorage(operand->get()).print(llvm::outs());
-    }
-  );
-}
+static llvm::cl::opt<bool> EnableDumpUses(
+    "enable-accessed-storage-dump-uses", llvm::cl::init(false),
+    llvm::cl::desc("With --sil-access-storage-dumper, dump all uses"));
 
 namespace {
 
 /// Dumps sorage information for each access.
 class AccessedStorageDumper : public SILModuleTransform {
+  llvm::SmallVector<Operand *, 32> uses;
+
+  void dumpAccessedStorage(Operand *operand) {
+    findAccessedStorage(operand->get()).print(llvm::outs());
+    auto pathAndBase = AccessPathWithBase::compute(operand->get());
+    pathAndBase.print(llvm::outs());
+
+    if (!pathAndBase.accessPath.isValid() || !EnableDumpUses)
+      return;
+
+    uses.clear();
+    pathAndBase.collectUses(uses, /*collectContainingUses*/ false);
+    llvm::outs() << "Exact Uses {\n";
+    for (auto *useOperand : uses) {
+      llvm::outs() << *useOperand->getUser() << "  ";
+      auto usePathAndBase = AccessPathWithBase::compute(useOperand->get());
+      usePathAndBase.accessPath.printPath(llvm::outs());
+      assert(pathAndBase.accessPath.contains(usePathAndBase.accessPath)
+             && "access path does not contain use access path");
+    }
+    llvm::outs() << "}\n";
+    uses.clear();
+    pathAndBase.collectUses(uses, /*collectContainingUses*/ true);
+    llvm::outs() << "Overlapping Uses {\n";
+    for (auto *useOperand : uses) {
+      llvm::outs() << *useOperand->getUser() << "  ";
+      auto usePathAndBase = AccessPathWithBase::compute(useOperand->get());
+      usePathAndBase.accessPath.printPath(llvm::outs());
+      assert(pathAndBase.accessPath.mayOverlap(usePathAndBase.accessPath)
+             && "access path does not contain use access path");
+    }
+    llvm::outs() << "}\n";
+  }
 
   void run() override {
     for (auto &fn : *getModule()) {
@@ -45,8 +73,12 @@ class AccessedStorageDumper : public SILModuleTransform {
       }
       for (auto &bb : fn) {
         for (auto &inst : bb) {
-          if (inst.mayReadOrWriteMemory())
-            dumpAccessedStorage(&inst);
+          if (inst.mayReadOrWriteMemory()) {
+            llvm::outs() << "###For MemOp: " << inst;
+            visitAccessedAddress(&inst, [this](Operand *operand) {
+              dumpAccessedStorage(operand);
+            });
+          }
         }
       }
     }

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(swiftSILOptimizer PRIVATE
   AADumper.cpp
   AccessSummaryDumper.cpp
+  AccessPathVerification.cpp
   AccessedStorageAnalysisDumper.cpp
   AccessedStorageDumper.cpp
   BasicCalleePrinter.cpp

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -216,7 +216,7 @@ internal struct ReflectionInfo : Sequence {
 }
 
 internal func sendBytes<T>(from address: UnsafePointer<T>, count: Int) {
-  var source = address
+  var source = UnsafeRawPointer(address)
   var bytesLeft = count
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
   while bytesLeft > 0 {

--- a/test/SILOptimizer/accessed_storage.sil
+++ b/test/SILOptimizer/accessed_storage.sil
@@ -1,4 +1,7 @@
 // RUN: %target-sil-opt %s -accessed-storage-dump -enable-sil-verify-all -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -access-path-verification -o /dev/null
+
+// REQUIRES: PTRSIZE=64
 
 sil_stage canonical
 
@@ -14,6 +17,9 @@ struct MyStruct {
 // CHECK-LABEL: @testStructPhiCommon
 // CHECK: store
 // CHECK: Argument %0 = argument of bb0 : $*MyStruct
+// CHECK: Base: %0 = argument of bb0 : $*MyStruct
+// CHECK: Storage: Argument %0 = argument of bb0 : $*MyStruct
+// CHECK: Path: (#0)
 sil hidden @testStructPhiCommon : $@convention(thin) (@inout MyStruct) -> () {
 bb0(%0 : $*MyStruct):
   %2 = struct_element_addr %0 : $*MyStruct, #MyStruct.i
@@ -41,6 +47,7 @@ bb3(%6 : $Builtin.RawPointer) :
 //
 // CHECK-LABEL: @testStructPhiDivergent
 // CHECK: store
+// CHECK: INVALID
 // CHECK: INVALID
 sil hidden @testStructPhiDivergent : $@convention(thin) (@inout MyStruct) -> () {
 bb0(%0 : $*MyStruct):
@@ -74,6 +81,7 @@ bb3(%6 : $Builtin.RawPointer) :
 //
 // CHECK-LABEL: @testStructPhiChained
 // CHECK:   store
+// CHECK: INVALID
 // CHECK: INVALID
 sil hidden @testStructPhiChained : $@convention(thin) (@inout MyStruct, @inout Int64) -> () {
 bb0(%0 : $*MyStruct, %1 : $*Int64):
@@ -123,9 +131,15 @@ struct MyArray<T> {
 
 // CHECK-LABEL: @arrayValue
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
-// CHECK: Tail  %{{.*}} = unchecked_ref_cast [[REF:%[0-9]+]] : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Base:    %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $Int64
+// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Path:    (@3,#0)
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
-// CHECK: Tail  %{{.*}} = unchecked_ref_cast [[REF:%[0-9]+]] : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Base:    %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $Int64
+// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Path:    (@4,#0)
 sil [ossa] @arrayValue : $@convention(thin) (@guaranteed MyArray<Int64>) -> Int64 {
 bb0(%0 : @guaranteed $MyArray<Int64>):
   %1 = integer_literal $Builtin.Word, 3
@@ -148,4 +162,304 @@ bb0(%0 : @guaranteed $MyArray<Int64>):
   cond_fail %17 : $Builtin.Int1, "arithmetic overflow"
   %19 = struct $Int64 (%16 : $Builtin.Int64)
   return %19 : $Int64
+}
+
+// CHECK-LABEL: @staticIndexAddrChain
+// CHECK:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@1,#0)
+// CHECK:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Argument %{{.*}} = argument of bb0 : $Builtin.RawPointer
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@2,#0)
+sil [ossa] @staticIndexAddrChain : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*MyStruct
+  %2 = integer_literal $Builtin.Word, 1
+  %3 = index_addr %1 : $*MyStruct, %2 : $Builtin.Word
+  %4 = struct_element_addr %3 : $*MyStruct, #MyStruct.i
+  %5 = load [trivial] %4 : $*Int64
+  %6 = index_addr %3 : $*MyStruct, %2 : $Builtin.Word
+  %7 = struct_element_addr %6 : $*MyStruct, #MyStruct.i
+  %8 = load [trivial] %7 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @staticIndexAddrSubobject
+// CHECK: ###For MemOp:   %5 = load [trivial] %4 : $*Int64
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer        // user: %1
+// CHECK: INVALID
+sil [ossa] @staticIndexAddrSubobject : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*MyStruct
+  %2 = struct_element_addr %1 : $*MyStruct, #MyStruct.i
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = index_addr %2 : $*Int64, %3 : $Builtin.Word
+  %5 = load [trivial] %4 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @dynamicIndexAddrChain
+// CHECK:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@Unknown,#0)
+// CHECK:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@Unknown,#0)
+sil [ossa] @dynamicIndexAddrChain : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to $*MyStruct
+  %3 = index_addr %2 : $*MyStruct, %1 : $Builtin.Word
+  %4 = struct_element_addr %3 : $*MyStruct, #MyStruct.i
+  %5 = load [trivial] %4 : $*Int64
+  %6 = integer_literal $Builtin.Word, 1
+  %7 = index_addr %3 : $*MyStruct, %6 : $Builtin.Word
+  %8 = struct_element_addr %7 : $*MyStruct, #MyStruct.i
+  %9 = load [trivial] %8 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @staticIndexAddrCancel
+// CHECK:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@1,#0)
+// CHECK:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@2,#0)
+sil [ossa] @staticIndexAddrCancel : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*MyStruct
+  %2 = integer_literal $Builtin.Word, 1
+  %3 = index_addr %1 : $*MyStruct, %2 : $Builtin.Word
+  %4 = struct_element_addr %3 : $*MyStruct, #MyStruct.i
+  %5 = load [trivial] %4 : $*Int64
+  %6 = integer_literal $Builtin.Word, -1
+  %7 = index_addr %3 : $*MyStruct, %2 : $Builtin.Word
+  %8 = struct_element_addr %7 : $*MyStruct, #MyStruct.i
+  %9 = load [trivial] %8 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+class A {
+  var prop0: Int64
+}
+class B : A {
+  var prop1: Int64
+}
+
+// CHECK-LABEL: @testNonUniquePropertyIndex
+// CHECK:   store %0 to %{{.*}} : $*Int64
+// CHECK: Class   %{{.*}} = alloc_ref $B
+// CHECK:   Field: var prop1: Int64 Index: 1
+// CHECK: Base:   %{{.*}} = ref_element_addr %{{.*}} : $B, #B.prop1
+// CHECK: Storage: Class   %{{.*}} = alloc_ref $B
+// CHECK:   Field: var prop1: Int64 Index: 1
+// CHECK: Path: ()
+// CHECK:   store %0 to %{{.*}} : $*Int64
+// CHECK: Class   %{{.*}} = upcast %{{.*}} : $B to $A
+// CHECK:   Field: var prop0: Int64 Index: 0
+// CHECK: Base:   %{{.*}} = ref_element_addr %{{.*}} : $A, #A.prop0
+// CHECK: Storage: Class   %{{.*}} = upcast %{{.*}} : $B to $A
+// CHECK:   Field: var prop0: Int64 Index: 0
+// CHECK: Path: ()
+sil @testNonUniquePropertyIndex : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_ref $B
+  %2 = ref_element_addr %1 : $B, #B.prop1
+  store %0 to %2 : $*Int64
+  %4 = upcast %1 : $B to $A
+  %5 = ref_element_addr %4 : $A, #A.prop0
+  store %0 to %5 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @testRefTailAndStruct0
+// CHECK: %{{.*}} = load %{{.*}} : $*Builtin.Int64
+// CHECK: Class   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK:   Field: @usableFromInline final var countAndCapacity: _ArrayBody Index: 0
+// CHECK: Base:   %{{.*}} = ref_element_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+// CHECK: Storage: Class   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK:   Field: @usableFromInline final var countAndCapacity: _ArrayBody Index: 0
+// CHECK: Path: (#0,#0,#0)
+// CHECK:   %{{.*}} = load %{{.*}} : $*_StringGuts
+// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Base:   %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $String
+// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Path: (#0)
+// CHECK: %{{.*}} = load %{{.*}} : $*String
+// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Base:   %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $String
+// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Path: ()
+sil hidden [noinline] @testRefTailAndStruct0 : $@convention(thin) (@owned MyArray<String>) -> () {
+bb0(%0 : $MyArray<String>):
+  %1 = struct_extract %0 : $MyArray<String>, #MyArray._buffer
+  %2 = struct_extract %1 : $_MyArrayBuffer<String>, #_MyArrayBuffer._storage
+  %3 = struct_extract %2 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
+  %4 = unchecked_ref_cast %3 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %5 = ref_element_addr [immutable] %4 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %6 = struct_element_addr %5 : $*_ArrayBody, #_ArrayBody._storage
+  %7 = struct_element_addr %6 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %8 = struct_element_addr %7 : $*Int, #Int._value
+  %9 = load %8 : $*Builtin.Int64
+  %10 = ref_tail_addr [immutable] %4 : $__ContiguousArrayStorageBase, $String
+  %11 = struct_element_addr %10 : $*String, #String._guts
+  %12 = load %11 : $*_StringGuts
+  %13 = load %10 : $*String
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: @testPointerDynamicIndex
+// CHECK: ###For MemOp: %{{.*}} = load [trivial] %{{.*}} : $*MyStruct
+// CHECK: Base: %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@Unknown)
+sil [serialized] [ossa] @testPointerDynamicIndex : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*MyStruct
+  %3 = index_addr %2 : $*MyStruct, %1 : $Builtin.Word
+  %4 = address_to_pointer %3 : $*MyStruct to $Builtin.RawPointer
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*MyStruct
+  %6 = load [trivial] %5 : $*MyStruct
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @testAddressToPointer
+// CHECK: ###For MemOp:   %3 = load [trivial] %{{.*}} : $*MyStruct
+// CHECK: Base: %0 = argument of bb0 : $*MyStruct
+// CHECK: Storage: Argument %0 = argument of bb0 : $*MyStruct
+// CHECK: Path: ()
+// CHECK: ###For MemOp:   %5 = load [trivial] %4 : $*Int64
+// CHECK: Base: %0 = argument of bb0 : $*MyStruct
+// CHECK: Storage: Argument %0 = argument of bb0 : $*MyStruct
+// CHECK: Path: (#0)
+sil [serialized] [ossa] @testAddressToPointer : $@convention(thin) (@in MyStruct) -> () {
+bb18(%0 : $*MyStruct):
+  %1 = address_to_pointer %0 : $*MyStruct to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*MyStruct
+  %3 = load [trivial] %2 : $*MyStruct
+  %4 = struct_element_addr %0 : $*MyStruct, #MyStruct.i
+  %5 = load [trivial] %4 : $*Int64
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: @testIndexLoop
+// CHECK: ###For MemOp:   %3 = load %2 : $*AnyObject
+// CHECK: Base:   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: ()
+// CHECK: ###For MemOp:   %7 = load %6 : $*AnyObject
+// CHECK: Base:   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   store %7 to %6 : $*AnyObject                    // id: %8
+// CHECK: Base:   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: (@Unknown)
+sil shared @testIndexLoop : $@convention(thin) (UnsafeMutablePointer<AnyObject>) -> UnsafeMutablePointer<AnyObject> {
+bb0(%0 : $UnsafeMutablePointer<AnyObject>):
+  %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*AnyObject
+  %3 = load %2 : $*AnyObject
+  br bb1(%1 : $Builtin.RawPointer)
+
+bb1(%5 : $Builtin.RawPointer):
+  %6 = pointer_to_address %5 : $Builtin.RawPointer to [strict] $*AnyObject
+  %7 = load %6 : $*AnyObject
+  store %7 to %6 : $*AnyObject
+  %9 = integer_literal $Builtin.Word, 1
+  %10 = index_addr %6 : $*AnyObject, %9 : $Builtin.Word
+  %11 = address_to_pointer %10 : $*AnyObject to $Builtin.RawPointer
+  cond_br undef, bb2, bb3(%11 : $Builtin.RawPointer)
+
+bb2:
+  br bb1(%11 : $Builtin.RawPointer)
+
+bb3(%14 : $Builtin.RawPointer):
+  %15 = struct $UnsafeMutablePointer<AnyObject> (%14 : $Builtin.RawPointer)
+  return %15 : $UnsafeMutablePointer<AnyObject>
+}
+
+// Handle index_addr boundary conditions
+// Most will end up as "unknown" offset, but we shouldn't crash.
+// CHECK-LABEL: @indexAddrBoundaries
+// CHECK: ###For MemOp:   %4 = load %3 : $*Int
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   %7 = load %6 : $*Int
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   %10 = load %9 : $*Int
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   %13 = load %12 : $*Int
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   %16 = load %15 : $*Int
+// CHECK: Path: (@1073741823)
+// CHECK: ###For MemOp:   %19 = load %18 : $*Int
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   %22 = load %21 : $*Int
+// CHECK: Path: (@Unknown)
+// CHECK: ###For MemOp:   %25 = load %24 : $*Int
+// CHECK: Path: (@-1073741823)
+// CHECK: ###For MemOp:   %28 = load %27 : $*Int
+// CHECK: Path: (@-1)
+sil @indexAddrBoundaries : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Int
+  // INT_MIN (IndexTrie root)
+  %2 = integer_literal $Builtin.Word, 2147483648  // '0x80000000'
+  %3 = index_addr %1 : $*Int, %2 : $Builtin.Word
+  %4 = load %3 : $*Int
+  // INT_MIN (IndexTrie root)
+  %5 = integer_literal $Builtin.Word, -2147483648 // '0x80000000'
+  %6 = index_addr %1 : $*Int, %5 : $Builtin.Word
+  %7 = load %6 : $*Int
+  // INT_MAX (TailIndex)
+  %8 = integer_literal $Builtin.Word, 2147483647  // '0x7fffffff'
+  %9 = index_addr %1 : $*Int, %8 : $Builtin.Word
+  %10 = load %9 : $*Int
+  // Largest unsigned offset + 1
+  %11 = integer_literal $Builtin.Word, 1073741824 // '0x40000000'
+  %12 = index_addr %1 : $*Int, %11 : $Builtin.Word
+  %13 = load %12 : $*Int
+  // Largest unsigned offset
+  %14 = integer_literal $Builtin.Word, 1073741823 // '0x3fffffff'
+  %15 = index_addr %1 : $*Int, %14 : $Builtin.Word
+  %16 = load %15 : $*Int
+  // Smallest signed offset - 1
+  %17 = integer_literal $Builtin.Word, -1073741825 // '0xbfffffff'
+  %18 = index_addr %1 : $*Int, %17 : $Builtin.Word
+  %19 = load %18 : $*Int
+  // Smallest signed offset (Unknown offset)
+  %20 = integer_literal $Builtin.Word, -1073741824 // '0xc0000000'
+  %21 = index_addr %1 : $*Int, %20 : $Builtin.Word
+  %22 = load %21 : $*Int
+  // Smallest signed offset + 1 (concrete offset)
+  %23 = integer_literal $Builtin.Word, -1073741823 // '0xc0000001'
+  %24 = index_addr %1 : $*Int, %23 : $Builtin.Word
+  %25 = load %24 : $*Int
+  // Largest Negative
+  %26 = integer_literal $Builtin.Word, -1          // '0xffffffff'
+  %27 = index_addr %1 : $*Int, %26 : $Builtin.Word
+  %28 = load %27 : $*Int
+  //
+  %99 = tuple ()
+  return %99 : $()
 }

--- a/test/SILOptimizer/accesspath_uses.sil
+++ b/test/SILOptimizer/accesspath_uses.sil
@@ -1,0 +1,532 @@
+// RUN: %target-sil-opt %s -accessed-storage-dump -enable-accessed-storage-dump-uses -enable-sil-verify-all -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -access-path-verification -o /dev/null
+
+// REQUIRES: PTRSIZE=64
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct MyStruct {
+  @_hasStorage @_hasInitialValue var i: Int64 { get set }
+  @_hasStorage @_hasInitialValue var j: Int64 { get set }
+}
+
+// unknown offset contains subobject indices
+// CHECK-LABEL: @testDynamicIndexWithSubObject
+// CHECK: ###For MemOp: %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK: Path: (#0)
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK-NEXT:   Path: (#0)
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:   %{{.*}} = load [trivial] %{{.*}} : $*Int64
+// CHECK-NEXT:   Path: (#0)
+// CHECK-NEXT:   %{{.*}} = load [trivial] %{{.*}} : $*MyStruct
+// CHECK-NEXT:   Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp: %{{.*}} = load [trivial] %{{.*}} : $*MyStruct
+// CHECK: Path: (@Unknown)
+// CHECK-NEXT: Exact Uses {
+// CHECK-NEXT: }
+// CHECK-NEXT: Overlapping Uses {
+// CHECK-NEXT:   %{{.*}} = struct_element_addr %{{.*}} : $*MyStruct, #MyStruct.i
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT:   %{{.*}} = load [trivial] %{{.*}} : $*MyStruct
+// CHECK-NEXT:   Path: (@Unknown)
+// CHECK-NEXT: }
+sil [serialized] [ossa] @testDynamicIndexWithSubObject : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*MyStruct
+  %3 = struct_element_addr %2 : $*MyStruct, #MyStruct.i
+  %4 = load [trivial] %3 : $*Int64
+  %5 = index_addr %2 : $*MyStruct, %1 : $Builtin.Word
+  %6 = load [trivial] %5 : $*MyStruct
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// An unknown offset contains known offsets.
+// CHECK-LABEL: @testDynamicIndexWithStaticIndex
+// CHECK: ###For MemOp:   %5 = load [trivial] %4 : $*MyStruct
+// CHECK: Path: (@1)
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %5 = load [trivial] %4 : $*MyStruct
+// CHECK-NEXT:   Path: (@1)
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:   %5 = load [trivial] %4 : $*MyStruct
+// CHECK-NEXT:   Path: (@1)
+// CHECK-NEXT:   %7 = load [trivial] %6 : $*MyStruct
+// CHECK-NEXT:   Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %7 = load [trivial] %6 : $*MyStruct
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:   %5 = load [trivial] %4 : $*MyStruct
+// CHECK-NEXT: Path: (@1)
+// CHECK-NEXT:   %7 = load [trivial] %6 : $*MyStruct
+// CHECK-NEXT: Path: (@Unknown)
+// CHECK-NEXT: }
+sil [serialized] [ossa] @testDynamicIndexWithStaticIndex : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*MyStruct
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = index_addr %2 : $*MyStruct, %3 : $Builtin.Word
+  %5 = load [trivial] %4 : $*MyStruct
+  %6 = index_addr %2 : $*MyStruct, %1 : $Builtin.Word
+  %7 = load [trivial] %6 : $*MyStruct
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// Even though the static offset does not match the first load, the
+// dynamic offset should cancel it.
+// CHECK-LABEL: @testChainedStaticDynamicIndex
+// CHECK: ###For MemOp:   %3 = load [trivial] %2 : $*MyStruct
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %3 = load [trivial] %2 : $*MyStruct
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT: }
+// CHECK-NEXT: Overlapping Uses {
+// CHECK-NEXT:   %3 = load [trivial] %2 : $*MyStruct
+// CHECK-NEXT: Path: ()
+// CHECK-NEXT:   %8 = load [trivial] %7 : $*MyStruct
+// CHECK-NEXT: Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %6 = load [trivial] %5 : $*MyStruct
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@1)
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %6 = load [trivial] %5 : $*MyStruct
+// CHECK-NEXT:   Path: (@1)
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %6 = load [trivial] %5 : $*MyStruct
+// CHECK-NEXT:  Path: (@1)
+// CHECK-NEXT:  %8 = load [trivial] %7 : $*MyStruct
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %8 = load [trivial] %7 : $*MyStruct
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load [trivial] %2 : $*MyStruct
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %6 = load [trivial] %5 : $*MyStruct
+// CHECK-NEXT:  Path: (@1)
+// CHECK-NEXT:  %8 = load [trivial] %7 : $*MyStruct
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+sil [serialized] [ossa] @testChainedStaticDynamicIndex : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*MyStruct
+  %3 = load [trivial] %2 : $*MyStruct
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr %2 : $*MyStruct, %4 : $Builtin.Word
+  %6 = load [trivial] %5 : $*MyStruct
+  %7 = index_addr %5 : $*MyStruct, %1 : $Builtin.Word
+  %8 = load [trivial] %7 : $*MyStruct
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// Static indices cancel.
+// Unknown offset overlaps with subobject projections.
+//
+// CHECK-LABEL: @staticIndexAddrCancel
+// CHECK: ###For MemOp:   %3 = load [trivial] %2 : $*Int64
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (#0)
+// CHECK: Exact Uses {
+// CHECK-NEXT:  %3 = load [trivial] %2 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT:  %9 = load [trivial] %8 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load [trivial] %2 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT:  %9 = load [trivial] %8 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %9 = load [trivial] %8 : $*Int64
+// CHECK: Storage: Argument %0 = argument of bb0 : $Builtin.RawPointer
+// CHECK: Path: (#0)
+// CHECK: Exact Uses {
+// CHECK-NEXT:  %3 = load [trivial] %2 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT:  %9 = load [trivial] %8 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load [trivial] %2 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT:  %9 = load [trivial] %8 : $*Int64
+// CHECK-NEXT:  Path: (#0)
+// CHECK-NEXT: }
+sil [ossa] @staticIndexAddrCancel : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*MyStruct
+  %2 = struct_element_addr %1 : $*MyStruct, #MyStruct.i
+  %3 = load [trivial] %2 : $*Int64
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr %1 : $*MyStruct, %4 : $Builtin.Word
+  %6 = integer_literal $Builtin.Word, -1
+  %7 = index_addr %5 : $*MyStruct, %6 : $Builtin.Word
+  %8 = struct_element_addr %7 : $*MyStruct, #MyStruct.i
+  %9 = load [trivial] %8 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Increment an indexable address by one in a loop, with subobject
+// uses inside and outside the loop.
+//
+// CHECK-LABEL: @testIndexLoop
+// CHECK: ###For MemOp:   %3 = load %2 : $*AnyObject
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  %3 = load %2 : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load %2 : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %7 = load %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %10 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %7 = load %6 : $*AnyObject
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load %2 : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %7 = load %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %10 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   store %7 to %6 : $*AnyObject
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load %2 : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %7 = load %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %10 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   store %7 to %10 : $*AnyObject
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load %2 : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %7 = load %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %10 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %17 = load %16 : $*AnyObject
+// CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %3 = load %2 : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %7 = load %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %6 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  store %7 to %10 : $*AnyObject
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT: }
+sil shared @testIndexLoop : $@convention(thin) (UnsafeMutablePointer<AnyObject>) -> AnyObject {
+bb0(%0 : $UnsafeMutablePointer<AnyObject>):
+  %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*AnyObject
+  %3 = load %2 : $*AnyObject
+  br bb1(%1 : $Builtin.RawPointer)
+
+bb1(%5 : $Builtin.RawPointer):
+  %6 = pointer_to_address %5 : $Builtin.RawPointer to [strict] $*AnyObject
+  %7 = load %6 : $*AnyObject
+  store %7 to %6 : $*AnyObject
+  %9 = integer_literal $Builtin.Word, 1
+  %10 = index_addr %6 : $*AnyObject, %9 : $Builtin.Word
+  store %7 to %10 : $*AnyObject
+  %12 = address_to_pointer %10 : $*AnyObject to $Builtin.RawPointer
+  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+
+bb2:
+  br bb1(%12 : $Builtin.RawPointer)
+
+bb3(%15 : $Builtin.RawPointer):
+  %16 = pointer_to_address %15 : $Builtin.RawPointer to [strict] $*AnyObject
+  %17 = load %16 : $*AnyObject
+  return %17 : $AnyObject
+}
+
+// CHECK-LABEL: @testEnumUses
+// CHECK: ###For MemOp:   copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK: Storage: Argument %0 = argument of bb0 : $*IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  debug_value_addr %0 : $*IntTEnum<T>, let, name "self", argno 1
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  debug_value_addr %0 : $*IntTEnum<T>, let, name "self", argno 1
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %8 = load [trivial] %7 : $*Int
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  destroy_addr %13 : $*T
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %8 = load [trivial] %7 : $*Int
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  destroy_addr %13 : $*T
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %2 : $*IntTEnum<T>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: Overlapping Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: ###For MemOp:   %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: Overlapping Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: ###For MemOp:   %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: Overlapping Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: ###For MemOp:   %8 = load [trivial] %7 : $*Int
+// CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: Overlapping Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: ###For MemOp:   %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+// CHECK: Overlapping Uses {
+// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+// CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+// CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+// CHECK:  %8 = load [trivial] %7 : $*Int
+// CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+// CHECK: }
+enum IntTEnum<T> {
+  indirect case int(Int)
+  case other(T)
+
+  var getValue: Int {get }
+}
+
+sil hidden [ossa] @testEnumUses : $@convention(method) <T> (@in_guaranteed IntTEnum<T>) -> Int {
+bb0(%0 : $*IntTEnum<T>):
+  debug_value_addr %0 : $*IntTEnum<T>, let, name "self", argno 1
+  %2 = alloc_stack $IntTEnum<T>
+  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
+
+bb1:
+  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
+  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
+  %7 = project_box %6 : $<τ_0_0> { var Int } <T>, 0
+  %8 = load [trivial] %7 : $*Int
+  debug_value %8 : $Int, let, name "x"
+  destroy_value %6 : $<τ_0_0> { var Int } <T>
+  dealloc_stack %2 : $*IntTEnum<T>
+  br bb3(%8 : $Int)
+
+bb2:
+  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
+  %14 = integer_literal $Builtin.Int64, 0
+  %15 = struct $Int (%14 : $Builtin.Int64)
+  destroy_addr %13 : $*T
+  dealloc_stack %2 : $*IntTEnum<T>
+  br bb3(%15 : $Int)
+
+bb3(%19 : $Int):
+  return %19 : $Int
+}
+
+class Storage {}
+
+// Test that tail_addr is always an unknown offset.
+//
+// CHECK-LABEL: @inlinedArrayProp
+// CHECK: ###For MemOp:   %{{.*}} = load [trivial] %{{.*}} : $*Int
+// CHECK: Tail %0 = argument of bb0 : $Storage
+// CHECK: Base: %{{.*}} = ref_tail_addr %0 : $Storage, $UInt
+// CHECK: Storage: Tail %0 = argument of bb0 : $Storage
+// CHECK: Path: (@Unknown)
+// CHECK: Exact Uses {
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  %8 = load [trivial] %7 : $*Int
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  end_access %7 : $*Int
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  end_access %5 : $*Int
+// CHECK-NEXT:  Path: (@Unknown)
+// CHECK-NEXT:  end_access %2 : $*UInt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+sil hidden [ossa] @inlinedArrayProp : $@convention(thin) (@guaranteed Storage) -> Int {
+bb0(%0 : @guaranteed $Storage):
+  %1 = ref_tail_addr %0 : $Storage, $UInt
+  %2 = begin_access [read] [static] %1 : $*UInt
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = tail_addr %2 : $*UInt, %3 : $Builtin.Word, $Int
+  %5 = begin_access [read] [static] %4 : $*Int
+  %6 = index_addr %5 : $*Int, %3 : $Builtin.Word
+  %7 = begin_access [read] [static] %6 : $*Int
+  %8 = load [trivial] %7 : $*Int
+  end_access %7 : $*Int
+  end_access %5 : $*Int
+  end_access %2 : $*UInt
+  return %8 : $Int
+}

--- a/test/SILOptimizer/alias-analysis.sil
+++ b/test/SILOptimizer/alias-analysis.sil
@@ -1,0 +1,60 @@
+// RUN: %target-sil-opt %s -aa-kind=all -aa-dump -o /dev/null | %FileCheck %s
+
+// General black-box alias analysis tests. White-box unit tests are
+// specific to the aa-kind, such as basic-aa.sil and typed-access-tb-aa.sil.
+
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Swift
+import SwiftShims
+import Builtin
+
+struct MyStruct {
+  @_hasStorage @_hasInitialValue var i: Int64 { get set }
+  @_hasStorage @_hasInitialValue var j: Int64 { get set }
+}
+
+struct OuterStruct {
+  @_hasStorage @_hasInitialValue var s: MyStruct { get set }
+}
+
+// Test overlaping access on a different path; the user has misused an index offset
+// CHECK-LABEL: @testOffsetBehindProjection
+// CHECK: PAIR #28.
+// CHECK:   %4 = load %3 : $*Int64
+// CHECK:   %6 = load %5 : $*Int64
+// CHECK: MayAlias
+sil shared @testOffsetBehindProjection : $@convention(thin) (@inout MyStruct) -> () {
+bb0(%0 : $*MyStruct):
+  %1 = struct_element_addr %0 : $*MyStruct, #MyStruct.i
+  %2 = integer_literal $Builtin.Word, 1
+  %3 = index_addr %1 : $*Int64, %2 : $Builtin.Word
+  %4 = load %3 : $*Int64
+  // load from a different subobject overlaps
+  %5 = struct_element_addr %0 : $*MyStruct, #MyStruct.j
+  %6 = load %5 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @testOffsetsBehindProjectionOverlap
+// CHECK: PAIR #28.
+// CHECK:   %3 = load %2 : $*Int64
+// CHECK:   %7 = load %6 : $*Int64
+// CHECK: MayAlias
+sil shared @testOffsetsBehindProjectionOverlap : $@convention(thin) (@inout OuterStruct) -> () {
+bb0(%0 : $*OuterStruct):
+  %1 = struct_element_addr %0 : $*OuterStruct, #OuterStruct.s
+  %2 = struct_element_addr %1 : $*MyStruct, #MyStruct.i
+  %3 = load %2 : $*Int64
+  // Loading from a different index within the same subobject still appears to overlap.
+  // Indexing from a subobject is always considered an unknown index.
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr %1 : $*MyStruct, %4 : $Builtin.Word
+  %6 = struct_element_addr %5 : $*MyStruct, #MyStruct.i
+  %7 = load %6 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1176,14 +1176,27 @@ bb0(%0 : $*Builtin.Int64, %1 : $Builtin.NativeObject):
   return %6 : $(Builtin.Int64, Builtin.Int64)
 }
 
-sil @dont_crash_on_index_addr_projection : $@convention(thin) (Builtin.RawPointer) -> Int {
+sil @dont_crash_on_index_addr_projection : $@convention(thin) (Builtin.RawPointer) -> (Int, Int, Int, Int) {
 bb0(%0 : $Builtin.RawPointer):
-  %3 = integer_literal $Builtin.Word, 4294967295
+  // Negative (valid constant index)
+  %3 = integer_literal $Builtin.Word, 4294967295 // '0xffffffff'
   %4 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Int
-  // Just check if we can handle an index_addr projection with the special value of 0xffffffff
   %5 = index_addr %4 : $*Int, %3 : $Builtin.Word
   %6 = load %5 : $*Int
-  return %6 : $Int
+  // TailIndex (invalid constant index)
+  %7 = integer_literal $Builtin.Word, 2147483647 // '0x7fffffff'
+  %8 = index_addr %4 : $*Int, %7 : $Builtin.Word
+  %9 = load %8 : $*Int
+  // UnknownOffset (valid index)
+  %10 = integer_literal $Builtin.Word, 3221225472 // '0xC0000000'
+  %11 = index_addr %4 : $*Int, %10 : $Builtin.Word
+  %12 = load %11 : $*Int
+  // Root (unused/invalid index))
+  %13 = integer_literal $Builtin.Word, 2147483648 // '0x80000000'
+  %14 = index_addr %4 : $*Int, %13 : $Builtin.Word
+  %15 = load %14 : $*Int
+  %99 = tuple (%6 : $Int, %9 : $Int, %12 : $Int, %15 : $Int)
+  return %99 : $(Int, Int, Int, Int)
 }
 
 sil @overwrite_int : $@convention(thin) (@inout Int, Int) -> ()


### PR DESCRIPTION
Begin to formalize the model for valid memory access in SIL. Ignoring ownership, every access is a def-use chain in three parts:

object root -> formal access base -> memory operation address

AccessPath abstracts over this path and standardizes the identity of a
memory access throughout the optimizer. This abstraction is the basis for a new AccessPathVerification.

With that verification, we now have all the properties we need for the type of analysis requires for exclusivity enforcement, but now generalized for any memory analysis. This is suitable for an extremely lightweight analysis with no side data structures. We currently have a massive amount of ad-hoc memory analysis throughout SIL, which is incredibly unmaintainable, bug-prone, and not performance-robust. We can begin taking advantage of this verifably complete model to solve that problem.

The properties this gives us are:

Access analysis must be complete over memory operations: every memory operation needs a recognizable valid access. An access can be unidentified only to the extent that it is rooted in some non-address type and we can prove that it is at least *not* part of an access to a nominal class or global property. Pointer provenance is also required for future IRGen-level bitfield optimizations.

Access analysis must be complete over address users: for an identified object root all memory accesses including subobjects must be discoverable.

Access analysis must be symmetric: use-def and def-use analysis must
be consistent.

AccessPath is merely a wrapper around the existing accessed-storage utilities and IndexTrieNode. Existing passes already very succesfully use this approach, but in an ad-hoc way. With a general utility we can:

- update passes to use this approach to identify memory access,
  reducing the space and time complexity of those algorithms.

- implement an inexpensive on-the-fly, debug mode address lifetime analysis

- implement a lightweight debug mode alias analysis

- ultimately improve the power, efficiency, and maintainability of
  full alias analysis

- make our type-based alias analysis sensistive to the access path
