### PR TITLE
[docs] Add comments clarifying roles of Type.h and Types.h.

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -1,4 +1,4 @@
-//===--- Type.h - Swift Language Type ASTs ----------------------*- C++ -*-===//
+//===--- Type.h - Value objects for Swift and SIL types ---------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,7 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the Type class.
+// This file defines the Type and CanType classes, which are value objects
+// used to cheaply pass around different kinds of types. The full hierarchy for
+// Swift and SIL types -- including tuple types, function types and more -- is
+// defined in Types.h.
 //
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the TypeBase class and subclasses.
+// This file defines the TypeBase class and subclasses, which describe the Swift
+// and SIL ASTs. See also: Type.h.
 //
 //===----------------------------------------------------------------------===//
 
@@ -282,7 +283,9 @@ enum class TypeMatchFlags {
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 
-/// TypeBase - Base class for all types in Swift.
+/// Base class for all types which describe the Swift and SIL ASTs.
+///
+/// See TypeNodes.def for a succinct description of the full class hierarchy.
 class alignas(1 << TypeAlignInBits) TypeBase {
   
   friend class ASTContext;


### PR DESCRIPTION
I really want to rename `Types.h` to `TypeHierarchy.h` but I figured I could at least land this without anyone complaining.