### PR TITLE
[DebugInfo] Fix test REQUIRES to run on Windows.

### DIFF
--- a/test/DebugInfo/line-directive-codeview.swift
+++ b/test/DebugInfo/line-directive-codeview.swift
@@ -12,7 +12,7 @@ func myFunc() {
   markUsed("jump directly to def")
 }
 
-// REQUIRES: OS=Windows
+// REQUIRES: OS=windows-msvc
 // RUN: %swiftc_driver %s -S -g -debug-info-format=codeview -target x86_64-unknown-windows-msvc -o - | %FileCheck --check-prefix CV-CHECK %s
 // CV-CHECK: .cv_file [[MAIN:[0-9]+]] "{{.*}}line-directive-codeview.swift"
 // CV-CHECK: .cv_loc {{[0-9]+}} [[MAIN]] 1 {{0?}}


### PR DESCRIPTION
From what I know, `OS=Windows` doesn't work, it needs to be `windows-msvc`. https://github.com/apple/swift/pull/33109/commits/c94ffcf389c2846824d1258ca076887a7e56e407