### PR TITLE
[opt-remark] Add @_semantics("optremark{.$SIL_PASS_NAME}") that force opt remarks on functions.

### DIFF
--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -93,5 +93,16 @@ SEMANTICS_ATTR(CONVERT_TO_OBJECTIVE_C, "convertToObjectiveC")
 
 SEMANTICS_ATTR(KEYPATH_KVC_KEY_PATH_STRING, "keypath.kvcKeyPathString")
 
+/// The prefix used to force opt-remarks to be emitted in a specific function.
+///
+/// If used just by itself "optremark", it is assumed that /all/ opt remarks
+/// should be emitted. Otherwise, one can add a suffix after a '.' that
+/// specifies a pass to emit opt-remarks from. So for instance to get just
+/// information from 'sil-opt-remark-gen', one would write:
+/// "optremark.sil-opt-remark-gen". One can add as many as one wishes. Keep in
+/// mind that if the function itself is inlined, one will lose the optremark so
+/// consider inlining where to put these.
+SEMANTICS_ATTR(FORCE_EMIT_OPT_REMARK_PREFIX, "optremark")
+
 #undef SEMANTICS_ATTR
 

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_SIL_OPTIMIZATIONREMARKEMITTER_H
 #define SWIFT_SIL_OPTIMIZATIONREMARKEMITTER_H
 
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/SIL/SILArgument.h"

--- a/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
+++ b/lib/SILOptimizer/Transforms/OptRemarkGenerator.cpp
@@ -12,8 +12,10 @@
 
 #define DEBUG_TYPE "sil-opt-remark-gen"
 
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OptimizationRemark.h"
+#include "swift/SIL/Projection.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
@@ -266,7 +268,9 @@ class OptRemarkGenerator : public SILFunctionTransform {
 
     return bool(langOpts.OptimizationRemarkMissedPattern) ||
            bool(langOpts.OptimizationRemarkPassedPattern) ||
-           fn->getModule().getSILRemarkStreamer();
+           fn->getModule().getSILRemarkStreamer() ||
+           fn->hasSemanticsAttrThatStartsWith(
+               semantics::FORCE_EMIT_OPT_REMARK_PREFIX);
   }
 
   /// The entry point to the transformation.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -298,6 +298,13 @@ bool SILPerformanceInliner::isProfitableToInline(
   // It is always OK to inline a simple call.
   // TODO: May be consider also the size of the callee?
   if (isPureCall(AI, SEA)) {
+    OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, &ORE, [&]() {
+      using namespace OptRemark;
+      return RemarkPassed("Inline", *AI.getInstruction())
+             << "Pure call. Always profitable to inline "
+             << NV("Callee", Callee);
+    });
+
     LLVM_DEBUG(dumpCaller(AI.getFunction());
                llvm::dbgs() << "    pure-call decision " << Callee->getName()
                             << '\n');
@@ -487,9 +494,24 @@ bool SILPerformanceInliner::isProfitableToInline(
   auto *bb = AI.getInstruction()->getParent();
   auto bbIt = BBToWeightMap.find(bb);
   if (bbIt != BBToWeightMap.end()) {
-    return profileBasedDecision(AI, Benefit, Callee, CalleeCost,
-                                NumCallerBlocks, bbIt);
+    if (profileBasedDecision(AI, Benefit, Callee, CalleeCost, NumCallerBlocks,
+                             bbIt)) {
+      OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, &ORE, [&]() {
+        using namespace OptRemark;
+        return RemarkPassed("Inline", *AI.getInstruction())
+               << "Profitable due to provided profile";
+      });
+      return true;
+    }
+
+    OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, &ORE, [&]() {
+      using namespace OptRemark;
+      return RemarkMissed("Inline", *AI.getInstruction())
+             << "Not profitable due to provided profile";
+    });
+    return false;
   }
+
   if (isClassMethodAtOsize && Benefit > OSizeClassMethodBenefit) {
     Benefit = OSizeClassMethodBenefit;
   }
@@ -498,7 +520,7 @@ bool SILPerformanceInliner::isProfitableToInline(
   if (CalleeCost > Benefit) {
     OptRemark::Emitter::emitOrDebug(DEBUG_TYPE, &ORE, [&]() {
       using namespace OptRemark;
-      return RemarkMissed("NoInlinedCost", *AI.getInstruction())
+      return RemarkMissed("Inline", *AI.getInstruction())
              << "Not profitable to inline function " << NV("Callee", Callee)
              << " (cost = " << NV("Cost", CalleeCost)
              << ", benefit = " << NV("Benefit", Benefit) << ")";

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -65,6 +65,7 @@ bb0:
 
 bb1:
   %f = function_ref @callee : $@convention(thin) () -> ()
+  // REMARKS_PASSED: {{.*}}inliner_coldblocks.sil:[[# @LINE + 1]]:8: remark: Pure call. Always profitable to inline "callee"
   %a = apply %f() : $@convention(thin) () -> ()
   br bb2
 
@@ -193,13 +194,13 @@ bb0:
   %c30 = builtin "assert_configuration"() : $Builtin.Int32
 
   %f = function_ref @update_global: $@convention(thin) () -> ()
-  // REMARKS_PASSED: inliner_coldblocks.sil:223:3: remark: "update_global" inlined into "regular_large_callee" (cost = {{.*}}, benefit = {{.*}})
+  // REMARKS_PASSED: inliner_coldblocks.sil:[[# @LINE + 27]]:3: remark: "update_global" inlined into "regular_large_callee" (cost = {{.*}}, benefit = {{.*}})
   // YAML:      --- !Passed
   // YAML-NEXT: Pass:            sil-inliner
-  // YAML-NEXT: Name:            sil.Inlined
+  // YAML-NEXT: Name:            sil.Inline
   // YAML-NEXT: DebugLoc:
   // YAML:        File:            {{.*}}inliner_coldblocks.sil
-  // YAML:        Line:            223
+  // YAML:        Line:            [[#@LINE + 21]]
   // YAML:        Column:          3
   // YAML-NEXT: Function:        regular_large_callee
   // YAML-NEXT: Args:
@@ -212,7 +213,7 @@ bb0:
   // YAML-NEXT:   - Caller:          '"regular_large_callee"'
   // YAML-NEXT:     DebugLoc:
   // YAML:            File:            {{.*}}inliner_coldblocks.sil
-  // YAML:            Line:            162
+  // YAML:            Line:            [[# @LINE - 53]]
   // YAML:            Column:          6
   // YAML-NEXT:   - String:          ' (cost = '
   // YAML-NEXT:   - Cost:            '{{.*}}'
@@ -233,13 +234,13 @@ bb0:
 sil @dont_inline_regular_large_callee : $@convention(thin) () -> () {
 bb0:
   %f = function_ref @regular_large_callee : $@convention(thin) () -> ()
-  // REMARKS_MISSED: inliner_coldblocks.sil:258:8: remark: Not profitable to inline function "regular_large_callee" (cost = {{.*}}, benefit = {{.*}})
+  // REMARKS_MISSED: inliner_coldblocks.sil:[[# @LINE + 22]]:8: remark: Not profitable to inline function "regular_large_callee" (cost = {{.*}}, benefit = {{.*}})
   // YAML:      --- !Missed
   // YAML-NEXT: Pass:            sil-inliner
-  // YAML-NEXT: Name:            sil.NoInlinedCost
+  // YAML-NEXT: Name:            sil.Inline
   // YAML-NEXT: DebugLoc:
   // YAML:        File:            {{.*}}inliner_coldblocks.sil
-  // YAML:        Line:            258
+  // YAML:        Line:            [[# @LINE + 16]]
   // YAML:        Column:          8
   // YAML-NEXT: Function:        dont_inline_regular_large_callee
   // YAML-NEXT: Args:
@@ -247,7 +248,7 @@ bb0:
   // YAML-NEXT:   - Callee:          '"regular_large_callee"'
   // YAML-NEXT:     DebugLoc:
   // YAML:       File:            {{.*}}inliner_coldblocks.sil
-  // YAML:       Line:            162
+  // YAML:       Line:            [[# @LINE - 88]]
   // YAML:       Column:          6
   // YAML-NEXT:   - String:          ' (cost = '
   // YAML-NEXT:   - Cost:            '{{.*}}'
@@ -304,6 +305,7 @@ bb0:
 sil @inline_large_callee_on_fast_path : $@convention(thin) () -> () {
 bb0:
   %f = function_ref @large_callee_on_fast_path : $@convention(thin) () -> ()
+  // REMARKS_PASSED: inliner_coldblocks.sil:[[# @LINE + 1]]:8: remark: Pure call. Always profitable to inline "large_callee_on_fast_path"
   %a = apply %f() : $@convention(thin) () -> ()
   %r = tuple ()
   return %r : $()

--- a/test/SILOptimizer/opt-remark-generator-semantics.swift
+++ b/test/SILOptimizer/opt-remark-generator-semantics.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -emit-sil %s -verify -Osize
+//
+// NOTE: We only emit opt-remarks with -Osize,-O today! -O does drop way more
+// stuff though, so we test with -Osize.
+
+public class Klass {}
+
+public var mySingleton = Klass()
+
+@_semantics("optremark")
+@inline(never)
+public func forceOptRemark() -> Klass {
+    return mySingleton // expected-remark {{retain}}
+                       // expected-note @-6 {{of 'mySingleton'}}
+}
+
+@_semantics("optremark.sil-opt-remark-gen")
+@inline(never)
+public func forceOptRemark2() -> Klass {
+    return mySingleton // expected-remark {{retain}}
+                       // expected-note @-13 {{of 'mySingleton'}}
+}
+
+@_semantics("optremark.fail")
+@inline(never)
+public func failMatch() -> Klass {
+    return mySingleton
+}
+
+@_semantics("optremark")
+public func allocateInlineCallee() -> Klass {
+    return Klass() // expected-remark {{Pure call. Always profitable to inline "main.Klass.__allocating_init()"}}
+}
+
+@_semantics("optremark.sil-inliner")
+public func allocateInlineCallee2() -> Klass {
+    return Klass() // expected-remark {{Pure call. Always profitable to inline "main.Klass.__allocating_init()"}}
+}
+
+// This makes sure we don't emit any remarks if we do not have semantics.
+public func allocateInlineCallee3() -> Klass {
+    return Klass()
+}
+
+@_semantics("optremark.sil-inliner")
+@_semantics("optremark.sil-opt-remark-gen")
+public func mix1() -> (Klass, Klass) {
+    return (mySingleton, Klass()) // expected-remark {{Pure call. Always profitable to inline "main.Klass.__allocating_init()"}}
+                                  // expected-remark @-1:5 {{retain}}
+                                  // expected-note @-42:12 {{of 'mySingleton'}}
+}
+
+@_semantics("optremark.sil-inliner")
+public func mix2() -> (Klass, Klass) {
+    return (mySingleton, Klass()) // expected-remark {{Pure call. Always profitable to inline "main.Klass.__allocating_init()"}}
+}
+
+@_semantics("optremark.sil-opt-remark-gen")
+public func mix3() -> (Klass, Klass) {
+    return (mySingleton, Klass()) // expected-remark @:5 {{retain}}
+                                  // expected-note @-53:12 {{of 'mySingleton'}}
+}
+
+@_semantics("optremark")
+public func mix4() -> (Klass, Klass) {
+    return (mySingleton, Klass()) // expected-remark {{Pure call. Always profitable to inline "main.Klass.__allocating_init()"}}
+                                  // expected-remark @-1:5 {{retain}}
+                                  // expected-note @-60:12 {{of 'mySingleton'}}
+}
+
+public func mix5() -> (Klass, Klass) {
+    return (mySingleton, Klass())
+}

--- a/test/SILOptimizer/opt-remark-generator.sil
+++ b/test/SILOptimizer/opt-remark-generator.sil
@@ -6,14 +6,10 @@ import Builtin
 
 sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
-  strong_retain %0 : $Builtin.NativeObject // expected-remark {{Found retain:}}
-                                           // expected-note @-1 {{Unable to infer any values being retained.}}
-  retain_value %0 : $Builtin.NativeObject  // expected-remark {{Found retain:}}
-                                           // expected-note @-1 {{Unable to infer any values being retained.}}
-  strong_release %0 : $Builtin.NativeObject // expected-remark {{Found release:}}
-                                            // expected-note @-1 {{Unable to infer any values being released.}}
-  release_value %0 : $Builtin.NativeObject // expected-remark {{Found release:}}
-                                           // expected-note @-1 {{Unable to infer any values being released.}}
+  strong_retain %0 : $Builtin.NativeObject // expected-remark {{retain}}
+  retain_value %0 : $Builtin.NativeObject  // expected-remark {{retain}}
+  strong_release %0 : $Builtin.NativeObject // expected-remark {{release}}
+  release_value %0 : $Builtin.NativeObject // expected-remark {{release}}
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -5,47 +5,47 @@
 
 // CHECK: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
+// CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
 // CHECK-NEXT:                    Line: 59, Column: 5 }
 // CHECK-NEXT: Function:        'getGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found retain:'
-// CHECK-NEXT:   - InferredValue:   'on value:'
+// CHECK-NEXT:   - String:          retain
+// CHECK-NEXT:   - InferredValue:   'of ''global'''
 // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
 // CHECK-NEXT:                        Line: 55, Column: 12 }
 // CHECK-NEXT: ...
 // CHECK-NEXT: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
+// CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
 // CHECK-NEXT:                    Line: 67, Column: 5 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found retain:'
-// CHECK-NEXT:   - InferredValue:   'on value:'
+// CHECK-NEXT:   - String:          retain
+// CHECK-NEXT:   - InferredValue:   'of ''x'''
 // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
 // CHECK-NEXT:                        Line: 64, Column: 9 }
 // CHECK-NEXT: ...
 // CHECK-NEXT: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
+// CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
 // CHECK-NEXT:                    Line: 67, Column: 12 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found release:'
-// CHECK-NEXT:   - InferValueFailure: Unable to infer any values being released.
+// CHECK-NEXT:   - String:          release
+
 // CHECK-NEXT: ...
 // CHECK-NEXT: --- !Missed
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory-management
+// CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator.swift', 
 // CHECK-NEXT:                    Line: 67, Column: 12 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'Found release:'
-// CHECK-NEXT:   - InferredValue:   'on value:'
+// CHECK-NEXT:   - String:          release
+// CHECK-NEXT:   - InferredValue:   'of ''x'''
 // CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator.swift',
 // CHECK-NEXT:                        Line: 64, Column: 9 }
 // CHECK-NEXT: ...
@@ -56,18 +56,17 @@ public var global = Klass()
 
 @inline(never)
 public func getGlobal() -> Klass {
-    return global // expected-remark @:5 {{Found retain:}}
-                  // expected-note @-5:12 {{on value:}}
+    return global // expected-remark @:5 {{retain}}
+                  // expected-note @-5:12 {{of 'global'}}
 }
 
 public func useGlobal() {
     let x = getGlobal()
     // Make sure that the retain msg is at the beginning of the print and the
     // releases are the end of the print.
-    print(x) // expected-remark @:5 {{Found retain:}}
-             // expected-note @-4:9 {{on value:}}
-             // expected-remark @-2:12 {{Found release:}}
-             // expected-note @-3:12 {{Unable to infer any values being released.}}
-             // expected-remark @-4:12 {{Found release:}}
-             // expected-note @-8:9 {{on value:}}
+    print(x) // expected-remark @:5 {{retain}}
+             // expected-note @-4:9 {{of 'x'}}
+             // expected-remark @-2:12 {{release}}
+             // expected-remark @-3:12 {{release}}
+             // expected-note @-7:9 {{of 'x'}}
 }


### PR DESCRIPTION
This PR contains two commits. The first commit does a little bit of cleanup in preparation for the first by cleaning up some remarks [mainly b/c I noticed when playing with this in Xcode, they looked really bad = (, so I wanted to fix them a little].

The second commit is more interesting. I'll let its commit msg speak for itself:

----

    More specifically, if one wants to force emit /all/ opt-remarks on a function, mark it with:
    ```
    @_semantics("optremark")
    ```
    
    If one wants to emit opt-remarks only for a specific SIL pass (like lets say
    sil-opt-remark-gen), one can write:
    
    ```
    @_semantics("optremark.sil-opt-remark-gen")
    ```
    
    I made the pattern matching strict so if you just put in a '.' or add additional
    suffixes, it will not pattern match. I think that this is sufficient for a
    prototyping tool.
    
    This is useful if one wants to play around with opt-remarks when optimizing code
    in Xcode or any IDE that can use serialized diagnostics.
