### PR TITLE
test: decode the output of `lldb -P` as UTF-8

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -102,7 +102,7 @@ def get_lldb_python_path(lldb_build_root):
     lldb_path = os.path.join(lldb_build_root, 'bin', 'lldb')
     if not os.access(lldb_path, os.F_OK):
         return None
-    return subprocess.check_output([lldb_path, "-P"]).rstrip()
+    return subprocess.check_output([lldb_path, "-P"]).rstrip().decode('utf-8')
 
 ###
 


### PR DESCRIPTION
We currently use the byte string as the PYTHONPATH with Python 3, which
is odd.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
