### PR TITLE
test: loosen match in Frontend/crash-in-user-code

### DIFF
--- a/test/Frontend/crash-in-user-code.swift
+++ b/test/Frontend/crash-in-user-code.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
 
-// CHECK: Stack dump:
+// CHECK: {{Stack dump|stack trace}}:
 // CHECK-NEXT: Program arguments:
 // CHECK-NEXT: Swift version
 // CHECK-NEXT: Contents of {{.*}}.filelist.txt:


### PR DESCRIPTION
The test checked for `Stack dump:` but on the VS2017 build, the output
is `Current stack trace:` which would prevent the match.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
