### PR TITLE
[build-script] copy over the simulator libclang_rt.*.a libraries to a…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2375,12 +2375,30 @@ for host in "${ALL_HOSTS[@]}"; do
                         echo "copying compiler-rt embedded builtins from ${HOST_CXX_BUILTINS_DIR} into the local clang build directory ${DEST_BUILTINS_DIR}."
 
                         for OS in ios watchos tvos; do
+                            # Copy over the device .a
                             LIB_NAME="libclang_rt.$OS.a"
                             HOST_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$LIB_NAME"
                             if [[ -f "${HOST_LIB_PATH}" ]]; then
                                 call cp "${HOST_LIB_PATH}" "${DEST_BUILTINS_DIR}/${LIB_NAME}"
                             elif [[ "${VERBOSE_BUILD}" ]]; then
                                 echo "no file exists at ${HOST_LIB_PATH}"
+                            fi
+                            # Copy over the simulator .a
+                            SIM_LIB_NAME="libclang_rt.${OS}sim.a"
+                            HOST_SIM_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$SIM_LIB_NAME"
+                            if [[ -f "${HOST_SIM_LIB_PATH}" ]]; then
+                                call cp "${HOST_SIM_LIB_PATH}" "${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
+                            elif [[ "${HOST_LIB_PATH}" ]]; then
+                                # The simulator .a might not exist if the host
+                                # Xcode is old. In that case, copy over the
+                                # device library to the simulator location to allow
+                                # clang to find it. The device library has the simulator
+                                # slices in Xcode that doesn't have the simulator .a, so
+                                # the link is still valid.
+                                echo "copying over faux-sim library ${HOST_LIB_PATH} to ${SIM_LIB_NAME}"
+                                call cp "${HOST_LIB_PATH}" "${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
+                            elif [[ "${VERBOSE_BUILD}" ]]; then
+                                echo "no file exists at ${HOST_SIM_LIB_PATH}"
                             fi
                         done
                     done


### PR DESCRIPTION
…llow clang to link with them

Clang's driver started linking with libclang_rt.<os>sim.a when building for simulator.

Swift's build need to adapt to this clang change, by ensuring that the libclang_rt.<os>sim.a libraries are created during the build
