### PR TITLE
Enable validation reflection tests passing on Linux

### DIFF
--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -5,7 +5,7 @@
 // RUN: %target-run %target-swift-reflection-test %t/inherits_Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Bool | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Double | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_254CaseNoPayloads.swift
+++ b/validation-test/Reflection/reflect_Enum_254CaseNoPayloads.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_254CaseNoPayloads | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_value.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_value.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_value | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_NoCase.swift
+++ b/validation-test/Reflection/reflect_Enum_NoCase.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_NoCase | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseIntPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseIntPayload.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseIntPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseNoPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseNoPayload.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseNoPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseNoPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseNoPayload.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseNoPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseOneStructPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseOneStructPayload.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseOneStructPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-ALL
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_TwoCaseTwoPayloads.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseTwoPayloads.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseTwoPayloads | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Float | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_class | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_empty_struct.swift
+++ b/validation-test/Reflection/reflect_empty_struct.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // UNSUPPORTED: use_os_stdlib

--- a/validation-test/Reflection/reflect_empty_struct_compat.swift
+++ b/validation-test/Reflection/reflect_empty_struct_compat.swift
@@ -4,7 +4,7 @@
 // RUN: %target-codesign %t/reflect_empty_struct
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // UNSUPPORTED: use_os_stdlib

--- a/validation-test/Reflection/reflect_nested.swift
+++ b/validation-test/Reflection/reflect_nested.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_nested
 // RUN: %target-run %target-swift-reflection-test %t/reflect_nested 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 


### PR DESCRIPTION
This PR enables the tests validation tests (with the new `reflection_test_support` directive) that are already passing on Linux with no further modifications necessary after the work done in #32339.

@vedantk @adrian-prantl 