### PR TITLE
Conditionalize 'num_extra_inhabitants' in 64 bit platforms's tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1998,3 +1998,13 @@ lit_config.note("Available features: " + ", ".join(sorted(config.available_featu
 # Windows currently does not support basic reflection support.
 if 'objc_interop' in config.available_features or ('swift_stdlib_asserts' in config.available_features and not kIsWindows):
     config.available_features.add('reflection_test_support')
+
+# num_extra_inhabitants on 64 bits differs between Mac and everywhere else.
+# Add it, as a variable in order to substitute it in the tests
+if platform.system() == 'Darwin':
+    num_extra_inhabitants_64bit = 2147483647
+else:
+    num_extra_inhabitants_64bit = 4096
+add_num_extra_inhabitants = "-D#num_extra_inhabitants_64bit={} ".format(num_extra_inhabitants_64bit)
+config.substitutions.append(('%add_num_extra_inhabitants', add_num_extra_inhabitants))
+

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/existentials
 // RUN: %target-codesign %t/existentials
-// RUN: %target-run %target-swift-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -318,27 +318,27 @@ reflect(any: he)
 // CHECK-64:        Type info:
 // CHECK-64:        (struct size=144 alignment=8 stride=144
 // CHECK-64-NEXT:   (field name=singleError offset=0
-// CHECK-64-NEXT:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=error offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-64-NEXT:   (field name=errorInComposition offset=8
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=customError offset=56
-// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=customErrorInComposition offset=96
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -2,12 +2,12 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-codesign %t/functions
 
-// RUN: %target-run %target-swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
 // FIXME: Should not require objc_interop -- please put Objective-C-specific
 // testcases in functions_objc.swift
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -57,9 +57,9 @@ func concrete(x: Int, y: Any) {
 // CHECK-64:      Type info:
 // CHECK-64-NEXT: (closure_context size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=16
-// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))
 }
 
 concrete(x: 10, y: true)
@@ -153,17 +153,17 @@ func generic<T : P, U, V : C>(x: T, y: U, z: V, i: Int) {
 // CHECK-64-NEXT:      (field name=_value offset=0
 // CHECK-64-NEXT:        (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:  (field offset=56
-// CHECK-64-NEXT:    (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:    (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:      (field name=_guts offset=0
-// CHECK-64-NEXT:        (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:        (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:          (field name=_object offset=0
-// CHECK-64-NEXT:            (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:            (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:              (field name=_countAndFlagsBits offset=0
 // CHECK-64-NEXT:                (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                  (field name=_value offset=0
 // CHECK-64-NEXT:                    (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:              (field name=_object offset=8
-// CHECK-64-NEXT:                (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64-NEXT:                (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK-64-NEXT:  (field offset=72
 // CHECK-64-NEXT:    (reference kind=strong refcounting=native)))
 }
@@ -291,7 +291,7 @@ class CapturingClass {
   // CHECK-64:      Type info:
   // CHECK-64-NEXT: (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT: (field offset=16
-  // CHECK-64-NEXT:   (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+  // CHECK-64-NEXT:   (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
   // CHECK-64-NEXT:     (field offset=0
   // CHECK-64-NEXT:       (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:         (field name=_value offset=0
@@ -327,9 +327,9 @@ class CapturingClass {
   // CHECK-64:        Type info:
   // CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:   (field offset=16
-  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
   // CHECK-64-NEXT:       (case name=some index=0 offset=0
-  // CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+  // CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
   // CHECK-64-NEXT:           (field name=object offset=0
   // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))))
   // CHECK-64-NEXT:       (case name=none index=1))))
@@ -408,7 +408,7 @@ class CapturingClass {
   // CHECK-64-NEXT:   (field offset=16
   // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
   // CHECK-64-NEXT:   (field offset=24
-  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
   // CHECK-64-NEXT:       (case name=some index=0 offset=0
   // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
   // CHECK-64-NEXT:       (case name=none index=1))))

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Array
 // RUN: %target-codesign %t/reflect_Array
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Array | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Array | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -29,7 +29,7 @@ reflect(object: obj)
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Character
 // RUN: %target-codesign %t/reflect_Character
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Character | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Character | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -28,19 +28,19 @@ reflect(object: obj)
 // CHECK-64-LABEL: Type info:
 // CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT: (field name=t offset=16
-// CHECK-64-NEXT:   (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:   (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:     (field name=_str offset=0
-// CHECK-64-NEXT:       (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:       (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:         (field name=_guts offset=0
-// CHECK-64-NEXT:           (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:           (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:             (field name=_object offset=0
-// CHECK-64-NEXT:               (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:               (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:                 (field name=_countAndFlagsBits offset=0
 // CHECK-64-NEXT:                   (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                     (field name=_value offset=0
 // CHECK-64-NEXT:                       (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:                 (field name=_object offset=8
-// CHECK-64-NEXT:                   (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))))))))
+// CHECK-64-NEXT:                   (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))))))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Dictionary
 // RUN: %target-codesign %t/reflect_Dictionary
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Dictionary | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Dictionary | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -29,7 +29,7 @@ reflect(object: obj)
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.

--- a/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCasePointerPayload.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SingleCasePointerPayload
 // RUN: %target-codesign %t/reflect_Enum_SingleCasePointerPayload
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCasePointerPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCasePointerPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -35,21 +35,21 @@ reflect(object: ClassWithSingleCasePointerPayloadEnum())
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=e1 offset=16
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
 // CHECK-64:         (reference kind=strong refcounting=native))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e2 offset=24
 // CHECK-64:     (reference kind=strong refcounting=native))
 // CHECK-64:   (field name=e3 offset=32
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
 // CHECK-64:         (reference kind=strong refcounting=native))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e4 offset=40
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:           (case name=some index=0 offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (case name=none index=1)))

--- a/validation-test/Reflection/reflect_Enum_TwoCaseOnePointerPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_TwoCaseOnePointerPayload.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_TwoCaseOnePointerPayload
 // RUN: %target-codesign %t/reflect_Enum_TwoCaseOnePointerPayload
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseOnePointerPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_TwoCaseOnePointerPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -41,45 +41,45 @@ reflect(object: ClassWithTwoCaseOnePointerPayloadEnum())
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=64 alignment=8 stride=64 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=e1 offset=16
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:           (case name=valid index=0 offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (case name=invalid index=1)))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e2 offset=24
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=valid index=0 offset=0
 // CHECK-64:         (reference kind=strong refcounting=native))
 // CHECK-64:       (case name=invalid index=1)))
 // CHECK-64:   (field name=e3 offset=32
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=valid index=0 offset=0
 // CHECK-64:         (reference kind=strong refcounting=native))
 // CHECK-64:       (case name=invalid index=1)))
 // CHECK-64:   (field name=e4 offset=40
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:           (case name=valid index=0 offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (case name=invalid index=1)))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e5 offset=48
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:           (case name=valid index=0 offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (case name=invalid index=1)))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (field name=e6 offset=56
-// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:           (case name=some index=0 offset=0
-// CHECK-64:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:               (case name=valid index=0 offset=0
 // CHECK-64:                 (reference kind=strong refcounting=native))
 // CHECK-64:               (case name=invalid index=1)))
@@ -147,7 +147,7 @@ reflect(enum: TwoCaseOnePointerPayloadEnum.valid(Marker()))
 // CHECK-64-NEXT: (enum reflect_Enum_TwoCaseOnePointerPayload.TwoCaseOnePointerPayloadEnum)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64-NEXT:   (case name=valid index=0 offset=0
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (case name=invalid index=1))
@@ -181,7 +181,7 @@ reflect(enum: TwoCaseOnePointerPayloadEnum.invalid)
 // CHECK-64-NEXT: (enum reflect_Enum_TwoCaseOnePointerPayload.TwoCaseOnePointerPayloadEnum)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64-NEXT:   (case name=valid index=0 offset=0
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (case name=invalid index=1))

--- a/validation-test/Reflection/reflect_Enum_values.swift
+++ b/validation-test/Reflection/reflect_Enum_values.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_values
 // RUN: %target-codesign %t/reflect_Enum_values
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_values | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK%target-ptrsize --check-prefix=CHECKALL --dump-input=fail
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_values | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK%target-ptrsize --check-prefix=CHECKALL --dump-input=fail %add_num_extra_inhabitants
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
@@ -93,17 +93,17 @@ reflect(object: ManyCasesNoPayloadC())
 // CHECKALL-NEXT:       (case name=c index=2)
 // CHECKALL-NEXT:       (case name=d index=3)))
 // CHECK64-NEXT:   (field name=s offset=24
-// CHECK64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:       (field name=_guts offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_object offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_value offset=0
 // CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:               (field name=_object offset=8
-// CHECK64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))))))
+// CHECK64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))))))
 // CHECK32-NEXT:   (field name=s offset=12
 // CHECK32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK32-NEXT:       (field name=_guts offset=0
@@ -423,70 +423,70 @@ reflect(object: ManyCasesOnePayloadC())
 // CHECKALL: Type info:
 // CHECK64-NEXT: (class_instance size=80 alignment=8 stride=80 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:   (field name=payload offset=16
-// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK64-NEXT:       (case name=payload index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=otherA index=1)
 // CHECK64-NEXT:       (case name=otherB index=2)
 // CHECK64-NEXT:       (case name=otherC index=3)))
 // CHECK64-NEXT:   (field name=a offset=32
-// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK64-NEXT:       (case name=payload index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=otherA index=1)
 // CHECK64-NEXT:       (case name=otherB index=2)
 // CHECK64-NEXT:       (case name=otherC index=3)))
 // CHECK64-NEXT:   (field name=b offset=48
-// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK64-NEXT:       (case name=payload index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=otherA index=1)
 // CHECK64-NEXT:       (case name=otherB index=2)
 // CHECK64-NEXT:       (case name=otherC index=3)))
 // CHECK64-NEXT:   (field name=c offset=64
-// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK64-NEXT:       (case name=payload index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))))
 // CHECK64-NEXT:       (case name=otherA index=1)
 // CHECK64-NEXT:       (case name=otherB index=2)
 // CHECK64-NEXT:       (case name=otherC index=3)))
@@ -664,95 +664,95 @@ reflect(object: ManyCasesManyPayloadsC())
 // CHECK64-NEXT:   (field name=a offset=16
 // CHECK64-NEXT:     (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=252 bitwise_takable=1
 // CHECK64-NEXT:       (case name=a index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=b index=1 offset=0
-// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_buffer offset=0
-// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_storage offset=0
-// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=rawValue offset=0
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=c index=2 offset=0
-// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_variant offset=0
-// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=object offset=0
-// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=rawValue offset=0
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=extra index=3)))
 // CHECK64-NEXT:   (field name=b offset=40
 // CHECK64-NEXT:     (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=252 bitwise_takable=1
 // CHECK64-NEXT:       (case name=a index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=b index=1 offset=0
-// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_buffer offset=0
-// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_storage offset=0
-// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=rawValue offset=0
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=c index=2 offset=0
-// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_variant offset=0
-// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=object offset=0
-// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=rawValue offset=0
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=extra index=3)))
 // CHECK64-NEXT:   (field name=c offset=64
 // CHECK64-NEXT:     (multi_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=252 bitwise_takable=1
 // CHECK64-NEXT:       (case name=a index=0 offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_guts offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_object offset=0
-// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                       (field name=_value offset=0
 // CHECK64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:                   (field name=_object offset=8
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=b index=1 offset=0
-// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_buffer offset=0
-// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_storage offset=0
-// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=rawValue offset=0
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=c index=2 offset=0
-// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_variant offset=0
-// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=object offset=0
-// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:                   (field name=rawValue offset=0
-// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:       (case name=extra index=3))))
 
 // CHECK32-NEXT: (class_instance size=44 alignment=4 stride=44 num_extra_inhabitants=0 bitwise_takable=1
@@ -1520,19 +1520,19 @@ reflect(enum: ManyCasesOneStringPayload.payload("hello, world"))
 // CHECKALL-NEXT: (enum reflect_Enum_values.ManyCasesOneStringPayload)
 
 // CHECKALL: Type info:
-// CHECK64-NEXT: (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK64-NEXT: (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK64-NEXT:   (case name=payload index=0 offset=0
-// CHECK64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:       (field name=_guts offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_object offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_value offset=0
 // CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:               (field name=_object offset=8
-// CHECK64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:   (case name=otherA index=1)
 // CHECK64-NEXT:   (case name=otherB index=2)
 // CHECK64-NEXT:   (case name=otherC index=3))
@@ -1590,19 +1590,19 @@ reflect(enum: ManyCasesOneStringPayload.otherB)
 // CHECKALL-NEXT: (enum reflect_Enum_values.ManyCasesOneStringPayload)
 
 // CHECKALL: Type info:
-// CHECK64-NEXT: (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=2147483644 bitwise_takable=1
+// CHECK64-NEXT: (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-3]] bitwise_takable=1
 // CHECK64-NEXT:   (case name=payload index=0 offset=0
-// CHECK64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:       (field name=_guts offset=0
-// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:           (field name=_object offset=0
-// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK64-NEXT:               (field name=_countAndFlagsBits offset=0
 // CHECK64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK64-NEXT:                   (field name=_value offset=0
 // CHECK64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK64-NEXT:               (field name=_object offset=8
-// CHECK64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 // CHECK64-NEXT:   (case name=otherA index=1)
 // CHECK64-NEXT:   (case name=otherB index=2)
 // CHECK64-NEXT:   (case name=otherC index=3))

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Set
 // RUN: %target-codesign %t/reflect_Set
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Set | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Set | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -29,7 +29,7 @@ reflect(object: obj)
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_String
 // RUN: %target-codesign %t/reflect_String
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_String | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_String | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -29,7 +29,7 @@ reflect(object: obj)
 // CHECK-64: Type info:
 // CHECK-64-NEXT: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=t offset=16
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.

--- a/validation-test/Reflection/reflect_empty_struct.swift
+++ b/validation-test/Reflection/reflect_empty_struct.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct
 // RUN: %target-codesign %t/reflect_empty_struct
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
+// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail %add_num_extra_inhabitants
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
@@ -35,15 +35,15 @@ reflect(object: obj)
 // CHECK-64:   (field name=a offset=16
 // CHECK-64:     ({{builtin|struct}} size=0 alignment={{1|4}} stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=b offset=16
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:   (field name=c offset=48
 // CHECK-64:     ({{builtin|struct}} size=0 alignment={{1|4}} stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=d offset=48
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}

--- a/validation-test/Reflection/reflect_empty_struct_compat.swift
+++ b/validation-test/Reflection/reflect_empty_struct_compat.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct
 // RUN: %target-codesign %t/reflect_empty_struct
-// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
+// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail %add_num_extra_inhabitants
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
@@ -35,15 +35,15 @@ reflect(object: obj)
 // CHECK-64:   (field name=a offset=16
 // CHECK-64:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=b offset=16
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:   (field name=c offset=48
 // CHECK-64:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=d offset=48
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -2,9 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_existential
 // RUN: %target-codesign %t/reflect_existential
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_existential | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_existential | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
-// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
@@ -32,9 +32,9 @@ reflect(object: TestGeneric(D() as Any))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1)))))
 
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
@@ -57,9 +57,9 @@ reflect(object: TestGeneric(D() as P))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=56 alignment=8 stride=56 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
 // CHECK-64:       (field name=wtable offset=32
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
@@ -87,7 +87,7 @@ reflect(object: TestGeneric(D() as (P & AnyObject)))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=object offset=0
 // CHECK-64:         (reference kind=strong refcounting=unknown))
 // CHECK-64:       (field name=wtable offset=8
@@ -117,7 +117,7 @@ reflect(object: TestGeneric(D() as CP))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=object offset=0
 // CHECK-64:         (reference kind=strong refcounting=unknown))
 // CHECK-64:       (field name=wtable offset=8
@@ -148,7 +148,7 @@ reflect(object: TestGeneric(D() as (C & P)))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=object offset=0
 // CHECK-64:         (reference kind=strong refcounting=native))
 // CHECK-64:       (field name=wtable offset=8

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_multiple_types
 // RUN: %target-codesign %t/reflect_multiple_types
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_multiple_types | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_multiple_types | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
@@ -118,7 +118,7 @@ reflect(object: obj)
 // CHECK-64-LABEL: Type info:
 // CHECK-64-NEXT: (class_instance size=185 alignment=8 stride=192 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=t00 offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-64:   (field name=t01 offset=24
 // CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
@@ -126,22 +126,22 @@ reflect(object: obj)
 // CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 
 // CHECK-64-NEXT:   (field name=t02 offset=32
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_str offset=0
-// CHECK-64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_guts offset=0
-// CHECK-64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_object offset=0
-// CHECK-64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_countAndFlagsBits offset=0
 // CHECK-64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                       (field name=_value offset=0
 // CHECK-64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:                   (field name=_object offset=8
-// CHECK-64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))))
+// CHECK-64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))))
 
 // CHECK-64-NEXT:   (field name=t03 offset=48
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-64:   (field name=t04 offset=56
 // CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
@@ -180,12 +180,12 @@ reflect(object: obj)
 // CHECK-64-NEXT:   (field name=t14 offset=128
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:   (field name=t15 offset=136
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 
 // (unstable implementation details omitted)
 
 // CHECK-64:   (field name=t16 offset=144
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-64:   (field name=t17 offset=160


### PR DESCRIPTION
Quoting @tbkka: `The number of extra inhabitants actually depends to some extent on the OS. Apple platforms reserve a 4GB "page zero" on 64 bit platforms in order to help detect 32/64 bit errors. [...] But Linux only reserves a 4K page zero, so there are only 4096 invalid pointer values.`

This PR adds variables `num_extra_inhabitants`, `num_extra_inhabitants_minus_1`, `num_extra_inhabitants_minus_2` and `num_extra_inhabitants_minus_3`, with the proper platform's values, and replaces the usages of those raw values by the variables.

It also enables the tests under Linux which are now working thanks to these changes and #32339.