### PR TITLE
Disable a hack that causes breakage on Python 3.8

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -5,13 +5,11 @@ import sys
 import update_checkout
 
 if __name__ == '__main__':
-    # The internal Windows implementation tries to import the current module using
-    # sys.modules[__name__]. This file (called 'update-checkout') is not a valid
-    # Python module name, as it contains a '-' and doesn't end with '.py'. This
-    # results in errors running update-checkout on Windows:'ImportError: No module
-    # named update-checkout'.
-    # As such, we need to manually set sys.modules[__name__] to a valid module
-    # identifier to work around these errors.
-    sys.modules[__name__] = sys.modules['update_checkout']
+    # This line was added in dfe3af81b2 to address an importing issue on
+    # Windows.  It causes this script to break badly when used with
+    # Python 3.8 on macOS. Disabling for all Python 3 until someone
+    # can help sort out what's really needed for Windows:
+    if sys.version_info.major < 3:
+        sys.modules[__name__] = sys.modules['update_checkout']
 
     update_checkout.main()


### PR DESCRIPTION
The hack to sys.modules here was added unconditionally to fix an import problem on
Windows (with Python 2.7???).

This script works fine on Python 2.7 on macOS either with or without this hack.

This script breaks badly on Python 3.8 on macOS with this hack, so I've disabled
it here for all Python 3.

(Note: The broken behavior here is only obvious if you have `python` set to run Python 3.)