### PR TITLE
Add _getMetadataSection{,Count,Name} to API digester allow list

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -134,7 +134,6 @@ public func _getTypeByMangledNameInContext(
   genericArguments: UnsafeRawPointer?)
   -> Any.Type?
 
-#if INTERNAL_CHECKS_ENABLED
 @_silgen_name("swift_getMetadataSection")
 public func _getMetadataSection(
   _ index: UInt)
@@ -148,4 +147,3 @@ public func _getMetadataSectionCount()
 public func _getMetadataSectionName(
   _ metadata_section: UnsafeRawPointer)
   -> UnsafePointer<CChar>
-#endif

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -39,6 +39,3 @@ Struct _ObjectRuntimeFunctionCountersState is a new API without @available attri
 Struct _RuntimeFunctionCounters is a new API without @available attribute
 Func _swift_isImmutableCOWBuffer(_:) is a new API without @available attribute
 Func _swift_setImmutableCOWBuffer(_:_:) is a new API without @available attribute
-Func _getMetadataSection(_:) is a new API without @available attribute
-Func _getMetadataSectionCount() is a new API without @available attribute
-Func _getMetadataSectionName(_:) is a new API without @available attribute

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -30,3 +30,8 @@
 
 Func _prespecialize() is a new API without @available attribute
 Func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(_:_:_:_:_:_:) is a new API without @available attribute
+
+// These reflection APIs are exposed to facilitate building SwiftReflectionTest.swift when testing Release builds.
+Func _getMetadataSection(_:) is a new API without @available attribute
+Func _getMetadataSectionCount() is a new API without @available attribute
+Func _getMetadataSectionName(_:) is a new API without @available attribute


### PR DESCRIPTION
  These APIs facilitate building SwiftReflectionTest.swift when testing Release builds.

rdar://66103895