### PR TITLE
[Python3] Fix test failures in update_checkout

### DIFF
--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -12,7 +12,7 @@
 
 import os
 
-from scheme_mock import call_quietly
+from .scheme_mock import call_quietly
 
 from . import scheme_mock
 

--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -12,9 +12,9 @@
 
 import os
 
+from . import scheme_mock
 from .scheme_mock import call_quietly
 
-from . import scheme_mock
 
 WORKTREE_NAME = "feature"
 

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -166,7 +166,7 @@ def update_single_repository(pool_args):
                         result = shell.run(['git', 'rev-parse', checkout_target])
                         revision = result[0].strip()
                         shell.run(['git', 'checkout', revision], echo=True)
-                    except Exception as e:
+                    except Exception:
                         raise originalException
 
             # It's important that we checkout, fetch, and rebase, in order.


### PR DESCRIPTION
Make the update_checkout tests pass for both Python 2 and Python 3.