### PR TITLE
[Sema] Diagnose access to the underlying storage of a lazy variable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3006,6 +3006,8 @@ ERROR(lazy_must_be_property,none,
       "lazy is only valid for members of a struct or class", ())
 ERROR(lazy_not_strong,none,
       "lazy properties cannot be %0", (ReferenceOwnership))
+ERROR(lazy_var_storage_access,none,
+     "access to the underlying storage of a lazy property is not allowed", ())
 
 // Debugger function attribute.
 ERROR(attr_for_debugger_support_only,none,

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -1993,6 +1993,9 @@
   msg: >-
     cannot declare entity named %0; the '$' prefix is reserved for
     implicitly-synthesized declarations
+- id: lazy_var_storage_access
+  msg: >-
+    access to the underlying storage of a lazy property is not allowed
 
 - id: anon_closure_arg_not_in_closure
   msg: >-

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -189,3 +189,32 @@ class ReferenceStaticInLazyProperty {
   static var i = 42
   static func f() -> Int { return 0 }
 }
+
+// Explicit access to the lazy variable storage
+class LazyVarContainer {
+  lazy var foo: Int = {
+    return 0
+  }()
+
+  func accessLazyStorage() {
+    $__lazy_storage_$_foo = nil // expected-error {{access to the underlying storage of a lazy property is not allowed}}
+    print($__lazy_storage_$_foo!) // expected-error {{access to the underlying storage of a lazy property is not allowed}}
+    _ = $__lazy_storage_$_foo == nil // expected-error {{access to the underlying storage of a lazy property is not allowed}}
+  }
+}
+
+// Make sure we can still access a synthesized variable with the same name as a lazy storage variable
+// i.e. $__lazy_storage_$_{property_name} when using property wrapper where the property name is 
+// '__lazy_storage_$_{property_name}'.
+@propertyWrapper
+struct Wrapper {
+  var wrappedValue: Int { 1 }
+  var projectedValue: Int { 1 }
+}
+
+struct PropertyWrapperContainer {
+  @Wrapper var __lazy_storage_$_foo
+  func test() {
+    _ = $__lazy_storage_$_foo  // This is okay.
+  }
+}


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/21996, the name of the underlying storage variable of a `lazy var` has been changed to `$__lazy_storage_$_{property_name}`. You couldn't actually write an identifier in (Swift) source beginning with an `$` before (except anonymous closure params like `$0` and etc), but since the introduction of property wrappers, you can do that and this has inadvertently allowed access to the `lazy var` storage and made it possible to "reset" it.

So, detect use of `$__lazy_storage_$_{property_name}` identifier in (Swift) source and emit a tailored error diagnostic.
