### PR TITLE
[AST] Mark repr invalid only if `@autoclosure` parameter doesn't poin…

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2345,15 +2345,23 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     }
   }
 
-  if (hasFunctionAttr && !fnRepr) {
-    if (attrs.has(TAK_autoclosure)) {
+  if (attrs.has(TAK_autoclosure)) {
+    // If this is a situation where function type is wrapped
+    // into a number of parens, let's try to look through them,
+    // because parens are insignificant here e.g.:
+    //
+    // let _: (@autoclosure (() -> Void)) -> Void = { _ in }
+    if (!ty->is<FunctionType>()) {
       // @autoclosure is going to be diagnosed when type of
       // the parameter is validated, because that attribute
       // applies to the declaration now.
       repr->setInvalid();
-      attrs.clearAttribute(TAK_autoclosure);
     }
 
+    attrs.clearAttribute(TAK_autoclosure);
+  }
+
+  if (hasFunctionAttr && !fnRepr) {
     const auto diagnoseInvalidAttr = [&](TypeAttrKind kind) {
       if (kind == TAK_escaping) {
         Type optionalObjectType = ty->getOptionalObjectType();

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -295,3 +295,36 @@ struct SR_11938_S : @autoclosure SR_11938_P {} // expected-error {{'@autoclosure
 
 // SR-9178
 func bar<T>(_ x: @autoclosure T) {} // expected-error 1{{@autoclosure attribute only applies to function types}}
+
+func test_autoclosure_type_in_parens() {
+  let _: (@autoclosure (() -> Void)) -> Void = { _ in } // Ok
+
+  struct Test {
+    func bugSingle<T: RawRepresentable>(defaultValue: @autoclosure (() -> T)) -> T { // Ok
+      defaultValue()
+    }
+
+    func bugMultiple<T: RawRepresentable>(defaultValue: @autoclosure ((() -> T))) -> T { // Ok
+      defaultValue()
+    }
+  }
+
+  enum E : String {
+    case foo = "foo"
+    case bar = "bar"
+  }
+
+  _ = Test().bugSingle(defaultValue: E.foo)   // Ok
+  _ = Test().bugMultiple(defaultValue: E.bar) // Ok
+}
+
+func test_autoclosure_with_typealias() {
+  typealias ConcreteFunc = () -> Int
+  typealias GenericFunc<T> = () -> T
+
+  func test(cr: @autoclosure ConcreteFunc) -> Int { cr() } // Ok
+  func test<Q>(gn: @autoclosure GenericFunc<Q>) -> Q { gn() } // Ok
+
+  _ = test(cr: 0) // Ok
+  _ = test(gn: 1) // Ok
+}


### PR DESCRIPTION
…t to function type

Instead on depending on repr to be a function, let's only check
whether type resolved for `@autoclosure` points to a function type
because it's allowed for `@autoclosure` parameters to be to
wrapped into parens or be represented by a typealias.

Resolves: rdar://problem/65704049

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
