### PR TITLE
[Python3] Fix "undefined symbol 'unicode'" from python_lint

### DIFF
--- a/test/Incremental/Verifier/gen-output-file-map.py
+++ b/test/Incremental/Verifier/gen-output-file-map.py
@@ -9,6 +9,13 @@ import os
 import sys
 
 
+# Python 2 `unicode` was renamed `str` in Python 3.  To consistently support
+# both, define `unicode` to be `str` when using Python 3.  Once we can drop
+# Python 2 support, delete this and change all uses of `unicode` to `str`.
+if sys.version_info[0] >= 2:
+    unicode = str
+
+
 def fatal(msg):
     print(msg, file=sys.stderr)
     sys.exit(1)
@@ -62,21 +69,14 @@ def main(arguments):
         'swift-dependencies': './main-buildrecord.swiftdeps'
     }
 
-    # TODO: this is for python 2 and python 3 compatibility.  Once Python 2 is
-    # removed, this function can be removed.
-    def to_unicode(r):
-        if sys.version_info[0] < 3:
-            return unicode(r)
-        return str(r)
-
     with io.open(output_path, 'w', encoding='utf-8', newline='\n') as f:
-        f.write(to_unicode(json.dumps(all_records, ensure_ascii=False)))
+        f.write(unicode(json.dumps(all_records, ensure_ascii=False)))
 
     if args.response_output_file is not None:
         with io.open(args.response_output_file, 'w',
                      encoding='utf-8', newline='\n') as f:
             for line in response_file_contents:
-                f.write(to_unicode(line + " "))
+                f.write(unicode(line + " "))
 
 
 if __name__ == '__main__':

--- a/test/Incremental/Verifier/gen-output-file-map.py
+++ b/test/Incremental/Verifier/gen-output-file-map.py
@@ -12,7 +12,7 @@ import sys
 # Python 2 `unicode` was renamed `str` in Python 3.  To consistently support
 # both, define `unicode` to be `str` when using Python 3.  Once we can drop
 # Python 2 support, delete this and change all uses of `unicode` to `str`.
-if sys.version_info[0] >= 2:
+if sys.version_info[0] >= 3:
     unicode = str
 
 

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -14,6 +14,15 @@ from functools import reduce
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 
 
+# Python 2 `unicode` was renamed `str` in Python 3.  To consistently support
+# both, define `unicode` to be `str` when using Python 3.  Once we can drop
+# Python 2 support, delete this and change all uses of `unicode` to `str`.
+# (Currently, this is only here to avoid a python_lint failure from unicode
+# references below.)
+if sys.version_info[0] >= 2:
+    unicode = str
+
+
 class RoundTripTask(object):
     def __init__(self, input_filename, action, swift_syntax_test,
                  skip_bad_syntax):

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -19,7 +19,7 @@ logging.basicConfig(format='%(message)s', level=logging.INFO)
 # Python 2 support, delete this and change all uses of `unicode` to `str`.
 # (Currently, this is only here to avoid a python_lint failure from unicode
 # references below.)
-if sys.version_info[0] >= 2:
+if sys.version_info[0] >= 3:
     unicode = str
 
 


### PR DESCRIPTION
This is a little tricky.

Python 2 "unicode" was renamed to "str" in Python 3.

For Python 2 compatibility, we need to use "unicode" in a couple
of places, but that's not defined on Python 3, which causes
python_lint errors (even if the reference is never actually executed).

To workaround this, when running in Python 3, define "unicode"
as a synonym for "str".  This defines the symbol (avoiding the
"undefined symbol" error from python lint) while preserving
the correct functionality on both Python 2 and Python 3.

When we drop Python 2 support (which we should do as soon as
possible), we can drop this workaround and globally replace
"unicode" with "str" to get the right Python 3-only functionality.
