### PR TITLE
[Function Builders] Teach diagnostics about function builder body result types...

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -240,6 +240,13 @@ ValueDecl *RequirementFailure::getDeclRef() const {
     return type->getAnyGeneric();
   };
 
+  // If the locator is for a function builder body result type, the requirement
+  // came from the function's return type.
+  if (getLocator()->isForFunctionBuilderBodyResult()) {
+    auto *func = getAsDecl<FuncDecl>(getAnchor());
+    return getAffectedDeclFromType(func->getResultInterfaceType());
+  }
+
   if (isFromContextualType())
     return getAffectedDeclFromType(getContextualType(getRawAnchor()));
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7443,10 +7443,9 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 
   // If there is a function builder to apply, do so now.
   if (functionBuilderType) {
-    auto *calleeLocator = getCalleeLocator(getConstraintLocator(locator));
     if (auto result = matchFunctionBuilder(
             closure, functionBuilderType, closureType->getResult(),
-            ConstraintKind::Conversion, calleeLocator, locator)) {
+            ConstraintKind::Conversion, locator)) {
       return result->isSuccess();
     }
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -251,8 +251,7 @@ bool ConstraintLocator::isForOptionalTry() const {
 }
 
 bool ConstraintLocator::isForFunctionBuilderBodyResult() const {
-  auto elt = getFirstElementAs<LocatorPathElt::FunctionBuilderBodyResult>();
-  return elt.hasValue();
+  return isFirstElement<LocatorPathElt::FunctionBuilderBodyResult>();
 }
 
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -91,6 +91,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ClosureResult:
   case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ConstructorMember:
+  case ConstraintLocator::FunctionBuilderBodyResult:
   case ConstraintLocator::InstanceType:
   case ConstraintLocator::AutoclosureResult:
   case ConstraintLocator::OptionalPayload:
@@ -249,6 +250,11 @@ bool ConstraintLocator::isForOptionalTry() const {
   return directlyAt<OptionalTryExpr>();
 }
 
+bool ConstraintLocator::isForFunctionBuilderBodyResult() const {
+  auto elt = getFirstElementAs<LocatorPathElt::FunctionBuilderBodyResult>();
+  return elt.hasValue();
+}
+
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?
@@ -345,6 +351,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
 
     case FunctionResult:
       out << "function result";
+      break;
+
+    case FunctionBuilderBodyResult:
+      out << "function builder body result";
       break;
 
     case SequenceElementType:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -391,6 +391,14 @@ public:
     return false;
   }
 
+  /// Check whether the first element in the path of this locator (if any)
+  /// is a given \c LocatorPathElt subclass.
+  template <class T>
+  bool isFirstElement() const {
+    auto path = getPath();
+    return !path.empty() && path.front().is<T>();
+  }
+
   /// Attempts to cast the first path element of the locator to a specific
   /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or
   /// the locator has no path elements.

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -381,6 +381,9 @@ public:
   /// Determine whether this locator points to the `try?` expression.
   bool isForOptionalTry() const;
 
+  /// Determine whether this locator is for a function builder body result type.
+  bool isForFunctionBuilderBodyResult() const;
+
   /// Determine whether this locator points directly to a given expression.
   template <typename E> bool directlyAt() const {
     if (auto *expr = getAnchor().dyn_cast<Expr *>())

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -75,6 +75,9 @@ SIMPLE_LOCATOR_PATH_ELT(FunctionArgument)
 /// The result type of a function.
 SIMPLE_LOCATOR_PATH_ELT(FunctionResult)
 
+/// The result type of a function builder body.
+SIMPLE_LOCATOR_PATH_ELT(FunctionBuilderBodyResult)
+
 /// A generic argument.
 /// FIXME: Add support for named generic arguments?
 CUSTOM_LOCATOR_PATH_ELT(GenericArgument)

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -477,6 +477,12 @@ template <typename T> bool isExpr(ASTNode node) {
   return isa<T>(E);
 }
 
+template <typename T = Decl> T *getAsDecl(ASTNode node) {
+  if (auto *E = node.dyn_cast<Decl *>())
+    return dyn_cast_or_null<T>(E);
+  return nullptr;
+}
+
 SourceLoc getLoc(ASTNode node);
 SourceRange getSourceRange(ASTNode node);
 
@@ -4341,7 +4347,7 @@ public:
   Optional<TypeMatchResult> matchFunctionBuilder(
       AnyFunctionRef fn, Type builderType, Type bodyResultType,
       ConstraintKind bodyResultConstraintKind,
-      ConstraintLocator *calleeLocator, ConstraintLocatorBuilder locator);
+      ConstraintLocatorBuilder locator);
 
 private:
   /// The kind of bindings that are permitted.

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -572,3 +572,16 @@ wrapperifyInfer(true) { x in // expected-error{{unable to infer type of a closur
   intValue + x
 }
 
+struct DoesNotConform {}
+
+struct MyView {
+  @TupleBuilder var value: some P { // expected-error {{return type of property 'value' requires that 'DoesNotConform' conform to 'P'}}
+    // expected-note@-1 {{opaque return type declared here}}
+    DoesNotConform()
+  }
+
+  @TupleBuilder func test() -> some P { // expected-error {{return type of instance method 'test()' requires that 'DoesNotConform' conform to 'P'}}
+    // expected-note@-1 {{opaque return type declared here}}
+    DoesNotConform()
+  }
+}


### PR DESCRIPTION
...in order to properly diagnose requirement failures that aren't anchored at an expression.

* Add a new locator path element `FunctionBuilderBodyResult`
* When adding the constraint to match the function builder transformed type with the body result type, anchor at the function decl and add the `FunctionBuilderBodyResult` path element.
* When computing the affected decl for a `RequirementFailure` that has a locator pointing to a `FunctionBuilderBodyResult`, get the affected decl from the function result type
* Remove an unused parameter to `matchFunctionBuilder`

Resolves: rdar://problem/65683605