### PR TITLE
[cxx-interop] [nfc] HasMemberWithDestructor => StructWithSubobjectDestructor in comment.

### DIFF
--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -12,7 +12,7 @@ public func testStructWithDestructor() {
   let d = StructWithDestructor()
 }
 
-// Make sure that "HasMemberWithDestructor" is marked as non-trivial by checking
+// Make sure that "StructWithSubobjectDestructor" is marked as non-trivial by checking
 // for a "destroy_addr".
 // CHECK-LABEL: @$s4main33testStructWithSubobjectDestructoryyF
 // CHECK: [[AS:%.*]] = alloc_stack $StructWithSubobjectDestructor


### PR DESCRIPTION
The type "HasMemberWithDestructor" doesn't exist. It was replaced with StructWithSubobjectDestructor but the comment wasn't updated.
