### PR TITLE
[Sema] Diagnose wrapped property if its projected value property conflicts with lazy variable storage property

### DIFF
--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -874,6 +874,14 @@ struct TestInvalidRedeclaration3 {
   var _foo1 = 123 // expected-error {{invalid redeclaration of synthesized property '_foo1'}}
 }
 
+// Diagnose when wrapped property uses the name we use for lazy variable storage property.
+struct TestInvalidRedeclaration4 {
+  @WrapperWithProjectedValue var __lazy_storage_$_foo: Int
+  // expected-error@-1 {{invalid redeclaration of synthesized property '$__lazy_storage_$_foo'}}
+  // expected-note@-2 {{'$__lazy_storage_$_foo' synthesized for property wrapper projected value}}
+  lazy var foo = 1
+}
+
 // ---------------------------------------------------------------------------
 // Closures in initializers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The compiler currently crashes when diagnosing a redeclaration error when a lazy property has a name which generates a storage variable with a name that conflicts with the projected value variable's name. This is possible if the lazy variable is called `{prop_name}` and the wrapped property is called `__lazy_storage_$_{prop_name}`:

```swift
@propertyWrapper
struct WrapperWithProjectedValue<T> {
  var wrappedValue: T
  var projectedValue: T { return wrappedValue }
}

struct Foo {
  lazy var foo = 1
  @WrapperWithProjectedValue var __lazy_storage_$_foo: Int
}
```

This is quite an unlikely situation, but it's much better diagnose the wrapped property instead of crashing.