### PR TITLE
Introduce LoweredSILRequest

### DIFF
--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -131,6 +131,9 @@ struct IRGenDescriptor {
   const SILOptions &SILOpts;
 
   Lowering::TypeConverter &Conv;
+
+  /// The SILModule to emit. If \c nullptr, a fresh SILModule will be requested
+  /// during IRGen (which will eventually become the default behavior).
   SILModule *SILMod;
 
   StringRef ModuleName;

--- a/include/swift/AST/SILOptimizerRequests.h
+++ b/include/swift/AST/SILOptimizerRequests.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/EvaluatorDependencies.h"
+#include "swift/AST/SILGenRequests.h"
 #include "swift/AST/SimpleRequest.h"
 
 namespace swift {
@@ -68,6 +69,23 @@ void simple_display(llvm::raw_ostream &out,
                     const SILPipelineExecutionDescriptor &desc);
 
 SourceLoc extractNearestSourceLoc(const SILPipelineExecutionDescriptor &desc);
+
+/// Produces lowered SIL from a Swift file or module, ready for IRGen. This runs
+/// the diagnostic, optimization, and lowering SIL passes.
+class LoweredSILRequest
+    : public SimpleRequest<LoweredSILRequest,
+                           std::unique_ptr<SILModule>(ASTLoweringDescriptor),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  std::unique_ptr<SILModule> evaluate(Evaluator &evaluator,
+                                      ASTLoweringDescriptor desc) const;
+};
 
 /// Report that a request of the given kind is being evaluated, so it
 /// can be recorded by the stats reporter.

--- a/include/swift/AST/SILOptimizerTypeIDZone.def
+++ b/include/swift/AST/SILOptimizerTypeIDZone.def
@@ -17,3 +17,6 @@
 SWIFT_REQUEST(SILOptimizer, ExecuteSILPipelineRequest,
               evaluator::SideEffect(SILPipelineExecutionDescriptor),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(SILOptimizer, LoweredSILRequest,
+              std::unique_ptr<SILModule>(ASTLoweringDescriptor),
+              Uncached, NoLocationInfo)

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SILGenRequests.h"
+#include "swift/AST/SILOptimizerRequests.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/Platform.h"
@@ -912,15 +913,26 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
                                        IRGenDescriptor desc) const {
   const auto &Opts = desc.Opts;
   const auto &PSPs = desc.PSPs;
-
-  auto SILMod = std::unique_ptr<SILModule>(desc.SILMod);
   auto *M = desc.getParentModule();
+  auto &Ctx = M->getASTContext();
+  assert(!Ctx.hadError());
+
+  // If we've been provided a SILModule, use it. Otherwise request the lowered
+  // SIL for the file or module.
+  auto SILMod = std::unique_ptr<SILModule>(desc.SILMod);
+  if (!SILMod) {
+    auto loweringDesc =
+        ASTLoweringDescriptor{desc.Ctx, desc.Conv, desc.SILOpts};
+    SILMod = llvm::cantFail(Ctx.evaluator(LoweredSILRequest{loweringDesc}));
+
+    // If there was an error, bail.
+    if (Ctx.hadError())
+      return GeneratedModule::null();
+  }
+
   auto filesToEmit = desc.getFiles();
   auto *primaryFile =
       dyn_cast_or_null<SourceFile>(desc.Ctx.dyn_cast<FileUnit *>());
-
-  auto &Ctx = M->getASTContext();
-  assert(!Ctx.hadError());
 
   IRGenerator irgen(Opts, *SILMod);
 
@@ -1429,9 +1441,8 @@ GeneratedModule OptimizedIRRequest::evaluate(Evaluator &evaluator,
 
   bindExtensions(*parentMod);
 
-  // Type-check the files that need lowering to SIL.
-  auto loweringDesc = ASTLoweringDescriptor{desc.Ctx, desc.Conv, desc.SILOpts};
-  for (auto *file : loweringDesc.getFiles()) {
+  // Type-check the files that need emitting.
+  for (auto *file : desc.getFiles()) {
     if (auto *SF = dyn_cast<SourceFile>(file))
       performTypeChecking(*SF);
   }
@@ -1439,25 +1450,6 @@ GeneratedModule OptimizedIRRequest::evaluate(Evaluator &evaluator,
   if (ctx.hadError())
     return GeneratedModule::null();
 
-  auto silMod = llvm::cantFail(evaluator(ASTLoweringRequest{loweringDesc}));
-  silMod->installSILRemarkStreamer();
-  silMod->setSerializeSILAction([](){});
-
-  // Run SIL passes.
-  runSILDiagnosticPasses(*silMod);
-  runSILOptimizationPasses(*silMod);
-  silMod->verify();
-
-  if (ctx.hadError())
-    return GeneratedModule::null();
-
-  runSILLoweringPasses(*silMod);
-
-  if (ctx.hadError())
-    return GeneratedModule::null();
-
-  // Perform IRGen with the generated SILModule.
-  desc.SILMod = silMod.release();
   auto irMod = llvm::cantFail(evaluator(IRGenRequest{desc}));
   if (!irMod)
     return irMod;


### PR DESCRIPTION
Add a request that produces lowered SIL for a file or module and use it in IRGenRequest if no SILModule is provided.