### PR TITLE
[TF] Remove PythonKit from build presets.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2490,9 +2490,6 @@ stdlib-deployment-targets=macosx-x86_64
 swift-primary-variant-sdk=OSX
 swift-primary-variant-arch=x86_64
 
-pythonkit
-install-pythonkit
-
 # Do not link libz3.
 llvm-cmake-options=-DLLVM_ENABLE_Z3_SOLVER=NO
 
@@ -2552,9 +2549,6 @@ darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 mixin-preset=
     buildbot_linux
 
-pythonkit
-install-pythonkit
-
 # The swift-package-tests fail when run with python3.
 test-installable-package=
 
@@ -2564,9 +2558,6 @@ llvm-cmake-options=-DLLVM_ENABLE_Z3_SOLVER=NO
 [preset: tensorflow_linux,no_test]
 mixin-preset=
     buildbot_linux,no_test
-
-pythonkit
-install-pythonkit
 
 # The swift-package-tests fail when run with python3.
 test-installable-package=


### PR DESCRIPTION
PythonKit was removed as a Swift build dependency in 9f0e0a6.

PythonKit was instead added as a CMake dependency of tensorflow/swift-apis in
tensorflow/swift-apis#1045.

---

Fixes build error:
```
[./utils/build-script] NOTE: using preset "tensorflow_linux,tensorflow_swift_apis,no_test", which expands to

./utils/build-script --assertions --swift-enable-ast-verifier=0 '--swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-inproc' '--llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld' --llbuild --swiftpm --xctest --libicu --libcxx --build-ninja --install-llvm --install-swift --install-lldb --install-llbuild --install-swiftpm --install-xctest --install-libicu --install-prefix=/usr --install-libcxx --install-sourcekit-lsp --build-swift-static-stdlib --build-swift-static-sdk-overlay --build-swift-stdlib-unittest-extra --test-installable-package --toolchain-benchmarks --install-destdir=/swift-base/swift/swift-nightly-install --installable-package=/swift-base/swift/swift-tensorflow-LOCAL-2020-07-28-a-.tar.gz --build-subdir=buildbot_linux --lldb --release --test --validation-test --long-test --stress-test --test-optimized --foundation --libdispatch --indexstore-db --sourcekit-lsp '--lit-args=-v --time-tests' --lldb-test-swift-only --install-foundation --install-libdispatch --reconfigure --skip-test-cmark --skip-test-lldb --skip-test-swift --skip-test-llbuild --skip-test-swiftpm --skip-test-xctest --skip-test-foundation --skip-test-libdispatch --skip-test-playgroundsupport --skip-test-libicu --skip-test-indexstore-db --skip-test-sourcekit-lsp --pythonkit --install-pythonkit --test-installable-package= --tensorflow-swift-apis --install-tensorflow-swift-apis

error: unknown setting: pythonkit
```