### PR TITLE
[CSBindings] Refactor `getPotentialBindings` into `inferBindingsFor` + `infer`

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -753,8 +753,6 @@ bool ConstraintSystem::PotentialBindings::infer(
     const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &exactTypes,
     Constraint *constraint, bool &hasNonDependentMemberRelationalConstraints,
     bool &hasDependentMemberRelationalConstraints) {
-  SmallVector<PotentialBinding, 4> literalBindings;
-
   switch (constraint->getKind()) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -374,7 +374,7 @@ ConstraintSystem::determineBestBindings() {
   // First, let's collect all of the possible bindings.
   for (auto *typeVar : getTypeVariables()) {
     if (!typeVar->getImpl().hasRepresentativeOrFixed())
-      cache.insert({typeVar, getPotentialBindings(typeVar)});
+      cache.insert({typeVar, inferBindingsFor(typeVar, /*finalize=*/false)});
   }
 
   // Now let's see if we could infer something for related type
@@ -543,12 +543,48 @@ bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
 }
 
 ConstraintSystem::PotentialBindings
-ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar) {
-  auto bindings = getPotentialBindings(typeVar);
+ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar,
+                                   bool finalize) const {
+  assert(typeVar->getImpl().getRepresentative(nullptr) == typeVar &&
+         "not a representative");
+  assert(!typeVar->getImpl().getFixedType(nullptr) && "has a fixed type");
 
-  llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>
-      inferred;
-  bindings.finalize(*this, inferred);
+  PotentialBindings bindings(typeVar);
+
+  // Gather the constraints associated with this type variable.
+  auto constraints = CG.gatherConstraints(
+      typeVar, ConstraintGraph::GatheringKind::EquivalenceClass);
+
+  llvm::SmallPtrSet<CanType, 4> exactTypes;
+  bool hasNonDependentMemberRelationalConstraints = false;
+  bool hasDependentMemberRelationalConstraints = false;
+
+  for (auto *constraint : constraints) {
+    bool failed = bindings.infer(*this, exactTypes, constraint,
+                                 hasNonDependentMemberRelationalConstraints,
+                                 hasDependentMemberRelationalConstraints);
+
+    // Upon inference failure let's produce an empty set of bindings.
+    if (failed)
+      return {typeVar};
+  }
+
+  // If there were both dependent-member and non-dependent-member relational
+  // constraints, consider this "fully bound"; we don't want to touch it.
+  if (hasDependentMemberRelationalConstraints) {
+    if (hasNonDependentMemberRelationalConstraints)
+      bindings.FullyBound = true;
+    else
+      bindings.Bindings.clear();
+  }
+
+  if (finalize) {
+    llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>
+        inferred;
+
+    bindings.finalize(*this, inferred);
+  }
+
   return bindings;
 }
 
@@ -713,259 +749,238 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 /// Retrieve the set of potential type bindings for the given
 /// representative type variable, along with flags indicating whether
 /// those types should be opened.
-ConstraintSystem::PotentialBindings
-ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
-  assert(typeVar->getImpl().getRepresentative(nullptr) == typeVar &&
-         "not a representative");
-  assert(!typeVar->getImpl().getFixedType(nullptr) && "has a fixed type");
-
+bool ConstraintSystem::PotentialBindings::infer(
+    const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &exactTypes,
+    Constraint *constraint, bool &hasNonDependentMemberRelationalConstraints,
+    bool &hasDependentMemberRelationalConstraints) {
   // Determines whether this type variable represents an object
   // of the optional type extracted by force unwrap.
   bool isOptionalObject = false;
-  if (auto *locator = typeVar->getImpl().getLocator()) {
+  if (auto *locator = TypeVar->getImpl().getLocator()) {
     auto anchor = locator->getAnchor();
     isOptionalObject = isExpr<ForceValueExpr>(anchor);
   }
 
-  // Gather the constraints associated with this type variable.
-  auto constraints =
-      getConstraintGraph().gatherConstraints(
-          typeVar, ConstraintGraph::GatheringKind::EquivalenceClass);
-
-  PotentialBindings result(typeVar);
-
-  // Consider each of the constraints related to this type variable.
-  llvm::SmallPtrSet<CanType, 4> exactTypes;
   SmallVector<PotentialBinding, 4> literalBindings;
-  bool hasNonDependentMemberRelationalConstraints = false;
-  bool hasDependentMemberRelationalConstraints = false;
-  for (auto constraint : constraints) {
-    switch (constraint->getKind()) {
-    case ConstraintKind::Bind:
-    case ConstraintKind::Equal:
-    case ConstraintKind::BindParam:
-    case ConstraintKind::BindToPointerType:
-    case ConstraintKind::Subtype:
-    case ConstraintKind::Conversion:
-    case ConstraintKind::ArgumentConversion:
-    case ConstraintKind::OperatorArgumentConversion:
-    case ConstraintKind::OptionalObject: {
-      // If there is a `bind param` constraint associated with
-      // current type variable, result should be aware of that
-      // fact. Binding set might be incomplete until
-      // this constraint is resolved, because we currently don't
-      // look-through constraints expect to `subtype` to try and
-      // find related bindings.
-      // This only affects type variable that appears one the
-      // right-hand side of the `bind param` constraint and
-      // represents result type of the closure body, because
-      // left-hand side gets types from overload choices.
-      if (constraint->getKind() == ConstraintKind::BindParam &&
-          constraint->getSecondType()->isEqual(typeVar))
-        result.PotentiallyIncomplete = true;
 
-      auto binding = getPotentialBindingForRelationalConstraint(
-          result, constraint, hasDependentMemberRelationalConstraints,
-          hasNonDependentMemberRelationalConstraints);
-      if (!binding)
-        break;
+  switch (constraint->getKind()) {
+  case ConstraintKind::Bind:
+  case ConstraintKind::Equal:
+  case ConstraintKind::BindParam:
+  case ConstraintKind::BindToPointerType:
+  case ConstraintKind::Subtype:
+  case ConstraintKind::Conversion:
+  case ConstraintKind::ArgumentConversion:
+  case ConstraintKind::OperatorArgumentConversion:
+  case ConstraintKind::OptionalObject: {
+    // If there is a `bind param` constraint associated with
+    // current type variable, result should be aware of that
+    // fact. Binding set might be incomplete until
+    // this constraint is resolved, because we currently don't
+    // look-through constraints expect to `subtype` to try and
+    // find related bindings.
+    // This only affects type variable that appears one the
+    // right-hand side of the `bind param` constraint and
+    // represents result type of the closure body, because
+    // left-hand side gets types from overload choices.
+    if (constraint->getKind() == ConstraintKind::BindParam &&
+        constraint->getSecondType()->isEqual(TypeVar))
+      PotentiallyIncomplete = true;
 
-      auto type = binding->BindingType;
-      if (exactTypes.insert(type->getCanonicalType()).second) {
-        result.addPotentialBinding(*binding);
+    auto binding = cs.getPotentialBindingForRelationalConstraint(
+        *this, constraint, hasDependentMemberRelationalConstraints,
+        hasNonDependentMemberRelationalConstraints);
+    if (!binding)
+      break;
 
-        // Result of force unwrap is always connected to its base
-        // optional type via `OptionalObject` constraint which
-        // preserves l-valueness, so in case where object type got
-        // inferred before optional type (because it got the
-        // type from context e.g. parameter type of a function call),
-        // we need to test type with and without l-value after
-        // delaying bindings for as long as possible.
-        if (isOptionalObject && !type->is<LValueType>()) {
-          result.addPotentialBinding(binding->withType(LValueType::get(type)));
-          result.FullyBound = true;
-        }
+    auto type = binding->BindingType;
+    if (exactTypes.insert(type->getCanonicalType()).second) {
+      addPotentialBinding(*binding);
 
-        if (auto *locator = typeVar->getImpl().getLocator()) {
-          auto path = locator->getPath();
-          auto voidType = getASTContext().TheEmptyTupleType;
+      // Result of force unwrap is always connected to its base
+      // optional type via `OptionalObject` constraint which
+      // preserves l-valueness, so in case where object type got
+      // inferred before optional type (because it got the
+      // type from context e.g. parameter type of a function call),
+      // we need to test type with and without l-value after
+      // delaying bindings for as long as possible.
+      if (isOptionalObject && !type->is<LValueType>()) {
+        addPotentialBinding(binding->withType(LValueType::get(type)));
+        FullyBound = true;
+      }
 
-          // If this is a type variable representing closure result,
-          // which is on the right-side of some relational constraint
-          // let's have it try `Void` as well because there is an
-          // implicit conversion `() -> T` to `() -> Void` and this
-          // helps to avoid creating a thunk to support it.
-          if (!path.empty() &&
-              path.back().getKind() == ConstraintLocator::ClosureResult &&
-              binding->Kind == AllowedBindingKind::Supertypes &&
-              exactTypes.insert(voidType).second) {
-            result.addPotentialBinding({voidType, binding->Kind, constraint},
-                                       /*allowJoinMeet=*/false);
-          }
+      if (auto *locator = TypeVar->getImpl().getLocator()) {
+        auto path = locator->getPath();
+        auto voidType = cs.getASTContext().TheEmptyTupleType;
+
+        // If this is a type variable representing closure result,
+        // which is on the right-side of some relational constraint
+        // let's have it try `Void` as well because there is an
+        // implicit conversion `() -> T` to `() -> Void` and this
+        // helps to avoid creating a thunk to support it.
+        if (!path.empty() &&
+            path.back().getKind() == ConstraintLocator::ClosureResult &&
+            binding->Kind == AllowedBindingKind::Supertypes &&
+            exactTypes.insert(voidType).second) {
+          addPotentialBinding({voidType, binding->Kind, constraint},
+                              /*allowJoinMeet=*/false);
         }
       }
-      break;
     }
-    case ConstraintKind::KeyPathApplication: {
-      if (result.FullyBound)
-        continue;
+    break;
+  }
+  case ConstraintKind::KeyPathApplication: {
+    if (FullyBound)
+      return false;
 
-      // If this variable is in the application projected result type, mark the
-      // result as `FullyBound` to ensure we delay binding until we've bound
-      // other type variables in the KeyPathApplication constraint. This ensures
-      // we try to bind the key path type first, which can allow us to discover
-      // additional bindings for the result type.
-      SmallPtrSet<TypeVariableType *, 4> typeVars;
-      findInferableTypeVars(simplifyType(constraint->getThirdType()), typeVars);
-      if (typeVars.count(typeVar))
-        result.FullyBound = true;
+    // If this variable is in the application projected result type, mark the
+    // result as `FullyBound` to ensure we delay binding until we've bound
+    // other type variables in the KeyPathApplication constraint. This ensures
+    // we try to bind the key path type first, which can allow us to discover
+    // additional bindings for the result type.
+    SmallPtrSet<TypeVariableType *, 4> typeVars;
+    findInferableTypeVars(cs.simplifyType(constraint->getThirdType()),
+                          typeVars);
+    if (typeVars.count(TypeVar))
+      FullyBound = true;
 
-      break;
-    }
+    break;
+  }
 
-    case ConstraintKind::BridgingConversion:
-    case ConstraintKind::CheckedCast:
-    case ConstraintKind::EscapableFunctionOf:
-    case ConstraintKind::OpenedExistentialOf:
-    case ConstraintKind::KeyPath:
-    case ConstraintKind::FunctionInput:
-    case ConstraintKind::FunctionResult:
-    case ConstraintKind::OpaqueUnderlyingType:
-      // Constraints from which we can't do anything.
-      break;
+  case ConstraintKind::BridgingConversion:
+  case ConstraintKind::CheckedCast:
+  case ConstraintKind::EscapableFunctionOf:
+  case ConstraintKind::OpenedExistentialOf:
+  case ConstraintKind::KeyPath:
+  case ConstraintKind::FunctionInput:
+  case ConstraintKind::FunctionResult:
+  case ConstraintKind::OpaqueUnderlyingType:
+    // Constraints from which we can't do anything.
+    break;
 
-    case ConstraintKind::DynamicTypeOf: {
-      // Direct binding of the left-hand side could result
-      // in `DynamicTypeOf` failure if right-hand side is
-      // bound (because 'Bind' requires equal types to
-      // succeed), or left is bound to Any which is not an
-      // [existential] metatype.
-      auto dynamicType = constraint->getFirstType();
-      if (auto *tv = dynamicType->getAs<TypeVariableType>()) {
-        if (tv->getImpl().getRepresentative(nullptr) == typeVar)
-          return {typeVar};
-      }
-
-      // This is right-hand side, let's continue.
-      break;
+  case ConstraintKind::DynamicTypeOf: {
+    // Direct binding of the left-hand side could result
+    // in `DynamicTypeOf` failure if right-hand side is
+    // bound (because 'Bind' requires equal types to
+    // succeed), or left is bound to Any which is not an
+    // [existential] metatype.
+    auto dynamicType = constraint->getFirstType();
+    if (auto *tv = dynamicType->getAs<TypeVariableType>()) {
+      if (tv->getImpl().getRepresentative(nullptr) == TypeVar)
+        return true;
     }
 
-    case ConstraintKind::Defaultable:
-    case ConstraintKind::DefaultClosureType:
-      // Do these in a separate pass.
-      if (getFixedTypeRecursive(constraint->getFirstType(), true)
-              ->getAs<TypeVariableType>() == typeVar) {
-        result.Defaults.push_back(constraint);
-        hasNonDependentMemberRelationalConstraints = true;
-      }
-      break;
+    // This is right-hand side, let's continue.
+    break;
+  }
 
-    case ConstraintKind::Disjunction:
-      // FIXME: Recurse into these constraints to see whether this
-      // type variable is fully bound by any of them.
-      result.InvolvesTypeVariables = true;
-
-      // If there is additional context available via disjunction
-      // associated with closure literal (e.g. coercion to some other
-      // type) let's delay resolving the closure until the disjunction
-      // is attempted.
-      if (typeVar->getImpl().isClosureType())
-        return {typeVar};
-
-      break;
-
-    case ConstraintKind::ConformsTo:
-    case ConstraintKind::SelfObjectOfProtocol:
-      // Swift 3 allowed the use of default types for normal conformances
-      // to expressible-by-literal protocols.
-      if (getASTContext().LangOpts.EffectiveLanguageVersion[0] >= 4)
-        continue;
-
-      if (!constraint->getSecondType()->is<ProtocolType>())
-        continue;
-
-      LLVM_FALLTHROUGH;
-
-    case ConstraintKind::LiteralConformsTo: {
-      // Record constraint where protocol requirement originated
-      // this is useful to use for the binding later.
-      result.Protocols.push_back(constraint);
+  case ConstraintKind::Defaultable:
+  case ConstraintKind::DefaultClosureType:
+    // Do these in a separate pass.
+    if (cs.getFixedTypeRecursive(constraint->getFirstType(), true)
+            ->getAs<TypeVariableType>() == TypeVar) {
+      Defaults.push_back(constraint);
       hasNonDependentMemberRelationalConstraints = true;
-      break;
     }
+    break;
 
-    case ConstraintKind::ApplicableFunction:
-    case ConstraintKind::DynamicCallableApplicableFunction:
-    case ConstraintKind::BindOverload: {
-      if (result.FullyBound && result.InvolvesTypeVariables)
-        continue;
+  case ConstraintKind::Disjunction:
+    // FIXME: Recurse into these constraints to see whether this
+    // type variable is fully bound by any of them.
+    InvolvesTypeVariables = true;
 
-      // If this variable is in the left-hand side, it is fully bound.
-      SmallPtrSet<TypeVariableType *, 4> typeVars;
-      findInferableTypeVars(simplifyType(constraint->getFirstType()), typeVars);
-      if (typeVars.count(typeVar))
-        result.FullyBound = true;
+    // If there is additional context available via disjunction
+    // associated with closure literal (e.g. coercion to some other
+    // type) let's delay resolving the closure until the disjunction
+    // is attempted.
+    if (TypeVar->getImpl().isClosureType())
+      return true;
 
-      if (result.InvolvesTypeVariables)
-        continue;
+    break;
 
-      // If this and another type variable occur, this result involves
-      // type variables.
-      findInferableTypeVars(simplifyType(constraint->getSecondType()),
-                            typeVars);
-      if (typeVars.size() > 1 && typeVars.count(typeVar))
-        result.InvolvesTypeVariables = true;
+  case ConstraintKind::ConformsTo:
+  case ConstraintKind::SelfObjectOfProtocol:
+    // Swift 3 allowed the use of default types for normal conformances
+    // to expressible-by-literal protocols.
+    if (cs.getASTContext().LangOpts.EffectiveLanguageVersion[0] >= 4)
+      return false;
 
-      break;
-    }
+    if (!constraint->getSecondType()->is<ProtocolType>())
+      return false;
 
-    case ConstraintKind::ValueMember:
-    case ConstraintKind::UnresolvedValueMember:
-    case ConstraintKind::ValueWitness:
-      // If our type variable shows up in the base type, there's
-      // nothing to do.
-      // FIXME: Can we avoid simplification here?
-      if (ConstraintSystem::typeVarOccursInType(
-              typeVar, simplifyType(constraint->getFirstType()),
-              &result.InvolvesTypeVariables)) {
-        continue;
-      }
+    LLVM_FALLTHROUGH;
 
-      // If the type variable is in the list of member type
-      // variables, it is fully bound.
-      // FIXME: Can we avoid simplification here?
-      if (ConstraintSystem::typeVarOccursInType(
-              typeVar, simplifyType(constraint->getSecondType()),
-              &result.InvolvesTypeVariables)) {
-        result.FullyBound = true;
-      }
-      break;
-
-    case ConstraintKind::OneWayEqual:
-    case ConstraintKind::OneWayBindParam: {
-      // Don't produce any bindings if this type variable is on the left-hand
-      // side of a one-way binding.
-      auto firstType = constraint->getFirstType();
-      if (auto *tv = firstType->getAs<TypeVariableType>()) {
-        if (tv->getImpl().getRepresentative(nullptr) == typeVar)
-          return {typeVar};
-      }
-
-      break;
-    }
-    }
+  case ConstraintKind::LiteralConformsTo: {
+    // Record constraint where protocol requirement originated
+    // this is useful to use for the binding later.
+    Protocols.push_back(constraint);
+    hasNonDependentMemberRelationalConstraints = true;
+    break;
   }
 
-  // If there were both dependent-member and non-dependent-member relational
-  // constraints, consider this "fully bound"; we don't want to touch it.
-  if (hasDependentMemberRelationalConstraints) {
-    if (hasNonDependentMemberRelationalConstraints)
-      result.FullyBound = true;
-    else
-      result.Bindings.clear();
+  case ConstraintKind::ApplicableFunction:
+  case ConstraintKind::DynamicCallableApplicableFunction:
+  case ConstraintKind::BindOverload: {
+    if (FullyBound && InvolvesTypeVariables)
+      return false;
+
+    // If this variable is in the left-hand side, it is fully bound.
+    SmallPtrSet<TypeVariableType *, 4> typeVars;
+    findInferableTypeVars(cs.simplifyType(constraint->getFirstType()),
+                          typeVars);
+    if (typeVars.count(TypeVar))
+      FullyBound = true;
+
+    if (InvolvesTypeVariables)
+      return false;
+
+    // If this and another type variable occur, this result involves
+    // type variables.
+    findInferableTypeVars(cs.simplifyType(constraint->getSecondType()),
+                          typeVars);
+    if (typeVars.size() > 1 && typeVars.count(TypeVar))
+      InvolvesTypeVariables = true;
+
+    break;
   }
 
-  return result;
+  case ConstraintKind::ValueMember:
+  case ConstraintKind::UnresolvedValueMember:
+  case ConstraintKind::ValueWitness:
+    // If our type variable shows up in the base type, there's
+    // nothing to do.
+    // FIXME: Can we avoid simplification here?
+    if (ConstraintSystem::typeVarOccursInType(
+            TypeVar, cs.simplifyType(constraint->getFirstType()),
+            &InvolvesTypeVariables)) {
+      return false;
+    }
+
+    // If the type variable is in the list of member type
+    // variables, it is fully bound.
+    // FIXME: Can we avoid simplification here?
+    if (ConstraintSystem::typeVarOccursInType(
+            TypeVar, cs.simplifyType(constraint->getSecondType()),
+            &InvolvesTypeVariables)) {
+      FullyBound = true;
+    }
+    break;
+
+  case ConstraintKind::OneWayEqual:
+  case ConstraintKind::OneWayBindParam: {
+    // Don't produce any bindings if this type variable is on the left-hand
+    // side of a one-way binding.
+    auto firstType = constraint->getFirstType();
+    if (auto *tv = firstType->getAs<TypeVariableType>()) {
+      if (tv->getImpl().getRepresentative(nullptr) == TypeVar)
+        return true;
+    }
+
+    break;
+  }
+  }
+
+  return false;
 }
 
 /// Check whether the given type can be used as a binding for the given

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -22,7 +22,7 @@ using namespace swift;
 using namespace constraints;
 
 void ConstraintSystem::PotentialBindings::inferTransitiveBindings(
-    ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes,
+    const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes,
     const llvm::SmallDenseMap<TypeVariableType *,
                               ConstraintSystem::PotentialBindings>
         &inferredBindings) {
@@ -119,7 +119,7 @@ isUnviableDefaultType(Type defaultType,
 }
 
 void ConstraintSystem::PotentialBindings::inferDefaultTypes(
-    ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes) {
+    const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes) {
   auto isDirectRequirement = [&](Constraint *constraint) -> bool {
     if (auto *typeVar = constraint->getFirstType()->getAs<TypeVariableType>()) {
       auto *repr = cs.getRepresentative(typeVar);
@@ -275,7 +275,7 @@ void ConstraintSystem::PotentialBindings::inferDefaultTypes(
 }
 
 void ConstraintSystem::PotentialBindings::finalize(
-    ConstraintSystem &cs,
+    const ConstraintSystem &cs,
     const llvm::SmallDenseMap<TypeVariableType *,
                               ConstraintSystem::PotentialBindings>
         &inferredBindings) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4609,9 +4609,7 @@ private:
 public:
     bool infer(const ConstraintSystem &cs,
                llvm::SmallPtrSetImpl<CanType> &exactTypes,
-               Constraint *constraint,
-               bool &hasNonDependentMemberRelationalConstraints,
-               bool &hasDependentMemberRelationalConstraints);
+               Constraint *constraint);
 
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
@@ -4688,10 +4686,8 @@ public:
 
 private:
   Optional<ConstraintSystem::PotentialBinding>
-  getPotentialBindingForRelationalConstraint(
-      PotentialBindings &result, Constraint *constraint,
-      bool &hasDependentMemberRelationalConstraints,
-      bool &hasNonDependentMemberRelationalConstraints) const;
+  getPotentialBindingForRelationalConstraint(PotentialBindings &result,
+                                             Constraint *constraint) const;
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar) const;
 
   /// Add a constraint to the constraint system.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4582,6 +4582,7 @@ private:
     /// if it has only concrete types or would resolve a closure.
     bool favoredOverDisjunction(Constraint *disjunction) const;
 
+private:
     /// Detect `subtype` relationship between two type variables and
     /// attempt to infer supertype bindings transitively e.g.
     ///
@@ -4604,6 +4605,7 @@ private:
     void inferDefaultTypes(ConstraintSystem &cs,
                            llvm::SmallPtrSetImpl<CanType> &existingTypes);
 
+public:
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
     void finalize(ConstraintSystem &cs,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4595,20 +4595,21 @@ private:
     /// \param inferredBindings The set of all bindings inferred for type
     /// variables in the workset.
     void inferTransitiveBindings(
-        ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes,
+        const ConstraintSystem &cs,
+        llvm::SmallPtrSetImpl<CanType> &existingTypes,
         const llvm::SmallDenseMap<TypeVariableType *,
                                   ConstraintSystem::PotentialBindings>
             &inferredBindings);
 
     /// Infer bindings based on any protocol conformances that have default
     /// types.
-    void inferDefaultTypes(ConstraintSystem &cs,
+    void inferDefaultTypes(const ConstraintSystem &cs,
                            llvm::SmallPtrSetImpl<CanType> &existingTypes);
 
 public:
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
-    void finalize(ConstraintSystem &cs,
+    void finalize(const ConstraintSystem &cs,
                   const llvm::SmallDenseMap<TypeVariableType *,
                                             ConstraintSystem::PotentialBindings>
                       &inferredBindings);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4607,6 +4607,12 @@ private:
                            llvm::SmallPtrSetImpl<CanType> &existingTypes);
 
 public:
+    bool infer(const ConstraintSystem &cs,
+               llvm::SmallPtrSetImpl<CanType> &exactTypes,
+               Constraint *constraint,
+               bool &hasNonDependentMemberRelationalConstraints,
+               bool &hasDependentMemberRelationalConstraints);
+
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
     void finalize(const ConstraintSystem &cs,
@@ -4677,7 +4683,8 @@ public:
 
   /// Infer bindings for the given type variable based on current
   /// state of the constraint system.
-  PotentialBindings inferBindingsFor(TypeVariableType *typeVar);
+  PotentialBindings inferBindingsFor(TypeVariableType *typeVar,
+                                     bool finalize = true) const;
 
 private:
   Optional<ConstraintSystem::PotentialBinding>

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2945,7 +2945,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
         out << " as ";
         Type(fixed).print(out, PO);
       } else {
-        getPotentialBindings(tv).dump(out, 1);
+        inferBindingsFor(tv).dump(out, 1);
       }
     } else {
       out << " equivalent to ";


### PR DESCRIPTION
Split `getPotentialBindings` in two:

- `inferBindingsFor` should take responsibility for finding constraints
   to be evaluated as potential binding sources;
- `PotentialBindings::infer` would process constraints provided by
   `inferBindingsFor` and "extract" bindings from them.

This is done to separate "sourcing" logic from "inference" and
make the former pluggable, so bindings could be computed based
on changes in constraint graph in the future.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
