### PR TITLE
test: sort the environment for `remote-run`

### DIFF
--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -5,4 +5,4 @@ RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run -v 
 
 CHECK: {{^:foo: :bar:$}}
 
-VERBOSE: /usr/bin/env FOO=foo BAR=bar sh -c echo ":${FOO}:" ":${BAR}:"
+VERBOSE: /usr/bin/env BAR=bar FOO=foo sh -c echo ":${FOO}:" ":${BAR}:"

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -68,7 +68,7 @@ class CommandRunner(object):
         self.run_sftp(sftp_commands)
 
     def run_remote(self, command, remote_env={}):
-        env_strings = ['{0}={1}'.format(k,v) for k,v in remote_env.items()]
+        env_strings = ['{0}={1}'.format(k,v) for k,v in sorted(remote_env.items())]
         remote_invocation = self.remote_invocation(
             ['/usr/bin/env'] + env_strings + command)
         remote_proc = self.popen(remote_invocation, stdin=subprocess.PIPE,


### PR DESCRIPTION
With Python 3, there have been some sorting inconsistencies.  Always
sort the items to allow for the lit test to reliably match the output.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
