### PR TITLE
[5.3][Serialization] Add option to load swiftmodule files as volatile and avoid mmap

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -350,6 +350,9 @@ namespace swift {
     /// If set to \c false, fall back to the legacy manual reference name tracking code.
     bool EnableRequestBasedIncrementalDependencies = true;
 
+    /// Load swiftmodule files in memory as volatile and avoid mmap.
+    bool EnableVolatileModules = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -455,6 +455,9 @@ def warn_long_expression_type_checking_EQ : Joined<["-"], "warn-long-expression-
 def Rmodule_interface_rebuild : Flag<["-"], "Rmodule-interface-rebuild">,
   HelpText<"Emits a remark if an imported module needs to be re-compiled from its module interface">;
 
+def enable_volatile_modules : Flag<["-"], "enable-volatile-modules">,
+  HelpText<"Load Swift modules in memory">;
+
 def solver_expression_time_threshold_EQ : Joined<["-"], "solver-expression-time-threshold=">;
 
 def solver_disable_shrink :

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -583,6 +583,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.VerifyAllSubstitutionMaps |= Args.hasArg(OPT_verify_all_substitution_maps);
 
+  Opts.EnableVolatileModules |= Args.hasArg(OPT_enable_volatile_modules);
+
   Opts.UseDarwinPreStableABIBit =
     (Target.isMacOSX() && Target.isMacOSXVersionLT(10, 14, 4)) ||
     (Target.isiOS() && Target.isOSVersionLT(12, 2)) ||

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -337,8 +337,15 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   }
 
   // Actually load the file and error out if necessary.
+  //
+  // Use the default arguments except for IsVolatile. Force avoiding the use of
+  // mmap to workaround issues on NFS when the swiftmodule file loaded changes
+  // on disk while it's in use.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleOrErr =
-      FS.getBufferForFile(ModulePath);
+      FS.getBufferForFile(ModulePath,
+                          /*FileSize=*/-1,
+                          /*RequiresNullTerminator=*/true,
+                          /*IsVolatile=*/true);
   if (!ModuleOrErr)
     return ModuleOrErr.getError();
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -338,7 +338,8 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
 
   // Actually load the file and error out if necessary.
   //
-  // Use the default arguments except for IsVolatile. Force avoiding the use of
+  // Use the default arguments except for IsVolatile that is set by the
+  // frontend option -enable-volatile-modules. If set, we avoid the use of
   // mmap to workaround issues on NFS when the swiftmodule file loaded changes
   // on disk while it's in use.
   //
@@ -351,11 +352,12 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   // the surface look like memory corruption.
   //
   // rdar://63755989
+  bool enableVolatileModules = Ctx.LangOpts.EnableVolatileModules;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleOrErr =
       FS.getBufferForFile(ModulePath,
                           /*FileSize=*/-1,
                           /*RequiresNullTerminator=*/true,
-                          /*IsVolatile=*/true);
+                          /*IsVolatile=*/enableVolatileModules);
   if (!ModuleOrErr)
     return ModuleOrErr.getError();
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -341,6 +341,16 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   // Use the default arguments except for IsVolatile. Force avoiding the use of
   // mmap to workaround issues on NFS when the swiftmodule file loaded changes
   // on disk while it's in use.
+  //
+  // In practice, a swiftmodule file can chane when a client uses a
+  // swiftmodule file from a framework while the framework is recompiled and
+  // installed over existing files. Or when many processes rebuild the same
+  // module interface.
+  //
+  // We have seen these scenarios leading to deserialization errors that on
+  // the surface look like memory corruption.
+  //
+  // rdar://63755989
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleOrErr =
       FS.getBufferForFile(ModulePath,
                           /*FileSize=*/-1,


### PR DESCRIPTION
Swiftmodule files are loaded with mmap when read by a client for deserialization. This can lead to crashes when building Swift projects in parallel if a client is reading from a swiftmodule file while the project installing it replaces the file. This PR adds a frontend flag to force loading swiftmodule files as volatile and avoid mmap.

- Scope of Issue: This is affecting Swift projects building in sizable build environments.
- Risk: Low, this change will make the Swift compiler use more memory but only when the flag is passed.
- Cherry-pick of #33001 and #33052.
- Resolves: rdar://63755989