### PR TITLE
[5.3][Function Builders] Teach diagnostics about function builder body result types...

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1583,8 +1583,12 @@ ConstraintSystem::matchFunctionBuilder(
   // If builder is applied to the closure expression then
   // `closure body` to `closure result` matching should
   // use special locator.
-  if (auto *closure = fn.getAbstractClosureExpr())
+  if (auto *closure = fn.getAbstractClosureExpr()) {
     locator = getConstraintLocator(closure, ConstraintLocator::ClosureResult);
+  } else {
+    locator = getConstraintLocator(locator.getAnchor(),
+                                   ConstraintLocator::FunctionBuilderBodyResult);
+  }
 
   // Bind the body result type to the type of the transformed expression.
   addConstraint(bodyResultConstraintKind, transformedType, bodyResultType,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -269,6 +269,8 @@ public:
       Apply = dyn_cast<ApplyExpr>(parentExpr);
   }
 
+  SourceLoc getLoc() const override;
+
   unsigned getRequirementIndex() const {
     auto reqElt =
         getLocator()->castLastElementTo<LocatorPathElt::AnyRequirement>();

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -249,8 +249,7 @@ bool ConstraintLocator::isForOptionalTry() const {
 }
 
 bool ConstraintLocator::isForFunctionBuilderBodyResult() const {
-  auto elt = getFirstElementAs<LocatorPathElt::FunctionBuilderBodyResult>();
-  return elt.hasValue();
+  return isFirstElement<LocatorPathElt::FunctionBuilderBodyResult>();
 }
 
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -90,6 +90,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ClosureResult:
   case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ConstructorMember:
+  case ConstraintLocator::FunctionBuilderBodyResult:
   case ConstraintLocator::InstanceType:
   case ConstraintLocator::AutoclosureResult:
   case ConstraintLocator::OptionalPayload:
@@ -247,6 +248,11 @@ bool ConstraintLocator::isForOptionalTry() const {
   return directlyAt<OptionalTryExpr>();
 }
 
+bool ConstraintLocator::isForFunctionBuilderBodyResult() const {
+  auto elt = getFirstElementAs<LocatorPathElt::FunctionBuilderBodyResult>();
+  return elt.hasValue();
+}
+
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?
@@ -343,6 +349,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
 
     case FunctionResult:
       out << "function result";
+      break;
+
+    case FunctionBuilderBodyResult:
+      out << "function builder body result";
       break;
 
     case SequenceElementType:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -375,6 +375,9 @@ public:
   /// Determine whether this locator points to the `try?` expression.
   bool isForOptionalTry() const;
 
+  /// Determine whether this locator is for a function builder body result type.
+  bool isForFunctionBuilderBodyResult() const;
+
   /// Determine whether this locator points directly to a given expression.
   template <class E> bool directlyAt() const {
     auto *anchor = getAnchor();

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -384,6 +384,14 @@ public:
     return anchor && isa<E>(anchor) && getPath().empty();
   }
 
+  /// Check whether the first element in the path of this locator (if any)
+  /// is a given \c LocatorPathElt subclass.
+  template <class T>
+  bool isFirstElement() const {
+    auto path = getPath();
+    return !path.empty() && path.front().is<T>();
+  }
+
   /// Attempts to cast the first path element of the locator to a specific
   /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or
   /// the locator has no path elements.

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -75,6 +75,9 @@ SIMPLE_LOCATOR_PATH_ELT(FunctionArgument)
 /// The result type of a function.
 SIMPLE_LOCATOR_PATH_ELT(FunctionResult)
 
+/// The result type of a function builder body.
+SIMPLE_LOCATOR_PATH_ELT(FunctionBuilderBodyResult)
+
 /// A generic argument.
 /// FIXME: Add support for named generic arguments?
 CUSTOM_LOCATOR_PATH_ELT(GenericArgument)

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -572,3 +572,16 @@ wrapperifyInfer(true) { x in // expected-error{{unable to infer type of a closur
   intValue + x
 }
 
+struct DoesNotConform {}
+
+struct MyView {
+  @TupleBuilder var value: some P { // expected-error {{return type of property 'value' requires that 'DoesNotConform' conform to 'P'}}
+    // expected-note@-1 {{opaque return type declared here}}
+    DoesNotConform()
+  }
+
+  @TupleBuilder func test() -> some P { // expected-error {{return type of instance method 'test()' requires that 'DoesNotConform' conform to 'P'}}
+    // expected-note@-1 {{opaque return type declared here}}
+    DoesNotConform()
+  }
+}


### PR DESCRIPTION
...in order to properly diagnose requirement failures on a builder-transformed type.

This is mostly a cherry-pick of https://github.com/apple/swift/pull/33149, but working around not being able to anchor the constraint between the function result type and the transformed type on the function decl.

Reviewed by @xedin 

---

* Add a new locator path element `FunctionBuilderBodyResult`
* When adding the constraint to match the function builder transformed type with the body result type, add the `FunctionBuilderBodyResult` path element.
* When computing the affected decl for a `RequirementFailure` that has a locator pointing to a `FunctionBuilderBodyResult`, get the affected decl from the function result type
* Override `getLoc` in `RequirementFailure` to always produce the diagnostic at the function declaration when the fix is for a `FunctionBuilderBodyResult`, since the anchor can be `nullptr`

Resolves: rdar://problem/66247196