### PR TITLE
[SE-0163] Migrate from deprecated Unicode APIs (part 3)

### DIFF
--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -172,20 +172,7 @@ public struct StaticString {
       return body(UnsafeBufferPointer(
         start: utf8Start, count: utf8CodeUnitCount))
     } else {
-      var buffer: UInt64 = 0
-      var i = 0
-      let sink: (UInt8) -> Void = {
-#if _endian(little)
-        buffer = buffer | (UInt64($0) << (UInt64(i) * 8))
-#else
-        buffer = buffer | (UInt64($0) << (UInt64(7-i) * 8))
-#endif
-        i += 1
-      }
-      UTF8.encode(unicodeScalar, into: sink)
-      return body(UnsafeBufferPointer(
-        start: UnsafePointer(Builtin.addressof(&buffer)),
-        count: i))
+      return unicodeScalar.withUTF8CodeUnits { body($0) }
     }
   }
 

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -136,5 +136,5 @@ class GenericRuncer<T> : Gizmo {
 }
 
 // CHECK: define internal swiftcc void [[PARTIAL_FORWARDING_THUNK]](%swift.refcounted* swiftself %0) {{.*}} {
-// CHECK: @"$ss12StaticStringV14withUTF8BufferyxxSRys5UInt8VGXElFyAEcfU_"
+// CHECK: @"$ss12StaticStringV14withUTF8BufferyxxSRys5UInt8VGXElFxAFXEfU_"
 // CHECK: }


### PR DESCRIPTION
Follow-up to: apple/swift#32920