### PR TITLE
[5.3] Mark main() as used

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1864,7 +1864,9 @@ void irgen::updateLinkageForDefinition(IRGenModule &IGM,
   // Exclude "main", because it should naturally be used, and because adding it
   // to llvm.used leaves a dangling use when the REPL attempts to discard
   // intermediate mains.
-  if (LinkInfo::isUsed(IRL) && global->getName() != SWIFT_ENTRY_POINT_FUNCTION)
+  if (LinkInfo::isUsed(IRL)
+      && (!IGM.getOptions().IntegratedREPL
+          || global->getName() != SWIFT_ENTRY_POINT_FUNCTION))
     IGM.addUsedGlobal(global);
 }
 
@@ -1959,7 +1961,9 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM,
   // Exclude "main", because it should naturally be used, and because adding it
   // to llvm.used leaves a dangling use when the REPL attempts to discard
   // intermediate mains.
-  if (linkInfo.isUsed() && name != SWIFT_ENTRY_POINT_FUNCTION) {
+  if (linkInfo.isUsed()
+      && (!IGM.getOptions().IntegratedREPL
+          || name != SWIFT_ENTRY_POINT_FUNCTION)) {
     IGM.addUsedGlobal(fn);
   }
 

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -3,6 +3,8 @@
 // REQUIRES: CPU=x86_64
 
 sil_stage canonical
+import Builtin
+import Swift
 
 sil private @foo : $@convention(thin) () -> () {
 bb0:
@@ -43,12 +45,20 @@ bb0:
   return %1 : $()
 }
 
-// CHECK-macho: @llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*)], section "llvm.metadata"
-// CHECK-elf: @llvm.used = appending global [3 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([0 x i8], [0 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata"
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %2 = integer_literal $Builtin.Int32, 0          // user: %3
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        // user: %4
+  return %3 : $Int32                              // id: %4
+}
+
+// CHECK-macho: @llvm.used = appending global [3 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*)], section "llvm.metadata"
+// CHECK-elf: @llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata"
 
 // CHECK: define linkonce_odr hidden swiftcc void @qux()
 // CHECK: define hidden swiftcc void @fred()
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @frieda()
+// CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main
 
 // NEGATIVE-NOT: @foo
 // NEGATIVE-NOT: @bar


### PR DESCRIPTION
…except when the integrated REPL is in use. This prevents dead code stripping from removing the `main()` function used in widgets.

Fixes rdar://65862827.