### PR TITLE
[build] Don’t mark toolchain snapshots as requiring a dev Swift runtime

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3053,7 +3053,6 @@ function build_and_test_installable_package() {
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DISABLE_REQUIRED_ARCLITE string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_LINK_OBJC_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DEVELOPMENT_TOOLCHAIN string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 
           call chmod a+r "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 


### PR DESCRIPTION
The development toolchains we provide on swift.org set the SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME flag in their Info.plist, which makes Xcode

1) refuse to allow running apps compiled with them on iOS (and other embedded) devices.
2) set DYLD_LIBRARY_PATH on macOS such that executables compiled with the toolchain load the toolchain’s custom stdlib/overlay dylibs instead of using the OS-provided one.

I believe neither of these behaviors are desirable. We ought to be able to test prerelease compilers by trying to compile & run iOS applications with them, and the stdlib that comes from a random toolchain snapshot won’t necessarily function well (or at all) as a replacement for the one that was built for the specific OS version it’s running on.

Rather, these toolchains should compile apps using a Swift Standard Library module that matches the compiler, but at runtime they should load the OS-built libraries; i.e., the resulting binaries should be running in a backward- (or forward-) deployment mode.

Resolves rdar://66252035.
