### PR TITLE
SILCombine: optimize casts of existential boxes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -226,6 +226,36 @@ void eraseUsesOfInstruction(
 /// value itself)
 void eraseUsesOfValue(SILValue value);
 
+/// Gets the concrete value which is stored in an existential box.
+/// Returns %value in following pattern:
+///
+///    %existentialBox = alloc_existential_box $Error, $ConcreteError
+///    %a = project_existential_box $ConcreteError in %existentialBox : $Error
+///    store %value to %a : $*ConcreteError
+///
+/// Returns an invalid SILValue in case there are multiple stores or any unknown
+/// users of \p existentialBox.
+/// The \p ignoreUser is ignored in the user list of \p existentialBox.
+SILValue
+getConcreteValueOfExistentialBox(AllocExistentialBoxInst *existentialBox,
+                                 SILInstruction *ignoreUser);
+
+/// Gets the concrete value which is stored in an existential box, which itself
+/// is stored in \p addr.
+/// Returns %value in following pattern:
+///
+///    %b = alloc_existential_box $Error, $ConcreteError
+///    %a = project_existential_box $ConcreteError in %b : $Error
+///    store %value to %a : $*ConcreteError
+///    %addr = alloc_stack $Error
+///    store %b to %addr : $*Error
+///
+/// Returns an invalid SILValue in case there are multiple stores or any unknown
+/// users of \p addr or the existential box.
+/// The \p ignoreUser is ignored in the user list of \p addr.
+SILValue getConcreteValueOfExistentialBoxAddr(SILValue addr,
+                                              SILInstruction *ignoreUser);
+
 FullApplySite findApplyFromDevirtualizedResult(SILValue value);
 
 /// Cast a value into the expected, ABI compatible type if necessary.

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -240,6 +240,16 @@ bool SILCombiner::runOnFunction(SILFunction &F) {
   return Changed;
 }
 
+void SILCombiner::eraseInstIncludingUsers(SILInstruction *inst) {
+  for (SILValue result : inst->getResults()) {
+    while (!result->use_empty()) {
+      eraseInstIncludingUsers(result->use_begin()->getUser());
+    }
+  }
+  eraseInstFromFunction(*inst);
+}
+
+
 //===----------------------------------------------------------------------===//
 //                                Entry Points
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -147,6 +147,10 @@ public:
     return nullptr;
   }
 
+  // Erases \p inst and all of its users, recursively.
+  // The caller has to make sure that all users are removable (e.g. dead).
+  void eraseInstIncludingUsers(SILInstruction *inst);
+
   SILInstruction *eraseInstFromFunction(SILInstruction &I,
                                         bool AddOperandsToWorklist = true) {
     SILBasicBlock::iterator nullIter;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -337,12 +337,53 @@ SILCombiner::visitUncheckedRefCastAddrInst(UncheckedRefCastAddrInst *URCI) {
   return eraseInstFromFunction(*URCI);
 }
 
+template <class CastInst>
+static bool canBeUsedAsCastDestination(SILValue value, CastInst *castInst,
+                                       DominanceAnalysis *DA) {
+  return value &&
+         value->getType() == castInst->getTargetLoweredType().getObjectType() &&
+         DA->get(castInst->getFunction())->properlyDominates(value, castInst);
+}
+
+
 SILInstruction *
 SILCombiner::
 visitUnconditionalCheckedCastAddrInst(UnconditionalCheckedCastAddrInst *UCCAI) {
   if (UCCAI->getFunction()->hasOwnership())
     return nullptr;
 
+  // Optimize the unconditional_checked_cast_addr in this pattern:
+  //
+  //   %box = alloc_existential_box $Error, $ConcreteError
+  //   %a = project_existential_box $ConcreteError in %b : $Error
+  //   store %value to %a : $*ConcreteError
+  //   %err = alloc_stack $Error
+  //   store %box to %err : $*Error
+  //   %dest = alloc_stack $ConcreteError
+  //   unconditional_checked_cast_addr Error in %err : $*Error to
+  //                                ConcreteError in %dest : $*ConcreteError
+  //
+  // to:
+  //   ...
+  //   retain_value %value : $ConcreteError
+  //   destroy_addr %err : $*Error
+  //   store %value to %dest $*ConcreteError
+  //
+  // This lets the alloc_existential_box become dead and it can be removed in
+  // following optimizations.
+  SILValue val = getConcreteValueOfExistentialBoxAddr(UCCAI->getSrc(), UCCAI);
+  if (canBeUsedAsCastDestination(val, UCCAI, DA)) {
+    SILBuilderContext builderCtx(Builder.getModule(), Builder.getTrackingList());
+    SILBuilderWithScope builder(UCCAI, builderCtx);
+    SILLocation loc = UCCAI->getLoc();
+    builder.createRetainValue(loc, val, builder.getDefaultAtomicity());
+    builder.createDestroyAddr(loc, UCCAI->getSrc());
+    builder.createStore(loc, val, UCCAI->getDest(),
+                        StoreOwnershipQualifier::Unqualified);
+    return eraseInstFromFunction(*UCCAI);
+  }
+
+  // Perform the purly type-based cast optimization.
   if (CastOpt.optimizeUnconditionalCheckedCastAddrInst(UCCAI))
     MadeChange = true;
 
@@ -522,6 +563,62 @@ visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *CCABI) {
   if (CCABI->getFunction()->hasOwnership())
     return nullptr;
 
+  // Optimize the checked_cast_addr_br in this pattern:
+  //
+  //   %box = alloc_existential_box $Error, $ConcreteError
+  //   %a = project_existential_box $ConcreteError in %b : $Error
+  //   store %value to %a : $*ConcreteError
+  //   %err = alloc_stack $Error
+  //   store %box to %err : $*Error
+  //   %dest = alloc_stack $ConcreteError
+  //   checked_cast_addr_br <consumption-kind> Error in %err : $*Error to
+  //        ConcreteError in %dest : $*ConcreteError, success_bb, failing_bb
+  //
+  // to:
+  //   ...
+  //   retain_value %value : $ConcreteError
+  //   destroy_addr %err : $*Error           // if consumption-kind is take
+  //   store %value to %dest $*ConcreteError
+  //   br success_bb
+  //
+  // This lets the alloc_existential_box become dead and it can be removed in
+  // following optimizations.
+  //
+  // TODO: Also handle the WillFail case.
+  SILValue val = getConcreteValueOfExistentialBoxAddr(CCABI->getSrc(), CCABI);
+  if (canBeUsedAsCastDestination(val, CCABI, DA)) {
+    SILBuilderContext builderCtx(Builder.getModule(), Builder.getTrackingList());
+    SILBuilderWithScope builder(CCABI, builderCtx);
+    SILLocation loc = CCABI->getLoc();
+    builder.createRetainValue(loc, val, builder.getDefaultAtomicity());
+    switch (CCABI->getConsumptionKind()) {
+      case CastConsumptionKind::TakeAlways:
+      case CastConsumptionKind::TakeOnSuccess:
+        builder.createDestroyAddr(loc, CCABI->getSrc());
+        break;
+      case CastConsumptionKind::CopyOnSuccess:
+        break;
+      case CastConsumptionKind::BorrowAlways:
+        llvm_unreachable("BorrowAlways is not supported on addresses");
+    }
+    builder.createStore(loc, val, CCABI->getDest(),
+                        StoreOwnershipQualifier::Unqualified);
+                        
+    // Replace the cast with a constant conditional branch.
+    // Don't just create an unconditional branch to not change the CFG in
+    // SILCombine. SimplifyCFG will clean that up.
+    //
+    // Another possibility would be to run this optimization in SimplifyCFG.
+    // But this has other problems, like it's more difficult to reason about a
+    // consistent dominator tree in SimplifyCFG.
+    SILType boolTy = SILType::getBuiltinIntegerType(1, builder.getASTContext());
+    auto *trueVal = builder.createIntegerLiteral(loc, boolTy, 1);
+    builder.createCondBranch(loc, trueVal, CCABI->getSuccessBB(),
+                             CCABI->getFailureBB());
+    return eraseInstFromFunction(*CCABI);
+  }
+
+  // Perform the purly type-based cast optimization.
   if (CastOpt.optimizeCheckedCastAddrBranchInst(CCABI))
     MadeChange = true;
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -55,66 +55,40 @@ SILCombiner::visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {
   //   debug_value %6#0 : $Error
   //   strong_release %6#0 : $Error
 
-  StoreInst *SingleStore = nullptr;
-  StrongReleaseInst *SingleRelease = nullptr;
-  ProjectExistentialBoxInst *SingleProjection = nullptr;
-
-  // For each user U of the alloc_existential_box...
-  for (auto U : getNonDebugUses(AEBI)) {
-
-    if (auto *PEBI = dyn_cast<ProjectExistentialBoxInst>(U->getUser())) {
-      if (SingleProjection) return nullptr;
-      SingleProjection = PEBI;
-      for (auto AddrUse : getNonDebugUses(PEBI)) {
-        // Record stores into the box.
-        if (auto *SI = dyn_cast<StoreInst>(AddrUse->getUser())) {
-          // If this is not the only store into the box then bail out.
-          if (SingleStore) return nullptr;
-          SingleStore = SI;
-          continue;
-        }
-        // If there are other users to the box value address then bail out.
-        return nullptr;
-      }
-      continue;
-    }
-
-    // Record releases of the box.
-    if (auto *RI = dyn_cast<StrongReleaseInst>(U->getUser())) {
-      // If this is not the only release of the box then bail out.
-      if (SingleRelease) return nullptr;
-      SingleRelease = RI;
-      continue;
-    }
-
-    // If there are other users to the box then bail out.
+  SILValue boxedValue =
+    getConcreteValueOfExistentialBox(AEBI, /*ignoreUser*/ nullptr);
+  if (!boxedValue)
     return nullptr;
+
+  // Check if the box is released at a single place. That's the end of its
+  // lifetime.
+  StrongReleaseInst *singleRelease = nullptr;
+  for (Operand *use : AEBI->getUses()) {
+    if (auto *RI = dyn_cast<StrongReleaseInst>(use->getUser())) {
+      // If this is not the only release of the box then bail out.
+      if (singleRelease)
+        return nullptr;
+      singleRelease = RI;
+    }
   }
+  if (!singleRelease)
+    return nullptr;
 
-  if (SingleStore && SingleRelease) {
-    assert(SingleProjection && "store without a projection");
-    // Release the value that was stored into the existential box. The box
-    // is going away so we need to release the stored value.
-    // NOTE: It's important that the release is inserted at the single
-    // release of the box and not at the store, because a balancing retain could
-    // be _after_ the store, e.g:
-    //      %box = alloc_existential_box
-    //      %addr = project_existential_box %box
-    //      store %value to %addr
-    //      retain_value %value    // must insert the release after this retain
-    //      strong_release %box
-    Builder.setInsertionPoint(SingleRelease);
-    Builder.createReleaseValue(AEBI->getLoc(), SingleStore->getSrc(),
-                               SingleRelease->getAtomicity());
+  // Release the value that was stored into the existential box. The box
+  // is going away so we need to release the stored value.
+  // NOTE: It's important that the release is inserted at the single
+  // release of the box and not at the store, because a balancing retain could
+  // be _after_ the store, e.g:
+  //      %box = alloc_existential_box
+  //      %addr = project_existential_box %box
+  //      store %value to %addr
+  //      retain_value %value    // must insert the release after this retain
+  //      strong_release %box
+  Builder.setInsertionPoint(singleRelease);
+  Builder.createReleaseValue(AEBI->getLoc(), boxedValue,
+                             singleRelease->getAtomicity());
 
-    // Erase the instruction that stores into the box and the release that
-    // releases the box, and finally, release the box.
-    eraseInstFromFunction(*SingleRelease);
-    eraseInstFromFunction(*SingleStore);
-    eraseInstFromFunction(*SingleProjection);
-    return eraseInstFromFunction(*AEBI);
-  }
-
+  eraseInstIncludingUsers(AEBI);
   return nullptr;
 }
 

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -38,6 +38,7 @@ public enum Result<Success, Failure: Error> {
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new success value if this instance represents a success.
+  @inlinable
   public func map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
@@ -75,6 +76,7 @@ public enum Result<Success, Failure: Error> {
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new failure value if this instance represents a failure.
+  @inlinable
   public func mapError<NewFailure>(
     _ transform: (Failure) -> NewFailure
   ) -> Result<Success, NewFailure> {
@@ -112,6 +114,7 @@ public enum Result<Success, Failure: Error> {
   ///   instance.
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new failure value if this instance represents a failure.
+  @inlinable
   public func flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
@@ -130,6 +133,7 @@ public enum Result<Success, Failure: Error> {
   ///   instance.
   /// - Returns: A `Result` instance, either from the closure or the previous 
   ///   `.success`.
+  @inlinable
   public func flatMapError<NewFailure>(
     _ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
@@ -157,6 +161,7 @@ public enum Result<Success, Failure: Error> {
   ///
   /// - Returns: The success value, if the instance represents a success.
   /// - Throws: The failure value, if the instance represents a failure.
+  @inlinable
   public func get() throws -> Success {
     switch self {
     case let .success(success):

--- a/test/SILOptimizer/existential_box_elimination.swift
+++ b/test/SILOptimizer/existential_box_elimination.swift
@@ -1,0 +1,83 @@
+// RUN: %target-build-swift -O -wmo %s -module-name=test -Xfrontend -sil-verify-all -emit-sil | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -wmo -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+
+
+final class LifetimeTracking {
+  static var numObjects = 0
+  init() { LifetimeTracking.numObjects += 1 }
+  deinit { LifetimeTracking.numObjects -= 1 }
+}
+
+public struct TestError: Error {
+  var errno: Int
+  let t = LifetimeTracking()
+
+  init(errno: Int) { self.errno = errno }
+}
+
+@inline(never)
+@_optimize(none)
+internal func internalImplementation(somethingGood: Bool) -> Result<Int, TestError> {
+  return somethingGood ? .success(27) : .failure(TestError(errno:123))
+}
+
+public func publicWrapper(somethingGood: Bool) throws -> Int {
+  return try internalImplementation(somethingGood: somethingGood).get()
+}
+
+// CHECK-LABEL: sil [noinline] @$s4test0A13WithForceCast13somethingGoodSiSb_tF
+// CHECK:       [[F:%[0-9]+]] = function_ref @$s4test22internalImplementation13somethingGoods6ResultOySiAA9TestErrorVGSb_tF
+// CHECK:       apply [[F]]
+// CHECK:       switch_enum
+// CHECK:     bb1:
+// CHECK-NOT:   alloc_existential_box
+// CHECK-NOT:   apply
+// CHECK: } // end sil function '$s4test0A13WithForceCast13somethingGoodSiSb_tF'
+@inline(never)
+public func testWithForceCast(somethingGood: Bool) -> Int {
+  do {
+    return try publicWrapper(somethingGood: somethingGood)
+  } catch let e {
+    return (e as! TestError).errno
+  }
+}
+
+// CHECK-LABEL: sil [noinline] @$s4test0A19WithMultipleCatches13somethingGoodSiSb_tF
+// CHECK:       [[F:%[0-9]+]] = function_ref @$s4test22internalImplementation13somethingGoods6ResultOySiAA9TestErrorVGSb_tF
+// CHECK:       apply [[F]]
+// CHECK:       switch_enum
+// CHECK:     bb1:
+// CHECK-NOT:   alloc_existential_box
+// CHECK-NOT:   apply
+// CHECK: } // end sil function '$s4test0A19WithMultipleCatches13somethingGoodSiSb_tF'
+@inline(never)
+public func testWithMultipleCatches(somethingGood: Bool) -> Int {
+  do {
+    return try publicWrapper(somethingGood: somethingGood)
+  } catch let e as TestError {
+    return e.errno
+  } catch {
+    fatalError()
+  }
+}
+
+@inline(never)
+func checkResult(_ result: Int, expected: Int) {
+  if result != expected {
+    fatalError("unexpected result: \(result) != \(expected)")
+  }
+  if LifetimeTracking.numObjects != 0 {
+    fatalError("objects leaked!")
+  }
+}
+
+checkResult(testWithForceCast(somethingGood: true), expected: 27)
+checkResult(testWithMultipleCatches(somethingGood: true), expected: 27)
+
+checkResult(testWithForceCast(somethingGood: false), expected: 123)
+checkResult(testWithMultipleCatches(somethingGood: false), expected: 123)

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2995,6 +2995,292 @@ bb0(%0 : $*Array<Error>):
   return %52 : $()
 }
 
+struct TestError: Error {
+  var payload: AnyObject
+}
+
+struct OtherError: Error {
+  var payload: AnyObject
+}
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast
+// CHECK:      [[E:%[0-9]+]] = alloc_stack $Error
+// CHECK:      [[T:%[0-9]+]] = alloc_stack $TestError
+// CHECK-NEXT: retain_value %0
+// CHECK-NEXT: destroy_addr [[E]]
+// CHECK-NEXT: store %0 to [[T]]
+// CHECK-NEXT: struct_element_addr
+// CHECK:   } // end sil function 'unconditional_existential_box_cast'
+sil @unconditional_existential_box_cast : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+sil @unknown_use_of_TestError : $@convention(thin) (@inout TestError) -> ()
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_unknown_user1
+// CHECK:   unconditional_checked_cast_addr
+// CHECK: } // end sil function 'unconditional_existential_box_cast_unknown_user1'
+sil @unconditional_existential_box_cast_unknown_user1 : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %u = function_ref @unknown_use_of_TestError : $@convention(thin) (@inout TestError) -> ()
+  %r = apply %u(%2) : $@convention(thin) (@inout TestError) -> ()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+sil @unknown_use_of_box : $@convention(thin) (Error) -> ()
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_unknown_user2
+// CHECK:   unconditional_checked_cast_addr
+// CHECK: } // end sil function 'unconditional_existential_box_cast_unknown_user2'
+sil @unconditional_existential_box_cast_unknown_user2 : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %u = function_ref @unknown_use_of_box : $@convention(thin) (Error) -> ()
+  %r = apply %u(%1) : $@convention(thin) (Error) -> ()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+sil @unknown_use_of_Error : $@convention(thin) (@inout Error) -> ()
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_unknown_user3
+// CHECK:   unconditional_checked_cast_addr
+// CHECK: } // end sil function 'unconditional_existential_box_cast_unknown_user3'
+sil @unconditional_existential_box_cast_unknown_user3 : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %u = function_ref @unknown_use_of_Error : $@convention(thin) (@inout Error) -> ()
+  %r = apply %u(%5) : $@convention(thin) (@inout Error) -> ()
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_multiple_stores1
+// CHECK:   unconditional_checked_cast_addr
+// CHECK: } // end sil function 'unconditional_existential_box_cast_multiple_stores1'
+sil @unconditional_existential_box_cast_multiple_stores1 : $@convention(thin) (@guaranteed TestError, @guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError, %0a : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  store %0a to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_multiple_stores2
+// CHECK:   unconditional_checked_cast_addr
+// CHECK: } // end sil function 'unconditional_existential_box_cast_multiple_stores2'
+sil @unconditional_existential_box_cast_multiple_stores2 : $@convention(thin) (@guaranteed TestError, @owned Error) -> @owned AnyObject {
+bb0(%0 : $TestError, %0a : $Error):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  store %1 to %5 : $*Error
+  store %0a to %5 : $*Error
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_wrong_type
+// CHECK:   unconditional_checked_cast_addr
+// CHECK: } // end sil function 'unconditional_existential_box_cast_wrong_type'
+sil @unconditional_existential_box_cast_wrong_type : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $OtherError
+  unconditional_checked_cast_addr Error in %5 : $*Error to OtherError in %7 : $*OtherError
+  %10 = struct_element_addr %7 : $*OtherError, #OtherError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*OtherError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+}
+
+// CHECK-LABEL: sil @unconditional_existential_box_cast_not_dominating
+// CHECK:      [[E:%[0-9]+]] = alloc_stack $Error
+// CHECK:      [[T:%[0-9]+]] = alloc_stack $TestError
+// CHECK-NEXT: retain_value %0
+// CHECK-NEXT: destroy_addr [[E]]
+// CHECK-NEXT: store %0 to [[T]]
+// CHECK-NEXT: struct_element_addr
+// CHECK:   } // end sil function 'unconditional_existential_box_cast_not_dominating'
+sil @unconditional_existential_box_cast_not_dominating : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  cond_br undef, bb1, bb2
+bb1:
+  store %0 to %2 : $*TestError
+  br bb2
+bb2:
+  cond_br undef, bb3, bb4
+bb3:
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  unconditional_checked_cast_addr Error in %5 : $*Error to TestError in %7 : $*TestError
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+bb4:
+  %20 = integer_literal $Builtin.Int1, -1
+  cond_fail %20 : $Builtin.Int1
+  unreachable
+}
+
+// CHECK-LABEL: sil @conditional_existential_box_cast
+// CHECK:      [[E:%[0-9]+]] = alloc_stack $Error
+// CHECK:      [[T:%[0-9]+]] = alloc_stack $TestError
+// CHECK-NEXT: retain_value %0
+// CHECK-NEXT: store %0 to [[T]]
+// CHECK-NEXT: [[I:%[0-9]+]] = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: cond_br [[I]], bb1, bb2
+// CHECK:   } // end sil function 'conditional_existential_box_cast'
+sil @conditional_existential_box_cast : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  checked_cast_addr_br copy_on_success Error in %5 : $*Error to TestError in %7 : $*TestError, bb1, bb2
+
+bb1:
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+
+bb2:
+  %20 = integer_literal $Builtin.Int1, -1
+  cond_fail %20 : $Builtin.Int1
+  unreachable
+}
+
+// CHECK-LABEL: sil @taking_conditional_existential_box_cast
+// CHECK:      [[E:%[0-9]+]] = alloc_stack $Error
+// CHECK:      [[T:%[0-9]+]] = alloc_stack $TestError
+// CHECK-NEXT: retain_value %0
+// CHECK-NEXT: destroy_addr [[E]]
+// CHECK-NEXT: store %0 to [[T]]
+// CHECK-NEXT: [[I:%[0-9]+]] = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: cond_br [[I]], bb1, bb2
+// CHECK:   } // end sil function 'taking_conditional_existential_box_cast'
+sil @taking_conditional_existential_box_cast : $@convention(thin) (@guaranteed TestError) -> @owned AnyObject {
+bb0(%0 : $TestError):
+  %1 = alloc_existential_box $Error, $TestError
+  %2 = project_existential_box $TestError in %1 : $Error
+  store %0 to %2 : $*TestError
+  %4 = builtin "willThrow"(%1 : $Error) : $()
+  %5 = alloc_stack $Error
+  strong_retain %1 : $Error
+  store %1 to %5 : $*Error
+  %7 = alloc_stack $TestError
+  checked_cast_addr_br take_on_success Error in %5 : $*Error to TestError in %7 : $*TestError, bb1, bb2
+
+bb1:
+  %10 = struct_element_addr %7 : $*TestError, #TestError.payload
+  %11 = load %10 : $*AnyObject
+  strong_release %1 : $Error
+  dealloc_stack %7 : $*TestError
+  dealloc_stack %5 : $*Error
+  return %11 : $AnyObject
+
+bb2:
+  %20 = integer_literal $Builtin.Int1, -1
+  cond_fail %20 : $Builtin.Int1
+  unreachable
+}
+
 sil [reabstraction_thunk] @_TTRXFo_oSS_dSb_XFo_iSS_iSb_ : $@convention(thin) (@in String, @owned @callee_owned (@owned String) -> Bool) -> @out Bool
 sil [reabstraction_thunk] @_TTRXFo_iSS_iSb_XFo_oSS_dSb_ : $@convention(thin) (@owned String, @owned @callee_owned (@in String) -> @out Bool) -> Bool
 

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -192,6 +192,17 @@ ErrorTests.test("test dealloc empty error box") {
 }
 
 var errors: [Error] = []
+
+@inline(never)
+func throwNegativeOne() throws {
+  throw UnsignedError.negativeOne
+}
+
+@inline(never)
+func throwJazzHands() throws {
+  throw SillyError.JazzHands
+}
+
 ErrorTests.test("willThrow") {
   if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
     // Error isn't allowed in a @convention(c) function when ObjC interop is
@@ -204,12 +215,12 @@ ErrorTests.test("willThrow") {
     willThrow.storeBytes(of: callback, as: WillThrow.self)
     expectTrue(errors.isEmpty)
     do {
-      throw UnsignedError.negativeOne
+      try throwNegativeOne()
     } catch {}
     expectEqual(UnsignedError.self, type(of: errors.last!))
 
     do {
-      throw SillyError.JazzHands
+      try throwJazzHands()
     } catch {}
     expectEqual(2, errors.count)
     expectEqual(SillyError.self, type(of: errors.last!))


### PR DESCRIPTION
 Optimize the unconditional_checked_cast_addr in this pattern:
```
   %box = alloc_existential_box $Error, $ConcreteError
   %a = project_existential_box $ConcreteError in %b : $Error
   store %value to %a : $*ConcreteError
   %err = alloc_stack $Error
   store %box to %err : $*Error
   %dest = alloc_stack $ConcreteError
   unconditional_checked_cast_addr Error in %err : $*Error to ConcreteError in %dest : $*ConcreteError
```
to:
```
   ...
   retain_value %value : $ConcreteError
   destroy_addr %err : $*Error
   store %value to %dest $*ConcreteError
```

This lets the alloc_existential_box become dead and it can be removed in following optimizations.
The same optimization is also done for conditional_checked_cast_addr.

*There is also an implication for debugging:*
Each "throw" in the code calls the runtime function swift_willThrow. The function is used by the debugger to set a breakpoint and also add hooks.
This optimization can completely eliminate a "throw", including the runtime call.
So, with optimized code, the user might not see the program to break at a throw, whereas in the source code it is actually throwing.
On the other hand, eliminating the existential box is a significant performance win and we don't guarantee any debugging behavior for optimized code anyway. So I think this is a reasonable trade-off.
I added an option "-Xllvm -keep-will-throw-call" to keep the runtime call which can be used if someone want's to reliably break on "throw" in optimized builds.

To make this optimization work smoothly with the Result type from the library, I had to make the Result methods inlinable. For a use case see the SILOptimizer/existential_box_elimination.swift test file.

rdar://problem/66055678