### PR TITLE
Use .str() when converting StringRef to std::string in ModuleInterfaceLoader

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -243,11 +243,11 @@ private:
       if (key == "moduleName") {
         moduleName = val;
       } else if (key == "modulePath") {
-        result.modulePath = val;
+        result.modulePath = val.str();
       } else if (key == "docPath") {
-        result.moduleDocPath = val;
+        result.moduleDocPath = val.str();
       } else if (key == "sourceInfoPath") {
-        result.moduleSourceInfoPath = val;
+        result.moduleSourceInfoPath = val.str();
       } else {
         // Being forgiving for future fields.
         continue;


### PR DESCRIPTION
This implicit conversion is no longer correct and just happens to work when linking against the version of LLVM currently used in CI. The implicit conversion operator for `std::string` has been removed upstream so this change is meant to unblock being able to build against more-recent LLVM versions.