### PR TITLE
[Python3] Use correct Python version for LLDB-related tests

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | PYTHONPATH=%lldb-python-path %{python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
+// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{lldb-python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -104,6 +104,12 @@ def get_lldb_python_path(lldb_build_root):
         return None
     return subprocess.check_output([lldb_path, "-P"]).rstrip().decode('utf-8')
 
+def get_lldb_python_from_path(lldb_path):
+    for c in lldb_path.split('/'):
+        if re.match('^python[23].[0-9][0-9]*$', c):
+            return c
+    return None
+
 ###
 
 # Check that the object root is known.
@@ -1953,8 +1959,15 @@ if config.lldb_build_root != "":
         Specified lldb_build_root, but could not find lldb in that build root
         """)
     else:
-        config.available_features.add('lldb')
-        config.substitutions.append(('%lldb-python-path', lldb_python_path))
+        lldb_python = get_lldb_python_from_path(lldb_python_path)
+        if lldb_python == None:
+            lit_config.warning("""
+            Unable to determine python version from LLDB Python path %s
+            """ % lldb_python_path)
+        else:
+            config.available_features.add('lldb')
+            config.substitutions.append(('%lldb-python-path', lldb_python_path))
+            config.substitutions.append(('%lldb-python', 'PYTHONPATH=%s %s' % (lldb_python_path, lldb_python)))
 
 # Disable randomized hash seeding by default. Tests need to manually opt in to
 # random seeds by unsetting the SWIFT_DETERMINISTIC_HASHING environment

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -106,7 +106,7 @@ def get_lldb_python_path(lldb_build_root):
 
 def get_lldb_python_from_path(lldb_path):
     (head, tail) = os.path.split(lldb_path)
-    if tail and re.match('^python[23].[0-9][0-9]*$', tail):
+    if tail and re.match('^python[23][.0-9]*$', tail):
         return tail
     if head and head != lldb_path:
         return get_lldb_python_from_path(head)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -105,9 +105,11 @@ def get_lldb_python_path(lldb_build_root):
     return subprocess.check_output([lldb_path, "-P"]).rstrip().decode('utf-8')
 
 def get_lldb_python_from_path(lldb_path):
-    for c in lldb_path.split('/'):
-        if re.match('^python[23].[0-9][0-9]*$', c):
-            return c
+    (head, tail) = os.path.split(lldb_path)
+    if tail and re.match('^python[23].[0-9][0-9]*$', tail):
+        return tail
+    if head and head != lldb_path:
+        return get_lldb_python_from_path(head)
     return None
 
 ###

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1967,7 +1967,7 @@ if config.lldb_build_root != "":
         else:
             config.available_features.add('lldb')
             config.substitutions.append(('%lldb-python-path', lldb_python_path))
-            config.substitutions.append(('%lldb-python', 'PYTHONPATH=%s %s' % (lldb_python_path, lldb_python)))
+            config.substitutions.append(('%{lldb-python}', 'PYTHONPATH=%s %s' % (lldb_python_path, lldb_python)))
 
 # Disable randomized hash seeding by default. Tests need to manually opt in to
 # random seeds by unsetting the SWIFT_DETERMINISTIC_HASHING environment


### PR DESCRIPTION
LLDB builds a Python module in the form of a C shared library.  This is used in some Swift tests.

Since Python module format changed between Python 2 and Python 3, these tests must be run with the same Python version that was used when LLDB built it.

Of course, in a system with multiple Python versions installed, this may or may not be the same version used by the rest of the Swift build.

This adds some logic to lit.cfg to figure out the version of Python used by LLDB and expose that as `%{lldb-python}` for use in tests that need to access the LLDB module.