### PR TITLE
[build] SourceKit no longer cross-compiles with the Swift 5.3 snapshots

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -78,7 +78,7 @@ function(add_sourcekit_default_compiler_flags target)
       ${${SWIFT_HOST_VARIANT_ARCH}_INCLUDE})
   endif()
   target_compile_options(${target} PRIVATE
-    -fblocks)
+    ${c_compile_flags} -fblocks)
   target_link_options(${target} PRIVATE
     ${link_flags})
   target_link_directories(${target} PRIVATE


### PR DESCRIPTION
There was [a mixup in #29451 and a CMake flag was dropped](https://github.com/apple/swift/pull/29451/files#diff-c64de95aaad2bda58b3ed8f3a0ad284bR74), this puts it back.

Resolves SR-13315

I just tried cross-compiling the July 20 source snapshot from the 5.3 branch for Android and SourceKit wasn't cross-compiling because of this missing CMake flag. Adding it back got SourceKit cross-compiling again.