### PR TITLE
test: normalize the path before opening

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -400,9 +400,9 @@ class ParseContext(object):
     def __init__(self, filename, template=None):
         self.filename = os.path.abspath(filename)
         if sys.platform == 'win32':
-            self.filename = self.filename.replace('\\', '/')
+            self.filename = '/'.join(self.filename.split(os.sep))
         if template is None:
-            with io.open(filename, encoding='utf-8') as f:
+            with io.open(os.path.normpath(filename), encoding='utf-8') as f:
                 self.template = f.read()
         else:
             self.template = template
@@ -1251,7 +1251,7 @@ def main():
     if args.file == '-':
         ast = parse_template('stdin', sys.stdin.read())
     else:
-        with io.open(args.file, 'r', encoding='utf-8') as f:
+        with io.open(os.path.normpath(args.file), 'r', encoding='utf-8') as f:
             ast = parse_template(args.file, f.read())
     if args.dump:
         print(ast)


### PR DESCRIPTION
The tests mix path separators when passing paths to `gyb`.  Ensure that
we normalize the path string to allow the use of mixed path separators.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
