### PR TITLE
Instead of random file name, use a hash as a deterministic name for Swift source file list in _compile_swift_files

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -688,9 +688,9 @@ function(_compile_swift_files
   # need to work around this by avoiding long command line arguments. This can
   # be achieved by writing the list of file paths to a file, then reading that
   # list in the Python script.
-  string(RANDOM file_name)
-  set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
   string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
+  string(SHA1 file_name "'${source_files_quoted}'")
+  set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
   file(WRITE "${file_path}" "'${source_files_quoted}'")
 
   # If this platform/architecture combo supports backward deployment to old
@@ -717,7 +717,7 @@ function(_compile_swift_files
       OUTPUT ${standard_outputs}
       DEPENDS
         ${swift_compiler_tool_dep}
-        ${file_path} ${source_files} ${SWIFTFILE_DEPENDS}
+        ${source_files} ${SWIFTFILE_DEPENDS}
         ${swift_ide_test_dependency}
         ${create_dirs_dependency_target}
         ${copy_legacy_layouts_dep}


### PR DESCRIPTION
This fixes an unnecessary rebuild of the standard library every time you trigger a CMake configure step, which was caused by using a random file name in the command line that builds stdlib. Let's use a hash of the content to get a deterministic file name.