### PR TITLE
Special-case catalyst when computing a path for stdlib_dir in lit config

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1450,7 +1450,10 @@ config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 # Add 'stdlib_dir' as the path to the stdlib resource directory
 stdlib_dir = os.path.join(config.swift_lib_dir, "swift")
 if platform.system() == 'Darwin':
-    stdlib_dir = os.path.join(stdlib_dir, config.target_sdk_name)
+    if run_os == 'maccatalyst':
+        stdlib_dir = os.path.join(stdlib_dir, run_os)
+    else:
+        stdlib_dir = os.path.join(stdlib_dir, config.target_sdk_name)
 else:
     stdlib_dir = os.path.join(stdlib_dir, config.target_sdk_name, target_arch)
 config.substitutions.append(('%stdlib_dir', stdlib_dir))


### PR DESCRIPTION
`target_sdk_name` is `macosx` when targeting `maccatalyst`, but the stdlib swift modules are placed under `swift/maccatalyst` instead of `swift/macosx`. 

Using `run_os`is not correct in the general sense though, hence the requirement for a special case instead of just replacing `target_sdk_name` with it. For example, it would be invalid to use `run_os` instead of `target_sdk_name` on Windows, because the `sdk_name` is going to be `windows` while the `run_os` variable may be `windows-msvc`.