### PR TITLE
[Concurrency] Stub out an experimental concurrency support library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,10 @@ option(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING
   "Enable experimental Swift differentiable programming features"
   FALSE)
 
+option(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
+  "Enable experimental Swift concurrency model"
+  FALSE)
+
 #
 # End of user-configurable options.
 #
@@ -852,6 +856,7 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
   message(STATUS "")
 
   message(STATUS "Differentiable Programming Support: ${SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING}")
+  message(STATUS "Concurrency Support: ${SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY}")
   message(STATUS "")
 else()
   message(STATUS "Not building Swift standard library, SDK overlays, and runtime")

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -89,6 +89,10 @@ if(SWIFT_BUILD_STDLIB)
   if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
     add_subdirectory(Differentiation)
   endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+    add_subdirectory(Concurrency)
+  endif()
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -1,0 +1,32 @@
+#===--- CMakeLists.txt - Concurrency support library ---------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
+add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  PartialAsyncTask.swift
+
+  SWIFT_MODULE_DEPENDS_OSX Darwin
+  SWIFT_MODULE_DEPENDS_IOS Darwin
+  SWIFT_MODULE_DEPENDS_TVOS Darwin
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+  SWIFT_MODULE_DEPENDS_LINUX Glibc
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
+  SWIFT_MODULE_DEPENDS_OPENBSD Glibc
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc
+  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
+
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -parse-stdlib
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  DARWIN_INSTALL_NAME_DIR "@rpath"
+  INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+public struct PartialAsyncTask {
+  private var context: UnsafeMutablePointer<_SwiftContext>
+
+  public func run() { }
+}

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources
   ThreadLocalStorage.h
   UnicodeShims.h
   Visibility.h
+  _SwiftConcurrency.h
 
   CoreMediaOverlayShims.h
   DispatchOverlayShims.h

--- a/stdlib/public/SwiftShims/_SwiftConcurrency.h
+++ b/stdlib/public/SwiftShims/_SwiftConcurrency.h
@@ -1,0 +1,33 @@
+//===--- _SwiftConcurrency.h - Swift Concurrency Support --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines types and support functions for the Swift concurrency model.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_CONCURRENCY_H
+#define SWIFT_CONCURRENCY_H
+
+#ifdef __cplusplus
+namespace swift {
+extern "C" {
+#endif
+
+typedef struct _SwiftContext {
+  struct _SwiftContext *parentContext;
+} _SwiftContext;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace swift
+#endif
+
+#endif // SWIFT_CONCURRENCY_H

--- a/stdlib/public/SwiftShims/module.modulemap
+++ b/stdlib/public/SwiftShims/module.modulemap
@@ -80,3 +80,7 @@ module _SwiftClockKitOverlayShims {
 module _SwiftCoreMediaOverlayShims {
   header "CoreMediaOverlayShims.h"
 }
+
+module _SwiftConcurrencyShims {
+  header "_SwiftConcurrency.h"
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -163,6 +163,7 @@ normalize_boolean_spelling(SWIFT_ASAN_BUILD)
 normalize_boolean_spelling(SWIFT_BUILD_SYNTAXPARSERLIB)
 normalize_boolean_spelling(SWIFT_ENABLE_SOURCEKIT_TESTS)
 normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
+normalize_boolean_spelling(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
 is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" SWIFT_OPTIMIZED)
 
 set(profdata_merge_worker
@@ -361,6 +362,10 @@ _Block_release(void) { }\n")
 
       if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
         list(APPEND LIT_ARGS "--param" "differentiable_programming")
+      endif()
+
+      if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+        list(APPEND LIT_ARGS "--param" "concurrency")
       endif()
 
       foreach(test_subset ${TEST_SUBSETS})

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -125,6 +125,8 @@ if '@SWIFT_INCLUDE_TOOLS@' == 'TRUE':
 
 if "@SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING@" == "TRUE":
     config.available_features.add('differentiable_programming')
+if "@SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY@" == "TRUE":
+    config.available_features.add('concurrency')
 
 # Let the main config do the real work.
 if config.test_exec_root is None:

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+// Make sure the import succeeds
+import _Concurrency
+
+// Make sure the type shows up
+extension PartialAsyncTask {
+}

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1095,6 +1095,10 @@ def create_argument_parser():
            help='Enable experimental Swift differentiable programming language'
                 ' features.')
 
+    option('--enable-experimental-concurrency', toggle_true,
+           default=True,
+           help='Enable experimental Swift concurrency model.')
+
     # -------------------------------------------------------------------------
     in_group('Unsupported options')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -143,6 +143,7 @@ EXPECTED_DEFAULTS = {
     'dry_run': False,
     'enable_asan': False,
     'enable_experimental_differentiable_programming': True,
+    'enable_experimental_concurrency': True,
     'enable_lsan': False,
     'enable_sanitize_coverage': False,
     'disable_guaranteed_normal_arguments': False,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -503,6 +503,7 @@ EXPECTED_OPTIONS = [
     EnableOption('--distcc'),
     EnableOption('--enable-asan'),
     EnableOption('--enable-experimental-differentiable-programming'),
+    EnableOption('--enable-experimental-concurrency'),
     EnableOption('--enable-lsan'),
     EnableOption('--enable-sanitize-coverage'),
     EnableOption('--enable-tsan'),

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -49,6 +49,9 @@ class Swift(product.Product):
         self.cmake_options.extend(
             self._enable_experimental_differentiable_programming)
 
+        # Add experimental concurrency flag.
+        self.cmake_options.extend(self._enable_experimental_concurrency)
+
     @classmethod
     def is_build_script_impl_product(cls):
         """is_build_script_impl_product -> bool
@@ -133,6 +136,11 @@ updated without updating swift.py?")
     def _enable_experimental_differentiable_programming(self):
         return [('SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL',
                  self.args.enable_experimental_differentiable_programming)]
+
+    @property
+    def _enable_experimental_concurrency(self):
+        return [('SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY:BOOL',
+                 self.args.enable_experimental_concurrency)]
 
     @classmethod
     def get_dependencies(cls):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -322,7 +322,6 @@ class SwiftTestCase(unittest.TestCase):
             [x for x in swift.cmake_options
              if 'DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING' in x])
 
-
     def test_experimental_concurrency_flags(self):
         self.args.enable_experimental_concurrency = True
         swift = Swift(

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -58,7 +58,8 @@ class SwiftTestCase(unittest.TestCase):
             disable_guaranteed_normal_arguments=True,
             force_optimized_typechecker=False,
             enable_stdlibcore_exclusivity_checking=False,
-            enable_experimental_differentiable_programming=False)
+            enable_experimental_differentiable_programming=False,
+            enable_experimental_concurrency=False)
 
         # Setup shell
         shell.dry_run = True
@@ -89,7 +90,8 @@ class SwiftTestCase(unittest.TestCase):
             '-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE',
             '-DSWIFT_FORCE_OPTIMIZED_TYPECHECKER:BOOL=FALSE',
             '-DSWIFT_STDLIB_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING:BOOL=FALSE',
-            '-DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL=FALSE'
+            '-DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL=FALSE',
+            '-DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(expected))
 
@@ -105,7 +107,8 @@ class SwiftTestCase(unittest.TestCase):
             '-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE',
             '-DSWIFT_FORCE_OPTIMIZED_TYPECHECKER:BOOL=FALSE',
             '-DSWIFT_STDLIB_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING:BOOL=FALSE',
-            '-DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL=FALSE'
+            '-DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL=FALSE',
+            '-DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY:BOOL=FALSE'
         ]
         self.assertEqual(set(swift.cmake_options), set(flags_set))
 
@@ -318,3 +321,17 @@ class SwiftTestCase(unittest.TestCase):
              'TRUE'],
             [x for x in swift.cmake_options
              if 'DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING' in x])
+
+
+    def test_experimental_concurrency_flags(self):
+        self.args.enable_experimental_concurrency = True
+        swift = Swift(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertEqual(
+            ['-DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY:BOOL='
+             'TRUE'],
+            [x for x in swift.cmake_options
+             if 'DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY' in x])


### PR DESCRIPTION
The experimental concurrency model will require a supporting runtime
and possibly end-user-visible library constructs. Introduce a stub of
such a library, enabled by a new `build-script` option
`--enable-experimental-concurrency`, so we have a place to put this
work.
