### PR TITLE
[5.3][SourceKit] Fix issue where `CompletionCheckDependencyInterval` is set to 0 when the global config request is sent

### DIFF
--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -1,0 +1,75 @@
+import ClangFW
+import SwiftFW
+
+func foo() {
+  /*HERE*/
+}
+
+// Checks that, due to default check delay, a modification will be ignored and fast completion will still activate.
+// REQUIRES: shell
+
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/MyProject)
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -target %target-triple \
+// RUN:   -module-name MyProject \
+// RUN:   -F %t/Frameworks \
+// RUN:   -I %t/MyProject \
+// RUN:   -import-objc-header %t/MyProject/Bridging.h \
+// RUN:   %t/MyProject/Library.swift \
+// RUN:   %s \
+// RUN: )
+// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- echo '### Modify framework (c)' == \
+// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -shell -- echo '### Checking dependencies' == \
+// RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
+
+// RUN:   | %FileCheck %s
+
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify framework (c)
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Checking dependencies
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc_mod()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -440,11 +440,9 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     if (!Req.getInt64(KeyOptimizeForIDE, EditorMode, true)) {
       OptimizeForIDE = EditorMode;
     }
-    Optional<unsigned> CompletionCheckDependencyInterval;
-    int64_t IntervalValue = 0;
-    if (!Req.getInt64(KeyCompletionCheckDependencyInterval,
-                      IntervalValue, /*isOptional=*/true))
-      CompletionCheckDependencyInterval = IntervalValue;
+    Optional<unsigned> CompletionCheckDependencyInterval =
+      Req.getOptionalInt64(KeyCompletionCheckDependencyInterval)
+        .map([](int64_t v)->unsigned{return v;});
 
     GlobalConfig::Settings UpdatedConfig = Config->update(
         OptimizeForIDE, CompletionCheckDependencyInterval);


### PR DESCRIPTION
master: https://github.com/apple/swift/pull/33198

* **Explanation**: Fast completion mode was intended to check dependencies after a delay, to avoid doing lots of I/O stat calls for every completion invocation. But by mistake the delay was unintentionally set to '0' when a 'global config' request is sent by the client, meaning this default optimization for delaying the I/O checks is not enabled when using completion in Xcode.
* **Scope**: SourceKit completion
* **Risk**: Very low. Simple targeted fix.
* **Testing**: Added regression test.
* **Issue**: rdar://66309544
* **Reviewer**: @rintaro 