### PR TITLE
[5.3][CodeCompletion] Fix issue in dependency checking for the editing file

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -297,6 +297,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
 
   auto &CI = *CachedCI;
   auto *oldSF = CI.getCodeCompletionFile().get();
+  assert(oldSF->getBufferID());
 
   auto *oldState = oldSF->getDelayedParserState();
   assert(oldState->hasCodeCompletionDelayedDeclState());
@@ -304,12 +305,12 @@ bool CompletionInstance::performCachedOperationIfPossible(
 
   auto &SM = CI.getSourceMgr();
   auto bufferName = completionBuffer->getBufferIdentifier();
-  if (SM.getIdentifierForBuffer(SM.getCodeCompletionBufferID()) != bufferName)
+  if (SM.getIdentifierForBuffer(*oldSF->getBufferID()) != bufferName)
     return false;
 
   if (shouldCheckDependencies()) {
     if (areAnyDependentFilesInvalidated(
-            CI, CurrentModule, *FileSystem, SM.getCodeCompletionBufferID(),
+            CI, CurrentModule, *FileSystem, *oldSF->getBufferID(),
             DependencyCheckedTimestamp, InMemoryDependencyHash))
       return false;
     DependencyCheckedTimestamp = std::chrono::system_clock::now();

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -1,0 +1,100 @@
+// BEGIN State1.swift
+import ClangFW
+import SwiftFW
+
+func foo(val: MyStruct) {
+   /*HERE*/
+}
+
+// BEGIN State2.swift
+import ClangFW
+import SwiftFW
+
+func foo(val: MyStruct) {
+    val./*HERE*/
+}
+
+// BEGIN DUMMY.swift
+
+// Checks that editing and saving the current file doesn't affect dependency checking.
+// REQUIRES: shell
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Frameworks)
+// RUN: %empty-directory(%t/MyProject)
+
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: COMPILER_ARGS=( \
+// RUN:   -target %target-triple \
+// RUN:   -module-name MyProject \
+// RUN:   -F %t/Frameworks \
+// RUN:   -I %t/MyProject \
+// RUN:   -import-objc-header %t/MyProject/Bridging.h \
+// RUN:   %t/MyProject/Library.swift \
+// RUN:   %t/test.swift \
+// RUN: )
+// RUN: INPUT_DIR=%S/Inputs/checkdeps
+// RUN: DEPCHECK_INTERVAL=1
+// RUN: SLEEP_TIME=2
+
+// RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
+// RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+
+// RUN: cp %t/State1.swift %t/test.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+
+// RUN:   -shell -- echo "### Initial" == \
+// RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -shell -- echo "### Modify own file - 1" == \
+// RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
+// RUN:   -req=complete -pos=5:9 %t/test.swift -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -shell -- echo "### Modify own file - 2" == \
+// RUN:   -shell -- cp %t/State1.swift %t/test.swift == \
+// RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \
+
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -shell -- echo "### Modify own file - 3" == \
+// RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
+// RUN:   -req=complete -pos=5:9 %t/test.swift -- ${COMPILER_ARGS[@]} \
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: ### Initial
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify own file - 1
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify own file - 2
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "clangFWFunc()"
+// CHECK-DAG: key.description: "swiftFWFunc()"
+// CHECK-DAG: key.description: "localClangFunc()"
+// CHECK-DAG: key.description: "localSwiftFunc()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Modify own file - 3
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1


### PR DESCRIPTION
Cherry-pick of #33200 into `release/5.3`

* **Explanation**: Fix an issue where fast-completion is disabled when the current editing file is saved in the file system. Previously it used `SM.getCodeCompletionBufferID()` as the "current editing file ID" but that is not correct because it points the buffer of the previous completion. We need to use `getBufferID()` of `CI.getCodeCompletionFile()` instead.
* **Scope**: Code completion
* **Risk**: Low
* **Testing**: Added regression test case
* **Issue**: rdar://problem/66301353
* **Reviewer**: Argyrios Kyrtzidis (@akyrtzi)