### PR TITLE
Type substitution: When substituting SILFunctionTypes we substitute unbound Objective-C generic for bound ones (take 2)

### DIFF
--- a/test/IRGen/generic_classes_objc.sil
+++ b/test/IRGen/generic_classes_objc.sil
@@ -84,3 +84,13 @@ bb0(%0 : $Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Res
   %2 = tuple ()
   return %2 : $()
 }
+
+struct PlainGeneric<T> {}
+
+// This used to assert.
+sil @repo2 : $@convention(thin) (@guaranteed Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <PlainGeneric<ObjcGenericClass<SomeClass>>>>) -> () {
+bb0(%0 : $Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <PlainGeneric<ObjcGenericClass<SomeClass>>> >):
+  debug_value %0 : $Optional<@callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <PlainGeneric<ObjcGenericClass<SomeClass>>>>, let, name "completion", argno 1
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
IRGen does so. So don't assert on the case when there is a nested
Objective-C type.

(follow-up to #32027 rdar://63509292 which fixed the non-nested case)

rdar://66302139