### PR TITLE
[5.3][Sema] Warn on exporting implementation-only imported types in SPI

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2678,6 +2678,12 @@ ERROR(decl_from_hidden_module,none,
       "%select{%3 has been imported as implementation-only|"
       "it is an SPI imported from %3}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
+WARNING(decl_from_hidden_module_warn,none,
+      "cannot use %0 %1 %select{in SPI|as property wrapper in SPI|"
+      "in an extension with public or '@usableFromInline' members|"
+      "in an extension with conditional conformances}2; "
+      "%select{%3 has been imported as implementation-only}4",
+      (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 ERROR(conformance_from_implementation_only_module,none,
       "cannot use conformance of %0 to %1 %select{here|as property wrapper here|"
       "in an extension with public or '@usableFromInline' members|"

--- a/test/SPI/implementation_only_spi_import_exposability.swift
+++ b/test/SPI/implementation_only_spi_import_exposability.swift
@@ -1,0 +1,51 @@
+/// @_implementationOnly imported decls (SPI or not) should not be exposed in SPI.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -DLIB %s -module-name Lib -emit-module-path %t/Lib.swiftmodule
+// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
+
+#if LIB
+
+@_spi(A) public func spiFunc() {}
+
+@_spi(A) public struct SPIStruct {
+  public init() {}
+}
+
+@_spi(A) public protocol SPIProtocol {}
+
+public func ioiFunc() {}
+
+public struct IOIStruct {
+  public init() {}
+}
+
+public protocol IOIProtocol {}
+
+#elseif CLIENT
+
+@_spi(A) @_implementationOnly import Lib
+
+@_spi(B) public func leakSPIStruct(_ a: SPIStruct) -> SPIStruct { fatalError() } // expected-warning 2 {{cannot use struct 'SPIStruct' in SPI; 'Lib' has been imported as implementation-only}}
+@_spi(B) public func leakIOIStruct(_ a: IOIStruct) -> IOIStruct { fatalError() } // expected-warning 2 {{cannot use struct 'IOIStruct' in SPI; 'Lib' has been imported as implementation-only}}
+
+public struct PublicStruct : IOIProtocol, SPIProtocol { // expected-error {{cannot use protocol 'IOIProtocol' here; 'Lib' has been imported as implementation-only}}
+// expected-error @-1 {{cannot use protocol 'SPIProtocol' here; 'Lib' has been imported as implementation-only}}
+  public var spiStruct = SPIStruct() // expected-error {{cannot use struct 'SPIStruct' here; 'Lib' has been imported as implementation-only}}
+  public var ioiStruct = IOIStruct() // expected-error {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
+
+  @inlinable
+  public func publicInlinable() {
+    spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+    ioiFunc() // expected-error {{global function 'ioiFunc()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    let s = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+    let i = IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+  }
+}
+
+@_spi(B)
+public struct LocalSPIStruct : IOIProtocol, SPIProtocol { // expected-warning {{cannot use protocol 'IOIProtocol' in SPI; 'Lib' has been imported as implementation-only}}
+// expected-warning @-1 {{cannot use protocol 'SPIProtocol' in SPI; 'Lib' has been imported as implementation-only}}
+}
+
+#endif


### PR DESCRIPTION
This completes type-checking work for #32902. Bringing back the diagnostic on exporting implementation-only imported types in SPI as a warning. This check was previously reverted from 5.3, and now it can be valid when relying solely on swiftmodule files or when using `-experimental-spi-imports`. This is part of a staged transition to a long term language feature of imports as SPI.

- Scope of Issue: This is affecting projects using both @_implementationOnly and @_spi.
- Origination: Introduction of @_spi, and revert in #32552.
- Risk: Low, this only adds a warning on decls marked with @_spi.
- Resolves: rdar://66336527