### PR TITLE
[Runtime] Auth args to compareTypeContextDescriptors.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2063,6 +2063,11 @@ bool swift::equalContexts(const ContextDescriptor *a,
 SWIFT_CC(swift)
 bool swift::swift_compareTypeContextDescriptors(
     const TypeContextDescriptor *a, const TypeContextDescriptor *b) {
+  a = swift_auth_data_non_address(
+      a, SpecialPointerAuthDiscriminators::TypeDescriptor);
+  b = swift_auth_data_non_address(
+      b, SpecialPointerAuthDiscriminators::TypeDescriptor);
+
   // The implementation is the same as the implementation of
   // swift::equalContexts except that the handling of non-type
   // context descriptors and casts to TypeContextDescriptor are removed.


### PR DESCRIPTION
When `swift_compareTypeContextDescriptors` was added, it did not auth the `TypeContextDescriptor` arguments that were passed to it.  Fix that here.

There are not any uses of this function yet, so there are no signs that need to be added.