### PR TITLE
[AutoDiff] Add reverse-mode `switch_enum` support for `Optional`.

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2257,11 +2257,11 @@ void PullbackCloner::Implementation::visitSILBasicBlock(SILBasicBlock *bb) {
     // an `Optional`-typed value. `switch_enum` instructions require
     // special-case adjoint value propagation for the operand.
     auto isSwitchEnumInstOnOptional =
-        [&Ctx = getASTContext()](TermInst *termInst) {
+        [&ctx = getASTContext()](TermInst *termInst) {
           if (!termInst)
             return false;
           if (auto *sei = dyn_cast<SwitchEnumInst>(termInst)) {
-            auto *optionalEnumDecl = Ctx.getOptionalDecl();
+            auto *optionalEnumDecl = ctx.getOptionalDecl();
             auto operandTy = sei->getOperand()->getType();
             return operandTy.getASTType().getEnumOrBoundGenericEnum() ==
                    optionalEnumDecl;

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2108,7 +2108,8 @@ void PullbackCloner::Implementation::accumulateAdjointForOptional(
 
   // Accumulate adjoint for the incoming `Optional` value.
   addToAdjointBuffer(bb, optionalValue, optTanAdjBuf, pbLoc);
-  // TODO: investigate why enabling this produces a crash for `Tracked<Float>?` differentiation.
+  // TODO: Investigate why enabling this produces a crash for `Tracked<Float>?`
+  // differentiation.
   // builder.emitDestroyAddr(pbLoc, optTanAdjBuf);
   builder.createDeallocStack(pbLoc, optTanAdjBuf);
 }

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -655,8 +655,6 @@ private:
   //--------------------------------------------------------------------------//
 
   /// Given a `wrappedAdjoint` value of type `T.TangentVector`, creates an
-  ///
-  /// Given a `wrappedAdjoint` value of type `T.TangentVector`, creates an
   /// `Optional<T>.TangentVector` value from it and adds it to the adjoint value
   /// of `optionalValue`.
   ///

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2126,6 +2126,21 @@ void PullbackCloner::Implementation::visitSILBasicBlock(SILBasicBlock *bb) {
       auto *predBB = std::get<0>(pair);
       auto incomingValue = std::get<1>(pair);
       blockTemporaries[getPullbackBlock(predBB)].insert(concreteBBArgAdjCopy);
+      if (auto *termInst = bbArg->getSingleTerminator()) {
+        if (auto *sei = dyn_cast<SwitchEnumInst>(termInst)) {
+          auto *optionalEnumDecl = getASTContext().getOptionalDecl();
+          if (sei->getOperand()->getType().getASTType().getEnumOrBoundGenericEnum() == optionalEnumDecl) {
+            llvm::errs() << "HELLO!\n";
+            sei->dump();
+            // Construct a `Optional.TangentVector` and call `setAdjointValue`
+            // with it.
+            //
+            // setAdjointValue(predBB, incomingValue,
+            //                 makeConcreteAdjointValue(optionalAdjValue));
+            continue;
+          }
+        }
+      }
       setAdjointValue(predBB, incomingValue,
                       makeConcreteAdjointValue(concreteBBArgAdjCopy));
     }

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2110,7 +2110,8 @@ void PullbackCloner::Implementation::accumulateAdjointForOptional(
 
   // Accumulate adjoint for the incoming `Optional` value.
   addToAdjointBuffer(bb, optionalValue, optTanAdjBuf, pbLoc);
-  builder.emitDestroyAddr(pbLoc, optTanAdjBuf);
+  // TODO: investigate why enabling this produces a crash for `Tracked<Float>?` differentiation.
+  // builder.emitDestroyAddr(pbLoc, optTanAdjBuf);
   builder.createDeallocStack(pbLoc, optTanAdjBuf);
 }
 

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2103,14 +2103,11 @@ void PullbackCloner::Implementation::accumulateAdjointForOptional(
   // apply %init_fn(%optTanAdjBuf, %optArgBuf, %metatype)
   builder.createApply(pbLoc, initFnRef, subMap,
                       {optTanAdjBuf, optArgBuf, metatype});
-  builder.emitDestroyAddr(pbLoc, optArgBuf);
   builder.createDeallocStack(pbLoc, optArgBuf);
 
   // Accumulate adjoint for the incoming `Optional` value.
   addToAdjointBuffer(bb, optionalValue, optTanAdjBuf, pbLoc);
-  // TODO: Investigate why enabling this produces a crash for `Tracked<Float>?`
-  // differentiation.
-  // builder.emitDestroyAddr(pbLoc, optTanAdjBuf);
+  builder.emitDestroyAddr(pbLoc, optTanAdjBuf);
   builder.createDeallocStack(pbLoc, optTanAdjBuf);
 }
 

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -200,7 +200,7 @@ func checked_cast_addr_nonactive_result<T: Differentiable>(_ x: T) -> T {
 @differentiable
 // expected-note @+1 {{when differentiating this function definition}}
 func checked_cast_addr_active_result<T: Differentiable>(x: T) -> T {
-  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  // expected-note @+1 {{expression is not differentiable}}
   if let y = x as? Float {
     // Use `y: Float?` value in an active way.
     return y as! T
@@ -744,8 +744,8 @@ func testClassModifyAccessor(_ c: inout C) {
 @differentiable
 // expected-note @+1 {{when differentiating this function definition}}
 func testActiveOptional(_ x: Float) -> Float {
-  // expected-note @+1 {{differentiating enum values is not yet supported}}
   var maybe: Float? = 10
+  // expected-note @+1 {{expression is not differentiable}}
   maybe = x
   return maybe!
 }

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -157,8 +157,8 @@ class C<T: Differentiable>: Differentiable {
 @differentiable
 // expected-note @+1 {{when differentiating this function definition}}
 func usesOptionals(_ x: Float) -> Float {
-  // expected-note @+1 {{differentiating enum values is not yet supported}}
   var maybe: Float? = 10
+  // expected-note @+1 {{expression is not differentiable}}
   maybe = x
   return maybe!
 }

--- a/test/AutoDiff/SILOptimizer/optional.swift
+++ b/test/AutoDiff/SILOptimizer/optional.swift
@@ -1,0 +1,75 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import DifferentiationUnittest
+
+var OptionalTests = TestSuite("OptionalDifferentiation")
+
+//===----------------------------------------------------------------------===//
+// Basic tests.
+//===----------------------------------------------------------------------===//
+
+/*
+// Note: this lowers to `try_apply` instead of `switch_enum`, and is
+// not directly relevant.
+@differentiable
+func optional1(_ maybeX: Float?) -> Float {
+  return maybeX ?? 10
+}
+*/
+
+OptionalTests.test("Let") {
+  @differentiable
+  func optional2(_ maybeX: Float?) -> Float {
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional2), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional2), .init(0.0))
+}
+
+OptionalTests.test("Switch") {
+  @differentiable
+  func optional3(_ maybeX: Float?) -> Float {
+    switch maybeX {
+    case nil: return 10
+    case let .some(x): return x * x
+    }
+  }
+
+  expectEqual(gradient(at: 10, in: optional3), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional3), .init(0.0))
+}
+
+OptionalTests.test("Var1") {
+  @differentiable
+  func optional4(_ maybeX: Float?) -> Float {
+    var maybeX = maybeX
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional4), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional4), .init(0.0))
+}
+
+OptionalTests.test("Var2") {
+  @differentiable
+  func optional5(_ maybeX: Float?) -> Float {
+    if var x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional5), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional5), .init(0.0))
+}
+
+runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -54,6 +54,19 @@ OptionalTests.test("Let") {
   expectEqual(gradient(at: nil, in: optional_let_nested), .init(.init(0.0)))
 
   @differentiable
+  func optional_let_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+    if let maybeX = nestedMaybeX {
+      if let x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_let_nested_tracked), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_let_nested_tracked), .init(.init(0.0)))
+
+  @differentiable
   func optional_let_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
     if let x = maybeX {
         return x
@@ -62,6 +75,9 @@ OptionalTests.test("Let") {
   }
   expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
+
+  expectEqual(gradient(at: Tracked<Float>.init(10), Tracked<Float>.init(20), in: optional_let_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, Tracked<Float>.init(20), in: optional_let_generic), (.init(0.0), 1.0))
 
   @differentiable
   func optional_let_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
@@ -90,6 +106,16 @@ OptionalTests.test("Switch") {
   expectEqual(gradient(at: nil, in: optional_switch), .init(0.0))
 
   @differentiable
+  func optional_switch_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
+    switch maybeX {
+    case nil: return 10
+    case let .some(x): return x * x
+    }
+  }
+  expectEqual(gradient(at: 10, in: optional_switch_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_switch_tracked), .init(0.0))
+
+  @differentiable
   func optional_switch_nested(_ nestedMaybeX: Float??) -> Float {
     switch nestedMaybeX {
     case nil: return 10
@@ -102,6 +128,20 @@ OptionalTests.test("Switch") {
   }
   expectEqual(gradient(at: 10, in: optional_switch_nested), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_switch_nested), .init(.init(0.0)))
+
+  @differentiable
+  func optional_switch_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+    switch nestedMaybeX {
+    case nil: return 10
+    case let .some(maybeX):
+      switch maybeX {
+        case nil: return 10
+        case let .some(x): return x * x
+      }
+    }
+  }
+  expectEqual(gradient(at: 10, in: optional_switch_nested_tracked), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_switch_nested_tracked), .init(.init(0.0)))
 
   @differentiable
   func optional_switch_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
@@ -141,6 +181,17 @@ OptionalTests.test("Var1") {
   expectEqual(gradient(at: nil, in: optional_var1), .init(0.0))
 
   @differentiable
+  func optional_var1_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
+    var maybeX = maybeX
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_var1_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_var1_tracked), .init(0.0))
+
+  @differentiable
   func optional_var1_nested(_ nestedMaybeX: Float??) -> Float {
     var nestedMaybeX = nestedMaybeX
     if let maybeX = nestedMaybeX {
@@ -153,6 +204,20 @@ OptionalTests.test("Var1") {
   }
   expectEqual(gradient(at: 10, in: optional_var1_nested), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_var1_nested), .init(.init(0.0)))
+
+  @differentiable
+  func optional_var1_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+    var nestedMaybeX = nestedMaybeX
+    if let maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_var1_nested_tracked), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_var1_nested_tracked), .init(.init(0.0)))
 
   @differentiable
   func optional_var1_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
@@ -192,6 +257,16 @@ OptionalTests.test("Var2") {
   expectEqual(gradient(at: nil, in: optional_var2), .init(0.0))
 
   @differentiable
+  func optional_var2_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
+    if var x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_var2_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_var2_tracked), .init(0.0))
+
+  @differentiable
   func optional_var2_nested(_ nestedMaybeX: Float??) -> Float {
     if var maybeX = nestedMaybeX {
       if var x = maybeX {
@@ -203,6 +278,19 @@ OptionalTests.test("Var2") {
   }
   expectEqual(gradient(at: 10, in: optional_var2_nested), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_var2_nested), .init(.init(0.0)))
+
+  @differentiable
+  func optional_var2_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+    if var maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_var2_nested_tracked), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_var2_nested_tracked), .init(.init(0.0)))
 
   @differentiable
   func optional_var2_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -21,17 +21,17 @@ func optional1(_ maybeX: Float?) -> Float {
 
 OptionalTests.test("Let") {
   @differentiable
-  func optional2(_ maybeX: Float?) -> Float {
+  func optional_let(_ maybeX: Float?) -> Float {
     if let x = maybeX {
         return x * x
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional2), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional2), .init(0.0))
+  expectEqual(gradient(at: 10, in: optional_let), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_let), .init(0.0))
 
   @differentiable
-  func optional_nested2(_ nestedMaybeX: Float??) -> Float {
+  func optional_let_nested(_ nestedMaybeX: Float??) -> Float {
     if let maybeX = nestedMaybeX {
       if let x = maybeX {
         return x * x
@@ -40,8 +40,34 @@ OptionalTests.test("Let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_nested2), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_nested2), .init(.init(0.0)))
+  expectEqual(gradient(at: 10, in: optional_let_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_let_nested), .init(.init(0.0)))
+
+  @differentiable
+  func optional_let_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    if let x = maybeX {
+        return x
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
+
+  // This test is failing
+  /* @differentiable
+  func optional_let_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+    if let maybeX = nestedMaybeX {
+      if let x = maybeX {
+        return x
+      }
+      return defaultValue
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional_let_nested_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_let_nested_generic), (.init(0.0), 1.0)) */
 }
 
 OptionalTests.test("Switch") {
@@ -57,7 +83,7 @@ OptionalTests.test("Switch") {
   expectEqual(gradient(at: nil, in: optional_switch), .init(0.0))
 
   @differentiable
-  func optional_nested3(_ nestedMaybeX: Float??) -> Float {
+  func optional_switch_nested(_ nestedMaybeX: Float??) -> Float {
     switch nestedMaybeX {
     case nil: return 10
     case let .some(maybeX):
@@ -68,38 +94,9 @@ OptionalTests.test("Switch") {
     }
   }
 
-  expectEqual(gradient(at: 10, in: optional_nested3), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_nested3), .init(.init(0.0)))
-}
+  expectEqual(gradient(at: 10, in: optional_switch_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_switch_nested), .init(.init(0.0)))
 
-OptionalTests.test("Var1") {
-  @differentiable
-  func optional4(_ maybeX: Float?) -> Float {
-    var maybeX = maybeX
-    if let x = maybeX {
-        return x * x
-    }
-    return 10
-  }
-
-  expectEqual(gradient(at: 10, in: optional4), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional4), .init(0.0))
-}
-
-OptionalTests.test("Var2") {
-  @differentiable
-  func optional5(_ maybeX: Float?) -> Float {
-    if var x = maybeX {
-      return x * x
-    }
-    return 10
-  }
-
-  expectEqual(gradient(at: 10, in: optional5), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional5), .init(0.0))
-}
-
-OptionalTests.test("Generic") {
   @differentiable
   func optional_switch_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
     switch maybeX {
@@ -111,57 +108,9 @@ OptionalTests.test("Generic") {
   expectEqual(gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
 
-  @differentiable
-  func optional7<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
-    if let x = maybeX {
-        return x
-    }
-    return defaultValue
-  }
-
-  expectEqual(gradient(at: 10, 20, in: optional7), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional7), (.init(0.0), 1.0))
-
-  @differentiable
-  func optional8<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
-    var maybeX = maybeX
-    if let x = maybeX {
-        return x
-    }
-    return defaultValue
-  }
-
-  expectEqual(gradient(at: 10, 20, in: optional8), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional8), (.init(0.0), 1.0))
-
-  @differentiable
-  func optional9<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
-    if var x = maybeX {
-      return x
-    }
-    return defaultValue
-  }
-
-  expectEqual(gradient(at: 10, 20, in: optional9), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional9), (.init(0.0), 1.0))
-
-  // These tests are failing:
-  /*@differentiable
-  func optional10<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
-    if let maybeX = nestedMaybeX {
-      if let x = maybeX {
-        return x
-      }
-      return defaultValue
-    }
-    return defaultValue
-  }
-
-  expectEqual(gradient(at: 10, 20, in: optional10), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional10), (.init(0.0), 1.0))
-
-  @differentiable
-  func optional11<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+  // TODO: this test is failing
+  /* @differentiable
+  func optional_switch_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
     switch nestedMaybeX {
     case nil: return defaultValue
     case let .some(maybeX):
@@ -172,8 +121,58 @@ OptionalTests.test("Generic") {
     }
   }
 
-  expectEqual(gradient(at: 10, 20, in: optional11), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional11), (.init(0.0), 1.0)) */
+  expectEqual(gradient(at: 10, 20, in: optional_switch_nested_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_switch_nested_generic), (.init(0.0), 1.0)) */
+}
+
+OptionalTests.test("Var1") {
+  @differentiable
+  func optional_var1(_ maybeX: Float?) -> Float {
+    var maybeX = maybeX
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional_var1), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_var1), .init(0.0))
+
+  @differentiable
+  func optional_var1_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    var maybeX = maybeX
+    if let x = maybeX {
+        return x
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
+}
+
+OptionalTests.test("Var2") {
+  @differentiable
+  func optional_var2(_ maybeX: Float?) -> Float {
+    if var x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional_var2), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_var2), .init(0.0))
+
+  @differentiable
+  func optional_var2_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    if var x = maybeX {
+      return x
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -98,4 +98,17 @@ OptionalTests.test("Var2") {
   expectEqual(gradient(at: nil, in: optional5), .init(0.0))
 }
 
+OptionalTests.test("Generic") {
+  @differentiable
+  func optional6<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    switch maybeX {
+    case nil: return defaultValue
+    case let .some(x): return x
+    }
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional6), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional6), (.init(0.0), 1.0))
+}
+
 runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -27,9 +27,22 @@ OptionalTests.test("Let") {
     }
     return 10
   }
-
   expectEqual(gradient(at: 10, in: optional2), .init(20.0))
   expectEqual(gradient(at: nil, in: optional2), .init(0.0))
+
+  // FIXME: This test currently crashes.
+  @differentiable
+  func optional_nested2(_ nestedMaybeX: Float??) -> Float {
+    if let maybeX = nestedMaybeX {
+      if let x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_nested2), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_nested2), .init(.init(0.0)))
 }
 
 OptionalTests.test("Switch") {

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -11,8 +11,8 @@ var OptionalTests = TestSuite("OptionalDifferentiation")
 //===----------------------------------------------------------------------===//
 
 /*
-// Note: this lowers to `try_apply` instead of `switch_enum`, and is
-// not directly relevant.
+// TODO(TF-433): operator `??` lowers to `try_apply` instead of `switch_enum`,
+// which is not yet supported by differentiation.
 @differentiable
 func optional1(_ maybeX: Float?) -> Float {
   return maybeX ?? 10

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -46,15 +46,15 @@ OptionalTests.test("Let") {
 
 OptionalTests.test("Switch") {
   @differentiable
-  func optional3(_ maybeX: Float?) -> Float {
+  func optional_switch(_ maybeX: Float?) -> Float {
     switch maybeX {
     case nil: return 10
     case let .some(x): return x * x
     }
   }
 
-  expectEqual(gradient(at: 10, in: optional3), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional3), .init(0.0))
+  expectEqual(gradient(at: 10, in: optional_switch), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_switch), .init(0.0))
 
   @differentiable
   func optional_nested3(_ nestedMaybeX: Float??) -> Float {
@@ -67,6 +67,7 @@ OptionalTests.test("Switch") {
       }
     }
   }
+
   expectEqual(gradient(at: 10, in: optional_nested3), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_nested3), .init(.init(0.0)))
 }
@@ -100,15 +101,15 @@ OptionalTests.test("Var2") {
 
 OptionalTests.test("Generic") {
   @differentiable
-  func optional6<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+  func optional_switch_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
     switch maybeX {
     case nil: return defaultValue
     case let .some(x): return x
     }
   }
 
-  expectEqual(gradient(at: 10, 20, in: optional6), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional6), (.init(0.0), 1.0))
+  expectEqual(gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
 
   @differentiable
   func optional7<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
@@ -143,6 +144,36 @@ OptionalTests.test("Generic") {
 
   expectEqual(gradient(at: 10, 20, in: optional9), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional9), (.init(0.0), 1.0))
+
+  // These tests are failing:
+  /*@differentiable
+  func optional10<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+    if let maybeX = nestedMaybeX {
+      if let x = maybeX {
+        return x
+      }
+      return defaultValue
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional10), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional10), (.init(0.0), 1.0))
+
+  @differentiable
+  func optional11<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+    switch nestedMaybeX {
+    case nil: return defaultValue
+    case let .some(maybeX):
+      switch maybeX {
+        case nil: return defaultValue
+        case let .some(x): return x
+      }
+    }
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional11), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional11), (.init(0.0), 1.0)) */
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -31,6 +31,16 @@ OptionalTests.test("Let") {
   expectEqual(gradient(at: nil, in: optional_let), .init(0.0))
 
   @differentiable
+  func optional_let_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+  expectEqual(gradient(at: 10, in: optional_let_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional_let_tracked), .init(0.0))
+
+  @differentiable
   func optional_let_nested(_ nestedMaybeX: Float??) -> Float {
     if let maybeX = nestedMaybeX {
       if let x = maybeX {
@@ -50,7 +60,6 @@ OptionalTests.test("Let") {
     }
     return defaultValue
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
 
@@ -77,7 +86,6 @@ OptionalTests.test("Switch") {
     case let .some(x): return x * x
     }
   }
-
   expectEqual(gradient(at: 10, in: optional_switch), .init(20.0))
   expectEqual(gradient(at: nil, in: optional_switch), .init(0.0))
 
@@ -92,7 +100,6 @@ OptionalTests.test("Switch") {
       }
     }
   }
-
   expectEqual(gradient(at: 10, in: optional_switch_nested), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_switch_nested), .init(.init(0.0)))
 
@@ -103,7 +110,6 @@ OptionalTests.test("Switch") {
     case let .some(x): return x
     }
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
 
@@ -118,7 +124,6 @@ OptionalTests.test("Switch") {
       }
     }
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_switch_nested_generic), (.init(.init(1.0)), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_switch_nested_generic), (.init(.init(0.0)), 1.0))
 }
@@ -132,7 +137,6 @@ OptionalTests.test("Var1") {
     }
     return 10
   }
-
   expectEqual(gradient(at: 10, in: optional_var1), .init(20.0))
   expectEqual(gradient(at: nil, in: optional_var1), .init(0.0))
 
@@ -147,7 +151,6 @@ OptionalTests.test("Var1") {
     }
     return 10
   }
-
   expectEqual(gradient(at: 10, in: optional_var1_nested), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_var1_nested), .init(.init(0.0)))
 
@@ -159,7 +162,6 @@ OptionalTests.test("Var1") {
     }
     return defaultValue
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
 
@@ -174,7 +176,6 @@ OptionalTests.test("Var1") {
     }
     return defaultValue
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_var1_nested_generic), (.init(.init(1.0)), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_var1_nested_generic), (.init(.init(0.0)), 1.0))
 }
@@ -187,7 +188,6 @@ OptionalTests.test("Var2") {
     }
     return 10
   }
-
   expectEqual(gradient(at: 10, in: optional_var2), .init(20.0))
   expectEqual(gradient(at: nil, in: optional_var2), .init(0.0))
 
@@ -201,7 +201,6 @@ OptionalTests.test("Var2") {
     }
     return 10
   }
-
   expectEqual(gradient(at: 10, in: optional_var2_nested), .init(.init(20.0)))
   expectEqual(gradient(at: nil, in: optional_var2_nested), .init(.init(0.0)))
 
@@ -212,7 +211,6 @@ OptionalTests.test("Var2") {
     }
     return defaultValue
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
 
@@ -226,7 +224,6 @@ OptionalTests.test("Var2") {
     }
     return defaultValue
   }
-
   expectEqual(gradient(at: 10, 20, in: optional_var2_nested_generic), (.init(.init(1.0)), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_var2_nested_generic), (.init(.init(0.0)), 1.0))
 }

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -109,6 +109,40 @@ OptionalTests.test("Generic") {
 
   expectEqual(gradient(at: 10, 20, in: optional6), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional6), (.init(0.0), 1.0))
+
+  @differentiable
+  func optional7<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    if let x = maybeX {
+        return x
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional7), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional7), (.init(0.0), 1.0))
+
+  @differentiable
+  func optional8<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    var maybeX = maybeX
+    if let x = maybeX {
+        return x
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional8), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional8), (.init(0.0), 1.0))
+
+  @differentiable
+  func optional9<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    if var x = maybeX {
+      return x
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional9), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional9), (.init(0.0), 1.0))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -54,7 +54,6 @@ OptionalTests.test("Let") {
   expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
 
-  // This test is failing
   @differentiable
   func optional_let_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
     if let maybeX = nestedMaybeX {

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -55,7 +55,7 @@ OptionalTests.test("Let") {
   expectEqual(gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
 
   // This test is failing
-  /* @differentiable
+  @differentiable
   func optional_let_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
     if let maybeX = nestedMaybeX {
       if let x = maybeX {
@@ -66,8 +66,8 @@ OptionalTests.test("Let") {
     return defaultValue
   }
 
-  expectEqual(gradient(at: 10, 20, in: optional_let_nested_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_let_nested_generic), (.init(0.0), 1.0)) */
+  expectEqual(gradient(at: 10.0, 20.0, in: optional_let_nested_generic), (.init(.init(1.0)), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_let_nested_generic), (.init(.init(0.0)), 1.0))
 }
 
 OptionalTests.test("Switch") {
@@ -108,8 +108,7 @@ OptionalTests.test("Switch") {
   expectEqual(gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
 
-  // TODO: this test is failing
-  /* @differentiable
+  @differentiable
   func optional_switch_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
     switch nestedMaybeX {
     case nil: return defaultValue
@@ -121,8 +120,8 @@ OptionalTests.test("Switch") {
     }
   }
 
-  expectEqual(gradient(at: 10, 20, in: optional_switch_nested_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_switch_nested_generic), (.init(0.0), 1.0)) */
+  expectEqual(gradient(at: 10, 20, in: optional_switch_nested_generic), (.init(.init(1.0)), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_switch_nested_generic), (.init(.init(0.0)), 1.0))
 }
 
 OptionalTests.test("Var1") {
@@ -139,6 +138,21 @@ OptionalTests.test("Var1") {
   expectEqual(gradient(at: nil, in: optional_var1), .init(0.0))
 
   @differentiable
+  func optional_var1_nested(_ nestedMaybeX: Float??) -> Float {
+    var nestedMaybeX = nestedMaybeX
+    if let maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional_var1_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_var1_nested), .init(.init(0.0)))
+
+  @differentiable
   func optional_var1_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
     var maybeX = maybeX
     if let x = maybeX {
@@ -149,6 +163,21 @@ OptionalTests.test("Var1") {
 
   expectEqual(gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
+
+  @differentiable
+  func optional_var1_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+    var nestedMaybeX = nestedMaybeX
+    if let maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x
+      }
+      return defaultValue
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional_var1_nested_generic), (.init(.init(1.0)), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_var1_nested_generic), (.init(.init(0.0)), 1.0))
 }
 
 OptionalTests.test("Var2") {
@@ -164,6 +193,20 @@ OptionalTests.test("Var2") {
   expectEqual(gradient(at: nil, in: optional_var2), .init(0.0))
 
   @differentiable
+  func optional_var2_nested(_ nestedMaybeX: Float??) -> Float {
+    if var maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional_var2_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_var2_nested), .init(.init(0.0)))
+
+  @differentiable
   func optional_var2_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
     if var x = maybeX {
       return x
@@ -173,6 +216,20 @@ OptionalTests.test("Var2") {
 
   expectEqual(gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
   expectEqual(gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
+
+  @differentiable
+  func optional_var2_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+    if var maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x
+      }
+      return defaultValue
+    }
+    return defaultValue
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional_var2_nested_generic), (.init(.init(1.0)), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional_var2_nested_generic), (.init(.init(0.0)), 1.0))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -30,7 +30,6 @@ OptionalTests.test("Let") {
   expectEqual(gradient(at: 10, in: optional2), .init(20.0))
   expectEqual(gradient(at: nil, in: optional2), .init(0.0))
 
-  // FIXME: This test currently crashes.
   @differentiable
   func optional_nested2(_ nestedMaybeX: Float??) -> Float {
     if let maybeX = nestedMaybeX {
@@ -56,6 +55,20 @@ OptionalTests.test("Switch") {
 
   expectEqual(gradient(at: 10, in: optional3), .init(20.0))
   expectEqual(gradient(at: nil, in: optional3), .init(0.0))
+
+  @differentiable
+  func optional_nested3(_ nestedMaybeX: Float??) -> Float {
+    switch nestedMaybeX {
+    case nil: return 10
+    case let .some(maybeX):
+      switch maybeX {
+        case nil: return 10
+        case let .some(x): return x * x
+      }
+    }
+  }
+  expectEqual(gradient(at: 10, in: optional_nested3), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, in: optional_nested3), .init(.init(0.0)))
 }
 
 OptionalTests.test("Var1") {


### PR DESCRIPTION
Reverse mode autodiff now works on `Optional`s, i.e. `switch_enum` and `switch_enum_addr` SIL instructions are supported now.