### PR TITLE
[5.3][CodeCompletion] Handle @autoclosure in context type analysis

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -790,6 +790,8 @@ class ExprContextAnalyzer {
             auto argTy = ty;
             if (paramType.isInOut())
               argTy = InOutType::get(argTy);
+            else if (paramType.isAutoClosure() && argTy->is<AnyFunctionType>())
+              argTy = argTy->castTo<AnyFunctionType>()->getResult();
             if (seenTypes.insert(argTy.getPointer()).second)
               recordPossibleType(argTy);
           }

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -122,6 +122,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_5 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_6 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_CONDITION | %FileCheck %s -check-prefix=TERNARY_CONDITION
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AUTOCLOSURE | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AUTOCLOSURE_OPT | %FileCheck %s -check-prefix=UNRESOLVED_3_OPT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AUTOCLOSURE_FUNCTY | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AUTOCLOSURE_FUNCTY_OPT | %FileCheck %s -check-prefix=UNRESOLVED_3_OPT
 
 enum SomeEnum1 {
   case South
@@ -782,4 +786,20 @@ func testTernaryOperator2(cond: Bool) {
 // TERNARY_CONDITION: Begin completions
 // TERNARY_CONDITION-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init()[#Bool#]; name=init()
 // TERNARY_CONDITION: End completions
+}
+
+func receiveAutoclosure(_: @autoclosure () -> SomeEnum1) {}
+func receiveAutoclosureOpt(_: @autoclosure () -> SomeEnum1?) {}
+func testAutoclosre() {
+  receiveAutoclosure(.#^AUTOCLOSURE^#)
+  // Same as UNRESOLVED_3
+
+  receiveAutoclosureOpt(.#^AUTOCLOSURE_OPT^#)
+  // Same as UNRESOLVED_3_OPT
+}
+func testAutoclosreFuncTy(fn: (@autoclosure () -> SomeEnum1) -> Void, fnOpt: (@autoclosure () -> SomeEnum1?) -> Void) {
+  fn(.#^AUTOCLOSURE_FUNCTY^#)
+  // Same as UNRESOLVED_3
+  fnOpt(.#^AUTOCLOSURE_FUNCTY_OPT^#)
+  // Same as UNRESOLVED_3_OPT
 }


### PR DESCRIPTION
Cherry-pick of #33217 into `release/5.3`

* **Explanation**: Unresolved member completion didn't use to work at argument position for `@autoclosure` parameters. Previously the context type is incorrectly resolved to a function type, but it should actually be the result type of the function type.
* **Scope**: Context type analysis for code completion
* **Risk**: Very Low. The change is trivial and safe
* **Testing**: Added regression test cases
* **Issue**: rdar://problem/65802490
* **Reviewer**: Ben Langmuir (@benlangmuir)