### PR TITLE
[CSBindings] Don't attempt to rank unviable bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -377,6 +377,28 @@ ConstraintSystem::determineBestBindings() {
       cache.insert({typeVar, getPotentialBindings(typeVar)});
   }
 
+  // Determine whether given type variable with its set of bindings is
+  // viable to be attempted on the next step of the solver. If type variable
+  // has no "direct" bindings of any kind e.g. direct bindings to concrete
+  // types, default types from "defaultable" constraints or literal
+  // conformances, such type variable is not viable to be evaluated to be
+  // attempted next.
+  auto isViableForRanking =
+      [this](const ConstraintSystem::PotentialBindings &bindings) -> bool {
+    auto *typeVar = bindings.TypeVar;
+
+    // If type variable is marked as a potential hole there is always going
+    // to be at least one binding available for it.
+    if (shouldAttemptFixes() && typeVar->getImpl().canBindToHole())
+      return true;
+
+    return !bindings.Bindings.empty() || !bindings.Defaults.empty() ||
+           llvm::any_of(bindings.Protocols, [&](Constraint *constraint) {
+             return bool(
+                 TypeChecker::getDefaultType(constraint->getProtocol(), DC));
+           });
+  };
+
   // Now let's see if we could infer something for related type
   // variables based on other bindings.
   for (auto *typeVar : getTypeVariables()) {
@@ -386,9 +408,21 @@ ConstraintSystem::determineBestBindings() {
 
     auto &bindings = cachedBindings->getSecond();
 
+    // Before attempting to infer transitive bindings let's check
+    // whether there are any viable "direct" bindings associated with
+    // current type variable, if there are none - it means that this type
+    // variable could only be used to transitively infer bindings for
+    // other type variables and can't participate in ranking.
+    //
+    // Viable bindings include - any types inferred from constraints
+    // associated with given type variable, any default constraints,
+    // or any conformance requirements to literal protocols with can
+    // produce a default type.
+    bool isViable = isViableForRanking(bindings);
+
     bindings.finalize(*this, cache);
 
-    if (!bindings)
+    if (!bindings || !isViable)
       continue;
 
     if (isDebugMode()) {

--- a/test/Constraints/rdar66234725.swift
+++ b/test/Constraints/rdar66234725.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+protocol Func {
+  associatedtype Result
+
+  init()
+
+  mutating func update<D: P>(data: D)
+
+  func finalize() -> Result
+}
+
+struct S<T: P, F: Func> {
+  var arr: [T]
+
+  func test() -> [F.Result] {
+    return stride(from: 0, to: arr.endIndex, by: 2).map {
+      (arr[$0], $0 < arr.index(before: arr.endIndex) ? arr[$0.advanced(by: 1)] : nil) // Ok
+    }.map { (lhs, rhs) -> F.Result in
+      var fun = F()
+      fun.update(data: lhs)
+      fun.update(data: rhs!)
+      return fun.finalize()
+    }
+  }
+}

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -663,14 +663,14 @@ struct FunctionConversionParameterSubstToOrigReabstractionTest {
   }
 }
 
-// CHECK: sil hidden [ossa] @$s19function_conversion9dontCrashyyF
-// CHECK: [[FORCE_CAST:%.*]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF
-// CHECK-NEXT: [[DOWNCAST_RESULT:%.*]] = apply [[FORCE_CAST]]<(String, String), (AnyHashable, Any)>({{.*}})
-// CHECK-NEXT: [[ADDR:%.*]] = alloc_stack $Array<(AnyHashable, Any)>
-// CHECK-NEXT: store [[DOWNCAST_RESULT]] to [init] [[ADDR]] : $*Array<(AnyHashable, Any)>
-// CHECK-NEXT: // function_ref Dictionary.init<A>(uniqueKeysWithValues:)
-// CHECK-NEXT: [[DICT_INIT:%.*]] = function_ref @$sSD20uniqueKeysWithValuesSDyxq_Gqd__n_tcSTRd__x_q_t7ElementRtd__lufC
-// CHECK-NEXT: apply [[DICT_INIT]]<AnyHashable, Any, [(AnyHashable, Any)]>([[ADDR]], [[TYPE:%.*]])
+// CHECK: sil {{.*}} [ossa] @$sS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR
+// CHECK:  [[TUPLE:%.*]] = apply %4(%2, %3) : $@noescape @callee_guaranteed (@guaranteed String, @guaranteed String) -> (@owned String, @owned String)
+// CHECK:  ([[LHS:%.*]], [[RHS:%.*]]) = destructure_tuple [[TUPLE]]
+// CHECK:  [[ADDR:%.*]] = alloc_stack $String
+// CHECK:  store [[LHS]] to [init] [[ADDR]] : $*String
+// CHECK:  [[CVT:%.*]] = function_ref @$ss21_convertToAnyHashableys0cD0VxSHRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0) -> @out AnyHashable
+// CHECK:  apply [[CVT]]<String>(%0, [[ADDR]])
+// CHECK: } // end sil function '$sS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR'
 
 func dontCrash() {
   let userInfo = ["hello": "world"]

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -103,7 +103,7 @@ _ = A<String, Int>(a: "foo", // expected-error {{cannot convert value of type 'S
   b: 42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
 _ = B(a: 12, b: 42)
 _ = B(a: 12, b: 42 as Float)
-_ = B(a: "foo", b: 42)     // expected-error {{conflicting arguments to generic parameter 'T1' ('String' vs. 'Int')}}
+_ = B(a: "foo", b: 42)     // expected-error {{conflicting arguments to generic parameter 'T1' ('Int' vs. 'String')}}
 _ = C(a: "foo", b: 42)
 _ = C(a: 42,        // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
   b: 42)


### PR DESCRIPTION
If a type variable doesn't have any "direct" bindings let's not
consider it as viable to be attempted next. Such type variables
are helps purely to accommodate transitive binding inference
for other members of subtype chain.

Resolves: rdar://problem/66234725

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
