### PR TITLE
[5.3] Stop pretending that macOS 11 is macOS 10.16

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -622,14 +622,6 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
           micro = firstMacARM64e.getSubminor().getValueOr(0);
         }
 
-        // Temporary hack: adjust macOS version passed to the linker from
-        // 11 down to 10.16, but only for x86.
-        if (triple.isX86() && major == 11) {
-          major = 10;
-          minor = 16;
-          micro = 0;
-        }
-
         break;
       case DarwinPlatformKind::IPhoneOS:
       case DarwinPlatformKind::IPhoneOSSimulator:

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -107,11 +107,12 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -sdk %S/Inputs/MacOSX10.15.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_UNVERSIONED %s
 
 // Check arm64 macOS first deployment version adjustment.
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target arm64-apple-macosx10.15.1 %s 2>&1 | %FileCheck -check-prefix ARM64E_MACOS_LINKER %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target arm64-apple-macosx10.15.1 %s 2>&1 | %FileCheck -check-prefix MACOS_11_0 %s
 
-// Check x86 macOS 11 deployment version adjustment.
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx11.0 %s 2>&1 | %FileCheck -check-prefix X86_MACOS11_LINKER %s
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target arm64-apple-macosx11.0 %s 2>&1 | %FileCheck -check-prefix ARM64E_MACOS_LINKER %s
+// Check x86 macOS 11 deployment version adjustment is gone.
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.16 %s 2>&1 | %FileCheck -check-prefix MACOS_11_0 %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx11.0 %s 2>&1 | %FileCheck -check-prefix MACOS_11_0 %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target arm64-apple-macosx11.0 %s 2>&1 | %FileCheck -check-prefix MACOS_11_0 %s
 
 // Check arm64 simulators first deployment version adjustment.
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target arm64-apple-ios13.0-simulator %s 2>&1 | %FileCheck -check-prefix ARM64_IOS_SIMULATOR_LINKER %s
@@ -119,10 +120,9 @@
 
 // MACOS_10_15: -platform_version macos 10.9.0 10.15.0
 // MACOS_10_15_4: -platform_version macos 10.9.0 10.15.4
+// MACOS_11_0: -platform_version macos 11.0.0
 // MACOS_UNVERSIONED: -platform_version macos 10.9.0 0.0.0
 
-// ARM64E_MACOS_LINKER: -platform_version macos 11.0.0
-// X86_MACOS11_LINKER: -platform_version macos 10.16.0
 // X86_64_WATCHOS_SIM_LINKER: -platform_version watchos-simulator 7.0.0
 // ARM64_IOS_SIMULATOR_LINKER: -platform_version ios-simulator 14.0.0
 


### PR DESCRIPTION
This reverts the functional portions of commit 5566ace6e027a5609b3a16ae696b4f5b25264c72 and adjusts the tests.

Fixes rdar://64137561.