### PR TITLE
[AutoDiff] Add reverse-mode differentiation support for `switch_enum_addr`

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2126,6 +2126,21 @@ void PullbackCloner::Implementation::visitSILBasicBlock(SILBasicBlock *bb) {
       auto *predBB = std::get<0>(pair);
       auto incomingValue = std::get<1>(pair);
       blockTemporaries[getPullbackBlock(predBB)].insert(concreteBBArgAdjCopy);
+      if (auto *termInst = bbArg->getSingleTerminator()) {
+        if (auto *sei = dyn_cast<SwitchEnumInst>(termInst)) {
+          auto *optionalEnumDecl = getASTContext().getOptionalDecl();
+          if (sei->getOperand()->getType().getASTType().getEnumOrBoundGenericEnum() == optionalEnumDecl) {
+            llvm::errs() << "HELLO!\n";
+            sei->dump();
+            // Construct a `Optional.TangentVector` and call `setAdjointValue`
+            // with it.
+            //
+            // setAdjointValue(predBB, incomingValue,
+            //                 makeConcreteAdjointValue(optionalAdjValue));
+            continue;
+          }
+        }
+      }
       setAdjointValue(predBB, incomingValue,
                       makeConcreteAdjointValue(concreteBBArgAdjCopy));
     }

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1503,6 +1503,97 @@ public:
     }
   }
 
+  /// Handle `unchecked_take_enum_data_addr` instruction.
+  ///   Original: y = unchecked_take_enum_data_addr x : $*Enum, #Enum.Case
+  ///   Adjoint: adj[x] += adj[y]
+  ///             (assuming adj[x] and adj[y] have the same type)
+  void visitUncheckedTakeEnumDataAddrInst(UncheckedTakeEnumDataAddrInst *utedai) {
+    auto *bb = utedai->getParent();
+    auto adjBuf = getAdjointBuffer(bb, utedai);
+    auto enumTy = utedai->getOperand()->getType();
+    auto *optionalEnumDecl = getASTContext().getOptionalDecl();
+    if (enumTy.getASTType().getEnumOrBoundGenericEnum() != optionalEnumDecl) {
+      LLVM_DEBUG(getADDebugStream()
+               << "Unhandled instruction in PullbackCloner: " << *utedai);
+      getContext().emitNondifferentiabilityError(
+        utedai, getInvoker(), diag::autodiff_expression_not_differentiable_note);
+      errorOccurred = true;
+      return;
+    }
+    auto pbLoc = getPullback().getLocation();
+    // `Optional<T>`
+    auto optionalTy = remapType(enumTy);
+    // `T`
+    auto Ty = optionalTy.getOptionalObjectType();
+    // `T.TangentVector`
+    auto tanTy = remapType(adjBuf->getType());
+    // `Optional<T.TangentVector>`
+    auto optionalTanTy = SILType::getOptionalType(tanTy);
+    // `Optional<T>.TangentVector`
+    auto tangentVectorTy = getRemappedTangentType(optionalTy);
+    // `Optional<T>.TangentVector` Decl
+    auto *structDecl = cast<StructType>(tangentVectorTy.getASTType()).getStructOrBoundGenericStruct();
+    // Lookup `Optional<T>.TangentVector.init`.
+    auto initLookup = structDecl->lookupDirect(DeclBaseName::createConstructor());
+    ConstructorDecl *constructorDecl = nullptr;
+    for (auto *candidate : initLookup) {
+      auto candidateModule = candidate->getModuleContext();
+      if (candidateModule->getName() == builder.getASTContext().Id_Differentiation ||
+        candidateModule->isStdlibModule()) {
+        assert(!constructorDecl && "Multiple `Optional.TangentVector.init`s");
+        constructorDecl = cast<ConstructorDecl>(candidate);
+#ifdef NDEBUG
+        break;
+#endif
+      }
+    }
+    assert(constructorDecl && "No `Optional.TangentVector.init`");
+
+    // Allocate a local buffer to store the Optional adjoint value.
+    auto *optTanAdjBuf = builder.createAllocStack(pbLoc, tangentVectorTy);
+    // %metatype = metatype $Optional<T>.TangentVector.Type
+    auto metatypeType = CanMetatypeType::get(tangentVectorTy.getASTType(),
+                                              MetatypeRepresentation::Thin);
+    auto metatypeSILType = SILType::getPrimitiveObjectType(metatypeType);
+    auto metatype = builder.createMetatype(pbLoc, metatypeSILType);
+    // Find `Optional<T.TangentVector>.some` EnumElementDecl.
+    auto someEltDecl = builder.getASTContext().getOptionalSomeDecl();
+    // Allocate a local buffer to convert the `concreteBBArgAdjCopy` to `Optional<T.TangentVector>`.
+    // (For `Optional<T>.TangentVector.init` input.)
+    auto *optArgBuf = builder.createAllocStack(pbLoc, optionalTanTy);
+    // %enum = init_enum_data_addr %optArgBuf $Optional<T.TangentVector>, #Optional.some!enumelt, %concreteBBArgAdjCopy : $T
+    auto enumAddr = builder.createInitEnumDataAddr(
+        pbLoc, optArgBuf, someEltDecl, tanTy.getAddressType());
+    // copy_addr %adjBuf to [initialization] %enum
+    builder.createCopyAddr(pbLoc, adjBuf, enumAddr, IsNotTake,
+                           IsInitialization);
+    // inject_enum_addr %optArgBuf : $*Optional<T.TangentVector>, #Optional.some!enumelt
+    builder.createInjectEnumAddr(pbLoc, optArgBuf, someEltDecl);
+    SILOptFunctionBuilder fb(getContext().getTransform());
+    // %init_fn = function_ref @Optional<T>.TangentVector.init
+    auto *initFn = fb.getOrCreateFunction(
+        pbLoc, SILDeclRef(constructorDecl), NotForDefinition);
+    auto *initFnRef = builder.createFunctionRef(pbLoc, initFn);
+    // Find Differentiable conformance for `T` and get SubstitutionMap.
+    auto *swiftModule = getModule().getSwiftModule();
+    auto *diffProto = builder.getASTContext().getProtocol(KnownProtocolKind::Differentiable);
+    auto diffConf = swiftModule->lookupConformance(Ty.getASTType(), diffProto);
+    assert(!diffConf.isInvalid() && "Missing conformance to `Differentiable`");
+    auto subMap = SubstitutionMap::get(
+        initFn->getLoweredFunctionType()->getSubstGenericSignature(),
+        ArrayRef<Type>(Ty.getASTType()), {diffConf});
+    // %apply %init_fn(%optTanAdjBuf, %optArgBuf, %metatype)
+    builder.createApply(pbLoc, initFnRef, subMap,
+                        {optTanAdjBuf, optArgBuf, metatype});
+    builder.emitDestroyAddr(pbLoc, optArgBuf);
+    builder.createDeallocStack(pbLoc, optArgBuf);
+
+    // Add created `Optional<T>.TangentVector` to the adjoint.
+    addToAdjointBuffer(bb, utedai->getOperand(), optTanAdjBuf, pbLoc);
+    builder.emitDestroyAddr(pbLoc, optTanAdjBuf);
+    builder.createDeallocStack(pbLoc, optTanAdjBuf);
+  }
+
 #define NOT_DIFFERENTIABLE(INST, DIAG) void visit##INST##Inst(INST##Inst *inst);
 #undef NOT_DIFFERENTIABLE
 

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -157,8 +157,8 @@ class C<T: Differentiable>: Differentiable {
 @differentiable
 // expected-note @+1 {{when differentiating this function definition}}
 func usesOptionals(_ x: Float) -> Float {
-  // expected-note @+1 {{differentiating enum values is not yet supported}}
   var maybe: Float? = 10
+  // expected-note @+1 {{expression is not differentiable}}
   maybe = x
   return maybe!
 }

--- a/test/AutoDiff/SILOptimizer/optional.swift
+++ b/test/AutoDiff/SILOptimizer/optional.swift
@@ -1,0 +1,75 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import DifferentiationUnittest
+
+var OptionalTests = TestSuite("OptionalDifferentiation")
+
+//===----------------------------------------------------------------------===//
+// Basic tests.
+//===----------------------------------------------------------------------===//
+
+/*
+// Note: this lowers to `try_apply` instead of `switch_enum`, and is
+// not directly relevant.
+@differentiable
+func optional1(_ maybeX: Float?) -> Float {
+  return maybeX ?? 10
+}
+*/
+
+OptionalTests.test("Let") {
+  @differentiable
+  func optional2(_ maybeX: Float?) -> Float {
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional2), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional2), .init(0.0))
+}
+
+OptionalTests.test("Switch") {
+  @differentiable
+  func optional3(_ maybeX: Float?) -> Float {
+    switch maybeX {
+    case nil: return 10
+    case let .some(x): return x * x
+    }
+  }
+
+  expectEqual(gradient(at: 10, in: optional3), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional3), .init(0.0))
+}
+
+OptionalTests.test("Var1") {
+  @differentiable
+  func optional4(_ maybeX: Float?) -> Float {
+    var maybeX = maybeX
+    if let x = maybeX {
+        return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional4), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional4), .init(0.0))
+}
+
+OptionalTests.test("Var2") {
+  @differentiable
+  func optional5(_ maybeX: Float?) -> Float {
+    if var x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+
+  expectEqual(gradient(at: 10, in: optional5), .init(20.0))
+  expectEqual(gradient(at: nil, in: optional5), .init(0.0))
+}
+
+runAllTests()

--- a/test/AutoDiff/SILOptimizer/optional.swift
+++ b/test/AutoDiff/SILOptimizer/optional.swift
@@ -72,4 +72,17 @@ OptionalTests.test("Var2") {
   expectEqual(gradient(at: nil, in: optional5), .init(0.0))
 }
 
+OptionalTests.test("Generic") {
+  @differentiable
+  func optional6<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+    switch maybeX {
+    case nil: return defaultValue
+    case let .some(x): return x
+    }
+  }
+
+  expectEqual(gradient(at: 10, 20, in: optional6), (.init(1.0), 0.0))
+  expectEqual(gradient(at: nil, 20, in: optional6), (.init(0.0), 1.0))
+}
+
 runAllTests()


### PR DESCRIPTION
On top of `switch_enum`, now `switch_enum_addr` SIL instruction can be differentiated.