### PR TITLE
Sema: Make type resolution for EnumElementPattern less eager

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -513,6 +513,14 @@ void recordLookupOfTopLevelName(DeclContext *topLevelContext, DeclName name,
 } // end namespace namelookup
 
 /// Retrieve the set of nominal type declarations that are directly
+/// referenced in the given \c typeRepr, looking through typealiases.
+/// 
+/// \param dc The \c DeclContext from which to perform lookup.
+TinyPtrVector<NominalTypeDecl *>
+getDirectlyReferencedNominalTypeDecls(ASTContext &ctx, TypeRepr *typeRepr,
+                                      DeclContext *dc, bool &anyObject);
+
+/// Retrieve the set of nominal type declarations that are directly
 /// "inherited" by the given declaration at a particular position in the
 /// list of "inherited" types.
 ///

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2501,30 +2501,22 @@ namespace {
         if (enumPattern->getParentType() || enumPattern->getParentTypeRepr()) {
           // Resolve the parent type.
           Type parentType = [&]() -> Type {
-            if (auto preTy = enumPattern->getParentType()) {
-              return preTy;
+            if (const auto resolvedTy = enumPattern->getParentType()) {
+              assert(resolvedTy->hasUnboundGenericType() == false &&
+                     "A pre-resolved type must be fully bound");
+              return resolvedTy;
             }
             return resolveTypeReferenceInExpression(
                 enumPattern->getParentTypeRepr(),
-                TypeResolverContext::InExpression, [](auto unboundTy) {
-                  // FIXME: We ought to pass an OpenUnboundGenericType object
-                  // rather than calling CS.openUnboundGenericType below, but
-                  // sometimes the parent type is resolved eagerly in
-                  // ResolvePattern::visitUnresolvedDotExpr, letting unbound
-                  // generics escape.
-                  return unboundTy;
-                });
+                TypeResolverContext::InExpression,
+                OpenUnboundGenericType(
+                    CS, CS.getConstraintLocator(
+                            locator, {LocatorPathElt::PatternMatch(pattern),
+                                      ConstraintLocator::ParentType})));
           }();
 
           if (!parentType)
             return Type();
-
-          parentType = CS.openUnboundGenericTypes(
-              parentType, CS.getConstraintLocator(
-                              locator, {LocatorPathElt::PatternMatch(pattern),
-                                        ConstraintLocator::ParentType}));
-
-          assert(parentType);
 
           // Perform member lookup into the parent's metatype.
           Type parentMetaType = MetatypeType::get(parentType);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -467,31 +467,26 @@ public:
     if (!ExprToIdentTypeRepr(components, Context).visit(ude->getBase()))
       return nullptr;
 
-    const auto options =
-        TypeResolutionOptions(None) | TypeResolutionFlags::SilenceErrors;
+    auto *const repr = IdentTypeRepr::create(Context, components);
 
-    auto *repr = IdentTypeRepr::create(Context, components);
+    // See first if the repr unambiguously references an enum declaration.
+    bool anyObject = false;
+    const auto &referencedDecls =
+        getDirectlyReferencedNominalTypeDecls(Context, repr, DC, anyObject);
+    if (referencedDecls.size() != 1)
+      return nullptr;
 
-    // See if the repr resolves to a type.
-    const auto resolution =
-        TypeResolution::forContextual(DC, options, [](auto unboundTy) {
-          // FIXME: Don't let unbound generic types escape type resolution.
-          // For now, just return the unbound generic type.
-          return unboundTy;
-        });
-    const auto ty = resolution.resolveType(repr);
-    auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
+    auto *const enumDecl = dyn_cast<EnumDecl>(referencedDecls.front());
     if (!enumDecl)
       return nullptr;
 
-    EnumElementDecl *referencedElement
-      = lookupEnumMemberElement(DC, ty, ude->getName(), ude->getLoc());
+    EnumElementDecl *referencedElement =
+        lookupEnumMemberElement(DC, enumDecl->getDeclaredInterfaceType(),
+                                ude->getName(), ude->getLoc());
     if (!referencedElement)
       return nullptr;
 
-    auto *base =
-        TypeExpr::createForMemberDecl(repr, ude->getNameLoc(), enumDecl);
-    base->setType(MetatypeType::get(ty));
+    auto *const base = new (Context) TypeExpr(repr);
     return new (Context)
         EnumElementPattern(base, ude->getDotLoc(), ude->getNameLoc(),
                            ude->getName(), referencedElement, nullptr);
@@ -569,37 +564,31 @@ public:
       baseTE = TypeExpr::createImplicit(enumDecl->getDeclaredTypeInContext(),
                                         Context);
     } else {
-      const auto options =
-          TypeResolutionOptions(None) | TypeResolutionFlags::SilenceErrors;
-
       // Otherwise, see whether we had an enum type as the penultimate
       // component, and look up an element inside it.
-      auto *prefixRepr = IdentTypeRepr::create(Context, components);
+      auto *const prefixRepr = IdentTypeRepr::create(Context, components);
 
-      // See first if the entire repr resolves to a type.
-      const Type enumTy =
-          TypeResolution::forContextual(DC, options, [](auto unboundTy) {
-            // FIXME: Don't let unbound generic types escape type resolution.
-            // For now, just return the unbound generic type.
-            return unboundTy;
-          }).resolveType(prefixRepr);
-      auto *enumDecl = dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal());
+      // See first if the repr unambiguously references an enum declaration.
+      bool anyObject = false;
+      const auto &referencedDecls = getDirectlyReferencedNominalTypeDecls(
+          Context, prefixRepr, DC, anyObject);
+      if (referencedDecls.size() != 1)
+        return nullptr;
+
+      auto *const enumDecl = dyn_cast<EnumDecl>(referencedDecls.front());
       if (!enumDecl)
         return nullptr;
 
-      referencedElement
-        = lookupEnumMemberElement(DC, enumTy,
-                                  tailComponent->getNameRef(),
-                                  tailComponent->getLoc());
+      referencedElement = lookupEnumMemberElement(
+          DC, enumDecl->getDeclaredInterfaceType(), tailComponent->getNameRef(),
+          tailComponent->getLoc());
       if (!referencedElement)
         return nullptr;
 
-      baseTE = TypeExpr::createForMemberDecl(
-          prefixRepr, tailComponent->getNameLoc(), enumDecl);
-      baseTE->setType(MetatypeType::get(enumTy));
+      baseTE = new (Context) TypeExpr(prefixRepr);
     }
 
-    assert(baseTE && baseTE->getType() && "Didn't initialize base expression?");
+    assert(baseTE && "Didn't initialize base expression?");
     assert(!isa<GenericIdentTypeRepr>(tailComponent) &&
            "should be handled above");
 
@@ -1437,11 +1426,25 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
 
       enumTy = type;
     } else {
+      // Validate the parent type if we haven't done so yet.
+      if (EEP->getParentType().isNull()) {
+        const auto resolution =
+            TypeResolution::forContextual(dc, options, [](auto unboundTy) {
+              // FIXME: Don't let unbound generic types escape type resolution.
+              // For now, just return the unbound generic type.
+              return unboundTy;
+            });
+        const auto ty = resolution.resolveType(EEP->getParentTypeRepr());
+        EEP->setParentType(ty);
+
+        if (ty->hasError()) {
+          return nullptr;
+        }
+      }
+
       // Check if the explicitly-written enum type matches the type we're
       // coercing to.
-      assert(!EEP->getParentType().isNull()
-             && "enum with resolved element doesn't specify parent type?!");
-      auto parentTy = EEP->getParentType();
+      const Type parentTy = EEP->getParentType();
       // If the type matches exactly, use it.
       if (parentTy->isEqual(type)) {
         enumTy = type;

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -343,10 +343,14 @@ func rdar32241441() {
 
 // SR-6100
 struct One<Two> { // expected-note{{'Two' declared as parameter to type 'One'}}
-    public enum E: Error {
-        // if you remove associated value, everything works
-        case SomeError(String)
+  public enum E: Error {
+    // if you remove associated value, everything works
+    case SomeError(String)
+
+    static func foo(error: Error) {
+      if case SomeError = error {}
     }
+  }
 }
 
 func testOne() {


### PR DESCRIPTION
Delay contextual type resolution for `EnumElementPattern` until `coercePatternToType` is called to further reduce the scope of `UnboundGenericType`, and use name lookup instead to resolve the pattern.

The definitive fix would be to move `CaseStmt` checking into the constraint system (AFAIK `CaseStmt` is the only remaining place where `EnumElementPattern` checking still relies on `coercePatternToType`).