### PR TITLE
[5.3] Type substitution: When substituting SILFunctionTypes we substitute unbound Objective-C generic for bound ones

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3594,6 +3594,8 @@ public:
   /// initializer.
   bool hasDefaultInitializer() const;
 
+  bool isTypeErasedGenericClass() const;
+
   /// Retrieves the synthesized zero parameter default initializer for this
   /// declaration, or \c nullptr if it doesn't have one.
   ConstructorDecl *getDefaultInitializer() const;

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -389,6 +389,7 @@ class CanType : public Type {
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
   static bool isObjCExistentialTypeImpl(CanType type);
+  static bool isTypeErasedGenericClassTypeImpl(CanType type);
   static CanType getOptionalObjectTypeImpl(CanType type);
   static CanType getReferenceStorageReferentImpl(CanType type);
   static CanType getWithoutSpecifierTypeImpl(CanType type);
@@ -473,6 +474,11 @@ public:
   /// Is this an ObjC-compatible existential type?
   bool isObjCExistentialType() const {
     return isObjCExistentialTypeImpl(*this);
+  }
+
+  // Is this an ObjC generic class.
+  bool isTypeErasedGenericClassType() const {
+    return isTypeErasedGenericClassTypeImpl(*this);
   }
 
   ClassDecl *getClassOrBoundGenericClass() const; // in Types.h

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4190,6 +4190,14 @@ bool NominalTypeDecl::hasDefaultInitializer() const {
                            false);
 }
 
+bool NominalTypeDecl::isTypeErasedGenericClass() const {
+  // ObjC classes are type erased.
+  // TODO: Unless they have magic methods...
+  if (auto clas = dyn_cast<ClassDecl>(this))
+    return clas->hasClangNode() && clas->isGenericContext();
+  return false;
+}
+
 ConstructorDecl *NominalTypeDecl::getDefaultInitializer() const {
   if (!hasDefaultInitializer())
     return nullptr;

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -163,3 +163,6 @@ __attribute__((swift_name("OuterType.InnerType")))
 @protocol P
 - (oneway void)stuff;
 @end
+
+@interface ObjcGenericClass<__covariant SectionType>
+@end

--- a/test/IRGen/generic_classes_objc.sil
+++ b/test/IRGen/generic_classes_objc.sil
@@ -72,3 +72,25 @@ protocol P2 { }
 // CHECK-SAME: i16 3, i16 3, i16 5, i16 0
 class Generic3WithReqs<T: P1, U: P2, V: P2> { }
 sil_vtable Generic3WithReqs { }
+
+
+class SomeClass{}
+sil_vtable SomeClass {}
+
+// This used to assert.
+sil @repo : $@convention(thin) (@guaranteed Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <ObjcGenericClass<SomeClass>>>) -> () {
+bb0(%0 : $Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <ObjcGenericClass<SomeClass>> >):
+  debug_value %0 : $Optional<@callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <ObjcGenericClass<SomeClass>>>, let, name "completion", argno 1
+  %2 = tuple ()
+  return %2 : $()
+}
+
+struct PlainGeneric<T> {}
+
+// This used to assert.
+sil @repo2 : $@convention(thin) (@guaranteed Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <PlainGeneric<ObjcGenericClass<SomeClass>>>>) -> () {
+bb0(%0 : $Optional< @callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <PlainGeneric<ObjcGenericClass<SomeClass>>> >):
+  debug_value %0 : $Optional<@callee_guaranteed @substituted <τ_0_1> (@in_guaranteed Result<τ_0_1, Error>) -> () for <PlainGeneric<ObjcGenericClass<SomeClass>>>>, let, name "completion", argno 1
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
IRGen does so. So don't assert on the case when there is a (nested) Objective-C
type.

Description: Fix an assert that is to eager when types contain objc
generic types. We would crash in assert builds.

Risk: Low. Only affects assert builds.

Testing: Regression test added

Reviewed by: Joe Groff

Original PR: #33211
rdar://66302139
