### PR TITLE
[Sema] Do not diagnose contextual type mismatches for malformed key path expressions

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5648,7 +5648,13 @@ public:
   /// components from the argument array.
   void resolveComponents(ASTContext &C,
                          ArrayRef<Component> resolvedComponents);
-  
+
+  /// Indicates if the key path expression is composed by a single invalid
+  /// component. e.g. missing component `\Root`
+  bool hasSingleInvalidComponent() const {
+    return Components.size() == 1 && !Components.front().isValid();
+  }
+
   /// Retrieve the string literal expression, which will be \c NULL prior to
   /// type checking and a string literal after type checking for an
   /// @objc key path.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1224,8 +1224,8 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
       } else if (srcLocator->directlyAt<ObjectLiteralExpr>()) {
         fix = SpecifyObjectLiteralTypeImport::create(cs, dstLocator);
       } else if (srcLocator->isKeyPathRoot()) {
-        // If we recorded a invalid key path fix, let's skip this root fix
-        // because it wouldn't produce a useful diagnostic.
+        // If we recorded an invalid key path fix, let's skip this specify root
+        // type fix because it wouldn't produce a useful diagnostic.
         auto *kpLocator = cs.getConstraintLocator(srcLocator->getAnchor());
         if (cs.hasFixFor(kpLocator, FixKind::AllowKeyPathWithoutComponents))
           return true;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1224,6 +1224,12 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
       } else if (srcLocator->directlyAt<ObjectLiteralExpr>()) {
         fix = SpecifyObjectLiteralTypeImport::create(cs, dstLocator);
       } else if (srcLocator->isKeyPathRoot()) {
+        // If we recorded a invalid key path fix, let's skip this root fix
+        // because it wouldn't produce a useful diagnostic.
+        auto *kpLocator = cs.getConstraintLocator(srcLocator->getAnchor());
+        if (cs.hasFixFor(kpLocator, FixKind::AllowKeyPathMissingComponent))
+          return true;
+        
         fix = SpecifyKeyPathRootType::create(cs, dstLocator);
       }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1227,7 +1227,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
         // If we recorded a invalid key path fix, let's skip this root fix
         // because it wouldn't produce a useful diagnostic.
         auto *kpLocator = cs.getConstraintLocator(srcLocator->getAnchor());
-        if (cs.hasFixFor(kpLocator, FixKind::AllowKeyPathMissingComponent))
+        if (cs.hasFixFor(kpLocator, FixKind::AllowKeyPathWithoutComponents))
           return true;
         
         fix = SpecifyKeyPathRootType::create(cs, dstLocator);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6766,9 +6766,9 @@ bool InvalidEmptyKeyPathFailure::diagnoseAsError() {
   assert(KPE && KPE->hasSingleInvalidComponent() &&
          "Expected a malformed key path expression");
 
-  // String interpolation represented as key path expressions e.g. \(x),
-  // \(x, a: 1) and this is already diagnosed. So let's skip it because
-  // that is not the case for a empty key path diagnostic.
+  // If we have a string interpolation represented as key path expressions
+  // e.g. \(x), \(x, a: 1). Let's skip it because this would be already
+  // diagnosed and it is not the case for an extra empty key path diagnostic.
   auto *root = KPE->getParsedRoot();
   if (root && (isa<ParenExpr>(root) || isa<TupleExpr>(root)))
     return true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6761,7 +6761,7 @@ void TrailingClosureRequiresExplicitLabel::fixIt(
                          isExpr<SubscriptExpr>(anchor) ? "]" : ")");
 }
 
-bool AllowKeyPathMissingComponentFailure::diagnoseAsError() {
+bool InvalidEmptyKeyPathFailure::diagnoseAsError() {
   auto *KPE = getAsExpr<KeyPathExpr>(getAnchor());
   assert(KPE && KPE->hasSingleInvalidComponent() &&
          "Expected a malformed key path expression");

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6760,3 +6760,19 @@ void TrailingClosureRequiresExplicitLabel::fixIt(
   diagnostic.fixItInsert(newRParenLoc,
                          isExpr<SubscriptExpr>(anchor) ? "]" : ")");
 }
+
+bool AllowKeyPathMissingComponentFailure::diagnoseAsError() {
+  auto *KPE = getAsExpr<KeyPathExpr>(getAnchor());
+  assert(KPE && KPE->hasSingleInvalidComponent() &&
+         "Expected a malformed key path expression");
+
+  // String interpolation represented as key path expressions e.g. \(x),
+  // \(x, a: 1) and this is already diagnosed. So let's skip it because
+  // that is not the case for a empty key path diagnostic.
+  auto *root = KPE->getParsedRoot();
+  if (root && (isa<ParenExpr>(root) || isa<TupleExpr>(root)))
+    return true;
+
+  emitDiagnostic(diag::expr_swift_keypath_empty);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2253,10 +2253,10 @@ private:
 /// \code
 /// let _ : KeyPath<A, B> = \A
 /// \endcode
-class AllowKeyPathMissingComponentFailure final : public FailureDiagnostic {
+class InvalidEmptyKeyPathFailure final : public FailureDiagnostic {
 public:
-  AllowKeyPathMissingComponentFailure(const Solution &solution,
-                                      ConstraintLocator *locator)
+  InvalidEmptyKeyPathFailure(const Solution &solution,
+                             ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator) {}
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2248,7 +2248,7 @@ private:
              const FunctionArgApplyInfo &info) const;
 };
 
-/// Diagnose situations where we have key path missing a component.
+/// Diagnose situations where we have a key path with no components.
 ///
 /// \code
 /// let _ : KeyPath<A, B> = \A

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2248,6 +2248,20 @@ private:
              const FunctionArgApplyInfo &info) const;
 };
 
+/// Diagnose situations where we have key path missing a component.
+///
+/// \code
+/// let _ : KeyPath<A, B> = \A
+/// \endcode
+class AllowKeyPathMissingComponentFailure final : public FailureDiagnostic {
+public:
+  AllowKeyPathMissingComponentFailure(const Solution &solution,
+                                      ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1539,3 +1539,15 @@ SpecifyLabelToAssociateTrailingClosure::create(ConstraintSystem &cs,
   return new (cs.getAllocator())
       SpecifyLabelToAssociateTrailingClosure(cs, locator);
 }
+
+bool AllowKeyPathMissingComponent::diagnose(const Solution &solution,
+                                            bool asNote) const {
+  AllowKeyPathMissingComponentFailure failure(solution, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowKeyPathMissingComponent *
+AllowKeyPathMissingComponent::create(ConstraintSystem &cs,
+                                     ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowKeyPathMissingComponent(cs, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1540,14 +1540,14 @@ SpecifyLabelToAssociateTrailingClosure::create(ConstraintSystem &cs,
       SpecifyLabelToAssociateTrailingClosure(cs, locator);
 }
 
-bool AllowKeyPathMissingComponent::diagnose(const Solution &solution,
-                                            bool asNote) const {
-  AllowKeyPathMissingComponentFailure failure(solution, getLocator());
+bool AllowKeyPathWithoutComponents::diagnose(const Solution &solution,
+                                             bool asNote) const {
+  InvalidEmptyKeyPathFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
 }
 
-AllowKeyPathMissingComponent *
-AllowKeyPathMissingComponent::create(ConstraintSystem &cs,
-                                     ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AllowKeyPathMissingComponent(cs, locator);
+AllowKeyPathWithoutComponents *
+AllowKeyPathWithoutComponents::create(ConstraintSystem &cs,
+                                      ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowKeyPathWithoutComponents(cs, locator);
 }

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -274,7 +274,7 @@ enum class FixKind : uint8_t {
   /// parameter in the call.
   SpecifyLabelToAssociateTrailingClosure,
 
-  /// Allow key path expressions missing component.
+  /// Allow key path expressions with no components.
   AllowKeyPathWithoutComponents,
 };
 
@@ -1961,7 +1961,7 @@ public:
   create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
 
-/// Diagnose situations where we have key path missing a component.
+/// Diagnose situations where we have a key path with no components.
 ///
 /// \code
 /// let _ : KeyPath<A, B> = \A

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -275,7 +275,7 @@ enum class FixKind : uint8_t {
   SpecifyLabelToAssociateTrailingClosure,
 
   /// Allow key path expressions missing component.
-  AllowKeyPathMissingComponent,
+  AllowKeyPathWithoutComponents,
 };
 
 class ConstraintFix {
@@ -1966,17 +1966,18 @@ public:
 /// \code
 /// let _ : KeyPath<A, B> = \A
 /// \endcode
-class AllowKeyPathMissingComponent final : public ConstraintFix {
-  AllowKeyPathMissingComponent(ConstraintSystem &cs, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AllowKeyPathMissingComponent, locator) {}
+class AllowKeyPathWithoutComponents final : public ConstraintFix {
+  AllowKeyPathWithoutComponents(ConstraintSystem &cs,
+                                ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowKeyPathWithoutComponents, locator) {}
 
 public:
   std::string getName() const override { return "key path missing component"; }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  static AllowKeyPathMissingComponent *create(ConstraintSystem &cs,
-                                              ConstraintLocator *locator);
+  static AllowKeyPathWithoutComponents *create(ConstraintSystem &cs,
+                                               ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -266,13 +266,16 @@ enum class FixKind : uint8_t {
 
   /// Specify key path root type when it cannot be infered from context.
   SpecifyKeyPathRootType,
-  
+
   /// Unwrap optional base on key path application.
   UnwrapOptionalBaseKeyPathApplication,
 
   /// Explicitly specify a label to match trailing closure to a certain
   /// parameter in the call.
   SpecifyLabelToAssociateTrailingClosure,
+
+  /// Allow key path expressions missing component.
+  AllowKeyPathMissingComponent,
 };
 
 class ConstraintFix {
@@ -1956,6 +1959,24 @@ public:
 
   static SpecifyLabelToAssociateTrailingClosure *
   create(ConstraintSystem &cs, ConstraintLocator *locator);
+};
+
+/// Diagnose situations where we have key path missing a component.
+///
+/// \code
+/// let _ : KeyPath<A, B> = \A
+/// \endcode
+class AllowKeyPathMissingComponent final : public ConstraintFix {
+  AllowKeyPathMissingComponent(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowKeyPathMissingComponent, locator) {}
+
+public:
+  std::string getName() const override { return "key path missing component"; }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowKeyPathMissingComponent *create(ConstraintSystem &cs,
+                                              ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8130,7 +8130,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
     // If we have a malformed KeyPathExpr e.g. let _: KeyPath<A, C> = \A
     // let's record a AllowKeyPathMissingComponent fix.
     if (keyPath->hasSingleInvalidComponent()) {
-      auto *fix = AllowKeyPathMissingComponent::create(
+      auto *fix = AllowKeyPathWithoutComponents::create(
           *this, getConstraintLocator(locator));
       return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
     }
@@ -9997,7 +9997,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowCoercionToForceCast:
   case FixKind::SpecifyKeyPathRootType:
   case FixKind::SpecifyLabelToAssociateTrailingClosure:
-  case FixKind::AllowKeyPathMissingComponent: {
+  case FixKind::AllowKeyPathWithoutComponents: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1900,7 +1900,6 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
 
   // Key paths must be spelled with at least one component.
   if (components.empty()) {
-    DE.diagnose(KPE->getLoc(), diag::expr_swift_keypath_empty);
     // Passes further down the pipeline expect keypaths to always have at least
     // one component, so stuff an invalid component in the AST for recovery.
     components.push_back(KeyPathExpr::Component());

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -36,7 +36,7 @@ struct A: Hashable {
   func hash(into hasher: inout Hasher) { fatalError() }
 }
 struct B {}
-struct C<T> { // expected-note 3 {{'T' declared as parameter to type 'C'}}
+struct C<T> { // expected-note 4 {{'T' declared as parameter to type 'C'}}
   var value: T
   subscript() -> T { get { return value } }
   subscript(sub: Sub) -> T { get { return value } set { } }
@@ -224,15 +224,17 @@ func testKeyPathInGenericContext<H: Hashable, X>(hashable: H, anything: X) {
 }
 
 func testDisembodiedStringInterpolation(x: Int) {
-  \(x) // expected-error{{string interpolation}} expected-error{{}}
-  \(x, radix: 16) // expected-error{{string interpolation}} expected-error{{}}
+  \(x) // expected-error{{string interpolation can only appear inside a string literal}} 
+  \(x, radix: 16) // expected-error{{string interpolation can only appear inside a string literal}} 
 }
 
 func testNoComponents() {
   let _: KeyPath<A, A> = \A // expected-error{{must have at least one component}}
-  let _: KeyPath<C, A> = \C // expected-error{{must have at least one component}} expected-error{{}}
+  let _: KeyPath<C, A> = \C // expected-error{{must have at least one component}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type 'KeyPath<Root, Value>' to specified type 'KeyPath<C<T>, A>'}}
+  let _: KeyPath<A, C> = \A // expected-error{{must have at least one component}} 
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  _ = \A // expected-error {{key path must have at least one component}}
 }
 
 struct TupleStruct {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This just skips contextual type diagnostic for malformed key path expressions, because this leads at the very least, extra not good diagnostics. What do you think? 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
