### PR TITLE
StringOptimization: handle static let variables for String constant folding.

### DIFF
--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -260,8 +260,7 @@ SILFunction *getCalleeOfOnceCall(BuiltinInst *BI);
 /// Given an addressor, AddrF, find the call to the global initializer if
 /// present, otherwise return null. If an initializer is returned, then
 /// `CallToOnce` is initialized to the corresponding builtin "once" call.
-SILFunction *findInitializer(SILModule *Module, SILFunction *AddrF,
-                             BuiltinInst *&CallToOnce);
+SILFunction *findInitializer(SILFunction *AddrF, BuiltinInst *&CallToOnce);
 
 /// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
 /// rewrite the initialization pattern.

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -299,6 +299,8 @@ PASS(SILCombine, "sil-combine",
      "Combine SIL Instructions via Peephole Optimization")
 PASS(SILDebugInfoGenerator, "sil-debuginfo-gen",
      "Generate Debug Information with Source Locations into Textual SIL")
+PASS(EarlySROA, "early-sroa",
+     "Scalar Replacement of Aggregate Stack Objects on high-level SIL")
 PASS(SROA, "sroa",
      "Scalar Replacement of Aggregate Stack Objects")
 PASS(SROABBArgs, "sroa-bb-args",

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -220,9 +220,9 @@ SILGlobalVariable *swift::getVariableOfGlobalInit(SILFunction *AddrF) {
   // and the globalinit_func is called by "once" from a single location,
   // continue; otherwise bail.
   BuiltinInst *CallToOnce;
-  auto *InitF = findInitializer(&AddrF->getModule(), AddrF, CallToOnce);
+  auto *InitF = findInitializer(AddrF, CallToOnce);
 
-  if (!InitF || !InitF->getName().startswith("globalinit_"))
+  if (!InitF)
     return nullptr;
 
   // If the globalinit_func is trivial, continue; otherwise bail.
@@ -247,8 +247,8 @@ SILFunction *swift::getCalleeOfOnceCall(BuiltinInst *BI) {
 }
 
 // Find the globalinit_func by analyzing the body of the addressor.
-SILFunction *swift::findInitializer(SILModule *Module, SILFunction *AddrF,
-                             BuiltinInst *&CallToOnce) {
+SILFunction *swift::findInitializer(SILFunction *AddrF,
+                                    BuiltinInst *&CallToOnce) {
   // We only handle a single SILBasicBlock for now.
   if (AddrF->size() != 1)
     return nullptr;
@@ -272,7 +272,10 @@ SILFunction *swift::findInitializer(SILModule *Module, SILFunction *AddrF,
   }
   if (!CallToOnce)
     return nullptr;
-  return getCalleeOfOnceCall(CallToOnce);
+  SILFunction *callee = getCalleeOfOnceCall(CallToOnce);
+  if (!callee->getName().startswith("globalinit_"))
+    return nullptr;
+  return callee;
 }
 
 SILGlobalVariable *

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -431,9 +431,8 @@ bool SILGlobalOpt::optimizeInitializer(SILFunction *AddrF,
   // If the addressor contains a single "once" call, it calls globalinit_func,
   // and the globalinit_func is called by "once" from a single location,
   // continue; otherwise bail.
-  auto *InitF = findInitializer(Module, AddrF, CallToOnce);
-  if (!InitF || !InitF->getName().startswith("globalinit_") ||
-      InitializerCount[InitF] > 1)
+  auto *InitF = findInitializer(AddrF, CallToOnce);
+  if (!InitF || InitializerCount[InitF] > 1)
     return false;
 
   // If the globalinit_func is trivial, continue; otherwise bail.

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -493,6 +493,8 @@ static void addHighLevelFunctionPipeline(SILPassPipelinePlan &P) {
   addFunctionPasses(P, OptimizationLevelKind::HighLevel);
 
   addHighLevelLoopOptPasses(P);
+  
+  P.addStringOptimization();
 }
 
 // After "high-level" function passes have processed the entire call tree, run
@@ -528,8 +530,6 @@ static void addSerializePipeline(SILPassPipelinePlan &P) {
 
 static void addMidLevelFunctionPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("MidLevel,Function", true /*isFunctionPassPipeline*/);
-
-  P.addStringOptimization();
 
   addFunctionPasses(P, OptimizationLevelKind::MidLevel);
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -222,7 +222,7 @@ void addHighLevelLoopOptPasses(SILPassPipelinePlan &P) {
   // Perform classic SSA optimizations for cleanup.
   P.addLowerAggregateInstrs();
   P.addSILCombine();
-  P.addSROA();
+  P.addEarlySROA();
   P.addMem2Reg();
   P.addDCE();
   P.addSILCombine();
@@ -290,7 +290,11 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   P.addLowerAggregateInstrs();
 
   // Split up operations on stack-allocated aggregates (struct, tuple).
-  P.addSROA();
+  if (OpLevel == OptimizationLevelKind::HighLevel) {
+    P.addEarlySROA();
+  } else {
+    P.addSROA();
+  }
 
   // Promote stack allocations to values.
   P.addMem2Reg();

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -375,15 +375,15 @@ static void replaceLoad(LoadInst *LI, SILValue val, AllocStackInst *ASI) {
 
 static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
   SILFunction *F = DAI->getFunction();
+  auto Ty = DAI->getOperand()->getType();
 
-  assert(DAI->getOperand()->getType().isLoadable(*F) &&
+  assert(Ty.isLoadable(*F) &&
          "Unexpected promotion of address-only type!");
 
-  assert(NewValue && "Expected a value to release!");
+  assert(NewValue || (Ty.is<TupleType>() && Ty.getAs<TupleType>()->getNumElements() == 0));
 
   SILBuilderWithScope Builder(DAI);
 
-  auto Ty = DAI->getOperand()->getType();
   auto &TL = F->getTypeLowering(Ty);
 
   bool expand = shouldExpand(DAI->getModule(),

--- a/test/SILOptimizer/string_optimization.swift
+++ b/test/SILOptimizer/string_optimization.swift
@@ -12,6 +12,8 @@ import Foundation
 
 struct Outer {
   struct Inner { }
+
+  static let staticString = "static"
 }
 
 // More types are tested in test/stdlib/TypeName.swift and
@@ -34,6 +36,15 @@ public func testTypeNameInterpolation() -> String {
 public func testFoldCompleteInterpolation() -> String {
   let s = "is"
   return "-\([Int].self) \(s) \("cool")+"
+}
+
+// CHECK-LABEL: sil [noinline] @$s4test0A13FoldStaticLetSSyF
+// CHECK-NOT: apply
+// CHECK-NOT: bb1
+// CHECK: } // end sil function '$s4test0A13FoldStaticLetSSyF'
+@inline(never)
+public func testFoldStaticLet() -> String {
+  return "-\(Outer.staticString)+"
 }
 
 // CHECK-LABEL: sil [noinline] @$s4test0A19UnqualifiedTypeNameSSyF 
@@ -91,6 +102,9 @@ printEmbeeded(testTypeNameInterpolation())
 
 // CHECK-OUTPUT: <-Array<Int> is cool+>
 printEmbeeded(testFoldCompleteInterpolation())
+
+// CHECK-OUTPUT: <-static+>
+printEmbeeded(testFoldStaticLet())
 
 // CHECK-OUTPUT: <Inner>
 printEmbeeded(testUnqualifiedTypeName())


### PR DESCRIPTION
For example, constant fold:
```
struct Str {
    static let s = "hello"
}
...
let x = "<\(Str.s)>"
```

This PR also contains some other minor changes which are required for this optimization. For details see the commit list.