### PR TITLE
Replace trivial calls to getDeclaredType() with getDeclaredInterfaceType()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2986,6 +2986,11 @@ public:
   Type getCachedUnderlyingType() const { return UnderlyingTy.getType(); }
 
   /// For generic typealiases, return the unbound generic type.
+  ///
+  /// Since UnboundGenericType is on its way out, so is this method. Try to
+  /// avoid introducing new callers if possible. Instead of passing around
+  /// an UnboundGenericType, considering passing around the Decl itself
+  /// instead.
   UnboundGenericType *getUnboundGenericType() const;
 
   /// Retrieve a sugared interface type containing the structure of the interface
@@ -3372,6 +3377,11 @@ public:
 
   /// getDeclaredType - Retrieve the type declared by this entity, without
   /// any generic parameters bound if this is a generic type.
+  ///
+  /// Since UnboundGenericType is on its way out, so is this method. Try to
+  /// avoid introducing new callers if possible. Instead of passing around
+  /// an UnboundGenericType, considering passing around the Decl itself
+  /// instead.
   Type getDeclaredType() const;
 
   /// getDeclaredInterfaceType - Retrieve the type declared by this entity, with

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4310,11 +4310,6 @@ public:
   /// protocol.
   bool inheritsFrom(const ProtocolDecl *Super) const;
   
-  ProtocolType *getDeclaredType() const {
-    return reinterpret_cast<ProtocolType *>(
-      NominalTypeDecl::getDeclaredType().getPointer());
-  }
-  
   SourceLoc getStartLoc() const { return ProtocolLoc; }
   SourceRange getSourceRange() const {
     return SourceRange(ProtocolLoc, getBraces().End);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2179,6 +2179,8 @@ END_CAN_TYPE_WRAPPER(TupleType, Type)
 
 /// UnboundGenericType - Represents a generic type where the type arguments have
 /// not yet been resolved.
+///
+/// This type is on its way out. Try to avoid introducing new usages.
 class UnboundGenericType : public AnyGenericType,
     public llvm::FoldingSetNode {
 private:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -772,7 +772,7 @@ FuncDecl *ASTContext::getSequenceMakeIterator() const {
 
 CanType ASTContext::getExceptionType() const {
   if (auto exn = getErrorDecl()) {
-    return exn->getDeclaredType()->getCanonicalType();
+    return exn->getDeclaredInterfaceType()->getCanonicalType();
   } else {
     // Use Builtin.NativeObject just as a stand-in.
     return TheNativeObjectType;
@@ -864,7 +864,7 @@ CanType ASTContext::getNeverType() const {
   auto neverDecl = getNeverDecl();
   if (!neverDecl)
     return CanType();
-  return neverDecl->getDeclaredType()->getCanonicalType();
+  return neverDecl->getDeclaredInterfaceType()->getCanonicalType();
 }
 
 #define KNOWN_OBJC_TYPE_DECL(MODULE, NAME, DECLTYPE) \
@@ -1073,7 +1073,7 @@ ASTContext::getBuiltinInitDecl(NominalTypeDecl *decl,
   if (witness)
     return witness;
 
-  auto type = decl->getDeclaredType();
+  auto type = decl->getDeclaredInterfaceType();
   auto builtinProtocol = getProtocol(builtinProtocolKind);
   auto builtinConformance = getStdlibModule()->lookupConformance(
       type, builtinProtocol);
@@ -1102,12 +1102,12 @@ FuncDecl *getBinaryComparisonOperatorIntDecl(const ASTContext &C, StringRef op, 
   if (!C.getIntDecl() || !C.getBoolDecl())
     return nullptr;
 
-  auto intType = C.getIntDecl()->getDeclaredType();
+  auto intType = C.getIntDecl()->getDeclaredInterfaceType();
   auto isIntParam = [&](AnyFunctionType::Param param) {
     return (!param.isVariadic() && !param.isInOut() &&
             param.getPlainType()->isEqual(intType));
   };
-  auto boolType = C.getBoolDecl()->getDeclaredType();
+  auto boolType = C.getBoolDecl()->getDeclaredInterfaceType();
   auto decl = lookupOperatorFunc(C, op, intType, 
       [=](FunctionType *type) {
     // Check for the signature: (Int, Int) -> Bool
@@ -4264,7 +4264,7 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
       if (auto objcBridgeable
             = getProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
         auto conformance = dc->getParentModule()->lookupConformance(
-            nominal->getDeclaredType(), objcBridgeable);
+            nominal->getDeclaredInterfaceType(), objcBridgeable);
         if (conformance) {
           result =
               ForeignRepresentationInfo::forBridged(conformance.getConcrete());

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -153,7 +153,7 @@ Type ASTBuilder::createNominalType(GenericTypeDecl *decl, Type parent) {
   bool isImported = nominalDecl->hasClangNode() ||
       nominalDecl->getAttrs().hasAttribute<ClangImporterSynthesizedTypeAttr>();
   if (isImported && !nominalDecl->isGenericContext())
-    return nominalDecl->getDeclaredType();
+    return nominalDecl->getDeclaredInterfaceType();
 
   // Validate the parent type.
   if (!validateParentType(nominalDecl, parent))
@@ -572,7 +572,7 @@ Type ASTBuilder::createProtocolCompositionType(
     bool isClassBound) {
   std::vector<Type> members;
   for (auto protocol : protocols)
-    members.push_back(protocol->getDeclaredType());
+    members.push_back(protocol->getDeclaredInterfaceType());
   if (superclass && superclass->getClassOrBoundGenericClass())
     members.push_back(superclass);
   return ProtocolCompositionType::get(Ctx, members, isClassBound);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5045,7 +5045,7 @@ swift::getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
           isa<EnumDecl>(decl) &&
           cast<EnumDecl>(decl)->hasRawType())
         continue;
-      Results.push_back(TypeLoc::withoutLoc(proto->getDeclaredType()));
+      Results.push_back(TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
     }
   }
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4102,7 +4102,8 @@ public:
       case SILFunctionType::Representation::WitnessMethod:
         Printer << "witness_method: ";
         printTypeDeclName(
-            witnessMethodConformance.getRequirement()->getDeclaredType());
+            witnessMethodConformance.getRequirement()->getDeclaredType()
+                ->castTo<ProtocolType>());
         break;
       case SILFunctionType::Representation::Closure:
         Printer << "closure";

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1040,7 +1040,8 @@ public:
       case StmtConditionElement::CK_Boolean: {
         auto *E = elt.getBoolean();
         if (shouldVerifyChecked(E))
-          checkSameType(E->getType(), Ctx.getBoolDecl()->getDeclaredType(),
+          checkSameType(E->getType(),
+                        Ctx.getBoolDecl()->getDeclaredInterfaceType(),
                         "condition type");
         break;
       }
@@ -1633,7 +1634,8 @@ public:
         abort();
       }
 
-      checkSameType(E->getType(), anyHashableDecl->getDeclaredType(),
+      checkSameType(E->getType(),
+                    anyHashableDecl->getDeclaredInterfaceType(),
                     "AnyHashableErasureExpr and the standard AnyHashable type");
 
       if (E->getConformance().getRequirement() != hashableDecl) {
@@ -3355,7 +3357,7 @@ public:
 
     Type checkExceptionTypeExists(const char *where) {
       auto exn = Ctx.getErrorDecl();
-      if (exn) return exn->getDeclaredType();
+      if (exn) return exn->getDeclaredInterfaceType();
 
       Out << "exception type does not exist in " << where << "\n";
       abort();

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -282,7 +282,7 @@ GenericSignature autodiff::getConstrainedDerivativeGenericSignature(
     // Require differentiability parameters to conform to `Differentiable`.
     auto paramType = originalFnTy->getParameters()[paramIdx].getInterfaceType();
     Requirement req(RequirementKind::Conformance, paramType,
-                    diffableProto->getDeclaredType());
+                    diffableProto->getDeclaredInterfaceType());
     requirements.push_back(req);
     if (isTranspose) {
       // Require linearity parameters to additionally satisfy

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -496,7 +496,7 @@ namespace {
     void addConformanceRequirement(const G &generator, ProtocolDecl *proto) {
       Requirement req(RequirementKind::Conformance,
                       generator.build(*this),
-                      proto->getDeclaredType());
+                      proto->getDeclaredInterfaceType());
       addedRequirements.push_back(req);
     }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5068,7 +5068,7 @@ public:
       if (differentiableProtocol && fnTy->isDifferentiable()) {
         auto addConformanceConstraint = [&](Type type, ProtocolDecl *protocol) {
           Requirement req(RequirementKind::Conformance, type,
-                          protocol->getDeclaredType());
+                          protocol->getDeclaredInterfaceType());
           Builder.addRequirement(req, source, nullptr);
         };
         auto addSameTypeConstraint = [&](Type firstType,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2323,7 +2323,7 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
     // Protocol extensions need an inheritance clause due to how name lookup
     // is implemented.
     if (auto *proto = ext->getExtendedProtocolDecl()) {
-      auto protoType = proto->getDeclaredType();
+      auto protoType = proto->getDeclaredInterfaceType();
       TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
       genericParams->getParams().front()->setInherited(
         ctx.AllocateCopy(selfInherited));
@@ -2343,7 +2343,7 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
     auto selfId = ctx.Id_Self;
     auto selfDecl = new (ctx) GenericTypeParamDecl(
         proto, selfId, SourceLoc(), /*depth=*/0, /*index=*/0);
-    auto protoType = proto->getDeclaredType();
+    auto protoType = proto->getDeclaredInterfaceType();
     TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
     selfDecl->setInherited(ctx.AllocateCopy(selfInherited));
     selfDecl->setImplicit();

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -337,7 +337,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   for (auto reqt : genericSig->getRequirements()) {
     if (reqt.getKind() == RequirementKind::Conformance) {
       if (reqt.getFirstType()->isEqual(type) &&
-          reqt.getSecondType()->isEqual(proto->getDeclaredType()))
+          reqt.getSecondType()->isEqual(proto->getDeclaredInterfaceType()))
         return getConformances()[index];
 
       ++index;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -552,7 +552,7 @@ synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
   auto getterDecl = cast<AccessorDecl>(afd);
   auto enumDecl = static_cast<EnumDecl *>(context);
   auto rawTy = enumDecl->getRawType();
-  auto enumTy = enumDecl->getDeclaredType();
+  auto enumTy = enumDecl->getDeclaredInterfaceType();
 
   ASTContext &ctx = getterDecl->getASTContext();
   auto *selfDecl = getterDecl->getImplicitSelfDecl();
@@ -1892,7 +1892,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
   auto &C = importer.SwiftContext;
   auto swiftValueDecl = dyn_cast_or_null<ValueDecl>(
       importer.importDecl(errorDomainDecl, importer.CurrentVersion));
-  auto stringTy = C.getStringDecl()->getDeclaredType();
+  auto stringTy = C.getStringDecl()->getDeclaredInterfaceType();
   assert(stringTy && "no string type available");
   if (!swiftValueDecl || !swiftValueDecl->getInterfaceType()->isEqual(stringTy)) {
     // Couldn't actually import it as an error enum, fall back to enum
@@ -6962,7 +6962,8 @@ void SwiftDeclConverter::importObjCProtocols(
     if (auto proto = castIgnoringCompatibilityAlias<ProtocolDecl>(
             Impl.importDecl(*cp, getActiveSwiftVersion()))) {
       addProtocols(proto, protocols, knownProtocols);
-      inheritedTypes.push_back(TypeLoc::withoutLoc(proto->getDeclaredType()));
+      inheritedTypes.push_back(
+        TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
     }
   }
 
@@ -7013,7 +7014,8 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
         if (!proto) {
           return None;
         }
-        inherited.push_back(TypeLoc::withoutLoc(proto->getDeclaredType()));
+        inherited.push_back(
+          TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
       }
     }
     if (inherited.empty()) {

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -558,38 +558,38 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
     } else if (tokenI[1].is(clang::tok::pipepipe)) {
       bool result  = firstValue.getBoolValue() || secondValue.getBoolValue();
       resultValue  = llvm::APSInt::get(result);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Logical AND.
     } else if (tokenI[1].is(clang::tok::ampamp)) {
       bool result  = firstValue.getBoolValue() && secondValue.getBoolValue();
       resultValue  = llvm::APSInt::get(result);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Equality.
     } else if (tokenI[1].is(clang::tok::equalequal)) {
       resultValue     = llvm::APSInt::get(firstValue == secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Less than.
     } else if (tokenI[1].is(clang::tok::less)) {
       resultValue     = llvm::APSInt::get(firstValue < secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Less than or equal.
     } else if (tokenI[1].is(clang::tok::lessequal)) {
       resultValue     = llvm::APSInt::get(firstValue <= secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Greater than.
     } else if (tokenI[1].is(clang::tok::greater)) {
       resultValue     = llvm::APSInt::get(firstValue > secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Greater than or equal.
     } else if (tokenI[1].is(clang::tok::greaterequal)) {
       resultValue     = llvm::APSInt::get(firstValue >= secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
 
     // Unhandled operators.
     } else {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -180,7 +180,7 @@ namespace {
     if (!opaquePointer) {
       return Type();
     }
-    return {opaquePointer->getDeclaredType(),
+    return {opaquePointer->getDeclaredInterfaceType(),
             type.isReferenceType() ? ImportHint::None
                                     : ImportHint::OtherPointer};
   }
@@ -417,7 +417,7 @@ namespace {
            : Impl.SwiftContext.getUnsafeMutableRawPointerDecl());
         if (!pointerTypeDecl)
           return Type();
-        return {pointerTypeDecl->getDeclaredType(),
+        return {pointerTypeDecl->getDeclaredInterfaceType(),
                 ImportHint::OtherPointer};
       }
 
@@ -964,7 +964,7 @@ namespace {
                 memberTypes.push_back(superclassType);
 
               for (auto protocolDecl : typeParam->getConformingProtocols())
-                memberTypes.push_back(protocolDecl->getDeclaredType());
+                memberTypes.push_back(protocolDecl->getDeclaredInterfaceType());
 
               bool hasExplicitAnyObject = false;
               if (memberTypes.empty())
@@ -980,7 +980,7 @@ namespace {
           importedType = BoundGenericClassType::get(
             imported, nullptr, importedTypeArgs);
         } else {
-          importedType = imported->getDeclaredType();
+          importedType = imported->getDeclaredInterfaceType();
         }
  
         if (!type->qual_empty()) {
@@ -1028,7 +1028,7 @@ namespace {
         if (auto objcClassDef = objcClass->getDefinition())
           bridgedType = mapSwiftBridgeAttr(objcClassDef);
         else if (objcClass->getName() == "NSString")
-          bridgedType = Impl.SwiftContext.getStringDecl()->getDeclaredType();
+          bridgedType = Impl.SwiftContext.getStringDecl()->getDeclaredInterfaceType();
 
         if (bridgedType) {
           // Gather the type arguments.
@@ -1083,7 +1083,7 @@ namespace {
                   keyStructDecl == Impl.SwiftContext.getDictionaryDecl() ||
                   keyStructDecl == Impl.SwiftContext.getArrayDecl()) {
                 if (auto anyHashable = Impl.SwiftContext.getAnyHashableDecl())
-                  keyType = anyHashable->getDeclaredType();
+                  keyType = anyHashable->getDeclaredInterfaceType();
                 else
                   keyType = Type();
               }
@@ -1124,7 +1124,7 @@ namespace {
           if (!proto)
             return Type();
 
-          members.push_back(proto->getDeclaredType());
+          members.push_back(proto->getDeclaredInterfaceType());
         }
 
         importedType = ProtocolCompositionType::get(Impl.SwiftContext,
@@ -1409,14 +1409,14 @@ static ImportedType adjustTypeForConcreteImport(
     // Turn BOOL and DarwinBoolean into Bool in contexts that can bridge types
     // losslessly.
     if (bridging == Bridgeability::Full && canBridgeTypes(importKind))
-      importedType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      importedType = impl.SwiftContext.getBoolDecl()->getDeclaredInterfaceType();
     break;
 
   case ImportHint::NSUInteger:
     // When NSUInteger is used as an enum's underlying type or if it does not
     // come from a system module, make sure it stays unsigned.
     if (importKind == ImportTypeKind::Enum || !allowNSUIntegerAsInt)
-      importedType = impl.SwiftContext.getUIntDecl()->getDeclaredType();
+      importedType = impl.SwiftContext.getUIntDecl()->getDeclaredInterfaceType();
     break;
 
   case ImportHint::CFPointer:
@@ -1647,7 +1647,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     switch (getClangASTContext().BuiltinInfo.getTypeString(builtinID)[0]) {
     case 'z': // size_t
     case 'Y': // ptrdiff_t
-      return {SwiftContext.getIntDecl()->getDeclaredType(), false};
+      return {SwiftContext.getIntDecl()->getDeclaredInterfaceType(), false};
     default:
       break;
     }
@@ -2462,7 +2462,7 @@ Type ClangImporter::Implementation::getNSObjectType() {
     return NSObjectTy;
 
   if (auto decl = dyn_cast_or_null<ClassDecl>(importDeclByName("NSObject"))) {
-    NSObjectTy = decl->getDeclaredType();
+    NSObjectTy = decl->getDeclaredInterfaceType();
     return NSObjectTy;
   }
 
@@ -2528,7 +2528,7 @@ static Type getNamedProtocolType(ClangImporter::Implementation &impl,
             impl.importDecl(decl->getUnderlyingDecl(), impl.CurrentVersion)) {
       if (auto protoDecl =
               dynCastIgnoringCompatibilityAlias<ProtocolDecl>(swiftDecl)) {
-        return protoDecl->getDeclaredType();
+        return protoDecl->getDeclaredInterfaceType();
       }
     }
   }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -465,7 +465,7 @@ public:
       printer << " : ";
 
       ProtocolDecl *proto = protoAndAvailability.first;
-      proto->getDeclaredType()->print(printer, printOptions);
+      proto->getDeclaredInterfaceType()->print(printer, printOptions);
 
       printer << " {}\n";
     }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1749,11 +1749,11 @@ static Type
 defaultTypeLiteralKind(CodeCompletionLiteralKind kind, ASTContext &Ctx) {
   switch (kind) {
   case CodeCompletionLiteralKind::BooleanLiteral:
-    return Ctx.getBoolDecl()->getDeclaredType();
+    return Ctx.getBoolDecl()->getDeclaredInterfaceType();
   case CodeCompletionLiteralKind::IntegerLiteral:
-    return Ctx.getIntDecl()->getDeclaredType();
+    return Ctx.getIntDecl()->getDeclaredInterfaceType();
   case CodeCompletionLiteralKind::StringLiteral:
-    return Ctx.getStringDecl()->getDeclaredType();
+    return Ctx.getStringDecl()->getDeclaredInterfaceType();
   case CodeCompletionLiteralKind::ArrayLiteral:
     return Ctx.getArrayDecl()->getDeclaredType();
   case CodeCompletionLiteralKind::DictionaryLiteral:
@@ -4130,7 +4130,7 @@ public:
       builder.addRightBracket();
     });
 
-    auto floatType = context.getFloatDecl()->getDeclaredType();
+    auto floatType = context.getFloatDecl()->getDeclaredInterfaceType();
     addFromProto(LK::ColorLiteral, [&](Builder &builder) {
       builder.addBaseName("#colorLiteral");
       builder.addLeftParen();
@@ -4144,7 +4144,7 @@ public:
       builder.addRightParen();
     });
 
-    auto stringType = context.getStringDecl()->getDeclaredType();
+    auto stringType = context.getStringDecl()->getDeclaredInterfaceType();
     addFromProto(LK::ImageLiteral, [&](Builder &builder) {
       builder.addBaseName("#imageLiteral");
       builder.addLeftParen();

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -410,7 +410,7 @@ if (Builtin.ID == BuiltinValueKind::id) { \
     auto error = args.claimNext();
     auto errorBuffer = IGF.getErrorResultSlot(
                SILType::getPrimitiveObjectType(IGF.IGM.Context.getErrorDecl()
-                                                  ->getDeclaredType()
+                                                  ->getDeclaredInterfaceType()
                                                   ->getCanonicalType()));
     IGF.Builder.CreateStore(error, errorBuffer);
     

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -780,8 +780,8 @@ private:
     auto *PD = dyn_cast<ProtocolDecl>(NTD);
     if (CD && CD->getSuperclass()) {
       addTypeRef(CD->getSuperclass(), CD->getGenericSignature());
-    } else if (PD && PD->getDeclaredType()->getSuperclass()) {
-      addTypeRef(PD->getDeclaredType()->getSuperclass(),
+    } else if (PD && PD->getDeclaredInterfaceType()->getSuperclass()) {
+      addTypeRef(PD->getDeclaredInterfaceType()->getSuperclass(),
                  PD->getGenericSignature());
     } else {
       B.addInt32(0);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -948,7 +948,7 @@ private:
       } else {
         // Discriminated union case without argument. Fallback to Int
         // as the element type; there is no storage here.
-        Type IntTy = IGM.Context.getIntDecl()->getDeclaredType();
+        Type IntTy = IGM.Context.getIntDecl()->getDeclaredInterfaceType();
         ElemDbgTy = DebugTypeInfo(IntTy, DbgTy.getStorageType(), Size(0),
                                   Alignment(1), true, false);
       }

--- a/lib/SIL/IR/SILDefaultWitnessTable.cpp
+++ b/lib/SIL/IR/SILDefaultWitnessTable.cpp
@@ -97,7 +97,8 @@ convertToDefinition(ArrayRef<Entry> entries) {
 
 std::string SILDefaultWitnessTable::getUniqueName() const {
   Mangle::ASTMangler Mangler;
-  return Mangler.mangleTypeWithoutPrefix(getProtocol()->getDeclaredType());
+  return Mangler.mangleTypeWithoutPrefix(
+    getProtocol()->getDeclaredInterfaceType());
 }
 
 SILDefaultWitnessTable::~SILDefaultWitnessTable() {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1177,8 +1177,8 @@ public:
     for (unsigned i : indices(upperBoundConformances)) {
       auto proto = upperBoundConformances[i];
       auto conformance = substTypeConformances[i];
-      substRequirements.push_back(Requirement(RequirementKind::Conformance,
-                                              param, proto->getDeclaredType()));
+      substRequirements.push_back(Requirement(RequirementKind::Conformance, param,
+                                              proto->getDeclaredInterfaceType()));
       substConformances.push_back(conformance);
     }
     

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1780,7 +1780,7 @@ SubstitutionMap getApplySubstitutionsFromParsed(
           return conformance;
 
         SP.P.diagnose(loc, diag::sil_substitution_mismatch, replacementType,
-                      proto->getDeclaredType());
+                      proto->getDeclaredInterfaceType());
         failed = true;
 
         return ProtocolConformanceRef(proto);

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -205,7 +205,7 @@ static CanType getHashableExistentialType(ModuleDecl *M) {
   auto hashable =
     M->getASTContext().getProtocol(KnownProtocolKind::Hashable);
   if (!hashable) return CanType();
-  return hashable->getDeclaredType()->getCanonicalType();
+  return hashable->getDeclaredInterfaceType()->getCanonicalType();
 }
 
 /// Check if a given type conforms to _BridgedToObjectiveC protocol.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1868,7 +1868,7 @@ RValue SILGenFunction::emitAnyHashableErasure(SILLocation loc,
   auto convertFn = SGM.getConvertToAnyHashable(loc);
   if (!convertFn)
     return emitUndefRValue(
-        loc, getASTContext().getAnyHashableDecl()->getDeclaredType());
+        loc, getASTContext().getAnyHashableDecl()->getDeclaredInterfaceType());
 
   // Construct the substitution for T: Hashable.
   auto subMap = SubstitutionMap::getProtocolSubstitutions(
@@ -2742,7 +2742,7 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
     params.push_back({loweredBaseTy, paramConvention});
     auto &C = SGM.getASTContext();
     if (!indexes.empty())
-      params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredType()
+      params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredInterfaceType()
                                                    ->getCanonicalType(),
                         ParameterConvention::Direct_Unowned});
     
@@ -2893,7 +2893,7 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
                         : paramConvention});
     // indexes
     if (!indexes.empty())
-      params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredType()
+      params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredInterfaceType()
                                                    ->getCanonicalType(),
                         ParameterConvention::Direct_Unowned});
     
@@ -3040,10 +3040,10 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
   }
 
   auto &C = SGM.getASTContext();
-  auto unsafeRawPointerTy = C.getUnsafeRawPointerDecl()->getDeclaredType()
+  auto unsafeRawPointerTy = C.getUnsafeRawPointerDecl()->getDeclaredInterfaceType()
                                                        ->getCanonicalType();
-  auto boolTy = C.getBoolDecl()->getDeclaredType()->getCanonicalType();
-  auto intTy = C.getIntDecl()->getDeclaredType()->getCanonicalType();
+  auto boolTy = C.getBoolDecl()->getDeclaredInterfaceType()->getCanonicalType();
+  auto intTy = C.getIntDecl()->getDeclaredInterfaceType()->getCanonicalType();
 
   auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
 

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2823,7 +2823,7 @@ AllocStackInst *PullbackCloner::Implementation::getArrayAdjointElementBuffer(
   auto *eltIndexLiteral =
       builder.createIntegerLiteral(loc, builtinIntType, eltIndex);
   auto intType = SILType::getPrimitiveObjectType(
-      ctx.getIntDecl()->getDeclaredType()->getCanonicalType());
+      ctx.getIntDecl()->getDeclaredInterfaceType()->getCanonicalType());
   // %index_int = struct $Int (%index_literal)
   auto *eltIndexInt = builder.createStruct(loc, intType, {eltIndexLiteral});
   auto *swiftModule = getModule().getSwiftModule();

--- a/lib/SILOptimizer/Transforms/StringOptimization.cpp
+++ b/lib/SILOptimizer/Transforms/StringOptimization.cpp
@@ -108,7 +108,7 @@ bool StringOptimization::run(SILFunction *F) {
   if (!stringDecl)
     return false;
   stringType = SILType::getPrimitiveObjectType(
-                 CanType(stringDecl->getDeclaredType()));
+                 stringDecl->getDeclaredInterfaceType()->getCanonicalType());
 
   bool changed = false;
   

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -400,7 +400,7 @@ ConcreteExistentialInfo::ConcreteExistentialInfo(SILValue existential,
   // There is no ConcreteValue in this case.
 
   /// Determine the ExistentialConformances and SubstitutionMap.
-  ExistentialType = Protocol->getDeclaredType()->getCanonicalType();
+  ExistentialType = Protocol->getDeclaredInterfaceType()->getCanonicalType();
   initializeSubstitutionMap(ProtocolConformanceRef(ConcreteConformance), M);
 
   assert(isValid());

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3594,7 +3594,10 @@ namespace {
           ctx.Diags.diagnose(SourceLoc(), diag::broken_bool);
         }
 
-        cs.setType(isSomeExpr, boolDecl ? boolDecl->getDeclaredType() : Type());
+        cs.setType(isSomeExpr,
+                   boolDecl
+                   ? boolDecl->getDeclaredInterfaceType()
+                   : Type());
         return isSomeExpr;
       }
 
@@ -8068,7 +8071,7 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
   if (forEachStmtInfo.whereExpr) {
     auto *boolDecl = dc->getASTContext().getBoolDecl();
     assert(boolDecl);
-    Type boolType = boolDecl->getDeclaredType();
+    Type boolType = boolDecl->getDeclaredInterfaceType();
     assert(boolType);
 
     SolutionApplicationTarget whereTarget(
@@ -8269,7 +8272,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
         return None;
 
       // FIXME: Feels like we could leverage existing code more.
-      Type boolType = cs.getASTContext().getBoolDecl()->getDeclaredType();
+      Type boolType = cs.getASTContext().getBoolDecl()->getDeclaredInterfaceType();
       guardExpr = solution.coerceToType(
           guardExpr, boolType, cs.getConstraintLocator(info.guardExpr));
       if (!guardExpr)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1159,7 +1159,7 @@ namespace {
                                       TVO_PrefersSubtypeBinding |
                                       TVO_CanBindToNoEscape);
       CS.addConstraint(ConstraintKind::LiteralConformsTo, tv,
-                       protocol->getDeclaredType(),
+                       protocol->getDeclaredInterfaceType(),
                        CS.getConstraintLocator(expr));
       return tv;
     }
@@ -1184,7 +1184,7 @@ namespace {
                                       TVO_PrefersSubtypeBinding |
                                       TVO_CanBindToNoEscape);
       CS.addConstraint(ConstraintKind::LiteralConformsTo, tv,
-                       interpolationProto->getDeclaredType(),
+                       interpolationProto->getDeclaredInterfaceType(),
                        locator);
 
       if (auto appendingExpr = expr->getAppendingExpr()) {
@@ -1222,7 +1222,7 @@ namespace {
           return nullptr;
 
         auto unsafeRawPointer = ctx.getUnsafeRawPointerDecl();
-        return unsafeRawPointer->getDeclaredType();
+        return unsafeRawPointer->getDeclaredInterfaceType();
       }
 
       default:
@@ -1257,7 +1257,7 @@ namespace {
                        TVO_CanBindToHole);
 
       CS.addConstraint(ConstraintKind::LiteralConformsTo, witnessType,
-                       protocol->getDeclaredType(), exprLoc);
+                       protocol->getDeclaredInterfaceType(), exprLoc);
 
       // The arguments are required to be argument-convertible to the
       // idealized parameter type of the initializer, which generally
@@ -1815,7 +1815,7 @@ namespace {
         contextualArrayElementType = *arrayElementType;
 
         CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
-                         arrayProto->getDeclaredType(),
+                         arrayProto->getDeclaredInterfaceType(),
                          locator);
         
         unsigned index = 0;
@@ -1885,7 +1885,7 @@ namespace {
 
       // The array must be an array literal type.
       CS.addConstraint(ConstraintKind::LiteralConformsTo, arrayTy,
-                       arrayProto->getDeclaredType(),
+                       arrayProto->getDeclaredInterfaceType(),
                        locator);
       
       // Its subexpression should be convertible to a tuple (T.Element...).
@@ -1950,7 +1950,7 @@ namespace {
         Type contextualDictionaryElementType = TupleType::get(tupleElts, C);
         
         CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
-                         dictionaryProto->getDeclaredType(),
+                         dictionaryProto->getDeclaredInterfaceType(),
                          locator);
         
         unsigned index = 0;
@@ -1971,7 +1971,7 @@ namespace {
 
       // The dictionary must be a dictionary literal type.
       CS.addConstraint(ConstraintKind::LiteralConformsTo, dictionaryTy,
-                       dictionaryProto->getDeclaredType(),
+                       dictionaryProto->getDeclaredInterfaceType(),
                        locator);
 
 
@@ -2481,7 +2481,7 @@ namespace {
       }
 
       case PatternKind::Bool:
-        return setType(CS.getASTContext().getBoolDecl()->getDeclaredType());
+        return setType(CS.getASTContext().getBoolDecl()->getDeclaredInterfaceType());
 
       case PatternKind::EnumElement: {
         auto enumPattern = cast<EnumElementPattern>(pattern);
@@ -2701,7 +2701,7 @@ namespace {
           // Okay, now it should be safe to coerce the pattern.
           // Pull the top-level pattern back out.
           pattern = LabelItem.getPattern();
-          Type exnType = CS.getASTContext().getErrorDecl()->getDeclaredType();
+          Type exnType = CS.getASTContext().getErrorDecl()->getDeclaredInterfaceType();
 
           if (!exnType)
             return false;
@@ -2978,7 +2978,7 @@ namespace {
 
       CS.addConstraint(
           ConstraintKind::Conversion, CS.getType(expr->getCondExpr()),
-          boolDecl->getDeclaredType(),
+          boolDecl->getDeclaredInterfaceType(),
           CS.getConstraintLocator(expr, ConstraintLocator::Condition));
 
       // The branches must be convertible to a common type.
@@ -3130,7 +3130,7 @@ namespace {
         return Type();
       }
 
-      return boolDecl->getDeclaredType();
+      return boolDecl->getDeclaredInterfaceType();
     }
 
     Type visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
@@ -3307,7 +3307,7 @@ namespace {
     }
     
     Type visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {
-      return CS.getASTContext().getBoolDecl()->getDeclaredType();
+      return CS.getASTContext().getBoolDecl()->getDeclaredInterfaceType();
     }
 
     Type visitLazyInitializerExpr(LazyInitializerExpr *expr) {
@@ -3947,7 +3947,8 @@ generateForEachStmtConstraints(
   cs.addConstraint(ConstraintKind::Conversion, cs.getType(sequence),
                    sequenceType, locator);
   cs.addConstraint(ConstraintKind::ConformsTo, sequenceType,
-                   sequenceProto->getDeclaredType(), contextualLocator);
+                   sequenceProto->getDeclaredInterfaceType(),
+                   contextualLocator);
 
   // Check the element pattern.
   ASTContext &ctx = cs.getASTContext();
@@ -4008,7 +4009,7 @@ generateForEachStmtConstraints(
     if (!boolDecl)
       return None;
 
-    Type boolType = boolDecl->getDeclaredType();
+    Type boolType = boolDecl->getDeclaredInterfaceType();
     if (!boolType)
       return None;
 
@@ -4194,7 +4195,7 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
     return true;
   }
 
-  Type boolTy = boolDecl->getDeclaredType();
+  Type boolTy = boolDecl->getDeclaredInterfaceType();
   for (const auto &condElement : condition) {
     switch (condElement.getKind()) {
     case StmtConditionElement::CK_Availability:

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -567,13 +567,15 @@ bool CompareDeclSpecializationRequest::evaluate(
   case SelfTypeRelationship::ConformsTo:
     assert(conformance);
     cs.addConstraint(ConstraintKind::ConformsTo, selfTy1,
-                     cast<ProtocolDecl>(outerDC2)->getDeclaredType(), locator);
+                     cast<ProtocolDecl>(outerDC2)->getDeclaredInterfaceType(),
+                     locator);
     break;
 
   case SelfTypeRelationship::ConformedToBy:
     assert(conformance);
     cs.addConstraint(ConstraintKind::ConformsTo, selfTy2,
-                     cast<ProtocolDecl>(outerDC1)->getDeclaredType(), locator);
+                     cast<ProtocolDecl>(outerDC1)->getDeclaredInterfaceType(),
+                     locator);
     break;
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5501,7 +5501,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // If we're supposed to generate constraints, do so.
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
-        Constraint::create(*this, kind, type, protocol->getDeclaredType(),
+        Constraint::create(*this, kind, type,
+                           protocol->getDeclaredInterfaceType(),
                            getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
@@ -5558,7 +5559,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   if (!shouldAttemptFixes())
     return SolutionKind::Error;
 
-  auto protocolTy = protocol->getDeclaredType();
+  auto protocolTy = protocol->getDeclaredInterfaceType();
 
   // If this conformance has been fixed already, let's just consider this done.
   if (isFixedRequirement(getConstraintLocator(locator), protocolTy))
@@ -7196,9 +7197,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
               auto result =
                   baseTy->is<MetatypeType>()
                       ? solveWithNewBaseOrName(ExistentialMetatypeType::get(
-                                                   proto->getDeclaredType()),
+                                                   proto->getDeclaredInterfaceType()),
                                                member)
-                      : solveWithNewBaseOrName(proto->getDeclaredType(),
+                      : solveWithNewBaseOrName(proto->getDeclaredInterfaceType(),
                                                member);
               if (result == SolutionKind::Solved)
                 return recordFix(
@@ -8963,7 +8964,7 @@ getDynamicCallableMethods(Type type, ConstraintSystem &CS,
     if (auto archetype = dyn_cast<ArchetypeType>(canType)) {
       SmallVector<Type, 2> componentTypes;
       for (auto protocolDecl : archetype->getConformsTo())
-        componentTypes.push_back(protocolDecl->getDeclaredType());
+        componentTypes.push_back(protocolDecl->getDeclaredInterfaceType());
       if (auto superclass = archetype->getSuperclass())
         componentTypes.push_back(superclass);
       return calculateForComponentTypes(componentTypes);
@@ -9159,7 +9160,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
     auto arrayLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
     addConstraint(ConstraintKind::ConformsTo, tvParam,
-                  arrayLitProto->getDeclaredType(), locator);
+                  arrayLitProto->getDeclaredInterfaceType(), locator);
     auto elementAssocType = arrayLitProto->getAssociatedType(
         ctx.Id_ArrayLiteralElement);
     argumentType = DependentMemberType::get(tvParam, elementAssocType);
@@ -9167,7 +9168,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
     auto dictLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
     addConstraint(ConstraintKind::ConformsTo, tvParam,
-                  dictLitProto->getDeclaredType(), locator);
+                  dictLitProto->getDeclaredInterfaceType(), locator);
     auto valueAssocType = dictLitProto->getAssociatedType(ctx.Id_Value);
     argumentType = DependentMemberType::get(tvParam, valueAssocType);
   }
@@ -9639,7 +9640,8 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                                  TVO_CanBindToNoEscape);
     
     addConstraint(ConstraintKind::ConformsTo, tv,
-                  hashableProtocol->getDeclaredType(), constraintLocator);
+                  hashableProtocol->getDeclaredInterfaceType(),
+                  constraintLocator);
 
     return matchTypes(type1, tv, ConstraintKind::Conversion, subflags,
                       locator);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -323,11 +323,11 @@ synthesizeStubBody(AbstractFunctionDecl *fn, void *) {
   }
 
   auto *staticStringDecl = ctx.getStaticStringDecl();
-  auto staticStringType = staticStringDecl->getDeclaredType();
+  auto staticStringType = staticStringDecl->getDeclaredInterfaceType();
   auto staticStringInit = ctx.getStringBuiltinInitDecl(staticStringDecl);
 
   auto *uintDecl = ctx.getUIntDecl();
-  auto uintType = uintDecl->getDeclaredType();
+  auto uintType = uintDecl->getDeclaredInterfaceType();
   auto uintInit = ctx.getIntBuiltinInitDecl(uintDecl);
 
   // Create a call to Swift._unimplementedInitializer

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2202,7 +2202,7 @@ void ConstraintSystem::bindOverloadType(
       return;
 
     addConstraint(ConstraintKind::LiteralConformsTo, argType,
-                  stringLiteral->getDeclaredType(), locator);
+                  stringLiteral->getDeclaredInterfaceType(), locator);
 
     // If this is used inside of the keypath expression, we need to make
     // sure that argument is Hashable.
@@ -2355,7 +2355,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
             argType->getASTContext(), choice.getDecl()->getLoc(),
             KnownProtocolKind::Hashable)) {
       addConstraint(ConstraintKind::ConformsTo, argType,
-                    hashable->getDeclaredType(),
+                    hashable->getDeclaredInterfaceType(),
                     getConstraintLocator(
                         locator, LocatorPathElt::TupleElement(index)));
     }
@@ -4672,7 +4672,7 @@ SolutionApplicationTarget SolutionApplicationTarget::forForEachStmt(
     bool bindPatternVarsOneWay) {
   SolutionApplicationTarget target(
       stmt->getSequence(), dc, CTP_ForEachStmt,
-      sequenceProto->getDeclaredType(), /*isDiscarded=*/false);
+      sequenceProto->getDeclaredInterfaceType(), /*isDiscarded=*/false);
   target.expression.pattern = stmt->getPattern();
   target.expression.bindPatternVarsOneWay =
     bindPatternVarsOneWay || (stmt->getWhere() != nullptr);

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -314,7 +314,7 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
   // We want to look through all the var declarations of this type to create
   // enum cases based on those var names.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
-  auto *codingKeyType = codingKeyProto->getDeclaredType();
+  auto codingKeyType = codingKeyProto->getDeclaredInterfaceType();
   TypeLoc protoTypeLoc[1] = {TypeLoc::withoutLoc(codingKeyType)};
   MutableArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -78,7 +78,7 @@ deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
   auto *rawValueDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_rawValue,
       SourceLoc(), C.Id_rawValue, parentDC);
-  rawValueDecl->setInterfaceType(C.getIntDecl()->getDeclaredType());
+  rawValueDecl->setInterfaceType(C.getIntDecl()->getDeclaredInterfaceType());
   rawValueDecl->setSpecifier(ParamSpecifier::Default);
   rawValueDecl->setImplicit();
   auto *paramList = ParameterList::createWithoutLoc(rawValueDecl);
@@ -362,7 +362,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
   auto name = requirement->getBaseName();
   if (name == Context.Id_stringValue) {
     // Synthesize `var stringValue: String { get }`
-    auto stringType = Context.getStringDecl()->getDeclaredType();
+    auto stringType = Context.getStringDecl()->getDeclaredInterfaceType();
     auto synth = [rawType, stringType](AbstractFunctionDecl *getterDecl) {
       if (rawType && rawType->isEqual(stringType)) {
         // enum SomeStringEnum : String {
@@ -393,7 +393,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
 
   } else if (name == Context.Id_intValue) {
     // Synthesize `var intValue: Int? { get }`
-    auto intType = Context.getIntDecl()->getDeclaredType();
+    auto intType = Context.getIntDecl()->getDeclaredInterfaceType();
     auto optionalIntType = OptionalType::get(intType);
 
     auto synth = [rawType, intType](AbstractFunctionDecl *getterDecl) {
@@ -422,7 +422,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
     if (argumentNames.size() == 1) {
       if (argumentNames[0] == Context.Id_stringValue) {
         // Derive `init?(stringValue:)`
-        auto stringType = Context.getStringDecl()->getDeclaredType();
+        auto stringType = Context.getStringDecl()->getDeclaredInterfaceType();
         auto synth = [rawType, stringType](AbstractFunctionDecl *initDecl) {
           if (rawType && rawType->isEqual(stringType)) {
             // enum SomeStringEnum : String {
@@ -455,7 +455,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
         return deriveInitDecl(*this, stringType, Context.Id_stringValue, synth);
       } else if (argumentNames[0] == Context.Id_intValue) {
         // Synthesize `init?(intValue:)`
-        auto intType = Context.getIntDecl()->getDeclaredType();
+        auto intType = Context.getIntDecl()->getDeclaredInterfaceType();
         auto synthesizer = [rawType, intType](AbstractFunctionDecl *initDecl) {
           if (rawType && rawType->isEqual(intType)) {
             // enum SomeIntEnum : Int {

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -244,7 +244,7 @@ deriveComparable_lt(
     getParamDecl("b")
   });
 
-  auto boolTy = C.getBoolDecl()->getDeclaredType();
+  auto boolTy = C.getBoolDecl()->getDeclaredInterfaceType();
 
   Identifier generatedIdentifier;
   if (parentDC->getParentModule()->isResilient()) {
@@ -271,7 +271,7 @@ deriveComparable_lt(
   // Add the @_implements(Comparable, < (_:_:)) attribute
   if (generatedIdentifier != C.Id_LessThanOperator) {
     auto comparable = C.getProtocol(KnownProtocolKind::Comparable);
-    auto comparableType = comparable->getDeclaredType();
+    auto comparableType = comparable->getDeclaredInterfaceType();
     auto comparableTypeExpr = TypeExpr::createImplicit(comparableType, C);
     SmallVector<Identifier, 2> argumentLabels = { Identifier(), Identifier() };
     auto comparableDeclName = DeclName(C, DeclBaseName(C.Id_LessThanOperator),
@@ -354,7 +354,7 @@ void DerivedConformance::tryDiagnoseFailedComparableDerivation(
       ctx.Diags.diagnose(rawTypeLoc,
                          diag::comparable_synthesis_raw_value_not_allowed,
                          rawType, nominal->getDeclaredInterfaceType(),
-                         comparableProto->getDeclaredType());
+                         comparableProto->getDeclaredInterfaceType());
     }
   }
 }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -621,9 +621,9 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
 
   // Otherwise, synthesize a new struct.
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
-  auto diffableType = TypeLoc::withoutLoc(diffableProto->getDeclaredType());
+  auto diffableType = TypeLoc::withoutLoc(diffableProto->getDeclaredInterfaceType());
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
-  auto addArithType = TypeLoc::withoutLoc(addArithProto->getDeclaredType());
+  auto addArithType = TypeLoc::withoutLoc(addArithProto->getDeclaredInterfaceType());
 
   // By definition, `TangentVector` must conform to `Differentiable` and
   // `AdditiveArithmetic`.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -393,7 +393,7 @@ deriveEquatable_eq(
     getParamDecl("b")
   });
 
-  auto boolTy = C.getBoolDecl()->getDeclaredType();
+  auto boolTy = C.getBoolDecl()->getDeclaredInterfaceType();
 
   Identifier generatedIdentifier;
   if (parentDC->getParentModule()->isResilient()) {
@@ -422,7 +422,7 @@ deriveEquatable_eq(
   // Add the @_implements(Equatable, ==(_:_:)) attribute
   if (generatedIdentifier != C.Id_EqualsOperator) {
     auto equatableProto = C.getProtocol(KnownProtocolKind::Equatable);
-    auto equatableTy = equatableProto->getDeclaredType();
+    auto equatableTy = equatableProto->getDeclaredInterfaceType();
     auto equatableTyExpr = TypeExpr::createImplicit(equatableTy, C);
     SmallVector<Identifier, 2> argumentLabels = { Identifier(), Identifier() };
     auto equalsDeclName = DeclName(C, DeclBaseName(C.Id_EqualsOperator),
@@ -533,7 +533,7 @@ deriveHashable_hashInto(
     hashableProto->diagnose(diag::broken_hashable_no_hasher);
     return nullptr;
   }
-  Type hasherType = hasherDecl->getDeclaredType();
+  Type hasherType = hasherDecl->getDeclaredInterfaceType();
 
   // Params: self (implicit), hasher
   auto *hasherParamDecl = new (C) ParamDecl(SourceLoc(),
@@ -865,7 +865,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   ASTContext &C = derived.Context;
 
   auto parentDC = derived.getConformanceContext();
-  Type intType = C.getIntDecl()->getDeclaredType();
+  Type intType = C.getIntDecl()->getDeclaredInterfaceType();
 
   // We can't form a Hashable conformance if Int isn't Hashable or
   // ExpressibleByIntegerLiteral.
@@ -1005,7 +1005,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
                                 hashableProto)) {
         ConformanceDecl->diagnose(diag::type_does_not_conform,
                                   Nominal->getDeclaredType(),
-                                  hashableProto->getDeclaredType());
+                                  hashableProto->getDeclaredInterfaceType());
         // Ideally, this would be diagnosed in
         // ConformanceChecker::resolveWitnessViaLookup. That doesn't work for
         // Hashable because DerivedConformance::canDeriveHashable returns true

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -91,7 +91,7 @@ deriveBridgedNSError_enum_nsErrorDomain(
   //   }
   // }
 
-  auto stringTy = derived.Context.getStringDecl()->getDeclaredType();
+  auto stringTy = derived.Context.getStringDecl()->getDeclaredInterfaceType();
 
   // Define the property.
   VarDecl *propDecl;

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -50,7 +50,7 @@ void DerivedConformance::addMembersToConformanceContext(
 }
 
 Type DerivedConformance::getProtocolType() const {
-  return Protocol->getDeclaredType();
+  return Protocol->getDeclaredInterfaceType();
 }
 
 bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
@@ -216,7 +216,8 @@ void DerivedConformance::diagnoseAnyNonConformingMemberTypes(
       ctx.Diags.diagnose(
           reprLoc, diag::missing_member_type_conformance_prevents_synthesis,
           NonconformingMemberKind::AssociatedValue,
-          typeToDiagnose->getInterfaceType(), protocol->getDeclaredType(),
+          typeToDiagnose->getInterfaceType(),
+          protocol->getDeclaredInterfaceType(),
           nominal->getDeclaredInterfaceType());
     }
   }
@@ -229,7 +230,8 @@ void DerivedConformance::diagnoseAnyNonConformingMemberTypes(
           propertyToDiagnose->getLoc(),
           diag::missing_member_type_conformance_prevents_synthesis,
           NonconformingMemberKind::StoredProperty,
-          propertyToDiagnose->getInterfaceType(), protocol->getDeclaredType(),
+          propertyToDiagnose->getInterfaceType(),
+          protocol->getDeclaredInterfaceType(),
           nominal->getDeclaredInterfaceType());
     }
   }
@@ -581,7 +583,7 @@ GuardStmt *DerivedConformance::returnComparisonIfNotEqualGuard(ASTContext &C,
 
 /// Build a type-checked integer literal.
 static IntegerLiteralExpr *buildIntegerLiteral(ASTContext &C, unsigned index) {
-  Type intType = C.getIntDecl()->getDeclaredType();
+  Type intType = C.getIntDecl()->getDeclaredInterfaceType();
 
   auto literal = IntegerLiteralExpr::createFromUnsigned(C, index);
   literal->setType(intType);
@@ -606,7 +608,7 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
                                        const char *indexName) {
   ASTContext &C = enumDecl->getASTContext();
   Type enumType = enumVarDecl->getType();
-  Type intType = C.getIntDecl()->getDeclaredType();
+  Type intType = C.getIntDecl()->getDeclaredInterfaceType();
 
   auto indexVar = new (C) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Var,
                                   /*IsCaptureList*/false, SourceLoc(),

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1733,7 +1733,7 @@ bool TypeChecker::getDefaultGenericArgumentsString(
       }
 
       for (auto proto : archetypeTy->getConformsTo()) {
-        members.push_back(proto->getDeclaredType());
+        members.push_back(proto->getDeclaredInterfaceType());
         if (proto->requiresClass())
           hasExplicitAnyObject = false;
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2654,7 +2654,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
   auto &ctx = protocol->getASTContext();
   auto &diags = ctx.Diags;
   DeclContext *dc = protocol->getDeclContext();
-  Type protocolType = protocol->getDeclaredType();
+  Type protocolType = protocol->getDeclaredInterfaceType();
 
   // Get the NominalTypeDecl for the type eraser.
   Type typeEraser = attr->getResolvedType(protocol);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2353,7 +2353,7 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
     return true;
 
   auto resultTy = TypeChecker::typeCheckExpression(
-      expr, dc, boolDecl->getDeclaredType(),
+      expr, dc, boolDecl->getDeclaredInterfaceType(),
       CTP_Condition);
   return !resultTy;
 }
@@ -2552,7 +2552,7 @@ static Type replaceArchetypesWithTypeVariables(ConstraintSystem &cs,
         }
         for (auto proto : archetypeType->getConformsTo()) {
           cs.addConstraint(ConstraintKind::ConformsTo, replacement,
-                           proto->getDeclaredType(), locator);
+                           proto->getDeclaredInterfaceType(), locator);
         }
         types[origType] = replacement;
         return replacement;
@@ -3918,7 +3918,7 @@ static bool checkForDynamicAttribute(CanType ty,
   // (superclass or protocols) have the attribute.
   if (auto archetype = dyn_cast<ArchetypeType>(ty)) {
     for (auto proto : archetype->getConformsTo()) {
-      if (hasAttribute(proto->getDeclaredType()))
+      if (hasAttribute(proto->getDeclaredInterfaceType()))
         return true;
     }
     if (auto superclass = archetype->getSuperclass()) {
@@ -3949,7 +3949,7 @@ static bool checkForDynamicAttribute(CanType ty,
 
   // Check the protocols the type conforms to.
   for (auto proto : nominal->getAllProtocols()) {
-    if (hasAttribute(proto->getDeclaredType()))
+    if (hasAttribute(proto->getDeclaredInterfaceType()))
       return true;
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -179,7 +179,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
 
       if (!PD->isObjC()) {
         diags.diagnose(TypeRange.Start, diag::not_objc_protocol,
-                       PD->getDeclaredType());
+                       PD->getDeclaredInterfaceType());
         return;
       }
     }
@@ -672,7 +672,7 @@ bool swift::isRepresentableInObjC(
         return false;
       }
 
-      errorResultType = boolDecl->getDeclaredType()->getCanonicalType();
+      errorResultType = boolDecl->getDeclaredInterfaceType()->getCanonicalType();
     } else if (!resultType->getOptionalObjectType() &&
                isValidObjectiveCErrorResultType(dc, resultType)) {
       // Functions that return a (non-optional) type bridged to Objective-C
@@ -1345,8 +1345,8 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
       for (auto inherited : proto->getInheritedProtocols()) {
         if (!inherited->isObjC()) {
           proto->diagnose(diag::objc_protocol_inherits_non_objc_protocol,
-                          proto->getDeclaredType(),
-                          inherited->getDeclaredType());
+                          proto->getDeclaredInterfaceType(),
+                          inherited->getDeclaredInterfaceType());
           inherited->diagnose(diag::kind_declname_declared_here,
                               DescriptiveDeclKind::Protocol,
                               inherited->getName());

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -585,7 +585,8 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
   if (auto PD = dyn_cast<ProtocolDecl>(GC)) {
     auto self = PD->getSelfInterfaceType()->castTo<GenericTypeParamType>();
     auto req =
-        Requirement(RequirementKind::Conformance, self, PD->getDeclaredType());
+        Requirement(RequirementKind::Conformance, self,
+                    PD->getDeclaredInterfaceType());
     auto sig = GenericSignature::get({self}, {req});
 
     // Debugging of the generic signature builder and generic signature

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1698,7 +1698,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
                        diag::default_associated_type_req_fail,
                        failedDefaultedWitness,
                        failedDefaultedAssocType->getName(),
-                       proto->getDeclaredType(),
+                       proto->getDeclaredInterfaceType(),
                        failedDefaultedResult.getRequirement(),
                        failedDefaultedResult.isConformanceRequirement());
       });

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -600,7 +600,7 @@ public:
     // Coerce the operand to the exception type.
     auto E = TS->getSubExpr();
 
-    Type exnType = getASTContext().getErrorDecl()->getDeclaredType();
+    Type exnType = getASTContext().getErrorDecl()->getDeclaredInterfaceType();
     if (!exnType) return TS;
 
     TypeChecker::typeCheckExpression(E, DC, exnType,

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1518,7 +1518,7 @@ SwiftDeclCollector::constructTypeNode(Type T, TypeInitInfo Info) {
     Root->addChild(constructTypeNode(MTT->getInstanceType()));
   } else if (auto ATT = T->getAs<ArchetypeType>()) {
     for (auto Pro : ATT->getConformsTo()) {
-      Root->addChild(constructTypeNode(Pro->getDeclaredType()));
+      Root->addChild(constructTypeNode(Pro->getDeclaredInterfaceType()));
     }
   }
   return Root;

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -773,7 +773,7 @@ public:
     std::vector<sma::TypeName> Result;
     Result.reserve(AllProtocols.size());
     for (const auto *PD : AllProtocols) {
-      Result.emplace_back(convertToTypeName(PD->getDeclaredType()));
+      Result.emplace_back(convertToTypeName(PD->getDeclaredInterfaceType()));
     }
     return Result;
   }


### PR DESCRIPTION
Our eventual goal is to completely remove UnboundGenericType. One of the places where we return an UnboundGenericType is from getDeclaredType().

This PR begins the preparations for removing getDeclaredType() by replacing calls with getDeclaredInterfaceType() when the declaration is known to be non-generic, in which case it returns the same thing.