### PR TITLE
[Python3] Find the matching Python interpreter for LLDB in its build dir

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -104,13 +104,11 @@ def get_lldb_python_path(lldb_build_root):
         return None
     return subprocess.check_output([lldb_path, "-P"]).rstrip().decode('utf-8')
 
-def get_lldb_python_from_path(lldb_path):
-    (head, tail) = os.path.split(lldb_path)
-    if tail and re.match('^python[23][.0-9]*$', tail):
-        return tail
-    if head and head != lldb_path:
-        return get_lldb_python_from_path(head)
-    return None
+def get_lldb_python_interpreter(lldb_build_root):
+    python_path = os.path.join(lldb_build_root, 'bin', 'lldb-python')
+    if not os.access(python_path, os.F_OK):
+        return None
+    return python_path
 
 ###
 
@@ -1959,20 +1957,19 @@ config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libd
 
 if config.lldb_build_root != "":
     lldb_python_path = get_lldb_python_path(config.lldb_build_root)
+    lldb_python_interpreter = get_lldb_python_interpreter(config.lldb_build_root)
     if lldb_python_path == None:
         lit_config.warning("""
         Specified lldb_build_root, but could not find lldb in that build root
         """)
+    elif lldb_python_interpreter == None:
+        lit_config.warning("""
+        Specified lldb_build_root, but could not find lldb-python in that build root
+        """)
     else:
-        lldb_python = get_lldb_python_from_path(lldb_python_path)
-        if lldb_python == None:
-            lit_config.warning("""
-            Unable to determine python version from LLDB Python path %s
-            """ % lldb_python_path)
-        else:
-            config.available_features.add('lldb')
-            config.substitutions.append(('%lldb-python-path', lldb_python_path))
-            config.substitutions.append(('%{lldb-python}', 'PYTHONPATH=%s %s' % (lldb_python_path, lldb_python)))
+        config.available_features.add('lldb')
+        config.substitutions.append(('%lldb-python-path', lldb_python_path))
+        config.substitutions.append(('%{lldb-python}', 'PYTHONPATH=%s %s' % (lldb_python_path, lldb_python_interpreter)))
 
 # Disable randomized hash seeding by default. Tests need to manually opt in to
 # random seeds by unsetting the SWIFT_DETERMINISTIC_HASHING environment


### PR DESCRIPTION
Instead of trying to guess which Python interperter matches the Python
that LLDB was build against, rely on the interpreter being present in
the build directory for testing. This way the two will always be in
sync.