### PR TITLE
[sourcekitd] Fix potential race in semantic highlighting tests

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -109,7 +109,7 @@ public:
   void parse(ImmutableTextSnapshotRef Snapshot, SwiftLangSupport &Lang,
              bool BuildSyntaxTree,
              swift::SyntaxParsingCache *SyntaxCache = nullptr);
-  void readSyntaxInfo(EditorConsumer &consumer);
+  void readSyntaxInfo(EditorConsumer &consumer, bool ReportDiags);
   void readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
                         EditorConsumer& Consumer);
 

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -388,13 +388,9 @@ TEST_F(EditTest, AnnotationsAfterOpen) {
   TestConsumer Consumer;
   open(DocName, Contents, Args, Consumer);
   ASSERT_FALSE(waitForDocUpdate()) << "timed out";
-  if (Consumer.DiagStage == SemaDiagStage) {
-    // AST already built, annotations are on Consumer.
-  } else {
-    // Re-query.
-    reset(Consumer);
-    replaceText(DocName, 0, 0, "", Consumer);
-  }
+  ASSERT_EQ(ParseDiagStage, Consumer.DiagStage);
+  reset(Consumer);
+  replaceText(DocName, 0, 0, "", Consumer);
 
   ASSERT_EQ(0u, Consumer.Diags.size());
   checkTokens(Consumer.Annotations, {
@@ -424,13 +420,9 @@ TEST_F(EditTest, AnnotationsAfterEdit) {
   TestConsumer Consumer;
   open(DocName, Contents, Args, Consumer);
   ASSERT_FALSE(waitForDocUpdate()) << "timed out";
-  if (Consumer.DiagStage == SemaDiagStage) {
-    // AST already built, annotations are on Consumer.
-  } else {
-    // Re-query.
-    reset(Consumer);
-    replaceText(DocName, 0, 0, "", Consumer);
-  }
+  ASSERT_EQ(ParseDiagStage, Consumer.DiagStage);
+  reset(Consumer);
+  replaceText(DocName, 0, 0, "", Consumer);
   checkTokens(Consumer.Annotations, {
     "[off=22 len=3 source.lang.swift.ref.struct system]",
   });


### PR DESCRIPTION
In order to make range-shifting for semantic highlighting testable,
disable returning semantic information during an "open" request. This
has no real value anyway, since it only happens very rarely, and it
makes testing range shifting impossible to do deterministically.

rdar://problem/66386179