### PR TITLE
[Property Wrappers] Don't inject the wrapped value placeholder in CSApply if the apply expression is a nullptr

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1666,7 +1666,7 @@ public:
       return false;
 
     auto *wrappedVar = expression.propertyWrapper.wrappedVar;
-    if (!wrappedVar || wrappedVar->isStatic())
+    if (!apply || !wrappedVar || wrappedVar->isStatic())
       return false;
 
     return expression.propertyWrapper.innermostWrappedValueInit == apply;

--- a/test/Sema/property_wrappers.swift
+++ b/test/Sema/property_wrappers.swift
@@ -5,7 +5,7 @@ struct Transaction {
 }
 
 @propertyWrapper
-struct Wrapper<Value> {
+struct WrapperWithClosureArg<Value> {
   var wrappedValue: Value
 
   init(wrappedValue: Value,
@@ -21,9 +21,26 @@ struct R_59685601 {
   // CHECK-NEXT: property_wrapper_value_placeholder_expr implicit type='String'
   // CHECK-NEXT: opaque_value_expr implicit type='String'
   // CHECK-NEXT: string_literal_expr type='String'
-  @Wrapper(reset: { value, transaction in
+  @WrapperWithClosureArg(reset: { value, transaction in
     transaction.state = 10
   })
   private var value = "hello"
 }
 
+@propertyWrapper
+struct Wrapper<Value> {
+  var wrappedValue: Value
+}
+
+// CHECK-LABEL: struct_decl{{.*}}TestInitSubscript
+struct TestInitSubscript {
+  enum Color: CaseIterable { case pink }
+
+  // CHECK: tuple_expr type='(wrappedValue: TestInitSubscript.Color)'
+  // CHECK: subscript_expr type='TestInitSubscript.Color'
+  // CHECK: paren_expr type='(Int)'
+  // CHECK-NOT: property_wrapper_value_placeholder_expr implicit type='Int'
+  // CHECK: integer_literal_expr type='Int'
+  @Wrapper(wrappedValue: Color.allCases[0])
+  var color: Color
+}


### PR DESCRIPTION
The can happen for subscript calls because `coerceCallArguments` is called with a nullptr for the `ApplyExpr`. 

This caused CSApply to inject the wrapped value placeholder around subscript arguments for subscript calls inside the wrapper attribute when no wrapped value is specified via `=`.

Resolves: rdar://problem/66045798