### PR TITLE
[Tests] Mark two test cases 'UNSUPPORTED: use_os_stdlib'

### DIFF
--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -3,6 +3,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 import Swift
 import StdlibUnittest

--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -15,6 +15,7 @@
 // -----------------------------------------------------------------------------
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency)
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 import StdlibUnittest
 #if _runtime(_ObjC)


### PR DESCRIPTION
test/Runtime/demangleToMetadata.swift
test/stdlib/Casts.swift

rdar://problem/66394834
rdar://problem/66394791