### PR TITLE
[TypeChecker] Diagnose empty `switch` statements in function builder …

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -699,6 +699,18 @@ protected:
     if (!cs)
       return nullptr;
 
+    // If there are no 'case' statements in the body let's try
+    // to diagnose this situation via limited exhaustiveness check
+    // before failing a builder transform, otherwise type-checker
+    // might end up without any diagnostics which leads to crashes
+    // in SILGen.
+    if (capturedCaseVars.empty()) {
+      TypeChecker::checkSwitchExhaustiveness(switchStmt, dc,
+                                             /*limitChecking=*/true);
+      hadError = true;
+      return nullptr;
+    }
+
     // Form the expressions that inject the result of each case into the
     // appropriate
     llvm::TinyPtrVector<Expr *> injectedCaseExprs;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -759,6 +759,18 @@ protected:
   }
 
   VarDecl *visitCaseStmt(CaseStmt *caseStmt, Expr *subjectExpr) {
+    auto *body = caseStmt->getBody();
+
+    // Explicitly disallow `case` statements with empty bodies
+    // since that helps to diagnose other issues with switch
+    // statements by excluding invalid cases.
+    if (auto *BS = dyn_cast<BraceStmt>(body)) {
+      if (BS->getNumElements() == 0) {
+        hadError = true;
+        return nullptr;
+      }
+    }
+
     // If needed, generate constraints for everything in the case statement.
     if (cs) {
       auto locator = cs->getConstraintLocator(

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -584,4 +584,9 @@ struct MyView {
     // expected-note@-1 {{opaque return type declared here}}
     DoesNotConform()
   }
+
+  @TupleBuilder var emptySwitch: some P {
+    switch Optional.some(1) { // expected-error {{'switch' statement body must have at least one 'case' or 'default' block; do you want to add a default case?}}
+    }
+  }
 }

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -589,4 +589,17 @@ struct MyView {
     switch Optional.some(1) { // expected-error {{'switch' statement body must have at least one 'case' or 'default' block; do you want to add a default case?}}
     }
   }
+
+  @TupleBuilder var invalidSwitchOne: some P {
+    switch Optional.some(1) {
+    case . // expected-error {{expected ':' after 'case'}}
+    } // expected-error {{expected identifier after '.' expression}}
+  }
+
+  @TupleBuilder var invalidSwitchMultiple: some P {
+    switch Optional.some(1) {
+    case .none: // expected-error {{'case' label in a 'switch' should have at least one executable statement}}
+    case . // expected-error {{expected ':' after 'case'}}
+    } // expected-error {{expected identifier after '.' expression}}
+  }
 }


### PR DESCRIPTION
…bodies

If there are no 'case' statements in the body let's try
to diagnose this situation via limited exhaustiveness check
before failing a builder transform, otherwise type-checker
might end up without any diagnostics which leads to crashes
in SILGen.

Resolves: rdar://problem/65983237

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
