### PR TITLE
test: restore Windows compatibility

### DIFF
--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import argparse
 import io
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -25,7 +26,7 @@ def run_command(cmd):
     if sys.version_info[0] < 3:
         cmd = list(map(lambda s: s.encode('utf-8'), cmd))
     print(' '.join([escapeCmdArg(arg) for arg in cmd]))
-    if sys.version_info[0] < 3:
+    if sys.version_info[0] < 3 or platform.system() == 'Windows':
         return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     else:
         return subprocess.check_output(list(map(lambda s: s.encode('utf-8'), cmd)),


### PR DESCRIPTION
The subprocess handling on Windows requires bytes-like objects rather
than strings.  Ensure that we don't convert on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
