### PR TITLE
test: convert the output to string

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -72,7 +72,7 @@ def darwin_get_sw_vers(commandPrefix=[]):
 
 def darwin_get_ios_sim_vers():
     sim_output = subprocess.check_output(['xcrun', 'simctl', 'list', 'runtimes'])
-    ios_version_str = re.findall(r'iOS \d+\.*\d*',sim_output)
+    ios_version_str = re.findall(r'iOS \d+\.*\d*', sim_output.encode('utf-8'))
     return [float(v.strip('iOS')) for v in ios_version_str]
 
 # Returns the "prefix" command that should be prepended to the command line to


### PR DESCRIPTION
With Python 3, the regular expression match will fail due to a mismatch
in types:

```
TypeError: cannot use a string pattern on a bytes-like object
```

Convert the output to a string object.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
