### PR TITLE
[AST] NFC: Formalize two patterns into TypeNodes.def

### DIFF
--- a/include/swift/AST/CanTypeVisitor.h
+++ b/include/swift/AST/CanTypeVisitor.h
@@ -61,11 +61,11 @@ public:
 #define TYPE(CLASS, PARENT) ABSTRACT_TYPE(CLASS, PARENT)
 #define ABSTRACT_SUGARED_TYPE(CLASS, PARENT)
 #define SUGARED_TYPE(CLASS, PARENT)
-  // Don't allow unchecked types by default, but allow visitors to opt-in to
+  // Don't allow invalid types by default, but allow visitors to opt-in to
   // handling them.
-#define UNCHECKED_TYPE(CLASS, PARENT)                          \
+#define INVALID_TYPE(CLASS, PARENT)                            \
   RetTy visit##CLASS##Type(Can##CLASS##Type T, Args... args) { \
-     llvm_unreachable("unchecked type");                       \
+     llvm_unreachable("invalid type");                         \
   }
 #include "swift/AST/TypeNodes.def"
 };

--- a/include/swift/AST/TypeDifferenceVisitor.h
+++ b/include/swift/AST/TypeDifferenceVisitor.h
@@ -39,13 +39,13 @@ public:
 #define TYPE(CLASS, PARENT) ABSTRACT_TYPE(CLASS, PARENT)
 #define ABSTRACT_SUGARED_TYPE(CLASS, PARENT)
 #define SUGARED_TYPE(CLASS, PARENT)
-  // Don't allow unchecked types by default, but allow visitors to opt-in to
+  // Don't allow invalid types by default, but allow visitors to opt-in to
   // handling them.
-#define UNCHECKED_TYPE(CLASS, PARENT)                          \
+#define INVALID_TYPE(CLASS, PARENT)                            \
   RetTy visit##CLASS##Type(Can##CLASS##Type type1,             \
                            Can##CLASS##Type type2,             \
                            Args... args) {                     \
-     llvm_unreachable("unchecked type");                       \
+     llvm_unreachable("invalid type");                         \
   }
 #include "swift/AST/TypeNodes.def"
 };

--- a/include/swift/AST/TypeNodes.def
+++ b/include/swift/AST/TypeNodes.def
@@ -35,7 +35,7 @@
 //
 // If you add a new sugared type, be sure to test it in PrintAsObjC!
 
-/// UNCHECKED_TYPE(id, parent)
+/// INVALID_TYPE(id, parent)
 ///   This type is not present in valid, type-checked programs.
 ///   The default behavior is TYPE(id, parent).
 
@@ -47,6 +47,10 @@
 ///   programs and it cannot be the type of an expression.
 ///   The default behavior is TYPE(id, parent).
 
+/// NON_SIL_TYPE(id, parent)
+///   This type is not part of the type system after SIL type lowering.
+///   The default behavior is TYPE(id, parent).
+
 #ifndef ALWAYS_CANONICAL_TYPE
 #define ALWAYS_CANONICAL_TYPE(id, parent) TYPE(id, parent)
 #endif
@@ -55,12 +59,16 @@
 #define BUILTIN_TYPE(id, parent) ALWAYS_CANONICAL_TYPE(id, parent)
 #endif
 
+#ifndef NON_SIL_TYPE
+#define NON_SIL_TYPE(id, parent) TYPE(id, parent)
+#endif
+
 #ifndef SUGARED_TYPE
 #define SUGARED_TYPE(id, parent) TYPE(id, parent)
 #endif
 
-#ifndef UNCHECKED_TYPE
-#define UNCHECKED_TYPE(id, parent) TYPE(id, parent)
+#ifndef INVALID_TYPE
+#define INVALID_TYPE(id, parent) NON_SIL_TYPE(id, parent)
 #endif
 
 #ifndef ARTIFICIAL_TYPE
@@ -71,6 +79,10 @@
 /// is to ignore them.
 #ifndef ABSTRACT_TYPE
 #define ABSTRACT_TYPE(Id, Parent)
+#endif
+
+#ifndef NON_SIL_ABSTRACT_TYPE
+#define NON_SIL_ABSTRACT_TYPE(Id, Parent) ABSTRACT_TYPE(Id, Parent)
 #endif
 
 #ifndef ABSTRACT_SUGARED_TYPE
@@ -87,8 +99,8 @@
 #define LAST_TYPE(Id)
 #endif
 
-TYPE(Error, Type)
-UNCHECKED_TYPE(Unresolved, Type)
+INVALID_TYPE(Error, Type)
+INVALID_TYPE(Unresolved, Type)
 ABSTRACT_TYPE(Builtin, Type)
   ABSTRACT_TYPE(AnyBuiltinInteger, BuiltinType)
     BUILTIN_TYPE(BuiltinInteger, AnyBuiltinIntegerType)
@@ -122,13 +134,13 @@ ABSTRACT_TYPE(AnyGeneric, Type)
       TYPE(BoundGenericStruct, BoundGenericType)
       TYPE_RANGE(BoundGeneric, BoundGenericClass, BoundGenericStruct)
     TYPE_RANGE(NominalOrBoundGenericNominal, Enum, BoundGenericStruct)
-  UNCHECKED_TYPE(UnboundGeneric, Type)
+  INVALID_TYPE(UnboundGeneric, Type)
   TYPE_RANGE(AnyGeneric, Enum, UnboundGeneric)
 ABSTRACT_TYPE(AnyMetatype, Type)
   TYPE(Metatype, AnyMetatypeType)
   TYPE(ExistentialMetatype, AnyMetatypeType)
 ALWAYS_CANONICAL_TYPE(Module, Type)
-TYPE(DynamicSelf, Type)
+NON_SIL_TYPE(DynamicSelf, Type)
 ABSTRACT_TYPE(Substitutable, Type)
   ABSTRACT_TYPE(Archetype, SubstitutableType)
     ALWAYS_CANONICAL_TYPE(PrimaryArchetype, ArchetypeType)
@@ -139,18 +151,18 @@ ABSTRACT_TYPE(Substitutable, Type)
   TYPE(GenericTypeParam, SubstitutableType)
   TYPE_RANGE(Substitutable, PrimaryArchetype, GenericTypeParam)
 TYPE(DependentMember, Type)
-ABSTRACT_TYPE(AnyFunction, Type)
-  TYPE(Function, AnyFunctionType)
-  TYPE(GenericFunction, AnyFunctionType)
+NON_SIL_ABSTRACT_TYPE(AnyFunction, Type)
+  NON_SIL_TYPE(Function, AnyFunctionType)
+  NON_SIL_TYPE(GenericFunction, AnyFunctionType)
   TYPE_RANGE(AnyFunction, Function, GenericFunction)
 ARTIFICIAL_TYPE(SILFunction, Type)
 ARTIFICIAL_TYPE(SILBlockStorage, Type)
 ARTIFICIAL_TYPE(SILBox, Type)
 ARTIFICIAL_TYPE(SILToken, Type)
 TYPE(ProtocolComposition, Type)
-TYPE(LValue, Type)
-TYPE(InOut, Type)
-UNCHECKED_TYPE(TypeVariable, Type)
+NON_SIL_TYPE(LValue, Type)
+NON_SIL_TYPE(InOut, Type)
+INVALID_TYPE(TypeVariable, Type)
 ABSTRACT_SUGARED_TYPE(Sugar, Type)
   SUGARED_TYPE(Paren, SugarType)
   SUGARED_TYPE(TypeAlias, SugarType)
@@ -166,9 +178,11 @@ LAST_TYPE(Dictionary) // Sugared types are last to make isa<SugarType>() fast.
 
 #undef TYPE_RANGE
 #undef ABSTRACT_SUGARED_TYPE
+#undef NON_SIL_ABSTRACT_TYPE
 #undef ABSTRACT_TYPE
-#undef UNCHECKED_TYPE
+#undef INVALID_TYPE
 #undef ARTIFICIAL_TYPE
+#undef NON_SIL_TYPE
 #undef SUGARED_TYPE
 #undef BUILTIN_TYPE
 #undef ALWAYS_CANONICAL_TYPE

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -616,22 +616,13 @@ public:
 
 // Statically prevent SILTypes from being directly cast to a type
 // that's not legal as a SIL value.
-#define NON_SIL_TYPE(ID)                                             \
-template<> Can##ID##Type SILType::getAs<ID##Type>() const = delete;  \
-template<> Can##ID##Type SILType::castTo<ID##Type>() const = delete; \
-template<> bool SILType::is<ID##Type>() const = delete;
-NON_SIL_TYPE(Function)
-NON_SIL_TYPE(GenericFunction)
-NON_SIL_TYPE(AnyFunction)
-NON_SIL_TYPE(LValue)
-NON_SIL_TYPE(InOut)
-#undef NON_SIL_TYPE
-
 #define TYPE(ID, PARENT)
-#define UNCHECKED_TYPE(ID, PARENT)                                   \
+#define INVALID_TYPE(ID, PARENT)                                     \
 template<> Can##ID##Type SILType::getAs<ID##Type>() const = delete;  \
 template<> Can##ID##Type SILType::castTo<ID##Type>() const = delete; \
 template<> bool SILType::is<ID##Type>() const = delete;
+#define NON_SIL_TYPE(ID, PARENT) INVALID_TYPE(ID, PARENT)
+#define NON_SIL_ABSTRACT_TYPE(ID, PARENT) INVALID_TYPE(ID, PARENT)
 #include "swift/AST/TypeNodes.def"
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILType T) {

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -39,11 +39,10 @@ static bool isLeafTypeMetadata(CanType type) {
   switch (type->getKind()) {
 #define SUGARED_TYPE(ID, SUPER) \
   case TypeKind::ID:
-#define UNCHECKED_TYPE(ID, SUPER) \
+#define INVALID_TYPE(ID, SUPER) \
   case TypeKind::ID:
 #define TYPE(ID, SUPER)
 #include "swift/AST/TypeNodes.def"
-  case TypeKind::Error:
     llvm_unreachable("kind is invalid for a canonical type");
 
 #define ARTIFICIAL_TYPE(ID, SUPER) \

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1888,13 +1888,7 @@ const TypeInfo *TypeConverter::convertType(CanType ty) {
   PrettyStackTraceType stackTrace(IGM.Context, "converting", ty);
 
   switch (ty->getKind()) {
-  case TypeKind::Error: {
-    // We might see error types if type checking has failed.
-    // Try to do something graceful and return an zero sized type.
-    auto &ctx = ty->getASTContext();
-    return convertTupleType(cast<TupleType>(ctx.TheEmptyTupleType));
-  }
-#define UNCHECKED_TYPE(id, parent) \
+#define INVALID_TYPE(id, parent) \
   case TypeKind::id: \
     llvm_unreachable("found a " #id "Type in IR-gen");
 #define SUGARED_TYPE(id, parent) \

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6838,11 +6838,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
 #define SUGARED_TYPE(Name, Parent) case TypeKind::Name:
 #define BUILTIN_TYPE(Name, Parent) case TypeKind::Name:
-#define UNCHECKED_TYPE(Name, Parent) case TypeKind::Name:
+#define INVALID_TYPE(Name, Parent) case TypeKind::Name:
 #define ARTIFICIAL_TYPE(Name, Parent) case TypeKind::Name:
 #define TYPE(Name, Parent)
 #include "swift/AST/TypeNodes.def"
-  case TypeKind::Error:
   case TypeKind::InOut:
   case TypeKind::Module:
   case TypeKind::Enum:
@@ -6887,11 +6886,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
 #define SUGARED_TYPE(Name, Parent) case TypeKind::Name:
 #define BUILTIN_TYPE(Name, Parent) case TypeKind::Name:
-#define UNCHECKED_TYPE(Name, Parent) case TypeKind::Name:
+#define INVALID_TYPE(Name, Parent) case TypeKind::Name:
 #define ARTIFICIAL_TYPE(Name, Parent) case TypeKind::Name:
 #define TYPE(Name, Parent)
 #include "swift/AST/TypeNodes.def"
-  case TypeKind::Error:
   case TypeKind::Module:
   case TypeKind::Tuple:
   case TypeKind::Enum:


### PR DESCRIPTION
1) Formalize non-SIL types
2) Rename UNCHECKED_TYPE to INVALID_TYPE
3) Mark ErrorType as being an INVALID_TYPE