### PR TITLE
[NFC] [cxx-interop] Rename IsCxxNotTriviallyCopyable -> IsCxxNonTrivial.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -554,14 +554,14 @@ protected:
     IsIncompatibleWithWeakReferences : 1
   );
 
-  SWIFT_INLINE_BITFIELD(StructDecl, NominalTypeDecl, 1+1,
-    /// True if this struct has storage for fields that aren't accessible in
-    /// Swift.
-    HasUnreferenceableStorage : 1,
-    /// True if this struct is imported from C++ and not trivially copyable.
-    IsCxxNotTriviallyCopyable : 1
-  );
-  
+  SWIFT_INLINE_BITFIELD(
+      StructDecl, NominalTypeDecl, 1 + 1,
+      /// True if this struct has storage for fields that aren't accessible in
+      /// Swift.
+      HasUnreferenceableStorage : 1,
+      /// True if this struct is imported from C++ and does not have trivial value witness functions.
+      IsCxxNonTrivial : 1);
+
   SWIFT_INLINE_BITFIELD(EnumDecl, NominalTypeDecl, 2+1,
     /// True if the enum has cases and at least one case has associated values.
     HasAssociatedValues : 2,
@@ -3789,13 +3789,9 @@ public:
     Bits.StructDecl.HasUnreferenceableStorage = v;
   }
 
-  bool isCxxNotTriviallyCopyable() const {
-    return Bits.StructDecl.IsCxxNotTriviallyCopyable;
-  }
+  bool isCxxNonTrivial() const { return Bits.StructDecl.IsCxxNonTrivial; }
 
-  void setIsCxxNotTriviallyCopyable(bool v) {
-    Bits.StructDecl.IsCxxNotTriviallyCopyable = v;
-  }
+  void setIsCxxNonTrivial(bool v) { Bits.StructDecl.IsCxxNonTrivial = v; }
 };
 
 /// This is the base type for AncestryOptions. Each flag describes possible

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4132,7 +4132,7 @@ StructDecl::StructDecl(SourceLoc StructLoc, Identifier Name, SourceLoc NameLoc,
     StructLoc(StructLoc)
 {
   Bits.StructDecl.HasUnreferenceableStorage = false;
-  Bits.StructDecl.IsCxxNotTriviallyCopyable = false;
+  Bits.StructDecl.IsCxxNonTrivial = false;
 }
 
 bool NominalTypeDecl::hasMemberwiseInitializer() const {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3454,20 +3454,19 @@ namespace {
       result->setHasUnreferenceableStorage(hasUnreferenceableStorage);
 
       if (auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(decl)) {
-        result->setIsCxxNotTriviallyCopyable(
-            !cxxRecordDecl->isTriviallyCopyable());
+        result->setIsCxxNonTrivial(!cxxRecordDecl->isTriviallyCopyable());
 
         for (auto ctor : cxxRecordDecl->ctors()) {
           if (ctor->isCopyConstructor() &&
               (ctor->isDeleted() || ctor->getAccess() != clang::AS_public)) {
-            result->setIsCxxNotTriviallyCopyable(true);
+            result->setIsCxxNonTrivial(true);
             break;
           }
         }
 
         if (auto dtor = cxxRecordDecl->getDestructor()) {
           if (dtor->isDeleted() || dtor->getAccess() != clang::AS_public) {
-            result->setIsCxxNotTriviallyCopyable(true);
+            result->setIsCxxNonTrivial(true);
           }
         }
       }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1452,7 +1452,7 @@ namespace {
       if (handleResilience(structType, D, properties))
         return handleAddressOnly(structType, properties);
 
-      if (D->isCxxNotTriviallyCopyable()) {
+      if (D->isCxxNonTrivial()) {
         properties.setAddressOnly();
         properties.setNonTrivial();
       }


### PR DESCRIPTION
`IsCxxNonTrivial` is set for a variety of reasons, for example, it's set when the struct contains a bitfield, has a custom destructor, or has a custom copy constructor. The name `IsCxxNotTriviallyCopyable` only implies the latter.