### PR TITLE
Windows: add DWMAPI to modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -156,6 +156,13 @@ module WinSDK [system] {
     link "DbgHelp.Lib"
   }
 
+  module DWM {
+    header "dwmapi.h"
+    export *
+
+    link "dwmapi.lib"
+  }
+
   module FCI {
     header "fci.h"
     export *


### PR DESCRIPTION
Add an entry for the DWM API to the WinSDK headers.  Without this the
DWM APIs are not available.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
