### PR TITLE
[Serialization] Force destructor creation for imported class for SIB deserialization

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1611,6 +1611,14 @@ giveUpFastPath:
                                            getXRefDeclNameForError());
       }
 
+      if (memberName.getKind() == DeclBaseName::Kind::Destructor) {
+        assert(isa<ClassDecl>(nominal));
+        // Force creation of an implicit destructor
+        auto CD = dyn_cast<ClassDecl>(nominal);
+        values.push_back(CD->getDestructor());
+        break;
+      }
+
       if (!privateDiscriminator.empty()) {
         ModuleDecl *searchModule = M;
         if (!searchModule)

--- a/test/Serialization/Inputs/objc-xref/module.modulemap
+++ b/test/Serialization/Inputs/objc-xref/module.modulemap
@@ -1,0 +1,4 @@
+module ObjCXRef {
+  header "objc_xref.h"
+  export *
+}

--- a/test/Serialization/Inputs/objc-xref/objc_xref.h
+++ b/test/Serialization/Inputs/objc-xref/objc_xref.h
@@ -1,0 +1,2 @@
+@interface MyObject
+@end

--- a/test/Serialization/xref-deinit.swift
+++ b/test/Serialization/xref-deinit.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-sib %s -o %t/xref-deinit.sib -I%t -I %S/Inputs/objc-xref
+// RUN: %target-swift-frontend -emit-sil %t/xref-deinit.sib -I%t -I %S/Inputs/objc-xref
+
+// REQUIRES: objc_interop
+
+import ObjCXRef
+
+public class Object: MyObject {}


### PR DESCRIPTION
Swift class deinit decl can be implicitly synthesized when emitting swiftmodule, so swiftmodule always have deinit decl. So resolution of x-refs to deinit of swift class always success.
But when x-refs points deinit of clang imported class, it always failed because clang importer doesn't force to synthesize deinit before looking up.

x-refs to deinit decl appears in only deinit of its subclasses, so it's serialized only when deinit have body. And deinit has body only on SIB because deinit is always non-inlinable.

It means that this missing of deinit creation can be problem only on SIB.

This commit changes to force to synthesize class deinit decl before looking up members.
