### PR TITLE
[NFC] Remove empty check for SingleExpression in Refactoring.cpp findConcatenatedExpressions

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1846,11 +1846,7 @@ findConcatenatedExpressions(ResolvedRangeInfo Info, ASTContext &Ctx) {
 
   switch (Info.Kind) {
   case RangeKind::SingleExpression:
-    // FIXME: the range info kind should imply non-empty list.
-    if (!Info.ContainedNodes.empty())
-      E = Info.ContainedNodes[0].get<Expr*>();
-    else
-      return nullptr;
+    E = Info.ContainedNodes[0].get<Expr*>();
     break;
   case RangeKind::PartOfExpression:
     E = Info.CommonExprParent;


### PR DESCRIPTION
As the fixme states, this check seems to be unnecessary, local tests are ok without it, but not sure if maybe it was there for a reason... 



