### PR TITLE
[NFC] Use consistent naming scheme for predicate methods.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1634,8 +1634,8 @@ struct TargetFunctionTypeMetadata : public TargetMetadata<Runtime> {
   FunctionMetadataConvention getConvention() const {
     return Flags.getConvention();
   }
-  bool async() const { return Flags.async(); }
-  bool throws() const { return Flags.throws(); }
+  bool isAsync() const { return Flags.isAsync(); }
+  bool isThrowing() const { return Flags.isThrowing(); }
   bool hasParameterFlags() const { return Flags.hasParameterFlags(); }
   bool isEscaping() const { return Flags.isEscaping(); }
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -855,13 +855,9 @@ public:
     return FunctionMetadataConvention((Data&ConventionMask) >> ConventionShift);
   }
 
-  bool async() const {
-    return bool(Data & AsyncMask);
-  }
+  bool isAsync() const { return bool(Data & AsyncMask); }
 
-  bool throws() const {
-    return bool(Data & ThrowsMask);
-  }
+  bool isThrowing() const { return bool(Data & ThrowsMask); }
 
   bool isEscaping() const {
     return bool (Data & EscapingMask);

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -240,9 +240,9 @@ public:
 
   constexpr bool isNoEscape() const { return bits & NoEscapeMask; }
 
-  constexpr bool async() const { return bits & AsyncMask; }
+  constexpr bool isAsync() const { return bits & AsyncMask; }
 
-  constexpr bool throws() const { return bits & ThrowsMask; }
+  constexpr bool isThrowing() const { return bits & ThrowsMask; }
 
   constexpr DifferentiabilityKind getDifferentiabilityKind() const {
     return DifferentiabilityKind((bits & DifferentiabilityMask) >>
@@ -394,9 +394,9 @@ public:
 
   constexpr bool isNoEscape() const { return builder.isNoEscape(); }
 
-  constexpr bool async() const { return builder.async(); }
+  constexpr bool isAsync() const { return builder.isAsync(); }
 
-  constexpr bool throws() const { return builder.throws(); }
+  constexpr bool isThrowing() const { return builder.isThrowing(); }
 
   constexpr DifferentiabilityKind getDifferentiabilityKind() const {
     return builder.getDifferentiabilityKind();

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -529,8 +529,8 @@ public:
 
   TupleTypeRepr *getArgsTypeRepr() const { return ArgsTy; }
   TypeRepr *getResultTypeRepr() const { return RetTy; }
-  bool async() const { return AsyncLoc.isValid(); }
-  bool throws() const { return ThrowsLoc.isValid(); }
+  bool isAsync() const { return AsyncLoc.isValid(); }
+  bool isThrowing() const { return ThrowsLoc.isValid(); }
 
   SourceLoc getAsyncLoc() const { return AsyncLoc; }
   SourceLoc getThrowsLoc() const { return ThrowsLoc; }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3076,13 +3076,9 @@ public:
     return getExtInfo().isNoEscape();
   }
 
-  bool async() const {
-    return getExtInfo().async();
-  }
+  bool isAsync() const { return getExtInfo().isAsync(); }
 
-  bool throws() const {
-    return getExtInfo().throws();
-  }
+  bool isThrowing() const { return getExtInfo().isThrowing(); }
 
   bool isDifferentiable() const { return getExtInfo().isDifferentiable(); }
   DifferentiabilityKind getDifferentiabilityKind() const {

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -803,8 +803,8 @@ public:
 
       auto flags = FunctionTypeFlags()
                        .withConvention(Function->getConvention())
-                       .withAsync(Function->async())
-                       .withThrows(Function->throws())
+                       .withAsync(Function->isAsync())
+                       .withThrows(Function->isThrowing())
                        .withParameterFlags(Function->hasParameterFlags())
                        .withEscaping(Function->isEscaping());
       auto BuiltFunction =

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -406,9 +406,9 @@ Type ASTBuilder::createFunctionType(
                                                  representation);
 
   auto einfo =
-      FunctionType::ExtInfoBuilder(representation, noescape, flags.throws(),
+      FunctionType::ExtInfoBuilder(representation, noescape, flags.isThrowing(),
                                    diffKind, clangFunctionType)
-          .withAsync(flags.async())
+          .withAsync(flags.isAsync())
           .build();
 
   return FunctionType::get(funcParams, output, einfo);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2988,9 +2988,9 @@ public:
   void visitFunctionTypeRepr(FunctionTypeRepr *T) {
     printCommon("type_function");
     OS << '\n'; printRec(T->getArgsTypeRepr());
-    if (T->async())
+    if (T->isAsync())
       OS << " async ";
-    if (T->throws())
+    if (T->isThrowing())
       OS << " throws ";
     OS << '\n'; printRec(T->getResultTypeRepr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
@@ -3760,8 +3760,8 @@ namespace {
                    getSILFunctionTypeRepresentationString(representation));
 
       printFlag(!T->isNoEscape(), "escaping");
-      printFlag(T->async(), "async");
-      printFlag(T->throws(), "throws");
+      printFlag(T->isAsync(), "async");
+      printFlag(T->isThrowing(), "throws");
 
       OS << "\n";
       Indent += 2;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2272,9 +2272,9 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
                                          const ValueDecl *forDecl) {
   appendFunctionResultType(fn->getResult(), forDecl);
   appendFunctionInputType(fn->getParams(), forDecl);
-  if (fn->async())
+  if (fn->isAsync())
     appendOperator("Y");
-  if (fn->throws())
+  if (fn->isThrowing())
     appendOperator("K");
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4167,10 +4167,10 @@ public:
     // If we're stripping argument labels from types, do it when printing.
     visitAnyFunctionTypeParams(T->getParams(), /*printLabels*/false);
 
-    if (T->async())
+    if (T->isAsync())
       Printer << " " << "async";
 
-    if (T->throws())
+    if (T->isThrowing())
       Printer << " " << tok::kw_throws;
 
     Printer << " -> ";
@@ -4210,10 +4210,10 @@ public:
 
    visitAnyFunctionTypeParams(T->getParams(), /*printLabels*/true);
 
-    if (T->async())
+    if (T->isAsync())
       Printer << " " << "async";
 
-    if (T->throws())
+    if (T->isThrowing())
       Printer << " " << tok::kw_throws;
 
     Printer << " -> ";

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1801,7 +1801,7 @@ public:
         E->dump(Out);
         Out << "\n";
         abort();
-      } else if (E->throws() && !FT->throws()) {
+      } else if (E->throws() && !FT->isThrowing()) {
         Out << "apply expression is marked as throwing, but function operand"
                "does not have a throwing function type\n";
         E->dump(Out);
@@ -3024,7 +3024,7 @@ public:
       if (AFD->hasImplicitSelfDecl())
         fnTy = fnTy->getResult()->castTo<FunctionType>();
 
-      if (AFD->hasThrows() != fnTy->getExtInfo().throws()) {
+      if (AFD->hasThrows() != fnTy->getExtInfo().isThrowing()) {
         Out << "function 'throws' flag does not match function type\n";
         AFD->dump(Out);
         abort();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2578,8 +2578,8 @@ mapSignatureExtInfo(AnyFunctionType::ExtInfo info,
     return AnyFunctionType::ExtInfo();
   return AnyFunctionType::ExtInfoBuilder()
       .withRepresentation(info.getRepresentation())
-      .withAsync(info.async())
-      .withThrows(info.throws())
+      .withAsync(info.isAsync())
+      .withThrows(info.isThrowing())
       .build();
 }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1932,14 +1932,14 @@ bool AbstractClosureExpr::isBodyThrowing() const {
   if (getType()->hasError())
     return false;
   
-  return getType()->castTo<FunctionType>()->getExtInfo().throws();
+  return getType()->castTo<FunctionType>()->getExtInfo().isThrowing();
 }
 
 bool AbstractClosureExpr::isBodyAsync() const {
   if (getType()->hasError())
     return false;
 
-  return getType()->castTo<FunctionType>()->getExtInfo().async();
+  return getType()->castTo<FunctionType>()->getExtInfo().isAsync();
 }
 
 bool AbstractClosureExpr::hasSingleExpressionBody() const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2265,8 +2265,8 @@ getForeignRepresentable(Type type, ForeignLanguage language,
   // Function types.
   if (auto functionType = type->getAs<FunctionType>()) {
     // Cannot handle async or throwing functions.
-    if (functionType->getExtInfo().async() ||
-        functionType->getExtInfo().throws())
+    if (functionType->getExtInfo().isAsync() ||
+        functionType->getExtInfo().isThrowing())
       return failure();
 
     // Whether we have found any types that are bridged.
@@ -2603,7 +2603,7 @@ static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
   auto ext1 = fn1->getExtInfo();
   auto ext2 = fn2->getExtInfo();
   if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
-    if (ext2.throws()) {
+    if (ext2.isThrowing()) {
       ext1 = ext1.withThrows(true);
     }
   }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -221,7 +221,7 @@ void FunctionTypeRepr::printImpl(ASTPrinter &Printer,
                                  const PrintOptions &Opts) const {
   Printer.callPrintStructurePre(PrintStructureKind::FunctionType);
   printTypeRepr(ArgsTy, Printer, Opts);
-  if (throws()) {
+  if (isThrowing()) {
     Printer << " ";
     Printer.printKeyword("throws", Opts);
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2669,7 +2669,7 @@ public:
                         const AbstractFunctionDecl *AFD) {
     if (AFD && AFD->getAttrs().hasAttribute<RethrowsAttr>())
       Builder.addAnnotatedRethrows();
-    else if (AFT->throws())
+    else if (AFT->isThrowing())
       Builder.addAnnotatedThrows();
   }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1461,8 +1461,8 @@ namespace {
       auto flagsVal = FunctionTypeFlags()
                           .withNumParameters(numParams)
                           .withConvention(metadataConvention)
-                          .withAsync(type->async())
-                          .withThrows(type->throws())
+                          .withAsync(type->isAsync())
+                          .withThrows(type->isThrowing())
                           .withParameterFlags(hasFlags)
                           .withEscaping(isEscaping)
                           .withDifferentiabilityKind(

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2016,9 +2016,10 @@ static CanSILFunctionType getSILFunctionType(
 
   // Map 'throws' to the appropriate error convention.
   Optional<SILResultInfo> errorResult;
-  assert((!foreignInfo.Error || substFnInterfaceType->getExtInfo().throws()) &&
-         "foreignError was set but function type does not throw?");
-  if (substFnInterfaceType->getExtInfo().throws() && !foreignInfo.Error) {
+  assert(
+      (!foreignInfo.Error || substFnInterfaceType->getExtInfo().isThrowing()) &&
+      "foreignError was set but function type does not throw?");
+  if (substFnInterfaceType->getExtInfo().isThrowing() && !foreignInfo.Error) {
     assert(!origType.isForeign() &&
            "using native Swift error convention for foreign type!");
     SILType exnType = SILType::getExceptionType(TC.Context);
@@ -4178,7 +4179,7 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   bridgingFnPattern.rewriteType(genericSig, curried);
 
   // Build the uncurried function type.
-  if (innerExtInfo.throws())
+  if (innerExtInfo.isThrowing())
     extInfo = extInfo.withThrows(true);
 
   bridgedParams.push_back(selfParam);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2216,7 +2216,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
 
   auto innerExtInfo =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
-                                      funcType->throws())
+                                      funcType->isThrowing())
           .build();
 
   return CanAnyFunctionType::get(

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -494,12 +494,12 @@ swift::classifyDynamicCast(ModuleDecl *M,
 
       // An async function cannot be cast to a non-async function and
       // vice-versa.
-      if (sourceFunction->async() != targetFunction->async())
+      if (sourceFunction->isAsync() != targetFunction->isAsync())
         return DynamicCastFeasibility::WillFail;
 
       // A non-throwing source function can be cast to a throwing target type,
       // but not vice versa.
-      if (sourceFunction->throws() && !targetFunction->throws())
+      if (sourceFunction->isThrowing() && !targetFunction->isThrowing())
         return DynamicCastFeasibility::WillFail;
       
       // The cast can't change the representation at runtime.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3860,7 +3860,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
     auto emitter = specializedEmitter.getEarlyEmitter();
 
     assert(uncurriedSites.size() == 1);
-    assert(!formalType->getExtInfo().throws());
+    assert(!formalType->getExtInfo().isThrowing());
     SILLocation uncurriedLoc = uncurriedSites[0].Loc;
 
     // We should be able to enforce that these arguments are
@@ -5441,7 +5441,7 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
     subscriptIndices.emplace({});
 
   emission.addCallSite(loc, std::move(subscriptIndices),
-                       accessType->throws());
+                       accessType->isThrowing());
 
   // T
   return emission.apply(c);
@@ -5483,8 +5483,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
     }
   }
   assert(values.isValid());
-  emission.addCallSite(loc, std::move(values),
-                       accessType->throws());
+  emission.addCallSite(loc, std::move(values), accessType->isThrowing());
   // ()
   emission.apply();
 }
@@ -5518,7 +5517,7 @@ ManagedValue SILGenFunction::emitAddressorAccessor(
     subscriptIndices.emplace({});
 
   emission.addCallSite(loc, std::move(subscriptIndices),
-                       accessType->throws());
+                       accessType->isThrowing());
 
   // Unsafe{Mutable}Pointer<T> or
   // (Unsafe{Mutable}Pointer<T>, Builtin.UnknownPointer) or
@@ -5580,7 +5579,7 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
     subscriptIndices.emplace({});
 
   emission.addCallSite(loc, std::move(subscriptIndices),
-                       accessType->throws());
+                       accessType->isThrowing());
 
   auto endApplyHandle = emission.applyCoroutine(yields);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -982,7 +982,7 @@ namespace {
       Expr *closureBody = closureCall;
       closureBody = coerceToType(closureCall, resultTy, locator);
 
-      if (selfFnTy->getExtInfo().throws()) {
+      if (selfFnTy->getExtInfo().isThrowing()) {
         closureBody = new (context) TryExpr(closureBody->getStartLoc(), closureBody,
                                             cs.getType(closureBody),
                                             /*implicit=*/true);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -785,7 +785,7 @@ public:
       : ContextualFailure(solution, fromType, toType, locator) {
     auto fnType1 = fromType->castTo<FunctionType>();
     auto fnType2 = toType->castTo<FunctionType>();
-    assert(fnType1->throws() != fnType2->throws());
+    assert(fnType1->isThrowing() != fnType2->isThrowing());
   }
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -577,7 +577,7 @@ class DropThrowsAttribute final : public ContextualMismatch {
   DropThrowsAttribute(ConstraintSystem &cs, FunctionType *fromType,
                       FunctionType *toType, ConstraintLocator *locator)
       : ContextualMismatch(cs, fromType, toType, locator) {
-    assert(fromType->throws() != toType->throws());
+    assert(fromType->isThrowing() != toType->isThrowing());
   }
 
 public:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1808,9 +1808,9 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator) {
   // A non-throwing function can be a subtype of a throwing function.
-  if (func1->throws() != func2->throws()) {
+  if (func1->isThrowing() != func2->isThrowing()) {
     // Cannot drop 'throws'.
-    if (func1->throws() || kind < ConstraintKind::Subtype) {
+    if (func1->isThrowing() || kind < ConstraintKind::Subtype) {
       if (!shouldAttemptFixes())
         return getTypeMatchFailure(locator);
 
@@ -1822,7 +1822,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   }
 
   // 'async' and non-'async' function types are not compatible.
-  if (func1->async() != func2->async())
+  if (func1->isAsync() != func2->isAsync())
     return getTypeMatchFailure(locator);
 
   // A non-@noescape function type can be a subtype of a @noescape function

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2495,7 +2495,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       auto boundFunctionType = boundType->getAs<AnyFunctionType>();
 
       if (boundFunctionType &&
-          CD->hasThrows() != boundFunctionType->throws()) {
+          CD->hasThrows() != boundFunctionType->isThrowing()) {
         boundType = boundFunctionType->withExtInfo(
             boundFunctionType->getExtInfo().withThrows());
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1988,7 +1988,7 @@ void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {
 static bool hasThrowingFunctionParameter(CanType type) {
   // Only consider throwing function types.
   if (auto fnType = dyn_cast<AnyFunctionType>(type)) {
-    return fnType->getExtInfo().throws();
+    return fnType->getExtInfo().isThrowing();
   }
 
   // Look through tuples.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -200,13 +200,13 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
   }
 
   if (auto fnTy = T->getAs<FunctionType>()) {
-    if (fnTy->getExtInfo().async() ) {
+    if (fnTy->getExtInfo().isAsync()) {
       diags.diagnose(TypeRange.Start, diag::not_objc_function_type_async)
         .highlight(TypeRange);
       return;
     }
 
-    if (fnTy->getExtInfo().throws() ) {
+    if (fnTy->getExtInfo().isThrowing()) {
       diags.diagnose(TypeRange.Start, diag::not_objc_function_type_throwing)
         .highlight(TypeRange);
       return;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -695,14 +695,14 @@ swift::matchWitness(
     }
 
     // If the witness is 'async', the requirement must be.
-    if (witnessFnType->getExtInfo().async() !=
-          reqFnType->getExtInfo().async()) {
+    if (witnessFnType->getExtInfo().isAsync() !=
+          reqFnType->getExtInfo().isAsync()) {
       return RequirementMatch(witness, MatchKind::AsyncConflict);
     }
 
     // If the witness is 'throws', the requirement must be.
-    if (witnessFnType->getExtInfo().throws() &&
-        !reqFnType->getExtInfo().throws()) {
+    if (witnessFnType->getExtInfo().isThrowing() &&
+        !reqFnType->getExtInfo().isThrowing()) {
       return RequirementMatch(witness, MatchKind::ThrowsConflict);
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2674,7 +2674,7 @@ Type TypeResolver::resolveASTFunctionType(
   }
 
   FunctionType::ExtInfoBuilder extInfoBuilder(
-      FunctionTypeRepresentation::Swift, noescape, repr->throws(), diffKind,
+      FunctionTypeRepresentation::Swift, noescape, repr->isThrowing(), diffKind,
       /*clangFunctionType*/ nullptr);
 
   const clang::Type *clangFnType = parsedClangFunctionType;
@@ -2684,7 +2684,7 @@ Type TypeResolver::resolveASTFunctionType(
         params, outputTy, AnyFunctionType::Representation::CFunctionPointer);
 
   auto extInfo = extInfoBuilder.withRepresentation(representation)
-                     .withAsync(repr->async())
+                     .withAsync(repr->isAsync())
                      .withClangFunctionType(clangFnType)
                      .build();
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4136,8 +4136,8 @@ public:
         getRawStableFunctionTypeRepresentation(fnTy->getRepresentation()),
         clangType,
         fnTy->isNoEscape(),
-        fnTy->async(),
-        fnTy->throws(),
+        fnTy->isAsync(),
+        fnTy->isThrowing(),
         getRawStableDifferentiabilityKind(fnTy->getDifferentiabilityKind()));
 
     serializeFunctionTypeParams(fnTy);
@@ -4151,7 +4151,7 @@ public:
     GenericFunctionTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
         S.addTypeRef(fnTy->getResult()),
         getRawStableFunctionTypeRepresentation(fnTy->getRepresentation()),
-        fnTy->async(), fnTy->throws(),
+        fnTy->isAsync(), fnTy->isThrowing(),
         getRawStableDifferentiabilityKind(fnTy->getDifferentiabilityKind()),
         S.addGenericSignatureRef(genericSig));
 

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -573,9 +573,9 @@ public:
     result->addChild(resultTy, Dem);
 
     auto funcNode = Dem.createNode(kind);
-    if (F->getFlags().throws())
+    if (F->getFlags().isThrowing())
       funcNode->addChild(Dem.createNode(Node::Kind::ThrowsAnnotation), Dem);
-    if (F->getFlags().async())
+    if (F->getFlags().isAsync())
       funcNode->addChild(Dem.createNode(Node::Kind::AsyncAnnotation), Dem);
     funcNode->addChild(parameters, Dem);
     funcNode->addChild(result, Dem);

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1828,7 +1828,7 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
       return _fail(src, srcType, targetType, flags);
     
     // If the target type can't throw, neither can the source.
-    if (srcFn->throws() && !targetFn->throws())
+    if (srcFn->isThrowing() && !targetFn->isThrowing())
       return _fail(src, srcType, targetType, flags);
     
     // The result and argument types must match.

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -561,9 +561,9 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     result->addChild(resultTy, Dem);
     
     auto funcNode = Dem.createNode(kind);
-    if (func->throws())
+    if (func->isThrowing())
       funcNode->addChild(Dem.createNode(Node::Kind::ThrowsAnnotation), Dem);
-    if (func->async())
+    if (func->isAsync())
       funcNode->addChild(Dem.createNode(Node::Kind::AsyncAnnotation), Dem);
     funcNode->addChild(parameters, Dem);
     funcNode->addChild(result, Dem);


### PR DESCRIPTION
Rename: bool throws() -> isThrowing(), bool async() -> isAsync().