### PR TITLE
[5.3][CodeCompletion] Disable multi trailing closure completion at newline

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3203,6 +3203,16 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
       if (!Tok.is(tok::code_complete))
         break;
 
+      // FIXME: Additional trailing closure completion on newline positions.
+      //   let foo = SomeThing {
+      //     ...
+      //   }
+      //   <HERE>
+      // This was previously enabled, but it failed to suggest 'foo' because
+      // the token was considered a part of the initializer.
+      if (Tok.isAtStartOfLine())
+        break;
+
       // If the current completion mode doesn't support trailing closure
       // completion, leave the token here and let "postfix completion" to
       // handle it.

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -17,6 +17,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_FALLBACK_2 | %FileCheck %s -check-prefix=INIT_FALLBACK
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBERDECL_SAMELINE | %FileCheck %s -check-prefix=MEMBERDECL_SAMELINE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBERDECL_NEWLINE | %FileCheck %s -check-prefix=MEMBERDECL_NEWLINE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INITIALIZED_VARDECL_SAMELINE | %FileCheck %s -check-prefix=INITIALIZED_VARDECL_SAMELINE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INITIALIZED_VARDECL_NEWLINE | %FileCheck %s -check-prefix=INITIALIZED_VARDECL_NEWLINE
 
 func globalFunc1(fn1: () -> Int, fn2: () -> String) {}
 func testGlobalFunc() {
@@ -27,8 +29,8 @@ func testGlobalFunc() {
 // GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
 // GLOBALFUNC_SAMELINE: End completions
 
-// GLOBALFUNC_NEWLINE: Begin completions, 1 items
-// GLOBALFUNC_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// GLOBALFUNC_NEWLINE: Begin completions
+// FIXME-GLOBALFUNC_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
 // GLOBALFUNC_NEWLINE: End completions
 
   globalFunc1()
@@ -60,7 +62,7 @@ func testMethod(value: MyStruct) {
 // METHOD_SAMELINE: End completions
 
 // METHOD_NEWLINE: Begin completions
-// METHOD_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#];
+// FIXME-METHOD_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#];
 // METHOD_NEWLINE-DAG: Keyword[class]/None:                class;
 // METHOD_NEWLINE-DAG: Keyword[if]/None:                   if;
 // METHOD_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -91,8 +93,8 @@ func testOverloadedInit() {
 // INIT_OVERLOADED_SAMELINE: End completions
 
 // INIT_OVERLOADED_NEWLINE: Begin completions
-// INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
-// INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -118,8 +120,8 @@ func testOptionalInit() {
 // INIT_OPTIONAL_SAMELINE: End completions
 
 // INIT_OPTIONAL_NEWLINE: Begin completions
-// INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
-// INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -142,8 +144,8 @@ func testOptionalInit() {
 // INIT_REQUIRED_SAMELINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_1: End completions
 
-// INIT_REQUIRED_NEWLINE_1: Begin completions, 1 items
-// INIT_REQUIRED_NEWLINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_REQUIRED_NEWLINE_1: Begin completions
+// FIXME-INIT_REQUIRED_NEWLINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_1: End completions
 
   // missing 'fn3'.
@@ -158,8 +160,8 @@ func testOptionalInit() {
 // INIT_REQUIRED_SAMELINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_2: End completions
 
-// INIT_REQUIRED_NEWLINE_2: Begin completions, 1 items
-// INIT_REQUIRED_NEWLINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INIT_REQUIRED_NEWLINE_2: Begin completions
+// FIXME-INIT_REQUIRED_NEWLINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_2: End completions
 
   // Call is completed.
@@ -225,7 +227,7 @@ struct TestNominalMember: P {
 // MEMBERDECL_SAMELINE: End completions
 
 // MEMBERDECL_NEWLINE: Begin completions
-// MEMBERDECL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// FIXME-MEMBERDECL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {() -> String in|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_NEWLINE-DAG: Keyword[enum]/None:                 enum; name=enum
 // MEMBERDECL_NEWLINE-DAG: Keyword[func]/None:                 func; name=func
 // MEMBERDECL_NEWLINE-DAG: Keyword[private]/None:              private; name=private
@@ -233,4 +235,23 @@ struct TestNominalMember: P {
 // MEMBERDECL_NEWLINE-DAG: Keyword[var]/None:                  var; name=var
 // MEMBERDECL_NEWLINE-DAG: Decl[InstanceMethod]/Super:         func foo() {|}; name=foo()
 // MEMBERDECL_NEWLINE: End completions
+}
+
+func testInitializedVarDecl() {
+    let localVal = TestStruct {
+        1
+    } #^INITIALIZED_VARDECL_SAMELINE^#
+    #^INITIALIZED_VARDECL_NEWLINE^#
+// INITIALIZED_VARDECL_SAMELINE: Begin completions, 4 items
+// INITIALIZED_VARDECL_SAMELINE-NOT: localVal
+// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {() -> String in|}#}[#() -> String#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {() -> String in|}#}[#() -> String#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct#];
+// INITIALIZED_VARDECL_SAMELINE-NOT: localVal
+// INITIALIZED_VARDECL_SAMELINE: End completions
+
+// INITIALIZED_VARDECL_NEWLINE: Begin completions
+// INITIALIZED_VARDECL_NEWLINE-DAG: Decl[LocalVar]/Local:               localVal[#TestStruct#];
+// INITIALIZED_VARDECL_NEWLINE: End completions
 }


### PR DESCRIPTION
Cherry-pick of #33262 into `release/5.3`

* **Explanation**: Fix an issue where code completion doesn't suggest let/var decls initialized with trailing closure expression at next line of the declaration. This was caused by multiple trailing closure completion recently introduced. As a workaround, disable trailing closure completion on newline positions.
* **Scope**: Code completion at next line of trailing closures
* **Risk**: Low
* **Testing**: Added regression test cases
* **Issue**: rdar://problem/66456159
* **Reviewer**: Ben Langmuir (@benlangmuir)