### PR TITLE
Improve @guaranteed args handling in ARCSequenceOpts

### DIFF
--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -365,6 +365,14 @@ bool BottomUpRefCountState::handlePotentialGuaranteedUser(
   if (!mayGuaranteedUseValue(PotentialGuaranteedUser, getRCRoot(), AA))
     return false;
 
+  // If we can prove that the pointer we are tracking cannot be decremented,
+  // return. On return, BottomUpRefCountState::handlePotentialUser can correctly
+  // handle transition of refcount state. It transitions from a Decrement
+  // refcount state to a MighBeUsed refcount state
+  if (!mayDecrementRefCount(PotentialGuaranteedUser, getRCRoot(), AA)) {
+    return false;
+   }
+
   // Instructions that we do not recognize (and thus will not move) and that
   // *must* use RCIdentity, implies we are always known safe as long as meet
   // over all path constraints are satisfied.
@@ -815,6 +823,13 @@ bool TopDownRefCountState::handlePotentialGuaranteedUser(
   // return...
   if (!mayGuaranteedUseValue(PotentialGuaranteedUser, getRCRoot(), AA))
     return false;
+
+  // If we can prove that the pointer we are tracking cannot be decremented,
+  // return. On return, TopDownRefCountState::handlePotentialUser can correctly
+  // handle transition of refcount state.
+  if (!mayDecrementRefCount(PotentialGuaranteedUser, getRCRoot(), AA)) {
+    return false;
+   }
 
   // Otherwise, update our step given that we have a potential decrement.
   return handleGuaranteedUser(PotentialGuaranteedUser, getRCRoot(),

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -395,6 +395,53 @@ bb0(%0 : $*Builtin.Int32):
   return %4: $()
 }
 
+struct Int {
+  var value : Builtin.Int64
+}
+
+sil @guaranteed_call : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int64>) -> () {
+bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK_LABEL: sil hidden [noinline] @$test_guaranteed_call :
+// CHECK: bb1{{.*}}:
+// CHECK-NOT: strong_retain
+// CHECK: apply
+// CHECK-NOT: strong_release
+// CHECK: bb2:
+// CHECK_LABEL: } // end sil function '$test_guaranteed_call'
+sil hidden [noinline] @$test_guaranteed_call : $@convention(thin) () -> () {
+bb0:
+  %box = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  %proj = project_box %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>, 0
+  %0 = integer_literal $Builtin.Int64, 1
+  %1 = integer_literal $Builtin.Int64, 100
+  %funcref = function_ref @guaranteed_call : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int64>) -> ()
+  %3 = struct $Int (%0 : $Builtin.Int64)
+  %6 = integer_literal $Builtin.Int1, -1
+  br bb1(%0 : $Builtin.Int64)
+
+bb1(%8 : $Builtin.Int64):
+  %9 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %0 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %10 = tuple_extract %9 : $(Builtin.Int64, Builtin.Int1), 0
+  %11 = struct $Int (%10 : $Builtin.Int64)
+  %12 = builtin "cmp_eq_Int64"(%10 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  strong_retain %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  apply %funcref (%box) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Builtin.Int64>) -> ()
+  strong_release %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  cond_br %12, bb3, bb2
+
+bb2:
+  br bb1(%10 : $Builtin.Int64)
+
+bb3:
+  strong_release %box : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  %17 = tuple ()
+  return %17 : $()
+}
+
 // CHECK-LABEL: sil @silargument_retain_iterated : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
 // CHECK: bb0
 // CHECK-NEXT: function_ref user


### PR DESCRIPTION
@guaranteed args are treated conservatively in ARCSequenceOpts. A function call with a @guaranteed arg is assumed to decrement refcount of the @guaranteed arg. 

`handleGuaranteedUser` transitions conservatively from a `Decrement` refcount state to `MightBeDecremented` refcount state on a guaranteed use. Since an apply with a guaranteed arg that does not escape cannot decrement the refcount. This conservative transition is unnecessary. For such cases where the instruction being visited cannot decrement the refcount we should fallback to `handleUser` which correctly transitions from `Decrement` refcount state to `MightBeUsed` for uses where refcount cannot be decremented.
  
With this change, use `swift::mayDecrementRefCount` which uses EscapeAnalysis to determine if we need to transition conservatively at the instruction being visited.
