### PR TITLE
[5.3] [IRGen] Add main() to __swift5_entry.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1781,6 +1781,9 @@ static std::string getEntryPointSection(IRGenModule &IGM) {
 }
 
 void IRGenerator::emitEntryPointInfo() {
+  if (Opts.IntegratedREPL) {
+    return;
+  }
   SILFunction *entrypoint = nullptr;
   if (!(entrypoint = SIL.lookUpFunction(SWIFT_ENTRY_POINT_FUNCTION))) {
     return;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1111,6 +1111,8 @@ void IRGenerator::emitGlobalTopLevel(llvm::StringSet<> *linkerDirectives) {
     IRGenModule *IGM = Iter.second;
     IGM->finishEmitAfterTopLevel();
   }
+
+  emitEntryPointInfo();
 }
 
 void IRGenModule::finishEmitAfterTopLevel() {
@@ -1755,6 +1757,44 @@ void IRGenModule::emitVTableStubs() {
     else
       ApplyIRLinkage(IRLinkage::ExternalExport).to(alias);
   }
+}
+
+static std::string getEntryPointSection(IRGenModule &IGM) {
+  std::string sectionName;
+  switch (IGM.TargetInfo.OutputObjectFormat) {
+  case llvm::Triple::UnknownObjectFormat:
+    llvm_unreachable("Don't know how to emit field records table for "
+                     "the selected object format.");
+  case llvm::Triple::MachO:
+    sectionName = "__TEXT, __swift5_entry, regular, no_dead_strip";
+    break;
+  case llvm::Triple::ELF:
+  case llvm::Triple::Wasm:
+    sectionName = "swift5_entry";
+    break;
+  case llvm::Triple::XCOFF:
+  case llvm::Triple::COFF:
+    sectionName = ".sw5entr$B";
+    break;
+  }
+  return sectionName;
+}
+
+void IRGenerator::emitEntryPointInfo() {
+  SILFunction *entrypoint = nullptr;
+  if (!(entrypoint = SIL.lookUpFunction(SWIFT_ENTRY_POINT_FUNCTION))) {
+    return;
+  }
+  auto &IGM = *getGenModule(entrypoint);
+  ConstantInitBuilder builder(IGM);
+  auto entrypointInfo = builder.beginStruct();
+  entrypointInfo.addRelativeAddress(
+      IGM.getAddrOfSILFunction(entrypoint, NotForDefinition));
+  auto var = entrypointInfo.finishAndCreateGlobal(
+      "\x01l_entry_point", Alignment(4),
+      /*isConstant*/ true, llvm::GlobalValue::PrivateLinkage);
+  var->setSection(getEntryPointSection(IGM));
+  IGM.addUsedGlobal(var);
 }
 
 static IRLinkage

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -392,6 +392,9 @@ public:
   // Emit the code to replace dynamicReplacement(for:) functions.
   void emitDynamicReplacements();
 
+  // Emit info that describes the entry point to the module, if it has one.
+  void emitEntryPointInfo();
+
   /// Checks if metadata for this type can be emitted lazily. This is true for
   /// non-public types as well as imported types, except for classes and
   /// protocols which are always emitted eagerly.

--- a/test/IRGen/Inputs/at-main-struct-simple.swift
+++ b/test/IRGen/Inputs/at-main-struct-simple.swift
@@ -1,0 +1,6 @@
+@main
+struct Entry {
+  static func main() {
+    print("howdy mundo")
+  }
+}

--- a/test/IRGen/entrypoint-section-run.cpp
+++ b/test/IRGen/entrypoint-section-run.cpp
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang %s -isysroot %sdk -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-build-swift %S/Inputs/at-main-struct-simple.swift -O -parse-as-library -emit-library -o %t/libHowdy.dylib -module-name Howdy
+// RUN: %target-run %t/main %t/libHowdy.dylib | %FileCheck %s
+
+// REQUIRES: OS=macosx,CPU=x86_64
+// REQUIRES: executable_test
+// UNSUPPORTED: remote_run
+
+#include <dlfcn.h>
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("no argument!\n");
+    return 1;
+  }
+  auto *dylibPath = argv[1];
+  auto *handle = dlopen(dylibPath, RTLD_LAZY);
+  if (!handle) {
+    printf("no library!\n");
+    return 1;
+  }
+
+  using MainFunction = void(int, char *[]);
+  MainFunction *mainFunction = nullptr;
+  for (int index = 0; index < _dyld_image_count(); ++index) {
+    auto *imageName = _dyld_get_image_name(index);
+    if (strcmp(dylibPath, imageName)) {
+      printf("skipping %s\n", imageName);
+      continue;
+    }
+    auto *header =
+        reinterpret_cast<const mach_header_64 *>(_dyld_get_image_header(index));
+    size_t size;
+    auto *data = getsectiondata(header, "__TEXT", "__swift5_entry", &size);
+    int32_t offset = *reinterpret_cast<int32_t *>(data);
+    mainFunction = reinterpret_cast<MainFunction *>(
+        reinterpret_cast<int64_t>(data) + offset);
+
+    break;
+  }
+  if (!mainFunction) {
+    printf("no function!");
+    return 1;
+  }
+  mainFunction(argc, argv); // CHECK: howdy mundo
+}

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -52,8 +52,11 @@ bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>
   return %3 : $Int32                              // id: %4
 }
 
-// CHECK-macho: @llvm.used = appending global [3 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*)], section "llvm.metadata"
-// CHECK-elf: @llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata"
+// CHECK-macho: @"\01l_entry_point" = private constant { i32 } { i32 trunc (i64 sub (i64 ptrtoint (i32 (i32, i8**)* @main to i64), i64 ptrtoint ({ i32 }* @"\01l_entry_point" to i64)) to i32) }, section "__TEXT, __swift5_entry, regular, no_dead_strip", align 4
+// CHECK-elf: @"\01l_entry_point" = private constant { i32 } { i32 trunc (i64 sub (i64 ptrtoint (i32 (i32, i8**)* @main to i64), i64 ptrtoint ({ i32 }* @"\01l_entry_point" to i64)) to i32) }, section "swift5_entry", align 4
+
+// CHECK-macho: @llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*), i8* bitcast ({ i32 }* @"\01l_entry_point" to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*)], section "llvm.metadata", align 8
+// CHECK-elf: @llvm.used = appending global [5 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32 (i32, i8**)* @main to i8*), i8* bitcast ({ i32 }* @"\01l_entry_point" to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([12 x i8], [12 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata", align 8
 
 // CHECK: define linkonce_odr hidden swiftcc void @qux()
 // CHECK: define hidden swiftcc void @fred()


### PR DESCRIPTION
To enable lookup of the entry point, emit a pointer to that entry point into a new section; on MachO, the `__swift5_entry` section of the` __TEXT` segment.

PR against master: https://github.com/apple/swift/pull/33246

rdar://problem/66402358