### PR TITLE
[5.3][Diagnostics] Do more checking before recording `force downcast` fix

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -951,8 +951,6 @@ bool MissingExplicitConversionFailure::diagnoseAsError() {
     return false;
 
   bool useAs = TypeChecker::isExplicitlyConvertibleTo(fromType, toType, DC);
-  if (!useAs && !TypeChecker::checkedCastMaySucceed(fromType, toType, DC))
-    return false;
 
   auto *expr = findParentExpr(anchor);
   if (!expr)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2913,6 +2913,9 @@ static bool
 repairViaBridgingCast(ConstraintSystem &cs, Type fromType, Type toType,
                       SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
                       ConstraintLocatorBuilder locator) {
+  if (fromType->hasTypeVariable() || toType->hasTypeVariable())
+    return false;
+
   auto objectType1 = fromType->getOptionalObjectType();
   auto objectType2 = toType->getOptionalObjectType();
 
@@ -2929,6 +2932,9 @@ repairViaBridgingCast(ConstraintSystem &cs, Type fromType, Type toType,
   }
 
   if (!canBridgeThroughCast(cs, fromType, toType))
+    return false;
+
+  if (!TypeChecker::checkedCastMaySucceed(fromType, toType, cs.DC))
     return false;
 
   conversionsOrFixes.push_back(ForceDowncast::create(

--- a/test/Constraints/rdar65254452.swift
+++ b/test/Constraints/rdar65254452.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+class Obj: NSObject {
+}
+
+class Container {
+  var objects: [Obj]
+  init(objects: [Obj]) {}
+}
+
+func test(other: Container) {
+  _ = Container(objects: other)
+  // expected-error@-1 {{cannot convert value of type 'Container' to expected argument type '[Obj]'}}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/33272

---

- Explanation:

Solver should do more checking upfront before recording
`force downcast` fix, to make sure that it's indeed always
applicable when recorded, otherwise it would be possible
to misdiagnose or omit diagnostics in certain situations.

- Scope: Limited to situations when it is possible to find an ObjC bridged type 
                for right-hand side of the conversion ("to" type) but the other side
               ("from" type) can't be bridged to such a type.

- Resolves: rdar://problem/65254452

- Risk: Very Low

- Testing: Added regression tests

- Reviewer: @hborla 

Resolves: rdar://problem/65254452
(cherry picked from commit d89c096af75524dd5e1cf7bc2d1d0fb43997db9c)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
