### PR TITLE
SILGen: Lower formal callee type pre-opaque-type-substitution.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -315,7 +315,8 @@ private:
   CanFunctionType SubstFormalInterfaceType;
 
   /// The substitutions applied to OrigFormalInterfaceType to produce
-  /// SubstFormalInterfaceType.
+  /// SubstFormalInterfaceType, substituted into the current type expansion
+  /// context.
   SubstitutionMap Substitutions;
 
   /// The list of values captured by our callee.
@@ -351,14 +352,14 @@ private:
   /// Constructor for Callee::forDirect.
   Callee(SILGenFunction &SGF, SILDeclRef standaloneFunction,
          AbstractionPattern origFormalType, CanAnyFunctionType substFormalType,
-         SubstitutionMap subs, SILLocation l,
+         SubstitutionMap subs, SubstitutionMap formalSubs, SILLocation l,
          bool callDynamicallyReplaceableImpl = false)
       : kind(callDynamicallyReplaceableImpl
                  ? Kind::StandaloneFunctionDynamicallyReplaceableImpl
                  : Kind::StandaloneFunction),
         Constant(standaloneFunction), OrigFormalInterfaceType(origFormalType),
         SubstFormalInterfaceType(
-            getSubstFormalInterfaceType(substFormalType, subs)),
+            getSubstFormalInterfaceType(substFormalType, formalSubs)),
         Substitutions(subs), Loc(l) {}
 
   /// Constructor called by all for* factory methods except forDirect and
@@ -387,7 +388,9 @@ public:
     auto &ci = SGF.getConstantInfo(SGF.getTypeExpansionContext(), c);
     return Callee(
         SGF, c, ci.FormalPattern, ci.FormalType,
-        subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext()), l,
+        subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext()),
+        subs,
+        l,
         callPreviousDynamicReplaceableImpl);
   }
 

--- a/test/SILGen/opaque_type_substitution_through_substitutions.swift
+++ b/test/SILGen/opaque_type_substitution_through_substitutions.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+
+// rdar://problem/65683913
+
+@_silgen_name("foo") func foo() -> Int
+
+func createSomeOpaqueObject() -> some CustomStringConvertible {
+    foo()
+}
+
+struct TypeWitness<R> {
+    init(witness _: R) { }
+
+    var type: R.Type { R.self }
+    func getType() -> R.Type { R.self }
+}
+
+let w = TypeWitness(witness: createSomeOpaqueObject())
+print(w.getType())


### PR DESCRIPTION
Explanation: Fixes a regression in handling generic functions that are called with opaque types as their generic arguments, which would cause functions generically returning functions or metatypes to crash or potentially miscompile.

Scope: Regression from Swift 5.2

Risk: Low.

Testing: Swift CI, compatibility suite

Reviewed by: @aschwaighofer 

