### PR TITLE
[Serialization] Serialize subclassScope to keep linkage

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -511,17 +511,16 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   GenericSignatureID genericSigID;
   unsigned rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isAsync, specialPurpose, inlineStrategy,
-      optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
-      isWeakImported, LIST_VER_TUPLE_PIECES(available),
+      optimizationMode, subclassScope, effect, numSpecAttrs,
+      hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
       scratch, rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isAsync, specialPurpose, inlineStrategy,
-      optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
-      isWeakImported, LIST_VER_TUPLE_PIECES(available),
-      isDynamic, isExactSelfClass,
-      funcTyID, replacedFunctionID, genericSigID,
+      optimizationMode, subclassScope, effect, numSpecAttrs,
+      hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
+      isDynamic, isExactSelfClass, funcTyID, replacedFunctionID, genericSigID,
       clangNodeOwnerID, SemanticsIDs);
 
   if (funcTyID == 0) {
@@ -645,6 +644,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setEffectsKind(EffectsKind(effect));
     fn->setOptimizationMode(OptimizationMode(optimizationMode));
     fn->setAlwaysWeakImported(isWeakImported);
+    fn->setClassSubclassScope(SubclassScope(subclassScope));
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);
@@ -2830,17 +2830,16 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   GenericSignatureID genericSigID;
   unsigned rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isAsync, isGlobal, inlineStrategy,
-      optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
-      isWeakImported, LIST_VER_TUPLE_PIECES(available),
+      optimizationMode, subclassScope, effect, numSpecAttrs,
+      hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass;
   ArrayRef<uint64_t> SemanticsIDs;
   SILFunctionLayout::readRecord(
       scratch, rawLinkage, isTransparent, isSerialized, isThunk,
       isWithoutactuallyEscapingThunk, isAsync, isGlobal, inlineStrategy,
-      optimizationMode, effect, numSpecAttrs, hasQualifiedOwnership,
-      isWeakImported, LIST_VER_TUPLE_PIECES(available),
-      isDynamic, isExactSelfClass,
-      funcTyID, replacedFunctionID, genericSigID,
+      optimizationMode, subclassScope, effect, numSpecAttrs,
+      hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
+      isDynamic, isExactSelfClass, funcTyID, replacedFunctionID, genericSigID,
       clangOwnerID, SemanticsIDs);
   auto linkage = fromStableSILLinkage(rawLinkage);
   if (!linkage) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 568; // removed UTF16
+const uint16_t SWIFTMODULE_VERSION_MINOR = 569; // subclass scope
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -281,6 +281,7 @@ namespace sil_block {
                      BCFixed<3>,  // specialPurpose
                      BCFixed<2>,  // inlineStrategy
                      BCFixed<2>,  // optimizationMode
+                     BCFixed<2>,  // classSubclassScope
                      BCFixed<3>,  // side effect info.
                      BCVBR<8>,    // number of specialize attributes
                      BCFixed<1>,  // has qualified ownership

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -435,11 +435,11 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.isThunk(), (unsigned)F.isWithoutActuallyEscapingThunk(),
       (unsigned)F.isAsync(), (unsigned)F.getSpecialPurpose(),
       (unsigned)F.getInlineStrategy(), (unsigned)F.getOptimizationMode(),
-      (unsigned)F.getEffectsKind(), (unsigned)numSpecAttrs,
-      (unsigned)F.hasOwnership(), F.isAlwaysWeakImported(),
-      LIST_VER_TUPLE_PIECES(available), (unsigned)F.isDynamicallyReplaceable(),
-      (unsigned)F.isExactSelfClass(), FnID, replacedFunctionID, genericSigID,
-      clangNodeOwnerID, SemanticsIDs);
+      (unsigned)F.getClassSubclassScope(), (unsigned)F.getEffectsKind(),
+      (unsigned)numSpecAttrs, (unsigned)F.hasOwnership(),
+      F.isAlwaysWeakImported(), LIST_VER_TUPLE_PIECES(available),
+      (unsigned)F.isDynamicallyReplaceable(), (unsigned)F.isExactSelfClass(),
+      FnID, replacedFunctionID, genericSigID, clangNodeOwnerID, SemanticsIDs);
 
   if (NoBody)
     return;

--- a/test/Serialization/access-level.swift
+++ b/test/Serialization/access-level.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix DIRECT-CHECK
+// RUN: %target-swift-frontend -emit-sib %s -o %t/access-level.sib
+// RUN: %target-swift-frontend -emit-ir %t/access-level.sib | %FileCheck %s --check-prefix FROM-SIB-CHECK
+
+// Ensure that the method linkage is default external when lowered from .swift directly
+// DIRECT-CHECK-NOT: define{{.*}}internal{{.*}}swiftcc{{.*}}void @"$s4main7VisitorC13visitExprImpl33_205B03B83823935B4865F4617387553BLLyyF"
+
+// Ensure that the method linkage is default external when lowered from .swift -> .sib -> .ll
+// FROM-SIB-CHECK-NOT: define{{.*}}internal{{.*}}swiftcc{{.*}}void @"$s4main7VisitorC13visitExprImpl33_205B03B83823935B4865F4617387553BLLyyF"
+
+open class Visitor {
+    public func visit() {
+        visitExprImpl()
+    }
+    @_optimize(none)
+    private func visitExprImpl() {
+    }
+}


### PR DESCRIPTION
subclassScope was always set as NotApplicable when deserialized but we need to serialize and deserialize it to keep correct linkage when using SIB


```swift
open class Visitor {
    public func visit() {
        visitExprImpl()
    }
    @_optimize(none)
    private func visitExprImpl() {
    }
}
```

In this case, `visitExprImpl` is private but subclassScope is External. So it should be lowered as an external function at LLVM IR level. 

But once it's serialized into SIB, subclassScope of `visitExprImpl` was deserialized as NotApplicable because it was not serialized. This mismatch makes `visitExprImpl` lowered as an internal function at LLVM IR level.

So `subclassScope` should be serialized.

CC: @compnerd 

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
