### PR TITLE
[AST] NFC: Fix ForeignErrorConvention constructor

### DIFF
--- a/include/swift/AST/ForeignErrorConvention.h
+++ b/include/swift/AST/ForeignErrorConvention.h
@@ -95,8 +95,8 @@ private:
   CanType ResultType;
 
   ForeignErrorConvention(Kind kind, unsigned parameterIndex, IsOwned_t isOwned,
-                         IsReplaced_t isReplaced, Type parameterType,
-                         Type resultType = Type())
+                         IsReplaced_t isReplaced, CanType parameterType,
+                         CanType resultType = CanType())
       : info(kind, parameterIndex, isOwned, isReplaced),
         ErrorParameterType(parameterType), ResultType(resultType) {}
 


### PR DESCRIPTION
Due to a quirk of how C++ "explicit" works, the ForeignErrorConvention constructor used `Type` instead of `CanType`. While we're in here, clean up some of the code.