### PR TITLE
[build-preset] Add swift-driver to CI builder presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -371,6 +371,7 @@ libcxx
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
+swift-driver
 indexstore-db
 sourcekit-lsp
 
@@ -396,6 +397,7 @@ install-llvm
 install-swift
 install-llbuild
 install-swiftpm
+install-swift-driver
 install-libcxx
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA,xcode]
@@ -418,6 +420,7 @@ swift-primary-variant-arch=x86_64
 skip-build-llbuild
 skip-test-llbuild
 skip-test-swiftpm
+skip-test-swift-driver
 skip-test-playgroundsupport
 
 # This preset is used by CI to test swift-corelibs-xctest.
@@ -602,12 +605,14 @@ build-ninja
 libcxx
 llbuild
 swiftpm
+swift-driver
 indexstore-db
 sourcekit-lsp
 install-llvm
 install-swift
 install-llbuild
 install-swiftpm
+install-swift-driver
 install-libcxx
 
 # We need to build the unittest extras so we can test
@@ -791,6 +796,7 @@ mixin-preset=
 
 llbuild
 swiftpm
+swift-driver
 xctest
 libicu
 libcxx
@@ -803,6 +809,7 @@ install-swift
 install-lldb
 install-llbuild
 install-swiftpm
+install-swift-driver
 install-xctest
 install-libicu
 install-prefix=/usr
@@ -859,6 +866,7 @@ skip-test-lldb
 skip-test-swift
 skip-test-llbuild
 skip-test-swiftpm
+skip-test-swift-driver
 skip-test-xctest
 skip-test-foundation
 skip-test-libdispatch
@@ -1020,6 +1028,7 @@ lldb
 #test
 foundation
 swiftpm
+swift-driver
 xctest
 
 build-subdir=buildbot_linux
@@ -1032,6 +1041,7 @@ install-lldb
 install-llbuild
 install-foundation
 install-swiftpm
+install-swift-driver
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;dev
@@ -1079,6 +1089,7 @@ libcxx
 libicu
 llbuild
 swiftpm
+swift-driver
 xctest
 foundation
 libdispatch
@@ -1092,6 +1103,7 @@ install-swift
 install-llbuild
 install-libicu
 install-swiftpm
+install-swift-driver
 install-foundation
 install-libdispatch
 install-xctest
@@ -1195,6 +1207,7 @@ watchos
 lldb
 llbuild
 swiftpm
+swift-driver
 swiftsyntax
 skstresstester
 swiftevolve
@@ -1226,6 +1239,7 @@ install-swift
 install-lldb
 install-llbuild
 install-swiftpm
+install-swift-driver
 install-swiftsyntax
 install-skstresstester
 install-swiftevolve
@@ -1319,6 +1333,7 @@ dash-dash
 
 skip-test-swift
 skip-test-swiftpm
+skip-test-swift-driver
 skip-test-llbuild
 skip-test-lldb
 skip-test-cmark
@@ -1350,6 +1365,7 @@ dash-dash
 
 skip-test-swift
 skip-test-swiftpm
+skip-test-swift-driver
 skip-test-llbuild
 skip-test-lldb
 skip-test-cmark
@@ -1487,6 +1503,7 @@ libcxx
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
+swift-driver
 swiftsyntax
 
 # Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
@@ -1500,6 +1517,7 @@ install-llvm
 install-swift
 install-llbuild
 install-swiftpm
+install-swift-driver
 install-libcxx
 
 # Build the stress tester and SwiftEvolve
@@ -1685,6 +1703,22 @@ assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
+
+#===------------------------------------------------------------------------===#
+# Test Swift Driver (new)
+#===------------------------------------------------------------------------===#
+
+[preset: buildbot_swift-driver_macos]
+mixin-preset=mixin_swiftpm_package_macos_platform
+release
+assertions
+swift-driver
+
+[preset: buildbot_swift-driver_linux]
+mixin-preset=mixin_swiftpm_package_linux_platform
+release
+assertions
+swift-driver
 
 #===------------------------------------------------------------------------===#
 # Test Swift Syntax
@@ -2373,10 +2407,12 @@ validation-test
 build-ninja
 llbuild
 swiftpm
+swift-driver
 install-llbuild
 install-llvm
 install-swift
 install-swiftpm
+install-swift-driver
 reconfigure
 verbose-build
 skip-build-benchmarks


### PR DESCRIPTION
Build and test the new integrated swift driver against the just-built toolchain.
The new, integrated swift-driver is seeing a lot of development that goes hand-in-hand with the frontend so it would be extremely helpful to ensure we do not accidentally break `swift-driver` with frontend changes. 

