### PR TITLE
test: permit running executable tests on macOS on ASi

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -825,10 +825,12 @@ if run_vendor == 'apple':
     target_options_for_mock_sdk_after = sdk_overlay_dir_opt
     target_future_version = ''
 
-    if 'arm' in run_cpu and swift_test_mode != 'only_non_executable':
-        raise RuntimeError('Device tests are currently only supported when '
-        'the swift_test_mode is "only_non_executable". Current '
-        'swift_test_mode is {}.'.format(swift_test_mode))
+    # Only permit non-executable tests for ARM on Darwin unless you are on macOS
+    if 'arm' in run_cpu and run_os not in ('macosx',):
+        if swift_test_mode != 'only_non_executable':
+            raise RuntimeError('Device tests are currently only supported when '
+            'the swift_test_mode is "only_non_executable". Current '
+            'swift_test_mode is {}.'.format(swift_test_mode))
 
     if 'arm' in run_cpu and not (run_os == 'macosx' or run_os == 'maccatalyst'):
        # iOS/tvOS/watchOS device


### PR DESCRIPTION
This allows for running the full test suite on ASi.  This is required to
enable building Swift with tests on ASi.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
