### PR TITLE
test: macOS on ASi conforms to the stable ABI

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -708,6 +708,10 @@ if (run_os == 'maccatalyst'):
   target_os_abi = 'macosx'
   target_os_is_maccatalyst = "TRUE"
   config.available_features.add("OS=ios")
+# macOS on ASi uses the stable ABI
+if run_os in ('macosx',) and run_cpu in ('arm64',):
+  target_mandates_stable_abi = "TRUE"
+  config.available_features.add('swift_only_stable_abi')
 if (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-cygnus', 'windows-gnu', 'windows-msvc', 'linux-android', 'linux-androideabi']):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')


### PR DESCRIPTION
Configure the test suite properly for the expected ABI for macOS on ASi.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
