### PR TITLE
Revert "[Sema/Index] Resolve #keyPath components so they get handled by indexing, semantic highlighting, etc."

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5259,7 +5259,6 @@ public:
       OptionalWrap,
       Identity,
       TupleElement,
-      DictionaryKey,
     };
   
   private:
@@ -5368,16 +5367,6 @@ public:
                        propertyType,
                        loc);
     }
-
-    /// Create a component for a dictionary key (#keyPath only).
-    static Component forDictionaryKey(DeclNameRef UnresolvedName,
-                                      Type valueType,
-                                      SourceLoc loc) {
-      return Component(nullptr, UnresolvedName, nullptr, {}, {},
-                       Kind::DictionaryKey,
-                       valueType,
-                       loc);
-    }
     
     /// Create a component for a subscript.
     static Component forSubscript(ASTContext &ctx,
@@ -5468,7 +5457,6 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
-      case Kind::DictionaryKey:
         return true;
 
       case Kind::UnresolvedSubscript:
@@ -5493,7 +5481,6 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
-      case Kind::DictionaryKey:
         return nullptr;
       }
       llvm_unreachable("unhandled kind");
@@ -5513,7 +5500,6 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
-      case Kind::DictionaryKey:
         llvm_unreachable("no subscript labels for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5536,7 +5522,6 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
-      case Kind::DictionaryKey:
         return {};
       }
       llvm_unreachable("unhandled kind");
@@ -5548,7 +5533,6 @@ public:
     DeclNameRef getUnresolvedDeclName() const {
       switch (getKind()) {
       case Kind::UnresolvedProperty:
-      case Kind::DictionaryKey:
         return Decl.UnresolvedName;
 
       case Kind::Invalid:
@@ -5579,7 +5563,6 @@ public:
       case Kind::OptionalForce:
       case Kind::Identity:
       case Kind::TupleElement:
-      case Kind::DictionaryKey:
         llvm_unreachable("no decl ref for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5599,7 +5582,6 @@ public:
         case Kind::Identity:
         case Kind::Property:
         case Kind::Subscript:
-        case Kind::DictionaryKey:
           llvm_unreachable("no field number for this kind");
       }
       llvm_unreachable("unhandled kind");

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2829,11 +2829,6 @@ public:
         PrintWithColorRAII(OS, DiscriminatorColor)
           << "#" << component.getTupleIndex();
         break;
-      case KeyPathExpr::Component::Kind::DictionaryKey:
-        PrintWithColorRAII(OS, ASTNodeColor) << "dict_key";
-        PrintWithColorRAII(OS, IdentifierColor)
-          << "  key='" << component.getUnresolvedDeclName() << "'";
-        break;
       }
       PrintWithColorRAII(OS, TypeColor)
         << " type='" << GetTypeOfKeyPathComponent(E, i) << "'";

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1127,7 +1127,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::Invalid:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::TupleElement:
-      case KeyPathExpr::Component::Kind::DictionaryKey:
         // No subexpr to visit.
         break;
       }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2385,7 +2385,6 @@ void KeyPathExpr::Component::setSubscriptIndexHashableConformances(
   case Kind::Property:
   case Kind::Identity:
   case Kind::TupleElement:
-  case Kind::DictionaryKey:
     llvm_unreachable("no hashable conformances for this kind");
   }
 }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -412,7 +412,6 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Identity:
-      case KeyPathExpr::Component::Kind::DictionaryKey:
         break;
       }
     }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3734,11 +3734,6 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
       llvm_unreachable("not resolved");
-      break;
-
-    case KeyPathExpr::Component::Kind::DictionaryKey:
-      llvm_unreachable("DictionaryKey only valid in #keyPath");
-      break;
     }
   }
   

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -237,9 +237,6 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
       // Don't bother building the key path string if the key path didn't even
       // resolve.
       return false;
-    case KeyPathExpr::Component::Kind::DictionaryKey:
-      llvm_unreachable("DictionaryKey only valid in #keyPath expressions.");
-      return false;
     }
   }
   
@@ -4693,10 +4690,6 @@ namespace {
         case KeyPathExpr::Component::Kind::OptionalWrap:
         case KeyPathExpr::Component::Kind::TupleElement:
           llvm_unreachable("already resolved");
-          break;
-        case KeyPathExpr::Component::Kind::DictionaryKey:
-          llvm_unreachable("DictionaryKey only valid in #keyPath");
-          break;
         }
 
         // Update "componentTy" with the result type of the last component.
@@ -7752,8 +7745,9 @@ namespace {
             componentType = solution.simplifyType(cs.getType(kp, i));
             assert(!componentType->hasTypeVariable() &&
                    "Should not write type variable into key-path component");
-            kp->getMutableComponents()[i].setComponentType(componentType);
           }
+
+          kp->getMutableComponents()[i].setComponentType(componentType);
         }
       }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3485,9 +3485,6 @@ namespace {
         }
         case KeyPathExpr::Component::Kind::Identity:
           continue;
-        case KeyPathExpr::Component::Kind::DictionaryKey:
-          llvm_unreachable("DictionaryKey only valid in #keyPath");
-          break;
         }
 
         // By now, `base` is the result type of this component. Set it in the

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8236,9 +8236,6 @@ ConstraintSystem::simplifyKeyPathConstraint(
     case KeyPathExpr::Component::Kind::TupleElement:
       llvm_unreachable("not implemented");
       break;
-    case KeyPathExpr::Component::Kind::DictionaryKey:
-      llvm_unreachable("DictionaryKey only valid in #keyPath");
-      break;
     }
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -493,7 +493,6 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     case ComponentKind::OptionalChain:
     case ComponentKind::OptionalWrap:
     case ComponentKind::Identity:
-    case ComponentKind::DictionaryKey:
       // These components don't have any callee associated, so just continue.
       break;
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2522,7 +2522,6 @@ private:
       case KeyPathExpr::Component::Kind::OptionalWrap:
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Identity:
-      case KeyPathExpr::Component::Kind::DictionaryKey:
         break;
       }
     }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -621,21 +621,9 @@ static Optional<Type> getTypeOfCompletionContextExpr(
 
   case CompletionTypeCheckKind::KeyPath:
     referencedDecl = nullptr;
-    if (auto keyPath = dyn_cast<KeyPathExpr>(parsedExpr)) {
-      auto components = keyPath->getComponents();
-      if (!components.empty()) {
-        auto &last = components.back();
-        if (last.isResolved()) {
-          if (last.getKind() == KeyPathExpr::Component::Kind::Property)
-            referencedDecl = last.getDeclRef();
-          Type lookupTy = last.getComponentType();
-          ASTContext &Ctx = DC->getASTContext();
-          if (auto bridgedClass = Ctx.getBridgedToObjC(DC, lookupTy))
-            return bridgedClass;
-          return lookupTy;
-        }
-      }
-    }
+    if (auto keyPath = dyn_cast<KeyPathExpr>(parsedExpr))
+      return TypeChecker::checkObjCKeyPathExpr(DC, keyPath,
+                                               /*requireResultType=*/true);
 
     return None;
   }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -221,7 +221,6 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     case KeyPathExpr::Component::Kind::OptionalWrap:
     case KeyPathExpr::Component::Kind::Property:
     case KeyPathExpr::Component::Kind::Subscript:
-    case KeyPathExpr::Component::Kind::DictionaryKey:
       llvm_unreachable("already resolved!");
     }
     
@@ -242,9 +241,6 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       // From here, we're resolving a property. Use the current type.
       updateState(/*isProperty=*/true, currentType);
 
-      auto resolved = KeyPathExpr::Component::
-        forDictionaryKey(componentName, currentType, componentNameLoc);
-      resolvedComponents.push_back(resolved);
       continue;
     }
 
@@ -325,14 +321,10 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     if (auto var = dyn_cast<VarDecl>(found)) {
       // Resolve this component to the variable we found.
       auto varRef = ConcreteDeclRef(var);
-      Type varTy = var->getInterfaceType();
-
-      // Updates currentType
-      updateState(/*isProperty=*/true, varTy);
-
-      auto resolved = KeyPathExpr::Component::forProperty(varRef, currentType,
-                                                          componentNameLoc);
+      auto resolved =
+        KeyPathExpr::Component::forProperty(varRef, Type(), componentNameLoc);
       resolvedComponents.push_back(resolved);
+      updateState(/*isProperty=*/true, var->getInterfaceType());
 
       // Check that the property is @objc.
       if (!var->isObjC()) {
@@ -398,15 +390,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         break;
       }
 
-      // Updates currentType based on newType.
       updateState(/*isProperty=*/false, newType);
-
-      // Resolve this component to the type we found.
-      auto typeRef = ConcreteDeclRef(type);
-      auto resolved = KeyPathExpr::Component::forProperty(typeRef, currentType,
-                                                          componentNameLoc);
-      resolvedComponents.push_back(resolved);
-
       continue;
     }
 

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -6,16 +6,6 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_2 | %FileCheck -check-prefix=CHECK-IN_KEYPATH %s
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_3 | %FileCheck -check-prefix=CHECK-IN_KEYPATH_BRIDGED_STRING %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_4 | %FileCheck -check-prefix=CHECK-IN_KEYPATH_BRIDGED_STRING %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_5 | %FileCheck -check-prefixes=CHECK-IN_KEYPATH,CHECK-IN_KEYPATH_OPT %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_6 | %FileCheck -check-prefixes=CHECK-IN_KEYPATH,CHECK-IN_KEYPATH_OPT %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_KEYPATH_7 | %FileCheck -check-prefixes=CHECK-IN_KEYPATH_BRIDGED_STRING %s
-
 
 // REQUIRES: objc_interop
 
@@ -31,11 +21,9 @@ func selectorArg1(obj: NSObject) {
   acceptKeyPath(#^KEYPATH_ARG^#
 }
 
-@objcMembers class ObjCClass : NSObject {
+class ObjCClass : NSObject {
   var prop1: String = ""
   var prop2: ObjCClass?
-  var prop3: [ObjCClass]? = []
-  var prop4: [String: String] = [:]
 
   func completeInKeyPath1() {
     _ = #keyPath(#^IN_KEYPATH_1^#
@@ -46,42 +34,12 @@ func completeInKeyPath2() {
   _ = #keyPath(ObjCClass.#^IN_KEYPATH_2^#
 }
 
-func completeInKeyPath3() {
-   _ = #keyPath(ObjCClass.prop1.#^IN_KEYPATH_3^#
-}
-func completeInKeyPath3() {
-     _ = #keyPath(String.#^IN_KEYPATH_4^#
-}
-
-func completeInKeyPath4() {
-  _ = #keyPath(ObjCClass.prop2.#^IN_KEYPATH_5^#
-}
-
-func completeInKeyPath5() {
-  _ = #keyPath(ObjCClass.prop3.#^IN_KEYPATH_6^#
-}
-
-func completeInKeyPath6() {
-  _ = #keyPath(ObjCClass.prop4.anythingHere.#^IN_KEYPATH_7^#
-}
-
 // CHECK-AFTER_POUND-NOT: keyPath
 
 // CHECK-KEYPATH_ARG: Keyword/None/TypeRelation[Identical]: #keyPath({#@objc property sequence#})[#String#]; name=#keyPath(@objc property sequence)
 
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop1[#String#]; name=prop1
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2
-// CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop3[#[ObjCClass]?#]; name=prop3
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/Super:            hashValue[#Int#]; name=hashValue
-
-// Make sure we unwrap optionals (members of Optional itself are invalid in this context)
-//
-// CHECK-IN_KEYPATH_OPT-NOT: name=map
-
-// Make sure we handle bridged types (i.e. show NSString members rather than String members)
-//
-// CHECK-IN_KEYPATH_BRIDGED_STRING: Decl[InstanceVar]/CurrNominal/IsSystem: urlsInText[#[URL]#]; name=urlsInText
-// CHECK-IN_KEYPATH_BRIDGED_STRING: Decl[InstanceVar]/CurrNominal/IsSystem: uppercased[#String!#]; name=uppercased
-// CHECK-IN_KEYPATH_BRIDGED_STRING-NOT: name=count
 
 

--- a/test/Index/index_keypaths.swift
+++ b/test/Index/index_keypaths.swift
@@ -1,11 +1,15 @@
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-indexed-symbols -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 // REQUIRES: objc_interop
-
-import Foundation
 
 struct MyStruct {
   struct Inner {
     let myProp = 1
+  }
+}
+
+class MyClass {
+  class Inner {
+    @objc var myProp = 1
   }
 }
 
@@ -15,33 +19,9 @@ let a = \MyStruct.Inner.myProp
 // CHECK: [[@LINE-3]]:19 | {{.*}} | Inner
 let b: KeyPath<MyStruct.Inner, Int> = \.myProp
 // CHECK: [[@LINE-1]]:41 | {{.*}} | myProp
-
-@objc class MyClass: NSObject {
-  @objc class Inner: NSObject {
-    @objc var myProp = 1
-    @objc var otherProp:[String: MyClass.Inner] = [:]
-    func method() {
-      let c: String = #keyPath(myProp)
-      // CHECK: [[@LINE-1]]:32 | {{.*}} | myProp
-    }
-  }
-}
-
-let d: String = #keyPath(MyClass.Inner.myProp)
-// CHECK: [[@LINE-1]]:26 | {{.*}} | MyClass
-// CHECK: [[@LINE-2]]:34 | {{.*}} | Inner
-// CHECK: [[@LINE-3]]:40 | {{.*}} | myProp
-
-let e = \MyClass.Inner.myProp
+let c = \MyClass.Inner.myProp
 // CHECK: [[@LINE-1]]:24 | {{.*}} | myProp
 // CHECK: [[@LINE-2]]:10 | {{.*}} | MyClass
 // CHECK: [[@LINE-3]]:18 | {{.*}} | Inner
-
-let f: KeyPath<MyClass.Inner, Int> = \.myProp
+let d: KeyPath<MyClass.Inner, Int> = \.myProp
 // CHECK: [[@LINE-1]]:40 | {{.*}} | myProp
-
-let g: String = #keyPath(MyClass.Inner.otherProp.someDictKey.myProp)
-// CHECK: [[@LINE-1]]:26 | {{.*}} | MyClass
-// CHECK: [[@LINE-2]]:34 | {{.*}} | Inner
-// CHECK: [[@LINE-3]]:40 | {{.*}} | otherProp
-// CHECK: [[@LINE-4]]:62 | {{.*}} | myProp

--- a/test/expr/primary/keypath/keypath-objc.swift
+++ b/test/expr/primary/keypath/keypath-objc.swift
@@ -57,7 +57,7 @@ func testKeyPath(a: A, b: B) {
   let _: String = #keyPath(A.propString)
 
   // Property of String property (which looks on NSString)
-  let _: String = #keyPath(A.propString.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propString.URLsInText)
 
   // String property with a suffix
   let _: String = #keyPath(A.propString).description
@@ -72,7 +72,7 @@ func testKeyPath(a: A, b: B) {
 
   // Array property (make sure we look at the array element).
   let _: String = #keyPath(A.propArray)
-  let _: String = #keyPath(A.propArray.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propArray.URLsInText)
 
   // Dictionary property (make sure we look at the value type).
   let _: String = #keyPath(A.propDict.anyKeyName)
@@ -80,20 +80,20 @@ func testKeyPath(a: A, b: B) {
 
   // Set property (make sure we look at the set element).
   let _: String = #keyPath(A.propSet)
-  let _: String = #keyPath(A.propSet.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propSet.URLsInText)
 
   // AnyObject property
-  let _: String = #keyPath(A.propAnyObject.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propAnyObject.URLsInText)  
   let _: String = #keyPath(A.propAnyObject.propA)  
   let _: String = #keyPath(A.propAnyObject.propB)  
   let _: String = #keyPath(A.propAnyObject.description)  
 
   // NSString property
-  let _: String = #keyPath(A.propNSString.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propNSString.URLsInText)  
 
   // NSArray property (AnyObject array element).
   let _: String = #keyPath(A.propNSArray)
-  let _: String = #keyPath(A.propNSArray.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propNSArray.URLsInText)
 
   // NSDictionary property (AnyObject value type).
   let _: String = #keyPath(A.propNSDict.anyKeyName)
@@ -101,7 +101,7 @@ func testKeyPath(a: A, b: B) {
 
   // NSSet property (AnyObject set element).
   let _: String = #keyPath(A.propNSSet)
-  let _: String = #keyPath(A.propNSSet.URLsInText) // expected-error{{'URLsInText' has been renamed to 'urlsInText'}}
+  let _: String = #keyPath(A.propNSSet.URLsInText)
 
   // Property with keyword name.
   let _: String = #keyPath(A.repeat)


### PR DESCRIPTION
Reverts apple/swift#33245

This caused source compatibility failures.
rdar://problem/66526501