### PR TITLE
[sil] Define ValueOwnershipKind::isCompatibleWith(SILValue v).

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -41,6 +41,7 @@ class SILLocation;
 class DeadEndBlocks;
 class ValueBaseUseIterator;
 class ValueUseIterator;
+class SILValue;
 
 /// An enumeration which contains values for all the concrete ValueBase
 /// subclasses.
@@ -187,6 +188,12 @@ struct ValueOwnershipKind {
   bool isCompatibleWith(ValueOwnershipKind other) const {
     return merge(other).hasValue();
   }
+
+  /// Returns isCompatibleWith(other.getOwnershipKind()).
+  ///
+  /// Definition is inline after SILValue is defined to work around circular
+  /// dependencies.
+  bool isCompatibleWith(SILValue other) const;
 
   template <typename RangeTy>
   static Optional<ValueOwnershipKind> merge(RangeTy &&r) {
@@ -439,6 +446,10 @@ public:
   /// Verify that this SILValue and its uses respects ownership invariants.
   void verifyOwnership(DeadEndBlocks *DEBlocks = nullptr) const;
 };
+
+inline bool ValueOwnershipKind::isCompatibleWith(SILValue other) const {
+  return isCompatibleWith(other.getOwnershipKind());
+}
 
 /// A map from a ValueOwnershipKind that an operand can accept to a
 /// UseLifetimeConstraint that describes the effect that the operand's use has


### PR DESCRIPTION
This just returns isCompatibleWith(v.getOwnershipKind()). Just makes some code
easier to write.
