### PR TITLE
[5.3][Diagnostics] Detect and diagnose type mismatches related to function…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2107,6 +2107,11 @@ bool ContextualFailure::diagnoseAsError() {
     return true;
   }
 
+  case ConstraintLocator::FunctionBuilderBodyResult: {
+    diagnostic = *getDiagnosticFor(CTP_Initialization, toType);
+    break;
+  }
+
   default:
     return false;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4264,6 +4264,12 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::FunctionBuilderBodyResult: {
+    conversionsOrFixes.push_back(ContextualMismatch::create(
+        *this, lhs, rhs, getConstraintLocator(locator)));
+    break;
+  }
+
   default:
     break;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3531,6 +3531,11 @@ void constraints::simplifyLocator(Expr *&anchor,
       continue;
     }
 
+    case ConstraintLocator::FunctionBuilderBodyResult: {
+      path = path.slice(1);
+      break;
+    }
+
     default:
       // FIXME: Lots of other cases to handle.
       break;

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -602,4 +602,8 @@ struct MyView {
     case . // expected-error {{expected ':' after 'case'}}
     } // expected-error {{expected identifier after '.' expression}}
   }
+
+  @TupleBuilder var invalidConversion: Int {
+    "" // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
+  }
 }


### PR DESCRIPTION
… builder result

Cherry-pick of https://github.com/apple/swift/pull/33298

---

- Explanation:

Generic requirement failures are already covered but general type
mismatches have to be handled separately.

- Scope: Limited to function builder bodies with produce incorrect type.

- Resolves: rdar://problem/65413640

- Risk: Very Low

- Testing: Added regression tests

- Reviewer: @hborla 

Resolves: rdar://problem/65413640
(cherry picked from commit 98007904b83a6cc5ef3b8320635c9258972dfcff)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
