### PR TITLE
[IRGen] Use the lexical decl context for VarDecls.

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -98,6 +98,11 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
         refFinder.TraverseDecl(executableDecl);
         next = executableDecl;
     }
+
+    if (auto var = dyn_cast<clang::VarDecl>(next))
+      if (!var->isFileVarDecl())
+	continue;
+
     ClangCodeGen->HandleTopLevelDecl(clang::DeclGroupRef(next));
   }
 }

--- a/test/IRGen/Inputs/local_extern.h
+++ b/test/IRGen/Inputs/local_extern.h
@@ -1,0 +1,21 @@
+static inline int _no_prior_var() {
+  extern int var;
+  return var;
+}
+
+static inline int _no_prior_func() {
+  extern int func();
+  return func();
+}
+
+static int prior_var = 1;
+static inline int _prior_var() {
+  extern int prior_var;
+  return prior_var;
+}
+
+static inline int prior_func() { return 1; }
+static inline int _prior_func() {
+  extern int prior_func();
+  return prior_func();
+}

--- a/test/IRGen/local_extern.swift
+++ b/test/IRGen/local_extern.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/local_extern.h %s -emit-ir | %FileCheck %s
+// CHECK: @var = external global i32
+// CHECK: @prior_var = internal global i32
+// CHECK: declare i32 @func
+// CHECK: define internal i32 @prior_func
+
+print("\(_no_prior_var())")
+print("\(_no_prior_func())")
+print("\(_prior_var())")
+print("\(_prior_func())")


### PR DESCRIPTION
In emitClangDecl, we spend some time ensuring that we only pass file or top-level decls to LLVM. This is done by examining the decl context (via Decl::getDeclContext) and determining whether isFileContext is true. On the LLVM side, CodeGenModule::EmitGlobal asserts if the decl eventually passed to it is not a "file scoped" via VarDecl::isFileVarDecl.
    
Generally, these concepts match in all cases but one. Local extern variables have a decl context which has isFileContext being true, just like global extern variables, but isFileVarDecl does *not* return true -- it is a local variable, after all.
    
Indeed, isFileVarDecl is implemented by examining the context with Decl::getLexicalDeclContext instead of Decl::getDeclContext. Thus, we should probably be using getLexicalDeclContext instead of getDeclContext in emitClangDecl, so we properly match the expectations on the LLVM side.
    
This indirectly addresses #28968, since that contains the only part of the Swift stdlib that uses a local extern variable, but any header that is used with Swift that contains a local extern variable will cause the compiler to assert when built with assertions enabled.

//

Note to the prospective reviewer: I'm fairly confident this is correct, but it would be great for someone more familiar with this corner of the code to double-check my reasoning and whether this change is valid.