### PR TITLE
[utils] Add Uxtheme.h to VFS overlay

### DIFF
--- a/utils/WindowsSDKVFSOverlay.yaml.in
+++ b/utils/WindowsSDKVFSOverlay.yaml.in
@@ -149,6 +149,9 @@ roots:
       - name: unknwn.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Unknwn.h"
+      - name: uxtheme.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Uxtheme.h"
       - name: unknwnbase.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Unknwnbase.h"


### PR DESCRIPTION
This is needed for building the stdlib for Windows now.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
