### PR TITLE
[Statement checker] Always wire up case vars with bindSwitchCasePatternVars

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -814,13 +814,13 @@ class CaseLabelItem {
     Default,
   };
 
-  Pattern *CasePattern;
+  llvm::PointerIntPair<Pattern *, 1, bool> CasePatternAndResolved;
   SourceLoc WhereLoc;
   llvm::PointerIntPair<Expr *, 1, Kind> GuardExprAndKind;
 
   CaseLabelItem(Kind kind, Pattern *casePattern, SourceLoc whereLoc,
                 Expr *guardExpr)
-    : CasePattern(casePattern), WhereLoc(whereLoc),
+    : CasePatternAndResolved(casePattern, false), WhereLoc(whereLoc),
       GuardExprAndKind(guardExpr, kind) {}
 
 public:
@@ -848,9 +848,19 @@ public:
   SourceLoc getEndLoc() const;
   SourceRange getSourceRange() const;
 
-  Pattern *getPattern() { return CasePattern; }
-  const Pattern *getPattern() const { return CasePattern; }
-  void setPattern(Pattern *CasePattern) { this->CasePattern = CasePattern; }
+  Pattern *getPattern() {
+    return CasePatternAndResolved.getPointer();
+  }
+  const Pattern *getPattern() const {
+    return CasePatternAndResolved.getPointer();
+  }
+  bool isPatternResolved() const {
+    return CasePatternAndResolved.getInt();
+  }
+  void setPattern(Pattern *CasePattern, bool resolved) {
+    this->CasePatternAndResolved.setPointer(CasePattern);
+    this->CasePatternAndResolved.setInt(resolved);
+  }
 
   /// Return the guard expression if present, or null if the case label has
   /// no guard.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1628,7 +1628,7 @@ Stmt *Traversal::visitSwitchStmt(SwitchStmt *S) {
 Stmt *Traversal::visitCaseStmt(CaseStmt *S) {
   for (auto &CLI : S->getMutableCaseLabelItems()) {
     if (auto *newPattern = doIt(CLI.getPattern()))
-      CLI.setPattern(newPattern);
+      CLI.setPattern(newPattern, /*resolved=*/CLI.isPatternResolved());
     else
       return nullptr;
     if (CLI.getGuardExpr()) {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -392,16 +392,16 @@ SourceLoc RepeatWhileStmt::getEndLoc() const { return Cond->getEndLoc(); }
 
 SourceRange CaseLabelItem::getSourceRange() const {
   if (auto *E = getGuardExpr())
-    return { CasePattern->getStartLoc(), E->getEndLoc() };
-  return CasePattern->getSourceRange();
+    return { getPattern()->getStartLoc(), E->getEndLoc() };
+  return getPattern()->getSourceRange();
 }
 SourceLoc CaseLabelItem::getStartLoc() const {
-  return CasePattern->getStartLoc();
+  return getPattern()->getStartLoc();
 }
 SourceLoc CaseLabelItem::getEndLoc() const {
   if (auto *E = getGuardExpr())
     return E->getEndLoc();
-  return CasePattern->getEndLoc();
+  return getPattern()->getEndLoc();
 }
 
 CaseStmt::CaseStmt(CaseParentKind parentKind, SourceLoc itemIntroducerLoc,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8262,7 +8262,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
                                          target.getDeclContext());
     if (auto coercedPattern = TypeChecker::coercePatternToType(
             contextualPattern, patternType, patternOptions)) {
-      (*caseLabelItem)->setPattern(coercedPattern);
+      (*caseLabelItem)->setPattern(coercedPattern, /*resolved=*/true);
     } else {
       return None;
     }
@@ -8584,7 +8584,8 @@ SolutionApplicationTarget SolutionApplicationTarget::walk(ASTWalker &walker) {
   case Kind::caseLabelItem:
     if (auto newPattern =
             caseLabelItem.caseLabelItem->getPattern()->walk(walker)) {
-      caseLabelItem.caseLabelItem->setPattern(newPattern);
+      caseLabelItem.caseLabelItem->setPattern(
+          newPattern, caseLabelItem.caseLabelItem->isPatternResolved());
     }
     if (auto guardExpr = caseLabelItem.caseLabelItem->getGuardExpr()) {
       if (auto newGuardExpr = guardExpr->walk(walker))

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2660,12 +2660,14 @@ namespace {
 
           // Okay, resolve the pattern.
           Pattern *pattern = LabelItem.getPattern();
-          pattern = TypeChecker::resolvePattern(pattern, CS.DC,
-                                         /*isStmtCondition*/false);
-          if (!pattern) return false;
+          if (!LabelItem.isPatternResolved()) {
+            pattern = TypeChecker::resolvePattern(pattern, CS.DC,
+                                           /*isStmtCondition*/false);
+            if (!pattern) return false;
 
-          // Save that aside while we explore the type.
-          LabelItem.setPattern(pattern);
+            // Save that aside while we explore the type.
+            LabelItem.setPattern(pattern, /*resolved=*/true);
+          }
 
           // Require the pattern to have a particular shape: a number
           // of is-patterns applied to an irrefutable pattern.
@@ -2704,7 +2706,7 @@ namespace {
           if (!pattern)
             return false;
 
-          LabelItem.setPattern(pattern);
+          LabelItem.setPattern(pattern, /*resolved=*/true);
           return LabelItem.isSyntacticallyExhaustive();
         }
 
@@ -4229,14 +4231,17 @@ bool ConstraintSystem::generateConstraints(
     CaseStmt *caseStmt, DeclContext *dc, Type subjectType,
     ConstraintLocator *locator) {
   // Pre-bind all of the pattern variables within the case.
-  bindSwitchCasePatternVars(caseStmt);
+  bindSwitchCasePatternVars(dc, caseStmt);
 
   for (auto &caseLabelItem : caseStmt->getMutableCaseLabelItems()) {
     // Resolve the pattern.
-    auto *pattern = TypeChecker::resolvePattern(
-        caseLabelItem.getPattern(), dc, /*isStmtCondition=*/false);
-    if (!pattern)
-      return true;
+    auto *pattern = caseLabelItem.getPattern();
+    if (!caseLabelItem.isPatternResolved()) {
+      pattern = TypeChecker::resolvePattern(
+          pattern, dc, /*isStmtCondition=*/false);
+      if (!pattern)
+        return true;
+    }
 
     // Generate constraints for the pattern, including one-way bindings for
     // any variables that show up in this pattern, because those variables

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Timer.h"
+#include <iterator>
 
 using namespace swift;
 
@@ -1086,19 +1087,15 @@ public:
 
   void checkCaseLabelItemPattern(CaseStmt *caseBlock, CaseLabelItem &labelItem,
                                  bool &limitExhaustivityChecks,
-                                 Type subjectType,
-                                 SmallVectorImpl<VarDecl *> **prevCaseDecls,
-                                 SmallVectorImpl<VarDecl *> **nextCaseDecls) {
+                                 Type subjectType) {
     Pattern *pattern = labelItem.getPattern();
-    auto *newPattern = TypeChecker::resolvePattern(pattern, DC,
-                                                   /*isStmtCondition*/ false);
-    if (!newPattern) {
-      pattern->collectVariables(**nextCaseDecls);
-      std::swap(*prevCaseDecls, *nextCaseDecls);
-      return;
+    if (!labelItem.isPatternResolved()) {
+      pattern = TypeChecker::resolvePattern(
+          pattern, DC, /*isStmtCondition*/ false);
+      if (!pattern) {
+        return;
+      }
     }
-
-    pattern = newPattern;
 
     // Coerce the pattern to the subject's type.
     bool coercionError = false;
@@ -1122,15 +1119,7 @@ public:
         VD->setInvalid();
       });
     }
-    labelItem.setPattern(pattern);
-
-    // If we do not have decls from the previous case that we need to match,
-    // just return. This only happens with the first case label item.
-    if (!*prevCaseDecls) {
-      pattern->collectVariables(**nextCaseDecls);
-      std::swap(*prevCaseDecls, *nextCaseDecls);
-      return;
-    }
+    labelItem.setPattern(pattern, /*resolved=*/true);
 
     // Otherwise for each variable in the pattern, make sure its type is
     // identical to the initial case decl and stash the previous case decl as
@@ -1142,88 +1131,56 @@ public:
       // We know that prev var decls matches the initial var decl. So if we can
       // match prevVarDecls, we can also match initial var decl... So for each
       // decl in prevVarDecls...
-      for (auto *expected : **prevCaseDecls) {
-        // If we do not match the name of vd, continue.
-        if (!expected->hasName() || expected->getName() != vd->getName())
-          continue;
+      auto expected = vd->getParentVarDecl();
+      if (!expected)
+        return;
 
-        // Ok, we found a match! Before we leave, mark expected as the parent of
-        // vd and add vd to the next case decl list for the next iteration.
-        SWIFT_DEFER {
-          vd->setParentVarDecl(expected);
-          (*nextCaseDecls)->push_back(vd);
-        };
+      // Then we check for errors.
+      //
+      // NOTE: We emit the diagnostics against the initial case label item var
+      // decl associated with expected to ensure that we always emit
+      // diagnostics against a single reference var decl. If we used expected
+      // instead, we would emit confusing diagnostics since a correct var decl
+      // after an incorrect var decl will be marked as incorrect. For instance
+      // given the following case statement.
+      //
+      //   case .a(let x), .b(var x), .c(let x):
+      //
+      // if we use expected, we will emit errors saying that .b(var x) needs
+      // to be a let and .c(let x) needs to be a var. Thus if one
+      // automatically applied both fix-its, one would still get an error
+      // producing program:
+      //
+      //   case .a(let x), .b(let x), .c(var x):
+      //
+      // More complex case label item lists could cause even longer fixup
+      // sequences. Thus, we emit errors against the VarDecl associated with
+      // expected in the initial case label item list.
+      //
+      // Luckily, it is easy for us to compute this since we only change the
+      // parent field of the initial case label item's VarDecls /after/ we
+      // finish updating the parent pointers of the VarDecls associated with
+      // all other CaseLabelItems. So that initial group of VarDecls are
+      // guaranteed to still have a parent pointer pointing at our
+      // CaseStmt. Since we have setup the parent pointer VarDecl linked list
+      // for all other CaseLabelItem var decls that we have already processed,
+      // we can use our VarDecl linked list to find that initial case label
+      // item VarDecl.
+      auto *initialCaseVarDecl = expected;
+      while (auto *prev = initialCaseVarDecl->getParentVarDecl()) {
+        initialCaseVarDecl = prev;
+      }
+      assert(isa<CaseStmt>(initialCaseVarDecl->getParentPatternStmt()));
 
-        // Then we check for errors.
-        //
-        // NOTE: We emit the diagnostics against the initial case label item var
-        // decl associated with expected to ensure that we always emit
-        // diagnostics against a single reference var decl. If we used expected
-        // instead, we would emit confusing diagnostics since a correct var decl
-        // after an incorrect var decl will be marked as incorrect. For instance
-        // given the following case statement.
-        //
-        //   case .a(let x), .b(var x), .c(let x):
-        //
-        // if we use expected, we will emit errors saying that .b(var x) needs
-        // to be a let and .c(let x) needs to be a var. Thus if one
-        // automatically applied both fix-its, one would still get an error
-        // producing program:
-        //
-        //   case .a(let x), .b(let x), .c(var x):
-        //
-        // More complex case label item lists could cause even longer fixup
-        // sequences. Thus, we emit errors against the VarDecl associated with
-        // expected in the initial case label item list.
-        //
-        // Luckily, it is easy for us to compute this since we only change the
-        // parent field of the initial case label item's VarDecls /after/ we
-        // finish updating the parent pointers of the VarDecls associated with
-        // all other CaseLabelItems. So that initial group of VarDecls are
-        // guaranteed to still have a parent pointer pointing at our
-        // CaseStmt. Since we have setup the parent pointer VarDecl linked list
-        // for all other CaseLabelItem var decls that we have already processed,
-        // we can use our VarDecl linked list to find that initial case label
-        // item VarDecl.
-        auto *initialCaseVarDecl = expected;
-        while (auto *prev = initialCaseVarDecl->getParentVarDecl()) {
-          initialCaseVarDecl = prev;
-        }
-        assert(isa<CaseStmt>(initialCaseVarDecl->getParentPatternStmt()));
-
-        if (!initialCaseVarDecl->isInvalid() &&
-            !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
-          getASTContext().Diags.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
-                      vd->getType(), initialCaseVarDecl->getType());
-          vd->setInvalid();
-          initialCaseVarDecl->setInvalid();
-        }
-
-        if (initialCaseVarDecl->isLet() == vd->isLet()) {
-          return;
-        }
-
-        auto diag = vd->diagnose(diag::mutability_mismatch_multiple_pattern_list,
-                                 vd->isLet(), initialCaseVarDecl->isLet());
-
-        BindingPattern *foundVP = nullptr;
-        vd->getParentPattern()->forEachNode([&](Pattern *P) {
-          if (auto *VP = dyn_cast<BindingPattern>(P))
-            if (VP->getSingleVar() == vd)
-              foundVP = VP;
-        });
-        if (foundVP)
-          diag.fixItReplace(foundVP->getLoc(),
-                            initialCaseVarDecl->isLet() ? "let" : "var");
+      if (!initialCaseVarDecl->isInvalid() &&
+          !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
+        getASTContext().Diags.diagnose(
+            vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
+            vd->getType(), initialCaseVarDecl->getType());
         vd->setInvalid();
         initialCaseVarDecl->setInvalid();
       }
     });
-
-    // Clear our previous case decl list and the swap in the new decls for the
-    // next iteration.
-    (*prevCaseDecls)->clear();
-    std::swap(*prevCaseDecls, *nextCaseDecls);
   }
 
   template <typename Iterator>
@@ -1235,38 +1192,18 @@ public:
                      CaseStmt *>::value,
         "Expected an iterator over CaseStmt *");
 
-    SmallVector<VarDecl *, 8> scratchMemory1;
-    SmallVector<VarDecl *, 8> scratchMemory2;
-    CaseStmt *previousBlock = nullptr;
-
     // First pass: check all of the bindings.
-    for (auto i = casesBegin; i != casesEnd; ++i) {
-      auto *caseBlock = *i;
-
-      scratchMemory1.clear();
-      scratchMemory2.clear();
-
-      SmallVectorImpl<VarDecl *> *prevCaseDecls = nullptr;
-      SmallVectorImpl<VarDecl *> *nextCaseDecls = &scratchMemory1;
+    for (auto *caseBlock : make_range(casesBegin, casesEnd)) {
+      // Bind all of the pattern variables together so we can follow the
+      // "parent" pointers later on.
+      bindSwitchCasePatternVars(DC, caseBlock);
 
       auto caseLabelItemArray = caseBlock->getMutableCaseLabelItems();
-      {
-        // Peel off the first iteration so we handle the first case label
-        // especially since we use it to begin the validation chain.
-        auto &labelItem = caseLabelItemArray.front();
-
+      for (auto &labelItem : caseLabelItemArray) {
         // Resolve the pattern in our case label if it has not been resolved and
         // check that our var decls follow invariants.
         checkCaseLabelItemPattern(caseBlock, labelItem, limitExhaustivityChecks,
-                                  subjectType, &prevCaseDecls, &nextCaseDecls);
-
-        // After this is complete, prevCaseDecls will be pointing at
-        // scratchMemory1 which contains the initial case block's var decls and
-        // nextCaseDecls will be a nullptr. Set nextCaseDecls to point at
-        // scratchMemory2 for the next iterations.
-        assert(prevCaseDecls == &scratchMemory1);
-        assert(nextCaseDecls == nullptr);
-        nextCaseDecls = &scratchMemory2;
+                                  subjectType);
 
         // Check the guard expression, if present.
         if (auto *guard = labelItem.getGuardExpr()) {
@@ -1278,56 +1215,10 @@ public:
       // Setup the types of our case body var decls.
       for (auto *expected : caseBlock->getCaseBodyVariablesOrEmptyArray()) {
         assert(expected->hasName());
-        for (auto *prev : *prevCaseDecls) {
-          if (!prev->hasName() || expected->getName() != prev->getName()) {
-            continue;
-          }
-          if (prev->hasInterfaceType())
-            expected->setInterfaceType(prev->getInterfaceType());
-          break;
-        }
+        auto prev = expected->getParentVarDecl();
+        if (prev->hasInterfaceType())
+          expected->setInterfaceType(prev->getInterfaceType());
       }
-
-      // Then check the rest.
-      for (auto &labelItem : caseLabelItemArray.drop_front()) {
-        // Resolve the pattern in our case label if it has not been resolved
-        // and check that our var decls follow invariants.
-        checkCaseLabelItemPattern(caseBlock, labelItem, limitExhaustivityChecks,
-                                  subjectType, &prevCaseDecls, &nextCaseDecls);
-        // Check the guard expression, if present.
-        if (auto *guard = labelItem.getGuardExpr()) {
-          limitExhaustivityChecks |= TypeChecker::typeCheckCondition(guard, DC);
-          labelItem.setGuardExpr(guard);
-        }
-      }
-
-      // Our last CaseLabelItem's VarDecls are now in
-      // prevCaseDecls. Wire them up as parents of our case body var
-      // decls.
-      //
-      // NOTE: We know that the two lists of var decls must be in sync. Remember
-      // that we constructed our case body VarDecls from the first
-      // CaseLabelItems var decls. Just now we proved that all other
-      // CaseLabelItems have matching var decls of the first meaning
-      // transitively that our last case label item must have matching var decls
-      // for our case stmts CaseBodyVarDecls.
-      //
-      // NOTE: We do not check that we matched everything here. That is because
-      // the check has already been done by comparing the 1st CaseLabelItem var
-      // decls. If we insert a check here, we will emit the same error multiple
-      // times.
-      for (auto *expected : caseBlock->getCaseBodyVariablesOrEmptyArray()) {
-        assert(expected->hasName());
-        for (auto *prev : *prevCaseDecls) {
-          if (!prev->hasName() || expected->getName() != prev->getName()) {
-            continue;
-          }
-          expected->setParentVarDecl(prev);
-          break;
-        }
-      }
-
-      previousBlock = caseBlock;
     }
 
     // Second pass: type-check the body statements.
@@ -2301,9 +2192,9 @@ void swift::checkUnknownAttrRestrictions(
   }
 }
 
-void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
+void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
   llvm::SmallDenseMap<Identifier, std::pair<VarDecl *, bool>, 4> latestVars;
-  auto recordVar = [&](VarDecl *var) {
+  auto recordVar = [&](Pattern *pattern, VarDecl *var) {
     if (!var->hasName())
       return;
 
@@ -2316,7 +2207,7 @@ void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
       var->setParentVarDecl(entry.first);
 
       // Check for a mutability mismatch.
-      if (entry.second != var->isLet()) {
+      if (pattern && entry.second != var->isLet()) {
         // Find the original declaration.
         auto initialCaseVarDecl = entry.first;
         while (auto parentVar = initialCaseVarDecl->getParentVarDecl())
@@ -2326,7 +2217,7 @@ void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
                                   var->isLet(), initialCaseVarDecl->isLet());
 
         BindingPattern *foundVP = nullptr;
-        var->getParentPattern()->forEachNode([&](Pattern *P) {
+        pattern->forEachNode([&](Pattern *P) {
           if (auto *VP = dyn_cast<BindingPattern>(P))
             if (VP->getSingleVar() == var)
               foundVP = VP;
@@ -2334,6 +2225,9 @@ void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
         if (foundVP)
           diag.fixItReplace(foundVP->getLoc(),
                             initialCaseVarDecl->isLet() ? "let" : "var");
+
+        var->setInvalid();
+        initialCaseVarDecl->setInvalid();
       }
     } else {
       entry.second = var->isLet();
@@ -2345,12 +2239,24 @@ void swift::bindSwitchCasePatternVars(CaseStmt *caseStmt) {
 
   // Wire up the parent var decls for each variable that occurs within
   // the patterns of each case item. in source order.
-  for (const auto &caseItem : caseStmt->getCaseLabelItems()) {
-    caseItem.getPattern()->forEachVariable(recordVar);
+  for (auto &caseItem : caseStmt->getMutableCaseLabelItems()) {
+    // Resolve the pattern.
+    auto *pattern = caseItem.getPattern();
+    if (!caseItem.isPatternResolved()) {
+      pattern = TypeChecker::resolvePattern(
+          pattern, dc, /*isStmtCondition=*/false);
+      if (!pattern)
+        continue;
+    }
+
+    caseItem.setPattern(pattern, /*resolved=*/true);
+    pattern->forEachVariable( [&](VarDecl *var) {
+      recordVar(pattern, var);
+    });
   }
 
   // Wire up the case body variables to the latest patterns.
   for (auto bodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
-    recordVar(bodyVar);
+    recordVar(nullptr, bodyVar);
   }
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1389,7 +1389,7 @@ void checkUnknownAttrRestrictions(
 /// Each of the "x" variables must eventually have the same type, and agree on
 /// let vs. var. This function does not perform any of that validation, leaving
 /// it to later stages.
-void bindSwitchCasePatternVars(CaseStmt *stmt);
+void bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *stmt);
 
 } // end namespace swift
 

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -477,6 +477,8 @@ func testCaseMutabilityMismatches(e: E3) {
             var x): // expected-error{{'var' pattern binding must match previous 'let' pattern binding}}
       x
       y += "a"
+    default:
+      "default"
     }
   }
 }


### PR DESCRIPTION
bindSwitchCasePatternVars() was introduced as a simpler way to wire up
the "parent" links for case variables with same-named case variables
from the previous case item, and is used in the function builders code
to handle switch statements. It duplicated some logic from the
statement checker that did the same thing using a more complicated
algorithm.

Switch (ha ha) the logic in the statement checker over to using
bindSwitchCasePatternVars(), fixing a bug involving unresolved
patterns along the way, and remove the old code that incrementally
wired up the parent links. The resulting code is simpler and is
unified across the various code paths.