### PR TITLE
[Localization] Ignore diagnostic IDs that are available in YAML and not in `.def`

### DIFF
--- a/lib/AST/LocalizationFormat.cpp
+++ b/lib/AST/LocalizationFormat.cpp
@@ -48,7 +48,7 @@ template <> struct ScalarEnumerationTraits<LocalDiagID> {
 #include "swift/AST/DiagnosticsAll.def"
     // Ignore diagnostic IDs that are available in the YAML file and not
     // available in the `.def` file.
-    if (!io.outputting() && io.matchEnumFallback())
+    if (io.matchEnumFallback())
       value = LocalDiagID::NumDiags;
   }
 };
@@ -106,6 +106,10 @@ readYAML(llvm::yaml::IO &io, T &Seq, bool, Context &Ctx) {
       yamlize(io, current, true, Ctx);
       io.postflightElement(SaveInfo);
 
+      // A diagnostic ID might be present in YAML and not in `.def` file,
+      // if that's the case ScalarEnumerationTraits will assign the diagnostic ID
+      // to `LocalDiagID::NumDiags`. Since the diagnostic ID isn't available
+      // in `.def` it shouldn't be stored in the diagnostics array.
       if (current.id != LocalDiagID::NumDiags) {
         // YAML file isn't guaranteed to have diagnostics in order of their
         // declaration in `.def` files, to accommodate that we need to leave

--- a/lib/AST/LocalizationFormat.cpp
+++ b/lib/AST/LocalizationFormat.cpp
@@ -46,6 +46,10 @@ template <> struct ScalarEnumerationTraits<LocalDiagID> {
 #define DIAG(KIND, ID, Options, Text, Signature)                               \
   io.enumCase(value, #ID, LocalDiagID::ID);
 #include "swift/AST/DiagnosticsAll.def"
+    // Ignore diagnostic IDs that are available in the YAML file and not
+    // available in the `.def` file.
+    if (!io.outputting() && io.matchEnumFallback())
+      value = LocalDiagID::NumDiags;
   }
 };
 
@@ -101,12 +105,15 @@ readYAML(llvm::yaml::IO &io, T &Seq, bool, Context &Ctx) {
       DiagnosticNode current;
       yamlize(io, current, true, Ctx);
       io.postflightElement(SaveInfo);
-      // YAML file isn't guaranteed to have diagnostics in order of their
-      // declaration in `.def` files, to accommodate that we need to leave
-      // holes in diagnostic array for diagnostics which haven't yet been
-      // localized and for the ones that have `DiagnosticNode::id`
-      // indicates their position.
-      Seq[static_cast<unsigned>(current.id)] = std::move(current.msg);
+
+      if (current.id != LocalDiagID::NumDiags) {
+        // YAML file isn't guaranteed to have diagnostics in order of their
+        // declaration in `.def` files, to accommodate that we need to leave
+        // holes in diagnostic array for diagnostics which haven't yet been
+        // localized and for the ones that have `DiagnosticNode::id`
+        // indicates their position.
+        Seq[static_cast<unsigned>(current.id)] = std::move(current.msg);
+      }
     }
   }
   io.endSequence();

--- a/test/diagnostics/Localization/Inputs/en.yaml
+++ b/test/diagnostics/Localization/Inputs/en.yaml
@@ -17,6 +17,9 @@
 # 
 #===----------------------------------------------------------------------===#
 
+- id: "not_available_in_def"
+  msg: "Shouldn't be produced"
+
 - id: "lex_unterminated_string"
   msg: "unterminated string literal"
   


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR modifies `ScalarEnumerationTraits` to handle diagnostic IDs that are available in YAML and not in `.def`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
cc @xedin 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
