### PR TITLE
[stdlib] Preserve random-access Mirror.children inside AnyCollection

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -137,7 +137,12 @@ public struct Mirror {
 
   /// A collection of `Child` elements describing the structure of the
   /// reflected subject.
-  public var children: Children { AnyCollection(_children) }
+  public var children: Children {
+    switch _children {
+      case let .left(l): return AnyCollection(l)
+      case let .right(r): return AnyCollection(r)
+    }
+  }
 
   /// A suggested display style for the reflected subject.
   public let displayStyle: DisplayStyle?

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -150,6 +150,25 @@ mirrors.test("LabeledStructure") {
   expectEqual("[bark: 1, bite: Zee]", h.testDescription)
 }
 
+mirrors.test("ErasedChildren") {
+  let m1 = Mirror(reflecting: 1..<4)
+  let c1 = AnyRandomAccessCollection(m1.children)
+  expectNotNil(c1)
+  expectNil(c1?.first?.label)
+  expectTrue(c1?.first?.label as? Int == 1)
+  expectNil(c1?.last?.label)
+  expectTrue(c1?.last?.value as? Int == 3)
+
+  struct Foo { let i = 42; let s = "bar" }
+  let m2 = Mirror(reflecting: Foo())
+  let c2 = AnyRandomAccessCollection(m2.children)
+  expectNotNil(c2)
+  expectTrue(c2?.first?.label == "i")
+  expectTrue(c2?.first?.label as? Int == 42)
+  expectTrue(c2?.last?.label == "s")
+  expectTrue(c2?.last?.value as? String == "bar")
+}
+
 mirrors.test("Legacy") {
   let m = Mirror(reflecting: [1, 2, 3])
   expectTrue(m.subjectType == [Int].self)


### PR DESCRIPTION
#32041 unintentionally lost the random-access nature of some collections. While the returned type is `AnyCollection`, you could restore random-access via `AnyRandomAccessCollection(mirror.children)`, but this now returned `nil` for some children. This PR restores this.