### PR TITLE
[test] Ensure clang importer sdk uses its own CoreFoundation overlay

### DIFF
--- a/test/IDE/print_clang_header_i386.swift
+++ b/test/IDE/print_clang_header_i386.swift
@@ -4,5 +4,7 @@
 // XFAIL: linux, freebsd
 
 // RUN: echo '#include "header-to-print.h"' > %t.i386.m
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -I %t --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.i386.txt

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swift
@@ -1,3 +1,3 @@
 @_exported import CoreFoundation
 
-protocol _CFObject {}
+protocol _CFObject: Hashable {}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -459,6 +459,7 @@ config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
 config.substitutions.append(('%build-clang-importer-objc-overlays',
                              '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module && '
                              '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift && '
+                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreFoundation.swift && '
                              '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift'))
 
 # FIXME: BEGIN -enable-source-import hackaround


### PR DESCRIPTION
We noticed that Some tests using the clang importer sdk ended up using the CoreFoundation overlay built as part of
Swift instead of the mock one provided.