### PR TITLE
test: swap parameters in test assertion (NFC)

### DIFF
--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -278,7 +278,7 @@ DispatchAPI.test("DispatchTime.SchedulerTimeType.Stridable") {
 	    let time1 = DispatchQueue.SchedulerTimeType(.init(uptimeNanoseconds: 10000))
 	    let time2 = DispatchQueue.SchedulerTimeType(.init(uptimeNanoseconds: 10431))
 	    let addedTime = time2.distance(to: time1)
-	    expectEqual(addedTime.magnitude, (10000 - 10431))
+	    expectEqual((10000 - 10431), addedTime.magnitude)
 	}
 }
 


### PR DESCRIPTION
Swap the parameters in `assertEqual` to improve diagnostics on failure.
This now prints as:

```
stdout>>> expected: -431 (of type Swift.int)
stdout>>> actual: -11 (of type Swift.int)
```

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
