### PR TITLE
test: disable a couple of IRGen tests on ASi

### DIFF
--- a/test/IRGen/class_update_callback_without_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_without_fixed_layout.sil
@@ -6,7 +6,7 @@
 
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=iosmac
-// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: CPU=arm64 || CPU=arm64e
 
 // With the old deployment target, these classes use the 'singleton' metadata
 // initialization pattern. The class is not statically visible to Objective-C,

--- a/test/IRGen/eager-class-initialization.swift
+++ b/test/IRGen/eager-class-initialization.swift
@@ -4,7 +4,7 @@
 
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=iosmac
-// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: CPU=arm64 || CPU=arm64e
 
 // See also eager-class-initialization-stable-abi.swift, for the stable ABI
 // deployment target test.


### PR DESCRIPTION
macOS[>=10.14.4] support the ability to update the class metadata, which
is used unconditionally with resiliently-sized fields.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
