### PR TITLE
[Concurrency] Fix syntax tree creation

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -397,7 +397,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     SourceLoc awaitLoc = consumeToken(tok::kw___await);
     ParserResult<Expr> sub = parseExprUnary(message, isExprBasic);
     if (!sub.hasCodeCompletion() && !sub.isNull()) {
-      ElementContext.setCreateSyntax(SyntaxKind::TryExpr);
+      ElementContext.setCreateSyntax(SyntaxKind::AwaitExpr);
       sub = makeParserResult(new (Context) AwaitExpr(awaitLoc, sub.get()));
     }
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -465,10 +465,10 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       ParsedFunctionTypeSyntaxBuilder Builder(*SyntaxContext);
       Builder.useReturnType(std::move(*SyntaxContext->popIf<ParsedTypeSyntax>()));
       Builder.useArrow(SyntaxContext->popToken());
-      if (asyncLoc.isValid())
-        Builder.useAsyncKeyword(SyntaxContext->popToken());
       if (throwsLoc.isValid())
         Builder.useThrowsOrRethrowsKeyword(SyntaxContext->popToken());
+      if (asyncLoc.isValid())
+        Builder.useAsyncKeyword(SyntaxContext->popToken());
 
       auto InputNode(std::move(*SyntaxContext->popIf<ParsedTypeSyntax>()));
       if (auto TupleTypeNode = InputNode.getAs<ParsedTupleTypeSyntax>()) {

--- a/test/Parse/async-syntax.swift
+++ b/test/Parse/async-syntax.swift
@@ -10,3 +10,7 @@ func testTypeExprs() {
   let _ = [() async -> ()]()
   let _ = [() async throws -> ()]()
 }
+
+func testAwaitOperator() async {
+  let _ = __await asyncGlobal1()
+}

--- a/test/Parse/async-syntax.swift
+++ b/test/Parse/async-syntax.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -verify-syntax-tree
+
+func asyncGlobal1() async { }
+func asyncGlobal2() async throws { }
+
+typealias AsyncFunc1 = () async -> ()
+typealias AsyncFunc2 = () async throws -> ()
+
+func testTypeExprs() {
+  let _ = [() async -> ()]()
+  let _ = [() async throws -> ()]()
+}

--- a/test/Serialization/Inputs/def_async.swift
+++ b/test/Serialization/Inputs/def_async.swift
@@ -1,0 +1,1 @@
+public func doSomethingBig() async -> Int { return 0 }

--- a/test/Serialization/async.swift
+++ b/test/Serialization/async.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_async~partial.swiftmodule -primary-file %S/Inputs/def_async.swift -module-name def_async -enable-experimental-concurrency
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_async~partial.swiftmodule -module-name def_async -o %t/def_async.swiftmodule -enable-experimental-concurrency
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown -enable-experimental-concurrency
+
+import def_async
+
+func testDoSomethingBig() {
+  let _: () -> Int = doSomethingBig // expected-error{{cannot convert value of type '() async -> Int' to specified type '() -> Int'}}
+}

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -471,7 +471,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
   auto IntArg = SyntaxFactory::makeBlankTupleTypeElement()
     .withType(Int);
-  auto Async = SyntaxFactory::makeContextualKeyword(
+  auto Async = SyntaxFactory::makeIdentifier(
       "async", { }, { Trivia::spaces(1) });
   auto Throws = SyntaxFactory::makeThrowsKeyword({}, { Trivia::spaces(1) });
   auto Rethrows = SyntaxFactory::makeRethrowsKeyword({},

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -76,7 +76,8 @@ DECL_NODES = [
     Node('FunctionSignature', kind='Syntax',
          children=[
              Child('Input', kind='ParameterClause'),
-             Child('AsyncKeyword', kind='ContextualKeywordToken',
+             Child('AsyncKeyword', kind='IdentifierToken',
+                   classification='Keyword',
                    text_choices=['async'], is_optional=True),
              Child('ThrowsOrRethrowsKeyword', kind='Token',
                    is_optional=True,

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -191,7 +191,8 @@ EXPR_NODES = [
     # NOTE: This appears only in SequenceExpr.
     Node('ArrowExpr', kind='Expr',
          children=[
-             Child('AsyncKeyword', kind='ContextualKeywordToken',
+             Child('AsyncKeyword', kind='IdentifierToken',
+                   classification='Keyword',
                    text_choices=['async'], is_optional=True),
              Child('ThrowsToken', kind='ThrowsToken',
                    is_optional=True),

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -167,8 +167,9 @@ TYPE_NODES = [
              Child('Arguments', kind='TupleTypeElementList',
                    collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken'),
-             Child('AsyncKeyword', kind='Token', text_choices=['async'],
-                   is_optional=True),
+             Child('AsyncKeyword', kind='IdentifierToken',
+                   classification='Keyword',
+                   text_choices=['async'], is_optional=True),
              Child('ThrowsOrRethrowsKeyword', kind='Token',
                    is_optional=True,
                    token_choices=[


### PR DESCRIPTION
Fixes bugs in the description and creation of the syntax tree for the experimental concurrency syntax:
* `async` wasn't modeled correctly in the syntax tree
* `async` and `throws` were handled in the wrong order for function types
* `__await` expressions were creating the wrong syntax nodes

... all because I forgot to add a `-verify-syntax-tree` test. Fix that mistake.