### PR TITLE
[Localization] Make the serialization tool print the removed diagnostics

### DIFF
--- a/test/diagnostics/Localization/Inputs/en.yaml
+++ b/test/diagnostics/Localization/Inputs/en.yaml
@@ -22,12 +22,24 @@
 
 - id: "lex_unterminated_string"
   msg: "unterminated string literal"
-  
+
+- id: "not_available_in_def_2"
+  msg: "Shouldn't be produced"
+
 - id: "var_init_self_referential"
   msg: "variable used within its own initial value"
 
 - id: "cannot_find_in_scope"
   msg: "cannot %select{find|find operator}1 %0 in scope"
 
+- id: "not_available_in_def_3"
+  msg: "Shouldn't be produced"
+
 - id: "warning_invalid_locale_code"
   msg: "unsupported locale code; supported locale codes are '%0'"
+
+- id: "not_available_in_def_4"
+  msg: "Shouldn't be produced"
+
+- id: "not_available_in_def_5"
+  msg: "Shouldn't be produced"

--- a/test/diagnostics/Localization/fr_localization.swift
+++ b/test/diagnostics/Localization/fr_localization.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/fr.yaml --output-directory=%t/
-// RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/en.yaml --output-directory=%t/
+// RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/en.yaml --output-directory=%t/ 2>&1 | %FileCheck %s
 // RUN: %target-typecheck-verify-swift -localization-path %t -locale fr
 
+// CHECK: These diagnostic IDs are no longer availiable: 'not_available_in_def, not_available_in_def_2, not_available_in_def_3, not_available_in_def_4, not_available_in_def_5'
 _ = "HI!
 // expected-error@-1{{chaîne non terminée littérale}}
 var self1 = self1 // expected-error {{variable utilisée dans sa propre valeur initiale}}

--- a/tools/swift-serialize-diagnostics/swift-serialize-diagnostics.cpp
+++ b/tools/swift-serialize-diagnostics/swift-serialize-diagnostics.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/LocalizationFormat.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -80,6 +81,16 @@ int main(int argc, char *argv[]) {
     llvm::errs() << "Cannot serialize diagnostic file "
                  << options::InputFilePath << '\n';
     return EXIT_FAILURE;
+  }
+
+  // Print out the diagnostics IDs that are available in YAML but not available
+  // in `.def`
+  if (!yaml.unknownIDs.empty()) {
+    llvm::errs() << "These diagnostic IDs are no longer availiable: '";
+    llvm::interleave(
+        yaml.unknownIDs, [&](std::string id) { llvm::errs() << id; },
+        [&] { llvm::errs() << ", "; });
+    llvm::errs() << "'\n";
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
<!-- What's in this pull request? -->
In this PR, I created a vector in `swift::diag` that will keep track of the diagnostic IDs that got removed from `.def` and still available in YAML. Then in the `swift-serialize-diagnostics` I'm printing out all of the removed diagnostic IDs. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
cc @xedin 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
