### PR TITLE
[5.3] IRGen: ObjC method lists are not const.

### DIFF
--- a/test/IRGen/class_update_callback_with_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_with_fixed_layout.sil
@@ -51,7 +51,7 @@ sil_vtable SubclassOfClassWithResilientField {}
 // -- the update callback
 // CHECK-SAME: @"$s39class_update_callback_with_fixed_layout23ClassWithResilientFieldCMU"
 
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, {{.*}}", align 8
 
 // Class has static metadata:
 // CHECK-LABEL: @"$s39class_update_callback_with_fixed_layout23ClassWithResilientFieldCMf"

--- a/test/IRGen/class_update_callback_without_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_without_fixed_layout.sil
@@ -63,7 +63,7 @@ sil_vtable SubclassOfClassWithResilientField {}
 // -- the update callback
 // CHECK-NEW-SAME: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMU{{(\.ptrauth)?}}"
 
-// CHECK-SAME: }, section "__DATA, __objc_const"
+// CHECK-SAME: }, section "__DATA, {{.*}}"
 
 // Class has static metadata:
 // CHECK-LABEL: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMf"

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -96,7 +96,7 @@ import Foundation
 // CHECK:       i8* bitcast (void ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasCfETo" to i8*)
 // CHECK:     }
 // CHECK:   ]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: @_PROPERTIES__TtC11objc_bridge3Bas = internal constant { i32, i32, [5 x { i8*, i8* }] } {
 

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -34,7 +34,7 @@
 // CHECK-SAME:   i8* null,
 // CHECK-SAME:   i8* null,
 // CHECK-SAME:   i8* null
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, {{.*}}", align 8
 // CHECK: @_DATA__TtC17objc_class_export3Foo = internal constant {{.*\*}} } {
 // CHECK-SAME:   i32 128,
 // CHECK-SAME:   i32 16,
@@ -47,7 +47,7 @@
 // CHECK-SAME:   @_IVARS__TtC17objc_class_export3Foo,
 // CHECK-SAME:   i8* null,
 // CHECK-SAME:   _PROPERTIES__TtC17objc_class_export3Foo
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, {{.*}}", align 8
 // CHECK: @"$s17objc_class_export3FooCMf" = internal global <{{.*}} }> <{
 // CHECK-SAME:   void ([[FOO]]*)* @"$s17objc_class_export3FooCfD",
 // CHECK-SAME:   i8** @"$sBOWV",

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -27,7 +27,7 @@ import objc_extension_base
 // CHECK-SAME:   @"_CATEGORY_CLASS_METHODS_Gizmo_$_objc_extensions",
 // CHECK-SAME:   @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions",
 // CHECK-SAME:   i8* null
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, {{.*}}", align 8
 
 @objc protocol NewProtocol {
   func brandNewInstanceMethod()
@@ -67,7 +67,7 @@ extension Gizmo: NewProtocol {
 // CHECK:   {{.*}} @"_CATEGORY_CLASS_METHODS_Gizmo_$_objc_extensions1",
 // CHECK:   i8* null,
 // CHECK:   i8* null
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 extension Gizmo {
   @objc func brandSpankingNewInstanceMethod() {
@@ -92,7 +92,7 @@ class Hoozit : NSObject {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[STR:@.*]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void ([[OPAQUE:%.*]]*, i8*)* @"$s15objc_extensions6HoozitC7blibbleyyFTo" to i8*)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK-LABEL: @"_CATEGORY_CLASS_METHODS__TtC15objc_extensions6Hoozit_$_objc_extensions" = internal constant
 // CHECK:   i32 24,
@@ -102,7 +102,7 @@ class Hoozit : NSObject {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[STR]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void (i8*, i8*)* @"$s15objc_extensions6HoozitC7blobbleyyFZTo" to i8*)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK-LABEL: @"_CATEGORY__TtC15objc_extensions6Hoozit_$_objc_extensions" = internal constant
 // CHECK:   i8* getelementptr inbounds ([16 x i8], [16 x i8]* [[CATEGORY_NAME]], i64 0, i64 0),
@@ -111,7 +111,7 @@ class Hoozit : NSObject {
 // CHECK:   {{.*}} @"_CATEGORY_CLASS_METHODS__TtC15objc_extensions6Hoozit_$_objc_extensions",
 // CHECK:   i8* null,
 // CHECK:   i8* null
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 extension Hoozit {
   @objc func blibble() { }
@@ -127,7 +127,7 @@ class SwiftOnly { }
 // CHECK:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"\01L_selector_data(wibble)", i64 0, i64 0),
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[STR]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void (i8*, i8*)* @"$s15objc_extensions9SwiftOnlyC6wibbleyyFTo" to i8*)
-// CHECK:   }] }, section "__DATA, __objc_const", align 8
+// CHECK:   }] }, section "__DATA, {{.*}}", align 8
 extension SwiftOnly {
   @objc func wibble() { }
 }
@@ -157,7 +157,7 @@ extension NSObject {
 // CHECK-SAME:   i8* getelementptr inbounds ([16 x i8], [16 x i8]* [[CATEGORY_NAME]], i64 0, i64 0),
 // CHECK-SAME:   @"_CATEGORY_INSTANCE_METHODS__TtCC15objc_extensions5Outer5Inner_$_objc_extensions",
 // CHECK-SAME:   i8* null
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, {{.*}}", align 8
 
 class Outer : NSObject {
   class Inner : NSObject {}
@@ -175,7 +175,7 @@ class NSDogcow : NSObject {}
 
 // CHECK: [[NAME:@.*]] = private unnamed_addr constant [5 x i8] c"woof\00"
 // CHECK: [[ATTR:@.*]] = private unnamed_addr constant [7 x i8] c"Tq,N,D\00"
-// CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_extensions8NSDogcow_$_objc_extensions" = internal constant {{.*}} [[NAME]], {{.*}} [[ATTR]], {{.*}}, section "__DATA, __objc_const", align 8
+// CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_extensions8NSDogcow_$_objc_extensions" = internal constant {{.*}} [[NAME]], {{.*}} [[ATTR]], {{.*}}, section "__DATA, {{.*}}", align 8
 extension NSDogcow {
   @NSManaged var woof: Int
 }

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -79,7 +79,7 @@ class ObjcDestructible: NSObject {
 // CHECK-macosx:     i8* bitcast (i8 (i8*, i8*, %4**)* @"$s12objc_methods3FooC4failyyKFTo" to i8*)
 // CHECK-ios:     i8* bitcast (i1 (i8*, i8*, %4**)* @"$s12objc_methods3FooC4failyyKFTo" to i8*)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 // CHECK: @_INSTANCE_METHODS__TtC12objc_methods16ObjcDestructible = internal constant { {{.*}}] } {
 // CHECK:   i32 24,
 // CHECK:   i32 2,
@@ -88,7 +88,7 @@ class ObjcDestructible: NSObject {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[NO_ARGS_SIGNATURE]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void (%6*, i8*)* @"$s12objc_methods16ObjcDestructibleCfETo" to i8*) }]
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 // CHECK: [[BLOCK_SIGNATURE_EXT_1:@.*]] = private unnamed_addr constant [18 x i8] c"v24@0:8@?<q@?q>16\00"
 // CHECK: [[BLOCK_SIGNATURE_EXT_2:@.*]] = private unnamed_addr constant [19 x i8] c"v24@0:8@?<q@?qq>16\00"
 // CHECK: [[STRING_SIGNATURE_EXT:@.*]] = private unnamed_addr constant [31 x i8] c"@\22NSString\2224@0:8@\22NSString\2216\00"

--- a/test/IRGen/objc_properties.swift
+++ b/test/IRGen/objc_properties.swift
@@ -112,7 +112,7 @@ class SomeWrapperTests {
 // CHECK-NEW:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SHARED_NAME]], i64 0, i64 0),
 // CHECK-NEW:     i8* getelementptr inbounds ([5 x i8], [5 x i8]* [[SHARED_ATTRS]], i64 0, i64 0)
 // CHECK-NEW:   }]
-// CHECK-NEW: }, section "__DATA, __objc_const", align 8
+// CHECK-NEW: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: @_METACLASS_DATA__TtC15objc_properties10SomeObject = internal constant { {{.*}} } {
 // CHECK-SAME:   i32 {{[0-9]+}}, i32 {{[0-9]+}}, i32 {{[0-9]+}}, i32 {{[0-9]+}},
@@ -122,7 +122,7 @@ class SomeWrapperTests {
 // CHECK-SAME:   i8* null, i8* null, i8* null,
 // CHECK-NEW-SAME:   { {{.+}} }* @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject
 // CHECK-OLD-SAME:   i8* null
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: [[GETTER_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"@16@0:8\00"
 // CHECK: [[SETTER_SIGNATURE:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
@@ -163,7 +163,7 @@ class SomeWrapperTests {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
 // CHECK:     @"$s15objc_properties10SomeObjectCACycfcTo{{(.ptrauth)?}}"
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // This appears earlier because it's also used in an ivar description.
 // CHECK: [[BAREIVAR_NAME:@.*]] = private unnamed_addr constant [9 x i8] c"bareIvar\00"
@@ -195,7 +195,7 @@ class SomeWrapperTests {
 // CHECK:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[WIBBLE_NAME]], i64 0, i64 0),
 // CHECK:     i8* getelementptr inbounds ([50 x i8], [50 x i8]* [[WIBBLE_ATTRS]], i64 0, i64 0)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: @_DATA__TtC15objc_properties10SomeObject = internal constant { {{.+}} } {
 // CHECK:   i32 {{[0-9]+}}, i32 {{[0-9]+}}, i32 {{[0-9]+}}, i32 {{[0-9]+}},
@@ -206,7 +206,7 @@ class SomeWrapperTests {
 // CHECK:   { {{.+}} }* @_IVARS__TtC15objc_properties10SomeObject,
 // CHECK:   i8* null,
 // CHECK:   { {{.+}} }* @_PROPERTIES__TtC15objc_properties10SomeObject
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_properties10SomeObject_$_objc_properties" = internal constant { {{.*}}] } {
 // CHECK:   i32 24,
@@ -220,7 +220,7 @@ class SomeWrapperTests {
 // CHECK:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
 // CHECK:     @"$s15objc_properties10SomeObjectC17extensionPropertyACvsTo{{(.ptrauth)?}}"
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: [[EXTENSIONPROPERTY_NAME:@.*]] = private unnamed_addr constant [18 x i8] c"extensionProperty\00"
 
@@ -231,7 +231,7 @@ class SomeWrapperTests {
 // CHECK:     i8* getelementptr inbounds ([18 x i8], [18 x i8]* [[EXTENSIONPROPERTY_NAME]], i64 0, i64 0),
 // CHECK:     i8* getelementptr inbounds ([42 x i8], [42 x i8]* [[READWRITE_ATTRS]], i64 0, i64 0)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK-NEW: [[EXTENSIONCLASSPROPERTY_NAME:@.*]] = private unnamed_addr constant [19 x i8] c"extensionClassProp\00"
 // CHECK-NEW: [[EXTENSIONCLASSPROPERTY_ATTRS:@.*]] = private unnamed_addr constant [7 x i8] c"T#,N,R\00"
@@ -246,7 +246,7 @@ class SomeWrapperTests {
 // CHECK-NEW:   }, {
 // CHECK-NEW:	  i8* getelementptr inbounds ([26 x i8], [26 x i8]* [[EXTENSIONSTATICPROPERTY_NAME]], i64 0, i64 0),
 // CHECK-NEW:	  i8* getelementptr inbounds ([5 x i8], [5 x i8]* [[SHARED_ATTRS]], i64 0, i64 0) }]
-// CHECK-NEW: }, section "__DATA, __objc_const", align 8
+// CHECK-NEW: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: @"_CATEGORY__TtC15objc_properties10SomeObject_$_objc_properties" = internal constant { {{.+}} } {
 // CHECK:   i8* getelementptr inbounds ([{{.+}} x i8], [{{.+}} x i8]* {{@.+}}, i64 0, i64 0),
@@ -258,7 +258,7 @@ class SomeWrapperTests {
 // CHECK-NEW:   { {{.+}} }* @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties",
 // CHECK-OLD:   i8* null,
 // CHECK:   i32 60
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 
 // CHECK: @_INSTANCE_METHODS__TtC15objc_properties4Tree =
@@ -283,7 +283,7 @@ class SomeWrapperTests {
 // CHECK:   i8* null,
 // CHECK-NEW:   { {{.+}} }* @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_
 // CHECK-OLD:   i8* null
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 
 // CHECK: [[PROTOCOLPROPERTY_NAME:@.+]] = private unnamed_addr constant [6 x i8] c"value\00"
@@ -296,7 +296,7 @@ class SomeWrapperTests {
 // CHECK:     i8* getelementptr inbounds ([6 x i8], [6 x i8]* [[PROTOCOLPROPERTY_NAME]], i64 0, i64 0),
 // CHECK:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[PROTOCOLPROPERTY_ATTRS]], i64 0, i64 0)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // CHECK-NEW: [[PROTOCOLCLASSPROPERTY_NAME:@.+]] = private unnamed_addr constant [15 x i8] c"sharedInstance\00"
 // CHECK-NEW: [[PROTOCOLCLASSPROPERTY_ATTRS:@.+]] = private unnamed_addr constant [7 x i8] c"T@,N,&\00"
@@ -308,4 +308,4 @@ class SomeWrapperTests {
 // CHECK-NEW:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* [[PROTOCOLCLASSPROPERTY_NAME]], i64 0, i64 0),
 // CHECK-NEW:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[PROTOCOLCLASSPROPERTY_ATTRS]], i64 0, i64 0)
 // CHECK-NEW:   }]
-// CHECK-NEW: }, section "__DATA, __objc_const", align 8
+// CHECK-NEW: }, section "__DATA, {{.*}}", align 8

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -32,7 +32,7 @@ class Foo : NSRuncing, NSFunging, Ansible {
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s14objc_protocols3FooC5fungeyyFTo" to i8*) },
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s14objc_protocols3FooC3fooyyFTo" to i8*)
 // CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 class Bar {
   func bar() {}
@@ -57,7 +57,7 @@ extension Bar : NSRuncing, NSFunging {
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s14objc_protocols3BarC5fungeyyFTo" to i8*) },
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s14objc_protocols3BarC3fooyyFTo" to i8*) }
 // CHECK:   ]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // class Bas from objc_protocols_Bas module
 extension Bas : NSRuncing {
@@ -71,7 +71,7 @@ extension Bas : NSRuncing {
 // CHECK:   [1 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s18objc_protocols_Bas0C0C0a1_B0E3fooyyFTo" to i8*) }
 // CHECK:   ]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // -- Swift protocol refinement of ObjC protocols.
 protocol Frungible : NSRuncing, NSFunging {
@@ -93,7 +93,7 @@ class Zim : Frungible {
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s14objc_protocols3ZimC5fungeyyFTo" to i8*) },
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s14objc_protocols3ZimC3fooyyFTo" to i8*) }
 // CHECK:   ]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 // class Zang from objc_protocols_Bas module
 extension Zang : Frungible {
@@ -112,7 +112,7 @@ extension Zang : Frungible {
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s18objc_protocols_Bas4ZangC0a1_B0E5runceyyFTo" to i8*) },
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s18objc_protocols_Bas4ZangC0a1_B0E3fooyyFTo" to i8*) }
 // CHECK:   ]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: }, section "__DATA, {{.*}}", align 8
 
 @objc protocol BaseProtocol { }
 protocol InheritingProtocol : BaseProtocol { }

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -35,7 +35,7 @@
 // CHECK-32:   i8* null,
 // CHECK-32:   i8* null,
 // CHECK-32:   i8* null
-// CHECK-32: }, section "__DATA, __objc_const", align 4
+// CHECK-32: }, section "__DATA, {{.*}}", align 4
 
 // CHECK-64: @_METACLASS_DATA__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}* } {
 // CHECK-64:   i32 129,
@@ -49,7 +49,7 @@
 // CHECK-64:   i8* null,
 // CHECK-64:   i8* null,
 // CHECK-64:   i8* null
-// CHECK-64: }, section "__DATA, __objc_const", align 8
+// CHECK-64: }, section "__DATA, {{.*}}", align 8
 
 // CHECK-32: [[METHOD_TYPE_ENCODING1:@.*]] = private unnamed_addr constant [7 x i8] c"l8@0:4\00"
 // CHECK-64: [[METHOD_TYPE_ENCODING1:@.*]] = private unnamed_addr constant [8 x i8] c"q16@0:8\00"
@@ -110,7 +110,7 @@
 // CHECK-32:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@[0-9]+}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfeTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }]
-// CHECK-32: }, section "__DATA, __objc_const", align 4
+// CHECK-32: }, section "__DATA, {{.*}}", align 4
 
 // CHECK-64: @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
 // CHECK-64:   i32 24,
@@ -160,7 +160,7 @@
 // CHECK-64:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@[0-9]+}}, i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfeTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }]
-// CHECK-64: }, section "__DATA, __objc_const", align 8
+// CHECK-64: }, section "__DATA, {{.*}}", align 8
 
 // CHECK: [[STRING_X:@.*]] = private unnamed_addr constant [2 x i8] c"x\00"
 // CHECK-64: [[STRING_EMPTY:@.*]] = private unnamed_addr constant [1 x i8] zeroinitializer
@@ -174,7 +174,7 @@
 // CHECK-32:     i8* getelementptr inbounds ([1 x i8], [1 x i8]* {{.*}}, i32 0, i32 0),
 // CHECK-32:     i32 2,
 // CHECK-32:     i32 4 }]
-// CHECK-32: }, section "__DATA, __objc_const", align 4
+// CHECK-32: }, section "__DATA, {{.*}}", align 4
 
 // CHECK-64: @_IVARS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
 // CHECK-64:   i32 32,
@@ -185,7 +185,7 @@
 // CHECK-64:     i8* getelementptr inbounds ([1 x i8], [1 x i8]* [[STRING_EMPTY]], i64 0, i64 0),
 // CHECK-64:     i32 3,
 // CHECK-64:     i32 8 }]
-// CHECK-64: }, section "__DATA, __objc_const", align 8
+// CHECK-64: }, section "__DATA, {{.*}}", align 8
 
 // CHECK-32: @_DATA__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}* } {
 // CHECK-32:   i32 132,
@@ -198,7 +198,7 @@
 // CHECK-32:   @_IVARS__TtC13objc_subclass10SwiftGizmo,
 // CHECK-32:   i8* null,
 // CHECK-32:   @_PROPERTIES__TtC13objc_subclass10SwiftGizmo
-// CHECK-32: }, section "__DATA, __objc_const", align 4
+// CHECK-32: }, section "__DATA, {{.*}}", align 4
 
 // CHECK-64: @_DATA__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}* } {
 // CHECK-64:    i32 132,
@@ -212,7 +212,7 @@
 // CHECK-64:    @_IVARS__TtC13objc_subclass10SwiftGizmo,
 // CHECK-64:    i8* null,
 // CHECK-64:    @_PROPERTIES__TtC13objc_subclass10SwiftGizmo
-// CHECK-64:  }, section "__DATA, __objc_const", align 8
+// CHECK-64:  }, section "__DATA, {{.*}}", align 8
 
 // CHECK-NOT: @_TMCSo13SwiftGizmo = {{.*NSObject}}
 
@@ -247,7 +247,7 @@
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CfETo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }
 // CHECK-32:   ]
-// CHECK-32: }, section "__DATA, __objc_const", align 4
+// CHECK-32: }, section "__DATA, {{.*}}", align 4
 
 // CHECK-64: @_INSTANCE_METHODS__TtC13objc_subclass11SwiftGizmo2 = internal constant { i32, {{.*}}] } {
 // CHECK-64:   i32 24,

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -188,4 +188,4 @@ class C: P {
 }
 
 // CHECK-macosx: [[ENC5:@.*]] = private unnamed_addr constant [9 x i8] c"Vv16@0:8\00"
-// CHECK-macosx: @_PROTOCOL_INSTANCE_METHODS_P = {{.*}}@"\01L_selector_data(stuff)"{{.*}}[[ENC5]]{{.*}}, section "__DATA, __objc_const", align 8
+// CHECK-macosx: @_PROTOCOL_INSTANCE_METHODS_P = {{.*}}@"\01L_selector_data(stuff)"{{.*}}[[ENC5]]{{.*}}


### PR DESCRIPTION
Explanation: We incorrectly placed method lists in `__DATA,__objc_const`, causing us to dirty pages in the shared cache that are intended to remain clean

Scope: Performance issue

Issue: rdar://problem/66630432

Risk: Low. Should be no impact to end user code

Testing: Swift CI

Reviewed by: @mikeash 