### PR TITLE
[AST] Introduce ErrorDecl for dangling attributes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -173,7 +173,8 @@ enum class DescriptiveDeclKind : uint8_t {
   MissingMember,
   Requirement,
   OpaqueResultType,
-  OpaqueVarType
+  OpaqueVarType,
+  Error,
 };
 
 /// Describes which spelling was used in the source for the 'static' or 'class'
@@ -7309,6 +7310,17 @@ public:
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::MissingMember;
   }
+};
+
+class ErrorDecl : public Decl {
+  SourceLoc Loc;
+
+public:
+  ErrorDecl(DeclContext *DC, SourceLoc Loc);
+
+  SourceRange getSourceRange() const { return Loc; }
+  SourceLoc getLocFromSource() const { return Loc; }
+  static bool classof(const Decl *D) { return D->getKind() == DeclKind::Error; }
 };
 
 inline bool AbstractStorageDecl::isSettable(const DeclContext *UseDC,

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -191,7 +191,8 @@ ABSTRACT_DECL(Operator, Decl)
   OPERATOR_DECL(PostfixOperator, OperatorDecl)
   DECL_RANGE(Operator, InfixOperator, PostfixOperator)
 
-LAST_DECL(PostfixOperator)
+DECL(Error, Decl)
+LAST_DECL(Error)
 
 #undef NOMINAL_TYPE_DECL
 #undef CONTEXT_DECL

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1284,6 +1284,11 @@ namespace {
           << '\"' << MMD->getName() << '\"';
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
+
+    void visitErrorDecl(ErrorDecl *ED) {
+      printCommon(ED, "error_decl");
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
   };
 } // end anonymous namespace
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3367,6 +3367,8 @@ void PrintAST::visitMissingMemberDecl(MissingMemberDecl *decl) {
   Printer << " */";
 }
 
+void PrintAST::visitErrorDecl(ErrorDecl *decl) {}
+
 void PrintAST::visitBraceStmt(BraceStmt *stmt) {
   printBraceStmt(stmt);
 }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -842,6 +842,7 @@ public:
   VISIT_AND_IGNORE(ParamDecl)
   VISIT_AND_IGNORE(PoundDiagnosticDecl)
   VISIT_AND_IGNORE(MissingMemberDecl)
+  VISIT_AND_IGNORE(ErrorDecl)
 
   // This declaration is handled from the PatternBindingDecl
   VISIT_AND_IGNORE(VarDecl)

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -455,6 +455,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     return false;
   }
 
+  bool visitErrorDecl(ErrorDecl *ED) {
+    return false;
+  }
+
   //===--------------------------------------------------------------------===//
   //                                  Exprs
   //===--------------------------------------------------------------------===//

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -163,6 +163,7 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(Param);
   TRIVIAL_KIND(Module);
   TRIVIAL_KIND(MissingMember);
+  TRIVIAL_KIND(Error);
 
    case DeclKind::Enum:
      return cast<EnumDecl>(this)->getGenericParams()
@@ -328,6 +329,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(Requirement, "requirement");
   ENTRY(OpaqueResultType, "result");
   ENTRY(OpaqueVarType, "type");
+  ENTRY(Error, "error");
   }
 #undef ENTRY
   llvm_unreachable("bad DescriptiveDeclKind");
@@ -1080,6 +1082,7 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
   case DeclKind::PoundDiagnostic:
   case DeclKind::PrecedenceGroup:
   case DeclKind::MissingMember:
+  case DeclKind::Error:
     llvm_unreachable("not a ValueDecl");
 
   case DeclKind::AssociatedType:
@@ -2346,6 +2349,7 @@ bool ValueDecl::isInstanceMember() const {
   case DeclKind::PoundDiagnostic:
   case DeclKind::PrecedenceGroup:
   case DeclKind::MissingMember:
+  case DeclKind::Error:
     llvm_unreachable("Not a ValueDecl");
 
   case DeclKind::Class:
@@ -7902,6 +7906,12 @@ void Decl::setClangNode(ClangNode Node) {
 #include "swift/AST/DeclNodes.def"
   }
   *(ptr - 1) = Node.getOpaqueValue();
+}
+
+ErrorDecl::ErrorDecl(DeclContext *DC, SourceLoc Loc)
+    : Decl(DeclKind::Error, DC), Loc(Loc) {
+  assert(DC->getASTContext().Diags.hadAnyError() &&
+         "'ErrorDecl' should not be constructed without errors");
 }
 
 // See swift/Basic/Statistic.h for declaration: this enables tracing Decls, is

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -475,6 +475,7 @@ CodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
   case DeclKind::PoundDiagnostic:
   case DeclKind::MissingMember:
   case DeclKind::OpaqueType:
+  case DeclKind::Error:
     llvm_unreachable("not expecting such a declaration result");
   case DeclKind::Module:
     return CodeCompletionDeclKind::Module;

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2101,6 +2101,8 @@ namespace {
       if (auto setter = subscript->getOpaqueAccessor(AccessorKind::Set))
         methods.push_back(setter);
     }
+
+    void visitErrorDecl(ErrorDecl *d) { llvm_unreachable("shouldn't be here"); }
   };
 } // end anonymous namespace
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -250,6 +250,8 @@ public:
       Builder.CreateCall(class_replaceMethod, setterArgs);
     }
   }
+
+  void visitErrorDecl(ErrorDecl *d) { llvm_unreachable("not expected"); }
 };
 
 /// Create a descriptor for JITed @objc protocol using the ObjC runtime.
@@ -411,6 +413,8 @@ public:
       Builder.CreateCall(protocol_addMethodDescription, setterArgs);
     }
   }
+
+  void visitErrorDecl(ErrorDecl *d) { llvm_unreachable("not expected"); }
 };
 
 } // end anonymous namespace
@@ -2204,6 +2208,7 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   case DeclKind::AssociatedType:
   case DeclKind::IfConfig: 
   case DeclKind::PoundDiagnostic:
+  case DeclKind::Error:
     return;
 
   case DeclKind::Enum:
@@ -4447,6 +4452,7 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
 
     case DeclKind::IfConfig:
     case DeclKind::PoundDiagnostic:
+    case DeclKind::Error:
       continue;
 
     case DeclKind::Func:

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -242,6 +242,7 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
     case DeclKind::MissingMember:
     case DeclKind::Module:
     case DeclKind::OpaqueType:
+    case DeclKind::Error:
       break;
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3972,6 +3972,14 @@ Parser::parseDecl(ParseDeclOptions Flags,
         }
       }
     }
+
+    // If some attributes are parsed but not a decl, create an 'ErrorDecl'
+    // and attach the attributes to it. So they aren't discarded.
+    if (!Attributes.isEmpty()) {
+      auto decl = new (Context) ErrorDecl(CurDeclContext, PreviousLoc);
+      decl->getAttrs() = Attributes;
+      DeclResult = makeParserErrorResult(decl);
+    }
   }
 
   if (DeclResult.isParseError() && Tok.is(tok::code_complete)) {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -249,6 +249,7 @@ public:
   void visitDestructorDecl(DestructorDecl *d) {}
   void visitModuleDecl(ModuleDecl *d) { }
   void visitMissingMemberDecl(MissingMemberDecl *d) {}
+  void visitErrorDecl(ErrorDecl *d) {}
 
   // Emitted as part of its storage.
   void visitAccessorDecl(AccessorDecl *ad) {}

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1080,6 +1080,7 @@ public:
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
   void visitMissingMemberDecl(MissingMemberDecl *) {}
+  void visitErrorDecl(ErrorDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }
@@ -1205,6 +1206,7 @@ public:
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
   void visitMissingMemberDecl(MissingMemberDecl *) {}
+  void visitErrorDecl(ErrorDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -448,6 +448,7 @@ public:
   UNREACHABLE(Param, "does not have access control")
   UNREACHABLE(GenericTypeParam, "does not have access control")
   UNREACHABLE(MissingMember, "does not have access control")
+  UNREACHABLE(Error, "does not have access control")
 #undef UNREACHABLE
 
 #define UNINTERESTING(KIND) \
@@ -1038,6 +1039,7 @@ public:
   UNREACHABLE(Param, "does not have access control")
   UNREACHABLE(GenericTypeParam, "does not have access control")
   UNREACHABLE(MissingMember, "does not have access control")
+  UNREACHABLE(Error, "does not have access control")
 #undef UNREACHABLE
 
 #define UNINTERESTING(KIND) \
@@ -1781,6 +1783,7 @@ public:
   UNREACHABLE(Import, "not applicable")
   UNREACHABLE(TopLevelCode, "not applicable")
   UNREACHABLE(Module, "not applicable")
+  UNREACHABLE(Error, "not applicable")
 
   UNREACHABLE(Param, "handled by the enclosing declaration")
   UNREACHABLE(GenericTypeParam, "handled by the enclosing declaration")

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2179,6 +2179,9 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     llvm_unreachable("should not get here");
     return Type();
 
+  case DeclKind::Error:
+    return ErrorType::get(Context);
+
   case DeclKind::AssociatedType: {
     auto assocType = cast<AssociatedTypeDecl>(D);
     auto interfaceTy = assocType->getDeclaredInterfaceType();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2659,6 +2659,10 @@ public:
       addDelayedFunction(DD);
     }
   }
+
+  void visitErrorDecl(ErrorDecl *ED) {
+    // TODO: Should we type check attributes?
+  }
 };
 } // end anonymous namespace
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1545,6 +1545,9 @@ static bool shouldSerializeMember(Decl *D) {
   case DeclKind::Func:
   case DeclKind::Accessor:
     return true;
+
+  case DeclKind::Error:
+    return false;
   }
 
   llvm_unreachable("Unhandled DeclKind in switch.");
@@ -3725,6 +3728,10 @@ public:
 
   void visitMissingMemberDecl(const MissingMemberDecl *) {
     llvm_unreachable("member placeholders shouldn't be serialized");
+  }
+
+  void visitErrorDecl(const ErrorDecl *) {
+    llvm_unreachable("error decl should not be serialized");
   }
 };
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -967,6 +967,7 @@ static bool isValidProtocolMemberForTBDGen(const Decl *D) {
   case DeclKind::InfixOperator:
   case DeclKind::PrefixOperator:
   case DeclKind::PostfixOperator:
+  case DeclKind::Error:
     return false;
   }
   llvm_unreachable("covered switch");

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -491,6 +491,9 @@ class PropertyDelgate {
     var x = 1; x
   })
   var something
+
+  // CHECK: @<type>MyDelegate</type>(<int>12</int>)
+  @MyDelegate(12)
 }
 
 // CHECK: <kw>func</kw> acceptBuilder<T>(


### PR DESCRIPTION
If parsing decl failed, the parsed attributes were just discarded. Preserve parsed attributes in AST by attaching them to newly introduced `ErrorDecl`. e.g.
```swift
struct MyStruct {
  ...

  @SomeThing
  // Implicit 'ErrorDecl' here
}
```
 `ErrorDecl` is just a placeholder for an un-parsed decl.