### PR TITLE
[Runtime] Fix the isa mask assert for ARM64e.

### DIFF
--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -68,6 +68,9 @@ OBJC_EXPORT Class objc_readClassPair(Class cls,
                                      const struct objc_image_info *info)
     __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0);
 
+// Magic symbol whose _address_ is the runtime's isa mask.
+OBJC_EXPORT const struct { char c; } objc_absolute_packed_isa_class_mask;
+
 
 namespace swift {
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -198,18 +198,9 @@ static id _getClassDescription(Class cls) {
 
 @implementation SwiftObject
 + (void)initialize {
-#if SWIFT_HAS_ISA_MASKING && !NDEBUG
-  // Older OSes may not have this variable, or it may not match. This code only
-  // runs on older OSes in certain testing scenarios, so that doesn't matter.
-  // Only perform the check on newer OSes where the value should definitely
-  // match.
-#  if SWIFT_BUILD_HAS_BACK_DEPLOYMENT
-  if (!_swift_isBackDeploying())
-#  endif
-  {
-    assert(&objc_debug_isa_class_mask);
-    assert(objc_debug_isa_class_mask == SWIFT_ISA_MASK);
-  }
+#if SWIFT_HAS_ISA_MASKING && !TARGET_OS_SIMULATOR && !NDEBUG
+  assert(&objc_absolute_packed_isa_class_mask);
+  assert((uintptr_t)&objc_absolute_packed_isa_class_mask == SWIFT_ISA_MASK);
 #endif
 }
 


### PR DESCRIPTION
Swift's isa mask includes the signature bits. objc_debug_isa_class_mask does not. Switch to objc_absolute_packed_isa_class_mask instead, which does.

While we're at it, get rid of the now-unnecessary guards for back-deployment.

rdar://problem/60148213