### PR TITLE
test: repair stdlib/Dispatch on ASi

### DIFF
--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -278,7 +278,15 @@ DispatchAPI.test("DispatchTime.SchedulerTimeType.Stridable") {
 	    let time1 = DispatchQueue.SchedulerTimeType(.init(uptimeNanoseconds: 10000))
 	    let time2 = DispatchQueue.SchedulerTimeType(.init(uptimeNanoseconds: 10431))
 	    let addedTime = time2.distance(to: time1)
-	    expectEqual((10000 - 10431), addedTime.magnitude)
+            // The magnitude of the time sum is in nanosecond units.  Although
+            // the units match up, the internal representation of the
+            // DispatchTime may round up to multiples of Mach timebase.  This
+            // requires the difference being converted, which is performed here
+            // by constructing a `DispatchTime` from the delta.  However, the
+            // parameter is a `UInt64` which requires us to perform the negation
+            // manually.
+	    expectEqual(-Int(DispatchTime(uptimeNanoseconds: 10431 - 10000).uptimeNanoseconds),
+                        addedTime.magnitude)
 	}
 }
 


### PR DESCRIPTION
The conversion of the naonseconds to Mach ticks in multiples of Mach
timebase units alters the time.  This would fail on ASi where mach ticks
are not synonymous with nanoseconds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
