### PR TITLE
Fix build error due to missing include of llvm/Support/FileSystem.h

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -24,6 +24,7 @@
 #include "swift/AST/TypeLoc.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VersionTuple.h"
 


### PR DESCRIPTION
DiagnosticEngine.h uses llvm::sys::fs:exists but doesn't directly
include the header that provides it, which results in a build error due
to upstream llvm changes. This patch includes that header.
