### PR TITLE
Initial support for clang::CodeGen::ABIArgInfo::IndirectAliased

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1204,6 +1204,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
       ParamIRTypes.append(types.begin(), types.end());
       break;
     }
+    case clang::CodeGen::ABIArgInfo::IndirectAliased:
     case clang::CodeGen::ABIArgInfo::Indirect: {
       assert(i >= clangToSwiftParamOffset &&
              "Unexpected index for indirect byval argument");
@@ -2377,6 +2378,7 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
       emitDirectExternalArgument(IGF, paramType, AI, in, out, isOutlined);
       break;
     }
+    case clang::CodeGen::ABIArgInfo::IndirectAliased:
     case clang::CodeGen::ABIArgInfo::Indirect: {
       auto &ti = cast<LoadableTypeInfo>(IGF.getTypeInfo(paramType));
 
@@ -2567,6 +2569,7 @@ void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
     emitDirectForeignParameter(IGF, params, AI, paramExplosion, paramTy,
                                paramTI);
     return;
+  case clang::CodeGen::ABIArgInfo::IndirectAliased:
   case clang::CodeGen::ABIArgInfo::Indirect: {
     Address address = paramTI.getAddressForPointer(params.claimNext());
     paramTI.loadAsTake(IGF, address, paramExplosion);


### PR DESCRIPTION
This patch makes it so that Swift can still build against llvm-project
ToT. clang::CodeGen::ABIArgInfo::IndirectAliased and Indirect seem to be
very similar, so for now I have the switch statements falling through to
the clang::CodeGen::ABIArgInfo::Indirect behavior. I was considering
making them unreachable instead.

I'd like to have this reviewed by someone that understands the code in swift/lib/IRGen/GenCall.cpp and clang::CodeGen::ABIArgInfo better than I do. 

This is to address changes from llvm-project ToT in llvm/llvm-project@30eeb74