### PR TITLE
[ssa-updater] Modernize style before adding support for guaranteed parameters

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -18,9 +18,14 @@
 #include "swift/SIL/SILValue.h"
 
 namespace llvm {
-  template<typename T> class SSAUpdaterTraits;
-  template<typename T> class SmallVectorImpl;
-}
+
+template <typename T>
+class SSAUpdaterTraits;
+
+template <typename T>
+class SmallVectorImpl;
+
+} // namespace llvm
 
 namespace swift {
 
@@ -31,7 +36,7 @@ class SILUndef;
 
 /// Independent utility that canonicalizes BB arguments by reusing structurally
 /// equivalent arguments and replacing the original arguments with casts.
-SILValue replaceBBArgWithCast(SILPhiArgument *Arg);
+SILValue replaceBBArgWithCast(SILPhiArgument *arg);
 
 /// This class updates SSA for a set of SIL instructions defined in multiple
 /// blocks.
@@ -40,16 +45,16 @@ class SILSSAUpdater {
 
   // A map of basic block to available phi value.
   using AvailableValsTy = llvm::DenseMap<SILBasicBlock *, SILValue>;
-  std::unique_ptr<AvailableValsTy> AV;
+  std::unique_ptr<AvailableValsTy> blockToAvailableValueMap;
 
-  SILType ValType;
+  SILType type;
 
   // The SSAUpdaterTraits specialization uses this sentinel to mark 'new' phi
   // nodes (all the incoming edge arguments have this sentinel set).
-  std::unique_ptr<SILUndef, void(*)(SILUndef *)> PHISentinel;
+  std::unique_ptr<SILUndef, void (*)(SILUndef *)> phiSentinel;
 
   // If not null updated with inserted 'phi' nodes (SILArgument).
-  SmallVectorImpl<SILPhiArgument *> *InsertedPHIs;
+  SmallVectorImpl<SILPhiArgument *> *insertedPhis;
 
   // Not copyable.
   void operator=(const SILSSAUpdater &) = delete;
@@ -57,21 +62,21 @@ class SILSSAUpdater {
 
 public:
   explicit SILSSAUpdater(
-      SmallVectorImpl<SILPhiArgument *> *InsertedPHIs = nullptr);
+      SmallVectorImpl<SILPhiArgument *> *insertedPhis = nullptr);
   ~SILSSAUpdater();
 
-  void setInsertedPhis(SmallVectorImpl<SILPhiArgument *> *insertedPhis) {
-    InsertedPHIs = insertedPhis;
+  void setInsertedPhis(SmallVectorImpl<SILPhiArgument *> *inputInsertedPhis) {
+    insertedPhis = inputInsertedPhis;
   }
 
   /// Initialize for a use of a value of type.
-  void Initialize(SILType T);
+  void initialize(SILType type);
 
-  bool HasValueForBlock(SILBasicBlock *BB) const;
-  void AddAvailableValue(SILBasicBlock *BB, SILValue V);
+  bool hasValueForBlock(SILBasicBlock *block) const;
+  void addAvailableValue(SILBasicBlock *block, SILValue value);
 
   /// Construct SSA for a value that is live at the *end* of a basic block.
-  SILValue GetValueAtEndOfBlock(SILBasicBlock *BB);
+  SILValue getValueAtEndOfBlock(SILBasicBlock *block);
 
   /// Construct SSA for a value that is live in the middle of a block.
   /// This handles the case where the use is before a definition of the value.
@@ -85,15 +90,15 @@ public:
   ///
   /// In this case we need to insert a 'PHI' node at the beginning of BB2
   /// merging val_1 and val_2.
-  SILValue GetValueInMiddleOfBlock(SILBasicBlock *BB);
+  SILValue getValueInMiddleOfBlock(SILBasicBlock *block);
 
-  void RewriteUse(Operand &Op);
+  void rewriteUse(Operand &operand);
 
-  void *allocate(unsigned Size, unsigned Align) const;
-  static void deallocateSentinel(SILUndef *U);
+  void *allocate(unsigned size, unsigned align) const;
+  static void deallocateSentinel(SILUndef *undef);
+
 private:
-
-  SILValue GetValueAtEndOfBlockInternal(SILBasicBlock *BB);
+  SILValue getValueAtEndOfBlockInternal(SILBasicBlock *block);
 };
 
 /// Utility to wrap 'Operand's to deal with invalidation of
@@ -112,15 +117,15 @@ private:
 /// identify the use allowing us to reconstruct the use after the branch has
 /// been changed.
 class UseWrapper {
-  Operand *U;
-  SILBasicBlock *Parent;
+  Operand *wrappedUse;
+  SILBasicBlock *parent;
   enum {
     kRegularUse,
     kBranchUse,
     kCondBranchUseTrue,
     kCondBranchUseFalse
-  } Type;
-  unsigned Idx;
+  } type;
+  unsigned index;
 
 public:
 
@@ -131,7 +136,7 @@ public:
   /// (ValueUseIterator) become invalid as they point to freed operands.
   /// Instead we store the branch's parent and the idx so that we can
   /// reconstruct the use.
-  UseWrapper(Operand *Use);
+  UseWrapper(Operand *use);
 
   Operand *getOperand();
 

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -519,13 +519,13 @@ protected:
       return;
 
     // Update SSA form.
-    SSAUp.Initialize(V->getType());
-    SSAUp.AddAvailableValue(OrigBB, V);
+    SSAUp.initialize(V->getType());
+    SSAUp.addAvailableValue(OrigBB, V);
     SILValue NewVal = getMappedValue(V);
-    SSAUp.AddAvailableValue(getOpBasicBlock(OrigBB), NewVal);
+    SSAUp.addAvailableValue(getOpBasicBlock(OrigBB), NewVal);
     for (auto U : UseList) {
       Operand *Use = U;
-      SSAUp.RewriteUse(*Use);
+      SSAUp.rewriteUse(*Use);
     }
   }
 

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -1062,8 +1062,8 @@ void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, Ins
   LLVM_DEBUG(llvm::dbgs() << "Creating preload " << *initialLoad);
 
   SILSSAUpdater ssaUpdater;
-  ssaUpdater.Initialize(initialLoad->getType());
-  ssaUpdater.AddAvailableValue(preheader, initialLoad);
+  ssaUpdater.initialize(initialLoad->getType());
+  ssaUpdater.addAvailableValue(preheader, initialLoad);
 
   // Set all stored values as available values in the ssaUpdater.
   // If there are multiple stores in a block, only the last one counts.
@@ -1078,7 +1078,7 @@ void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, Ins
       if (isLoadFromAddr(dyn_cast<LoadInst>(SI->getSrc()), addr))
         return;
 
-      ssaUpdater.AddAvailableValue(SI->getParent(), SI->getSrc());
+      ssaUpdater.addAvailableValue(SI->getParent(), SI->getSrc());
     }
   }
 
@@ -1099,7 +1099,7 @@ void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, Ins
       // If we didn't see a store in this block yet, get the current value from
       // the ssaUpdater.
       if (!currentVal)
-        currentVal = ssaUpdater.GetValueInMiddleOfBlock(block);
+        currentVal = ssaUpdater.getValueInMiddleOfBlock(block);
       SILValue projectedValue = projectLoadValue(LI->getOperand(), addr,
                                                  currentVal, LI);
       LLVM_DEBUG(llvm::dbgs() << "Replacing stored load " << *LI << " with "
@@ -1117,8 +1117,8 @@ void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, Ins
                "should have split critical edges");
         SILBuilder B(succ->begin());
         auto *SI = B.createStore(loc.getValue(),
-                                 ssaUpdater.GetValueInMiddleOfBlock(succ),
-                                 addr, StoreOwnershipQualifier::Unqualified);
+                                 ssaUpdater.getValueInMiddleOfBlock(succ), addr,
+                                 StoreOwnershipQualifier::Unqualified);
         (void)SI;
         LLVM_DEBUG(llvm::dbgs() << "Creating loop-exit store " << *SI);
       }

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -131,9 +131,9 @@ static void updateSSAForUseOfValue(
   assert(Res->getType() == MappedValue->getType() && "The types must match");
 
   insertedPhis.clear();
-  updater.Initialize(Res->getType());
-  updater.AddAvailableValue(Header, Res);
-  updater.AddAvailableValue(EntryCheckBlock, MappedValue);
+  updater.initialize(Res->getType());
+  updater.addAvailableValue(Header, Res);
+  updater.addAvailableValue(EntryCheckBlock, MappedValue);
 
   // Because of the way that phi nodes are represented we have to collect all
   // uses before we update SSA. Modifying one phi node can invalidate another
@@ -155,7 +155,7 @@ static void updateSSAForUseOfValue(
 
     assert(user->getParent() != EntryCheckBlock
            && "The entry check block should dominate the header");
-    updater.RewriteUse(*use);
+    updater.rewriteUse(*use);
   }
   // Canonicalize inserted phis to avoid extra BB Args.
   for (SILPhiArgument *arg : insertedPhis) {

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -334,13 +334,13 @@ updateSSA(SILModule &M, SILLoop *Loop,
       if (!Loop->contains(Use->getUser()->getParent()))
         UseList.push_back(UseWrapper(Use));
     // Update SSA of use with the available values.
-    SSAUp.Initialize(OrigValue->getType());
-    SSAUp.AddAvailableValue(OrigValue->getParentBlock(), OrigValue);
+    SSAUp.initialize(OrigValue->getType());
+    SSAUp.addAvailableValue(OrigValue->getParentBlock(), OrigValue);
     for (auto NewValue : MapEntry.second)
-      SSAUp.AddAvailableValue(NewValue->getParentBlock(), NewValue);
+      SSAUp.addAvailableValue(NewValue->getParentBlock(), NewValue);
     for (auto U : UseList) {
       Operand *Use = U;
-      SSAUp.RewriteUse(*Use);
+      SSAUp.rewriteUse(*Use);
     }
   }
 }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -686,7 +686,7 @@ AvailableValueAggregator::aggregateFullyAvailableValue(SILType loadTy,
   // have multiple insertion points if we are storing exactly the same value
   // implying that we can just copy firstVal at each insertion point.
   SILSSAUpdater updater(&insertedPhiNodes);
-  updater.Initialize(loadTy);
+  updater.initialize(loadTy);
 
   Optional<SILValue> singularValue;
   for (auto *insertPt : insertPts) {
@@ -707,7 +707,7 @@ AvailableValueAggregator::aggregateFullyAvailableValue(SILType loadTy,
     }
 
     // And then put the value into the SSA updater.
-    updater.AddAvailableValue(insertPt->getParent(), eltVal);
+    updater.addAvailableValue(insertPt->getParent(), eltVal);
   }
 
   // If we only are tracking a singular value, we do not need to construct
@@ -727,7 +727,7 @@ AvailableValueAggregator::aggregateFullyAvailableValue(SILType loadTy,
   }
 
   // Finally, grab the value from the SSA updater.
-  SILValue result = updater.GetValueInMiddleOfBlock(B.getInsertionBB());
+  SILValue result = updater.getValueInMiddleOfBlock(B.getInsertionBB());
   assert(result.getOwnershipKind().isCompatibleWith(ValueOwnershipKind::Owned));
   if (isTake() || !B.hasOwnership()) {
     return result;
@@ -863,7 +863,7 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType loadTy,
   // never have the same value along all paths unless we have a trivial value
   // meaning the SSA updater given a non-trivial value must /always/ be used.
   SILSSAUpdater updater(&insertedPhiNodes);
-  updater.Initialize(loadTy);
+  updater.initialize(loadTy);
 
   Optional<SILValue> singularValue;
   for (auto *i : insertPts) {
@@ -881,7 +881,7 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType loadTy,
       singularValue = SILValue();
     }
 
-    updater.AddAvailableValue(i->getParent(), eltVal);
+    updater.addAvailableValue(i->getParent(), eltVal);
   }
 
   SILBasicBlock *insertBlock = B.getInsertionBB();
@@ -902,7 +902,7 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType loadTy,
   }
 
   // Finally, grab the value from the SSA updater.
-  SILValue eltVal = updater.GetValueInMiddleOfBlock(insertBlock);
+  SILValue eltVal = updater.getValueInMiddleOfBlock(insertBlock);
   assert(!B.hasOwnership() ||
          eltVal.getOwnershipKind().isCompatibleWith(ValueOwnershipKind::Owned));
   assert(eltVal->getType() == loadTy && "Subelement types mismatch");

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -535,10 +535,10 @@ static void insertReleases(ArrayRef<StoreInst*> Stores,
   assert(!Stores.empty());
   SILValue StVal = Stores.front()->getSrc();
 
-  SSAUp.Initialize(StVal->getType());
+  SSAUp.initialize(StVal->getType());
 
   for (auto *Store : Stores)
-    SSAUp.AddAvailableValue(Store->getParent(), Store->getSrc());
+    SSAUp.addAvailableValue(Store->getParent(), Store->getSrc());
 
   SILLocation Loc = Stores[0]->getLoc();
   for (auto *RelPoint : ReleasePoints) {
@@ -547,7 +547,7 @@ static void insertReleases(ArrayRef<StoreInst*> Stores,
     // the right thing for local uses. We have already ensured a single store
     // per block, and all release points occur after all stores. Therefore we
     // can simply ask SSAUpdater for the reaching store.
-    SILValue RelVal = SSAUp.GetValueAtEndOfBlock(RelPoint->getParent());
+    SILValue RelVal = SSAUp.getValueAtEndOfBlock(RelPoint->getParent());
     if (StVal->getType().isReferenceCounted(RelPoint->getModule()))
       B.createStrongRelease(Loc, RelVal, B.getDefaultAtomicity());
     else

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -1337,14 +1337,14 @@ SILValue RLEContext::computePredecessorLocationValue(SILBasicBlock *BB,
 
   // Finally, collect all the values for the SILArgument, materialize it using
   // the SSAUpdater.
-  Updater.Initialize(
+  Updater.initialize(
       L.getType(&BB->getModule(), TypeExpansionContext(*BB->getParent()))
           .getObjectType());
   for (auto V : Values) {
-    Updater.AddAvailableValue(V.first, V.second);
+    Updater.addAvailableValue(V.first, V.second);
   }
 
-  return Updater.GetValueInMiddleOfBlock(BB);
+  return Updater.getValueInMiddleOfBlock(BB);
 }
 
 bool RLEContext::collectLocationValues(SILBasicBlock *BB, LSLocation &L,

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -107,9 +107,9 @@ void BasicBlockCloner::updateSSAAfterCloning() {
     for (auto *use : inst->getUses())
       useList.push_back(UseWrapper(use));
 
-    ssaUpdater.Initialize(inst->getType());
-    ssaUpdater.AddAvailableValue(origBB, inst);
-    ssaUpdater.AddAvailableValue(getNewBB(), newResult);
+    ssaUpdater.initialize(inst->getType());
+    ssaUpdater.addAvailableValue(origBB, inst);
+    ssaUpdater.addAvailableValue(getNewBB(), newResult);
 
     if (useList.empty())
       continue;
@@ -124,7 +124,7 @@ void BasicBlockCloner::updateSSAAfterCloning() {
       if (user->getParent() == origBB)
         continue;
 
-      ssaUpdater.RewriteUse(*use);
+      ssaUpdater.rewriteUse(*use);
     }
   }
 }


### PR DESCRIPTION
Specifically:

1. I made methods, variables camelCase.
2. I expanded out variable names (e.x.: bb -> block, predBB -> predBlocks, U -> wrappedUse).
3. I changed typedef -> using.
4. I changed a few c style for loops into for each loops using llvm::enumerate.

NOTE: I left the parts needed for syncing to LLVM in the old style since LLVM
needs these to exist for CRTP to work correctly for the SILSSAUpdater.

----

Just getting this off my local branch so it can percolate a little.