### PR TITLE
[5.3] Fix crash on circular reference in checkContextualRequirements()

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/rdar64992293.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar64992293.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+public protocol SomeProtocol {}
+
+public struct Impl<Param>: SomeProtocol where Param: SomeProtocol {}
+
+public struct Wrapper<Content> where Content: SomeProtocol {}
+
+public extension Wrapper where Content == Impl<WrapperParam> {
+  typealias WrapperParam = SomeProtocol
+}
+


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/32776

---

- Explanation:

If a circularity issue is diagnosed while resolving a type’s generic signature, the resulting generic signature is null. Clients like type resolution must handle this case explicitly. This patch shores up a case where we did not consider this possibility. It provides a narrow fix for a class of crash-on-invalid bugs that often manifest when users are in the middle of editing code.

- Scope: rdar://66287881 shows that users encounter this crash with some regularity while editing code. 

- Resolves: rdar://problem/66656428, rdar://64992293, rdar://66287881

- Risk: Very Low

- Testing: Added regression tests

- Reviewer: @slavapestov, @CodaFi 