### PR TITLE
[SR-13262][Sema] Adding contextual type purpose for where clause expression in constraint system

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4019,6 +4019,9 @@ generateForEachStmtConstraints(
     if (cs.generateConstraints(whereTarget, FreeTypeVariableBinding::Disallow))
       return None;
 
+    cs.setContextualType(forEachStmtInfo.whereExpr,
+                         TypeLoc::withoutLoc(boolType), CTP_Condition);
+
     forEachStmtInfo.whereExpr = whereTarget.getAsExpr();
   }
 

--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -72,3 +72,16 @@ _ = p =*= &o
 
 func rdar25963182(_ bytes: [UInt8] = nil) {}
 // expected-error@-1 {{nil default argument value cannot be converted to type}}
+
+// SR-13262
+struct SR13262_S {}
+
+func SR13262(_ x: Int) {}
+func SR13262_Int(_ x: Int) -> Int { 0 }
+func SR13262_SF(_ x: Int) -> SR13262_S { SR13262_S() }
+
+func testSR13262(_ arr: [Int]) {
+  for x in arr where SR13262(x) {} // expected-error {{cannot convert value of type '()' to expected condition type 'Bool'}}
+  for x in arr where SR13262_Int(x) {} // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}} {{22-22=(}} {{36-36= != 0)}} 
+  for x in arr where SR13262_SF(x) {} // expected-error {{cannot convert value of type 'SR13262_S' to expected condition type 'Bool'}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Making sure that we set the condition contextual type purpose for the contextual type conversion to bool on `for` statements where clause.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13262.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
