### PR TITLE
SR-13362: no baseline is available for the standard library on ASi

### DIFF
--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -17,6 +17,13 @@
 
 // REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_asserts
+
+// SR-13362
+// This currently fails on non-Intel architectures due to no baseline being
+// available and it is not possible to filter across architectures in the
+// output.
+// XFAIL: CPU=arm64 || CPU=arm64e
+
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -diagnose-sdk -module Swift -o %t.tmp/changes.txt -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi -avoid-location

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -1,4 +1,11 @@
 // REQUIRES: OS=macosx
+
+// SR-13362
+// This currently fails on non-Intel architectures due to no baseline being
+// available and it is not possible to filter across architectures in the
+// output.
+// XFAIL: CPU=arm64 || CPU=arm64e
+
 // RUN: %empty-directory(%t.tmp)
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -diagnose-sdk -module Swift -o %t.tmp/changes.txt -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -avoid-location


### PR DESCRIPTION
The standard library on non-Intel targets get compared to the baseline
from the Intel targets which is not guaranteed to be identical.  Mark
the checks as expected failures on non-x86_64 targets.  Although this is
entirely unsatisfying, it allows progress in the short term.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
