### PR TITLE
test: use the `swift_only_stable_abi` feature instead of adhoc checks

### DIFF
--- a/test/IRGen/class_update_callback_without_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_without_fixed_layout.sil
@@ -5,8 +5,7 @@
 // RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution -O %s -target %target-pre-stable-abi-triple
 
 // REQUIRES: objc_interop
-// UNSUPPORTED: OS=iosmac
-// UNSUPPORTED: CPU=arm64 || CPU=arm64e
+// UNSUPPORTED: swift_only_stable_abi
 
 // With the old deployment target, these classes use the 'singleton' metadata
 // initialization pattern. The class is not statically visible to Objective-C,

--- a/test/IRGen/eager-class-initialization.swift
+++ b/test/IRGen/eager-class-initialization.swift
@@ -3,8 +3,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir -target %target-pre-stable-abi-triple | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-OLD
 
 // REQUIRES: objc_interop
-// UNSUPPORTED: OS=iosmac
-// UNSUPPORTED: CPU=arm64 || CPU=arm64e
+// UNSUPPORTED: swift_only_stable_abi
 
 // See also eager-class-initialization-stable-abi.swift, for the stable ABI
 // deployment target test.

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -8,7 +8,7 @@
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/old.ast
 
 // REQUIRES: objc_interop
-// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: swift_only_stable_abi
 
 // See also nscoding_stable_abi.swift, for the stable ABI deployment
 // target test.


### PR DESCRIPTION
Use the proper `swift_only_stable_abi` check to ensure that the tests do
not run on targets that do not support the pre-stable ABI.

Thanks to @slavapestov for pointing out that there was a better way!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
