### PR TITLE
[Sema] Allow inference of binding to differing lvalue-ness type var…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2696,7 +2696,7 @@ namespace {
       // then we're in an ambiguity tolerant mode used for diagnostic
       // generation.  Just leave this as an unresolved member reference.
       Type resultTy = simplifyType(cs.getType(expr));
-      if (resultTy->getRValueType()->is<UnresolvedType>()) {
+      if (resultTy->hasUnresolvedType()) {
         cs.setType(expr, resultTy);
         return expr;
       }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -715,8 +715,7 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 
   // Make sure we aren't trying to equate type variables with different
   // lvalue-binding rules.
-  if (auto otherTypeVar =
-          type->lookThroughAllOptionalTypes()->getAs<TypeVariableType>()) {
+  if (auto otherTypeVar = type->getAs<TypeVariableType>()) {
     if (typeVar->getImpl().canBindToLValue() !=
         otherTypeVar->getImpl().canBindToLValue())
       return None;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6590,6 +6590,14 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       baseObjTy->is<AnyMetatypeType>() &&
       constraintKind == ConstraintKind::UnresolvedValueMember) {
     if (auto objectType = instanceTy->getOptionalObjectType()) {
+      // If we don't have a wrapped type yet, we can't look through the optional
+      // type.
+      if (objectType->getAs<TypeVariableType>()) {
+        MemberLookupResult result;
+        result.OverallResult = MemberLookupResult::Unsolved;
+        return result;
+      }
+
       if (objectType->mayHaveMembers()) {
         LookupResult &optionalLookup = lookupMember(objectType, memberName);
         for (auto result : optionalLookup)

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -296,8 +296,7 @@ switch staticMembers {
   // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
 
   case .prop: break
-  // TODO: repeated error message
-  case .optProp: break // expected-error* {{not unwrapped}}
+  case .optProp: break
 
   case .method: break // expected-error{{member 'method' expects argument of type 'Int'}}
   case .method(0): break
@@ -311,9 +310,6 @@ switch staticMembers {
 
   case .optMethod: break // expected-error{{member 'optMethod' expects argument of type 'Int'}}
   case .optMethod(0): break
-  // expected-error@-1 {{value of optional type 'StaticMembers?' must be unwrapped to a value of type 'StaticMembers'}}
-  // expected-note@-2 {{coalesce}}
-  // expected-note@-3 {{force-unwrap}}
 }
 
 _ = 0

--- a/test/expr/delayed-ident/enum.swift
+++ b/test/expr/delayed-ident/enum.swift
@@ -25,3 +25,13 @@ e2a = .Second(5)
 var e2b: E2 = .Second(5)
 e2b = .First
 var e2c: E2 = .First // expected-error{{generic parameter 'T' could not be inferred}}
+
+// SR-13357
+struct SR13357 {}
+extension Optional where Wrapped == SR13357 {
+    static var sr13357: Self { .none }
+}
+
+func f_sr13357<T>(_: T?) { }
+
+f_sr13357(.sr13357)

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -52,3 +52,17 @@ var _: HasClosure = .factoryOpt(3)
 // expected-note@-3 {{force-unwrap}}
 // FIXME: we should accept this
 var _: HasClosure = .factoryOpt!(4) // expected-error {{cannot infer contextual base in reference to member 'factoryOpt'}}
+
+infix operator =%: ComparisonPrecedence
+
+extension Optional {
+    static func =%(lhs: Self, rhs: Self) -> Bool { return true }
+}
+
+struct ImplicitMembers {
+    static var optional: ImplicitMembers? = ImplicitMembers()
+}
+
+func implicit(_ i: inout ImplicitMembers) {
+    if i =% .optional {}
+}


### PR DESCRIPTION
when we have an optional type. This uncovered an error with unresolved member lookup where we allowed an unresolved value member constraint to fail if lookup failed in an optional type wrapping a type variable.

This resolves SR-13357.
