### PR TITLE
[Diagnostics] Extract backward scan deprecation warning into a fix/diagnostic

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5462,124 +5462,6 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
   return false;
 }
 
-/// Attach a Fix-It to the given diagnostic to give the trailing closure
-/// argument a label.
-static void labelTrailingClosureArgument(
-    ASTContext &ctx, Expr *fn, Expr *arg, Identifier paramName,
-    Expr *trailingClosure, InFlightDiagnostic &diag) {
-  // Dig out source locations.
-  SourceLoc existingRParenLoc;
-  SourceLoc leadingCommaLoc;
-  if (auto tupleExpr = dyn_cast<TupleExpr>(arg)) {
-    existingRParenLoc = tupleExpr->getRParenLoc();
-    assert(tupleExpr->getNumElements() >= 2 && "Should be a ParenExpr?");
-    leadingCommaLoc = Lexer::getLocForEndOfToken(
-        ctx.SourceMgr,
-        tupleExpr->getElements()[tupleExpr->getNumElements()-2]->getEndLoc());
-  } else {
-    auto parenExpr = cast<ParenExpr>(arg);
-    existingRParenLoc = parenExpr->getRParenLoc();
-  }
-
-  // Figure out the text to be inserted before the trailing closure.
-  SmallString<16> insertionText;
-  SourceLoc insertionLoc;
-  if (leadingCommaLoc.isValid()) {
-    insertionText += ", ";
-    assert(existingRParenLoc.isValid());
-    insertionLoc = leadingCommaLoc;
-  } else if (existingRParenLoc.isInvalid()) {
-    insertionText += "(";
-    insertionLoc = Lexer::getLocForEndOfToken(
-        ctx.SourceMgr, fn->getEndLoc());
-  } else {
-    insertionLoc = existingRParenLoc;
-  }
-
-  // Add the label, if there is one.
-  if (!paramName.empty()) {
-    insertionText += paramName.str();
-    insertionText += ": ";
-  }
-
-  // If there is an existing right parentheses, remove it while we
-  // insert the new text.
-  if (existingRParenLoc.isValid()) {
-    SourceLoc afterExistingRParenLoc = Lexer::getLocForEndOfToken(
-        ctx.SourceMgr, existingRParenLoc);
-    diag.fixItReplaceChars(
-        insertionLoc, afterExistingRParenLoc, insertionText);
-  } else {
-    // Insert the appropriate prefix.
-    diag.fixItInsert(insertionLoc, insertionText);
-  }
-
-  // Insert a right parenthesis after the closing '}' of the trailing closure;
-  SourceLoc newRParenLoc = Lexer::getLocForEndOfToken(
-      ctx.SourceMgr, trailingClosure->getEndLoc());
-  diag.fixItInsert(newRParenLoc, ")");
-}
-
-/// Find the trailing closure argument of a tuple or parenthesized expression.
-///
-/// Due to a quirk of the backward scan that could allow reordering of
-/// arguments in the presence of a trailing closure, it might not be the last
-/// argument in the tuple.
-static Expr *findTrailingClosureArgument(Expr *arg) {
-  if (auto parenExpr = dyn_cast<ParenExpr>(arg)) {
-    return parenExpr->getSubExpr();
-  }
-
-  auto tupleExpr = cast<TupleExpr>(arg);
-  SourceLoc endLoc = tupleExpr->getEndLoc();
-  for (Expr *elt : llvm::reverse(tupleExpr->getElements())) {
-    if (elt->getEndLoc() == endLoc)
-      return elt;
-  }
-
-  return tupleExpr->getElements().back();
-}
-
-/// Find the index of the parameter that binds the given argument.
-static unsigned findParamBindingArgument(
-    ArrayRef<ParamBinding> parameterBindings, unsigned argIndex) {
-  for (unsigned paramIdx : indices(parameterBindings)) {
-    if (llvm::find(parameterBindings[paramIdx], argIndex)
-          != parameterBindings[paramIdx].end())
-      return paramIdx;
-  }
-
-  llvm_unreachable("No parameter binds the argument?");
-}
-
-/// Warn about the use of the deprecated "backward" scan for matching the
-/// unlabeled trailing closure. It was needed to properly type check, but
-/// this code will break with a future version of Swift.
-static void warnAboutTrailingClosureBackwardScan(
-    ConcreteDeclRef callee, Expr *fn, Expr *arg,
-    ArrayRef<AnyFunctionType::Param> params,
-    Optional<unsigned> unlabeledTrailingClosureIndex,
-    ArrayRef<ParamBinding> parameterBindings) {
-
-  Expr *trailingClosure = findTrailingClosureArgument(arg);
-  unsigned paramIdx = findParamBindingArgument(
-      parameterBindings, *unlabeledTrailingClosureIndex);
-  ASTContext &ctx = params[paramIdx].getPlainType()->getASTContext();
-  Identifier paramName = params[paramIdx].getLabel();
-
-  {
-    auto diag = ctx.Diags.diagnose(
-        trailingClosure->getStartLoc(),
-        diag::unlabeled_trailing_closure_deprecated, paramName);
-    labelTrailingClosureArgument(
-        ctx, fn, arg, paramName, trailingClosure, diag);
-  }
-
-  if (auto decl = callee.getDecl()) {
-    ctx.Diags.diagnose(decl, diag::decl_declared_here, decl->getName());
-  }
-}
-
 Expr *ExprRewriter::coerceCallArguments(
     Expr *arg, AnyFunctionType *funcType,
     ConcreteDeclRef callee,
@@ -5670,13 +5552,6 @@ Expr *ExprRewriter::coerceCallArguments(
   auto *argParen = dyn_cast<ParenExpr>(arg);
   // FIXME: Eventually, we want to enforce that we have either argTuple or
   // argParen here.
-
-  // Warn about the backward scan being deprecated.
-  if (trailingClosureMatching == TrailingClosureMatching::Backward) {
-    warnAboutTrailingClosureBackwardScan(
-        callee, apply ? apply->getFn() : nullptr, arg, params,
-        unlabeledTrailingClosureIndex, parameterBindings);
-  }
 
   SourceLoc lParenLoc, rParenLoc;
   if (argTuple) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2215,7 +2215,7 @@ public:
 };
 
 /// Diagnose situations when trailing closure has been matched to a specific
-/// parameter via deprecated backward scan.
+/// parameter via a deprecated backward scan.
 ///
 /// \code
 /// func multiple_trailing_with_defaults(

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2214,6 +2214,30 @@ public:
   SourceLoc getLoc() const override;
 };
 
+/// Diagnose situations when trailing closure has been matched to a specific
+/// parameter via deprecated backward scan.
+///
+/// \code
+/// func multiple_trailing_with_defaults(
+///   duration: Int,
+///   animations: (() -> Void)? = nil,
+///   completion: (() -> Void)? = nil) {}
+///
+/// multiple_trailing_with_defaults(duration: 42) {} // picks `completion:`
+/// \endcode
+class TrailingClosureRequiresExplicitLabel final : public FailureDiagnostic {
+public:
+  TrailingClosureRequiresExplicitLabel(const Solution &solution,
+                                       ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+
+private:
+  void fixIt(InFlightDiagnostic &diagnostic,
+             const FunctionArgApplyInfo &info) const;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1526,3 +1526,15 @@ UnwrapOptionalBaseKeyPathApplication::attempt(ConstraintSystem &cs, Type baseTy,
   return new (cs.getAllocator())
       UnwrapOptionalBaseKeyPathApplication(cs, baseTy, rootTy, locator);
 }
+
+bool SpecifyLabelToAssociateTrailingClosure::diagnose(const Solution &solution,
+                                                      bool asNote) const {
+  return false;
+}
+
+SpecifyLabelToAssociateTrailingClosure *
+SpecifyLabelToAssociateTrailingClosure::create(ConstraintSystem &cs,
+                                               ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      SpecifyLabelToAssociateTrailingClosure(cs, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1529,7 +1529,8 @@ UnwrapOptionalBaseKeyPathApplication::attempt(ConstraintSystem &cs, Type baseTy,
 
 bool SpecifyLabelToAssociateTrailingClosure::diagnose(const Solution &solution,
                                                       bool asNote) const {
-  return false;
+  TrailingClosureRequiresExplicitLabel failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 SpecifyLabelToAssociateTrailingClosure *

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1208,6 +1208,9 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
 
   // Match up the call arguments to the parameters.
   SmallVector<ParamBinding, 4> parameterBindings;
+  TrailingClosureMatching selectedTrailingMatching =
+      TrailingClosureMatching::Forward;
+
   {
     ArgumentFailureTracker listener(cs, argsWithLabels, params, locator);
     auto callArgumentMatch = constraints::matchCallArguments(
@@ -1224,10 +1227,10 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
       return cs.getTypeMatchAmbiguous();
     }
 
+    selectedTrailingMatching = callArgumentMatch->trailingClosureMatching;
     // Record the direction of matching used for this call.
-    cs.recordTrailingClosureMatch(
-        cs.getConstraintLocator(locator),
-        callArgumentMatch->trailingClosureMatching);
+    cs.recordTrailingClosureMatch(cs.getConstraintLocator(locator),
+                                  selectedTrailingMatching);
 
     // If there was a disjunction because both forward and backward were
     // possible, increase the score for forward matches to bias toward the
@@ -1314,6 +1317,15 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
           cs.increaseScore(SK_FunctionConversion);
           matchingAutoClosureResult = false;
         }
+      }
+
+      // In case solver matched trailing based on the backward scan,
+      // let's produce a warning which would suggest to add a label
+      // to disambiguate in the future.
+      if (selectedTrailingMatching == TrailingClosureMatching::Backward &&
+          argIdx == *argInfo->UnlabeledTrailingClosureIndex) {
+        cs.recordFix(SpecifyLabelToAssociateTrailingClosure::create(
+            cs, cs.getConstraintLocator(loc)));
       }
 
       // If argument comes for declaration it should loose
@@ -9963,7 +9975,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowKeyPathRootTypeMismatch:
   case FixKind::UnwrapOptionalBaseKeyPathApplication:
   case FixKind::AllowCoercionToForceCast:
-  case FixKind::SpecifyKeyPathRootType: {
+  case FixKind::SpecifyKeyPathRootType:
+  case FixKind::SpecifyLabelToAssociateTrailingClosure: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -554,6 +554,9 @@ public:
         ArgType(argType), ParamIdx(paramIdx), FnInterfaceType(fnInterfaceType),
         FnType(fnType), Callee(callee) {}
 
+  /// \returns The list of the arguments used for this application.
+  Expr *getArgListExpr() const { return ArgListExpr; }
+
   /// \returns The argument being applied.
   Expr *getArgExpr() const { return ArgExpr; }
 
@@ -579,6 +582,11 @@ public:
 
     assert(isa<ParenExpr>(ArgListExpr));
     return Identifier();
+  }
+
+  Identifier getParamLabel() const {
+    auto param = FnType->getParams()[ParamIdx];
+    return param.getLabel();
   }
 
   /// \returns A textual description of the argument suitable for diagnostics.

--- a/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_ambiguity.swift
@@ -92,3 +92,33 @@ func notAmbiguous3(
 func testNotAmbiguous3() {
   notAmbiguous3 { $0 }
 }
+
+// Ambiguous subscript
+struct S {
+  subscript( // expected-note {{'subscript(a:_:_:)' declared here}}
+    a a: Int,
+    fn1: (() -> Void)? = nil,
+    fn2: (() -> Void)? = nil) -> Bool {
+    get { return true }
+  }
+
+  subscript( // expected-note {{'subscript(b:_:fn2:)' declared here}}
+    b b: Int,
+    fn1: (() -> Void)? = nil,
+    fn2 fn2: (() -> Void)? = nil) -> Bool {
+    get { return true }
+  }
+
+  static func foo( // expected-note {{'foo(c:fn1:fn2:)' declared here}}
+    c: Int,
+    fn1: (() -> Void)? = nil,
+    fn2: (() -> Void)? = nil) -> S {
+    return S()
+  }
+}
+
+func test_ambiguous_subscript_unresolved_member(s: S) {
+  _ = s[a: 42] {} // expected-warning {{backward matching of the unlabeled trailing closure is deprecated; label the argument with '_' to suppress this warning}} {{14-15=, }} {{18-18=]}}
+  _ = s[b: 42] {} // expected-warning {{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'fn2' to suppress this warning}} {{14-15=, fn2: }} {{18-18=]}}
+  let _: S = .foo(c: 42) {} // expected-warning {{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'fn2' to suppress this warning}} {{24-25=, fn2: }} {{28-28=)}}
+}


### PR DESCRIPTION
Instead of trying to detect this issue during solution application let's add a fix every
time trailing closure is matched via a backward scan. This also makes it easy to diagnose
subscript, unresolved member calls and other expressions which allow unlabeled 
trailing closures.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
