### PR TITLE
Revert "Temporarily disable failing test"

### DIFF
--- a/test/attr/attr_availability_canonical_macos_version.swift
+++ b/test/attr/attr_availability_canonical_macos_version.swift
@@ -1,5 +1,4 @@
 // RUN: %swift -typecheck -verify -parse-stdlib -module-name Swift -target x86_64-apple-macosx11.0 %s
-// REQUIRES: rdar66693249
 
 
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 11.0,


### PR DESCRIPTION
Reverts apple/swift#33365. It's only failing on the 5.3 branch.