### PR TITLE
[SymbolGraph] Check Loc validity before extracting text

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -684,7 +684,7 @@ bool SemaAnnotator::
 passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data) {
   SourceManager &SM = D->getASTContext().SourceMgr;
   SourceLoc BaseStart = Loc.getBaseNameLoc(), BaseEnd = BaseStart;
-  if (SM.extractText({BaseStart, 1}) == "`")
+  if (BaseStart.isValid() && SM.extractText({BaseStart, 1}) == "`")
     BaseEnd = Lexer::getLocForEndOfToken(SM, BaseStart.getAdvancedLoc(1));
   return passReference(D, Ty, BaseStart, {BaseStart, BaseEnd}, Data);
 }

--- a/test/SymbolGraph/Something/Inputs/SomeProtocol.swift
+++ b/test/SymbolGraph/Something/Inputs/SomeProtocol.swift
@@ -1,0 +1,3 @@
+public protocol P {
+  func foo()
+}

--- a/test/SymbolGraph/Something/Something.swift
+++ b/test/SymbolGraph/Something/Something.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/SomeProtocol.swift -module-name SomeProtocol -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name Something -emit-module -emit-module-path %t/ -I %t
+// RUN: %target-swift-symbolgraph-extract -module-name Something -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Something.symbols.json
+
+import protocol SomeProtocol.P
+
+public struct MyStruct: P {
+  public func foo() {}
+}
+
+// CHECK: "kind": "conformsTo",
+// CHECK-NEXT: "source": "s:9Something8MyStructV",
+// CHECK-NEXT: "target": "s:12SomeProtocol1PP",


### PR DESCRIPTION
Hit this crash while walking an `import protocol ...` declaration.
Check loc validity before calling `SourceManager::extractText`:
there is an assertion at the beginning of this function.

rdar://65258208