### PR TITLE
Sema: Don't need to derive CaseIterable's AllCases associated type

### DIFF
--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -69,15 +69,6 @@ static ArraySliceType *computeAllCasesType(NominalTypeDecl *enumDecl) {
   return ArraySliceType::get(enumType);
 }
 
-static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
-  // enum SomeEnum : CaseIterable {
-  //   @derived
-  //   typealias AllCases = [SomeEnum]
-  // }
-  auto *rawInterfaceType = computeAllCasesType(cast<EnumDecl>(derived.Nominal));
-  return derived.getConformanceContext()->mapTypeIntoContext(rawInterfaceType);
-}
-
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   // Conformance can't be synthesized in an extension.
   if (checkAndDiagnoseDisallowedContext(requirement))
@@ -111,18 +102,3 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 
   return propDecl;
 }
-
-Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
-  // Check that we can actually derive CaseIterable for this type.
-  if (!canDeriveConformance(Nominal))
-    return nullptr;
-
-  if (assocType->getName() == Context.Id_AllCases) {
-    return deriveCaseIterable_AllCases(*this);
-  }
-
-  Context.Diags.diagnose(assocType->getLoc(),
-                         diag::broken_case_iterable_requirement);
-  return nullptr;
-}
-

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -163,12 +163,6 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveCaseIterable(ValueDecl *requirement);
 
-  /// Derive a CaseIterable type witness for an enum if it has no associated
-  /// values for any of its cases.
-  ///
-  /// \returns the derived member, which will also be added to the type.
-  Type deriveCaseIterable(AssociatedTypeDecl *assocType);
-
   /// Determine if a RawRepresentable requirement can be derived for a type.
   ///
   /// This is implemented for non-empty enums without associated values,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5691,8 +5691,6 @@ TypeChecker::deriveTypeWitness(DeclContext *DC,
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
     return std::make_pair(derived.deriveRawRepresentable(AssocType), nullptr);
-  case KnownProtocolKind::CaseIterable:
-    return std::make_pair(derived.deriveCaseIterable(AssocType), nullptr);
   case KnownProtocolKind::Differentiable:
     return derived.deriveDifferentiable(AssocType);
   default:

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -249,7 +249,7 @@ extension RawRepresentable where RawValue: Hashable, Self: Hashable {
 /// demonstrates this automatic implementation.
 public protocol CaseIterable {
   /// A type that can represent a collection of all values of this type.
-  associatedtype AllCases: Collection
+  associatedtype AllCases: Collection = [Self]
     where AllCases.Element == Self
   
   /// A collection of all values of this type.

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -896,11 +896,10 @@ struct SynthesizedConformance3: Hashable {
 enum SynthesizedConformance4: CaseIterable {
   case a, b, c, d
   #^OVERRIDE_SYNTHESIZED_4^#
-// OVERRIDE_SYNTHESIZED_4: Begin completions, 4 items
+// OVERRIDE_SYNTHESIZED_4: Begin completions, 3 items
 // OVERRIDE_SYNTHESIZED_4-DAG: Decl[InstanceVar]/Super/IsSystem:       var hashValue: Int
 // OVERRIDE_SYNTHESIZED_4-DAG: Decl[InstanceMethod]/Super/IsSystem:    func hash(into hasher: inout Hasher) {|};
 // OVERRIDE_SYNTHESIZED_4-DAG: Decl[StaticVar]/Super/IsSystem:         static var allCases: [SynthesizedConformance4];
-// OVERRIDE_SYNTHESIZED_4-DAG: Decl[AssociatedType]/Super/IsSystem:    typealias AllCases = {#(Type)#};
 }
 
 class SynthesizedConformance5: SynthesizedConformance2 {


### PR DESCRIPTION
Just declaring a default in the standard library works fine.
