### PR TITLE
test: repair Interpreter/bridged_casts_folding on ASi

### DIFF
--- a/test/Interpreter/bridged_casts_folding.swift
+++ b/test/Interpreter/bridged_casts_folding.swift
@@ -57,7 +57,7 @@ Tests.test("NSString => Array<Int>. Crashing test case") {
   // CHECK: [       OK ] BridgedCastFolding.NSString => Array<Int>. Crashing test case
 
   // CHECK-OPT-LABEL: [ RUN      ] BridgedCastFolding.NSString => Array<Int>. Crashing test case
-  // CHECK-OPT: stderr>>> OK: saw expected "crashed: sigill"
+  // CHECK-OPT: stderr>>> OK: saw expected "crashed: sig{{ill|trap}}"
   // CHECK-OPT: [       OK ] BridgedCastFolding.NSString => Array<Int>. Crashing test case
   expectCrashLater()
   do {
@@ -129,7 +129,7 @@ Tests.test("NSNumber (Int) -> String. Crashing test.") {
   // CHECK: [       OK ] BridgedCastFolding.NSNumber (Int) -> String. Crashing test.
 
   // CHECK-OPT-LABEL: [ RUN      ] BridgedCastFolding.NSNumber (Int) -> String. Crashing test.
-  // CHECK-OPT: stderr>>> OK: saw expected "crashed: sigill"
+  // CHECK-OPT: stderr>>> OK: saw expected "crashed: sig{{ill|trap}}"
   // CHECK-OPT: [       OK ] BridgedCastFolding.NSNumber (Int) -> String. Crashing test.
   expectCrashLater()
   do {
@@ -392,7 +392,7 @@ Tests.test("String -> NSNumber. Crashing Test Case") {
   // CHECK: [       OK ] BridgedCastFolding.String -> NSNumber. Crashing Test Case
 
   // CHECK-OPT-LABEL: [ RUN      ] BridgedCastFolding.String -> NSNumber. Crashing Test Case
-  // CHECK-OPT: stderr>>> OK: saw expected "crashed: sigill"
+  // CHECK-OPT: stderr>>> OK: saw expected "crashed: sig{{ill|trap}}"
   // CHECK-OPT: [       OK ] BridgedCastFolding.String -> NSNumber. Crashing Test Case
   expectCrashLater()
   do {


### PR DESCRIPTION
ARM64 generates a `brk #0x1` for `unreachable` which generates a
SIGTRAP.  On x86, we would generate a `ud2` rather than `int 3` which
are treated as `SIGILL` and `SIGTRAP` respectively.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
