### PR TITLE
[SymbolGraph] Don't link type identifier fragments to private symbols

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -138,7 +138,15 @@ void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
   openFragment(FragmentKind::TypeIdentifier);
   printText(Name.str());
   USR.clear();
-  if (Name.str() != "Self") {
+
+  auto ShouldLink = Name.str() != "Self";
+  if (const auto *TD = T->getAnyNominal()) {
+    if (SG->isImplicitlyPrivate(TD)) {
+      ShouldLink = false;
+    }
+  }
+
+  if (ShouldLink) {
     llvm::raw_svector_ostream OS(USR);
     ide::printDeclUSR(RefTo, OS);
   }

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
@@ -59,6 +59,9 @@ public:
     Text,
   };
 private:
+  /// The symbol graph for which a declaration is being printed.
+  const SymbolGraph *SG;
+
   /// The output stream to print fragment objects to.
   llvm::json::OStream &OS;
 
@@ -81,9 +84,11 @@ private:
   unsigned NumFragments;
 
 public:
-  DeclarationFragmentPrinter(llvm::json::OStream &OS,
+  DeclarationFragmentPrinter(const SymbolGraph *SG,
+                             llvm::json::OStream &OS,
                              Optional<StringRef> Key = None)
-    : OS(OS),
+    : SG(SG),
+      OS(OS),
       Kind(FragmentKind::None),
       NumFragments(0) {
     if (Key) {

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -558,7 +558,7 @@ void
 SymbolGraph::serializeDeclarationFragments(StringRef Key,
                                            const Symbol &S,
                                            llvm::json::OStream &OS) {
-  DeclarationFragmentPrinter Printer(OS, Key);
+  DeclarationFragmentPrinter Printer(this, OS, Key);
   auto Options = getDeclarationFragmentsPrintOptions();
   if (S.getSynthesizedBaseType()) {
     Options.setBaseType(S.getSynthesizedBaseType());
@@ -570,7 +570,7 @@ void
 SymbolGraph::serializeNavigatorDeclarationFragments(StringRef Key,
                                                     const Symbol &S,
                                                     llvm::json::OStream &OS) {
-  DeclarationFragmentPrinter Printer(OS, Key);
+  DeclarationFragmentPrinter Printer(this, OS, Key);
 
   if (const auto *TD = dyn_cast<GenericTypeDecl>(S.getSymbolDecl())) {
     Printer.printAbridgedType(TD, /*PrintKeyword=*/false);
@@ -587,7 +587,7 @@ void
 SymbolGraph::serializeSubheadingDeclarationFragments(StringRef Key,
                                                      const Symbol &S,
                                                      llvm::json::OStream &OS) {
-  DeclarationFragmentPrinter Printer(OS, Key);
+  DeclarationFragmentPrinter Printer(this, OS, Key);
 
   if (const auto *TD = dyn_cast<GenericTypeDecl>(S.getSymbolDecl())) {
     Printer.printAbridgedType(TD, /*PrintKeyword=*/true);
@@ -603,7 +603,7 @@ SymbolGraph::serializeSubheadingDeclarationFragments(StringRef Key,
 void
 SymbolGraph::serializeDeclarationFragments(StringRef Key, Type T,
                                             llvm::json::OStream &OS) {
-  DeclarationFragmentPrinter Printer(OS, Key);
+  DeclarationFragmentPrinter Printer(this, OS, Key);
   T->print(Printer, getDeclarationFragmentsPrintOptions());
 }
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/UnderscoreNotLinked.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/UnderscoreNotLinked.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name UnderscoreNotLinked -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name UnderscoreNotLinked -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/UnderscoreNotLinked.symbols.json
+
+public protocol _ShouldntBeLinked {}
+public protocol ShouldBeLinked : _ShouldntBeLinked {}
+public struct MyStruct : ShouldBeLinked {}
+
+// CHECK: "spelling": "_ShouldntBeLinked"
+// CHECK-NOT: "preciseIdentifier": "s:19UnderscoreNotLinked011_ShouldntBeC0P"


### PR DESCRIPTION
These links will never resolve because the symbols are never emitted
in the first place.

rdar://64178490