### PR TITLE
Add checks that the endpoints of partial ranges are not-NaN.

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -330,10 +330,12 @@ extension Comparable {
   /// - Parameters:
   ///   - minimum: The lower bound for the range.
   ///   - maximum: The upper bound for the range.
+  ///
+  /// - Precondition: `minimum <= maximum`.
   @_transparent
   public static func ... (minimum: Self, maximum: Self) -> ClosedRange<Self> {
     _precondition(
-      minimum <= maximum, "Can't form Range with upperBound < lowerBound")
+      minimum <= maximum, "Range requires lowerBound <= upperBound")
     return ClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
   }
 }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -529,7 +529,11 @@ public struct PartialRangeThrough<Bound: Comparable> {
   public let upperBound: Bound
   
   @inlinable // trivial-implementation
-  public init(_ upperBound: Bound) { self.upperBound = upperBound }
+  public init(_ upperBound: Bound) {
+    _precondition(upperBound == upperBound,
+      "PartialRangeThrough requries that upperBound not be unordered.")
+    self.upperBound = upperBound
+  }
 }
 
 extension PartialRangeThrough: RangeExpression {
@@ -644,7 +648,11 @@ public struct PartialRangeFrom<Bound: Comparable> {
   public let lowerBound: Bound
 
   @inlinable // trivial-implementation
-  public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
+  public init(_ lowerBound: Bound) {
+    _precondition(lowerBound == lowerBound,
+      "PartialRangeFrom requries that lowerBound not be unordered.")
+    self.lowerBound = lowerBound
+  }
 }
 
 extension PartialRangeFrom: RangeExpression {
@@ -726,7 +734,7 @@ extension Comparable {
   @_transparent
   public static func ..< (minimum: Self, maximum: Self) -> Range<Self> {
     _precondition(minimum <= maximum,
-      "Can't form Range with upperBound < lowerBound")
+      "Range requires lowerBound <= upperBound")
     return Range(uncheckedBounds: (lower: minimum, upper: maximum))
   }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -529,11 +529,7 @@ public struct PartialRangeThrough<Bound: Comparable> {
   public let upperBound: Bound
   
   @inlinable // trivial-implementation
-  public init(_ upperBound: Bound) {
-    _precondition(upperBound == upperBound,
-      "PartialRangeThrough requries that upperBound not be unordered.")
-    self.upperBound = upperBound
-  }
+  public init(_ upperBound: Bound) { self.upperBound = upperBound }
 }
 
 extension PartialRangeThrough: RangeExpression {
@@ -648,11 +644,7 @@ public struct PartialRangeFrom<Bound: Comparable> {
   public let lowerBound: Bound
 
   @inlinable // trivial-implementation
-  public init(_ lowerBound: Bound) {
-    _precondition(lowerBound == lowerBound,
-      "PartialRangeFrom requries that lowerBound not be unordered.")
-    self.lowerBound = lowerBound
-  }
+  public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
 }
 
 extension PartialRangeFrom: RangeExpression {
@@ -731,6 +723,8 @@ extension Comparable {
   /// - Parameters:
   ///   - minimum: The lower bound for the range.
   ///   - maximum: The upper bound for the range.
+  ///
+  /// - Precondition: `minimum <= maximum`.
   @_transparent
   public static func ..< (minimum: Self, maximum: Self) -> Range<Self> {
     _precondition(minimum <= maximum,
@@ -760,8 +754,12 @@ extension Comparable {
   ///     // Prints "[10, 20, 30]"
   ///
   /// - Parameter maximum: The upper bound for the range.
+  ///
+  /// - Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN).
   @_transparent
   public static prefix func ..< (maximum: Self) -> PartialRangeUpTo<Self> {
+    _precondition(maximum == maximum,
+      "Range cannot have an unordered upper bound.")
     return PartialRangeUpTo(maximum)
   }
 
@@ -787,8 +785,12 @@ extension Comparable {
   ///     // Prints "[10, 20, 30, 40]"
   ///
   /// - Parameter maximum: The upper bound for the range.
+  ///
+  /// - Precondition: `maximum` must compare equal to itself (i.e. cannot be NaN).
   @_transparent
   public static prefix func ... (maximum: Self) -> PartialRangeThrough<Self> {
+    _precondition(maximum == maximum,
+      "Range cannot have an unordered upper bound.")
     return PartialRangeThrough(maximum)
   }
 
@@ -814,8 +816,12 @@ extension Comparable {
   ///     // Prints "[40, 50, 60, 70]"
   ///
   /// - Parameter minimum: The lower bound for the range.
+  ///
+  /// - Precondition: `minimum` must compare equal to itself (i.e. cannot be NaN).
   @_transparent
   public static postfix func ... (minimum: Self) -> PartialRangeFrom<Self> {
+    _precondition(minimum == minimum,
+      "Range cannot have an unordered lower bound.")
     return PartialRangeFrom(minimum)
   }
 }

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -74,7 +74,47 @@ RangeTraps.test("CountablePartialRangeFrom")
     _ = it.next()
 }
 
+RangeTraps.test("nanLowerBound")
+  .code {
+  expectCrashLater()
+  _ = Double.nan ... 0
+}
 
+RangeTraps.test("nanUpperBound")
+  .code {
+  expectCrashLater()
+  _ = 0 ... Double.nan
+}
+
+RangeTraps.test("nanLowerBoundPartial")
+  .code {
+  expectCrashLater()
+  _ = Double.nan ..< 0
+}
+
+RangeTraps.test("nanUpperBoundPartial")
+  .code {
+  expectCrashLater()
+  _ = 0 ..< Double.nan
+}
+
+RangeTraps.test("fromNaN")
+  .code {
+  expectCrashLater()
+  _ = Double.nan...
+}
+
+RangeTraps.test("toNaN")
+  .code {
+  expectCrashLater()
+  _ = ..<Double.nan
+}
+
+RangeTraps.test("throughNaN")
+  .code {
+  expectCrashLater()
+  _ = ...Double.nan
+}
 
 runAllTests()
 

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -401,7 +401,7 @@ ${TestSuite}.test("Equatable") {
 
 ${TestSuite}.test("'${op}' traps when upperBound < lowerBound")
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "Can't form Range with upperBound < lowerBound" : "")
+    "Range requires lowerBound <= upperBound" : "")
   .code {
   let _1 = ${Bound}(1)
   let _2 = ${Bound}(2)


### PR DESCRIPTION
We can't actually check for NaN (because the notion doesn't exist for Comparable), but we can require that the endpoint is non-exceptional by checking if it equals itself.

This will introduce a little bit of overhead for types that have non-trivial conformances to Comparable, but no worse than the check for creating a bounded range, so that should be acceptable (and it should be optimized away in concrete contexts, and it won't be noticed for the types where performance matters most).

Also updated the wording of the error message on the check for bounded ranges, to correctly reflect the actual condition being enforced when one of the endpoints is exceptional.

Addresses an issue that I noted on this SE thread: https://forums.swift.org/t/add-a-clamp-function-to-algorithm-swift/5405/45