### PR TITLE
Add default IR attributes to helper functions

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4862,6 +4862,7 @@ static llvm::Function *shouldDefineHelper(IRGenModule &IGM,
   if (!def) return nullptr;
   if (!def->empty()) return nullptr;
 
+  def->setAttributes(IGM.constructInitialAttributes());
   ApplyIRLinkage(IRLinkage::InternalLinkOnceODR).to(def);
   def->setDoesNotThrow();
   def->setCallingConv(IGM.DefaultCC);

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -277,6 +277,7 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
     
   auto layoutFn = llvm::Function::Create(fnTy,
     llvm::GlobalValue::PrivateLinkage, "keypath_get_arg_layout", IGM.getModule());
+  layoutFn->setAttributes(IGM.constructInitialAttributes());
     
   {
     IRGenFunction IGF(IGM, layoutFn);
@@ -378,6 +379,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
       auto destroyFn = llvm::Function::Create(destroyType,
         llvm::GlobalValue::PrivateLinkage, "keypath_destroy", IGM.getModule());
       destroy = destroyFn;
+      destroyFn->setAttributes(IGM.constructInitialAttributes());
       
       IRGenFunction IGF(IGM, destroyFn);
       if (IGM.DebugInfo)
@@ -426,6 +428,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
       auto copyFn = llvm::Function::Create(copyType,
         llvm::GlobalValue::PrivateLinkage, "keypath_copy", IGM.getModule());
       copy = copyFn;
+      copyFn->setAttributes(IGM.constructInitialAttributes());
       
       IRGenFunction IGF(IGM, copyFn);
       if (IGM.DebugInfo)
@@ -538,6 +541,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
       
   auto initFn = llvm::Function::Create(fnTy,
     llvm::GlobalValue::PrivateLinkage, "keypath_arg_init", IGM.getModule());
+  initFn->setAttributes(IGM.constructInitialAttributes());
     
   {
     IRGenFunction IGF(IGM, initFn);
@@ -945,23 +949,16 @@ emitKeyPathComponent(IRGenModule &IGM,
         // Note that we'd need to do this anyway in JIT mode because we would
         // need to unique the selector at runtime anyway.
         auto selectorName = IGM.getObjCSelectorName(declRef);
-        llvm::Type *fnParams[] = {IGM.Int8PtrTy};
-        auto fnTy = llvm::FunctionType::get(IGM.Int8PtrTy, fnParams, false);
         SmallString<32> fnName;
         fnName.append("keypath_get_selector_");
         fnName.append(selectorName);
-        auto fn = cast<llvm::Function>(
-          IGM.Module.getOrInsertFunction(fnName, fnTy).getCallee());
-        if (fn->empty()) {
-          fn->setLinkage(llvm::Function::PrivateLinkage);
-          IRGenFunction subIGF(IGM, fn);
-          if (IGM.DebugInfo)
-            IGM.DebugInfo->emitArtificialFunction(subIGF, fn);
-          
+        auto fn = IGM.getOrCreateHelperFunction(fnName, IGM.Int8PtrTy,
+                                                {IGM.Int8PtrTy},
+                                      [&selectorName](IRGenFunction &subIGF) {
           auto selectorValue = subIGF.emitObjCSelectorRefLoad(selectorName);
           subIGF.Builder.CreateRet(selectorValue);
-        }
-        
+        });
+
         idValue = fn;
         idResolution = KeyPathComponentHeader::FunctionCall;
       } else {

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -1354,6 +1354,7 @@ irgen::getOrCreateGetExtraInhabitantTagFunction(IRGenModule &IGM,
   auto fn = llvm::Function::Create(fnTy, llvm::Function::PrivateLinkage,
                                    "__swift_get_extra_inhabitant_index",
                                    &IGM.Module);
+  fn->setAttributes(IGM.constructInitialAttributes());
   fn->setCallingConv(IGM.SwiftCC);
   IRGenFunction IGF(IGM, fn);
   auto parameters = IGF.collectParameters();
@@ -1427,8 +1428,9 @@ irgen::getOrCreateStoreExtraInhabitantTagFunction(IRGenModule &IGM,
 
   // TODO: use a meaningful mangled name and internal/shared linkage.
   auto fn = llvm::Function::Create(fnTy, llvm::Function::PrivateLinkage,
-                                   "__swift_get_extra_inhabitant_index",
+                                   "__swift_store_extra_inhabitant_index",
                                    &IGM.Module);
+  fn->setAttributes(IGM.constructInitialAttributes());
   fn->setCallingConv(IGM.SwiftCC);
   IRGenFunction IGF(IGM, fn);
   auto parameters = IGF.collectParameters();

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1407,6 +1407,7 @@ void IRGenModule::emitAutolinkInfo() {
         llvm::Function::Create(llvm::FunctionType::get(VoidTy, false),
                                llvm::GlobalValue::ExternalLinkage, buf,
                                &Module);
+    ForceImportThunk->setAttributes(constructInitialAttributes());
     ApplyIRLinkage(IRLinkage::ExternalExport).to(ForceImportThunk);
     if (Triple.supportsCOMDAT())
       if (auto *GO = cast<llvm::GlobalObject>(ForceImportThunk))

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -54,7 +54,7 @@ entry(%n : $Builtin.NativeObject):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8** } @u_cast_to_class_existential(%objc_object* %0)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, {{.*}} @"$s5casts2CPMp"
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* %0, %swift.type* %1, %swift.protocol* %2) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* %0, %swift.type* %1, %swift.protocol* %2) {{.*}} {
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -80,7 +80,7 @@ entry(%a : $@thick Any.Type):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @u_cast_to_class_existential_2(%objc_object* %0)
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, {{.*}} @"$s5casts2CPMp"{{[^,]*}}, {{.*}} @"$s5casts3CP2Mp"
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* %0, %swift.type* %1, %swift.protocol* %2, %swift.protocol* %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* %0, %swift.type* %1, %swift.protocol* %2, %swift.protocol* %3)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -122,7 +122,7 @@ entry(%a : $@thick Any.Type):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8** } @c_cast_to_class_existential(%objc_object* %0)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* {{.*}}, %swift.type* %.Type, {{.*}} @"$s5casts2CPMp"
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* %0, %swift.type* %1, %swift.protocol* %2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* %0, %swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -152,7 +152,7 @@ nay:
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @c_cast_to_class_existential_2(%objc_object* %0)
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8* {{%.*}}, %swift.type* {{%.*}}, {{.*}} @"$s5casts2CPMp" {{[^,]*}}, {{.*}} @"$s5casts3CP2Mp"
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8* %0, %swift.type* %1, %swift.protocol* %2, %swift.protocol* %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8* %0, %swift.type* %1, %swift.protocol* %2, %swift.protocol* %3)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont

--- a/test/IRGen/default_function_ir_attributes.swift
+++ b/test/IRGen/default_function_ir_attributes.swift
@@ -1,0 +1,175 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-runtime --check-prefix=CHECK -DINT=i%target-ptrsize
+
+protocol P0 {}
+protocol P1 {}
+struct P0Conformer: P0, Hashable {}
+protocol CP0 : AnyObject {}
+protocol CP1 : AnyObject {}
+class C {}
+
+struct S {
+  var stored: Int
+  var computed: Int {
+    get { stored }
+    set {}
+  }
+  subscript<T: P0>(t: T) -> Int {
+    get { 0 }
+    set {}
+  }
+}
+
+enum SinglePayloadEnum<T> {
+  case value(T)
+  case different
+  case otherwise
+}
+
+struct OutlinedOperations<T> {
+  var first: T
+  var second: T
+  var third: T
+  var fourth: T
+}
+struct StructHoldingOutlined<T> {
+  var outlined: OutlinedOperations<T>
+  var element: T
+}
+
+//   main
+// CHECK-LABEL: define {{.*}} @main(
+// CHECK-SAME: [[ATTRS_SIMPLE:#[0-9]+]]
+
+//   class deinit
+// CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes1CCfd"(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   outlined operation
+// CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes18OutlinedOperationsVyxGlWOc"(
+// CHECK-SAME: [[ATTRS_NOINLINE_NOUNWIND:#[0-9]+]]
+
+//   normal function
+// CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes3fooyyF"(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+func foo() {}
+
+//   helper function: __swift_instantiateConcreteTypeFromMangledName
+// CHECK-LABEL: define {{.*}} @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME:#[0-9]+]]
+
+func use_metadata() -> Any.Type {
+  return ((C) -> Int).self
+}
+
+//   helper function: dynamic_cast_existential_1_unconditional
+// CHECK-LABEL: define {{.*}} @dynamic_cast_existential_1_unconditional(
+// CHECK-SAME: [[ATTRS_NOUNWIND:#[0-9]+]]
+
+func test_class_existential_cast_0(value: AnyObject) -> CP0 {
+  value as! CP0
+}
+
+//   helper function: dynamic_cast_existential_2_unconditional
+// CHECK-LABEL: define {{.*}} @dynamic_cast_existential_2_unconditional(
+// CHECK-SAME: [[ATTRS_NOUNWIND]]
+
+func test_class_existential_cast_1(value: AnyObject) -> CP0 & CP1 {
+  value as! CP0 & CP1
+}
+
+//   helper function: dynamic_cast_existential_2_conditional
+// CHECK-LABEL: define {{.*}} @dynamic_cast_existential_2_conditional(
+// CHECK-SAME: [[ATTRS_NOUNWIND]]
+
+func test_class_existential_cast_2(value: AnyObject) -> (CP0 & CP1)? {
+  value as? CP0 & CP1
+}
+
+//   helper function: dynamic_cast_existential_1_superclass_unconditional
+// CHECK-LABEL: define {{.*}} @dynamic_cast_existential_1_superclass_unconditional(
+// CHECK-SAME: [[ATTRS_NOUNWIND]]
+
+func test_class_existential_cast_3(value: AnyObject) -> C & CP0 {
+  value as! C & CP0
+}
+
+//   metadata accessor
+// CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes1CCMa"(
+// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]]
+
+//   helper function: dynamic_cast_existential_1_superclass_conditional
+// CHECK-LABEL: define {{.*}} @dynamic_cast_existential_1_superclass_conditional(
+// CHECK-SAME: [[ATTRS_NOUNWIND]]
+
+func test_class_existential_cast_4(value: AnyObject) -> (C & CP0)? {
+  value as? C & CP0
+}
+
+//   helper function: SIL-generated key path getter
+// CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes1SV8computedSivpACTK"(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: SIL-generated key path setter
+// CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes1SV8computedSivpACTk"(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+func test_computed_key_path_sil_thunks() -> KeyPath<S, Int> {
+  \S.computed
+}
+
+//   helper function: IR-generated key path getter
+// CHECK-LABEL: define {{.*}} @keypath_get(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path setter
+// CHECK-LABEL: define {{.*}} @keypath_set(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path arg layout accessor
+// CHECK-LABEL: define {{.*}} @keypath_get_arg_layout(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path destroy function
+// CHECK-LABEL: define {{.*}} @keypath_destroy(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path copy function
+// CHECK-LABEL: define {{.*}} @keypath_copy(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path equals function
+// CHECK-LABEL: define {{.*}} @keypath_equals(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path hash function
+// CHECK-LABEL: define {{.*}} @keypath_hash(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: IR-generated key path argument initializer
+// CHECK-LABEL: define {{.*}} @keypath_arg_init(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+func test_computed_key_path_generic_thunks<T: P0 & Hashable>(value: T) -> KeyPath<S, Int> {
+  return \S[value]
+}
+
+//   helper function: __swift_get_extra_inhabitant_index(
+// CHECK-LABEL: define {{.*}} @__swift_get_extra_inhabitant_index(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: __swift_store_extra_inhabitant_index(
+// CHECK-LABEL: define {{.*}} @__swift_store_extra_inhabitant_index(
+// CHECK-SAME: [[ATTRS_SIMPLE]]
+
+//   helper function: __swift_instantiateGenericMetadata
+// CHECK-LABEL: define {{.*}} @__swift_instantiateGenericMetadata(
+// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]]
+
+//   Use the presence of a target-cpu attribute as a litmus for
+//   whether constructInitialAttributes was called, since it's very
+//   unlikely that handrolled code generation would think to add one.
+// CHECK: attributes [[ATTRS_SIMPLE]] = { [[CUSTOM_ATTRS:.*target-cpu.*]] }{{$}}
+// CHECK-DAG: attributes [[ATTRS_NOINLINE_NOUNWIND]] = { noinline nounwind {{.*target-cpu.*}} }
+// CHECK-DAG: attributes [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]] = { noinline nounwind readnone {{.*}}"frame-pointer"="none"{{.*target-cpu.*}} }
+// CHECK-DAG: attributes [[ATTRS_NOUNWIND]] = { nounwind [[CUSTOM_ATTRS]] }{{$}}

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -45,7 +45,7 @@ entry(%0 : $@objc_metatype C.Type):
   unreachable
 }
 
-// CHECK: define private i8* [[SELECTOR_FN]]
+// CHECK: define linkonce_odr hidden i8* [[SELECTOR_FN]]
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   %1 = load {{.*}}selector(x)
 // CHECK-NEXT:   ret i8* %1

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -109,7 +109,7 @@ bb0(%0 : @owned $C, %1 : @owned $C & P):
   return %result : $()
 }
 
-// CHECK-LABEL: define private { i8*, i8** } @dynamic_cast_existential_1_superclass_unconditional(i8* %0, %swift.type* %1, %swift.type*
+// CHECK-LABEL: define linkonce_odr hidden { i8*, i8** } @dynamic_cast_existential_1_superclass_unconditional(i8* %0, %swift.type* %1, %swift.type*
 // CHECK:     entry:
 // CHECK-NEXT:  [[RESULT:%.*]] = call %swift.type* @swift_dynamicCastMetatype(%swift.type* %1, %swift.type* %2)
 // CHECK-NEXT:  [[IS_SUBCLASS:%.*]] = icmp ne %swift.type* [[RESULT]], null
@@ -150,7 +150,7 @@ bb0(%0 : @owned $C):
   return %result : $()
 }
 
-// CHECK-LABEL: define private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* %0, %swift.type*
+// CHECK-LABEL: define linkonce_odr hidden { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* %0, %swift.type*
 // CHECK:     entry:
 // CHECK-NEXT:  [[WTABLE:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, {{.*}} %2)
 // CHECK-NEXT:  [[IS_NOT_CONFORMING:%.*]] = icmp eq i8** [[WTABLE]], null

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -40,10 +40,10 @@ import someModule
 // NO-FORCE-LOAD-NOT: FORCE_LOAD
 // NO-FORCE-LOAD-NOT -lmodule
 // NO-FORCE-LOAD-NOT -lmagic
-// FORCE-LOAD: define{{( dllexport)?}} void @"_swift_FORCE_LOAD_$_module"() {{(comdat )?}}{
+// FORCE-LOAD: define{{( dllexport)?}} void @"_swift_FORCE_LOAD_$_module"() {{(comdat )?(#[0-9]+ )?}}{
 // FORCE-LOAD:   ret void
 // FORCE-LOAD: }
-// FORCE-LOAD-HEX: define{{( dllexport)?}} void @"_swift_FORCE_LOAD_$306d6f64756c65"() {{(comdat )?}}{
+// FORCE-LOAD-HEX: define{{( dllexport)?}} void @"_swift_FORCE_LOAD_$306d6f64756c65"() {{(comdat )?(#[0-9]+ )?}}{
 // FORCE-LOAD-HEX:   ret void
 // FORCE-LOAD-HEX: }
 


### PR DESCRIPTION
Add default IR attributes to helper functions and convert several more places to use `getOrCreateHelperFunction`.
    
This means that several of these places are now emitting shared functions rather than private ones, which I've verified is okay.  There are some other places where privacy is still unfortunately necessary.

I've also fixed the name of the store-extra-inhabitants helper function to say "store" instead of "get", which is longstanding (but harmless because it's private).
    
Fixes rdar://66707994.