### PR TITLE
[SR-13359] [Sema] Tailored diagnostics for missing subscript members on tuple type base

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -88,6 +88,14 @@ ERROR(could_not_find_subscript_member_did_you_mean,none,
       "did you mean to use the subscript operator?",
       (Type))
 
+ERROR(could_not_find_subscript_member_tuple, none,
+      "tuple type %0 element cannot be accessed using subscript",
+      (Type))
+ERROR(could_not_find_subscript_member_tuple_did_you_mean_use_dot, none,
+      "tuple type %0 element cannot be accessed using subscript; "
+      "did you mean to use '.' to access element?",
+      (Type))
+
 ERROR(could_not_find_enum_case,none,
       "enum type %0 has no case %1; did you mean %2?",
       (Type, DeclNameRef, DeclName))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -89,12 +89,11 @@ ERROR(could_not_find_subscript_member_did_you_mean,none,
       (Type))
 
 ERROR(could_not_find_subscript_member_tuple, none,
-      "tuple type %0 element cannot be accessed using subscript",
-      (Type))
+      "cannot access element using subscript for tuple type %0; "
+      "use '.' notation instead", (Type))
 ERROR(could_not_find_subscript_member_tuple_did_you_mean_use_dot, none,
-      "tuple type %0 element cannot be accessed using subscript; "
-      "did you mean to use '.' to access element?",
-      (Type))
+      "cannot access element using subscript for tuple type %0; "
+      "did you mean to use '.%1'?", (Type, StringRef))
 
 ERROR(could_not_find_enum_case,none,
       "enum type %0 has no case %1; did you mean %2?",

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3457,7 +3457,7 @@ bool MissingMemberFailure::diagnoseForSubscriptMemberWithTupleBase() const {
 
       emitDiagnostic(
           diag::could_not_find_subscript_member_tuple_did_you_mean_use_dot,
-          baseType)
+          baseType, literal->getDigitsText())
           .fixItReplace(index->getSourceRange(), OS.str());
       return true;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3450,16 +3450,28 @@ bool MissingMemberFailure::diagnoseForSubscriptMemberWithTupleBase() const {
   if (SE->getNumArguments() == 1) {
     auto *literal =
         dyn_cast<IntegerLiteralExpr>(index->getSemanticsProvidingExpr());
-    if (literal && !literal->isNegative()) {
-      llvm::SmallString<4> dotAccess;
-      llvm::raw_svector_ostream OS(dotAccess);
-      OS << "." << literal->getDigitsText();
 
-      emitDiagnostic(
-          diag::could_not_find_subscript_member_tuple_did_you_mean_use_dot,
-          baseType, literal->getDigitsText())
-          .fixItReplace(index->getSourceRange(), OS.str());
-      return true;
+    llvm::Regex NumericRegex("^[0-9]+$");
+    // Literal expressions may have other types of representations e.g. 0x01,
+    // 0b01. So let's make sure to only suggest this tailored literal fix-it for
+    // number only literals.
+    if (literal && NumericRegex.match(literal->getDigitsText())) {
+      unsigned int literalValue = 0;
+      literal->getDigitsText().getAsInteger(/*Radix*/ 0, literalValue);
+
+      // Verify if the literal value is within the bounds of tuple elements.
+      if (!literal->isNegative() &&
+          literalValue < tupleType->getNumElements()) {
+        llvm::SmallString<4> dotAccess;
+        llvm::raw_svector_ostream OS(dotAccess);
+        OS << "." << literalValue;
+
+        emitDiagnostic(
+            diag::could_not_find_subscript_member_tuple_did_you_mean_use_dot,
+            baseType, literal->getDigitsText())
+            .fixItReplace(index->getSourceRange(), OS.str());
+        return true;
+      }
     }
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1079,7 +1079,7 @@ private:
   /// e.g
   /// ```swift
   ///   let tuple: (Int, Int) = (0, 0)
-  ///   _ = tuple[0]
+  ///   _ = tuple[0] // -> tuple.0.
   ///  ```
   bool diagnoseForSubscriptMemberWithTupleBase() const;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1075,6 +1075,14 @@ private:
   /// that defaults the element type. e.g. _ = [.e]
   bool diagnoseInLiteralCollectionContext() const;
 
+  /// Tailored diagnostics for missing subscript member on a tuple base type.
+  /// e.g
+  /// ```swift
+  ///   let tuple: (Int, Int) = (0, 0)
+  ///   _ = tuple[0]
+  ///  ```
+  bool diagnoseForSubscriptMemberWithTupleBase() const;
+
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,
                                           DeclNameRef memberName);

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -2969,13 +2969,11 @@
 
 - id: could_not_find_subscript_member_tuple
   msg: >-
-    cannot access element using subscript for tuple type %0; 
-    use '.' notation instead
+    cannot access element using subscript for tuple type %0; use '.' notation instead
 
 - id: could_not_find_subscript_member_tuple_did_you_mean_use_dot
   msg: >-
-    cannot access element using subscript for tuple type %0; 
-    did you mean to use '.%1'?
+    cannot access element using subscript for tuple type %0; did you mean to use '.%1'?
 
 - id: could_not_find_enum_case
   msg: >-

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -2967,6 +2967,16 @@
     value of type %0 has no property or method named 'subscript'; did you
     mean to use the subscript operator?
 
+- id: could_not_find_subscript_member_tuple
+  msg: >-
+    cannot access element using subscript for tuple type %0; 
+    use '.' notation instead
+
+- id: could_not_find_subscript_member_tuple_did_you_mean_use_dot
+  msg: >-
+    cannot access element using subscript for tuple type %0; 
+    did you mean to use '.%1'?
+
 - id: could_not_find_enum_case
   msg: >-
     enum type %0 has no case %1; did you mean %2?

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -676,22 +676,41 @@ let _ : (Int, Any) = (1, .e) // expected-error {{type 'Any' has no member 'e'}}
 _ = (1, .e) // expected-error {{cannot infer contextual base in reference to member 'e'}}
 
 // SR-13359
+
+// SR-13359
 typealias Pair = (Int, Int)
 func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: Int, b: Int)) {
   _ = pair[0] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; did you mean to use '.0'?}} {{11-14=.0}}
+  _ = pair[1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; did you mean to use '.1'?}} {{11-14=.1}}
+  _ = pair[2] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
+  _ = pair[100] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = pair["strting"] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = pair[-1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = pair[1, 1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = void[0] // expected-error {{value of type 'Void' has no subscripts}}
+  // Other representations of literals
+  _ = pair[0x00] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
+  _ = pair[0b00] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
 
   _ = alias[0] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); did you mean to use '.0'?}} {{12-15=.0}}
+  _ = alias[1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); did you mean to use '.1'?}} {{12-15=.1}}
+  _ = alias[2] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+  _ = alias[100] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias["strting"] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias[-1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias[1, 1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+  _ = alias[0x00] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+  _ = alias[0b00] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
 
   // Labeled tuple base
   _ = labeled[0] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; did you mean to use '.0'?}} {{14-17=.0}}
+  _ = labeled[1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; did you mean to use '.1'?}} {{14-17=.1}}
+  _ = labeled[2] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled[100] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled["strting"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[-1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[1, 1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled[0x00] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled[0b00] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+
 }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -674,3 +674,18 @@ _ = [.e: 1] // expected-error {{reference to member 'e' cannot be resolved witho
 let _ : [Int: Any] = [1 : .e] // expected-error {{type 'Any' has no member 'e'}}
 let _ : (Int, Any) = (1, .e) // expected-error {{type 'Any' has no member 'e'}}
 _ = (1, .e) // expected-error {{cannot infer contextual base in reference to member 'e'}}
+
+// SR-13359
+typealias Pair = (Int, Int)
+func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void) {
+  _ = pair[0] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript; did you mean to use '.' to access element?}} {{11-14=.0}}
+  _ = pair["strting"] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript}} {{none}}
+  _ = pair[-1] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript}} {{none}}
+  _ = pair[1, 1] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript}} {{none}}
+  _ = void[0] // expected-error {{value of type 'Void' has no subscripts}}
+
+  _ = alias[0] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript; did you mean to use '.' to access element?}} {{12-15=.0}}
+  _ = alias["strting"] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript}} {{none}}
+  _ = alias[-1] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript}} {{none}}
+  _ = alias[1, 1] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript}} {{none}}
+}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -677,15 +677,21 @@ _ = (1, .e) // expected-error {{cannot infer contextual base in reference to mem
 
 // SR-13359
 typealias Pair = (Int, Int)
-func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void) {
-  _ = pair[0] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript; did you mean to use '.' to access element?}} {{11-14=.0}}
-  _ = pair["strting"] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript}} {{none}}
-  _ = pair[-1] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript}} {{none}}
-  _ = pair[1, 1] // expected-error {{tuple type '(Int, Int)' element cannot be accessed using subscript}} {{none}}
+func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: Int, b: Int)) {
+  _ = pair[0] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; did you mean to use '.0'?}} {{11-14=.0}}
+  _ = pair["strting"] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
+  _ = pair[-1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
+  _ = pair[1, 1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = void[0] // expected-error {{value of type 'Void' has no subscripts}}
 
-  _ = alias[0] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript; did you mean to use '.' to access element?}} {{12-15=.0}}
-  _ = alias["strting"] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript}} {{none}}
-  _ = alias[-1] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript}} {{none}}
-  _ = alias[1, 1] // expected-error {{tuple type 'Pair' (aka '(Int, Int)') element cannot be accessed using subscript}} {{none}}
+  _ = alias[0] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); did you mean to use '.0'?}} {{12-15=.0}}
+  _ = alias["strting"] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+  _ = alias[-1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+  _ = alias[1, 1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+
+  // Labeled tuple base
+  _ = labeled[0] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; did you mean to use '.0'?}} {{14-17=.0}}
+  _ = labeled["strting"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled[-1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled[1, 1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
 }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -676,8 +676,6 @@ let _ : (Int, Any) = (1, .e) // expected-error {{type 'Any' has no member 'e'}}
 _ = (1, .e) // expected-error {{cannot infer contextual base in reference to member 'e'}}
 
 // SR-13359
-
-// SR-13359
 typealias Pair = (Int, Int)
 func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: Int, b: Int)) {
   _ = pair[0] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; did you mean to use '.0'?}} {{11-14=.0}}
@@ -712,5 +710,11 @@ func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: I
   _ = labeled[1, 1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[0x00] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[0b00] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+
+  // Suggesting use label access
+  _ = labeled["a"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; did you mean to use '.a'?}} {{14-19=.a}}
+  _ = labeled["b"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; did you mean to use '.b'?}} {{14-19=.b}}
+  _ = labeled["c"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled[""] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
 
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds a tailored diagnostic for missing subscript members on tuple type base.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13359.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
