### PR TITLE
IRGen: Override clang default frame pointer elimination settings in VS2017

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -102,6 +102,10 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
 
   auto &CGO = Importer->getClangCodeGenOpts();
   CGO.OptimizationLevel = Opts.shouldOptimize() ? 3 : 0;
+#if defined(_MSC_VER) && _MSC_VER < 1920
+  // For VS2017 and below use frame pointers to get stack traces
+  CGO.setFramePointer(clang::CodeGenOptions::FramePointerKind::NonLeaf);
+#endif
 
   CGO.DiscardValueNames = !Opts.shouldProvideValueNames();
   switch (Opts.DebugInfoLevel) {


### PR DESCRIPTION
In order to generate stack traces when exceptions happen, it seems that VS2017 needs of frame pointers in some of the functions. This recovers a small override that was present up to the introduction of #31986 but only for VS2017.

Without this change crash-in-user-code.swift test fails (because the output doesn't include the stack trace as provided by LLVM exception stack trace capturing), but the test passes with it. In order to not change VS2019 (or other compilers), which succeed at the test already, the fix is gated to only compile in VS2017.