### PR TITLE
[AutoDiff] Fix `Optional` differentiation crash.

### DIFF
--- a/stdlib/private/DifferentiationUnittest/CMakeLists.txt
+++ b/stdlib/private/DifferentiationUnittest/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_target_library(swiftDifferentiationUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed first. Module name is inferred from the filename.
-  DifferentiationUnittest.swift
+  GYB_SOURCES DifferentiationUnittest.swift.gyb
 
   SWIFT_MODULE_DEPENDS _Differentiation StdlibUnittest
   INSTALL_IN_COMPONENT stdlib-experimental

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
@@ -1,4 +1,4 @@
-//===--- DifferentiationUnittest.swift ------------------------------------===//
+//===--- DifferentiationUnittest.swift.gyb --------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -43,19 +43,21 @@ public extension TestSuite {
     _ testFunction: @escaping () -> Void
   ) {
     test(name, file: file, line: line) {
-      withLeakChecking(expectedLeakCount: expectedLeakCount, file: file,
-                       line: line, testFunction)
+      withLeakChecking(
+        expectedLeakCount: expectedLeakCount, file: file,
+        line: line, testFunction)
     }
   }
 }
 
-/// A type that tracks the number of live instances of a wrapped value type.
+/// A resilient type that tracks the number of live instances of a wrapped
+/// value type.
 ///
 /// `Tracked<T>` is used to check for memory leaks in functions created via
 /// automatic differentiation.
 public struct Tracked<T> {
-  fileprivate class Box {
-    fileprivate var value : T
+  internal class Box {
+    fileprivate var value: T
     init(_ value: T) {
       self.value = value
       _GlobalLeakCount.count += 1
@@ -64,71 +66,109 @@ public struct Tracked<T> {
       _GlobalLeakCount.count -= 1
     }
   }
-  private var handle: Box
+  internal var handle: Box
 
-  @differentiable(where T : Differentiable, T == T.TangentVector)
+  @differentiable(where T: Differentiable, T == T.TangentVector)
   public init(_ value: T) {
     self.handle = Box(value)
   }
 
-  @differentiable(where T : Differentiable, T == T.TangentVector)
+  @differentiable(where T: Differentiable, T == T.TangentVector)
   public var value: T {
     get { handle.value }
     set { handle.value = newValue }
   }
 }
 
-extension Tracked : ExpressibleByFloatLiteral where T : ExpressibleByFloatLiteral {
+/// A non-resilient type that tracks the number of live instances of a wrapped
+/// value type.
+///
+/// `NonresilientTracked<T>` is used to check for memory leaks in functions
+/// created via automatic differentiation.
+@frozen
+public struct NonresilientTracked<T> {
+  @usableFromInline
+  internal class Box {
+    fileprivate var value: T
+    init(_ value: T) {
+      self.value = value
+      _GlobalLeakCount.count += 1
+    }
+    deinit {
+      _GlobalLeakCount.count -= 1
+    }
+  }
+  @usableFromInline
+  internal var handle: Box
+
+  @differentiable(where T: Differentiable, T == T.TangentVector)
+  public init(_ value: T) {
+    self.handle = Box(value)
+  }
+
+  @differentiable(where T: Differentiable, T == T.TangentVector)
+  public var value: T {
+    get { handle.value }
+    set { handle.value = newValue }
+  }
+}
+
+% for Self in ['Tracked', 'NonresilientTracked']:
+
+extension ${Self}: ExpressibleByFloatLiteral
+where T: ExpressibleByFloatLiteral {
   public init(floatLiteral value: T.FloatLiteralType) {
     self.handle = Box(T(floatLiteral: value))
   }
 }
 
-extension Tracked : CustomStringConvertible {
-  public var description: String { return "Tracked(\(value))" }
+extension ${Self}: CustomStringConvertible {
+  public var description: String { return "${Self}(\(value))" }
 }
 
-extension Tracked : ExpressibleByIntegerLiteral where T : ExpressibleByIntegerLiteral {
+extension ${Self}: ExpressibleByIntegerLiteral
+where T: ExpressibleByIntegerLiteral {
   public init(integerLiteral value: T.IntegerLiteralType) {
     self.handle = Box(T(integerLiteral: value))
   }
 }
 
-extension Tracked : Comparable where T : Comparable {
-  public static func < (lhs: Tracked, rhs: Tracked) -> Bool {
+extension ${Self}: Comparable where T: Comparable {
+  public static func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return lhs.value < rhs.value
   }
-  public static func <= (lhs: Tracked, rhs: Tracked) -> Bool {
+  public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return lhs.value <= rhs.value
   }
-  public static func > (lhs: Tracked, rhs: Tracked) -> Bool {
+  public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return lhs.value > rhs.value
   }
-  public static func >= (lhs: Tracked, rhs: Tracked) -> Bool {
+  public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return lhs.value >= rhs.value
   }
 }
 
-extension Tracked : AdditiveArithmetic where T : AdditiveArithmetic {
-  public static var zero: Tracked { return Tracked(T.zero) }
-  public static func + (lhs: Tracked, rhs: Tracked) -> Tracked {
-    return Tracked(lhs.value + rhs.value)
+extension ${Self}: AdditiveArithmetic where T: AdditiveArithmetic {
+  public static var zero: ${Self} { return ${Self}(T.zero) }
+  public static func + (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
+    return ${Self}(lhs.value + rhs.value)
   }
-  public static func - (lhs: Tracked, rhs: Tracked) -> Tracked {
-    return Tracked(lhs.value - rhs.value)
+  public static func - (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
+    return ${Self}(lhs.value - rhs.value)
   }
 }
 
-extension Tracked : Equatable where T : Equatable {
-  public static func == (lhs: Tracked, rhs: Tracked) -> Bool {
+extension ${Self}: Equatable where T: Equatable {
+  public static func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return lhs.value == rhs.value
   }
 }
 
-extension Tracked : SignedNumeric & Numeric where T : SignedNumeric, T == T.Magnitude {
-  public typealias Magnitude = Tracked<T.Magnitude>
+extension ${Self}: SignedNumeric & Numeric
+where T: SignedNumeric, T == T.Magnitude {
+  public typealias Magnitude = ${Self}<T.Magnitude>
 
-  public init?<U>(exactly source: U) where U : BinaryInteger {
+  public init?<U>(exactly source: U) where U: BinaryInteger {
     if let t = T(exactly: source) {
       self.init(t)
     }
@@ -136,169 +176,191 @@ extension Tracked : SignedNumeric & Numeric where T : SignedNumeric, T == T.Magn
   }
   public var magnitude: Magnitude { return Magnitude(value.magnitude) }
 
-  public static func * (lhs: Tracked, rhs: Tracked) -> Tracked {
-    return Tracked(lhs.value * rhs.value)
+  public static func * (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
+    return ${Self}(lhs.value * rhs.value)
   }
 
-  public static func *= (lhs: inout Tracked, rhs: Tracked) {
+  public static func *= (lhs: inout ${Self}, rhs: ${Self}) {
     lhs = lhs * rhs
   }
 }
 
-extension Tracked where T : FloatingPoint {
-  public static func / (lhs: Tracked, rhs: Tracked) -> Tracked {
-    return Tracked(lhs.value / rhs.value)
+extension ${Self} where T: FloatingPoint {
+  public static func / (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
+    return ${Self}(lhs.value / rhs.value)
   }
 
-  public static func /= (lhs: inout Tracked, rhs: Tracked) {
+  public static func /= (lhs: inout ${Self}, rhs: ${Self}) {
     lhs = lhs / rhs
   }
 }
 
-extension Tracked : Strideable where T : Strideable, T.Stride == T.Stride.Magnitude {
-  public typealias Stride = Tracked<T.Stride>
+extension ${Self}: Strideable
+where T: Strideable, T.Stride == T.Stride.Magnitude {
+  public typealias Stride = ${Self}<T.Stride>
 
-  public func distance(to other: Tracked) -> Stride {
+  public func distance(to other: ${Self}) -> Stride {
     return Stride(value.distance(to: other.value))
   }
-  public func advanced(by n: Stride) -> Tracked {
-    return Tracked(value.advanced(by: n.value))
+  public func advanced(by n: Stride) -> ${Self} {
+    return ${Self}(value.advanced(by: n.value))
   }
 }
 
 // For now, `T` must be restricted to trivial types (like `Float` or `Tensor`).
-extension Tracked : Differentiable where T : Differentiable, T == T.TangentVector {
-  public typealias TangentVector = Tracked<T.TangentVector>
+extension ${Self}: Differentiable
+where T: Differentiable, T == T.TangentVector {
+  public typealias TangentVector = ${Self}<T.TangentVector>
 }
 
-extension Tracked where T : Differentiable, T == T.TangentVector {
+extension ${Self} where T: Differentiable, T == T.TangentVector {
   @usableFromInline
   @derivative(of: init)
   internal static func _vjpInit(_ value: T)
-      -> (value: Self, pullback: (Self.TangentVector) -> (T.TangentVector)) {
-    return (Tracked(value), { v in v.value })
+    -> (value: Self, pullback: (Self.TangentVector) -> (T.TangentVector))
+  {
+    return (${Self}(value), { v in v.value })
   }
 
   @usableFromInline
   @derivative(of: init)
   internal static func _jvpInit(_ value: T)
-      -> (value: Self, differential: (T.TangentVector) -> (Self.TangentVector)) {
-    return (Tracked(value), { v in Tracked(v) })
+    -> (value: Self, differential: (T.TangentVector) -> (Self.TangentVector))
+  {
+    return (${Self}(value), { v in ${Self}(v) })
   }
 
   @usableFromInline
   @derivative(of: value)
-  internal func _vjpValue() -> (value: T, pullback: (T.TangentVector) -> Self.TangentVector) {
-    return (value, { v in Tracked(v) })
+  internal func _vjpValue() -> (
+    value: T, pullback: (T.TangentVector) -> Self.TangentVector
+  ) {
+    return (value, { v in ${Self}(v) })
   }
 
   @usableFromInline
   @derivative(of: value)
-  internal func _jvpValue() -> (value: T, differential: (Self.TangentVector) -> T.TangentVector) {
+  internal func _jvpValue() -> (
+    value: T, differential: (Self.TangentVector) -> T.TangentVector
+  ) {
     return (value, { v in v.value })
   }
 }
 
-extension Tracked where T : Differentiable, T == T.TangentVector {
+extension ${Self} where T: Differentiable, T == T.TangentVector {
   @usableFromInline
   @derivative(of: +)
   internal static func _vjpAdd(lhs: Self, rhs: Self)
-      -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    -> (value: Self, pullback: (Self) -> (Self, Self))
+  {
     return (lhs + rhs, { v in (v, v) })
   }
 
   @usableFromInline
   @derivative(of: +)
   internal static func _jvpAdd(lhs: Self, rhs: Self)
-      -> (value: Self, differential: (Self, Self) -> Self) {
+    -> (value: Self, differential: (Self, Self) -> Self)
+  {
     return (lhs + rhs, { $0 + $1 })
   }
 
   @usableFromInline
   @derivative(of: -)
   internal static func _vjpSubtract(lhs: Self, rhs: Self)
-      -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    -> (value: Self, pullback: (Self) -> (Self, Self))
+  {
     return (lhs - rhs, { v in (v, .zero - v) })
   }
 
   @usableFromInline
   @derivative(of: -)
   internal static func _jvpSubtract(lhs: Self, rhs: Self)
-      -> (value: Self, differential: (Self, Self) -> Self) {
+    -> (value: Self, differential: (Self, Self) -> Self)
+  {
     return (lhs - rhs, { $0 - $1 })
   }
 }
 
-extension Tracked where T : Differentiable & SignedNumeric, T == T.Magnitude,
-                        T == T.TangentVector {
+extension ${Self}
+where
+  T: Differentiable & SignedNumeric, T == T.Magnitude,
+  T == T.TangentVector
+{
   @usableFromInline
   @derivative(of: *)
   internal static func _vjpMultiply(lhs: Self, rhs: Self)
-      -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    -> (value: Self, pullback: (Self) -> (Self, Self))
+  {
     return (lhs * rhs, { v in (v * rhs, v * lhs) })
   }
 
   @usableFromInline
   @derivative(of: *)
   internal static func _jvpMultiply(lhs: Self, rhs: Self)
-      -> (value: Self, differential: (Self, Self) -> (Self)) {
+    -> (value: Self, differential: (Self, Self) -> (Self))
+  {
     return (lhs * rhs, { (dx, dy) in dx * rhs + dy * lhs })
   }
 }
 
-extension Tracked where T : Differentiable & FloatingPoint, T == T.TangentVector {
+extension ${Self}
+where T: Differentiable & FloatingPoint, T == T.TangentVector {
   @usableFromInline
   @derivative(of: /)
   internal static func _vjpDivide(lhs: Self, rhs: Self)
-      -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    -> (value: Self, pullback: (Self) -> (Self, Self))
+  {
     return (lhs / rhs, { v in (v / rhs, -lhs / (rhs * rhs) * v) })
   }
 
   @usableFromInline
   @derivative(of: /)
   internal static func _jvpDivide(lhs: Self, rhs: Self)
-      -> (value: Self, differential: (Self, Self) -> (Self)) {
+    -> (value: Self, differential: (Self, Self) -> (Self))
+  {
     return (lhs / rhs, { (dx, dy) in dx / rhs - lhs / (rhs * rhs) * dy })
   }
 }
 
-// Differential operators for `Tracked<T>`.
+// Differential operators for `${Self}<T>`.
 
 public func gradient<T, R: FloatingPoint>(
-  at x: T, in f: @differentiable (T) -> Tracked<R>
+  at x: T, in f: @differentiable (T) -> ${Self}<R>
 ) -> T.TangentVector where R.TangentVector == R {
   return pullback(at: x, in: f)(1)
 }
 
 public func gradient<T, U, R: FloatingPoint>(
-  at x: T, _ y: U, in f: @differentiable (T, U) -> Tracked<R>
+  at x: T, _ y: U, in f: @differentiable (T, U) -> ${Self}<R>
 ) -> (T.TangentVector, U.TangentVector) where R.TangentVector == R {
   return pullback(at: x, y, in: f)(1)
 }
 
 public func derivative<T: FloatingPoint, R>(
-  at x: Tracked<T>, in f: @differentiable (Tracked<T>) -> R
+  at x: ${Self}<T>, in f: @differentiable (${Self}<T>) -> R
 ) -> R.TangentVector where T.TangentVector == T {
   return differential(at: x, in: f)(1)
 }
 
 public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
-  at x: Tracked<T>, _ y: Tracked<U>,
-  in f: @differentiable (Tracked<T>, Tracked<U>) -> R
+  at x: ${Self}<T>, _ y: ${Self}<U>,
+  in f: @differentiable (${Self}<T>, ${Self}<U>) -> R
 ) -> R.TangentVector where T.TangentVector == T, U.TangentVector == U {
   return differential(at: x, y, in: f)(1, 1)
 }
 
 public func valueWithGradient<T, R: FloatingPoint>(
-  at x: T, in f: @differentiable (T) -> Tracked<R>
-) -> (value: Tracked<R>, gradient: T.TangentVector) {
+  at x: T, in f: @differentiable (T) -> ${Self}<R>
+) -> (value: ${Self}<R>, gradient: T.TangentVector) {
   let (y, pullback) = valueWithPullback(at: x, in: f)
   return (y, pullback(1))
 }
 
 public func valueWithDerivative<T: FloatingPoint, R>(
-  at x: Tracked<T>, in f: @differentiable (Tracked<T>) -> R
+  at x: ${Self}<T>, in f: @differentiable (${Self}<T>) -> R
 ) -> (value: R, derivative: R.TangentVector) {
   let (y, differential) = valueWithDifferential(at: x, in: f)
   return (y, differential(1))
 }
+
+% end

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -1,8 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-import StdlibUnittest
 import DifferentiationUnittest
+import StdlibUnittest
 
 var OptionalTests = TestSuite("OptionalDifferentiation")
 
@@ -23,7 +23,7 @@ OptionalTests.test("Let") {
   @differentiable
   func optional_let(_ maybeX: Float?) -> Float {
     if let x = maybeX {
-        return x * x
+      return x * x
     }
     return 10
   }
@@ -33,12 +33,26 @@ OptionalTests.test("Let") {
   @differentiable
   func optional_let_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
     if let x = maybeX {
-        return x * x
+      return x * x
     }
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_let_tracked), .init(20.0))
   expectEqual(gradient(at: nil, in: optional_let_tracked), .init(0.0))
+
+  @differentiable
+  func optional_let_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
+    -> NonresilientTracked<Float>
+  {
+    if let x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_let_nonresilient_tracked), .init(20.0))
+  expectEqual(
+    gradient(at: nil, in: optional_let_nonresilient_tracked), .init(0.0))
 
   @differentiable
   func optional_let_nested(_ nestedMaybeX: Float??) -> Float {
@@ -54,7 +68,9 @@ OptionalTests.test("Let") {
   expectEqual(gradient(at: nil, in: optional_let_nested), .init(.init(0.0)))
 
   @differentiable
-  func optional_let_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+  func optional_let_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<
+    Float
+  > {
     if let maybeX = nestedMaybeX {
       if let x = maybeX {
         return x * x
@@ -63,24 +79,55 @@ OptionalTests.test("Let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_let_nested_tracked), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_let_nested_tracked), .init(.init(0.0)))
+  expectEqual(
+    gradient(at: 10, in: optional_let_nested_tracked), .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_let_nested_tracked), .init(.init(0.0)))
 
   @differentiable
-  func optional_let_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+  func optional_let_nested_nonresilient_tracked(
+    _ nestedMaybeX: NonresilientTracked<Float>??
+  ) -> NonresilientTracked<Float> {
+    if let maybeX = nestedMaybeX {
+      if let x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_let_nested_nonresilient_tracked),
+    .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_let_nested_nonresilient_tracked),
+    .init(.init(0.0)))
+
+  @differentiable
+  func optional_let_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T)
+    -> T
+  {
     if let x = maybeX {
-        return x
+      return x
     }
     return defaultValue
   }
   expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
 
-  expectEqual(gradient(at: Tracked<Float>.init(10), Tracked<Float>.init(20), in: optional_let_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, Tracked<Float>.init(20), in: optional_let_generic), (.init(0.0), 1.0))
+  expectEqual(
+    gradient(
+      at: Tracked<Float>.init(10), Tracked<Float>.init(20),
+      in: optional_let_generic), (.init(1.0), 0.0))
+  expectEqual(
+    gradient(at: nil, Tracked<Float>.init(20), in: optional_let_generic),
+    (.init(0.0), 1.0))
 
   @differentiable
-  func optional_let_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+  func optional_let_nested_generic<T: Differentiable>(
+    _ nestedMaybeX: T??, _ defaultValue: T
+  ) -> T {
     if let maybeX = nestedMaybeX {
       if let x = maybeX {
         return x
@@ -90,8 +137,12 @@ OptionalTests.test("Let") {
     return defaultValue
   }
 
-  expectEqual(gradient(at: 10.0, 20.0, in: optional_let_nested_generic), (.init(.init(1.0)), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_let_nested_generic), (.init(.init(0.0)), 1.0))
+  expectEqual(
+    gradient(at: 10.0, 20.0, in: optional_let_nested_generic),
+    (.init(.init(1.0)), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_let_nested_generic),
+    (.init(.init(0.0)), 1.0))
 }
 
 OptionalTests.test("Switch") {
@@ -116,13 +167,27 @@ OptionalTests.test("Switch") {
   expectEqual(gradient(at: nil, in: optional_switch_tracked), .init(0.0))
 
   @differentiable
+  func optional_switch_nonresilient_tracked(
+    _ maybeX: NonresilientTracked<Float>?
+  ) -> NonresilientTracked<Float> {
+    switch maybeX {
+    case nil: return 10
+    case let .some(x): return x * x
+    }
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_switch_nonresilient_tracked), .init(20.0))
+  expectEqual(
+    gradient(at: nil, in: optional_switch_nonresilient_tracked), .init(0.0))
+
+  @differentiable
   func optional_switch_nested(_ nestedMaybeX: Float??) -> Float {
     switch nestedMaybeX {
     case nil: return 10
     case let .some(maybeX):
       switch maybeX {
-        case nil: return 10
-        case let .some(x): return x * x
+      case nil: return 10
+      case let .some(x): return x * x
       }
     }
   }
@@ -130,42 +195,76 @@ OptionalTests.test("Switch") {
   expectEqual(gradient(at: nil, in: optional_switch_nested), .init(.init(0.0)))
 
   @differentiable
-  func optional_switch_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+  func optional_switch_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
+    -> Tracked<Float>
+  {
     switch nestedMaybeX {
     case nil: return 10
     case let .some(maybeX):
       switch maybeX {
-        case nil: return 10
-        case let .some(x): return x * x
+      case nil: return 10
+      case let .some(x): return x * x
       }
     }
   }
-  expectEqual(gradient(at: 10, in: optional_switch_nested_tracked), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_switch_nested_tracked), .init(.init(0.0)))
+  expectEqual(
+    gradient(at: 10, in: optional_switch_nested_tracked), .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_switch_nested_tracked), .init(.init(0.0)))
 
   @differentiable
-  func optional_switch_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+  func optional_switch_nested_nonresilient_tracked(
+    _ nestedMaybeX: NonresilientTracked<Float>??
+  ) -> NonresilientTracked<Float> {
+    switch nestedMaybeX {
+    case nil: return 10
+    case let .some(maybeX):
+      switch maybeX {
+      case nil: return 10
+      case let .some(x): return x * x
+      }
+    }
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_switch_nested_nonresilient_tracked),
+    .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_switch_nested_nonresilient_tracked),
+    .init(.init(0.0)))
+
+  @differentiable
+  func optional_switch_generic<T: Differentiable>(
+    _ maybeX: T?, _ defaultValue: T
+  ) -> T {
     switch maybeX {
     case nil: return defaultValue
     case let .some(x): return x
     }
   }
-  expectEqual(gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
+  expectEqual(
+    gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
 
   @differentiable
-  func optional_switch_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+  func optional_switch_nested_generic<T: Differentiable>(
+    _ nestedMaybeX: T??, _ defaultValue: T
+  ) -> T {
     switch nestedMaybeX {
     case nil: return defaultValue
     case let .some(maybeX):
       switch maybeX {
-        case nil: return defaultValue
-        case let .some(x): return x
+      case nil: return defaultValue
+      case let .some(x): return x
       }
     }
   }
-  expectEqual(gradient(at: 10, 20, in: optional_switch_nested_generic), (.init(.init(1.0)), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_switch_nested_generic), (.init(.init(0.0)), 1.0))
+  expectEqual(
+    gradient(at: 10, 20, in: optional_switch_nested_generic),
+    (.init(.init(1.0)), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_switch_nested_generic),
+    (.init(.init(0.0)), 1.0))
 }
 
 OptionalTests.test("Var1") {
@@ -173,7 +272,7 @@ OptionalTests.test("Var1") {
   func optional_var1(_ maybeX: Float?) -> Float {
     var maybeX = maybeX
     if let x = maybeX {
-        return x * x
+      return x * x
     }
     return 10
   }
@@ -184,12 +283,27 @@ OptionalTests.test("Var1") {
   func optional_var1_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
     var maybeX = maybeX
     if let x = maybeX {
-        return x * x
+      return x * x
     }
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var1_tracked), .init(20.0))
   expectEqual(gradient(at: nil, in: optional_var1_tracked), .init(0.0))
+
+  @differentiable
+  func optional_var1_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
+    -> NonresilientTracked<Float>
+  {
+    var maybeX = maybeX
+    if let x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_var1_nonresilient_tracked), .init(20.0))
+  expectEqual(
+    gradient(at: nil, in: optional_var1_nonresilient_tracked), .init(0.0))
 
   @differentiable
   func optional_var1_nested(_ nestedMaybeX: Float??) -> Float {
@@ -206,7 +320,9 @@ OptionalTests.test("Var1") {
   expectEqual(gradient(at: nil, in: optional_var1_nested), .init(.init(0.0)))
 
   @differentiable
-  func optional_var1_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+  func optional_var1_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
+    -> Tracked<Float>
+  {
     var nestedMaybeX = nestedMaybeX
     if let maybeX = nestedMaybeX {
       if var x = maybeX {
@@ -216,22 +332,50 @@ OptionalTests.test("Var1") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var1_nested_tracked), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_var1_nested_tracked), .init(.init(0.0)))
+  expectEqual(
+    gradient(at: 10, in: optional_var1_nested_tracked), .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_var1_nested_tracked), .init(.init(0.0)))
 
   @differentiable
-  func optional_var1_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+  func optional_var1_nested_nonresilient_tracked(
+    _ nestedMaybeX: NonresilientTracked<Float>??
+  ) -> NonresilientTracked<Float> {
+    var nestedMaybeX = nestedMaybeX
+    if let maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_var1_nested_nonresilient_tracked),
+    .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_var1_nested_nonresilient_tracked),
+    .init(.init(0.0)))
+
+  @differentiable
+  func optional_var1_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T)
+    -> T
+  {
     var maybeX = maybeX
     if let x = maybeX {
-        return x
+      return x
     }
     return defaultValue
   }
-  expectEqual(gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
+  expectEqual(
+    gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
 
   @differentiable
-  func optional_var1_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+  func optional_var1_nested_generic<T: Differentiable>(
+    _ nestedMaybeX: T??, _ defaultValue: T
+  ) -> T {
     var nestedMaybeX = nestedMaybeX
     if let maybeX = nestedMaybeX {
       if var x = maybeX {
@@ -241,8 +385,12 @@ OptionalTests.test("Var1") {
     }
     return defaultValue
   }
-  expectEqual(gradient(at: 10, 20, in: optional_var1_nested_generic), (.init(.init(1.0)), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_var1_nested_generic), (.init(.init(0.0)), 1.0))
+  expectEqual(
+    gradient(at: 10, 20, in: optional_var1_nested_generic),
+    (.init(.init(1.0)), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_var1_nested_generic),
+    (.init(.init(0.0)), 1.0))
 }
 
 OptionalTests.test("Var2") {
@@ -267,6 +415,20 @@ OptionalTests.test("Var2") {
   expectEqual(gradient(at: nil, in: optional_var2_tracked), .init(0.0))
 
   @differentiable
+  func optional_var2_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
+    -> NonresilientTracked<Float>
+  {
+    if var x = maybeX {
+      return x * x
+    }
+    return 10
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_var2_nonresilient_tracked), .init(20.0))
+  expectEqual(
+    gradient(at: nil, in: optional_var2_nonresilient_tracked), .init(0.0))
+
+  @differentiable
   func optional_var2_nested(_ nestedMaybeX: Float??) -> Float {
     if var maybeX = nestedMaybeX {
       if var x = maybeX {
@@ -280,7 +442,9 @@ OptionalTests.test("Var2") {
   expectEqual(gradient(at: nil, in: optional_var2_nested), .init(.init(0.0)))
 
   @differentiable
-  func optional_var2_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<Float> {
+  func optional_var2_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
+    -> Tracked<Float>
+  {
     if var maybeX = nestedMaybeX {
       if var x = maybeX {
         return x * x
@@ -289,21 +453,48 @@ OptionalTests.test("Var2") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var2_nested_tracked), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_var2_nested_tracked), .init(.init(0.0)))
+  expectEqual(
+    gradient(at: 10, in: optional_var2_nested_tracked), .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_var2_nested_tracked), .init(.init(0.0)))
 
   @differentiable
-  func optional_var2_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T) -> T {
+  func optional_var2_nested_nonresilient_tracked(
+    _ nestedMaybeX: NonresilientTracked<Float>??
+  ) -> NonresilientTracked<Float> {
+    if var maybeX = nestedMaybeX {
+      if var x = maybeX {
+        return x * x
+      }
+      return 10
+    }
+    return 10
+  }
+  expectEqual(
+    gradient(at: 10, in: optional_var2_nested_nonresilient_tracked),
+    .init(.init(20.0)))
+  expectEqual(
+    gradient(at: nil, in: optional_var2_nested_nonresilient_tracked),
+    .init(.init(0.0)))
+
+  @differentiable
+  func optional_var2_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T)
+    -> T
+  {
     if var x = maybeX {
       return x
     }
     return defaultValue
   }
-  expectEqual(gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
+  expectEqual(
+    gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
 
   @differentiable
-  func optional_var2_nested_generic<T: Differentiable>(_ nestedMaybeX: T??, _ defaultValue: T) -> T {
+  func optional_var2_nested_generic<T: Differentiable>(
+    _ nestedMaybeX: T??, _ defaultValue: T
+  ) -> T {
     if var maybeX = nestedMaybeX {
       if var x = maybeX {
         return x
@@ -312,8 +503,12 @@ OptionalTests.test("Var2") {
     }
     return defaultValue
   }
-  expectEqual(gradient(at: 10, 20, in: optional_var2_nested_generic), (.init(.init(1.0)), 0.0))
-  expectEqual(gradient(at: nil, 20, in: optional_var2_nested_generic), (.init(.init(0.0)), 1.0))
+  expectEqual(
+    gradient(at: 10, 20, in: optional_var2_nested_generic),
+    (.init(.init(1.0)), 0.0))
+  expectEqual(
+    gradient(at: nil, 20, in: optional_var2_nested_generic),
+    (.init(.init(0.0)), 1.0))
 }
 
 runAllTests()


### PR DESCRIPTION
Fix `Optional` differentiation crash for non-resilient `Wrapped` reference type.
Add `NonresilientTracked` type to `DifferentiationUnittest` for testing.
Add and reformat tests.

Resolves SR-13377.