### PR TITLE
Serialization: add an option to allow deserializing @_implementationOnly dependencies

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -385,6 +385,12 @@ namespace swift {
     /// Load swiftmodule files in memory as volatile and avoid mmap.
     bool EnableVolatileModules = false;
 
+    /// Allow deserializing implementation only dependencies. This should only
+    /// be set true by lldb and other tooling, so that deserilization
+    /// recovery issues won't bring down the debugger.
+    /// TODO: remove this when @_implementationOnly modules are robust enough.
+    bool AllowDeserializingImplementationOnly = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2006,7 +2006,8 @@ ModuleDecl *ModuleFile::getModule(ModuleID MID) {
       llvm_unreachable("implementation detail only");
     }
   }
-  return getModule(getIdentifier(MID));
+  return getModule(getIdentifier(MID),
+                   getContext().LangOpts.AllowDeserializingImplementationOnly);
 }
 
 ModuleDecl *ModuleFile::getModule(ArrayRef<Identifier> name,


### PR DESCRIPTION
In theory, we shouldn't need to deserialize @_implementationOnly dependencies. However,
potential decl recovery issues may bring down lldb if we insist on not importing these
dependencies, resulting in bad user experience as a result. This patch adds an internal
option to allow importing them and it should only be set by lldb and other tools.

rdar://65570721
