### PR TITLE
Don't build with stdlib assertions on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -786,7 +786,7 @@ llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-h
 
 [preset: mixin_linux_installation]
 mixin-preset=
-    mixin_lightweight_assertions
+    mixin_lightweight_assertions,no-stdlib-asserts
     mixin_linux_install_components_with_clang
 
 llbuild


### PR DESCRIPTION
Apparently we have been building with stdlib assertions enabled on Linux. A recent change (https://github.com/apple/swift/pull/33390) caused a massive performance regression on Linux, which brought this to light.