### PR TITLE
Windows: include `direct.h` in `sys.stat` module

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -95,6 +95,7 @@ module ucrt [system] {
 
         module stat {
           header "sys/stat.h"
+          header "direct.h"
           export *
         }
 


### PR DESCRIPTION
On Unicies `sys/stat.h` will provide `mkdir`.  Windows provides the
POSIX requirement through the portable name `_mkdir` which is declared
in the `direct.h` header.  This adds the additional header to the `ucrt`
module to allow access to this function.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
