### PR TITLE
[SourceKit/CodeFormat] Indent lines in multi-line strings

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -352,7 +352,7 @@ public:
   static SourceLoc getLocForStartOfLine(SourceManager &SM, SourceLoc Loc);
 
   /// Retrieve the source location for the end of the line containing the
-  /// given token, which is the location of the start of the next line.
+  /// given location, which is the location of the start of the next line.
   static SourceLoc getLocForEndOfLine(SourceManager &SM, SourceLoc Loc);
 
   /// Retrieve the string used to indent the line that contains the given

--- a/test/SourceKit/CodeFormat/indent-multiline-string-interp.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string-interp.swift
@@ -1,0 +1,57 @@
+let s1 = """
+  \(
+    45
+)
+  """
+
+let s2 = """
+  \(
+    45
+  )
+"""
+
+let s3 = """
+\(
+  45
+)
+  """
+
+let s4 = """
+  foo \( 45 /*
+comment content
+*/) bar
+  """
+
+// RUN: %sourcekitd-test -req=format -line=2 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=3 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=4 %s >>%t.response
+
+// RUN: %sourcekitd-test -req=format -line=8 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=9 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=10 %s >>%t.response
+
+// RUN: %sourcekitd-test -req=format -line=14 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=15 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=16 %s >>%t.response
+
+// RUN: %sourcekitd-test -req=format -line=20 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=21 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=22 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "  \\("
+// CHECK: key.sourcetext: "    45"
+// CHECK: key.sourcetext: "  )"
+
+// CHECK: key.sourcetext: "  \\("
+// CHECK: key.sourcetext: "    45"
+// CHECK: key.sourcetext: "  )"
+
+// CHECK: key.sourcetext: "  \\("
+// CHECK: key.sourcetext: "    45"
+// CHECK: key.sourcetext: ")"
+
+// CHECK: key.sourcetext: "  foo \\( 45 /*"
+// CHECK: key.sourcetext: "         comment content"
+// CHECK: key.sourcetext: "         */) bar"

--- a/test/SourceKit/CodeFormat/indent-multiline-string-nested.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string-nested.swift
@@ -1,0 +1,25 @@
+func foo() {
+    let s1 = """
+        this is line1 in outer string \("""
+  nested string in interpolation
+            """)
+
+    this is line2 in outer string
+        """
+}
+
+// RUN: %sourcekitd-test -req=format -line=3 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=4 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=5 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=6 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=7 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=8 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "        this is line1 in outer string \\(\"\"\""
+// CHECK: key.sourcetext: "            nested string in interpolation"
+// CHECK: key.sourcetext: "            \"\"\")"
+// CHECK: key.sourcetext: "        "
+// CHECK: key.sourcetext: "        this is line2 in outer string"
+// CHECK: key.sourcetext: "        \"\"\""

--- a/test/SourceKit/CodeFormat/indent-multiline-string-trailing-interp.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string-trailing-interp.swift
@@ -1,0 +1,31 @@
+// RUN: %sourcekitd-test -req=format -line=24 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=25 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=26 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=27 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=28 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=29 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=30 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=31 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// The end quotes are ignored as it would be impossible to know whether
+// they are part of the interpolation or another string, etc.
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    this is line1"
+// CHECK: key.sourcetext: ""
+// CHECK: key.sourcetext: "this is line2"
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    and this is a line with trailing interpolation \\(1 +"
+// CHECK: key.sourcetext: " "
+// CHECK: key.sourcetext: " \"\"\""
+
+let s1 = """
+
+this is line1
+
+    this is line2
+
+ and this is a line with trailing interpolation \(1 +
+
+  """

--- a/test/SourceKit/CodeFormat/indent-multiline-string-trailing-ownline.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string-trailing-ownline.swift
@@ -1,0 +1,24 @@
+// RUN: %sourcekitd-test -req=format -line=19 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=20 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=21 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=22 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=23 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=24 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "  "
+// CHECK: key.sourcetext: "  this is line1"
+// CHECK: key.sourcetext: ""
+// CHECK: key.sourcetext: "this is line2"
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    "
+
+let s1 =
+  """
+
+this is line1
+
+    this is line2
+
+

--- a/test/SourceKit/CodeFormat/indent-multiline-string-trailing.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string-trailing.swift
@@ -1,0 +1,23 @@
+// RUN: %sourcekitd-test -req=format -line=18 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=19 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=20 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=21 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=22 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=23 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    this is line1"
+// CHECK: key.sourcetext: ""
+// CHECK: key.sourcetext: "this is line2"
+// CHECK: key.sourcetext: "  "
+// CHECK: key.sourcetext: "  "
+
+let s1 = """
+
+this is line1
+
+  this is line2
+
+

--- a/test/SourceKit/CodeFormat/indent-multiline-string.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string.swift
@@ -1,20 +1,44 @@
 func foo() {
   let s1 = """
-this is line1,
-     this is line2,
+
+this is line1
+
+     this is line2
+
+
+  this is line3
+ this is a line with interpolation \(1 +
+    2)
+    """
+
+  let s2 = """
 """
-  let s1 =
-  "content"
 }
 
-// RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
-// RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
-// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
-// RUN: %sourcekitd-test -req=format -line=7 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=2 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=3 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=4 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=5 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=6 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=7 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=8 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=9 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=10 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=11 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=12 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=15 %s >>%t.response
 
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
-// CHECK: key.sourcetext: "this is line1,"
-// CHECK: key.sourcetext: "     this is line2,"
+// CHECK: key.sourcetext: "    let s1 = \"\"\""
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    this is line1"
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "     this is line2"
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    "
+// CHECK: key.sourcetext: "    this is line3"
+// CHECK: key.sourcetext: "    this is a line with interpolation \\(1 +"
+// CHECK: key.sourcetext: "                                        2)"
+// CHECK: key.sourcetext: "    \"\"\""
 // CHECK: key.sourcetext: "\"\"\""
-// CHECK: key.sourcetext: "    \"content\""


### PR DESCRIPTION
The first commit fixes a couple bugs in the Lexer::getLocFor*Line methods in a couple edge cases.

The second updates the formatter to indent multi-line strings where it can. When it's an un-closed string it will indent new lines to the first previous line that isn't whitespace-only, unless that line is the same as the start quotes. In that case it will either indent to the start quotes if that line is only quotes or add an extra indent level otherwise. For closed strings we have to be a little more careful since we don't want to add significant (and possibly unintended) whitespace, so those lines are only indented when they would otherwise be invalid (ie. less than the end quotes).

This could add trailing whitespace to existing lines, but I think that's better behaviour than what's there now. This could be fixed if the whole range was passed in instead of a line at a time, as the indentation could be different when it is *actually* a single line in that case.

Resolves rdar://32181422