### PR TITLE
[Sema] Refactor error-handling checking to effects-handling checking

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4008,10 +4008,13 @@ ERROR(throw_in_nonexhaustive_catch,none,
       "error is not handled because the enclosing catch is not exhaustive", ())
 
 ERROR(throwing_call_in_illegal_context,none,
-      "call can throw, but errors cannot be thrown out of %0",
-      (StringRef))
+      "call can throw, but errors cannot be thrown out of "
+      "%select{<<ERROR>>|a default argument|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}0",
+      (unsigned))
 ERROR(throw_in_illegal_context,none,
-      "errors cannot be thrown out of %0", (StringRef))
+      "errors cannot be thrown out of "
+      "%select{<<ERROR>>|a default argument|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}0",
+      (unsigned))
 
 ERROR(throwing_operator_without_try,none,
       "operator can throw but expression is not marked with 'try'", ())

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -46,7 +46,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckDeclObjC.cpp
   TypeCheckDeclOverride.cpp
   TypeCheckDeclPrimary.cpp
-  TypeCheckError.cpp
+  TypeCheckEffects.cpp
   TypeCheckExpr.cpp
   TypeCheckExprObjC.cpp
   TypeCheckGeneric.cpp

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -354,7 +354,7 @@ public:
 
         if (NB != B) {
           FD->setBody(NB);
-          TypeChecker::checkFunctionErrorHandling(FD);
+          TypeChecker::checkFunctionEffects(FD);
         }
       }
     } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
@@ -695,7 +695,7 @@ void swift::performPCMacro(SourceFile &SF) {
             BraceStmt *NewBody = I.transformBraceStmt(Body, true);
             if (NewBody != Body) {
               TLCD->setBody(NewBody);
-              TypeChecker::checkTopLevelErrorHandling(TLCD);
+              TypeChecker::checkTopLevelEffects(TLCD);
               TypeChecker::contextualizeTopLevelCode(TLCD);
             }
             return false;

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -294,7 +294,7 @@ public:
         BraceStmt *NB = transformBraceStmt(B);
         if (NB != B) {
           FD->setBody(NB);
-          TypeChecker::checkFunctionErrorHandling(FD);
+          TypeChecker::checkFunctionEffects(FD);
         }
       }
     } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
@@ -893,7 +893,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
             BraceStmt *NewBody = I.transformBraceStmt(Body);
             if (NewBody != Body) {
               FD->setBody(NewBody);
-              TypeChecker::checkFunctionErrorHandling(FD);
+              TypeChecker::checkFunctionEffects(FD);
             }
             return false;
           }
@@ -905,7 +905,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
             BraceStmt *NewBody = I.transformBraceStmt(Body, true);
             if (NewBody != Body) {
               TLCD->setBody(NewBody);
-              TypeChecker::checkTopLevelErrorHandling(TLCD);
+              TypeChecker::checkTopLevelEffects(TLCD);
             }
             return false;
           }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1066,7 +1066,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
       if (TypeChecker::typeCheckExpression(exprToCheck, ED,
                                            rawTy,
                                            CTP_EnumCaseRawValue)) {
-        TypeChecker::checkEnumElementErrorHandling(elt, exprToCheck);
+        TypeChecker::checkEnumElementEffects(elt, exprToCheck);
       }
     }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -881,7 +881,7 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), ErrorType::get(ctx));
   }
 
-  TypeChecker::checkInitializerErrorHandling(dc, initExpr);
+  TypeChecker::checkInitializerEffects(dc, initExpr);
 
   // Walk the checked initializer and contextualize any closures
   // we saw there.
@@ -1657,7 +1657,7 @@ public:
               PBD->getInitContext(i));
           if (initContext) {
             // Check safety of error-handling in the declaration, too.
-            TypeChecker::checkInitializerErrorHandling(initContext, init);
+            TypeChecker::checkInitializerEffects(initContext, init);
             TypeChecker::contextualizeInitializer(initContext, init);
           }
         }

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1030,17 +1030,17 @@ public:
 
   static void diagnoseThrowInIllegalContext(DiagnosticEngine &Diags,
                                             ASTNode node,
-                                            StringRef description) {
+                                            Kind kind) {
     if (auto *e = node.dyn_cast<Expr*>()) {
       if (isa<ApplyExpr>(e)) {
         Diags.diagnose(e->getLoc(), diag::throwing_call_in_illegal_context,
-                       description);
+                       static_cast<unsigned>(kind));
         return;
       }
     }
 
     Diags.diagnose(node.getStartLoc(), diag::throw_in_illegal_context,
-                   description);
+                   static_cast<unsigned>(kind));
   }
 
   static void maybeAddRethrowsNote(DiagnosticEngine &Diags, SourceLoc loc,
@@ -1174,31 +1174,15 @@ public:
       return;
 
     case Kind::EnumElementInitializer:
-      diagnoseThrowInIllegalContext(Diags, E, "an enum case raw value");
-      return;
-
     case Kind::GlobalVarInitializer:
-      diagnoseThrowInIllegalContext(Diags, E, "a global variable initializer");
-      return;
-
     case Kind::IVarInitializer:
-      diagnoseThrowInIllegalContext(Diags, E, "a property initializer");
-      return;
-
     case Kind::DefaultArgument:
-      diagnoseThrowInIllegalContext(Diags, E, "a default argument");
-      return;
-
     case Kind::CatchPattern:
-      diagnoseThrowInIllegalContext(Diags, E, "a catch pattern");
+    case Kind::CatchGuard:
+    case Kind::DeferBody:
+      diagnoseThrowInIllegalContext(Diags, E, getKind());
       return;
 
-    case Kind::CatchGuard:
-      diagnoseThrowInIllegalContext(Diags, E, "a catch guard expression");
-      return;
-    case Kind::DeferBody:
-      diagnoseThrowInIllegalContext(Diags, E, "a defer body");
-      return;
     }
     llvm_unreachable("bad context kind");
   }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1698,7 +1698,7 @@ static Type getFunctionBuilderType(FuncDecl *FD) {
 bool TypeChecker::typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   auto res = evaluateOrDefault(AFD->getASTContext().evaluator,
                                TypeCheckFunctionBodyRequest{AFD}, true);
-  TypeChecker::checkFunctionErrorHandling(AFD);
+  TypeChecker::checkFunctionEffects(AFD);
   TypeChecker::computeCaptures(AFD);
   return res;
 }
@@ -2152,7 +2152,7 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   BraceStmt *Body = TLCD->getBody();
   StmtChecker(TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
-  checkTopLevelErrorHandling(TLCD);
+  checkTopLevelEffects(TLCD);
   performTopLevelDeclDiagnostics(TLCD);
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2491,7 +2491,7 @@ static void typeCheckSynthesizedWrapperInitializer(
           dyn_cast_or_null<Initializer>(pbd->getInitContext(i))) {
     TypeChecker::contextualizeInitializer(initializerContext, initializer);
   }
-  TypeChecker::checkPropertyWrapperErrorHandling(pbd, initializer);
+  TypeChecker::checkPropertyWrapperEffects(pbd, initializer);
 }
 
 static PropertyWrapperMutability::Value

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1147,11 +1147,11 @@ void diagnoseIfDeprecated(SourceRange SourceRange,
 void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
 
 /// Check error handling in the given type-checked top-level code.
-void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
-void checkFunctionErrorHandling(AbstractFunctionDecl *D);
-void checkInitializerErrorHandling(Initializer *I, Expr *E);
-void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
-void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
+void checkTopLevelEffects(TopLevelCodeDecl *D);
+void checkFunctionEffects(AbstractFunctionDecl *D);
+void checkInitializerEffects(Initializer *I, Expr *E);
+void checkEnumElementEffects(EnumElementDecl *D, Expr *expr);
+void checkPropertyWrapperEffects(PatternBindingDecl *binding,
                                        Expr *expr);
 
 /// If an expression references 'self.init' or 'super.init' in an


### PR DESCRIPTION
The code that is used to check for proper uses of error handling (e.g., throwing call sites are covered by a `try`) is a specialized form of effects handling. Refactor all of the error-handling code, generalizing it to allow for independent checks (such as `async`) to work properly.