### PR TITLE
[ConstraintSystem] Don't update the work list when merging type variables in addJoinConstraint

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4529,7 +4529,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           return formUnsolvedResult();
 
         // Merge the equivalence classes corresponding to these two variables.
-        mergeEquivalenceClasses(rep1, rep2);
+        mergeEquivalenceClasses(rep1, rep2, /*updateWorkList=*/true);
         return getTypeMatchSuccess();
       }
 
@@ -4581,7 +4581,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         if (!rep1->getImpl().canBindToInOut() ||
             !rep2->getImpl().canBindToLValue()) {
           // Merge the equivalence classes corresponding to these two variables.
-          mergeEquivalenceClasses(rep1, rep2);
+          mergeEquivalenceClasses(rep1, rep2, /*updateWorkList=*/true);
           return getTypeMatchSuccess();
         }
       }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3443,7 +3443,7 @@ public:
   /// distinct.
   void mergeEquivalenceClasses(TypeVariableType *typeVar1,
                                TypeVariableType *typeVar2,
-                               bool updateWorkList = true);
+                               bool updateWorkList);
 
   /// Flags that direct type matching.
   enum TypeMatchFlags {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3147,7 +3147,7 @@ public:
 
           if (originalRep) {
             if (originalRep != currentRep)
-              mergeEquivalenceClasses(currentRep, originalRep);
+              mergeEquivalenceClasses(currentRep, originalRep, /*updateWorkList=*/false);
             continue;
           }
 

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -12,8 +12,6 @@
 // REQUIRES: long_test
 // REQUIRES: CPU=arm64 || CPU=x86_64
 
-// REQUIRES: rdar66807959
-
 // Check if the optimizer can optimize the whole array into a statically
 // initialized global
 


### PR DESCRIPTION
The missing `/*updateWorkList=*/false` argument turns `mergeEquivalenceClasses` into a very expensive operation because it needs to gather constraints in order to update the worklist. It isn't necessary to activate these constraints anyway because the `conforms to ExpressibleBy*` constraints will be unsolvable at this point.

Resolves: rdar://problem/66807959