### PR TITLE
[build] invoke swift-serialize-diagnostics for host architecture

### DIFF
--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -10,6 +10,7 @@ add_custom_command(TARGET diagnostic-database
 )
 
 add_dependencies(swift-frontend diagnostic-database)
+add_dependencies(diagnostic-database swift-serialize-diagnostics)
 
 swift_install_in_component(
   DIRECTORY ${CMAKE_BINARY_DIR}/share/swift/diagnostics/

--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -4,7 +4,7 @@ add_custom_command(TARGET diagnostic-database
   COMMAND
     ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/diagnostics/ ${CMAKE_BINARY_DIR}/share/swift/diagnostics/
   COMMAND
-    $<TARGET_FILE:swift-serialize-diagnostics>
+    "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swift-serialize-diagnostics"
       --input-file-path ${CMAKE_BINARY_DIR}/share/swift/diagnostics/en.yaml
       --output-directory ${CMAKE_BINARY_DIR}/share/swift/diagnostics/
 )


### PR DESCRIPTION
As a result of #33346 we are relying on the tool for the current architecture -- this will
work for the host architecture but will fail when crosscompiling.

Addresses rdar://66800239