### PR TITLE
[TF] Fix tensorflow-branch-only macOS test failures.

### DIFF
--- a/test/Incremental/Verifier/single-file-private/AnyObject.swift
+++ b/test/Incremental/Verifier/single-file-private/AnyObject.swift
@@ -59,6 +59,9 @@ import Foundation
 // expected-private-member {{Swift.Encodable.callAsFunction}}
 // expected-private-member {{Swift.Decodable.callAsFunction}}
 // expected-private-member {{Foundation._OptionalForKVO.callAsFunction}}
+// SWIFT_ENABLE_TENSORFLOW
+// expected-private-member {{Swift.Differentiable.callAsFunction}}
+// SWIFT_ENABLE_TENSORFLOW END
 
 // expected-provides {{AnyObject}}
 func lookupOnAnyObject(object: AnyObject) { // expected-provides {{lookupOnAnyObject}}

--- a/test/Incremental/Verifier/single-file/AnyObject.swift
+++ b/test/Incremental/Verifier/single-file/AnyObject.swift
@@ -59,6 +59,9 @@ import Foundation
 // expected-private-member {{Swift.Encodable.callAsFunction}}
 // expected-private-member {{Swift.Decodable.callAsFunction}}
 // expected-private-member {{Foundation._OptionalForKVO.callAsFunction}}
+// SWIFT_ENABLE_TENSORFLOW
+// expected-private-member {{Swift.Differentiable.callAsFunction}}
+// SWIFT_ENABLE_TENSORFLOW END
 
 // expected-provides {{AnyObject}}
 func lookupOnAnyObject(object: AnyObject) { // expected-provides {{lookupOnAnyObject}}


### PR DESCRIPTION
Fix test failures:

<details>
<p>

```
FAIL: Swift(macosx-x86_64) :: Incremental/Verifier/single-file/AnyObject.swift (2064 of 6215)
******************** TEST 'Swift(macosx-x86_64) :: Incremental/Verifier/single-file/AnyObject.swift' FAILED ********************
Script:
--
: 'RUN: at line 10';   rm -rf "/Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file/Output/AnyObject.swift.tmp" && mkdir -p "/Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file/Output/AnyObject.swift.tmp"
: 'RUN: at line 11';   /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file/../gen-output-file-map.py -o /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file/Output/AnyObject.swift.tmp /Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file
: 'RUN: at line 12';   cd /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file/Output/AnyObject.swift.tmp && xcrun --toolchain default --sdk '/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk' /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9  -module-cache-path '/Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache' -Xlinker -rpath -Xlinker /usr/lib/swift  -typecheck -output-file-map /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file/Output/AnyObject.swift.tmp/output.json -incremental -disable-direct-intramodule-dependencies -module-name main -verify-incremental-dependencies /Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file/AnyObject.swift
--
Exit Code: 1

Command Output (stderr):
--
/Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file/AnyObject.swift:75:1: error: unexpected non-cascading member dependency: Swift.Differentiable.callAsFunction

^
// expected-private-member{{Swift.Differentiable.callAsFunction}}

--

********************
FAIL: Swift(macosx-x86_64) :: Incremental/Verifier/single-file-private/AnyObject.swift (2065 of 6215)
******************** TEST 'Swift(macosx-x86_64) :: Incremental/Verifier/single-file-private/AnyObject.swift' FAILED ********************
Script:
--
: 'RUN: at line 10';   rm -rf "/Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file-private/Output/AnyObject.swift.tmp" && mkdir -p "/Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file-private/Output/AnyObject.swift.tmp"
: 'RUN: at line 11';   /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file-private/../gen-output-file-map.py -o /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file-private/Output/AnyObject.swift.tmp /Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file-private
: 'RUN: at line 12';   cd /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file-private/Output/AnyObject.swift.tmp && xcrun --toolchain default --sdk '/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk' /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9  -module-cache-path '/Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache' -Xlinker -rpath -Xlinker /usr/lib/swift  -typecheck -output-file-map /Users/swiftninjas/s4tf/build/buildbot_osx/swift-macosx-x86_64/test-macosx-x86_64/Incremental/Verifier/single-file-private/Output/AnyObject.swift.tmp/output.json -incremental -module-name main -enable-direct-intramodule-dependencies -verify-incremental-dependencies /Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file-private/AnyObject.swift
--
Exit Code: 1

Command Output (stderr):
--
/Users/swiftninjas/s4tf/swift/test/Incremental/Verifier/single-file-private/AnyObject.swift:76:1: error: unexpected non-cascading member dependency: Swift.Differentiable.callAsFunction

^
// expected-private-member{{Swift.Differentiable.callAsFunction}}

--
```

</p>
</details>

Locally verified the fixes. These test failures weren't caught because `tensorflow` branch macOS CI has been down for a while.