### PR TITLE
abi-checker: allow ABI checker to deserialize @_implementationOnly modules on demand

### DIFF
--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2548,6 +2548,8 @@ static int prepareForDump(const char *Main,
     InitInvok.getLangOptions().Target.isOSDarwin();
   InitInvok.getClangImporterOptions().ModuleCachePath =
   options::ModuleCachePath;
+  // Module recovery issue shouldn't bring down the tool.
+  InitInvok.getLangOptions().AllowDeserializingImplementationOnly = true;
 
   if (!options::SwiftVersion.empty()) {
     using version::Version;


### PR DESCRIPTION
This could prevent the tool from crashing when module recovery failed.