### PR TITLE
[ConstraintSystem] A couple of adjustments to make interaction between solution and code completion simpler

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8415,6 +8415,10 @@ Type Solution::getType(ASTNode node) const {
   return cs.getType(node);
 }
 
+Type Solution::getResolvedType(ASTNode node) const {
+  return simplifyType(getType(node));
+}
+
 void Solution::setExprTypes(Expr *expr) const {
   if (!expr)
     return;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -176,7 +176,41 @@ bool ConstraintSystem::isTypeReference(Expr *E) {
       });
 }
 
+bool Solution::isTypeReference(Expr *E) const {
+  return E->isTypeReference(
+      [&](Expr *expr) -> Type { return simplifyType(getType(expr)); },
+      [&](Expr *expr) -> Decl * {
+        ConstraintLocator *locator = nullptr;
+        if (auto *UDE = dyn_cast<UnresolvedDotExpr>(E)) {
+          locator = getConstraintLocator(UDE, {ConstraintLocator::Member});
+        }
+
+        if (auto *UME = dyn_cast<UnresolvedMemberExpr>(E)) {
+          locator =
+              getConstraintLocator(UME, {ConstraintLocator::UnresolvedMember});
+        }
+
+        if (isa<OverloadSetRefExpr>(E))
+          locator = getConstraintLocator(const_cast<Expr *>(E));
+
+        if (locator) {
+          if (auto selectedOverload = getOverloadChoiceIfAvailable(locator)) {
+            const auto &choice = selectedOverload->choice;
+            return choice.getDeclOrNull();
+          }
+        }
+
+        return nullptr;
+      });
+}
+
 bool ConstraintSystem::isStaticallyDerivedMetatype(Expr *E) {
+  return E->isStaticallyDerivedMetatype(
+      [&](Expr *E) -> Type { return simplifyType(getType(E)); },
+      [&](Expr *E) -> bool { return isTypeReference(E); });
+}
+
+bool Solution::isStaticallyDerivedMetatype(Expr *E) const {
   return E->isStaticallyDerivedMetatype(
       [&](Expr *E) -> Type { return simplifyType(getType(E)); },
       [&](Expr *E) -> bool { return isTypeReference(E); });

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1428,7 +1428,7 @@ void ConstraintSystem::solveForCodeCompletion(
 
   cs.shrink(expr);
 
-  if (cs.generateConstraints(expr, DC))
+  if (!cs.generateConstraints(expr, DC))
     return;
 
   llvm::SmallVector<Solution, 4> solutions;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1190,6 +1190,11 @@ public:
   /// Retrieve the type of the given node, as recorded in this solution.
   Type getType(ASTNode node) const;
 
+  /// Retrieve the type of the given node as recorded in this solution
+  /// and resolve all of the type variables in contains to form a fully
+  /// "resolved" concrete type.
+  Type getResolvedType(ASTNode node) const;
+
   /// Resolve type variables present in the raw type, using generic parameter
   /// types where possible.
   Type resolveInterfaceType(Type type) const;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1210,6 +1210,16 @@ public:
         : nullptr;
   }
 
+  /// This method implements functionality of `Expr::isTypeReference`
+  /// with data provided by a given solution.
+  bool isTypeReference(Expr *E) const;
+
+  /// Call Expr::isIsStaticallyDerivedMetatype on the given
+  /// expression, using a custom accessor for the type on the
+  /// expression that reads the type from the Solution
+  /// expression type map.
+  bool isStaticallyDerivedMetatype(Expr *E) const;
+
   SWIFT_DEBUG_DUMP;
 
   /// Dump this solution.


### PR DESCRIPTION
- Add a variant of `isStaticallyDerivedMetatype` to `Solution`
- Fix incorrect exist condition in `solveForCodeCompletion`
- Add `Solution::getResolvedType` to avoid repetitive `simplifyType(getType(ASTNode))` pattern

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
