### PR TITLE
Parse concurrency syntax when parsing for syntax-tree-only mode.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -688,6 +688,14 @@ public:
   Optional<StringRef>
   getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText);
 
+  /// Returns true to indicate that experimental concurrency syntax should be
+  /// parsed if the parser is generating only a syntax tree or if the user has
+  /// passed the `-enable-experimental-concurrency` flag to the frontend.
+  bool shouldParseExperimentalConcurrency() const {
+    return Context.LangOpts.EnableExperimentalConcurrency ||
+      Context.LangOpts.ParseForSyntaxTreeOnly;
+  }
+
 public:
   InFlightDiagnostic diagnose(SourceLoc Loc, Diagnostic Diag) {
     if (Diags.isDiagnosticPointsToFirstBadToken(Diag.getID()) &&

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -330,7 +330,7 @@ parse_operator:
     case tok::identifier: {
       // 'async' followed by 'throws' or '->' implies that we have an arrow
       // expression.
-      if (!(Context.LangOpts.EnableExperimentalConcurrency &&
+      if (!(shouldParseExperimentalConcurrency() &&
             Tok.isContextualKeyword("async") &&
             peekToken().isAny(tok::arrow, tok::kw_throws)))
         goto done;
@@ -392,8 +392,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   SyntaxParsingContext ElementContext(SyntaxContext,
                                       SyntaxContextKind::Expr);
 
-  if (Context.LangOpts.EnableExperimentalConcurrency &&
-      Tok.is(tok::kw___await)) {
+  if (shouldParseExperimentalConcurrency() && Tok.is(tok::kw___await)) {
     SourceLoc awaitLoc = consumeToken(tok::kw___await);
     ParserResult<Expr> sub = parseExprUnary(message, isExprBasic);
     if (!sub.hasCodeCompletion() && !sub.isNull()) {
@@ -2448,7 +2447,7 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
   // Consume 'async', 'throws', and 'rethrows', but in any order.
   auto consumeAsyncThrows = [&] {
     bool hadAsync = false;
-    if (Context.LangOpts.EnableExperimentalConcurrency &&
+    if (shouldParseExperimentalConcurrency() &&
         Tok.isContextualKeyword("async")) {
       consumeToken();
       hadAsync = true;
@@ -2457,7 +2456,7 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
     if (!consumeIf(tok::kw_throws) && !consumeIf(tok::kw_rethrows))
       return;
 
-    if (Context.LangOpts.EnableExperimentalConcurrency && !hadAsync &&
+    if (shouldParseExperimentalConcurrency() && !hadAsync &&
         Tok.isContextualKeyword("async")) {
       consumeToken();
     }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -824,7 +824,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
 void Parser::parseAsyncThrows(
     SourceLoc existingArrowLoc, SourceLoc &asyncLoc, SourceLoc &throwsLoc,
     bool *rethrows) {
-  if (Context.LangOpts.EnableExperimentalConcurrency &&
+  if (shouldParseExperimentalConcurrency() &&
       Tok.isContextualKeyword("async")) {
     asyncLoc = consumeToken();
 
@@ -857,7 +857,7 @@ void Parser::parseAsyncThrows(
         .fixItInsert(existingArrowLoc, (keyword + " ").str());
     }
 
-    if (Context.LangOpts.EnableExperimentalConcurrency &&
+    if (shouldParseExperimentalConcurrency() &&
         Tok.isContextualKeyword("async")) {
       asyncLoc = consumeToken();
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -412,7 +412,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
 
   // Parse an async specifier.
   SourceLoc asyncLoc;
-  if (Context.LangOpts.EnableExperimentalConcurrency &&
+  if (shouldParseExperimentalConcurrency() &&
       Tok.isContextualKeyword("async")) {
     asyncLoc = consumeToken();
   }
@@ -423,7 +423,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   SourceLoc throwsLoc;
   if (Tok.isAny(tok::kw_throws, tok::kw_rethrows, tok::kw_throw, tok::kw_try) &&
       (peekToken().is(tok::arrow) ||
-       (Context.LangOpts.EnableExperimentalConcurrency &&
+       (shouldParseExperimentalConcurrency() &&
         peekToken().isContextualKeyword("async")))) {
     if (Tok.isAny(tok::kw_rethrows, tok::kw_throw, tok::kw_try)) {
       // 'rethrows' is only allowed on function declarations for now.
@@ -436,7 +436,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
     throwsLoc = consumeToken();
 
     // 'async' must preceed 'throws'; accept this but complain.
-    if (Context.LangOpts.EnableExperimentalConcurrency &&
+    if (shouldParseExperimentalConcurrency() &&
         Tok.isContextualKeyword("async")) {
       asyncLoc = consumeToken();
 
@@ -1589,7 +1589,7 @@ bool Parser::canParseType() {
   }
 
   // Handle type-function if we have an 'async'.
-  if (Context.LangOpts.EnableExperimentalConcurrency &&
+  if (shouldParseExperimentalConcurrency() &&
       Tok.isContextualKeyword("async")) {
     consumeToken();
 
@@ -1605,7 +1605,7 @@ bool Parser::canParseType() {
 
     // Allow 'async' here even though it is ill-formed, so we can provide
     // a better error.
-    if (Context.LangOpts.EnableExperimentalConcurrency &&
+    if (shouldParseExperimentalConcurrency() &&
         Tok.isContextualKeyword("async"))
       consumeToken();
 

--- a/test/Syntax/Parser/async.swift
+++ b/test/Syntax/Parser/async.swift
@@ -1,0 +1,28 @@
+// Verify that async parses correctly via the parser lib even without the
+// experimental flag being set in LangOpts.
+//
+// REQUIRES: syntax_parser_lib
+// RUN: %swift-syntax-parser-test %s -dump-diags 2>&1 | %FileCheck %s
+
+func asyncGlobal1() async { }
+func asyncGlobal2() async throws { }
+
+typealias AsyncFunc1 = () async -> ()
+typealias AsyncFunc2 = () async throws -> ()
+
+func testTypeExprs() {
+  let _ = [() async -> ()]()
+  let _ = [() async throws -> ()]()
+}
+
+func testAwaitOperator() async {
+  let _ = __await asyncGlobal1()
+}
+
+func testAsyncClosure() {
+  let _ = { () async in 5 }
+  let _ = { () throws in 5 }
+  let _ = { () async throws in 5 }
+}
+
+// CHECK: 0 error(s) 0 warnings(s) 0 note(s)

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -610,7 +610,6 @@ int parseFile(
   Invocation.getLangOptions().VerifySyntaxTree = options::VerifySyntaxTree;
   Invocation.getLangOptions().RequestEvaluatorGraphVizPath = options::GraphVisPath;
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
-  Invocation.getLangOptions().EnableExperimentalConcurrency = true;
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
 


### PR DESCRIPTION
This allows the syntax parser library and SwiftSyntax to successfully
parse code using this experimental feature without requiring an API
to pass compiler flags into the parser.
