### PR TITLE
Implement Richer Diagnostics for Cross-File Synthesis Failures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2765,8 +2765,9 @@ ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
       "be satisfied by a 'required' initializer in the class definition",
       (Type, DeclName))
 ERROR(cannot_synthesize_in_crossfile_extension,none,
-      "implementation of %0 cannot be automatically synthesized in an extension "
-      "in a different file to the type", (Type))
+      "extension outside of file declaring %0 %1 prevents automatic synthesis "
+      "of %2 for protocol %3",
+      (DescriptiveDeclKind, DeclName, DeclName, Type))
 
 ERROR(broken_additive_arithmetic_requirement,none,
       "AdditiveArithmetic protocol is broken: unexpected requirement", ())

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
@@ -490,8 +491,27 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
       Nominal->getModuleScopeContext() !=
           getConformanceContext()->getModuleScopeContext()) {
     ConformanceDecl->diagnose(diag::cannot_synthesize_in_crossfile_extension,
+                              Nominal->getDescriptiveKind(), Nominal->getName(),
+                              synthesizing->getName(),
                               getProtocolType());
     Nominal->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
+
+    // In editor mode, try to insert a stub.
+    if (Context.LangOpts.DiagnosticsEditorMode) {
+      auto Extension = cast<ExtensionDecl>(getConformanceContext());
+      auto FixitLocation = Extension->getBraces().Start;
+      llvm::SmallString<128> Text;
+      {
+        llvm::raw_svector_ostream SS(Text);
+        swift::printRequirementStub(synthesizing, Nominal,
+                                    Nominal->getDeclaredType(),
+                                    Extension->getStartLoc(), SS);
+        if (!Text.empty()) {
+          ConformanceDecl->diagnose(diag::missing_witnesses_general)
+            .fixItInsertAfter(FixitLocation, Text.str());
+        }
+      }
+    }
     return true;
   }
 

--- a/localization/diagnostics/en.yaml
+++ b/localization/diagnostics/en.yaml
@@ -6556,8 +6556,8 @@
 
 - id: cannot_synthesize_in_crossfile_extension
   msg: >-
-    implementation of %0 cannot be automatically synthesized in an extension
-    in a different file to the type
+    extension outside of file declaring %0 %1 prevents automatic synthesis
+    of %2 for protocol %3
 
 - id: broken_additive_arithmetic_requirement
   msg: >-

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -570,8 +570,10 @@ class WrappedProperties: Differentiable {
 
 // Test derived conformances in disallowed contexts.
 
-// expected-error @+1 2 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
 extension OtherFileNonconforming: Differentiable {}
+// expected-error @-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-2 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'zeroTangentVectorInitializer' for protocol 'Differentiable'}}
 
-// expected-error @+1 2 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
 extension GenericOtherFileNonconforming: Differentiable {}
+// expected-error @-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-2 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'zeroTangentVectorInitializer' for protocol 'Differentiable'}}

--- a/test/AutoDiff/Sema/DerivedConformances/struct_additive_arithmetic.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_additive_arithmetic.swift
@@ -113,8 +113,12 @@ where T: AdditiveArithmetic {}
 
 // Test derived conformances in disallowed contexts.
 
-// expected-error @+1 3 {{implementation of 'AdditiveArithmetic' cannot be automatically synthesized in an extension in a different file to the type}}
 extension OtherFileNonconforming: AdditiveArithmetic {}
+// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'zero' for protocol 'AdditiveArithmetic'}}
+// expected-error @-2 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of '+' for protocol 'AdditiveArithmetic'}}
+// expected-error @-3 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of '-' for protocol 'AdditiveArithmetic'}}
 
-// expected-error @+1 3 {{implementation of 'AdditiveArithmetic' cannot be automatically synthesized in an extension in a different file to the type}}
 extension GenericOtherFileNonconforming: AdditiveArithmetic {}
+// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'zero' for protocol 'AdditiveArithmetic'}}
+// expected-error @-2 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of '+' for protocol 'AdditiveArithmetic'}}
+// expected-error @-3 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of '-' for protocol 'AdditiveArithmetic'}}

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -383,8 +383,10 @@ struct WrappedProperties: Differentiable {
 
 // Verify that cross-file derived conformances are disallowed.
 
-// expected-error @+1 2 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
 extension OtherFileNonconforming: Differentiable {}
+// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-2 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'zeroTangentVectorInitializer' for protocol 'Differentiable'}}
 
-// expected-error @+1 2 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
 extension GenericOtherFileNonconforming: Differentiable {}
+// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-2 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'zeroTangentVectorInitializer' for protocol 'Differentiable'}}

--- a/test/Sema/Inputs/fixits-derived-conformances-multifile.swift
+++ b/test/Sema/Inputs/fixits-derived-conformances-multifile.swift
@@ -1,0 +1,6 @@
+public enum Enum { case one } // expected-note {{type declared here}}
+public enum GenericEnum<T> { case one(Int) } // expected-note {{type declared here}}
+
+public struct Struct {} // expected-note {{type declared here}}
+public struct GenericStruct<T> {} // expected-note {{type declared here}}
+

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -224,7 +224,7 @@ enum Complex2 {
 }
 extension Complex2 : Hashable {}
 extension Complex2 : CaseIterable {}  // expected-error {{type 'Complex2' does not conform to protocol 'CaseIterable'}}
-extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
+extension FromOtherFile: CaseIterable {} // expected-error {{extension outside of file declaring enum 'FromOtherFile' prevents automatic synthesis of 'allCases' for protocol 'CaseIterable'}}
 extension CaseIterableAcrossFiles: CaseIterable {
   public static var allCases: [CaseIterableAcrossFiles] {
     return [ .A ]
@@ -248,7 +248,7 @@ extension OtherFileNonconforming: Hashable {
   func hash(into hasher: inout Hasher) {}
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{extension outside of file declaring enum 'YetOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
 extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}}
 
 // Verify that an indirect enum doesn't emit any errors as long as its "leaves"
@@ -319,7 +319,7 @@ extension UnusedGenericDeriveExtension: Hashable {}
 // Cross-file synthesis is disallowed for conditional cases just as it is for
 // non-conditional ones.
 extension GenericOtherFileNonconforming: Equatable where T: Equatable {}
-// expected-error@-1{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
+// expected-error@-1{{extension outside of file declaring generic enum 'GenericOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
 
 // rdar://problem/41852654
 

--- a/test/Sema/fixits-derived-conformances.swift
+++ b/test/Sema/fixits-derived-conformances.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -emit-library -module-name Types %S/Inputs/fixits-derived-conformances-multifile.swift -o %t/%target-library-name(Types)
+// RUN: %swift -typecheck -target %target-triple -I %t -diagnostics-editor-mode -verify %s
+
+import Types
+
+extension GenericEnum: Equatable { }
+// expected-error@-1 {{extension outside of file declaring generic enum 'GenericEnum' prevents automatic synthesis of '==' for protocol 'Equatable'}}
+// expected-note@-2 {{do you want to add protocol stubs?}}{{35-35=\n    public static func == (lhs: GenericEnum, rhs: GenericEnum) -> Bool {\n        <#code#>\n    \}\n}}
+
+extension Struct: Equatable { }
+// expected-error@-1 {{extension outside of file declaring struct 'Struct' prevents automatic synthesis of '==' for protocol 'Equatable'}}
+// expected-note@-2 {{do you want to add protocol stubs?}}{{30-30=\n    public static func == (lhs: Struct, rhs: Struct) -> Bool {\n        <#code#>\n    \}\n}}
+extension GenericStruct: Equatable { }
+// expected-error@-1 {{extension outside of file declaring generic struct 'GenericStruct' prevents automatic synthesis of '==' for protocol 'Equatable'}}
+// expected-note@-2 {{do you want to add protocol stubs?}}{{37-37=\n    public static func == (lhs: GenericStruct, rhs: GenericStruct) -> Bool {\n        <#code#>\n    \}\n}}
+
+extension Enum: CaseIterable { }
+// expected-error@-1 {{extension outside of file declaring enum 'Enum' prevents automatic synthesis of 'allCases' for protocol 'CaseIterable'}}
+// expected-note@-2 {{do you want to add protocol stubs?}}{{31-31=\n    public static var allCases: [Enum]\n}}
+

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -196,7 +196,7 @@ extension OtherFileNonconforming: Hashable {
   func hash(into hasher: inout Hasher) {}
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{extension outside of file declaring struct 'YetOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
 
 // Verify that we can add Hashable conformance in an extension by only
 // implementing hash(into:)
@@ -253,7 +253,7 @@ extension UnusedGenericDeriveExtension: Hashable {}
 
 // Cross-file synthesis is still disallowed for conditional cases
 extension GenericOtherFileNonconforming: Equatable where T: Equatable {}
-// expected-error@-1{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
+// expected-error@-1{{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of '==' for protocol 'Equatable'}}
 
 // rdar://problem/41852654
 


### PR DESCRIPTION
Mention the type, the requirement, and the extension in the error that
follows. In editor mode, try to insert stubs for the missing requirement
as well so the user isn't just left with a pile of unactionable errors.