### PR TITLE
[NFC] Rework serialization changes in #32811

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 557; // #fileID
+const uint16_t SWIFTMODULE_VERSION_MINOR = 556; // Serialization of -implicit-dynamic
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -459,10 +459,8 @@ using ValueOwnershipField = BCFixed<2>;
 enum class DefaultArgumentKind : uint8_t {
   None = 0,
   Normal,
-  FileID,
-  FilePath,
-  FileIDSpelledAsFile,
   FilePathSpelledAsFile,
+  FilePath,
   Line,
   Column,
   Function,
@@ -472,6 +470,8 @@ enum class DefaultArgumentKind : uint8_t {
   EmptyArray,
   EmptyDictionary,
   StoredProperty,
+  FileIDSpelledAsFile,
+  FileID
 };
 using DefaultArgumentField = BCFixed<4>;
 


### PR DESCRIPTION
This tweaks the implementation of SE-0285 to preserve backwards compatibility with the previous module serialization format. Existing default arguments all keep their previous values when serialized; #fileID and Swift 6 #file are given previously unused values.

Fixes rdar://66810027.