### PR TITLE
SIL: Don't canonicalize struct field and enum element types against the wrong signature

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1304,7 +1304,7 @@ public:
     if (origContextType->hasTypeParameter()) {
       origContextType = origSig->getGenericEnvironment()
         ->mapTypeIntoContext(origContextType)
-        ->getCanonicalType(origSig);
+        ->getCanonicalType();
     }
 
     auto result = origContextType

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1623,7 +1623,7 @@ namespace {
       for (auto field : D->getStoredProperties()) {
         auto substFieldType =
           field->getInterfaceType().subst(subMap)
-               ->getCanonicalType(D->getGenericSignature());
+               ->getCanonicalType();
         
         // We are determining the recursive properties of the struct here,
         // not the lowered types of the fields, so instead of lowering the
@@ -1676,7 +1676,7 @@ namespace {
         
         auto substEltType =
           elt->getArgumentInterfaceType().subst(subMap)
-             ->getCanonicalType(D->getGenericSignature());
+             ->getCanonicalType();
         
         auto origEltType = origType.unsafeGetSubstFieldType(elt,
                               elt->getArgumentInterfaceType()

--- a/validation-test/compiler_crashers_2_fixed/rdar65272763.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar65272763.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct S1<T1> {}
+public extension S1 where T1 == Int {
+    public struct S2<T2> {
+        let value: T2
+        
+        public init(value: T2) {
+            self.value = value
+        }
+    }
+    
+    public init<T>(s: [S2<T>]) {
+        self.init()
+        
+        s.forEach { _ in
+            
+        }
+    }
+}
+


### PR DESCRIPTION
The replacement types of the substitution map are either going
to be contextual types, or interface types using some generic
signature. There is no requirement that this generic signature
is the generic signature of the type declaration itself.

By using the generic signature of the type declaration, we
could incorrectly canonicalize generic parameters to concrete
types if the type itself was defined in a constrained extension,
as in the test case here.

Fixes <rdar://problem/65272763>.