### PR TITLE
[Diag] [Localization] Switch diagnostic messages from `.def` to the new format 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ tags
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
+# Copied diagnostics files in test/Driver/diagnositcs
+test/Driver/Inputs/diagnostics
+
 # Generated docs
 docs/_build
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -697,12 +697,12 @@ namespace swift {
 
   public:
     explicit DiagnosticEngine(SourceManager &SourceMgr,
-                              std::string defaultLocalizationMessagesPath)
+                              std::string DefaultLocalizationPath)
         : SourceMgr(SourceMgr), ActiveDiagnostic(),
           TransactionStrings(TransactionAllocator) {
-      assert(!defaultLocalizationMessagesPath.empty());
+      assert(!DefaultLocalizationPath.empty());
       std::string defaultLocale = "en";
-      llvm::SmallString<128> filePath(defaultLocalizationMessagesPath);
+      llvm::SmallString<128> filePath(DefaultLocalizationPath);
       llvm::sys::path::append(filePath, defaultLocale);
       llvm::sys::path::replace_extension(filePath, ".db");
 

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -71,6 +71,8 @@ public:
   std::string LocalizationCode = "";
   std::string LocalizationPath = "";
 
+  std::string DefaultLocalizationMessagesPath = "";
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -68,7 +68,7 @@ public:
   std::string DiagnosticDocumentationPath = "";
 
   // Default directory path for localized diagnostic messages.
-  std::string DefaultLocalizationMessagesPath = "";
+  std::string DefaultLocalizationPath = "";
 
   // Locale code and directory path for localized diagnostic messages.
   std::string LocalizationCode = "";

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -67,9 +67,8 @@ public:
 
   std::string DiagnosticDocumentationPath = "";
 
+  // Locale code and directory path for localized diagnostics.
   std::string LocalizationCode = "";
-
-  // Diagnostic messages directory path.
   std::string LocalizationPath = "";
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -67,11 +67,12 @@ public:
 
   std::string DiagnosticDocumentationPath = "";
 
-  // Locale code and directory path for localized diagnostics.
+  // Default directory path for localized diagnostic messages.
+  std::string DefaultLocalizationMessagesPath = "";
+
+  // Locale code and directory path for localized diagnostic messages.
   std::string LocalizationCode = "";
   std::string LocalizationPath = "";
-
-  std::string DefaultLocalizationMessagesPath = "";
 
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -469,7 +469,7 @@ class CompilerInstance {
 
 public:
   // Out of line to avoid having to import SILModule.h.
-  CompilerInstance(std::string defaultLocalizationMessagesPath);
+  CompilerInstance(std::string DefaultLocalizationPath);
   ~CompilerInstance();
 
   CompilerInstance(const CompilerInstance &) = delete;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -426,7 +426,7 @@ public:
 class CompilerInstance {
   CompilerInvocation Invocation;
   SourceManager SourceMgr;
-  DiagnosticEngine Diagnostics{SourceMgr};
+  DiagnosticEngine Diagnostics;
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<Lowering::TypeConverter> TheSILTypes;
   std::unique_ptr<DiagnosticVerifier> DiagVerifier;
@@ -469,7 +469,7 @@ class CompilerInstance {
 
 public:
   // Out of line to avoid having to import SILModule.h.
-  CompilerInstance();
+  CompilerInstance(std::string defaultLocalizationMessagesPath);
   ~CompilerInstance();
 
   CompilerInstance(const CompilerInstance &) = delete;

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -37,7 +37,7 @@ namespace swift {
     ///
     /// \returns A new diagnostic consumer that serializes diagnostics.
   std::unique_ptr<DiagnosticConsumer>
-  createConsumer(llvm::StringRef outputPath, DiagnosticOptions &diagOpts);
+  createConsumer(llvm::StringRef outputPath, const DiagnosticOptions &diagOpts);
   }
 }
 

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -35,8 +35,9 @@ namespace swift {
     /// \param outputPath the file path to write the diagnostics to.
     ///
     /// \returns A new diagnostic consumer that serializes diagnostics.
-    std::unique_ptr<DiagnosticConsumer>
-    createConsumer(llvm::StringRef outputPath);
+  std::unique_ptr<DiagnosticConsumer>
+  createConsumer(llvm::StringRef outputPath,
+                 std::string defaultLocalizationMessagesPath);
   }
 }
 

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_SERIALIZEDDIAGNOSTICCONSUMER_H
 #define SWIFT_SERIALIZEDDIAGNOSTICCONSUMER_H
 
+#include "swift/Basic/DiagnosticOptions.h"
 #include <memory>
 
 namespace llvm {
@@ -36,8 +37,7 @@ namespace swift {
     ///
     /// \returns A new diagnostic consumer that serializes diagnostics.
   std::unique_ptr<DiagnosticConsumer>
-  createConsumer(llvm::StringRef outputPath,
-                 std::string defaultLocalizationMessagesPath);
+  createConsumer(llvm::StringRef outputPath, DiagnosticOptions &diagOpts);
   }
 }
 

--- a/include/swift/IDE/Refactoring.h
+++ b/include/swift/IDE/Refactoring.h
@@ -13,10 +13,11 @@
 #ifndef SWIFT_IDE_REFACTORING_H
 #define SWIFT_IDE_REFACTORING_H
 
-#include "llvm/ADT/StringRef.h"
-#include "swift/Basic/LLVM.h"
 #include "swift/AST/DiagnosticConsumer.h"
+#include "swift/Basic/DiagnosticOptions.h"
+#include "swift/Basic/LLVM.h"
 #include "swift/IDE/Utils.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
   class ModuleDecl;
@@ -115,31 +116,37 @@ StringRef getDescriptiveRenameUnavailableReason(RenameAvailableKind Kind);
 
 bool refactorSwiftModule(ModuleDecl *M, RefactoringOptions Opts,
                          SourceEditConsumer &EditConsumer,
-                         DiagnosticConsumer &DiagConsumer);
+                         DiagnosticConsumer &DiagConsumer,
+                         const DiagnosticOptions &DiagOpts);
 
 int syntacticRename(SourceFile *SF, llvm::ArrayRef<RenameLoc> RenameLocs,
                     SourceEditConsumer &EditConsumer,
-                    DiagnosticConsumer &DiagConsumer);
+                    DiagnosticConsumer &DiagConsumer,
+                    const DiagnosticOptions &DiagOpts);
 
 int findSyntacticRenameRanges(SourceFile *SF,
                               llvm::ArrayRef<RenameLoc> RenameLocs,
                               FindRenameRangesConsumer &RenameConsumer,
-                              DiagnosticConsumer &DiagConsumer);
+                              DiagnosticConsumer &DiagConsumer,
+                              const DiagnosticOptions &DiagOpts);
 
 int findLocalRenameRanges(SourceFile *SF, RangeConfig Range,
                           FindRenameRangesConsumer &RenameConsumer,
-                          DiagnosticConsumer &DiagConsumer);
+                          DiagnosticConsumer &DiagConsumer,
+                          const DiagnosticOptions &DiagOpts);
 
 ArrayRef<RefactoringKind>
 collectAvailableRefactorings(SourceFile *SF, RangeConfig Range,
                              bool &RangeStartMayNeedRename,
                              std::vector<RefactoringKind> &Scratch,
-                             llvm::ArrayRef<DiagnosticConsumer*> DiagConsumers);
+                             llvm::ArrayRef<DiagnosticConsumer *> DiagConsumers,
+                             const DiagnosticOptions &DiagOpts);
 
 ArrayRef<RefactoringKind>
 collectAvailableRefactorings(SourceFile *SF, ResolvedCursorInfo CursorInfo,
                              std::vector<RefactoringKind> &Scratch,
-                             bool ExcludeRename);
+                             bool ExcludeRename,
+                             const DiagnosticOptions &DiagOpts);
 
 /// Stores information about the reference that rename availability is being
 /// queried on.

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -78,8 +78,11 @@ struct SourceCompleteResult {
 };
 
 SourceCompleteResult
-isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf, SourceFileKind SFKind);
-SourceCompleteResult isSourceInputComplete(StringRef Text, SourceFileKind SFKind);
+isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
+                      SourceFileKind SFKind, CompilerInvocation &Invok);
+SourceCompleteResult isSourceInputComplete(StringRef Text,
+                                           SourceFileKind SFKind,
+                                           CompilerInvocation &Invok);
 
 bool initInvocationByClangArguments(ArrayRef<const char *> ArgList,
                                     CompilerInvocation &Invok,

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -79,10 +79,10 @@ struct SourceCompleteResult {
 
 SourceCompleteResult
 isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
-                      SourceFileKind SFKind, CompilerInvocation &Invok);
+                      SourceFileKind SFKind, const CompilerInvocation &Invok);
 SourceCompleteResult isSourceInputComplete(StringRef Text,
                                            SourceFileKind SFKind,
-                                           CompilerInvocation &Invok);
+                                           const CompilerInvocation &Invok);
 
 bool initInvocationByClangArguments(ArrayRef<const char *> ArgList,
                                     CompilerInvocation &Invok,

--- a/include/swift/Localization/LocalizationFormat.h
+++ b/include/swift/Localization/LocalizationFormat.h
@@ -140,12 +140,10 @@ public:
 
 class LocalizationProducer {
 public:
-  /// If the  message isn't available/localized in the current `yaml` file,
-  /// return the fallback default message.
-  virtual llvm::StringRef getMessageOr(swift::DiagID id,
-                                       llvm::StringRef defaultMessage) const {
-    return defaultMessage;
-  }
+  /// Get a diagnostic  message from the current `yaml` or `.db` file. If it's
+  /// not available return `llvm::None`.
+  virtual llvm::Optional<llvm::StringRef>
+  getMessageOr(swift::DiagID id) const = 0;
 
   virtual ~LocalizationProducer() {}
 };
@@ -157,8 +155,7 @@ public:
   /// The diagnostics IDs that are no longer available in `.def`
   std::vector<std::string> unknownIDs;
   explicit YAMLLocalizationProducer(llvm::StringRef filePath);
-  llvm::StringRef getMessageOr(swift::DiagID id,
-                               llvm::StringRef defaultMessage) const override;
+  llvm::Optional<llvm::StringRef> getMessageOr(swift::DiagID id) const override;
 
   /// Iterate over all of the available (non-empty) translations
   /// maintained by this producer, callback gets each translation
@@ -178,8 +175,7 @@ public:
   explicit SerializedLocalizationProducer(
       std::unique_ptr<llvm::MemoryBuffer> buffer);
 
-  llvm::StringRef getMessageOr(swift::DiagID id,
-                               llvm::StringRef defaultMessage) const override;
+  llvm::Optional<llvm::StringRef> getMessageOr(swift::DiagID id) const override;
 };
 
 class LocalizationInput : public llvm::yaml::Input {

--- a/include/swift/Localization/LocalizationFormat.h
+++ b/include/swift/Localization/LocalizationFormat.h
@@ -143,7 +143,7 @@ public:
   /// Get a diagnostic  message from the current `yaml` or `.db` file. If it's
   /// not available return `llvm::None`.
   virtual llvm::Optional<llvm::StringRef>
-  getMessageOr(swift::DiagID id) const = 0;
+  getMessage(swift::DiagID id) const = 0;
 
   virtual ~LocalizationProducer() {}
 };
@@ -155,7 +155,7 @@ public:
   /// The diagnostics IDs that are no longer available in `.def`
   std::vector<std::string> unknownIDs;
   explicit YAMLLocalizationProducer(llvm::StringRef filePath);
-  llvm::Optional<llvm::StringRef> getMessageOr(swift::DiagID id) const override;
+  llvm::Optional<llvm::StringRef> getMessage(swift::DiagID id) const override;
 
   /// Iterate over all of the available (non-empty) translations
   /// maintained by this producer, callback gets each translation
@@ -175,7 +175,7 @@ public:
   explicit SerializedLocalizationProducer(
       std::unique_ptr<llvm::MemoryBuffer> buffer);
 
-  llvm::Optional<llvm::StringRef> getMessageOr(swift::DiagID id) const override;
+  llvm::Optional<llvm::StringRef> getMessage(swift::DiagID id) const override;
 };
 
 class LocalizationInput : public llvm::yaml::Input {

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -269,11 +269,14 @@ namespace swift {
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                const LangOptions &LangOpts, const TypeCheckerOptions &TyOpts,
                StringRef ModuleName,
+               std::string defaultLocalizationMessagesPath,
                std::shared_ptr<SyntaxParseActions> spActions = nullptr,
                SyntaxParsingCache *SyntaxCache = nullptr);
-    ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
-               unsigned Offset, unsigned EndOffset);
+               std::string defaultLocalizationMessagesPath);
+    ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
+               unsigned Offset, unsigned EndOffset,
+               std::string defaultLocalizationMessagesPath);
 
     ~ParserUnit();
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SUBSYSTEMS_H
 #define SWIFT_SUBSYSTEMS_H
 
+#include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/PrimarySpecificPaths.h"
@@ -268,15 +269,14 @@ namespace swift {
   public:
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                const LangOptions &LangOpts, const TypeCheckerOptions &TyOpts,
-               StringRef ModuleName,
-               std::string defaultLocalizationMessagesPath,
+               StringRef ModuleName, const DiagnosticOptions &DiagOpts,
                std::shared_ptr<SyntaxParseActions> spActions = nullptr,
                SyntaxParsingCache *SyntaxCache = nullptr);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
-               std::string defaultLocalizationMessagesPath);
+               const DiagnosticOptions &DiagOpts);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                unsigned Offset, unsigned EndOffset,
-               std::string defaultLocalizationMessagesPath);
+               const DiagnosticOptions &DiagOpts);
 
     ~ParserUnit();
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1017,9 +1017,9 @@ DiagnosticEngine::diagnosticStringFor(const DiagID id,
   if (printDiagnosticName) {
     return debugDiagnosticStrings[(unsigned)id];
   }
-  auto defaultMessage = defaultLocalization.get()->getMessageOr(id);
+  auto defaultMessage = defaultLocalization.get()->getMessage(id);
   if (localization) {
-    auto localizedMessage = localization.get()->getMessageOr(id);
+    auto localizedMessage = localization.get()->getMessage(id);
     if (localizedMessage) {
       return localizedMessage.getValue();
     }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1017,13 +1017,14 @@ DiagnosticEngine::diagnosticStringFor(const DiagID id,
   if (printDiagnosticName) {
     return debugDiagnosticStrings[(unsigned)id];
   }
-  auto defaultMessage = diagnosticStrings[(unsigned)id];
+  auto defaultMessage = defaultLocalization.get()->getMessageOr(id);
   if (localization) {
-    auto localizedMessage =
-        localization.get()->getMessageOr(id, defaultMessage);
-    return localizedMessage;
+    auto localizedMessage = localization.get()->getMessageOr(id);
+    if (localizedMessage) {
+      return localizedMessage.getValue();
+    }
   }
-  return defaultMessage;
+  return defaultMessage.getValue();
 }
 
 const char *InFlightDiagnostic::fixItStringFor(const FixItID id) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -79,6 +79,15 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   llvm::sys::path::remove_filename(DiagnosticMessagesDir); // Remove /bin
   llvm::sys::path::append(DiagnosticMessagesDir, "share", "swift", "diagnostics");
   DiagnosticOpts.LocalizationPath = std::string(DiagnosticMessagesDir.str());
+
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(Path);
+  llvm::sys::path::remove_filename(
+      DefaultDiagnosticMessagesDir); // Remove /swift
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /bin
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  DiagnosticOpts.DefaultLocalizationMessagesPath =
+      std::string(DefaultDiagnosticMessagesDir.str());
 }
 
 void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -86,7 +86,7 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /bin
   llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
                           "diagnostics");
-  DiagnosticOpts.DefaultLocalizationMessagesPath =
+  DiagnosticOpts.DefaultLocalizationPath =
       std::string(DefaultDiagnosticMessagesDir.str());
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -46,8 +46,8 @@
 
 using namespace swift;
 
-CompilerInstance::CompilerInstance(std::string defaultLocalizationMessagesPath)
-    : Diagnostics(SourceMgr, defaultLocalizationMessagesPath) {}
+CompilerInstance::CompilerInstance(std::string DefaultLocalizationPath)
+    : Diagnostics(SourceMgr, DefaultLocalizationPath) {}
 CompilerInstance::~CompilerInstance() = default;
 
 std::string CompilerInvocation::getPCHHash() const {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -46,7 +46,8 @@
 
 using namespace swift;
 
-CompilerInstance::CompilerInstance() = default;
+CompilerInstance::CompilerInstance(std::string defaultLocalizationMessagesPath)
+    : Diagnostics(SourceMgr, defaultLocalizationMessagesPath) {}
 CompilerInstance::~CompilerInstance() = default;
 
 std::string CompilerInvocation::getPCHHash() const {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1469,7 +1469,8 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   if (subInvocation.parseArgs(SubArgs, Diags)) {
     return std::make_error_code(std::errc::not_supported);
   }
-  CompilerInstance subInstance;
+  CompilerInstance subInstance(
+      subInvocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   SubCompilerInstanceInfo info;
   info.Instance = &subInstance;
   info.CompilerVersion = CompilerVersion;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1470,7 +1470,7 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
     return std::make_error_code(std::errc::not_supported);
   }
   CompilerInstance subInstance(
-      subInvocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      subInvocation.getDiagnosticOptions().DefaultLocalizationPath);
   SubCompilerInstanceInfo info;
   info.Instance = &subInstance;
   info.CompilerVersion = CompilerVersion;

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -100,7 +100,7 @@ struct SharedState : llvm::RefCountedBase<SharedState> {
 class SerializedDiagnosticConsumer : public DiagnosticConsumer {
   /// State shared among the various clones of this diagnostic consumer.
   llvm::IntrusiveRefCntPtr<SharedState> State;
-  std::string DefaultLocalizationMessagesPath;
+  std::string DefaultLocalizationPath;
   bool CalledFinishProcessing = false;
   bool CompilationWasComplete = true;
 
@@ -108,8 +108,7 @@ public:
   SerializedDiagnosticConsumer(StringRef serializedDiagnosticsPath,
                                const DiagnosticOptions &diagOpts)
       : State(new SharedState(serializedDiagnosticsPath)),
-        DefaultLocalizationMessagesPath(
-            diagOpts.DefaultLocalizationMessagesPath) {
+        DefaultLocalizationPath(diagOpts.DefaultLocalizationPath) {
     emitPreamble();
   }
 
@@ -138,7 +137,7 @@ public:
     if (EC) {
       // Create a temporary diagnostics engine to print the error to stderr.
       SourceManager dummyMgr;
-      DiagnosticEngine DE(dummyMgr, DefaultLocalizationMessagesPath);
+      DiagnosticEngine DE(dummyMgr, DefaultLocalizationPath);
       PrintingDiagnosticConsumer PDC;
       DE.addConsumer(PDC);
       DE.diagnose(SourceLoc(), diag::cannot_open_serialized_file,

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -106,7 +106,7 @@ class SerializedDiagnosticConsumer : public DiagnosticConsumer {
 
 public:
   SerializedDiagnosticConsumer(StringRef serializedDiagnosticsPath,
-                               DiagnosticOptions &diagOpts)
+                               const DiagnosticOptions &diagOpts)
       : State(new SharedState(serializedDiagnosticsPath)),
         DefaultLocalizationMessagesPath(
             diagOpts.DefaultLocalizationMessagesPath) {
@@ -210,7 +210,7 @@ private:
 namespace swift {
 namespace serialized_diagnostics {
 std::unique_ptr<DiagnosticConsumer>
-createConsumer(StringRef outputPath, DiagnosticOptions &diagOpts) {
+createConsumer(StringRef outputPath, const DiagnosticOptions &diagOpts) {
   return std::make_unique<SerializedDiagnosticConsumer>(outputPath, diagOpts);
 }
 } // namespace serialized_diagnostics

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -106,9 +106,10 @@ class SerializedDiagnosticConsumer : public DiagnosticConsumer {
 
 public:
   SerializedDiagnosticConsumer(StringRef serializedDiagnosticsPath,
-                               std::string defaultLocalizationMessagesPath)
+                               DiagnosticOptions &diagOpts)
       : State(new SharedState(serializedDiagnosticsPath)),
-        DefaultLocalizationMessagesPath(defaultLocalizationMessagesPath) {
+        DefaultLocalizationMessagesPath(
+            diagOpts.DefaultLocalizationMessagesPath) {
     emitPreamble();
   }
 
@@ -209,10 +210,8 @@ private:
 namespace swift {
 namespace serialized_diagnostics {
 std::unique_ptr<DiagnosticConsumer>
-createConsumer(StringRef outputPath,
-               std::string defaultLocalizationMessagesPath) {
-  return std::make_unique<SerializedDiagnosticConsumer>(
-      outputPath, defaultLocalizationMessagesPath);
+createConsumer(StringRef outputPath, DiagnosticOptions &diagOpts) {
+  return std::make_unique<SerializedDiagnosticConsumer>(outputPath, diagOpts);
 }
 } // namespace serialized_diagnostics
 } // namespace swift

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -985,7 +985,7 @@ namespace {
 class JSONFixitWriter
   : public DiagnosticConsumer, public migrator::FixitFilter {
   std::string FixitsOutputPath;
-  std::string DefaultLocalizationMessagesPath;
+  std::string DefaultLocalizationPath;
   std::unique_ptr<llvm::raw_ostream> OSPtr;
   bool FixitAll;
   std::vector<SingleEdit> AllEdits;
@@ -994,8 +994,7 @@ public:
   JSONFixitWriter(std::string fixitsOutputPath,
                   const DiagnosticOptions &DiagOpts)
       : FixitsOutputPath(fixitsOutputPath),
-        DefaultLocalizationMessagesPath(
-            DiagOpts.DefaultLocalizationMessagesPath),
+        DefaultLocalizationPath(DiagOpts.DefaultLocalizationPath),
         FixitAll(DiagOpts.FixitCodeForAllDiagnostics) {}
 
 private:
@@ -1017,7 +1016,7 @@ private:
     if (EC) {
       // Create a temporary diagnostics engine to print the error to stderr.
       SourceManager dummyMgr;
-      DiagnosticEngine DE(dummyMgr, DefaultLocalizationMessagesPath);
+      DiagnosticEngine DE(dummyMgr, DefaultLocalizationPath);
       PrintingDiagnosticConsumer PDC;
       DE.addConsumer(PDC);
       DE.diagnose(SourceLoc(), diag::cannot_open_file,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2299,7 +2299,7 @@ createDispatchingDiagnosticConsumerIfNeeded(
 static std::unique_ptr<DiagnosticConsumer>
 createSerializedDiagnosticConsumerIfNeeded(
     const FrontendInputsAndOutputs &inputsAndOutputs,
-    DiagnosticOptions &diagOpts) {
+    const DiagnosticOptions &diagOpts) {
   return createDispatchingDiagnosticConsumerIfNeeded(
       inputsAndOutputs,
       [&](const InputFile &input) -> std::unique_ptr<DiagnosticConsumer> {

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -714,8 +714,14 @@ bool swift::batchScanModuleDependencies(CompilerInvocation &invok,
       pInstance = subInstanceMap[entry.arguments].get();
     } else {
       // Create a new instance by the arguments and save it in the map.
-      pInstance = subInstanceMap.insert({entry.arguments,
-        std::make_unique<CompilerInstance>()}).first->getValue().get();
+      pInstance =
+          subInstanceMap
+              .insert(
+                  {entry.arguments,
+                   std::make_unique<CompilerInstance>(
+                       invok.getDiagnosticOptions().DefaultLocalizationPath)})
+              .first->getValue()
+              .get();
       SmallVector<const char*, 4> args;
       llvm::cl::TokenizeGNUCommandLine(entry.arguments, saver, args);
       CompilerInvocation subInvok = invok;

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -322,7 +322,8 @@ bool CompletionInstance::performCachedOperationIfPossible(
   langOpts.EnableTypeFingerprints = false;
   TypeCheckerOptions typeckOpts = CI.getASTContext().TypeCheckerOpts;
   SearchPathOptions searchPathOpts = CI.getASTContext().SearchPathOpts;
-  DiagnosticEngine tmpDiags(tmpSM);
+  DiagnosticEngine tmpDiags(
+      tmpSM, Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   std::unique_ptr<ASTContext> tmpCtx(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, tmpSM, tmpDiags));
   registerParseRequestFunctions(tmpCtx->evaluator);
@@ -501,7 +502,8 @@ bool CompletionInstance::performNewOperation(
 
   auto isCachedCompletionRequested = ArgsHash.hasValue();
 
-  auto TheInstance = std::make_unique<CompilerInstance>();
+  auto TheInstance = std::make_unique<CompilerInstance>(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Track non-system dependencies in fast-completion mode to invalidate the
   // compiler instance if any dependent files are modified.

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -323,7 +323,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
   TypeCheckerOptions typeckOpts = CI.getASTContext().TypeCheckerOpts;
   SearchPathOptions searchPathOpts = CI.getASTContext().SearchPathOpts;
   DiagnosticEngine tmpDiags(
-      tmpSM, Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      tmpSM, Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   std::unique_ptr<ASTContext> tmpCtx(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, tmpSM, tmpDiags));
   registerParseRequestFunctions(tmpCtx->evaluator);
@@ -503,7 +503,7 @@ bool CompletionInstance::performNewOperation(
   auto isCachedCompletionRequested = ArgsHash.hasValue();
 
   auto TheInstance = std::make_unique<CompilerInstance>(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Track non-system dependencies in fast-completion mode to invalidate the
   // compiler instance if any dependent files are modified.

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1176,7 +1176,7 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   auto Instance = std::make_unique<swift::CompilerInstance>(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   if (Instance->setup(Invocation))
     llvm_unreachable("Failed setup");
 

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -104,9 +104,7 @@ ide::isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
                            SourceFileKind SFKind, CompilerInvocation &Invok) {
   SourceManager SM;
   auto BufferID = SM.addNewSourceBuffer(std::move(MemBuf));
-  ParserUnit Parse(
-      SM, SFKind, BufferID,
-      Invok.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+  ParserUnit Parse(SM, SFKind, BufferID, Invok.getDiagnosticOptions());
   Parse.parse();
   SourceCompleteResult SCR;
   SCR.IsComplete = !Parse.getParser().isInputIncomplete();

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -101,10 +101,12 @@ static const char *skipStringInCode(const char *p, const char *End) {
 
 SourceCompleteResult
 ide::isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
-                           SourceFileKind SFKind) {
+                           SourceFileKind SFKind, CompilerInvocation &Invok) {
   SourceManager SM;
   auto BufferID = SM.addNewSourceBuffer(std::move(MemBuf));
-  ParserUnit Parse(SM, SFKind, BufferID);
+  ParserUnit Parse(
+      SM, SFKind, BufferID,
+      Invok.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   Parse.parse();
   SourceCompleteResult SCR;
   SCR.IsComplete = !Parse.getParser().isInputIncomplete();
@@ -182,10 +184,11 @@ ide::isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
   return SCR;
 }
 
-SourceCompleteResult
-ide::isSourceInputComplete(StringRef Text,SourceFileKind SFKind) {
+SourceCompleteResult ide::isSourceInputComplete(StringRef Text,
+                                                SourceFileKind SFKind,
+                                                CompilerInvocation &Invok) {
   return ide::isSourceInputComplete(llvm::MemoryBuffer::getMemBufferCopy(Text),
-                                    SFKind);
+                                    SFKind, Invok);
 }
 
 // Adjust the cc1 triple string we got from clang, to make sure it will be

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -101,7 +101,7 @@ static const char *skipStringInCode(const char *p, const char *End) {
 
 SourceCompleteResult
 ide::isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
-                           SourceFileKind SFKind, CompilerInvocation &Invok) {
+                           SourceFileKind SFKind, const CompilerInvocation &Invok) {
   SourceManager SM;
   auto BufferID = SM.addNewSourceBuffer(std::move(MemBuf));
   ParserUnit Parse(SM, SFKind, BufferID, Invok.getDiagnosticOptions());
@@ -184,7 +184,7 @@ ide::isSourceInputComplete(std::unique_ptr<llvm::MemoryBuffer> MemBuf,
 
 SourceCompleteResult ide::isSourceInputComplete(StringRef Text,
                                                 SourceFileKind SFKind,
-                                                CompilerInvocation &Invok) {
+                                                const CompilerInvocation &Invok) {
   return ide::isSourceInputComplete(llvm::MemoryBuffer::getMemBufferCopy(Text),
                                     SFKind, Invok);
 }

--- a/lib/Localization/LocalizationFormat.cpp
+++ b/lib/Localization/LocalizationFormat.cpp
@@ -59,6 +59,8 @@ template <> struct ScalarEnumerationTraits<LocalDiagID> {
 namespace swift {
 namespace diag {
 
+using namespace llvm;
+
 void SerializedLocalizationWriter::insert(swift::DiagID id,
                                           llvm::StringRef translation) {
   generator.insert(static_cast<uint32_t>(id), translation);
@@ -95,12 +97,12 @@ SerializedLocalizationProducer::SerializedLocalizationProducer(
 }
 
 llvm::Optional<llvm::StringRef>
-SerializedLocalizationProducer::getMessageOr(swift::DiagID id) const {
+SerializedLocalizationProducer::getMessage(swift::DiagID id) const {
   auto value = SerializedTable.get()->find(id);
   llvm::StringRef diagnosticMessage((const char *)value.getDataPtr(),
                                     value.getDataLen());
   if (diagnosticMessage.empty())
-    return llvm::None;
+    return None;
 
   return diagnosticMessage;
 }
@@ -114,12 +116,12 @@ YAMLLocalizationProducer::YAMLLocalizationProducer(llvm::StringRef filePath) {
 }
 
 llvm::Optional<llvm::StringRef>
-YAMLLocalizationProducer::getMessageOr(swift::DiagID id) const {
+YAMLLocalizationProducer::getMessage(swift::DiagID id) const {
   if (diagnostics.empty())
-    return llvm::None;
+    return None;
   const std::string &diagnosticMessage = diagnostics[(unsigned)id];
   if (diagnosticMessage.empty())
-    return llvm::None;
+    return None;
   return llvm::StringRef(diagnosticMessage);
 }
 
@@ -136,7 +138,7 @@ llvm::Optional<uint32_t> LocalizationInput::readID(llvm::yaml::IO &io) {
   LocalDiagID diagID;
   io.mapRequired("id", diagID);
   if (diagID == LocalDiagID::NumDiags)
-    return llvm::None;
+    return None;
   return static_cast<uint32_t>(diagID);
 }
 

--- a/lib/Localization/LocalizationFormat.cpp
+++ b/lib/Localization/LocalizationFormat.cpp
@@ -94,13 +94,13 @@ SerializedLocalizationProducer::SerializedLocalizationProducer(
       base + tableOffset, base + sizeof(offset_type), base));
 }
 
-llvm::StringRef SerializedLocalizationProducer::getMessageOr(
-    swift::DiagID id, llvm::StringRef defaultMessage) const {
+llvm::Optional<llvm::StringRef>
+SerializedLocalizationProducer::getMessageOr(swift::DiagID id) const {
   auto value = SerializedTable.get()->find(id);
   llvm::StringRef diagnosticMessage((const char *)value.getDataPtr(),
                                     value.getDataLen());
   if (diagnosticMessage.empty())
-    return defaultMessage;
+    return llvm::None;
 
   return diagnosticMessage;
 }
@@ -113,15 +113,14 @@ YAMLLocalizationProducer::YAMLLocalizationProducer(llvm::StringRef filePath) {
   unknownIDs = std::move(yin.unknownIDs);
 }
 
-llvm::StringRef
-YAMLLocalizationProducer::getMessageOr(swift::DiagID id,
-                                       llvm::StringRef defaultMessage) const {
+llvm::Optional<llvm::StringRef>
+YAMLLocalizationProducer::getMessageOr(swift::DiagID id) const {
   if (diagnostics.empty())
-    return defaultMessage;
+    return llvm::None;
   const std::string &diagnosticMessage = diagnostics[(unsigned)id];
   if (diagnosticMessage.empty())
-    return defaultMessage;
-  return diagnosticMessage;
+    return llvm::None;
+  return llvm::StringRef(diagnosticMessage);
 }
 
 void YAMLLocalizationProducer::forEachAvailable(

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -147,7 +147,7 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
   }
 
   auto Instance = std::make_unique<swift::CompilerInstance>(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   if (Instance->setup(Invocation)) {
     return nullptr;
   }

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -146,7 +146,8 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
                   input.isPrimary() ? InputBuffer.get() : input.buffer()));
   }
 
-  auto Instance = std::make_unique<swift::CompilerInstance>();
+  auto Instance = std::make_unique<swift::CompilerInstance>(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   if (Instance->setup(Invocation)) {
     return nullptr;
   }

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -30,6 +30,7 @@ _swift_gyb_target_sources(swiftParse PRIVATE
 target_link_libraries(swiftParse PRIVATE
   swiftAST
   swiftSyntax
-  swiftSyntaxParse)
+  swiftSyntaxParse
+  swiftLocalization)
 
 add_dependencies(swiftParse swift-parse-syntax-generated-headers)

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1202,8 +1202,7 @@ struct ParserUnit::Implementation {
                  std::shared_ptr<SyntaxParseActions> spActions,
                  const DiagnosticOptions &DiagOpts)
       : SPActions(std::move(spActions)), LangOpts(Opts),
-        TypeCheckerOpts(TyOpts),
-        Diags(SM, DiagOpts.DefaultLocalizationMessagesPath),
+        TypeCheckerOpts(TyOpts), Diags(SM, DiagOpts.DefaultLocalizationPath),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts, SM,
                              Diags)) {
     auto parsingOpts = SourceFile::getDefaultParsingOptions(LangOpts);

--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -9,6 +9,11 @@ add_custom_command(TARGET diagnostic-database
       --output-directory ${CMAKE_BINARY_DIR}/share/swift/diagnostics/
 )
 
+add_custom_command(TARGET diagnostic-database
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/share/swift/diagnostics/ ${CMAKE_CURRENT_SOURCE_DIR}/../test/Driver/Inputs/diagnostics/
+)
+
 add_dependencies(swift-frontend diagnostic-database)
 add_dependencies(diagnostic-database swift-serialize-diagnostics)
 

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -45,7 +45,9 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=0 2>&1 | %FileCheck -check-prefix=FILELIST %s
 
-// RUN: %empty-directory(%t)/DISTINCTIVE-PATH/usr/bin/
+// RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/bin)
+// RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/share/swift/diagnostics)
+// RUN: cp -a %S/Inputs/diagnostics/. %t/DISTINCTIVE-PATH/usr/share/swift/diagnostics
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/DISTINCTIVE-PATH/usr/bin/swiftc)
 // RUN: ln -s "swiftc" %t/DISTINCTIVE-PATH/usr/bin/swift-update
 // RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -c -update-code -target x86_64-apple-macosx10.9 %s 2>&1 > %t.upd.txt

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -6,6 +6,8 @@
 
 // RUN: rm -rf %t
 // RUN: %empty-directory(%t/bin)
+// RUN: %empty-directory(%t/share/swift/diagnostics)
+// RUN: cp -a %S/Inputs/diagnostics/. %t/share/swift/diagnostics
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/bin/swiftc)
 // RUN: %empty-directory(%t/lib/swift/clang/lib/darwin/)
 

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -16,6 +16,8 @@
 // RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=LLDB %s
 
 // RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/bin)
+// RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/share/swift/diagnostics)
+// RUN: cp -a %S/Inputs/diagnostics/. %t/Toolchains/Test.xctoolchain/usr/share/swift/diagnostics
 // RUN: mv %t/usr/bin/swift %t/Toolchains/Test.xctoolchain/usr/bin/swift
 // RUN: %t/Toolchains/Test.xctoolchain/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -7,6 +7,8 @@
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/usr/bin
+// RUN: %empty-directory(%t/usr/share/swift/diagnostics)
+// RUN: cp -a %S/Inputs/diagnostics/. %t/usr/share/swift/diagnostics
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/usr/bin/swift)
 
 // RUN: %t/usr/bin/swift -sdk "" -deprecated-integrated-repl -### | %FileCheck -check-prefix=INTEGRATED %s

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -3,6 +3,8 @@
 
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir/usr/bin
+// RUN: %empty-directory(%t.dir/usr/share/swift/diagnostics)
+// RUN: cp -a %S/Inputs/diagnostics/. %t.dir/usr/share/swift/diagnostics
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t.dir/usr/bin/swift)
 
 // RUN: %t.dir/usr/bin/swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s

--- a/test/Driver/windows-link-job.swift
+++ b/test/Driver/windows-link-job.swift
@@ -1,4 +1,6 @@
 // RUN: %empty-directory(%t/DISTINCTIVE-WINDOWS-PATH/usr/bin)
+// RUN: %empty-directory(%t/DISTINCTIVE-WINDOWS-PATH/usr/share/swift/diagnostics)
+// RUN: cp -a %S/Inputs/diagnostics/. %t/DISTINCTIVE-WINDOWS-PATH/usr/share/swift/diagnostics
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc)
 // RUN: env PATH= %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
 // CHECK: {{^}}clang

--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -54,19 +54,24 @@ public:
 
 class Context {
   std::string RuntimeLibPath;
+  std::string DefaultLocalizationPath;
   std::string DiagnosticDocumentationPath;
   std::unique_ptr<LangSupport> SwiftLang;
   std::shared_ptr<NotificationCenter> NotificationCtr;
   std::shared_ptr<GlobalConfig> Config;
 
 public:
-  Context(StringRef RuntimeLibPath, StringRef DiagnosticDocumentationPath,
+  Context(StringRef RuntimeLibPath, std::string DefaultLocalizationPath, 
+          StringRef DiagnosticDocumentationPath,
           llvm::function_ref<std::unique_ptr<LangSupport>(Context &)>
               LangSupportFactoryFn,
           bool shouldDispatchNotificationsOnMain = true);
   ~Context();
 
   StringRef getRuntimeLibPath() const { return RuntimeLibPath; }
+  StringRef getDefaultLocalizationPath() const {
+    return DefaultLocalizationPath;
+  }
   StringRef getDiagnosticDocumentationPath() const {
     return DiagnosticDocumentationPath;
   }

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -37,11 +37,12 @@ unsigned GlobalConfig::getCompletionCheckDependencyInterval() const {
 }
 
 SourceKit::Context::Context(
-    StringRef RuntimeLibPath, StringRef DiagnosticDocumentationPath,
+    StringRef RuntimeLibPath, std::string DefaultLocalizationPath, StringRef DiagnosticDocumentationPath,
     llvm::function_ref<std::unique_ptr<LangSupport>(Context &)>
         LangSupportFactoryFn,
     bool shouldDispatchNotificationsOnMain)
     : RuntimeLibPath(RuntimeLibPath),
+      DefaultLocalizationPath(DefaultLocalizationPath),
       DiagnosticDocumentationPath(DiagnosticDocumentationPath),
       NotificationCtr(
           new NotificationCenter(shouldDispatchNotificationsOnMain)),

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -52,7 +52,9 @@ public:
   struct Implementation;
   Implementation &Impl;
 
-  explicit ASTUnit(uint64_t Generation, std::shared_ptr<SwiftStatistics> Stats);
+  std::string DefaultLocalizationPath;
+
+  explicit ASTUnit(uint64_t Generation, std::shared_ptr<SwiftStatistics> Stats, std::string DefaultLocalizationPath);
   ~ASTUnit();
 
   swift::CompilerInstance &getCompilerInstance() const;
@@ -88,11 +90,13 @@ public:
 typedef std::shared_ptr<SwiftASTConsumer> SwiftASTConsumerRef;
 
 class SwiftASTManager : public std::enable_shared_from_this<SwiftASTManager> {
+  std::string DefaultLocalizationPath;
 public:
   explicit SwiftASTManager(std::shared_ptr<SwiftEditorDocumentFileMap>,
                            std::shared_ptr<GlobalConfig> Config,
                            std::shared_ptr<SwiftStatistics> Stats,
                            StringRef RuntimeResourcePath,
+                           std::string DefaultLocalizationPath,
                            StringRef DiagnosticDocumentationPath);
   ~SwiftASTManager();
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1057,8 +1057,9 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx, StringRef ModuleName,
 
 static bool reportModuleDocInfo(CompilerInvocation Invocation,
                                 StringRef ModuleName,
-                                DocInfoConsumer &Consumer) {
-  CompilerInstance CI;
+                                DocInfoConsumer &Consumer,
+                                std::string DefaultLocalizationPath) {
+  CompilerInstance CI(DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -1073,7 +1074,7 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
   if (getModuleInterfaceInfo(Ctx, ModuleName, IFaceInfo))
     return true;
 
-  CompilerInstance ParseCI;
+  CompilerInstance ParseCI{Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath};
   if (makeParserAST(ParseCI, IFaceInfo.Text, Invocation))
     return true;
   addParameterEntities(ParseCI, IFaceInfo);
@@ -1177,8 +1178,9 @@ static bool getSourceTextInfo(CompilerInstance &CI,
 
 static bool reportSourceDocInfo(CompilerInvocation Invocation,
                                 llvm::MemoryBuffer *InputBuf,
-                                DocInfoConsumer &Consumer) {
-  CompilerInstance CI;
+                                DocInfoConsumer &Consumer,
+                                std::string DefaultLocalizationPath) {
+  CompilerInstance CI(DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -1363,7 +1365,7 @@ syntacticRename(llvm::MemoryBuffer *InputBuf,
                 ArrayRef<const char*> Args,
                 CategorizedEditsReceiver Receiver) {
   std::string Error;
-  CompilerInstance ParseCI;
+  CompilerInstance ParseCI(DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   ParseCI.addDiagnosticConsumer(&PrintDiags);
   SourceFile *SF = getSyntacticSourceFile(InputBuf, Args, ParseCI, Error);
@@ -1381,7 +1383,7 @@ void SwiftLangSupport::findRenameRanges(
     llvm::MemoryBuffer *InputBuf, ArrayRef<RenameLocations> RenameLocations,
     ArrayRef<const char *> Args, CategorizedRenameRangesReceiver Receiver) {
   std::string Error;
-  CompilerInstance ParseCI;
+  CompilerInstance ParseCI(DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   ParseCI.addDiagnosticConsumer(&PrintDiags);
   SourceFile *SF = getSyntacticSourceFile(InputBuf, Args, ParseCI, Error);
@@ -1492,7 +1494,7 @@ void SwiftLangSupport::getDocInfo(llvm::MemoryBuffer *InputBuf,
                                   StringRef ModuleName,
                                   ArrayRef<const char *> Args,
                                   DocInfoConsumer &Consumer) {
-  CompilerInstance CI;
+  CompilerInstance CI(DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -1510,13 +1512,13 @@ void SwiftLangSupport::getDocInfo(llvm::MemoryBuffer *InputBuf,
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
 
   if (!ModuleName.empty()) {
-    bool Error = reportModuleDocInfo(Invocation, ModuleName, Consumer);
+    bool Error = reportModuleDocInfo(Invocation, ModuleName, Consumer, DefaultLocalizationPath);
     if (Error)
       Consumer.failed("Error occurred");
     return;
   }
 
-  Failed = reportSourceDocInfo(Invocation, InputBuf, Consumer);
+  Failed = reportSourceDocInfo(Invocation, InputBuf, Consumer, DefaultLocalizationPath);
   if (Failed)
     Consumer.failed("Error occurred");
 }
@@ -1528,7 +1530,7 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
 
-  CompilerInstance CI;
+  CompilerInstance CI(DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1074,7 +1074,8 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
   if (getModuleInterfaceInfo(Ctx, ModuleName, IFaceInfo))
     return true;
 
-  CompilerInstance ParseCI{Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath};
+  CompilerInstance ParseCI{
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath};
   if (makeParserAST(ParseCI, IFaceInfo.Text, Invocation))
     return true;
   addParameterEntities(ParseCI, IFaceInfo);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1987,7 +1987,8 @@ void SwiftEditorDocument::parse(ImmutableTextSnapshotRef Snapshot,
   // all tokens are visited and thus token collection is invalid
   CompInv.getLangOptions().CollectParsedToken = (SyntaxCache == nullptr);
   // Access to Impl.SyntaxInfo is guarded by Impl.AccessMtx
-  CompInv.getDiagnosticOptions().DefaultLocalizationMessagesPath = DefaultLocalizationPath;
+  CompInv.getDiagnosticOptions().DefaultLocalizationPath =
+      DefaultLocalizationPath;
   Impl.SyntaxInfo.reset(
     new SwiftDocumentSyntaxInfo(CompInv, Snapshot, Args, Impl.FilePath));
 
@@ -2402,7 +2403,8 @@ void verifyIncrementalParse(SwiftEditorDocumentRef EditorDoc,
   CompilerInvocation Invocation;
   Invocation.getLangOptions().BuildSyntaxTree = true;
   std::vector<std::string> Args;
-  Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath = DefaultLocalizationPath;
+  Invocation.getDiagnosticOptions().DefaultLocalizationPath =
+      DefaultLocalizationPath;
   SwiftDocumentSyntaxInfo ScratchSyntaxInfo(Invocation,
                                             EditorDoc->getLatestSnapshot(),
                                             Args, EditorDoc->getFilePath());

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -287,7 +287,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   StringRef FileExt = llvm::sys::path::extension(Filename);
 
   bool IsModuleIndexing = (FileExt == ".swiftmodule" || FileExt == ".pcm");
-  CompilerInstance CI;
+  CompilerInstance CI(DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);

--- a/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
@@ -34,6 +34,8 @@ namespace SourceKit {
 class SwiftInterfaceGenContext :
   public llvm::ThreadSafeRefCountedBase<SwiftInterfaceGenContext> {
 public:
+  std::string DefaultLocalizationPath;
+
   static SwiftInterfaceGenContextRef create(StringRef DocumentName,
                                             bool IsModule,
                                             StringRef ModuleOrHeaderName,
@@ -41,18 +43,21 @@ public:
                                             swift::CompilerInvocation Invocation,
                                             std::string &ErrorMsg,
                                             bool SynthesizedExtensions,
-                                            Optional<StringRef> InterestedUSR);
+                                            Optional<StringRef> InterestedUSR,
+                                            std::string DefaultLocalizationPath);
 
   static SwiftInterfaceGenContextRef
     createForTypeInterface(swift::CompilerInvocation Invocation,
                            StringRef TypeUSR,
-                           std::string &ErrorMsg);
+                           std::string &ErrorMsg,
+                           std::string DefaultLocalizationPath);
 
   static SwiftInterfaceGenContextRef createForSwiftSource(StringRef DocumentName,
                                                           StringRef SourceFileName,
                                                           ASTUnitRef AstUnit,
                                                           swift::CompilerInvocation Invocation,
-                                                          std::string &ErrMsg);
+                                                          std::string &ErrMsg,
+                                                          std::string DefaultLocalizationPath);
 
   ~SwiftInterfaceGenContext();
 
@@ -99,7 +104,7 @@ public:
 private:
   Implementation &Impl;
 
-  SwiftInterfaceGenContext();
+  SwiftInterfaceGenContext(std::string DefaultLocalizationPath);
 };
 
 } // namespace SourceKit

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -270,6 +270,7 @@ configureCompletionInstance(std::shared_ptr<CompletionInstance> CompletionInst,
 
 SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
     : NotificationCtr(SKCtx.getNotificationCenter()),
+      DefaultLocalizationPath(SKCtx.getDefaultLocalizationPath()), 
       CCCache(new SwiftCompletionCache) {
   llvm::SmallString<128> LibPath(SKCtx.getRuntimeLibPath());
   llvm::sys::path::append(LibPath, "swift");
@@ -280,7 +281,7 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
   EditorDocuments = std::make_shared<SwiftEditorDocumentFileMap>();
   ASTMgr = std::make_shared<SwiftASTManager>(
       EditorDocuments, SKCtx.getGlobalConfiguration(), Stats,
-      RuntimeResourcePath, DiagnosticDocumentationPath);
+      RuntimeResourcePath, DefaultLocalizationPath, DiagnosticDocumentationPath);
 
   CompletionInst = std::make_shared<CompletionInstance>();
   configureCompletionInstance(CompletionInst, SKCtx.getGlobalConfiguration());
@@ -1005,7 +1006,7 @@ bool SwiftLangSupport::performCompletionLikeOperation(
       UnresolvedInputFile, Offset, bufferIdentifier);
 
   SourceManager SM;
-  DiagnosticEngine Diags(SM);
+  DiagnosticEngine Diags(SM, DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   EditorDiagConsumer TraceDiags;
   trace::TracedOperation TracedOp{trace::OperationKind::CodeCompletion};

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -81,6 +81,8 @@ namespace SourceKit {
 class SwiftEditorDocument :
     public ThreadSafeRefCountedBase<SwiftEditorDocument> {
 
+  std::string DefaultLocalizationPath;
+
   struct Implementation;
   Implementation &Impl;
 
@@ -88,6 +90,7 @@ public:
 
   SwiftEditorDocument(StringRef FilePath, SwiftLangSupport &LangSupport,
        llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fileSystem,
+       std::string DefaultLocalizationPath,
        swift::ide::CodeFormatOptions Options = swift::ide::CodeFormatOptions());
   ~SwiftEditorDocument();
 
@@ -298,6 +301,7 @@ struct SwiftStatistics {
 class SwiftLangSupport : public LangSupport {
   std::shared_ptr<NotificationCenter> NotificationCtr;
   std::string RuntimeResourcePath;
+  std::string DefaultLocalizationPath;
   std::string DiagnosticDocumentationPath;
   std::shared_ptr<SwiftASTManager> ASTMgr;
   std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocuments;
@@ -319,6 +323,9 @@ public:
   }
 
   StringRef getRuntimeResourcePath() const { return RuntimeResourcePath; }
+  StringRef getDefaultLocalizationPath() const {
+    return DefaultLocalizationPath;
+  }
   StringRef getDiagnosticDocumentationPath() const {
     return DiagnosticDocumentationPath;
   }

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
@@ -113,6 +113,13 @@ std::string sourcekitd::getRuntimeLibPath() {
   return libPath.str().str();
 }
 
+std::string sourcekitd::getDefaultLocalizationPath() {
+  llvm::SmallString<128> docPath;
+  getToolchainPrefixPath(docPath);
+  llvm::sys::path::append(docPath, "share", "swift", "diagnostics");
+  return docPath.str().str();
+}
+
 std::string sourcekitd::getDiagnosticDocumentationPath() {
   llvm::SmallString<128> docPath;
   getToolchainPrefixPath(docPath);

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -215,6 +215,13 @@ std::string sourcekitd::getRuntimeLibPath() {
   return path.str().str();
 }
 
+std::string sourcekitd::getDefaultLocalizationPath() {
+  llvm::SmallString<128> path;
+  getToolchainPrefixPath(path);
+  llvm::sys::path::append(path, "share", "swift", "diagnostics");
+  return path.str().str();
+}
+
 std::string sourcekitd::getDiagnosticDocumentationPath() {
   llvm::SmallString<128> path;
   getToolchainPrefixPath(path);

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -175,6 +175,7 @@ SourceKit::UIdent UIdentFromSKDUID(sourcekitd_uid_t uid);
 
 std::string getRuntimeLibPath();
 std::string getDiagnosticDocumentationPath();
+std::string getDefaultLocalizationPath();
 
 void writeEscaped(llvm::StringRef Str, llvm::raw_ostream &OS);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -115,6 +115,7 @@ void sourcekitd::initialize() {
   llvm::EnablePrettyStackTrace();
   GlobalCtx =
       new SourceKit::Context(sourcekitd::getRuntimeLibPath(),
+                             sourcekitd::getDefaultLocalizationPath(),
                              sourcekitd::getDiagnosticDocumentationPath(),
                              SourceKit::createSwiftLangSupport);
   GlobalCtx->getNotificationCenter()->addDocumentUpdateNotificationReceiver(

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -153,10 +153,19 @@ static int run_driver(StringRef ExecName,
 
   std::string Path = getExecutablePath(argv[0]);
 
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(Path);
+  llvm::sys::path::remove_filename(
+      DefaultDiagnosticMessagesDir); // Remove /swift
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /bin
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  std::string DefaultLocalizationPath =
+      std::string(DefaultDiagnosticMessagesDir.str());
+
   PrintingDiagnosticConsumer PDC;
 
   SourceManager SM;
-  DiagnosticEngine Diags(SM);
+  DiagnosticEngine Diags(SM, DefaultLocalizationPath);
   Diags.addConsumer(PDC);
 
   Driver TheDriver(Path, ExecName, argv, Diags);

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -129,13 +129,22 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
                     void *MainAddr) {
   INITIALIZE_LLVM();
 
-  CompilerInstance Instance;
+  std::string MainExecutablePath =
+      llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(MainExecutablePath);
+  llvm::sys::path::remove_filename(
+      DefaultDiagnosticMessagesDir); // Remove /swift
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /bin
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  std::string DefaultLocalizationPath =
+      std::string(DefaultDiagnosticMessagesDir.str());
+
+  CompilerInstance Instance(DefaultLocalizationPath);
   PrintingDiagnosticConsumer PDC;
   Instance.addDiagnosticConsumer(&PDC);
 
   ModuleWrapInvocation Invocation;
-  std::string MainExecutablePath =
-      llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
   Invocation.setMainExecutablePath(MainExecutablePath);
 
   // Parse arguments.

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -62,7 +62,7 @@ public:
     Parser.reset(new ParserUnit(
         SM, SourceFileKind::Main, BufferID, CompInv.getLangOptions(),
         CompInv.getTypeCheckerOptions(), CompInv.getModuleName(),
-        CompInv.getDiagnosticOptions().DefaultLocalizationMessagesPath));
+        CompInv.getDiagnosticOptions()));
     Parser->getDiagnosticEngine().addConsumer(DiagConsumer);
     Parser->parse();
   }

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -208,7 +208,8 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
 
   PrintingDiagnosticConsumer DiagPrinter;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   CI.getDiags().addConsumer(DiagPrinter);
 
   if (CI.setup(Invocation)) {

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -209,7 +209,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
   PrintingDiagnosticConsumer DiagPrinter;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   CI.getDiags().addConsumer(DiagPrinter);
 
   if (CI.setup(Invocation)) {

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -17,13 +17,14 @@
 
 #include "swift-c/SyntaxParser/SwiftSyntaxParser.h"
 #include "swift/AST/Module.h"
+#include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Parse/SyntaxParseActions.h"
+#include "swift/Subsystems.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
 #include "swift/Syntax/SyntaxNodes.h"
-#include "swift/Subsystems.h"
 #include <Block.h>
 
 using namespace swift;
@@ -288,13 +289,17 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
   // Disable name lookups during parsing.
   // Not ready yet:
   // langOpts.EnableASTScopeLookup = true;
+  DiagnosticOptions DiagOpts;
+  DiagOpts.DefaultLocalizationMessagesPath =
+      "/Volumes/Extreme/swift-source/build/Ninja-DebugAssert/"
+      "swift-macosx-x86_64/share/swift/diagnostics";
 
   auto parseActions =
     std::make_shared<CLibParseActions>(*this, SM, bufID);
   // We have to use SourceFileKind::Main to avoid diagnostics like
   // illegal_top_level_expr
   ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts, tyckOpts,
-                "syntax_parse_module", std::move(parseActions),
+                "syntax_parse_module", DiagOpts, std::move(parseActions),
                 /*SyntaxCache=*/nullptr);
   std::unique_ptr<SynParserDiagConsumer> pConsumer;
   if (DiagHandler) {

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -290,7 +290,7 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
   // Not ready yet:
   // langOpts.EnableASTScopeLookup = true;
   DiagnosticOptions DiagOpts;
-  DiagOpts.DefaultLocalizationMessagesPath =
+  DiagOpts.DefaultLocalizationPath =
       "/Volumes/Extreme/swift-source/build/Ninja-DebugAssert/"
       "swift-macosx-x86_64/share/swift/diagnostics";
 

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -291,12 +291,13 @@ int main(int argc, char **argv) {
 
   // Create a Swift compiler.
   llvm::SmallVector<std::string, 4> modules;
-  swift::CompilerInstance CI;
   swift::CompilerInvocation Invocation;
 
   Invocation.setMainExecutablePath(
       llvm::sys::fs::getMainExecutable(argv[0],
           reinterpret_cast<void *>(&anchorForGetMainExecutable)));
+  swift::CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Infer SDK and Target triple from the module.
   if (!extendedInfo.getSDKPath().empty())

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -40,6 +40,11 @@
 #include <fstream>
 #include <sstream>
 
+// This function isn't referenced outside its translation unit, but it
+// can't use the "static" keyword because its address is used for
+// getMainExecutable (since some platforms don't support taking the
+// address of main, and some platforms can't implement getMainExecutable
+// without being given the address of a function in the main executable).
 void anchorForGetMainExecutable() {}
 
 using namespace llvm::MachO;

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -297,7 +297,7 @@ int main(int argc, char **argv) {
       llvm::sys::fs::getMainExecutable(argv[0],
           reinterpret_cast<void *>(&anchorForGetMainExecutable)));
   swift::CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Infer SDK and Target triple from the module.
   if (!extendedInfo.getSDKPath().empty())

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
   }
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -255,7 +255,8 @@ int main(int argc, char **argv) {
     exit(-1);
   }
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
   }
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -171,7 +171,8 @@ int main(int argc, char **argv) {
     exit(-1);
   }
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -174,7 +174,8 @@ int main(int argc, char **argv) {
     exit(-1);
   }
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
   }
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -410,7 +410,7 @@ int main(int argc, char **argv) {
   }
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -409,7 +409,8 @@ int main(int argc, char **argv) {
     exit(-1);
   }
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -164,6 +164,7 @@ class SDKContext {
   llvm::StringSet<> TextData;
   llvm::BumpPtrAllocator Allocator;
   SourceManager SourceMgr;
+  std::string DefaultLocalizationPath;
   DiagnosticEngine Diags;
   UpdatedNodesMap UpdateMap;
   NodeMap TypeAliasUpdateMap;
@@ -179,7 +180,7 @@ public:
 #define IDENTIFIER_WITH_NAME(Name, IdStr) StringRef Id_##Name = IdStr;
 #include "swift/AST/KnownIdentifiers.def"
 
-  SDKContext(CheckerOptions Options);
+  SDKContext(CheckerOptions Options, std::string DefaultLocalizationPath);
 
   llvm::BumpPtrAllocator &allocator() {
     return Allocator;
@@ -228,7 +229,7 @@ public:
   Optional<uint8_t> getFixedBinaryOrder(ValueDecl *VD) const;
 
   CompilerInstance &newCompilerInstance() {
-    CIs.emplace_back(new CompilerInstance());
+    CIs.emplace_back(new CompilerInstance(DefaultLocalizationPath));
     return *CIs.back();
   }
   template<class YAMLNodeTy, typename ...ArgTypes>
@@ -795,16 +796,18 @@ SDKNodeRoot *getEmptySDKNodeRoot(SDKContext &SDKCtx);
 void dumpSDKRoot(SDKNodeRoot *Root, StringRef OutputFile);
 
 int dumpSDKContent(const CompilerInvocation &InitInvok,
-                   const llvm::StringSet<> &ModuleNames,
-                   StringRef OutputFile, CheckerOptions Opts);
+                   const llvm::StringSet<> &ModuleNames, StringRef OutputFile,
+                   CheckerOptions Opts, std::string DefaultLocalizationPath);
 
 /// Mostly for testing purposes, this function de-serializes the SDK dump in
 /// dumpPath and re-serialize them to OutputPath. If the tool performs correctly,
 /// the contents in dumpPath and OutputPath should be identical.
 int deserializeSDKDump(StringRef dumpPath, StringRef OutputPath,
-                       CheckerOptions Opts);
+                       CheckerOptions Opts,
+                       std::string DefaultLocalizationPath);
 
-int findDeclUsr(StringRef dumpPath, CheckerOptions Opts);
+int findDeclUsr(StringRef dumpPath, CheckerOptions Opts,
+                std::string DefaultLocalizationPath);
 
 void nodeSetDifference(ArrayRef<SDKNode*> Left, ArrayRef<SDKNode*> Right,
   NodeVector &LeftMinusRight, NodeVector &RightMinusLeft);

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2322,7 +2322,7 @@ createDiagConsumer(llvm::raw_ostream &OS, bool &FailOnError,
   if (!options::SerializedDiagPath.empty()) {
     FailOnError = true;
     DiagnosticOptions DiagOpts;
-    DiagOpts.DefaultLocalizationMessagesPath = DefaultLocalizationPath;
+    DiagOpts.DefaultLocalizationPath = DefaultLocalizationPath;
     return serialized_diagnostics::createConsumer(options::SerializedDiagPath,
                                                   DiagOpts);
   } else if (options::CompilerStyleDiags) {

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2299,7 +2299,8 @@ static std::unique_ptr<DiagnosticConsumer>
 createDiagConsumer(llvm::raw_ostream &OS, bool &FailOnError) {
   if (!options::SerializedDiagPath.empty()) {
     FailOnError = true;
-    return serialized_diagnostics::createConsumer(options::SerializedDiagPath);
+    return serialized_diagnostics::createConsumer(options::SerializedDiagPath,
+                                                  "test");
   } else if (options::CompilerStyleDiags) {
     FailOnError = true;
     return std::make_unique<PrintingDiagnosticConsumer>();

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -26,10 +26,12 @@
 // can be reflected as source-breaking changes for API users. If they are,
 // the output of api-digester will include such changes.
 
+#include "swift/AST/DiagnosticsModuleDiffer.h"
+#include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
-#include "swift/AST/DiagnosticsModuleDiffer.h"
 #include "swift/IDE/APIDigesterData.h"
+
 #include <functional>
 #include "ModuleAnalyzerNodes.h"
 #include "ModuleDiagsConsumer.h"

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -6,5 +6,6 @@ target_link_libraries(swift-dependency-tool
                       PRIVATE
                         swiftAST
                         swiftParse
+                        swiftLocalization
                         swiftClangImporter)
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -932,7 +932,7 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
   Invocation.setMainExecutablePath(MainExecutablePath);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   CI.addDiagnosticConsumer(&PDC);
   if (CI.setup(Invocation))
     return 1;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1326,7 +1326,7 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
   Invocation.setInputKind(InputFileKind::Swift);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -1541,7 +1541,7 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
 
   if (RunTypeChecker) {
     CompilerInstance CI(
-        Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+        Invocation.getDiagnosticOptions().DefaultLocalizationPath);
     CI.addDiagnosticConsumer(&PrintDiags);
     if (CI.setup(Invocation))
       return 1;
@@ -1613,7 +1613,7 @@ static int doDumpImporterLookupTables(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2075,7 +2075,7 @@ static int doSemanticAnnotation(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2149,7 +2149,7 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
     Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2194,7 +2194,7 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addPrimaryInputFile(SourceFilename);
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2252,7 +2252,7 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
 
   CompilerInvocation Invocation(InitInvok);
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
   if (CI.setup(Invocation))
@@ -2466,7 +2466,7 @@ static int doPrintModuleGroups(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2520,7 +2520,7 @@ static int doPrintModuleMetaData(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2588,7 +2588,7 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2646,7 +2646,7 @@ static int doPrintHeaders(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2700,7 +2700,7 @@ static int doPrintSwiftFileInterface(const CompilerInvocation &InitInvok,
       SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2733,7 +2733,7 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
       SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2850,7 +2850,7 @@ static int doPrintTypes(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3092,7 +3092,7 @@ static int doDumpComments(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3118,7 +3118,7 @@ static int doPrintComments(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3143,7 +3143,7 @@ static int doPrintModuleComments(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3182,7 +3182,7 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3245,7 +3245,7 @@ static int doPrintTypeInterface(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
@@ -3295,7 +3295,7 @@ static int doPrintTypeInterfaceForTypeUsr(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
@@ -3459,7 +3459,7 @@ static int doReconstructType(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -3497,7 +3497,7 @@ static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().CollectParsedToken = true;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -3600,7 +3600,7 @@ static int doPrintIndexedSymbols(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().TypoCorrectionLimit = 0;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -3632,7 +3632,7 @@ static int doPrintIndexedSymbolsFromModule(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3669,7 +3669,7 @@ static int doPrintUSRs(const CompilerInvocation &InitInvok,
   ImporterOpts.DetailedPreprocessingRecord = true;
 
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3684,12 +3684,12 @@ static int doPrintUSRs(const CompilerInvocation &InitInvok,
   return 0;
 }
 
-static int
-doTestCreateCompilerInvocation(ArrayRef<const char *> Args, bool ForceNoOutputs,
-                               std::string DefaultLocalizationMessagesPath) {
+static int doTestCreateCompilerInvocation(ArrayRef<const char *> Args,
+                                          bool ForceNoOutputs,
+                                          std::string DefaultLocalizationPath) {
   PrintingDiagnosticConsumer PDC;
   SourceManager SM;
-  DiagnosticEngine Diags(SM, DefaultLocalizationMessagesPath);
+  DiagnosticEngine Diags(SM, DefaultLocalizationPath);
   Diags.addConsumer(PDC);
 
   CompilerInvocation CI;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1325,7 +1325,8 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.setInputKind(InputFileKind::Swift);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -1539,7 +1540,8 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
   PrintingDiagnosticConsumer PrintDiags;
 
   if (RunTypeChecker) {
-    CompilerInstance CI;
+    CompilerInstance CI(
+        Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
     CI.addDiagnosticConsumer(&PrintDiags);
     if (CI.setup(Invocation))
       return 1;
@@ -1577,12 +1579,11 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
             SM, BufferID, Invocation.getMainFileSyntaxParsingCache(),
             syntaxArena);
 
-    ParserUnit Parser(SM, SourceFileKind::Main, BufferID,
-                      Invocation.getLangOptions(),
-                      Invocation.getTypeCheckerOptions(),
-                      Invocation.getModuleName(),
-                      SynTreeCreator,
-                      Invocation.getMainFileSyntaxParsingCache());
+    ParserUnit Parser(
+        SM, SourceFileKind::Main, BufferID, Invocation.getLangOptions(),
+        Invocation.getTypeCheckerOptions(), Invocation.getModuleName(),
+        Invocation.getDiagnosticOptions(), SynTreeCreator,
+        Invocation.getMainFileSyntaxParsingCache());
 
     registerParseRequestFunctions(Parser.getParser().Context.evaluator);
     registerTypeCheckerRequestFunctions(Parser.getParser().Context.evaluator);
@@ -1611,7 +1612,8 @@ static int doDumpImporterLookupTables(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -1811,12 +1813,11 @@ static int doStructureAnnotation(const CompilerInvocation &InitInvok,
           SM, BufferID, Invocation.getMainFileSyntaxParsingCache(),
           syntaxArena);
 
-  ParserUnit Parser(SM, SourceFileKind::Main, BufferID,
-                    Invocation.getLangOptions(),
-                    Invocation.getTypeCheckerOptions(),
-                    Invocation.getModuleName(),
-                    SynTreeCreator,
-                    Invocation.getMainFileSyntaxParsingCache());
+  ParserUnit Parser(
+      SM, SourceFileKind::Main, BufferID, Invocation.getLangOptions(),
+      Invocation.getTypeCheckerOptions(), Invocation.getModuleName(),
+      Invocation.getDiagnosticOptions(), SynTreeCreator,
+      Invocation.getMainFileSyntaxParsingCache());
 
   registerParseRequestFunctions(Parser.getParser().Context.evaluator);
   registerTypeCheckerRequestFunctions(
@@ -2073,7 +2074,8 @@ static int doSemanticAnnotation(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2099,9 +2101,8 @@ static int doInputCompletenessTest(const CompilerInvocation &InitInvok,
 
   llvm::raw_ostream &OS = llvm::outs();
   OS << SourceFilename << ": ";
-  if (isSourceInputComplete(std::move(FileBuf), SourceFileKind::Main)
-          .IsComplete,
-      InitInvok.getDiagnosticOptions().DefaultLocalizationMessagesPath) {
+  if (isSourceInputComplete(std::move(FileBuf), SourceFileKind::Main, InitInvok)
+          .IsComplete) {
     OS << "IS_COMPLETE\n";
   } else {
     OS << "IS_INCOMPLETE\n";
@@ -2147,7 +2148,8 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
   if (!RunTypeChecker)
     Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2191,7 +2193,8 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
                                   StringRef SourceFilename) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addPrimaryInputFile(SourceFilename);
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -2248,7 +2251,8 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
   using NodeKind = Demangle::Node::Kind;
 
   CompilerInvocation Invocation(InitInvok);
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
   if (CI.setup(Invocation))
@@ -2461,7 +2465,8 @@ static int doPrintModuleGroups(const CompilerInvocation &InitInvok,
                                const std::vector<std::string> ModulesToPrint) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2514,7 +2519,8 @@ static int doPrintModuleMetaData(const CompilerInvocation &InitInvok,
                                  const std::vector<std::string> ModulesToPrint) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2581,7 +2587,8 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
                           bool SynthesizeExtensions) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2638,7 +2645,8 @@ static int doPrintHeaders(const CompilerInvocation &InitInvok,
                           bool AnnotatePrint) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2691,7 +2699,8 @@ static int doPrintSwiftFileInterface(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addPrimaryInputFile(
       SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2723,7 +2732,8 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addPrimaryInputFile(
       SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -2839,7 +2849,8 @@ static int doPrintTypes(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3080,7 +3091,8 @@ static int doDumpComments(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3105,7 +3117,8 @@ static int doPrintComments(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3129,7 +3142,8 @@ static int doPrintModuleComments(const CompilerInvocation &InitInvok,
                                  StringRef CommentsXMLSchema) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3167,7 +3181,8 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
                                 const std::vector<std::string> ModulesToPrint) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3229,7 +3244,8 @@ static int doPrintTypeInterface(const CompilerInvocation &InitInvok,
     return 1;
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
@@ -3278,7 +3294,8 @@ static int doPrintTypeInterfaceForTypeUsr(const CompilerInvocation &InitInvok,
                                           const StringRef Usr) {
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
@@ -3441,7 +3458,8 @@ static int doReconstructType(const CompilerInvocation &InitInvok,
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(SourceFilename);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -3478,7 +3496,8 @@ static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().BuildSyntaxTree = true;
   Invocation.getLangOptions().CollectParsedToken = true;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -3580,7 +3599,8 @@ static int doPrintIndexedSymbols(const CompilerInvocation &InitInvok,
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
   Invocation.getLangOptions().TypoCorrectionLimit = 0;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
 
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -3611,7 +3631,8 @@ static int doPrintIndexedSymbolsFromModule(const CompilerInvocation &InitInvok,
                                            StringRef ModuleName) {
   CompilerInvocation Invocation(InitInvok);
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3647,7 +3668,8 @@ static int doPrintUSRs(const CompilerInvocation &InitInvok,
   ClangImporterOptions &ImporterOpts = Invocation.getClangImporterOptions();
   ImporterOpts.DetailedPreprocessingRecord = true;
 
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
@@ -3662,10 +3684,12 @@ static int doPrintUSRs(const CompilerInvocation &InitInvok,
   return 0;
 }
 
-static int doTestCreateCompilerInvocation(ArrayRef<const char *> Args, bool ForceNoOutputs) {
+static int
+doTestCreateCompilerInvocation(ArrayRef<const char *> Args, bool ForceNoOutputs,
+                               std::string DefaultLocalizationMessagesPath) {
   PrintingDiagnosticConsumer PDC;
   SourceManager SM;
-  DiagnosticEngine Diags(SM);
+  DiagnosticEngine Diags(SM, DefaultLocalizationMessagesPath);
   Diags.addConsumer(PDC);
 
   CompilerInvocation CI;
@@ -3721,7 +3745,21 @@ int main(int argc, char *argv[]) {
         ForceNoOutputs = true;
         Args = Args.drop_front();
       }
-      return doTestCreateCompilerInvocation(Args, ForceNoOutputs);
+
+      std::string MainExecutablePath = llvm::sys::fs::getMainExecutable(
+          argv[0], reinterpret_cast<void *>(&anchorForGetMainExecutable));
+      llvm::SmallString<128> DefaultDiagnosticMessagesDir(MainExecutablePath);
+      llvm::sys::path::remove_filename(
+          DefaultDiagnosticMessagesDir); // Remove /swift-ide-test
+      llvm::sys::path::remove_filename(
+          DefaultDiagnosticMessagesDir); // Remove /bin
+      llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                              "diagnostics");
+      std::string DefaultLocalizationPath =
+          std::string(DefaultDiagnosticMessagesDir.str());
+
+      return doTestCreateCompilerInvocation(Args, ForceNoOutputs,
+                                            DefaultLocalizationPath);
     }
   }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2091,15 +2091,17 @@ static int doSemanticAnnotation(const CompilerInvocation &InitInvok,
   return 0;
 }
 
-static int doInputCompletenessTest(StringRef SourceFilename) {
+static int doInputCompletenessTest(const CompilerInvocation &InitInvok,
+                                   StringRef SourceFilename) {
   std::unique_ptr<llvm::MemoryBuffer> FileBuf;
   if (setBufferForFile(SourceFilename, FileBuf))
     return 1;
 
   llvm::raw_ostream &OS = llvm::outs();
   OS << SourceFilename << ": ";
-  if (isSourceInputComplete(std::move(FileBuf),
-                            SourceFileKind::Main).IsComplete) {
+  if (isSourceInputComplete(std::move(FileBuf), SourceFileKind::Main)
+          .IsComplete,
+      InitInvok.getDiagnosticOptions().DefaultLocalizationMessagesPath) {
     OS << "IS_COMPLETE\n";
   } else {
     OS << "IS_INCOMPLETE\n";
@@ -4055,7 +4057,7 @@ int main(int argc, char *argv[]) {
     break;
 
   case ActionType::TestInputCompleteness:
-    ExitCode = doInputCompletenessTest(options::SourceFilename);
+    ExitCode = doInputCompletenessTest(InitInvok, options::SourceFilename);
     break;
 
   case ActionType::PrintASTNotTypeChecked:

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -312,7 +312,8 @@ int main(int argc, char *argv[]) {
   if (options::Action == RefactoringKind::FindLocalRenameRanges) {
     RangeConfig Range = getRange(BufferID, SM, StartLoc, EndLoc);
     FindRenameRangesAnnotatingConsumer Consumer(SM, BufferID, llvm::outs());
-    return findLocalRenameRanges(SF, Range, Consumer, PrintDiags);
+    return findLocalRenameRanges(SF, Range, Consumer, PrintDiags,
+                                 Invocation.getDiagnosticOptions());
   }
 
   if (options::Action == RefactoringKind::GlobalRename ||
@@ -341,11 +342,13 @@ int main(int argc, char *argv[]) {
     switch (options::Action) {
     case RefactoringKind::GlobalRename: {
       SourceEditOutputConsumer EditConsumer(SM, BufferID, llvm::outs());
-      return syntacticRename(SF, RenameLocs, EditConsumer, PrintDiags);
+      return syntacticRename(SF, RenameLocs, EditConsumer, PrintDiags,
+                             Invocation.getDiagnosticOptions());
     }
     case RefactoringKind::FindGlobalRenameRanges: {
       FindRenameRangesAnnotatingConsumer Consumer(SM, BufferID, llvm::outs());
-      return findSyntacticRenameRanges(SF, RenameLocs, Consumer, PrintDiags);
+      return findSyntacticRenameRanges(SF, RenameLocs, Consumer, PrintDiags,
+                                       Invocation.getDiagnosticOptions());
     }
     default:
       llvm_unreachable("unexpected refactoring kind");
@@ -358,8 +361,9 @@ int main(int argc, char *argv[]) {
     std::vector<RefactoringKind> Scratch;
     ArrayRef<RefactoringKind> AllKinds;
     bool RangeStartMayNeedRename = false;
-    AllKinds = collectAvailableRefactorings(SF, Range,RangeStartMayNeedRename,
-                                            Scratch, {&PrintDiags});
+    AllKinds = collectAvailableRefactorings(SF, Range, RangeStartMayNeedRename,
+                                            Scratch, {&PrintDiags},
+                                            Invocation.getDiagnosticOptions());
     llvm::outs() << "Action begins\n";
     for (auto Kind : AllKinds) {
       llvm::outs() << getDescriptiveRefactoringKindName(Kind) << "\n";
@@ -381,5 +385,5 @@ int main(int argc, char *argv[]) {
                                                       llvm::outs()));
 
   return refactorSwiftModule(CI.getMainModule(), RefactoringConfig, *pConsumer,
-                             PrintDiags);
+                             PrintDiags, Invocation.getDiagnosticOptions());
 }

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -258,7 +258,8 @@ int main(int argc, char *argv[]) {
   for (auto FileName : options::InputFilenames)
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   Invocation.setModuleName(options::ModuleName);
-  CompilerInstance CI;
+  CompilerInstance CI(
+      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   Invocation.setModuleName(options::ModuleName);
   CompilerInstance CI(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -625,7 +625,7 @@ int parseFile(
   llvm::raw_string_ostream DiagOS(DiagsString);
   PrintingDiagnosticConsumer DiagConsumer(DiagOS);
   CompilerInstance Instance(
-      Invocation.getDiagnosticOptions().DefaultLocalizationMessagesPath);
+      Invocation.getDiagnosticOptions().DefaultLocalizationPath);
   Instance.addDiagnosticConsumer(&DiagConsumer);
   if (Instance.setup(Invocation)) {
     llvm::errs() << "Unable to set up compiler instance";

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -25,6 +25,16 @@
 using namespace swift;
 using namespace llvm;
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 class ArithmeticExpr {
  public:
   enum class Kind {
@@ -218,7 +228,7 @@ TEST(ArithmeticEvaluator, Simple) {
                                        lifeUniverseEverything);
 
   SourceManager sourceMgr;
-  DiagnosticEngine diags(sourceMgr);
+  DiagnosticEngine diags(sourceMgr, getDefaultLocalizationPath());
   LangOptions opts;
   opts.DebugDumpCycles = false;
   opts.BuildRequestDependencyGraph = true;
@@ -345,7 +355,7 @@ TEST(ArithmeticEvaluator, Cycle) {
   sum->rhs = product;
 
   SourceManager sourceMgr;
-  DiagnosticEngine diags(sourceMgr);
+  DiagnosticEngine diags(sourceMgr, getDefaultLocalizationPath());
   LangOptions opts;
   opts.DebugDumpCycles = false;
   opts.BuildRequestDependencyGraph = false;

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(SwiftASTTests
    swiftParse
    swiftSema
 )
+
+target_compile_definitions(SwiftASTTests PRIVATE
+  SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -17,6 +17,16 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 namespace swift {
 namespace unittest {
 
@@ -32,7 +42,7 @@ public:
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 
-  TestContextBase() : Diags(SourceMgr) {
+  TestContextBase() : Diags(SourceMgr, getDefaultLocalizationPath()) {
     LangOpts.Target = llvm::Triple(llvm::sys::getProcessTriple());
   }
 };

--- a/unittests/ClangImporter/CMakeLists.txt
+++ b/unittests/ClangImporter/CMakeLists.txt
@@ -8,3 +8,6 @@ target_link_libraries(SwiftClangImporterTests
     swiftParse
     swiftAST
 )
+
+target_compile_definitions(SwiftClangImporterTests PRIVATE
+  SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -41,6 +41,16 @@ static bool emitFileWithContents(StringRef base, StringRef name,
   return emitFileWithContents(createFilename(base, name), contents, pathOut);
 }
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 TEST(ClangImporterTest, emitPCHInMemory) {
   // Create a temporary cache on disk and clean it up at the end.
   ClangImporterOptions options;
@@ -76,7 +86,7 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
   swift::SourceManager sourceMgr;
-  swift::DiagnosticEngine diags(sourceMgr);
+  swift::DiagnosticEngine diags(sourceMgr, getDefaultLocalizationPath());
   std::unique_ptr<ASTContext> context(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context, options);

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -183,7 +183,7 @@ TEST(ClangImporterTest, missingSubmodule) {
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
   swift::SourceManager sourceMgr;
-  swift::DiagnosticEngine diags(sourceMgr);
+  swift::DiagnosticEngine diags(sourceMgr, getDefaultLocalizationPath());
   std::unique_ptr<ASTContext> context(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context, options);

--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -9,3 +9,6 @@ target_link_libraries(SwiftDriverTests PRIVATE
    swiftAST
    swiftClangImporter
    swiftDriver)
+
+target_compile_definitions(SwiftDriverTests PRIVATE
+  SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
@@ -23,6 +23,16 @@ using namespace swift;
 using namespace fine_grained_dependencies;
 using namespace mocking_fine_grained_dependency_graphs;
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 void mocking_fine_grained_dependency_graphs::simulateLoad(
     ModuleDepGraph &g, const driver::Job *cmd,
     const DependencyDescriptions &dependencyDescriptions,
@@ -47,7 +57,7 @@ mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
       interfaceHashIfNonEmpty.empty() ? swiftDeps : interfaceHashIfNonEmpty;
 
   SourceManager sm;
-  DiagnosticEngine diags(sm);
+  DiagnosticEngine diags(sm, getDefaultLocalizationPath());
 
   auto sfdg =
       UnitTestSourceFileDepGraphFactory(

--- a/unittests/FrontendTool/CMakeLists.txt
+++ b/unittests/FrontendTool/CMakeLists.txt
@@ -6,3 +6,6 @@ target_link_libraries(SwiftFrontendTests
   PRIVATE
     swiftFrontend
     swiftFrontendTool)
+
+target_compile_definitions(SwiftFrontendTests PRIVATE
+  SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -45,6 +45,16 @@ static bool emitFileWithContents(StringRef base, StringRef name,
   return emitFileWithContents(createFilename(base, name), contents, pathOut);
 }
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 namespace unittest {
 
 class OpenTrackingFileSystem : public llvm::vfs::ProxyFileSystem {
@@ -92,7 +102,7 @@ protected:
 
     sourceMgr.setFileSystem(fs);
     PrintingDiagnosticConsumer printingConsumer;
-    DiagnosticEngine diags(sourceMgr);
+    DiagnosticEngine diags(sourceMgr, getDefaultLocalizationPath());
     diags.addConsumer(printingConsumer);
     TypeCheckerOptions typeckOpts;
     LangOptions langOpts;

--- a/unittests/Parse/CMakeLists.txt
+++ b/unittests/Parse/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(SwiftParseTests
     # FIXME: Sema must go last because of circular dependencies with AST.
     swiftSema
 )
+
+target_compile_definitions(SwiftParseTests PRIVATE
+  SWIFTLIB_DIR=\"${SWIFTLIB_DIR}\")

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -21,6 +21,16 @@ using namespace swift;
 using namespace llvm;
 using syntax::TriviaKind;
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 // The test fixture.
 class LexerTest : public ::testing::Test {
 public:
@@ -781,7 +791,7 @@ TEST_F(LexerTest, DiagnoseEmbeddedNul) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source, SourceLen));
 
   StringCaptureDiagnosticConsumer DiagConsumer;
-  DiagnosticEngine Diags(SourceMgr);
+  DiagnosticEngine Diags(SourceMgr, getDefaultLocalizationPath());
   Diags.addConsumer(DiagConsumer);
 
   Lexer L(LangOpts, SourceMgr, BufferID, &Diags,
@@ -803,7 +813,7 @@ TEST_F(LexerTest, DiagnoseEmbeddedNulOffset) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source, SourceLen));
 
   StringCaptureDiagnosticConsumer DiagConsumer;
-  DiagnosticEngine Diags(SourceMgr);
+  DiagnosticEngine Diags(SourceMgr, getDefaultLocalizationPath());
   Diags.addConsumer(DiagConsumer);
 
   Lexer L(LangOpts, SourceMgr, BufferID, &Diags,

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -94,7 +94,7 @@ public:
   
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
     DiagnosticOptions DiagOpts;
-    DiagOpts.DefaultLocalizationMessagesPath = getDefaultLocalizationPath();
+    DiagOpts.DefaultLocalizationPath = getDefaultLocalizationPath();
     swift::ParserUnit PU(SM, SourceFileKind::Main, BufID, LangOpts,
                          TypeCheckerOptions(), "unknown", DiagOpts);
     SmallVector<Decl *, 8> decls;

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -27,6 +27,16 @@ static StringRef getRuntimeLibPath() {
   return sys::path::parent_path(SWIFTLIB_DIR);
 }
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 namespace {
 
 class NullEditorConsumer : public EditorConsumer {
@@ -116,6 +126,7 @@ public:
 
   CursorInfoTest()
       : Ctx(*new SourceKit::Context(getRuntimeLibPath(),
+                                    getDefaultLocalizationPath(),
                                     /*diagnosticDocumentationPath*/ "",
                                     SourceKit::createSwiftLangSupport,
                                     /*dispatchOnMain=*/false)) {

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -32,6 +32,16 @@ static StringRef getRuntimeLibPath() {
   return sys::path::parent_path(SWIFTLIB_DIR);
 }
 
+static std::string getDefaultLocalizationPath() {
+  std::string libPath = llvm::sys::path::parent_path(SWIFTLIB_DIR);
+  llvm::SmallString<128> DefaultDiagnosticMessagesDir(libPath);
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /lib
+  llvm::sys::path::remove_filename(DefaultDiagnosticMessagesDir); // Remove /.
+  llvm::sys::path::append(DefaultDiagnosticMessagesDir, "share", "swift",
+                          "diagnostics");
+  return std::string(DefaultDiagnosticMessagesDir.str());
+}
+
 namespace {
 
 struct Token {
@@ -124,6 +134,7 @@ public:
     // thread may be active trying to use it to post notifications.
     // FIXME: Use shared_ptr ownership to avoid such issues.
     Ctx = new SourceKit::Context(getRuntimeLibPath(),
+                                 getDefaultLocalizationPath(),
                                  /*diagnosticDocumentationPath*/ "",
                                  SourceKit::createSwiftLangSupport,
                                  /*dispatchOnMain=*/false);


### PR DESCRIPTION
In this PR I'm completely switching the diagnostic messages from `.def` to the new format i.e. `YAML` or `.db` (serialized format). This will also handle the removal of messages' text from `.def` and only depending on `en.yaml`.