### PR TITLE
SIL: Fix TypeExpansionContext() constructor to get the right DeclContext from a SILFunction

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4477,19 +4477,9 @@ StringRef SILFunctionType::ABICompatibilityCheckResult::getMessage() const {
   llvm_unreachable("Covered switch isn't completely covered?!");
 }
 
-static DeclContext *getDeclContextForExpansion(const SILFunction &f) {
-  auto *dc = f.getDeclContext();
-  if (!dc)
-    dc = f.getModule().getSwiftModule();
-  auto *currentModule = f.getModule().getSwiftModule();
-  if (!dc || !dc->isChildContextOf(currentModule))
-    dc = currentModule;
-  return dc;
-}
-
 TypeExpansionContext::TypeExpansionContext(const SILFunction &f)
     : expansion(f.getResilienceExpansion()),
-      inContext(getDeclContextForExpansion(f)),
+      inContext(f.getModule().getAssociatedContext()),
       isContextWholeModule(f.getModule().isWholeModule()) {}
 
 CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext(

--- a/test/SILGen/opaque_result_type_private.swift
+++ b/test/SILGen/opaque_result_type_private.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-emit-silgen -primary-file %s -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-sil -primary-file %s -O -disable-availability-checking
+
+// CHECK-LABEL: sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+
+// CHECK: [[BOX:%.*]] = alloc_stack $PrivateClass
+// CHECK: [[FN:%.*]] = function_ref @$s26opaque_result_type_private19returnPrivateOpaqueQryF : $@convention(thin) () -> @out PrivateClass
+// CHECK: apply [[FN]]([[BOX]]) : $@convention(thin) () -> @out PrivateClass
+// CHECK: [[RESULT:%.*]] = load [take] [[BOX]] : $*PrivateClass
+// CHECK: destroy_value [[RESULT]] : $PrivateClass
+// CHECK: dealloc_stack [[BOX]] : $*PrivateClass
+_ = returnPrivateOpaque()
+
+// CHECK: [[BOX:%.*]] = alloc_stack $LocalClass
+// CHECK: [[FN:%.*]] = function_ref @$s26opaque_result_type_private17returnLocalOpaqueQryF : $@convention(thin) () -> @out LocalClass
+// CHECK: apply [[FN]]([[BOX]]) : $@convention(thin) () -> @out LocalClass
+// CHECK: [[RESULT:%.*]] = load [take] [[BOX]] : $*LocalClass
+// CHECK: destroy_value [[RESULT]] : $LocalClass
+// CHECK: dealloc_stack [[BOX]] : $*LocalClass
+_ = returnLocalOpaque()
+
+fileprivate class PrivateClass {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26opaque_result_type_private19returnPrivateOpaqueQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s26opaque_result_type_private19returnPrivateOpaqueQryF", 0) 🦸
+func returnPrivateOpaque() -> some Any {
+  return PrivateClass()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26opaque_result_type_private17returnLocalOpaqueQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s26opaque_result_type_private17returnLocalOpaqueQryF", 0) 🦸
+func returnLocalOpaque() -> some Any {
+  class LocalClass {}
+
+  return LocalClass()
+}


### PR DESCRIPTION
Using the SILFunction's DeclContext produces the wrong result for
the @main function, because it returns the ModuleDecl even in
a non-WMO build.

Instead, let's always just use SILModule::getAssociatedContext(),
which also simplifies the code here.

Fixes <rdar://problem/66791399>.
