### PR TITLE
[Explicit Module Builds] Distinguish whether an explicit module is a framework.

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -129,7 +129,7 @@ public:
       ArrayRef<StringRef> buildCommandLine,
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash,
-      bool isFramework = false
+      bool isFramework
   ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Swift,
                                     compiledModulePath),
       swiftInterfaceFile(swiftInterfaceFile),

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -107,6 +107,9 @@ public:
   /// The hash value that will be used for the generated module
   const std::string contextHash;
 
+  /// A flag that indicates this dependency is a framework
+  const bool isFramework;
+
   /// Bridging header file, if there is one.
   Optional<std::string> bridgingHeaderFile;
 
@@ -125,7 +128,8 @@ public:
       ArrayRef<std::string> compiledModuleCandidates,
       ArrayRef<StringRef> buildCommandLine,
       ArrayRef<StringRef> extraPCMArgs,
-      StringRef contextHash
+      StringRef contextHash,
+      bool isFramework = false
   ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Swift,
                                     compiledModulePath),
       swiftInterfaceFile(swiftInterfaceFile),
@@ -133,7 +137,7 @@ public:
                                compiledModuleCandidates.end()),
       buildCommandLine(buildCommandLine.begin(), buildCommandLine.end()),
       extraPCMArgs(extraPCMArgs.begin(), extraPCMArgs.end()),
-      contextHash(contextHash) { }
+      contextHash(contextHash), isFramework(isFramework) { }
 
   ModuleDependenciesStorageBase *clone() const override {
     return new SwiftModuleDependenciesStorage(*this);
@@ -242,21 +246,22 @@ public:
       ArrayRef<std::string> compiledCandidates,
       ArrayRef<StringRef> buildCommands,
       ArrayRef<StringRef> extraPCMArgs,
-      StringRef contextHash) {
+      StringRef contextHash,
+      bool isFramework) {
     std::string compiledModulePath;
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
           compiledModulePath, swiftInterfaceFile, compiledCandidates, buildCommands,
-          extraPCMArgs, contextHash));
+          extraPCMArgs, contextHash, isFramework));
   }
 
   /// Describe the module dependencies for a serialized or parsed Swift module.
   static ModuleDependencies forSwiftModule(
-      const std::string &compiledModulePath) {
+      const std::string &compiledModulePath, bool isFramework) {
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
           compiledModulePath, None, ArrayRef<std::string>(), ArrayRef<StringRef>(),
-          ArrayRef<StringRef>(), StringRef()));
+          ArrayRef<StringRef>(), StringRef(), isFramework));
   }
 
   /// Describe the main Swift module.
@@ -265,7 +270,7 @@ public:
     return ModuleDependencies(
         std::make_unique<SwiftModuleDependenciesStorage>(
           compiledModulePath, None, ArrayRef<std::string>(),
-          ArrayRef<StringRef>(), extraPCMArgs, StringRef()));
+          ArrayRef<StringRef>(), extraPCMArgs, StringRef(), false));
   }
 
   /// Describe the module dependencies for a Clang module that can be

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -112,7 +112,6 @@
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "llvm/Support/StringSaver.h"
-#include <sstream>
 
 namespace clang {
 class CompilerInstance;
@@ -263,8 +262,14 @@ private:
       } else if (key == "sourceInfoPath") {
         result.moduleSourceInfoPath = val.str();
       } else if (key == "isFramework") {
-        std::istringstream is(val.str());
-        is >> std::boolalpha >> result.isFramework;
+        auto valStr = val.str();
+        valStr.erase(std::remove(valStr.begin(), valStr.end(), '\n'), valStr.end());
+        if (valStr.compare("true") == 0)
+          result.isFramework = true;
+        else if (valStr.compare("false") == 0)
+          result.isFramework = false;
+        else
+          llvm_unreachable("Unexpected JSON value for isFramework");
       } else {
         // Being forgiving for future fields.
         continue;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -139,7 +139,8 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsFramework) override;
 
   bool canImportModule(Located<Identifier> mID) override;
 
@@ -298,12 +299,13 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   ModuleInterfaceLoaderOptions Opts;
 
   std::error_code findModuleFilesInDirectory(
-    AccessPathElem ModuleID,
-    const SerializedModuleBaseName &BaseName,
-    SmallVectorImpl<char> *ModuleInterfacePath,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
+     AccessPathElem ModuleID,
+     const SerializedModuleBaseName &BaseName,
+     SmallVectorImpl<char> *ModuleInterfacePath,
+     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+     bool IsFramework) override;
 
   bool isCached(StringRef DepPath) override;
 public:

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -73,12 +73,12 @@ protected:
                                              StringRef extension) const;
 
   using AccessPathElem = Located<Identifier>;
-  bool findModule(AccessPathElem moduleID,
-                  SmallVectorImpl<char> *moduleInterfacePath,
-                  std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-                  bool &isFramework, bool &isSystemModule);
+  virtual bool findModule(AccessPathElem moduleID,
+                          SmallVectorImpl<char> *moduleInterfacePath,
+                          std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
+                          std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
+                          std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
+                          bool &isFramework, bool &isSystemModule);
 
   /// Attempts to search the provided directory for a loadable serialized
   /// .swiftmodule with the provided `ModuleFilename`. Subclasses must

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -98,7 +98,8 @@ protected:
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) = 0;
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsFramework) = 0;
 
   std::error_code
   openModuleFile(
@@ -229,7 +230,8 @@ class ImplicitSerializedModuleLoader : public SerializedModuleLoaderBase {
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsFramework) override;
 
   bool maybeDiagnoseTargetMismatch(
       SourceLoc sourceLocation,
@@ -274,7 +276,8 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsFramework) override;
 
   bool maybeDiagnoseTargetMismatch(
       SourceLoc sourceLocation,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -950,7 +950,8 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   SmallVectorImpl<char> *ModuleInterfacePath,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
+  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+  bool IsFramework) {
 
   // If running in OnlySerialized mode, ModuleInterfaceLoader
   // should not have been constructed at all.
@@ -1527,7 +1528,8 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsFramework) {
   StringRef moduleName = ModuleID.Item.str();
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no explicit module path is given matches the name, return with an

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1522,28 +1522,29 @@ ExplicitSwiftModuleLoader::ExplicitSwiftModuleLoader(
 
 ExplicitSwiftModuleLoader::~ExplicitSwiftModuleLoader() { delete &Impl; }
 
-std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
-    AccessPathElem ModuleID,
-    const SerializedModuleBaseName &BaseName,
-    SmallVectorImpl<char> *ModuleInterfacePath,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool IsFramework) {
+bool ExplicitSwiftModuleLoader::findModule(AccessPathElem ModuleID,
+           SmallVectorImpl<char> *ModuleInterfacePath,
+           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+           bool &IsFramework, bool &IsSystemModule) {
   StringRef moduleName = ModuleID.Item.str();
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no explicit module path is given matches the name, return with an
   // error code.
   if (it == Impl.ExplicitModuleMap.end()) {
-    return std::make_error_code(std::errc::not_supported);
+    return false;
   }
   auto &moduleInfo = it->getValue();
   if (moduleInfo.moduleBuffer) {
     // We found an explicit module matches the given name, give the buffer
     // back to the caller side.
     *ModuleBuffer = std::move(moduleInfo.moduleBuffer);
-    return std::error_code();
+    return true;
   }
+
+  // Set IsFramework bit according to the moduleInfo
+  IsFramework = moduleInfo.isFramework;
 
   auto &fs = *Ctx.SourceMgr.getFileSystem();
   // Open .swiftmodule file
@@ -1552,7 +1553,7 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
     // We cannot read the module content, diagnose.
     Ctx.Diags.diagnose(SourceLoc(), diag::error_opening_explicit_module_file,
                        moduleInfo.modulePath);
-    return moduleBuf.getError();
+    return false;
   }
 
   assert(moduleBuf);
@@ -1568,13 +1569,13 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
         // We cannot read the module content, diagnose.
         Ctx.Diags.diagnose(SourceLoc(), diag::error_opening_explicit_module_file,
                            moduleInfo.modulePath);
-        return moduleBuf.getError();
+        return false;
       }
     } else {
       // We cannot read the module content, diagnose.
       Ctx.Diags.diagnose(SourceLoc(), diag::error_opening_explicit_module_file,
                          moduleInfo.modulePath);
-      return forwardingModule.getError();
+      return false;
     }
   }
   assert(moduleBuf);
@@ -1593,7 +1594,19 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
     if (moduleSourceInfoBuf)
       *ModuleSourceInfoBuffer = std::move(moduleSourceInfoBuf.get());
   }
-  return std::error_code();
+  return true;
+}
+
+std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
+  AccessPathElem ModuleID,
+  const SerializedModuleBaseName &BaseName,
+  SmallVectorImpl<char> *ModuleInterfacePath,
+  std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+  bool IsFramework) {
+  llvm_unreachable("Not supported in the Explicit Swift Module Loader.");
+  return std::make_error_code(std::errc::not_supported);
 }
 
 bool ExplicitSwiftModuleLoader::canImportModule(

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -216,6 +216,13 @@ namespace {
     out << "\"";
   }
 
+  /// Write a boolean value as JSON.
+  void writeJSONValue(llvm::raw_ostream &out,
+                      bool value,
+                      unsigned indentLevel) {
+    out.write_escaped(value ? "true" : "false");
+  }
+
   /// Write a module identifier.
   void writeJSONValue(llvm::raw_ostream &out,
                       const ModuleDependencyID &module,
@@ -397,6 +404,11 @@ static void writeJSON(llvm::raw_ostream &out,
             swiftDeps->compiledModulePath, 5,
             /*trailingComma=*/false);
       }
+      writeJSONSingleField(
+          out, "isFramework",
+          swiftDeps->isFramework, 5,
+          /*trailingComma=*/!swiftDeps->extraPCMArgs.empty() ||
+                           swiftDeps->bridgingHeaderFile.hasValue());
       if (!swiftDeps->extraPCMArgs.empty()) {
         out.indent(5 * 2);
         out << "\"extraPcmArgs\": [\n";

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -682,7 +682,6 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
     std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
     bool isFramework) {
   assert(moduleInputBuffer);
-
   StringRef moduleBufferID = moduleInputBuffer->getBufferIdentifier();
   StringRef moduleDocBufferID;
   if (moduleDocInputBuffer)
@@ -993,7 +992,6 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
   StringRef moduleInterfacePathStr =
     Ctx.AllocateCopy(moduleInterfacePath.str());
-
   auto *file =
       loadAST(*M, moduleID.Loc, moduleInterfacePathStr,
               std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -396,7 +396,7 @@ llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
                        &extInfo);
 
   // Map the set of dependencies over to the "module dependencies".
-  auto dependencies = ModuleDependencies::forSwiftModule(modulePath.str());
+  auto dependencies = ModuleDependencies::forSwiftModule(modulePath.str(), isFramework);
   llvm::StringSet<> addedModuleNames;
   for (const auto &dependency : loadedModuleFile->getDependencies()) {
     // FIXME: Record header dependency?
@@ -422,7 +422,8 @@ std::error_code ImplicitSerializedModuleLoader::findModuleFilesInDirectory(
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsFramework) {
   assert(((ModuleBuffer && ModuleDocBuffer) ||
           (!ModuleBuffer && !ModuleDocBuffer)) &&
          "Module and Module Doc buffer must both be initialized or NULL");
@@ -538,7 +539,7 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
   /// Returns true if a target-specific module file was found, false if an error
   /// was diagnosed, or None if neither one happened and the search should
   /// continue.
-  auto findTargetSpecificModuleFiles = [&]() -> Optional<bool> {
+  auto findTargetSpecificModuleFiles = [&](bool IsFramework) -> Optional<bool> {
     Optional<SerializedModuleBaseName> firstAbsoluteBaseName;
 
     for (const auto &targetSpecificBaseName : targetSpecificBaseNames) {
@@ -552,7 +553,8 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
                         absoluteBaseName,
                         moduleInterfacePath,
                         moduleBuffer, moduleDocBuffer,
-                        moduleSourceInfoBuffer);
+                        moduleSourceInfoBuffer,
+                        IsFramework);
       if (!result) {
         return true;
       } else if (result == std::errc::not_supported) {
@@ -603,13 +605,13 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
 
           if (checkTargetSpecificModule)
             // A .swiftmodule directory contains architecture-specific files.
-            return findTargetSpecificModuleFiles();
+            return findTargetSpecificModuleFiles(isFramework);
 
           SerializedModuleBaseName absoluteBaseName{currPath, genericBaseName};
 
           auto result = findModuleFilesInDirectory(
               moduleID, absoluteBaseName, moduleInterfacePath,
-              moduleBuffer, moduleDocBuffer, moduleSourceInfoBuffer);
+              moduleBuffer, moduleDocBuffer, moduleSourceInfoBuffer, isFramework);
           if (!result)
             return true;
           else if (result == std::errc::not_supported)
@@ -628,7 +630,7 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
           // Frameworks always use architecture-specific files within a
           // .swiftmodule directory.
           llvm::sys::path::append(currPath, "Modules");
-          return findTargetSpecificModuleFiles();
+          return findTargetSpecificModuleFiles(isFramework);
         }
         }
         llvm_unreachable("covered switch");
@@ -1081,7 +1083,8 @@ std::error_code MemoryBufferSerializedModuleLoader::findModuleFilesInDirectory(
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsFramework) {
   // This is a soft error instead of an llvm_unreachable because this API is
   // primarily used by LLDB which makes it more likely that unwitting changes to
   // the Swift compiler accidentally break the contract.

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -90,6 +90,9 @@ struct SwiftModuleDetails: Codable {
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
   var extraPcmArgs: [String]?
+
+  /// A flag to indicate whether or not this module is a framework.
+  var isFramework: Bool
 }
 
 /// Details specific to Swift external modules.

--- a/test/ScanDependencies/can_import_with_map.swift
+++ b/test/ScanDependencies/can_import_with_map.swift
@@ -8,15 +8,18 @@
 // RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
-// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/stdlib_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/ononesupport_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules

--- a/test/ScanDependencies/explicit-framework-irgen.swift
+++ b/test/ScanDependencies/explicit-framework-irgen.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: echo "/// Some cool comments" > %t/foo.swift
+// RUN: echo "public func foo() {}" >> %t/foo.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": true" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -emit-object -emit-module -disable-implicit-swift-modules -explicit-swift-module-map-file %t/inputs/map.json -o %t/explicit-framework-irgen.o %s
+import Foo
+
+// This test is to verify autolinking behavior so it is macOS-specific. 
+// REQUIRES OS=macosx
+
+// RUN: otool -l %t/explicit-framework-irgen.o | %FileCheck %s
+// CHECK: cmd LC_LINKER_OPTION
+// CHECK-NEXT:  cmdsize 32
+// CHECK-NEXT:  count 2
+// CHECK-NEXT:  string #1 -framework
+// CHECK-NEXT:  string #2 Foo

--- a/test/ScanDependencies/explicit-framework-irgen.swift
+++ b/test/ScanDependencies/explicit-framework-irgen.swift
@@ -27,11 +27,11 @@
 import Foo
 
 // This test is to verify autolinking behavior so it is macOS-specific. 
-// REQUIRES OS=macosx
+// REQUIRES: OS=macosx
 
 // RUN: otool -l %t/explicit-framework-irgen.o | %FileCheck %s
 // CHECK: cmd LC_LINKER_OPTION
-// CHECK-NEXT:  cmdsize 32
-// CHECK-NEXT:  count 2
+// CHECK-NEXT:  cmdsize
+// CHECK-NEXT:  count
 // CHECK-NEXT:  string #1 -framework
 // CHECK-NEXT:  string #2 Foo

--- a/test/ScanDependencies/explicit-module-map-forwarding-module.swift
+++ b/test/ScanDependencies/explicit-module-map-forwarding-module.swift
@@ -18,15 +18,18 @@
 // RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%/t/inputs/Foo-from-interface.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
-// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/stdlib_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/ononesupport_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -enable-swiftsourceinfo -source-filename %s -explicit-swift-module-map-file %t/inputs/map.json | %FileCheck %s

--- a/test/ScanDependencies/explicit-module-map.swift
+++ b/test/ScanDependencies/explicit-module-map.swift
@@ -9,15 +9,18 @@
 // RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
-// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/stdlib_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/ononesupport_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -enable-swiftsourceinfo -source-filename %s -explicit-swift-module-map-file %t/inputs/map.json | %FileCheck %s

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -6,23 +6,18 @@
 // RUN: echo "\"moduleName\": \"SomeExternalModule\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%/t/inputs/SomeExternalModule.swiftmodule\"," >> %/t/inputs/map.json
 // RUN: echo "\"docPath\": \"%/t/inputs/SomeExternalModule.swiftdoc\"," >> %/t/inputs/map.json
-// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/SomeExternalModule.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/SomeExternalModule.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/stdlib_module\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/ononesupport_module\"" >> %/t/inputs/map.json
-// RUN: echo "}]" >> %/t/inputs/map.json
-
-
-// RUN: echo "[{" > %/t/inputs/map.json
-// RUN: echo "\"moduleName\": \"SomeExternalModule\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/t/inputs/SomeExternalModule.swiftmodule\"," >> %/t/inputs/map.json
-// RUN: echo "\"docPath\": \"%/t/inputs/SomeExternalModule.swiftdoc\"," >> %/t/inputs/map.json
-// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/SomeExternalModule.swiftsourceinfo\"" >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules

--- a/test/ScanDependencies/module_framework.swift
+++ b/test/ScanDependencies/module_framework.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s < %t/deps.json
+// REQUIRES: objc_interop
+
+import CryptoKit
+
+// CHECK: "mainModuleName": "deps"
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-NEXT: "swift": "CryptoKit"
+// CHECK-NEXT: }
+// CHECK-NEXT: {
+// CHECK-NEXT: "swift": "Swift"
+// CHECK-NEXT: }
+// CHECK-NEXT: {
+// CHECK-NEXT: "swift": "SwiftOnoneSupport"
+// CHECK-NEXT: }
+// CHECK-NEXT: ],
+
+// CHECK: "isFramework": true

--- a/test/ScanDependencies/module_framework.swift
+++ b/test/ScanDependencies/module_framework.swift
@@ -3,8 +3,8 @@
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json
-// REQUIRES: objc_interop
-
+// REQUIRES: OS=macosx
+  
 import CryptoKit
 
 // CHECK: "mainModuleName": "deps"

--- a/test/ScanDependencies/module_not_found.swift
+++ b/test/ScanDependencies/module_not_found.swift
@@ -7,10 +7,12 @@
 // RUN: echo "[{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
 // RUN: echo "\"modulePath\": \"%stdlib_dir/SwiftOnoneSupport.swiftmodule/%module-target-triple.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // Add the -I search path to ensure we do not accidentally implicitly load Foo.swiftmodule

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -116,7 +116,7 @@ protected:
       loader->findModuleFilesInDirectory({moduleName, SourceLoc()},
         SerializedModuleBaseName(tempDir, SerializedModuleBaseName("Library")),
         /*ModuleInterfacePath*/nullptr,
-        &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer);
+        &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer, /*IsFramework*/false);
     ASSERT_FALSE(error);
     ASSERT_FALSE(diags.hadAnyError());
 


### PR DESCRIPTION
- In the fast dependency scanner, depending on whether a module interface was found via the import search path or framework search path, encode into the dependency graph Swift module details a flag specifying whether a given module is a framework.
- And `isFramework` to the Explicit Module Map struct and its parser. 
- Refactor the `ExplicitSwiftModuleLoader` to operate at the level of `findModule` instead of `findModuleFilesInDirectory`. 
    - It doesn't really make sense for this loader to have the `SerializedModuleLoaderBase` apply it for every given search path because this loader should not be aware of the file system/search paths.
    - `findModule` is responsible for setting the `isFramework` flag for its callers. In the `SerializedModuleLoaderBase` it also passes this flag down to `findModuleFilesInDirectory` so that e.g. the `ModuleDependencyScanner` is aware of which search path produced a given module (framework or import). If we were to now set this flag inside `findModuleFilesInDirectory` some times, and accept it as input in others, that would be a huge mess.

Resolves rdar://problem/66863063
