### PR TITLE
Update the tensorflow branch to 2.3

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -367,7 +367,7 @@
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2020-08-04-a",
                 "PythonKit": "master",
                 "swift-format": "master",
-                "tensorflow": "v2.2.0-rc0",
+                "tensorflow": "v2.3",
                 "tensorflow-swift-apis": "master"
             }
         }


### PR DESCRIPTION
This is so the .bazelversion from this checkout is matched up with the bazel version required by swift-apis.