### PR TITLE
[CodeCompletion] Enable ASTScope in code completion

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -172,7 +172,7 @@ private:
   bool IsPrimary;
 
   /// The scope map that describes this source file.
-  std::unique_ptr<ASTScope> Scope;
+  NullablePtr<ASTScope> Scope = nullptr;
 
   /// The set of validated opaque return type decls in the source file.
   llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
@@ -467,6 +467,10 @@ public:
 
   /// Retrieve the scope that describes this source file.
   ASTScope &getScope();
+
+  void clearScope() {
+    Scope = nullptr;
+  }
 
   /// Retrieves the previously set delayed parser state, asserting that it
   /// exists.

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -38,6 +38,20 @@ class SourceManager {
   /// to speed up stats.
   mutable llvm::DenseMap<StringRef, llvm::vfs::Status> StatusCache;
 
+  struct ReplacedRangeType {
+    SourceRange Original;
+    SourceRange New;
+    ReplacedRangeType() {}
+    ReplacedRangeType(NoneType) {}
+    ReplacedRangeType(SourceRange Original, SourceRange New)
+        : Original(Original), New(New) {
+      assert(Original.isValid() && New.isValid());
+    }
+
+    explicit operator bool() const { return Original.isValid(); }
+  };
+  ReplacedRangeType ReplacedRange;
+
   // \c #sourceLocation directive handling.
   struct VirtualFile {
     CharSourceRange Range;
@@ -88,6 +102,9 @@ public:
   }
 
   SourceLoc getCodeCompletionLoc() const;
+
+  const ReplacedRangeType &getReplacedRange() const { return ReplacedRange; }
+  void setReplacedRange(const ReplacedRangeType &val) { ReplacedRange = val; }
 
   /// Returns true if \c LHS is before \c RHS in the source buffer.
   bool isBeforeInBuffer(SourceLoc LHS, SourceLoc RHS) const {

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -82,6 +82,15 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
   // Someday, just use the assertion below. For now, print out lots of info for
   // debugging.
   if (!startingScope) {
+
+    // Be lenient in code completion mode. There are cases where the decl
+    // context doesn't match with the ASTScope. e.g. dangling attributes.
+    // FIXME: Create ASTScope tree even for invalid code.
+    if (innermost &&
+        startingContext->getASTContext().SourceMgr.hasCodeCompletionBuffer()) {
+      return innermost;
+    }
+
     llvm::errs() << "ASTScopeImpl: resorting to startingScope hack, file: "
                  << sourceFile->getFilename() << "\n";
     // The check is costly, and inactive lookups will end up here, so don't
@@ -143,6 +152,20 @@ bool ASTScopeImpl::checkSourceRangeOfThisASTNode() const {
   return true;
 }
 
+/// If the \p loc is in a new buffer but \p range is not, consider the location
+/// is at the start of replaced range. Otherwise, returns \p loc as is.
+static SourceLoc translateLocForReplacedRange(SourceManager &sourceMgr,
+                                              SourceRange range,
+                                              SourceLoc loc) {
+  if (const auto &replacedRange = sourceMgr.getReplacedRange()) {
+    if (sourceMgr.rangeContainsTokenLoc(replacedRange.New, loc) &&
+        !sourceMgr.rangeContains(replacedRange.New, range)) {
+      return replacedRange.Original.Start;
+    }
+  }
+  return loc;
+}
+
 NullablePtr<ASTScopeImpl>
 ASTScopeImpl::findChildContaining(SourceLoc loc,
                                   SourceManager &sourceMgr) const {
@@ -152,24 +175,24 @@ ASTScopeImpl::findChildContaining(SourceLoc loc,
 
     bool operator()(const ASTScopeImpl *scope, SourceLoc loc) {
       ASTScopeAssert(scope->checkSourceRangeOfThisASTNode(), "Bad range.");
-      return -1 == ASTScopeImpl::compare(scope->getSourceRangeOfScope(), loc,
-                                         sourceMgr,
+      auto rangeOfScope = scope->getSourceRangeOfScope();
+      loc = translateLocForReplacedRange(sourceMgr, rangeOfScope, loc);
+      return -1 == ASTScopeImpl::compare(rangeOfScope, loc, sourceMgr,
                                          /*ensureDisjoint=*/false);
     }
     bool operator()(SourceLoc loc, const ASTScopeImpl *scope) {
-      ASTScopeAssert(scope->checkSourceRangeOfThisASTNode(), "Bad range.");
-      // Alternatively, we could check that loc < start-of-scope
-      return 0 >= ASTScopeImpl::compare(loc, scope->getSourceRangeOfScope(),
-                                        sourceMgr,
-                                        /*ensureDisjoint=*/false);
+      return !(*this)(scope, loc);
     }
   };
   auto *const *child = std::lower_bound(
       getChildren().begin(), getChildren().end(), loc, CompareLocs{sourceMgr});
 
-  if (child != getChildren().end() &&
-      sourceMgr.rangeContainsTokenLoc((*child)->getSourceRangeOfScope(), loc))
-    return *child;
+  if (child != getChildren().end()) {
+    auto rangeOfScope = (*child)->getSourceRangeOfScope();
+    loc = translateLocForReplacedRange(sourceMgr, rangeOfScope, loc);
+    if (sourceMgr.rangeContainsTokenLoc(rangeOfScope, loc))
+      return *child;
+  }
 
   return nullptr;
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2387,7 +2387,7 @@ StringRef SourceFile::getFilename() const {
 
 ASTScope &SourceFile::getScope() {
   if (!Scope)
-    Scope = std::unique_ptr<ASTScope>(new (getASTContext()) ASTScope(this));
+    Scope = new (getASTContext()) ASTScope(this);
   return *Scope.get();
 }
 

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -417,6 +417,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
 
     auto *AFD = cast<AbstractFunctionDecl>(DC);
     AFD->setBodyToBeReparsed(newBodyRange);
+    SM.setReplacedRange({AFD->getOriginalBodySourceRange(), newBodyRange});
 
     traceDC = AFD;
     break;

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -418,6 +418,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
     auto *AFD = cast<AbstractFunctionDecl>(DC);
     AFD->setBodyToBeReparsed(newBodyRange);
     SM.setReplacedRange({AFD->getOriginalBodySourceRange(), newBodyRange});
+    oldSF->clearScope();
 
     traceDC = AFD;
     break;
@@ -602,9 +603,6 @@ bool swift::ide::CompletionInstance::performOperation(
 
   // We don't need token list.
   Invocation.getLangOptions().CollectParsedToken = false;
-
-  // FIXME: ASTScopeLookup doesn't support code completion yet.
-  Invocation.disableASTScopeLookup();
 
   if (EnableASTCaching) {
     // Compute the signature of the invocation.

--- a/test/IDE/complete_attributes.swift
+++ b/test/IDE/complete_attributes.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP_LEVEL_ATTR_1 -code-completion-keywords=false | %FileCheck %s -check-prefix=ERROR_COMMON
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER_DECL_ATTR_1 -code-completion-keywords=false | %FileCheck %s -check-prefix=ERROR_COMMON
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ATTRARG_MEMBER | %FileCheck %s -check-prefix=MEMBER_MyValue
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ATTRARG_MEMBER_IN_CLOSURE | %FileCheck %s -check-prefix=MEMBER_MyValue
 
 // ERROR_COMMON: found code completion token
 // ERROR_COMMON-NOT: Keyword/
@@ -8,4 +10,23 @@
 
 class MemberDeclAttribute {
   @#^MEMBER_DECL_ATTR_1^# func memberDeclAttr1() {}
+}
+
+struct MyValue {
+  init() {}
+  static var val: Int
+}
+
+// MEMBER_MyValue: Begin completions, 4 items
+// MEMBER_MyValue-DAG: Keyword[self]/CurrNominal:          self[#MyValue.Type#];
+// MEMBER_MyValue-DAG: Keyword/CurrNominal:                Type[#MyValue.Type#];
+// MEMBER_MyValue-DAG: Decl[Constructor]/CurrNominal:      init()[#MyValue#];
+// MEMBER_MyValue-DAG: Decl[StaticVar]/CurrNominal:        val[#Int#];
+// MEMBER_MyValue: End completions
+
+class TestUknownDanglingAttr1 {
+  @UknownAttr(arg: MyValue.#^ATTRARG_MEMBER^#)
+}
+class TestUknownDanglingAttr2 {
+  @UknownAttr(arg: { MyValue.#^ATTRARG_MEMBER_IN_CLOSURE^# })
 }

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -349,3 +349,10 @@ struct SR_10466<T> {
 extension SR_10466 where T == Never { // expected-note {{requirement specified as 'T' == 'Never' [with T = T]}}
   typealias A = Int
 }
+
+#if true
+protocol Rdar66943328 {
+  associatedtype Assoc
+}
+extension Rdar66943328 where Assoc == Int // expected-error {{expected '{' in extension}}
+#endif


### PR DESCRIPTION
Enable ASTScope lookup (by default) in code completion.
rdar://problem/58939376

For fast-completion where the body of `AbstractFunctionDecl` might be replaced with another body parsed from another source buffer:
* Use `getOriginalBodySourceRange()` for `AbstractFunctionBodyScope`
* Remember the replaced range in `SourceManager`
* Translate source ranges for finding scopes when the lookup location is in the replaced range (`findInnermostEnclosingScope()`)
* Bypass source range checks when the child scope from the replaced range (`widenSourceRangeForChildren()` and `verifyThatChildrenAreContainedWithin `)
* Clear `ASTScope` for each completion

Unrelated to fast completion:
* Add generic params and where clause scope even with missing body
* Be lenient with `ASTScope` / `DeclContext` mismatch in code completion mode
