### PR TITLE
[5.3] [Python3] Use correct Python version for LLDB-related tests (#33181)

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | PYTHONPATH=%lldb-python-path %{python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
+// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{lldb-python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -139,6 +139,14 @@ assert darwin_sdk_build_version_cmp("11B1", "11A1") > 0
 assert darwin_sdk_build_version_cmp("11A22", "11A100") < 0
 assert darwin_sdk_build_version_cmp("11A100", "11A22") > 0
 
+def get_lldb_python_from_path(lldb_path):
+    (head, tail) = os.path.split(lldb_path)
+    if tail and re.match('^python[23][.0-9]*$', tail):
+        return tail
+    if head and head != lldb_path:
+        return get_lldb_python_from_path(head)
+    return None
+
 ###
 
 # Check that the object root is known.
@@ -1853,9 +1861,21 @@ config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 
 if config.lldb_build_root != "":
-    config.available_features.add('lldb')
     lldb_python_path = get_lldb_python_path(config.lldb_build_root)
-    config.substitutions.append(('%lldb-python-path', lldb_python_path))
+    if lldb_python_path == None:
+        lit_config.warning("""
+        Specified lldb_build_root, but could not find lldb in that build root
+        """)
+    else:
+        lldb_python = get_lldb_python_from_path(lldb_python_path)
+        if lldb_python == None:
+            lit_config.warning("""
+            Unable to determine python version from LLDB Python path %s
+            """ % lldb_python_path)
+        else:
+            config.available_features.add('lldb')
+            config.substitutions.append(('%lldb-python-path', lldb_python_path))
+            config.substitutions.append(('%{lldb-python}', 'PYTHONPATH=%s %s' % (lldb_python_path, lldb_python)))
 
 # Disable randomized hash seeding by default. Tests need to manually opt in to
 # random seeds by unsetting the SWIFT_DETERMINISTIC_HASHING environment


### PR DESCRIPTION
* Use the correct Python executable to match LLDB

The linux-fatal-backtrace script needs to run with an LLDB
module loaded into Python.  This in turn requires that the
test be run with the exact same Python version as was used
by LLDB (not just the same Python module directory).  This
can get confused on systems with multiple versions of Python
installed.

This replaces `lldb-python-path` (the Python module directory path)
with `lldb-python` (which is the correct Python version run with
the LLDB path).  This should ensure that this test is always
run with the same Python version and module that LLDB used.

* Use consistent braces for the lldb-python substitution

* Use os.path utilities to dissect paths

* Allow `python3` as a path identifier

Previous code required a decimal point before it would
recognize a path component as a Python version identifier,
so it would accept `python2.7` but not `python3`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
