### PR TITLE
Fixup IdentifierInfo Key Confusion

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1714,7 +1714,6 @@ bool ClangImporter::canImportModule(Located<Identifier> moduleID) {
 
 ModuleDecl *ClangImporter::Implementation::loadModuleClang(
     SourceLoc importLoc, ArrayRef<Located<Identifier>> path) {
-  auto &clangContext = getClangASTContext();
   auto &clangHeaderSearch = getClangPreprocessor().getHeaderSearchInfo();
 
   // Look up the top-level module first, to see if it exists at all.
@@ -1728,8 +1727,9 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
   SmallVector<std::pair<clang::IdentifierInfo *, clang::SourceLocation>, 4>
       clangPath;
   for (auto component : path) {
-    clangPath.push_back({&clangContext.Idents.get(component.Item.str()),
-                         exportSourceLoc(component.Loc)});
+    clangPath.emplace_back(
+        getClangPreprocessor().getIdentifierInfo(component.Item.str()),
+        exportSourceLoc(component.Loc));
   }
 
   auto &rawDiagClient = Instance->getDiagnosticClient();


### PR DESCRIPTION
Clang has two sources of IdentifierInfo pointers: the ASTContext and the
Preprocessor. Even though the keys from each can be used to index into
the other's tables, doing so has detrimental effects on the Clang
Importer.

At the very least, it will cause the Clang Importer to re-load modules
that should have already been cached down by implicit module builds.
This is because the module will build itself against a properly interned
key from the Preprocessor, but be looked up by a key from the ASTContext
after that.

Once in a blue moon, this may even allow Clang to return garbage to us,
though I'm still verifying that. For now, let's patch up this mess by
using the right source of keys.