### PR TITLE
[Sema] Define availability specification macros with a frontend flag

### DIFF
--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -85,6 +85,9 @@ class PlatformVersionConstraintAvailabilitySpec : public AvailabilitySpec {
 
   SourceRange VersionSrcRange;
 
+  // Location of the macro expanded to create this spec.
+  SourceLoc MacroLoc;
+
 public:
   PlatformVersionConstraintAvailabilitySpec(PlatformKind Platform,
                                             SourceLoc PlatformLoc,
@@ -116,6 +119,10 @@ public:
   llvm::VersionTuple getRuntimeVersion() const { return RuntimeVersion; }
 
   SourceRange getSourceRange() const;
+
+  // Location of the macro expanded to create this spec.
+  SourceLoc getMacroLoc() const { return MacroLoc; }
+  void setMacroLoc(SourceLoc loc) { MacroLoc = loc; }
 
   void print(raw_ostream &OS, unsigned Indent) const;
   

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1431,6 +1431,22 @@ WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
       "unexpected version number in '%0' attribute for non-specific platform "
       "'*'", (StringRef))
 
+// availability macro
+ERROR(attr_availability_wildcard_in_macro, none,
+      "future platforms identified by '*' cannot be used in "
+      "an availability macro definition", ())
+ERROR(attr_availability_missing_macro_name,none,
+      "expected an identifier to begin an availability macro definition", ())
+ERROR(attr_availability_expected_colon_macro,none,
+      "expected ':' after '%0' in availability macro definition",
+      (StringRef))
+ERROR(attr_availability_unknown_version,none,
+      "reference to undefined version '%0' for availability macro '%1'",
+      (StringRef, StringRef))
+ERROR(attr_availability_duplicate,none,
+      "duplicate definition of availability macro '%0' for version '%1'",
+      (StringRef, StringRef))
+
 // originallyDefinedIn
 ERROR(originally_defined_in_missing_rparen,none,
       "expected ')' in @_originallyDefinedIn argument list", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4922,6 +4922,10 @@ WARNING(public_decl_needs_availability, none,
         "public declarations should have an availability attribute when building "
         "with -require-explicit-availability", ())
 
+ERROR(availability_macro_in_inlinable, none,
+      "availability macro cannot be used in inlinable %0",
+      (DescriptiveDeclKind))
+
 // This doesn't display as an availability diagnostic, but it's
 // implemented there and fires when these subscripts are marked
 // unavailable, so it seems appropriate to put it here.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -111,6 +111,9 @@ namespace swift {
     /// when using RequireExplicitAvailability.
     std::string RequireExplicitAvailabilityTarget;
 
+    // Availability macros definitions to be expanded at parsing.
+    SmallVector<StringRef, 4> AvailabilityMacros;
+
     /// If false, '#file' evaluates to the full path rather than a
     /// human-readable string.
     bool EnableConcisePoundFile = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -414,6 +414,11 @@ def require_explicit_availability_target : Separate<["-"], "require-explicit-ava
   HelpText<"Suggest fix-its adding @available(<target>, *) to public declarations without availability">,
   MetaVarName<"<target>">;
 
+def define_availability : Separate<["-"], "define-availability">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Define an availability macro in the format 'macroName : iOS 13.0, macOS 10.15'">,
+  MetaVarName<"<macro>">;
+
 def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Name of the module to build">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -504,6 +504,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  for (const Arg *A : Args.filtered(OPT_define_availability)) {
+    Opts.AvailabilityMacros.push_back(A->getValue());
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_value_recursion_threshold)) {
     unsigned threshold;
     if (StringRef(A->getValue()).getAsInteger(10, threshold)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1408,8 +1408,18 @@ Parser::parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs) {
     return makeParserError(); // Failed to match the version, that's an error.
   }
 
-  Specs.append(VersionMatch->getSecond().begin(),
-               VersionMatch->getSecond().end());
+  // Make a copy of the specs to add the macro source location
+  // for the diagnostic about the use of macros in inlinable code.
+  SourceLoc MacroLoc = Tok.getLoc();
+  for (auto *Spec : VersionMatch->getSecond())
+    if (auto *PlatformVersionSpec =
+          dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec)) {
+      auto SpecCopy =
+        new (Context) PlatformVersionConstraintAvailabilitySpec(
+                                                       *PlatformVersionSpec);
+      SpecCopy->setMacroLoc(MacroLoc);
+      Specs.push_back(SpecCopy);
+    }
 
   return makeParserSuccess();
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1372,6 +1372,115 @@ void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,
   }
 }
 
+bool Parser::peekAvailabilityMacroName() {
+  parseAllAvailabilityMacroArguments();
+  AvailabilityMacroMap Map = AvailabilityMacros;
+
+  StringRef MacroName = Tok.getText();
+  return Map.find(MacroName) != Map.end();
+}
+
+ParserStatus
+Parser::parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs) {
+  // Get the macros from the compiler arguments.
+  parseAllAvailabilityMacroArguments();
+  AvailabilityMacroMap Map = AvailabilityMacros;
+
+  StringRef MacroName = Tok.getText();
+  auto NameMatch = Map.find(MacroName);
+  if (NameMatch == Map.end())
+    return makeParserSuccess(); // No match, it could be a standard platform.
+
+  consumeToken();
+
+  llvm::VersionTuple Version;
+  SourceRange VersionRange;
+  if (Tok.isAny(tok::integer_literal, tok::floating_literal)) {
+    if (parseVersionTuple(Version, VersionRange,
+                          diag::avail_query_expected_version_number))
+      return makeParserError();
+  }
+
+  auto VersionMatch = NameMatch->getSecond().find(Version);
+  if (VersionMatch == NameMatch->getSecond().end()) {
+    diagnose(PreviousLoc, diag::attr_availability_unknown_version,
+        Version.getAsString(), MacroName);
+    return makeParserError(); // Failed to match the version, that's an error.
+  }
+
+  Specs.append(VersionMatch->getSecond().begin(),
+               VersionMatch->getSecond().end());
+
+  return makeParserSuccess();
+}
+
+void Parser::parseAllAvailabilityMacroArguments() {
+
+  if (AvailabilityMacrosComputed) return;
+
+  AvailabilityMacroMap Map;
+
+  SourceManager &SM = Context.SourceMgr;
+  const LangOptions &LangOpts = Context.LangOpts;
+
+  for (StringRef macro: LangOpts.AvailabilityMacros) {
+
+    // Create temporary parser.
+    int bufferID = SM.addMemBufferCopy(macro,
+                                       "-define-availability argument");
+    swift::ParserUnit PU(SM,
+                         SourceFileKind::Main, bufferID,
+                         LangOpts,
+                         TypeCheckerOptions(), "unknown");
+
+    ForwardingDiagnosticConsumer PDC(Context.Diags);
+    PU.getDiagnosticEngine().addConsumer(PDC);
+
+    // Parse the argument.
+    AvailabilityMacroDefinition ParsedMacro;
+    ParserStatus Status =
+      PU.getParser().parseAvailabilityMacroDefinition(ParsedMacro);
+    if (Status.isError())
+      continue;
+
+    // Copy the Specs to the requesting ASTContext from the temporary context
+    // that parsed the argument.
+    auto SpecsCopy = SmallVector<AvailabilitySpec*, 4>();
+    for (auto *Spec : ParsedMacro.Specs)
+      if (auto *PlatformVersionSpec =
+          dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec)) {
+        auto SpecCopy =
+          new (Context) PlatformVersionConstraintAvailabilitySpec(
+                                                         *PlatformVersionSpec);
+        SpecsCopy.push_back(SpecCopy);
+      }
+
+    ParsedMacro.Specs = SpecsCopy;
+
+    // Find the macro info by name.
+    AvailabilityMacroVersionMap MacroDefinition;
+    auto NameMatch = Map.find(ParsedMacro.Name);
+    if (NameMatch != Map.end()) {
+      MacroDefinition = NameMatch->getSecond();
+    }
+
+    // Set the macro info by version.
+    auto PreviousEntry =
+      MacroDefinition.insert({ParsedMacro.Version, ParsedMacro.Specs});
+    if (!PreviousEntry.second) {
+      diagnose(PU.getParser().PreviousLoc, diag::attr_availability_duplicate,
+               ParsedMacro.Name, ParsedMacro.Version.getAsString());
+    }
+
+    // Save back the macro spec.
+    Map.erase(ParsedMacro.Name);
+    Map.insert({ParsedMacro.Name, MacroDefinition});
+  }
+
+  AvailabilityMacros = Map;
+  AvailabilityMacrosComputed = true;
+}
+
 bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                    DeclAttrKind DK) {
   // Ok, it is a valid attribute, eat it, and then process it.
@@ -1975,7 +2084,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     StringRef Platform = Tok.getText();
 
     if (Platform != "*" &&
-        peekToken().isAny(tok::integer_literal, tok::floating_literal)) {
+        (peekToken().isAny(tok::integer_literal, tok::floating_literal) ||
+         peekAvailabilityMacroName())) {
       // We have the short form of available: @available(iOS 8.0.1, *)
       SmallVector<AvailabilitySpec *, 5> Specs;
       ParserStatus Status = parseAvailabilitySpecList(Specs);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1183,8 +1183,10 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
 
 /// Validate availability spec list, emitting diagnostics if necessary and removing
 /// specs for unrecognized platforms.
-static void validateAvailabilitySpecList(Parser &P,
-    SmallVectorImpl<AvailabilitySpec *> &Specs) {
+static void
+validateAvailabilitySpecList(Parser &P,
+                             SmallVectorImpl<AvailabilitySpec *> &Specs,
+                             bool ParsingMacroDefinition) {
   llvm::SmallSet<PlatformKind, 4> Platforms;
   bool HasOtherPlatformSpec = false;
 
@@ -1232,8 +1234,13 @@ static void validateAvailabilitySpecList(Parser &P,
     }
   }
 
-  if (!HasOtherPlatformSpec) {
-    SourceLoc InsertWildcardLoc = Specs.back()->getSourceRange().End;
+  if (ParsingMacroDefinition) {
+    if (HasOtherPlatformSpec) {
+      SourceLoc InsertWildcardLoc = P.PreviousLoc;
+      P.diagnose(InsertWildcardLoc, diag::attr_availability_wildcard_in_macro);
+    }
+  } else if (!HasOtherPlatformSpec) {
+    SourceLoc InsertWildcardLoc = P.PreviousLoc;
     P.diagnose(InsertWildcardLoc, diag::availability_query_wildcard_required)
         .fixItInsertAfter(InsertWildcardLoc, ", *");
   }
@@ -1285,7 +1292,40 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
 }
 
 ParserStatus
-Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
+Parser::parseAvailabilityMacroDefinition(AvailabilityMacroDefinition &Result) {
+
+  // Prime the lexer.
+  if (Tok.is(tok::NUM_TOKENS))
+    consumeTokenWithoutFeedingReceiver();
+
+  if (!Tok.isIdentifierOrUnderscore()) {
+    diagnose(Tok, diag::attr_availability_missing_macro_name);
+    return makeParserError();
+  }
+
+  Result.Name = Tok.getText();
+  consumeToken();
+
+  if (Tok.isAny(tok::integer_literal, tok::floating_literal)) {
+    SourceRange VersionRange;
+    if (parseVersionTuple(Result.Version, VersionRange,
+                          diag::avail_query_expected_version_number)) {
+      return makeParserError();
+    }
+  }
+
+  if (!consumeIf(tok::colon)) {
+    diagnose(Tok, diag::attr_availability_expected_colon_macro, Result.Name);
+    return makeParserError();
+  }
+
+  return parseAvailabilitySpecList(Result.Specs,
+                                   /*ParsingMacroDefinition=*/true);
+}
+
+ParserStatus
+Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs,
+                                  bool ParsingMacroDefinition) {
   SyntaxParsingContext AvailabilitySpecContext(
       SyntaxContext, SyntaxKind::AvailabilitySpecList);
   ParserStatus Status = makeParserSuccess();
@@ -1295,14 +1335,34 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
   while (1) {
     SyntaxParsingContext AvailabilityEntryContext(
         SyntaxContext, SyntaxKind::AvailabilityArgument);
-    auto SpecResult = parseAvailabilitySpec();
-    if (auto *Spec = SpecResult.getPtrOrNull()) {
-      Specs.push_back(Spec);
-    } else {
-      if (SpecResult.hasCodeCompletion()) {
-        return makeParserCodeCompletionStatus();
+
+    // First look for a macro as we need Specs for the expansion.
+    bool MatchedAMacro = false;
+    if (!ParsingMacroDefinition && Tok.is(tok::identifier)) {
+      SmallVector<AvailabilitySpec *, 4> MacroSpecs;
+      ParserStatus MacroStatus = parseAvailabilityMacro(MacroSpecs);
+
+      if (MacroStatus.isError()) {
+        // There's a parsing error if the platform name matches a macro
+        // but something goes wrong after.
+        Status.setIsParseError();
+        MatchedAMacro = true;
+      } else {
+        MatchedAMacro = !MacroSpecs.empty();
+        Specs.append(MacroSpecs.begin(), MacroSpecs.end());
       }
-      Status.setIsParseError();
+    }
+
+    if (!MatchedAMacro) {
+      auto SpecResult = parseAvailabilitySpec();
+      if (auto *Spec = SpecResult.getPtrOrNull()) {
+        Specs.push_back(Spec);
+      } else {
+        if (SpecResult.hasCodeCompletion()) {
+          return makeParserCodeCompletionStatus();
+        }
+        Status.setIsParseError();
+      }
     }
 
     // We don't allow binary operators to combine specs.
@@ -1362,7 +1422,7 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
   }
 
   if (Status.isSuccess() && !Status.hasCodeCompletion())
-    validateAvailabilitySpecList(*this, Specs);
+    validateAvailabilitySpecList(*this, Specs, ParsingMacroDefinition);
 
   return Status;
 }

--- a/test/ModuleInterface/availability-expansion.swift
+++ b/test/ModuleInterface/availability-expansion.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck -module-name Test -emit-module-interface-path %t/Test.swiftinterface %s -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0" -define-availability "_iOS9Aligned:macOS 10.11, iOS 9.0" -define-availability "_iOS9:iOS 9.0" -define-availability "_macOS10_11:macOS 10.11" -define-availability "_myProject 1.0:macOS 10.11" -define-availability "_myProject 2.5:macOS 10.12"
+// RUN: %FileCheck %s < %t/Test.swiftinterface
+
+@available(_iOS8Aligned, *)
+public func onMacOS10_10() {}
+// CHECK: @available(macOS 10.10, iOS 8.0, *)
+// CHECK-NEXT: public func onMacOS10_10
+
+@available(_iOS9Aligned, *)
+public func onMacOS10_11() {}
+// CHECK: @available(macOS 10.11, iOS 9.0, *)
+// CHECK-NEXT: public func onMacOS10_11()
+
+@available(_iOS9, _macOS10_11, tvOS 11.0, *)
+public func composed() {}
+// CHECK: @available(iOS 9.0, macOS 10.11, tvOS 11.0, *)
+// CHECK-NEXT: public func composed()
+
+@available(_myProject 1.0, *)
+public func onMyProjectV1() {}
+// CHECK: @available(macOS 10.11, *)
+// CHECK-NEXT: public func onMyProjectV1
+
+@available(_myProject 2.5, *)
+public func onMyProjectV2_5() {}
+// CHECK: @available(macOS 10.12, *)
+// CHECK-NEXT: public func onMyProjectV2_5

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -58,3 +58,17 @@ func client() {
 
   if #available(_unknownMacro, *) { } // expected-error {{expected version number}}
 }
+
+@inlinable
+public func forbidMacrosInInlinableCode() {
+  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+}
+
+@_alwaysEmitIntoClient
+public func forbidMacrosInInlinableCode1() {
+  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+}

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -1,0 +1,60 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0" \
+// RUN:   -define-availability "_iOS9Aligned:macOS 10.11, iOS 9.0" \
+// RUN:   -define-availability "_iOS9:iOS 9.0" \
+// RUN:   -define-availability "_macOS10_11:macOS 10.11" \
+// RUN:   -define-availability "_myProject 1.0:macOS 10.11" \
+// RUN:   -define-availability "_myProject 2.5:macOS 10.12"
+// REQUIRES: OS=macosx
+
+@available(_iOS8Aligned, *)
+public func onMacOS10_10() {}
+
+@available(_iOS9Aligned, *)
+public func onMacOS10_11() {}
+
+@available(_iOS9, _macOS10_11, tvOS 11.0, *)
+public func composed() {}
+
+@available(_iOS8Aligned, *)
+@available(macOS, deprecated: 10.10)
+public func onMacOSDeprecated() {}
+
+@available(_myProject, *) // expected-error {{expected declaration}}
+// expected-error @-1 {{reference to undefined version '0' for availability macro '_myProject'}}
+public func onMyProject() {}
+
+@available(_myProject 1.0, *)
+public func onMyProjectV1() {}
+
+@available(_myProject 2.5, *)
+public func onMyProjectV2_5() {}
+
+@available(_myProject 3.0, *)// expected-error {{expected declaration}}
+// expected-error @-1 {{reference to undefined version '3.0' for availability macro '_myProject'}}
+public func onMyProjectV3() {}
+
+@available(_myProject 3_0, *)// expected-error {{expected declaration}}
+// expected-error @-1 {{expected version number}}
+public func brokenVersion() {}
+
+@available(_unkownMacro, *) // expected-error {{expected declaration}}
+// expected-error @-1 {{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
+public func unkownMacro() {}
+
+@available(_iOS9) // expected-error {{must handle potential future platforms with '*'}}
+public func noOtherOSes() {}
+
+@available(_iOS8Aligned, *)
+func client() {
+  onMacOS10_10()
+  onMacOS10_11() // expected-error {{is only available in macOS 10.11 or newer}}
+  // expected-note @-1 {{add 'if #available' version check}}
+  onMacOSDeprecated()
+
+  if #available(_iOS9Aligned, *) {
+    onMacOS10_11()
+  }
+
+  if #available(_unknownMacro, *) { } // expected-error {{expected version number}}
+}

--- a/test/Sema/availability_define_parsing.swift
+++ b/test/Sema/availability_define_parsing.swift
@@ -1,0 +1,31 @@
+// RUN: not %target-swift-frontend -typecheck %s \
+// RUN:   -define-availability "_brokenParse:a b c d" \
+// RUN:   -define-availability ":a b c d" \
+// RUN:   -define-availability "_justAName" \
+// RUN:   -define-availability "_brokenPlatforms:spaceOS 10.11" \
+// RUN:   -define-availability "_refuseWildcard:iOS 13.0, *" \
+// RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
+// RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
+// RUN:   2>&1 | %FileCheck %s
+
+// Force reading the argument macros.
+@available(_brokenPlatforms)
+public func brokenPlaforms() {}
+
+// CHECK: -define-availability argument:1:16: error: expected version number
+// CHECK-NEXT: _brokenParse:a b c d
+
+// CHECK: -define-availability argument:1:1: error: expected an identifier to begin an availability macro definition
+// CHECK-NEXT: :a b c d
+
+// CHECK: -define-availability argument:1:11: error: expected ':' after '_justAName' in availability macro definition
+// CHECK-NEXT: _justAName
+
+// CHECK: -define-availability argument:1:31: warning: unrecognized platform name 'spaceOS'
+// CHECK-NEXT: _brokenPlatforms:spaceOS 10.11
+
+// CHECK: -define-availability argument:1:27: error: future platforms identified by '*' cannot be used in an availability macro
+// CHECK-NEXT: _refuseWildcard
+
+// CHECK: duplicate definition of availability macro '_duplicateVersion' for version '1.0'
+// CHECK-NEXT: _duplicateVersion


### PR DESCRIPTION
Introduce availability macros defined by a frontend flag. This feature makes it possible to set the availability versions at the moment of compilation instead of having it hard coded in the sources. It can be used by projects with a need to change the availability depending on the compilation context while using the same sources.

The availability macro is defined with the `-define-availability` flag:

`swift-frontend MyLib.swift -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0” -define-availability "_myProject 1.0:macOS 10.12, iOS 10.0"  ...`

The macro can be used in code instead of a platform name and version:

```
@available(_iOS8Aligned, *)
public func foo() {}

// Macros can be referenced with their version and be combined with other platform specifications.
@available(_myProject 1.0, tvOS 12.0, *)
public func projectFunc() {}

func client() {
  // Macros can be used for conditional availability checks.
  if #available(_iOS8Aligned, *) {
    foo()
  }

  if #available(_myProject 1.0, tvOS 12.0, *) {
    projectFunc()
  }
}
```

The use of availability macros in the `@available` specification is expanded at parsing and should not be visible in any compiler outputs. This includes the swiftinterfaces which will show the full classic availability specification. The `foo` function in the previous will be printed in the swiftinterfaces as:

```
@available(macOS 10.10, iOS 8.0, *)
public func foo()
```

Verion numbers, or triples, are optional on macros. A macro without an explicit version defaults to the version 0.

Availability macros can’t be used in inlinable code as it is copied textually in the generated swiftinterface files. Further work would could lift this limitation.

rdar://problem/65612624