### PR TITLE
[metadata prespecialization] Add canonical prespecialization to end of type descriptors.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1326,6 +1326,10 @@ class TypeContextDescriptorFlags : public FlagSet<uint16_t> {
     /// Meaningful for all type-descriptor kinds.
     HasImportInfo = 2,
 
+    /// Set if the type descriptor has a pointer to a list of canonical 
+    /// prespecializations.
+    HasCanonicalMetadataPrespecializations = 3,
+
     // Type-specific flags:
 
     /// The kind of reference that this class makes to its resilient superclass
@@ -1392,6 +1396,8 @@ public:
   }
 
   FLAGSET_DEFINE_FLAG_ACCESSORS(HasImportInfo, hasImportInfo, setHasImportInfo)
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS(HasCanonicalMetadataPrespecializations, hasCanonicalMetadataPrespecializations, setHasCanonicalMetadataPrespecializations)
 
   FLAGSET_DEFINE_FLAG_ACCESSORS(Class_HasVTable,
                                 class_hasVTable,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3853,6 +3853,19 @@ llvm::GlobalValue *IRGenModule::defineAlias(LinkEntity entity,
   if (entry) {
     auto existingVal = cast<llvm::GlobalValue>(entry);
 
+    for (auto iterator = std::begin(LLVMUsed); iterator < std::end(LLVMUsed); ++iterator) {
+      llvm::Value *thisValue = *iterator;
+      if (thisValue == existingVal) {
+        LLVMUsed.erase(iterator);
+      }
+    }
+    for (auto iterator = std::begin(LLVMCompilerUsed); iterator < std::end(LLVMCompilerUsed); ++iterator) {
+      llvm::Value *thisValue = *iterator;
+      if (thisValue == existingVal) {
+        LLVMCompilerUsed.erase(iterator);
+      }
+    }
+
     // FIXME: MC breaks when emitting alias references on some platforms
     // (rdar://problem/22450593 ). Work around this by referring to the aliasee
     // instead.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1164,18 +1164,42 @@ void IRGenerator::emitTypeMetadataRecords() {
   }
 }
 
+void IRGenerator::
+    deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRecords(
+        IRGenModule &IGM, CanType typeWithCanonicalMetadataPrespecialization,
+        NominalTypeDecl &decl) {
+  // The accessor depends on canonical metadata records because they are
+  // returned from the function when the arguments match.
+  //
+  // TODO: Once work of looking through canonical prespecialized metadata has
+  //       been moved into getGenericMetadata, this reemission will no longer
+  //       be necessary.
+  auto *accessor = IGM.getAddrOfTypeMetadataAccessFunction(
+      decl.getDeclaredType()->getCanonicalType(), NotForDefinition);
+  accessor->deleteBody();
+  IGM.IRGen.noteUseOfMetadataAccessor(&decl);
+
+  // The type context descriptor depends on canonical metadata records because
+  // pointers to them are attached as trailing objects to it.
+  //
+  // Don't call
+  //
+  //     noteUseOfTypeContextDescriptor
+  //
+  // here because we don't want to reemit metadata.
+  emitLazyTypeContextDescriptor(IGM, &decl, RequireMetadata);
+}
+
 /// Emit any lazy definitions (of globals or functions or whatever
 /// else) that we require.
 void IRGenerator::emitLazyDefinitions() {
   while (!LazyTypeMetadata.empty() ||
          !LazySpecializedTypeMetadataRecords.empty() ||
          !LazyTypeContextDescriptors.empty() ||
-         !LazyOpaqueTypeDescriptors.empty() ||
-         !LazyFieldDescriptors.empty() ||
-         !LazyFunctionDefinitions.empty() ||
-         !LazyWitnessTables.empty() ||
-         !LazyCanonicalSpecializedMetadataAccessors.empty()) {
-
+         !LazyOpaqueTypeDescriptors.empty() || !LazyFieldDescriptors.empty() ||
+         !LazyFunctionDefinitions.empty() || !LazyWitnessTables.empty() ||
+         !LazyCanonicalSpecializedMetadataAccessors.empty() ||
+         !LazyMetadataAccessors.empty()) {
     // Emit any lazy type metadata we require.
     while (!LazyTypeMetadata.empty()) {
       NominalTypeDecl *type = LazyTypeMetadata.pop_back_val();
@@ -1187,10 +1211,23 @@ void IRGenerator::emitLazyDefinitions() {
       emitLazyTypeMetadata(*IGM.get(), type);
     }
     while (!LazySpecializedTypeMetadataRecords.empty()) {
-      CanType type = LazySpecializedTypeMetadataRecords.pop_back_val();
-      auto *nominal = type->getNominalOrBoundGenericNominal();
-      CurrentIGMPtr IGM = getGenModule(nominal->getDeclContext());
-      emitLazySpecializedGenericTypeMetadata(*IGM.get(), type);
+      CanType theType;
+      TypeMetadataCanonicality canonicality;
+      std::tie(theType, canonicality) =
+          LazySpecializedTypeMetadataRecords.pop_back_val();
+      auto *nominal = theType->getNominalOrBoundGenericNominal();
+      CurrentIGMPtr IGMPtr = getGenModule(nominal->getDeclContext());
+      auto &IGM = *IGMPtr.get();
+      // A new canonical prespecialized metadata changes both the type
+      // descriptor (adding a new entry to the trailing list of metadata) and
+      // the metadata accessor (adding a new list of generic arguments against
+      // which to compare the arguments to the function).  Consequently, it is
+      // necessary to force these to be reemitted.
+      if (canonicality == TypeMetadataCanonicality::Canonical) {
+        deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRecords(
+            IGM, theType, *nominal);
+      }
+      emitLazySpecializedGenericTypeMetadata(IGM, theType);
     }
     while (!LazyTypeContextDescriptors.empty()) {
       NominalTypeDecl *type = LazyTypeContextDescriptors.pop_back_val();
@@ -1236,15 +1273,23 @@ void IRGenerator::emitLazyDefinitions() {
           LazyCanonicalSpecializedMetadataAccessors.pop_back_val();
       auto *nominal = theType->getAnyNominal();
       assert(nominal);
-      CurrentIGMPtr IGM = getGenModule(nominal->getDeclContext());
-      emitLazyCanonicalSpecializedMetadataAccessor(*IGM.get(), theType);
+      CurrentIGMPtr IGMPtr = getGenModule(nominal->getDeclContext());
+      auto &IGM = *IGMPtr.get();
+      // TODO: Once non-canonical accessors are available, this variable should
+      //       reflect the canonicality of the accessor rather than always being
+      //       canonical.
+      auto canonicality = TypeMetadataCanonicality::Canonical;
+      if (canonicality == TypeMetadataCanonicality::Canonical) {
+        deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRecords(
+            IGM, theType, *nominal);
+      }
+      emitLazyCanonicalSpecializedMetadataAccessor(IGM, theType);
     }
-  }
-
-  while (!LazyMetadataAccessors.empty()) {
-    NominalTypeDecl *nominal = LazyMetadataAccessors.pop_back_val();
-    CurrentIGMPtr IGM = getGenModule(nominal->getDeclContext());
-    emitLazyMetadataAccessor(*IGM.get(), nominal);
+    while (!LazyMetadataAccessors.empty()) {
+      NominalTypeDecl *nominal = LazyMetadataAccessors.pop_back_val();
+      CurrentIGMPtr IGM = getGenModule(nominal->getDeclContext());
+      emitLazyMetadataAccessor(*IGM.get(), nominal);
+    }
   }
 
   FinishedEmittingLazyDefinitions = true;
@@ -1442,17 +1487,19 @@ static bool typeKindCanBePrespecialized(TypeKind theKind) {
   }
 }
 
-void IRGenerator::noteUseOfSpecializedGenericTypeMetadata(CanType type) {
-  assert(typeKindCanBePrespecialized(type->getKind()));
-  auto key = type->getAnyNominal();
+void IRGenerator::noteUseOfSpecializedGenericTypeMetadata(
+    IRGenModule &IGM, CanType theType, TypeMetadataCanonicality canonicality) {
+  assert(typeKindCanBePrespecialized(theType->getKind()));
+  auto key = theType->getAnyNominal();
   assert(key);
   assert(key->isGenericContext());
-  auto &enqueuedSpecializedTypes = CanonicalSpecializationsForGenericTypes[key];
+  auto &enqueuedSpecializedTypes =
+      MetadataPrespecializationsForGenericTypes[key];
   if (llvm::all_of(enqueuedSpecializedTypes,
-                   [&](CanType enqueued) { return enqueued != type; })) {
+                   [&](auto enqueued) { return enqueued.first != theType; })) {
     assert(!FinishedEmittingLazyDefinitions);
-    LazySpecializedTypeMetadataRecords.push_back(type);
-    enqueuedSpecializedTypes.push_back(type);
+    LazySpecializedTypeMetadataRecords.push_back({theType, canonicality});
+    enqueuedSpecializedTypes.push_back({theType, canonicality});
   }
 }
 
@@ -4032,7 +4079,8 @@ IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
   if (shouldPrespecializeGenericMetadata()) {
     if (auto nominal = concreteType->getAnyNominal()) {
       if (nominal->isGenericContext()) {
-        IRGen.noteUseOfSpecializedGenericTypeMetadata(concreteType);
+        IRGen.noteUseOfSpecializedGenericTypeMetadata(*this, concreteType,
+                                                      canonicality);
       }
     }
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -300,6 +300,10 @@ static void buildMethodDescriptorFields(IRGenModule &IGM,
 
 void IRGenModule::emitNonoverriddenMethodDescriptor(const SILVTable *VTable,
                                                     SILDeclRef declRef) {
+  auto entity = LinkEntity::forMethodDescriptor(declRef);
+
+  auto *var = cast<llvm::GlobalVariable>(getAddrOfLLVMVariable(entity, ConstantInit(), DebugTypeInfo()));
+  var->setInitializer(nullptr);
  
   ConstantInitBuilder ib(*this);
   ConstantStructBuilder sb(ib.beginStruct(MethodDescriptorStructTy));
@@ -308,7 +312,6 @@ void IRGenModule::emitNonoverriddenMethodDescriptor(const SILVTable *VTable,
   
   auto init = sb.finishAndCreateFuture();
   
-  auto entity = LinkEntity::forMethodDescriptor(declRef);
   getAddrOfLLVMVariable(entity, init, DebugTypeInfo());
 }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1218,6 +1218,7 @@ namespace {
     void setCommonFlags(TypeContextDescriptorFlags &flags) {
       setClangImportedFlags(flags);
       setMetadataInitializationKind(flags);
+      setHasCanonicalMetadataPrespecializations(flags);
     }
     
     void setClangImportedFlags(TypeContextDescriptorFlags &flags) {
@@ -1249,6 +1250,19 @@ namespace {
 
     void setMetadataInitializationKind(TypeContextDescriptorFlags &flags) {
       flags.setMetadataInitialization(MetadataInitialization);
+    }
+
+    void setHasCanonicalMetadataPrespecializations(TypeContextDescriptorFlags &flags) {
+      flags.setHasCanonicalMetadataPrespecializations(hasCanonicalMetadataPrespecializations());
+    }
+
+    bool hasCanonicalMetadataPrespecializations() {
+      return IGM.shouldPrespecializeGenericMetadata() &&
+             llvm::any_of(IGM.IRGen.metadataPrespecializationsForType(Type),
+                          [](auto pair) {
+                            return pair.second ==
+                                   TypeMetadataCanonicality::Canonical;
+                          });
     }
 
     void maybeAddMetadataInitialization() {
@@ -1310,6 +1324,28 @@ namespace {
       addIncompleteMetadata();
     }
 
+    void maybeAddCanonicalMetadataPrespecializations() {
+      if (Type->isGenericContext() && hasCanonicalMetadataPrespecializations()) {
+        asImpl().addCanonicalMetadataPrespecializations();
+      }
+    }
+
+    void addCanonicalMetadataPrespecializations() {
+      auto specializations = IGM.IRGen.metadataPrespecializationsForType(Type);
+      auto count = llvm::count_if(specializations, [](auto pair) {
+        return pair.second == TypeMetadataCanonicality::Canonical;
+      });
+      B.addInt32(count);
+      for (auto pair : specializations) {
+        if (pair.second != TypeMetadataCanonicality::Canonical) {
+          continue;
+        }
+        auto specialization = pair.first;
+        auto *metadata = IGM.getAddrOfTypeMetadata(specialization);
+        B.addRelativeAddress(metadata);
+      }
+    }
+
     // Subclasses should provide:
     // ContextDescriptorKind getContextKind();
     // void addLayoutInfo();
@@ -1335,6 +1371,11 @@ namespace {
     {
       auto &layout = IGM.getMetadataLayout(getType());
       FieldVectorOffset = layout.getFieldOffsetVectorOffset().getStatic();
+    }
+
+    void layout() {
+      super::layout();
+      maybeAddCanonicalMetadataPrespecializations();
     }
 
     ContextDescriptorKind getContextKind() {
@@ -1396,6 +1437,11 @@ namespace {
       auto &layout = IGM.getMetadataLayout(getType());
       if (layout.hasPayloadSizeOffset())
         PayloadSizeOffset = layout.getPayloadSizeOffset().getStatic();
+    }
+
+    void layout() {
+      super::layout();
+      maybeAddCanonicalMetadataPrespecializations();
     }
     
     ContextDescriptorKind getContextKind() {
@@ -1511,6 +1557,7 @@ namespace {
       addVTable();
       addOverrideTable();
       addObjCResilientClassStubInfo();
+      maybeAddCanonicalMetadataPrespecializations();
     }
 
     void addIncompleteMetadataOrRelocationFunction() {
@@ -1782,6 +1829,19 @@ namespace {
         IGM.getAddrOfObjCResilientClassStub(
           getType(), NotForDefinition,
           TypeMetadataAddress::AddressPoint));
+    }
+
+    void addCanonicalMetadataPrespecializations() {
+      super::addCanonicalMetadataPrespecializations();
+      auto specializations = IGM.IRGen.metadataPrespecializationsForType(Type);
+      for (auto pair : specializations) {
+        if (pair.second != TypeMetadataCanonicality::Canonical) {
+          continue;
+        }
+        auto specialization = pair.first;
+        auto *function = IGM.getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(specialization, NotForDefinition);
+        B.addRelativeAddress(function);
+      }
     }
   };
   

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -102,6 +102,9 @@ static FunctionPointer lookupMethod(IRGenFunction &IGF, SILDeclRef declRef) {
 
 void IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
   auto *f = getAddrOfDispatchThunk(declRef, ForDefinition);
+  if (!f->isDeclaration()) {
+    f->deleteBody();
+  }
 
   IRGenFunction IGF(*this, f);
 
@@ -163,6 +166,9 @@ IRGenModule::getAddrOfMethodLookupFunction(ClassDecl *classDecl,
 
 void IRGenModule::emitMethodLookupFunction(ClassDecl *classDecl) {
   auto *f = getAddrOfMethodLookupFunction(classDecl, ForDefinition);
+  if (!f->isDeclaration()) {
+    f->deleteBody();
+  }
 
   IRGenFunction IGF(*this, f);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -192,6 +192,11 @@ enum RequireMetadata_t : bool {
   RequireMetadata = true
 };
 
+enum class TypeMetadataCanonicality : bool {
+  Noncanonical,
+  Canonical,
+};
+
 /// The principal singleton which manages all of IR generation.
 ///
 /// The IRGenerator delegates the emission of different top-level entities
@@ -259,17 +264,20 @@ private:
   /// queued up.
   llvm::SmallPtrSet<NominalTypeDecl *, 4> LazilyEmittedFieldMetadata;
 
-  /// Maps every generic type that is specialized within the module to its
-  /// specializations.
-  llvm::DenseMap<NominalTypeDecl *, llvm::SmallVector<CanType, 4>>
-      CanonicalSpecializationsForGenericTypes;
+  /// Maps every generic type whose metadata is specialized within the module
+  /// to its specializations.
+  llvm::DenseMap<
+      NominalTypeDecl *,
+      llvm::SmallVector<std::pair<CanType, TypeMetadataCanonicality>, 4>>
+      MetadataPrespecializationsForGenericTypes;
 
   llvm::DenseMap<NominalTypeDecl *, llvm::SmallVector<CanType, 4>>
       CanonicalSpecializedAccessorsForGenericTypes;
 
   /// The queue of specialized generic types whose prespecialized metadata to
   /// emit.
-  llvm::SmallVector<CanType, 4> LazySpecializedTypeMetadataRecords;
+  llvm::SmallVector<std::pair<CanType, TypeMetadataCanonicality>, 4>
+      LazySpecializedTypeMetadataRecords;
 
   /// The queue of metadata accessors to emit.
   ///
@@ -423,10 +431,15 @@ public:
 
   void ensureRelativeSymbolCollocation(SILDefaultWitnessTable &wt);
 
-  llvm::SmallVector<CanType, 4>
-  canonicalSpecializationsForType(NominalTypeDecl *type) {
-    return CanonicalSpecializationsForGenericTypes.lookup(type);
+  llvm::SmallVector<std::pair<CanType, TypeMetadataCanonicality>, 4>
+  metadataPrespecializationsForType(NominalTypeDecl *type) {
+    return MetadataPrespecializationsForGenericTypes.lookup(type);
   }
+
+  void
+  deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRecords(
+      IRGenModule &IGM, CanType typeWithCanonicalMetadataPrespecialization,
+      NominalTypeDecl &decl);
 
   void noteUseOfMetadataAccessor(NominalTypeDecl *decl) {
     if (LazyMetadataAccessors.count(decl) == 0) {
@@ -438,7 +451,8 @@ public:
     noteUseOfTypeGlobals(type, true, RequireMetadata);
   }
 
-  void noteUseOfSpecializedGenericTypeMetadata(CanType type);
+  void noteUseOfSpecializedGenericTypeMetadata(
+      IRGenModule &IGM, CanType theType, TypeMetadataCanonicality canonicality);
   void noteUseOfCanonicalSpecializedMetadataAccessor(CanType forType);
 
   void noteUseOfTypeMetadata(CanType type) {
@@ -545,11 +559,6 @@ enum class MangledTypeRefRole {
   /// The mangled type reference is used for a default associated type
   /// witness.
   DefaultAssociatedTypeWitness,
-};
-
-enum class TypeMetadataCanonicality : bool {
-  Noncanonical,
-  Canonical,
 };
 
 /// IRGenModule - Primary class for emitting IR for global declarations.

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
@@ -9,6 +9,33 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" =
+//      CHECK: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:  %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s7Generic11OneArgumentVy0C07IntegerVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s7Generic11OneArgumentVMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -20,8 +47,31 @@ import Generic
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s7Generic11OneArgumentVy0C07IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVy0C07IntegerVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVy0C07IntegerVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
@@ -7,7 +7,33 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s8Argument03OneA0VyAA7IntegerVGMN" =
+//      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s8Argument03OneA0VMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -18,8 +44,31 @@ func consume<T>(_ t: T) {
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s8Argument03OneA0VyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s8Argument03OneA0VyAA7IntegerVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s8Argument03OneA0VyAA7IntegerVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
@@ -7,7 +7,35 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s8Argument03OneA0VyAA7IntegerVGMN" =
+//      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s8Argument03OneA0VMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i8** @"$s8Argument7IntegerVAA1PAAWP",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -18,8 +46,31 @@ func consume<T>(_ t: T) {
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s8Argument03OneA0VyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s8Argument03OneA0VyAA7IntegerVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s8Argument03OneA0VyAA7IntegerVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
@@ -8,7 +8,35 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN" =
+//      CHECK: @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:  i8**,
+// CHECK-SAME:  [[INT]],
+// CHECK-SAME:  %swift.type_descriptor*,
+// CHECK-SAME:  %swift.type*,
+// CHECK-SAME:  i8**,
+// CHECK-SAME:  i32,
+// CHECK-SAME:  i32,
+// CHECK-SAME:  i64
+// CHECK-SAME:}> <{
+//           :  i8** getelementptr inbounds (
+//           :    %swift.vwtable,
+//           :    %swift.vwtable* @"
+// CHECK-SAME:    $s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GWV
+//           :    ",
+//           :    i32 0,
+//           :    i32 0
+//           :  ),
+// CHECK-SAME:  [[INT]] 512,
+//           :  %swift.type_descriptor* @"
+// CHECK-SAME:  $s6Module11OneArgumentVMn
+//           :  ",
+// CHECK-SAME:  %swift.type* @"$s6Module7IntegerVN",
+// CHECK-SAME:  i8** @"$s6Module7IntegerVAA1P8ArgumentWP",
+// CHECK-SAME:  i32 0,
+// CHECK-SAME:  i32 {{4|8}},
+// CHECK-SAME:  i64 1
+// CHECK-SAME:}>,
+// CHECK-SAME:align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -20,8 +48,31 @@ import Module
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
@@ -7,7 +7,35 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s8Argument03OneA0VyAA7IntegerVGMN" =
+//      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s8Argument03OneA0VMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i8** @"$s8Argument7IntegerVAA1PAAWP",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -18,8 +46,31 @@ func consume<T>(_ t: T) {
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s8Argument03OneA0VyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s8Argument03OneA0VyAA7IntegerVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s8Argument03OneA0VyAA7IntegerVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
@@ -8,7 +8,43 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN" =
+//      CHECK: @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+//           :   [
+//           :     4 x i8
+//           :   ],
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s6Module11TwoArgumentVyAA7IntegerV0C0ADVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s6Module11TwoArgumentVMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s6Module7IntegerVN",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i32 {{8|16}},
+//           :   [
+//           :     4 x i8
+//           :   ] zeroinitializer,
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -20,8 +56,31 @@ import Module
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( TwoArgument(Module.Integer(13), Argument.Integer(17)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
@@ -7,7 +7,43 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s8Argument03TwoA0VyAA7IntegerVGMN" =
+//      CHECK: @"$s8Argument03TwoA0VyAA7IntegerVAEGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+//           :   [
+//           :     4 x i8
+//           :   ],
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s8Argument03TwoA0VyAA7IntegerVAEGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s8Argument03TwoA0VMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i32 {{8|16}},
+//           :   [
+//           :     4 x i8
+//           :   ] zeroinitializer,
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -18,8 +54,31 @@ func consume<T>(_ t: T) {
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s8Argument03TwoA0VyAA7IntegerVAEGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s8Argument03TwoA0VyAA7IntegerVAEGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s8Argument03TwoA0VyAA7IntegerVAEGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( TwoArgument(Integer(13), Integer(17)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
@@ -8,7 +8,33 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" =
+//      CHECK: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s7Generic11OneArgumentVy0C07IntegerVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s7Generic11OneArgumentVMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s8Argument7IntegerVN",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -20,8 +46,31 @@ import Generic
 import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s7Generic11OneArgumentVy0C07IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVy0C07IntegerVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVy0C07IntegerVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
@@ -7,7 +7,33 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK-NOT: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" =
+//      CHECK: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" = linkonce_odr hidden constant <{
+// CHECK-SAME:   i8**,
+// CHECK-SAME:   [[INT]],
+// CHECK-SAME:   %swift.type_descriptor*,
+// CHECK-SAME:   %swift.type*,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i32,
+// CHECK-SAME:   i64
+// CHECK-SAME: }> <{
+//           :   i8** getelementptr inbounds (
+//           :     %swift.vwtable,
+//           :     %swift.vwtable* @"
+// CHECK-SAME:     $s7Generic11OneArgumentVyAA7IntegerVGWV
+//           :     ",
+//           :     i32 0,
+//           :     i32 0
+//           :   ),
+// CHECK-SAME:   [[INT]] 512,
+//           :   %swift.type_descriptor* @"
+// CHECK-SAME:   $s7Generic11OneArgumentVMn
+//           :   ",
+// CHECK-SAME:   %swift.type* @"$s7Generic7IntegerVN",
+// CHECK-SAME:   i32 0,
+// CHECK-SAME:   i32 {{4|8}},
+// CHECK-SAME:   i64 1
+// CHECK-SAME: }>,
+// CHECK-SAME: align [[ALIGNMENT]]
 
 @inline(never)
 func consume<T>(_ t: T) {
@@ -18,8 +44,31 @@ func consume<T>(_ t: T) {
 import Generic
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   [[METADATA:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s7Generic11OneArgumentVyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture {{%[0-9]+}}, %swift.type* [[METADATA]])
+//      CHECK:   [[CANONICALIZED_METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @swift_getCanonicalSpecializedMetadata(
+// CHECK-SAME:     [[INT]] 0, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type,
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{
+// CHECK-SAME:           i8**,
+// CHECK-SAME:           [[INT]],
+// CHECK-SAME:           %swift.type_descriptor*,
+// CHECK-SAME:           %swift.type*,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i32,
+// CHECK-SAME:           i64
+// CHECK-SAME:         }>* @"$s7Generic11OneArgumentVyAA7IntegerVGMN" to %swift.full_type*
+// CHECK-SAME:       ),
+// CHECK-SAME:       i32 0,
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ),
+// CHECK-SAME:   %swift.type** @"$s7Generic11OneArgumentVyAA7IntegerVGMJ"
+// CHECK-SAME:   )
+// CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
+// CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[CANONICALIZED_METADATA]]
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )


### PR DESCRIPTION
Enumerating the canonical prespecializations at the end of the type descriptors enables both (1) lifting one of the limitations on cross-module prespecializations and also (2) lifting the logic for iterating through the canonical prespecializations from individual metadata accessors into getGenericMetadata.