### PR TITLE
[NFC] Fix -Wsuggest-override warnings

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -325,7 +325,7 @@ public:
   ExtraIndentStreamPrinter(raw_ostream &out, StringRef extraIndent)
   : StreamPrinter(out), ExtraIndent(extraIndent) { }
 
-  virtual void printIndent() {
+  virtual void printIndent() override {
     printText(ExtraIndent);
     StreamPrinter::printIndent();
   }

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -109,7 +109,7 @@ public:
 
 class ClangModuleLoader : public ModuleLoader {
 private:
-  virtual void anchor();
+  virtual void anchor() override;
 
 protected:
   using ModuleLoader::ModuleLoader;

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -65,7 +65,7 @@ class PrettyStackTraceRequest : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceRequest(const Request &request) : request(request) { }
 
-  void print(llvm::raw_ostream &out) const {
+  void print(llvm::raw_ostream &out) const override {
     out << "While evaluating request ";
     simple_display(out, request);
     out << "\n";
@@ -85,9 +85,9 @@ public:
   CyclicalRequestError(const Request &request, const Evaluator &evaluator)
     : request(request), evaluator(evaluator) {}
 
-  virtual void log(llvm::raw_ostream &out) const;
+  virtual void log(llvm::raw_ostream &out) const override;
 
-  virtual std::error_code convertToErrorCode() const {
+  virtual std::error_code convertToErrorCode() const override {
     // This is essentially unused, but is a temporary requirement for
     // llvm::ErrorInfo subclasses.
     llvm_unreachable("shouldn't get std::error_code from CyclicalRequestError");

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -375,7 +375,7 @@ class LambdaDeclConsumer : public VisibleDeclConsumer {
 public:
   LambdaDeclConsumer(Fn &&callback) : Callback(std::move(callback)) {}
 
-  void foundDecl(ValueDecl *VD, DeclVisibilityKind reason, DynamicLookupInfo) {
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind reason, DynamicLookupInfo) override {
     Callback(VD, reason);
   }
 };

--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -51,7 +51,7 @@ public:
   PrettyStackTraceLocation(const ASTContext &C, const char *action,
                            SourceLoc loc)
     : Context(C), Loc(loc), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printDeclDescription(llvm::raw_ostream &out, const Decl *D,
@@ -65,7 +65,7 @@ class PrettyStackTraceDecl : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceDecl(const char *action, const Decl *D)
     : TheDecl(D), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 /// PrettyStackTraceAnyFunctionRef - Observe that we are processing a specific
@@ -76,7 +76,7 @@ class PrettyStackTraceAnyFunctionRef : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceAnyFunctionRef(const char *action, AnyFunctionRef ref)
     : TheRef(ref), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printExprDescription(llvm::raw_ostream &out, Expr *E,
@@ -91,7 +91,7 @@ class PrettyStackTraceExpr : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceExpr(const ASTContext &C, const char *action, Expr *E)
     : Context(C), TheExpr(E), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printStmtDescription(llvm::raw_ostream &out, Stmt *S,
@@ -106,7 +106,7 @@ class PrettyStackTraceStmt : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceStmt(const ASTContext &C, const char *action, Stmt *S)
     : Context(C), TheStmt(S), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printPatternDescription(llvm::raw_ostream &out, Pattern *P,
@@ -121,7 +121,7 @@ class PrettyStackTracePattern : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTracePattern(const ASTContext &C, const char *action, Pattern *P)
     : Context(C), ThePattern(P), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printTypeDescription(llvm::raw_ostream &out, Type T,
@@ -135,7 +135,7 @@ class PrettyStackTraceType : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceType(const ASTContext &C, const char *action, Type type)
     : Context(C), TheType(type), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 /// PrettyStackTraceClangType - Observe that we are processing a
@@ -146,7 +146,7 @@ class PrettyStackTraceClangType : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceClangType(const char *action, const clang::Type *type)
     : TheType(type), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 /// Observe that we are processing a specific type representation.
@@ -158,7 +158,7 @@ public:
   PrettyStackTraceTypeRepr(const ASTContext &C, const char *action,
                            TypeRepr *type)
     : Context(C), TheType(type), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 /// PrettyStackTraceConformance - Observe that we are processing a
@@ -171,7 +171,7 @@ public:
   PrettyStackTraceConformance(const ASTContext &C, const char *action,
                               const ProtocolConformance *conformance)
     : Context(C), Conformance(conformance), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printConformanceDescription(llvm::raw_ostream &out,
@@ -217,7 +217,7 @@ public:
   PrettyStackTraceDifferentiabilityWitness(
       const char *action, const SILDifferentiabilityWitnessKey key)
       : Key(key), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 void printDifferentiabilityWitnessDescription(
@@ -232,7 +232,7 @@ class PrettyStackTraceDeclContext : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceDeclContext(const char *action, const DeclContext *DC)
     : DC(DC), Action(action) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 } // end namespace swift

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -148,7 +148,7 @@ public:
   };
 
 private:
-  virtual void anchor();
+  virtual void anchor() override;
   InputInfo inputInfo;
 
 public:
@@ -191,7 +191,7 @@ public:
 
 class InterpretJobAction : public JobAction {
 private:
-  virtual void anchor();
+  virtual void anchor() override;
 
 public:
   explicit InterpretJobAction()
@@ -205,7 +205,7 @@ public:
 
 class BackendJobAction : public JobAction {
 private:
-  virtual void anchor();
+  virtual void anchor() override;
   
   // In case of multi-threaded compilation, the compile-action produces multiple
   // output bitcode-files. For each bitcode-file a BackendJobAction is created.
@@ -220,7 +220,7 @@ public:
     return A->getKind() == Action::Kind::BackendJob;
   }
   
-  virtual size_t getInputIndex() const { return InputIndex; }
+  virtual size_t getInputIndex() const override { return InputIndex; }
 };
 
 class REPLJobAction : public JobAction {
@@ -231,7 +231,7 @@ public:
     RequireLLDB
   };
 private:
-  virtual void anchor();
+  virtual void anchor() override;
   Mode RequestedMode;
 public:
   REPLJobAction(Mode mode)
@@ -247,7 +247,7 @@ public:
 };
 
 class MergeModuleJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
 public:
   MergeModuleJobAction(ArrayRef<const Action *> Inputs)
       : JobAction(Action::Kind::MergeModuleJob, Inputs,
@@ -259,7 +259,7 @@ public:
 };
 
 class ModuleWrapJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
 public:
   ModuleWrapJobAction(ArrayRef<const Action *> Inputs)
       : JobAction(Action::Kind::ModuleWrapJob, Inputs,
@@ -271,7 +271,7 @@ public:
 };
 
 class AutolinkExtractJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
 public:
   AutolinkExtractJobAction(ArrayRef<const Action *> Inputs)
       : JobAction(Action::Kind::AutolinkExtractJob, Inputs,
@@ -283,7 +283,7 @@ public:
 };
 
 class GenerateDSYMJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
 public:
   explicit GenerateDSYMJobAction(const Action *Input)
       : JobAction(Action::Kind::GenerateDSYMJob, Input,
@@ -295,7 +295,7 @@ public:
 };
 
 class VerifyDebugInfoJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
 public:
   explicit VerifyDebugInfoJobAction(const Action *Input)
       : JobAction(Action::Kind::VerifyDebugInfoJob, Input,
@@ -309,7 +309,7 @@ public:
 class GeneratePCHJobAction : public JobAction {
   std::string PersistentPCHDir;
 
-  virtual void anchor();
+  virtual void anchor() override;
 public:
   GeneratePCHJobAction(const Action *Input, StringRef persistentPCHDir)
       : JobAction(Action::Kind::GeneratePCHJob, Input,
@@ -326,7 +326,7 @@ public:
 };
 
 class DynamicLinkJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
   LinkKind Kind;
 
 public:
@@ -344,7 +344,7 @@ public:
 };
 
 class StaticLinkJobAction : public JobAction {
-  virtual void anchor();
+  virtual void anchor() override;
 
 public:
   StaticLinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K)

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -181,7 +181,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                                 remote::RemoteAddress address,
-                                int *extraInhabitantIndex) const;
+                                int *extraInhabitantIndex) const override;
 
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Builtin;
@@ -208,7 +208,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                                 remote::RemoteAddress address,
-                                int *index) const;
+                                int *index) const override;
 
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Record;
@@ -299,7 +299,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                                 remote::RemoteAddress address,
-                                int *extraInhabitantIndex) const {
+                                int *extraInhabitantIndex) const override {
     if (getNumExtraInhabitants() == 0) {
       *extraInhabitantIndex = -1;
       return true;

--- a/include/swift/SIL/OptimizationRemark.h
+++ b/include/swift/SIL/OptimizationRemark.h
@@ -57,7 +57,6 @@ struct ArgumentKeyKind {
   InnerTy innerValue;
 
   ArgumentKeyKind(InnerTy value) : innerValue(value) {}
-  ArgumentKeyKind(const ArgumentKeyKind &kind) : innerValue(kind.innerValue) {}
 
   operator InnerTy() const { return innerValue; }
 

--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -39,7 +39,7 @@ public:
   PrettyStackTraceSILLocation(const char *action, SILLocation loc,
                               ASTContext &C)
     : Loc(loc), Action(action), Context(C) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 
@@ -62,7 +62,7 @@ public:
   PrettyStackTraceSILFunction(llvm::Twine &&twine, const SILFunction *func)
       : func(func), data(), action(twine.toNullTerminatedStringRef(data)) {}
 
-  virtual void print(llvm::raw_ostream &os) const;
+  virtual void print(llvm::raw_ostream &os) const override;
 
 protected:
   void printFunctionInfo(llvm::raw_ostream &out) const;
@@ -77,7 +77,7 @@ public:
   PrettyStackTraceSILNode(const char *action, const SILNode *node)
     : Node(node), Action(action) {}
 
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 } // end namespace swift

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -73,7 +73,7 @@ public:
   SymbolicValueBumpAllocator() {}
   ~SymbolicValueBumpAllocator() {}
 
-  void *allocate(unsigned long byteSize, unsigned alignment) {
+  void *allocate(unsigned long byteSize, unsigned alignment) override {
     return bumpAllocator.Allocate(byteSize, alignment);
   }
 };

--- a/include/swift/SIL/SILDebuggerClient.h
+++ b/include/swift/SIL/SILDebuggerClient.h
@@ -38,11 +38,11 @@ public:
   virtual SILValue emitLValueForVariable(VarDecl *var,
                                          SILBuilder &builder) = 0;
 
-  inline SILDebuggerClient *getAsSILDebuggerClient() {
+  inline SILDebuggerClient *getAsSILDebuggerClient() override {
     return this;
   }
 private:
-  virtual void anchor();
+  virtual void anchor() override;
 };
 
 } // namespace swift

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -99,10 +99,10 @@ public:
   bool hasUnresolvedOpenedArchetypeDefinitions();
 
   // Handling of instruction removal notifications.
-  bool needsNotifications() { return true; }
+  bool needsNotifications() override { return true; }
 
   // Handle notifications about removals of instructions.
-  void handleDeleteNotification(SILNode *node);
+  void handleDeleteNotification(SILNode *node) override;
 
   // Dump the contents.
   void dump() const;

--- a/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
+++ b/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
@@ -30,7 +30,7 @@ public:
   PrettyStackTraceSILFunctionTransform(SILFunctionTransform *SFT,
                                        unsigned PassNumber);
 
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 class PrettyStackTraceSILModuleTransform : public llvm::PrettyStackTraceEntry {
@@ -41,7 +41,7 @@ public:
   PrettyStackTraceSILModuleTransform(SILModuleTransform *SMT,
                                      unsigned PassNumber)
       : SMT(SMT), PassNumber(PassNumber) {}
-  virtual void print(llvm::raw_ostream &OS) const;
+  virtual void print(llvm::raw_ostream &OS) const override;
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
@@ -236,7 +236,7 @@ public:
   }
 
   /// Returns whether the LSValue has been initialized properly.
-  bool isValid() const {
+  bool isValid() const override {
     if (CoveringValue)
       return true;
     return LSBase::isValid();
@@ -261,7 +261,7 @@ public:
     return Path.getValue().createExtract(Base, Inst, true);
   }
 
-  void print(llvm::raw_ostream &os) {
+  void print(llvm::raw_ostream &os) override {
     if (CoveringValue) {
       os << "Covering Value";
       return;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7923,7 +7923,7 @@ void Decl::setClangNode(ClangNode Node) {
 // dependency.
 
 struct DeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Decl *D = static_cast<const Decl *>(Entity);
@@ -7936,7 +7936,7 @@ struct DeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
     }
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Decl *D = static_cast<const Decl *>(Entity);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2470,14 +2470,14 @@ SourceLoc swift::extractNearestSourceLoc(const DefaultArgumentExpr *expr) {
 // dependency.
 
 struct ExprTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Expr *E = static_cast<const Expr *>(Entity);
     OS << Expr::getKindName(E->getKind());
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Expr *E = static_cast<const Expr *>(Entity);

--- a/lib/AST/InlinableText.cpp
+++ b/lib/AST/InlinableText.cpp
@@ -78,7 +78,7 @@ struct ExtractInactiveRanges : public ASTWalker {
     ranges.push_back(charRange);
   }
 
-  bool walkToDeclPre(Decl *d) {
+  bool walkToDeclPre(Decl *d) override {
     auto icd = dyn_cast<IfConfigDecl>(d);
     if (!icd) return true;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2657,14 +2657,14 @@ const clang::Module* ModuleEntity::getAsClangModule() const {
 // dependency.
 
 struct SourceFileTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const SourceFile *SF = static_cast<const SourceFile *>(Entity);
     OS << llvm::sys::path::filename(SF->getFilename());
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     // SourceFiles don't have SourceLocs of their own; they contain them.
   }
 };

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -517,7 +517,7 @@ SourceRange ExprPattern::getSourceRange() const {
 // dependency.
 
 struct PatternTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Pattern *P = static_cast<const Pattern *>(Entity);
@@ -526,7 +526,7 @@ struct PatternTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
     }
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Pattern *P = static_cast<const Pattern *>(Entity);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1489,7 +1489,7 @@ ProtocolConformanceRef::getCanonicalConformanceRef() const {
 
 struct ProtocolConformanceTraceFormatter
     : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const ProtocolConformance *C =
@@ -1497,7 +1497,7 @@ struct ProtocolConformanceTraceFormatter
     C->printName(OS);
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const ProtocolConformance *C =

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -524,14 +524,14 @@ SwitchStmt *SwitchStmt::create(LabeledStmtInfo LabelInfo, SourceLoc SwitchLoc,
 // dependency.
 
 struct StmtTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Stmt *S = static_cast<const Stmt *>(Entity);
     OS << Stmt::getKindName(S->getKind());
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const Stmt *S = static_cast<const Stmt *>(Entity);

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -454,14 +454,14 @@ void SILBoxTypeRepr::printImpl(ASTPrinter &Printer,
 // linkage dependency.
 
 struct TypeReprTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const TypeRepr *TR = static_cast<const TypeRepr *>(Entity);
     TR->print(OS);
   }
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const TypeRepr *TR = static_cast<const TypeRepr *>(Entity);

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -87,11 +87,11 @@ namespace {
         : Command(std::move(Cmd)) {}
 
     virtual std::vector<CompileCommand>
-    getCompileCommands(StringRef FilePath) const {
+    getCompileCommands(StringRef FilePath) const override {
       return {Command};
     }
 
-    virtual std::vector<CompileCommand> getAllCompileCommands() const {
+    virtual std::vector<CompileCommand> getAllCompileCommands() const override {
       return {Command};
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8885,7 +8885,7 @@ ClangImporter::getEnumConstantName(const clang::EnumConstantDecl *enumConstant){
 // linkage dependency.
 
 struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const clang::Decl *CD = static_cast<const clang::Decl *>(Entity);
@@ -8908,7 +8908,7 @@ struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
   }
 
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     if (CSM) {

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -154,7 +154,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
           Result(result) {}
 
     void foundDecl(ValueDecl *VD, DeclVisibilityKind reason,
-                   DynamicLookupInfo) {
+                   DynamicLookupInfo) override {
       if (isMatchingMethod(VD) && !VD->shouldHideFromEditor())
         Result.push_back(VD);
     }

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -158,7 +158,7 @@ void ContextInfoCallbacks::getImplicitMembers(
         : DC(DC), CurModule(DC->getParentModule()), T(T), Result(Result) {}
 
     void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
-                   DynamicLookupInfo) {
+                   DynamicLookupInfo) override {
       if (canBeImplictMember(VD) && !VD->shouldHideFromEditor())
         Result.push_back(VD);
     }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -629,7 +629,7 @@ void SILFunction::setObjCReplacement(Identifier replacedFunc) {
 // linkage dependency.
 
 struct SILFunctionTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
-  void traceName(const void *Entity, raw_ostream &OS) const {
+  void traceName(const void *Entity, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const SILFunction *F = static_cast<const SILFunction *>(Entity);
@@ -637,7 +637,7 @@ struct SILFunctionTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
   }
 
   void traceLoc(const void *Entity, SourceManager *SM,
-                clang::SourceManager *CSM, raw_ostream &OS) const {
+                clang::SourceManager *CSM, raw_ostream &OS) const override {
     if (!Entity)
       return;
     const SILFunction *F = static_cast<const SILFunction *>(Entity);

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -537,7 +537,7 @@ class CopyForwarding {
   public:
     CopySrcUserVisitor(CopyForwarding &CPF) : CPF(CPF) {}
 
-    virtual bool visitNormalUse(SILInstruction *user) {
+    virtual bool visitNormalUse(SILInstruction *user) override {
       if (isa<LoadInst>(user))
         CPF.IsSrcLoadedFrom = true;
 
@@ -549,18 +549,18 @@ class CopyForwarding {
       // Bail on multiple uses in the same instruction to avoid complexity.
       return CPF.SrcUserInsts.insert(user).second;
     }
-    virtual bool visitTake(CopyAddrInst *take) {
+    virtual bool visitTake(CopyAddrInst *take) override {
       if (take->getSrc() == take->getDest())
         return false;
 
       CPF.TakePoints.push_back(take);
       return true;
     }
-    virtual bool visitDestroy(DestroyAddrInst *destroy) {
+    virtual bool visitDestroy(DestroyAddrInst *destroy) override {
       CPF.DestroyPoints.push_back(destroy);
       return true;
     }
-    virtual bool visitDebugValue(DebugValueAddrInst *debugValue) {
+    virtual bool visitDebugValue(DebugValueAddrInst *debugValue) override {
       return CPF.SrcDebugValueInsts.insert(debugValue).second;
     }
   };
@@ -635,17 +635,17 @@ public:
   CopyDestUserVisitor(SmallPtrSetImpl<SILInstruction *> &DestUsers)
       : DestUsers(DestUsers) {}
 
-  virtual bool visitNormalUse(SILInstruction *user) {
+  virtual bool visitNormalUse(SILInstruction *user) override {
     // Bail on multiple uses in the same instruction to avoid complexity.
     return DestUsers.insert(user).second;
   }
-  virtual bool visitTake(CopyAddrInst *take) {
+  virtual bool visitTake(CopyAddrInst *take) override {
     return DestUsers.insert(take).second;
   }
-  virtual bool visitDestroy(DestroyAddrInst *destroy) {
+  virtual bool visitDestroy(DestroyAddrInst *destroy) override {
     return DestUsers.insert(destroy).second;
   }
-  virtual bool visitDebugValue(DebugValueAddrInst *debugValue) {
+  virtual bool visitDebugValue(DebugValueAddrInst *debugValue) override {
     return DestUsers.insert(debugValue).second;
   }
 };

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1177,7 +1177,7 @@ class VarDeclMultipleReferencesChecker : public ASTWalker {
   VarDecl *varDecl;
   int count;
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
       if (DRE->getDecl() == varDecl)
         ++count;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2013,7 +2013,7 @@ public:
                                           ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator), MemberName(member) {}
 
-  bool diagnoseAsError();
+  bool diagnoseAsError() override;
 };
 
 class UnableToInferClosureParameterType final : public FailureDiagnostic {
@@ -2022,7 +2022,7 @@ public:
                                     ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator) {}
 
-  bool diagnoseAsError();
+  bool diagnoseAsError() override;
 };
 
 class UnableToInferClosureReturnType final : public FailureDiagnostic {
@@ -2031,7 +2031,7 @@ public:
                                  ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator) {}
 
-  bool diagnoseAsError();
+  bool diagnoseAsError() override;
 };
 
 class UnableToInferProtocolLiteralType final : public FailureDiagnostic {
@@ -2065,7 +2065,7 @@ public:
                                       ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator) {}
 
-  bool diagnoseAsError();
+  bool diagnoseAsError() override;
 };
 
 /// Emits a warning about an attempt to use the 'as' operator as the 'as!'

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1694,9 +1694,9 @@ class CoerceToCheckedCast final : public ContextualMismatch {
                            locator) {}
 
 public:
-  std::string getName() const { return "as to as!"; }
+  std::string getName() const override { return "as to as!"; }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static CoerceToCheckedCast *attempt(ConstraintSystem &cs, Type fromType,
                                       Type toType, ConstraintLocator *locator);
@@ -1707,11 +1707,11 @@ class RemoveInvalidCall final : public ConstraintFix {
       : ConstraintFix(cs, FixKind::RemoveCall, locator) {}
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     return "remove extraneous call from value of non-function type";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
@@ -1749,13 +1749,13 @@ class SpecifyBaseTypeForContextualMember final : public ConstraintFix {
         MemberName(member) {}
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     const auto baseName = MemberName.getBaseName();
     return "specify base type in reference to member '" +
            baseName.userFacingName().str() + "'";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
@@ -1766,9 +1766,9 @@ class SpecifyClosureParameterType final : public ConstraintFix {
       : ConstraintFix(cs, FixKind::SpecifyClosureParameterType, locator) {}
 
 public:
-  std::string getName() const;
+  std::string getName() const override;
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static SpecifyClosureParameterType *create(ConstraintSystem &cs,
                                              ConstraintLocator *locator);
@@ -1779,11 +1779,11 @@ class SpecifyClosureReturnType final : public ConstraintFix {
       : ConstraintFix(cs, FixKind::SpecifyClosureReturnType, locator) {}
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     return "specify closure return type";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static SpecifyClosureReturnType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -1794,11 +1794,11 @@ class SpecifyObjectLiteralTypeImport final : public ConstraintFix {
       : ConstraintFix(cs, FixKind::SpecifyObjectLiteralTypeImport, locator) {}
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     return "import required module to gain access to a default literal type";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static SpecifyObjectLiteralTypeImport *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
@@ -1810,11 +1810,11 @@ class AddQualifierToAccessTopLevelName final : public ConstraintFix {
       : ConstraintFix(cs, FixKind::AddQualifierToAccessTopLevelName, locator) {}
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     return "qualify reference to access top-level function";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AddQualifierToAccessTopLevelName *create(ConstraintSystem &cs,
                                                   ConstraintLocator *locator);
@@ -1825,11 +1825,11 @@ class AllowNonClassTypeToConvertToAnyObject final : public ContextualMismatch {
                                         ConstraintLocator *locator);
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     return "allow non-class type to convert to 'AnyObject'";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowNonClassTypeToConvertToAnyObject *
   create(ConstraintSystem &cs, Type type, ConstraintLocator *locator);
@@ -1852,11 +1852,11 @@ class AllowCoercionToForceCast final : public ContextualMismatch {
                            toType, locator, /*warning*/ true) {}
 
 public:
-  std::string getName() const {
+  std::string getName() const override {
     return "allow coercion to be treated as a force-cast";
   }
 
-  bool diagnose(const Solution &solution, bool asNote = false) const;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AllowCoercionToForceCast *create(ConstraintSystem &cs, Type fromType,
                                           Type toType,
@@ -1894,11 +1894,11 @@ class SpecifyKeyPathRootType final : public ConstraintFix {
         : ConstraintFix(cs, FixKind::SpecifyKeyPathRootType, locator) {}
 
   public:
-    std::string getName() const {
+    std::string getName() const override {
       return "specify key path root type";
     }
 
-    bool diagnose(const Solution &solution, bool asNote = false) const;
+    bool diagnose(const Solution &solution, bool asNote = false) const override;
 
     static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -962,12 +962,12 @@ namespace {
       public:
         StrangeInterpolationRewriter(ASTContext &Ctx) : Context(Ctx) {}
 
-        virtual bool walkToDeclPre(Decl *D) {
+        virtual bool walkToDeclPre(Decl *D) override {
           // We don't want to look inside decls.
           return false;
         }
 
-        virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+        virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
           // One InterpolatedStringLiteralExpr should never be nested inside
           // another except as a child of a CallExpr, and we don't recurse into
           // the children of CallExprs.

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -86,7 +86,7 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
 
   // MARK: - SourceEntityWalker
 
-  virtual bool walkToDeclPre(Decl *D, CharSourceRange Range);
+  virtual bool walkToDeclPre(Decl *D, CharSourceRange Range) override;
 };
 
 } // end namespace symbolgraphgen

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -317,13 +317,13 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *index) const {
+                       int *index) const override {
     return false;
   }
 
   bool projectEnumValue(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *CaseIndex) const {
+                       int *CaseIndex) const override {
     return false;
   }
 };
@@ -337,13 +337,13 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *index) const {
+                       int *index) const override {
     return false;
   }
 
   bool projectEnumValue(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *CaseIndex) const {
+                       int *CaseIndex) const override {
     return false;
   }
 };
@@ -361,14 +361,14 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *index) const {
+                       int *index) const override {
     *index = -1;
     return true;
   }
 
   bool projectEnumValue(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *CaseIndex) const {
+                       int *CaseIndex) const override {
     *CaseIndex = 0;
     return true;
   }
@@ -389,7 +389,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *index) const {
+                       int *index) const override {
     uint32_t tag = 0;
     if (!reader.readInteger(address, getSize(), &tag)) {
       return false;
@@ -404,7 +404,7 @@ public:
 
   bool projectEnumValue(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *CaseIndex) const {
+                       int *CaseIndex) const override {
     uint32_t tag = 0;
     if (!reader.readInteger(address, getSize(), &tag)) {
       return false;
@@ -433,7 +433,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *extraInhabitantIndex) const {
+                       int *extraInhabitantIndex) const override {
     FieldInfo PayloadCase = getCases()[0];
     if (getSize() < PayloadCase.TI.getSize()) {
       // Single payload enums that use a separate tag don't export any XIs
@@ -464,7 +464,7 @@ public:
 
   bool projectEnumValue(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *CaseIndex) const {
+                       int *CaseIndex) const override {
     auto PayloadCase = getCases()[0];
     auto PayloadSize = PayloadCase.TI.getSize();
     auto DiscriminatorAddress = address + PayloadSize;
@@ -550,7 +550,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *extraInhabitantIndex) const {
+                       int *extraInhabitantIndex) const override {
     unsigned long PayloadSize = getPayloadSize();
     unsigned PayloadCount = getNumPayloadCases();
     unsigned TagSize = getSize() - PayloadSize;
@@ -573,7 +573,7 @@ public:
 
   bool projectEnumValue(remote::MemoryReader &reader,
                         remote::RemoteAddress address,
-                        int *CaseIndex) const {
+                        int *CaseIndex) const override {
     unsigned long PayloadSize = getPayloadSize();
     unsigned PayloadCount = getNumPayloadCases();
     unsigned NumCases = getNumCases();
@@ -802,7 +802,7 @@ public:
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
-                       int *extraInhabitantIndex) const {
+                       int *extraInhabitantIndex) const override {
     unsigned long payloadSize = getPayloadSize();
 
     // Multi payload enums that use spare bits export unused tag values as XIs.
@@ -879,7 +879,7 @@ public:
 
   bool projectEnumValue(remote::MemoryReader &reader,
                         remote::RemoteAddress address,
-                        int *CaseIndex) const {
+                        int *CaseIndex) const override {
     unsigned long payloadSize = getPayloadSize();
     unsigned NumPayloadCases = getNumPayloadCases();
 

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -247,16 +247,16 @@ struct ReflectionMirrorImpl {
 
 // Implementation for tuples.
 struct TupleImpl : ReflectionMirrorImpl {
-  char displayStyle() {
+  char displayStyle() override {
     return 't';
   }
   
-  intptr_t count() {
+  intptr_t count() override {
     auto *Tuple = static_cast<const TupleTypeMetadata *>(type);
     return Tuple->NumElements;
   }
   
-  intptr_t childOffset(intptr_t i) {
+  intptr_t childOffset(intptr_t i) override {
     auto *Tuple = static_cast<const TupleTypeMetadata *>(type);
 
     if (i < 0 || (size_t)i > Tuple->NumElements)
@@ -268,7 +268,7 @@ struct TupleImpl : ReflectionMirrorImpl {
   }
 
   const FieldType childMetadata(intptr_t i, const char **outName,
-                                void (**outFreeFunc)(const char *)) {
+                                void (**outFreeFunc)(const char *)) override {
     auto *Tuple = static_cast<const TupleTypeMetadata *>(type);
 
     if (i < 0 || (size_t)i > Tuple->NumElements)
@@ -306,7 +306,7 @@ struct TupleImpl : ReflectionMirrorImpl {
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
+                      void (**outFreeFunc)(const char *)) override {
     auto eltOffset = childOffset(i);
     auto fieldType = childMetadata(i, outName, outFreeFunc);
 
@@ -437,11 +437,11 @@ struct StructImpl : ReflectionMirrorImpl {
     return Description->isReflectable();
   }
 
-  char displayStyle() {
+  char displayStyle() override {
     return 's';
   }
   
-  intptr_t count() {
+  intptr_t count() override {
     if (!isReflectable()) {
       return 0;
     }
@@ -450,7 +450,7 @@ struct StructImpl : ReflectionMirrorImpl {
     return Struct->getDescription()->NumFields;
   }
 
-  intptr_t childOffset(intptr_t i) {
+  intptr_t childOffset(intptr_t i) override {
     auto *Struct = static_cast<const StructMetadata *>(type);
 
     if (i < 0 || (size_t)i > Struct->getDescription()->NumFields)
@@ -461,7 +461,7 @@ struct StructImpl : ReflectionMirrorImpl {
   }
 
   const FieldType childMetadata(intptr_t i, const char **outName,
-                                void (**outFreeFunc)(const char *)) {
+                                void (**outFreeFunc)(const char *)) override {
     StringRef name;
     FieldType fieldInfo;
     std::tie(name, fieldInfo) = getFieldAt(type, i);
@@ -474,7 +474,7 @@ struct StructImpl : ReflectionMirrorImpl {
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
+                      void (**outFreeFunc)(const char *)) override {
     auto fieldInfo = childMetadata(i, outName, outFreeFunc);
 
     auto *bytes = reinterpret_cast<char*>(value);
@@ -516,11 +516,11 @@ struct EnumImpl : ReflectionMirrorImpl {
     return name.data();
   }
 
-  char displayStyle() {
+  char displayStyle() override {
     return 'e';
   }
   
-  intptr_t count() {
+  intptr_t count() override {
     if (!isReflectable()) {
       return 0;
     }
@@ -535,17 +535,17 @@ struct EnumImpl : ReflectionMirrorImpl {
     return (payloadType != nullptr) ? 1 : 0;
   }
 
-  intptr_t childOffset(intptr_t i) {
+  intptr_t childOffset(intptr_t i) override {
     return 0;
   }
 
   const FieldType childMetadata(intptr_t i, const char **outName,
-                                void (**outFreeFunc)(const char *)) {
+                                void (**outFreeFunc)(const char *)) override {
     return FieldType();
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
+                      void (**outFreeFunc)(const char *)) override {
     unsigned tag;
     const Metadata *payloadType;
     bool indirect;
@@ -589,7 +589,7 @@ struct EnumImpl : ReflectionMirrorImpl {
     return AnyReturn(result);
   }
   
-  const char *enumCaseName() {
+  const char *enumCaseName() override {
     if (!isReflectable()) {
       return nullptr;
     }
@@ -607,7 +607,7 @@ struct ClassImpl : ReflectionMirrorImpl {
     return Description->isReflectable();
   }
 
-  char displayStyle() {
+  char displayStyle() override {
     return 'c';
   }
   
@@ -635,7 +635,7 @@ struct ClassImpl : ReflectionMirrorImpl {
     swift::crash("No superclass mirror found");
   }
 
-  intptr_t count() {
+  intptr_t count() override {
     if (!isReflectable())
       return 0;
 
@@ -646,7 +646,7 @@ struct ClassImpl : ReflectionMirrorImpl {
     return count;
   }
 
-  intptr_t recursiveCount() {
+  intptr_t recursiveCount() override {
     if (hasSuperclassMirror()) {
       return superclassMirror().recursiveCount() + count();
     }
@@ -654,7 +654,7 @@ struct ClassImpl : ReflectionMirrorImpl {
     return count();
   }
 
-  intptr_t childOffset(intptr_t i) {
+  intptr_t childOffset(intptr_t i) override {
     auto *Clas = static_cast<const ClassMetadata*>(type);
     auto description = Clas->getDescription();
 
@@ -679,7 +679,7 @@ struct ClassImpl : ReflectionMirrorImpl {
     return (intptr_t)fieldOffset;
   }
 
-  intptr_t recursiveChildOffset(intptr_t i) {
+  intptr_t recursiveChildOffset(intptr_t i) override {
     if (hasSuperclassMirror()) {
       auto superMirror = superclassMirror();
       auto superclassFieldCount = superMirror.recursiveCount();
@@ -695,7 +695,7 @@ struct ClassImpl : ReflectionMirrorImpl {
   }
 
   const FieldType childMetadata(intptr_t i, const char **outName,
-                                void (**outFreeFunc)(const char *)) {
+                                void (**outFreeFunc)(const char *)) override {
     StringRef name;
     FieldType fieldInfo;
     std::tie(name, fieldInfo) = getFieldAt(type, i);
@@ -709,8 +709,7 @@ struct ClassImpl : ReflectionMirrorImpl {
 
   const FieldType recursiveChildMetadata(intptr_t i,
                                          const char **outName,
-                                         void (**outFreeFunc)(const char *))
-  {
+                                         void (**outFreeFunc)(const char *)) override {
     if (hasSuperclassMirror()) {
       auto superMirror = superclassMirror();
       auto superclassFieldCount = superMirror.recursiveCount();
@@ -726,7 +725,7 @@ struct ClassImpl : ReflectionMirrorImpl {
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
-                      void (**outFreeFunc)(const char *)) {
+                      void (**outFreeFunc)(const char *)) override {
     auto fieldInfo = childMetadata(i, outName, outFreeFunc);
 
     auto *bytes = *reinterpret_cast<char * const *>(value);
@@ -794,25 +793,25 @@ struct ObjCClassImpl : ClassImpl {
 
 // Implementation for metatypes.
 struct MetatypeImpl : ReflectionMirrorImpl {
-  char displayStyle() {
+  char displayStyle() override {
     return '\0';
   }
   
-  intptr_t count() {
+  intptr_t count() override {
     return 0;
   }
 
-  intptr_t childOffset(intptr_t i) {
+  intptr_t childOffset(intptr_t i) override {
     swift::crash("Metatypes have no children.");
   }
 
   const FieldType childMetadata(intptr_t i, const char **outName,
-                                void (**outFreeFunc)(const char *)) {
+                                void (**outFreeFunc)(const char *)) override {
     swift::crash("Metatypes have no children.");
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
-                    void (**outFreeFunc)(const char *)) {
+                    void (**outFreeFunc)(const char *)) override {
     swift::crash("Metatypes have no children.");
   }
 };
@@ -820,25 +819,25 @@ struct MetatypeImpl : ReflectionMirrorImpl {
 
 // Implementation for opaque types.
 struct OpaqueImpl : ReflectionMirrorImpl {
-  char displayStyle() {
+  char displayStyle() override {
     return '\0';
   }
   
-  intptr_t count() {
+  intptr_t count() override {
     return 0;
   }
   
-  intptr_t childOffset(intptr_t i) {
+  intptr_t childOffset(intptr_t i) override {
     swift::crash("Opaque types have no children.");
   }
 
   const FieldType childMetadata(intptr_t i, const char **outName,
-                                void (**outFreeFunc)(const char *)) {
+                                void (**outFreeFunc)(const char *)) override {
     swift::crash("Opaque types have no children.");
   }
 
   AnyReturn subscript(intptr_t i, const char **outName,
-                    void (**outFreeFunc)(const char *)) {
+                    void (**outFreeFunc)(const char *)) override {
     swift::crash("Opaque types have no children.");
   }
 };


### PR DESCRIPTION
LLVM, as of 77e0e9e17daf0865620abcd41f692ab0642367c4, now builds with -Wsuggest-override. Let's clean up the swift sources rather than disable the warning locally.