### PR TITLE
[docs] Update Testing.md

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,4 +1,3 @@
-
 # Testing Swift
 
 This document describes how we test the Swift compiler, the Swift runtime, and
@@ -28,7 +27,8 @@ We use multiple approaches to test the Swift toolchain.
   skips the iOS, tvOS, and watchOS platforms.
 
 The [test/lit.cfg](https://github.com/apple/swift/blob/master/test/lit.cfg)
-uses an iOS 10.3 simulator configuration named "iPhone 5" for 32-bit testing.
+uses an iOS 10.3 simulator configuration named "iPhone 5", for 32-bit testing
+on Intel-based Macs.
 
 1.  Download and install the iOS 10.3 simulator runtime, in Xcode's
     [Components](https://help.apple.com/xcode/#/deva7379ae35) preferences.
@@ -38,7 +38,9 @@ uses an iOS 10.3 simulator configuration named "iPhone 5" for 32-bit testing.
     window, or with the command line:
 
     ```sh
-    xcrun simctl create 'iPhone 5' com.apple.CoreSimulator.SimDeviceType.iPhone-5 com.apple.CoreSimulator.SimRuntime.iOS-10-3
+    xcrun simctl create 'iPhone 5' \
+      com.apple.CoreSimulator.SimDeviceType.iPhone-5 \
+      com.apple.CoreSimulator.SimRuntime.iOS-10-3
     ```
 
 3.  Append `--ios` to the `utils/build-script` command line (see below).


### PR DESCRIPTION
32-bit processes are not supported on Macs with Apple silicon (see Xcode 12 Release Notes).