### PR TITLE
[DNM/SILGen] Default argument generator visibility.

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -260,7 +260,7 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   // if the function was type-checked in Swift 4 mode.
   if (kind == SILDeclRef::Kind::DefaultArgGenerator) {
     if (isSerialized())
-      return maybeAddExternal(SILLinkage::PublicNonABI);
+      return maybeAddExternal(SILLinkage::Public);
   }
 
   enum class Limit {


### PR DESCRIPTION
Hi Apple,

Thought I’d raise this PR as a possible change to make default argument generators non-hidden which would help me (in the long term) resolve an issue I’m seeing with [“code Injection”](https://github.com/johnno1962/InjectionIII) for Swift. If a user tries to inject code which contains a call to a function using a default argument, InjectionIII fails as is shown in [this issue](https://github.com/johnno1962/InjectionIII/issues/201#issuecomment-672857073). This is because while the function is public and accessible the default argument generators are "hidden" and the symbol is not available for dynamic linking which seems inconsistent.

Is there any chance it would be possible these functions be emitted public then this issue would not arise. @slavapestov, I see you made [this commit](https://github.com/apple/swift/pull/13934) for which I’m sure there are ABI “reasons” but could this be revisited specifically for default argument generators? At present I’m having to suggest users work around by running a program that patches object files to publish these symbols.

Cheers,