### PR TITLE
IRGen: be less aggressive about applying COMDAT

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2024,8 +2024,10 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM,
     IGM.Module.getFunctionList().push_back(fn);
   }
 
-  ApplyIRLinkage({linkInfo.getLinkage(), linkInfo.getVisibility(), linkInfo.getDLLStorage()})
-      .to(fn);
+  ApplyIRLinkage({linkInfo.getLinkage(),
+                  linkInfo.getVisibility(),
+                  linkInfo.getDLLStorage()})
+      .to(fn, linkInfo.isForDefinition());
 
   llvm::AttrBuilder initialAttrs;
   IGM.constructInitialFnAttributes(initialAttrs, FuncOptMode);
@@ -2082,7 +2084,7 @@ llvm::GlobalVariable *swift::irgen::createVariable(
   ApplyIRLinkage({linkInfo.getLinkage(),
                   linkInfo.getVisibility(),
                   linkInfo.getDLLStorage()})
-      .to(var);
+      .to(var, linkInfo.isForDefinition());
   var->setAlignment(llvm::MaybeAlign(alignment.getValue()));
 
   // Everything externally visible is considered used in Swift.
@@ -4742,7 +4744,7 @@ IRGenModule::getAddrOfWitnessTableLazyAccessFunction(
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
   entry = createFunction(*this, link, signature);
   ApplyIRLinkage({link.getLinkage(), link.getVisibility(), link.getDLLStorage()})
-      .to(entry);
+      .to(entry, link.isForDefinition());
   return entry;
 }
 

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1329,7 +1329,7 @@ void IRGenModule::emitSILProperty(SILProperty *prop) {
       ApplyIRLinkage({linkInfo.getLinkage(),
                       linkInfo.getVisibility(),
                       llvm::GlobalValue::DLLExportStorageClass})
-          .to(GA);
+          .to(GA, linkInfo.isForDefinition());
     }
     return;
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3635,7 +3635,7 @@ static void emitObjCClassSymbol(IRGenModule &IGM,
       ptrTy->getElementType(), ptrTy->getAddressSpace(), link.getLinkage(),
       link.getName(), metadata, &IGM.Module);
   ApplyIRLinkage({link.getLinkage(), link.getVisibility(), link.getDLLStorage()})
-      .to(alias);
+      .to(alias, link.isForDefinition());
 }
 
 /// Emit the type metadata or metadata template for a class.

--- a/test/IRGen/Inputs/comdat1.swift
+++ b/test/IRGen/Inputs/comdat1.swift
@@ -1,0 +1,5 @@
+private final class C {}
+public func f() {
+  var cs: [C] = []
+  cs.append(C())
+}

--- a/test/IRGen/Inputs/comdat2.swift
+++ b/test/IRGen/Inputs/comdat2.swift
@@ -1,0 +1,4 @@
+public func g() {
+  var a: [Int] = []
+  a.append(1)
+}

--- a/test/IRGen/comdat.swift
+++ b/test/IRGen/comdat.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/comdat1.swift %S/Inputs/comdat2.swift -O -num-threads 1 -module-name comdat -o %t/comdat1.ll -o %t/comdat2.ll
+// RUN: %FileCheck -check-prefix CHECK-1 %s < %t/comdat1.ll
+// RUN: %FileCheck -check-prefix CHECK-2 %s < %t/comdat2.ll
+
+// REQUIRES: OS=windows-msvc
+
+// Ensure that the definition is marked as COMDAT
+// CHECK-1: "$s6comdat1C33_{{.*}}LLCMa" = comdat any
+// CHECK-1: "$s6comdat1C33_{{.*}}LLCMn" = comdat any
+
+// Ensure that no foward declaration is emitted
+// CHECK-2-NOT: "$s6comdat1C33_{{.*}}LLCMa" = comdat any
+// CHECK-2-NOT: "$s6comdat1C33_{{.*}}LLCMn" = comdat any


### PR DESCRIPTION
COMDAT can only be applied to definitions, not declarations.  This
manifested in builds of llbuild with SwiftPM on Windows.  The nominal
type descriptor accessor declaration was marked as COMDAT.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
