### PR TITLE
[Concurrency] Treat 'await' as a contextual keyword.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -379,7 +379,7 @@ done:
 /// parseExprSequenceElement
 ///
 ///   expr-sequence-element(Mode):
-///     '__await' expr-sequence-element(Mode)
+///     'await' expr-sequence-element(Mode)
 ///     'try' expr-sequence-element(Mode)
 ///     'try' '?' expr-sequence-element(Mode)
 ///     'try' '!' expr-sequence-element(Mode)
@@ -392,8 +392,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   SyntaxParsingContext ElementContext(SyntaxContext,
                                       SyntaxContextKind::Expr);
 
-  if (shouldParseExperimentalConcurrency() && Tok.is(tok::kw___await)) {
-    SourceLoc awaitLoc = consumeToken(tok::kw___await);
+  if (shouldParseExperimentalConcurrency() && Tok.isContextualKeyword("await")) {
+    SourceLoc awaitLoc = consumeToken();
     ParserResult<Expr> sub = parseExprUnary(message, isExprBasic);
     if (!sub.hasCodeCompletion() && !sub.isNull()) {
       ElementContext.setCreateSyntax(SyntaxKind::AwaitExpr);

--- a/test/Parse/async-syntax.swift
+++ b/test/Parse/async-syntax.swift
@@ -12,11 +12,15 @@ func testTypeExprs() {
 }
 
 func testAwaitOperator() async {
-  let _ = __await asyncGlobal1()
+  let _ = await asyncGlobal1()
 }
 
 func testAsyncClosure() {
   let _ = { () async in 5 }
   let _ = { () throws in 5 }
   let _ = { () async throws in 5 }
+}
+
+func testAwait() async {
+  let _ = await asyncGlobal1()
 }

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -41,3 +41,14 @@ func testTypeExprs() {
 
   let _ = [() -> async ()]() // expected-error{{'async' may only occur before '->'}}{{18-24=}}{{15-15=async }}
 }
+
+// Parsing await syntax.
+struct MyFuture {
+  func await() -> Int { 0 }
+}
+
+func testAwaitExpr() async {
+  let _ = await asyncGlobal1()
+  let myFuture = MyFuture()
+  let _ = myFuture.await()
+}

--- a/test/Syntax/Parser/async.swift
+++ b/test/Syntax/Parser/async.swift
@@ -16,7 +16,7 @@ func testTypeExprs() {
 }
 
 func testAwaitOperator() async {
-  let _ = __await asyncGlobal1()
+  let _ = await asyncGlobal1()
 }
 
 func testAsyncClosure() {

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
 
 func test1(asyncfp : () async -> Int, fp : () -> Int) async {
-  _ = __await asyncfp()
-  _ = __await asyncfp() + asyncfp()
-  _ = __await asyncfp() + fp()
-  _ = __await fp() + 42  // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
+  _ = await asyncfp()
+  _ = await asyncfp() + asyncfp()
+  _ = await asyncfp() + fp()
+  _ = await fp() + 42  // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
   _ = asyncfp() // expected-error {{call is 'async' but is not marked with 'await'}}
 }
 
@@ -12,25 +12,25 @@ func getInt() async -> Int { return 5 }
 
 // Locations where "await" is prohibited.
 func test2(
-  defaulted: Int = __await getInt() // expected-error{{'async' call cannot occur in a default argument}}
+  defaulted: Int = await getInt() // expected-error{{'async' call cannot occur in a default argument}}
 ) async {
   defer {
-    _ = __await getInt() // expected-error{{'async' call cannot occur in a defer body}}
+    _ = await getInt() // expected-error{{'async' call cannot occur in a defer body}}
   }
   print("foo")
 }
 
 func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}}
-  _ = __await getInt() // expected-error{{'async' in a function that does not support concurrency}}
+  _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
 }
 
 enum SomeEnum: Int {
-case foo = __await 5 // expected-error{{raw value for enum case must be a literal}}
+case foo = await 5 // expected-error{{raw value for enum case must be a literal}}
 }
 
 struct SomeStruct {
-  var x = __await getInt() // expected-error{{'async' call cannot occur in a property initializer}}
-  static var y = __await getInt() // expected-error{{'async' call cannot occur in a global variable initializer}}
+  var x = await getInt() // expected-error{{'async' call cannot occur in a property initializer}}
+  static var y = await getInt() // expected-error{{'async' call cannot occur in a global variable initializer}}
 }
 
 func acceptAutoclosureNonAsync(_: @autoclosure () -> Int) async { }
@@ -46,27 +46,27 @@ struct HasAsyncBad {
 }
 
 func testAutoclosure() async {
-  __await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument is not marked with 'await'}}
-  __await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
+  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument is not marked with 'await'}}
+  await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 
-  __await acceptAutoclosureAsync(__await getInt())
-  __await acceptAutoclosureNonAsync(__await getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
+  await acceptAutoclosureAsync(await getInt())
+  await acceptAutoclosureNonAsync(await getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 
-  __await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument is not marked with 'await'}}
-  __await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
+  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument is not marked with 'await'}}
+  await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 }
 
 // Test inference of 'async' from the body of a closure.
 func testClosure() {
   let closure = {
-     __await getInt()
+     await getInt()
   }
 
   let _: () -> Int = closure // expected-error{{cannot convert value of type '() async -> Int' to specified type '() -> Int'}}
 
   let closure2 = { () async -> Int in
     print("here")
-    return __await getInt()
+    return await getInt()
   }
 
   let _: () -> Int = closure2 // expected-error{{cannot convert value of type '() async -> Int' to specified type '() -> Int'}}

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -49,7 +49,9 @@ EXPR_NODES = [
     # await foo()
     Node('AwaitExpr', kind='Expr',
          children=[
-             Child('AwaitKeyword', kind='AwaitToken'),
+             Child('AwaitKeyword', kind='IdentifierToken',
+                   classification='Keyword',
+                   text_choices=['await']),
              Child('Expression', kind='Expr'),
          ]),
 

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -196,7 +196,6 @@ SYNTAX_TOKENS = [
     ExprKeyword('True', 'true', serialization_code=51),
     ExprKeyword('Try', 'try', serialization_code=52),
     ExprKeyword('Throws', 'throws', serialization_code=53),
-    ExprKeyword('Await', '__await', serialization_code=123),
 
     Keyword('__FILE__', '__FILE__', serialization_code=54),
     Keyword('__LINE__', '__LINE__', serialization_code=55),


### PR DESCRIPTION
Replace the uglified '__await' keyword with a contextual keyword
'await'. This is more of what we would actually want for the
concurrency model.

When concurrency is enabled, this will be a source-breaking change,
because this is valid Swift code today:

```swift
  struct MyFuture<T> {
    func await() ->  }
    func doSomething() {
      let result = await()
    }
  }
```

but the call to `await()` will be parsed as an await expression when
concurrency is enabled. The source break is behind the experimental
concurrency flag, but this way we can see how much of an issue it is
in practice.
