### PR TITLE
[ConstraintLocator] Always store the PathElementKind in each locator path element.

### DIFF
--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -32,54 +32,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, ASTNode anchor,
   id.AddInteger(path.size());
   for (auto elt : path) {
     id.AddInteger(elt.getKind());
-    switch (elt.getKind()) {
-    case GenericParameter:
-      id.AddPointer(elt.castTo<LocatorPathElt::GenericParameter>().getType());
-      break;
-
-    case ProtocolRequirement: {
-      auto reqElt = elt.castTo<LocatorPathElt::ProtocolRequirement>();
-      id.AddPointer(reqElt.getDecl());
-      break;
-    }
-
-    case Witness:
-      id.AddPointer(elt.castTo<LocatorPathElt::Witness>().getDecl());
-      break;
-
-    case KeyPathDynamicMember: {
-      auto kpElt = elt.castTo<LocatorPathElt::KeyPathDynamicMember>();
-      id.AddPointer(kpElt.getKeyPathDecl());
-      break;
-    }
-
-    case PatternMatch:
-      id.AddPointer(elt.castTo<LocatorPathElt::PatternMatch>().getPattern());
-      break;
-
-    case ArgumentAttribute:
-    case GenericArgument:
-    case NamedTupleElement:
-    case TupleElement:
-    case ApplyArgToParam:
-    case OpenedGeneric:
-    case KeyPathComponent:
-    case ConditionalRequirement:
-    case TypeParameterRequirement:
-    case ContextualType:
-    case SynthesizedArgument:
-    case TernaryBranch:
-    case ClosureBody: {
-      auto numValues = numNumericValuesInPathElement(elt.getKind());
-      for (unsigned i = 0; i < numValues; ++i)
-        id.AddInteger(elt.getValue(i));
-      break;
-    }
-#define SIMPLE_LOCATOR_PATH_ELT(Name) case Name :
-#include "ConstraintLocatorPathElts.def"
-    // Nothing to do for simple locator elements.
-    break;
-    }
+    id.AddInteger(elt.getRawStorage());
   }
 }
 

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -64,42 +64,6 @@ public:
 #include "ConstraintLocatorPathElts.def"
   };
 
-  /// Determine the number of numeric values used for the given path
-  /// element kind.
-  static unsigned numNumericValuesInPathElement(PathElementKind kind) {
-    switch (kind) {
-#define SIMPLE_LOCATOR_PATH_ELT(Name) case Name :
-#include "ConstraintLocatorPathElts.def"
-    case GenericParameter:
-    case ProtocolRequirement:
-    case Witness:
-    case PatternMatch:
-      return 0;
-
-    case ClosureBody:
-    case ContextualType:
-    case OpenedGeneric:
-    case GenericArgument:
-    case NamedTupleElement:
-    case TupleElement:
-    case KeyPathComponent:
-    case SynthesizedArgument:
-    case KeyPathDynamicMember:
-    case TernaryBranch:
-    case ArgumentAttribute:
-      return 1;
-
-    case TypeParameterRequirement:
-    case ConditionalRequirement:
-      return 2;
-
-    case ApplyArgToParam:
-      return 3;
-    }
-
-    llvm_unreachable("Unhandled PathElementKind in switch.");
-  }
-
   /// Flags for efficiently recording certain information about a path.
   /// All of this information should be re-derivable from the path.
   ///
@@ -120,97 +84,18 @@ public:
   /// a kind (PathElementKind) and a value used to describe specific
   /// kinds further (e.g., the position of a tuple element).
   class PathElement {
-    /// Describes the kind of data stored here.
-    enum StoredKind : unsigned char {
-      StoredPointer,
-      StoredInteger,
-    };
-
     PathElementKind kind;
 
-    /// The actual storage for the path element, which involves both a
-    /// storage kind and a value.
-    ///
-    /// The current storage involves a three-bit "storage kind", which selects
-    /// among the possible value stores. The value stores can either be a
-    /// pointer or an unsigned int. Use \c getValue or \c getStoredPointer
-    /// to work with this value.
-    ///
-    /// \note The "storage kind" is stored in the  \c storedKind field.
-    uint64_t storage : 61;
-
-    /// The kind of value stored in \c storage. Valid values are those
-    /// from the StoredKind enum.
-    uint64_t storedKind : 3;
-
-    /// Retrieve a value associated with the path element.
-    unsigned getValue(unsigned index) const {
-      unsigned numValues = numNumericValuesInPathElement(getKind());
-      assert(index < numValues && "Index out of range for path element value");
-
-      // We pack values into 16 bit components of the storage, with value0
-      // being stored in the upper bits, valueN in the lower bits. Therefore we
-      // need to shift out any extra values in the lower bits.
-      auto extraValues = numValues - index - 1;
-      auto value = storage >> (extraValues * 16);
-      return value & 0xFFFF;
-    }
-
-    PathElement(PathElementKind kind, unsigned value)
-      : kind(kind), storage(value), storedKind(StoredInteger)
-    {
-      assert(numNumericValuesInPathElement(kind) == 1 &&
-             "Path element kind does not require 1 value");
-      assert(value == getValue(0) && "value truncated");
-    }
-
-    PathElement(PathElementKind kind, unsigned value0, unsigned value1)
-      : kind(kind), storage(value0 << 16 | value1),
-        storedKind(StoredInteger)
-    {
-      assert(numNumericValuesInPathElement(kind) == 2 &&
-             "Path element kind does not require 2 values");
-      assert(value0 == getValue(0) && "value0 truncated");
-      assert(value1 == getValue(1) && "value1 truncated");
-    }
-
-    PathElement(PathElementKind kind, uint64_t value0, uint64_t value1, uint64_t value2)
-        : kind(kind), storage(value0 << 32 | value1 << 16 | value2),
-          storedKind(StoredInteger) {
-      assert(numNumericValuesInPathElement(kind) == 3 &&
-             "Path element kind does not require 3 values");
-      assert(value0 == getValue(0) && "value0 truncated");
-      assert(value1 == getValue(1) && "value1 truncated");
-      assert(value2 == getValue(2) && "value2 truncated");
-    }
-
-    /// Store a path element with an associated pointer, accessible using
-    /// \c getStoredPointer.
-    template <typename T>
-    PathElement(PathElementKind kind, T *ptr)
-        : kind(kind), storage((reinterpret_cast<uintptr_t>(ptr) >> 3)),
-          storedKind(StoredPointer) {
-      assert(ptr == getStoredPointer<T>());
-    }
-
-    /// Retrieve an associated pointer for the element. The type \c T must match
-    /// the type used when creating the path element.
-    template <typename T>
-    T *getStoredPointer() const {
-      assert(storedKind == StoredPointer);
-      return reinterpret_cast<T *>(storage << 3);
-    }
+    /// The storage for the path element value. The value stores can either
+    /// be a pointer or an unsigned int. Only custom path elements store values.
+    uint64_t storage;
 
   public:
 #define LOCATOR_PATH_ELT(Name) class Name;
 #include "ConstraintLocatorPathElts.def"
 
-    PathElement(PathElementKind kind)
-      : kind(kind), storage(0), storedKind(StoredInteger)
-    {
-      assert(numNumericValuesInPathElement(kind) == 0 &&
-             "Path element requires value");
-    }
+    PathElement(PathElementKind kind, uint64_t storage = 0)
+      : kind(kind), storage(storage) {}
 
     /// Retrieve the kind of path element.
     PathElementKind getKind() const { return kind; }
@@ -552,20 +437,76 @@ public: \
 };
 #include "ConstraintLocatorPathElts.def"
 
+/// A base class for custom path elements that store numeric values.
+template <unsigned NumValues>
+class StoredIntegerElement: public LocatorPathElt {
+public:
+  template <unsigned NumNumericInputs = NumValues,
+            typename = typename std::enable_if<NumNumericInputs == 1>::type>
+  StoredIntegerElement(ConstraintLocator::PathElementKind kind, unsigned value)
+    : LocatorPathElt(kind, value) {
+    assert(value == getValue<0>() && "value truncated");
+  }
+
+  template <unsigned NumNumericInputs = NumValues,
+            typename = typename std::enable_if<NumNumericInputs == 2>::type>
+  StoredIntegerElement(ConstraintLocator::PathElementKind kind, unsigned value0, unsigned value1)
+    : LocatorPathElt(kind, (value0 << 16 | value1)) {
+    assert(value0 == getValue<0>() && "value0 truncated");
+    assert(value1 == getValue<1>() && "value1 truncated");
+  }
+
+  template <unsigned NumNumericInputs = NumValues,
+            typename = typename std::enable_if<NumNumericInputs == 3>::type>
+  StoredIntegerElement(ConstraintLocator::PathElementKind kind, unsigned value0,
+                       unsigned value1, unsigned value2)
+      : LocatorPathElt(kind, uint64_t(value0) << 32 | uint64_t(value1) << 16 | uint64_t(value2)) {
+    assert(value0 == getValue<0>() && "value0 truncated");
+    assert(value1 == getValue<1>() && "value1 truncated");
+    assert(value2 == getValue<2>() && "value2 truncated");
+  }
+
+  /// Retrieve a value associated with the path element.
+  template <unsigned Index = 0,
+            typename = typename std::enable_if<(Index < NumValues)>::type>
+  unsigned getValue() const {
+    // We pack values into 16 bit components of the storage, with value0
+    // being stored in the upper bits, valueN in the lower bits. Therefore we
+    // need to shift out any extra values in the lower bits.
+    auto extraValues = NumValues - Index - 1;
+    auto value = getRawStorage() >> (extraValues * 16);
+    return value & 0xFFFF;
+  }
+};
+
+/// A base class for custom path elements that store a pointer.
+template <typename T>
+class StoredPointerElement: public LocatorPathElt {
+public:
+  StoredPointerElement(ConstraintLocator::PathElementKind kind, const T *ptr)
+      : LocatorPathElt(kind, reinterpret_cast<uintptr_t>(ptr)) {
+    assert(ptr == getStoredPointer());
+  }
+
+  /// Retrieve the associated pointer for the element.
+  T *getStoredPointer() const { return reinterpret_cast<T *>(getRawStorage()); }
+};
+
 // The following LocatorPathElt subclasses are used to expose accessors for
 // specific path element information. They shouldn't introduce additional
-// storage, as LocatorPathElt gets passed about by value.
+// storage, as LocatorPathElt gets passed about by value. Custom path elements
+// should subclass StoredIntegerElement to store unsigned values, or StoredPointerElement
+// to store pointer values.
 
-class LocatorPathElt::ApplyArgToParam final : public LocatorPathElt {
+class LocatorPathElt::ApplyArgToParam final : public StoredIntegerElement<3> {
 public:
   ApplyArgToParam(unsigned argIdx, unsigned paramIdx, ParameterTypeFlags flags)
-      : LocatorPathElt(ConstraintLocator::ApplyArgToParam, argIdx, paramIdx,
-                       flags.toRaw()) {}
+      : StoredIntegerElement(ConstraintLocator::ApplyArgToParam, argIdx, paramIdx, flags.toRaw()) {}
 
-  unsigned getArgIdx() const { return getValue(0); }
-  unsigned getParamIdx() const { return getValue(1); }
+  unsigned getArgIdx() const { return getValue<0>(); }
+  unsigned getParamIdx() const { return getValue<1>(); }
   ParameterTypeFlags getParameterFlags() const {
-    return ParameterTypeFlags::fromRaw(getValue(2));
+    return ParameterTypeFlags::fromRaw(getValue<2>());
   }
 
   static bool classof(const LocatorPathElt *elt) {
@@ -573,12 +514,12 @@ public:
   }
 };
 
-class LocatorPathElt::SynthesizedArgument final : public LocatorPathElt {
+class LocatorPathElt::SynthesizedArgument final : public StoredIntegerElement<1> {
 public:
   SynthesizedArgument(unsigned index)
-      : LocatorPathElt(ConstraintLocator::SynthesizedArgument, index) {}
+      : StoredIntegerElement(ConstraintLocator::SynthesizedArgument, index) {}
 
-  unsigned getIndex() const { return getValue(0); }
+  unsigned getIndex() const { return getValue(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::SynthesizedArgument;
@@ -586,15 +527,15 @@ public:
 };
 
 /// Abstract superclass for any kind of tuple element.
-class LocatorPathElt::AnyTupleElement : public LocatorPathElt {
+class LocatorPathElt::AnyTupleElement : public StoredIntegerElement<1> {
 protected:
   AnyTupleElement(PathElementKind kind, unsigned index)
-      : LocatorPathElt(kind, index) {
+      : StoredIntegerElement(kind, index) {
     assert(classof(this) && "classof needs updating");
   }
 
 public:
-  unsigned getIndex() const { return getValue(0); }
+  unsigned getIndex() const { return getValue(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->is<LocatorPathElt::TupleElement>() ||
@@ -624,24 +565,24 @@ public:
   }
 };
 
-class LocatorPathElt::KeyPathComponent final : public LocatorPathElt {
+class LocatorPathElt::KeyPathComponent final : public StoredIntegerElement<1> {
 public:
   KeyPathComponent(unsigned index)
-      : LocatorPathElt(ConstraintLocator::KeyPathComponent, index) {}
+      : StoredIntegerElement(ConstraintLocator::KeyPathComponent, index) {}
 
-  unsigned getIndex() const { return getValue(0); }
+  unsigned getIndex() const { return getValue(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::KeyPathComponent;
   }
 };
 
-class LocatorPathElt::GenericArgument final : public LocatorPathElt {
+class LocatorPathElt::GenericArgument final : public StoredIntegerElement<1> {
 public:
   GenericArgument(unsigned index)
-      : LocatorPathElt(ConstraintLocator::GenericArgument, index) {}
+      : StoredIntegerElement(ConstraintLocator::GenericArgument, index) {}
 
-  unsigned getIndex() const { return getValue(0); }
+  unsigned getIndex() const { return getValue(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::GenericArgument;
@@ -650,17 +591,17 @@ public:
 
 /// Abstract superclass for any kind of element that describes a requirement
 /// placed on a type within a requirements clause.
-class LocatorPathElt::AnyRequirement : public LocatorPathElt {
+class LocatorPathElt::AnyRequirement : public StoredIntegerElement<2> {
 protected:
   AnyRequirement(PathElementKind kind, unsigned index, RequirementKind reqKind)
-      : LocatorPathElt(kind, index, static_cast<unsigned>(reqKind)) {
+      : StoredIntegerElement(kind, index, static_cast<unsigned>(reqKind)) {
     assert(classof(this) && "classof needs updating");
   }
 
 public:
-  unsigned getIndex() const { return getValue(0); }
+  unsigned getIndex() const { return getValue<0>(); }
   RequirementKind getRequirementKind() const {
-    return static_cast<RequirementKind>(getValue(1));
+    return static_cast<RequirementKind>(getValue<1>());
   }
 
   static bool classof(const LocatorPathElt *elt) {
@@ -693,69 +634,67 @@ public:
   }
 };
 
-class LocatorPathElt::ClosureBody final : public LocatorPathElt {
+class LocatorPathElt::ClosureBody final : public StoredIntegerElement<1> {
   public:
   ClosureBody(bool hasExplicitReturn = false)
-    : LocatorPathElt(ConstraintLocator::ClosureBody,
-                     hasExplicitReturn) {}
+    : StoredIntegerElement(ConstraintLocator::ClosureBody, hasExplicitReturn) {}
 
   /// Indicates whether body of the closure has any `return` statements.
-  bool hasExplicitReturn() const { return bool(getValue(0)); }
+  bool hasExplicitReturn() const { return bool(getValue()); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::ClosureBody;
   }
 };
 
-class LocatorPathElt::ContextualType final : public LocatorPathElt {
+class LocatorPathElt::ContextualType final : public StoredIntegerElement<1> {
 public:
   ContextualType(bool isForSingleExprFunction = false)
-      : LocatorPathElt(ConstraintLocator::ContextualType,
-                       isForSingleExprFunction) {}
+      : StoredIntegerElement(ConstraintLocator::ContextualType, isForSingleExprFunction) {}
 
   /// Whether this element points to the contextual type associated with the
   /// result of a single expression function.
-  bool isForSingleExprFunction() const { return bool(getValue(0)); }
+  bool isForSingleExprFunction() const { return bool(getValue()); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::ContextualType;
   }
 };
 
-class LocatorPathElt::Witness final : public LocatorPathElt {
+class LocatorPathElt::Witness final : public StoredPointerElement<ValueDecl> {
 public:
   Witness(ValueDecl *witness)
-      : LocatorPathElt(PathElementKind::Witness, witness) {}
+      : StoredPointerElement(PathElementKind::Witness, witness) {}
 
-  ValueDecl *getDecl() const { return getStoredPointer<ValueDecl>(); }
+  ValueDecl *getDecl() const { return getStoredPointer(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == PathElementKind::Witness;
   }
 };
 
-class LocatorPathElt::ProtocolRequirement final : public LocatorPathElt {
+class LocatorPathElt::ProtocolRequirement final : public StoredPointerElement<ValueDecl> {
 public:
   ProtocolRequirement(ValueDecl *decl)
-      : LocatorPathElt(PathElementKind::ProtocolRequirement, decl) {}
+      : StoredPointerElement(PathElementKind::ProtocolRequirement, decl) {}
 
-  ValueDecl *getDecl() const { return getStoredPointer<ValueDecl>(); }
+  ValueDecl *getDecl() const { return getStoredPointer(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == PathElementKind::ProtocolRequirement;
   }
 };
 
-class LocatorPathElt::GenericParameter final : public LocatorPathElt {
+class LocatorPathElt::GenericParameter final : public StoredPointerElement<GenericTypeParamType> {
 public:
   GenericParameter(GenericTypeParamType *type)
-      : LocatorPathElt(PathElementKind::GenericParameter, type) {
+      : StoredPointerElement(PathElementKind::GenericParameter, type) {
     static_assert(alignof(GenericTypeParamType) >= 4,
                   "archetypes insufficiently aligned");
   }
 
   GenericTypeParamType *getType() const {
-    return getStoredPointer<GenericTypeParamType>();
+    return getStoredPointer();
   }
 
   static bool classof(const LocatorPathElt *elt) {
@@ -763,13 +702,13 @@ public:
   }
 };
 
-class LocatorPathElt::OpenedGeneric final : public LocatorPathElt {
+class LocatorPathElt::OpenedGeneric final : public StoredPointerElement<GenericSignatureImpl> {
 public:
   OpenedGeneric(GenericSignature sig)
-      : LocatorPathElt(PathElementKind::OpenedGeneric, sig.getPointer()) {}
+      : StoredPointerElement(PathElementKind::OpenedGeneric, sig.getPointer()) {}
 
   GenericSignature getSignature() const {
-    return getStoredPointer<GenericSignatureImpl>();
+    return getStoredPointer();
   }
 
   static bool classof(const LocatorPathElt *elt) {
@@ -777,13 +716,13 @@ public:
   }
 };
 
-class LocatorPathElt::KeyPathDynamicMember final : public LocatorPathElt {
+class LocatorPathElt::KeyPathDynamicMember final : public StoredPointerElement<NominalTypeDecl> {
 public:
   KeyPathDynamicMember(NominalTypeDecl *keyPathDecl)
-      : LocatorPathElt(PathElementKind::KeyPathDynamicMember, keyPathDecl) {}
+      : StoredPointerElement(PathElementKind::KeyPathDynamicMember, keyPathDecl) {}
 
   NominalTypeDecl *getKeyPathDecl() const {
-    return getStoredPointer<NominalTypeDecl>();
+    return getStoredPointer();
   }
 
   static bool classof(const LocatorPathElt *elt) {
@@ -791,43 +730,42 @@ public:
   }
 };
 
-class LocatorPathElt::TernaryBranch final : public LocatorPathElt {
+class LocatorPathElt::TernaryBranch final : public StoredIntegerElement<1> {
 public:
   TernaryBranch(bool side)
-      : LocatorPathElt(ConstraintLocator::TernaryBranch, side) {}
+      : StoredIntegerElement(ConstraintLocator::TernaryBranch, side) {}
 
-  bool forThen() const { return bool(getValue(0)); }
+  bool forThen() const { return bool(getValue()); }
 
-  bool forElse() const { return !bool(getValue(0)); }
+  bool forElse() const { return !bool(getValue()); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::TernaryBranch;
   }
 };
 
-class LocatorPathElt::PatternMatch final : public LocatorPathElt {
+class LocatorPathElt::PatternMatch final : public StoredPointerElement<Pattern> {
 public:
   PatternMatch(Pattern *pattern)
-      : LocatorPathElt(PathElementKind::PatternMatch, pattern) {}
+      : StoredPointerElement(PathElementKind::PatternMatch, pattern) {}
 
-  Pattern *getPattern() const { return getStoredPointer<Pattern>(); }
+  Pattern *getPattern() const { return getStoredPointer(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::PatternMatch;
   }
 };
 
-class LocatorPathElt::ArgumentAttribute final : public LocatorPathElt {
+class LocatorPathElt::ArgumentAttribute final : public StoredIntegerElement<1> {
 public:
   enum Attribute : uint8_t { InOut, Escaping };
 
 private:
   ArgumentAttribute(Attribute attr)
-      : LocatorPathElt(ConstraintLocator::ArgumentAttribute,
-                       static_cast<uint8_t>(attr)) {}
+      : StoredIntegerElement(ConstraintLocator::ArgumentAttribute, static_cast<uint8_t>(attr)) {}
 
 public:
-  Attribute getAttr() const { return static_cast<Attribute>(getValue(0)); }
+  Attribute getAttr() const { return static_cast<Attribute>(getValue()); }
 
   static ArgumentAttribute forInOut() {
     return ArgumentAttribute(Attribute::InOut);

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -780,6 +780,36 @@ public:
   }
 };
 
+namespace details {
+  template <typename CustomPathElement>
+  class PathElement {
+    static constexpr bool hasStoredValueImpl(...) { return false; }
+
+    template <unsigned N>
+    static constexpr bool hasStoredValueImpl(StoredIntegerElement<N> *) { return true; }
+
+    template <typename T>
+    static constexpr bool hasStoredValueImpl(StoredPointerElement<T> *) { return true; }
+
+  public:
+    static constexpr bool hasStoredValue() {
+      return hasStoredValueImpl(static_cast<CustomPathElement *>(nullptr));
+    }
+  };
+}
+
+template <typename CustomPathElement>
+constexpr bool isValidCustomPathElement() {
+  return details::PathElement<CustomPathElement>::hasStoredValue();
+}
+
+// All custom path element classes must inherit from StoredIntegerElement or StoredPointerElement
+#define CUSTOM_LOCATOR_PATH_ELT(Name) \
+static_assert(isValidCustomPathElement<LocatorPathElt::Name>(), \
+    "Custom path elements must inherit from StoredIntegerElement or StoredPointerElement");
+#include "ConstraintLocatorPathElts.def"
+
+
 /// A simple stack-only builder object that constructs a
 /// constraint locator without allocating memory.
 ///

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -201,8 +201,6 @@ public:
       return reinterpret_cast<T *>(storage << 3);
     }
 
-    friend class ConstraintLocator;
-
   public:
 #define LOCATOR_PATH_ELT(Name) class Name;
 #include "ConstraintLocatorPathElts.def"
@@ -216,6 +214,9 @@ public:
 
     /// Retrieve the kind of path element.
     PathElementKind getKind() const { return kind; }
+
+    /// Retrieve the raw storage value.
+    uint64_t getRawStorage() const { return storage; }
 
     /// Attempts to cast the path element to a specific \c LocatorPathElt
     /// subclass, returning \c None if unsuccessful.


### PR DESCRIPTION
* Always storing the `PathElementKind` lifts the restriction of only allowing 8 different kinds of path elements to store non-numeric values (because of the previous 3 bit storage for `storedKind` and the 1:1 mapping of `StoredKind` to `PathElementKind`)
* This change also removes the `StoredKind` enum and instead statically enforces invariants about the stored value(s) for each custom path element where possible.