### PR TITLE
[CodeCompletion] Parse #if block containing CC token as active 

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -741,8 +741,6 @@ public:
     return Mem;
   }
 
-  static bool areInactiveIfConfigClausesSupported();
-
 private:
   static ast_scope::ASTSourceFileScope *createScopeTree(SourceFile *);
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -479,23 +479,6 @@ public:
   }
 
 public:
-  /// When ASTScopes are enabled for code completion,
-  /// IfConfigs will pose a challenge because we may need to field lookups into
-  /// the inactive clauses, but the AST contains redundancy: the active clause's
-  /// elements are present in the members or elements of an IterableTypeDecl or
-  /// BraceStmt alongside of the IfConfigDecl. In addition there are two more
-  /// complications:
-  ///
-  /// 1. The active clause's elements may be nested inside an init self
-  /// rebinding decl (as in StringObject.self).
-  ///
-  /// 2. The active clause may be before or after the inactive ones
-  ///
-  /// So, when encountering an IfConfigDecl, we will expand  the inactive
-  /// elements. Also, always sort members or elements so that the child scopes
-  /// are in source order (Just one of several reasons we need to sort.)
-  ///
-  static const bool includeInactiveIfConfigClauses = false;
 
 private:
   static std::vector<ASTNode> expandIfConfigClauses(ArrayRef<ASTNode> input) {
@@ -526,9 +509,6 @@ private:
               if (isa<IfConfigDecl>(d))
                 expandIfConfigClausesInto(expansion, {d}, true);
           }
-        } else if (includeInactiveIfConfigClauses) {
-          expandIfConfigClausesInto(expansion, clause.Elements,
-                                    /*isInAnActiveNode=*/false);
         }
       }
     }
@@ -760,10 +740,6 @@ void ASTScope::buildFullyExpandedTree() { impl->buildFullyExpandedTree(); }
 void ASTScope::
     buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals() {
   impl->buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals();
-}
-
-bool ASTScope::areInactiveIfConfigClausesSupported() {
-  return ScopeCreator::includeInactiveIfConfigClauses;
 }
 
 void ASTScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
@@ -2083,10 +2059,8 @@ public:
     //    catchForDebugging(D, "DictionaryBridging.swift", 694);
     if (const auto *dc = dyn_cast<DeclContext>(D))
       record(dc);
-    if (auto *icd = dyn_cast<IfConfigDecl>(D)) {
-      walkToClauses(icd);
+    if (isa<IfConfigDecl>(D))
       return false;
-    }
     if (auto *pd = dyn_cast<ParamDecl>(D))
       record(pd->getDefaultArgumentInitContext());
     else if (auto *pbd = dyn_cast<PatternBindingDecl>(D))
@@ -2104,18 +2078,6 @@ public:
   }
 
 private:
-  void walkToClauses(IfConfigDecl *icd) {
-    for (auto &clause : icd->getClauses()) {
-      // Generate scopes for any closures in the condition
-      if (ScopeCreator::includeInactiveIfConfigClauses && clause.isActive) {
-        if (clause.Cond)
-          clause.Cond->walk(*this);
-        for (auto n : clause.Elements)
-          n.walk(*this);
-      }
-    }
-  }
-
   void recordInitializers(PatternBindingDecl *pbd) {
     for (auto idx : range(pbd->getNumPatternEntries()))
       record(pbd->getInitContext(idx));

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -85,8 +85,6 @@ template <typename Range> Decl *getElementAt(const Range &Decls, unsigned N) {
 /// Find the equivalent \c DeclContext with \p DC from \p SF AST.
 /// This assumes the AST which contains \p DC has exact the same structure with
 /// \p SF.
-/// FIXME: This doesn't support IfConfigDecl blocks. If \p DC is in an inactive
-///        config block, this function returns \c false.
 static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
                                                            SourceFile *SF) {
   PrettyStackTraceDeclContext trace("getting equivalent decl context for", DC);
@@ -129,7 +127,6 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
     }
 
     // Not found in the decl context tree.
-    // FIXME: Probably DC is in an inactive #if block.
     if (N == ~0U) {
       return nullptr;
     }

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -614,6 +614,7 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
   bool hasCCToken = false;
   if (SourceMgr.hasCodeCompletionBuffer() &&
       SourceMgr.getCodeCompletionBufferID() == L->getBufferID()) {
+    llvm::SaveAndRestore<Optional<llvm::MD5>> H(CurrentTokenHash, None);
     BacktrackingScope backtrack(*this);
     auto startLoc = Tok.getLoc();
     skipSingle();
@@ -676,6 +677,7 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
 
     // Treat the region containing code completion token as "active".
     if (hasCCToken && !foundActive) {
+      llvm::SaveAndRestore<Optional<llvm::MD5>> H(CurrentTokenHash, None);
       BacktrackingScope backtrack(*this);
       auto startLoc = Tok.getLoc();
       skipUntilConditionalBlockClose();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -695,8 +695,9 @@ void Parser::skipSingle() {
 void Parser::skipUntil(tok T1, tok T2) {
   // tok::NUM_TOKENS is a sentinel that means "don't skip".
   if (T1 == tok::NUM_TOKENS && T2 == tok::NUM_TOKENS) return;
-  
-  while (Tok.isNot(T1, T2, tok::eof, tok::pound_endif, tok::code_complete))
+
+  while (Tok.isNot(T1, T2, tok::eof, tok::pound_endif, tok::pound_else,
+                   tok::pound_elseif))
     skipSingle();
 }
 

--- a/test/IDE/complete_in_ifconfig.swift
+++ b/test/IDE/complete_in_ifconfig.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+struct MyStruct {
+    init() {}
+    var value: Int
+}
+
+// MEMBER_MyStruct: Begin completions, 2 items
+// MEMBER_MyStruct-DAG: Keyword[self]/CurrNominal:          self[#MyStruct#];
+// MEMBER_MyStruct-DAG: Decl[InstanceVar]/CurrNominal:      value[#Int#];
+// MEMBER_MyStruct: End completions
+
+#if true
+let toplevelActive = MyStruct()
+_ = toplevelActive.#^MEMBER_TOPLEVEL_ACTIVE?check=MEMBER_MyStruct^#
+#else
+let toplevelInactive = MyStruct()
+_ = toplevelInactive.#^MEMBER_TOPLEVEL_INACTIVE?check=MEMBER_MyStruct^#
+#endif
+
+func foo() {
+#if true
+  let infuncActive = MyStruct()
+  _ = infuncActive.#^MEMBER_INFUNC_ACTIVE?check=MEMBER_MyStruct^#
+#else
+  let infuncInactive = MyStruct()
+  _ = infuncInactive.#^MEMBER_INFUNC_INACTIVE?check=MEMBER_MyStruct^#
+#endif
+}
+
+protocol TestP {
+  func foo()
+  func bar()
+}
+struct TestStruct: TestP {
+#if true
+  func foo() {}
+  func #^OVERRIDE_ACTIVE^#
+// OVERRIDE_ACTIVE: Begin completions, 1 items
+// OVERRIDE_ACTIVE-DAG: Decl[InstanceMethod]/Super:         bar() {|};
+// OVERRIDE_ACTIVE: End completions
+#else
+  func bar() {}
+  func #^OVERRIDE_INACTIVE^#
+// OVERRIDE_INACTIVE: Begin completions, 1 items
+// OVERRIDE_INACTIVE-DAG: Decl[InstanceMethod]/Super:         foo() {|};
+// OVERRIDE_INACTIVE: End completions
+#endif
+}
+
+struct TestStruct2 {
+#if true
+  func activeFunc() {}
+  func test() {
+    self.#^SELF_ACTIVE^#
+  }
+// SELF_ACTIVE: Begin completions, 3 items
+// SELF_ACTIVE-DAG: Keyword[self]/CurrNominal:          self[#TestStruct2#];
+// SELF_ACTIVE-DAG: Decl[InstanceMethod]/CurrNominal:   activeFunc()[#Void#];
+// SELF_ACTIVE-DAG: Decl[InstanceMethod]/CurrNominal:   test()[#Void#];
+// SELF_ACTIVE: End completions
+#else
+  func inactiveFunc() {}
+  func test() {
+    self.#^SELF_INACTIVE^#
+  }
+// SELF_INACTIVE: Begin completions, 3 items
+// SELF_INACTIVE-DAG: Keyword[self]/CurrNominal:          self[#TestStruct2#];
+// SELF_INACTIVE-DAG: Decl[InstanceMethod]/CurrNominal:   inactiveFunc()[#Void#];
+// SELF_INACTIVE-DAG: Decl[InstanceMethod]/CurrNominal:   test()[#Void#];
+// SELF_INACTIVE: End completions
+#endif
+}
+

--- a/test/SourceKit/CodeComplete/complete_sequence_in_ifconfig.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_in_ifconfig.swift
@@ -1,0 +1,54 @@
+struct MyStruct {
+    init() {}
+    var value: Int = 1
+}
+
+func foo(arg: MyStruct) {
+  #if true
+  _ = arg./*8:11*/
+  #else
+  _ = arg./*10:11*/
+  #endif
+}
+
+struct TestStruct {
+  #if true
+  func testActive(arg: MyStruct) {
+    _ = arg./*17:13*/
+  }
+  #else
+  func testInactive(arg: MyStruct) {
+    _ = arg./*21:13*/
+  }
+  #endif
+}
+
+// Test that (1) fast completion happens even in inactive #if blocks, and
+// (2) #if in toplevel decls invalidate cached ASTContext
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=8:11 %s -- %s -parse-as-library == \
+// RUN:   -req=complete -pos=10:11 %s -- %s -parse-as-library == \
+// RUN:   -req=complete -pos=17:13 %s -- %s -parse-as-library == \
+// RUN:   -req=complete -pos=21:13 %s -- %s -parse-as-library \
+// RUN:   | %FileCheck %s --check-prefix=RESULT
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "value"
+// RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "value"
+// RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "value"
+// RESULT: ]
+// RESULT: key.reusingastcontext: 1
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "value"
+// RESULT: ]
+// RESULT-NOT: key.reusingastcontext: 1


### PR DESCRIPTION
Treat the region containing the completion location as "active" during parsing.

1. When `#if` is found, see if the completion location is between `#if` and `#endif` (using backtracking.) If not, parse the entire `#if ... #endif` normally
2. For each region, see if the completion location is in the region (using backtracking.) If yes, parse it as "active" block, otherwise treat it "inactive"

This is not so efficient because the Lexer runs up to 3 times for each IfConfig region. But Lexer is pretty fast, and doesn't consume much memory. So it shouldn't be a problem.

This also guarantees that the completion never happens inside "inactive" blocks. Since `Sema` usually don't expect type checking inside inactive blocks, this change might improve the overall stability of code-completion inside `#if ... #endif`.

The second commit is removing `includeInactiveIfConfigClauses` from `ASTScope`. This flag was prepared for code-completion, but had never been enabled. Now that, we guarantee that name lookup never happen inside inactive blocks, we don't need this flag anymore. cc: @davidungar

rdar://problem/67027408