### PR TITLE
[Concurrency] Add @asyncHandler attribute.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -560,6 +560,11 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   100)
 
+SIMPLE_DECL_ATTR(asyncHandler, AsyncHandler,
+  OnFunc | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove |
+  NotSerialized, 101)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -562,8 +562,8 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
 
 SIMPLE_DECL_ATTR(asyncHandler, AsyncHandler,
   OnFunc | UserInaccessible |
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove |
-  NotSerialized, 101)
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  101)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5888,6 +5888,13 @@ public:
   /// type of the function will be `async` as well.
   bool hasAsync() const { return Bits.AbstractFunctionDecl.Async; }
 
+  /// Returns true if the function is a suitable 'async' context.
+  ///
+  /// Functions that are an 'async' context can make calls to 'async' functions.
+  bool isAsyncContext() const {
+    return hasAsync() || getAttrs().hasAttribute<AsyncHandlerAttr>();
+  }
+
   /// Returns true if the function body throws.
   bool hasThrows() const { return Bits.AbstractFunctionDecl.Throws; }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4047,7 +4047,7 @@ WARNING(no_throw_in_do_with_catch,none,
 ERROR(async_call_without_await,none,
       "call is 'async' but is not marked with 'await'", ())
 ERROR(async_call_without_await_in_autoclosure,none,
-      "call is 'async' in an autoclosure argument is not marked with 'await'", ())
+      "call is 'async' in an autoclosure argument that is not marked with 'await'", ())
 WARNING(no_async_in_await,none,
         "no calls to 'async' functions occur within 'await' expression", ())
 ERROR(async_call_in_illegal_context,none,
@@ -4064,6 +4064,8 @@ ERROR(async_in_nonasync_function,none,
       (bool, bool))
 NOTE(note_add_async_to_function,none,
      "add 'async' to function %0 to make it asynchronous", (DeclName))
+NOTE(note_add_asynchandler_to_function,none,
+     "add '@asyncHandler' to function %0 to create an implicit asynchronous context", (DeclName))
 ERROR(not_objc_function_async,none,
       "'async' function cannot be represented in Objective-C", ())
 NOTE(not_objc_function_type_async,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4074,6 +4074,28 @@ NOTE(protocol_witness_async_conflict,none,
 ERROR(async_autoclosure_nonasync_function,none,
       "'async' autoclosure parameter in a non-'async' function", ())
 
+ERROR(asynchandler_attr_requires_concurrency,none,
+      "'@asyncHandler' is only valid when experimental concurrency is enabled",
+      ())
+ERROR(asynchandler_non_func,none,
+      "'@asyncHandler' can only be applied to functions",
+      ())
+ERROR(asynchandler_returns_value,none,
+      "'@asyncHandler' function can only return 'Void'",
+      ())
+ERROR(asynchandler_throws,none,
+      "'@asyncHandler' function cannot throw",
+      ())
+ERROR(asynchandler_async,none,
+      "'@asyncHandler' function cannot be 'async' itself",
+      ())
+ERROR(asynchandler_inout_parameter,none,
+      "'inout' parameter is not allowed in '@asyncHandler' function",
+      ())
+ERROR(asynchandler_mutating,none,
+      "'@asyncHandler' function cannot be 'mutating'",
+      ())
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Types
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -41,6 +41,66 @@
 
 using namespace swift;
 
+/// Check whether the @asyncHandler attribute can be applied to the given
+/// function declaration.
+///
+/// \param diagnose Whether to emit a diagnostic when a problem is encountered.
+///
+/// \returns \c true if there was a problem with adding the attribute, \c false
+/// otherwise.
+static bool checkAsyncHandler(FuncDecl *func, bool diagnose) {
+  if (!func->getResultInterfaceType()->isVoid()) {
+    if (diagnose) {
+      func->diagnose(diag::asynchandler_returns_value)
+          .highlight(func->getBodyResultTypeLoc().getSourceRange());
+    }
+
+    return true;
+  }
+
+  if (func->hasThrows()) {
+    if (diagnose) {
+      func->diagnose(diag::asynchandler_throws)
+          .fixItRemove(func->getThrowsLoc());
+    }
+
+    return true;
+  }
+
+  if (func->hasAsync()) {
+    if (diagnose) {
+      func->diagnose(diag::asynchandler_async)
+          .fixItRemove(func->getAsyncLoc());
+    }
+
+    return true;
+  }
+
+  for (auto param : *func->getParameters()) {
+    if (param->isInOut()) {
+      if (diagnose) {
+        param->diagnose(diag::asynchandler_inout_parameter)
+            .fixItRemove(param->getSpecifierLoc());
+      }
+
+      return true;
+    }
+  }
+
+  if (func->isMutating()) {
+    if (diagnose) {
+      auto diag = func->diagnose(diag::asynchandler_mutating);
+      if (auto mutatingAttr = func->getAttrs().getAttribute<MutatingAttr>()) {
+        diag.fixItRemove(mutatingAttr->getRange());
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
 namespace {
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
@@ -270,42 +330,7 @@ public:
       return;
     }
 
-    if (!func->getResultInterfaceType()->isVoid()) {
-      func->diagnose(diag::asynchandler_returns_value)
-          .highlight(func->getBodyResultTypeLoc().getSourceRange());
-      attr->setInvalid();
-      return;
-    }
-
-    if (func->hasThrows()) {
-      func->diagnose(diag::asynchandler_throws)
-          .fixItRemove(func->getThrowsLoc());
-      attr->setInvalid();
-      return;
-    }
-
-    if (func->hasAsync()) {
-      func->diagnose(diag::asynchandler_async)
-          .fixItRemove(func->getAsyncLoc());
-      attr->setInvalid();
-      return;
-    }
-
-    for (auto param : *func->getParameters()) {
-      if (param->isInOut()) {
-        param->diagnose(diag::asynchandler_inout_parameter)
-            .fixItRemove(param->getSpecifierLoc());
-        attr->setInvalid();
-        return;
-      }
-    }
-
-    if (func->isMutating()) {
-      auto diag = Ctx.Diags.diagnose(func, diag::asynchandler_mutating);
-      diag.highlight(attr->getRangeWithAt());
-      if (auto mutatingAttr = func->getAttrs().getAttribute<MutatingAttr>()) {
-        diag.fixItRemove(mutatingAttr->getRange());
-      }
+    if (checkAsyncHandler(func, /*diagnose=*/true)) {
       attr->setInvalid();
       return;
     }
@@ -5200,4 +5225,14 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
 
   // Set the resolved linearity parameter indices in the attribute.
   attr->setParameterIndices(linearParamIndices);
+}
+
+void swift::addAsyncNotes(FuncDecl *func) {
+  func->diagnose(diag::note_add_async_to_function, func->getName());
+
+  if (!checkAsyncHandler(func, /*diagnose=*/false)) {
+    func->diagnose(
+            diag::note_add_asynchandler_to_function, func->getName())
+        .fixItInsert(func->getAttributeInsertionLoc(false), "@asyncHandler ");
+  }
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2155,11 +2155,10 @@ static Type validateParameterType(ParamDecl *decl) {
     if (auto fnType = Ty->getAs<FunctionType>()) {
       if (fnType->isAsync() &&
           !(isa<AbstractFunctionDecl>(dc) &&
-            cast<AbstractFunctionDecl>(dc)->hasAsync())) {
+            cast<AbstractFunctionDecl>(dc)->isAsyncContext())) {
         decl->diagnose(diag::async_autoclosure_nonasync_function);
-        if (auto func = dyn_cast<FuncDecl>(dc)) {
-          func->diagnose(diag::note_add_async_to_function, func->getName());
-        }
+        if (auto func = dyn_cast<FuncDecl>(dc))
+          addAsyncNotes(func);
       }
     }
   }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1416,6 +1416,7 @@ namespace  {
     UNINTERESTING_ATTR(AccessControl)
     UNINTERESTING_ATTR(Alignment)
     UNINTERESTING_ATTR(AlwaysEmitIntoClient)
+    UNINTERESTING_ATTR(AsyncHandler)
     UNINTERESTING_ATTR(Borrowed)
     UNINTERESTING_ATTR(CDecl)
     UNINTERESTING_ATTR(Consuming)

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -932,7 +932,7 @@ public:
       }
     }
 
-    return Context(D->hasThrows(), D->hasAsync(), AnyFunctionRef(D));
+    return Context(D->hasThrows(), D->isAsyncContext(), AnyFunctionRef(D));
   }
 
   static Context forDeferBody() {
@@ -1254,7 +1254,7 @@ public:
     if (!func)
       return;
 
-    func->diagnose(diag::note_add_async_to_function, func->getName());
+    addAsyncNotes(func);
   }
 
   void diagnoseUnhandledAsyncSite(DiagnosticEngine &Diags, ASTNode node) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1391,6 +1391,10 @@ void checkUnknownAttrRestrictions(
 /// it to later stages.
 void bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *stmt);
 
+/// Add notes suggesting the addition of 'async' or '@asyncHandler', as
+/// appropriate, to a diagnostic for a function that isn't an async context.
+void addAsyncNotes(FuncDecl *func);
+
 } // end namespace swift
 
 #endif

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -1,6 +1,15 @@
 // RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
 
-@asyncHandler func asyncHandler1() { }
+func globalAsyncFunction() async -> Int { 0 }
+
+@asyncHandler func asyncHandler1() {
+  // okay, it's an async context
+  let _ = await globalAsyncFunction()
+}
+
+@asyncHandler func asyncHandler2(fn: @autoclosure () async -> Int ) {
+  // okay, it's an async context
+}
 
 @asyncHandler
 func asyncHandlerBad1() -> Int { 0 }

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
+
+@asyncHandler func asyncHandler1() { }
+
+@asyncHandler
+func asyncHandlerBad1() -> Int { 0 }
+// expected-error@-1{{'@asyncHandler' function can only return 'Void'}}
+
+@asyncHandler
+func asyncHandlerBad2() async { }
+// expected-error@-1{{'@asyncHandler' function cannot be 'async' itself}}{{25-31=}}
+
+@asyncHandler
+func asyncHandlerBad3() throws { }
+// expected-error@-1{{'@asyncHandler' function cannot throw}}{{25-32=}}
+
+@asyncHandler
+func asyncHandlerBad4(result: inout Int) { }
+// expected-error@-1{{'inout' parameter is not allowed in '@asyncHandler' function}}
+
+struct X {
+  @asyncHandler func asyncHandlerMethod() { }
+
+  @asyncHandler
+  mutating func asyncHandlerMethodBad1() { }
+  // expected-error@-1{{'@asyncHandler' function cannot be 'mutating'}}{{3-12=}}
+
+  @asyncHandler init() { }
+  // expected-error@-1{{@asyncHandler may only be used on 'func' declarations}}
+}

--- a/test/attr/asynchandler_noconcurrency.swift
+++ b/test/attr/asynchandler_noconcurrency.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+@asyncHandler func asyncHandler1() { }
+// expected-error@-1{{'@asyncHandler' is only valid when experimental concurrency is enabled}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -21,6 +21,7 @@ func test2(
 }
 
 func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}}
+  // expected-note@-1{{add '@asyncHandler' to function 'test3()' to create an implicit asynchronous context}}{{1-1=@asyncHandler }}
   _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
 }
 
@@ -36,7 +37,7 @@ struct SomeStruct {
 func acceptAutoclosureNonAsync(_: @autoclosure () -> Int) async { }
 func acceptAutoclosureAsync(_: @autoclosure () async -> Int) async { }
 
-func acceptAutoclosureNonAsyncBad(_: @autoclosure () async -> Int) { }
+func acceptAutoclosureNonAsyncBad(_: @autoclosure () async -> Int) -> Int { 0 }
 // expected-error@-1{{'async' autoclosure parameter in a non-'async' function}}
 // expected-note@-2{{add 'async' to function 'acceptAutoclosureNonAsyncBad' to make it asynchronous}}
 
@@ -46,13 +47,13 @@ struct HasAsyncBad {
 }
 
 func testAutoclosure() async {
-  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument is not marked with 'await'}}
+  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
   await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 
   await acceptAutoclosureAsync(await getInt())
   await acceptAutoclosureNonAsync(await getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 
-  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument is not marked with 'await'}}
+  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
   await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 }
 


### PR DESCRIPTION
An asynchronous handler behaves externally like a synchronous function,
but internally it is handled like an asynchronous function, meaning
that it can execute operations with suspension points such as calling
other async functions.  The body of the function is executed just as if
it and its caller were async functions, except that the caller is
resumed when the callee reaches its first suspension point rather than
only when the callee exits.