### PR TITLE
DO NOT MERGE -- warn about explicit meta-metatypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4136,6 +4136,9 @@ WARNING(class_super_not_usable_from_inline_warn,none,
         "should be '@usableFromInline' or public",
         (bool))
 
+ERROR(meta_metatype_deprecated,none,
+      "meta-metatypes are deprecated and will be removed in a future release", ())
+
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))
 ERROR(tuple_single_element,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3596,6 +3596,10 @@ Type TypeResolver::resolveMetatypeType(MetatypeTypeRepr *repr,
     return ErrorType::get(getASTContext());
   }
 
+  if (ty->is<AnyMetatypeType>()) {
+    diagnose(repr->getStartLoc(), diag::meta_metatype_deprecated);
+  }
+
   Optional<MetatypeRepresentation> storedRepr;
   
   // In SIL mode, a metatype must have a @thin, @thick, or
@@ -3627,6 +3631,10 @@ Type TypeResolver::resolveProtocolType(ProtocolTypeRepr *repr,
   auto ty = resolveType(repr->getBase(), options.withoutContext());
   if (ty->hasError()) {
     return ErrorType::get(getASTContext());
+  }
+
+  if (ty->is<AnyMetatypeType>()) {
+    diagnose(repr->getStartLoc(), diag::meta_metatype_deprecated);
   }
 
   Optional<MetatypeRepresentation> storedRepr;

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -186,9 +186,7 @@ var f2: (B) -> Bool = { $0 is D }
 func metatype_casts<T, U>(_ b: B.Type, t:T.Type, u: U.Type) {
   _ = b is D.Type
   _ = T.self is U.Type
-  _ = type(of: T.self) is U.Type.Type
   _ = type(of: b) is D.Type // expected-warning{{always fails}}
-  _ = b is D.Type.Type // expected-warning{{always fails}}
 
 }
 

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -45,19 +45,6 @@ class WashingMachine : Toaster {}
 class Dryer : WashingMachine {}
 class HairDryer {}
 
-let a: Toaster.Type.Protocol = Toaster.Type.self
-let b: Any.Type.Type = Toaster.Type.self // expected-error {{cannot convert value of type 'Toaster.Type.Protocol' to specified type 'Any.Type.Type'}}
-let c: Any.Type.Protocol = Toaster.Type.self // expected-error {{cannot convert value of type 'Toaster.Type.Protocol' to specified type 'Any.Type.Protocol'}}
-let d: Toaster.Type.Type = WashingMachine.Type.self
-let e: Any.Type.Type = WashingMachine.Type.self
-let f: Toaster.Type.Type = Dryer.Type.self
-let g: Toaster.Type.Type = HairDryer.Type.self // expected-error {{cannot convert value of type 'HairDryer.Type.Type' to specified type 'Toaster.Type.Type'}}
-let h: WashingMachine.Type.Type = Dryer.Type.self // expected-error {{cannot convert value of type 'Dryer.Type.Type' to specified type 'WashingMachine.Type.Type'}}
-
-func generic<T : WashingMachine>(_ t: T.Type) {
-  let _: Toaster.Type.Type = type(of: t)
-}
-
 // rdar://problem/20780797
 protocol P2 {
   init(x: Int)

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -196,8 +196,6 @@ func meta_metatypes() {
   let _: P.Protocol = P.self
   _ = P.Type.self
   _ = P.Protocol.self
-  _ = P.Protocol.Protocol.self // expected-error{{cannot use 'Protocol' with non-protocol type 'P.Protocol'}}
-  _ = P.Protocol.Type.self
   _ = B.Type.self
 }
 


### PR DESCRIPTION
A naive `grep` of the source compatibility suite suggests that users aren't using meta-metatypes. Let's test that theory.

For random people looking at this pull request, I'm of the opinion that removing meta-metatypes from the language allows for better internal optimizations.