### PR TITLE
[Serialization] Serialize isUserAccessible on functions

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2995,6 +2995,7 @@ public:
     DeclID accessorStorageDeclID;
     bool overriddenAffectsABI, needsNewVTableEntry, isTransparent;
     DeclID opaqueReturnTypeID;
+    bool isUserAccessible;
     ArrayRef<uint64_t> nameAndDependencyIDs;
 
     if (!isAccessor) {
@@ -3012,6 +3013,7 @@ public:
                                           rawAccessLevel,
                                           needsNewVTableEntry,
                                           opaqueReturnTypeID,
+                                          isUserAccessible,
                                           nameAndDependencyIDs);
     } else {
       decls_block::AccessorLayout::readRecord(scratch, contextID, isImplicit,
@@ -3196,6 +3198,7 @@ public:
     fn->setForcedStaticDispatch(hasForcedStaticDispatch);
     ctx.evaluator.cacheOutput(NeedsNewVTableEntryRequest{fn},
                               std::move(needsNewVTableEntry));
+    fn->setUserAccessible(isUserAccessible);
 
     if (opaqueReturnTypeID) {
       ctx.evaluator.cacheOutput(

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 569; // subclass scope
+const uint16_t SWIFTMODULE_VERSION_MINOR = 570; // isUserAccessible
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1307,6 +1307,7 @@ namespace decls_block {
     AccessLevelField, // access level
     BCFixed<1>,   // requires a new vtable slot
     DeclIDField,  // opaque result type decl
+    BCFixed<1>,   // isUserAccessible?
     BCArray<IdentifierIDField> // name components,
                                // followed by TypeID dependencies
     // The record is trailed by:

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3437,6 +3437,7 @@ public:
                            rawAccessLevel,
                            fn->needsNewVTableEntry(),
                            S.addDeclRef(fn->getOpaqueResultTypeDecl()),
+                           fn->isUserAccessible(),
                            nameComponentsAndDependencies);
 
     writeGenericParams(fn->getGenericParams());

--- a/test/IDE/Inputs/complete_user_accessibility_helper.swift
+++ b/test/IDE/Inputs/complete_user_accessibility_helper.swift
@@ -1,0 +1,3 @@
+public enum MyEnum {
+  case foo, bar
+}

--- a/test/IDE/complete_user_accessible.swift
+++ b/test/IDE/complete_user_accessible.swift
@@ -1,0 +1,19 @@
+/// Check that serialized non user accessible functions are not autocompleted.
+/// rdar://problem/53891642
+/// SR-7460
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/complete_user_accessibility_helper.swift -module-name helper -emit-module-path %t/helper.swiftmodule
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=USER-ACCESS -I %t | %FileCheck %s -check-prefix=USER-ACCESS
+
+import helper
+
+{
+  _ = MyEnum.#^USER-ACCESS^#
+// USER-ACCESS:          Begin completions
+// USER-ACCESS-DAG:      Keyword[self]/CurrNominal:          self[#MyEnum.Type#]; name=self
+// USER-ACCESS-DAG:      Keyword/CurrNominal:                Type[#MyEnum.Type#]; name=Type
+// USER-ACCESS-DAG:      Decl[EnumElement]/CurrNominal:      foo[#MyEnum#]; name=foo
+// USER-ACCESS-DAG:      Decl[EnumElement]/CurrNominal:      bar[#MyEnum#]; name=bar
+// USER-ACCESS-NOT:      __derived_enum_equals
+}


### PR DESCRIPTION
Serializing `isUserAccessible` on functions should keep `__derived_enum_equals` out of the autocompletion on types imported from a binary module. This will provided the same behavior as for local types and types from system modules.

rdar://problem/53891642
SR-7460