### PR TITLE
[metadata prespecialization] Bump availability.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -669,6 +669,10 @@ public:
   /// compiler for the target platform.
   AvailabilityContext getSwift53Availability();
 
+  /// Get the runtime availability of features introduced in the Swift 5.4
+  /// compiler for the target platform.
+  AvailabilityContext getSwift54Availability();
+
   /// Get the runtime availability of features that have been introduced in the
   /// Swift compiler for future versions of the target platform.
   AvailabilityContext getSwiftFutureAvailability();

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -306,21 +306,21 @@ AvailabilityContext ASTContext::getTypesInAbstractMetadataStateAvailability() {
 }
 
 AvailabilityContext ASTContext::getPrespecializedGenericMetadataAvailability() {
-  return getSwift53Availability();
+  return getSwift54Availability();
 }
 
 AvailabilityContext ASTContext::getCompareTypeContextDescriptorsAvailability() {
-  return getSwiftFutureAvailability();
+  return getSwift54Availability();
 }
 
 AvailabilityContext
 ASTContext::getCompareProtocolConformanceDescriptorsAvailability() {
-  return getSwiftFutureAvailability();
+  return getSwift54Availability();
 }
 
 AvailabilityContext
 ASTContext::getIntermodulePrespecializedGenericMetadataAvailability() {
-  return getSwiftFutureAvailability();
+  return getSwift54Availability();
 }
 
 AvailabilityContext ASTContext::getSwift52Availability() {
@@ -382,6 +382,10 @@ AvailabilityContext ASTContext::getSwift53Availability() {
   } else {
     return AvailabilityContext::alwaysAvailable();
   }
+}
+
+AvailabilityContext ASTContext::getSwift54Availability() {
+  return getSwiftFutureAvailability();
 }
 
 AvailabilityContext ASTContext::getSwiftFutureAvailability() {

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -1,5 +1,5 @@
 
-// RUN: %swift -prespecialize-generic-metadata -module-name generic_metatypes -target x86_64-apple-macosx50.99  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -prespecialize-generic-metadata -module-name generic_metatypes -target x86_64-apple-macosx99.99  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
 // RUN: %swift -prespecialize-generic-metadata -module-name generic_metatypes -target x86_64-apple-ios99.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
 // RUN: %swift -prespecialize-generic-metadata -module-name generic_metatypes -target x86_64-apple-tvos99.0     -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
 // RUN: %swift -prespecialize-generic-metadata -module-name generic_metatypes -target i386-apple-watchos9.99    -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32  %s


### PR DESCRIPTION
Previously, the availability was 5.3.  Since `compareProtocolConformanceDescriptors` was added in 5.4 and was used by
metadata accessors with baked-in checks for arguments which matched prespecializations, 5.3 was incorrect.  Moreover, now that the searching for matches is done by `getGenericMetadata`, the metadata accessors no longer contain the early exits, so running against a 5.3 runtime would entail the metadata accessor failing to produce canonical prespecialized records.

Here, the availability is bumped to 5.4 which includes the runtime changes to support the metadata accessors not having early exits to return prespecialized records.