### PR TITLE
IRGen: Store scalars as bytes to avoid undefined bits

### DIFF
--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1010,7 +1010,9 @@ entry(%0 : $Builtin.Int63):
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %1 to i63*
-// CHECK-64:   store i63 [[T]], i63* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i63* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64
+// CHECK-64:   store i64 [[BYTE]], i64* [[BYTE_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
 sil @single_payload_spare_bit_inject_x_indirect : $(Builtin.Int63, @inout SinglePayloadSpareBit) -> () {
@@ -1784,7 +1786,9 @@ entry(%0 : $Builtin.Int62):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i62*
-// CHECK-64:   store i62 [[NATIVECC_TRUNC]], i62* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i62* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[BYTE:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[BYTE]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
@@ -1825,7 +1829,9 @@ entry(%0 : $Builtin.Int63):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i63*
-// CHECK-64:   store i63 [[NATIVECC_TRUNC]], i63* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i63* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[BYTE:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[BYTE]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
@@ -2024,7 +2030,9 @@ entry(%0 : $Builtin.Int62):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i62*
-// CHECK-64:   store i62 [[NATIVECC_TRUNC]], i62* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i62* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[BYTE:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[BYTE]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x3FFF_FFFF_FFFF_FFFF
@@ -2060,7 +2068,9 @@ entry(%0 : $Builtin.Int60):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i60*
-// CHECK-64:   store i60 [[NATIVECC_TRUNC]], i60* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i60* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[BYTE:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[BYTE]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x3FFF_FFFF_FFFF_FFFF

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -1014,7 +1014,9 @@ entry(%0 : $Builtin.Int63):
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future21SinglePayloadSpareBitO* %1 to i63*
-// CHECK-64:   store i63 [[T]], i63* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i63* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[BYTE:%.*]] = zext i63 [[T]] to i64
+// CHECK-64:   store i64 [[BYTE]], i64* [[BYTE_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
 sil @single_payload_spare_bit_inject_x_indirect : $(Builtin.Int63, @inout SinglePayloadSpareBit) -> () {
@@ -1788,7 +1790,9 @@ entry(%0 : $Builtin.Int62):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i62*
-// CHECK-64:   store i62 [[NATIVECC_TRUNC]], i62* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i62* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[VAL:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[VAL]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
@@ -1829,7 +1833,9 @@ entry(%0 : $Builtin.Int63):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i63*
-// CHECK-64:   store i63 [[NATIVECC_TRUNC]], i63* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i63* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[VAL:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[VAL]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
@@ -2028,7 +2034,9 @@ entry(%0 : $Builtin.Int62):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i62*
-// CHECK-64:   store i62 [[NATIVECC_TRUNC]], i62* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i62* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[VAL:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[VAL]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x3FFF_FFFF_FFFF_FFFF
@@ -2064,7 +2072,9 @@ entry(%0 : $Builtin.Int60):
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i60*
-// CHECK-64:   store i60 [[NATIVECC_TRUNC]], i60* [[DATA_ADDR]]
+// CHECK-64:   [[BYTE_ADDR:%.*]] = bitcast i60* [[DATA_ADDR]] to i64*
+// CHECK-64:   [[VAL:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
+// CHECK-64:   store i64 [[VAL]], i64* [[BYTE_ADDR]]
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x3FFF_FFFF_FFFF_FFFF

--- a/test/Interpreter/enum.swift
+++ b/test/Interpreter/enum.swift
@@ -698,3 +698,49 @@ func testCase() {
 
 // CHECK: Container(storage: a.MultiIndirectRef.ind(5))
 testCase()
+
+
+enum BitEnum {
+  case first
+  case second
+}
+protocol Init {
+  init()
+}
+struct TrailingByte : Init {
+  var x = 2
+  var y = BitEnum.first
+  init() {
+    x = 2
+    y = BitEnum.first
+  }
+}
+
+@inline(never)
+func capture<T>(_ t: inout T) {
+  print("captured \(t)")
+}
+
+@inline(never)
+func reproduction<T: Init>(_ x: Int, _ y: Int, _ t: T) {
+  var o : Optional<T> = nil
+
+
+  for i in 0 ..< x {
+     if  i == y {
+        o = T()
+     }
+  }
+
+  capture(&o)
+
+  if var byte = o {
+    print("there is a byte (failure)")
+    print(byte)
+  } else {
+    print("there is no byte")
+  }
+}
+
+// CHECK: there is no byte
+reproduction(2, 3, TrailingByte())


### PR DESCRIPTION
Don't tempt llvm to misbehave on partially initialized bytes -- it will.

rdar:///66701259