### PR TITLE
[Runtime] Reimplement protocol conformance cache with a hash table

### DIFF
--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -46,6 +46,20 @@ template <typename Runtime> struct MetadataCacheNode {
   typename Runtime::StoredPointer Right;
 };
 
+template <typename Runtime> struct ConcurrentHashMap {
+  typename Runtime::StoredSize ReaderCount;
+  typename Runtime::StoredSize ElementCount;
+  typename Runtime::StoredPointer Elements;
+  typename Runtime::StoredPointer Indices;
+  // We'll ignore the remaining fields for now....
+};
+
+template <typename Runtime> struct ConformanceCacheEntry {
+  typename Runtime::StoredPointer Type;
+  typename Runtime::StoredPointer Proto;
+  typename Runtime::StoredPointer Witness;
+};
+
 } // end namespace reflection
 } // end namespace swift
 

--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -17,6 +17,7 @@
 #include <functional>
 #include <stdint.h>
 #include <vector>
+#include "llvm/ADT/Hashing.h"
 #include "llvm/Support/Allocator.h"
 #include "Atomic.h"
 #include "Debug.h"
@@ -24,6 +25,10 @@
 
 #if defined(__FreeBSD__) || defined(__CYGWIN__) || defined(__HAIKU__)
 #include <stdio.h>
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <malloc/malloc.h>
 #endif
 
 namespace swift {
@@ -488,8 +493,8 @@ public:
     const ElemTy *end() { return Start + Count; }
     size_t count() { return Count; }
   };
-  
-  // This type cannot be safely copied, moved, or deleted.
+
+  // This type cannot be safely copied or moved.
   ConcurrentReadableArray(const ConcurrentReadableArray &) = delete;
   ConcurrentReadableArray(ConcurrentReadableArray &&) = delete;
   ConcurrentReadableArray &operator=(const ConcurrentReadableArray &) = delete;
@@ -527,7 +532,7 @@ public:
     if (ReaderCount.load(std::memory_order_acquire) == 0)
       deallocateFreeList();
   }
-  
+
   Snapshot snapshot() {
     incrementReaders();
     auto *storage = Elements.load(SWIFT_MEMORY_ORDER_CONSUME);
@@ -538,6 +543,382 @@ public:
     auto count = storage->Count.load(std::memory_order_acquire);
     const auto *ptr = storage->data();
     return Snapshot(this, ptr, count);
+  }
+};
+
+using llvm::hash_value;
+
+/// A hash table that can be queried without taking any locks. Writes are still
+/// locked and serialized, but only with respect to other locks. Writers can add
+/// elements and clear the table, but they cannot remove individual elements.
+/// Readers work by taking a snapshot of the table and then querying that
+/// snapshot.
+///
+/// The basic structure of the table consists of two arrays. Elements are stored
+/// in a contiguous array, with new elements appended to the end. The second
+/// array is the actual hash table, and it contains indices into the elements
+/// array. This scheme cuts down on wasted space when the elements are larger
+/// than a few bytes: instead of wasting `(1 - loadFactor) * sizeof(element)`
+/// bytes on unused space in the hash table, we only waste `(1 - loadFactor) *
+/// sizeof(index)`. This scheme also avoids readers seeing partially constructed
+/// elements.
+///
+/// Reader/writer synchronization for new elements is handled by keeping an
+/// element count which is only incremented when the element has been fully
+/// constructed. A reader which sees an index beyond its view of the current
+/// count will ignore it and treat that as if there was no entry.
+///
+/// Reader/writer synchronization for resizing the arrays is handled by tracking
+/// the current number of active readers. When resizing, the new array is
+/// allocated, the data copied, and then the old array is placed in a free list.
+/// The free list is only deallocated if there are no readers, otherwise freeing
+/// is deferred.
+///
+/// Reader/writer synchronization for clearing the table is a combination of the
+/// above. By keeping the old arrays around until all readers are finished, we
+/// ensure that readers which started before the clear see valid (pre-clear)
+/// data. Readers which see any array as empty will produce no results, thus
+/// providing valid post-clear data.
+template <class ElemTy> struct ConcurrentReadableHashMap {
+  // We use memcpy and don't call destructors. Make sure the elements will put
+  // up with this.
+  static_assert(std::is_trivially_copyable<ElemTy>::value,
+                "Elements must be trivially copyable.");
+  static_assert(std::is_trivially_destructible<ElemTy>::value,
+                "Elements must not have destructors (they won't be called).");
+
+private:
+  /// The type of the elements of the indices array. TODO: use one or two byte
+  /// indices for smaller tables to save more memory.
+  using Index = unsigned;
+
+  /// The reciprocal of the load factor at which we expand the table. A value of
+  /// 4 means that we resize at 1/4 = 75% load factor.
+  static const size_t ResizeProportion = 4;
+
+  /// Get the "good size" for a given allocation size. When available, this
+  /// rounds up to the next allocation quantum by calling `malloc_good_size`.
+  /// Otherwise, just return the passed-in size, which is always valid even if
+  /// not necessarily optimal.
+  size_t goodSize(size_t size) {
+#if defined(__APPLE__) && defined(__MACH__)
+    return malloc_good_size(size);
+#else
+    return size;
+#endif
+  }
+
+  /// A private class representing the storage of the indices. In order to
+  /// ensure that readers can get a consistent view of the indices with a single
+  /// atomic read, we store the size of the indices array inline, as the first
+  /// element in the array.
+  ///
+  /// We want the number of indices to be a power of two so that we can use a
+  /// bitwise AND to convert a hash code to an index. We want the entire array
+  /// to be a power of two in size to be friendly to the allocator, but the size
+  /// is stored inline. We work around this contradiction by considering the
+  /// first index to always be occupied with a value that never matches any key.
+  struct IndexStorage {
+    std::atomic<Index> Mask;
+
+    static IndexStorage *allocate(size_t capacity) {
+      assert((capacity & (capacity - 1)) == 0 &&
+             "Capacity must be a power of 2");
+      auto *ptr =
+          reinterpret_cast<IndexStorage *>(calloc(capacity, sizeof(Mask)));
+      if (!ptr)
+        swift::crash("Could not allocate memory.");
+      ptr->Mask.store(capacity - 1, std::memory_order_relaxed);
+      return ptr;
+    }
+
+    std::atomic<Index> &at(size_t i) { return (&Mask)[i]; }
+  };
+
+  /// The number of readers currently active, equal to the number of snapshot
+  /// objects currently alive.
+  std::atomic<size_t> ReaderCount;
+
+  /// The number of elements in the elements array.
+  std::atomic<size_t> ElementCount;
+
+  /// The array of elements.
+  std::atomic<ElemTy *> Elements;
+
+  /// The array of indices.
+  std::atomic<IndexStorage *> Indices;
+
+  /// The writer lock, which must be taken before any mutation of the table.
+  Mutex WriterLock;
+
+  /// The maximum number of elements that the current elements array can hold.
+  size_t ElementCapacity;
+
+  /// The list of element arrays to be freed once no readers are active.
+  std::vector<ElemTy *> ElementFreeList;
+
+  /// The list of index arrays to be freed once no readers are active.
+  std::vector<IndexStorage *> IndicesFreeList;
+
+  void incrementReaders() {
+    ReaderCount.fetch_add(1, std::memory_order_acquire);
+  }
+
+  void decrementReaders() {
+    ReaderCount.fetch_sub(1, std::memory_order_release);
+  }
+
+  /// Free all the arrays in the free lists.
+  void deallocateFreeList() {
+    for (auto *storage : ElementFreeList)
+      free(storage);
+    ElementFreeList.clear();
+    ElementFreeList.shrink_to_fit();
+
+    for (auto *indices : IndicesFreeList)
+      free(indices);
+    IndicesFreeList.clear();
+    IndicesFreeList.shrink_to_fit();
+  }
+
+  /// Free all the arrays in the free lists if there are no active readers. If
+  /// there are active readers, do nothing.
+  void deallocateFreeListIfSafe() {
+    if (ReaderCount.load(std::memory_order_relaxed) == 0)
+      deallocateFreeList();
+  }
+
+  /// Grow the elements array, adding the old array to the free list and
+  /// returning the new array with all existing elements copied into it.
+  ElemTy *resize(ElemTy *elements, size_t elementCount) {
+    // Grow capacity by 25%, making sure we grow by at least 1.
+    size_t newCapacity =
+        std::max(elementCount + (elementCount >> 2), elementCount + 1);
+    size_t newSize = newCapacity * sizeof(ElemTy);
+
+    newSize = goodSize(newSize);
+    newCapacity = newSize / sizeof(ElemTy);
+
+    ElemTy *newElements = static_cast<ElemTy *>(malloc(newSize));
+    if (elements) {
+      memcpy(newElements, elements, elementCount * sizeof(ElemTy));
+      ElementFreeList.push_back(elements);
+    }
+
+    ElementCapacity = newCapacity;
+    Elements.store(newElements, std::memory_order_release);
+    return newElements;
+  }
+
+  /// Grow the indices array, adding the old array to the free list and
+  /// returning the new array with all existing indices copied into it. This
+  /// operation performs a rehash, so that the indices are in the correct
+  /// location in the new array.
+  IndexStorage *resize(IndexStorage *indices, Index indicesMask,
+                       ElemTy *elements) {
+    // Mask is size - 1. Double the size. Start with 4 (fits into 16-byte malloc
+    // bucket).
+    size_t newCount = indices ? 2 * (indicesMask + 1) : 4;
+    size_t newMask = newCount - 1;
+
+    IndexStorage *newIndices = IndexStorage::allocate(newCount);
+
+    for (size_t i = 1; i <= indicesMask; i++) {
+      Index index = indices->at(i).load(std::memory_order_relaxed);
+      if (index == 0)
+        continue;
+
+      auto *element = &elements[index - 1];
+      auto hash = hash_value(*element);
+
+      size_t newI = hash & newMask;
+      while (newIndices->at(newI) != 0)
+        newI = (newI + 1) & newMask;
+      newIndices->at(newI).store(index, std::memory_order_relaxed);
+    }
+
+    Indices.store(newIndices, std::memory_order_release);
+
+    IndicesFreeList.push_back(indices);
+
+    return newIndices;
+  }
+
+  /// Search for the given key within the given indices and elements arrays. If
+  /// an entry already exists for that key, return a pointer to the element. If
+  /// no entry exists, return a pointer to the location in the indices array
+  /// where the index of the new element would be stored.
+  template <class KeyTy>
+  static std::pair<ElemTy *, std::atomic<Index> *>
+  find(const KeyTy &key, IndexStorage *indices, size_t elementCount,
+       ElemTy *elements) {
+    if (!indices)
+      return {nullptr, nullptr};
+    auto hash = hash_value(key);
+    auto indicesMask = indices->Mask.load(std::memory_order_relaxed);
+
+    auto i = hash & indicesMask;
+    while (true) {
+      // Index 0 is used for the mask and is not actually an index.
+      if (i == 0)
+        i++;
+
+      auto *indexPtr = &indices->at(i);
+      auto index = indexPtr->load(std::memory_order_acquire);
+      // Element indices are 1-based, 0 means no entry.
+      if (index == 0)
+        return {nullptr, indexPtr};
+      if (index - 1 < elementCount) {
+        auto *candidate = &elements[index - 1];
+        if (candidate->matchesKey(key))
+          return {candidate, nullptr};
+      }
+
+      i = (i + 1) & indicesMask;
+    }
+  }
+
+public:
+  // This type cannot be safely copied or moved.
+  ConcurrentReadableHashMap(const ConcurrentReadableHashMap &) = delete;
+  ConcurrentReadableHashMap(ConcurrentReadableHashMap &&) = delete;
+  ConcurrentReadableHashMap &
+  operator=(const ConcurrentReadableHashMap &) = delete;
+
+  ConcurrentReadableHashMap()
+      : ReaderCount(0), ElementCount(0), Elements(nullptr), Indices(nullptr),
+        ElementCapacity(0) {}
+
+  ~ConcurrentReadableHashMap() {
+    assert(ReaderCount.load(std::memory_order_acquire) == 0 &&
+           "deallocating ConcurrentReadableHashMap with outstanding snapshots");
+    deallocateFreeList();
+  }
+
+  /// Readers take a snapshot of the hash map, then work with the snapshot.
+  class Snapshot {
+    ConcurrentReadableHashMap *Map;
+    IndexStorage *Indices;
+    ElemTy *Elements;
+    size_t ElementCount;
+
+  public:
+    Snapshot(ConcurrentReadableHashMap *map, IndexStorage *indices,
+             ElemTy *elements, size_t elementCount)
+        : Map(map), Indices(indices), Elements(elements),
+          ElementCount(elementCount) {}
+
+    Snapshot(const Snapshot &other)
+        : Map(other.Map), Indices(other.Indices), Elements(other.Elements),
+          ElementCount(other.ElementCount) {
+      Map->incrementReaders();
+    }
+
+    ~Snapshot() { Map->decrementReaders(); }
+
+    /// Search for an element matching the given key. Returns a pointer to the
+    /// found element, or nullptr if no matching element exists.
+    template <class KeyTy> const ElemTy *find(const KeyTy &key) {
+      if (!Indices || !ElementCount || !Elements)
+        return nullptr;
+      return ConcurrentReadableHashMap::find(key, Indices, ElementCount,
+                                             Elements)
+          .first;
+    }
+  };
+
+  /// Take a snapshot of the current state of the hash map.
+  Snapshot snapshot() {
+    incrementReaders();
+    auto *indices = Indices.load(SWIFT_MEMORY_ORDER_CONSUME);
+    auto elementCount = ElementCount.load(std::memory_order_acquire);
+    auto *elements = Elements.load(std::memory_order_acquire);
+
+    return Snapshot(this, indices, elements, elementCount);
+  }
+
+  /// Get an element by key, or insert a new element for that key if one is not
+  /// already present. Invoke `call` with the pointer to the element. BEWARE:
+  /// `call` is invoked with the internal writer lock held, keep work to a
+  /// minimum.
+  ///
+  /// `call` is passed the following parameters:
+  ///   - `element`: the pointer to the element corresponding to `key`
+  ///   - `created`: true if the element is newly created, false if it already
+  ///                exists
+  /// `call` returns a `bool`. When `created` is `true`, the return values mean:
+  ///   - `true` the new entry is to be kept
+  ///   - `false` indicates that the new entry is discarded
+  /// If the new entry is kept, then the new element MUST be initialized, and
+  /// have a hash value that matches the hash value of `key`.
+  ///
+  /// The return value is ignored when `created` is `false`.
+  template <class KeyTy, typename Call>
+  void getOrInsert(KeyTy key, const Call &call) {
+    ScopedLock guard(WriterLock);
+
+    auto *indices = Indices.load(std::memory_order_relaxed);
+    if (!indices)
+      indices = resize(indices, 0, nullptr);
+
+    auto indicesMask = indices->Mask.load(std::memory_order_relaxed);
+    auto elementCount = ElementCount.load(std::memory_order_relaxed);
+    auto *elements = Elements.load(std::memory_order_relaxed);
+
+    auto found = find(key, indices, elementCount, elements);
+    if (found.first) {
+      call(found.first, false);
+      deallocateFreeListIfSafe();
+      return;
+    }
+
+    // The actual capacity is indicesMask + 1. The number of slots in use is
+    // elementCount + 1, since the mask also takes a slot.
+    auto emptyCount = (indicesMask + 1) - (elementCount + 1);
+    auto proportion = (indicesMask + 1) / emptyCount;
+    if (proportion >= ResizeProportion) {
+      indices = resize(indices, indicesMask, elements);
+      found = find(key, indices, elementCount, elements);
+      assert(!found.first && "Shouldn't suddenly find the key after rehashing");
+    }
+
+    if (elementCount >= ElementCapacity) {
+      elements = resize(elements, elementCount);
+    }
+    auto *element = &elements[elementCount];
+
+    // Order matters: fill out the element, then update the count,
+    // then update the index.
+    bool keep = call(element, true);
+    if (keep) {
+      assert(hash_value(key) == hash_value(*element) &&
+             "Element must have the same hash code as its key.");
+      ElementCount.store(elementCount + 1, std::memory_order_release);
+      found.second->store(elementCount + 1, std::memory_order_release);
+    }
+
+    deallocateFreeListIfSafe();
+  }
+
+  /// Clear the hash table, freeing (when safe) all memory currently used for
+  /// indices and elements.
+  void clear() {
+    ScopedLock guard(WriterLock);
+
+    auto *indices = Indices.load(std::memory_order_relaxed);
+    auto *elements = Elements.load(std::memory_order_relaxed);
+
+    // Order doesn't matter here, snapshots will gracefully handle any field
+    // being NULL/0 while the others are not.
+    Indices.store(nullptr, std::memory_order_relaxed);
+    ElementCount.store(0, std::memory_order_relaxed);
+    Elements.store(nullptr, std::memory_order_relaxed);
+    ElementCapacity = 0;
+
+    IndicesFreeList.push_back(indices);
+    ElementFreeList.push_back(elements);
+
+    deallocateFreeListIfSafe();
   }
 };
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -198,31 +198,27 @@ namespace {
         : Type(type), Proto(proto) {
       assert(type);
     }
+
+    friend llvm::hash_code hash_value(const ConformanceCacheKey &key) {
+      return llvm::hash_combine(key.Type, key.Proto);
+    }
   };
 
   struct ConformanceCacheEntry {
   private:
-    const Metadata *Type; 
-    const ProtocolDescriptor *Proto;
-    std::atomic<const ProtocolConformanceDescriptor *> Description;
-    std::atomic<size_t> FailureGeneration;
+    ConformanceCacheKey Key;
+    const WitnessTable *Witness;
 
   public:
-    ConformanceCacheEntry(ConformanceCacheKey key,
-                          const ProtocolConformanceDescriptor *description,
-                          size_t failureGeneration)
-      : Type(key.Type), Proto(key.Proto), Description(description),
-        FailureGeneration(failureGeneration) {
+    ConformanceCacheEntry(ConformanceCacheKey key, const WitnessTable *witness)
+        : Key(key), Witness(witness) {}
+
+    bool matchesKey(const ConformanceCacheKey &key) const {
+      return Key.Type == key.Type && Key.Proto == key.Proto;
     }
 
-    int compareWithKey(const ConformanceCacheKey &key) const {
-      if (key.Type != Type) {
-        return (uintptr_t(key.Type) < uintptr_t(Type) ? -1 : 1);
-      } else if (key.Proto != Proto) {
-        return (uintptr_t(key.Proto) < uintptr_t(Proto) ? -1 : 1);
-      } else {
-        return 0;
-      }
+    friend llvm::hash_code hash_value(const ConformanceCacheEntry &entry) {
+      return hash_value(entry.Key);
     }
 
     template <class... Args>
@@ -230,69 +226,54 @@ namespace {
       return 0;
     }
 
-    bool isSuccessful() const {
-      return Description.load(std::memory_order_relaxed) != nullptr;
-    }
-
-    void makeSuccessful(const ProtocolConformanceDescriptor *description) {
-      Description.store(description, std::memory_order_release);
-    }
-
-    void updateFailureGeneration(size_t failureGeneration) {
-      assert(!isSuccessful());
-      FailureGeneration.store(failureGeneration, std::memory_order_relaxed);
-    }
-
-    /// Get the cached conformance descriptor, if successful.
-    const ProtocolConformanceDescriptor *getDescription() const {
-      assert(isSuccessful());
-      return Description.load(std::memory_order_acquire);
-    }
-    
-    /// Get the generation in which this lookup failed.
-    size_t getFailureGeneration() const {
-      assert(!isSuccessful());
-      return FailureGeneration.load(std::memory_order_relaxed);
+    /// Get the cached witness table, or null if we cached failure.
+    const WitnessTable *getWitnessTable() const {
+      return Witness;
     }
   };
 } // end anonymous namespace
 
 // Conformance Cache.
 struct ConformanceState {
-  ConcurrentMap<ConformanceCacheEntry> Cache;
+  ConcurrentReadableHashMap<ConformanceCacheEntry> Cache;
   ConcurrentReadableArray<ConformanceSection> SectionsToScan;
   
   ConformanceState() {
     initializeProtocolConformanceLookup();
   }
 
-  void cacheSuccess(const Metadata *type, const ProtocolDescriptor *proto,
-                    const ProtocolConformanceDescriptor *description) {
-    auto result = Cache.getOrInsert(ConformanceCacheKey(type, proto),
-                                    description, 0);
+  void cacheResult(const Metadata *type, const ProtocolDescriptor *proto,
+                   const WitnessTable *witness, size_t sectionsCount) {
+    Cache.getOrInsert(ConformanceCacheKey(type, proto),
+                      [&](ConformanceCacheEntry *entry, bool created) {
+                        // Create the entry if needed. If it already exists,
+                        // we're done.
+                        if (!created)
+                          return false;
 
-    // If the entry was already present, we may need to update it.
-    if (!result.second) {
-      result.first->makeSuccessful(description);
-    }
-  }
+                        // Check the current sections count against what was
+                        // passed in. If a section count was passed in and they
+                        // don't match, then this is not an authoritative entry
+                        // and it may have been obsoleted, because the new
+                        // sections could contain a conformance in a more
+                        // specific type.
+                        //
+                        // If they DO match, then we can safely add. Another
+                        // thread might be adding new sections at this point,
+                        // but we will not race with them. That other thread
+                        // will add the new sections, then clear the cache. When
+                        // it clears the cache, it will block waiting for this
+                        // code to complete and relinquish Cache's writer lock.
+                        // If we cache a stale entry, it will be immediately
+                        // cleared.
+                        if (sectionsCount > 0 &&
+                            SectionsToScan.snapshot().count() != sectionsCount)
+                          return false; // abandon the new entry
 
-  void cacheFailure(const Metadata *type, const ProtocolDescriptor *proto,
-                    size_t failureGeneration) {
-    auto result =
-      Cache.getOrInsert(ConformanceCacheKey(type, proto),
-                        (const ProtocolConformanceDescriptor *) nullptr,
-                        failureGeneration);
-
-    // If the entry was already present, we may need to update it.
-    if (!result.second) {
-      result.first->updateFailureGeneration(failureGeneration);
-    }
-  }
-
-  ConformanceCacheEntry *findCached(const Metadata *type,
-                                    const ProtocolDescriptor *proto) {
-    return Cache.find(ConformanceCacheKey(type, proto));
+                        new (entry) ConformanceCacheEntry(
+                            ConformanceCacheKey(type, proto), witness);
+                        return true; // keep the new entry
+                      });
   }
 
 #ifndef NDEBUG
@@ -323,6 +304,10 @@ _registerProtocolConformances(ConformanceState &C,
                               const ProtocolConformanceRecord *begin,
                               const ProtocolConformanceRecord *end) {
   C.SectionsToScan.push_back(ConformanceSection{begin, end});
+
+  // Blow away the conformances cache to get rid of any negative entries that
+  // may now be obsolete.
+  C.Cache.clear();
 }
 
 void swift::addImageProtocolConformanceBlockCallbackUnsafe(
@@ -357,98 +342,29 @@ swift::swift_registerProtocolConformances(const ProtocolConformanceRecord *begin
   _registerProtocolConformances(C, begin, end);
 }
 
-
-struct ConformanceCacheResult {
-  // true if description is an authoritative result as-is.
-  // false if more searching is required (for example, because a cached
-  // failure was returned in failureEntry but it is out-of-date.
-  bool isAuthoritative;
-
-  // The matching conformance descriptor, or null if no cached conformance
-  // was found.
-  const ProtocolConformanceDescriptor *description;
-
-  // If the search fails, this may be the negative cache entry for the
-  // queried type itself. This entry may be null or out-of-date.
-  ConformanceCacheEntry *failureEntry;
-
-  static ConformanceCacheResult
-  cachedSuccess(const ProtocolConformanceDescriptor *description) {
-    return ConformanceCacheResult { true, description, nullptr };
-  }
-
-  static ConformanceCacheResult
-  cachedFailure(ConformanceCacheEntry *entry, bool auth) {
-    return ConformanceCacheResult { auth, nullptr, entry };
-  }
-
-  static ConformanceCacheResult
-  cacheMiss() {
-    return ConformanceCacheResult { false, nullptr, nullptr };
-  }
-};
-
 /// Search for a conformance descriptor in the ConformanceCache.
-static
-ConformanceCacheResult
+/// First element of the return value is `true` if the result is authoritative
+/// i.e. the result is for the type itself and not a superclass. If `false`
+/// then we cached a conformance on a superclass, but that may be overridden.
+/// A return value of `{ false, nullptr }` indicates nothing was cached.
+static std::pair<bool, const WitnessTable *>
 searchInConformanceCache(const Metadata *type,
                          const ProtocolDescriptor *protocol) {
   auto &C = Conformances.get();
   auto origType = type;
-  ConformanceCacheEntry *failureEntry = nullptr;
+  auto snapshot = C.Cache.snapshot();
 
-recur:
-  {
-    // Try the specific type first.
-    if (auto *Value = C.findCached(type, protocol)) {
-      if (Value->isSuccessful()) {
-        // Found a conformance on the type or some superclass. Return it.
-        return ConformanceCacheResult::cachedSuccess(Value->getDescription());
-      }
-
-      // Found a negative cache entry.
-
-      bool isAuthoritative;
-      if (type == origType) {
-        // This negative cache entry is for the original query type.
-        // Remember it so it can be returned later.
-        failureEntry = Value;
-        // An up-to-date entry for the original type is authoritative.
-        isAuthoritative = true;
-      } else {
-        // An up-to-date cached failure for a superclass of the type is not
-        // authoritative: there may be a still-undiscovered conformance
-        // for the original query type.
-        isAuthoritative = false;
-      }
-
-      // Check if the negative cache entry is up-to-date.
-      if (Value->getFailureGeneration() == C.SectionsToScan.snapshot().count()) {
-        // Negative cache entry is up-to-date. Return failure along with
-        // the original query type's own cache entry, if we found one.
-        // (That entry may be out of date but the caller still has use for it.)
-        return ConformanceCacheResult::cachedFailure(failureEntry,
-                                                     isAuthoritative);
-      }
-
-      // Negative cache entry is out-of-date.
-      // Continue searching for a better result.
+  while (type) {
+    if (auto *Value = snapshot.find(ConformanceCacheKey(type, protocol))) {
+      return {type == origType, Value->getWitnessTable()};
     }
+
+    // If there is a superclass, look there.
+    type = _swift_class_getSuperclass(type);
   }
 
-  // If there is a superclass, look there.
-  if (auto superclass = _swift_class_getSuperclass(type)) {
-    type = superclass;
-    goto recur;
-  }
-
-  // We did not find an up-to-date cache entry.
-  // If we found an out-of-date entry for the original query type then
-  // return it (non-authoritatively). Otherwise return a cache miss.
-  if (failureEntry)
-    return ConformanceCacheResult::cachedFailure(failureEntry, false);
-  else
-    return ConformanceCacheResult::cacheMiss();
+  // We did not find a cache entry.
+  return {false, nullptr};
 }
 
 namespace {
@@ -475,14 +391,6 @@ namespace {
         candidateIsMetadata = true;
         return;
       }
-    }
-
-    /// Retrieve the conforming type as metadata, or NULL if the candidate's
-    /// conforming type is described in another way (e.g., a nominal type
-    /// descriptor).
-    const Metadata *getConformingTypeAsMetadata() const {
-      return candidateIsMetadata ? static_cast<const Metadata *>(candidate)
-                                 : nullptr;
     }
 
     const ContextDescriptor *
@@ -544,40 +452,21 @@ namespace {
   };
 }
 
-static const ProtocolConformanceDescriptor *
-swift_conformsToSwiftProtocolImpl(const Metadata * const type,
-                                  const ProtocolDescriptor *protocol,
-                                  StringRef module) {
+static const WitnessTable *
+swift_conformsToProtocolImpl(const Metadata *const type,
+                             const ProtocolDescriptor *protocol) {
   auto &C = Conformances.get();
 
-  // See if we have a cached conformance. The ConcurrentMap data structure
-  // allows us to insert and search the map concurrently without locking.
-  auto FoundConformance = searchInConformanceCache(type, protocol);
-  // If the result (positive or negative) is authoritative, return it.
-  if (FoundConformance.isAuthoritative)
-    return FoundConformance.description;
+  // See if we have an authoritative cached conformance. The
+  // ConcurrentReadableHashMap data structure allows us to search the map
+  // concurrently without locking.
+  auto found = searchInConformanceCache(type, protocol);
+  if (found.first)
+    return found.second;
 
-  auto failureEntry = FoundConformance.failureEntry;
-
-  // Prepare to scan conformance records.
+  // Scan conformance records.
   auto snapshot = C.SectionsToScan.snapshot();
-  
-  // Scan only sections that were not scanned yet.
-  // If we found an out-of-date negative cache entry,
-  // we need not to re-scan the sections that it covers.
-  auto startIndex = failureEntry ? failureEntry->getFailureGeneration() : 0;
-  auto endIndex = snapshot.count();
-
-  // If there are no unscanned sections outstanding
-  // then we can cache failure and give up now.
-  if (startIndex == endIndex) {
-    C.cacheFailure(type, protocol, snapshot.count());
-    return nullptr;
-  }
-
-  // Really scan conformance records.
-  for (size_t i = startIndex; i < endIndex; ++i) {
-    auto &section = snapshot.Start[i];
+  for (auto &section : snapshot) {
     // Eagerly pull records for nondependent witnesses into our cache.
     for (const auto &record : section) {
       auto &descriptor = *record.get();
@@ -586,40 +475,25 @@ swift_conformsToSwiftProtocolImpl(const Metadata * const type,
       if (descriptor.getProtocol() != protocol)
         continue;
 
-      // If there's a matching type, record the positive result.
+      // If there's a matching type, record the positive result and return it.
+      // The matching type is exact, so they can't go stale, and we should
+      // always cache them.
       ConformanceCandidate candidate(descriptor);
-      if (candidate.getMatchingType(type)) {
-        const Metadata *matchingType = candidate.getConformingTypeAsMetadata();
-        if (!matchingType)
-          matchingType = type;
-
-        C.cacheSuccess(matchingType, protocol, &descriptor);
+      if (auto *matchingType = candidate.getMatchingType(type)) {
+        auto witness = descriptor.getWitnessTable(matchingType);
+        C.cacheResult(matchingType, protocol, witness, /*always cache*/ 0);
       }
     }
   }
-  
-  // Conformance scan is complete.
 
-  // Search the cache once more, and this time update the cache if necessary.
-  FoundConformance = searchInConformanceCache(type, protocol);
-  if (FoundConformance.isAuthoritative) {
-    return FoundConformance.description;
-  } else {
-    C.cacheFailure(type, protocol, snapshot.count());
-    return nullptr;
-  }
-}
+  // Try the search again to look for the most specific cached conformance.
+  found = searchInConformanceCache(type, protocol);
 
-static const WitnessTable *
-swift_conformsToProtocolImpl(const Metadata * const type,
-                             const ProtocolDescriptor *protocol) {
-  auto description =
-    swift_conformsToSwiftProtocol(type, protocol, StringRef());
-  if (!description)
-    return nullptr;
+  // If it's not authoritative, then add an authoritative entry for this type.
+  if (!found.first)
+    C.cacheResult(type, protocol, found.second, snapshot.count());
 
-  return description->getWitnessTable(
-      findConformingSuperclass(type, description));
+  return found.second;
 }
 
 const ContextDescriptor *

--- a/stdlib/toolchain/Compatibility50/CompatibilityOverride.def
+++ b/stdlib/toolchain/Compatibility50/CompatibilityOverride.def
@@ -134,6 +134,13 @@ OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , , swift
                               const ProtocolDescriptor *protocol),
                              (type, protocol))
 
+OVERRIDE_PROTOCOLCONFORMANCE(conformsToSwiftProtocol,
+                             const ProtocolConformanceDescriptor *, , , swift::,
+                             (const Metadata * const type,
+                              const ProtocolDescriptor *protocol,
+                              StringRef moduleName),
+                             (type, protocol, moduleName))
+
 OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))

--- a/stdlib/toolchain/Compatibility50/CompatibilityOverride.h
+++ b/stdlib/toolchain/Compatibility50/CompatibilityOverride.h
@@ -1,0 +1,61 @@
+//===--- CompatibiltyOverride.h - Back-deploying compatibility fixes --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Support back-deploying compatibility fixes for newer apps running on older runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef COMPATIBILITY_OVERRIDE_H
+#define COMPATIBILITY_OVERRIDE_H
+
+#include "../../public/runtime/Private.h"
+#include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Once.h"
+#include <type_traits>
+
+namespace swift {
+
+#define COMPATIBILITY_UNPAREN(...) __VA_ARGS__
+
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Original_ ## name) typedArgs;
+#include "CompatibilityOverride.def"
+
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Override_ ## name)(COMPATIBILITY_UNPAREN typedArgs, \
+                                           Original_ ## name originalImpl);
+#include "CompatibilityOverride.def"
+
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  Override_ ## name getOverride_ ## name();
+#include "CompatibilityOverride.def"
+
+
+/// Used to define an override point. The override point #defines the appropriate
+/// OVERRIDE macro from CompatibilityOverride.def to this macro, then includes
+/// the file to generate the override points. The original implementation of the
+/// functionality must be available as swift_funcNameHereImpl.
+#define COMPATIBILITY_OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  attrs ccAttrs ret namespace swift_ ## name typedArgs {                          \
+    static Override_ ## name Override;                                            \
+    static swift_once_t Predicate;                                                \
+    swift_once(&Predicate, [](void *) {                                           \
+      Override = getOverride_ ## name();                                          \
+    }, nullptr);                                                                  \
+    if (Override != nullptr)                                                      \
+      return Override(COMPATIBILITY_UNPAREN namedArgs, swift_ ## name ## Impl);   \
+    return swift_ ## name ## Impl namedArgs; \
+  }
+
+} /* end namespace swift */
+
+#endif /* COMPATIBILITY_OVERRIDE_H */

--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -16,7 +16,7 @@
 
 #include "Overrides.h"
 #include "../Compatibility51/Overrides.h"
-#include "../../public/runtime/CompatibilityOverride.h"
+#include "CompatibilityOverride.h"
 
 #include <dlfcn.h>
 #include <mach-o/dyld.h>
@@ -28,7 +28,7 @@ struct OverrideSection {
   uintptr_t version;
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
-#include "../../public/runtime/CompatibilityOverride.def"
+#include "CompatibilityOverride.def"
 };
   
 OverrideSection Swift50Overrides

--- a/stdlib/toolchain/Compatibility51/CompatibilityOverride.def
+++ b/stdlib/toolchain/Compatibility51/CompatibilityOverride.def
@@ -134,6 +134,13 @@ OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , , swift
                               const ProtocolDescriptor *protocol),
                              (type, protocol))
 
+OVERRIDE_PROTOCOLCONFORMANCE(conformsToSwiftProtocol,
+                             const ProtocolConformanceDescriptor *, , , swift::,
+                             (const Metadata * const type,
+                              const ProtocolDescriptor *protocol,
+                              StringRef moduleName),
+                             (type, protocol, moduleName))
+
 OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , , swift::,
                  (const void *pattern, const void *arguments),
                  (pattern, arguments))

--- a/stdlib/toolchain/Compatibility51/CompatibilityOverride.h
+++ b/stdlib/toolchain/Compatibility51/CompatibilityOverride.h
@@ -1,0 +1,61 @@
+//===--- CompatibiltyOverride.h - Back-deploying compatibility fixes --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Support back-deploying compatibility fixes for newer apps running on older runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef COMPATIBILITY_OVERRIDE_H
+#define COMPATIBILITY_OVERRIDE_H
+
+#include "../../public/runtime/Private.h"
+#include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Once.h"
+#include <type_traits>
+
+namespace swift {
+
+#define COMPATIBILITY_UNPAREN(...) __VA_ARGS__
+
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Original_ ## name) typedArgs;
+#include "CompatibilityOverride.def"
+
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  ccAttrs typedef ret (*Override_ ## name)(COMPATIBILITY_UNPAREN typedArgs, \
+                                           Original_ ## name originalImpl);
+#include "CompatibilityOverride.def"
+
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  Override_ ## name getOverride_ ## name();
+#include "CompatibilityOverride.def"
+
+
+/// Used to define an override point. The override point #defines the appropriate
+/// OVERRIDE macro from CompatibilityOverride.def to this macro, then includes
+/// the file to generate the override points. The original implementation of the
+/// functionality must be available as swift_funcNameHereImpl.
+#define COMPATIBILITY_OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  attrs ccAttrs ret namespace swift_ ## name typedArgs {                          \
+    static Override_ ## name Override;                                            \
+    static swift_once_t Predicate;                                                \
+    swift_once(&Predicate, [](void *) {                                           \
+      Override = getOverride_ ## name();                                          \
+    }, nullptr);                                                                  \
+    if (Override != nullptr)                                                      \
+      return Override(COMPATIBILITY_UNPAREN namedArgs, swift_ ## name ## Impl);   \
+    return swift_ ## name ## Impl namedArgs; \
+  }
+
+} /* end namespace swift */
+
+#endif /* COMPATIBILITY_OVERRIDE_H */

--- a/stdlib/toolchain/Compatibility51/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility51/Overrides.cpp
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../../public/runtime/CompatibilityOverride.h"
+#include "CompatibilityOverride.h"
 #include "Overrides.h"
 
 #include <dlfcn.h>
@@ -27,7 +27,7 @@ struct OverrideSection {
   uintptr_t version;
 #define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
   Override_ ## name name;
-#include "../../public/runtime/CompatibilityOverride.def"
+#include "CompatibilityOverride.def"
 };
   
 OverrideSection Swift51Overrides

--- a/tools/swift-inspect/Sources/swift-inspect/Inspector.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Inspector.swift
@@ -121,14 +121,36 @@ private func QueryDataLayoutFn(context: UnsafeMutableRawPointer?,
                               type: DataLayoutQueryType,
                               inBuffer: UnsafeMutableRawPointer?,
                               outBuffer: UnsafeMutableRawPointer?) -> CInt {
+  let is64 = MemoryLayout<UnsafeRawPointer>.stride == 8
+
   switch type {
-  case DLQ_GetPointerSize:
+  case DLQ_GetPointerSize, DLQ_GetSizeSize:
     let size = UInt8(MemoryLayout<UnsafeRawPointer>.stride)
     outBuffer!.storeBytes(of: size, toByteOffset: 0, as: UInt8.self)
     return 1
   case DLQ_GetPtrAuthMask:
     let mask = GetPtrauthMask()
     outBuffer!.storeBytes(of: mask, toByteOffset: 0, as: UInt.self)
+    return 1
+  case DLQ_GetObjCReservedLowBits:
+    var size: UInt8 = 0
+#if os(macOS)
+    // The low bit is reserved only on 64-bit macOS.
+    if is64 {
+      size = 1
+    }
+#endif
+    outBuffer!.storeBytes(of: size, toByteOffset: 0, as: UInt8.self)
+    return 1
+  case DLQ_GetLeastValidPointerValue:
+    var value: UInt64 = 0x1000
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    // 64-bit Apple platforms reserve the low 4GB.
+    if is64 {
+      value = 0x100000000
+    }
+#endif
+    outBuffer!.storeBytes(of: value, toByteOffset: 0, as: UInt64.self)
     return 1
   default:
     return 0

--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -168,11 +168,6 @@ TEST_F(CompatibilityOverrideTest, test_swift_conformsToProtocol) {
   ASSERT_EQ(Result, nullptr);  
 }
 
-TEST_F(CompatibilityOverrideTest, test_swift_conformsToSwiftProtocol) {
-  auto Result = swift_conformsToSwiftProtocol(nullptr, nullptr, StringRef());
-  ASSERT_EQ(Result, nullptr);
-}
-
 TEST_F(CompatibilityOverrideTest, test_swift_getTypeByMangledNode) {
   Demangler demangler;
   auto Result = swift_getTypeByMangledNode(MetadataState::Abstract,

--- a/unittests/runtime/Concurrent.cpp
+++ b/unittests/runtime/Concurrent.cpp
@@ -154,3 +154,348 @@ TEST(ConcurrentReadableArrayTest, MultiThreaded2) {
 
   ASSERT_EQ(array.snapshot().count(), (size_t)writerCount * insertCount);
 }
+
+struct SingleThreadedValue {
+  size_t key;
+  size_t x;
+  SingleThreadedValue(size_t key, size_t x) : key(key), x(x) {}
+  bool matchesKey(size_t key) { return this->key == key; }
+  friend llvm::hash_code hash_value(const SingleThreadedValue &value) {
+    return llvm::hash_value(value.key);
+  }
+};
+
+TEST(ConcurrentReadableHashMapTest, SingleThreaded) {
+  ConcurrentReadableHashMap<SingleThreadedValue> map;
+
+  auto permute = [](size_t value) { return value ^ 0x33333333U; };
+
+  auto add = [&](size_t limit) {
+    for (size_t i = 0; i < limit; i++)
+      map.getOrInsert(permute(i),
+                      [&](SingleThreadedValue *value, bool created) {
+                        if (created)
+                          new (value) SingleThreadedValue(permute(i), i);
+                        return true;
+                      });
+  };
+  auto check = [&](size_t limit) {
+    auto snapshot = map.snapshot();
+    ASSERT_EQ(snapshot.find((size_t)~0), nullptr);
+    for (size_t i = 0; i < limit; i++) {
+      auto *value = snapshot.find(permute(i));
+      ASSERT_NE(value, nullptr);
+      ASSERT_EQ(permute(i), value->key);
+      ASSERT_EQ(i, value->x);
+    }
+  };
+
+  check(0);
+  add(1);
+  check(1);
+  add(16);
+  check(16);
+  add(100);
+  check(100);
+  add(1000);
+  check(1000);
+  add(1000000);
+  check(1000000);
+
+  map.clear();
+  check(0);
+
+  add(1);
+  check(1);
+  map.clear();
+  check(0);
+
+  add(16);
+  check(16);
+  map.clear();
+  check(0);
+
+  add(100);
+  check(100);
+  map.clear();
+  check(0);
+
+  add(1000);
+  check(1000);
+  map.clear();
+  check(0);
+
+  add(1000000);
+  check(1000000);
+  map.clear();
+  check(0);
+}
+
+struct MultiThreadedKey {
+  int threadNumber;
+  int n;
+  friend llvm::hash_code hash_value(const MultiThreadedKey &value) {
+    return llvm::hash_combine(value.threadNumber, value.n);
+  }
+};
+
+struct MultiThreadedValue {
+  int threadNumber;
+  int n;
+  int x;
+  MultiThreadedValue(MultiThreadedKey key, int x)
+      : threadNumber(key.threadNumber), n(key.n), x(x) {}
+  bool matchesKey(const MultiThreadedKey &key) {
+    return threadNumber == key.threadNumber && n == key.n;
+  }
+  friend llvm::hash_code hash_value(const MultiThreadedValue &value) {
+    return llvm::hash_combine(value.threadNumber, value.n);
+  }
+};
+
+// Test simultaneous readers and writers.
+TEST(ConcurrentReadableHashMapTest, MultiThreaded) {
+  const int writerCount = 16;
+  const int readerCount = 8;
+  const int insertCount = 10000;
+
+  ConcurrentReadableHashMap<MultiThreadedValue> map;
+
+  // NOTE: The bizarre lambdas around the ASSERT_ statements works around the
+  // fact that these macros emit return statements, which conflict with our
+  // need to return true/false from these lambdas. Wrapping them in a lambda
+  // neutralizes the return.
+
+  auto writer = [&](int threadNumber) {
+    // Insert half, then insert all, to test adding an existing key.
+    for (int i = 0; i < insertCount / 2; i++)
+      map.getOrInsert(MultiThreadedKey{threadNumber, i}, [&](MultiThreadedValue
+                                                                 *value,
+                                                             bool created) {
+        [&] { ASSERT_TRUE(created); }();
+        new (value) MultiThreadedValue(MultiThreadedKey{threadNumber, i}, i);
+        return true;
+      });
+    // Test discarding a new entry.
+    for (int i = 0; i < insertCount; i++)
+      map.getOrInsert(MultiThreadedKey{threadNumber, i},
+                      [&](MultiThreadedValue *value, bool created) {
+                        [&] { ASSERT_EQ(created, i >= insertCount / 2); }();
+                        return false;
+                      });
+    for (int i = 0; i < insertCount; i++)
+      map.getOrInsert(MultiThreadedKey{threadNumber, i}, [&](MultiThreadedValue
+                                                                 *value,
+                                                             bool created) {
+        if (created) {
+          [&] { ASSERT_GE(i, insertCount / 2); }();
+          new (value) MultiThreadedValue(MultiThreadedKey{threadNumber, i}, i);
+        } else {
+          [&] { ASSERT_LT(i, insertCount / 2); }();
+        }
+        return true;
+      });
+  };
+
+  auto reader = [&] {
+    bool done = false;
+    while (!done) {
+      done = true;
+      for (int threadNumber = 0; threadNumber < writerCount; threadNumber++) {
+        // Read from the top down. We should see zero or more missing entries,
+        // and then the rest are present. Any hole is a bug.
+        int firstSeen = -1;
+        auto snapshot = map.snapshot();
+        for (int i = insertCount - 1; i >= 0; i--) {
+          MultiThreadedKey key = {threadNumber, i};
+          const MultiThreadedValue *value = snapshot.find(key);
+          if (value) {
+            if (firstSeen == -1)
+              firstSeen = value->x;
+            ASSERT_EQ(value->x, i);
+          } else {
+            ASSERT_EQ(firstSeen, -1);
+            done = false;
+          }
+        }
+      }
+    }
+  };
+
+  threadedExecute(writerCount + readerCount, [&](int i) {
+    if (i < writerCount)
+      writer(i);
+    else
+      reader();
+  });
+}
+
+// Test readers and writers while also constantly clearing the map.
+TEST(ConcurrentReadableHashMapTest, MultiThreaded2) {
+  const int writerCount = 16;
+  const int readerCount = 8;
+  const int insertCount = 10000;
+
+  ConcurrentReadableHashMap<MultiThreadedValue> map;
+
+  std::atomic<int> writerDoneCount = {0};
+  auto writer = [&](int threadNumber) {
+    for (int i = 0; i < insertCount; i++)
+      map.getOrInsert(MultiThreadedKey{threadNumber, i}, [&](MultiThreadedValue
+                                                                 *value,
+                                                             bool created) {
+        [&] { ASSERT_TRUE(created); }();
+        new (value) MultiThreadedValue(MultiThreadedKey{threadNumber, i}, i);
+        return true;
+      });
+    writerDoneCount.fetch_add(1, std::memory_order_relaxed);
+  };
+
+  auto reader = [&] {
+    while (writerDoneCount.load(std::memory_order_relaxed) < writerCount) {
+      for (int threadNumber = 0; threadNumber < writerCount; threadNumber++) {
+        // Read from the top down. We should see a single contiguous region of
+        // entries. Multiple regions indicates a bug.
+        int firstSeen = -1;
+        int lastSeen = -1;
+        auto snapshot = map.snapshot();
+        for (int i = insertCount - 1; i >= 0; i--) {
+          MultiThreadedKey key = {threadNumber, i};
+          const MultiThreadedValue *value = snapshot.find(key);
+          if (value) {
+            if (firstSeen == -1)
+              firstSeen = value->x;
+            if (lastSeen != -1)
+              ASSERT_EQ(lastSeen, i + 1);
+            lastSeen = value->x;
+            ASSERT_EQ(value->x, i);
+          }
+        }
+      }
+    }
+  };
+
+  auto clear = [&] {
+    while (writerDoneCount.load(std::memory_order_relaxed) < writerCount) {
+      map.clear();
+    }
+  };
+
+  threadedExecute(writerCount + readerCount + 1, [&](int i) {
+    if (i < writerCount)
+      writer(i);
+    else if (i < writerCount + readerCount)
+      reader();
+    else
+      clear();
+  });
+}
+
+// Test readers and writers, with readers taking lots of snapshots.
+TEST(ConcurrentReadableHashMapTest, MultiThreaded3) {
+  const int writerCount = 16;
+  const int readerCount = 8;
+  const int insertCount = 10000;
+
+  ConcurrentReadableHashMap<MultiThreadedValue> map;
+
+  std::atomic<int> writerDoneCount = {0};
+  auto writer = [&](int threadNumber) {
+    for (int i = 0; i < insertCount; i++)
+      map.getOrInsert(MultiThreadedKey{threadNumber, i}, [&](MultiThreadedValue
+                                                                 *value,
+                                                             bool created) {
+        [&] { ASSERT_TRUE(created); }();
+        new (value) MultiThreadedValue(MultiThreadedKey{threadNumber, i}, i);
+        return true;
+      });
+    writerDoneCount.fetch_add(1, std::memory_order_relaxed);
+  };
+
+  auto reader = [&] {
+    while (writerDoneCount.load(std::memory_order_relaxed) < writerCount) {
+      for (int threadNumber = 0; threadNumber < writerCount; threadNumber++) {
+        // Read from the top down. When we're not clearing the map, we should
+        // see zero or more missing entries, and then the rest are present. Any
+        // hole is a bug.
+        int firstSeen = -1;
+        int lastSeen = -1;
+        for (int i = insertCount - 1; i >= 0; i--) {
+          auto snapshot = map.snapshot();
+          MultiThreadedKey key = {threadNumber, i};
+          const MultiThreadedValue *value = snapshot.find(key);
+          if (value) {
+            if (firstSeen == -1)
+              firstSeen = value->x;
+            if (lastSeen != -1)
+              ASSERT_EQ(lastSeen, i + 1);
+            lastSeen = value->x;
+            ASSERT_EQ(value->x, i);
+          }
+        }
+      }
+    }
+  };
+
+  threadedExecute(writerCount + readerCount, [&](int i) {
+    if (i < writerCount)
+      writer(i);
+    else
+      reader();
+  });
+}
+
+// Test readers and writers, with readers taking lots of snapshots, and
+// simultaneous clearing.
+TEST(ConcurrentReadableHashMapTest, MultiThreaded4) {
+  const int writerCount = 16;
+  const int readerCount = 8;
+  const int insertCount = 10000;
+
+  ConcurrentReadableHashMap<MultiThreadedValue> map;
+
+  std::atomic<int> writerDoneCount = {0};
+  auto writer = [&](int threadNumber) {
+    for (int i = 0; i < insertCount; i++)
+      map.getOrInsert(MultiThreadedKey{threadNumber, i}, [&](MultiThreadedValue
+                                                                 *value,
+                                                             bool created) {
+        [&] { ASSERT_TRUE(created); }();
+        new (value) MultiThreadedValue(MultiThreadedKey{threadNumber, i}, i);
+        return true;
+      });
+    writerDoneCount.fetch_add(1, std::memory_order_relaxed);
+  };
+
+  auto reader = [&] {
+    while (writerDoneCount.load(std::memory_order_relaxed) < writerCount) {
+      for (int threadNumber = 0; threadNumber < writerCount; threadNumber++) {
+        // With clearing, we can't expect any particular pattern. Just validate
+        // the values we do see, and make sure we don't crash.
+        for (int i = insertCount - 1; i >= 0; i--) {
+          auto snapshot = map.snapshot();
+          MultiThreadedKey key = {threadNumber, i};
+          const MultiThreadedValue *value = snapshot.find(key);
+          if (value) {
+            ASSERT_EQ(value->x, i);
+          }
+        }
+      }
+    }
+  };
+
+  auto clear = [&] {
+    while (writerDoneCount.load(std::memory_order_relaxed) < writerCount) {
+      map.clear();
+    }
+  };
+
+  threadedExecute(writerCount + readerCount + 1, [&](int i) {
+    if (i < writerCount)
+      writer(i);
+    else if (i < writerCount + readerCount)
+      reader();
+    else
+      clear();
+  });
+}


### PR DESCRIPTION
# Summary

The protocol conformance cache currently uses `ConcurrentMap` from `Concurrent.h`, which is a binary tree. The large amount of pointer chasing means that it performs less than optimally on modern hardware, and there's also a great deal of memory overhead from the left/right pointers. The entries themselves are only four words, so those child pointers add 50% overhead.

# New Hash Map Type

This PR adds a new type to `Concurrent.h`, `ConcurrentReadableHashMap`, which is intended to replace `ConcurrentMap`, and changes the protocol conformance cache to use it. I plan to replace other uses of `ConcurrentMap` as well; this is just the first place I decided to target.

The design of `ConcurrentReadableHashMap` is detailed in the comments above the implementation. The executive summary is:

1. Use a lock to coordinate writers. Readers don't lock.
2. Keep an atomic count of readers to avoid freeing memory that's being read.
3. Keep the supported operations to a bare minimum: insert, look up, clear all.
4. Use an array of small integers as the actual hash table, with those integers being indexes into a separate array of elements. This minimizes wasted space due to the table's load factor. A table that's only 50% full will only waste `n/2 * 4` bytes instead of `n/2 * sizeof(Element)` bytes. I plan to make the code adaptive so that it can use indices of 1 or 2 bytes when the number of elements is small. Currently it always uses 4 bytes per index regardless of size.

# Protocol Conformance Cache Updates

The protocol conformance cache is updated to use `ConcurrentReadableHashMap`. This was not quite a drop-in replacement, for a couple of reasons.

Negative cache entries (i.e. "type `T` does not conform to protocol `P`) can become invalid, when a dynamic library is loaded at runtime that contains a conformance. The existing code handles this by storing a `failureGeneration` on each cache entry. The global "failure generation" is increased when dynamic libraries are loaded, so readers can tell when a negative entry is obsolete. In that case, the readers will scan the new libraries and then update the entry with either a hit or a new `failureGeneration`.

This requires updating the cache entry in place, which is inconvenient for the new cache. It also requires 8 bytes (on 64-bit systems) per cache entry, which is 25% of the total entry size. Instead of using this scheme, the updated code clears the conformance cache when dynamic libraries are loaded. This will result in redoing a bunch of work for positive (i.e. "type `T` conforms to protocol `P`) entries, but dynamic library loading is extremely rare so this is an acceptable tradeoff.

There's also a change to what the cache actually caches. Protocol conformance checks involve a two-stage lookup:

1. Search conformance descriptors to find the apprapriate `ProtocolConformanceDescriptor *` for the given type and protocol we're looking for.
2. Get the `WitnessTable *` for the type and conformance descriptor.

Step 2 can be fairly expensive, at least for conditional conformances. For reasons I don't fully understand (but which I'm sure were entirely reasonable at the time it was written... I think there was an attempt to cache based on type descriptors instead of metatype pointers, which would have reduced cache size, but it's not implemented now), the existing code puts the cache on step 1. The new code moves it to step 2, so that a cached conformance check is just a single hash table lookup and nothing else.

Step 1 was implemented with the runtime call `swift_conformsToSwiftProtocol`, and then step 2 was implemented with `swift_conformsToProtocol` which wraps `swift_conformsToSwiftProtocol` and then does the witness table lookup. `swift_conformsToSwiftProtocol` was not used by anything else, and this PR removes it entirely.

`swift_conformsToSwiftProtocol` was available as an override point in `CompatibilityOverrides.def`. This PR removes it from that file. Since it's still part of the overrides ABI for older Swift runtime, this PR puts copies of `CompatibilityOverrides.def` into the directories for the compatibility libraries for Swift 5.0 and 5.1. Overrides are version-specific so there's no need to maintain a common layout.

# Measurements

The benchmark run is below. The dedicated protocol conformance benchmark shows substantial improvements. Some nice smaller improvements show on various other benchmarks.

For memory usage, I used modified version of the protocol conformance benchmark to look at a program with 3,000 cached conformances, then examined the memory. With the existing code, that produces 3,000 allocations of 48 bytes each, for a total of 144kB plus the allocator overhead of 3,000 separate allocations. With the new implementation, we end up with a 96kB allocation for the elements array and 16kB for the indices, for a total of 112kB, for a pretty decent memory win. Support for two-byte indices would save another 8kB and cut this down to 104kB, so that would be a useful future enhancement.

rdar://problem/67268325