### PR TITLE
[Concurrency] Infer @asyncHandler from protocol requirements.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5892,8 +5892,11 @@ public:
   ///
   /// Functions that are an 'async' context can make calls to 'async' functions.
   bool isAsyncContext() const {
-    return hasAsync() || getAttrs().hasAttribute<AsyncHandlerAttr>();
+    return hasAsync() || isAsyncHandler();
   }
+
+  /// Returns true if the function is an @asyncHandler.
+  bool isAsyncHandler() const;
 
   /// Returns true if the function body throws.
   bool hasThrows() const { return Bits.AbstractFunctionDecl.Throws; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -781,6 +781,24 @@ public:
   void cacheResult(SelfAccessKind value) const;
 };
 
+/// Determine whether the given function is an @asyncHandler.
+class IsAsyncHandlerRequest :
+    public SimpleRequest<IsAsyncHandlerRequest,
+                         bool(FuncDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, FuncDecl *func) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 /// Request whether the storage has a mutating getter.
 class IsGetterMutatingRequest :
     public SimpleRequest<IsGetterMutatingRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -81,6 +81,8 @@ SWIFT_REQUEST(TypeChecker, ExtendedTypeRequest, Type(ExtensionDecl *), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest, Type(ValueDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsAsyncHandlerRequest, bool(FuncDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, GenericSignatureRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6691,6 +6691,17 @@ bool AbstractFunctionDecl::argumentNameIsAPIByDefault() const {
   return false;
 }
 
+bool AbstractFunctionDecl::isAsyncHandler() const {
+  auto func = dyn_cast<FuncDecl>(this);
+  if (!func)
+    return false;
+
+  auto mutableFunc = const_cast<FuncDecl *>(func);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           IsAsyncHandlerRequest{mutableFunc},
+                           false);
+}
+
 BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
   if ((getBodyKind() == BodyKind::Synthesize ||
        getBodyKind() == BodyKind::Unparsed) &&

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -41,6 +41,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckCaptures.cpp
   TypeCheckCircularity.cpp
   TypeCheckCodeCompletion.cpp
+  TypeCheckConcurrency.cpp
   TypeCheckConstraints.cpp
   TypeCheckDecl.cpp
   TypeCheckDeclObjC.cpp

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -29,7 +29,6 @@
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
-#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/StorageImpl.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -41,66 +40,6 @@
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
-
-/// Check whether the @asyncHandler attribute can be applied to the given
-/// function declaration.
-///
-/// \param diagnose Whether to emit a diagnostic when a problem is encountered.
-///
-/// \returns \c true if there was a problem with adding the attribute, \c false
-/// otherwise.
-static bool checkAsyncHandler(FuncDecl *func, bool diagnose) {
-  if (!func->getResultInterfaceType()->isVoid()) {
-    if (diagnose) {
-      func->diagnose(diag::asynchandler_returns_value)
-          .highlight(func->getBodyResultTypeLoc().getSourceRange());
-    }
-
-    return true;
-  }
-
-  if (func->hasThrows()) {
-    if (diagnose) {
-      func->diagnose(diag::asynchandler_throws)
-          .fixItRemove(func->getThrowsLoc());
-    }
-
-    return true;
-  }
-
-  if (func->hasAsync()) {
-    if (diagnose) {
-      func->diagnose(diag::asynchandler_async)
-          .fixItRemove(func->getAsyncLoc());
-    }
-
-    return true;
-  }
-
-  for (auto param : *func->getParameters()) {
-    if (param->isInOut()) {
-      if (diagnose) {
-        param->diagnose(diag::asynchandler_inout_parameter)
-            .fixItRemove(param->getSpecifierLoc());
-      }
-
-      return true;
-    }
-  }
-
-  if (func->isMutating()) {
-    if (diagnose) {
-      auto diag = func->diagnose(diag::asynchandler_mutating);
-      if (auto mutatingAttr = func->getAttrs().getAttribute<MutatingAttr>()) {
-        diag.fixItRemove(mutatingAttr->getRange());
-      }
-    }
-
-    return true;
-  }
-
-  return false;
-}
 
 namespace {
   /// This emits a diagnostic with a fixit to remove the attribute.
@@ -5224,83 +5163,4 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
 
   // Set the resolved linearity parameter indices in the attribute.
   attr->setParameterIndices(linearParamIndices);
-}
-
-void swift::addAsyncNotes(FuncDecl *func) {
-  func->diagnose(diag::note_add_async_to_function, func->getName());
-
-  if (!checkAsyncHandler(func, /*diagnose=*/false)) {
-    func->diagnose(
-            diag::note_add_asynchandler_to_function, func->getName())
-        .fixItInsert(func->getAttributeInsertionLoc(false), "@asyncHandler ");
-  }
-}
-
-bool IsAsyncHandlerRequest::evaluate(
-    Evaluator &evaluator, FuncDecl *func) const {
-  // Check whether the attribute was explicitly specified.
-  if (auto attr = func->getAttrs().getAttribute<AsyncHandlerAttr>()) {
-    // Check for well-formedness.
-    if (checkAsyncHandler(func, /*diagnose=*/true)) {
-      attr->setInvalid();
-      return false;
-    }
-
-    return true;
-  }
-
-  // Are we in a context where inference is possible?
-  auto dc = func->getDeclContext();
-  if (!dc->isTypeContext() || !dc->getParentSourceFile() ||
-      isa<ProtocolDecl>(dc) || !func->hasBody())
-    return false;
-
-  // Is it possible to infer @asyncHandler for this function at all?
-  if (checkAsyncHandler(func, /*diagnose=*/false))
-    return false;
-
-  // Add an implicit @asyncHandler attribute and return true. We're done.
-  auto addImplicitAsyncHandlerAttr = [&] {
-    func->getAttrs().add(new (func->getASTContext()) AsyncHandlerAttr(true));
-    return true;
-  };
-
-  // Check whether any of the conformances in the context of the function
-  // implies @asyncHandler.
-  {
-    auto idc = cast<IterableDeclContext>(dc->getAsDecl());
-    auto conformances = evaluateOrDefault(
-        dc->getASTContext().evaluator,
-        LookupAllConformancesInContextRequest{idc}, { });
-
-    for (auto conformance : conformances) {
-      auto protocol = conformance->getProtocol();
-      for (auto found : protocol->lookupDirect(func->getName())) {
-        if (!isa<ProtocolDecl>(found->getDeclContext()))
-          continue;
-
-        auto requirement = dyn_cast<FuncDecl>(found);
-        if (!requirement)
-          continue;
-
-        if (!requirement->isAsyncHandler())
-          continue;
-
-        auto witness = conformance->getWitnessDecl(requirement);
-        if (witness != func)
-          continue;
-
-        return addImplicitAsyncHandlerAttr();
-      }
-    }
-  }
-
-  // Look through dynamic replacements.
-  if (auto replaced = func->getDynamicallyReplacedDecl()) {
-    if (auto replacedFunc = dyn_cast<FuncDecl>(replaced))
-      if (replacedFunc->isAsyncHandler())
-        return addImplicitAsyncHandlerAttr();
-  }
-
-  return false;
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -330,10 +330,8 @@ public:
       return;
     }
 
-    if (checkAsyncHandler(func, /*diagnose=*/true)) {
-      attr->setInvalid();
-      return;
-    }
+    // Trigger the request to check for @asyncHandler.
+    (void)func->isAsyncHandler();
   }
 };
 } // end anonymous namespace
@@ -5235,4 +5233,20 @@ void swift::addAsyncNotes(FuncDecl *func) {
             diag::note_add_asynchandler_to_function, func->getName())
         .fixItInsert(func->getAttributeInsertionLoc(false), "@asyncHandler ");
   }
+}
+
+bool IsAsyncHandlerRequest::evaluate(
+    Evaluator &evaluator, FuncDecl *func) const {
+  // Check whether the attribute was explicitly specified.
+  if (auto attr = func->getAttrs().getAttribute<AsyncHandlerAttr>()) {
+    // Check for well-formedness.
+    if (checkAsyncHandler(func, /*diagnose=*/true)) {
+      attr->setInvalid();
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1,0 +1,160 @@
+//===--- TypeCheckConcurrency.cpp - Concurrency ---------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements type checking support for Swift's concurrency model.
+//
+//===----------------------------------------------------------------------===//
+#include "TypeChecker.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/TypeCheckRequests.h"
+
+using namespace swift;
+
+/// Check whether the @asyncHandler attribute can be applied to the given
+/// function declaration.
+///
+/// \param diagnose Whether to emit a diagnostic when a problem is encountered.
+///
+/// \returns \c true if there was a problem with adding the attribute, \c false
+/// otherwise.
+static bool checkAsyncHandler(FuncDecl *func, bool diagnose) {
+  if (!func->getResultInterfaceType()->isVoid()) {
+    if (diagnose) {
+      func->diagnose(diag::asynchandler_returns_value)
+          .highlight(func->getBodyResultTypeLoc().getSourceRange());
+    }
+
+    return true;
+  }
+
+  if (func->hasThrows()) {
+    if (diagnose) {
+      func->diagnose(diag::asynchandler_throws)
+          .fixItRemove(func->getThrowsLoc());
+    }
+
+    return true;
+  }
+
+  if (func->hasAsync()) {
+    if (diagnose) {
+      func->diagnose(diag::asynchandler_async)
+          .fixItRemove(func->getAsyncLoc());
+    }
+
+    return true;
+  }
+
+  for (auto param : *func->getParameters()) {
+    if (param->isInOut()) {
+      if (diagnose) {
+        param->diagnose(diag::asynchandler_inout_parameter)
+            .fixItRemove(param->getSpecifierLoc());
+      }
+
+      return true;
+    }
+  }
+
+  if (func->isMutating()) {
+    if (diagnose) {
+      auto diag = func->diagnose(diag::asynchandler_mutating);
+      if (auto mutatingAttr = func->getAttrs().getAttribute<MutatingAttr>()) {
+        diag.fixItRemove(mutatingAttr->getRange());
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+void swift::addAsyncNotes(FuncDecl *func) {
+  func->diagnose(diag::note_add_async_to_function, func->getName());
+
+  if (!checkAsyncHandler(func, /*diagnose=*/false)) {
+    func->diagnose(
+            diag::note_add_asynchandler_to_function, func->getName())
+        .fixItInsert(func->getAttributeInsertionLoc(false), "@asyncHandler ");
+  }
+}
+
+bool IsAsyncHandlerRequest::evaluate(
+    Evaluator &evaluator, FuncDecl *func) const {
+  // Check whether the attribute was explicitly specified.
+  if (auto attr = func->getAttrs().getAttribute<AsyncHandlerAttr>()) {
+    // Check for well-formedness.
+    if (checkAsyncHandler(func, /*diagnose=*/true)) {
+      attr->setInvalid();
+      return false;
+    }
+
+    return true;
+  }
+
+  // Are we in a context where inference is possible?
+  auto dc = func->getDeclContext();
+  if (!dc->isTypeContext() || !dc->getParentSourceFile() ||
+      isa<ProtocolDecl>(dc) || !func->hasBody())
+    return false;
+
+  // Is it possible to infer @asyncHandler for this function at all?
+  if (checkAsyncHandler(func, /*diagnose=*/false))
+    return false;
+
+  // Add an implicit @asyncHandler attribute and return true. We're done.
+  auto addImplicitAsyncHandlerAttr = [&] {
+    func->getAttrs().add(new (func->getASTContext()) AsyncHandlerAttr(true));
+    return true;
+  };
+
+  // Check whether any of the conformances in the context of the function
+  // implies @asyncHandler.
+  {
+    auto idc = cast<IterableDeclContext>(dc->getAsDecl());
+    auto conformances = evaluateOrDefault(
+        dc->getASTContext().evaluator,
+        LookupAllConformancesInContextRequest{idc}, { });
+
+    for (auto conformance : conformances) {
+      auto protocol = conformance->getProtocol();
+      for (auto found : protocol->lookupDirect(func->getName())) {
+        if (!isa<ProtocolDecl>(found->getDeclContext()))
+          continue;
+
+        auto requirement = dyn_cast<FuncDecl>(found);
+        if (!requirement)
+          continue;
+
+        if (!requirement->isAsyncHandler())
+          continue;
+
+        auto witness = conformance->getWitnessDecl(requirement);
+        if (witness != func)
+          continue;
+
+        return addImplicitAsyncHandlerAttr();
+      }
+    }
+  }
+
+  // Look through dynamic replacements.
+  if (auto replaced = func->getDynamicallyReplacedDecl()) {
+    if (auto replacedFunc = dyn_cast<FuncDecl>(replaced))
+      if (replacedFunc->isAsyncHandler())
+        return addImplicitAsyncHandlerAttr();
+  }
+
+  return false;
+}

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -103,6 +103,9 @@ bool IsAsyncHandlerRequest::evaluate(
     return true;
   }
 
+  if (!func->getASTContext().LangOpts.EnableExperimentalConcurrency)
+    return false;
+
   // Are we in a context where inference is possible?
   auto dc = func->getDeclContext();
   if (!dc->isTypeContext() || !dc->getParentSourceFile() ||

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -37,3 +37,16 @@ struct X {
   @asyncHandler init() { }
   // expected-error@-1{{@asyncHandler may only be used on 'func' declarations}}
 }
+
+
+// Inference of @asyncHandler
+protocol P {
+  @asyncHandler func callback()
+}
+
+extension X: P {
+  func callback() {
+    // okay, it's an async context
+    let _ = await globalAsyncFunction()
+ }
+}


### PR DESCRIPTION
Similar to what we do with function builders, infer `@asyncHandler` from
for witnesses to `@asyncHandler` protocol requirements.