### PR TITLE
[CodeCompletion] Skip an ASTScope assertion for labeled statements

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -691,7 +691,8 @@ public:
       // is equivalent to what we have here.
       if (LS->getStartLoc().isValid() && sourceFile &&
           SC.getASTContext().LangOpts.EnableASTScopeLookup &&
-          !SC.getASTContext().Diags.hadAnyError()) {
+          !SC.getASTContext().Diags.hadAnyError() &&
+          !SC.LeaveBraceStmtBodyUnchecked) {
         // The labeled statements from ASTScope lookup have the
         // innermost labeled statement first, so reverse it to
         // match the data structure maintained here.

--- a/validation-test/IDE/crashers_2_fixed/rdar67102611.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar67102611.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s > /dev/null
+
+for x in "foo" {
+    if x.#^A^# {
+    }
+}


### PR DESCRIPTION
Code completion performs `typeCheckASTNodeAtLoc()` which ignores `StmtChecker::ActiveLabeledStmts`. Since this is not necessary for code completions, skip an assertion to verify the correctness of `ASTScope`.

rdar://problem/67102611
