### PR TITLE
Sema: Check 'where' clause requirements on type witnesses

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -601,6 +601,11 @@ RequirementCheckResult checkGenericArguments(
     ArrayRef<Requirement> requirements, TypeSubstitutionFn substitutions,
     SubstOptions options = None);
 
+bool checkContextualRequirements(GenericTypeDecl *decl,
+                                 Type parentTy,
+                                 SourceLoc loc,
+                                 DeclContext *dc);
+
 /// Add any implicitly-defined constructors required for the given
 /// struct or class.
 void addImplicitConstructors(NominalTypeDecl *typeDecl);

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -36,12 +36,12 @@ let _ = SameType<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.self
 let _ = SameType<X>.Decl5<X>.self
 
-let _ = SameType<Y>.TypeAlias1.self // expected-error {{'SameType<Y>.TypeAlias1' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.TypeAlias2.self // expected-error {{'SameType<Y>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias1.self // expected-error {{'SameType<T>.TypeAlias1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias2.self // expected-error {{'SameType<T>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.TypeAlias3<X>.self // expected-error {{'SameType<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl2.self // expected-error {{'SameType<Y>.Decl2' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl3.self // expected-error {{'SameType<Y>.Decl3' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl2.self // expected-error {{'SameType<T>.Decl2' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl3.self // expected-error {{'SameType<T>.Decl3' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl4<X>.self // expected-error {{'SameType<Y>.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl5<X>.self // expected-error {{'SameType<Y>.Decl5' requires the types 'Y' and 'X' be equivalent}}
 
@@ -49,7 +49,7 @@ extension SameType: AssociatedType where T == X {}
 // expected-note@-1 {{requirement specified as 'T' == 'X' [with T = Y]}}
 
 let _ = SameType<X>.T.self
-let _ = SameType<Y>.T.self // expected-error {{'SameType<Y>.T' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.T.self // expected-error {{'SameType<T>.T' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
 
 
 struct Conforms<T> {}
@@ -112,14 +112,14 @@ let _ = SameType<X>.Decl1.Decl3.self
 let _ = SameType<X>.Decl1.Decl4<X>.self
 let _ = SameType<X>.Decl1.Decl5<X>.self
 
-let _ = SameType<Y>.Decl1.TypeAlias1.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.TypeAlias2.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.TypeAlias3<X>.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl1.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl2.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl3.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl4<X>.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl5<X>.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias1.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias2.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias3<X>.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl1.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl2.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl3.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl4<X>.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl5<X>.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
 
 extension SameType.Decl4 where U == X { // expected-note 5 {{requirement specified as 'U' == 'X' [with U = Y]}}
     typealias TypeAlias1 = T
@@ -144,12 +144,12 @@ let _ = SameType<X>.Decl4<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.Decl4<X>.self
 let _ = SameType<X>.Decl4<X>.Decl5<X>.self
 
-let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias1' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{'SameType<T>.Decl4<U>.TypeAlias1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{'SameType<T>.Decl4<U>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{'SameType<X>.Decl4<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl2.self // expected-error {{'SameType<X>.Decl4<Y>.Decl2' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl3.self // expected-error {{'SameType<X>.Decl4<Y>.Decl3' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{'SameType<T>.Decl4<U>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl2.self // expected-error {{'SameType<T>.Decl4<U>.Decl2' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl3.self // expected-error {{'SameType<T>.Decl4<U>.Decl3' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl4<X>.self // expected-error {{'SameType<X>.Decl4<Y>.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl5<X>.self // expected-error {{'SameType<X>.Decl4<Y>.Decl5' requires the types 'Y' and 'X' be equivalent}}
 

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -32,12 +32,12 @@ _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
 _ = B<Float>.S1()      // expected-error {{type 'Float' does not conform to protocol 'P'}}
 _ = B<String>.S2()
-// expected-error@-1 {{'B<String>.S2' (aka 'Int') requires the types '[String]' and '[Int]' be equivalent}}
+// expected-error@-1 {{'A<T, U>.S2' (aka 'Int') requires the types '[String]' and '[Int]' be equivalent}}
 
 _ = S<C>.A()           // Ok
 _ = S<Int>.A()         // expected-error {{type 'Int' does not conform to protocol 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
-_ = S<Int>.C()         // expected-error {{'S<Int>.C' (aka 'Int') requires the types 'Int' and 'Float' be equivalent}}
+_ = S<Int>.C()         // expected-error {{'S<T>.C' (aka 'Int') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
   _ = s.A() // expected-error {{referencing type alias 'A' on 'S' requires that 'T' conform to 'P'}}

--- a/test/Constraints/requirement_failures_in_contextual_type.swift
+++ b/test/Constraints/requirement_failures_in_contextual_type.swift
@@ -14,11 +14,11 @@ extension A where T == Int32 { // expected-note 3{{requirement specified as 'T' 
 }
 
 let _: A<Int>.B = 0
-// expected-error@-1 {{'A<Int>.B' requires the types 'Int' and 'Int32' be equivalent}}
+// expected-error@-1 {{'A<T>.B' requires the types 'Int' and 'Int32' be equivalent}}
 let _: A<Int>.C = 0
-// expected-error@-1 {{'A<Int>.C' (aka 'Int') requires the types 'Int' and 'Int32' be equivalent}}
+// expected-error@-1 {{'A<T>.C' (aka 'Int') requires the types 'Int' and 'Int32' be equivalent}}
 let _: A<Int>.B.E = 0
-// expected-error@-1 {{'A<Int>.B' requires the types 'Int' and 'Int32' be equivalent}}
+// expected-error@-1 {{'A<T>.B' requires the types 'Int' and 'Int32' be equivalent}}
 
 
 protocol P {}

--- a/test/Generics/constrained_type_witnesses.swift
+++ b/test/Generics/constrained_type_witnesses.swift
@@ -1,0 +1,75 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype A
+  // expected-note@-1 3{{protocol requires nested type 'A'; do you want to add it?}}
+}
+
+struct S1<T> {}
+
+extension S1 where T : P {
+  typealias A = Int
+}
+
+// This is rejected because S1.A is not a suitable witness for P.A.
+extension S1 : P {}
+// expected-error@-1 {{type 'S1<T>' does not conform to protocol 'P'}}
+
+struct S2<T> {}
+
+extension S2 where T : P {
+  typealias A = Never
+}
+
+// Hack: This is OK to make SwiftUI work, which accidentally relies on the
+// incorrect behavior with a typealias whose underlying type is 'Never'
+// (so it didn't hit the compiler crash).
+extension S2 : P {}
+
+// Here we have a suitable witness
+struct S3<T> {}
+
+extension S3 where T == Int {
+  typealias A = Int
+}
+
+extension S3 : P where T == Int {}
+
+// Check where clause on the type itself
+
+struct S4<T> {
+  typealias A = Int where T : P
+}
+
+extension S4 : P {}
+// expected-error@-1 {{type 'S4<T>' does not conform to protocol 'P'}}
+
+struct S5<T> {
+  typealias A = Never where T : P
+}
+
+extension S5 : P {}
+
+struct S6<T> {
+  typealias A = Int where T == Int
+}
+
+extension S6 : P where T == Int {}
+
+// Witness in a constrained protocol extension
+protocol Q {
+  associatedtype B
+}
+
+extension Q where B == Int {
+  typealias A = Int
+}
+
+struct S7 : Q, P {
+  typealias B = Int
+}
+
+struct S8 : Q, P {
+// expected-error@-1 {{type 'S8' does not conform to protocol 'P'}}
+  typealias B = String
+}

--- a/test/Generics/where_clause_contextually_generic_decls.swift
+++ b/test/Generics/where_clause_contextually_generic_decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 func bet() where A : B {} // expected-error {{'where' clause cannot be applied to a non-generic top-level declaration}}
 
@@ -148,7 +148,7 @@ _ = Container<String>.NestedAlias2.self // expected-error {{type 'String' does n
 _ = Container<Container<Bool>>.NestedClass.self // expected-error {{type 'Container<Bool>' does not conform to protocol 'Equatable'}}
 _ = Container<Void>.NestedStruct.self // expected-error {{type 'Void' does not conform to protocol 'Sequence'}}
 _ = Container<Array<Void>>.NestedStruct2.self // expected-error {{type 'Void' does not conform to protocol 'Comparable'}}
-_ = Container<String>.NestedStruct2.NestedEnum.self // expected-error {{'Container<String>.NestedStruct2.NestedEnum' requires the types 'String.Element' (aka 'Character') and 'Double' be equivalent}}
+_ = Container<String>.NestedStruct2.NestedEnum.self // expected-error {{'Container<T>.NestedStruct2.NestedEnum' requires the types 'String.Element' (aka 'Character') and 'Double' be equivalent}}
 _ = Container<Int>.NestedAlias2.self
 _ = Container<Bool>.NestedClass.self
 _ = Container<String>.NestedStruct.self

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -132,6 +132,7 @@ extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform
      where T : Equatable
 {
   typealias Index = Int
+  // expected-error@-1 {{invalid redeclaration of synthesized implementation for protocol requirement 'Index'}}
   func index(_ i: Index, offsetBy d: Int) -> Index {
     return i + d
   }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1732,7 +1732,7 @@ extension SR_11288_P4 where Self: AnyObject { // expected-note {{requirement spe
 }
 
 struct SR_11288_S4: SR_11288_P4 {
-  @SR_11288_Wrapper4 var answer = 42 // expected-error {{'SR_11288_S4.SR_11288_Wrapper4' (aka 'SR_11288_S0') requires that 'SR_11288_S4' be a class type}}
+  @SR_11288_Wrapper4 var answer = 42 // expected-error {{'Self.SR_11288_Wrapper4' (aka 'SR_11288_S0') requires that 'SR_11288_S4' be a class type}}
 }
 
 class SR_11288_C0: SR_11288_P4 {

--- a/validation-test/compiler_crashers_2_fixed/sr12327.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12327.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-frontend -emit-ir -O %s
+
+protocol A {
+    associatedtype Foo // Does not crash if renamed
+}
+
+protocol B {
+    associatedtype Foo // Does not crash if renamed
+    var aFoo: Foo { get }
+}
+
+public struct Wrapper<T> {
+    let wrapped: T
+}
+
+// Removing this extension or combining it with the next one prevents the crash
+extension Wrapper: A where T: A {
+    typealias Foo = Wrapper<T.Foo>
+}
+
+extension Wrapper: B where T: B {
+    var aFoo: Wrapper<T.Foo> {
+        return .init(wrapped: wrapped.aFoo)
+    }
+}
+
+public struct Model: B {
+    public struct Foo {}
+
+    public var aFoo: Foo {
+        return Foo()
+    }
+}
+
+// Attempting to specialize this method for Wrapper<Model> crashes the compiler
+func fooString<Body: B>(body: Body) -> String {
+    return "\(body.aFoo)"
+}
+
+public func foo(_ command: Wrapper<Model>) -> String {
+    return fooString(body: command)
+}

--- a/validation-test/compiler_crashers_2_fixed/sr9199.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr9199.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o %t.ll %s
+// RUN: not %target-swift-frontend -emit-ir %s
 
 // Just make sure we don't crash.
 


### PR DESCRIPTION
In the included test case, conformance checking of Wrapper : B would
pick up typealias Foo as a witness for the associated type B.Foo.

However, this typealias Foo is defined in a constrained extension where
T : A, and the underlying type references the associated type A.Foo
on T.

The resulting substitution is invalid when the conformance Wrapper : B
is used in a context where T does not conform to A.

Instead, we should ignore this typealias entirely, since it appears
in an unusable constrained extension.

Fixes <rdar://problem/60219705>, <https://bugs.swift.org/browse/SR-12327>,
<https://bugs.swift.org/browse/SR-12663>.