### PR TITLE
Simplify ArchetypeType::requiresClass()

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3835,6 +3835,11 @@ CanOpenedArchetypeType OpenedArchetypeType::get(Type existential,
     protos.push_back(proto->getDecl());
 
   auto layoutConstraint = layout.getLayoutConstraint();
+  if (!layoutConstraint && layout.requiresClass()) {
+    layoutConstraint = LayoutConstraint::getLayoutConstraint(
+        LayoutConstraintKind::Class);
+  }
+
   auto layoutSuperclass = layout.getSuperclass();
 
   auto arena = AllocationArena::Permanent;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3780,8 +3780,11 @@ public:
   }
 
   void visitErrorType(ErrorType *T) {
-    if (auto originalType = T->getOriginalType())
+    if (auto originalType = T->getOriginalType()) {
+      if (Options.PrintInSILBody)
+        Printer << "@error_type ";
       visit(originalType);
+    }
     else
       Printer << "<<error type>>";
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3206,14 +3206,8 @@ PrimaryArchetypeType::getNew(const ASTContext &Ctx,
 }
 
 bool ArchetypeType::requiresClass() const {
-  if (Bits.ArchetypeType.HasSuperclass)
-    return true;
   if (auto layout = getLayoutConstraint())
-    if (layout->isClass())
-      return true;
-  for (ProtocolDecl *conformed : getConformsTo())
-    if (conformed->requiresClass())
-      return true;
+    return layout->isClass();
   return false;
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4952,8 +4952,7 @@ ReferenceCounting TypeBase::getReferenceCounting() {
     auto archetype = cast<ArchetypeType>(type);
     auto layout = archetype->getLayoutConstraint();
     (void)layout;
-    assert(archetype->requiresClass() ||
-           (layout && layout->isRefCounted()));
+    assert(layout && layout->isRefCounted());
     if (auto supertype = archetype->getSuperclass())
       return supertype->getReferenceCounting();
     return ReferenceCounting::Unknown;

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -284,8 +284,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
 
   // If the archetype is class-constrained, use a class pointer
   // representation.
-  if (archetype->requiresClass() ||
-      (layout && layout->isRefCounted())) {
+  if (layout && layout->isRefCounted()) {
     auto refcount = archetype->getReferenceCounting();
 
     llvm::PointerType *reprTy;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -421,10 +421,6 @@ namespace {
 
     RetTy visitArchetypeType(CanArchetypeType type,
                              AbstractionPattern origType) {
-      if (type->requiresClass()) {
-        return asImpl().handleReference(type);
-      }
-
       auto LayoutInfo = type->getLayoutConstraint();
       if (LayoutInfo) {
         if (LayoutInfo->isFixedSizeTrivial()) {

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -428,9 +428,6 @@ bool llvm::DenseMapInfo<SimpleValue>::isEqual(SimpleValue LHS,
       return false;
 
     // ... and other constraints are equal.
-    if (LHSArchetypeTy->requiresClass() != RHSArchetypeTy->requiresClass())
-      return false;
-
     if (LHSArchetypeTy->getSuperclass().getPointer() !=
         RHSArchetypeTy->getSuperclass().getPointer())
       return false;

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -622,14 +622,20 @@ static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
     // The generic parameter has a layout constraint.
     // Check that the substitution has the same constraint.
     auto AIReplacement = Type(Param).subst(AISubs);
-    auto AIArchetype = AIReplacement->getAs<ArchetypeType>();
-    if (!AIArchetype)
-      return false;
-    auto AILayout = AIArchetype->getLayoutConstraint();
-    if (!AILayout)
-      return false;
-    if (AILayout != Layout)
-      return false;
+
+    if (Layout->isClass()) {
+      if (!AIReplacement->satisfiesClassConstraint())
+        return false;
+    } else {
+      auto AIArchetype = AIReplacement->getAs<ArchetypeType>();
+      if (!AIArchetype)
+        return false;
+      auto AILayout = AIArchetype->getLayoutConstraint();
+      if (!AILayout)
+        return false;
+      if (AILayout != Layout)
+        return false;
+    }
   }
   return true;
 }

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -47,55 +47,6 @@ bb0(%0 : $*T, %1 : $*T):
   return %9 : $()
 } // end sil function 'testInliningOfGenerics'
 
-sil hidden @P_combine : $@convention(method) <Self where Self : P><T> (@in T, @guaranteed Self) -> @owned @callee_owned (@in T) -> Bool {
-bb0(%0 : $*T, %1 : $Self):
-  // function_ref P.(combine<A> (first : A1) -> (A1) -> Bool).(closure #1)
-  %4 = function_ref @_TFFE50generic_inlining_partial_apply_opened_existentialsPS_1P7combineurFT5firstqd___Fqd__SbU_Fqd__Sb : $@convention(thin) <τ_0_0 where τ_0_0 : P><τ_1_0> (@in τ_1_0) -> Bool
-  %5 = partial_apply %4<Self, T>() : $@convention(thin) <τ_0_0 where τ_0_0 : P><τ_1_0> (@in τ_1_0) -> Bool
-  destroy_addr %0 : $*T
-  return %5 : $@callee_owned (@in T) -> Bool
-} // end sil function 'P_combine'
-
-// P.(combine<A> (first : A1) -> (A1) -> Bool).(closure #1)
-sil shared @_TFFE50generic_inlining_partial_apply_opened_existentialsPS_1P7combineurFT5firstqd___Fqd__SbU_Fqd__Sb : $@convention(thin) <Self where Self : P><T> (@in T) -> Bool {
-bb0(%0 : $*T):
-  %2 = integer_literal $Builtin.Int1, -1
-  %3 = struct $Bool (%2 : $Builtin.Int1)
-  destroy_addr %0 : $*T
-  return %3 : $Bool
-} // end sil function '_TFFE50generic_inlining_partial_apply_opened_existentialsPS_1P7combineurFT5firstqd___Fqd__SbU_Fqd__Sb'
-
-
-// Check that P_combine is not inlined into the generic function, because
-// doing so would result in a partial_apply instruction, with an opened existential
-// in the substitution list. And this cannot be handled by the IRGen yet.
-// CHECK-LABEL: sil @dont_inline_callee_with_opened_existential_in_partial_apply_substitution_list
-// CHECK: [[FUN_REF:%[0-9]+]] = function_ref @P_combine
-// CHECK: apply [[FUN_REF]]
-// CHECK: end sil function 'dont_inline_callee_with_opened_existential_in_partial_apply_substitution_list'
-sil @dont_inline_callee_with_opened_existential_in_partial_apply_substitution_list : $@convention(thin) <T where T : P> (@owned P) -> @owned @callee_owned (@owned T) -> Bool {
-bb0(%0 : $P):
-  %2 = open_existential_ref %0 : $P to $@opened("41B148C8-F49C-11E6-BE69-A45E60E99281") P
-  // function_ref P.combine<A> (first : A1) -> (A1) -> Bool
-  %3 = function_ref @P_combine : $@convention(method) <τ_0_0 where τ_0_0 : P><τ_1_0> (@in τ_1_0, @guaranteed τ_0_0) -> @owned @callee_owned (@in τ_1_0) -> Bool
-  %4 = open_existential_ref %0 : $P to $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P
-  %5 = witness_method $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P, #P.getSelf : <Self where Self : P> (Self) -> () -> Self, %4 : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> @owned τ_0_0
-  %6 = apply %5<@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P>(%4) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> @owned τ_0_0
-  %7 = init_existential_ref %6 : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P, $P
-  %8 = alloc_stack $P
-  store %7 to %8 : $*P
-  %10 = apply %3<@opened("41B148C8-F49C-11E6-BE69-A45E60E99281") P, P>(%8, %2) : $@convention(method) <τ_0_0 where τ_0_0 : P><τ_1_0> (@in τ_1_0, @guaranteed τ_0_0) -> @owned @callee_owned (@in τ_1_0) -> Bool
-  // function_ref thunk
-  %11 = function_ref @thunk1 : $@convention(thin) (@owned P, @owned @callee_owned (@in P) -> Bool) -> Bool
-  %12 = partial_apply %11(%10) : $@convention(thin) (@owned P, @owned @callee_owned (@in P) -> Bool) -> Bool
-  // function_ref thunk
-  %13 = function_ref @thunk2 : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned τ_0_0, @owned @callee_owned (@owned P) -> Bool) -> Bool
-  %14 = partial_apply %13<T>(%12) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned τ_0_0, @owned @callee_owned (@owned P) -> Bool) -> Bool
-  dealloc_stack %8 : $*P
-  strong_release %0 : $P
-  return %14 : $@callee_owned (@owned T) -> Bool
-} // end sil function 'dont_inline_callee_with_opened_existential_in_partial_apply_substitution_list'
-
 // thunk
 sil shared [transparent] [reabstraction_thunk] @thunk1 : $@convention(thin) (@owned P, @owned @callee_owned (@in P) -> Bool) -> Bool {
 bb0(%0 : $P, %1 : $@callee_owned (@in P) -> Bool):


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/33445, the GenericSignatureBuilder ensures that the presence of a superclass contraint, or conformance to a class-constrained protocol, guarantees that an equivalence class has a corresponding inferred layout constraint.

After making a similar adjustment to the logic for opening existentials, we can simplify ArchetypeType::requiresClass().