### PR TITLE
[coro-life-extend] Add an ossa pass that extends the lifetime of "simple" coroutines to allow for copies to be eliminated.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -400,6 +400,16 @@ bool getAllBorrowIntroducingValues(SILValue value,
 /// introducer, then we return a .some(BorrowScopeIntroducingValue).
 Optional<BorrowedValue> getSingleBorrowIntroducingValue(SILValue inputValue);
 
+/// Pass all uses of guaranteed value \p value to \p visitor looking through
+/// guaranteed forwarding instructions.
+///
+/// \returns true if we were able to visit all uses, false if callback asked us
+/// to end iterating early.
+/// \arg visitor The visitor callback passed in by the caller. Return false to
+/// stop visiting early.
+bool visitGuaranteedValueUsesIgnoringForwarding(
+    SILValue value, function_ref<bool(Operand *)> visitor);
+
 class InteriorPointerOperandKind {
 public:
   enum Kind : uint8_t {

--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -53,6 +53,11 @@ public:
   /// end the value's lifetime.
   using Frontier = SmallVector<SILInstruction *, 4>;
 
+  /// The lifetime frontier impl for the value. We provide a canned Frontier
+  /// type for users to use that works by default, but we use this in our
+  /// interfaces to allow for the user to use different sized small vector.
+  using FrontierImpl = SmallVectorImpl<SILInstruction *>;
+
   /// Constructor for the value \p def with a specific range of users.
   ///
   /// We templatize over the RangeTy so that we can initialize
@@ -105,7 +110,7 @@ public:
   ///
   /// If \p deBlocks is provided, all dead-end blocks are ignored. This
   /// prevents unreachable-blocks to be included in the frontier.
-  bool computeFrontier(Frontier &frontier, Mode mode,
+  bool computeFrontier(FrontierImpl &frontier, Mode mode,
                        DeadEndBlocks *deBlocks = nullptr);
 
   ArrayRef<std::pair<TermInst *, unsigned>> getCriticalEdges() {
@@ -124,7 +129,7 @@ public:
   }
 
   /// Checks if there is a dealloc_ref inside the value's live range.
-  bool containsDeallocRef(const Frontier &frontier);
+  bool containsDeallocRef(const FrontierImpl &frontier);
 
   /// For debug dumping.
   void dump() const;
@@ -158,7 +163,7 @@ private:
 /// Otherwise \p valueOrStackLoc must be a value type and in this case, inserts
 /// destroy_value at each instruction of the \p frontier.
 void endLifetimeAtFrontier(SILValue valueOrStackLoc,
-                           const ValueLifetimeAnalysis::Frontier &frontier,
+                           const ValueLifetimeAnalysis::FrontierImpl &frontier,
                            SILBuilderContext &builderCtxt);
 
 } // end namespace swift

--- a/lib/SILOptimizer/SemanticARC/CMakeLists.txt
+++ b/lib/SILOptimizer/SemanticARC/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(swiftSILOptimizer PRIVATE
   OwnedToGuaranteedPhiOpt.cpp
   Context.cpp
   SemanticARCOptVisitor.cpp
+  CoroutineLifetimeExtender.cpp
   )

--- a/lib/SILOptimizer/SemanticARC/CoroutineLifetimeExtender.cpp
+++ b/lib/SILOptimizer/SemanticARC/CoroutineLifetimeExtender.cpp
@@ -1,0 +1,304 @@
+//===--- CoroutineLifetimeExtender.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This pass contains a simple transform that extends the lifetime of a
+/// coroutine with a trivial resume to transitive uses of copies of yielded
+/// values from the coroutine and then eliminates those copies.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Context.h"
+#include "OwnershipLiveRange.h"
+#include "Transforms.h"
+
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/ValueLifetime.h"
+
+using namespace swift;
+using namespace swift::semanticarc;
+
+//===----------------------------------------------------------------------===//
+//                        Process Candidate Functions
+//===----------------------------------------------------------------------===//
+
+static bool processCandidates(Context &ctx,
+                              ArrayRef<FullApplySite> applySiteList) {
+  assert(!applySiteList.empty() && "Must have at least one candidate");
+
+  SmallVector<SILInstruction *, 32> scratchBuffer;
+  SmallVector<SILInstruction *, 32> frontier;
+  SmallVector<SILInstruction *, 32> destroyInsts;
+  bool madeChange = false;
+
+  // Now optimize each apply site that we can (converting to guaranteed) and
+  // then after we are done, expand the lifetime of the coroutine over those
+  // points.
+  for (auto fas : applySiteList) {
+    // Use RAII to ensure in the face of future code that we properly clear
+    // scratchBuffer, frontier on every iteration.
+    SWIFT_DEFER {
+      scratchBuffer.clear();
+      frontier.clear();
+      destroyInsts.clear();
+    };
+
+    // NOTE: This needs to be rewritten to use FullApplySite methods if we add
+    // additional coroutine call sites.
+    auto *bai = cast<BeginApplyInst>(fas);
+    bool didOptimizeCopy = false;
+
+    // Now we know that we have a simple enough coroutine that we can process,
+    // try to gather up copies that we /could/ eliminate if we lifetime extend.
+    // Return true if we found something and false otherwise.
+    for (SILValue yieldedValue : bai->getYieldedValues()) {
+      if (yieldedValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed) {
+        continue;
+      }
+
+      bool result = visitGuaranteedValueUsesIgnoringForwarding(
+          yieldedValue, [&](Operand *use) {
+            auto *cvi = dyn_cast<CopyValueInst>(use->getUser());
+            if (!cvi) {
+              return true; // Continue processing.
+            }
+
+            OwnershipLiveRange lr(cvi);
+
+            // For now if we have any unknown consuming uses bail. Eventually we
+            // should try to handle phis here and should track this
+            // info/post-process.
+            if (bool(lr.hasUnknownConsumingUse())) {
+              return true; // Continue processing.
+            }
+
+            llvm::copy(lr.getAllConsumingInsts(),
+                       std::back_inserter(scratchBuffer));
+            llvm::copy(lr.getDestroyingInsts(),
+                       std::back_inserter(destroyInsts));
+
+            // Now do a RAUW and convert forwarding insts to be guaranteed. The
+            // destroys are still around since we need them as liveness points.
+            cvi->replaceAllUsesWith(cvi->getOperand());
+            ctx.instModCallbacks.deleteInst(cvi);
+            std::move(lr).convertOwnedGeneralForwardingUsesToGuaranteed();
+            didOptimizeCopy = true;
+            madeChange = true;
+            return true; // Continue processing.
+          });
+      (void)result;
+      assert(result);
+    }
+
+    // If we did not optimize any actual copy, continue.
+    if (!didOptimizeCopy) {
+      continue;
+    }
+
+    // Otherwise, we know that we need to lifetime extend our coroutine over the
+    // transitive closure consisting of the original coroutine end_applies and
+    // the consuming uses of any copies that we eliminated. To do so, first add
+    // to our scratchBuffer our end applies. We stash the original scratch
+    // buffer size so we can just pop off the end_apply after we compute the
+    // ValueLifetime of the coroutine and eliminate them without needing a
+    // separate array.
+    unsigned originalScratchBufferSize = scratchBuffer.size();
+    SILValue tokenResult = bai->getTokenResult();
+
+    for (auto *eai : tokenResult->getUsersOfType<EndApplyInst>()) {
+      scratchBuffer.push_back(eai);
+    }
+
+    ValueLifetimeAnalysis analysis(bai, scratchBuffer);
+    bool success = analysis.computeFrontier(
+        frontier, ValueLifetimeAnalysis::Mode::DontModifyCFG,
+        &ctx.getDeadEndBlocks());
+    (void)success;
+    assert(success);
+
+    // Now that we have our frontier, delete off the end of our scratch buffer
+    // the end_apply.
+    while (scratchBuffer.size() != originalScratchBufferSize) {
+      // We use cast<> here just as a sanity check.
+      auto *eai = cast<EndApplyInst>(scratchBuffer.pop_back_val());
+      ctx.instModCallbacks.deleteInst(eai);
+    }
+    // And then clear the rest of the scratch buffer to prepare for the next
+    // iteration.
+    scratchBuffer.clear();
+
+    // Then add new end_apply along the new lifetime frontier of the coroutine.
+    while (!frontier.empty()) {
+      auto *insertionPoint = frontier.pop_back_val();
+      SILBuilderWithScope builder(insertionPoint);
+      auto *newInst =
+          builder.createEndApply(insertionPoint->getLoc(), tokenResult);
+      ctx.instModCallbacks.createdNewInst(newInst);
+    }
+
+    // And then delete all of the destroys.
+    while (!destroyInsts.empty()) {
+      ctx.instModCallbacks.deleteInst(destroyInsts.pop_back_val());
+    }
+  }
+
+  return madeChange;
+}
+
+//===----------------------------------------------------------------------===//
+//                             Gather Candidates
+//===----------------------------------------------------------------------===//
+
+// TODO: Make this stronger.
+static bool isSafeInstruction(SILInstruction *i) {
+  if (isa<EndBorrowInst>(i))
+    return true;
+  return !i->mayHaveSideEffects();
+}
+
+/// Returns true if \p fn is a coroutine such that both the yield and unwind
+/// edges both contain only instructions without side-effects that immediately
+/// end the function.
+static bool isSimpleCoroutine(SILFunction *fn) {
+  YieldInst *yi = nullptr;
+  for (auto &block : *fn) {
+    for (auto &inst : block) {
+      if (auto *newYI = dyn_cast<YieldInst>(&inst)) {
+        // Two yields!
+        if (yi) {
+          return false;
+        }
+        yi = newYI;
+      }
+    }
+  }
+
+  // No yields found!
+  if (!yi) {
+    return false;
+  }
+
+  // Ok, we found a single yield. Lets make sure that our unwind and resume
+  // blocks do not have side-effects and are function exiting.
+  //
+  // TODO: Make this stronger.
+  auto *resumeBlock = yi->getResumeBB();
+  auto *unwindBlock = yi->getUnwindBB();
+
+  if (!resumeBlock->getTerminator()->isFunctionExiting() ||
+      !unwindBlock->getTerminator()->isFunctionExiting()) {
+    return false;
+  }
+
+  for (auto &inst : *yi->getResumeBB()) {
+    if (!isSafeInstruction(&inst)) {
+      return false;
+    }
+  }
+
+  for (auto &inst : *yi->getUnwindBB()) {
+    if (!isSafeInstruction(&inst)) {
+      return false;
+    }
+  }
+
+  // Ok, we passed all of our tests! Return true!
+  return true;
+}
+
+static bool
+isEligibleApplySite(FullApplySite fas,
+                    SmallVectorImpl<FullApplySite> &accumulatedCandidates) {
+  // First check that we have a coroutine whose callee function has a single
+  // block resume that only contains instructions without side-effects.
+  if (!fas.beginsCoroutineEvaluation()) {
+    return false;
+  }
+
+  auto *callee = fas.getCalleeFunction();
+  if (!callee || !isSimpleCoroutine(callee)) {
+    return false;
+  }
+
+  // We only consider beginApply that never abort for simplicity.
+  //
+  // NOTE: This is assumed at the end of the function by our usage of
+  // getUsersOfType(). If this code is changed, we must change that other code
+  // as well.
+  //
+  // TODO: Can we handle abort?
+  auto *bai = cast<BeginApplyInst>(fas);
+  SILValue tokenResult = bai->getTokenResult();
+  for (auto *op : tokenResult->getUses()) {
+    if (!isa<EndApplyInst>(op->getUser())) {
+      return false;
+    }
+  }
+
+  // Now we know that we have a simple enough coroutine that we can process, try
+  // to gather up copies that we /could/ eliminate if we lifetime extend. Return
+  // true if we found something and false otherwise.
+  for (SILValue yieldedValue : bai->getYieldedValues()) {
+    if (yieldedValue.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
+      accumulatedCandidates.push_back(fas);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static bool
+gatherCandidates(SILFunction *fn,
+                 SmallVectorImpl<FullApplySite> &resultingCandidates) {
+  bool foundCandidate = false;
+  for (auto &block : *fn) {
+    for (auto &inst : block) {
+      if (auto fas = FullApplySite::isa(&inst)) {
+        if (isEligibleApplySite(fas, resultingCandidates)) {
+          foundCandidate = true;
+        }
+      }
+    }
+  }
+  return foundCandidate;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+bool swift::semanticarc::
+    tryEliminatingCopiesByLifetimeExtendingTrivialCoroutines(Context &ctx) {
+  // We do not perform this optimization when running as a guarantee
+  // optimization.
+  if (ctx.onlyGuaranteedOpts) {
+    return false;
+  }
+
+  // Gather up our candidate apply sites.
+  SmallVector<FullApplySite, 32> candidates;
+  if (!gatherCandidates(&ctx.fn, candidates)) {
+    // If we didn't find any candidates, bail.
+    return false;
+  }
+
+  // Then try to eliminate copies!
+  return processCandidates(ctx, candidates);
+}

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -17,8 +17,8 @@ using namespace swift;
 using namespace swift::semanticarc;
 
 OwnershipLiveRange::OwnershipLiveRange(SILValue value)
-    : introducer(*OwnedValueIntroducer::get(value)), destroyingUses(),
-      ownershipForwardingUses(), unknownConsumingUses() {
+    : consumingUses(), introducer(*OwnedValueIntroducer::get(value)),
+      destroyingUses(), ownershipForwardingUses(), unknownConsumingUses() {
   assert(introducer.value.getOwnershipKind() == ValueOwnershipKind::Owned);
 
   SmallVector<Operand *, 32> tmpDestroyingUses;

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
@@ -39,10 +39,6 @@ namespace semanticarc {
 /// phi arguments, struct, tuple). Instead we represent those as nodes in a
 /// larger phi ownership web, connected via individual OwnershipLiveRange.
 class LLVM_LIBRARY_VISIBILITY OwnershipLiveRange {
-  /// The value that we are computing the LiveRange for. Expected to be an owned
-  /// introducer and not to be forwarding.
-  OwnedValueIntroducer introducer;
-
   /// A vector that we store all of our uses into.
   ///
   /// Some properties of this array are:
@@ -55,6 +51,10 @@ class LLVM_LIBRARY_VISIBILITY OwnershipLiveRange {
   /// construct the LiveRange since going from small -> large could invalidate
   /// the uses.
   SmallVector<Operand *, 6> consumingUses;
+
+  /// The value that we are computing the LiveRange for. Expected to be an owned
+  /// introducer and not to be forwarding.
+  OwnedValueIntroducer introducer;
 
   /// A list of destroy_values of the live range.
   ///
@@ -85,6 +85,7 @@ class LLVM_LIBRARY_VISIBILITY OwnershipLiveRange {
 
 public:
   OwnershipLiveRange(SILValue value);
+
   OwnershipLiveRange(const OwnershipLiveRange &) = delete;
   OwnershipLiveRange &operator=(const OwnershipLiveRange &) = delete;
 
@@ -108,6 +109,14 @@ public:
   ArrayRef<Operand *> getAllConsumingUses() const { return consumingUses; }
 
   ArrayRef<Operand *> getDestroyingUses() const { return destroyingUses; }
+
+  /// Return a list of consuming uses that do not forward ownership and do not
+  /// release the underlying value.
+  ///
+  /// Example: a store of a value or an @owned argument.
+  ArrayRef<Operand *> getUnknownConsumingUses() const {
+    return unknownConsumingUses;
+  }
 
 private:
   struct OperandToUser;

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
@@ -110,3 +110,18 @@ bool SemanticARCOptVisitor::processWorklist() {
 
   return madeChange;
 }
+
+void SemanticARCOptVisitor::verify() const {
+#ifndef NDEBUG
+  for (auto optValue : visitedSinceLastMutation) {
+    if (SILValue value = optValue.getValueOr(SILValue())) {
+      assert(value);
+    }
+  }
+  for (auto optValue : worklist) {
+    if (SILValue value = optValue.getValueOr(SILValue())) {
+      assert(value);
+    }
+  }
+#endif
+}

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -58,6 +58,8 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
 
   DeadEndBlocks &getDeadEndBlocks() { return ctx.getDeadEndBlocks(); }
 
+  SILFunction *getFunction() const { return &ctx.fn; }
+
   /// Given a single value instruction, RAUW it with newValue, add newValue to
   /// the worklist, and then call eraseInstruction on i.
   void eraseAndRAUWSingleValueInstruction(SingleValueInstruction *i,
@@ -82,6 +84,8 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
     eraseInstruction(i);
   }
 
+  void verify() const;
+
   /// Pop values off of visitedSinceLastMutation, adding .some values to the
   /// worklist.
   void drainVisitedSinceLastMutationIntoWorklist() {
@@ -90,6 +94,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
       if (!nextValue.hasValue()) {
         continue;
       }
+      assert(*nextValue);
       worklist.insert(*nextValue);
     }
   }

--- a/lib/SILOptimizer/SemanticARC/Transforms.h
+++ b/lib/SILOptimizer/SemanticARC/Transforms.h
@@ -35,6 +35,23 @@ struct Context;
 /// eliminated ARC traffic as a result.
 bool tryConvertOwnedPhisToGuaranteedPhis(Context &ctx) LLVM_LIBRARY_VISIBILITY;
 
+/// In certain cases, we have tightly scoped trivial (1) coroutines that yield
+/// guaranteed values that are immediately copied before the coroutine's
+/// lifetime ends. In such a case, if the copy is never consumed, lifetime
+/// extend the coroutine over the uses of the copy and eliminate the copy.
+///
+/// (1) A "trivial" coroutine is a coroutine that only yields once and has
+/// resume/abort blocks without side-effects. This allows us to extend the
+/// lifetime of the coroutine without needing to worry about the coroutine's
+/// resume/abort blocks causing side-effects.
+///
+/// NOTE: This is intended to be run after canonicalizing the IR by eliminating
+/// redundant copies/@owned phis.
+///
+/// FIXME: Teach this how to lifetime extend over phi webs.
+bool tryEliminatingCopiesByLifetimeExtendingTrivialCoroutines(Context &ctx)
+    LLVM_LIBRARY_VISIBILITY;
+
 } // namespace semanticarc
 } // namespace swift
 

--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -90,7 +90,7 @@ SILInstruction *ValueLifetimeAnalysis::findLastUserInBlock(SILBasicBlock *bb) {
   llvm_unreachable("Expected to find use of value in block!");
 }
 
-bool ValueLifetimeAnalysis::computeFrontier(Frontier &frontier, Mode mode,
+bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
                                             DeadEndBlocks *deBlocks) {
   assert(!isAliveAtBeginOfBlock(getFunction()->getEntryBlock()) &&
          "Can't compute frontier for def which does not dominate all uses");
@@ -287,7 +287,7 @@ blockContainsDeallocRef(SILBasicBlock *bb,
   return false;
 }
 
-bool ValueLifetimeAnalysis::containsDeallocRef(const Frontier &frontier) {
+bool ValueLifetimeAnalysis::containsDeallocRef(const FrontierImpl &frontier) {
   SmallPtrSet<SILBasicBlock *, 8> frontierBlocks;
   // Search in live blocks where the value is not alive until the end of the
   // block, i.e. the live range is terminated by a frontier instruction.
@@ -326,7 +326,8 @@ void ValueLifetimeAnalysis::dump() const {
 }
 
 void swift::endLifetimeAtFrontier(
-    SILValue valueOrStackLoc, const ValueLifetimeAnalysis::Frontier &frontier,
+    SILValue valueOrStackLoc,
+    const ValueLifetimeAnalysis::FrontierImpl &frontier,
     SILBuilderContext &builderCtxt) {
   for (SILInstruction *endPoint : frontier) {
     SILBuilderWithScope builder(endPoint, builderCtxt);

--- a/test/SILOptimizer/coroutine_lifetime_extender.sil
+++ b/test/SILOptimizer/coroutine_lifetime_extender.sil
@@ -1,0 +1,478 @@
+// RUN: %target-sil-opt -semantic-arc-opts -sil-semantic-arc-coroutine-lifetime-extend-copy-elim %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+class Klass {
+  init()
+}
+
+class InternalState {
+  private final var _klass: Klass
+  final var klass: Klass { get }
+  init()
+}
+
+struct InternalStateWrapper {
+  private var _state: InternalState
+  private var _optState: FakeOptional<InternalState>
+  private var state: InternalState { get }
+  var klass: Klass { get }
+  init(_state: InternalState = InternalState())
+  init()
+}
+
+sil [ossa] @klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+
+sil hidden [ossa] @coroutine_access_class_in_internal_state : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass {
+bb0(%0 : @guaranteed $InternalState):
+  %2 = ref_element_addr %0 : $InternalState, #InternalState._klass
+  %3 = begin_access [read] [dynamic] %2 : $*Klass
+  %4 = load [copy] %3 : $*Klass
+  end_access %3 : $*Klass
+  yield %4 : $Klass, resume bb1, unwind bb2
+
+bb1:
+  destroy_value %4 : $Klass
+  %8 = tuple ()
+  return %8 : $()
+
+bb2:
+  destroy_value %4 : $Klass
+  unwind
+}
+
+sil private [ossa] @simple_coroutine_access_internal_state_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = struct_extract %0 : $InternalStateWrapper, #InternalStateWrapper._state
+  yield %2 : $InternalState, resume bb1, unwind bb2
+
+bb1:
+  %4 = tuple ()
+  return %4 : $()
+
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   ([[YIELDED_VALUE:%.*]], [[TOKEN_VALUE:%.*]]) = begin_apply {{%.*}}([[ARG]])
+// CHECK:   [[BORROWED_COPY_VALUE:%.*]] = begin_borrow [[YIELDED_VALUE]]
+// CHECK:   ({{%.*}}, [[TOKEN_VALUE_2:%.*]]) = begin_apply {{%.*}}([[BORROWED_COPY_VALUE]])
+// CHECK:   yield {{.*}}, resume [[RESUME_BB:bb[0-9]+]], unwind [[UNWIND_BB:bb[0-9]+]]
+//
+// CHECK: [[RESUME_BB]]:
+// CHECK:   end_apply [[TOKEN_VALUE_2]]
+// CHECK:   end_borrow [[BORROWED_COPY_VALUE]]
+// CHECK:   end_apply [[TOKEN_VALUE]]
+// CHECK:   return
+//
+// CHECK: [[UNWIND_BB]]:
+// CHECK:   end_apply [[TOKEN_VALUE_2]]
+// CHECK:   end_borrow [[BORROWED_COPY_VALUE]]
+// CHECK:   end_apply [[TOKEN_VALUE]]
+// CHECK:   unwind
+// CHECK: } // end sil function 'simple_coroutine_caller'
+sil hidden [ossa] @simple_coroutine_caller : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @simple_coroutine_access_internal_state_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  %5 = copy_value %3 : $InternalState
+  end_apply %4
+  %7 = begin_borrow %5 : $InternalState
+  %8 = function_ref @coroutine_access_class_in_internal_state : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass
+  (%9, %10) = begin_apply %8(%7) : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass
+  yield %9 : $Klass, resume bb1, unwind bb2
+
+bb1:
+  end_apply %10
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bb2:
+  end_apply %10
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  unwind
+}
+
+// Tests for forwarding insts.
+
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_direct_extract : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'simple_coroutine_caller_direct_extract'
+sil hidden [ossa] @simple_coroutine_caller_direct_extract : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @simple_coroutine_access_internal_state_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  %5 = copy_value %3 : $InternalState
+  end_apply %4
+  %7 = begin_borrow %5 : $InternalState
+  %9 = ref_element_addr %7 : $InternalState, #InternalState._klass
+  yield %9 : $*Klass, resume bb1, unwind bb2
+
+bb1:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bb2:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  unwind
+}
+
+// Test dead end blocks where we do not place various end_borrow, destroy_value
+// etc. Make sure to include a switch_enum test case so last use along a path is
+// a consuming use that is not a destroy.
+//
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_unreachable_1 : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'simple_coroutine_caller_unreachable_1'
+sil hidden [ossa] @simple_coroutine_caller_unreachable_1 : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @simple_coroutine_access_internal_state_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  %5 = copy_value %3 : $InternalState
+  end_apply %4
+  %7 = begin_borrow %5 : $InternalState
+  %9 = ref_element_addr %7 : $InternalState, #InternalState._klass
+  yield %9 : $*Klass, resume bb1, unwind bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  unwind
+
+bb3:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bb4:
+  unreachable
+}
+
+sil [ossa] @coroutine_get_optional_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed FakeOptional<InternalState> {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %1 = struct_extract %0 : $InternalStateWrapper, #InternalStateWrapper._optState
+  yield %1 : $FakeOptional<InternalState>, resume bb1, unwind bb2
+
+bb1:
+  %8 = tuple ()
+  return %8 : $()
+
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_unreachable_2 : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'simple_coroutine_caller_unreachable_2'
+sil hidden [ossa] @simple_coroutine_caller_unreachable_2 : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @coroutine_get_optional_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed FakeOptional<InternalState>
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed FakeOptional<InternalState>
+  %5 = copy_value %3 : $FakeOptional<InternalState>
+  end_apply %4
+  switch_enum %5 : $FakeOptional<InternalState>, case #FakeOptional.some: bbSome, case #FakeOptional.none: bbNone
+
+bbSome(%6 : @owned $InternalState):
+  %7 = begin_borrow %6 : $InternalState
+  yield %7 : $InternalState, resume bbResume, unwind bbUnwind
+
+bbUnwind:
+  end_borrow %7 : $InternalState
+  destroy_value %6 : $InternalState
+  unwind
+
+bbResume:
+  end_borrow %7 : $InternalState
+  destroy_value %6 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bbNone:
+  unreachable
+}
+
+sil @consume_internalstate : $@convention(thin) (@owned InternalState) -> ()
+
+// Make sure that if copy value is consumed, we bail
+//
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_consumed_copyvalue : $@convention(method) (@guaranteed InternalStateWrapper) -> () {
+// CHECK: copy_value
+// CHECK-NEXT: end_apply
+// CHECK-NEXT: switch_enum
+// CHECK: } // end sil function 'simple_coroutine_caller_consumed_copyvalue'
+sil hidden [ossa] @simple_coroutine_caller_consumed_copyvalue : $@convention(method) (@guaranteed InternalStateWrapper) -> () {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @coroutine_get_optional_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed FakeOptional<InternalState>
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed FakeOptional<InternalState>
+  %5 = copy_value %3 : $FakeOptional<InternalState>
+  end_apply %4
+  switch_enum %5 : $FakeOptional<InternalState>, case #FakeOptional.some: bbSome, case #FakeOptional.none: bbNone
+
+bbSome(%6 : @owned $InternalState):
+  %f = function_ref @consume_internalstate : $@convention(thin) (@owned InternalState) -> ()
+  apply %f(%6) : $@convention(thin) (@owned InternalState) -> ()
+  %15 = tuple ()
+  return %15 : $()
+
+bbNone:
+  unreachable
+}
+
+// Make sure we bail if our coroutine has an abort.
+
+// First make sure we succeed in eliminating the copy_value given the two end_apply diamonds.
+//
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_diamond_no_abort : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'simple_coroutine_caller_diamond_no_abort'
+sil hidden [ossa] @simple_coroutine_caller_diamond_no_abort : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @simple_coroutine_access_internal_state_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  %5 = copy_value %3 : $InternalState
+  cond_br undef, bb1a, bb1b
+
+bb1a:
+  end_apply %4
+  br bb1c
+
+bb1b:
+  end_apply %4
+  br bb1c
+
+bb1c:
+  %7 = begin_borrow %5 : $InternalState
+  %9 = ref_element_addr %7 : $InternalState, #InternalState._klass
+  yield %9 : $*Klass, resume bb1, unwind bb2
+
+bb1:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bb2:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  unwind
+}
+
+// Then make sure we do not eliminate the copy_value if we convert one of those end_apply to an abort_apply
+//
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_diamond_with_abort : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_coroutine_caller_diamond_with_abort'
+sil hidden [ossa] @simple_coroutine_caller_diamond_with_abort : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @in_guaranteed Klass {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @simple_coroutine_access_internal_state_from_wrapper : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  %5 = copy_value %3 : $InternalState
+  cond_br undef, bb1a, bb1b
+
+bb1a:
+  abort_apply %4
+  br bb1c
+
+bb1b:
+  end_apply %4
+  br bb1c
+
+bb1c:
+  %7 = begin_borrow %5 : $InternalState
+  %9 = ref_element_addr %7 : $InternalState, #InternalState._klass
+  yield %9 : $*Klass, resume bb1, unwind bb2
+
+bb1:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bb2:
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  unwind
+}
+
+// Make sure we bail if our coroutine yields multiple times. We can support this
+// with time, just for simplicity now we do not support it.
+sil private [ossa] @simple_coroutine_access_internal_state_from_wrapper_multiple_yield : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  cond_br undef, bb1a, bb1b
+
+bb1a:
+  %2 = struct_extract %0 : $InternalStateWrapper, #InternalStateWrapper._state
+  yield %2 : $InternalState, resume bb1c, unwind bb2a
+
+bb1b:
+  %3 = struct_extract %0 : $InternalStateWrapper, #InternalStateWrapper._state
+  yield %3 : $InternalState, resume bb1d, unwind bb2b
+
+bb1c:
+  br bb1
+
+bb1d:
+  br bb1
+
+bb1:
+  %4 = tuple ()
+  return %4 : $()
+
+bb2a:
+  br bb2
+
+bb2b:
+  br bb2
+
+bb2:
+  unwind
+}
+
+// We do not handle this due to the multiple yield.
+//
+// CHECK-LABEL: sil hidden [ossa] @simple_coroutine_caller_multiple_yield : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_coroutine_caller_multiple_yield'
+sil hidden [ossa] @simple_coroutine_caller_multiple_yield : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
+bb0(%0 : @guaranteed $InternalStateWrapper):
+  %2 = function_ref @simple_coroutine_access_internal_state_from_wrapper_multiple_yield : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState
+  %5 = copy_value %3 : $InternalState
+  end_apply %4
+  %7 = begin_borrow %5 : $InternalState
+  %8 = function_ref @coroutine_access_class_in_internal_state : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass
+  (%9, %10) = begin_apply %8(%7) : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass
+  yield %9 : $Klass, resume bb1, unwind bb2
+
+bb1:
+  end_apply %10
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  %15 = tuple ()
+  return %15 : $()
+
+bb2:
+  end_apply %10
+  end_borrow %7 : $InternalState
+  destroy_value %5 : $InternalState
+  unwind
+}
+
+sil [ossa] @simple_coroutine_yield_two_klass_tuple : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed (Klass, FakeOptional<Klass>) {
+bb0(%0 : @guaranteed $InternalState):
+  %2 = ref_element_addr %0 : $InternalState, #InternalState._klass
+//  %3 = begin_access [read] [dynamic] %2 : $*Klass
+  %4 = load_borrow %2 : $*Klass
+  %5 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %4 : $Klass
+  %6 = tuple(%4 : $Klass, %5 : $FakeOptional<Klass>)
+  yield %6 : $(Klass, FakeOptional<Klass>), resume bb1, unwind bb2
+
+bb1:
+  end_borrow %4 : $Klass
+//  end_access %3 : $*Klass
+  %8 = tuple ()
+  return %8 : $()
+
+bb2:
+  end_borrow %4 : $Klass
+//  end_access %3 : $*Klass
+  unwind
+}
+
+// Make sure that in the following, we can eliminate the copy_value,
+// destroy_value /and/ that we move the end apply in bb2 to be after the apply.
+//
+// CHECK-LABEL: sil [ossa] @simple_coroutine_yield_two_klass_tuple_caller : $@convention(thin) (@guaranteed InternalState) -> () {
+// CHECK-NOT: copy_value
+// CHECK-NOT: destroy_value
+// CHECK: bb2:
+// CHECK-NEXT:   apply {{%.*}}({{%.*}})
+// CHECK-NEXT:   end_apply
+// CHECK: } // end sil function 'simple_coroutine_yield_two_klass_tuple_caller'
+sil [ossa] @simple_coroutine_yield_two_klass_tuple_caller : $@convention(thin) (@guaranteed InternalState) -> () {
+bb0(%0 : @guaranteed $InternalState):
+  %1 = function_ref @simple_coroutine_yield_two_klass_tuple : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed (Klass, FakeOptional<Klass>)
+  %1a = function_ref @klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed (Klass, FakeOptional<Klass>)
+  %4 = tuple_extract %2 : $(Klass, FakeOptional<Klass>), 0
+  %5 = tuple_extract %2 : $(Klass, FakeOptional<Klass>), 1
+  %6 = copy_value %4 : $Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %6 : $Klass
+  %5a = unchecked_enum_data %5 : $FakeOptional<Klass>, #FakeOptional.some!enumelt
+  apply %1a(%5a) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_apply %3
+  br bb3
+
+bb2:
+  end_apply %3
+  apply %1a(%6) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %6 : $Klass
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simple_coroutine_yield_two_klass_tuple_caller_2 : $@convention(thin) (@guaranteed InternalState) -> () {
+// CHECK-NOT: copy_value
+// CHECK-NOT: destroy_value
+// CHECK: } // end sil function 'simple_coroutine_yield_two_klass_tuple_caller_2'
+sil [ossa] @simple_coroutine_yield_two_klass_tuple_caller_2 : $@convention(thin) (@guaranteed InternalState) -> () {
+bb0(%0 : @guaranteed $InternalState):
+  %1 = function_ref @simple_coroutine_yield_two_klass_tuple : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed (Klass, FakeOptional<Klass>)
+  %1a = function_ref @klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed (Klass, FakeOptional<Klass>)
+  %4 = tuple_extract %2 : $(Klass, FakeOptional<Klass>), 0
+  %5 = tuple_extract %2 : $(Klass, FakeOptional<Klass>), 1
+  %6 = copy_value %5 : $FakeOptional<Klass>
+  cond_br undef, bb1, bb2
+
+bb1:
+  switch_enum %6 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bbSome, case #FakeOptional.none!enumelt: bbNone
+
+bbSome(%7 : @owned $Klass):
+  destroy_value %7 : $Klass
+  %5a = unchecked_enum_data %5 : $FakeOptional<Klass>, #FakeOptional.some!enumelt
+  apply %1a(%5a) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_apply %3
+  br bb3
+
+bbNone:
+  apply %1a(%4) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_apply %3
+  br bb3
+
+bb2:
+  end_apply %3
+  %6a = unchecked_enum_data %6 : $FakeOptional<Klass>, #FakeOptional.some!enumelt
+  apply %1a(%6a) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %6a : $Klass
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/coroutine_lifetime_extender.swift
+++ b/test/SILOptimizer/coroutine_lifetime_extender.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -Osize -emit-sil -sil-stop-optzns-before-lowering-ownership %s | %FileCheck %s
+
+// End to end test that we can extend lifetimes as appropriate.
+
+public final class Klass {}
+
+public final class InternalState {
+    private var _klass = Klass()
+
+    public var klass: Klass {
+        _read { yield _klass }
+    }
+}
+
+public struct InternalStateWrapper {
+    private var _state: InternalState = InternalState()
+    private var state: InternalState {
+        _read { yield _state }
+    }
+
+    public var klass : Klass {
+        // Make sure there is no ARC traffic in this function and that we have
+        // simplified all of the ARC possible. We are relying on the verifier to
+        // check that we are properly interleaving the coroutines.
+        //
+        // CHECK-LABEL: sil [ossa] @$s27coroutine_lifetime_extender20InternalStateWrapperV5klassAA5KlassCvr : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
+        // CHECK-NOT: copy_value
+        // CHECK-NOT: begin_borrow
+        // CHECK: } // end sil function '$s27coroutine_lifetime_extender20InternalStateWrapperV5klassAA5KlassCvr'
+        _read { yield state.klass }
+    }
+}


### PR DESCRIPTION
This pattern comes up when one attempts to yield a value through multiple frames
with interleaving projection operations. Specifically:

```
final class Klass {}
final class InternalState {
    private var _klass = Klass()
    var klass: Klass {
        _read { yield _klass }
    }
}
struct InternalStateWrapper {
    private var _state: InternalState = InternalState()
    private var state: InternalState {
        _read { yield _state }
    }
    var klass : Klass {
        _read { yield state.klass }
    }
}
```

In this case without this patch in InternalStateWrapper.klass._read, we eagerly
copy state before accessing klass to be yielded:

```
sil hidden [ossa] @$s3out20InternalStateWrapperV5klassAA5KlassCvr : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
// %0 "self"                                      // users: %3, %1
bb0(%0 : @guaranteed $InternalStateWrapper):
  debug_value %0 : $InternalStateWrapper, let, name "self", argno 1 // id: %1
  // function_ref InternalStateWrapper.state.read
  %2 = function_ref @$s3out20InternalStateWrapperV5state33_34DE71879EE7D1DC94CAC23CDAE4052BLLAA0bC0Cvr : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState // user: %3
  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState // users: %5, %6
  %5 = copy_value %3 : $InternalState             // users: %14, %19, %7
  end_apply %4                                    // id: %6
  %7 = begin_borrow %5 : $InternalState           // users: %13, %18, %9
  // function_ref InternalState.klass.read
  %8 = function_ref @$s3out13InternalStateC5klassAA5KlassCvr : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass // user: %9
  (%9, %10) = begin_apply %8(%7) : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass // users: %11, %12, %17
  yield %9 : $Klass, resume bb1, unwind bb2       // id: %11
bb1:                                              // Preds: bb0
  end_apply %10                                   // id: %12
  end_borrow %7 : $InternalState                  // id: %13
  destroy_value %5 : $InternalState               // id: %14
  %15 = tuple ()                                  // user: %16
  return %15 : $()                                // id: %16
bb2:                                              // Preds: bb0
  end_apply %10                                   // id: %17
  end_borrow %7 : $InternalState                  // id: %18
  destroy_value %5 : $InternalState               // id: %19
  unwind                                          // id: %20
} // end sil function '$s3out20InternalStateWrapperV5klassAA5KlassCvr'
```

This patch adds a new pass called CoroutineLifetimeExtension that in cases like
the above where our coroutine has the properties that:

1. The resume/unwind blocks are function exiting.
2. The resume/unwind blocks only contain instructions without side-effects
3. The coroutine only has a single yield.

Then we can extend the lifetime of the coroutine to be after the destroy_values,
e.x.:

```
sil hidden [ossa] @$s3out20InternalStateWrapperV5klassAA5KlassCvr : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed Klass {
// %0 "self"                                      // users: %3, %1
bb0(%0 : @guaranteed $InternalStateWrapper):
  debug_value %0 : $InternalStateWrapper, let, name "self", argno 1 // id: %1
  // function_ref InternalStateWrapper.state.read
  %2 = function_ref @$s3out20InternalStateWrapperV5state33_34DE71879EE7D1DC94CAC23CDAE4052BLLAA0bC0Cvr : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState // user: %3
  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed InternalStateWrapper) -> @yields @guaranteed InternalState // users: %5, %6
  %5 = copy_value %3 : $InternalState             // users: %14, %19, %7
  %7 = begin_borrow %5 : $InternalState           // users: %13, %18, %9
  // function_ref InternalState.klass.read
  %8 = function_ref @$s3out13InternalStateC5klassAA5KlassCvr : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass // user: %9
  (%9, %10) = begin_apply %8(%7) : $@yield_once @convention(method) (@guaranteed InternalState) -> @yields @guaranteed Klass // users: %11, %12, %17
  yield %9 : $Klass, resume bb1, unwind bb2       // id: %11

bb1:                                              // Preds: bb0
  end_apply %10                                   // id: %12
  end_borrow %7 : $InternalState                  // id: %13
  destroy_value %5 : $InternalState               // id: %14
  end_apply %4                                    // id: %6
  %15 = tuple ()                                  // user: %16
  return %15 : $()                                // id: %16

bb2:                                              // Preds: bb0
  end_apply %10                                   // id: %17
  end_borrow %7 : $InternalState                  // id: %18
  destroy_value %5 : $InternalState               // id: %19
  end_apply %4                                    // id: %6
  unwind                                          // id: %20
} // end sil function '$s3out20InternalStateWrapperV5klassAA5KlassCvr'
```

allowing for SemanticARCOpts to eliminate all ref count traffic in this
function.

----

NOTE: This PR is just for testing right now.