### PR TITLE
[IRGen] Skip reemitting fields referenced by type context descriptor.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1168,6 +1168,7 @@ static void
 deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRecords(
     IRGenModule &IGM, CanType typeWithCanonicalMetadataPrespecialization,
     NominalTypeDecl &decl) {
+  IGM.IRGen.noteLazyReemissionOfNominalTypeDescriptor(&decl);
   // The type context descriptor depends on canonical metadata records because
   // pointers to them are attached as trailing objects to it.
   //

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -301,10 +301,12 @@ static void buildMethodDescriptorFields(IRGenModule &IGM,
 void IRGenModule::emitNonoverriddenMethodDescriptor(const SILVTable *VTable,
                                                     SILDeclRef declRef) {
   auto entity = LinkEntity::forMethodDescriptor(declRef);
-
   auto *var = cast<llvm::GlobalVariable>(getAddrOfLLVMVariable(entity, ConstantInit(), DebugTypeInfo()));
-  var->setInitializer(nullptr);
- 
+  if (!var->isDeclaration()) {
+    assert(IRGen.isLazilyReemittingNominalTypeDescriptor(VTable->getClass()));
+    return;
+  }
+
   ConstantInitBuilder ib(*this);
   ConstantStructBuilder sb(ib.beginStruct(MethodDescriptorStructTy));
 

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -103,7 +103,7 @@ static FunctionPointer lookupMethod(IRGenFunction &IGF, SILDeclRef declRef) {
 void IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
   auto *f = getAddrOfDispatchThunk(declRef, ForDefinition);
   if (!f->isDeclaration()) {
-    f->deleteBody();
+    return;
   }
 
   IRGenFunction IGF(*this, f);
@@ -167,7 +167,8 @@ IRGenModule::getAddrOfMethodLookupFunction(ClassDecl *classDecl,
 void IRGenModule::emitMethodLookupFunction(ClassDecl *classDecl) {
   auto *f = getAddrOfMethodLookupFunction(classDecl, ForDefinition);
   if (!f->isDeclaration()) {
-    f->deleteBody();
+    assert(IRGen.isLazilyReemittingNominalTypeDescriptor(classDecl));
+    return;
   }
 
   IRGenFunction IGF(*this, f);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -279,6 +279,8 @@ private:
   llvm::SmallVector<std::pair<CanType, TypeMetadataCanonicality>, 4>
       LazySpecializedTypeMetadataRecords;
 
+  llvm::SmallPtrSet<NominalTypeDecl *, 4> LazilyReemittedTypeContextDescriptors;
+
   /// The queue of metadata accessors to emit.
   ///
   /// The accessors must be emitted after everything else which might result in
@@ -434,6 +436,15 @@ public:
   llvm::SmallVector<std::pair<CanType, TypeMetadataCanonicality>, 4>
   metadataPrespecializationsForType(NominalTypeDecl *type) {
     return MetadataPrespecializationsForGenericTypes.lookup(type);
+  }
+
+  void noteLazyReemissionOfNominalTypeDescriptor(NominalTypeDecl *decl) {
+    LazilyReemittedTypeContextDescriptors.insert(decl);
+  }
+
+  bool isLazilyReemittingNominalTypeDescriptor(NominalTypeDecl *decl) {
+    return LazilyReemittedTypeContextDescriptors.find(decl) !=
+           std::end(LazilyReemittedTypeContextDescriptors);
   }
 
   void noteUseOfMetadataAccessor(NominalTypeDecl *decl) {


### PR DESCRIPTION
When reemitting a type context descriptor, several fields
- method lookup function
- dispatch thunk
- nonoverride method descriptor
were previously being reemitted.

In a couple of earlier commits, that behavior was altered to delete the fields before reemitting them.

  3ad2777a68d [IRGen] Erase nonoverride descriptor on emission.
  c25c180c088 [IRGen] Erase thunks before emission.

Here, the behavior is changed to simply exit early when these fields are being reemitted.  Also an assertion is added that these fields are redefined only when reemitting the type context descriptor.