### PR TITLE
[android] XFAIL opt-remark-generator.swift in ARMv7

### DIFF
--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swiftc_driver -O -Rpass-missed=sil-opt-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
 // REQUIRES: optimized_stdlib
 
+// XFAIL: OS=linux-androideabi && CPU=armv7
+
 public class Klass {}
 
 public var global = Klass()


### PR DESCRIPTION
Android ARMv7 doesn't seem to simplify the remarks from
Optional<SubKlass> to just SubKlass, while other platforms do.

I did not find any clues in #33171 what it might be happening, so XFAIL
the test to avoid a failing build.
