### PR TITLE
[android] Adapt test to upstream readobj output change.

### DIFF
--- a/test/DebugInfo/modulecache.swift
+++ b/test/DebugInfo/modulecache.swift
@@ -16,7 +16,7 @@ import ClangModule
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -c -g -o %t.o -module-cache-path %t -I %S/Inputs
 // RUN: llvm-readobj -h %t/*/ClangModule-*.pcm | %FileCheck %s
-// CHECK: Format: {{(Mach-O|ELF|elf64|COFF)}}
+// CHECK: Format: {{(Mach-O|ELF|elf64|COFF|elf32-littlearm)}}
 
 // 3. Test that swift-ide-check will not share swiftc's module cache.
 


### PR DESCRIPTION
This is a change that will be necessary for master-next. readobj seems
to report elf32-littlearm when compiling for Android ARMv7.

This is similar to commit f7cf5bde468e29ebe8239fbea53af39e7ecf4f5d which
is still available in master-next, but I think was (mistakenly) reverted
with #32265.

(cherry picked from commit 80135c913a43ee9c6a05d1f81698acf2be927171)

As requested in https://github.com/apple/swift/pull/33382#issuecomment-671470602