### PR TITLE
[Diag] Refactor `diagnosticStringFor` to return StringRef

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -22,6 +22,7 @@
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/LocalizationFormat.h"
 #include "swift/AST/TypeLoc.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/FileSystem.h"
@@ -987,7 +988,8 @@ namespace swift {
     void emitTentativeDiagnostics();
 
   public:
-    const char *diagnosticStringFor(const DiagID id, bool printDiagnosticName);
+    llvm::StringRef diagnosticStringFor(const DiagID id,
+                                        bool printDiagnosticName);
 
     /// If there is no clear .dia file for a diagnostic, put it in the one
     /// corresponding to the SourceLoc given here.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1010,8 +1010,9 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
     emitDiagnostic(childNote);
 }
 
-const char *DiagnosticEngine::diagnosticStringFor(const DiagID id,
-                                                  bool printDiagnosticName) {
+llvm::StringRef
+DiagnosticEngine::diagnosticStringFor(const DiagID id,
+                                      bool printDiagnosticName) {
   // TODO: Print diagnostic names from `localization`.
   if (printDiagnosticName) {
     return debugDiagnosticStrings[(unsigned)id];
@@ -1020,7 +1021,7 @@ const char *DiagnosticEngine::diagnosticStringFor(const DiagID id,
   if (localization) {
     auto localizedMessage =
         localization.get()->getMessageOr(id, defaultMessage);
-    return localizedMessage.data();
+    return localizedMessage;
   }
   return defaultMessage;
 }


### PR DESCRIPTION
**To make #33422 easier to review, I decided to open this PR.**

When I was testing #33422 and returning diagnostic messages from the hash table, there was a mismatch in some diagnostic messages because there was an extra `0x01` byte at the end of every diagnostic message. 

Currently, `diagnosticStringFor` returns a `const char *` obtained by calling `data()` on a `StringRef` coming from `LocalizationProducer::getMessageOr`. Since, `StringRef` isn't null-terminated, when converting it to a pointer and then back to a `StringRef` later - in `DiagnosticInfo` - causes the length to be wrong.

When changing `diagnosticStringFor` to return an `llvm::StringRef` instead and removing the calls to `data()`, the tests in #33422 will pass. 

cc @xedin, @owenv 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
