### PR TITLE
[FunctionBuilders] Implement graceful handling of pre-check failures

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1056,6 +1056,12 @@ namespace swift {
       }
     }
 
+    bool hasDiagnostics() const {
+      return std::distance(Engine.TentativeDiagnostics.begin() +
+                               PrevDiagnostics,
+                           Engine.TentativeDiagnostics.end()) > 0;
+    }
+
     /// Abort and close this transaction and erase all diagnostics
     /// record while it was open.
     void abort() {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1843,6 +1843,7 @@ public:
 
 struct PreCheckFunctionBuilderDescriptor {
   AnyFunctionRef Fn;
+  bool SuppressDiagnostics;
 
 private:
   // NOTE: Since source tooling (e.g. code completion) might replace the body,
@@ -1852,8 +1853,8 @@ private:
   BraceStmt *Body;
 
 public:
-  PreCheckFunctionBuilderDescriptor(AnyFunctionRef Fn)
-      : Fn(Fn), Body(Fn.getBody()) {}
+  PreCheckFunctionBuilderDescriptor(AnyFunctionRef Fn, bool suppressDiagnostics)
+      : Fn(Fn), SuppressDiagnostics(suppressDiagnostics), Body(Fn.getBody()) {}
 
   friend llvm::hash_code
   hash_value(const PreCheckFunctionBuilderDescriptor &owner) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1749,7 +1749,8 @@ public:
       // Suppress any diangostics which could be produced by this expression.
       DiagnosticTransaction transaction(diagEngine);
 
-      HasError |= ConstraintSystem::preCheckExpression(E, DC);
+      HasError |= ConstraintSystem::preCheckExpression(
+          E, DC, /*replaceInvalidRefsWithErrors=*/false);
       HasError |= transaction.hasDiagnostics();
 
       transaction.abort();

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1485,9 +1485,11 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   // If we encountered an error or there was an explicit result type,
   // bail out and report that to the caller.
   auto &ctx = func->getASTContext();
-  auto request = PreCheckFunctionBuilderRequest{AnyFunctionRef(func)};
-  switch (evaluateOrDefault(
-              ctx.evaluator, request, FunctionBuilderBodyPreCheck::Error)) {
+  auto request =
+      PreCheckFunctionBuilderRequest{{AnyFunctionRef(func),
+                                      /*SuppressDiagnostics=*/false}};
+  switch (evaluateOrDefault(ctx.evaluator, request,
+                            FunctionBuilderBodyPreCheck::Error)) {
   case FunctionBuilderBodyPreCheck::Okay:
     // If the pre-check was okay, apply the function-builder transform.
     break;
@@ -1619,7 +1621,8 @@ ConstraintSystem::matchFunctionBuilder(
 
   // Pre-check the body: pre-check any expressions in it and look
   // for return statements.
-  auto request = PreCheckFunctionBuilderRequest{fn};
+  auto request =
+      PreCheckFunctionBuilderRequest{{fn, /*SuppressDiagnostics=*/false}};
   switch (evaluateOrDefault(getASTContext().evaluator, request,
                             FunctionBuilderBodyPreCheck::Error)) {
   case FunctionBuilderBodyPreCheck::Okay:
@@ -1705,14 +1708,17 @@ namespace {
 class PreCheckFunctionBuilderApplication : public ASTWalker {
   AnyFunctionRef Fn;
   bool SkipPrecheck = false;
+  bool SuppressDiagnostics = false;
   std::vector<ReturnStmt *> ReturnStmts;
   bool HasError = false;
 
   bool hasReturnStmt() const { return !ReturnStmts.empty(); }
 
 public:
-  PreCheckFunctionBuilderApplication(AnyFunctionRef fn, bool skipPrecheck)
-      : Fn(fn), SkipPrecheck(skipPrecheck) {}
+  PreCheckFunctionBuilderApplication(AnyFunctionRef fn, bool skipPrecheck,
+                                     bool suppressDiagnostics)
+      : Fn(fn), SkipPrecheck(skipPrecheck),
+        SuppressDiagnostics(suppressDiagnostics) {}
 
   const std::vector<ReturnStmt *> getReturnStmts() const { return ReturnStmts; }
 
@@ -1753,7 +1759,9 @@ public:
           E, DC, /*replaceInvalidRefsWithErrors=*/false);
       HasError |= transaction.hasDiagnostics();
 
-      transaction.abort();
+      if (SuppressDiagnostics)
+        transaction.abort();
+
       return std::make_pair(false, HasError ? nullptr : E);
     }
   }
@@ -1788,11 +1796,15 @@ FunctionBuilderBodyPreCheck PreCheckFunctionBuilderRequest::evaluate(
           owner.Fn.getAbstractClosureExpr()))
     skipPrecheck = shouldTypeCheckInEnclosingExpression(closure);
 
-  return PreCheckFunctionBuilderApplication(owner.Fn, false).run();
+  return PreCheckFunctionBuilderApplication(
+             owner.Fn, /*skipPrecheck=*/false,
+             /*suppressDiagnostics=*/owner.SuppressDiagnostics)
+      .run();
 }
 
 std::vector<ReturnStmt *> TypeChecker::findReturnStatements(AnyFunctionRef fn) {
-  PreCheckFunctionBuilderApplication precheck(fn, true);
+  PreCheckFunctionBuilderApplication precheck(fn, /*skipPreCheck=*/true,
+                                              /*SuppressDiagnostics=*/true);
   (void)precheck.run();
   return precheck.getReturnStmts();
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1563,7 +1563,8 @@ bool IgnoreInvalidFunctionBuilderBody::diagnose(const Solution &solution,
     PreCheckWalker(DeclContext *dc) : DC(dc) {}
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      auto hasError = ConstraintSystem::preCheckExpression(E, DC);
+      auto hasError = ConstraintSystem::preCheckExpression(
+          E, DC, /*replaceInvalidRefsWithErrors=*/true);
       return std::make_pair(false, hasError ? nullptr : E);
     }
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -276,6 +276,9 @@ enum class FixKind : uint8_t {
 
   /// Allow key path expressions with no components.
   AllowKeyPathWithoutComponents,
+
+  /// Ignore function builder body which fails `pre-check` call.
+  IgnoreInvalidFunctionBuilderBody,
 };
 
 class ConstraintFix {
@@ -1978,6 +1981,26 @@ public:
 
   static AllowKeyPathWithoutComponents *create(ConstraintSystem &cs,
                                                ConstraintLocator *locator);
+};
+
+class IgnoreInvalidFunctionBuilderBody final : public ConstraintFix {
+  IgnoreInvalidFunctionBuilderBody(ConstraintSystem &cs,
+                                   ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::IgnoreInvalidFunctionBuilderBody, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore invalid function builder body";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreInvalidFunctionBuilderBody *create(ConstraintSystem &cs,
+                                                  ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9997,7 +9997,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowCoercionToForceCast:
   case FixKind::SpecifyKeyPathRootType:
   case FixKind::SpecifyLabelToAssociateTrailingClosure:
-  case FixKind::AllowKeyPathWithoutComponents: {
+  case FixKind::AllowKeyPathWithoutComponents:
+  case FixKind::IgnoreInvalidFunctionBuilderBody: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1411,7 +1411,8 @@ void ConstraintSystem::solveForCodeCompletion(
     llvm::function_ref<void(const Solution &)> callback) {
   // First, pre-check the expression, validating any types that occur in the
   // expression and folding sequence expressions.
-  if (ConstraintSystem::preCheckExpression(expr, DC))
+  if (ConstraintSystem::preCheckExpression(
+          expr, DC, /*replaceInvalidRefsWithErrors=*/true))
     return;
 
   ConstraintSystemOptions options;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4955,8 +4955,12 @@ private:
 public:
   /// Pre-check the expression, validating any types that occur in the
   /// expression and folding sequence expressions.
-  static bool preCheckExpression(Expr *&expr, DeclContext *dc);
-        
+  ///
+  /// \param replaceInvalidRefsWithErrors Indicates whether it's allowed
+  /// to replace any discovered invalid member references with `ErrorExpr`.
+  static bool preCheckExpression(Expr *&expr, DeclContext *dc,
+                                 bool replaceInvalidRefsWithErrors);
+
   /// Solve the system of constraints generated from provided target.
   ///
   /// \param target The target that we'll generate constraints from, which

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -553,10 +553,10 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
   // We allocate these expressions on the stack because we know they can't
   // escape and there isn't a better way to allocate scratch Expr nodes.
   UnresolvedDeclRefExpr UDRE(DeclNameRef(opName), refKind, DeclNameLoc(Loc));
-  auto *opExpr = TypeChecker::resolveDeclRefExpr(&UDRE, DC);
+  auto *opExpr = TypeChecker::resolveDeclRefExpr(
+      &UDRE, DC, /*replaceInvalidRefsWithErrors=*/true);
 
   switch (refKind) {
-
   case DeclRefKind::PostfixOperator: {
     // (postfix_unary_expr
     //   (declref_expr name=<opName>)
@@ -611,7 +611,8 @@ static Optional<Type> getTypeOfCompletionContextExpr(
                         CompletionTypeCheckKind kind,
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
-  if (constraints::ConstraintSystem::preCheckExpression(parsedExpr, DC))
+  if (constraints::ConstraintSystem::preCheckExpression(
+          parsedExpr, DC, /*replaceInvalidRefsWithErrors=*/true))
     return None;
 
   switch (kind) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -481,10 +481,17 @@ static bool findNonMembers(ArrayRef<LookupResultEntry> lookupResults,
 /// returning the resultant expression. Context is the DeclContext used
 /// for the lookup.
 Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
-                                      DeclContext *DC) {
+                                      DeclContext *DC,
+                                      bool replaceInvalidRefsWithErrors) {
   // Process UnresolvedDeclRefExpr by doing an unqualified lookup.
   DeclNameRef Name = UDRE->getName();
   SourceLoc Loc = UDRE->getLoc();
+
+  auto errorResult = [&]() -> Expr * {
+    if (replaceInvalidRefsWithErrors)
+      return new (DC->getASTContext()) ErrorExpr(UDRE->getSourceRange());
+    return UDRE;
+  };
 
   // Perform standard value name lookup.
   NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
@@ -506,7 +513,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
     if (diagnoseRangeOperatorMisspell(Context.Diags, UDRE) ||
         diagnoseIncDecOperator(Context.Diags, UDRE) ||
         diagnoseOperatorJuxtaposition(UDRE, DC)) {
-      return new (Context) ErrorExpr(UDRE->getSourceRange());
+      return errorResult();
     }
 
     // Try ignoring access control.
@@ -531,7 +538,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
 
       // Don't try to recover here; we'll get more access-related diagnostics
       // downstream if the type of the inaccessible decl is also inaccessible.
-      return new (Context) ErrorExpr(UDRE->getSourceRange());
+      return errorResult();
     }
 
     // TODO: Name will be a compound name if it was written explicitly as
@@ -625,7 +632,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
     // TODO: consider recovering from here.  We may want some way to suppress
     // downstream diagnostics, though.
 
-    return new (Context) ErrorExpr(UDRE->getSourceRange());
+    return errorResult();
   }
 
   // FIXME: Need to refactor the way we build an AST node from a lookup result!
@@ -916,6 +923,10 @@ namespace {
 
     Expr *ParentExpr;
 
+    /// Indicates whether pre-check is allowed to insert
+    /// implicit `ErrorExpr` in place of invalid references.
+    bool UseErrorExprs;
+
     /// A stack of expressions being walked, used to determine where to
     /// insert RebindSelfInConstructorExpr nodes.
     llvm::SmallVector<Expr *, 8> ExprStack;
@@ -1055,8 +1066,10 @@ namespace {
     }
 
   public:
-    PreCheckExpression(DeclContext *dc, Expr *parent)
-        : Ctx(dc->getASTContext()), DC(dc), ParentExpr(parent) {}
+    PreCheckExpression(DeclContext *dc, Expr *parent,
+                       bool replaceInvalidRefsWithErrors)
+        : Ctx(dc->getASTContext()), DC(dc), ParentExpr(parent),
+          UseErrorExprs(replaceInvalidRefsWithErrors) {}
 
     ASTContext &getASTContext() const { return Ctx; }
 
@@ -1122,7 +1135,8 @@ namespace {
       if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr)) {
         TypeChecker::checkForForbiddenPrefix(
             getASTContext(), unresolved->getName().getBaseName());
-        return finish(true, TypeChecker::resolveDeclRefExpr(unresolved, DC));
+        return finish(true, TypeChecker::resolveDeclRefExpr(unresolved, DC,
+                                                            UseErrorExprs));
       }
 
       // Let's try to figure out if `InOutExpr` is out of place early
@@ -1979,8 +1993,9 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 
 /// Pre-check the expression, validating any types that occur in the
 /// expression and folding sequence expressions.
-bool ConstraintSystem::preCheckExpression(Expr *&expr, DeclContext *dc) {
-  PreCheckExpression preCheck(dc, expr);
+bool ConstraintSystem::preCheckExpression(Expr *&expr, DeclContext *dc,
+                                          bool replaceInvalidRefsWithErrors) {
+  PreCheckExpression preCheck(dc, expr, replaceInvalidRefsWithErrors);
   // Perform the pre-check.
   if (auto result = expr->walk(preCheck)) {
     expr = result;
@@ -2107,7 +2122,8 @@ TypeChecker::typeCheckExpression(
 
   // First, pre-check the expression, validating any types that occur in the
   // expression and folding sequence expressions.
-  if (ConstraintSystem::preCheckExpression(expr, dc)) {
+  if (ConstraintSystem::preCheckExpression(
+          expr, dc, /*replaceInvalidRefsWithErrors=*/true)) {
     target.setExpr(expr);
     return None;
   }
@@ -2336,13 +2352,15 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
 
   // Precheck the sequence.
   Expr *sequence = stmt->getSequence();
-  if (ConstraintSystem::preCheckExpression(sequence, dc))
+  if (ConstraintSystem::preCheckExpression(
+          sequence, dc, /*replaceInvalidRefsWithErrors=*/true))
     return failed();
   stmt->setSequence(sequence);
 
   // Precheck the filtering condition.
   if (Expr *whereExpr = stmt->getWhere()) {
-    if (ConstraintSystem::preCheckExpression(whereExpr, dc))
+    if (ConstraintSystem::preCheckExpression(
+            whereExpr, dc, /*replaceInvalidRefsWithErrors=*/true))
       return failed();
 
     stmt->setWhere(whereExpr);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -530,9 +530,10 @@ public:
       
     
     // Perform unqualified name lookup to find out what the UDRE is.
-    return getSubExprPattern(TypeChecker::resolveDeclRefExpr(ude, DC));
+    return getSubExprPattern(TypeChecker::resolveDeclRefExpr(
+        ude, DC, /*replaceInvalidRefsWithErrors=*/true));
   }
-  
+
   // Call syntax forms a pattern if:
   // - the callee in 'Element(x...)' or '.Element(x...)'
   //   references an enum element. The arguments then form a tuple

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -315,7 +315,11 @@ Type getOptionalType(SourceLoc loc, Type elementType);
 /// Bind an UnresolvedDeclRefExpr by performing name lookup and
 /// returning the resultant expression.  Context is the DeclContext used
 /// for the lookup.
-Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
+///
+/// \param replaceInvalidRefsWithErrors Indicates whether it's allowed
+/// to replace any discovered invalid member references with `ErrorExpr`.
+Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
+                         bool replaceInvalidRefsWithErrors);
 
 /// Check for unsupported protocol types in the given declaration.
 void checkUnsupportedProtocolType(Decl *decl);

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -6,7 +6,7 @@ enum Either<T,U> {
 }
 
 @_functionBuilder
-struct TupleBuilder { // expected-note 3{{struct 'TupleBuilder' declared here}}
+struct TupleBuilder { // expected-note 2 {{struct 'TupleBuilder' declared here}}
   static func buildBlock() -> () { }
   
   static func buildBlock<T1>(_ t1: T1) -> T1 {
@@ -87,7 +87,7 @@ func testDiags() {
   // For loop
   tuplify(true) { _ in
     17
-    for c in name { // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilder'}}
+    for c in name {
     // expected-error@-1 {{cannot find 'name' in scope}}
     }
   }
@@ -418,13 +418,16 @@ func testNonExhaustiveSwitch(e: E) {
 // rdar://problem/59856491
 struct TestConstraintGenerationErrors {
   @TupleBuilder var buildTupleFnBody: String {
-    let a = nil // expected-error {{'nil' requires a contextual type}}
+    let a = nil // There is no diagnostic here because next line fails to pre-check, so body is invalid
     String(nothing) // expected-error {{cannot find 'nothing' in scope}}
   }
 
+  @TupleBuilder var nilWithoutContext: String {
+    let a = nil // expected-error {{'nil' requires a contextual type}}
+  }
+
   func buildTupleClosure() {
-    // FIXME: suppress the ambiguity error
-    tuplify(true) { _ in // expected-error {{type of expression is ambiguous without more context}}
+    tuplify(true) { _ in
       let a = nothing // expected-error {{cannot find 'nothing' in scope}}
       String(nothing) // expected-error {{cannot find 'nothing' in scope}}
     }

--- a/test/Constraints/rdar65320500.swift
+++ b/test/Constraints/rdar65320500.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Result {}
+
+@_functionBuilder
+struct Builder {
+  static func buildBlock() -> Result {
+    Result()
+  }
+}
+
+func test_builder<T>(@Builder _: () -> T) {}
+func test_builder(@Builder _: () -> Int) {}
+
+test_builder {
+  let _ = 0
+
+  if let x = does_not_exist { // expected-error {{cannot find 'does_not_exist' in scope}}
+  }
+}
+
+func test(_: Int) -> Bool {
+  return false
+}
+
+test_builder {
+  let totalSeconds = 42000
+  test(totalseconds / 3600) // expected-error {{cannot find 'totalseconds' in scope}}
+}
+
+test_builder {
+  test(doesntExist()) // expected-error {{cannot find 'doesntExist' in scope}}
+
+  if let result = doesntExist() { // expected-error {{cannot find 'doesntExist' in scope}}
+  }
+
+  if bar = test(42) {} // expected-error {{cannot find 'bar' in scope}}
+
+  let foo = bar() // expected-error {{cannot find 'bar' in scope}}
+
+  switch (doesntExist()) { // expected-error {{cannot find 'doesntExist' in scope}}
+  }
+}


### PR DESCRIPTION
Function builder bodies are applied in several stages. First of them is `pre-check`
stage which is, among other things, responsible for member lookup and reference 
resolution, if that action fails it would be diagnosed inline and affected
expression is going to be replaced with `ErrorExpr`. 

This works fine in context of regular expressions but not function builders, because
matching of function builder bodies happens in the middle of type-checking of 
enclosing context, so solver needs to implement graceful handling of such problems 
and delay diagnostics until solver reaches a solution.

To accommodate that  `PreCheckFunctionBuilderRequest`, 
`ConstraintSystem::preCheckExpression`, and `TypeChecker::resolveDeclRefExpr` 
have been adjusted to know explicitly whether diagnosing and AST mutation is permitted. 
Solver is adjusted to ignore closure bodies which fail pre-check in their entirety. 

Resolves: rdar://problem/65320500

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
