### PR TITLE
[AutoDiff] Fix `PullbackCloner` tangent value category mismatch crash

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -407,6 +407,7 @@ static CanSILFunctionType getAutoDiffDifferentialType(
     // result's convention is indirect.
     if (tl.isAddressOnly() && !isIndirectFormalResult(origResConv)) {
       switch (origResConv) {
+      case ResultConvention::Unowned:
       case ResultConvention::Owned:
         return ResultConvention::Indirect;
       default:

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2431,7 +2431,7 @@ bool PullbackCloner::Implementation::runForSemanticMemberGetter() {
 
   // Switch based on the base tangent struct's value category.
   // TODO(TF-1255): Simplify using unified adjoint value data structure.
-  switch (tangentVectorSILTy.getCategory()) {
+  switch (getTangentValueCategory(origSelf)) {
   case SILValueCategory::Object: {
     auto adjResult = getAdjointValue(origEntry, origResult);
     switch (adjResult.getKind()) {
@@ -2472,7 +2472,7 @@ bool PullbackCloner::Implementation::runForSemanticMemberGetter() {
       if (field == tanField) {
         // Switch based on the property's value category.
         // TODO(TF-1255): Simplify using unified adjoint value data structure.
-        switch (origResult->getType().getCategory()) {
+        switch (getTangentValueCategory(origResult)) {
         case SILValueCategory::Object: {
           auto adjResult = getAdjointValue(origEntry, origResult);
           auto adjResultValue = materializeAdjointDirect(adjResult, pbLoc);

--- a/test/AutoDiff/compiler_crashers_fixed/sr13411-tangent-value-category-mismatch.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13411-tangent-value-category-mismatch.swift
@@ -1,0 +1,12 @@
+// RUN: %target-build-swift %s
+// REQUIRES: asserts
+
+// SR-13411: Semantic member getter pullback generation crash due to tangent value category mismatch
+
+import _Differentiation
+
+struct Dense: Differentiable {
+  @differentiable
+  var bias: Float?
+}
+


### PR DESCRIPTION
Fix semantic member getter pullback generation crash due to tangent value category mismatch.
Resolves SR-13411.
