### PR TITLE
Untangle Clang Module Loading

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -877,6 +877,10 @@ public:
   /// \returns The requested module, or NULL if the module cannot be found.
   ModuleDecl *getModule(ImportPath::Module ModulePath);
 
+  // Attempts to load the matching overlay module for the given clang
+  // module into this ASTContext.
+  ModuleDecl *getOverlayModule(const FileUnit *ClangModule);
+
   ModuleDecl *getModuleByName(StringRef ModuleName);
 
   ModuleDecl *getModuleByIdentifier(Identifier ModuleID);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1920,8 +1920,9 @@ ModuleDecl *ASTContext::getOverlayModule(const FileUnit *FU) {
   assert(FU && FU->getKind() == FileUnitKind::ClangModule &&
          "Overlays can only be retrieved for clang modules!");
 
-  Identifier MName = FU->getParentModule()->getName();
-  if (auto *Existing = getLoadedModule({{MName, SourceLoc()}})) {
+  ImportPath::Module::Builder builder(FU->getParentModule()->getName());
+  auto ModPath = builder.get();
+  if (auto *Existing = getLoadedModule(ModPath)) {
     if (!Existing->isNonSwiftModule())
       return Existing;
   }
@@ -1930,7 +1931,7 @@ ModuleDecl *ASTContext::getOverlayModule(const FileUnit *FU) {
     if (importer.get() == getClangModuleLoader())
       continue;
 
-    if (ModuleDecl *M = importer->loadModule(SourceLoc(), {{MName, {}}})) {
+    if (ModuleDecl *M = importer->loadModule(SourceLoc(), ModPath)) {
       return M;
     }
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1850,9 +1850,6 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
 
   ClangModuleUnit *wrapperUnit = getWrapperForModule(clangModule, importLoc);
   ModuleDecl *result = wrapperUnit->getParentModule();
-  if (!ModuleWrappers[clangModule].getInt()) {
-    ModuleWrappers[clangModule].setInt(true);
-  }
 
   if (clangModule->isSubModule()) {
     finishLoadingClangModule(clangModule->getTopLevelModule(), importLoc);
@@ -2046,8 +2043,7 @@ ClangImporter::Implementation::~Implementation() {
 
 ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
     const clang::Module *underlying, SourceLoc diagLoc) {
-  auto &cacheEntry = ModuleWrappers[underlying];
-  if (ClangModuleUnit *cached = cacheEntry.getPointer())
+  if (ClangModuleUnit *cached = ModuleWrappers.lookup(underlying))
     return cached;
 
   // FIXME: Handle hierarchical names better.
@@ -2061,7 +2057,7 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
                                                  underlying);
   wrapper->addFile(*file);
   SwiftContext.getClangModuleLoader()->findOverlayFiles(diagLoc, wrapper, file);
-  cacheEntry.setPointer(file);
+  ModuleWrappers[underlying] = file;
 
   return file;
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1851,11 +1851,9 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
   ClangModuleUnit *wrapperUnit = getWrapperForModule(clangModule, importLoc);
   ModuleDecl *result = wrapperUnit->getParentModule();
 
-  if (clangModule->isSubModule()) {
-    finishLoadingClangModule(clangModule->getTopLevelModule(), importLoc);
-  } else {
-    if (!SwiftContext.getLoadedModule(result->getName()))
-      SwiftContext.addLoadedModule(result);
+  if (!clangModule->isSubModule() &&
+      !SwiftContext.getLoadedModule(result->getName())) {
+    SwiftContext.addLoadedModule(result);
   }
 
   return result;
@@ -3568,7 +3566,7 @@ void ClangModuleUnit::getImportedModulesForLookup(
       actualMod = wrapper->getParentModule();
     }
     assert(actualMod && "Missing imported overlay");
-    imports.emplace_back(ImportPath::Access()(), actualMod);
+    imports.emplace_back(ImportPath::Access(), actualMod);
   }
 
   // Cache our results for use next time.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
@@ -2438,10 +2439,14 @@ static ModuleDecl *tryLoadModule(ASTContext &C,
 
   // If we're synthesizing forward declarations, we don't want to pull in
   // the module too eagerly.
-  if (importForwardDeclarations)
+  if (importForwardDeclarations) {
     module = C.getLoadedModule(moduleName);
-  else
+  } else {
     module = C.getModuleByIdentifier(moduleName);
+    if (module) {
+      (void) namelookup::getAllImports(module);
+    }
+  }
 
   checkedModules[moduleName] = module;
   return module;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -526,14 +526,10 @@ private:
   /// NSObject, imported into Swift.
   Type NSObjectTy;
 
-  /// A pair containing a ClangModuleUnit,
-  /// and whether the overlays of its re-exported modules have all been forced
-  /// to load already.
-  using ModuleInitPair = llvm::PointerIntPair<ClangModuleUnit *, 1, bool>;
-
 public:
   /// A map from Clang modules to their Swift wrapper modules.
-  llvm::SmallDenseMap<const clang::Module *, ModuleInitPair, 16> ModuleWrappers;
+  llvm::SmallDenseMap<const clang::Module *, ClangModuleUnit *, 16>
+      ModuleWrappers;
 
   /// The module unit that contains declarations from imported headers.
   ClangModuleUnit *ImportedHeaderUnit = nullptr;

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -17,6 +17,7 @@
 #define DEBUG_TYPE "swift-import-resolution"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/NameLookup.h"
@@ -337,6 +338,11 @@ void ImportResolver::bindImport(UnboundImport &&I) {
     return;
   }
 
+  // Force load overlays for all imported modules.
+  // FIXME: This forces the creation of wrapper modules for all imports as
+  // well, and may do unnecessary work.
+  (void) namelookup::getAllImports(M);
+
   auto topLevelModule = I.getTopLevelModule(M, SF);
 
   I.validateOptions(topLevelModule, SF);
@@ -457,6 +463,7 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
       }
       continue;
     }
+    (void) namelookup::getAllImports(importModule);
     imports.emplace_back(importModule);
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -1011,10 +1012,12 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx, StringRef ModuleName,
   auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
   if (!Stdlib)
     return true;
+  (void) namelookup::getAllImports(Stdlib);
 
   auto *M = Ctx.getModuleByName(ModuleName);
   if (!M)
     return true;
+  (void) namelookup::getAllImports(M);
 
   PrintOptions Options = PrintOptions::printDocInterface();
   ModuleTraversalOptions TraversalOptions = None;
@@ -1541,12 +1544,15 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
     Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
+  (void) namelookup::getAllImports(Stdlib);
+
   auto *M = Ctx.getModuleByName(ModuleName);
   if (!M) {
     Error = "Cannot find the module.";
     Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
+  (void) namelookup::getAllImports(M);
   std::vector<StringRef> Scratch;
   Receiver(RequestResult<ArrayRef<StringRef>>::fromResult(
       collectModuleGroups(M, Scratch)));

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/Basic/Version.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -285,6 +286,7 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx,
     ErrMsg += ModuleName;
     return true;
   }
+  (void) namelookup::getAllImports(Mod);
 
   PrintOptions Options = PrintOptions::printModuleInterface();
   ModuleTraversalOptions TraversalOptions = None; // Don't print submodules.
@@ -384,6 +386,7 @@ SwiftInterfaceGenContext::create(StringRef DocumentName,
     ErrMsg = "Could not load the stdlib module";
     return nullptr;
   }
+  (void) namelookup::getAllImports(Stdlib);
 
   if (IsModule) {
     if (getModuleInterfaceInfo(Ctx, ModuleOrHeaderName, Group, IFaceGenCtx->Impl,
@@ -444,6 +447,8 @@ SwiftInterfaceGenContext::createForTypeInterface(CompilerInvocation Invocation,
     ErrorMsg = "Could not load the stdlib module";
     return nullptr;
   }
+  (void) namelookup::getAllImports(Stdlib);
+
   auto *Module = CI.getMainModule();
   if (!Module) {
     ErrorMsg = "Could not load the main module";

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -16,6 +16,7 @@
 #include "SourceKit/Support/Tracing.h"
 #include "SourceKit/Support/UIdent.h"
 
+#include "swift/AST/ImportCache.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Index/Index.h"
@@ -215,6 +216,9 @@ static void indexModule(llvm::MemoryBuffer *Input,
   ModuleDecl *Mod = nullptr;
   if (ModuleName == Ctx.StdlibModuleName.str()) {
     Mod = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
+    if (Mod) {
+      (void) namelookup::getAllImports(Mod);
+    }
   } else {
     Loader = ImplicitSerializedModuleLoader::create(Ctx);
     auto Buf = std::unique_ptr<llvm::MemoryBuffer>(

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1,4 +1,5 @@
 #include "llvm/ADT/STLExtras.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/SIL/SILDeclRef.h"
 #include <ModuleAnalyzerNodes.h>
 #include <algorithm>
@@ -2215,6 +2216,7 @@ swift::ide::api::getSDKNodeRoot(SDKContext &SDKCtx,
       if (Opts.AbortOnModuleLoadFailure)
         return nullptr;
     } else {
+      (void) namelookup::getAllImports(M);
       Modules.push_back(M);
     }
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2112,6 +2112,7 @@ static ModuleDecl *getModuleByFullName(ASTContext &Context, StringRef ModuleName
   ModuleDecl *Result = Context.getModuleByName(ModuleName);
   if (!Result || Result->failedToLoad())
     return nullptr;
+  (void) namelookup::getAllImports(Result);
   return Result;
 }
 
@@ -2119,6 +2120,7 @@ static ModuleDecl *getModuleByFullName(ASTContext &Context, Identifier ModuleNam
   ModuleDecl *Result = Context.getModuleByIdentifier(ModuleName);
   if (!Result || Result->failedToLoad())
     return nullptr;
+  (void) namelookup::getAllImports(Result);
   return Result;
 }
 


### PR DESCRIPTION
* `getOverlayModule` actually does what it says on the tin now.
* Callers forcing the entire import graph of a clang module including its overlays must now explicitly call `namelookup::getAllImports`