### PR TITLE
[Function builders] Allow `build` functions to be declared elsewhere.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -146,7 +146,11 @@ class BuilderClosureVisitor
     }
 
     bool found = false;
-    for (auto decl : builder->lookupDirect(fnName)) {
+    SmallVector<ValueDecl *, 4> foundDecls;
+    dc->lookupQualified(
+        builderType, DeclNameRef(fnName),
+        NL_QualifiedDefault | NL_ProtocolMembers, foundDecls);
+    for (auto decl : foundDecls) {
       if (auto func = dyn_cast<FuncDecl>(decl)) {
         // Function must be static.
         if (!func->isStatic())


### PR DESCRIPTION
Make the lookup of the various `build` functions for function builders
normal, qualified name lookup. This allows (e.g.) the implementation
of many of the 'build' functions to come from a protocol extension,
making function builders more composable. Thank you to @anreitersimon
on the Swift forums for the example!
