### PR TITLE
Disable test verify_all_overlays.py for asan builds

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -12,7 +12,7 @@
 # RUN: test ! -e %t/failures.txt || \
 # RUN:   diff %t/filter.txt %t/failures.txt
 
-# REQUIRES: nonexecutable_test
+# REQUIRES: nonexecutable_test, no_asan
 
 # Expected failures by platform
 # -----------------------------


### PR DESCRIPTION
Raises a stackoverflow error in some asan builds even though it is not a
runaway recursion.

rdar://67001903
