### PR TITLE
Frontend: add a new action -scan-clang-dependencies to scan a PCM's dependencies

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -133,7 +133,8 @@ public:
     EmitPCM, ///< Emit precompiled Clang module from a module map
     DumpPCM, ///< Dump information about a precompiled Clang module
 
-    ScanDependencies,   ///< Scan dependencies of Swift source files
+    ScanDependencies,        ///< Scan dependencies of Swift source files
+    ScanClangDependencies,   ///< Scan dependencies of a Clang module
     PrintVersion,       ///< Print version information.
   };
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1094,6 +1094,10 @@ def scan_dependencies : Flag<["-"], "scan-dependencies">,
   HelpText<"Scan dependencies of the given Swift sources">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
+def scan_clang_dependencies : Flag<["-"], "scan-clang-dependencies">,
+  HelpText<"Scan dependencies of the given Clang module">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+
 def enable_astscope_lookup : Flag<["-"], "enable-astscope-lookup">,
   Flags<[FrontendOption]>,
   HelpText<"Enable ASTScope-based unqualified name lookup">;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -354,6 +354,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::EmitImportedModules;
   if (Opt.matches(OPT_scan_dependencies))
     return FrontendOptions::ActionType::ScanDependencies;
+  if (Opt.matches(OPT_scan_clang_dependencies))
+    return FrontendOptions::ActionType::ScanClangDependencies;
   if (Opt.matches(OPT_parse))
     return FrontendOptions::ActionType::Parse;
   if (Opt.matches(OPT_resolve_imports))

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -64,6 +64,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::EmitPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
     return true;
   }
   llvm_unreachable("Unknown ActionType");
@@ -77,6 +78,7 @@ bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   case FrontendOptions::ActionType::DumpInterfaceHash:
   case FrontendOptions::ActionType::EmitImportedModules:
   case FrontendOptions::ActionType::ScanDependencies:
+  case FrontendOptions::ActionType::ScanClangDependencies:
   case FrontendOptions::ActionType::PrintVersion:
     return true;
   default:
@@ -174,6 +176,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
     return TY_ClangModuleFile;
 
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
     return TY_JSONDependencies;
   }
   llvm_unreachable("unhandled action");
@@ -213,6 +216,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
     return true;
   }
   llvm_unreachable("unhandled action");
@@ -237,6 +241,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return false;
   case ActionType::Typecheck:
@@ -285,6 +290,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return false;
   case ActionType::Typecheck:
@@ -322,6 +328,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return false;
   case ActionType::ResolveImports:
@@ -365,6 +372,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return false;
   case ActionType::MergeModules:
@@ -409,6 +417,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -454,6 +463,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
     return true;
 
   case ActionType::NoneAction:
@@ -499,6 +509,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return true;
   }
@@ -524,6 +535,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return false;
   case ActionType::EmitSILGen:
@@ -570,6 +582,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
     return false;
   case ActionType::Immediate:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1836,6 +1836,9 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::ActionType::ScanDependencies)
     return finishPipeline(scanDependencies(Instance));
 
+  if (Action == FrontendOptions::ActionType::ScanClangDependencies)
+    return finishPipeline(scanClangDependencies(Instance));
+
   if (observer)
     observer->performedSemanticAnalysis(Instance);
 

--- a/lib/FrontendTool/ScanDependencies.h
+++ b/lib/FrontendTool/ScanDependencies.h
@@ -20,6 +20,10 @@ class CompilerInstance;
 /// Scans the dependencies of the main module of \c instance.
 bool scanDependencies(CompilerInstance &instance);
 
+/// Scans the dependencies of the underlying clang module of the main module
+/// of \c instance.
+bool scanClangDependencies(CompilerInstance &instance);
+
 } // end namespace swift
 
 #endif

--- a/test/ScanDependencies/module_deps_clang_only.swift
+++ b/test/ScanDependencies/module_deps_clang_only.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: %target-swift-frontend -scan-clang-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules -module-name C
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s < %t/deps.json
+
+// CHECK:  	    "mainModuleName": "C",
+// CHECK-NEXT:  "modules": [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "clang": "C"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "modulePath": "C.pcm",
+// CHECK-NEXT:    "sourceFiles": [
+
+
+// CHECK:       "directDependencies": [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "clang": "B"
+// CHECK-NEXT:  }


### PR DESCRIPTION
For the issue mentioned in rdar://67079780, swift-driver needs to run clang dependencies
scanner multiple times with different target triples for a Swift target. This patch adds
a new scanning action to generate the JSON file for a given clang module to accommodate
this requirement.

Resolves: rdar://problem/67269210
