### PR TITLE
[build-presets.ini] Extract out osx_package no test into a mixin so we match how presets are setup for snapshots on Linux.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1340,14 +1340,7 @@ debug-llvm
 debug-swift
 no-swift-stdlib-assertions
 
-
-# macOS package with out test
-[preset: buildbot_osx_package,no_test]
-mixin-preset=
-    buildbot_osx_package
-
-dash-dash
-
+[preset: mixin_buildbot_osx_package,no_test]
 skip-test-swift
 skip-test-swiftpm
 skip-test-llbuild
@@ -1361,6 +1354,12 @@ skip-test-swiftevolve
 extra-cmake-options=
    -DCMAKE_C_FLAGS="-gline-tables-only"
    -DCMAKE_CXX_FLAGS="-gline-tables-only"
+
+# macOS package with out test
+[preset: buildbot_osx_package,no_test]
+mixin-preset=
+    buildbot_osx_package
+    mixin_buildbot_osx_package,no_test
 
 #===------------------------------------------------------------------------===#
 # LLDB build configurations


### PR DESCRIPTION
More importantly, it will allow for downstream projects to cascade on top of
snapshot no-test scheme, ensuring that as we modify/add projects, these other
downstream things will keep working.

The actual change here is NFC since I just extracted the preset.
