### PR TITLE
build: add the temporary workaround to Swift and lldb as well

### DIFF
--- a/utils/build-windows-rebranch.bat
+++ b/utils/build-windows-rebranch.bat
@@ -233,6 +233,7 @@ cmake^
     -DSWIFT_PATH_TO_CMARK_SOURCE:PATH=%source_root%\cmark^
     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH=%source_root%\swift-corelibs-libdispatch^
     -DLLVM_DIR:PATH=%build_root%\llvm\lib\cmake\llvm^
+    -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON^
     -DSWIFT_INCLUDE_DOCS:BOOL=NO^
     -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE:PATH=%source_root%\icu-%icu_version%\include\unicode^
     -DSWIFT_WINDOWS_x86_64_ICU_UC:PATH=%source_root%\icu-%icu_version%\lib64\icuuc.lib^
@@ -292,6 +293,7 @@ cmake^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DLLDB_DISABLE_PYTHON=YES^
     -DLLDB_INCLUDE_TESTS:BOOL=NO^
+    -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON^
     -S "%source_root%\lldb" %exitOnError%
 
 cmake --build "%build_root%\lldb" %exitOnError%


### PR DESCRIPTION
Ensure that we can build with the older toolchain when building Swift
and LLVM as well.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
