### PR TITLE
[master-next][test] Restrict xfail in test/Serialization/load-target-normalization.swift to asserts builds

### DIFF
--- a/test/Serialization/load-target-normalization.swift
+++ b/test/Serialization/load-target-normalization.swift
@@ -2,7 +2,7 @@
 // RUN: touch %t/ForeignModule.swiftmodule/garbage-garbage-garbage.swiftmodule
 
 // SR-12363: This test crashes on master-next.
-// XFAIL: *
+// XFAIL: asserts
 
 // Test format: We try to import ForeignModule with architectures besides
 // garbage-garbage-garbage and check the target triple listed in the error


### PR DESCRIPTION
It was failing because of an assertion, so unexpectedly passing on no_asserts builds.