### PR TITLE
[build] Use `shell.makedirs` instead of `os.makedirs`.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -49,7 +49,7 @@ class TensorFlowSwiftAPIs(product.Product):
         # result, we need to create the build tree before we can use it and
         # change into it.
         try:
-            os.makedirs(self.build_dir)
+            shell.makedirs(self.build_dir)
         except OSError:
             pass
 


### PR DESCRIPTION
`shell.makedirs` respects the `build-script` `--dry-run` argument, while `os.makedirs` does not.