### PR TITLE
Turn off library evolution for stdlib by default, keep it on only for Darwin

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -298,6 +298,12 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_OBJC_INTEROP=0")
   endif()
 
+  if("${CFLAGS_SDK}" IN_LIST SWIFT_APPLE_PLATFORMS)
+    list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=1")
+  else()
+    list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=0")
+  endif()
+
   if(NOT SWIFT_ENABLE_COMPATIBILITY_OVERRIDES)
     list(APPEND result "-DSWIFT_RUNTIME_NO_COMPATIBILITY_OVERRIDES")
   endif()

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -399,8 +399,8 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-sil-verify-all")
   endif()
 
-  # The standard library and overlays are always built resiliently.
-  if(SWIFTFILE_IS_STDLIB)
+  # The standard library and overlays are built resiliently on Darwin (has stable ABI).
+  if(SWIFTFILE_IS_STDLIB AND SWIFTFILE_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
     list(APPEND swift_flags "-enable-library-evolution")
   endif()
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -27,6 +27,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
+    -enable-library-evolution # To make @_implementationOnly imports work
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   DARWIN_INSTALL_NAME_DIR "@rpath"
   INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/runtime/KeyPaths.cpp
+++ b/stdlib/public/runtime/KeyPaths.cpp
@@ -119,9 +119,6 @@ void _destroy_temporary_continuation(YieldOnceBuffer *buffer, bool forUnwind) {
   YieldOnceTemporary::destroyAndDeallocateIn(buffer);
 }
 
-// The resilient offset to the start of KeyPath's class-specific data.
-extern "C" size_t MANGLE_SYM(s7KeyPathCMo);
-
 YieldOnceResult<const OpaqueValue*>
 swift::swift_readAtKeyPath(YieldOnceBuffer *buffer,
                            const OpaqueValue *root, void *keyPath) {
@@ -134,12 +131,11 @@ swift::swift_readAtKeyPath(YieldOnceBuffer *buffer,
   // data section of the class; the generic arguments are always at the start
   // of that.
   //
-  // We use the resilient access pattern because it's easy; since we're within
-  // KeyPath's resilience domain, that's not really necessary, and it would
-  // be totally valid to hard-code an offset.
+  // We're within KeyPath's resilience domain, let's just hard-code an offset
+  // to the start of KeyPath's class-specific data.
   auto keyPathGenericArgs =
     reinterpret_cast<const Metadata * const *>(
-      reinterpret_cast<const char*>(keyPathType) + MANGLE_SYM(s7KeyPathCMo));
+      reinterpret_cast<const char*>(keyPathType) + 0 /* XXX TODO FIXME */);
   const Metadata *valueTy = keyPathGenericArgs[1];
 
   // Allocate the buffer.

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -328,8 +328,13 @@ struct swift_closure {
   void *fptr;
   HeapObject *context;
 };
+#if SWIFT_LIBRARY_EVOLUTION
 SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
 MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+#else
+SWIFT_RUNTIME_STDLIB_API swift_closure
+MANGLE_SYM(s20_playgroundPrintHookySScSgvp);
+#endif
 
 static bool _shouldReportMissingReflectionMetadataWarnings() {
   // Missing metadata warnings noise up playground sessions and aren't really
@@ -339,7 +344,11 @@ static bool _shouldReportMissingReflectionMetadataWarnings() {
   // Guesstimate whether we're in a playground by looking at the
   // _playgroundPrintHook variable in the standard library, which is set during
   // playground execution.
+  #if SWIFT_LIBRARY_EVOLUTION
   auto hook = MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+  #else
+  auto hook = MANGLE_SYM(s20_playgroundPrintHookySScSgvp);
+  #endif
   if (hook.fptr) {
     swift_release(hook.context);
     return false;

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-sil -verify -Xllvm -debug-only=differentiation 2>&1 %s | %FileCheck %s
 // REQUIRES: asserts
+// REQUIRES: swift_stable_abi
 
 import _Differentiation
 

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// REQUIRES: swift_stable_abi
 
 // Test differentiation transform diagnostics.
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -enable-resilience -emit-sil -verify %s
 // REQUIRES: asserts
+// REQUIRES: swift_stable_abi
 
 // SR-12641: SILGen verification error regarding `ImmutableAddressUseVerifier` and AutoDiff-generated code.
 

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// REQUIRES: swift_stable_abi
 
 import DifferentiationUnittest
 import StdlibUnittest

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4 -enable-library-evolution
 
+// REQUIRES: swift_stable_abi
+
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {
   case (.none, _): return 1

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -5,6 +5,8 @@
 // RUN: %FileCheck -check-prefix=CHECK %s < %t/loaded_module_trace.trace.json
 // RUN: %FileCheck -check-prefix=CHECK-CONFIRM-ONELINE %s < %t/loaded_module_trace.trace.json
 
+// REQUIRES: swift_stable_abi
+
 // CHECK: {
 // CHECK: "version":2
 // CHECK: "name":"loaded_module_trace"

--- a/test/Driver/loaded_module_trace_env.swift
+++ b/test/Driver/loaded_module_trace_env.swift
@@ -2,6 +2,8 @@
 // RUN: env SWIFT_LOADED_MODULE_TRACE_FILE=%t %target-build-swift -module-name loaded_module_trace_env -c %s -o- > /dev/null
 // RUN: %FileCheck %s < %t
 
+// REQUIRES: swift_stable_abi
+
 // CHECK: {
 // CHECK: "version":2
 // CHECK: "name":"loaded_module_trace_env"

--- a/test/Driver/loaded_module_trace_multifile.swift
+++ b/test/Driver/loaded_module_trace_multifile.swift
@@ -4,6 +4,8 @@
 // RUN: %target-build-swift %s %S/Inputs/loaded_module_trace_imports_module.swift -emit-loaded-module-trace-path %t/multifile.trace.json -emit-library -o %t/loaded_module_trace_multifile -I %t
 // RUN: %FileCheck %s < %t/multifile.trace.json
 
+// REQUIRES: swift_stable_abi
+
 // This file only imports Module2, but the other file imports Module: hopefully they both appear!
 // The difference between this test and the one in loaded_module_trace is that here, we test that
 // dependencies from multiple files in the same module are accounted for correctly. As a result,

--- a/test/IRGen/open_boxed_existential.sil
+++ b/test/IRGen/open_boxed_existential.sil
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime
 
+// REQUIRES: swift_stable_abi
+
 import Swift
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i[0-9]+}} @open_boxed_existential(%swift.error* %0)

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -1,6 +1,7 @@
 // RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
+// REQUIRES: swift_stable_abi
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -5,6 +5,8 @@
 // RUN: %target-swift-frontend -module-name struct_resilience -Xllvm -sil-disable-pass=GuaranteedARCOpts -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s
 // RUN: %target-swift-frontend -module-name struct_resilience -I %t -emit-ir -enable-library-evolution -O %s
 
+// REQUIRES: swift_stable_abi
+
 import resilient_struct
 import resilient_enum
 

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -4,6 +4,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
+// REQUIRES: swift_stable_abi
 
 // Tests for traps at run time when enforcing exclusive access.
 

--- a/test/Interpreter/property_wrappers.swift
+++ b/test/Interpreter/property_wrappers.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
+// REQUIRES: swift_stable_abi
+
 protocol Observed: AnyObject {
   func broadcastValueWillChange<T>(newValue: T)
 }

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
 
+// REQUIRES: swift_stable_abi
+
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
 // required to allow address-type block args in canonical SIL.

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -3,6 +3,8 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -I %t
 // RUN: %target-typecheck-verify-swift -swift-version 4 -enable-library-evolution -enable-nonfrozen-enum-exhaustivity-diagnostics -I %t
 
+// REQUIRES: swift_stable_abi
+
 import exhaustive_switch_testable_helper
 
 func foo(a: Int?, b: Int?) -> Int {

--- a/test/multifile/resilient-witness.swift
+++ b/test/multifile/resilient-witness.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-frontend -module-name test -num-threads 1 -O -emit-ir -g %S/Inputs/resilient-witness-2.swift %s -o %t/resilient-witness-2.ll -o %t/resilient-witness.ll
 // RUN: %FileCheck %s < %t/resilient-witness.ll
 
+// REQUIRES: swift_stable_abi
+
 // We used to crash on this test case during code generation because the
 // resilient witness table and the witness of the equatable conformance was
 // emitted into different files. Because the witness is expressed as a relative

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -13,6 +13,7 @@
 # RUN:   diff %t/filter.txt %t/failures.txt
 
 # REQUIRES: nonexecutable_test, no_asan
+# REQUIRES: swift_stable_abi
 
 # Expected failures by platform
 # -----------------------------


### PR DESCRIPTION
Based on the discussion in <https://github.com/apple/swift/pull/33443>. This PR restricts the usage of -enable-library-evolution for the standard library only to Darwin platforms.