### PR TITLE
Sema: Fix crash-on-invalid on protocol requirements with 'where' clause constraints

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -850,7 +850,14 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
   Type openedFullWitnessType;
   Type reqType, openedFullReqType;
 
-  auto reqSig = req->getInnermostDeclContext()->getGenericSignatureOfContext();
+  GenericSignature reqSig = proto->getGenericSignature();
+  if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(req)) {
+    if (funcDecl->isGeneric())
+      reqSig = funcDecl->getGenericSignature();
+  } else if (auto *subscriptDecl = dyn_cast<SubscriptDecl>(req)) {
+    if (subscriptDecl->isGeneric())
+      reqSig = subscriptDecl->getGenericSignature();
+  }
 
   ClassDecl *covariantSelf = nullptr;
   if (witness->getDeclContext()->getExtendedProtocolDecl()) {

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -58,3 +58,25 @@ protocol P4 {
 protocol P5 {
   associatedtype Y where Y : S // expected-error {{type 'Self.Y' constrained to non-protocol, non-class type 'S'}}
 }
+
+protocol P6 {
+  associatedtype T
+  associatedtype U
+
+  func foo() where T == U
+  // expected-error@-1 {{instance method requirement 'foo()' cannot add constraint 'Self.T == Self.U' on 'Self'}}
+  // expected-note@-2 {{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}}
+}
+
+struct S2 : P6 {
+  // expected-error@-1 {{type 'S2' does not conform to protocol 'P6'}}
+  typealias T = Int
+  typealias U = String
+
+  func foo() {}
+  // expected-note@-1 {{candidate has non-matching type '() -> ()'}}
+
+  // FIXME: This error is bogus and should be omitted on account of the protocol requirement itself
+  // being invalid.
+}
+


### PR DESCRIPTION
RequirementEnvironment wasn't prepared to handle a protocol
requirement with additional 'where' clause constraints but
no generic parameters.

Since such a requirement necessarily runs afoul of the existing
"protocol requirements cannot constrain Self" rule, it suffices
to ignore such requirements when matching witnesses and let
the declaration checker diagnose this situation later.

Fixes <rdar://problem/61876053>.