### PR TITLE
IRGen: avoid tripping assertions on a move constructor invocation

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1890,8 +1890,9 @@ CallEmission::CallEmission(CallEmission &&other)
     LastArgWritten(other.LastArgWritten),
     EmittedCall(other.EmittedCall) {
   // Prevent other's destructor from asserting.
-  LastArgWritten = 0;
-  EmittedCall = true;
+  other.LastArgWritten = 0;
+  other.EmittedCall = true;
+  other.Temporaries.clear();
 }
 
 CallEmission::~CallEmission() {


### PR DESCRIPTION
The moved instance has not yet emitted the calls, however, the instance
is not meant to actually emit any arguments for the call as it has been
moved.  This would break when the compiler actually emits a move
constructor invocation rather and fails to do a NVRO instead.

Patch originally by Patrick Deschênes!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
