### PR TITLE
Add A Reproducer For rdar://48443680

### DIFF
--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -6,6 +6,10 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterOptions.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/FileSystemOptions.h"
+#include "clang/Basic/FileSystemStatCache.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
@@ -54,7 +58,6 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   // Create the includes.
   std::string include = createFilename(temp, "include");
   ASSERT_FALSE(llvm::sys::fs::create_directory(include));
-  options.ExtraArgs.emplace_back("-nosysteminc");
   options.ExtraArgs.emplace_back((llvm::Twine("-I") + include).str());
   ASSERT_FALSE(emitFileWithContents(include, "module.modulemap",
                                     "module A {\n"
@@ -87,4 +90,106 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   // the in-memory cache.
   ASSERT_FALSE(emitFileWithContents(PCH, "garbage"));
   ASSERT_TRUE(importer->canReadPCH(PCH));
+}
+
+class ForgetfulStatCache : public clang::FileSystemStatCache {
+private:
+  std::unique_ptr<clang::MemorizeStatCalls> RealStatCache;
+
+public:
+  ForgetfulStatCache() {
+    RealStatCache = std::make_unique<clang::MemorizeStatCalls>();
+  }
+  ~ForgetfulStatCache() = default;
+
+  std::error_code getStat(StringRef Path, llvm::vfs::Status &Status,
+                          bool isFile,
+                          std::unique_ptr<llvm::vfs::File> *F,
+                          llvm::vfs::FileSystem &FS) override {
+    if (llvm::sys::path::extension(Path) == ".pcm") {
+      const auto UID = llvm::sys::fs::UniqueID(1, std::numeric_limits<uint64_t>::max());
+      Status = llvm::vfs::Status(Path, UID,
+                                 /*MTime*/{}, /*User*/0, /*Group*/0,
+                                 /*Size*/0,
+                                 llvm::sys::fs::file_type::regular_file,
+                                 llvm::sys::fs::perms::all_all);
+      return std::error_code();
+    }
+
+    return clang::FileSystemStatCache::get(Path, Status, isFile, F,
+                                           RealStatCache.get(), FS);
+  }
+};
+
+TEST(ClangImporterTest, missingSubmodule) {
+  // Create a temporary cache on disk and clean it up at the end.
+  ClangImporterOptions options;
+  SmallString<256> temp;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ClangImporterTest.missingSubmodule", temp));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(temp); };
+
+  // Create a cache subdirectory for the modules and PCH.
+  std::string cache = createFilename(temp, "cache");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(cache));
+  options.ModuleCachePath = cache;
+  options.PrecompiledHeaderOutputDir = cache;
+
+  // Create the includes.
+  std::string include1 = createFilename(temp, "include1");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(include1));
+
+  std::string include2 = createFilename(temp, "include2");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(include2));
+
+  options.ExtraArgs.emplace_back((llvm::Twine("-I") + include1).str());
+  options.ExtraArgs.emplace_back((llvm::Twine("-I") + include2).str());
+  options.ExtraArgs.emplace_back("-DEXTRA_C_DEFINE=2");
+
+  ASSERT_FALSE(emitFileWithContents(include1, "module.modulemap",
+                                    "module CLib1 {\n"
+                                    "  umbrella header \"" + include1 + "/Clib1.h\"\n"
+                                    "  export * \n"
+                                    "}\n"
+                                    "module CLib2 {\n"
+                                    "  umbrella header \"" + include2 + "/Clib2.h\"\n"
+                                    "  export * \n"
+                                    "}\n"));
+  ASSERT_FALSE(emitFileWithContents(include1, "CLib1.h",
+                                    "#if !defined(EXTRA_C_DEFINE) || EXTRA_C_DEFINE != 2\n"
+                                    "#error \"unexpected compiler flags\"\n"
+                                    "#endif\n"
+                                    "void foo(void);\n"));
+  ASSERT_FALSE(emitFileWithContents(include2, "CLib2.h",
+                                    "#if !defined(EXTRA_C_DEFINE) || EXTRA_C_DEFINE != 2\n"
+                                    "#error \"unexpected compiler flags\"\n"
+                                    "#endif\n"
+                                    "void foo(void);\n"));
+
+  // Set up the importer.
+  swift::LangOptions langOpts;
+  langOpts.Target = llvm::Triple("x86_64", "apple", "darwin");
+  swift::TypeCheckerOptions typeckOpts;
+  INITIALIZE_LLVM();
+  swift::SearchPathOptions searchPathOpts;
+  swift::SourceManager sourceMgr;
+  swift::DiagnosticEngine diags(sourceMgr);
+  std::unique_ptr<ASTContext> context(
+      ASTContext::get(langOpts, typeckOpts, searchPathOpts, sourceMgr, diags));
+  auto importer = ClangImporter::create(*context, options);
+
+  // Install a stats cache that conveniently "forgets" that PCMs have different
+  // underlying FileEntry values.
+  importer->getClangInstance()
+    .getFileManager()
+    .setStatCache(std::make_unique<ForgetfulStatCache>());
+
+  context->addModuleLoader(std::move(importer));
+
+  auto CLib1 = context->getIdentifier("CLib1");
+  auto CLib2 = context->getIdentifier("CLib2");
+  // The first load succeeds and primes the ModuleManager with PCM data.
+  (void)context->getModule({ Located<Identifier>{ CLib1, {} } });
+  // The second load fails because we collide in the ModuleManager.
+  ASSERT_TRUE(context->getModule({ Located<Identifier>{ CLib2, {} } }) == nullptr);
 }


### PR DESCRIPTION
The ModuleManager in Clang maintains a mapping from FileEntry nodes to
ModuleFile data. Because FileEntry nodes are unique'd by underlying
inode number, an attacker can craft a collision by ensuring that two
different PCMs share an inode number.

This failure can be encountered with some regularity in a highly
concurrent compilation session on filesystems that use Orlov's Algorithm
to allocate inode numbers (like ext4 on Linux). Here, we use a much
simpler algorithm that forgets that PCMs have distinct inode numbers.

A future version of clang will increase the entropy of the key to
take into account the mod time and size, which we also conveniently map
to 0 to throw it off our trail.