### PR TITLE
Fallback to building Cmake from source on all platforms, not just Linux

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -256,9 +256,6 @@ class CMake(object):
     # the source and build the source if necessary. Returns the path to the
     # cmake binary.
     def check_cmake_version(self, source_root, build_root):
-        if platform.system() != 'Linux':
-            return
-
         cmake_source_dir = os.path.join(source_root, 'cmake')
         # If the source is not checked out then don't attempt to build cmake.
         if not os.path.isdir(cmake_source_dir):

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import platform
 import re
 from numbers import Number
 


### PR DESCRIPTION
On Linux, build-script will automatically build cmake if the source is available and there is no suitable cmake already installed.

There is no reason I can see to limit this behavior to Linux, so let's enable it everywhere.