### PR TITLE
build: switch to `cl` instead of `clang-cl` for lldb

### DIFF
--- a/utils/build-windows-rebranch.bat
+++ b/utils/build-windows-rebranch.bat
@@ -279,8 +279,8 @@ cmake^
     -B "%build_root%\lldb"^
     -G Ninja^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
-    -DCMAKE_C_COMPILER=clang-cl^
-    -DCMAKE_CXX_COMPILER=clang-cl^
+    -DCMAKE_C_COMPILER=cl^
+    -DCMAKE_CXX_COMPILER=cl^
     -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
     -DLLVM_DIR:PATH=%build_root%\llvm\lib\cmake\llvm^
     -DClang_DIR:PATH=%build_root%\llvm\lib\cmake\clang^


### PR DESCRIPTION
clang has a bug where the template handling triggers an assertion.  This
switches the compiler to MSVC's compiler as a temporary workaround.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
