### PR TITLE
Sema: Redeclaration checking should not mark implicit decls as invalid

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -754,35 +754,38 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
             declToDiagnose->diagnose(diag::invalid_redecl_implicit,
                                      current->getDescriptiveKind(),
                                      isProtocolRequirement, other->getName());
-          }
 
-          // Emit a specialized note if the one of the declarations is
-          // the backing storage property ('_foo') or projected value
-          // property ('$foo') for a wrapped property. The backing or
-          // projected var has the same source location as the wrapped
-          // property we diagnosed above, so we don't need to extract
-          // the original property.
-          const VarDecl *varToDiagnose = nullptr;
-          auto kind = PropertyWrapperSynthesizedPropertyKind::Backing;
-          if (auto currentVD = dyn_cast<VarDecl>(current)) {
-            if (auto currentKind =
-                    currentVD->getPropertyWrapperSynthesizedPropertyKind()) {
-              varToDiagnose = currentVD;
-              kind = *currentKind;
+            // Emit a specialized note if the one of the declarations is
+            // the backing storage property ('_foo') or projected value
+            // property ('$foo') for a wrapped property. The backing or
+            // projected var has the same source location as the wrapped
+            // property we diagnosed above, so we don't need to extract
+            // the original property.
+            const VarDecl *varToDiagnose = nullptr;
+            auto kind = PropertyWrapperSynthesizedPropertyKind::Backing;
+            if (auto currentVD = dyn_cast<VarDecl>(current)) {
+              if (auto currentKind =
+                      currentVD->getPropertyWrapperSynthesizedPropertyKind()) {
+                varToDiagnose = currentVD;
+                kind = *currentKind;
+              }
             }
-          }
-          if (auto otherVD = dyn_cast<VarDecl>(other)) {
-            if (auto otherKind =
-                    otherVD->getPropertyWrapperSynthesizedPropertyKind()) {
-              varToDiagnose = otherVD;
-              kind = *otherKind;
+            if (auto otherVD = dyn_cast<VarDecl>(other)) {
+              if (auto otherKind =
+                      otherVD->getPropertyWrapperSynthesizedPropertyKind()) {
+                varToDiagnose = otherVD;
+                kind = *otherKind;
+              }
             }
-          }
 
-          if (varToDiagnose) {
-            varToDiagnose->diagnose(
-                diag::invalid_redecl_implicit_wrapper, varToDiagnose->getName(),
-                kind == PropertyWrapperSynthesizedPropertyKind::Backing);
+            if (varToDiagnose) {
+              assert(declToDiagnose);
+              varToDiagnose->diagnose(
+                  diag::invalid_redecl_implicit_wrapper, varToDiagnose->getName(),
+                  kind == PropertyWrapperSynthesizedPropertyKind::Backing);
+            }
+
+            current->setInvalid();
           }
         } else {
           ctx.Diags.diagnoseWithNotes(
@@ -790,8 +793,9 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
                               current->getName()), [&]() {
             other->diagnose(diag::invalid_redecl_prev, other->getName());
           });
+
+          current->setInvalid();
         }
-        current->setInvalid();
       }
 
       // Make sure we don't do this checking again for the same decl. We also

--- a/validation-test/compiler_crashers_2_fixed/rdar67259506.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar67259506.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func foo<T : P & Q>(_: T, _: S<T>.A) {}
+
+public protocol P {
+  associatedtype A
+
+  func foo() -> A
+}
+
+public protocol Q {
+  associatedtype A
+
+  func bar() -> A
+}
+
+public struct S<T> {}
+
+extension S : P where T : P {
+  public func foo() -> Int {
+    return 0
+  }
+}
+
+extension S : Q where T : Q {
+  public func bar() -> Int {
+    return 0
+  }
+}


### PR DESCRIPTION
If both the 'other' and 'current' declarations are implicit, we don't
emit a diagnostic unless they are both derived from property wrappers
or lazy property storage.

However, we would still call setInvalid() unconditionally, which splats
an ErrorType into the interface type, which would crash in the AST
verifier if no other diagnostic was emitted.

Fixes <rdar://problem/67259506>.