### PR TITLE
[PrintAsObjC] Forward-declare bridged types

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -1339,6 +1339,7 @@ private:
     return true;
   }
 
+public:
   /// If \p nominal is bridged to an Objective-C class (via a conformance to
   /// _ObjectiveCBridgeable), return that class.
   ///
@@ -1369,6 +1370,7 @@ private:
     return objcType->getClassOrBoundGenericClass();
   }
 
+private:
   /// If the nominal type is bridged to Objective-C (via a conformance
   /// to _ObjectiveCBridgeable), print the bridged type.
   void printObjCBridgeableType(const NominalTypeDecl *swiftNominal,
@@ -2065,6 +2067,14 @@ void DeclAndTypePrinter::printAdHocCategory(
 
 bool DeclAndTypePrinter::isEmptyExtensionDecl(const ExtensionDecl *ED) {
   return getImpl().isEmptyExtensionDecl(ED);
+}
+
+const TypeDecl *DeclAndTypePrinter::getObjCTypeDecl(const TypeDecl* TD) {
+  if (auto *nominal = dyn_cast<NominalTypeDecl>(TD))
+    if (auto *bridged = getImpl().getObjCBridgedClass(nominal))
+      return bridged;
+
+  return TD;
 }
 
 StringRef

--- a/lib/PrintAsObjC/DeclAndTypePrinter.h
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.h
@@ -73,6 +73,14 @@ public:
   /// Is \p ED empty of members and protocol conformances to include?
   bool isEmptyExtensionDecl(const ExtensionDecl *ED);
 
+  /// Returns the type that will be printed by PrintAsObjC for a parameter or
+  /// result type resolved to this declaration.
+  ///
+  /// \warning This handles \c _ObjectiveCBridgeable types, but it doesn't
+  /// currently know about other aspects of PrintAsObjC behavior, like known
+  /// types.
+  const TypeDecl *getObjCTypeDecl(const TypeDecl* TD);
+
   /// Prints a category declaring the given members.
   ///
   /// All members must have the same parent type. The list must not be empty.

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/TypeDeclFinder.h"
@@ -235,6 +236,8 @@ public:
   }
 
   bool forwardDeclareMemberTypes(DeclRange members, const Decl *container) {
+    PrettyStackTraceDecl
+        entry("printing forward declarations needed by members of", container);
     switch (container->getKind()) {
     case DeclKind::Class:
     case DeclKind::Protocol:
@@ -247,6 +250,7 @@ public:
     bool hadAnyDelayedMembers = false;
     SmallVector<ValueDecl *, 4> nestedTypes;
     for (auto member : members) {
+      PrettyStackTraceDecl loopEntry("printing for member", member);
       auto VD = dyn_cast<ValueDecl>(member);
       if (!VD || !printer.shouldInclude(VD))
         continue;
@@ -269,6 +273,8 @@ public:
       ReferencedTypeFinder::walk(VD->getInterfaceType(),
                                  [&](ReferencedTypeFinder &finder,
                                      const TypeDecl *TD) {
+        PrettyStackTraceDecl
+            entry("walking its interface type, currently at", TD);
         if (TD == container)
           return;
 

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -278,6 +278,9 @@ public:
         if (TD == container)
           return;
 
+        // Bridge, if necessary.
+        TD = printer.getObjCTypeDecl(TD);
+
         if (finder.needsDefinition() && isa<NominalTypeDecl>(TD)) {
           // We can delay individual members of classes; do so if necessary.
           if (isa<ClassDecl>(container)) {

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -49,13 +49,35 @@ import SingleGenericClass
 // CHECK-NEXT: @end
 @objc class B1 : A1 {}
 
+// Used in BridgedTypes test case
+struct Notification: _ObjectiveCBridgeable {
+  func _bridgeToObjectiveC() -> NSNotification { fatalError() }
+  static func _forceBridgeFromObjectiveC(
+    _ source: NSNotification,
+    result: inout Self?
+  ) { fatalError() }
+  @discardableResult
+  static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSNotification,
+    result: inout Self?
+  ) -> Bool { fatalError() }
+  @_effects(readonly)
+  static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
+    -> Self { fatalError() }
+}
+
 // CHECK-LABEL: @interface BridgedTypes
 // CHECK-NEXT: - (NSDictionary * _Nonnull)dictBridge:(NSDictionary * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSNotification * _Nonnull)noteBridge:(NSNotification * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (NSSet * _Nonnull)setBridge:(NSSet * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc @objcMembers class BridgedTypes {
   @objc func dictBridge(_ x: Dictionary<NSObject, AnyObject>) -> Dictionary<NSObject, AnyObject> {
+    return x
+  }
+
+  @objc func noteBridge(_ x: Notification) -> Notification {
     return x
   }
 


### PR DESCRIPTION
The initial pass through a type’s members to forward-declare or import anything needed by them did not account for `_ObjectiveCBridgeable` conformances; instead, it would examine the Swift type being bridged from, either tripping an assertion or just failing to do anything. Treat these as references to the bridged type instead.

This PR also adds some PrettyStackTraces to PrintAsObjC to help with debugging future crashes in this area of the code.

Fixes rdar://67263753.
