### PR TITLE
update-checkout-config.json: adjust for tensorflow merge

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -352,7 +352,7 @@
                 "swift-tools-support-core": "0.1.8",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-08-11-a",
                 "swift-argument-parser": "0.3.0",
-                "swift-driver": "bf0026c636347b4c31aab21deb01943529b7e556",
+                "swift-driver": "b590b0c8e8a26c68602af7224af1bb203f23c31a",
                 "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2020-08-11-a",
                 "swift-stress-tester": "swift-DEVELOPMENT-SNAPSHOT-2020-08-11-a",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2020-08-11-a",


### PR DESCRIPTION
Adjust commit for `swift-driver`, which doesn't have `swift-DEVELOPMENT-SNAPSHOT` version tags like the other repositories.

Should fix this build issue:
```
s4tf/swiftpm/Sources/Build/ManifestBuilder.swift:397:20: error: no type named 'ExternalDependencyArtifactMap' in module 'SwiftDriver'
    -> SwiftDriver.ExternalDependencyArtifactMap {
                   ^
s4tf/swiftpm/Sources/Build/ManifestBuilder.swift:413:52: error: type 'ModuleDependencyId' has no member 'swiftPlaceholder'
            targetDependencyMap[ModuleDependencyId.swiftPlaceholder(moduleName)] =
                                ~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~~~
```