### PR TITLE
[SIL] Add flag to SILFunctionType::Profile for async.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4577,14 +4577,14 @@ public:
                                     
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getInvocationGenericSignature(),
-            getExtInfo(), getCoroutineKind(), getCalleeConvention(),
+            getExtInfo(), isAsync(), getCoroutineKind(), getCalleeConvention(),
             getParameters(), getYields(), getResults(),
             getOptionalErrorResult(), getWitnessMethodConformanceOrInvalid(),
             getPatternSubstitutions(), getInvocationSubstitutions());
   }
   static void
   Profile(llvm::FoldingSetNodeID &ID, GenericSignature genericSig, ExtInfo info,
-          SILCoroutineKind coroutineKind, ParameterConvention calleeConvention,
+          bool isAsync, SILCoroutineKind coroutineKind, ParameterConvention calleeConvention,
           ArrayRef<SILParameterInfo> params, ArrayRef<SILYieldInfo> yields,
           ArrayRef<SILResultInfo> results, Optional<SILResultInfo> errorResult,
           ProtocolConformanceRef conformance,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3245,6 +3245,7 @@ void SILFunctionType::Profile(
     llvm::FoldingSetNodeID &id,
     GenericSignature genericParams,
     ExtInfo info,
+    bool isAsync,
     SILCoroutineKind coroutineKind,
     ParameterConvention calleeConvention,
     ArrayRef<SILParameterInfo> params,
@@ -3258,6 +3259,7 @@ void SILFunctionType::Profile(
   auto infoKey = info.getFuncAttrKey();
   id.AddInteger(infoKey.first);
   id.AddPointer(infoKey.second);
+  id.AddBoolean(isAsync);
   id.AddInteger(unsigned(coroutineKind));
   id.AddInteger(unsigned(calleeConvention));
   id.AddInteger(params.size());
@@ -3471,8 +3473,8 @@ CanSILFunctionType SILFunctionType::get(
   invocationSubs = invocationSubs.getCanonical();
   
   llvm::FoldingSetNodeID id;
-  SILFunctionType::Profile(id, genericSig, ext, coroutineKind, callee, params,
-                           yields, normalResults, errorResult,
+  SILFunctionType::Profile(id, genericSig, ext, isAsync, coroutineKind, callee,
+                           params, yields, normalResults, errorResult,
                            witnessMethodConformance,
                            patternSubs, invocationSubs);
 

--- a/test/SIL/Parser/async.sil
+++ b/test/SIL/Parser/async.sil
@@ -1,5 +1,21 @@
 // RUN: %target-sil-opt -enable-sil-verify-all=true %s | %target-sil-opt -enable-sil-verify-all=true | %FileCheck %s
 
+import Builtin
+
+// CHECK: sil @not_async_test : $@convention(thin) () -> () {
+sil @not_async_test : $() -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// CHECK: sil @not_async_test2 : $@convention(thin) (Builtin.Int32) -> () {
+sil @not_async_test2 : $(Builtin.Int32) -> () {
+bb0(%int : $Builtin.Int32):
+  %0 = tuple ()
+  return %0 : $()
+}
+
 // CHECK: sil @async_test : $@async
 sil @async_test : $@async () -> () {
 bb0:


### PR DESCRIPTION
Previously, the flag was omitted, causing function types which were otherwise the same to have the same id, leading to caching woes.  Here, the issue is fixed by adding the boolean flag to the id, ensuring that types which differ only in that flag are still understood to be different.