### PR TITLE
Don't drop -DNDEBUG from CMAKE_CXX_FLAGS_RELEASE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,7 +635,9 @@ endif()
 
 if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
   # CMake's default for CMAKE_CXX_FLAGS_RELEASE is "-O3 -DNDEBUG". Let's avoid "-O3" for consistency
-  # between Release and RelWithDebInfo.
+  # between Release and RelWithDebInfo. Dropping -DNDEBUG from this setting is blocked by triggering
+  # a test failure of Swift-Unit :: Syntax/./SwiftSyntaxTests/TypeSyntaxTests.MetatypeTypeWithAPIs
+  # because unit tests don't currently explicitly set -DNDEBUG/-UNDEBUG.
   set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,9 +635,8 @@ endif()
 
 if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
   # CMake's default for CMAKE_CXX_FLAGS_RELEASE is "-O3 -DNDEBUG". Let's avoid "-O3" for consistency
-  # between Release and RelWithDebInfo. And let's not set -DNDEBUG because we're setting that manually
-  # based on LLVM_ENABLE_ASSERTIONS.
-  set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+  # between Release and RelWithDebInfo.
+  set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
   if(_lto_flag_out)


### PR DESCRIPTION
Dropping -DNDEBUG from CMAKE_CXX_FLAGS_RELEASE is causing a test failure: <https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/5340/>

I suggest just keeping -DNDEBUG in CMAKE_CXX_FLAGS_RELEASE because the CMake configs in AddSwift.cmake and AddSwiftStdlib.cmake are always appending either -DNDEBUG or -UNDEBUG afterwards anyway.