### PR TITLE
[AST] Fix declaration bitfields.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -283,7 +283,7 @@ class alignas(1 << DeclAlignInBits) Decl {
 protected:
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1,
     Kind : bitmax(NumDeclKindBits,8),
 
     /// Whether this declaration is invalid.
@@ -385,7 +385,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
 


### PR DESCRIPTION
Fix total bit count for `Decl` and `AbstractFunctionDecl` bitfields.

---

Discovered while debugging a stdlib compilation crash on Ubuntu 20.04 release+asserts: https://ci.swift.org/job/oss-swift-package-ubuntu-20_04/402/console

<details>

```
FAILED: stdlib/public/Platform/LINUX/x86_64/Glibc.o 
cd /home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform && /usr/bin/python3.8 /home/build-user/swift/utils/line-directive @/home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/3d684e9fecdb7fcd66d7b7c624faa1ddf41b9a5c.txt -- /home/build-user/build/buildbot_linux/swift-linux-x86_64/./bin/swiftc -c -sdk / -target x86_64-unknown-linux-gnu -resource-dir /home/build-user/build/buildbot_linux/swift-linux-x86_64/./lib/swift -O -D INTERNAL_CHECKS_ENABLED -D SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING -module-cache-path /home/build-user/build/buildbot_linux/swift-linux-x86_64/./module-cache -no-link-objc-runtime -enable-library-evolution -Xfrontend -enforce-exclusivity=unchecked -module-name Glibc -swift-version 5 -swift-version 5 -autolink-force-load -runtime-compatibility-version none -disable-autolinking-runtime-compatibility-dynamic-replacements -warn-swift3-objc-inference-complete -Xfrontend -verify-syntax-tree -warn-implicit-overrides -module-link-name swiftGlibc -whole-module-optimization -parse-as-library -I /home/build-user/build/buildbot_linux/swift-linux-x86_64/./lib/swift/linux/x86_64 -o /home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/LINUX/x86_64/Glibc.o @/home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/3d684e9fecdb7fcd66d7b7c624faa1ddf41b9a5c.txt
swift-frontend: /home/build-user/llvm-project/llvm/include/llvm/ADT/ArrayRef.h:250: const T &llvm::ArrayRef<swift::SILParameterInfo>::operator[](size_t) const [T = swift::SILParameterInfo]: Assertion `Index < Length && "Invalid index!"' failed.
Stack dump:
0.	Program arguments: /home/build-user/build/buildbot_linux/swift-linux-x86_64/bin/swift-frontend -frontend -c /home/build-user/swift/stdlib/public/Platform/Platform.swift /home/build-user/swift/stdlib/public/Platform/TiocConstants.swift /home/build-user/swift/stdlib/public/Platform/POSIXError.swift /home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/8/tgmath.swift /home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/8/Glibc.swift -supplementary-output-file-map /tmp/supplementaryOutputs-d93813 -target x86_64-unknown-linux-gnu -disable-objc-interop -sdk / -I /home/build-user/build/buildbot_linux/swift-linux-x86_64/./lib/swift/linux/x86_64 -autolink-force-load -warn-swift3-objc-inference-complete -warn-implicit-overrides -enable-library-evolution -module-cache-path /home/build-user/build/buildbot_linux/swift-linux-x86_64/./module-cache -module-link-name swiftGlibc -resource-dir /home/build-user/build/buildbot_linux/swift-linux-x86_64/./lib/swift -swift-version 5 -O -D INTERNAL_CHECKS_ENABLED -D SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS -D SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING -enforce-exclusivity=unchecked -verify-syntax-tree -parse-as-library -module-name Glibc -o /home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/LINUX/x86_64/Glibc.o -runtime-compatibility-version none -disable-autolinking-runtime-compatibility-dynamic-replacements 
1.	Swift version 5.3-dev (LLVM 73b878fbf94d283, Swift 342f3dd2f6a22e5)
2.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module Glibc)
3.	While silgen emitFunction SIL function "@$s5Glibc5frexpyx_SitxSBRzlF".
 for 'frexp(_:)' (at /home/build-user/build/buildbot_linux/swift-linux-x86_64/stdlib/public/Platform/8/tgmath.swift:78:8)
```

</details>

This change didn't end up fixing the crash (https://github.com/apple/swift/pull/33528 was the fix), but it seems good by itself for correctness.