### PR TITLE
[AutoDiff] Revert obsolete SIL undef hack.

### DIFF
--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -201,9 +201,11 @@ public:
         getModule(), vjpSubstMap, TypeExpansionContext::minimal());
     pullbackType = pullbackType.subst(getModule(), vjpSubstMap);
     auto pullbackFnType = pullbackType.castTo<SILFunctionType>();
-
     auto pullbackSubstType =
         pullbackPartialApply->getType().castTo<SILFunctionType>();
+
+    // If necessary, convert the pullback value to the returned pullback
+    // function type.
     SILValue pullbackValue;
     if (pullbackSubstType == pullbackFnType) {
       pullbackValue = pullbackPartialApply;
@@ -213,11 +215,8 @@ public:
           builder.createConvertFunction(loc, pullbackPartialApply, pullbackType,
                                         /*withoutActuallyEscaping*/ false);
     } else {
-      // When `diag::autodiff_loadable_value_addressonly_tangent_unsupported`
-      // applies, the return type may be ABI-incomaptible with the type of the
-      // partially applied pullback. In these cases, produce an undef and rely
-      // on other code to emit a diagnostic.
-      pullbackValue = SILUndef::get(pullbackType, *vjp);
+      llvm::report_fatal_error("Pullback value type is not ABI-compatible "
+                               "with the returned pullback type");
     }
 
     // Return a tuple of the original result and pullback.


### PR DESCRIPTION
Previously, JVP/VJP generation used a "return undef" hack when
differential/pullback values did not match the expected return type.

This was relevant before differentiation supported "loadable types with
address-only tangent types", which was diagnosed.

Now that support for the above exists, "return undef" should be removed and
replaced with an assertion.