### PR TITLE
[ModuleTrace] Early exit if a Clang module imports itself.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -588,8 +588,9 @@ void ABIDependencyEvaluator::computeABIDependenciesForClangModule(
     }
     if (import->isNonSwiftModule()
         && module->getTopLevelModule() == import->getTopLevelModule()
-        && !import->findUnderlyingClangModule()
-                  ->isSubModuleOf(module->findUnderlyingClangModule())) {
+        && (module == import
+            || !import->findUnderlyingClangModule()
+                      ->isSubModuleOf(module->findUnderlyingClangModule()))) {
       continue;
     }
     computeABIDependenciesForModule(import);

--- a/test/Driver/Inputs/imported_modules/SelfImport/module.modulemap
+++ b/test/Driver/Inputs/imported_modules/SelfImport/module.modulemap
@@ -1,0 +1,6 @@
+module Outer {
+ module Inner {
+  export Outer.Inner
+ }
+ export Outer
+}

--- a/test/Driver/loaded_module_trace_self_cycle.swift
+++ b/test/Driver/loaded_module_trace_self_cycle.swift
@@ -1,4 +1,4 @@
 // Check that this doesn't crash due to a self-cycle. rdar://67435472
-// RUN: not --crash %target-swift-frontend %s -emit-module -o /dev/null -emit-loaded-module-trace-path /dev/null -I %S/Inputs/imported_modules/SelfImport
+// RUN: %target-swift-frontend %s -emit-module -o /dev/null -emit-loaded-module-trace-path /dev/null -I %S/Inputs/imported_modules/SelfImport
 
 import Outer

--- a/test/Driver/loaded_module_trace_self_cycle.swift
+++ b/test/Driver/loaded_module_trace_self_cycle.swift
@@ -1,0 +1,4 @@
+// Check that this doesn't crash due to a self-cycle. rdar://67435472
+// RUN: not --crash %target-swift-frontend %s -emit-module -o /dev/null -emit-loaded-module-trace-path /dev/null -I %S/Inputs/imported_modules/SelfImport
+
+import Outer


### PR DESCRIPTION
Fixes rdar://67435472.