### PR TITLE
Support generic @compatibility_alias in PrintAsObjC

### DIFF
--- a/include/swift/AST/ClangNode.h
+++ b/include/swift/AST/ClangNode.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_CLANGNODE_H
 #define SWIFT_CLANGNODE_H
 
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/PointerUnion.h"
 
 namespace clang {
@@ -97,6 +98,8 @@ public:
 
   clang::SourceLocation getLocation() const;
   clang::SourceRange getSourceRange() const;
+
+  SWIFT_DEBUG_DUMP;
 
   void *getOpaqueValue() const { return Ptr.getOpaqueValue(); }
   static inline ClangNode getFromOpaqueValue(void *VP) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2996,11 +2996,29 @@ public:
   /// Retrieve a sugared interface type containing the structure of the interface
   /// type before any semantic validation has occured.
   Type getStructuralType() const;
-  
+
+  /// Whether the typealias forwards perfectly to its underlying type.
+  ///
+  /// If true, this typealias was created by ClangImporter to preserve source
+  /// compatibility with a previous language version's name for a type. Many
+  /// checks in Sema look through compatibility aliases even when they would
+  /// operate on other typealiases.
+  ///
+  /// \warning This has absolutely nothing to do with the Objective-C
+  /// \c compatibility_alias keyword.
   bool isCompatibilityAlias() const {
     return Bits.TypeAliasDecl.IsCompatibilityAlias;
   }
 
+  /// Sets whether the typealias forwards perfectly to its underlying type.
+  ///
+  /// Marks this typealias as having been created by ClangImporter to preserve
+  /// source compatibility with a previous language version's name for a type.
+  /// Many checks in Sema look through compatibility aliases even when they
+  /// would operate on other typealiases.
+  ///
+  /// \warning This has absolutely nothing to do with the Objective-C
+  /// \c compatibility_alias keyword.
   void markAsCompatibilityAlias(bool newValue = true) {
     Bits.TypeAliasDecl.IsCompatibilityAlias = newValue;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -116,6 +116,17 @@ const clang::Module *ClangNode::getClangModule() const {
   return nullptr;
 }
 
+void ClangNode::dump() const {
+  if (auto D = getAsDecl())
+    D->dump();
+  else if (auto M = getAsMacro())
+    M->dump();
+  else if (auto M = getAsModule())
+    M->dump();
+  else
+    llvm::errs() << "ClangNode contains nullptr\n";
+}
+
 // Only allow allocation of Decls using the allocator in ASTContext.
 void *Decl::operator new(size_t Bytes, const ASTContext &C,
                          unsigned Alignment) {

--- a/test/PrintAsObjC/Inputs/custom-modules/CompatibilityAlias.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/CompatibilityAlias.h
@@ -1,5 +1,7 @@
 // This file is meant to be included with modules turned off, compiled against
 // the fake clang-importer-sdk.
 #import <Foundation.h>
+#import <objc_generics.h>
 
 @compatibility_alias StringCheese NSString;
+@compatibility_alias GymClass GenericClass;

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -820,6 +820,9 @@ public class NonObjCClass { }
   // CHECK-NEXT: - (StringCheese * _Nullable)foo SWIFT_WARN_UNUSED_RESULT;
   @objc func foo() -> StringCheese? { return nil }
 
+  // CHECK-NEXT: - (GymClass<StringCheese *> * _Nullable)foosball SWIFT_WARN_UNUSED_RESULT;
+  @objc func foosball() -> GymClass<StringCheese>? { return nil }
+
   // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 }
 // CHECK-NEXT: @end


### PR DESCRIPTION
When Objective-C's `@compatibility_alias` feature is used with a class using lightweight generics, this ends up importing as a generic Swift typealias. PrintAsObjC previously didn’t handle declarations involving these types correctly; it would fail an assertion in asserts compilers, and potentially print an incorrect compatibility header in non-asserts compilers.

This PR makes it so that PrintAsObjC can now correctly print generic compatibility aliases imported from Objective-C modules. It is, of course, still not possible to declare a generic typealias in Swift that will be printed into the Objective-C header.

This PR also adds a `ClangNode::dump()` method for use in the debugger and adds doc comments clarifying what `TypeAliasDecl::{is,markAs}CompatibilityAlias()` are for (and that they have nothing to do with `@compatibility_alias`).

Fixes rdar://67256866.
