### PR TITLE
[5.3][CodeCompletion] Avoid prioritizing unavailable in LookupVisibleDecls

### DIFF
--- a/test/IDE/complete_rdar67155695.swift
+++ b/test/IDE/complete_rdar67155695.swift
@@ -1,0 +1,111 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=PUBLIC | %FileCheck %s --check-prefix=PUBLIC
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=INTERNAL | %FileCheck %s --check-prefix=INTERNAL
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=PRIVATE | %FileCheck %s --check-prefix=PRIVATE
+
+public protocol PubP {}
+
+public extension PubP {
+    func availableP_availableC() {}
+
+    func availableP_unavailableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_availableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_unavailableC() {}
+}
+
+struct TestForPubP: PubP {
+    func availableP_availableC() {}
+
+    @available(*, unavailable)
+    func availableP_unavailableC() {}
+
+    func unavailableP_availableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_unavailableC() {}
+}
+
+func test(val: TestForPubP) {
+    val.#^PUBLIC^#
+// PUBLIC: Begin completions, 4 items
+// PUBLIC-DAG: Keyword[self]/CurrNominal:          self[#TestForPubP#];
+// PUBLIC-DAG: Decl[InstanceMethod]/CurrNominal:   unavailableP_availableC()[#Void#];
+// PUBLIC-DAG: Decl[InstanceMethod]/Super:         availableP_availableC()[#Void#];
+// PUBLIC-DAG: Decl[InstanceMethod]/Super:         availableP_unavailableC()[#Void#];
+// PUBLIC: End completions
+}
+
+protocol InternalP {}
+
+extension InternalP {
+    func availableP_availableC() {}
+
+    func availableP_unavailableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_availableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_unavailableC() {}
+}
+
+struct TestForInternalP: InternalP {
+    func availableP_availableC() {}
+
+    @available(*, unavailable)
+    func availableP_unavailableC() {}
+
+    func unavailableP_availableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_unavailableC() {}
+}
+
+func test(val: TestForInternalP) {
+    val.#^INTERNAL^#
+// INTERNAL: Begin completions, 4 items
+// INTERNAL-DAG: Keyword[self]/CurrNominal:          self[#TestForInternalP#];
+// INTERNAL-DAG: Decl[InstanceMethod]/CurrNominal:   availableP_availableC()[#Void#];
+// INTERNAL-DAG: Decl[InstanceMethod]/CurrNominal:   unavailableP_availableC()[#Void#];
+// INTERNAL-DAG: Decl[InstanceMethod]/Super:         availableP_unavailableC()[#Void#];
+// INTERNAL: End completions
+}
+
+private protocol PrivP {}
+
+private extension PrivP {
+    func availableP_availableC() {}
+
+    func availableP_unavailableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_availableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_unavailableC() {}
+}
+
+struct TestForPrivP: PrivP {
+    func availableP_availableC() {}
+
+    @available(*, unavailable)
+    func availableP_unavailableC() {}
+
+    func unavailableP_availableC() {}
+
+    @available(*, unavailable)
+    func unavailableP_unavailableC() {}
+}
+
+func test(val: TestForPrivP) {
+    val.#^PRIVATE^#
+// PRIVATE: Begin completions, 4 items
+// PRIVATE-DAG: Keyword[self]/CurrNominal:          self[#TestForPrivP#];
+// PRIVATE-DAG: Decl[InstanceMethod]/CurrNominal:   availableP_availableC()[#Void#];
+// PRIVATE-DAG: Decl[InstanceMethod]/CurrNominal:   unavailableP_availableC()[#Void#];
+// PRIVATE-DAG: Decl[InstanceMethod]/Super:         availableP_unavailableC()[#Void#];
+// PRIVATE-DAG: End completions
+}


### PR DESCRIPTION
Cherry-pick of #33562 into `release/5.3`

* **Explanation**: Fix an issue where extension members don't appear in code completion if there are conflicting member marked `unavailable` in protocol extension.
* **Scope**: Code completion
* **Risk**: Low. Simple filtering logic fix
* **Issue**: rdar://problem/67155695
* **Testing**: Added regression test cases
* **Reviewer**: Ben Langmuir (@benlangmuir)

e.g.
```swift
extension String {
    func appendingPathComponent(_ pathComponent: String) -> String {
        return self
    }
}
func test(str: String) {
  str.<HERE> // This should show 'appendingPathComponent(_:)'
}
```