### PR TITLE
Minor cleanup in ARCSequenceOpts

### DIFF
--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -726,8 +726,9 @@ public:
     return getSubregionData().RPONumOfHeaderBlock;
   }
 
-  void dump() const;
-  void print(llvm::raw_ostream &os, bool insertSpaces = false) const;
+  void dump(bool isVerbose = false) const;
+  void print(llvm::raw_ostream &os, bool isShort = false,
+             bool isVerbose = false) const;
   void dumpName() const;
   void printName(llvm::raw_ostream &os) const;
 

--- a/lib/SILOptimizer/ARC/ARCSequenceOptUtils.h
+++ b/lib/SILOptimizer/ARC/ARCSequenceOptUtils.h
@@ -21,7 +21,7 @@
 #include "swift/SIL/SILInstruction.h"
 
 namespace swift {
-  bool isARCSignificantTerminator(TermInst *TI);
+bool isARCSignificantTerminator(TermInst *TI);
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.h
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.h
@@ -39,11 +39,9 @@ struct ARCPairingContext {
 
   ARCPairingContext(SILFunction &F, RCIdentityFunctionInfo *RCIA)
       : F(F), DecToIncStateMap(), IncToDecStateMap(), RCIA(RCIA) {}
-  bool performMatching(llvm::SmallVectorImpl<SILInstruction *> &NewInsts,
-                       llvm::SmallVectorImpl<SILInstruction *> &DeadInsts);
+  bool performMatching(llvm::SmallVectorImpl<SILInstruction *> &DeadInsts);
 
   void optimizeMatchingSet(ARCMatchingSet &MatchSet,
-                           llvm::SmallVectorImpl<SILInstruction *> &NewInsts,
                            llvm::SmallVectorImpl<SILInstruction *> &DeadInsts);
 };
 
@@ -68,10 +66,8 @@ struct BlockARCPairingContext {
     bool NestingDetected = Evaluator.run(FreezePostDomReleases);
     Evaluator.clear();
 
-    llvm::SmallVector<SILInstruction *, 8> NewInsts;
     llvm::SmallVector<SILInstruction *, 8> DeadInsts;
-    bool MatchedPair = Context.performMatching(NewInsts, DeadInsts);
-    NewInsts.clear();
+    bool MatchedPair = Context.performMatching(DeadInsts);
     while (!DeadInsts.empty())
       DeadInsts.pop_back_val()->eraseFromParent();
     return NestingDetected && MatchedPair;

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -118,7 +118,6 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
 void ARCSequenceDataflowEvaluator::mergePredecessors(
     ARCBBStateInfoHandle &DataHandle) {
   bool HasAtLeastOnePred = false;
-  llvm::SmallVector<SILBasicBlock *, 4> BBThatNeedInsertPts;
 
   SILBasicBlock *BB = DataHandle.getBB();
   ARCBBState &BBState = DataHandle.getState();

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -222,10 +222,8 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
       SetFactory);
 
   auto II = BB.rbegin();
-  if (isa<TermInst>(*II)) {
-    if (!isARCSignificantTerminator(&cast<TermInst>(*II))) {
-      II++;
-    }
+  if (!isARCSignificantTerminator(&cast<TermInst>(*II))) {
+    II++;
   }
 
   // For each instruction I in BB visited in reverse...

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -200,40 +200,14 @@ bool LoopARCSequenceDataflowEvaluator::processLoopBottomUp(
   bool NestingDetected = false;
 
   // For each BB in our post order...
-  auto Start = R->subregion_begin(), End = R->subregion_end();
-  if (Start == End)
-    return false;
-
-  --End;
-  while (Start != End) {
-    unsigned SubregionIndex = *End;
+  for (unsigned SubregionIndex : R->getReverseSubregions()) {
     auto *Subregion = LRFI->getRegion(SubregionIndex);
     auto &SubregionData = getARCState(Subregion);
 
     // This will always succeed since we have an entry for each BB in our post
     // order.
-    LLVM_DEBUG(llvm::dbgs() << "Processing Subregion#: " << SubregionIndex
-                            << "\n");
-
-    LLVM_DEBUG(llvm::dbgs() << "Merging Successors!\n");
-    mergeSuccessors(Subregion, SubregionData);
-
-    // Then perform the region optimization.
-    NestingDetected |= SubregionData.processBottomUp(
-        AA, RCFI, EAFI, LRFI, FreezeOwnedArgEpilogueReleases, IncToDecStateMap,
-        RegionStateInfo, SetFactory);
-    --End;
-  }
-
-  {
-    unsigned SubregionIndex = *End;
-    auto *Subregion = LRFI->getRegion(SubregionIndex);
-    auto &SubregionData = getARCState(Subregion);
-
-    // This will always succeed since we have an entry for each BB in our post
-    // order.
-    LLVM_DEBUG(llvm::dbgs() << "Processing Subregion#: " << SubregionIndex
-                            << "\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "Processing Subregion#: " << SubregionIndex << "\n");
 
     LLVM_DEBUG(llvm::dbgs() << "Merging Successors!\n");
     mergeSuccessors(Subregion, SubregionData);

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -285,9 +285,6 @@ handleRefCountInstMatch(SILInstruction *RefCountInst) {
     return false;
   case LatticeState::Decremented:
   case LatticeState::MightBeUsed:
-    // Unset InsertPt so we remove retain release pairs instead of
-    // performing code motion.
-    LLVM_FALLTHROUGH;
   case LatticeState::MightBeDecremented:
     return true;
   }

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -185,17 +185,13 @@ public:
   bool initWithMutatorInst(ImmutablePointerSet<SILInstruction> *I,
                            RCIdentityFunctionInfo *RCFI);
 
-  /// Update this reference count's state given the instruction \p I. \p
-  /// InsertPt is the point furthest up the CFG where we can move the currently
-  /// tracked reference count.
+  /// Update this reference count's state given the instruction \p I.
   void
   updateForSameLoopInst(SILInstruction *I,
                         ImmutablePointerSetFactory<SILInstruction> &SetFactory,
                         AliasAnalysis *AA);
 
-  /// Update this reference count's state given the instruction \p I. \p
-  /// InsertPts are the points furthest up the CFG where we can move the
-  /// currently tracked reference count.
+  /// Update this reference count's state given the instruction \p I.
   //
   /// The main difference in between this routine and update for same loop inst
   /// is that if we see any decrements on a value, we treat it as being
@@ -244,9 +240,7 @@ private:
   bool valueCanBeUsedGivenLatticeState() const;
 
   /// Given the current lattice state, if we have seen a use, advance the
-  /// lattice state. Return true if we do so and false otherwise. \p InsertPt is
-  /// the location where if \p PotentialUser is a user of this ref count, we
-  /// would insert a release.
+  /// lattice state. Return true if we do so and false otherwise.
   bool handleUser(SILValue RCIdentity,
                   ImmutablePointerSetFactory<SILInstruction> &SetFactory,
                   AliasAnalysis *AA);
@@ -264,9 +258,7 @@ private:
   bool valueCanBeGuaranteedUsedGivenLatticeState() const;
 
   /// Given the current lattice state, if we have seen a use, advance the
-  /// lattice state. Return true if we do so and false otherwise. \p InsertPt is
-  /// the location where if \p PotentialUser is a user of this ref count, we
-  /// would insert a release.
+  /// lattice state. Return true if we do so and false otherwise.
   bool
   handleGuaranteedUser(SILValue RCIdentity,
                        ImmutablePointerSetFactory<SILInstruction> &SetFactory,
@@ -338,17 +330,13 @@ public:
   /// Uninitialize the current state.
   void clear();
 
-  /// Update this reference count's state given the instruction \p I. \p
-  /// InsertPt is the point furthest up the CFG where we can move the currently
-  /// tracked reference count.
+  /// Update this reference count's state given the instruction \p I.
   void
   updateForSameLoopInst(SILInstruction *I,
                         ImmutablePointerSetFactory<SILInstruction> &SetFactory,
                         AliasAnalysis *AA);
 
-  /// Update this reference count's state given the instruction \p I. \p
-  /// InsertPts are the points furthest up the CFG where we can move the
-  /// currently tracked reference count.
+  /// Update this reference count's state given the instruction \p I.
   ///
   /// The main difference in between this routine and update for same loop inst
   /// is that if we see any decrements on a value, we treat it as being

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -45,8 +45,8 @@ LoopRegion::FunctionTy *LoopRegion::getFunction() const {
   return Ptr.get<FunctionTy *>();
 }
 
-void LoopRegion::dump() const {
-  print(llvm::outs());
+void LoopRegion::dump(bool isVerbose) const {
+  print(llvm::outs(), false, isVerbose);
   llvm::outs() << "\n";
 }
 
@@ -69,7 +69,8 @@ void LoopRegion::printName(llvm::raw_ostream &os) const {
   return;
 }
 
-void LoopRegion::print(llvm::raw_ostream &os, bool isShort) const {
+void LoopRegion::print(llvm::raw_ostream &os, bool isShort,
+                       bool isVerbose) const {
   os << "(region id:" << ID;
   if (isShort) {
     os << ")";
@@ -88,6 +89,20 @@ void LoopRegion::print(llvm::raw_ostream &os, bool isShort) const {
 
   os << " ucfh:" << (IsUnknownControlFlowEdgeHead? "true " : "false")
      << " ucft:" << (IsUnknownControlFlowEdgeTail? "true " : "false");
+
+  if (!isVerbose) {
+    return;
+  }
+  os << "\n";
+  if (isBlock()) {
+    getBlock()->dump();
+  } else if (isLoop()) {
+    getLoop()->dump();
+  } else if (isFunction()) {
+    getFunction()->dump();
+  } else {
+    llvm_unreachable("Unknown region type");
+  }
 }
 
 llvm::raw_ostream &llvm::operator<<(llvm::raw_ostream &os, LoopRegion &LR) {


### PR DESCRIPTION
This change removes some more dead code in ARCSequenceOpts. And adds more info to the LoopRegion printer

- Removes more reference to Insertion points and NewInsts that are no longer needed in ARCSequenceOpts
- Update bottom up loop traversal to remove some code duplication
- Add more info in LoopRegion printer, this is useful while calling dump() utilities within the debugger