### PR TITLE
Remove unnecessary @available check in Identifiable.swift

### DIFF
--- a/stdlib/public/core/Identifiable.swift
+++ b/stdlib/public/core/Identifiable.swift
@@ -38,7 +38,6 @@
 /// `ObjectIdentifier`), which is only guaranteed to remain unique for the
 /// lifetime of an object. If an object has a stronger notion of identity, it
 /// may be appropriate to provide a custom implementation.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Identifiable {
 
   /// A type representing the stable identity of the entity associated with
@@ -49,7 +48,6 @@ public protocol Identifiable {
   var id: ID { get }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Identifiable where Self: AnyObject {
   public var id: ObjectIdentifier {
     return ObjectIdentifier(self)


### PR DESCRIPTION
Removed the unnecessary `@available` check in [`Identifiable.swift`](https://github.com/apple/swift/blob/6b14c2a74609f3a2d2ab98829ff94800eba12ecc/stdlib/public/core/Identifiable.swift#L41)

I don't see any reason why these are here in the first place since it is a language feature! maybe someone can explain to me if I am missing something

Thanks!