### PR TITLE
[AutoDiff] Support forward mode differentiation of functions with `inout` parameters

### DIFF
--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -201,9 +201,11 @@ public:
         getModule(), vjpSubstMap, TypeExpansionContext::minimal());
     pullbackType = pullbackType.subst(getModule(), vjpSubstMap);
     auto pullbackFnType = pullbackType.castTo<SILFunctionType>();
-
     auto pullbackSubstType =
         pullbackPartialApply->getType().castTo<SILFunctionType>();
+
+    // If necessary, convert the pullback value to the returned pullback
+    // function type.
     SILValue pullbackValue;
     if (pullbackSubstType == pullbackFnType) {
       pullbackValue = pullbackPartialApply;
@@ -213,11 +215,8 @@ public:
           builder.createConvertFunction(loc, pullbackPartialApply, pullbackType,
                                         /*withoutActuallyEscaping*/ false);
     } else {
-      // When `diag::autodiff_loadable_value_addressonly_tangent_unsupported`
-      // applies, the return type may be ABI-incomaptible with the type of the
-      // partially applied pullback. In these cases, produce an undef and rely
-      // on other code to emit a diagnostic.
-      pullbackValue = SILUndef::get(pullbackType, *vjp);
+      llvm::report_fatal_error("Pullback value type is not ABI-compatible "
+                               "with the returned pullback type");
     }
 
     // Return a tuple of the original result and pullback.

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -205,8 +205,9 @@ extension ${Self} {
   static func _jvpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
   ) {
+    let oldLhs = lhs
     lhs *= rhs
-    return ((), { $0 *= $1 })
+    return ((), { $0 = $0 * rhs + oldLhs * $1 })
   }
 
   ${Availability(bits)}
@@ -251,8 +252,9 @@ extension ${Self} {
   static func _jvpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
   ) {
+    let oldLhs = lhs
     lhs /= rhs
-    return ((), { $0 /= $1 })
+    return ((), { $0 = ($0 * rhs - oldLhs * $1) / (rhs * rhs)  })
   }
 }
 

--- a/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
@@ -87,7 +87,7 @@ func activeInoutParamControlFlow(_ array: [Float]) -> Float {
 
 // FIXME(TF-984): Forward-mode crash due to unset tangent buffer.
 /*
-struct X : Differentiable {
+struct X: Differentiable {
   var x : Float
 
   @differentiable(wrt: y)
@@ -103,21 +103,11 @@ func activeMutatingMethod(_ x: Float) -> Float {
 }
 */
 
-/*struct Mut: Differentiable {}
+
+struct Mut: Differentiable {}
 extension Mut {
   @differentiable(wrt: x)
   mutating func mutatingMethod(_ x: Mut) {}
-
-  // exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
-  @differentiable(wrt: x)
-  mutating func mutatingMethodWithResult(_ x: Mut) -> Mut { return x }
-}
-
-// exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
-@differentiable(wrt: x)
-func nonActiveInoutParam(_ nonactive: inout Mut, _ x: Mut) -> Mut {
-  nonactive.mutatingMethod(x)
-  return x
 }
 
 @differentiable(wrt: x)
@@ -126,22 +116,6 @@ func activeInoutParamMutatingMethod(_ x: Mut) -> Mut {
   result.mutatingMethod(result)
   return result
 }
-
-// exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
-@differentiable(wrt: x)
-func activeInoutParamMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
-  var result = nonactive
-  result = result.mutatingMethodWithResult(x)
-  return result
-}
-
-// exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
-@differentiable(wrt: x)
-func activeInoutParamMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) -> Mut {
-  var result = (nonactive, x)
-  let result2 = result.0.mutatingMethodWithResult(result.0)
-  return result2
-}*/
 
 //===----------------------------------------------------------------------===//
 // Subset parameter differentiation thunks

--- a/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-forward-mode-differentiation -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-forward-mode-differentiation -verify %s
 
 // Test forward-mode differentiation transform diagnostics.
 
@@ -46,8 +46,6 @@ func nonVariedResult(_ x: Float) -> Float {
 // Multiple results
 //===----------------------------------------------------------------------===//
 
-// TODO(TF-983): Support differentiation of multiple results.
-/*
 func multipleResults(_ x: Float) -> (Float, Float) {
   return (x, x)
 }
@@ -56,28 +54,21 @@ func usesMultipleResults(_ x: Float) -> Float {
   let tuple = multipleResults(x)
   return tuple.0 + tuple.1
 }
-*/
 
 //===----------------------------------------------------------------------===//
 // `inout` parameter differentiation
 //===----------------------------------------------------------------------===//
 
-// expected-error @+1 {{function is not differentiable}}
 @differentiable
-// expected-note @+1 {{when differentiating this function definition}}
 func activeInoutParamNonactiveInitialResult(_ x: Float) -> Float {
   var result: Float = 1
-  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
   result += x
   return result
 }
 
-// expected-error @+1 {{function is not differentiable}}
 @differentiable
-// expected-note @+1 {{when differentiating this function definition}}
 func activeInoutParamTuple(_ x: Float) -> Float {
   var tuple = (x, x)
-  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
   tuple.0 *= x
   return x * tuple.0
 }
@@ -94,49 +85,63 @@ func activeInoutParamControlFlow(_ array: [Float]) -> Float {
   return result
 }
 
-struct Mut: Differentiable {}
+// FIXME(TF-984): Forward-mode crash due to unset tangent buffer.
+/*
+struct X : Differentiable {
+  var x : Float
+
+  @differentiable(wrt: y)
+  mutating func mutate(_ y: X) { self.x = y.x }
+}
+
+@differentiable
+func activeMutatingMethod(_ x: Float) -> Float {
+  let x1 = X.init(x: x)
+  var x2 = X.init(x: 0)
+  x2.mutate(x1)
+  return x1.x
+}
+*/
+
+/*struct Mut: Differentiable {}
 extension Mut {
   @differentiable(wrt: x)
   mutating func mutatingMethod(_ x: Mut) {}
+
+  // exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
+  @differentiable(wrt: x)
+  mutating func mutatingMethodWithResult(_ x: Mut) -> Mut { return x }
 }
 
-// FIXME(TF-984): Forward-mode crash due to unset tangent buffer.
-/*
+// exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(wrt: x)
 func nonActiveInoutParam(_ nonactive: inout Mut, _ x: Mut) -> Mut {
-  return nonactive.mutatingMethod(x)
+  nonactive.mutatingMethod(x)
+  return x
 }
-*/
 
-// FIXME(TF-984): Forward-mode crash due to unset tangent buffer.
-/*
 @differentiable(wrt: x)
 func activeInoutParamMutatingMethod(_ x: Mut) -> Mut {
   var result = x
-  result = result.mutatingMethod(result)
+  result.mutatingMethod(result)
   return result
 }
-*/
 
-// FIXME(TF-984): Forward-mode crash due to unset tangent buffer.
-/*
+// exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(wrt: x)
 func activeInoutParamMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
   var result = nonactive
-  result = result.mutatingMethod(x)
+  result = result.mutatingMethodWithResult(x)
   return result
 }
-*/
 
-// FIXME(TF-984): Forward-mode crash due to unset tangent buffer.
-/*
+// exxpected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(wrt: x)
 func activeInoutParamMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) -> Mut {
   var result = (nonactive, x)
-  let result2 = result.0.mutatingMethod(result.0)
+  let result2 = result.0.mutatingMethodWithResult(result.0)
   return result2
-}
-*/
+}*/
 
 //===----------------------------------------------------------------------===//
 // Subset parameter differentiation thunks

--- a/test/AutoDiff/validation-test/forward_mode_inout.swift
+++ b/test/AutoDiff/validation-test/forward_mode_inout.swift
@@ -77,9 +77,9 @@ ForwardModeInoutTests.test("InoutIdentity") {
 
 ForwardModeInoutTests.test("MultipleInoutParams") {
   func swap<T: Differentiable>(_ x: inout T, _ y: inout T) {
-      let z = x
-      x = y
-      y = z
+    let z = x
+    x = y
+    y = z
   }
 
   func first<T: Differentiable>(_ x: T, _ y: T) -> T {
@@ -100,7 +100,7 @@ ForwardModeInoutTests.test("MultipleInoutParams") {
 }
 
 ForwardModeInoutTests.test("StructMutatingMethod") {
-  struct Mut : Differentiable {
+  struct Mut: Differentiable {
     var x: Float
 
     mutating func add(_ y: Float) {
@@ -113,45 +113,45 @@ ForwardModeInoutTests.test("StructMutatingMethod") {
   }
 
   func identity(_ y: Float) -> Float {
-    var mut = Mut.init(x: 0.0)
+    var mut = Mut(x: 0.0)
     mut.add(y)
     return mut.x
   }
   expectEqual(1, derivative(at: 1, in: identity))
 
   func identity2(_ y: Float) -> Float {
-    var mut = Mut.init(x: 0.0)
-    let mut2 = Mut.init(x: y)
+    var mut = Mut(x: 0.0)
+    let mut2 = Mut(x: y)
     mut.addMut(mut2)
     return mut.x
   }
   expectEqual(1, derivative(at: 1, in: identity2))
 
   func double(_ y: Float) -> Float {
-    var mut = Mut.init(x: y)
+    var mut = Mut(x: y)
     mut.add(y)
     return mut.x
   }
   expectEqual(2, derivative(at: 1, in: double))
 
   func double2(_ y: Float) -> Float {
-    var mut = Mut.init(x: y)
-    let mut2 = Mut.init(x: y)
+    var mut = Mut(x: y)
+    let mut2 = Mut(x: y)
     mut.addMut(mut2)
     return mut.x
   }
   expectEqual(2, derivative(at: 1, in: double2))
 
   func square(_ y: Float) -> Float {
-    var mut = Mut.init(x: 0.0)
+    var mut = Mut(x: 0.0)
     mut.add(y * y)
     return mut.x
   }
   expectEqual(6, derivative(at: 3, in: square))
 
   func square2(_ y: Float) -> Float {
-    var mut = Mut.init(x: 0.0)
-    let mut2 = Mut.init(x: y * y)
+    var mut = Mut(x: 0.0)
+    let mut2 = Mut(x: y * y)
     mut.addMut(mut2)
     return mut.x
   }

--- a/test/AutoDiff/validation-test/forward_mode_inout.swift
+++ b/test/AutoDiff/validation-test/forward_mode_inout.swift
@@ -1,0 +1,161 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import DifferentiationUnittest
+
+var ForwardModeInoutTests = TestSuite("ForwardModeInoutDifferentiation")
+
+//===----------------------------------------------------------------------===//
+// Inout tests.
+//===----------------------------------------------------------------------===//
+
+import DifferentiationUnittest
+import StdlibUnittest
+
+ForwardModeInoutTests.test("Float.+=") {
+  func mutatingAddWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result += y
+    return result
+  }
+  expectEqual(20, differential(at: 4, 5, in: mutatingAddWrapper)(10, 10))
+}
+
+ForwardModeInoutTests.test("Float.-=") {
+  func mutatingSubtractWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result -= y
+    return result
+  }
+  expectEqual(0, differential(at: 4, 5, in: mutatingSubtractWrapper)(10, 10))
+  expectEqual(10, differential(at: 4, 5, in: mutatingSubtractWrapper)(20, 10))
+}
+
+ForwardModeInoutTests.test("Float.*=") {
+  func mutatingMultiplyWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result *= y
+    return result
+  }
+  expectEqual(22, differential(at: 4, 5, in: mutatingMultiplyWrapper)(2, 3))
+}
+
+ForwardModeInoutTests.test("Float./=") {
+  func mutatingDivideWrapper(_ x: Float, _ y: Float) -> Float {
+    var result: Float = x
+    result /= y
+    return result
+  }
+  expectEqual(-1, differential(at: 2, 3, in: mutatingDivideWrapper)(3, 9))
+}
+
+// Simplest possible `inout` parameter differentiation.
+ForwardModeInoutTests.test("InoutIdentity") {
+  // Semantically, an empty function with an `inout` parameter is an identity
+  // function.
+  func inoutIdentity(_ x: inout Float) {}
+
+  func identity(_ x: Float) -> Float {
+    var result = x
+    inoutIdentity(&result)
+    return result
+  }
+  expectEqual(1, derivative(at: 10, in: identity))
+  expectEqual(10, differential(at: 10, in: identity)(10))
+
+  func inoutIdentityGeneric<T: Differentiable>(_ x: inout T) {}
+
+  func identityGeneric<T: Differentiable>(_ x: T) -> T {
+    var result: T = x
+    inoutIdentityGeneric(&result)
+    return result
+  }
+  expectEqual(1, derivative(at: 10.0, in: identityGeneric))
+  expectEqual(10, differential(at: 10.0, in: identityGeneric)(10))
+}
+
+ForwardModeInoutTests.test("MultipleInoutParams") {
+  func swap<T: Differentiable>(_ x: inout T, _ y: inout T) {
+      let z = x
+      x = y
+      y = z
+  }
+
+  func first<T: Differentiable>(_ x: T, _ y: T) -> T {
+    var p1 = x
+    var p2 = y
+    swap(&p1, &p2)
+    return p2
+  }
+  expectEqual(1, differential(at: 1, 1, in: first)(1, 2))
+
+  func second<T: Differentiable>(_ x: T, _ y: T) -> T {
+    var p1 = x
+    var p2 = y
+    swap(&p1, &p2)
+    return p1
+  }
+  expectEqual(2, differential(at: 1, 1, in: second)(1, 2))
+}
+
+ForwardModeInoutTests.test("StructMutatingMethod") {
+  struct Mut : Differentiable {
+    var x: Float
+
+    mutating func add(_ y: Float) {
+      self.x += y
+    }
+
+    mutating func addMut(_ m: Mut) {
+      self.x += m.x
+    }
+  }
+
+  func identity(_ y: Float) -> Float {
+    var mut = Mut.init(x: 0.0)
+    mut.add(y)
+    return mut.x
+  }
+  expectEqual(1, derivative(at: 1, in: identity))
+
+  func identity2(_ y: Float) -> Float {
+    var mut = Mut.init(x: 0.0)
+    let mut2 = Mut.init(x: y)
+    mut.addMut(mut2)
+    return mut.x
+  }
+  expectEqual(1, derivative(at: 1, in: identity2))
+
+  func double(_ y: Float) -> Float {
+    var mut = Mut.init(x: y)
+    mut.add(y)
+    return mut.x
+  }
+  expectEqual(2, derivative(at: 1, in: double))
+
+  func double2(_ y: Float) -> Float {
+    var mut = Mut.init(x: y)
+    let mut2 = Mut.init(x: y)
+    mut.addMut(mut2)
+    return mut.x
+  }
+  expectEqual(2, derivative(at: 1, in: double2))
+
+  func square(_ y: Float) -> Float {
+    var mut = Mut.init(x: 0.0)
+    mut.add(y * y)
+    return mut.x
+  }
+  expectEqual(6, derivative(at: 3, in: square))
+
+  func square2(_ y: Float) -> Float {
+    var mut = Mut.init(x: 0.0)
+    let mut2 = Mut.init(x: y * y)
+    mut.addMut(mut2)
+    return mut.x
+  }
+  expectEqual(6, derivative(at: 3, in: square2))
+}
+
+runAllTests()


### PR DESCRIPTION
Adds forward mode support for `apply` instruction with `inout` arguments.

Example of supported code:
```
func add(_ x: inout Float, _ y: inout Float) -> Float {
  var result = x
  result += y
  return result
}
print(differential(at: 1, 1, in: add)(1, 1)) // prints "2"
```