### PR TITLE
[5.3] Patch A Regression in Lookup for CodingKeys

### DIFF
--- a/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi1.swift
+++ b/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi1.swift
@@ -21,3 +21,11 @@ struct SimpleStruct : Codable {
     let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct.CodingKeys' has no member 'z'}}
   }
 }
+
+// SR-13137 Ensure unqualified lookup installs CodingKeys regardless of the
+// order of primaries.
+struct A: Codable {
+  var property: String
+  static let propertyName = CodingKeys.property.stringValue
+}
+

--- a/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi2.swift
+++ b/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi2.swift
@@ -8,3 +8,11 @@ func foo() {
   // struct.
   let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
 }
+
+struct B {
+  static let propertyName = A.propertyName
+  
+  struct Nest {
+    static let propertyName = A.propertyName
+  }
+}


### PR DESCRIPTION
Cherry pick of #33582 

----

* **Explanation**: As part of the name lookup requestification, the code that synthesized CodingKeys was moved to the typechecker’s semantic lookup entrypoints. This migration covered the qualified lookup cases, but did not cover unqualified lookup. This broke clients that attempted to reference CodingKeys without qualification in files that were not the primary file where Codable synthesis usually takes place. This patch restore the behavior of the previous compiler by allowing unqualified lookup for CodingKeys to succeed once again.
* **Scope**: SR-13137 was reported by the maintainer of a very popular open source SQLite library - GRDB. That maintainer reports that a common mode of use of this library has been impacted by this regression. This library enjoys a large following, so the scope of the impact of this regression has the potential to be rather large. 
* **Risk**: Very Low. The fix to restore the old compiler’s behavior is extremely narrow. 
* **Issue**: rdar://problem/65088901
* **Testing**: Added regression tests from SR
* **Reviewer**: Doug Gregor