### PR TITLE
[CSGen] Abort constraint generation on error only if closure part…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2784,10 +2784,17 @@ namespace {
           return { true, expr };
         }
       } collectVarRefs(CS);
+
       closure->walk(collectVarRefs);
 
-      if (collectVarRefs.hasErrorExprs)
+      // If walker discovered error expressions, let's fail constraint
+      // genreation only if closure is going to participate
+      // in the type-check. This allows us to delay validation of
+      // multi-statement closures until body is opened.
+      if (shouldTypeCheckInEnclosingExpression(closure) &&
+          collectVarRefs.hasErrorExprs) {
         return Type();
+      }
 
       auto inferredType = inferClosureType(closure);
       if (!inferredType || inferredType->hasError())

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -141,6 +141,7 @@ func anonymousClosureArgsInClosureWithArgs() {
   var a5 = { (_: [Int], w: [Int]) in
     f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
     f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}}
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
   }
 }
 


### PR DESCRIPTION
…icipates in type-check

If reference collection discovered at least `ErrorExpr` in the body
of a closure, let's fail constraint generation only if it's a
single-statement closure, decision about multi-statement closures
should be delayed until body is opened.

This helps code completion because `ErrorExpr` could belong to
a statement unrelated to a completion, so it wouldn't affect
its correctness in any way.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
