### PR TITLE
[5.3][ModuleInterface] Don't print extensions to implementation-only imported types

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -107,8 +107,8 @@ public:
   /// Find all SPI names imported from \p importedModule by this module,
   /// collecting the identifiers in \p spiGroups.
   virtual void lookupImportedSPIGroups(
-                               const ModuleDecl *importedModule,
-                               SmallVectorImpl<Identifier> &spiGroups) const {};
+                            const ModuleDecl *importedModule,
+                            SmallSetVector<Identifier, 4> &spiGroups) const {};
 
 protected:
   /// Look up an operator declaration. Do not call directly, use

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -575,8 +575,9 @@ public:
 
   /// Find all SPI names imported from \p importedModule by this module,
   /// collecting the identifiers in \p spiGroups.
-  void lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                          SmallVectorImpl<Identifier> &spiGroups) const;
+  void lookupImportedSPIGroups(
+                         const ModuleDecl *importedModule,
+                         llvm::SmallSetVector<Identifier, 4> &spiGroups) const;
 
   /// \sa getImportedModules
   enum class ImportFilterKind {

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -612,6 +612,12 @@ public:
   void
   getImportedModulesForLookup(SmallVectorImpl<ImportedModule> &imports) const;
 
+  /// Has \p module been imported via an '@_implementationOnly' import
+  /// instead of another kind of import?
+  ///
+  /// This assumes that \p module was imported.
+  bool isImportedImplementationOnly(const ModuleDecl *module) const;
+
   /// Uniques the items in \p imports, ignoring the source locations of the
   /// access paths.
   ///

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -365,8 +365,9 @@ public:
   /// Find all SPI names imported from \p importedModule by this file,
   /// collecting the identifiers in \p spiGroups.
   virtual void
-  lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                         SmallVectorImpl<Identifier> &spiGroups) const override;
+  lookupImportedSPIGroups(
+                const ModuleDecl *importedModule,
+                llvm::SmallSetVector<Identifier, 4> &spiGroups) const override;
 
   // Is \p targetDecl accessible as an explictly imported SPI from this file?
   bool isImportedAsSPI(const ValueDecl *targetDecl) const;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -359,8 +359,9 @@ public:
          SmallVectorImpl<AbstractFunctionDecl *> &results) const override;
 
   virtual void
-  lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                         SmallVectorImpl<Identifier> &spiGroups) const override;
+  lookupImportedSPIGroups(
+                const ModuleDecl *importedModule,
+                llvm::SmallSetVector<Identifier, 4> &spiGroups) const override;
 
   Optional<CommentInfo> getCommentForDecl(const Decl *D) const override;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -168,6 +168,14 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(bool preferTypeRepr,
       if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
         if (!shouldPrint(ED->getExtendedNominal(), options))
           return false;
+
+        // Skip extensions to implementation-only imported types.
+        auto localModule = ED->getParentModule();
+        auto nominalModule = ED->getExtendedNominal()->getParentModule();
+        if (localModule != nominalModule &&
+            localModule->isImportedImplementationOnly(nominalModule))
+          return false;
+
         for (const Requirement &req : ED->getGenericRequirements()) {
           if (!isPublicOrUsableFromInline(req.getFirstType()))
             return false;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -639,8 +639,9 @@ void ModuleDecl::lookupObjCMethods(
   FORWARD(lookupObjCMethods, (selector, results));
 }
 
-void ModuleDecl::lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                                    SmallVectorImpl<Identifier> &spiGroups) const {
+void ModuleDecl::lookupImportedSPIGroups(
+                        const ModuleDecl *importedModule,
+                        llvm::SmallSetVector<Identifier, 4> &spiGroups) const {
   FORWARD(lookupImportedSPIGroups, (importedModule, spiGroups));
 }
 
@@ -2190,31 +2191,29 @@ bool SourceFile::isImportedImplementationOnly(const ModuleDecl *module) const {
   return !imports.isImportedBy(module, getParentModule());
 }
 
-void SourceFile::lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                                    SmallVectorImpl<Identifier> &spiGroups) const {
+void SourceFile::lookupImportedSPIGroups(
+                        const ModuleDecl *importedModule,
+                        llvm::SmallSetVector<Identifier, 4> &spiGroups) const {
   for (auto &import : Imports) {
     if (import.importOptions.contains(ImportFlags::SPIAccessControl) &&
         importedModule == std::get<ModuleDecl*>(import.module)) {
       auto importedSpis = import.spiGroups;
-      spiGroups.append(importedSpis.begin(), importedSpis.end());
+      spiGroups.insert(importedSpis.begin(), importedSpis.end());
     }
   }
 }
 
 bool SourceFile::isImportedAsSPI(const ValueDecl *targetDecl) const {
   auto targetModule = targetDecl->getModuleContext();
-  SmallVector<Identifier, 4> importedSPIGroups;
+  llvm::SmallSetVector<Identifier, 4> importedSPIGroups;
   lookupImportedSPIGroups(targetModule, importedSPIGroups);
   if (importedSPIGroups.empty()) return false;
 
   auto declSPIGroups = targetDecl->getSPIGroups();
 
-  // Note: If we reach a point where there are many SPI imports or SPI groups
-  // on decls we could optimize this further by using a set.
-  for (auto importedSPI : importedSPIGroups)
-    for (auto declSPI : declSPIGroups)
-      if (importedSPI == declSPI)
-        return true;
+  for (auto declSPI : declSPIGroups)
+    if (importedSPIGroups.count(declSPI))
+      return true;
 
   return false;
 }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -139,7 +139,7 @@ static void printImports(raw_ostream &out,
       continue;
     }
 
-    llvm::SmallVector<Identifier, 4> spis;
+    llvm::SmallSetVector<Identifier, 4> spis;
     M->lookupImportedSPIGroups(importedModule, spis);
 
     // Only print implementation-only imports which have an SPI import.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2665,13 +2665,14 @@ void ModuleFile::lookupObjCMethods(
   }
 }
 
-void ModuleFile::lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                                    SmallVectorImpl<Identifier> &spiGroups) const {
+void ModuleFile::lookupImportedSPIGroups(
+                        const ModuleDecl *importedModule,
+                        llvm::SmallSetVector<Identifier, 4> &spiGroups) const {
   for (auto &dep : Dependencies) {
     auto depSpis = dep.spiGroups;
     if (dep.Import.second == importedModule &&
         !depSpis.empty()) {
-      spiGroups.append(depSpis.begin(), depSpis.end());
+      spiGroups.insert(depSpis.begin(), depSpis.end());
     }
   }
 }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -816,8 +816,9 @@ public:
 
   /// Find all SPI names imported from \p importedModule by this module,
   /// collecting the identifiers in \p spiGroups.
-  void lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                              SmallVectorImpl<Identifier> &spiGroups) const;
+  void lookupImportedSPIGroups(
+                         const ModuleDecl *importedModule,
+                         llvm::SmallSetVector<Identifier, 4> &spiGroups) const;
 
   /// Reports all link-time dependencies.
   void collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1085,7 +1085,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
     else
       stableImportControl = ImportControl::ImplementationOnly;
 
-    SmallVector<Identifier, 4> spis;
+    llvm::SmallSetVector<Identifier, 4> spis;
     M->lookupImportedSPIGroups(import.second, spis);
 
     ImportedModule.emit(ScratchRecord,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1149,8 +1149,9 @@ void SerializedASTFile::lookupObjCMethods(
   File.lookupObjCMethods(selector, results);
 }
 
-void SerializedASTFile::lookupImportedSPIGroups(const ModuleDecl *importedModule,
-                                           SmallVectorImpl<Identifier> &spiGroups) const {
+void SerializedASTFile::lookupImportedSPIGroups(
+                        const ModuleDecl *importedModule,
+                        llvm::SmallSetVector<Identifier, 4> &spiGroups) const {
   File.lookupImportedSPIGroups(importedModule, spiGroups);
 }
 

--- a/test/ModuleInterface/empty-extension.swift
+++ b/test/ModuleInterface/empty-extension.swift
@@ -1,0 +1,49 @@
+// Test that we don't print extensions to implementation-only imported types.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %s -DIOI_LIB -module-name IOILib -emit-module-path %t/IOILib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %s -DEXPORTED_LIB -module-name IndirectLib -emit-module-path %t/IndirectLib.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module %s -DLIB -module-name Lib -emit-module-path %t/Lib.swiftmodule -I %t
+
+// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/out.swiftinterface %s -I %t -swift-version 5 -enable-library-evolution
+// RUN: %FileCheck %s < %t/out.swiftinterface
+
+#if IOI_LIB
+
+public struct IOIImportedType {
+  public func foo() {}
+}
+
+#elseif EXPORTED_LIB
+
+public struct ExportedType {
+  public func foo() {}
+}
+
+#elseif LIB
+
+@_exported import IndirectLib
+
+public struct NormalImportedType {
+  public func foo() {}
+}
+
+#else // Client
+
+import Lib
+@_implementationOnly import IOILib
+
+public protocol PublicProto {
+  func foo()
+}
+extension IOIImportedType : PublicProto {}
+// CHECK-NOT: IOIImportedType
+
+extension NormalImportedType : PublicProto {}
+// CHECK: extension NormalImportedType
+
+extension ExportedType : PublicProto {}
+// CHECK: extension ExportedType
+
+#endif

--- a/test/SPI/Inputs/ioi_helper.swift
+++ b/test/SPI/Inputs/ioi_helper.swift
@@ -1,0 +1,1 @@
+public struct IOIPublicStruct {}

--- a/test/SPI/experimental_spi_imports_swiftinterface.swift
+++ b/test/SPI/experimental_spi_imports_swiftinterface.swift
@@ -4,7 +4,7 @@
 
 /// Generate 3 empty modules.
 // RUN: touch %t/empty.swift
-// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name ExperimentalImported -emit-module-path %t/ExperimentalImported.swiftmodule -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %S/Inputs/ioi_helper.swift -module-name ExperimentalImported -emit-module-path %t/ExperimentalImported.swiftmodule -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name IOIImported -emit-module-path %t/IOIImported.swiftmodule -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name SPIImported -emit-module-path %t/SPIImported.swiftmodule -swift-version 5 -enable-library-evolution
 
@@ -24,3 +24,10 @@
 @_spi(dummy) import SPIImported
 // CHECK-PUBLIC: {{^}}import SPIImported
 // CHECK-PRIVATE: @_spi{{.*}} import SPIImported
+
+@_spi(X)
+extension IOIPublicStruct {
+  public func foo() {}
+}
+// CHECK-PUBLIC-NOT: IOIPublicStruct
+// CHECK-PRIVATE: @_spi{{.*}} extension IOIPublicStruct

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -21,7 +21,7 @@
 // RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/merged.swiftinterface
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/merged.private.swiftinterface
 
-@_spi(HelperSPI) @_spi(OtherSPI) import SPIHelper
+@_spi(HelperSPI) @_spi(OtherSPI) @_spi(OtherSPI) import SPIHelper
 // CHECK-PUBLIC: import SPIHelper
 // CHECK-PRIVATE: @_spi(OtherSPI) @_spi(HelperSPI) import SPIHelper
 

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -3,6 +3,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/spi_helper.swift -module-name SPIHelper -emit-module-path %t/SPIHelper.swiftmodule -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/SPIHelper.swiftinterface -emit-private-module-interface-path %t/SPIHelper.private.swiftinterface
+// RUN: %target-swift-frontend -emit-module %S/Inputs/ioi_helper.swift -module-name IOIHelper -emit-module-path %t/IOIHelper.swiftmodule -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/IOIHelper.swiftinterface -emit-private-module-interface-path %t/IOIHelper.private.swiftinterface
 
 /// Make sure that the public swiftinterface of spi_helper doesn't leak SPI.
 // RUN: %FileCheck -check-prefix=CHECK-HELPER %s < %t/SPIHelper.swiftinterface
@@ -25,6 +26,7 @@
 // CHECK-PUBLIC: import SPIHelper
 // CHECK-PRIVATE: @_spi(OtherSPI) @_spi(HelperSPI) import SPIHelper
 
+@_implementationOnly import IOIHelper
 public func foo() {}
 // CHECK-PUBLIC: foo()
 // CHECK-PRIVATE: foo()
@@ -154,6 +156,11 @@ private protocol PrivateConstraint {}
 extension PublicType: SPIProto2 where T: SPIProto2 {}
 // CHECK-PRIVATE: extension PublicType : {{.*}}.SPIProto2 where T : {{.*}}.SPIProto2
 // CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
+
+public protocol LocalPublicProto {}
+extension IOIPublicStruct : LocalPublicProto {}
+// CHECK-PRIVATE-NOT: IOIPublicStruct
+// CHECK-PUBLIC-NOT: IOIPublicStruct
 
 // The dummy conformance should be only in the private swiftinterface for
 // SPI extensions.


### PR DESCRIPTION
Extensions to implementation-only imported types are accepted during type-checking only if they don't define any public members. However if they declared a conformance to a public type they were also printed in the swiftinterface, making it unparsable because of an unknown type. Address this by still accepting such extensions but don't print them in the swiftinterface.

* Scope: This is affecting one Swift framework and potentially other users of the `@_implementationOnly` attribute.
* Risk: Low. This prints less extensions in the swiftinterfaces, but the removed extensions would all have been invalid. The check is also restricted to extensions without public members to avoid affecting some SPI use cases.
* Origination: The introduction of `@_implementationOnly`.
* Resolves: rdar://67516588
* Cherry-pick of #33575
* Testing: Added a test and manually diffed the generated swiftinterface for Swift frameworks.