### PR TITLE
[AutoDiff] Make `Optional.TangentVector.zero` return `.init(nil)`.

### DIFF
--- a/stdlib/public/Differentiation/OptionalDifferentiation.swift
+++ b/stdlib/public/Differentiation/OptionalDifferentiation.swift
@@ -23,7 +23,7 @@ extension Optional: Differentiable where Wrapped: Differentiable {
     }
 
     public static var zero: Self {
-      return Self(.zero)
+      return Self(nil)
     }
 
     public static func + (lhs: Self, rhs: Self) -> Self {

--- a/test/AutoDiff/stdlib/optional.swift
+++ b/test/AutoDiff/stdlib/optional.swift
@@ -64,11 +64,11 @@ OptionalDifferentiationTests.test("Optional.TangentVector operations") {
   }
 
   // AdditiveArithmetic.zero
-  expectEqual(.init(Float.zero), Float?.TangentVector.zero)
-  expectEqual(.init([Float].TangentVector.zero), [Float]?.TangentVector.zero)
+  expectEqual(.init(nil), Float?.TangentVector.zero)
+  expectEqual(.init(nil), [Float]?.TangentVector.zero)
 
-  expectEqual(.init(.init(Float.zero)), Float??.TangentVector.zero)
-  expectEqual(.init(.init([Float].TangentVector.zero)), [Float]??.TangentVector.zero)
+  expectEqual(.init(nil), Float??.TangentVector.zero)
+  expectEqual(.init(nil), [Float]??.TangentVector.zero)
 
   // AdditiveArithmetic.+, AdditiveArithmetic.-
   do {

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -28,7 +28,7 @@ OptionalTests.test("Let") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_let), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_let), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_let), .init(nil))
 
   @differentiable
   func optional_let_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -38,7 +38,7 @@ OptionalTests.test("Let") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_let_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_let_tracked), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_let_tracked), .init(nil))
 
   @differentiable
   func optional_let_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
@@ -52,7 +52,7 @@ OptionalTests.test("Let") {
   expectEqual(
     gradient(at: 10, in: optional_let_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_let_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, in: optional_let_nonresilient_tracked), .init(nil))
 
   @differentiable
   func optional_let_nested(_ nestedMaybeX: Float??) -> Float {
@@ -65,7 +65,7 @@ OptionalTests.test("Let") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_let_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_let_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: nil, in: optional_let_nested), .init(nil))
 
   @differentiable
   func optional_let_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<
@@ -82,7 +82,7 @@ OptionalTests.test("Let") {
   expectEqual(
     gradient(at: 10, in: optional_let_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_let_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, in: optional_let_nested_tracked), .init(nil))
 
   @differentiable
   func optional_let_nested_nonresilient_tracked(
@@ -101,7 +101,7 @@ OptionalTests.test("Let") {
     .init(.init(20.0)))
   expectEqual(
     gradient(at: nil, in: optional_let_nested_nonresilient_tracked),
-    .init(.init(0.0)))
+    .init(nil))
 
   @differentiable
   func optional_let_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T)
@@ -114,7 +114,7 @@ OptionalTests.test("Let") {
   }
   expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, in: optional_let_generic), (.init(nil), 1.0))
 
   expectEqual(
     gradient(
@@ -122,7 +122,7 @@ OptionalTests.test("Let") {
       in: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(
     gradient(at: nil, Tracked<Float>.init(20), in: optional_let_generic),
-    (.init(0.0), 1.0))
+    (.init(nil), 1.0))
 
   @differentiable
   func optional_let_nested_generic<T: Differentiable>(
@@ -142,7 +142,7 @@ OptionalTests.test("Let") {
     (.init(.init(1.0)), 0.0))
   expectEqual(
     gradient(at: nil, 20, in: optional_let_nested_generic),
-    (.init(.init(0.0)), 1.0))
+    (.init(nil), 1.0))
 }
 
 OptionalTests.test("Switch") {
@@ -154,7 +154,7 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(gradient(at: 10, in: optional_switch), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_switch), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_switch), .init(nil))
 
   @differentiable
   func optional_switch_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -164,7 +164,7 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(gradient(at: 10, in: optional_switch_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_switch_tracked), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_switch_tracked), .init(nil))
 
   @differentiable
   func optional_switch_nonresilient_tracked(
@@ -178,7 +178,7 @@ OptionalTests.test("Switch") {
   expectEqual(
     gradient(at: 10, in: optional_switch_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_switch_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, in: optional_switch_nonresilient_tracked), .init(nil))
 
   @differentiable
   func optional_switch_nested(_ nestedMaybeX: Float??) -> Float {
@@ -192,7 +192,7 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(gradient(at: 10, in: optional_switch_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_switch_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: nil, in: optional_switch_nested), .init(nil))
 
   @differentiable
   func optional_switch_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
@@ -210,7 +210,7 @@ OptionalTests.test("Switch") {
   expectEqual(
     gradient(at: 10, in: optional_switch_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_switch_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, in: optional_switch_nested_tracked), .init(nil))
 
   @differentiable
   func optional_switch_nested_nonresilient_tracked(
@@ -230,7 +230,7 @@ OptionalTests.test("Switch") {
     .init(.init(20.0)))
   expectEqual(
     gradient(at: nil, in: optional_switch_nested_nonresilient_tracked),
-    .init(.init(0.0)))
+    .init(nil))
 
   @differentiable
   func optional_switch_generic<T: Differentiable>(
@@ -244,7 +244,7 @@ OptionalTests.test("Switch") {
   expectEqual(
     gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, in: optional_switch_generic), (.init(nil), 1.0))
 
   @differentiable
   func optional_switch_nested_generic<T: Differentiable>(
@@ -264,7 +264,7 @@ OptionalTests.test("Switch") {
     (.init(.init(1.0)), 0.0))
   expectEqual(
     gradient(at: nil, 20, in: optional_switch_nested_generic),
-    (.init(.init(0.0)), 1.0))
+    (.init(nil), 1.0))
 }
 
 OptionalTests.test("Var1") {
@@ -277,7 +277,7 @@ OptionalTests.test("Var1") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var1), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var1), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_var1), .init(nil))
 
   @differentiable
   func optional_var1_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -288,7 +288,7 @@ OptionalTests.test("Var1") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var1_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var1_tracked), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_var1_tracked), .init(nil))
 
   @differentiable
   func optional_var1_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
@@ -303,7 +303,7 @@ OptionalTests.test("Var1") {
   expectEqual(
     gradient(at: 10, in: optional_var1_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_var1_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, in: optional_var1_nonresilient_tracked), .init(nil))
 
   @differentiable
   func optional_var1_nested(_ nestedMaybeX: Float??) -> Float {
@@ -317,7 +317,7 @@ OptionalTests.test("Var1") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var1_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_var1_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: nil, in: optional_var1_nested), .init(nil))
 
   @differentiable
   func optional_var1_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
@@ -335,7 +335,7 @@ OptionalTests.test("Var1") {
   expectEqual(
     gradient(at: 10, in: optional_var1_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_var1_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, in: optional_var1_nested_tracked), .init(nil))
 
   @differentiable
   func optional_var1_nested_nonresilient_tracked(
@@ -355,7 +355,7 @@ OptionalTests.test("Var1") {
     .init(.init(20.0)))
   expectEqual(
     gradient(at: nil, in: optional_var1_nested_nonresilient_tracked),
-    .init(.init(0.0)))
+    .init(nil))
 
   @differentiable
   func optional_var1_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T)
@@ -370,7 +370,7 @@ OptionalTests.test("Var1") {
   expectEqual(
     gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, in: optional_var1_generic), (.init(nil), 1.0))
 
   @differentiable
   func optional_var1_nested_generic<T: Differentiable>(
@@ -390,7 +390,7 @@ OptionalTests.test("Var1") {
     (.init(.init(1.0)), 0.0))
   expectEqual(
     gradient(at: nil, 20, in: optional_var1_nested_generic),
-    (.init(.init(0.0)), 1.0))
+    (.init(nil), 1.0))
 }
 
 OptionalTests.test("Var2") {
@@ -402,7 +402,7 @@ OptionalTests.test("Var2") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var2), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var2), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_var2), .init(nil))
 
   @differentiable
   func optional_var2_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -412,7 +412,7 @@ OptionalTests.test("Var2") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var2_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var2_tracked), .init(0.0))
+  expectEqual(gradient(at: nil, in: optional_var2_tracked), .init(nil))
 
   @differentiable
   func optional_var2_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
@@ -426,7 +426,7 @@ OptionalTests.test("Var2") {
   expectEqual(
     gradient(at: 10, in: optional_var2_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_var2_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, in: optional_var2_nonresilient_tracked), .init(nil))
 
   @differentiable
   func optional_var2_nested(_ nestedMaybeX: Float??) -> Float {
@@ -439,7 +439,7 @@ OptionalTests.test("Var2") {
     return 10
   }
   expectEqual(gradient(at: 10, in: optional_var2_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_var2_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: nil, in: optional_var2_nested), .init(nil))
 
   @differentiable
   func optional_var2_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
@@ -456,7 +456,7 @@ OptionalTests.test("Var2") {
   expectEqual(
     gradient(at: 10, in: optional_var2_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_var2_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, in: optional_var2_nested_tracked), .init(nil))
 
   @differentiable
   func optional_var2_nested_nonresilient_tracked(
@@ -475,7 +475,7 @@ OptionalTests.test("Var2") {
     .init(.init(20.0)))
   expectEqual(
     gradient(at: nil, in: optional_var2_nested_nonresilient_tracked),
-    .init(.init(0.0)))
+    .init(nil))
 
   @differentiable
   func optional_var2_generic<T: Differentiable>(_ maybeX: T?, _ defaultValue: T)
@@ -489,7 +489,7 @@ OptionalTests.test("Var2") {
   expectEqual(
     gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, in: optional_var2_generic), (.init(nil), 1.0))
 
   @differentiable
   func optional_var2_nested_generic<T: Differentiable>(
@@ -508,7 +508,7 @@ OptionalTests.test("Var2") {
     (.init(.init(1.0)), 0.0))
   expectEqual(
     gradient(at: nil, 20, in: optional_var2_nested_generic),
-    (.init(.init(0.0)), 1.0))
+    (.init(nil), 1.0))
 }
 
 runAllTests()


### PR DESCRIPTION
Previously, `Optional.TangentVector.zero` returned `.init(Wrapped.TangentVector.zero)`.

Now, it returns `.init(nil)`, which is more efficient. `Optional.TangentVector`
still upholds the `AdditiveArithmetic` monoid laws, e.g. `x + .zero = x`.

---

Example:

```swift
import _Differentiation

print(Float?.TangentVector.zero)
// Before: TangentVector(value: Optional(0.0))
// After: TangentVector(value: nil)

print(Float??.TangentVector.zero)
// Before: TangentVector(value: Optional((extension in _Differentiation):Swift.Optional<Swift.Float>.TangentVector(value: Optional(0.0))))
// After: TangentVector(value: nil)
```