### PR TITLE
[Package] When building a toolchain, don't copy the Resource directory.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1234,6 +1234,11 @@ verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
 
+# When producing a package, don't copy the Swift Resource/ directory.
+# This is mainly a space optimization.
+extra-cmake-options=
+   -DLLDB_FRAMEWORK_COPY_SWIFT_RESOURCES=0
+
 install-llvm
 install-swift
 install-lldb


### PR DESCRIPTION
Should dramatically improve the size of the snapshost produced,
as we don't have stdlib et similia included twice. Also, it helps when
producing fat binaries, as we don't have to implement any mechanism
for sandwiching all the slices together.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
