### PR TITLE
[CodeCompletion] Do not offer completion Wrapped members for optional key path root type

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3725,8 +3725,12 @@ public:
       llvm::SaveAndRestore<bool> ChangeNeedOptionalUnwrap(NeedOptionalUnwrap,
                                                           true);
       if (DotLoc.isValid()) {
+        // Let's not erase the dot if the completion is after a swift key path
+        // root because \A?.?.member is the correct way to access wrapped type
+        // member from an optional key path root.
+        auto loc = IsAfterSwiftKeyPathRoot ? DotLoc.getAdvancedLoc(1) : DotLoc;
         NumBytesToEraseForOptionalUnwrap = Ctx.SourceMgr.getByteDistance(
-            DotLoc, Ctx.SourceMgr.getCodeCompletionLoc());
+            loc, Ctx.SourceMgr.getCodeCompletionLoc());
       } else {
         NumBytesToEraseForOptionalUnwrap = 0;
       }
@@ -5930,7 +5934,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (!OnRoot && KPE->getComponents().back().getKind() ==
                        KeyPathExpr::Component::Kind::OptionalWrap) {
       // KeyPath expr with '?' (e.g. '\Ty.[0].prop?.another').
-      // Althogh expected type is optional, we should unwrap it because it's
+      // Although expected type is optional, we should unwrap it because it's
       // unwrapped.
       baseType = baseType->getOptionalObjectType();
     }

--- a/test/IDE/complete_swift_key_path_optional_root.swift
+++ b/test/IDE/complete_swift_key_path_optional_root.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_INFER_DOT_OPTIONAL | %FileCheck %s -check-prefix=PERSONTYPE-INFER-DOT-OPT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_DOT_OPTIONAL | %FileCheck %s -check-prefix=PERSONTYPE-DOT-OPT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_DOT_OPTIONAL_SPACE | %FileCheck %s -check-prefix=PERSONTYPE-DOT-OPT-SPACE
+
+class Person {
+    var name: String
+    var friends: [Person] = []
+    var bestFriend: Person? = nil
+    var itself: Person { return self }
+    init(name: String) {
+        self.name = name
+    }
+    func getName() -> String { return name }
+    subscript(_ index: Int) -> Int { get { return 1} }
+}
+
+extension Optional {
+    var optMember: String { "member" }
+}
+
+let _ : KeyPath<Person?, String> = \.#^TYPE_INFER_DOT_OPTIONAL^#
+// PERSONTYPE-INFER-DOT-OPT: Begin completions, 9 items
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.name[#String#]; name=name
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.friends[#[Person]#]; name=friends
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.bestFriend[#Person?#]; name=bestFriend
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.itself[#Person#]; name=itself
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[Subscript]/CurrNominal:     ?[{#(index): Int#}][#Int#]; name=[index: Int]
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:            optMember[#String#]; name=optMember
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   debugDescription[#String#]; name=debugDescription
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   customMirror[#Mirror#]; name=customMirror
+
+let _ : KeyPath<Person?, String> = \Person?.#^TYPE_DOT_OPTIONAL^#
+// PERSONTYPE-DOT-OPT: Begin completions, 9 items
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.name[#String#]; name=name
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.friends[#[Person]#]; name=friends
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.bestFriend[#Person?#]; name=bestFriend
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.itself[#Person#]; name=itself
+// PERSONTYPE-DOT-OPT-NEXT: Decl[Subscript]/CurrNominal:     ?[{#(index): Int#}][#Int#]; name=[index: Int]
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:            optMember[#String#]; name=optMember
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   debugDescription[#String#]; name=debugDescription
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   customMirror[#Mirror#]; name=customMirror
+
+let _ : KeyPath<Person?, String> = \Person?. #^TYPE_DOT_OPTIONAL_SPACE^#
+// PERSONTYPE-DOT-OPT-SPACE: Begin completions, 9 items
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.name[#String#]; name=name
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.friends[#[Person]#]; name=friends
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.bestFriend[#Person?#]; name=bestFriend
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.itself[#Person#]; name=itself
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[Subscript]/CurrNominal/Erase[1]:     ?[{#(index): Int#}][#Int#]; name=[index: Int]
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal:            optMember[#String#]; name=optMember
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   debugDescription[#String#]; name=debugDescription
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   customMirror[#Mirror#]; name=customMirror


### PR DESCRIPTION
<!-- What's in this pull request? -->
As described on the SR code completion is offering wrapped member for optional root key path type, which leads to invalid completions in some situations because using key path optional root to access wrapped members is invalid. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13426.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
