### PR TITLE
[SILGen] Emit unreachable code diagnostic for single expression closures with implicit returns too

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -292,7 +292,23 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
       // If this is an implicit statement or expression, just skip over it,
       // don't emit a diagnostic here.
       if (auto *S = ESD.dyn_cast<Stmt*>()) {
-        if (S->isImplicit()) continue;
+        // Return statement in a single-expression closure or function is
+        // implicit, but the result isn't. So, skip over return statements
+        // that are implicit and either have no results or the result is
+        // implicit. Otherwise, don't so we can emit unreachable code
+        // diagnostics.
+        if (S->isImplicit() && isa<ReturnStmt>(S)) {
+          auto returnStmt = cast<ReturnStmt>(S);
+          if (!returnStmt->hasResult()) {
+            continue;
+          }
+          if (returnStmt->getResult()->isImplicit()) {
+            continue;
+          }
+        }
+        if (S->isImplicit() && !isa<ReturnStmt>(S)) {
+          continue;
+        }
       } else if (auto *E = ESD.dyn_cast<Expr*>()) {
         // Optional chaining expressions are wrapped in a structure like.
         //

--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -9,6 +9,16 @@ func foo(baz: Never) -> Int { // expected-note {{'baz' is uninhabited, so this f
 
 func bar(baz: Never) -> Int {} // ok
 
+// SR-13432
+func map<T>(_ block: (Never) -> T) {}
+map { arg in // expected-note {{'arg' is uninhabited, so this function body can never be executed}}
+  5 // expected-warning {{will never be executed}}
+}
+
+map { arg in // expected-note {{'arg' is uninhabited, so this function body can never be executed}}
+  return 5 // expected-warning {{will never be executed}}
+}
+
 // We used to crash when emitting the closure below.
 enum E {
   static func f(_: E) {}

--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -25,3 +25,5 @@ enum E {
 }
 
 let _: (E.Type) -> (E) -> () = { s in { e in s.f(e) } }
+// expected-warning@-1 {{will never be executed}}
+// expected-note@-2 {{'e' is uninhabited, so this function body can never be executed}}


### PR DESCRIPTION
We don't emit unreachable code diagnostic for single expression closures if it has an implicit return. For example:

```swift
func map<T>(_ block: (Never) -> T) {}
map { _ in return 5 } // warning: will never be executed
map { _ in 5 } // no warning
```

This is because we skip implicit statements in SILGen if we encounter an unreachable location.

For implicit return statements in single expression closure or functions, the result expression is not implicit. So, let's use this knowledge to prevent skipping over the return statement.

---

Resolves SR-13432