### PR TITLE
Fixes example snippet in Array.swift

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -264,7 +264,7 @@
 ///     let colors = ["periwinkle", "rose", "moss"]
 ///     let moreColors: [String?] = ["ochre", "pine"]
 ///
-///     let url = NSURL(fileURLWithPath: "names.plist")
+///     let url = URL(fileURLWithPath: "names.plist")
 ///     (colors as NSArray).write(to: url, atomically: true)
 ///     // true
 ///


### PR DESCRIPTION
Uses URL instead of NSURL, otherwise example doesn't compile

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
