### PR TITLE
[AutoDiff] Fix PullbackCloner tangent value category mismatch issues.

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -538,6 +538,8 @@ static CanSILFunctionType getAutoDiffPullbackType(
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());
     ParameterConvention conv;
     switch (origResConv) {
+    case ResultConvention::Unowned:
+    case ResultConvention::UnownedInnerPointer:
     case ResultConvention::Owned:
     case ResultConvention::Autoreleased:
       if (tl.isAddressOnly()) {
@@ -546,10 +548,6 @@ static CanSILFunctionType getAutoDiffPullbackType(
         conv = tl.isTrivial() ? ParameterConvention::Direct_Unowned
                               : ParameterConvention::Direct_Guaranteed;
       }
-      break;
-    case ResultConvention::Unowned:
-    case ResultConvention::UnownedInnerPointer:
-      conv = ParameterConvention::Direct_Unowned;
       break;
     case ResultConvention::Indirect:
       conv = ParameterConvention::Indirect_In_Guaranteed;

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -557,6 +557,8 @@ void DifferentiableActivityInfo::dump(SILAutoDiffIndices indices,
     for (auto &inst : bb)
       for (auto res : inst.getResults())
         dump(res, indices, s);
-    s << '\n';
+    if (std::next(bb.getIterator()) != fn.end())
+      s << '\n';
   }
+  s << "End activity info for " << fn.getName() << " at " << indices << "\n\n";
 }

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1011,28 +1011,68 @@ public:
     auto *bb = si->getParent();
     auto loc = si->getLoc();
     auto *structDecl = si->getStructDecl();
-    auto av = getAdjointValue(bb, si);
-    switch (av.getKind()) {
-    case AdjointValueKind::Zero:
-      for (auto *field : structDecl->getStoredProperties()) {
-        auto fv = si->getFieldValue(field);
-        addAdjointValue(
-            bb, fv, makeZeroAdjointValue(getRemappedTangentType(fv->getType())),
-            loc);
+    switch (getTangentValueCategory(si)) {
+    case SILValueCategory::Object: {
+      auto av = getAdjointValue(bb, si);
+      switch (av.getKind()) {
+      case AdjointValueKind::Zero: {
+        for (auto *field : structDecl->getStoredProperties()) {
+          auto fv = si->getFieldValue(field);
+          addAdjointValue(
+              bb, fv,
+              makeZeroAdjointValue(getRemappedTangentType(fv->getType())), loc);
+        }
+        break;
       }
-      break;
-    case AdjointValueKind::Concrete: {
-      auto adjStruct = materializeAdjointDirect(std::move(av), loc);
-      auto *dti = builder.createDestructureStruct(si->getLoc(), adjStruct);
+      case AdjointValueKind::Concrete: {
+        auto adjStruct = materializeAdjointDirect(std::move(av), loc);
+        auto *dti = builder.createDestructureStruct(si->getLoc(), adjStruct);
 
-      // Find the struct `TangentVector` type.
-      auto structTy = remapType(si->getType()).getASTType();
+        // Find the struct `TangentVector` type.
+        auto structTy = remapType(si->getType()).getASTType();
 #ifndef NDEBUG
-      auto tangentVectorTy = getTangentSpace(structTy)->getCanonicalType();
-      assert(!getTypeLowering(tangentVectorTy).isAddressOnly());
-      assert(tangentVectorTy->getStructOrBoundGenericStruct());
+        auto tangentVectorTy = getTangentSpace(structTy)->getCanonicalType();
+        assert(!getTypeLowering(tangentVectorTy).isAddressOnly());
+        assert(tangentVectorTy->getStructOrBoundGenericStruct());
 #endif
 
+        // Accumulate adjoints for the fields of the `struct` operand.
+        unsigned fieldIndex = 0;
+        for (auto it = structDecl->getStoredProperties().begin();
+             it != structDecl->getStoredProperties().end();
+             ++it, ++fieldIndex) {
+          VarDecl *field = *it;
+          if (field->getAttrs().hasAttribute<NoDerivativeAttr>())
+            continue;
+          // Find the corresponding field in the tangent space.
+          auto *tanField = getTangentStoredProperty(
+              getContext(), field, structTy, loc, getInvoker());
+          if (!tanField) {
+            errorOccurred = true;
+            return;
+          }
+          auto tanElt = dti->getResult(fieldIndex);
+          addAdjointValue(bb, si->getFieldValue(field),
+                          makeConcreteAdjointValue(tanElt), si->getLoc());
+        }
+        break;
+      }
+      case AdjointValueKind::Aggregate: {
+        // Note: All user-called initializations go through the calls to the
+        // initializer, and synthesized initializers only have one level of
+        // struct formation which will not result into any aggregate adjoint
+        // valeus.
+        llvm_unreachable(
+            "Aggregate adjoint values should not occur for `struct` "
+            "instructions");
+      }
+      }
+      break;
+    }
+    case SILValueCategory::Address: {
+      auto adjBuf = getAdjointBuffer(bb, si);
+      // Find the struct `TangentVector` type.
+      auto structTy = remapType(si->getType()).getASTType();
       // Accumulate adjoints for the fields of the `struct` operand.
       unsigned fieldIndex = 0;
       for (auto it = structDecl->getStoredProperties().begin();
@@ -1047,19 +1087,25 @@ public:
           errorOccurred = true;
           return;
         }
-        auto tanElt = dti->getResult(fieldIndex);
-        addAdjointValue(bb, si->getFieldValue(field),
-                        makeConcreteAdjointValue(tanElt), si->getLoc());
+        auto *adjFieldBuf =
+            builder.createStructElementAddr(loc, adjBuf, tanField);
+        auto fieldValue = si->getFieldValue(field);
+        switch (getTangentValueCategory(fieldValue)) {
+        case SILValueCategory::Object: {
+          auto adjField = builder.emitLoadValueOperation(
+              loc, adjFieldBuf, LoadOwnershipQualifier::Copy);
+          recordTemporary(adjField);
+          addAdjointValue(bb, fieldValue, makeConcreteAdjointValue(adjField),
+                          loc);
+          break;
+        }
+        case SILValueCategory::Address: {
+          addToAdjointBuffer(bb, fieldValue, adjFieldBuf, loc);
+          break;
+        }
+        }
       }
-      break;
-    }
-    case AdjointValueKind::Aggregate: {
-      // Note: All user-called initializations go through the calls to the
-      // initializer, and synthesized initializers only have one level of struct
-      // formation which will not result into any aggregate adjoint valeus.
-      llvm_unreachable("Aggregate adjoint values should not occur for `struct` "
-                       "instructions");
-    }
+    } break;
     }
   }
 
@@ -1071,41 +1117,75 @@ public:
   void visitStructExtractInst(StructExtractInst *sei) {
     auto *bb = sei->getParent();
     auto loc = getValidLocation(sei);
-    auto structTy = remapType(sei->getOperand()->getType()).getASTType();
-    auto tangentVectorTy = getTangentSpace(structTy)->getCanonicalType();
-    assert(!getTypeLowering(tangentVectorTy).isAddressOnly());
-    auto tangentVectorSILTy = SILType::getPrimitiveObjectType(tangentVectorTy);
-    auto *tangentVectorDecl = tangentVectorTy->getStructOrBoundGenericStruct();
-    assert(tangentVectorDecl);
     // Find the corresponding field in the tangent space.
+    auto structTy = remapType(sei->getOperand()->getType()).getASTType();
     auto *tanField =
         getTangentStoredProperty(getContext(), sei, structTy, getInvoker());
-    assert(tanField && "Invalid projections should have been diagnosed");
-    // Accumulate adjoint for the `struct_extract` operand.
-    auto av = getAdjointValue(bb, sei);
-    switch (av.getKind()) {
-    case AdjointValueKind::Zero:
-      addAdjointValue(bb, sei->getOperand(),
-                      makeZeroAdjointValue(tangentVectorSILTy), loc);
-      break;
-    case AdjointValueKind::Concrete:
-    case AdjointValueKind::Aggregate: {
-      SmallVector<AdjointValue, 8> eltVals;
-      for (auto *field : tangentVectorDecl->getStoredProperties()) {
-        if (field == tanField) {
-          eltVals.push_back(av);
-        } else {
-          auto substMap = tangentVectorTy->getMemberSubstitutionMap(
-              field->getModuleContext(), field);
-          auto fieldTy = field->getType().subst(substMap);
-          auto fieldSILTy = getTypeLowering(fieldTy).getLoweredType();
-          assert(fieldSILTy.isObject());
-          eltVals.push_back(makeZeroAdjointValue(fieldSILTy));
+    // Check the `struct_extract` operand's value tangent category.
+    switch (getTangentValueCategory(sei->getOperand())) {
+    case SILValueCategory::Object: {
+      auto tangentVectorTy = getTangentSpace(structTy)->getCanonicalType();
+      auto *tangentVectorDecl =
+          tangentVectorTy->getStructOrBoundGenericStruct();
+      assert(tangentVectorDecl);
+      auto tangentVectorSILTy =
+          SILType::getPrimitiveObjectType(tangentVectorTy);
+      assert(tanField && "Invalid projections should have been diagnosed");
+      // Accumulate adjoint for the `struct_extract` operand.
+      auto av = getAdjointValue(bb, sei);
+      switch (av.getKind()) {
+      case AdjointValueKind::Zero:
+        addAdjointValue(bb, sei->getOperand(),
+                        makeZeroAdjointValue(tangentVectorSILTy), loc);
+        break;
+      case AdjointValueKind::Concrete:
+      case AdjointValueKind::Aggregate: {
+        SmallVector<AdjointValue, 8> eltVals;
+        for (auto *field : tangentVectorDecl->getStoredProperties()) {
+          if (field == tanField) {
+            eltVals.push_back(av);
+          } else {
+            auto substMap = tangentVectorTy->getMemberSubstitutionMap(
+                field->getModuleContext(), field);
+            auto fieldTy = field->getType().subst(substMap);
+            auto fieldSILTy = getTypeLowering(fieldTy).getLoweredType();
+            assert(fieldSILTy.isObject());
+            eltVals.push_back(makeZeroAdjointValue(fieldSILTy));
+          }
         }
+        addAdjointValue(bb, sei->getOperand(),
+                        makeAggregateAdjointValue(tangentVectorSILTy, eltVals),
+                        loc);
       }
-      addAdjointValue(bb, sei->getOperand(),
-                      makeAggregateAdjointValue(tangentVectorSILTy, eltVals),
-                      loc);
+      }
+      break;
+    }
+    case SILValueCategory::Address: {
+      auto adjBase = getAdjointBuffer(bb, sei->getOperand());
+      auto *adjBaseElt =
+          builder.createStructElementAddr(loc, adjBase, tanField);
+      // Check the `struct_extract`'s value tangent category.
+      switch (getTangentValueCategory(sei)) {
+      case SILValueCategory::Object: {
+        auto adjElt = getAdjointValue(bb, sei);
+        auto concreteAdjElt = materializeAdjointDirect(adjElt, loc);
+        auto concreteAdjEltCopy =
+            builder.emitCopyValueOperation(loc, concreteAdjElt);
+        auto *alloc = builder.createAllocStack(loc, adjElt.getType());
+        builder.emitStoreValueOperation(loc, concreteAdjEltCopy, alloc,
+                                        StoreOwnershipQualifier::Init);
+        accumulateIndirect(adjBaseElt, alloc, loc);
+        builder.createDestroyAddr(loc, alloc);
+        builder.createDeallocStack(loc, alloc);
+        break;
+      }
+      case SILValueCategory::Address: {
+        auto adjElt = getAdjointBuffer(bb, sei);
+        accumulateIndirect(adjBaseElt, adjElt, loc);
+        break;
+      }
+      }
+      break;
     }
     }
   }
@@ -1171,52 +1251,73 @@ public:
   ///                         excluding non-differentiable elements
   void visitTupleInst(TupleInst *ti) {
     auto *bb = ti->getParent();
-    auto av = getAdjointValue(bb, ti);
-    switch (av.getKind()) {
-    case AdjointValueKind::Zero:
-      for (auto elt : ti->getElements()) {
-        if (!getTangentSpace(elt->getType().getASTType()))
-          continue;
-        addAdjointValue(
-            bb, elt,
-            makeZeroAdjointValue(getRemappedTangentType(elt->getType())),
-            ti->getLoc());
+    auto loc = ti->getLoc();
+    switch (getTangentValueCategory(ti)) {
+    case SILValueCategory::Object: {
+      auto av = getAdjointValue(bb, ti);
+      switch (av.getKind()) {
+      case AdjointValueKind::Zero:
+        for (auto elt : ti->getElements()) {
+          if (!getTangentSpace(elt->getType().getASTType()))
+            continue;
+          addAdjointValue(
+              bb, elt,
+              makeZeroAdjointValue(getRemappedTangentType(elt->getType())),
+              loc);
+        }
+        break;
+      case AdjointValueKind::Concrete: {
+        auto adjVal = av.getConcreteValue();
+        auto adjValCopy = builder.emitCopyValueOperation(loc, adjVal);
+        SmallVector<SILValue, 4> adjElts;
+        if (!adjVal->getType().getAs<TupleType>()) {
+          recordTemporary(adjValCopy);
+          adjElts.push_back(adjValCopy);
+        } else {
+          auto *dti = builder.createDestructureTuple(loc, adjValCopy);
+          for (auto adjElt : dti->getResults())
+            recordTemporary(adjElt);
+          adjElts.append(dti->getResults().begin(), dti->getResults().end());
+        }
+        // Accumulate adjoints for `tuple` operands, skipping the
+        // non-`Differentiable` ones.
+        unsigned adjIndex = 0;
+        for (auto i : range(ti->getNumOperands())) {
+          if (!getTangentSpace(ti->getOperand(i)->getType().getASTType()))
+            continue;
+          auto adjElt = adjElts[adjIndex++];
+          addAdjointValue(bb, ti->getOperand(i),
+                          makeConcreteAdjointValue(adjElt), loc);
+        }
+        break;
       }
-      break;
-    case AdjointValueKind::Concrete: {
-      auto adjVal = av.getConcreteValue();
-      unsigned adjIdx = 0;
-      auto adjValCopy = builder.emitCopyValueOperation(ti->getLoc(), adjVal);
-      SmallVector<SILValue, 4> adjElts;
-      if (!adjVal->getType().getAs<TupleType>()) {
-        recordTemporary(adjValCopy);
-        adjElts.push_back(adjValCopy);
-      } else {
-        auto *dti = builder.createDestructureTuple(ti->getLoc(), adjValCopy);
-        for (auto adjElt : dti->getResults())
-          recordTemporary(adjElt);
-        adjElts.append(dti->getResults().begin(), dti->getResults().end());
-      }
-      // Accumulate adjoints for `tuple` operands, skipping the
-      // non-differentiable ones.
-      for (auto i : range(ti->getNumOperands())) {
-        if (!getTangentSpace(ti->getOperand(i)->getType().getASTType()))
-          continue;
-        auto adjElt = adjElts[adjIdx++];
-        addAdjointValue(bb, ti->getOperand(i), makeConcreteAdjointValue(adjElt),
-                        ti->getLoc());
+      case AdjointValueKind::Aggregate:
+        unsigned adjIndex = 0;
+        for (auto i : range(ti->getElements().size())) {
+          if (!getTangentSpace(ti->getElement(i)->getType().getASTType()))
+            continue;
+          addAdjointValue(bb, ti->getElement(i),
+                          av.getAggregateElement(adjIndex++), loc);
+        }
+        break;
       }
       break;
     }
-    case AdjointValueKind::Aggregate:
-      unsigned adjIdx = 0;
-      for (auto i : range(ti->getElements().size())) {
-        if (!getTangentSpace(ti->getElement(i)->getType().getASTType()))
+    case SILValueCategory::Address: {
+      auto adjBuf = getAdjointBuffer(bb, ti);
+      // Accumulate adjoints for `tuple` operands, skipping the
+      // non-`Differentiable` ones.
+      unsigned adjIndex = 0;
+      for (auto i : range(ti->getNumOperands())) {
+        if (!getTangentSpace(ti->getOperand(i)->getType().getASTType()))
           continue;
-        addAdjointValue(bb, ti->getElement(i), av.getAggregateElement(adjIdx++),
-                        ti->getLoc());
+        auto adjBufElt =
+            builder.createTupleElementAddr(loc, adjBuf, adjIndex++);
+        auto adjElt = getAdjointBuffer(bb, ti->getOperand(i));
+        accumulateIndirect(adjElt, adjBufElt, loc);
       }
       break;
+    }
     }
   }
 
@@ -1276,26 +1377,58 @@ public:
   ///             adj[x].n += adj[yn]
   void visitDestructureTupleInst(DestructureTupleInst *dti) {
     auto *bb = dti->getParent();
+    auto loc = dti->getLoc();
     auto tupleTanTy = getRemappedTangentType(dti->getOperand()->getType());
-    SmallVector<AdjointValue, 8> adjValues;
-    for (auto origElt : dti->getResults()) {
-      if (!getTangentSpace(remapType(origElt->getType()).getASTType()))
-        continue;
-      adjValues.push_back(getAdjointValue(bb, origElt));
+    // Check the `destructure_tuple` operand's value tangent category.
+    switch (getTangentValueCategory(dti->getOperand())) {
+    case SILValueCategory::Object: {
+      SmallVector<AdjointValue, 8> adjValues;
+      for (auto origElt : dti->getResults()) {
+        // Skip non-`Differentiable` tuple elements.
+        if (!getTangentSpace(remapType(origElt->getType()).getASTType()))
+          continue;
+        adjValues.push_back(getAdjointValue(bb, origElt));
+      }
+      // Handle tuple tangent type.
+      // Add adjoints for every tuple element that has a tangent space.
+      if (tupleTanTy.is<TupleType>()) {
+        assert(adjValues.size() > 1);
+        addAdjointValue(bb, dti->getOperand(),
+                        makeAggregateAdjointValue(tupleTanTy, adjValues), loc);
+      }
+      // Handle non-tuple tangent type.
+      // Add adjoint for the single tuple element that has a tangent space.
+      else {
+        assert(adjValues.size() == 1);
+        addAdjointValue(bb, dti->getOperand(), adjValues.front(), loc);
+      }
+      break;
     }
-    // Handle tuple tangent type.
-    // Add adjoints for every tuple element that has a tangent space.
-    if (tupleTanTy.is<TupleType>()) {
-      assert(adjValues.size() > 1);
-      addAdjointValue(bb, dti->getOperand(),
-                      makeAggregateAdjointValue(tupleTanTy, adjValues),
-                      dti->getLoc());
+    case SILValueCategory::Address: {
+      auto adjBuf = getAdjointBuffer(bb, dti->getOperand());
+      unsigned adjIndex = 0;
+      for (auto origElt : dti->getResults()) {
+        // Skip non-`Differentiable` tuple elements.
+        if (!getTangentSpace(remapType(origElt->getType()).getASTType()))
+          continue;
+        // Handle tuple tangent type.
+        // Add adjoints for every tuple element that has a tangent space.
+        if (tupleTanTy.is<TupleType>()) {
+          auto adjEltBuf = getAdjointBuffer(bb, origElt);
+          auto adjBufElt =
+              builder.createTupleElementAddr(loc, adjBuf, adjIndex);
+          accumulateIndirect(adjBufElt, adjEltBuf, loc);
+        }
+        // Handle non-tuple tangent type.
+        // Add adjoint for the single tuple element that has a tangent space.
+        else {
+          auto adjEltBuf = getAdjointBuffer(bb, origElt);
+          addToAdjointBuffer(bb, dti->getOperand(), adjEltBuf, loc);
+        }
+        ++adjIndex;
+      }
+      break;
     }
-    // Handle non-tuple tangent type.
-    // Add adjoint for the single tuple element that has a tangent space.
-    else {
-      assert(adjValues.size() == 1);
-      addAdjointValue(bb, dti->getOperand(), adjValues.front(), dti->getLoc());
     }
   }
 

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -744,6 +744,8 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
         pattern, tanType, TypeExpansionContext::minimal());
     ParameterConvention conv;
     switch (origResConv) {
+    case ResultConvention::Unowned:
+    case ResultConvention::UnownedInnerPointer:
     case ResultConvention::Owned:
     case ResultConvention::Autoreleased:
       if (tl.isAddressOnly()) {
@@ -752,10 +754,6 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
         conv = tl.isTrivial() ? ParameterConvention::Direct_Unowned
                               : ParameterConvention::Direct_Guaranteed;
       }
-      break;
-    case ResultConvention::Unowned:
-    case ResultConvention::UnownedInnerPointer:
-      conv = ParameterConvention::Direct_Unowned;
       break;
     case ResultConvention::Indirect:
       conv = ParameterConvention::Indirect_In_Guaranteed;

--- a/test/AutoDiff/validation-test/optional-property.swift
+++ b/test/AutoDiff/validation-test/optional-property.swift
@@ -1,0 +1,207 @@
+// RUN: %target-run-simple-swift
+// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -o /dev/null 2>&1 %s | %FileCheck %s
+// REQUIRES: executable_test
+
+// Test differentiation of `Optional` properties.
+
+import DifferentiationUnittest
+import StdlibUnittest
+
+var OptionalTests = TestSuite("OptionalPropertyDifferentiation")
+
+// Test `Optional` struct stored properties.
+
+struct Struct: Differentiable {
+  var stored: Float
+  var optional: Float?
+
+  @differentiable
+  func method() -> Float {
+    let s: Struct
+    do {
+      let tmp = Struct(stored: stored, optional: optional)
+      let tuple = (tmp, tmp)
+      s = tuple.0
+    }
+    if let x = s.optional {
+      return x * s.stored
+    }
+    return s.stored
+  }
+}
+
+// Check active SIL instructions in representative original functions.
+// This tests SIL instruction coverage of derivative function cloners (e.g. PullbackCloner).
+
+// CHECK-LABEL: [AD] Activity info for ${{.*}}Struct{{.*}}method{{.*}} at (parameters=(0) results=(0))
+// CHECK:   [ACTIVE] {{.*}} struct_extract {{%.*}} : $Struct, #Struct.stored
+// CHECK:   [ACTIVE] {{.*}} struct_extract {{%.*}} : $Struct, #Struct.optional
+// CHECK:   [ACTIVE] {{.*}} tuple ({{%.*}} : $Struct, {{%.*}} : $Struct)
+// CHECK:   [ACTIVE] {{.*}} destructure_tuple {{%.*}} : $(Struct, Struct)
+// CHECK:   [ACTIVE] {{.*}} struct_element_addr {{%.*}} : $*Struct, #Struct.optional
+// CHECK:   [ACTIVE] {{.*}} struct_element_addr {{%.*}} : $*Struct, #Struct.stored
+// CHECK-LABEL: End activity info for ${{.*}}Struct{{.*}}method{{.*}} at (parameters=(0) results=(0))
+
+// CHECK-LABEL: [AD] Activity info for $s4null6StructV6stored8optionalACSf_SfSgtcfC at (parameters=(0 1) results=(0))
+// CHECK:   [ACTIVE]   {{%.*}} struct $Struct ({{%.*}} : $Float, {{%.*}} : $Optional<Float>)
+// CHECK-LABEL: End activity info for $s4null6StructV6stored8optionalACSf_SfSgtcfC at (parameters=(0 1) results=(0))
+
+struct StructTracked: Differentiable {
+  var stored: NonresilientTracked<Float>
+  var optional: NonresilientTracked<Float>?
+
+  @differentiable
+  func method() -> NonresilientTracked<Float> {
+    let s: StructTracked
+    do {
+      let tmp = StructTracked(stored: stored, optional: optional)
+      let tuple = (tmp, tmp)
+      s = tuple.0
+    }
+    if let x = s.optional {
+      return x * s.stored
+    }
+    return s.stored
+  }
+}
+
+struct StructGeneric<T: Differentiable>: Differentiable {
+  var stored: T
+  var optional: T?
+
+  @differentiable
+  func method() -> T {
+    let s: StructGeneric
+    do {
+      let tmp = StructGeneric(stored: stored, optional: optional)
+      let tuple = (tmp, tmp)
+      s = tuple.0
+    }
+    if let x = s.optional {
+      return x
+    }
+    return s.stored
+  }
+}
+
+OptionalTests.test("Optional struct stored properties") {
+  expectEqual(
+    valueWithGradient(at: Struct(stored: 3, optional: 4), in: { $0.method() }),
+    (12, .init(stored: 4, optional: .init(3))))
+  expectEqual(
+    valueWithGradient(at: Struct(stored: 3, optional: nil), in: { $0.method() }),
+    (3, .init(stored: 1, optional: .init(0))))
+
+  expectEqual(
+    valueWithGradient(at: StructTracked(stored: 3, optional: 4), in: { $0.method() }),
+    (12, .init(stored: 4, optional: .init(3))))
+  expectEqual(
+    valueWithGradient(at: StructTracked(stored: 3, optional: nil), in: { $0.method() }),
+    (3, .init(stored: 1, optional: .init(0))))
+
+  expectEqual(
+    valueWithGradient(at: StructGeneric<Float>(stored: 3, optional: 4), in: { $0.method() }),
+    (4, .init(stored: 0, optional: .init(1))))
+  expectEqual(
+    valueWithGradient(at: StructGeneric<Float>(stored: 3, optional: nil), in: { $0.method() }),
+    (3, .init(stored: 1, optional: .init(0))))
+}
+
+// Test `Optional` class stored properties.
+
+struct Class: Differentiable {
+  var stored: Float
+  var optional: Float?
+
+  init(stored: Float, optional: Float?) {
+    self.stored = stored
+    self.optional = optional
+  }
+
+  @differentiable
+  func method() -> Float {
+    let c: Class
+    do {
+      let tmp = Class(stored: stored, optional: optional)
+      let tuple = (tmp, tmp)
+      c = tuple.0
+    }
+    if let x = c.optional {
+      return x * c.stored
+    }
+    return c.stored
+  }
+}
+
+struct ClassTracked: Differentiable {
+  var stored: NonresilientTracked<Float>
+  var optional: NonresilientTracked<Float>?
+
+  init(stored: NonresilientTracked<Float>, optional: NonresilientTracked<Float>?) {
+    self.stored = stored
+    self.optional = optional
+  }
+
+  @differentiable
+  func method() -> NonresilientTracked<Float> {
+    let c: ClassTracked
+    do {
+      let tmp = ClassTracked(stored: stored, optional: optional)
+      let tuple = (tmp, tmp)
+      c = tuple.0
+    }
+    if let x = c.optional {
+      return x * c.stored
+    }
+    return c.stored
+  }
+}
+
+struct ClassGeneric<T: Differentiable>: Differentiable {
+  var stored: T
+  var optional: T?
+
+  init(stored: T, optional: T?) {
+    self.stored = stored
+    self.optional = optional
+  }
+
+  @differentiable
+  func method() -> T {
+    let c: ClassGeneric
+    do {
+      let tmp = ClassGeneric(stored: stored, optional: optional)
+      let tuple = (tmp, tmp)
+      c = tuple.0
+    }
+    if let x = c.optional {
+      return x
+    }
+    return c.stored
+  }
+}
+
+OptionalTests.test("Optional class stored properties") {
+  expectEqual(
+    valueWithGradient(at: Class(stored: 3, optional: 4), in: { $0.method() }),
+    (12, .init(stored: 4, optional: .init(3))))
+  expectEqual(
+    valueWithGradient(at: Class(stored: 3, optional: nil), in: { $0.method() }),
+    (3, .init(stored: 1, optional: .init(0))))
+
+  expectEqual(
+    valueWithGradient(at: ClassTracked(stored: 3, optional: 4), in: { $0.method() }),
+    (12, .init(stored: 4, optional: .init(3))))
+  expectEqual(
+    valueWithGradient(at: ClassTracked(stored: 3, optional: nil), in: { $0.method() }),
+    (3, .init(stored: 1, optional: .init(0))))
+
+  expectEqual(
+    valueWithGradient(at: ClassGeneric<Tracked<Float>>(stored: 3, optional: 4), in: { $0.method() }),
+    (4, .init(stored: 0, optional: .init(1))))
+  expectEqual(
+    valueWithGradient(at: ClassGeneric<Tracked<Float>>(stored: 3, optional: nil), in: { $0.method() }),
+    (3, .init(stored: 1, optional: .init(0))))
+}
+
+runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Test differentiation of `Optional` values and operations.
+
 import DifferentiationUnittest
 import StdlibUnittest
 
@@ -9,7 +11,6 @@ var OptionalTests = TestSuite("OptionalDifferentiation")
 //===----------------------------------------------------------------------===//
 // Basic tests.
 //===----------------------------------------------------------------------===//
-
 
 // TODO(TF-433): operator `??` lowers to an active `try_apply`.
 /*
@@ -267,7 +268,7 @@ OptionalTests.test("Switch") {
     (.init(.init(0.0)), 1.0))
 }
 
-OptionalTests.test("Var1") {
+OptionalTests.test("Optional binding: if let") {
   @differentiable
   func optional_var1(_ maybeX: Float?) -> Float {
     var maybeX = maybeX
@@ -393,7 +394,7 @@ OptionalTests.test("Var1") {
     (.init(.init(0.0)), 1.0))
 }
 
-OptionalTests.test("Var2") {
+OptionalTests.test("Optional binding: if var") {
   @differentiable
   func optional_var2(_ maybeX: Float?) -> Float {
     if var x = maybeX {


### PR DESCRIPTION
Fix SIL pullback function type calculation: remap original `unowned` results to
the correct pullback parameter convention depending on the `TangentVector` type
lowering.

Make `PullbackCloner` visitors for the following instructions check and handle
tangent value categories: `struct`, `struct_extract`, `tuple`, `destructure_tuple`.

Add differentiation tests for `Optional` struct and class stored properties,
exercising the instruction visitors above.

Resolves SR-13430.

---

Example:

```swift
import _Differentiation

struct Struct: Differentiable {
  var stored: Float
  var optional: Float?

  @differentiable
  func method() -> Float {
    // Exercise various SIL instructions: `struct`, `struct_extract`, `tuple`, `destructure_tuple`.
    let s: Struct
    do {
      let tmp = Struct(stored: stored, optional: optional)
      let tuple = (tmp, tmp)
      s = tuple.0
    }
    if let x = s.optional {
      return x * s.stored
    }
    return s.stored
  }
}
```

Before: various derivative function type calculation and `PullbackCloner` crashes.
After: no crashes.