### PR TITLE
[5.3][FunctionBuilders] Implement graceful handling of pre-check failures

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1025,6 +1025,12 @@ namespace swift {
       }
     }
 
+    bool hasDiagnostics() const {
+      return std::distance(Engine.TentativeDiagnostics.begin() +
+                               PrevDiagnostics,
+                           Engine.TentativeDiagnostics.end()) > 0;
+    }
+
     /// Abort and close this transaction and erase all diagnostics
     /// record while it was open.
     void abort() {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1822,7 +1822,8 @@ enum class FunctionBuilderBodyPreCheck : uint8_t {
 class PreCheckFunctionBuilderRequest
     : public SimpleRequest<PreCheckFunctionBuilderRequest,
                            FunctionBuilderBodyPreCheck(AnyFunctionRef,
-                                                       BraceStmt *),
+                                                       BraceStmt *,
+                                                       bool),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1832,7 +1833,8 @@ private:
 
   // Evaluation.
   FunctionBuilderBodyPreCheck evaluate(Evaluator &evaluator, AnyFunctionRef fn,
-                                       BraceStmt *body) const;
+                                       BraceStmt *body,
+                                       bool suppressDiagnostics) const;
 
 public:
   // Separate caching.

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1374,9 +1374,10 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   // If we encountered an error or there was an explicit result type,
   // bail out and report that to the caller.
   auto &ctx = func->getASTContext();
-  auto request = PreCheckFunctionBuilderRequest{func, func->getBody()};
-  switch (evaluateOrDefault(
-              ctx.evaluator, request, FunctionBuilderBodyPreCheck::Error)) {
+  auto request = PreCheckFunctionBuilderRequest{func, func->getBody(),
+                                                /*suppressDiagnostics=*/false};
+  switch (evaluateOrDefault(ctx.evaluator, request,
+                            FunctionBuilderBodyPreCheck::Error)) {
   case FunctionBuilderBodyPreCheck::Okay:
     // If the pre-check was okay, apply the function-builder transform.
     break;
@@ -1524,16 +1525,27 @@ ConstraintSystem::matchFunctionBuilder(
 
   // Pre-check the body: pre-check any expressions in it and look
   // for return statements.
-  auto request = PreCheckFunctionBuilderRequest{fn, fn.getBody()};
+  auto request = PreCheckFunctionBuilderRequest{fn, fn.getBody(),
+                                                /*SuppressDiagnostics=*/true};
   switch (evaluateOrDefault(getASTContext().evaluator, request,
                             FunctionBuilderBodyPreCheck::Error)) {
   case FunctionBuilderBodyPreCheck::Okay:
     // If the pre-check was okay, apply the function-builder transform.
     break;
 
-  case FunctionBuilderBodyPreCheck::Error:
-    // If the pre-check had an error, flag that.
+  case FunctionBuilderBodyPreCheck::Error: {
+    if (!shouldAttemptFixes())
+      return getTypeMatchFailure(locator);
+
+    if (auto *closure =
+            dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
+      auto failed = recordFix(IgnoreInvalidFunctionBuilderBody::create(
+          *this, getConstraintLocator(closure)));
+      return failed ? getTypeMatchFailure(locator) : getTypeMatchSuccess();
+    }
+
     return getTypeMatchFailure(locator);
+  }
 
   case FunctionBuilderBodyPreCheck::HasReturnStmt:
     // If the body has a return statement, suppress the transform but
@@ -1626,14 +1638,17 @@ namespace {
 class PreCheckFunctionBuilderApplication : public ASTWalker {
   AnyFunctionRef Fn;
   bool SkipPrecheck = false;
+  bool SuppressDiagnostics = false;
   std::vector<ReturnStmt *> ReturnStmts;
   bool HasError = false;
 
   bool hasReturnStmt() const { return !ReturnStmts.empty(); }
 
 public:
-  PreCheckFunctionBuilderApplication(AnyFunctionRef fn, bool skipPrecheck)
-    : Fn(fn), SkipPrecheck(skipPrecheck) {}
+  PreCheckFunctionBuilderApplication(AnyFunctionRef fn, bool skipPrecheck,
+                                     bool suppressDiagnostics)
+      : Fn(fn), SkipPrecheck(skipPrecheck),
+        SuppressDiagnostics(suppressDiagnostics) {}
 
   const std::vector<ReturnStmt *> getReturnStmts() const { return ReturnStmts; }
 
@@ -1657,16 +1672,28 @@ public:
   }
 
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    if (SkipPrecheck)
+      return std::make_pair(false, E);
+
     // Pre-check the expression.  If this fails, abort the walk immediately.
     // Otherwise, replace the expression with the result of pre-checking.
     // In either case, don't recurse into the expression.
-    if (!SkipPrecheck &&
-        ConstraintSystem::preCheckExpression(E, /*DC*/ Fn.getAsDeclContext())) {
-      HasError = true;
-      return std::make_pair(false, nullptr);
-    }
+    {
+      auto *DC = Fn.getAsDeclContext();
+      auto &diagEngine = DC->getASTContext().Diags;
 
-    return std::make_pair(false, E);
+      // Suppress any diangostics which could be produced by this expression.
+      DiagnosticTransaction transaction(diagEngine);
+
+      HasError |= ConstraintSystem::preCheckExpression(
+          E, DC, /*replaceInvalidRefsWithErrors=*/false);
+      HasError |= transaction.hasDiagnostics();
+
+      if (SuppressDiagnostics)
+        transaction.abort();
+
+      return std::make_pair(false, HasError ? nullptr : E);
+    }
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
@@ -1692,18 +1719,20 @@ public:
 
 FunctionBuilderBodyPreCheck
 PreCheckFunctionBuilderRequest::evaluate(Evaluator &eval, AnyFunctionRef fn,
-                                         BraceStmt *body) const {
+                                         BraceStmt *body,
+                                         bool suppressDiagnostics) const {
   // NOTE: 'body' is passed only for the request evaluater caching key.
   // Since source tooling (e.g. code completion) might replace the body,
   // the function alone is not sufficient for the key.
   assert(fn.getBody() == body &&
          "body must be the current body of the function");
 
-  return PreCheckFunctionBuilderApplication(fn, false).run();
+  return PreCheckFunctionBuilderApplication(fn, false, suppressDiagnostics).run();
 }
 
 std::vector<ReturnStmt *> TypeChecker::findReturnStatements(AnyFunctionRef fn) {
-  PreCheckFunctionBuilderApplication precheck(fn, true);
+  PreCheckFunctionBuilderApplication precheck(fn, /*skipPreCheck=*/true,
+                                              /*SuppressDiagnostics=*/true);
   (void)precheck.run();
   return precheck.getReturnStmts();
 }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1106,7 +1106,14 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
       } else if (TypeVar->getImpl().isClosureParameterType()) {
         fix = SpecifyClosureParameterType::create(cs, dstLocator);
       } else if (TypeVar->getImpl().isClosureResultType()) {
-        fix = SpecifyClosureReturnType::create(cs, dstLocator);
+        auto *locator = TypeVar->getImpl().getLocator();
+        auto *closure = cast<ClosureExpr>(locator->getAnchor());
+        // If the whole body is being ignored due to a pre-check failure,
+        // let's not record a fix about result type since there is
+        // just not enough context to infer it without a body.
+        if (!cs.hasFixFor(cs.getConstraintLocator(closure),
+                          FixKind::IgnoreInvalidFunctionBuilderBody))
+          fix = SpecifyClosureReturnType::create(cs, dstLocator);
       } else if (srcLocator->getAnchor() &&
                  isa<ObjectLiteralExpr>(srcLocator->getAnchor())) {
         fix = SpecifyObjectLiteralTypeImport::create(cs, dstLocator);

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -264,6 +264,8 @@ enum class FixKind : uint8_t {
   /// Specify key path root type when it cannot be infered from context.
   SpecifyKeyPathRootType,
 
+  /// Ignore function builder body which fails `pre-check` call.
+  IgnoreInvalidFunctionBuilderBody,
 };
 
 class ConstraintFix {
@@ -1839,6 +1841,26 @@ class SpecifyKeyPathRootType final : public ConstraintFix {
 
     static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
+};
+
+class IgnoreInvalidFunctionBuilderBody final : public ConstraintFix {
+  IgnoreInvalidFunctionBuilderBody(ConstraintSystem &cs,
+                                   ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::IgnoreInvalidFunctionBuilderBody, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore invalid function builder body";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreInvalidFunctionBuilderBody *create(ConstraintSystem &cs,
+                                                  ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9712,7 +9712,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyObjectLiteralTypeImport:
   case FixKind::AllowKeyPathRootTypeMismatch:
   case FixKind::AllowCoercionToForceCast:
-  case FixKind::SpecifyKeyPathRootType: {
+  case FixKind::SpecifyKeyPathRootType:
+  case FixKind::IgnoreInvalidFunctionBuilderBody: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4606,8 +4606,12 @@ private:
 public:
   /// Pre-check the expression, validating any types that occur in the
   /// expression and folding sequence expressions.
-  static bool preCheckExpression(Expr *&expr, DeclContext *dc);
-        
+  ///
+  /// \param replaceInvalidRefsWithErrors Indicates whether it's allowed
+  /// to replace any discovered invalid member references with `ErrorExpr`.
+  static bool preCheckExpression(Expr *&expr, DeclContext *dc,
+                                 bool replaceInvalidRefsWithErrors);
+
   /// Solve the system of constraints generated from provided target.
   ///
   /// \param target The target that we'll generate constraints from, which

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -518,9 +518,10 @@ public:
       
     
     // Perform unqualified name lookup to find out what the UDRE is.
-    return getSubExprPattern(TypeChecker::resolveDeclRefExpr(ude, DC));
+    return getSubExprPattern(TypeChecker::resolveDeclRefExpr(
+        ude, DC, /*replaceInvalidRefsWithErrors=*/true));
   }
-  
+
   // Call syntax forms a pattern if:
   // - the callee in 'Element(x...)' or '.Element(x...)'
   //   references an enum element. The arguments then form a tuple

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -579,7 +579,8 @@ static Optional<Type> getTypeOfCompletionContextExpr(
                         CompletionTypeCheckKind kind,
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
-  if (constraints::ConstraintSystem::preCheckExpression(parsedExpr, DC))
+  if (constraints::ConstraintSystem::preCheckExpression(
+          parsedExpr, DC, /*replaceInvalidRefsWithErrors=*/true))
     return None;
 
   switch (kind) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -392,7 +392,11 @@ Type resolveIdentifierType(TypeResolution resolution, IdentTypeRepr *IdType,
 /// Bind an UnresolvedDeclRefExpr by performing name lookup and
 /// returning the resultant expression.  Context is the DeclContext used
 /// for the lookup.
-Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
+///
+/// \param replaceInvalidRefsWithErrors Indicates whether it's allowed
+/// to replace any discovered invalid member references with `ErrorExpr`.
+Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
+                         bool replaceInvalidRefsWithErrors);
 
 /// Validate the given type.
 ///

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -6,7 +6,7 @@ enum Either<T,U> {
 }
 
 @_functionBuilder
-struct TupleBuilder { // expected-note 3{{struct 'TupleBuilder' declared here}}
+struct TupleBuilder { // expected-note 2 {{struct 'TupleBuilder' declared here}}
   static func buildBlock() -> () { }
   
   static func buildBlock<T1>(_ t1: T1) -> T1 {
@@ -87,7 +87,7 @@ func testDiags() {
   // For loop
   tuplify(true) { _ in
     17
-    for c in name { // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilder'}}
+    for c in name {
     // expected-error@-1 {{cannot find 'name' in scope}}
     }
   }
@@ -418,13 +418,16 @@ func testNonExhaustiveSwitch(e: E) {
 // rdar://problem/59856491
 struct TestConstraintGenerationErrors {
   @TupleBuilder var buildTupleFnBody: String {
-    let a = nil // expected-error {{'nil' requires a contextual type}}
+    let a = nil // There is no diagnostic here because next line fails to pre-check, so body is invalid
     String(nothing) // expected-error {{cannot find 'nothing' in scope}}
   }
 
+  @TupleBuilder var nilWithoutContext: String {
+    let a = nil // expected-error {{'nil' requires a contextual type}}
+  }
+
   func buildTupleClosure() {
-    // FIXME: suppress the ambiguity error
-    tuplify(true) { _ in // expected-error {{type of expression is ambiguous without more context}}
+    tuplify(true) { _ in
       let a = nothing // expected-error {{cannot find 'nothing' in scope}}
       String(nothing) // expected-error {{cannot find 'nothing' in scope}}
     }

--- a/test/Constraints/rdar65320500.swift
+++ b/test/Constraints/rdar65320500.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Result {}
+
+@_functionBuilder
+struct Builder {
+  static func buildBlock() -> Result {
+    Result()
+  }
+}
+
+func test_builder<T>(@Builder _: () -> T) {}
+func test_builder(@Builder _: () -> Int) {}
+
+test_builder {
+  let _ = 0
+
+  if let x = does_not_exist { // expected-error {{cannot find 'does_not_exist' in scope}}
+  }
+}
+
+func test(_: Int) -> Bool {
+  return false
+}
+
+test_builder {
+  let totalSeconds = 42000
+  test(totalseconds / 3600) // expected-error {{cannot find 'totalseconds' in scope}}
+}
+
+test_builder {
+  test(doesntExist()) // expected-error {{cannot find 'doesntExist' in scope}}
+
+  if let result = doesntExist() { // expected-error {{cannot find 'doesntExist' in scope}}
+  }
+
+  if bar = test(42) {} // expected-error {{cannot find 'bar' in scope}}
+
+  let foo = bar() // expected-error {{cannot find 'bar' in scope}}
+
+  switch (doesntExist()) { // expected-error {{cannot find 'doesntExist' in scope}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/33509

---

- Explanation:

Function builder bodies are applied in several stages. First of them is `pre-check`
stage which is, among other things, responsible for member lookup and reference
resolution, if that action fails it would be diagnosed inline and affected
expression is going to be replaced with `ErrorExpr`.

This works fine in context of regular expressions but not function builders, because
matching of function builder bodies happens in the middle of type-checking of
enclosing context, so solver needs to implement graceful handling of such problems
and delay diagnostics until solver reaches a solution.

To accommodate that `PreCheckFunctionBuilderRequest`,
`ConstraintSystem::preCheckExpression`, and `TypeChecker::resolveDeclRefExpr`
have been adjusted to know explicitly whether diagnosing and AST mutation is permitted.
Solver is adjusted to ignore closure bodies which fail pre-check in their entirety.

- Scope: Limited to function builder bodies with incorrect references in them e.g. non-existent global functions, names with typos etc.

- Resolves: rdar://problem/65320500

- Risk: Low

- Testing: Added regression tests

- Reviewer: @hborla, @DougGregor 

Resolves: rdar://problem/65320500

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
