### PR TITLE
[Package] Fix passing -gline-tables-only when building.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1234,10 +1234,15 @@ verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
 
-# When producing a package, don't copy the Swift Resource/ directory.
-# This is mainly a space optimization.
+# When building for an Xcode toolchain, don't copy the Swift Resource/ directory
+# into the LLDB.framework. LLDB.framework will be installed alongside a Swift
+# compiler, so LLDB should use its resource directory directly.
+# Also, to reduce the size of the final toolchain, limit debug info to be
+# line-tables only.
 extra-cmake-options=
    -DLLDB_FRAMEWORK_COPY_SWIFT_RESOURCES=0
+   -DCMAKE_C_FLAGS="-gline-tables-only"
+   -DCMAKE_CXX_FLAGS="-gline-tables-only"
 
 install-llvm
 install-swift
@@ -1371,10 +1376,6 @@ skip-test-playgroundsupport
 skip-test-swiftsyntax
 skip-test-skstresstester
 skip-test-swiftevolve
-
-extra-cmake-options=
-   -DCMAKE_C_FLAGS="-gline-tables-only"
-   -DCMAKE_CXX_FLAGS="-gline-tables-only"
 
 # macOS package with out test
 [preset: buildbot_osx_package,no_test]


### PR DESCRIPTION
We should do regardless of whether we run the tests or not.
Also, clarify a comment while I'm here.