### PR TITLE
Correct the DeclContext Used For 'super.init()' Synthesis

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1764,9 +1764,9 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
     NLOptions subOptions = NL_QualifiedDefault | NL_KnownNonCascadingDependency;
 
     SmallVector<ValueDecl *, 4> lookupResults;
-    dc->lookupQualified(superclassDecl,
-                        DeclNameRef::createConstructor(),
-                        subOptions, lookupResults);
+    fromCtor->lookupQualified(superclassDecl,
+                              DeclNameRef::createConstructor(),
+                              subOptions, lookupResults);
 
     for (auto decl : lookupResults) {
       auto superclassCtor = dyn_cast<ConstructorDecl>(decl);

--- a/test/SILOptimizer/Inputs/definite_init_cross_module/OtherModule.swift
+++ b/test/SILOptimizer/Inputs/definite_init_cross_module/OtherModule.swift
@@ -41,3 +41,14 @@ public struct Empty {
 public struct GenericEmpty<T> {
   public init() {}
 }
+
+open class VisibleNoArgsDesignatedInit {
+  var x: Float
+  public init() { x = 0.0 }
+
+  // Add some designated inits the subclass cannot see.
+  private init(x: Float) { self.x = x }
+  fileprivate init(y: Float) { self.x = y }
+  internal init(z: Float) { self.x = z }
+}
+

--- a/test/SILOptimizer/definite_init_cross_module.swift
+++ b/test/SILOptimizer/definite_init_cross_module.swift
@@ -254,3 +254,27 @@ extension GenericEmpty {
   init(xx: Double) {
   } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
 }
+
+class AcceptsVisibleNoArgsDesignatedInit: VisibleNoArgsDesignatedInit {
+  var y: Float
+  init(y: Float) {
+    self.y = y
+    // no error
+  }
+}
+
+open class InModuleVisibleNoArgsDesignatedInit {
+  var x: Float
+  public init() { x = 0.0 }
+
+  // Add a designated init the subclass cannot see.
+  private init(x: Float) { self.x = x }
+}
+
+class AcceptsInModuleVisibleNoArgsDesignatedInit: InModuleVisibleNoArgsDesignatedInit {
+  var y: Float
+  init(y: Float) {
+    self.y = y
+    // no error
+  }
+}


### PR DESCRIPTION
When a subclass inherits from a superclass that declares a no-args
desginated initializer and no other visible inits, the subclass may
elide calls to 'super.init()'. The way this was enforced was by looking
into the superclass *from the subclass' init*, not from the subclass.
This ensured that not only would we get results for initializers, we'd
get results for initializers that were actually _callable_ from the
subclass.

The changes in apple/swift#33515 accidentally swapped the decl context
here, which caused this lookup to start returning additional results.
In that case, we consider it ambiguous as to which designated
initializer we should synthesize, and so we bail.

The net result is DI errors where there previously were none. Let's put
this back in order.

rdar://67560590, rdar://67686660, rdar://67690116, SR-13427