### PR TITLE
AST: Try harder to preserve type sugar in AbstractGenericSignatureRequest [5.3]

### DIFF
--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -19,6 +19,8 @@ public class Base<In, Out> {
 // CHECK-NEXT: public init<A>(_: A, _: A)
   public init<A>(_: A, _: A) {}
 
+// CHECK-NEXT: public init<C>(_: C) where C : main.Base<In, Out>
+  public init<C>(_: C) where C : Base<In, Out> {}
 // CHECK: }
 }
 
@@ -27,6 +29,7 @@ public class Derived<T> : Base<T, T> {
 // CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
 // CHECK-NEXT: override public init<A>(_ argument: A, _ argument: A)
+// CHECK-NEXT: override public init<C>(_ argument: C) where C : main.Base<T, T>
 // CHECK-NEXT: }
 }
 

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -587,7 +587,7 @@ class SR_4206_Base_7<T> {
 }
 
 class SR_4206_Derived_7<T>: SR_4206_Base_7<T> {
-  override func foo1() where T: SR_4206_Protocol_2 {} // expected-error {{overridden method 'foo1' has generic signature <T where T : SR_4206_Protocol_2> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T where τ_0_0 : SR_4206_Protocol_1>}}
+  override func foo1() where T: SR_4206_Protocol_2 {} // expected-error {{overridden method 'foo1' has generic signature <T where T : SR_4206_Protocol_2> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T where T : SR_4206_Protocol_1>}}
 
   override func foo2() {} // OK
 }
@@ -624,7 +624,7 @@ class SR_4206_Base_10<T> {
   func foo() where T: SR_4206_Protocol_1 {} // expected-note {{overridden declaration is here}}
 }
 class SR_4206_Derived_10<T, U>: SR_4206_Base_10<T> {
-  override func foo() where U: SR_4206_Protocol_1 {} // expected-error {{overridden method 'foo' has generic signature <T, U where U : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T, U where τ_0_0 : SR_4206_Protocol_1>}}
+  override func foo() where U: SR_4206_Protocol_1 {} // expected-error {{overridden method 'foo' has generic signature <T, U where U : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T, U where T : SR_4206_Protocol_1>}}
 }
 
 // Override with return type specialization


### PR DESCRIPTION
AbstractGenericSignatureRequest tries to minimize the number of GSBs that we
spin up by only creating a GSB if the generic parameter and requirement types
are canonical. If they're not canonical, it first canonicalizes them, then
kicks off a request to compute the canonical signature, and finally, re-applies
type sugar.

We would do this by building a mapping for re-sugaring generic parameters,
however this mapping was only populated for the newly-added generic parameters.

If some of the newly-added generic requirements mention the base signature's
generic parameters, they would remain canonicalized.

Fixes <rdar://problem/67579220>.