### PR TITLE
[CSApply] Handle OptionalForce component when is initial component on key path expr

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4732,9 +4732,21 @@ namespace {
               KeyPathExpr::Component::forOptionalChain(objectTy, loc));
           break;
         }
-        case KeyPathExpr::Component::Kind::OptionalForce:
-          buildKeyPathOptionalForceComponent(resolvedComponents);
+        case KeyPathExpr::Component::Kind::OptionalForce: {
+          // Handle force optional when it is the first component e.g.
+          // \String?.!.count
+          if (resolvedComponents.empty()) {
+            auto loc = origComponent.getLoc();
+            auto objectTy = componentTy->getOptionalObjectType();
+            assert(objectTy);
+
+            resolvedComponents.push_back(
+                KeyPathExpr::Component::forOptionalForce(objectTy, loc));
+          } else {
+            buildKeyPathOptionalForceComponent(resolvedComponents);
+          }
           break;
+        }
         case KeyPathExpr::Component::Kind::Invalid: {
           auto component = origComponent;
           component.setComponentType(leafTy);

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -179,3 +179,11 @@ func key_path_root_mismatch<T>(_ base: KeyPathBase?, subBase: KeyPathBaseSubtype
   let _ : T = subBase[keyPath: kpa] // expected-error {{key path with root type 'AnotherBase' cannot be applied to a base of type 'KeyPathBaseSubtype?'}}
 
 }
+
+// SR-13442
+func SR13442<T>(_ x: KeyPath<String?, T>) -> T { "1"[keyPath: x] }
+
+func testSR13442() {
+  _ = SR13442(\.!.count) // OK
+  _ = SR13442(\String?.!.count) // OK
+}


### PR DESCRIPTION
Fixing crash when ForceOptional kind is the first component on CSApply.


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13442.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
