### PR TITLE
AST: Fix ASTScopeLookup crash if a PatternBindingEntry's context is not a PatternBindingInitializer

### DIFF
--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -519,7 +519,7 @@ bool BraceStmtScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
 bool PatternEntryInitializerScope::lookupLocalsOrMembers(
     ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   // 'self' is available within the pattern initializer of a 'lazy' variable.
-  auto *initContext = cast_or_null<PatternBindingInitializer>(
+  auto *initContext = dyn_cast_or_null<PatternBindingInitializer>(
       decl->getInitContext(0));
   if (initContext) {
     if (auto *selfParam = initContext->getImplicitSelfDecl()) {
@@ -816,7 +816,7 @@ Optional<bool> ClosureBodyScope::resolveIsCascadingUseForThisScope(
 Optional<bool> PatternEntryInitializerScope::resolveIsCascadingUseForThisScope(
     Optional<bool> isCascadingUse) const {
   auto *const initContext = getPatternEntry().getInitContext();
-  auto *PBI = cast_or_null<PatternBindingInitializer>(initContext);
+  auto *PBI = dyn_cast_or_null<PatternBindingInitializer>(initContext);
   auto *isd = PBI ? PBI->getImplicitSelfDecl() : nullptr;
 
   // 'self' is available within the pattern initializer of a 'lazy' variable.

--- a/validation-test/compiler_crashers_2_fixed/rdar67239650.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar67239650.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+@_functionBuilder
+struct SillyBuilder {
+  static func buildBlock() -> () {}
+}
+
+struct SillyStruct {
+  init(@SillyBuilder _: () -> ()) {}
+}
+
+struct UsesSillyStruct {
+  var x: Int = 0
+
+  func foo() {
+    SillyStruct {
+      let fn = {
+        if true {
+          _ = x
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The function builder transform creates pattern bindings parented
in other DeclContexts. If those pattern binding initializer
expressions in turn contain multi-statement closures, we will
try to perform unqualified lookups from those contexts when we
get around to type checking the closure body.

Change some unconditional casts to conditional casts in ASTScope
lookup, to handle this case. The casts are only performed while
checking if the initializer context is part of a 'lazy'
property, which doesn't apply here.

Fixes <rdar://problem/67265731>.