### PR TITLE
[IDE] Skip visiting constructor references when the decl is unknown

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -715,6 +715,12 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
     }
   }
 
+  if (D == nullptr) {
+    // FIXME: When does this happen?
+    assert(false && "unhandled reference");
+    return true;
+  }
+
   CharSourceRange CharRange =
     Lexer::getCharSourceRangeFromSourceRange(D->getASTContext().SourceMgr,
                                              Range);


### PR DESCRIPTION
Skip visiting constructor references when the decl ends up being a nullptr. Only happens if the expression in CtorRefs ends up not being a DeclRefExpr after stripping off the (Identity|Try|Apply|AutoClosure)Expr's. I'm not sure when that would be, so for now I've left in an assert and skip the reference for release.

Resolves rdar://67412430
