### PR TITLE
[CSDiagnostics] Emit fix-its to insert requirement stubs for missing protocols in context

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -465,21 +465,22 @@ class NormalProtocolConformance : public RootProtocolConformance,
   uint64_t LoaderContextData;
   friend class ASTContext;
 
-  NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
-                            SourceLoc loc, DeclContext *dc,
-                            ProtocolConformanceState state)
-    : RootProtocolConformance(ProtocolConformanceKind::Normal, conformingType),
-      ProtocolAndState(protocol, state), Loc(loc), ContextAndInvalid(dc, false)
-  {
-    assert(!conformingType->hasArchetype() &&
-           "ProtocolConformances should store interface types");
-  }
-
   void resolveLazyInfo() const;
 
   void differenceAndStoreConditionalRequirements() const;
 
 public:
+  NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
+                            SourceLoc loc, DeclContext *dc,
+                            ProtocolConformanceState state)
+      : RootProtocolConformance(ProtocolConformanceKind::Normal,
+                                conformingType),
+        ProtocolAndState(protocol, state), Loc(loc),
+        ContextAndInvalid(dc, false) {
+    assert(!conformingType->hasArchetype() &&
+           "ProtocolConformances should store interface types");
+  }
+
   /// Get the protocol being conformed to.
   ProtocolDecl *getProtocol() const { return ProtocolAndState.getPointer(); }
 

--- a/test/decl/protocol/fixits_missing_protocols_in_context.swift
+++ b/test/decl/protocol/fixits_missing_protocols_in_context.swift
@@ -16,3 +16,30 @@ class C {
     // expected-note@-2 {{add missing conformance to 'P' to class 'C'}} {{8-8=: P}} {{10-10=\n    func method() {\n        <#code#>\n    \}\n\n    var property: Int\n}}
   }
 }
+
+// Test that we don't emit fix-it to insert a requirement stub if there is already a satisfying witness.
+
+class C1 {
+  var p: P?
+
+  func assign() {
+    p = self
+    // expected-error@-1 {{cannot assign value of type 'C1' to type 'P?'}}
+    // expected-note@-2 {{add missing conformance to 'P' to class 'C1'}} {{9-9=: P}} {{11-11=\n    var property: Int\n}}
+  }
+
+  func method() {}
+}
+
+class C2 {
+  var p: P?
+
+  func assign() {
+    p = self
+    // expected-error@-1 {{cannot assign value of type 'C2' to type 'P?'}}
+    // expected-note@-2 {{add missing conformance to 'P' to class 'C2'}} {{9-9=: P}}
+  }
+
+  func method() {}
+  var property: Int = 0
+}

--- a/test/decl/protocol/fixits_missing_protocols_in_context.swift
+++ b/test/decl/protocol/fixits_missing_protocols_in_context.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -typecheck -diagnostics-editor-mode -verify %s
+
+// Test that we emit fix-its to insert requirement stubs for the missing protocol conformance, in addition to adding the conformance.
+
+protocol P {
+  func method()
+  var property: Int { get }
+}
+
+class C {
+  var p: P?
+
+  func assign() {
+    p = self
+    // expected-error@-1 {{cannot assign value of type 'C' to type 'P?'}}
+    // expected-note@-2 {{add missing conformance to 'P' to class 'C'}} {{8-8=: P}} {{10-10=\n    func method() {\n        <#code#>\n    \}\n\n    var property: Int\n}}
+  }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/27026.

---

At the moment, we emit a fix-it to insert the missing conformance. For example:

```swift
protocol P {
  func method()
}

class C {
  var p: P?
  
  func assign() {
    p = self
  }
}
```

Here, we emit fix-it to add `: P` to `C`. With this change, we now also emit the requirement stub (`func method()`) if we're in editor mode.