### PR TITLE
[SIL] NFC: Moved flag to SILExtInfo.

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -495,16 +495,17 @@ class SILExtInfoBuilder {
   // If bits are added or removed, then TypeBase::SILFunctionTypeBits
   // and NumMaskBits must be updated, and they must match.
 
-  //   |representation|pseudogeneric| noescape |differentiability|
-  //   |    0 .. 3    |      4      |     5    |      6 .. 7     |
+  //   |representation|pseudogeneric| noescape | async | differentiability|
+  //   |    0 .. 3    |      4      |     5    |   6   |      7 .. 8     |
   //
   enum : unsigned {
     RepresentationMask = 0xF << 0,
     PseudogenericMask = 1 << 4,
     NoEscapeMask = 1 << 5,
-    DifferentiabilityMaskOffset = 6,
+    AsyncMask = 1 << 6,
+    DifferentiabilityMaskOffset = 7,
     DifferentiabilityMask = 0x3 << DifferentiabilityMaskOffset,
-    NumMaskBits = 8
+    NumMaskBits = 9
   };
 
   unsigned bits; // Naturally sized for speed.
@@ -523,10 +524,11 @@ public:
 
   // Constructor for polymorphic type.
   SILExtInfoBuilder(Representation rep, bool isPseudogeneric, bool isNoEscape,
-                    DifferentiabilityKind diffKind, const clang::Type *type)
+                    bool isAsync, DifferentiabilityKind diffKind,
+                    const clang::Type *type)
       : SILExtInfoBuilder(
             ((unsigned)rep) | (isPseudogeneric ? PseudogenericMask : 0) |
-                (isNoEscape ? NoEscapeMask : 0) |
+                (isNoEscape ? NoEscapeMask : 0) | (isAsync ? AsyncMask : 0) |
                 (((unsigned)diffKind << DifferentiabilityMaskOffset) &
                  DifferentiabilityMask),
             ClangTypeInfo(type)) {}
@@ -551,6 +553,8 @@ public:
 
   // Is this function guaranteed to be no-escape by the type system?
   constexpr bool isNoEscape() const { return bits & NoEscapeMask; }
+
+  constexpr bool isAsync() const { return bits & AsyncMask; }
 
   constexpr DifferentiabilityKind getDifferentiabilityKind() const {
     return DifferentiabilityKind((bits & DifferentiabilityMask) >>
@@ -616,6 +620,10 @@ public:
                                       : (bits & ~NoEscapeMask),
                              clangTypeInfo);
   }
+  SILExtInfoBuilder withAsync(bool isAsync = true) const {
+    return SILExtInfoBuilder(isAsync ? (bits | AsyncMask) : (bits & ~AsyncMask),
+                             clangTypeInfo);
+  }
   SILExtInfoBuilder
   withDifferentiabilityKind(DifferentiabilityKind differentiability) const {
     return SILExtInfoBuilder(
@@ -657,8 +665,8 @@ public:
 
   static SILExtInfo getThin() {
     return SILExtInfoBuilder(SILExtInfoBuilder::Representation::Thin, false,
-                             false, DifferentiabilityKind::NonDifferentiable,
-                             nullptr)
+                             false, false,
+                             DifferentiabilityKind::NonDifferentiable, nullptr)
         .build();
   }
 
@@ -680,6 +688,8 @@ public:
   constexpr bool isPseudogeneric() const { return builder.isPseudogeneric(); }
 
   constexpr bool isNoEscape() const { return builder.isNoEscape(); }
+
+  constexpr bool isAsync() const { return builder.isAsync(); }
 
   constexpr DifferentiabilityKind getDifferentiabilityKind() const {
     return builder.getDifferentiabilityKind();

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -362,12 +362,11 @@ protected:
     ID : 32
   );
 
-  SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+3+1+1+2+1+1,
+  SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+3+1+2+1+1,
     ExtInfoBits : NumSILExtInfoBits,
     HasClangTypeInfo : 1,
     CalleeConvention : 3,
     HasErrorResult : 1,
-    IsAsync : 1,
     CoroutineKind : 2,
     HasInvocationSubs : 1,
     HasPatternSubs : 1
@@ -3980,7 +3979,7 @@ private:
              + 1);
   }
 
-  SILFunctionType(GenericSignature genericSig, ExtInfo ext, bool isAsync,
+  SILFunctionType(GenericSignature genericSig, ExtInfo ext,
                   SILCoroutineKind coroutineKind,
                   ParameterConvention calleeConvention,
                   ArrayRef<SILParameterInfo> params,
@@ -3994,8 +3993,7 @@ private:
 
 public:
   static CanSILFunctionType
-  get(GenericSignature genericSig, ExtInfo ext, bool isAsync,
-      SILCoroutineKind coroutineKind,
+  get(GenericSignature genericSig, ExtInfo ext, SILCoroutineKind coroutineKind,
       ParameterConvention calleeConvention,
       ArrayRef<SILParameterInfo> interfaceParams,
       ArrayRef<SILYieldInfo> interfaceYields,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -308,7 +308,7 @@ class alignas(1 << TypeAlignInBits) TypeBase {
 
 protected:
   enum { NumAFTExtInfoBits = 9 };
-  enum { NumSILExtInfoBits = 8 };
+  enum { NumSILExtInfoBits = 9 };
   union { uint64_t OpaqueBits;
 
   SWIFT_INLINE_BITFIELD_BASE(TypeBase, bitmax(NumTypeKindBits,8) +
@@ -4046,7 +4046,7 @@ public:
     return SILCoroutineKind(Bits.SILFunctionType.CoroutineKind);
   }
 
-  bool isAsync() const { return Bits.SILFunctionType.IsAsync; }
+  bool isAsync() const { return getExtInfo().isAsync(); }
 
   /// Return the array of all the yields.
   ArrayRef<SILYieldInfo> getYields() const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4575,14 +4575,14 @@ public:
                                     
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getInvocationGenericSignature(),
-            getExtInfo(), isAsync(), getCoroutineKind(), getCalleeConvention(),
+            getExtInfo(), getCoroutineKind(), getCalleeConvention(),
             getParameters(), getYields(), getResults(),
             getOptionalErrorResult(), getWitnessMethodConformanceOrInvalid(),
             getPatternSubstitutions(), getInvocationSubstitutions());
   }
   static void
   Profile(llvm::FoldingSetNodeID &ID, GenericSignature genericSig, ExtInfo info,
-          bool isAsync, SILCoroutineKind coroutineKind, ParameterConvention calleeConvention,
+          SILCoroutineKind coroutineKind, ParameterConvention calleeConvention,
           ArrayRef<SILParameterInfo> params, ArrayRef<SILYieldInfo> yields,
           ArrayRef<SILResultInfo> results, Optional<SILResultInfo> errorResult,
           ProtocolConformanceRef conformance,

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -238,48 +238,59 @@ class ImplFunctionTypeFlags {
   unsigned Rep : 3;
   unsigned Pseudogeneric : 1;
   unsigned Escaping : 1;
+  unsigned Async : 1;
   unsigned DifferentiabilityKind : 2;
 
 public:
   ImplFunctionTypeFlags()
-      : Rep(0), Pseudogeneric(0), Escaping(0), DifferentiabilityKind(0) {}
+      : Rep(0), Pseudogeneric(0), Escaping(0), Async(0),
+        DifferentiabilityKind(0) {}
 
   ImplFunctionTypeFlags(ImplFunctionRepresentation rep, bool pseudogeneric,
-                        bool noescape,
+                        bool noescape, bool async,
                         ImplFunctionDifferentiabilityKind diffKind)
       : Rep(unsigned(rep)), Pseudogeneric(pseudogeneric), Escaping(noescape),
-        DifferentiabilityKind(unsigned(diffKind)) {}
+        Async(async), DifferentiabilityKind(unsigned(diffKind)) {}
 
   ImplFunctionTypeFlags
   withRepresentation(ImplFunctionRepresentation rep) const {
     return ImplFunctionTypeFlags(
-        rep, Pseudogeneric, Escaping,
+        rep, Pseudogeneric, Escaping, Async,
+        ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
+  }
+
+  ImplFunctionTypeFlags
+  withAsync() const {
+    return ImplFunctionTypeFlags(
+        ImplFunctionRepresentation(Rep), Pseudogeneric, Escaping, true,
         ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
 
   ImplFunctionTypeFlags
   withEscaping() const {
     return ImplFunctionTypeFlags(
-        ImplFunctionRepresentation(Rep), Pseudogeneric, true,
+        ImplFunctionRepresentation(Rep), Pseudogeneric, true, Async,
         ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
   
   ImplFunctionTypeFlags
   withPseudogeneric() const {
     return ImplFunctionTypeFlags(
-        ImplFunctionRepresentation(Rep), true, Escaping,
+        ImplFunctionRepresentation(Rep), true, Escaping, Async,
         ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
 
   ImplFunctionTypeFlags
   withDifferentiabilityKind(ImplFunctionDifferentiabilityKind diffKind) const {
     return ImplFunctionTypeFlags(ImplFunctionRepresentation(Rep), Pseudogeneric,
-                                 Escaping, diffKind);
+                                 Escaping, Async, diffKind);
   }
 
   ImplFunctionRepresentation getRepresentation() const {
     return ImplFunctionRepresentation(Rep);
   }
+
+  bool isAsync() const { return Async; }
 
   bool isEscaping() const { return Escaping; }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3260,7 +3260,6 @@ void SILFunctionType::Profile(
     llvm::FoldingSetNodeID &id,
     GenericSignature genericParams,
     ExtInfo info,
-    bool isAsync,
     SILCoroutineKind coroutineKind,
     ParameterConvention calleeConvention,
     ArrayRef<SILParameterInfo> params,
@@ -3274,7 +3273,6 @@ void SILFunctionType::Profile(
   auto infoKey = info.getFuncAttrKey();
   id.AddInteger(infoKey.first);
   id.AddPointer(infoKey.second);
-  id.AddBoolean(isAsync);
   id.AddInteger(unsigned(coroutineKind));
   id.AddInteger(unsigned(calleeConvention));
   id.AddInteger(params.size());
@@ -3486,8 +3484,8 @@ CanSILFunctionType SILFunctionType::get(
   invocationSubs = invocationSubs.getCanonical();
   
   llvm::FoldingSetNodeID id;
-  SILFunctionType::Profile(id, genericSig, ext, isAsync, coroutineKind, callee,
-                           params, yields, normalResults, errorResult,
+  SILFunctionType::Profile(id, genericSig, ext, coroutineKind, callee, params,
+                           yields, normalResults, errorResult,
                            witnessMethodConformance,
                            patternSubs, invocationSubs);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3300,7 +3300,6 @@ void SILFunctionType::Profile(
 SILFunctionType::SILFunctionType(
     GenericSignature genericSig,
     ExtInfo ext,
-    bool isAsync,
     SILCoroutineKind coroutineKind,
     ParameterConvention calleeConvention,
     ArrayRef<SILParameterInfo> params,
@@ -3326,7 +3325,6 @@ SILFunctionType::SILFunctionType(
          "Bits were dropped!");
   static_assert(SILExtInfoBuilder::NumMaskBits == NumSILExtInfoBits,
                 "ExtInfo and SILFunctionTypeBitfields must agree on bit size");
-  Bits.SILFunctionType.IsAsync = isAsync;
   Bits.SILFunctionType.CoroutineKind = unsigned(coroutineKind);
   NumParameters = params.size();
   if (coroutineKind == SILCoroutineKind::None) {
@@ -3470,7 +3468,7 @@ CanSILBlockStorageType SILBlockStorageType::get(CanType captureType) {
 
 CanSILFunctionType SILFunctionType::get(
     GenericSignature genericSig,
-    ExtInfo ext, bool isAsync, SILCoroutineKind coroutineKind,
+    ExtInfo ext, SILCoroutineKind coroutineKind,
     ParameterConvention callee,
     ArrayRef<SILParameterInfo> params,
     ArrayRef<SILYieldInfo> yields,
@@ -3537,7 +3535,7 @@ CanSILFunctionType SILFunctionType::get(
   }
 
   auto fnType =
-      new (mem) SILFunctionType(genericSig, ext, isAsync, coroutineKind, callee,
+      new (mem) SILFunctionType(genericSig, ext, coroutineKind, callee,
                                 params, yields, normalResults, errorResult,
                                 patternSubs, invocationSubs,
                                 ctx, properties, witnessMethodConformance);

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -530,7 +530,7 @@ Type ASTBuilder::createImplFunctionType(
 
   // [TODO: Store-SIL-Clang-type]
   auto einfo = SILExtInfoBuilder(representation, flags.isPseudogeneric(),
-                                 !flags.isEscaping(), diffKind,
+                                 !flags.isEscaping(), flags.isAsync(), diffKind,
                                  /*clangFunctionType*/ nullptr)
                    .build();
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -558,8 +558,7 @@ Type ASTBuilder::createImplFunctionType(
     auto conv = getResultConvention(errorResult->getConvention());
     funcErrorResult.emplace(type, conv);
   }
-  return SILFunctionType::get(genericSig, einfo,
-                              /*isAsync*/ false, funcCoroutineKind,
+  return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
                               funcCalleeConvention, funcParams, funcYields,
                               funcResults, funcErrorResult,
                               SubstitutionMap(), SubstitutionMap(), Ctx);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4133,6 +4133,9 @@ public:
     if (info.isNoEscape()) {
       Printer.printSimpleAttr("@noescape") << " ";
     }
+    if (info.isAsync()) {
+      Printer.printSimpleAttr("@async") << " ";
+    }
   }
 
   void visitAnyFunctionTypeParams(ArrayRef<AnyFunctionType::Param> Params,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4277,7 +4277,6 @@ public:
 
   void visitSILFunctionType(SILFunctionType *T) {
     printSILCoroutineKind(T->getCoroutineKind());
-    printSILAsyncAttr(T->isAsync());
     printFunctionExtInfo(T->getASTContext(), T->getExtInfo(),
                          T->getWitnessMethodConformanceOrInvalid());
     printCalleeConvention(T->getCalleeConvention());

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4378,7 +4378,6 @@ case TypeKind::Id:
     return SILFunctionType::get(
         fnTy->getInvocationGenericSignature(),
         fnTy->getExtInfo(),
-        fnTy->isAsync(),
         fnTy->getCoroutineKind(),
         fnTy->getCalleeConvention(),
         transInterfaceParams,
@@ -5372,7 +5371,7 @@ SILFunctionType::withInvocationSubstitutions(SubstitutionMap subs) const {
   assert(!subs || CanGenericSignature(subs.getGenericSignature())
                     == getInvocationGenericSignature());
   return SILFunctionType::get(getInvocationGenericSignature(),
-                          getExtInfo(), isAsync(), getCoroutineKind(),
+                          getExtInfo(), getCoroutineKind(),
                           getCalleeConvention(),
                           getParameters(), getYields(), getResults(),
                           getOptionalErrorResult(),
@@ -5390,7 +5389,7 @@ SILFunctionType::withPatternSubstitutions(SubstitutionMap subs) const {
   assert(!subs || CanGenericSignature(subs.getGenericSignature())
                     == getPatternGenericSignature());
   return SILFunctionType::get(getInvocationGenericSignature(),
-                          getExtInfo(), isAsync(), getCoroutineKind(),
+                          getExtInfo(), getCoroutineKind(),
                           getCalleeConvention(),
                           getParameters(), getYields(), getResults(),
                           getOptionalErrorResult(),
@@ -5409,7 +5408,7 @@ SILFunctionType::withPatternSpecialization(CanGenericSignature sig,
   assert(!subs || CanGenericSignature(subs.getGenericSignature())
                     == getSubstGenericSignature());
   return SILFunctionType::get(sig,
-                          getExtInfo(), isAsync(), getCoroutineKind(),
+                          getExtInfo(), getCoroutineKind(),
                           getCalleeConvention(),
                           getParameters(), getYields(), getResults(),
                           getOptionalErrorResult(),

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3056,7 +3056,7 @@ GenericTypeRequirements::GenericTypeRequirements(IRGenModule &IGM,
   // Construct a representative function type.
   auto generics = ncGenerics.getCanonicalSignature();
   auto fnType = SILFunctionType::get(generics, SILFunctionType::ExtInfo(),
-                                /*isAsync*/ false, SILCoroutineKind::None,
+                                SILCoroutineKind::None,
                                 /*callee*/ ParameterConvention::Direct_Unowned,
                                 /*params*/ {}, /*yields*/ {},
                                 /*results*/ {}, /*error*/ None,

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -297,7 +297,6 @@ LargeSILTypeMapper::getNewSILFunctionType(GenericEnvironment *env,
   auto newFnType = SILFunctionType::get(
       fnType->getInvocationGenericSignature(),
       fnType->getExtInfo(),
-      fnType->isAsync(),
       fnType->getCoroutineKind(),
       fnType->getCalleeConvention(),
       newParams,
@@ -2362,7 +2361,6 @@ static bool rewriteFunctionReturn(StructLoweringState &pass) {
     auto NewTy = SILFunctionType::get(
         loweredTy->getSubstGenericSignature(),
         loweredTy->getExtInfo(),
-        loweredTy->isAsync(),
         loweredTy->getCoroutineKind(),
         loweredTy->getCalleeConvention(),
         loweredTy->getParameters(),

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -107,7 +107,6 @@ SILType SILBuilder::getPartialApplyResultType(
 
   auto appliedFnType = SILFunctionType::get(nullptr,
                                             extInfo,
-                                            FTI->isAsync(),
                                             FTI->getCoroutineKind(),
                                             calleeConvention,
                                             newParams,

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -671,10 +671,9 @@ TypeBase::replaceSubstitutedSILFunctionTypesWithUnsubstituted(SILModule &M) cons
       
       if (!didChange)
         return sft;
-
+      
       return SILFunctionType::get(sft->getInvocationGenericSignature(),
-                                  sft->getExtInfo(), sft->isAsync(),
-                                  sft->getCoroutineKind(),
+                                  sft->getExtInfo(), sft->getCoroutineKind(),
                                   sft->getCalleeConvention(),
                                   newParams, newYields, newResults,
                                   newErrorResult,

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3003,7 +3003,6 @@ public:
 
     auto fnTy = SILFunctionType::get(nullptr,
                                      methodTy->getExtInfo(),
-                                     methodTy->isAsync(),
                                      methodTy->getCoroutineKind(),
                                      methodTy->getCalleeConvention(),
                                      dynParams,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -419,7 +419,7 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
                                       /*clangFunctionType*/ nullptr)
           .build();
 
-  auto functionTy = SILFunctionType::get(sig, extInfo, /*isAsync*/ false,
+  auto functionTy = SILFunctionType::get(sig, extInfo,
                                          SILCoroutineKind::YieldOnce,
                                          ParameterConvention::Direct_Unowned,
                                          params,
@@ -482,7 +482,7 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
   };
 
   CanSILFunctionType topLevelType = SILFunctionType::get(nullptr, extInfo,
-                                   /*isAsync*/ false, SILCoroutineKind::None,
+                                   SILCoroutineKind::None,
                                    ParameterConvention::Direct_Unowned,
                                    params, /*yields*/ {},
                                    SILResultInfo(Int32Ty,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -415,6 +415,7 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
       SILFunctionType::ExtInfoBuilder(SILFunctionTypeRepresentation::Thin,
                                       /*pseudogeneric*/ false,
                                       /*non-escaping*/ false,
+                                      /*async*/ false,
                                       DifferentiabilityKind::NonDifferentiable,
                                       /*clangFunctionType*/ nullptr)
           .build();

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -578,7 +578,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   }
 
   auto invokeTy = SILFunctionType::get(
-      genericSig, extInfo, /*isAsync*/ false, SILCoroutineKind::None,
+      genericSig, extInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, params, 
       /*yields*/ {}, blockInterfaceTy->getResults(),
       blockInterfaceTy->getOptionalErrorResult(),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2750,7 +2750,6 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
     
     return SILFunctionType::get(genericSig,
       SILFunctionType::ExtInfo::getThin(),
-      /*isAsync*/ false, 
       SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned,
       params, {}, result, None,
@@ -2897,10 +2896,9 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
       params.push_back({C.getUnsafeRawPointerDecl()->getDeclaredInterfaceType()
                                                    ->getCanonicalType(),
                         ParameterConvention::Direct_Unowned});
-
+    
     return SILFunctionType::get(genericSig,
       SILFunctionType::ExtInfo::getThin(),
-      /*isAsync*/ false,
       SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned,
       params, {}, {}, None,
@@ -3083,7 +3081,6 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
     
     auto signature = SILFunctionType::get(genericSig,
       SILFunctionType::ExtInfo::getThin(),
-      /*isAsync*/ false,
       SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned,
       params, /*yields*/ {}, results, None,
@@ -3258,7 +3255,6 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
     
     auto signature = SILFunctionType::get(genericSig,
       SILFunctionType::ExtInfo::getThin(),
-      /*isAsync*/ false,
       SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned,
       params, /*yields*/ {}, results, None,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -602,7 +602,6 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
                   SILFunctionType::ExtInfo()
                     .withRepresentation(SILFunctionType::Representation::
                                         CFunctionPointer),
-                  /*isAsync*/ false,
                   SILCoroutineKind::None,
                   ParameterConvention::Direct_Unowned,
                   SILParameterInfo(anyObjectMetaTy,
@@ -698,8 +697,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
             // has an overlay to fix the type of argv.
             .withRepresentation(SILFunctionType::Representation::Thin)
             .build(),
-        /*isAsync*/ false, SILCoroutineKind::None,
-        ParameterConvention::Direct_Unowned, argTypes,
+        SILCoroutineKind::None, ParameterConvention::Direct_Unowned, argTypes,
         /*yields*/ {},
         SILResultInfo(argc->getType().getASTType(), ResultConvention::Unowned),
         /*error result*/ None, SubstitutionMap(), SubstitutionMap(),

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3245,9 +3245,9 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   
   // The type of the thunk function.
   return SILFunctionType::get(
-      genericSig, extInfoBuilder.build(), expectedType->isAsync(),
-      expectedType->getCoroutineKind(), ParameterConvention::Direct_Unowned,
-      interfaceParams, interfaceYields, interfaceResults, interfaceErrorResult,
+      genericSig, extInfoBuilder.build(), expectedType->getCoroutineKind(),
+      ParameterConvention::Direct_Unowned, interfaceParams, interfaceYields,
+      interfaceResults, interfaceErrorResult,
       expectedType->getPatternSubstitutions(), SubstitutionMap(),
       getASTContext());
 }

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1587,10 +1587,10 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
   auto *diffGenericEnv =
       diffGenericSig ? diffGenericSig->getGenericEnvironment() : nullptr;
   auto diffType = SILFunctionType::get(
-      diffGenericSig, origTy->getExtInfo(), origTy->isAsync(),
-      origTy->getCoroutineKind(), origTy->getCalleeConvention(), dfParams, {},
-      dfResults, None, origTy->getPatternSubstitutions(),
-      origTy->getInvocationSubstitutions(), original->getASTContext());
+      diffGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
+      origTy->getCalleeConvention(), dfParams, {}, dfResults, None,
+      origTy->getPatternSubstitutions(), origTy->getInvocationSubstitutions(),
+      original->getASTContext());
 
   SILOptFunctionBuilder fb(context.getTransform());
   auto linkage = jvp->isSerialized() ? SILLinkage::Public : SILLinkage::Hidden;

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -242,9 +242,9 @@ CanSILFunctionType buildThunkType(SILFunction *fn,
 
   // The type of the thunk function.
   return SILFunctionType::get(
-      genericSig, extInfoBuilder.build(), expectedType->isAsync(),
-      expectedType->getCoroutineKind(), ParameterConvention::Direct_Unowned,
-      interfaceParams, interfaceYields, interfaceResults, interfaceErrorResult,
+      genericSig, extInfoBuilder.build(), expectedType->getCoroutineKind(),
+      ParameterConvention::Direct_Unowned, interfaceParams, interfaceYields,
+      interfaceResults, interfaceErrorResult,
       expectedType->getPatternSubstitutions(), SubstitutionMap(),
       fn->getASTContext());
 }

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -892,10 +892,10 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
   auto *pbGenericEnv =
       pbGenericSig ? pbGenericSig->getGenericEnvironment() : nullptr;
   auto pbType = SILFunctionType::get(
-      pbGenericSig, origTy->getExtInfo(), origTy->isAsync(),
-      origTy->getCoroutineKind(), origTy->getCalleeConvention(), pbParams, {},
-      adjResults, None, origTy->getPatternSubstitutions(),
-      origTy->getInvocationSubstitutions(), original->getASTContext());
+      pbGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
+      origTy->getCalleeConvention(), pbParams, {}, adjResults, None,
+      origTy->getPatternSubstitutions(), origTy->getInvocationSubstitutions(),
+      original->getASTContext());
 
   SILOptFunctionBuilder fb(context.getTransform());
   auto linkage = vjp->isSerialized() ? SILLinkage::Public : SILLinkage::Private;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -403,7 +403,7 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
 
   /// Return the new signature.
   return SILFunctionType::get(
-      NewGenericSig, ExtInfo, FTy->isAsync(), FTy->getCoroutineKind(),
+      NewGenericSig, ExtInfo, FTy->getCoroutineKind(),
       FTy->getCalleeConvention(), InterfaceParams, FTy->getYields(),
       FTy->getResults(), InterfaceErrorResult,
       SubstitutionMap(), SubstitutionMap(),

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -408,11 +408,10 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
       UsesGenerics ? FTy->getInvocationGenericSignature() : nullptr;
 
   return SILFunctionType::get(
-      GenericSig, ExtInfo, FTy->isAsync(), FTy->getCoroutineKind(),
-      FTy->getCalleeConvention(), InterfaceParams, InterfaceYields,
-      InterfaceResults, InterfaceErrorResult, FTy->getPatternSubstitutions(),
-      SubstitutionMap(), F->getModule().getASTContext(),
-      witnessMethodConformance);
+      GenericSig, ExtInfo, FTy->getCoroutineKind(), FTy->getCalleeConvention(),
+      InterfaceParams, InterfaceYields, InterfaceResults, InterfaceErrorResult,
+      FTy->getPatternSubstitutions(), SubstitutionMap(),
+      F->getModule().getASTContext(), witnessMethodConformance);
 }
 
 /// Compute what the function interface will look like based on the

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -428,9 +428,8 @@ ClosureCloner::initCloned(SILOptFunctionBuilder &FunctionBuilder,
   // Create the thin function type for the cloned closure.
   auto ClonedTy = SILFunctionType::get(
       OrigFTI->getInvocationGenericSignature(), OrigFTI->getExtInfo(),
-      OrigFTI->isAsync(), OrigFTI->getCoroutineKind(),
-      OrigFTI->getCalleeConvention(), ClonedInterfaceArgTys,
-      OrigFTI->getYields(), OrigFTI->getResults(),
+      OrigFTI->getCoroutineKind(), OrigFTI->getCalleeConvention(),
+      ClonedInterfaceArgTys, OrigFTI->getYields(), OrigFTI->getResults(),
       OrigFTI->getOptionalErrorResult(), SubstitutionMap(), SubstitutionMap(),
       M.getASTContext(), OrigFTI->getWitnessMethodConformanceOrInvalid());
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -670,7 +670,7 @@ ClosureSpecCloner::initCloned(SILOptFunctionBuilder &FunctionBuilder,
 
   auto ClonedTy = SILFunctionType::get(
       ClosureUserFunTy->getInvocationGenericSignature(), ExtInfo,
-      ClosureUserFunTy->isAsync(), ClosureUserFunTy->getCoroutineKind(),
+      ClosureUserFunTy->getCoroutineKind(),
       ClosureUserFunTy->getCalleeConvention(), NewParameterInfoList,
       ClosureUserFunTy->getYields(), ClosureUserFunTy->getResults(),
       ClosureUserFunTy->getOptionalErrorResult(),

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -872,8 +872,7 @@ static void emitFatalError(ADContext &context, SILFunction *f,
   // Fatal error function must have type `@convention(thin) () -> Never`.
   auto fatalErrorFnType = SILFunctionType::get(
       /*genericSig*/ nullptr, SILFunctionType::ExtInfo::getThin(),
-      /*isAsync*/ false, SILCoroutineKind::None,
-      ParameterConvention::Direct_Unowned, {},
+      SILCoroutineKind::None, ParameterConvention::Direct_Unowned, {},
       /*interfaceYields*/ {}, neverResultInfo,
       /*interfaceErrorResults*/ None, {}, {}, context.getASTContext());
   auto fnBuilder = SILOptFunctionBuilder(context.getTransform());
@@ -1025,10 +1024,10 @@ static SILValue promoteCurryThunkApplicationToDifferentiableFunction(
   auto newThunkResult = thunkResult.getWithInterfaceType(diffResultFnTy);
   auto thunkType = SILFunctionType::get(
       thunkTy->getSubstGenericSignature(), thunkTy->getExtInfo(),
-      thunkTy->isAsync(), thunkTy->getCoroutineKind(),
-      thunkTy->getCalleeConvention(), thunkTy->getParameters(), {},
-      {newThunkResult}, {}, thunkTy->getPatternSubstitutions(),
-      thunkTy->getInvocationSubstitutions(), thunkTy->getASTContext());
+      thunkTy->getCoroutineKind(), thunkTy->getCalleeConvention(),
+      thunkTy->getParameters(), {}, {newThunkResult}, {},
+      thunkTy->getPatternSubstitutions(), thunkTy->getInvocationSubstitutions(),
+      thunkTy->getASTContext());
 
   // Construct new curry thunk, returning a `@differentiable` function.
   SILOptFunctionBuilder fb(dt.getTransform());

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -699,9 +699,8 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
   // the parameters promoted.
   auto ClonedTy = SILFunctionType::get(
       OrigFTI->getInvocationGenericSignature(), OrigFTI->getExtInfo(),
-      OrigFTI->isAsync(), OrigFTI->getCoroutineKind(),
-      OrigFTI->getCalleeConvention(), ClonedInterfaceArgTys,
-      OrigFTI->getYields(), OrigFTI->getResults(),
+      OrigFTI->getCoroutineKind(), OrigFTI->getCalleeConvention(),
+      ClonedInterfaceArgTys, OrigFTI->getYields(), OrigFTI->getResults(),
       OrigFTI->getOptionalErrorResult(), OrigFTI->getPatternSubstitutions(),
       OrigFTI->getInvocationSubstitutions(), M.getASTContext(),
       OrigFTI->getWitnessMethodConformanceOrInvalid());

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -298,7 +298,7 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
   auto ExtInfo = SILFunctionType::ExtInfoBuilder(
                      SILFunctionType::Representation::Thin,
                      /*pseudogeneric*/ false, /*noescape*/ false,
-                     DifferentiabilityKind::NonDifferentiable,
+                     /*async*/ false, DifferentiabilityKind::NonDifferentiable,
                      /*clangFunctionType*/ nullptr)
                      .build();
   auto FunctionType = SILFunctionType::get(
@@ -1181,6 +1181,7 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
       SILFunctionType::ExtInfoBuilder(SILFunctionType::Representation::Thin,
                                       /*pseudogeneric*/ false,
                                       /*noescape*/ false,
+                                      /*async*/ false,
                                       DifferentiabilityKind::NonDifferentiable,
                                       /*clangFunctionType*/ nullptr)
           .build();

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -302,7 +302,7 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
                      /*clangFunctionType*/ nullptr)
                      .build();
   auto FunctionType = SILFunctionType::get(
-      nullptr, ExtInfo, /*isAsync*/ false, SILCoroutineKind::None,
+      nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, /*yields*/ {},
       Results, None,
       SubstitutionMap(), SubstitutionMap(),
@@ -1203,7 +1203,7 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
         SILResultInfo(BridgedReturn.getReturnType(), ResultConvention::Owned));
   }
   auto FunctionType = SILFunctionType::get(
-      nullptr, ExtInfo, /*isAsync*/ false, SILCoroutineKind::None,
+      nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, {},
       Results, None,
       SubstitutionMap(), SubstitutionMap(),

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -86,7 +86,8 @@ class BugReducerTester : public SILFunctionTransform {
         nullptr,
         SILFunctionType::ExtInfoBuilder(
             SILFunctionType::Representation::Thin, false /*isPseudoGeneric*/,
-            false /*noescape*/, DifferentiabilityKind::NonDifferentiable,
+            false /*noescape*/, false /*async*/,
+            DifferentiabilityKind::NonDifferentiable,
             nullptr /*clangFunctionType*/)
             .build(),
         SILCoroutineKind::None, ParameterConvention::Direct_Unowned,

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -89,8 +89,7 @@ class BugReducerTester : public SILFunctionTransform {
             false /*noescape*/, DifferentiabilityKind::NonDifferentiable,
             nullptr /*clangFunctionType*/)
             .build(),
-        /*isAsync*/ false, SILCoroutineKind::None,
-        ParameterConvention::Direct_Unowned,
+        SILCoroutineKind::None, ParameterConvention::Direct_Unowned,
         ArrayRef<SILParameterInfo>(), ArrayRef<SILYieldInfo>(), ResultInfoArray,
         None, SubstitutionMap(), SubstitutionMap(),
         getFunction()->getModule().getASTContext());

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -785,11 +785,10 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
 
   // Use the new specialized generic signature.
   auto NewFnTy = SILFunctionType::get(
-      CanSpecializedGenericSig, FnTy->getExtInfo(), FnTy->isAsync(),
-      FnTy->getCoroutineKind(), FnTy->getCalleeConvention(),
-      FnTy->getParameters(), FnTy->getYields(), FnTy->getResults(),
-      FnTy->getOptionalErrorResult(), FnTy->getPatternSubstitutions(),
-      SubstitutionMap(), M.getASTContext(),
+      CanSpecializedGenericSig, FnTy->getExtInfo(), FnTy->getCoroutineKind(),
+      FnTy->getCalleeConvention(), FnTy->getParameters(), FnTy->getYields(),
+      FnTy->getResults(), FnTy->getOptionalErrorResult(),
+      FnTy->getPatternSubstitutions(), SubstitutionMap(), M.getASTContext(),
       FnTy->getWitnessMethodConformanceOrInvalid());
 
   // This is an interface type. It should not have any archetypes.
@@ -857,7 +856,7 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
                      ? SubstFTy->getInvocationGenericSignature()
                      : CanGenericSignature();
   return SILFunctionType::get(
-      Signature, SubstFTy->getExtInfo(), SubstFTy->isAsync(),
+      Signature, SubstFTy->getExtInfo(),
       SubstFTy->getCoroutineKind(), SubstFTy->getCalleeConvention(),
       SpecializedParams, SpecializedYields, SpecializedResults,
       SubstFTy->getOptionalErrorResult(), SubstitutionMap(), SubstitutionMap(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2146,8 +2146,6 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       SILFunctionType::Representation rep;
       TypeRepr *witnessMethodProtocol = nullptr;
 
-      auto isAsync = attrs.has(TAK_async);
-
       auto coroutineKind = SILCoroutineKind::None;
       if (attrs.has(TAK_yield_once)) {
         coroutineKind = SILCoroutineKind::YieldOnce;
@@ -2226,7 +2224,8 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       // [TODO: Store-SIL-Clang-type]
       auto extInfo = SILFunctionType::ExtInfoBuilder(
                          rep, attrs.has(TAK_pseudogeneric),
-                         attrs.has(TAK_noescape), diffKind, nullptr)
+                         attrs.has(TAK_noescape), attrs.has(TAK_async), 
+                         diffKind, nullptr)
                          .build();
 
       ty = resolveSILFunctionType(fnRepr, options, coroutineKind, extInfo,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1749,7 +1749,6 @@ namespace {
 
     Type resolveSILFunctionType(FunctionTypeRepr *repr,
                                 TypeResolutionOptions options,
-                                bool isAsync = false,
                                 SILCoroutineKind coroutineKind
                                   = SILCoroutineKind::None,
                                 SILFunctionType::ExtInfo extInfo
@@ -2230,7 +2229,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                          attrs.has(TAK_noescape), diffKind, nullptr)
                          .build();
 
-      ty = resolveSILFunctionType(fnRepr, options, isAsync, coroutineKind, extInfo,
+      ty = resolveSILFunctionType(fnRepr, options, coroutineKind, extInfo,
                                   calleeConvention, witnessMethodProtocol);
       if (!ty || ty->hasError())
         return ty;
@@ -2845,7 +2844,6 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
 
 Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
                                           TypeResolutionOptions options,
-                                          bool isAsync,
                                           SILCoroutineKind coroutineKind,
                                           SILFunctionType::ExtInfo extInfo,
                                           ParameterConvention callee,
@@ -3040,8 +3038,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
            "found witness_method without matching conformance");
   }
 
-  return SILFunctionType::get(genericSig, extInfo, isAsync,
-                              coroutineKind, callee,
+  return SILFunctionType::get(genericSig, extInfo, coroutineKind, callee,
                               interfaceParams, interfaceYields,
                               interfaceResults, interfaceErrorResult,
                               interfacePatternSubs, invocationSubs,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5568,8 +5568,7 @@ public:
     if (!patternSubsOrErr)
       return patternSubsOrErr.takeError();
 
-    return SILFunctionType::get(invocationSig, extInfo,
-                                async, coroutineKind.getValue(),
+    return SILFunctionType::get(invocationSig, extInfo, coroutineKind.getValue(),
                                 calleeConvention.getValue(),
                                 allParams, allYields, allResults,
                                 errorResult,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5419,7 +5419,8 @@ public:
 
     auto extInfo =
         SILFunctionType::ExtInfoBuilder(*representation, pseudogeneric,
-                                        noescape, *diffKind, clangFunctionType)
+                                        noescape, async, *diffKind, 
+                                        clangFunctionType)
             .build();
 
     // Process the coroutine kind.

--- a/test/SIL/Parser/async.sil
+++ b/test/SIL/Parser/async.sil
@@ -16,7 +16,7 @@ bb0(%int : $Builtin.Int32):
   return %0 : $()
 }
 
-// CHECK: sil @async_test : $@async
+// CHECK: sil @async_test : $@convention(thin) @async
 sil @async_test : $@async () -> () {
 bb0:
   %0 = tuple ()

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -15,7 +15,7 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return undef : $()
 }
 
-// CHECK-LABEL: sil @async_test : $@async @convention(thin)
+// CHECK-LABEL: sil @async_test : $@convention(thin) @async
 sil @async_test : $@async () -> () {
 bb0:
   %0 = tuple ()


### PR DESCRIPTION
Previously the async flag was one of the bits of SILFunctionType.  Here it is moved into SILExtInfo.