### PR TITLE
[build-toolchain] Add an option to control if code built by the toolchain links by default to the OS runtime or the toolchain runtime.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1277,6 +1277,7 @@ darwin-toolchain-display-name-short=%(darwin_toolchain_display_name_short)s
 darwin-toolchain-name=%(darwin_toolchain_xctoolchain_name)s
 darwin-toolchain-version=%(darwin_toolchain_version)s
 darwin-toolchain-alias=%(darwin_toolchain_alias)s
+darwin-toolchain-require-use-os-runtime=0
 
 [preset: mixin_osx_package_test]
 build-subdir=buildbot_osx
@@ -1296,6 +1297,8 @@ lldb-test-swift-only
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s
 
+[preset: mixin_osx_package,use_os_runtime]:
+darwin-toolchain-require-use-os-runtime=1
 
 [preset: buildbot_osx_package]
 mixin-preset=
@@ -1306,6 +1309,11 @@ mixin-preset=
 # SKIP LLDB TESTS (67923799)
 skip-test-lldb
 
+[preset: buildbot_osx_package,use_os_runtime]
+mixin-preset=
+    buildbot_osx_package
+    mixin_osx_package,use_os_runtime
+
 [preset: buildbot_osx_package,no_assertions]
 mixin-preset=
     mixin_osx_package_base
@@ -1315,12 +1323,20 @@ dash-dash
 
 no-assertions
 
+[preset: buildbot_osx_package,no_assertions,use_os_runtime]
+mixin-preset=
+    buildbot_osx_package,no_assertions
+    mixin_osx_package,use_os_runtime
 
 [preset: buildbot_osx_package,no_assertions,lto]
 mixin-preset=buildbot_osx_package,no_assertions
 
 lto
 
+[preset: buildbot_osx_package,no_assertions,lto,use_os_runtime]
+mixin-preset=
+    buildbot_osx_package,no_assertions,lto
+    mixin_osx_package,use_os_runtime
 
 [preset: buildbot_osx_package,no_assertions,no_test]
 mixin-preset=
@@ -1339,6 +1355,10 @@ skip-test-swiftsyntax
 skip-test-skstresstester
 skip-test-swiftevolve
 
+[preset: buildbot_osx_package,no_assertions,no_test,use_os_runtime]
+mixin-preset=
+    buildbot_osx_package,no_assertions,no_test
+    mixin_osx_package,use_os_runtime
 
 # Debug version of the compilers, release version of the stdlib.
 [preset: buildbot_osx_package,tools=DA,stdlib=R]
@@ -1351,6 +1371,11 @@ assertions
 debug-llvm
 debug-swift
 no-swift-stdlib-assertions
+
+[preset: buildbot_osx_package,tools=DA,stdlib=R,use_os_runtime]
+mixin-preset=
+    buildbot_osx_package,tools=DA,stdlib=R
+    mixin_osx_package,use_os_runtime
 
 [preset: mixin_buildbot_osx_package,no_test]
 skip-test-swift
@@ -1369,6 +1394,14 @@ skip-test-swiftevolve
 mixin-preset=
     buildbot_osx_package
     mixin_buildbot_osx_package,no_test
+
+# macOS package without test that when linked against uses the OS runtime
+# instead of the toolchain runtime.
+[preset: buildbot_osx_package,no_test,use_os_runtime]
+mixin-preset=
+    buildbot_osx_package
+    mixin_buildbot_osx_package,no_test
+    mixin_osx_package,use_os_runtime
 
 #===------------------------------------------------------------------------===#
 # LLDB build configurations

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -114,6 +114,7 @@ KNOWN_SETTINGS=(
     darwin-toolchain-installer-package            ""                "The path to installer pkg"
     darwin-toolchain-name                         ""                "Directory name for xctoolchain"
     darwin-toolchain-version                      ""                "Version for xctoolchain info plist and installer pkg"
+    darwin-toolchain-require-use-os-runtime       "0"               "When setting up a plist for a toolchain, require the users of the toolchain to link against the OS instead of the packaged toolchain runtime. 0 for false, 1 for true"
     darwin-xcrun-toolchain                        "default"         "the name of the toolchain to use on Darwin"
 
     ## Build Types for Components
@@ -3050,6 +3051,11 @@ function build_and_test_installable_package() {
           COMPATIBILITY_VERSION_DISPLAY_STRING="Xcode 8.0"
           DARWIN_TOOLCHAIN_CREATED_DATE="$(date -u +'%a %b %d %T GMT %Y')"
 
+          SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME="YES"
+          if [[ "${DARWIN_TOOLCHAIN_REQUIRE_USE_OS_RUNTIME}" -eq "1" ]]; then
+              SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME="NO"
+          fi
+
           echo "-- Removing: ${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call rm -f ${DARWIN_TOOLCHAIN_INFO_PLIST}
 
@@ -3068,7 +3074,7 @@ function build_and_test_installable_package() {
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DISABLE_REQUIRED_ARCLITE string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_LINK_OBJC_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
           call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DEVELOPMENT_TOOLCHAIN string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME string '${SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 
           call chmod a+r "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -35,6 +35,9 @@ function usage() {
   echo "--preset-prefix"
   echo "Customize the preset invoked by prepending a prefix"
   echo ""
+  echo "--use-os-runtime"
+  echo "Require this toolchain to link against against the OS runtime rather than the toolchains packaged runtime"
+  echo ""
 }
 
 RESULT_DIR=$PWD
@@ -46,6 +49,8 @@ DRY_RUN=
 BUNDLE_PREFIX=
 PRESET_FILE_FLAGS=
 PRESET_PREFIX=
+PRESET_SUFFIX=
+
 case $(uname -s) in
   Darwin)
     SWIFT_PACKAGE=buildbot_osx_package,no_test
@@ -85,6 +90,9 @@ while [ $# -ne 0 ]; do
     --preset-prefix)
       shift
       PRESET_PREFIX="$1"
+  ;;
+    --use-os-runtime)
+      PRESET_SUFFIX=",use_os_runtime"
   ;;
   -h|--help)
     usage
@@ -133,7 +141,8 @@ DRY_RUN="${DRY_RUN}"
 DISTCC_FLAG="${DISTCC_FLAG}"
 PRESET_FILE_FLAGS="${PRESET_FILE_FLAGS}"
 
-./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}" \
+./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${PRESET_SUFFIX}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \
@@ -144,4 +153,5 @@ PRESET_FILE_FLAGS="${PRESET_FILE_FLAGS}"
         darwin_toolchain_display_name_short="${DISPLAY_NAME_SHORT}" \
         darwin_toolchain_xctoolchain_name="${TOOLCHAIN_NAME}" \
         darwin_toolchain_version="${TOOLCHAIN_VERSION}" \
-        darwin_toolchain_alias="Local"
+        darwin_toolchain_alias="Local" \
+        darwin_toolchain_require_use_os_runtime="${REQUIRE_USE_OS_RUNTIME}"


### PR DESCRIPTION
Today by default, we always link against the runtime runtime. This option just
lets our users decide what they want, but leaves the defaults alone.
