### PR TITLE
[RemoteMirror] Fix potential uninitialized data access in convertChild.

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -447,6 +447,12 @@ static swift_childinfo_t convertChild(const TypeInfo *TI, unsigned Index) {
     FieldInfo = &(RecordTI->getFields()[Index]);
   } else {
     assert(false && "convertChild(TI): TI must be record or enum typeinfo");
+    return {
+      "unknown TypeInfo kind",
+      0,
+      SWIFT_UNKNOWN,
+      0,
+    };
   }
 
   return {


### PR DESCRIPTION
The else branch of the type checking code just does assert(false). When asserts are off, the code will fall through and access the uninitialized FieldInfo variable. Instead, return something sensible for this error case.