### PR TITLE
[CodeCompletion] Don't update VFS content hash map after each completion

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -485,8 +485,6 @@ bool CompletionInstance::performCachedOperationIfPossible(
   }
 
   CachedReuseCount += 1;
-  cacheDependencyHashIfNeeded(CI, SM.getCodeCompletionBufferID(),
-                              InMemoryDependencyHash);
 
   return true;
 }

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -4,8 +4,8 @@ func foo(value: MyStruct) {
 
 // REQUIRES: shell
 
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
+// RUN: DEPCHECK_INTERVAL=2
+// RUN: SLEEP_TIME=3
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)
@@ -23,7 +23,14 @@ func foo(value: MyStruct) {
 
 // RUN:   -shell -- echo "### Keep" == \
 // RUN:   -shell -- sleep ${SLEEP_TIME} == \
-// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
+
+// RUN:   -shell -- echo "### Rollback without sleep" == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
+
+// RUN:   -shell -- echo "### After sleep" == \
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift \
 
 // RUN:   |  %FileCheck %s
 
@@ -50,3 +57,19 @@ func foo(value: MyStruct) {
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Rollback without sleep
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "extensionMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### After sleep
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "extensionMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1


### PR DESCRIPTION
This was not needed. The list of dependencies should not be changed during fast-completion sessions.
This was also harmful because it calls stat(2) for all the dependency files.

rdar://problem/67773257

(The updated test  passes even without this change.  Just to make sure it works correctly)
