### PR TITLE
[5.3][CodeCompletion] Don't update VFS content hash map after each completion

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -491,8 +491,6 @@ bool CompletionInstance::performCachedOperationIfPossible(
   }
 
   CachedReuseCount += 1;
-  cacheDependencyHashIfNeeded(CI, CurrentModule, SM.getCodeCompletionBufferID(),
-                              InMemoryDependencyHash);
 
   return true;
 }

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -4,8 +4,8 @@ func foo(value: MyStruct) {
 
 // REQUIRES: shell
 
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
+// RUN: DEPCHECK_INTERVAL=2
+// RUN: SLEEP_TIME=3
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)
@@ -23,7 +23,14 @@ func foo(value: MyStruct) {
 
 // RUN:   -shell -- echo "### Keep" == \
 // RUN:   -shell -- sleep ${SLEEP_TIME} == \
-// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
+
+// RUN:   -shell -- echo "### Rollback without sleep" == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
+
+// RUN:   -shell -- echo "### After sleep" == \
+// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift \
 
 // RUN:   |  %FileCheck %s
 
@@ -50,3 +57,19 @@ func foo(value: MyStruct) {
 // CHECK-DAG: key.description: "self"
 // CHECK: ]
 // CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### Rollback without sleep
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod_mod()"
+// CHECK-DAG: key.description: "extensionMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1
+
+// CHECK-LABEL: ### After sleep
+// CHECK: key.results: [
+// CHECK-DAG: key.description: "myStructMethod()"
+// CHECK-DAG: key.description: "extensionMethod()"
+// CHECK-DAG: key.description: "self"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1


### PR DESCRIPTION
Cherry-pick of #33645 into `release/5.3`

* **Explanation**: Fix an issue where stat is call on all the dependency files for each completion invocation. There was a function call that checks the files are from virtual file systems. It was completely unnecessary to do it after each fast-completion.
* **Scope**: Code completion
* **Risk**: Low
* **Testing**: There's no observable behavior change. A regression test case is updated to ensure that it behaves correctly.
* **Issue**: rdar://problem/67773257
* **Reviewer**: Ben Langmuir (@benlangmuir)