### PR TITLE
Revert "[Package] When building a toolchain, don't copy the Resource …

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1234,13 +1234,9 @@ verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
 
-# When building for an Xcode toolchain, don't copy the Swift Resource/ directory
-# into the LLDB.framework. LLDB.framework will be installed alongside a Swift
-# compiler, so LLDB should use its resource directory directly.
 # Also, to reduce the size of the final toolchain, limit debug info to be
 # line-tables only.
 extra-cmake-options=
-   -DLLDB_FRAMEWORK_COPY_SWIFT_RESOURCES=0
    -DCMAKE_C_FLAGS="-gline-tables-only"
    -DCMAKE_CXX_FLAGS="-gline-tables-only"
 


### PR DESCRIPTION
…directory."

This reverts commit 8337f961d8c24bdbe333f38d826b414598c70ce0. It seems that
without the resource directory any kind formatting of Foundation classes
doesn't work in the toolchain's swift:

```
  1> import Foundation
  2> let u = URL(string: "http://www.apple.com")!
u: URL = {}
```