### PR TITLE
Remove hardcoded symbol name parsing from SILOptimizer passes

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -176,6 +176,11 @@ Globals
   global ::= global 'MJ'                 // noncanonical specialized generic type metadata instantiation cache associated with global
   global ::= global 'MN'                 // noncanonical specialized generic type metadata for global
 
+  #if SWIFT_RUNTIME_VERSION >= 5.4
+    global ::= context (decl-name '_')+ 'WZ' // global variable one-time initialization function
+    global ::= context (decl-name '_')+ 'Wz' // global variable one-time initialization token
+  #endif
+
 A direct symbol resolves directly to the address of an object.  An
 indirect symbol resolves to the address of a pointer to the object.
 They are distinct manglings to make a certain class of bugs

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -146,7 +146,8 @@ public:
 
   std::string mangleGlobalVariableFull(const VarDecl *decl);
 
-  std::string mangleGlobalInit(const VarDecl *decl, int counter,
+  std::string mangleGlobalInit(const PatternBindingDecl *decl,
+                               unsigned entry,
                                bool isInitFunc);
 
   std::string mangleReabstractionThunkHelper(CanSILFunctionType ThunkType,

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -294,6 +294,9 @@ NODE(CanonicalSpecializedGenericTypeMetadataAccessFunction)
 NODE(MetadataInstantiationCache)
 NODE(NoncanonicalSpecializedGenericTypeMetadata)
 NODE(NoncanonicalSpecializedGenericTypeMetadataCache)
+NODE(GlobalVariableOnceFunction)
+NODE(GlobalVariableOnceToken)
+NODE(GlobalVariableOnceDeclList)
 
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -121,6 +121,7 @@ public:
   enum class Purpose : uint8_t {
     None,
     GlobalInit,
+    GlobalInitOnceFunction,
     LazyPropertyGetter
   };
 
@@ -832,6 +833,10 @@ public:
   /// function itself does not need this attribute. It is private and only
   /// called within the addressor.
   bool isGlobalInit() const { return specialPurpose == Purpose::GlobalInit; }
+    
+  bool isGlobalInitOnceFunction() const {
+    return specialPurpose == Purpose::GlobalInitOnceFunction;
+  }
 
   bool isLazyPropertyGetter() const {
     return specialPurpose == Purpose::LazyPropertyGetter;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -336,21 +336,29 @@ std::string ASTMangler::mangleKeyPathHashHelper(ArrayRef<CanType> indices,
   return finalize();
 }
 
-std::string ASTMangler::mangleGlobalInit(const VarDecl *decl, int counter,
+std::string ASTMangler::mangleGlobalInit(const PatternBindingDecl *pd,
+                                         unsigned pbdEntry,
                                          bool isInitFunc) {
-  auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
-  auto fileUnit = cast<FileUnit>(topLevelContext);
-  Identifier discriminator = fileUnit->getDiscriminatorForPrivateValue(decl);
-  assert(!discriminator.empty());
-  assert(!isNonAscii(discriminator.str()) &&
-         "discriminator contains non-ASCII characters");
-  assert(!clang::isDigit(discriminator.str().front()) &&
-         "not a valid identifier");
-
-  Buffer << "globalinit_";
-  appendIdentifier(discriminator.str());
-  Buffer << (isInitFunc ? "_func" : "_token");
-  Buffer << counter;
+  beginMangling();
+  
+  Pattern *pattern = pd->getPattern(pbdEntry);
+  bool first = true;
+  pattern->forEachVariable([&](VarDecl *D) {
+    if (first) {
+      appendContextOf(D);
+      first = false;
+    }
+    appendDeclName(D);
+    appendListSeparator();
+  });
+  assert(!first && "no variables in pattern binding?!");
+  
+  if (isInitFunc) {
+    appendOperator("WZ");
+  } else {
+    appendOperator("Wz");
+  }
+  
   return finalize();
 }
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -552,6 +552,9 @@ private:
     case Node::Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
     case Node::Kind::NoncanonicalSpecializedGenericTypeMetadata:
     case Node::Kind::NoncanonicalSpecializedGenericTypeMetadataCache:
+    case Node::Kind::GlobalVariableOnceDeclList:
+    case Node::Kind::GlobalVariableOnceFunction:
+    case Node::Kind::GlobalVariableOnceToken:
       return false;
     }
     printer_unreachable("bad node kind");
@@ -2465,6 +2468,28 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
   case Node::Kind::NoncanonicalSpecializedGenericTypeMetadataCache:
     Printer << "cache variable for noncanonical specialized generic type metadata for ";
     print(Node->getChild(0));
+    return nullptr;
+  case Node::Kind::GlobalVariableOnceToken:
+  case Node::Kind::GlobalVariableOnceFunction:
+    Printer << (kind == Node::Kind::GlobalVariableOnceToken
+                  ? "one-time initialization token for "
+                  : "one-time initialization function for ");
+    printContext(Node->getChild(0));
+    print(Node->getChild(1));
+    return nullptr;
+  case Node::Kind::GlobalVariableOnceDeclList:
+    if (Node->getNumChildren() == 1) {
+      print(Node->getChild(0));
+    } else {
+      Printer << '(';
+      for (unsigned i = 0, e = Node->getNumChildren(); i < e; ++i) {
+        if (i != 0) {
+          Printer << ", ";
+        }
+        print(Node->getChild(i));
+      }
+      Printer << ')';
+    }
     return nullptr;
   }
   printer_unreachable("bad node kind!");

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2139,6 +2139,15 @@ void Remangler::mangleAccessorFunctionReference(Node *node) {
 void Remangler::mangleMetadataInstantiationCache(Node *node) {
   unreachable("unsupported");
 }
+void Remangler::mangleGlobalVariableOnceToken(Node *node) {
+  unreachable("unsupported");
+}
+void Remangler::mangleGlobalVariableOnceFunction(Node *node) {
+  unreachable("unsupported");
+}
+void Remangler::mangleGlobalVariableOnceDeclList(Node *node) {
+  unreachable("unsupported");
+}
 
 void Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node) {
   Buffer << "MM";

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2566,6 +2566,23 @@ void Remangler::mangleNoncanonicalSpecializedGenericTypeMetadataCache(Node *node
   Buffer << "MJ";
 }
 
+void Remangler::mangleGlobalVariableOnceToken(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "Wz";
+}
+
+void Remangler::mangleGlobalVariableOnceFunction(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "WZ";
+}
+
+void Remangler::mangleGlobalVariableOnceDeclList(Node *node) {
+  for (unsigned i = 0, e = node->getNumChildren(); i < e; ++i) {
+    mangle(node->getChild(i));
+    Buffer << '_';
+  }
+}
+
 } // anonymous namespace
 
 /// The top-level interface to the remangler.

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -272,7 +272,7 @@ SILFunction *swift::findInitializer(SILFunction *AddrF,
   if (!CallToOnce)
     return nullptr;
   SILFunction *callee = getCalleeOfOnceCall(CallToOnce);
-  if (!callee->getName().startswith("globalinit_"))
+  if (!callee->isGlobalInitOnceFunction())
     return nullptr;
   return callee;
 }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2606,6 +2606,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   case SILFunction::Purpose::GlobalInit:
     OS << "[global_init] ";
     break;
+  case SILFunction::Purpose::GlobalInitOnceFunction:
+    OS << "[global_init_once_fn] ";
+    break;
   case SILFunction::Purpose::LazyPropertyGetter:
     OS << "[lazy_getter] ";
     break;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -961,6 +961,8 @@ static bool parseDeclSILOptional(bool *isTransparent,
       *specialPurpose = SILFunction::Purpose::GlobalInit;
     else if (specialPurpose && SP.P.Tok.getText() == "lazy_getter")
       *specialPurpose = SILFunction::Purpose::LazyPropertyGetter;
+    else if (specialPurpose && SP.P.Tok.getText() == "global_init_once_fn")
+      *specialPurpose = SILFunction::Purpose::GlobalInitOnceFunction;
     else if (isWeakImported && SP.P.Tok.getText() == "weak_imported") {
       if (M.getASTContext().LangOpts.Target.isOSBinFormatCOFF())
         SP.P.diagnose(SP.P.Tok, diag::attr_unsupported_on_target,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1366,6 +1366,7 @@ SILFunction *SILGenModule::emitLazyGlobalInitializer(StringRef funcName,
   auto *f = builder.createFunction(
       SILLinkage::Private, funcName, initSILType, nullptr, SILLocation(binding),
       IsNotBare, IsNotTransparent, IsNotSerialized, IsNotDynamic);
+  f->setSpecialPurpose(SILFunction::Purpose::GlobalInitOnceFunction);
   f->setDebugScope(new (M) SILDebugScope(RegularLocation(binding), f));
   auto dc = binding->getDeclContext();
   SILGenFunction(*this, *f, dc).emitLazyGlobalInitializer(binding, pbdEntry);

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -178,20 +178,8 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
                 ->areAllParamsConcrete());
   }
 
-  // Emit the lazy initialization token for the initialization expression.
-  auto counter = anonymousSymbolCounter++;
-
-  // Pick one variable of the pattern. Usually it's only one variable, but it
-  // can also be something like: var (a, b) = ...
-  Pattern *pattern = pd->getPattern(pbdEntry);
-  VarDecl *varDecl = nullptr;
-  pattern->forEachVariable([&](VarDecl *D) {
-    varDecl = D;
-  });
-  assert(varDecl);
-
   Mangle::ASTMangler TokenMangler;
-  std::string onceTokenBuffer = TokenMangler.mangleGlobalInit(varDecl, counter,
+  std::string onceTokenBuffer = TokenMangler.mangleGlobalInit(pd, pbdEntry,
                                                               false);
   
   auto onceTy = BuiltinIntegerType::getWordType(M.getASTContext());
@@ -207,7 +195,7 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
 
   // Emit the initialization code into a function.
   Mangle::ASTMangler FuncMangler;
-  std::string onceFuncBuffer = FuncMangler.mangleGlobalInit(varDecl, counter,
+  std::string onceFuncBuffer = FuncMangler.mangleGlobalInit(pd, pbdEntry,
                                                             true);
   
   SILFunction *onceFunc = emitLazyGlobalInitializer(onceFuncBuffer, pd,

--- a/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
@@ -47,7 +47,7 @@ class ARCLoopOpts : public SILFunctionTransform {
       return;
 
     // Skip global init functions.
-    if (F->getName().startswith("globalinit_"))
+    if (F->isGlobalInitOnceFunction())
       return;
 
     auto *LA = getAnalysis<SILLoopAnalysis>();

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -183,7 +183,7 @@ processFunctionWithoutLoopSupport(SILFunction &F, bool FreezePostDomReleases,
   // globalinit_func. Since that is not *that* interesting from an ARC
   // perspective (i.e. no ref count operations in a loop), disable it on such
   // functions temporarily in order to unblock others. This should be removed.
-  if (F.getName().startswith("globalinit_"))
+  if (F.isGlobalInitOnceFunction())
     return false;
 
   LLVM_DEBUG(llvm::dbgs() << "***** Processing " << F.getName() << " *****\n");
@@ -231,7 +231,7 @@ static bool processFunctionWithLoopSupport(
   // globalinit_func. Since that is not *that* interesting from an ARC
   // perspective (i.e. no ref count operations in a loop), disable it on such
   // functions temporarily in order to unblock others. This should be removed.
-  if (F.getName().startswith("globalinit_"))
+  if (F.isGlobalInitOnceFunction())
     return false;
 
   LLVM_DEBUG(llvm::dbgs() << "***** Processing " << F.getName() << " *****\n");

--- a/lib/SILOptimizer/IPO/CrossModuleSerializationSetup.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleSerializationSetup.cpp
@@ -337,9 +337,6 @@ bool CrossModuleSerializationSetup::canSerialize(SILInstruction *inst,
         });
     return canUse;
   }
-  if (auto *GAI = dyn_cast<GlobalAddrInst>(inst)) {
-    return !GAI->getReferencedGlobal()->getName().startswith("globalinit_");
-  }
   if (auto *MI = dyn_cast<MethodInst>(inst)) {
     return !MI->getMember().isForeign;
   }

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -260,7 +260,7 @@ void SILGlobalOpt::collectOnceCall(BuiltinInst *BI) {
     UnhandledOnceCallee = true;
     return;
   }
-  if (!Callee->getName().startswith("globalinit_"))
+  if (!Callee->isGlobalInitOnceFunction())
     return;
 
   // We currently disable optimizing the initializer if a globalinit_func

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 574; // reapply isUserAccessible
+const uint16_t SWIFTMODULE_VERSION_MINOR = 575; // GlobalInitOnceFunction SILFunction purpose
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/IRGen/big_types_corner_cases_tiny.swift
+++ b/test/IRGen/big_types_corner_cases_tiny.swift
@@ -4,7 +4,7 @@
 
 // DO NOT ADD ANY MORE CODE TO THIS FILE!
 
-// CHECK-LABEL: define internal void @globalinit
+// CHECK-LABEL: define internal void @{{.*}}WZ
 // CHECK: [[ALLOC:%.*]] = alloca %T27big_types_corner_cases_tiny30LoadableStructWithBiggerStringV
 // CHECK: call swiftcc void {{.*}}(%T27big_types_corner_cases_tiny30LoadableStructWithBiggerStringV* noalias nocapture sret [[ALLOC]]
 let model = ClassWithLoadableStructWithBiggerString().f()

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -53,6 +53,5 @@ extension A {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main(i32 %0, i8** %1) {{.*}} {
 // CHECK:      store  i64 {{.*}}, i64* getelementptr inbounds ([[INT]], [[INT]]* @"$s7globals2g0Sivp", i32 0, i32 0), align 8
 
-// FIXME: give these initializers a real mangled name
-// CHECK: define internal void @globalinit_{{.*}}func0() {{.*}} {
+// CHECK: define internal void @"{{.*}}WZ"() {{.*}} {
 // CHECK:      store i64 5, i64* getelementptr inbounds (%TSi, %TSi* @"$s7globals1AV3fooSivpZ", i32 0, i32 0), align 8

--- a/test/IRGen/lazy_globals.swift
+++ b/test/IRGen/lazy_globals.swift
@@ -2,12 +2,12 @@
 
 // REQUIRES: CPU=x86_64
 
-// CHECK: @globalinit_[[T:.*]]_token0 = internal global i64 0, align 8
+// CHECK: @"[[T:.*]]Wz" = internal global i64 0, align 8
 // CHECK: @"$s12lazy_globals1xSivp" = hidden global %TSi zeroinitializer, align 8
 // CHECK: @"$s12lazy_globals1ySivp" = hidden global %TSi zeroinitializer, align 8
 // CHECK: @"$s12lazy_globals1zSivp" = hidden global %TSi zeroinitializer, align 8
 
-// CHECK: define internal void @globalinit_[[T]]_func0() {{.*}} {
+// CHECK: define internal void @"[[T]]WZ"() {{.*}} {
 // CHECK: entry:
 // CHECK:   store i64 1, i64* getelementptr inbounds (%TSi, %TSi* @"$s12lazy_globals1xSivp", i32 0, i32 0), align 8
 // CHECK:   store i64 2, i64* getelementptr inbounds (%TSi, %TSi* @"$s12lazy_globals1ySivp", i32 0, i32 0), align 8
@@ -17,17 +17,17 @@
 
 // CHECK: define hidden swiftcc i8* @"$s12lazy_globals1xSivau"() {{.*}} {
 // CHECK: entry:
-// CHECK:   call void @swift_once(i64* @globalinit_[[T]]_token0, i8* bitcast (void ()* @globalinit_[[T]]_func0 to i8*), i8* undef)
+// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void ()* @"[[T]]WZ" to i8*), i8* undef)
 // CHECK: }
 
 // CHECK: define hidden swiftcc i8* @"$s12lazy_globals1ySivau"() {{.*}} {
 // CHECK: entry:
-// CHECK:   call void @swift_once(i64* @globalinit_[[T]]_token0, i8* bitcast (void ()* @globalinit_[[T]]_func0 to i8*), i8* undef)
+// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void ()* @"[[T]]WZ" to i8*), i8* undef)
 // CHECK: }
 
 // CHECK: define hidden swiftcc i8* @"$s12lazy_globals1zSivau"() {{.*}} {
 // CHECK: entry:
-// CHECK:   call void @swift_once(i64* @globalinit_[[T]]_token0, i8* bitcast (void ()* @globalinit_[[T]]_func0 to i8*), i8* undef)
+// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void ()* @"[[T]]WZ" to i8*), i8* undef)
 // CHECK: }
 var (x, y, z) = (1, 2, 3)
 

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -156,7 +156,7 @@ class Foo {
     return x
   }
  
-  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_33_E52D764B1F2009F2390B2B8DF62DAEB8_func0
+  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ
   // CHECK:         string_literal utf8 "Foo" 
   static let x = Foo(int:0)
 

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -156,7 +156,7 @@ class Foo {
     return x
   }
  
-  // CHECK-LABEL: sil private [ossa] @globalinit_33_E52D764B1F2009F2390B2B8DF62DAEB8_func0
+  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_33_E52D764B1F2009F2390B2B8DF62DAEB8_func0
   // CHECK:         string_literal utf8 "Foo" 
   static let x = Foo(int:0)
 

--- a/test/SILGen/fragile_globals.swift
+++ b/test/SILGen/fragile_globals.swift
@@ -11,7 +11,7 @@ var mygg = 29
 // Check if we have one token: from mygg.
 // Initializers from other modules are never fragile.
 
-// CHECK: sil_global private{{.*}} @globalinit_[[T3:.*]]_token0
+// CHECK: sil_global private{{.*}} @[[T3:.*]]Wz
 
 //@inlinable
 public func sum() -> Int {
@@ -21,8 +21,8 @@ public func sum() -> Int {
 // Check if all the addressors are inlined.
 
 // CHECK-LABEL: sil {{.*}}@$s15fragile_globals3sumSiyF
-// CHECK-DAG: global_addr @globalinit_[[T1:.*]]_token0
-// CHECK-DAG: function_ref @globalinit_[[T1]]_func0
+// CHECK-DAG: global_addr @[[T1:.*]]Wz
+// CHECK-DAG: function_ref @[[T1]]WZ
 // CHECK-DAG: global_addr @$s15fragile_globals4myggSivp
 // CHECK-DAG: function_ref @$s7ModuleA2ggSivau
 // CHECK-DAG: function_ref @$s7ModuleB2ggSivau

--- a/test/SILGen/global_resilience.swift
+++ b/test/SILGen/global_resilience.swift
@@ -43,7 +43,7 @@ public var myEmptyGlobal = MyEmptyStruct()
 
 // Mutable addressor for fixed-layout global
 
-// CHECK-LABEL: sil private [ossa] @globalinit_{{.*}}_func1
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_{{.*}}_func1
 // CHECK:         alloc_global @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVv
 // CHECK:         return
 
@@ -52,7 +52,7 @@ public var myEmptyGlobal = MyEmptyStruct()
 // CHECK:         global_addr @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVv
 // CHECK:         return
 
-// CHECK-OPT-LABEL: sil private @globalinit_{{.*}}_func1
+// CHECK-OPT-LABEL: sil private [global_init_once_fn] @globalinit_{{.*}}_func1
 // CHECK-OPT:     alloc_global @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVv
 // CHECK-OPT:     return
 

--- a/test/SILGen/global_resilience.swift
+++ b/test/SILGen/global_resilience.swift
@@ -43,21 +43,21 @@ public var myEmptyGlobal = MyEmptyStruct()
 
 // Mutable addressor for fixed-layout global
 
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_{{.*}}_func1
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ
 // CHECK:         alloc_global @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVv
 // CHECK:         return
 
 // CHECK-LABEL: sil [global_init] [ossa] @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVvau
-// CHECK:         function_ref @globalinit_{{.*}}_func1
+// CHECK:         function_ref @{{.*}}WZ
 // CHECK:         global_addr @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVv
 // CHECK:         return
 
-// CHECK-OPT-LABEL: sil private [global_init_once_fn] @globalinit_{{.*}}_func1
+// CHECK-OPT-LABEL: sil private [global_init_once_fn] @{{.*}}WZ
 // CHECK-OPT:     alloc_global @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVv
 // CHECK-OPT:     return
 
 // CHECK-OPT-LABEL: sil [global_init] @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVvau
-// CHECK-OPT:     function_ref @globalinit_{{.*}}_func1
+// CHECK-OPT:     function_ref @{{.*}}WZ
 // CHECK-OPT:     global_addr @$s17global_resilience19myFixedLayoutGlobalAA13MyEmptyStructVvp
 // CHECK-OPT:     return
 

--- a/test/SILGen/lazy_globals.swift
+++ b/test/SILGen/lazy_globals.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
-// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T:.*]]_func0 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*]]WZ : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals1xSiv
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals1xSivp : $*Int
 // CHECK:   store {{%.*}} to [trivial] [[XADDR]] : $*Int
 
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals1xSivau : $@convention(thin) () -> Builtin.RawPointer {
-// CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @globalinit_[[T]]_token0 : $*Builtin.Word
+// CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @[[T]]Wz : $*Builtin.Word
 // CHECK:   [[TOKEN_PTR:%.*]] = address_to_pointer [[TOKEN_ADDR]] : $*Builtin.Word to $Builtin.RawPointer
-// CHECK:   [[INIT_FUNC:%.*]] = function_ref @globalinit_[[T]]_func0 : $@convention(c) () -> ()
+// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) () -> ()
 // CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) () -> ()) : $()
 // CHECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s12lazy_globals1xSivp : $*Int
 // CHECK:   [[GLOBAL_PTR:%.*]] = address_to_pointer [[GLOBAL_ADDR]] : $*Int to $Builtin.RawPointer
@@ -16,7 +16,7 @@
 // CHECK: }
 var x: Int = 0
 
-// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T:.*]]_func1 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*]]WZ : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals3FooV3fooSivpZ
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals3FooV3fooSivpZ : $*Int
 // CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
@@ -24,9 +24,9 @@ var x: Int = 0
 
 struct Foo {
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals3FooV3fooSivau : $@convention(thin) () -> Builtin.RawPointer {
-// CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @globalinit_[[T]]_token1 : $*Builtin.Word
+// CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @[[T]]Wz : $*Builtin.Word
 // CHECK:   [[TOKEN_PTR:%.*]] = address_to_pointer [[TOKEN_ADDR]] : $*Builtin.Word to $Builtin.RawPointer
-// CHECK:   [[INIT_FUNC:%.*]] = function_ref @globalinit_[[T]]_func1 : $@convention(c) () -> ()
+// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) () -> ()
 // CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) () -> ()) : $()
 // CHECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s12lazy_globals3FooV3fooSivpZ : $*Int
 // CHECK:   [[GLOBAL_PTR:%.*]] = address_to_pointer [[GLOBAL_ADDR]] : $*Int to $Builtin.RawPointer
@@ -40,7 +40,7 @@ struct Foo {
   static var initialized: Int = 57
 }
 
-// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T:.*]]_func3 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*3bar.*]]WZ : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals3BarO3barSivpZ
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals3BarO3barSivpZ : $*Int
 // CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
@@ -48,9 +48,9 @@ struct Foo {
 
 enum Bar {
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals3BarO3barSivau : $@convention(thin) () -> Builtin.RawPointer {
-// CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @globalinit_[[T]]_token3 : $*Builtin.Word
+// CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @[[T]]Wz : $*Builtin.Word
 // CHECK:   [[TOKEN_PTR:%.*]] = address_to_pointer [[TOKEN_ADDR]] : $*Builtin.Word to $Builtin.RawPointer
-// CHECK:   [[INIT_FUNC:%.*]] = function_ref @globalinit_[[T]]_func3 : $@convention(c) () -> ()
+// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) () -> ()
 // CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) () -> ()) : $()
 // CHECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s12lazy_globals3BarO3barSivpZ : $*Int
 // CHECK:   [[GLOBAL_PTR:%.*]] = address_to_pointer [[GLOBAL_ADDR]] : $*Int to $Builtin.RawPointer
@@ -63,13 +63,13 @@ enum Bar {
 
 func f() -> (Int, Int) { return (1, 2) }
 
-// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T]]_func4 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*2a1.*2b1.*]]WZ : $@convention(c) () -> () {
 // CHECK:   function_ref @$s12lazy_globals1fSi_SityF : $@convention(thin) () -> (Int, Int)
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals2a1Sivau : $@convention(thin) () -> Builtin.RawPointer
-// CHECK:   function_ref @globalinit_[[T]]_func4 : $@convention(c) () -> ()
+// CHECK:   function_ref @[[T]]WZ : $@convention(c) () -> ()
 // CHECK:   global_addr @$s12lazy_globals2a1Sivp : $*Int
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals2b1Sivau : $@convention(thin) () -> Builtin.RawPointer {
-// CHECK:   function_ref @globalinit_[[T]]_func4 : $@convention(c) () -> ()
+// CHECK:   function_ref @[[T]]WZ : $@convention(c) () -> ()
 // CHECK:   global_addr @$s12lazy_globals2b1Sivp : $*Int
 var (a1, b1) = f()
 

--- a/test/SILGen/lazy_globals.swift
+++ b/test/SILGen/lazy_globals.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
-// CHECK: sil private [ossa] @globalinit_[[T:.*]]_func0 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T:.*]]_func0 : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals1xSiv
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals1xSivp : $*Int
 // CHECK:   store {{%.*}} to [trivial] [[XADDR]] : $*Int
@@ -16,7 +16,7 @@
 // CHECK: }
 var x: Int = 0
 
-// CHECK: sil private [ossa] @globalinit_[[T:.*]]_func1 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T:.*]]_func1 : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals3FooV3fooSivpZ
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals3FooV3fooSivpZ : $*Int
 // CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
@@ -40,7 +40,7 @@ struct Foo {
   static var initialized: Int = 57
 }
 
-// CHECK: sil private [ossa] @globalinit_[[T:.*]]_func3 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T:.*]]_func3 : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s12lazy_globals3BarO3barSivpZ
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals3BarO3barSivpZ : $*Int
 // CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
@@ -63,7 +63,7 @@ enum Bar {
 
 func f() -> (Int, Int) { return (1, 2) }
 
-// CHECK: sil private [ossa] @globalinit_[[T]]_func4 : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @globalinit_[[T]]_func4 : $@convention(c) () -> () {
 // CHECK:   function_ref @$s12lazy_globals1fSi_SityF : $@convention(thin) () -> (Int, Int)
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals2a1Sivau : $@convention(thin) () -> Builtin.RawPointer
 // CHECK:   function_ref @globalinit_[[T]]_func4 : $@convention(c) () -> ()

--- a/test/SILGen/lazy_globals_multiple_vars.swift
+++ b/test/SILGen/lazy_globals_multiple_vars.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
-// CHECK:       sil private [ossa] [[INIT_A_B:@globalinit_.*]] :
+// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_A_B:@globalinit_.*]] :
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1aSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1aSiv
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1bSiv
@@ -13,7 +13,7 @@
 // CHECK:         function_ref [[INIT_A_B]]
 var (a, b) = (1, 2)
 
-// CHECK:       sil private [ossa] [[INIT_C:@globalinit_.*]] :
+// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_C:@globalinit_.*]] :
 // CHECK-NOT:     global_addr @$s26lazy_globals_multiple_vars1dSiv
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1cSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1cSiv
@@ -21,7 +21,7 @@ var (a, b) = (1, 2)
 // CHECK:       sil hidden [global_init] [ossa] @$s26lazy_globals_multiple_vars1cSivau
 // CHECK:         global_addr [[TOKEN_C:@globalinit_.*]] :
 // CHECK:         function_ref [[INIT_C]]
-// CHECK:       sil private [ossa] [[INIT_D:@globalinit_.*]] :
+// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_D:@globalinit_.*]] :
 // CHECK-NOT:     global_addr @$s26lazy_globals_multiple_vars1cSiv
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1dSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1dSiv

--- a/test/SILGen/lazy_globals_multiple_vars.swift
+++ b/test/SILGen/lazy_globals_multiple_vars.swift
@@ -1,34 +1,34 @@
 // RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
-// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_A_B:@globalinit_.*]] :
+// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_A_B:@.*1a.*1b.*WZ]] :
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1aSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1aSiv
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1bSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1bSiv
 // CHECK:       sil hidden [global_init] [ossa] @$s26lazy_globals_multiple_vars1aSivau
-// CHECK:         global_addr [[TOKEN_A_B:@globalinit_.*]] :
+// CHECK:         global_addr [[TOKEN_A_B:@.*1a.*1b.*Wz]] :
 // CHECK:         function_ref [[INIT_A_B]]
 // CHECK:       sil hidden [global_init] [ossa] @$s26lazy_globals_multiple_vars1bSivau
 // CHECK:         global_addr [[TOKEN_A_B]]
 // CHECK:         function_ref [[INIT_A_B]]
 var (a, b) = (1, 2)
 
-// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_C:@globalinit_.*]] :
+// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_C:@.*1c.*WZ]] :
 // CHECK-NOT:     global_addr @$s26lazy_globals_multiple_vars1dSiv
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1cSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1cSiv
 // CHECK-NOT:     global_addr @$s26lazy_globals_multiple_vars1dSiv
 // CHECK:       sil hidden [global_init] [ossa] @$s26lazy_globals_multiple_vars1cSivau
-// CHECK:         global_addr [[TOKEN_C:@globalinit_.*]] :
+// CHECK:         global_addr [[TOKEN_C:@.*1c.*Wz]] :
 // CHECK:         function_ref [[INIT_C]]
-// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_D:@globalinit_.*]] :
+// CHECK:       sil private [global_init_once_fn] [ossa] [[INIT_D:@.*1d.*WZ]] :
 // CHECK-NOT:     global_addr @$s26lazy_globals_multiple_vars1cSiv
 // CHECK:         alloc_global @$s26lazy_globals_multiple_vars1dSiv
 // CHECK:         global_addr @$s26lazy_globals_multiple_vars1dSiv
 // CHECK-NOT:     global_addr @$s26lazy_globals_multiple_vars1cSiv
 // CHECK:       sil hidden [global_init] [ossa] @$s26lazy_globals_multiple_vars1dSivau
 // CHECK-NOT:     global_addr [[TOKEN_C]]
-// CHECK:         global_addr [[TOKEN_D:@globalinit_.*]] :
+// CHECK:         global_addr [[TOKEN_D:@.*1d.*Wz]] :
 // CHECK-NOT:     global_addr [[TOKEN_C]]
 // CHECK:         function_ref [[INIT_D]]
 var c = 1, d = 2

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -171,7 +171,7 @@ public struct DidSetWillSetTests {
 
 var global_observing_property : Int = zero {
   // The variable is initialized with "zero".
-  // CHECK-LABEL: sil private [ossa] @globalinit_{{.*}}_func1 : $@convention(c) () -> () {
+  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_{{.*}}_func1 : $@convention(c) () -> () {
   // CHECK: bb0:
   // CHECK-NEXT: alloc_global @$s9observers25global_observing_propertySiv
   // CHECK-NEXT: %1 = global_addr @$s9observers25global_observing_propertySivp : $*Int

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -171,7 +171,7 @@ public struct DidSetWillSetTests {
 
 var global_observing_property : Int = zero {
   // The variable is initialized with "zero".
-  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_{{.*}}_func1 : $@convention(c) () -> () {
+  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
   // CHECK: bb0:
   // CHECK-NEXT: alloc_global @$s9observers25global_observing_propertySiv
   // CHECK-NEXT: %1 = global_addr @$s9observers25global_observing_propertySivp : $*Int

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -627,17 +627,17 @@ func testShims() -> UInt32 {
 
 // --- global variable initialization.
 var globalString1 = "⓪" // start non-empty
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_33_{{.*}}_func0 : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
 // CHECK: alloc_global @$s20access_marker_verify13globalString1SSvp
 // CHECK: [[GA:%.*]] = global_addr @$s20access_marker_verify13globalString1SSvp : $*String
 // CHECK: apply
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[GA]] : $*String
 // CHECK: store %{{.*}} to [init] [[ACCESS]] : $*String
 // CHECK: end_access
-// CHECK-LABEL: } // end sil function 'globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func0'
+// CHECK-LABEL: } // end sil function '{{.*}}WZ'
 
 var globalString2 = globalString1
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func1 : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
 // CHECK: alloc_global @$s20access_marker_verify13globalString2SSvp
 // CHECK: [[GA:%.*]] = global_addr @$s20access_marker_verify13globalString2SSvp : $*String
 // CHECK: apply
@@ -648,7 +648,7 @@ var globalString2 = globalString1
 // CHECK: end_access [[INIT]] : $*String
 // CHECK: end_access [[ACCESS]] : $*String
 // CHECK-NOT: end_access
-// CHECK-LABEL: } // end sil function 'globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func1'
+// CHECK-LABEL: } // end sil function '{{.*}}WZ'
 
 
 // --- getter.
@@ -1037,13 +1037,13 @@ func testPointerInit(x: Int, y: UnsafeMutablePointer<Int>) {
 class testInitExistentialGlobal {
   static var testProperty: P = StructP()
 }
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit{{.*}} : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s20access_marker_verify25testInitExistentialGlobalC0D8PropertyAA1P_pvpZ
 // CHECK:   [[GADR:%.*]] = global_addr @$s20access_marker_verify25testInitExistentialGlobalC0D8PropertyAA1P_pvpZ : $*P
 // CHECK:   %{{.*}} = apply %{{.*}}({{.*}}) : $@convention(method) (@thin StructP.Type) -> StructP
 // CHECK:   [[EADR:%.*]] = init_existential_addr [[GADR]] : $*P, $StructP
 // CHECK:   store %{{.*}} to [trivial] [[EADR]] : $*StructP
-// CHECK-LABEL: } // end sil function 'globalinit
+// CHECK-LABEL: } // end sil function '{{.*}}WZ
 
 public enum SomeError: Swift.Error {
     case error

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -627,7 +627,7 @@ func testShims() -> UInt32 {
 
 // --- global variable initialization.
 var globalString1 = "⓪" // start non-empty
-// CHECK-LABEL: sil private [ossa] @globalinit_33_{{.*}}_func0 : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_33_{{.*}}_func0 : $@convention(c) () -> () {
 // CHECK: alloc_global @$s20access_marker_verify13globalString1SSvp
 // CHECK: [[GA:%.*]] = global_addr @$s20access_marker_verify13globalString1SSvp : $*String
 // CHECK: apply
@@ -637,7 +637,7 @@ var globalString1 = "⓪" // start non-empty
 // CHECK-LABEL: } // end sil function 'globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func0'
 
 var globalString2 = globalString1
-// CHECK-LABEL: sil private [ossa] @globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func1 : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func1 : $@convention(c) () -> () {
 // CHECK: alloc_global @$s20access_marker_verify13globalString2SSvp
 // CHECK: [[GA:%.*]] = global_addr @$s20access_marker_verify13globalString2SSvp : $*String
 // CHECK: apply
@@ -1037,7 +1037,7 @@ func testPointerInit(x: Int, y: UnsafeMutablePointer<Int>) {
 class testInitExistentialGlobal {
   static var testProperty: P = StructP()
 }
-// CHECK-LABEL: sil private [ossa] @globalinit{{.*}} : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit{{.*}} : $@convention(c) () -> () {
 // CHECK:   alloc_global @$s20access_marker_verify25testInitExistentialGlobalC0D8PropertyAA1P_pvpZ
 // CHECK:   [[GADR:%.*]] = global_addr @$s20access_marker_verify25testInitExistentialGlobalC0D8PropertyAA1P_pvpZ : $*P
 // CHECK:   %{{.*}} = apply %{{.*}}({{.*}}) : $@convention(method) (@thin StructP.Type) -> StructP

--- a/test/SILOptimizer/access_marker_verify_objc.swift
+++ b/test/SILOptimizer/access_marker_verify_objc.swift
@@ -12,14 +12,14 @@ import Foundation
 // --- initializer `let` of CFString.
 // The verifier should ignore this.
 
-// CHECK_LABEL: sil private @globalinit{{.*}} : $@convention(c) () -> () {
+// CHECK_LABEL: sil private @{{.*}}WZ : $@convention(c) () -> () {
 // CHECK: bb0:
 // CHECK:   alloc_global @$s25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ
 // CHECK:   [[GA:%.*]] = global_addr @$s25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ : $*CFString
 // CHECK-NOT: begin_access
 // CHECK:   store %{{.*}} to [init] [[GA]] : $*CFString
 // CHECK:   return %{{.*}} : $()                               
-// CHECK-LABEL: } // end sil function 'globalinit{{.*}}'
+// CHECK-LABEL: } // end sil function '{{.*}}WZ'
 class testCFString {
   public static let cfString: CFString = "" as CFString
 }

--- a/test/SILOptimizer/globalopt_trivial_nontrivial.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial.sil
@@ -38,7 +38,7 @@ sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
 
 sil_global hidden [let] @$nontrivialglobal : $TClass
 
-sil private @globalinit_trivialglobal_func : $@convention(c) () -> () {
+sil private [global_init_once_fn] @globalinit_trivialglobal_func : $@convention(c) () -> () {
 bb0:
   alloc_global @$trivialglobal 
   %1 = global_addr @$trivialglobal : $*TStruct 
@@ -83,13 +83,13 @@ bb0:
   return %4 : $Int32                              
 }
 
-// CHECK-LABEL: sil private @globalinit_nontrivialglobal_func :
+// CHECK-LABEL: sil private [global_init_once_fn] @globalinit_nontrivialglobal_func :
 // CHECK: alloc_global @$nontrivialglobal 
 // CHECK: [[GLOBL_ADDR:%.*]] = global_addr @$nontrivialglobal : $*TClass 
 // CHECK: [[REF:%.*]] = alloc_ref $TClass                          
 // CHECK: store [[REF]] to [[GLOBL_ADDR]] : $*TClass 
 // CHECK: } // end sil function 'globalinit_nontrivialglobal_func'
-sil private @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
+sil private [global_init_once_fn] @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
 bb0:
   alloc_global @$nontrivialglobal 
   %1 = global_addr @$nontrivialglobal : $*TClass 

--- a/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
@@ -32,7 +32,7 @@ sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
 
 sil_global hidden [let] @$nontrivialglobal : $TClass
 
-sil private [ossa] @globalinit_trivialglobal_func : $@convention(c) () -> () {
+sil private [global_init_once_fn] [ossa] @globalinit_trivialglobal_func : $@convention(c) () -> () {
 bb0:
   alloc_global @$trivialglobal 
   %1 = global_addr @$trivialglobal : $*TStruct 
@@ -75,13 +75,13 @@ bb0:
   return %4 : $Int32                              
 }
 
-// CHECK-LABEL: sil private [ossa] @globalinit_nontrivialglobal_func :
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @globalinit_nontrivialglobal_func :
 // CHECK: alloc_global @$nontrivialglobal 
 // CHECK: [[GLOBL_ADDR:%.*]] = global_addr @$nontrivialglobal : $*TClass 
 // CHECK: [[REF:%.*]] = alloc_ref $TClass                          
 // CHECK: store [[REF]] to [init] [[GLOBL_ADDR]] : $*TClass 
 // CHECK: } // end sil function 'globalinit_nontrivialglobal_func'
-sil private [ossa] @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
+sil private [global_init_once_fn] [ossa] @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
 bb0:
   alloc_global @$nontrivialglobal 
   %1 = global_addr @$nontrivialglobal : $*TClass 

--- a/test/SILOptimizer/inline_addressor.swift
+++ b/test/SILOptimizer/inline_addressor.swift
@@ -11,10 +11,10 @@ var totalsum = nonTrivialInit(true)
 
 //CHECK-LABEL: sil {{.*}}testit 
 //CHECK: {{^bb0}}
-//CHECK: globalinit_
+//CHECK: WZ
 //CHECK-NOT: {{^bb0}}
 //CHECK: {{^bb1}}
-//CHECK-NOT: globalinit
+//CHECK-NOT: WZ
 //CHECK-NOT: totalsum
 //CHECK-NOT: inputval
 //CHECK: {{^}$}}

--- a/test/SILOptimizer/static_initializer.sil
+++ b/test/SILOptimizer/static_initializer.sil
@@ -25,8 +25,8 @@ sil_global private @globalinit_token0 : $Builtin.Word
 // CHECK-NEXT: }
 sil_global @_Tv2ch1xSi : $Outer
 
-// CHECK-LABEL: sil private @globalinit_func0 : $@convention(c) () -> () {
-sil private @globalinit_func0 : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] @globalinit_func0 : $@convention(c) () -> () {
+sil private [global_init_once_fn] @globalinit_func0 : $@convention(c) () -> () {
 bb0:
   %0 = global_addr @_Tv2ch1xSi : $*Outer
   %1 = integer_literal $Builtin.Int32, 2

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -15,7 +15,7 @@
 // Check if the optimizer can optimize the whole array into a statically
 // initialized global
 
-// CHECK: sil_global private @globalinit_{{.*}} : $_ContiguousArrayStorage<String> = {
+// CHECK: sil_global private @{{.*9str_array.*}}WZTv_ : $_ContiguousArrayStorage<String> = {
 // CHECK:   %initval = object $_ContiguousArrayStorage<String>
 
 public let str_array: [String] = [


### PR DESCRIPTION
Give `globalinit_` symbols proper manglings so that they can be used for symbol ordering and other systemic optimization. Update optimization passes that looked for hardcoded symbol name patterns to use attributes instead.