### PR TITLE
build: remove the Python 2 check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -914,7 +914,6 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endif()
 endif()
 
-find_package(Python2 COMPONENTS Interpreter REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 #


### PR DESCRIPTION
The Swift build is now fully migrated to Python 3.  Although it is
backwards/forwards compatible, the build invokes everything with the
Python3 interpreter, and the Python 2 interpreter should be unused.
Remove the last reference to it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
