### PR TITLE
DependenciesScanner: include search path options in PCM building commands

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -254,6 +254,20 @@ void ClangImporter::recordModuleDependencies(
     swiftArgs.push_back("-module-name");
     swiftArgs.push_back(clangModuleDep.ModuleName);
 
+    // Pass down search paths to the -emit-module action.
+    // Unlike building Swift modules, we need to include all search paths to
+    // the clang invocation to build PCMs because transitive headers can only
+    // be found via search paths. Passing these headers as explicit inputs can
+    // be quite challenging.
+    for (auto &path: Impl.SwiftContext.SearchPathOpts.ImportSearchPaths) {
+      swiftArgs.push_back("-I");
+      swiftArgs.push_back(path);
+    }
+    for (auto &path: Impl.SwiftContext.SearchPathOpts.FrameworkSearchPaths) {
+      swiftArgs.push_back(path.IsSystem ? "-Fsystem": "-F");
+      swiftArgs.push_back(path.Path);
+    }
+
     // Swift frontend option for input file path (Foo.modulemap).
     swiftArgs.push_back(clangModuleDep.ClangModuleMapFile);
     // Module-level dependencies.

--- a/test/ScanDependencies/batch_module_scan.swift
+++ b/test/ScanDependencies/batch_module_scan.swift
@@ -28,6 +28,7 @@
 // CHECK-PCM-NEXT:    },
 // CHECK-PCM-NEXT:    {
 // CHECK-PCM-NEXT:      "modulePath": "F.pcm",
+// CHECK-PCM: "-I"
 
 // CHECK-SWIFT: {
 // CHECK-SWIFT-NEXT:  "mainModuleName": "F",

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -195,9 +195,7 @@ import SubE
 /// --------Clang module SwiftShims
 // CHECK-LABEL: "modulePath": "SwiftShims.pcm",
 
-// CHECK-NO-SEARCH-PATHS-NOT: "-I"
 // CHECK-NO-SEARCH-PATHS-NOT: "-sdk"
-// CHECK-NO-SEARCH-PATHS-NOT: "-F"
 // CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
 
 // Check make-style dependencies


### PR DESCRIPTION
Unlike Swift modules, building Clang PCMs requires search path options like -F and -I to
look for transitive header includes because in module maps, we can only find top-level headers.

rdar://67589328
