### PR TITLE
[build] Don't execute dsymutil in parallel

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2980,12 +2980,13 @@ for host in "${ALL_HOSTS[@]}"; do
             #
             # Exclude shell scripts and static archives.
             # Exclude swift-api-digester dSYM to reduce debug toolchain size.
+            # Run sequentially -- dsymutil is multithreaded and can be memory intensive
             (cd "${host_symroot}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
                grep -v '.py$' | \
                grep -v '.a$' | \
                grep -v 'swift-api-digester' | \
-               xargs -n 1 -P ${BUILD_JOBS} ${dsymutil_path})
+               xargs -n 1 -P 1 ${dsymutil_path})
 
             # Strip executables, shared libraries and static libraries in
             # `host_install_destdir`.

--- a/utils/parser-lib/darwin-extract-symbols
+++ b/utils/parser-lib/darwin-extract-symbols
@@ -46,11 +46,12 @@ function xcrun_find_tool() {
 # Run dsymutil on executables and shared libraries.
 #
 # Exclude shell scripts.
+# Run sequentially -- dsymutil is multithreaded and can be memory intensive
 (cd "${INSTALL_SYMROOT}" &&
  find ./"${INSTALL_PREFIX}" -perm -0111 -type f -print | \
    grep -v crashlog.py | \
    grep -v symbolication.py | \
-   xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))
+   xargs -n 1 -P 1 $(xcrun_find_tool dsymutil))
 
 # Strip executables, shared libraries and static libraries in INSTALL_DIR.
 find "${INSTALL_DIR}${INSTALL_PREFIX}/" \


### PR DESCRIPTION
`dsymutil` is already multithreaded and can be memory intensive --
execute it one at a time.

Addresses rdar://63892559