### PR TITLE
Fix ConnectionGraph verification for calls to no return functions.

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1623,6 +1623,13 @@ void EscapeAnalysis::ConnectionGraph::verify() const {
       if (auto ai = dyn_cast<ApplyInst>(&i)) {
         if (EA->canOptimizeArrayUninitializedCall(ai).isValid())
           continue;
+        // Ignore checking CGNode mapping for result of apply to a no return
+        // function that will have a null ReturnNode
+        if (auto *callee = ai->getReferencedFunctionOrNull()) {
+          if (EA->getFunctionInfo(callee)->isValid())
+            if (!EA->getConnectionGraph(callee)->getReturnNodeOrNull())
+              continue;
+        }
       }
       for (auto result : i.getResults()) {
         if (EA->getPointerBase(result))

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1983,3 +1983,27 @@ bb4:
   %z = tuple ()
   return %z : $()
 }
+
+// Test CGNode mapping for result of an apply to no return function
+// CHECK-LABEL:CG of $testcaller
+// CHECK:  Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK:  Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK:  Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-LABEL:End
+sil hidden [noinline] @$testcaller : $@convention(thin)  (@owned Z) -> () {
+bb0(%0 : $Z):
+  %2 = function_ref @$noreturncallee : $@convention(thin) (@guaranteed Z) -> @owned Z
+  %3 = apply %2(%0) : $@convention(thin) (@guaranteed Z) -> @owned Z
+  dealloc_ref %3 : $Z
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL:CG of $noreturncallee
+// CHECK:  Arg [ref] %0 Esc: A, Succ: 
+// CHECK-LABEL:End
+sil hidden [noinline] @$noreturncallee : $@convention(thin)  (@guaranteed Z) -> @owned Z {
+bb0(%0 : $Z):
+  unreachable
+}
+


### PR DESCRIPTION
Functions that do not have a return, and instead end with 'unreachable' due to NoReturnFolding will not have a ReturnNode in the connection graph.
A caller calling a no return function then may not have a CGNode corresponding to the call's result.
Fix the ConnectionGraph's verifier so we don't assert in such cases.
