### PR TITLE
[Sanitizer] Add smoke test for report symbolication

### DIFF
--- a/test/Sanitizers/symbolication-linux.swift
+++ b/test/Sanitizers/symbolication-linux.swift
@@ -1,0 +1,35 @@
+// RUN: %target-build-swift %s -sanitize=address -g -target %sanitizers-target-triple -o %t
+// RUN: env %env-ASAN_OPTIONS=abort_on_error=0                           not %target-run %t 2>&1 | %swift-demangle | %FileCheck %s -check-prefix=OOP
+// In-process symbolication doesn't work on Linux (yet)
+// XXX: env %env-ASAN_OPTIONS=abort_on_error=0,external_symbolizer_path= not %target-run %t 2>&1 | %swift-demangle | %FileCheck %s -check-prefix=IP
+// REQUIRES: executable_test
+// REQUIRES: asan_runtime
+// REQUIRES: OS=linux-gnu
+
+// Check that Sanitizer reports are properly symbolicated on Linux, both
+// out-of-process (via `llvm-symbolizer`) and when falling back to in-process
+// symbolication.  Note that `llvm-symbolizer` does not demangle Swift symbol
+// names, so we use `swift demangle`.
+
+func foo() {
+  let x = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+  x.deallocate()
+  print(x.pointee)
+}
+
+func bar() {
+  foo()
+}
+
+bar()
+
+
+// Out-of-process
+// OOP:      #0 0x{{[0-9a-f]+}} in main.foo() -> () {{.*}}symbolication-linux.swift:[[@LINE-11]]
+// OOP-NEXT: #1 0x{{[0-9a-f]+}} in main.bar() -> () {{.*}}symbolication-linux.swift:[[@LINE-8]]
+// OOP-NEXT: #2 0x{{[0-9a-f]+}} in main {{.*}}symbolication-linux.swift:[[@LINE-6]]
+
+// In-process
+// IP:      #0 0x{{[0-9a-f]+}} in main.foo() -> ()+0x
+// IP-NEXT: #1 0x{{[0-9a-f]+}} in main.bar() -> ()+0x
+// IP-NEXT: #2 0x{{[0-9a-f]+}} in main+0x

--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -1,0 +1,33 @@
+// RUN: %target-build-swift %s -sanitize=address -g -target %sanitizers-target-triple -o %t
+// RUN: env %env-ASAN_OPTIONS=abort_on_error=0                           not %target-run %t 2>&1 | %FileCheck %s -check-prefix=OOP
+// RUN: env %env-ASAN_OPTIONS=abort_on_error=0,external_symbolizer_path= not %target-run %t 2>&1 | %FileCheck %s -check-prefix=IP
+// REQUIRES: executable_test
+// REQUIRES: asan_runtime
+// REQUIRES: VENDOR=apple
+
+// Check that Sanitizer reports are properly symbolicated on Apple platforms,
+// both out-of-process (via `atos`) and when falling back to in-process
+// symbolication.  Note that `atos` also demangles Swift symbol names.
+
+func foo() {
+  let x = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+  x.deallocate()
+  print(x.pointee)
+}
+
+func bar() {
+  foo()
+}
+
+bar()
+
+
+// Out-of-process
+// OOP:      #0 0x{{[0-9a-f]+}} in foo() symbolication.swift:[[@LINE-11]]
+// OOP-NEXT: #1 0x{{[0-9a-f]+}} in bar() symbolication.swift:[[@LINE-8]]
+// OOP-NEXT: #2 0x{{[0-9a-f]+}} in main symbolication.swift:[[@LINE-6]]
+
+// In-process
+// IP:      #0 0x{{[0-9a-f]+}} in main.foo() -> ()+0x
+// IP-NEXT: #1 0x{{[0-9a-f]+}} in main.bar() -> ()+0x
+// IP-NEXT: #2 0x{{[0-9a-f]+}} in main+0x


### PR DESCRIPTION
Add a test that checks symbolication for out-of-process and in-process
symbolication with and without debug info.

Note that there already exist tests in the compiler-rt test suite that
check report symbolication.  The purpose of this test is to have a
simple smoke test for Swift, and specifically Swift demangling.

rdar://62753845
