### PR TITLE
ABIChecker: exclude decls with the @_alwaysEmitIntoClient attribute

### DIFF
--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -139,3 +139,6 @@ public class UnavailableOnMac {}
 extension SwiftObjcClass {
   public func functionUnavailableOnMac() {}
 }
+
+@_alwaysEmitIntoClient
+public func emitIntoClientFunc() {}

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1341,6 +1341,25 @@
       "hasMissingDesignatedInitializers": true
     },
     {
+      "kind": "Function",
+      "name": "emitIntoClientFunc",
+      "printedName": "emitIntoClientFunc()",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:4cake18emitIntoClientFuncyyF",
+      "moduleName": "cake",
+      "declAttributes": [
+        "AlwaysEmitIntoClient"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
       "kind": "TypeDecl",
       "name": "Int",
       "printedName": "Int",

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1603,6 +1603,11 @@ SDKContext::shouldIgnore(Decl *D, const Decl* Parent) const {
       if (isa<TypeAliasDecl>(VD))
         return true;
     }
+    // Exclude decls with @_alwaysEmitIntoClient if we are checking ABI.
+    // These decls are considered effectively public because they are usable
+    // from inline, so we have to manually exclude them here.
+    if (D->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
+      return true;
   } else {
     if (D->isPrivateStdlibDecl(false))
       return true;


### PR DESCRIPTION
Removing or updating @_alwaysEmitIntoClient functions are never ABI-breaking, thus
we should exclude them from the symbol set for ABI stability checking.

rdar://67883661
