### PR TITLE
[SR-13461] Relax An Assert

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -216,11 +216,9 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
           .forwardInto(SGF, Loc, init.get());
         ++elti;
       } else {
-#ifndef NDEBUG
-        assert(
-            field->getType()->isEqual(field->getParentInitializer()->getType())
-              && "Checked by sema");
-#endif
+        assert(field->getType()->getReferenceStorageReferent()->isEqual(
+                   field->getParentInitializer()->getType()) &&
+               "Initialization of field with mismatched type!");
 
         // Cleanup after this initialization.
         FullExpr scope(SGF.Cleanups, field->getParentPatternBinding());

--- a/validation-test/compiler_crashers_2_fixed/sr13461.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13461.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null %s
+// REQUIRES: asserts
+
+final class Klass {
+  static var current: Klass {
+    fatalError()
+  }
+}
+private struct Build<T> {
+  let val: T
+  unowned let unownedBinding = Klass.current
+  unowned(unsafe) let unownedUnsafeBinding = Klass.current
+  weak var weakBinding = Klass.current
+}
+private func phase<T>(_ val: T) -> Build<T> {
+  return Build<T>(val: val)
+}


### PR DESCRIPTION
This assert doesn't consider reference storage types in its predicate.
Look through them since they're not relevant to the type consistency
check it's trying to pick out.
