### PR TITLE
[Dependency Scanner] Prefix Clang dependency scanner search path arguments with `-Xcc`

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -260,12 +260,10 @@ void ClangImporter::recordModuleDependencies(
     // be found via search paths. Passing these headers as explicit inputs can
     // be quite challenging.
     for (auto &path: Impl.SwiftContext.SearchPathOpts.ImportSearchPaths) {
-      swiftArgs.push_back("-I");
-      swiftArgs.push_back(path);
+      addClangArg("-I" + path);
     }
     for (auto &path: Impl.SwiftContext.SearchPathOpts.FrameworkSearchPaths) {
-      swiftArgs.push_back(path.IsSystem ? "-Fsystem": "-F");
-      swiftArgs.push_back(path.Path);
+      addClangArg((path.IsSystem ? "-Fsystem": "-F") + path.Path);
     }
 
     // Swift frontend option for input file path (Foo.modulemap).

--- a/test/ScanDependencies/batch_module_scan.swift
+++ b/test/ScanDependencies/batch_module_scan.swift
@@ -28,7 +28,7 @@
 // CHECK-PCM-NEXT:    },
 // CHECK-PCM-NEXT:    {
 // CHECK-PCM-NEXT:      "modulePath": "F.pcm",
-// CHECK-PCM: "-I"
+// CHECK-PCM: "-I
 
 // CHECK-SWIFT: {
 // CHECK-SWIFT-NEXT:  "mainModuleName": "F",


### PR DESCRIPTION
And remove whitespace between the `-I` or `-F` and the actual filesystem path string.
Experimentally, this seems to be required for these paths to actually be picked up by the underlying scanner.
