### PR TITLE
[Dependency Scanner] Batch scanner: extract target triple from the PCMArgs for the batch invocation.

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -308,6 +308,7 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
   // Reform the Clang importer options.
   // FIXME: Just save a reference or copy so we can get this back.
   ClangImporterOptions importerOpts;
+  importerOpts.ExtraArgs = getExtraClangArgs();
 
   // Determine the command-line arguments for dependency scanning.
   auto &ctx = Impl.SwiftContext;
@@ -351,6 +352,7 @@ bool ClangImporter::addBridgingHeaderDependencies(
   // Reform the Clang importer options.
   // FIXME: Just save a reference or copy so we can get this back.
   ClangImporterOptions importerOpts;
+  importerOpts.ExtraArgs = getExtraClangArgs();
 
   // Retrieve the bridging header.
   std::string bridgingHeader = *targetModule.getBridgingHeader();

--- a/test/ScanDependencies/Inputs/CHeaders/G.h
+++ b/test/ScanDependencies/Inputs/CHeaders/G.h
@@ -1,1 +1,6 @@
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000
+#include "X.h"
+#endif
+
 void funcG(void);
+

--- a/test/ScanDependencies/Inputs/CHeaders/X.h
+++ b/test/ScanDependencies/Inputs/CHeaders/X.h
@@ -1,0 +1,1 @@
+void funcX(void);

--- a/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/module.modulemap
@@ -37,3 +37,8 @@ module I {
   header "I.h"
   export *
 }
+
+module X {
+  header "X.h"
+  export *
+}

--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/outputs)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: echo "[{" > %/t/inputs/input.json
+// RUN: echo "\"clangModuleName\": \"G\"," >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx10.9\"," >> %/t/inputs/input.json
+// RUN: echo "\"output\": \"%/t/outputs/G_109.pcm.json\"" >> %/t/inputs/input.json
+// RUN: echo "}," >> %/t/inputs/input.json
+// RUN: echo "{" >> %/t/inputs/input.json
+// RUN: echo "\"clangModuleName\": \"G\"," >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx11.0\"," >> %/t/inputs/input.json
+// RUN: echo "\"output\": \"%/t/outputs/G_110.pcm.json\"" >> %/t/inputs/input.json
+// RUN: echo "}]" >> %/t/inputs/input.json
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s -check-prefix=CHECK-PCM109 < %t/outputs/G_109.pcm.json
+// RUN: %FileCheck %s -check-prefix=CHECK-PCM110 < %t/outputs/G_110.pcm.json
+
+// CHECK-PCM109: 		{
+// CHECK-PCM109-NEXT:  "mainModuleName": "G",
+// CHECK-PCM109-NEXT:  "modules": [
+// CHECK-PCM109-NEXT:    {
+// CHECK-PCM109-NEXT:      "clang": "G"
+// CHECK-PCM109-NEXT:    },
+// CHECK-PCM109-NEXT:    {
+// CHECK-PCM109-NEXT:      "modulePath": "G.pcm",
+// CHECK-PCM109:       "directDependencies": [
+// CHECK-PCM109-NEXT:    {
+// CHECK-PCM109-NEXT:      "clang": "X"
+// CHECK-PCM109-NEXT:    }
+// CHECK-PCM109-NEXT:  ],
+// CHECK-PCM109: "-I
+
+// CHECK-PCM110: 		{
+// CHECK-PCM110-NEXT:  "mainModuleName": "G",
+// CHECK-PCM110-NEXT:  "modules": [
+// CHECK-PCM110-NEXT:    {
+// CHECK-PCM110-NEXT:      "clang": "G"
+// CHECK-PCM110-NEXT:    },
+// CHECK-PCM110-NEXT:    {
+// CHECK-PCM110-NEXT:      "modulePath": "G.pcm",
+// CHECK-PCM110:       "directDependencies": [
+// CHECK-PCM110-NEXT:  ],
+// CHECK-PCM110-NOT: "clang": "X"
+// CHECK-PCM110: "-I

--- a/test/ScanDependencies/can_import_placeholder.swift
+++ b/test/ScanDependencies/can_import_placeholder.swift
@@ -20,7 +20,7 @@
 // RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json

--- a/test/ScanDependencies/diagnose_dependency_cycle.swift
+++ b/test/ScanDependencies/diagnose_dependency_cycle.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
 
-// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules &> %t/out.txt
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 &> %t/out.txt
 
 // RUN: %FileCheck %s < %t/out.txt
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json
@@ -105,7 +105,6 @@ import SubE
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
 // CHECK-NEXT: "clang"
-// CHECK: "-fno-implicit-modules"
 
 /// --------Swift module E
 // CHECK: "swift": "E"

--- a/test/ScanDependencies/module_deps_clang_only.swift
+++ b/test/ScanDependencies/module_deps_clang_only.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-clang-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules -module-name C
+// RUN: %target-swift-frontend -scan-clang-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -module-name C
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -20,7 +20,7 @@
 // RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json

--- a/test/ScanDependencies/module_deps_private_interface.swift
+++ b/test/ScanDependencies/module_deps_private_interface.swift
@@ -6,7 +6,7 @@
 
 // RUN: cp %t/Foo.swiftinterface %t/Foo.private.swiftinterface
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json

--- a/test/ScanDependencies/module_framework.swift
+++ b/test/ScanDependencies/module_framework.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -disable-implicit-swift-modules -Xcc -Xclang -Xcc -fno-implicit-modules
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -Xcc -Xclang
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json


### PR DESCRIPTION
Otherwise the created invocation will end up re-using the parent compiler invocation's target triple for every created scanning instance.

I stumbled upon this when testing https://github.com/apple/swift-driver/pull/225. 
The PCMArgs we pass in to the batch scanner are intended to be clang arguments and are prefixed with `-Xcc`, so they do not affect the created compiler instance. 