### PR TITLE
[NFC] Clean Up FrontendTool

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -621,7 +621,7 @@ public:
   ///
   /// This is similar to a parse-only invocation, but module imports will also
   /// be processed.
-  void performParseAndResolveImportsOnly();
+  bool performParseAndResolveImportsOnly();
 
   /// Performs mandatory, diagnostic, and optimization passes over the SIL.
   /// \param silModule The SIL module that was generated during SILGen.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -294,8 +294,12 @@ public:
   /// '.../lib/swift', otherwise '.../lib/swift_static'.
   bool UseSharedResourceFolder = true;
 
-  /// \return true if action only parses without doing other compilation steps.
+  /// \return true if the given action only parses without doing other compilation steps.
   static bool shouldActionOnlyParse(ActionType);
+
+  /// \return true if the given action requires the standard library to be
+  /// loaded before it is run.
+  static bool doesActionRequireSwiftStandardLibrary(ActionType);
 
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -301,6 +301,9 @@ public:
   /// loaded before it is run.
   static bool doesActionRequireSwiftStandardLibrary(ActionType);
 
+  /// \return true if the given action requires input files to be provided.
+  static bool doesActionRequireInputs(ActionType action);
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -406,8 +406,7 @@ bool ArgsToFrontendOptionsConverter::setUpInputKindAndImmediateArgs() {
   if (Opts.InputsAndOutputs.verifyInputs(
           Diags, treatAsSIL,
           Opts.RequestedAction == FrontendOptions::ActionType::REPL,
-          (Opts.RequestedAction == FrontendOptions::ActionType::NoneAction ||
-           Opts.RequestedAction == FrontendOptions::ActionType::PrintVersion))){
+          !FrontendOptions::doesActionRequireInputs(Opts.RequestedAction))) {
     return true;
   }
   if (Opts.RequestedAction == FrontendOptions::ActionType::Immediate) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -848,7 +848,7 @@ void CompilerInstance::setMainModule(ModuleDecl *newMod) {
   Context->addLoadedModule(newMod);
 }
 
-void CompilerInstance::performParseAndResolveImportsOnly() {
+bool CompilerInstance::performParseAndResolveImportsOnly() {
   FrontendStatsTracer tracer(getStatsReporter(), "parse-and-resolve-imports");
 
   // Resolve imports for all the source files.
@@ -867,6 +867,7 @@ void CompilerInstance::performParseAndResolveImportsOnly() {
   mainModule->setHasResolvedImports();
 
   bindExtensions(*mainModule);
+  return Context->hadError();
 }
 
 void CompilerInstance::performSema() {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -73,18 +73,61 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
 
 bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   switch (action) {
-  case FrontendOptions::ActionType::Parse:
-  case FrontendOptions::ActionType::DumpParse:
-  case FrontendOptions::ActionType::EmitSyntax:
-  case FrontendOptions::ActionType::DumpInterfaceHash:
-  case FrontendOptions::ActionType::EmitImportedModules:
-  case FrontendOptions::ActionType::ScanDependencies:
-  case FrontendOptions::ActionType::ScanClangDependencies:
-  case FrontendOptions::ActionType::PrintVersion:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::EmitImportedModules:
+  case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
+  case ActionType::PrintVersion:
     return true;
   default:
     return false;
   }
+}
+
+bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
+  switch (action) {
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::EmitImportedModules:
+  case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
+  case ActionType::PrintVersion:
+  case ActionType::EmitPCH:
+  case ActionType::EmitPCM:
+  case ActionType::DumpPCM:
+  case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
+    return false;
+  case ActionType::ResolveImports:
+  case ActionType::Typecheck:
+  case ActionType::DumpAST:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitModuleOnly:
+  case ActionType::MergeModules:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::Immediate:
+  case ActionType::REPL:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+  case ActionType::DumpTypeInfo:
+    assert(!FrontendOptions::shouldActionOnlyParse(action) &&
+           "Parse-only actions should not load modules!");
+    return true;
+  }
+  llvm_unreachable("Unknown ActionType");
 }
 
 void FrontendOptions::forAllOutputPaths(

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -130,6 +130,47 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   llvm_unreachable("Unknown ActionType");
 }
 
+bool FrontendOptions::doesActionRequireInputs(ActionType action) {
+  switch (action) {
+  case ActionType::NoneAction:
+  case ActionType::PrintVersion:
+    return false;
+  case ActionType::REPL:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::EmitImportedModules:
+  case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
+  case ActionType::EmitPCH:
+  case ActionType::EmitPCM:
+  case ActionType::DumpPCM:
+  case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
+  case ActionType::ResolveImports:
+  case ActionType::Typecheck:
+  case ActionType::DumpAST:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitModuleOnly:
+  case ActionType::MergeModules:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::Immediate:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+  case ActionType::DumpTypeInfo:
+    return true;
+  }
+  llvm_unreachable("Unknown ActionType");
+}
+
 void FrontendOptions::forAllOutputPaths(
     const InputFile &input, llvm::function_ref<void(StringRef)> fn) const {
   if (RequestedAction != FrontendOptions::ActionType::EmitModuleOnly &&

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1229,7 +1229,7 @@ static void verifyGenericSignaturesIfNeeded(const CompilerInvocation &Invocation
     GenericSignatureBuilder::verifyGenericSignaturesInModule(module);
 }
 
-static void dumpAndPrintScopeMap(const CompilerInstance &Instance,
+static bool dumpAndPrintScopeMap(const CompilerInstance &Instance,
                                  SourceFile *SF) {
   // Not const because may require reexpansion
   ASTScope &scope = SF->getScope();
@@ -1239,13 +1239,14 @@ static void dumpAndPrintScopeMap(const CompilerInstance &Instance,
     llvm::errs() << "***Complete scope map***\n";
     scope.buildFullyExpandedTree();
     scope.print(llvm::errs());
-    return;
+    return Instance.getASTContext().hadError();
   }
   // Probe each of the locations, and dump what we find.
   for (auto lineColumn : opts.DumpScopeMapLocations) {
     scope.buildFullyExpandedTree();
     scope.dumpOneScopeMapLocation(lineColumn);
   }
+  return Instance.getASTContext().hadError();
 }
 
 static SourceFile *
@@ -1260,7 +1261,7 @@ getPrimaryOrMainSourceFile(const CompilerInstance &Instance) {
 
 /// Dumps the AST of all available primary source files. If corresponding output
 /// files were specified, use them; otherwise, dump the AST to stdout.
-static void dumpAST(CompilerInstance &Instance) {
+static bool dumpAST(CompilerInstance &Instance) {
   auto primaryFiles = Instance.getPrimarySourceFiles();
   if (!primaryFiles.empty()) {
     for (SourceFile *sourceFile: primaryFiles) {
@@ -1275,55 +1276,7 @@ static void dumpAST(CompilerInstance &Instance) {
     auto *SF = getPrimaryOrMainSourceFile(Instance);
     SF->dump(llvm::outs(), /*parseIfNeeded*/ true);
   }
-}
-
-/// We may have been told to dump the AST (either after parsing or
-/// type-checking, which is already differentiated in
-/// CompilerInstance::performSema()), so dump or print the main source file and
-/// return.
-
-static Optional<bool> dumpASTIfNeeded(CompilerInstance &Instance) {
-  const auto &opts = Instance.getInvocation().getFrontendOptions();
-  const FrontendOptions::ActionType Action = opts.RequestedAction;
-  ASTContext &Context = Instance.getASTContext();
-  switch (Action) {
-  default:
-    return None;
-
-  case FrontendOptions::ActionType::PrintAST:
-    getPrimaryOrMainSourceFile(Instance)
-        ->print(llvm::outs(), PrintOptions::printEverything());
-    break;
-
-  case FrontendOptions::ActionType::DumpScopeMaps:
-    dumpAndPrintScopeMap(Instance, getPrimaryOrMainSourceFile(Instance));
-    break;
-
-  case FrontendOptions::ActionType::DumpTypeRefinementContexts:
-    getPrimaryOrMainSourceFile(Instance)
-        ->getTypeRefinementContext()
-        ->dump(llvm::errs(), Context.SourceMgr);
-    break;
-
-  case FrontendOptions::ActionType::DumpInterfaceHash:
-    getPrimaryOrMainSourceFile(Instance)->dumpInterfaceHash(llvm::errs());
-    break;
-
-  case FrontendOptions::ActionType::EmitSyntax:
-    emitSyntax(getPrimaryOrMainSourceFile(Instance),
-               opts.InputsAndOutputs.getSingleOutputFilename());
-    break;
-
-  case FrontendOptions::ActionType::DumpParse:
-  case FrontendOptions::ActionType::DumpAST:
-    dumpAST(Instance);
-    break;
-
-  case FrontendOptions::ActionType::EmitImportedModules:
-    emitImportedModules(Context, Instance.getMainModule(), opts);
-    break;
-  }
-  return Context.hadError();
+  return Instance.getASTContext().hadError();
 }
 
 static void emitReferenceDependenciesForAllPrimaryInputsIfNeeded(
@@ -1747,40 +1700,187 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   emitCompiledSourceForAllPrimaryInputsIfNeeded(Instance);
 }
 
+static bool printSwiftVersion(const CompilerInvocation &Invocation) {
+  llvm::outs() << version::getSwiftFullVersion(
+                      version::Version::getCurrentLanguageVersion())
+               << '\n';
+  llvm::outs() << "Target: " << Invocation.getLangOptions().Target.str()
+               << '\n';
+  return false;
+}
+
+static bool
+withSemanticAnalysis(CompilerInstance &Instance, FrontendObserver *observer,
+                     llvm::function_ref<bool(CompilerInstance &)> cont) {
+  const auto &Invocation = Instance.getInvocation();
+  const auto &opts = Invocation.getFrontendOptions();
+  assert(!FrontendOptions::shouldActionOnlyParse(opts.RequestedAction) &&
+         "Action may only parse, but has requested semantic analysis!");
+
+  Instance.performSema();
+  if (observer)
+    observer->performedSemanticAnalysis(Instance);
+
+  switch (opts.CrashMode) {
+  case FrontendOptions::DebugCrashMode::AssertAfterParse:
+    debugFailWithAssertion();
+    return true;
+  case FrontendOptions::DebugCrashMode::CrashAfterParse:
+    debugFailWithCrash();
+    return true;
+  case FrontendOptions::DebugCrashMode::None:
+    break;
+  }
+
+  (void)migrator::updateCodeAndEmitRemapIfNeeded(&Instance);
+
+  if (Instance.getASTContext().hadError())
+    return true;
+
+  return cont(Instance);
+}
+
+static bool performScanDependencies(CompilerInstance &Instance) {
+  auto batchScanInput =
+      Instance.getASTContext().SearchPathOpts.BatchScanInputFilePath;
+  if (batchScanInput.empty()) {
+    return scanDependencies(Instance);
+  } else {
+    return batchScanModuleDependencies(Instance, batchScanInput);
+  }
+}
+
+static bool performParseOnly(ModuleDecl &MainModule) {
+  // A -parse invocation only cares about the side effects of parsing, so
+  // force the parsing of all the source files.
+  for (auto *file : MainModule.getFiles()) {
+    if (auto *SF = dyn_cast<SourceFile>(file))
+      (void)SF->getTopLevelDecls();
+  }
+  return MainModule.getASTContext().hadError();
+}
+
+static bool performAction(CompilerInstance &Instance,
+                          int &ReturnValue,
+                          FrontendObserver *observer) {
+  const auto &opts = Instance.getInvocation().getFrontendOptions();
+  auto &Context = Instance.getASTContext();
+  switch (Instance.getInvocation().getFrontendOptions().RequestedAction) {
+  // MARK: Trivial Actions
+  case FrontendOptions::ActionType::NoneAction:
+    return Context.hadError();
+  case FrontendOptions::ActionType::PrintVersion:
+    return printSwiftVersion(Instance.getInvocation());
+  case FrontendOptions::ActionType::REPL:
+    llvm::report_fatal_error("Compiler-internal integrated REPL has been "
+                             "removed; use the LLDB-enhanced REPL instead.");
+
+  // MARK: Actions for Clang and Clang Modules
+  // We've been asked to precompile a bridging header or module; we want to
+  // avoid touching any other inputs and just parse, emit and exit.
+  case FrontendOptions::ActionType::EmitPCH:
+    return precompileBridgingHeader(Instance);
+  case FrontendOptions::ActionType::EmitPCM:
+    return precompileClangModule(Instance);
+  case FrontendOptions::ActionType::DumpPCM:
+    return dumpPrecompiledClangModule(Instance);
+
+  // MARK: Module Interface Actions
+  case FrontendOptions::ActionType::CompileModuleFromInterface:
+  case FrontendOptions::ActionType::TypecheckModuleFromInterface:
+    return buildModuleFromInterface(Instance);
+
+  // MARK: Actions that Dump
+  case FrontendOptions::ActionType::DumpParse: {
+    return dumpAST(Instance);
+  }
+  case FrontendOptions::ActionType::DumpAST:
+    return withSemanticAnalysis(
+        Instance, observer,
+        [](CompilerInstance &Instance) { return dumpAST(Instance); });
+  case FrontendOptions::ActionType::PrintAST:
+    return withSemanticAnalysis(
+        Instance, observer, [](CompilerInstance &Instance) {
+          getPrimaryOrMainSourceFile(Instance)->print(
+              llvm::outs(), PrintOptions::printEverything());
+          return Instance.getASTContext().hadError();
+        });
+  case FrontendOptions::ActionType::DumpScopeMaps:
+    return withSemanticAnalysis(
+        Instance, observer, [](CompilerInstance &Instance) {
+          return dumpAndPrintScopeMap(Instance,
+                                      getPrimaryOrMainSourceFile(Instance));
+        });
+  case FrontendOptions::ActionType::DumpTypeRefinementContexts:
+    return withSemanticAnalysis(
+        Instance, observer, [](CompilerInstance &Instance) {
+          getPrimaryOrMainSourceFile(Instance)
+              ->getTypeRefinementContext()
+              ->dump(llvm::errs(), Instance.getASTContext().SourceMgr);
+          return Instance.getASTContext().hadError();
+        });
+  case FrontendOptions::ActionType::DumpInterfaceHash:
+    getPrimaryOrMainSourceFile(Instance)->dumpInterfaceHash(llvm::errs());
+    return Context.hadError();
+  case FrontendOptions::ActionType::EmitSyntax:
+    return emitSyntax(getPrimaryOrMainSourceFile(Instance),
+                      opts.InputsAndOutputs.getSingleOutputFilename());
+  case FrontendOptions::ActionType::EmitImportedModules:
+    return emitImportedModules(Instance.getMainModule(), opts);
+
+  // MARK: Dependency Scanning Actions
+  case FrontendOptions::ActionType::ScanDependencies:
+    return performScanDependencies(Instance);
+  case FrontendOptions::ActionType::ScanClangDependencies:
+    return scanClangDependencies(Instance);
+
+  // MARK: General Compilation Actions
+  case FrontendOptions::ActionType::Parse:
+    return performParseOnly(*Instance.getMainModule());
+  case FrontendOptions::ActionType::ResolveImports:
+    return Instance.performParseAndResolveImportsOnly();
+  case FrontendOptions::ActionType::Typecheck:
+    return withSemanticAnalysis(Instance, observer,
+                                [](CompilerInstance &Instance) {
+                                  return Instance.getASTContext().hadError();
+                                });
+  case FrontendOptions::ActionType::EmitSILGen:
+  case FrontendOptions::ActionType::EmitSIBGen:
+  case FrontendOptions::ActionType::EmitSIL:
+  case FrontendOptions::ActionType::EmitSIB:
+  case FrontendOptions::ActionType::EmitModuleOnly:
+  case FrontendOptions::ActionType::MergeModules:
+  case FrontendOptions::ActionType::Immediate:
+  case FrontendOptions::ActionType::EmitAssembly:
+  case FrontendOptions::ActionType::EmitIR:
+  case FrontendOptions::ActionType::EmitBC:
+  case FrontendOptions::ActionType::EmitObject:
+  case FrontendOptions::ActionType::DumpTypeInfo:
+    return withSemanticAnalysis(
+        Instance, observer, [&](CompilerInstance &Instance) {
+          assert(FrontendOptions::doesActionGenerateSIL(opts.RequestedAction) &&
+                 "All actions not requiring SILGen must have been handled!");
+          if (Instance.getInvocation().getInputKind() == InputFileKind::LLVM)
+            return compileLLVMIR(Instance);
+
+          return performCompileStepsPostSema(Instance, ReturnValue, observer);
+        });
+  }
+
+  assert(false && "Unhandled case in performCompile!");
+  return Context.hadError();
+}
+
 /// Performs the compile requested by the user.
 /// \param Instance Will be reset after performIRGeneration when the verifier
 ///                 mode is NoVerify and there were no errors.
 /// \returns true on error
-static bool performCompile(CompilerInvocation &Invok,
-                           CompilerInstance &Instance,
-                           ArrayRef<const char *> Args,
+static bool performCompile(CompilerInstance &Instance,
                            int &ReturnValue,
                            FrontendObserver *observer) {
   const auto &Invocation = Instance.getInvocation();
   const auto &opts = Invocation.getFrontendOptions();
   const FrontendOptions::ActionType Action = opts.RequestedAction;
-
-  // We've been asked to precompile a bridging header or module; we want to
-  // avoid touching any other inputs and just parse, emit and exit.
-  if (Action == FrontendOptions::ActionType::EmitPCH)
-    return precompileBridgingHeader(Instance);
-  if (Action == FrontendOptions::ActionType::EmitPCM)
-    return precompileClangModule(Instance);
-  if (Action == FrontendOptions::ActionType::DumpPCM)
-    return dumpPrecompiledClangModule(Instance);
-  if (Action == FrontendOptions::ActionType::PrintVersion) {
-    llvm::outs() << version::getSwiftFullVersion(
-      version::Version::getCurrentLanguageVersion()) << '\n';
-    llvm::outs() << "Target: "
-      << Invocation.getLangOptions().Target.str() << '\n';
-    return false;
-  }
-  if (Action == FrontendOptions::ActionType::CompileModuleFromInterface ||
-      Action == FrontendOptions::ActionType::TypecheckModuleFromInterface)
-    return buildModuleFromInterface(Instance);
-
-  if (Invocation.getInputKind() == InputFileKind::LLVM)
-    return compileLLVMIR(Instance);
 
   // If we aren't in a parse-only context and expect an implicit stdlib import,
   // load in the standard library. If we either fail to find it or encounter an
@@ -1793,95 +1893,27 @@ static bool performCompile(CompilerInvocation &Invok,
       return true;
   }
 
-  bool didFinishPipeline = false;
-  SWIFT_DEFER {
-    assert(didFinishPipeline && "Returned without calling finishPipeline");
-  };
-
-  auto finishPipeline = [&](bool hadError) -> bool {
-    // We might have freed the ASTContext already, but in that case we would
-    // have already performed these actions.
-    if (Instance.hasASTContext()) {
-      performEndOfPipelineActions(Instance);
-      hadError |= Instance.getASTContext().hadError();
+  assert([&]() -> bool {
+    if (FrontendOptions::shouldActionOnlyParse(Action)) {
+      // Parsing gets triggered lazily, but let's make sure we have the right
+      // input kind.
+      auto kind = Invocation.getInputKind();
+      return kind == InputFileKind::Swift ||
+             kind == InputFileKind::SwiftLibrary ||
+             kind == InputFileKind::SwiftModuleInterface;
     }
-    didFinishPipeline = true;
-    return hadError;
-  };
+    return true;
+  }() && "Only supports parsing .swift files");
 
-  auto &Context = Instance.getASTContext();
-  if (FrontendOptions::shouldActionOnlyParse(Action)) {
-    // Parsing gets triggered lazily, but let's make sure we have the right
-    // input kind.
-    auto kind = Invocation.getInputKind();
-    assert((kind == InputFileKind::Swift ||
-            kind == InputFileKind::SwiftLibrary ||
-            kind == InputFileKind::SwiftModuleInterface) &&
-           "Only supports parsing .swift files");
-    (void)kind;
-  } else if (Action == FrontendOptions::ActionType::ResolveImports) {
-    Instance.performParseAndResolveImportsOnly();
-    return finishPipeline(Context.hadError());
-  } else {
-    Instance.performSema();
+  bool hadError = performAction(Instance, ReturnValue, observer);
+
+  // We might have freed the ASTContext already, but in that case we would
+  // have already performed these actions.
+  if (Instance.hasASTContext()) {
+    performEndOfPipelineActions(Instance);
+    hadError |= Instance.getASTContext().hadError();
   }
-
-  if (Action == FrontendOptions::ActionType::Parse) {
-    // A -parse invocation only cares about the side effects of parsing, so
-    // force the parsing of all the source files.
-    for (auto *file : Instance.getMainModule()->getFiles()) {
-      if (auto *SF = dyn_cast<SourceFile>(file))
-        (void)SF->getTopLevelDecls();
-    }
-    return finishPipeline(Context.hadError());
-  }
-
-  if (Action == FrontendOptions::ActionType::ScanDependencies) {
-    auto batchScanInput = Instance.getASTContext().SearchPathOpts.BatchScanInputFilePath;
-    if (batchScanInput.empty())
-      return finishPipeline(scanDependencies(Instance));
-    else
-      return finishPipeline(batchScanModuleDependencies(Invok,
-                                                        Instance,
-                                                        batchScanInput));
-  }
-
-  if (Action == FrontendOptions::ActionType::ScanClangDependencies)
-    return finishPipeline(scanClangDependencies(Instance));
-
-  if (observer)
-    observer->performedSemanticAnalysis(Instance);
-
-  {
-    FrontendOptions::DebugCrashMode CrashMode = opts.CrashMode;
-    if (CrashMode == FrontendOptions::DebugCrashMode::AssertAfterParse)
-      debugFailWithAssertion();
-    else if (CrashMode == FrontendOptions::DebugCrashMode::CrashAfterParse)
-      debugFailWithCrash();
-  }
-
-  (void)migrator::updateCodeAndEmitRemapIfNeeded(&Instance);
-
-  if (Action == FrontendOptions::ActionType::REPL) {
-    llvm::report_fatal_error("Compiler-internal integrated REPL has been "
-                             "removed; use the LLDB-enhanced REPL instead.");
-  }
-
-  if (auto r = dumpASTIfNeeded(Instance))
-    return finishPipeline(*r);
-
-  if (Context.hadError())
-    return finishPipeline(/*hadError*/ true);
-
-  // We've just been told to perform a typecheck, so we can return now.
-  if (Action == FrontendOptions::ActionType::Typecheck)
-    return finishPipeline(/*hadError*/ false);
-
-  assert(FrontendOptions::doesActionGenerateSIL(Action) &&
-         "All actions not requiring SILGen must have been handled!");
-
-  return finishPipeline(
-      performCompileStepsPostSema(Instance, ReturnValue, observer));
+  return hadError;
 }
 
 static bool serializeSIB(SILModule *SM, const PrimarySpecificPaths &PSPs,
@@ -2655,7 +2687,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   }
 
   int ReturnValue = 0;
-  bool HadError = performCompile(Invocation, *Instance, Args, ReturnValue, observer);
+  bool HadError = performCompile(*Instance, ReturnValue, observer);
 
   if (verifierEnabled) {
     DiagnosticEngine &diags = Instance->getDiags();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1888,7 +1888,7 @@ static bool performCompile(CompilerInstance &Instance,
   // trigger a bunch of other errors due to the stdlib being missing, or at
   // worst crash downstream as many call sites don't currently handle a missing
   // stdlib.
-  if (!FrontendOptions::shouldActionOnlyParse(Action)) {
+  if (FrontendOptions::doesActionRequireSwiftStandardLibrary(Action)) {
     if (Instance.loadStdlibIfNeeded())
       return true;
   }

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -42,9 +42,9 @@ static void findAllClangImports(const clang::Module *module,
   }
 }
 
-bool swift::emitImportedModules(ASTContext &Context, ModuleDecl *mainModule,
+bool swift::emitImportedModules(ModuleDecl *mainModule,
                                 const FrontendOptions &opts) {
-
+  auto &Context = mainModule->getASTContext();
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   std::error_code EC;
   llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);

--- a/lib/FrontendTool/ImportedModules.h
+++ b/lib/FrontendTool/ImportedModules.h
@@ -20,8 +20,7 @@ class FrontendOptions;
 class ModuleDecl;
 
 /// Emit the names of the modules imported by \c mainModule.
-bool emitImportedModules(ASTContext &Context, ModuleDecl *mainModule,
-                         const FrontendOptions &opts);
+bool emitImportedModules(ModuleDecl *mainModule, const FrontendOptions &opts);
 } // end namespace swift
 
 #endif

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -690,9 +690,10 @@ bool swift::scanClangDependencies(CompilerInstance &instance) {
                                   .InputsAndOutputs.getSingleOutputFilename());
 }
 
-bool swift::batchScanModuleDependencies(CompilerInvocation &invok,
-                                        CompilerInstance &instance,
+bool swift::batchScanModuleDependencies(CompilerInstance &instance,
                                         llvm::StringRef batchInputFile) {
+  const CompilerInvocation &invok = instance.getInvocation();
+
   (void)instance.getMainModule();
   llvm::BumpPtrAllocator alloc;
   llvm::StringSaver saver(alloc);

--- a/lib/FrontendTool/ScanDependencies.h
+++ b/lib/FrontendTool/ScanDependencies.h
@@ -21,8 +21,7 @@ class CompilerInvocation;
 class CompilerInstance;
 
 /// Batch scan the dependencies for modules specified in \c batchInputFile.
-bool batchScanModuleDependencies(CompilerInvocation &invok,
-                                 CompilerInstance &instance,
+bool batchScanModuleDependencies(CompilerInstance &instance,
                                  llvm::StringRef batchInputFile);
 
 /// Scans the dependencies of the main module of \c instance.


### PR DESCRIPTION
Try to impose a simple structure that splits performing actions from the
pre and post-pipeline conditions. Wherever actions would take more than
a simple return, split them into functions. Refine functions that
perform effects to return status codes when they fail. Finally,
delineate functions that need semantic analysis from those that do not.