### PR TITLE
build: repair the build for newer MSVC release

### DIFF
--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -96,6 +96,12 @@ macro(swift_swap_compiler_if_needed target)
         set(CMAKE_C_COMPILER ${CLANG_LOCATION}/clang${CMAKE_EXECUTABLE_SUFFIX})
         set(CMAKE_CXX_COMPILER ${CLANG_LOCATION}/clang++${CMAKE_EXECUTABLE_SUFFIX})
       endif()
+
+      # Add a workaround for older clang-cl with a newer MSVC runtime.  MSVC
+      # 16.27 ships with a C++ compiler that enables conditional explicit from
+      # C++20 unconditionally.  Newer clang supports this, but the 5.3 release
+      # branch clang does not.  Add a workaround.
+      add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:_HAS_CONDITIONAL_EXPLICIT=0>)
     else()
       message(SEND_ERROR "${target} requires a clang based compiler")
     endif()

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -55,6 +55,12 @@ else()
   add_compile_options(-fno-sanitize=all)
 endif()
 
+# Add a workaround for older clang-cl with a newer MSVC runtime.  MSVC 16.27
+# ships with a C++ compiler that enables conditional explicit from C++20
+# unconditionally.  Newer clang supports this, but the 5.3 release branch clang
+# does not.  Add a workaround.
+add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:_HAS_CONDITIONAL_EXPLICIT=0>)
+
 # Do not enforce checks for LLVM's ABI-breaking build settings.
 # The Swift runtime uses some header-only code from LLVM's ADT classes,
 # but we do not want to link libSupport into the runtime. These checks rely


### PR DESCRIPTION
The newer VS2019 releases require conditional explicit support from
C++2a unconditionally.  This was added into the newer clang, but the
clang for the 5.3 release does not have this.  Add this workaround
instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
