### PR TITLE
 [Concurrency] Import Objective-C methods with completion handlers as async

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -63,6 +63,7 @@ namespace swift {
   class Type;
   class Expr;
   class DeclRefExpr;
+  class ForeignAsyncConvention;
   class ForeignErrorConvention;
   class LiteralExpr;
   class BraceStmt;
@@ -6148,7 +6149,15 @@ public:
   /// being dropped altogether. `None` is returned for a normal function
   /// or method.
   Optional<int> getForeignFunctionAsMethodSelfParameterIndex() const;
-  
+
+  /// Set information about the foreign async convention used by this
+  /// declaration.
+  void setForeignAsyncConvention(const ForeignAsyncConvention &convention);
+
+  /// Get information about the foreign async convention used by this
+  /// declaration, given that it is @objc and 'async'.
+  Optional<ForeignAsyncConvention> getForeignAsyncConvention() const;
+
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_AbstractFunctionDecl &&
            D->getKind() <= DeclKind::Last_AbstractFunctionDecl;
@@ -6277,7 +6286,8 @@ public:
                                   DeclContext *Parent);
 
   static FuncDecl *createImported(ASTContext &Context, SourceLoc FuncLoc,
-                                  DeclName Name, SourceLoc NameLoc, bool Throws,
+                                  DeclName Name, SourceLoc NameLoc,
+                                  bool Async, bool Throws,
                                   ParameterList *BodyParams, Type FnRetType,
                                   DeclContext *Parent, ClangNode ClangN);
 

--- a/include/swift/AST/ForeignAsyncConvention.h
+++ b/include/swift/AST/ForeignAsyncConvention.h
@@ -1,0 +1,81 @@
+//===--- ForeignAsyncConvention.h - Async conventions -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ForeignAsyncConvention structure, which
+// describes the rules for how to detect that a foreign API is asynchronous.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FOREIGN_ASYNC_CONVENTION_H
+#define SWIFT_FOREIGN_ASYNC_CONVENTION_H
+
+#include "swift/AST/Type.h"
+
+namespace swift {
+
+/// A small structure describing the async convention of a foreign declaration.
+class ForeignAsyncConvention {
+  /// The index of the completion handler parameters.
+  unsigned CompletionHandlerParamIndex;
+
+  /// When non-zero, indicates which parameter to the completion handler is the
+  /// Error? parameter (minus one) that makes this async function also throwing.
+  unsigned CompletionHandlerErrorParamIndex;
+public:
+  ForeignAsyncConvention()
+      : CompletionHandlerParamIndex(0), CompletionHandlerErrorParamIndex(0) { }
+
+  ForeignAsyncConvention(unsigned completionHandlerParamIndex,
+                         Optional<unsigned> completionHandlerErrorParamIndex)
+      : CompletionHandlerParamIndex(completionHandlerParamIndex),
+        CompletionHandlerErrorParamIndex(
+          completionHandlerErrorParamIndex
+            ? *completionHandlerErrorParamIndex + 1
+            : 0) {}
+
+  /// Retrieve the index of the completion handler parameter, which will be
+  /// erased from the Swift signature of the imported async function.
+  unsigned completionHandlerParamIndex() const {
+    return CompletionHandlerParamIndex;
+  }
+
+  /// Retrieve the index of the \c Error? parameter in the completion handler's
+  /// parameter list. When argument passed to this parameter is non-null, the
+  /// provided error will be thrown by the async function.
+  Optional<unsigned> completionHandlerErrorParamIndex() const {
+    if (CompletionHandlerErrorParamIndex == 0)
+      return None;
+
+    return CompletionHandlerErrorParamIndex - 1;
+  }
+
+  /// Whether the async function is throwing due to the completion handler
+  /// having an \c Error? parameter.
+  ///
+  /// Equivalent to \c static_cast<bool>(completionHandlerErrorParamIndex()).
+  bool isThrowing() const {
+    return CompletionHandlerErrorParamIndex != 0;
+  }
+
+  bool operator==(ForeignAsyncConvention other) const {
+    return CompletionHandlerParamIndex == other.CompletionHandlerParamIndex
+      && CompletionHandlerErrorParamIndex ==
+        other.CompletionHandlerErrorParamIndex;
+  }
+  bool operator!=(ForeignAsyncConvention other) const {
+    return !(*this == other);
+  }
+};
+
+}
+
+#endif

--- a/include/swift/AST/ForeignErrorConvention.h
+++ b/include/swift/AST/ForeignErrorConvention.h
@@ -81,6 +81,10 @@ public:
     }
 
     Info() = default;
+
+    Kind getKind() const {
+      return static_cast<Kind>(TheKind);
+    }
   };
 
 private:  
@@ -178,11 +182,24 @@ public:
   /// Returns the physical result type of the function, for functions
   /// that completely erase this information.
   CanType getResultType() const {
-    assert(getKind() == ZeroResult ||
-           getKind() == NonZeroResult);
+    assert(resultTypeErasedToVoid(getKind()));
     return ResultType;
   }
-  
+
+  /// Whether this kind of error import erases the result type to 'Void'.
+  static bool resultTypeErasedToVoid(Kind kind) {
+    switch (kind) {
+    case ZeroResult:
+    case NonZeroResult:
+      return true;
+
+    case ZeroPreservedResult:
+    case NilResult:
+    case NonNilError:
+      return false;
+    }
+  }
+
   bool operator==(ForeignErrorConvention other) const {
     return info.TheKind == other.info.TheKind
       && info.ErrorIsOwned == other.info.ErrorIsOwned

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7255,13 +7255,14 @@ FuncDecl *FuncDecl::createImplicit(ASTContext &Context,
 
 FuncDecl *FuncDecl::createImported(ASTContext &Context, SourceLoc FuncLoc,
                                    DeclName Name, SourceLoc NameLoc,
-                                   bool Throws, ParameterList *BodyParams,
+                                   bool Async, bool Throws,
+                                   ParameterList *BodyParams,
                                    Type FnRetType, DeclContext *Parent,
                                    ClangNode ClangN) {
   assert(ClangN && FnRetType);
   auto *const FD = FuncDecl::createImpl(
       Context, SourceLoc(), StaticSpellingKind::None, FuncLoc, Name, NameLoc,
-      /*Async=*/false, SourceLoc(), Throws, SourceLoc(),
+      Async, SourceLoc(), Throws, SourceLoc(),
       /*GenericParams=*/nullptr, Parent, ClangN);
   FD->setParameters(BodyParams);
   FD->setResultInterfaceType(FnRetType);

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -714,8 +714,7 @@ bool importer::isUnavailableInSwift(
   return false;
 }
 
-OptionalTypeKind importer::getParamOptionality(version::Version swiftVersion,
-                                               const clang::ParmVarDecl *param,
+OptionalTypeKind importer::getParamOptionality(const clang::ParmVarDecl *param,
                                                bool knownNonNull) {
   auto &clangCtx = param->getASTContext();
 

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -161,15 +161,11 @@ bool isUnavailableInSwift(const clang::Decl *decl, const PlatformAvailability &,
 
 /// Determine the optionality of the given Clang parameter.
 ///
-/// \param swiftLanguageVersion What version of Swift we're using, which affects
-/// how optionality is inferred.
-///
 /// \param param The Clang parameter.
 ///
 /// \param knownNonNull Whether a function- or method-level "nonnull" attribute
 /// applies to this parameter.
-OptionalTypeKind getParamOptionality(version::Version swiftLanguageVersion,
-                                     const clang::ParmVarDecl *param,
+OptionalTypeKind getParamOptionality(const clang::ParmVarDecl *param,
                                      bool knownNonNull);
 }
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3681,6 +3681,7 @@ void ClangImporter::Implementation::lookupValue(
             clangDecl->getMostRecentDecl();
 
         CurrentVersion.forEachOtherImportNameVersion(
+            SwiftContext.LangOpts.EnableExperimentalConcurrency,
             [&](ImportNameVersion nameVersion) {
           if (anyMatching)
             return;
@@ -3688,6 +3689,12 @@ void ClangImporter::Implementation::lookupValue(
           // Check to see if the name and context match what we expect.
           ImportedName newName = importFullName(recentClangDecl, nameVersion);
           if (!newName.getDeclName().matchesRef(name))
+            return;
+
+          // If we asked for an async import and didn't find one, skip this.
+          // This filters out duplicates.
+          if (nameVersion.supportsConcurrency() &&
+              !newName.getAsyncInfo())
             return;
 
           const clang::DeclContext *clangDC =

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -160,6 +160,7 @@ static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                                       DeclName name, SourceLoc nameLoc,
                                       ParameterList *bodyParams,
                                       Type resultTy,
+                                      bool async,
                                       bool throws,
                                       DeclContext *dc,
                                       ClangNode clangNode) {
@@ -176,7 +177,7 @@ static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                                 bodyParams,
                                 resultTy, dc, clangNode);
   } else {
-    return FuncDecl::createImported(ctx, funcLoc, name, nameLoc, throws,
+    return FuncDecl::createImported(ctx, funcLoc, name, nameLoc, async, throws,
                                     bodyParams, resultTy, dc, clangNode);
   }
 }
@@ -2254,7 +2255,7 @@ namespace {
     /// Whether the names we're importing are from the language version the user
     /// requested, or if these are decls from another version
     bool isActiveSwiftVersion() const {
-      return getVersion() == getActiveSwiftVersion();
+      return getVersion().withConcurrency(false) == getActiveSwiftVersion().withConcurrency(false);
     }
 
     void recordMemberInContext(const DeclContext *dc, ValueDecl *member) {
@@ -2300,7 +2301,7 @@ namespace {
         return canonicalName;
       }
 
-      // Special handling when we import using the older Swift name.
+      // Special handling when we import using the alternate Swift name.
       //
       // Import using the alternate Swift name. If that fails, or if it's
       // identical to the active Swift name, we won't introduce an alternate
@@ -2308,6 +2309,19 @@ namespace {
       auto alternateName = Impl.importFullName(D, getVersion());
       if (!alternateName)
         return ImportedName();
+
+      // Importing for concurrency is special in that the same declaration
+      // is imported both with a completion handler parameter and as 'async',
+      // creating two separate declarations.
+      if (getVersion().supportsConcurrency()) {
+        // If the resulting name isn't special for concurrency, it's not
+        // different.
+        if (!alternateName.getAsyncInfo())
+          return ImportedName();
+
+        // Otherwise, it's a legitimately different import.
+        return alternateName;
+      }
 
       if (alternateName.getDeclName() == canonicalName.getDeclName() &&
           alternateName.getEffectiveContext().equalsWithoutResolving(
@@ -2468,6 +2482,13 @@ namespace {
 
         if (getVersion() >= getActiveSwiftVersion())
           return;
+      }
+
+      // If this the active and current Swift versions differ based on
+      // concurrency, it's not actually a variant.
+      if (getVersion().supportsConcurrency() !=
+            getActiveSwiftVersion().supportsConcurrency()) {
+        return;
       }
 
       // TODO: some versions should be deprecated instead of unavailable
@@ -3837,9 +3858,10 @@ namespace {
 
       // FIXME: Poor location info.
       auto nameLoc = Impl.importSourceLoc(decl->getLocation());
-      result = createFuncOrAccessor(Impl.SwiftContext, loc, accessorInfo, name,
-                                    nameLoc, bodyParams, resultTy,
-                                    /*throws*/ false, dc, decl);
+      result = createFuncOrAccessor(
+          Impl.SwiftContext, loc, accessorInfo, name,
+          nameLoc, bodyParams, resultTy,
+          /*async*/ false, /*throws*/ false, dc, decl);
 
       if (!dc->isModuleScopeContext()) {
         if (selfIsInOut)
@@ -4410,6 +4432,16 @@ namespace {
         }
       }
 
+      // Determine whether the function is throwing and/or async.
+      bool throws = importedName.getErrorInfo().hasValue();
+      bool async = false;
+      auto asyncConvention = importedName.getAsyncInfo();
+      if (asyncConvention) {
+        async = true;
+        if (asyncConvention->isThrowing())
+          throws = true;
+      }
+
       auto resultTy = importedType.getType();
       auto isIUO = importedType.isImplicitlyUnwrapped();
 
@@ -4439,8 +4471,7 @@ namespace {
                                          importedName.getDeclName(),
                                          /*nameLoc*/SourceLoc(),
                                          bodyParams, resultTy,
-                                         importedName.getErrorInfo().hasValue(),
-                                         dc, decl);
+                                         async, throws, dc, decl);
 
       result->setAccess(getOverridableAccessLevel(dc));
 
@@ -4470,6 +4501,11 @@ namespace {
       // Record the error convention.
       if (errorConvention) {
         result->setForeignErrorConvention(*errorConvention);
+      }
+
+      // Record the async convention.
+      if (asyncConvention) {
+        result->setForeignAsyncConvention(*asyncConvention);
       }
 
       // Handle attributes.
@@ -4503,6 +4539,7 @@ namespace {
             Impl.addAlternateDecl(result, cast<ValueDecl>(imported));
         }
       }
+
       return result;
     }
 
@@ -6443,6 +6480,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
     return known->second;
 
   // Create the actual constructor.
+  assert(!importedName.getAsyncInfo());
   auto result = Impl.createDeclWithClangNode<ConstructorDecl>(
       objcMethod, AccessLevel::Public, importedName.getDeclName(),
       /*NameLoc=*/SourceLoc(), failability, /*FailabilityLoc=*/SourceLoc(),
@@ -7143,6 +7181,11 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         return;
 
       if (isa<AccessorDecl>(afd))
+        return;
+
+      // Asynch methods are also always imported without async, so don't
+      // record them here.
+      if (afd->hasAsync())
         return;
 
       auto objcMethod =

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1136,6 +1136,174 @@ Optional<ForeignErrorConvention::Info> NameImporter::considerErrorImport(
   return None;
 }
 
+/// Whether the given parameter name identifies a completion handler.
+static bool isCompletionHandlerParamName(StringRef paramName) {
+  return paramName == "completionHandler" || paramName == "completion" ||
+      paramName == "withCompletionHandler";
+}
+
+/// Whether the give base name implies that the first parameter is a completion
+/// handler.
+///
+/// \returns a trimmed base name when it does, \c None others
+static Optional<StringRef> isCompletionHandlerInBaseName(StringRef basename) {
+  if (basename.endswith("WithCompletionHandler")) {
+    return basename.drop_back(strlen("WithCompletionHandler"));
+  }
+
+  if (basename.endswith("WithCompletion")) {
+    return basename.drop_back(strlen("WithCompletion"));
+  }
+
+  return None;
+}
+
+
+// Determine whether the given type is a nullable NSError type.
+static bool isNullableNSErrorType(
+    clang::ASTContext &clangCtx, clang::QualType type) {
+  auto objcPtrType = type->getAs<clang::ObjCObjectPointerType>();
+  if (!objcPtrType)
+    return false;
+
+  auto iface = objcPtrType->getInterfaceDecl();
+  if (!iface || iface->getName() != "NSError")
+    return false;
+
+  // If nullability is specified, check it.
+  if (auto nullability = type->getNullability(clangCtx)) {
+    switch (translateNullability(*nullability)) {
+    case OTK_None:
+      return false;
+
+    case OTK_ImplicitlyUnwrappedOptional:
+    case OTK_Optional:
+      return true;
+    }
+  }
+
+  // Otherwise, assume it's nullable.
+  return true;
+}
+
+Optional<ForeignAsyncConvention>
+NameImporter::considerAsyncImport(
+    const clang::ObjCMethodDecl *clangDecl,
+    StringRef &baseName,
+    SmallVectorImpl<StringRef> &paramNames,
+    ArrayRef<const clang::ParmVarDecl *> params,
+    bool isInitializer, bool hasCustomName,
+    Optional<ForeignErrorConvention::Info> errorInfo) {
+  // If there are no unclaimed parameters, there's no .
+  unsigned errorParamAdjust = errorInfo ? 1 : 0;
+  if (params.size() - errorParamAdjust == 0)
+    return None;
+
+  // If the # of parameter names doesn't line up with the # of parameters,
+  // bail out. There are extra C parameters on the method or a custom name
+  // was incorrect.
+  if (params.size() != paramNames.size() + errorParamAdjust)
+    return None;
+
+  // The last parameter will be the completion handler for an async function.
+  unsigned completionHandlerParamIndex = params.size() - 1;
+  unsigned completionHandlerParamNameIndex = paramNames.size() - 1;
+
+  // Determine whether the naming indicates that this is a completion
+  // handler.
+  Optional<StringRef> newBaseName;
+  if (isCompletionHandlerParamName(paramNames[completionHandlerParamNameIndex])) {
+    // The parameter itself has an appropriate name.
+  } else if (!hasCustomName && completionHandlerParamIndex == 0 &&
+             (newBaseName = isCompletionHandlerInBaseName(baseName))) {
+    // The base name implies that the first parameter is a completion handler.
+  } else {
+    return None;
+  }
+
+  // Used for returns once we've determined that the method cannot be
+  // imported as async, even though it has what looks like a completion handler
+  // parameter.
+  auto notAsync = [&](const char *reason) -> Optional<ForeignAsyncConvention> {
+#ifdef ASYNC_IMPORT_DEBUG
+    llvm::errs() << "*** failed async import: " << reason << "\n";
+    clangDecl->dump(llvm::errs());
+#endif
+
+    return None;
+  };
+
+  // Initializers cannot be 'async'.
+  // FIXME: We might eventually allow this.
+  if (isInitializer)
+    return notAsync("initializers cannot be async");
+
+  // Check whether we method has a suitable return type.
+  if (clangDecl->getReturnType()->isVoidType()) {
+    // 'void' is the common case; the method produces no synchronous result.
+  } else if (errorInfo &&
+             ForeignErrorConvention::resultTypeErasedToVoid(
+                 errorInfo->getKind())) {
+    // The method has been imported as throwing in a manner that erased the
+    // result type to Void.
+  } else {
+    return notAsync("method does not return void");
+  }
+
+  // The completion handler parameter must have block type.
+  auto completionHandlerParam = params[completionHandlerParamIndex];
+  if (!isBlockParameter(completionHandlerParam))
+    return notAsync("parameter is not a block");
+
+  // Dig out the function type of the completion handler's block type.
+  // If there is no prototype, (e.g., the completion handler is of type
+  // void (^)()), we cannot importer it.
+  auto completionHandlerFunctionType =
+      completionHandlerParam->getType()->castAs<clang::BlockPointerType>()
+      ->getPointeeType()->getAs<clang::FunctionProtoType>();
+  if (!completionHandlerFunctionType)
+    return notAsync("block parameter does not have a prototype");
+
+  // The completion handler parameter must itself return 'void'.
+  if (!completionHandlerFunctionType->getReturnType()->isVoidType())
+    return notAsync("completion handler parameter does not return 'void'");
+
+  // Scan the parameters of the block type to look for a parameter of a
+  // nullable NSError type, which would indicate that the async method could
+  // throw.
+  Optional<unsigned> completionHandlerErrorParamIndex;
+  auto completionHandlerParamTypes =
+      completionHandlerFunctionType->getParamTypes();
+  auto &clangCtx = clangDecl->getASTContext();
+  for (unsigned paramIdx : indices(completionHandlerParamTypes)) {
+    auto paramType = completionHandlerParamTypes[paramIdx];
+
+    // We are only interested in nullable NSError parameters.
+    if (!isNullableNSErrorType(clangCtx, paramType))
+      continue;
+
+    // If this is the first nullable error parameter, note that.
+    if (!completionHandlerErrorParamIndex) {
+      completionHandlerErrorParamIndex = paramIdx;
+      continue;
+    }
+
+    // More than one nullable NSError parameter. Don't import as throwing.
+    completionHandlerErrorParamIndex = None;
+    break;
+  }
+
+  // Drop the completion handler parameter name.
+  paramNames.erase(paramNames.begin() + completionHandlerParamNameIndex);
+
+  // Update the base name, if needed.
+  if (newBaseName && !hasCustomName)
+    baseName = *newBaseName;
+
+  return ForeignAsyncConvention(
+      completionHandlerParamIndex, completionHandlerErrorParamIndex);
+}
+
 bool NameImporter::hasErrorMethodNameCollision(
     const clang::ObjCMethodDecl *method, unsigned paramIndex,
     StringRef suffixToStrip) {
@@ -1358,6 +1526,21 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
                                                  /*hasCustomName=*/true)) {
           result.info.hasErrorInfo = true;
           result.info.errorInfo = *errorInfo;
+        }
+
+        if (version.supportsConcurrency()) {
+          if (auto asyncInfo = considerAsyncImport(
+                  method, parsedName.BaseName, parsedName.ArgumentLabels,
+                  params, isInitializer, /*hasCustomName=*/true,
+                  result.getErrorInfo())) {
+            result.info.hasAsyncInfo = true;
+            result.info.asyncInfo = *asyncInfo;
+
+            // Update the name to reflect the new parameter labels.
+            result.declName = formDeclName(
+                swiftCtx, parsedName.BaseName, parsedName.ArgumentLabels,
+                /*isFunction=*/true, isInitializer);
+          }
         }
       }
 
@@ -1602,6 +1785,16 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         /*hasCustomName=*/false)) {
         result.info.hasErrorInfo = true;
         result.info.errorInfo = *errorInfo;
+    }
+
+    if (version.supportsConcurrency()) {
+      if (auto asyncInfo = considerAsyncImport(
+              objcMethod, baseName, argumentNames, params, isInitializer,
+              /*hasCustomName=*/false,
+              result.getErrorInfo())) {
+        result.info.hasAsyncInfo = true;
+        result.info.asyncInfo = *asyncInfo;
+      }
     }
 
     isFunction = true;
@@ -1892,6 +2085,7 @@ bool NameImporter::forEachDistinctImportName(
     seenNames.push_back(key);
 
   activeVersion.forEachOtherImportNameVersion(
+      swiftCtx.LangOpts.EnableExperimentalConcurrency,
       [&](ImportNameVersion nameVersion) {
         // Check to see if the name is different.
         ImportedName newName = importName(decl, nameVersion);

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -807,8 +807,6 @@ static bool omitNeedlessWordsInFunctionName(
     Optional<unsigned> errorParamIndex, bool returnsSelf, bool isInstanceMethod,
     NameImporter &nameImporter) {
   clang::ASTContext &clangCtx = nameImporter.getClangContext();
-  const version::Version &swiftLanguageVersion =
-      nameImporter.getLangOpts().EffectiveLanguageVersion;
 
   // Collect the parameter type names.
   StringRef firstParamName;
@@ -837,8 +835,7 @@ static bool omitNeedlessWordsInFunctionName(
     bool hasDefaultArg =
         ClangImporter::Implementation::inferDefaultArgument(
             param->getType(),
-            getParamOptionality(swiftLanguageVersion, param,
-                                !nonNullArgs.empty() && nonNullArgs[i]),
+            getParamOptionality(param, !nonNullArgs.empty() && nonNullArgs[i]),
             nameImporter.getIdentifier(baseName), argumentName, i == 0,
             isLastParameter, nameImporter) != DefaultArgumentKind::None;
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -23,6 +23,7 @@
 #include "swift/Basic/Version.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "clang/Sema/Sema.h"
 
@@ -42,15 +43,18 @@ enum { NumImportedAccessorKindBits = 3 };
 
 /// The name version
 class ImportNameVersion : public RelationalOperationsBase<ImportNameVersion> {
-  unsigned rawValue;
+  unsigned rawValue : 31;
+  unsigned concurrency : 1;
+
   friend llvm::DenseMapInfo<ImportNameVersion>;
 
   enum AsConstExpr_t { AsConstExpr };
 
-  constexpr ImportNameVersion() : rawValue(0) {}
+  constexpr ImportNameVersion() : rawValue(0), concurrency(false) {}
   constexpr ImportNameVersion(unsigned version, AsConstExpr_t)
-      : rawValue(version) {}
-  explicit ImportNameVersion(unsigned version) : rawValue(version) {
+      : rawValue(version), concurrency(false) {}
+  explicit ImportNameVersion(unsigned version, bool concurrency = false)
+      : rawValue(version), concurrency(concurrency) {
     assert(version >= 2 && "only Swift 2 and later are supported");
   }
 public:
@@ -67,7 +71,7 @@ public:
       return ImportNameVersion::swift4_2();
     }
     unsigned major = version[0];
-    return ImportNameVersion(major >= 5 ? major + 1 : major);
+    return ImportNameVersion(major >= 5 ? major + 1 : major, false);
   }
 
   unsigned majorVersionNumber() const {
@@ -89,11 +93,21 @@ public:
     return llvm::VersionTuple(majorVersionNumber(), minorVersionNumber());
   }
 
+  /// Whether to consider importing functions as 'async'.
+  bool supportsConcurrency() const { return concurrency; }
+
+  ImportNameVersion withConcurrency(bool concurrency) const {
+    ImportNameVersion result = *this;
+    result.concurrency = concurrency;
+    return result;
+  }
+
   bool operator==(ImportNameVersion other) const {
-    return rawValue == other.rawValue;
+    return rawValue == other.rawValue && concurrency == other.concurrency;
   }
   bool operator<(ImportNameVersion other) const {
-    return rawValue < other.rawValue;
+    return rawValue < other.rawValue ||
+        (rawValue == other.rawValue && concurrency < other.concurrency);
   }
 
   /// Calls \p action for each name version other than this one, first going
@@ -102,10 +116,19 @@ public:
   ///
   /// This is the most useful order for importing compatibility stubs.
   void forEachOtherImportNameVersion(
+      bool withConcurrency,
       llvm::function_ref<void(ImportNameVersion)> action) const {
     assert(*this >= ImportNameVersion::swift2());
 
     ImportNameVersion nameVersion = *this;
+    assert(!nameVersion.supportsConcurrency());
+
+    // If we've been asked to also consider concurrency, do so for the
+    // primary version (only).
+    if (withConcurrency) {
+      action(nameVersion.withConcurrency(true));
+    }
+
     while (nameVersion > ImportNameVersion::swift2()) {
       --nameVersion.rawValue;
       action(nameVersion);
@@ -175,6 +198,10 @@ class ImportedName {
     /// throwing Swift methods, describes how the mapping is performed.
     ForeignErrorConvention::Info errorInfo;
 
+    /// For names that map Objective-C completion handlers into async
+    /// Swift methods, describes how the mapping is performed.
+    ForeignAsyncConvention asyncInfo;
+
     /// For a declaration name that makes the declaration into an
     /// instance member, the index of the "Self" parameter.
     unsigned selfIndex;
@@ -201,11 +228,13 @@ class ImportedName {
 
     unsigned hasErrorInfo : 1;
 
+    unsigned hasAsyncInfo : 1;
+
     Info()
         : errorInfo(), selfIndex(), initKind(CtorInitializerKind::Designated),
           accessorKind(ImportedAccessorKind::None), hasCustomName(false),
           droppedVariadic(false), importAsMember(false), hasSelfIndex(false),
-          hasErrorInfo(false) {}
+          hasErrorInfo(false), hasAsyncInfo(false) {}
   } info;
 
 public:
@@ -236,6 +265,14 @@ public:
   Optional<ForeignErrorConvention::Info> getErrorInfo() const {
     if (info.hasErrorInfo)
       return info.errorInfo;
+    return None;
+  }
+
+  /// For names that map Objective-C methods with completion handlers into
+  /// async Swift methods, describes how the mapping is performed.
+  Optional<ForeignAsyncConvention> getAsyncInfo() const {
+    if (info.hasAsyncInfo)
+      return info.asyncInfo;
     return None;
   }
 
@@ -415,6 +452,14 @@ private:
                       SmallVectorImpl<StringRef> &paramNames,
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName);
+
+  Optional<ForeignAsyncConvention>
+  considerAsyncImport(const clang::ObjCMethodDecl *clangDecl,
+                      StringRef &baseName,
+                      SmallVectorImpl<StringRef> &paramNames,
+                      ArrayRef<const clang::ParmVarDecl *> params,
+                      bool isInitializer, bool hasCustomName,
+                      Optional<ForeignErrorConvention::Info> errorInfo);
 
   EffectiveClangContext determineEffectiveContext(const clang::NamedDecl *,
                                                   const clang::DeclContext *,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1988,6 +1988,42 @@ static Type mapGenericArgs(const DeclContext *fromDC,
   return type.subst(subs);
 }
 
+/// Decompose the type of a completion handler parameter in a function
+/// imported as 'async' and produce the result type of the 'async' function.
+static Type decomposeCompletionHandlerType(
+   Type paramTy, ForeignAsyncConvention info) {
+  auto fnType = paramTy->lookThroughAllOptionalTypes()->getAs<FunctionType>();
+  if (!fnType)
+    return Type();
+
+  SmallVector<TupleTypeElt, 2> resultTypeElts;
+  auto params = fnType->getParams();
+  for (unsigned paramIdx : indices(params)) {
+    const auto &param = params[paramIdx];
+    if (param.isInOut() || param.isVariadic())
+      return Type();
+
+    // If there is an error parameter to the completion handler, it is
+    // not part of the result type of the asynchronous function.
+    if (info.completionHandlerErrorParamIndex() &&
+        paramIdx == *info.completionHandlerErrorParamIndex())
+      continue;
+
+    resultTypeElts.push_back(param.getPlainType());
+  }
+
+  switch (resultTypeElts.size()) {
+  case 0:
+    return paramTy->getASTContext().getVoidDecl()->getDeclaredInterfaceType();
+
+  case 1:
+    return resultTypeElts.front().getType();
+
+  default:
+    return TupleType::get(resultTypeElts, paramTy->getASTContext());
+  }
+}
+
 ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     const DeclContext *dc, const clang::ObjCMethodDecl *clangDecl,
     ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
@@ -2024,6 +2060,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   CanType origSwiftResultTy;
   Optional<ForeignErrorConvention::Info> errorInfo =
       importedName.getErrorInfo();
+  auto asyncInfo = importedName.getAsyncInfo();
   OptionalTypeKind OptionalityOfReturn;
   if (clangDecl->hasAttr<clang::ReturnsNonNullAttr>()) {
     OptionalityOfReturn = OTK_None;
@@ -2122,6 +2159,9 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
       continue;
     }
 
+    bool paramIsCompletionHandler =
+        asyncInfo && paramIndex == asyncInfo->completionHandlerParamIndex();
+
     // Import the parameter type into Swift.
 
     // Check nullability of the parameter.
@@ -2189,6 +2229,21 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
         ++nameIndex;
       }
       continue;
+    }
+
+    // If this is a completion handler, figure out it's effect on the result
+    // type but don't build it into the parameter type.
+    if (paramIsCompletionHandler) {
+      if (Type replacedSwiftResultTy =
+              decomposeCompletionHandlerType(swiftParamTy, *asyncInfo)) {
+        swiftResultTy = replacedSwiftResultTy;
+
+        // FIXME: We will need an equivalent to "error parameter is replaced"
+        // for asynchronous functions. Perhaps add "async: ()"?
+        continue;
+      }
+
+      llvm_unreachable("async info computed incorrectly?");
     }
 
     // Map __attribute__((noescape)) to @noescape.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1747,8 +1747,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
 
     // Check nullability of the parameter.
     OptionalTypeKind OptionalityOfParam =
-        getParamOptionality(SwiftContext.LangOpts.EffectiveLanguageVersion,
-                            param, !nonNullArgs.empty() && nonNullArgs[index]);
+        getParamOptionality(param, !nonNullArgs.empty() && nonNullArgs[index]);
 
     ImportTypeKind importKind = ImportTypeKind::Parameter;
     if (param->hasAttr<clang::CFReturnsRetainedAttr>())
@@ -2127,8 +2126,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
 
     // Check nullability of the parameter.
     OptionalTypeKind optionalityOfParam
-        = getParamOptionality(SwiftContext.LangOpts.EffectiveLanguageVersion,
-                              param,
+        = getParamOptionality(param,
                               !nonNullArgs.empty() && nonNullArgs[paramIndex]);
 
     bool allowNSUIntegerAsIntInParam = isFromSystemModule;

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1857,6 +1857,7 @@ SwiftNameLookupExtension::hashExtension(llvm::hash_code code) const {
                             SWIFT_LOOKUP_TABLE_VERSION_MAJOR,
                             SWIFT_LOOKUP_TABLE_VERSION_MINOR,
                             inferImportAsMember,
+                            swiftCtx.LangOpts.EnableExperimentalConcurrency,
                             version::getSwiftFullVersion());
 }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify
+
+// REQUIRES: objc_interop
+import Foundation
+import ObjCConcurrency
+
+func testSlowServer(slowServer: SlowServer) async {
+  let _: Int = await slowServer.doSomethingSlow("mail")
+  let _: Bool = await slowServer.checkAvailability()
+  let _: String = await slowServer.findAnswer() ?? "nope"
+  let _: String = await slowServer.findAnswerFailingly() ?? "nope"
+  // FIXME: expected-error@-2{{call can throw, but it is not marked with 'try'}}
+  // FIXME: expected-error@-2{{call can throw, but it is not marked with 'try'}}
+}
+
+func testSlowServerOldSchool(slowServer: SlowServer) {
+  var i1: Int = 0
+  slowServer.doSomethingSlow("mail") { i in
+    i1 = i
+  }
+  print(i1)
+}

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -11,6 +11,8 @@ func testSlowServer(slowServer: SlowServer) async {
   let _: String = await slowServer.findAnswerFailingly() ?? "nope"
   // FIXME: expected-error@-2{{call can throw, but it is not marked with 'try'}}
   // FIXME: expected-error@-2{{call can throw, but it is not marked with 'try'}}
+  let _: Void = await slowServer.doSomethingFun("jump")
+  let _: (Int) -> Void = slowServer.completionHandler
 }
 
 func testSlowServerOldSchool(slowServer: SlowServer) {

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-concurrency > %t/ObjCConcurrency.printed.txt
+// RUN: %FileCheck -input-file %t/ObjCConcurrency.printed.txt %s
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: class SlowServer : NSObject {
+// CHECK-DAG:     func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-DAG:     func doSomethingSlow(_ operation: String) async -> Int
+// CHECK-DAG:     func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)
+// CHECK-DAG:     func doSomethingDangerous(_ operation: String) async throws -> String?
+// CHECK-DAG:     func checkAvailability(completionHandler: @escaping (Bool) -> Void)
+// CHECK-DAG:     func checkAvailability() async -> Bool
+// CHECK-DAG:     func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)
+// CHECK-DAG:     func findAnswer() async throws -> String?
+// CHECK-DAG:     func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws
+// CHECK-DAG:     func findAnswerFailingly() async throws -> String?
+// CHECK: {{^[}]$}}

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -16,4 +16,5 @@
 // CHECK-DAG:     func findAnswer() async throws -> String?
 // CHECK-DAG:     func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws
 // CHECK-DAG:     func findAnswerFailingly() async throws -> String?
+// CHECK-DAG:     func doSomethingFun(_ operation: String) async
 // CHECK: {{^[}]$}}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -1,0 +1,14 @@
+@import Foundation;
+@import ctypes;
+
+#pragma clang assume_nonnull begin
+
+@interface SlowServer : NSObject
+-(void)doSomethingSlow:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
+-(void)doSomethingDangerous:(NSString *)operation completionHandler:(void (^ _Nullable)(NSString *_Nullable, NSError * _Nullable))handler;
+-(void)checkAvailabilityWithCompletionHandler:(void (^)(BOOL isAvailable))completionHandler;
+-(void)findAnswerAsynchronously:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswer(completionHandler:)")));
+-(BOOL)findAnswerFailinglyWithError:(NSError * _Nullable * _Nullable)error completion:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswerFailingly(completionHandler:)")));
+@end
+
+#pragma clang assume_nonnull end

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -9,6 +9,8 @@
 -(void)checkAvailabilityWithCompletionHandler:(void (^)(BOOL isAvailable))completionHandler;
 -(void)findAnswerAsynchronously:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswer(completionHandler:)")));
 -(BOOL)findAnswerFailinglyWithError:(NSError * _Nullable * _Nullable)error completion:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswerFailingly(completionHandler:)")));
+-(void)doSomethingFun:(NSString *)operation then:(void (^)(void))completionHandler;
+@property(readwrite) void (^completionHandler)(NSInteger);
 @end
 
 #pragma clang assume_nonnull end

--- a/test/Inputs/clang-importer-sdk/usr/include/module.map
+++ b/test/Inputs/clang-importer-sdk/usr/include/module.map
@@ -136,3 +136,8 @@ module WinBOOL {
   header "winbool.h"
   export *
 }
+
+module ObjCConcurrency {
+  header "ObjCConcurrency.h"
+  export *
+}

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -102,6 +102,8 @@ def create_parser():
     parser.add_argument('--enable-infer-import-as-member', action='store_true',
                         help='Infer when a global could be imported as a ' +
                         'member.')
+    parser.add_argument('--enable-experimental-concurrency', action='store_true',
+                        help='Enable experimental concurrency model.')
     parser.add_argument('-swift-version', metavar='N',
                         help='the Swift version to use')
     parser.add_argument('-show-overlay', action='store_true',
@@ -328,6 +330,8 @@ def main():
     extra_args = ['-skip-imports']
     if args.enable_infer_import_as_member:
         extra_args = extra_args + ['-enable-infer-import-as-member']
+    if args.enable_experimental_concurrency:
+        extra_args = extra_args + ['-enable-experimental-concurrency']
     if args.swift_version:
         extra_args = extra_args + ['-swift-version', '%s' % args.swift_version]
 


### PR DESCRIPTION
When a given Objective-C method has a completion handler parameter
with an appropriate signature, import that Objective-C method as
async. For example, consider the following CloudKit API:

    - (void)fetchShareParticipantWithUserRecordID:(CKRecordID *)userRecordID
            completionHandler:(void (^)(CKShareParticipant * _Nullable shareParticipant, NSError * _Nullable error))completionHandler;

With the experimental concurrency model, this would import as:

    func fetchShareParticipant(withUserRecordID userRecordID: CKRecord.ID) async throws -> CKShare.Participant?

The compiler will be responsible for turning the caller's continuation
into a block to pass along to the completion handler. When the error
parameter of the completion handler is non-null, the async call
will result in that error being thrown. Otherwise, the other arguments
passed to that completion handler will be returned as the result of
the async call.

async versions of methods are imported alongside their
completion-handler versions, to maintain source compatibility with
existing code that provides a completion handler.

Note that this only covers the Clang importer portion of this task.