### PR TITLE
When building standalone stdlib, use Clang resource dir from the toolchain, not the system default

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1407,6 +1407,13 @@ for host in "${ALL_HOSTS[@]}"; do
         fi
     fi
 
+    if [[ "${NATIVE_CLANG_TOOLS_PATH}" ]] ; then
+        common_cmake_options_host+=(
+                -DCMAKE_C_COMPILER="${NATIVE_CLANG_TOOLS_PATH}/clang"
+                -DCMAKE_CXX_COMPILER="${NATIVE_CLANG_TOOLS_PATH}/clang++"
+            )
+    fi
+
     llvm_cmake_options=(
         "${llvm_cmake_options[@]}"
         -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"


### PR DESCRIPTION
This is to resolve this failure: <https://ci.swift.org/job/swift-PR-stdlib-with-toolchain-osx/6/consoleFull>