### PR TITLE
Add llvm-nm to list of LLVM tools built with stdlib standalone mode

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1542,13 +1542,14 @@ for host in "${ALL_HOSTS[@]}"; do
                     # build of Swift depend on these for building and testing.
                     build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)
                     # If we are not performing a toolchain only build, then we
-                    # also want to include FileCheck and not for testing
+                    # also want to include FileCheck, not, llvm-nm for testing
                     # purposes.
                     if [[ ! "${BUILD_TOOLCHAIN_ONLY}" ]] ; then
                       build_targets=(
                           "${build_targets[@]}"
                           FileCheck
                           not
+                          llvm-nm
                       )
                     fi
                 fi


### PR DESCRIPTION
This is to fix the two test failures from <https://ci.swift.org/job/swift-PR-stdlib-with-toolchain-osx/7/console>.