### PR TITLE
Mark Reflection_jit.swift as UNSUPPORTED for standalone stdlib builds

### DIFF
--- a/test/stdlib/Reflection_jit.swift
+++ b/test/stdlib/Reflection_jit.swift
@@ -2,3 +2,8 @@
 // RUN: %target-jit-run -parse-stdlib %S/Reflection.swift -- %S/Inputs/shuffle.jpg | %FileCheck %S/Reflection.swift
 
 // REQUIRES: swift_interpreter
+
+// Only run this test when we build host tools (e.g. bin/swift-frontend), avoid running it for standalone stdlib builds.
+// Standalone stdlib builds use downloadable toolchains from swift.org, which are codesigned in a way that doesn't let
+// the interpreter process (swift-frontend) dynamically load locally-built modules (libswiftCore).
+// REQUIRES: swift_tools_extra


### PR DESCRIPTION
To address this test failure: <https://ci.swift.org/job/swift-PR-stdlib-with-toolchain-osx/7/testReport/junit/Swift(macosx-x86_64)/stdlib/Reflection_jit_swift/>. See explanation in the PR diff.