### PR TITLE
[DependencyScanner] Change the scanner order to resolve placeholders first

### DIFF
--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -176,13 +176,19 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
   auto moduleId = Ctx.getIdentifier(moduleName);
   // Instantiate dependency scanning "loaders".
   SmallVector<std::unique_ptr<ModuleDependencyScanner>, 2> scanners;
-  scanners.push_back(std::make_unique<ModuleDependencyScanner>(
-      Ctx, LoadMode, moduleId, delegate));
+  // Placeholder dependencies must be resolved first, to prevent the ModuleDependencyScanner
+  // from first discovering artifacts of a previous build. Such artifacts are captured
+  // as compiledModuleCandidates in the dependency graph of the placeholder dependency module
+  // itself.
   scanners.push_back(std::make_unique<PlaceholderSwiftModuleScanner>(
       Ctx, LoadMode, moduleId, Ctx.SearchPathOpts.PlaceholderDependencyModuleMap,
       delegate));
+  scanners.push_back(std::make_unique<ModuleDependencyScanner>(
+      Ctx, LoadMode, moduleId, delegate));
 
   // Check whether there is a module with this name that we can import.
+  assert(isa<PlaceholderSwiftModuleScanner>(scanners[0].get()) &&
+         "Expected PlaceholderSwiftModuleScanner as the first dependency scanner loader.");
   for (auto &scanner : scanners) {
     if (scanner->canImportModule({moduleId, SourceLoc()})) {
       // Record the dependencies.

--- a/test/ScanDependencies/can_import_placeholder.swift
+++ b/test/ScanDependencies/can_import_placeholder.swift
@@ -8,16 +8,6 @@
 // RUN: echo "\"docPath\": \"%/t/inputs/SomeExternalModule.swiftdoc\"," >> %/t/inputs/map.json
 // RUN: echo "\"sourceInfoPath\": \"%/t/inputs/SomeExternalModule.swiftsourceinfo\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
-// RUN: echo "}," >> %/t/inputs/map.json
-// RUN: echo "{" >> %/t/inputs/map.json
-// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
-// RUN: echo "}," >> %/t/inputs/map.json
-// RUN: echo "{" >> %/t/inputs/map.json
-// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -8,16 +8,6 @@
 // RUN: echo "\"docPath\": \"%/t/inputs/SomeExternalModule.swiftdoc\"," >> %/t/inputs/map.json
 // RUN: echo "\"sourceInfoPath\": \"%/t/inputs/SomeExternalModule.swiftsourceinfo\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
-// RUN: echo "}," >> %/t/inputs/map.json
-// RUN: echo "{" >> %/t/inputs/map.json
-// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
-// RUN: echo "}," >> %/t/inputs/map.json
-// RUN: echo "{" >> %/t/inputs/map.json
-// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
-// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4


### PR DESCRIPTION
This is meant to address a problem that arises on incremental package builds:
A re-scan on an already-built package instead of a placeholder dependency produces a graph that contains a (non-placeholder) dependency consisting solely of the previously-built .swiftmodule. This is not the behaviour we would like here. Instead, we should respect that this is a placeholder dependency and ensure that the dependency graph for that dependency itself captures the fact that a previously-built module exists using `compiledModuleCandidates` field.