### PR TITLE
[WIP] Disable -disable-concrete-type-metadata-mangled-name-accessors flag.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1448,9 +1448,6 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_debugger_shadow_copies))
     Opts.DisableDebuggerShadowCopies = true;
 
-  if (Args.hasArg(OPT_disable_concrete_type_metadata_mangled_name_accessors))
-    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
-
   if (Args.hasArg(OPT_use_jit)) {
     Opts.UseJIT = true;
     if (const Arg *A = Args.getLastArg(OPT_dump_jit)) {

--- a/test/IRGen/access_type_metadata_by_mangled_name.swift
+++ b/test/IRGen/access_type_metadata_by_mangled_name.swift
@@ -1,8 +1,4 @@
 // RUN: %target-swift-frontend -emit-ir -parse-stdlib %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-endian
-// RUN: %target-swift-frontend -emit-ir -disable-concrete-type-metadata-mangled-name-accessors -parse-stdlib %s | %FileCheck %s --check-prefix=DISABLED
-
-// DISABLED-NOT: __swift_instantiateConcreteTypeFromMangledName
-// DISABLED-NOT: MD" = {{.*}} global
 
 // CHECK: @"$s36access_type_metadata_by_mangled_name3FooCyAA3BarCyAA3ZimCyAA4ZangCGGGMD" = linkonce_odr hidden global { i32, i32 }
 


### PR DESCRIPTION
With the improvements to protocol casting performance from #33487, experiment to see if the demangling overhead is manageable for people using this flag today.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
