### PR TITLE
[ConstraintSystem] NFC: Clarify why upward propagation of literal conforma…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -931,15 +931,7 @@ bool ConstraintSystem::PotentialBindings::infer(
 
   case ConstraintKind::ConformsTo:
   case ConstraintKind::SelfObjectOfProtocol:
-    // Swift 3 allowed the use of default types for normal conformances
-    // to expressible-by-literal protocols.
-    if (cs.getASTContext().LangOpts.EffectiveLanguageVersion[0] >= 4)
-      return false;
-
-    if (!constraint->getSecondType()->is<ProtocolType>())
-      return false;
-
-    LLVM_FALLTHROUGH;
+    return false;
 
   case ConstraintKind::LiteralConformsTo: {
     // Record constraint where protocol requirement originated


### PR DESCRIPTION
…nces is ncessary at the moment

Forward propagate (subtype -> supertype) only literal conformance
requirements since that helps solver to infer more types at
parameter positions.

```swift
func foo<T: ExpressibleByStringLiteral>(_: String, _: T) -> T {
  fatalError()
}

func bar(_: Any?) {}

func test() {
  bar(foo("", ""))
}
```

If one of the literal arguments doesn't propagate its
`ExpressibleByStringLiteral` conformance, we'd end up picking
`T` with only one type `Any?` which is incorrect.

This is not going to be necessary once bindings are filtered based
of requirements placed on a type variable.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
