### PR TITLE
Revert "Fallback to building Cmake from source on all platforms"

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import platform
 import re
 from numbers import Number
 
@@ -255,6 +256,9 @@ class CMake(object):
     # the source and build the source if necessary. Returns the path to the
     # cmake binary.
     def check_cmake_version(self, source_root, build_root):
+        if platform.system() != 'Linux':
+            return
+
         cmake_source_dir = os.path.join(source_root, 'cmake')
         # If the source is not checked out then don't attempt to build cmake.
         if not os.path.isdir(cmake_source_dir):

--- a/validation-test/BuildSystem/skip-local-build.test-sh
+++ b/validation-test/BuildSystem/skip-local-build.test-sh
@@ -1,8 +1,8 @@
 # REQUIRES: standalone_build
 #
-# RUN: %swift_src_root/utils/build-script --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG --dump-input=always
+# RUN: %swift_src_root/utils/build-script --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
 # CONFIG: "skip_local_build": true
 
-# RUN: %swift_src_root/utils/build-script --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY --dump-input=always
+# RUN: %swift_src_root/utils/build-script --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
 # DRY: build-script-impl
 # DRY-SAME: --skip-local-build


### PR DESCRIPTION
This is causing intermittent test failures on bots that build cmake. Also revert the input dumping that let me find this.