### PR TITLE
[AutoDiff] [Sema] Include certain 'let' properties in 'Differentiable' derived conformances.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2806,15 +2806,16 @@ WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_immutable_wrapper_implicit_noderivative_fixit,none,
       "synthesis of the 'Differentiable.move(along:)' requirement for %1 "
-      "requires 'wrappedValue' in property wrapper %0 to be mutable; "
-      "add an explicit '@noDerivative' attribute"
+      "requires 'wrappedValue' in property wrapper %0 to be mutable or have a "
+      "non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute"
       "%select{|, or conform %1 to 'AdditiveArithmetic'}2",
       (/*wrapperType*/ Identifier, /*nominalName*/ Identifier,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_let_property_implicit_noderivative_fixit,none,
       "synthesis of the 'Differentiable.move(along:)' requirement for %0 "
       "requires all stored properties not marked with `@noDerivative` to be "
-      "mutable; use 'var' instead, or add an explicit '@noDerivative' attribute"
+      "mutable or have a non-mutating 'move(along:)'; use 'var' instead, or "
+      "add an explicit '@noDerivative' attribute "
       "%select{|, or conform %0 to 'AdditiveArithmetic'}1",
       (/*nominalName*/ Identifier, /*nominalCanDeriveAdditiveArithmetic*/ bool))
 

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -29,26 +29,62 @@ func testEmpty() {
   assertConformsToAdditiveArithmetic(Empty.TangentVector.self)
 }
 
+protocol DifferentiableWithNonmutatingMoveAlong: Differentiable {}
+extension DifferentiableWithNonmutatingMoveAlong {
+  func move(along _: TangentVector) {}
+}
+
+class EmptyWithInheritedNonmutatingMoveAlong: DifferentiableWithNonmutatingMoveAlong {
+  typealias TangentVector = Empty.TangentVector
+  var zeroTangentVectorInitializer: () -> TangentVector { { .init() } }
+  static func proof_that_i_have_nonmutating_move_along() {
+    let empty = EmptyWithInheritedNonmutatingMoveAlong()
+    empty.move(along: .init())
+  }
+}
+
+class EmptyWrapper<T: Differentiable & AnyObject>: Differentiable {}
+func testEmptyWrapper() {
+  assertConformsToAdditiveArithmetic(Empty.TangentVector.self)
+  assertConformsToAdditiveArithmetic(EmptyWrapper<Empty>.TangentVector.self)
+}
+
 // Test structs with `let` stored properties.
 // Derived conformances fail because `mutating func move` requires all stored
 // properties to be mutable.
-class ImmutableStoredProperties: Differentiable {
+class ImmutableStoredProperties<T: Differentiable & AnyObject>: Differentiable {
   var okay: Float
 
   // expected-warning @+1 {{stored property 'nondiff' has no derivative because 'Int' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let nondiff: Int
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let diff: Float
 
-  init() {
+  let letClass: Empty // No error on class-bound differentiable `let` with a non-mutating 'move(along:)'.
+
+  let letClassWithInheritedNonmutatingMoveAlong: EmptyWithInheritedNonmutatingMoveAlong
+
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  let letClassGeneric: T // Error due to lack of non-mutating 'move(along:)'.
+
+  let letClassWrappingGeneric: EmptyWrapper<T> // No error on class-bound differentiable `let` with a non-mutating 'move(along:)'.
+
+  init(letClassGeneric: T) {
     okay = 0
     nondiff = 0
     diff = 0
+    letClass = Empty()
+    self.letClassGeneric = letClassGeneric
+    self.letClassWrappingGeneric = EmptyWrapper<T>()
   }
 }
 func testImmutableStoredProperties() {
-  _ = ImmutableStoredProperties.TangentVector(okay: 1)
+  _ = ImmutableStoredProperties<Empty>.TangentVector(
+    okay: 1, 
+    letClass: Empty.TangentVector(), 
+    letClassWithInheritedNonmutatingMoveAlong: Empty.TangentVector(), 
+    letClassWrappingGeneric: EmptyWrapper<Empty>.TangentVector())
 }
 class MutableStoredPropertiesWithInitialValue: Differentiable {
   var x = Float(1)
@@ -56,7 +92,7 @@ class MutableStoredPropertiesWithInitialValue: Differentiable {
 }
 // Test class with both an empty constructor and memberwise initializer.
 class AllMixedStoredPropertiesHaveInitialValue: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let x = Float(1)
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
@@ -550,7 +586,7 @@ struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 class WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int> = Generic()
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}

--- a/test/AutoDiff/validation-test/class_differentiation.swift
+++ b/test/AutoDiff/validation-test/class_differentiation.swift
@@ -524,4 +524,19 @@ ClassTests.test("ClassProperties") {
               gradient(at: Super(base: 2)) { foo in foo.squared })
 }
 
+ClassTests.test("LetProperties") {
+  final class Foo: Differentiable {
+    var x: Tracked<Float>
+    init(x: Tracked<Float>) { self.x = x }
+  }
+  final class Bar: Differentiable {
+    let x = Foo(x: 2)
+  }
+  let bar = Bar()
+  let grad = gradient(at: bar) { bar in (bar.x.x * bar.x.x).value }
+  expectEqual(Bar.TangentVector(x: .init(x: 6.0)), grad)
+  bar.move(along: grad)
+  expectEqual(8.0, bar.x.x)
+}
+
 runAllTests()


### PR DESCRIPTION
Today, `let` properties are treated as if they had `@noDerivative` and excluded from the derived `Differentiable` conformance implementation. This is limiting to properties that have a non-mutating `move(along:)` (e.g. class properties), which can be mathematically treated as differentiable variables.

This patch changes the derived conformances behavior such that `let` properties will be included as differentiable variables if they have a non-mutating `move(along:)`. This unblocks the following code:

```swift
final class Foo: Differentiable {
   let x: ClassStuff // Class type with a non-mutating 'move(along:)'

   // Synthesized code:
   //   struct TangentVector {
   //     var x: ClassStuff.TangentVector
   //   }
   //   ...
   //   func move(along direction: TangentVector) {
   //     x.move(along: direction.x)
   //   }
}
```

Resolves SR-13474 (rdar://67982207).