### PR TITLE
Don't crash on a bad -j input

### DIFF
--- a/test/Driver/badJ.swift
+++ b/test/Driver/badJ.swift
@@ -1,0 +1,2 @@
+// RUN: not %swiftc_driver %S/../Inputs/empty.swift -jsnort 2>&1 |  %FileCheck %s
+// CHECK-NOT: Stack dump

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -191,6 +191,8 @@ static int run_driver(StringRef ExecName,
 
   if (C) {
     std::unique_ptr<sys::TaskQueue> TQ = TheDriver.buildTaskQueue(*C);
+    if (!TQ)
+        return 1;
     return C->performJobs(std::move(TQ));
   }
 


### PR DESCRIPTION
In the driver, buildTaskQueue can fail if given a malformed -j argument. The status quo is to output a diagnostic, and then crash with a stack trace. Fix this to just exit 1 after the diagnostic.