### PR TITLE
[swift-driver-compatibility] Update diagnostic for *-prefix-map args

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -328,11 +328,11 @@ ERROR(error_optimization_remark_pattern, none, "%0 in '%1'",
       (StringRef, StringRef))
 
 ERROR(error_invalid_debug_prefix_map, none,
-      "invalid argument '%0' to -debug-prefix-map; it must be of the form "
-      "'original=remapped'", (StringRef))
+      "values for '-debug-prefix-map' must be in the format 'original=remapped'"
+      ", but '%0' was provided", (StringRef))
 ERROR(error_invalid_coverage_prefix_map, none,
-      "invalid argument '%0' to -coverage-prefix-map; it must be of the form "
-      "'original=remapped'", (StringRef))
+      "values for '-coverage-prefix-map' must be in the format "
+      "'original=remapped', but '%0' was provided", (StringRef))
 
 
 ERROR(error_unable_to_write_swift_ranges_file, none,

--- a/test/Driver/coverage-prefix-map.swift
+++ b/test/Driver/coverage-prefix-map.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swiftc_driver -### -coverage-prefix-map old=n=ew %s 2>&1 | %FileCheck %s -check-prefix CHECK-COMPLEX
 // RUN: %target-swiftc_driver -### -coverage-prefix-map old= %s 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
 
-// CHECK-INVALID: error: invalid argument 'old' to -coverage-prefix-map
+// CHECK-INVALID: error: values for '-coverage-prefix-map' must be in the format 'original=remapped', but 'old' was provided
 // CHECK-SIMPLE: coverage-prefix-map old=new
 // CHECK-COMPLEX: coverage-prefix-map old=n=ew
 // CHECK-EMPTY: coverage-prefix-map old=

--- a/test/Driver/debug-prefix-map.swift
+++ b/test/Driver/debug-prefix-map.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swiftc_driver -### -debug-prefix-map old=n=ew %s 2>&1 | %FileCheck %s -check-prefix CHECK-COMPLEX
 // RUN: %target-swiftc_driver -### -debug-prefix-map old= %s 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
 
-// CHECK-INVALID: error: invalid argument 'old' to -debug-prefix-map
+// CHECK-INVALID: error: values for '-debug-prefix-map' must be in the format 'original=remapped', but 'old' was provided
 // CHECK-SIMPLE: debug-prefix-map old=new
 // CHECK-COMPLEX: debug-prefix-map old=n=ew
 // CHECK-EMPTY: debug-prefix-map old=


### PR DESCRIPTION
This change tweaks the diagnostic text to read `error: values for '-coverage-prefix-map' must be in the format 'original=remapped', not 'old'`, and I'm updating swift-driver at the same time so that both drivers pass the relevant integration tests.