### PR TITLE
ASTDemangler: Fix reconstruction of opaque result type defined in a constrained extension [5.3]

### DIFF
--- a/test/TypeDecoder/opaque_return_type.swift
+++ b/test/TypeDecoder/opaque_return_type.swift
@@ -12,6 +12,12 @@ var prop: some P { return 0 }
 
 func bar() -> some Sequence { return [] }
 
+struct G<T> {}
+
+extension G where T == Int {
+  var baz: some P { return 0 }
+}
+
 // DEMANGLE: $s18opaque_return_type3fooQryFQOyQo_
 // CHECK: some P
 
@@ -20,6 +26,9 @@ func bar() -> some Sequence { return [] }
 
 // DEMANGLE: $s18opaque_return_type3barQryFQOyQo_
 // CHECK: some Sequence
+
+// DEMANGLE: $s18opaque_return_type1GVAASiRszlE3bazQrvpQOySi_Qo_
+// CHECK: some P
 
 // DEMANGLE: $s18opaque_return_type3barQryFQOyQo_7ElementSTQxD
 // CHECK: (some Sequence).Element


### PR DESCRIPTION
The mangling includes all generic parameters, even non-canonical ones.

Fixes <rdar://problem/67949286>.