### PR TITLE
Sema: Fix failure to emit diagnostic with some invalid member type references [5.3]

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1831,9 +1831,11 @@ public:
     if (auto rawTy = ED->getRawType()) {
       // The raw type must be one of the blessed literal convertible types.
       if (!computeAutomaticEnumValueKind(ED)) {
-        DE.diagnose(ED->getInherited().front().getSourceRange().Start,
-                    diag::raw_type_not_literal_convertible, rawTy);
-        ED->getInherited().front().setInvalidType(getASTContext());
+        if (!rawTy->is<ErrorType>()) {
+          DE.diagnose(ED->getInherited().front().getSourceRange().Start,
+                      diag::raw_type_not_literal_convertible, rawTy);
+          ED->getInherited().front().setInvalidType(getASTContext());
+        }
       }
       
       // We need at least one case to have a raw value.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -357,7 +357,8 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   return result;
 }
 
-bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
+TypeChecker::UnsupportedMemberTypeAccessKind
+TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
   // We don't allow lookups of a non-generic typealias of an unbound
   // generic type, because we have no way to model such a type in the
   // AST.
@@ -365,10 +366,7 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
   // For generic typealiases, the typealias itself has an unbound
   // generic form whose parent type can be another unbound generic
   // type.
-  //
-  // FIXME: Could lift this restriction once we have sugared
-  // "member types".
-  if (type->is<UnboundGenericType>()) {
+  if (type->hasUnboundGenericType()) {
     // Generic typealiases can be accessed with an unbound generic
     // base, since we represent the member type as an unbound generic
     // type.
@@ -379,12 +377,12 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
       if (!aliasDecl->isGeneric() &&
           aliasDecl->getUnderlyingType()->getCanonicalType()
             ->hasTypeParameter()) {
-        return true;
+        return UnsupportedMemberTypeAccessKind::TypeAliasOfUnboundGeneric;
       }
     }
 
     if (isa<AssociatedTypeDecl>(typeDecl))
-      return true;
+      return UnsupportedMemberTypeAccessKind::AssociatedTypeOfUnboundGeneric;
   }
 
   if (type->isExistentialType() &&
@@ -394,15 +392,13 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
       if (aliasDecl->getUnderlyingType()->getCanonicalType()
           ->hasTypeParameter())
-        return true;
-    } else {
-      // Don't allow lookups of other nested types of an existential type,
-      // because there is no way to represent such types.
-      return true;
+        return UnsupportedMemberTypeAccessKind::TypeAliasOfExistential;
+    } else if (isa<AssociatedTypeDecl>(typeDecl)) {
+      return UnsupportedMemberTypeAccessKind::AssociatedTypeOfExistential;
     }
   }
 
-  return false;
+  return UnsupportedMemberTypeAccessKind::None;
 }
 
 LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
@@ -441,7 +437,8 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       continue;
     }
 
-    if (isUnsupportedMemberTypeAccess(type, typeDecl)) {
+    if (isUnsupportedMemberTypeAccess(type, typeDecl)
+          != TypeChecker::UnsupportedMemberTypeAccessKind::None) {
       auto memberType = typeDecl->getDeclaredInterfaceType();
 
       // Add the type to the result set, so that we can diagnose the

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1088,9 +1088,18 @@ public:
   PrecedenceGroupDecl *lookupPrecedenceGroup(DeclContext *dc, Identifier name,
                                              SourceLoc nameLoc);
 
+  enum class UnsupportedMemberTypeAccessKind : uint8_t {
+    None,
+    TypeAliasOfUnboundGeneric,
+    TypeAliasOfExistential,
+    AssociatedTypeOfUnboundGeneric,
+    AssociatedTypeOfExistential
+  };
+
   /// Check whether the given declaration can be written as a
   /// member of the given base type.
-  bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
+  UnsupportedMemberTypeAccessKind
+  isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
 
   /// @}
 

--- a/test/Generics/unbound.swift
+++ b/test/Generics/unbound.swift
@@ -74,3 +74,20 @@ struct X1<T> {
   func bar<U>() where T: X2<U> {}
 }
 class X2<T> {}
+
+// <rdar://problem/67292528> missing check for unbound parent type
+struct Outer<K, V> {
+  struct Inner {}
+
+  struct Middle {
+    typealias Inner = Outer<K, V>.Middle
+  }
+}
+
+func makeInner() -> Outer<String, String>.Middle.Inner {
+  return .init()
+}
+
+var innerProperty: Outer.Middle.Inner = makeInner()
+// expected-error@-1 {{reference to generic type 'Outer' requires arguments in <...>}}
+

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -109,11 +109,11 @@ class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooN
 //===--- Inheritance list in enums.
 //===---
 
-enum EnumWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{raw type}} expected-error {{an enum with no cases}}
+enum EnumWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{an enum with no cases}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance1 : <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance1 : FooNonExistentProtocol {{{$}}
 
-enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}} expected-error {{raw type}} expected-error {{an enum with no cases}}
+enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}} expected-error {{an enum with no cases}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -51,10 +51,11 @@ protocol Racoon {
 }
 
 enum SillyRawEnum : SillyProtocol.InnerClass {} // expected-error {{an enum with no cases cannot declare a raw type}}
-// expected-error@-1 {{raw type}}
+// expected-error@-1 {{reference to generic type 'SillyProtocol.InnerClass' requires arguments in <...>}}
 
 protocol SillyProtocol {
   class InnerClass<T> {} // expected-error {{type 'InnerClass' cannot be nested in protocol 'SillyProtocol'}}
+  // expected-note@-1 {{generic type 'InnerClass' declared here}}
 }
 
 // N.B. Redeclaration checks don't see this case because `protocol A` is invalid.

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -79,7 +79,6 @@ enum mixed_redecl3 {} // expected-error {{invalid redeclaration}}
 // expected-note @-1 2{{found this candidate}}
 enum mixed_redecl3a : mixed_redecl3 {} // expected-error {{'mixed_redecl3' is ambiguous for type lookup in this context}}
 // expected-error@-1 {{an enum with no cases cannot declare a raw type}}
-// expected-error@-2 {{raw type}}
 class mixed_redecl3b : mixed_redecl3 {} // expected-error {{'mixed_redecl3' is ambiguous for type lookup in this context}}
 
 class mixed_redecl4 {} // expected-note {{previously declared here}}


### PR DESCRIPTION
There were two problems here:

- isUnsupportedMemberTypeReference() checked if the immediate parent type was
  an unbound generic type, but did not check for the parent of the parent, etc.

- The caller of isUnsupportedMemberTypeReference() had to re-check the
  various invalid conditions to determine what diagnostic to emit, and if
  none of those conditions matched it would just return an ErrorType without
  emitting a diagnostic.

Fix both of these by having isUnsupportedMemberTypeReference() return an
enum indicating what went wrong, and handle more cases.

Fixes <rdar://problem/67292528>.