### PR TITLE
IRGen: Ignore the metadata of fixed sized types with opaque result type parameters

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -39,7 +39,6 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
   }
 
   // Substitute opaque types if allowed.
-  auto origType = type;
   type =
       IGF.IGM.substOpaqueTypesWithUnderlyingTypes(type, CanGenericSignature());
 
@@ -49,9 +48,7 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
   // We don't need the metadata for fixed size types or types that are not ABI
   // accessible. Outlining will call the value witness of the enclosing type of
   // non ABI accessible field/element types.
-  if ((!origType.getASTType()->hasOpaqueArchetype() &&
-       isa<FixedTypeInfo>(ti)) ||
-      !ti.isABIAccessible()) {
+  if (isa<FixedTypeInfo>(ti) || !ti.isABIAccessible()) {
     return;
   }
 

--- a/test/IRGen/Inputs/opaque_result_type_private_underlying_2.swift
+++ b/test/IRGen/Inputs/opaque_result_type_private_underlying_2.swift
@@ -45,3 +45,39 @@ public struct PublicUnderlyingInlinable : A {
     return PublicS()
   }
 }
+
+
+public protocol P {}
+
+private struct PrivateSome : P {}
+public func getSome() -> some P {
+  return PrivateSome()
+}
+
+@propertyWrapper
+public struct Wrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue v: T) {
+    wrappedValue = v
+  }
+}
+
+public struct R<V, T: P>: P {
+  @Wrapper private var privateState = PrivateState()
+  var x: T? = nil
+
+  public init(_ v: V.Type, _ t: T) {
+    x = t
+  }
+
+  public mutating func modify() {
+    x = nil
+  }
+}
+
+private extension R {
+  struct PrivateState {
+    var x = 0
+  }
+}

--- a/test/IRGen/opaque_result_type_private_underlying.swift
+++ b/test/IRGen/opaque_result_type_private_underlying.swift
@@ -68,3 +68,11 @@ public struct MyThing {
     }
 }
 #endif
+
+public struct E<V> {
+   var body : some P {
+     var r = R(V.self, getSome())
+     r.modify()
+     return r
+   }
+}


### PR DESCRIPTION
The removed check by this patch seems somewhat arbitrary and the test case that
was added for it no longer fails.

rdar://67841860
