### PR TITLE
[NFC] Rework types and terms for imports' access paths

### DIFF
--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -45,6 +45,28 @@ introduces [reabstraction](#reabstraction) conversions when a value is used with
 different abstraction pattern. (This is where the infamous "reabstraction
 thunk helpers" sometimes seen in Swift backtraces come from.)
 
+## access path
+
+Broadly, an "access path" is a list of "accesses" which must be chained together
+to compute some output from an input. For instance, the generics system has a
+type called a `ConformanceAccessPath` which explains how to, for example,
+walk from `T: Collection` to `T: Sequence` to `T.Iterator: IteratorProtocol`.
+There are several different kinds of "access path" in different parts of the compiler,
+but they all follow this basic theme.
+
+In the specific context of imports, an "access path" is the `Bar` portion of a scoped
+import like `import class Foo.Bar`. Theoretically, it could have several identifiers
+to designate a nested type, although the compiler doesn't currently support this. It can
+also be empty, matching all top-level declarations in the module.
+
+Note, however, that there has historically been some confusion about the meaning of
+"access path" with regards to imports. You might see some code use "access path"
+to include the `Foo` part or even to describe a chain of submodule names where a
+declaration is not valid at all. (Strictly, the chain of module names is a "module path"
+and the combination of module path + access path is an "import path".)
+
+See `ImportPath` and the types nested inside it for more on this.
+
 ## archetype
 
 A placeholder for a generic parameter or an associated type within a

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -20,6 +20,7 @@
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/Import.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
@@ -859,12 +860,12 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  bool canImportModule(Located<Identifier> ModulePath);
+  bool canImportModule(ImportPath::Element ModulePath);
 
   /// \returns a module with a given name that was already loaded.  If the
   /// module was not loaded, returns nullptr.
   ModuleDecl *getLoadedModule(
-      ArrayRef<Located<Identifier>> ModulePath) const;
+      ImportPath::Module ModulePath) const;
 
   ModuleDecl *getLoadedModule(Identifier ModuleName) const;
 
@@ -874,7 +875,7 @@ public:
   /// be returned.
   ///
   /// \returns The requested module, or NULL if the module cannot be found.
-  ModuleDecl *getModule(ArrayRef<Located<Identifier>> ModulePath);
+  ModuleDecl *getModule(ImportPath::Module ModulePath);
 
   ModuleDecl *getModuleByName(StringRef ModuleName);
 

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -879,6 +879,8 @@ public:
 
   ModuleDecl *getModuleByName(StringRef ModuleName);
 
+  ModuleDecl *getModuleByIdentifier(Identifier ModuleID);
+
   /// Returns the standard library module, or null if the library isn't present.
   ///
   /// If \p loadIfAbsent is true, the ASTContext will attempt to load the module

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1514,7 +1514,7 @@ public:
     return getImportPath().getModulePath(getImportKind());
   }
 
-  ImportPath::Access getDeclPath() const {
+  ImportPath::Access getAccessPath() const {
     return getImportPath().getAccessPath(getImportKind());
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1464,11 +1464,7 @@ class ImportDecl final : public Decl,
     private llvm::TrailingObjects<ImportDecl, ImportPath::Element> {
   friend TrailingObjects;
   friend class Decl;
-public:
-  LLVM_ATTRIBUTE_DEPRECATED(typedef ImportPath::Element AccessPathElement,
-                            "use ImportPath::Element instead");
 
-private:
   SourceLoc ImportLoc;
   SourceLoc KindLoc;
 
@@ -1505,10 +1501,6 @@ public:
     return ImportPath({ getTrailingObjects<ImportPath::Element>(),
                         static_cast<size_t>(Bits.ImportDecl.NumPathElements) });
   }
-
-  LLVM_ATTRIBUTE_DEPRECATED(
-    ArrayRef<ImportPath::Element> getFullAccessPath() const,
-    "use getImportPath() instead") { return getImportPath().getRaw(); }
 
   ImportPath::Module getModulePath() const {
     return getImportPath().getModulePath(getImportKind());

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1457,21 +1457,6 @@ public:
 static_assert(sizeof(_GenericContext) + sizeof(DeclContext) ==
               sizeof(GenericContext), "Please add fields to _GenericContext");
 
-/// Describes what kind of name is being imported.
-///
-/// If the enumerators here are changed, make sure to update all diagnostics
-/// using ImportKind as a select index.
-enum class ImportKind : uint8_t {
-  Module = 0,
-  Type,
-  Struct,
-  Class,
-  Enum,
-  Protocol,
-  Var,
-  Func
-};
-
 /// ImportDecl - This represents a single import declaration, e.g.:
 ///   import Swift
 ///   import typealias Swift.Int

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -82,20 +82,20 @@ public:
   /// Find ValueDecls in the module and pass them to the given consumer object.
   ///
   /// This does a simple local lookup, not recursively looking through imports.
-  virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupVisibleDecls(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const {}
 
   /// Finds all class members defined in this file.
   ///
   /// This does a simple local lookup, not recursively looking through imports.
-  virtual void lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupClassMembers(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer) const {}
 
   /// Finds class members defined in this file with the given name.
   ///
   /// This does a simple local lookup, not recursively looking through imports.
-  virtual void lookupClassMember(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupClassMember(ImportPath::Access accessPath,
                                  DeclName name,
                                  SmallVectorImpl<ValueDecl*> &results) const {}
 

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -19,7 +19,15 @@
 #ifndef SWIFT_IMPORT_H
 #define SWIFT_IMPORT_H
 
+#include "swift/AST/Identifier.h"
+#include "swift/Basic/Located.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/STLExtras.h"
+
 namespace swift {
+class ASTContext;
+
 /// Describes what kind of name is being imported.
 ///
 /// If the enumerators here are changed, make sure to update all diagnostics
@@ -33,6 +41,291 @@ enum class ImportKind : uint8_t {
   Protocol,
   Var,
   Func
+};
+
+namespace detail {
+  using ImportPathElement = Located<Identifier>;
+  using ImportPathRaw = llvm::ArrayRef<ImportPathElement>;
+
+  template<typename Subclass>
+  class ImportPathBase {
+  public:
+    using Element = ImportPathElement;
+    using Raw = ImportPathRaw;
+
+  protected:
+    Raw raw;
+
+    ImportPathBase(Raw raw) : raw(raw) { }
+
+  public:
+    const Raw &getRaw() const { return raw; }
+
+    Raw::iterator begin() const {
+      return raw.begin();
+    }
+
+    Raw::iterator end() const {
+      return raw.end();
+    }
+
+    const Element &operator[](size_t i) const { return raw[i]; }
+    bool empty() const { return raw.empty(); }
+    size_t size() const { return raw.size(); }
+
+    const Element &front() const { return raw.front(); }
+    const Element &back() const { return raw.back(); }
+
+    /// True if \c this and \c other are precisely equal, including SourceLocs.
+    bool operator==(const Subclass &other) const {
+      return raw == other.raw;
+    }
+
+    /// True if \c this and \c other contain the same identifiers in the same
+    /// order, ignoring SourceLocs.
+    bool isSameAs(const Subclass &other) const {
+      return size() == other.size()
+             && std::equal(this->begin(), this->end(), other.begin(),
+                  [](const Element &l, const Element &r) -> bool {
+                    return l.Item == r.Item;
+                  }
+                );
+    }
+
+    Subclass getTopLevelPath() const {
+      assert(size() >= 1 && "nothing to take");
+      return Subclass(raw.take_front());
+    }
+
+    Subclass getParentPath() const {
+      assert(size() >= 0 && "nothing to take");
+      return Subclass(raw.drop_back());
+    }
+
+    SourceRange getSourceRange() const {
+      if (empty()) return SourceRange();
+      return SourceRange(raw.front().Loc, raw.back().Loc);
+    }
+  };
+
+  ImportPathRaw ImportPathBuilder_copyToImpl(ASTContext &ctx,
+                                             ImportPathRaw raw);
+
+  template<typename Subclass>
+  class ImportPathBuilder {
+    llvm::SmallVector<ImportPathElement, 4> scratch;
+
+  public:
+    Subclass get() const {
+      return Subclass(scratch);
+    }
+
+    Subclass copyTo(ASTContext &ctx) const {
+      return Subclass(ImportPathBuilder_copyToImpl(ctx, scratch));
+    }
+
+    ImportPathBuilder() : scratch() { }
+    ImportPathBuilder(const ImportPathElement &elem) : scratch() {
+      scratch = { elem };
+    }
+    ImportPathBuilder(Identifier name, SourceLoc loc = SourceLoc())
+        : ImportPathBuilder(ImportPathElement(name, loc)) { }
+
+    template<typename Iterator>
+    ImportPathBuilder(Iterator begin, Iterator end) : scratch(begin, end) { }
+
+    template<typename Range>
+    ImportPathBuilder(Range collection)
+        : scratch(collection.begin(), collection.end()) { }
+
+    void push_back(const ImportPathElement &elem) { scratch.push_back(elem); }
+    void push_back(Identifier name, SourceLoc loc = SourceLoc()) {
+      scratch.push_back({ name, loc });
+    }
+
+    void pop_back() { scratch.pop_back(); }
+
+    bool empty() const { return scratch.empty(); }
+    size_t size() const { return scratch.size(); }
+
+    llvm::SmallVector<ImportPathElement, 4>::iterator begin() {
+      return scratch.begin();
+    }
+    llvm::SmallVector<ImportPathElement, 4>::iterator end() {
+      return scratch.end();
+    }
+
+    const ImportPathElement &front() const { return scratch.front(); }
+    ImportPathElement &front() { return scratch.front(); }
+    const ImportPathElement &back() const { return scratch.back(); }
+    ImportPathElement &back() { return scratch.back(); }
+
+    template<typename Iterator>
+    void append(Iterator begin, Iterator end) {
+      scratch.append(begin, end);
+    }
+
+    template<typename Range>
+    void append(Range collection) {
+      append(collection.begin(), collection.end());
+    }
+  };
+}
+
+/// An undifferentiated series of dotted identifiers in an \c import statement,
+/// like \c Foo.Bar. Each identifier is packaged with its corresponding source
+/// location.
+///
+/// The first element of an \c ImportPath is always a top-level module name. The
+/// remaining elements could specify a scope (naming a declaration in the
+/// module) or a chain of submodule names. \c ImportPath does not differentiate
+/// between these cases; its \c getModule() and \c getAccess() methods take an
+/// \c ImportKind parameter to decide how to divvy up these identifiers.
+///
+/// \c ImportPath is only used when analyzing the parsed representation of code.
+/// Most code should use \c ImportPath::Module or \c ImportPath::Access, which
+/// have semantic meaning.
+///
+/// \c ImportPath is essentially a wrapper around \c ArrayRef and does not own
+/// its elements, so something else needs to manage their lifetime.
+/// \c ImportDecl owns the memory backing \c ImportDecl::getImportPath().
+class ImportPath : public detail::ImportPathBase<ImportPath> {
+public:
+  /// A single dotted name from an \c ImportPath, \c ImportPath::Module, or
+  /// \c ImportPath::Access, with its source location.
+  using Element = detail::ImportPathBase<ImportPath>::Element;
+
+  /// The backing type for \c ImportPath, \c ImportPath::Module, and
+  /// \c ImportPath::Access; namely, an \c ArrayRef of \c ImportPath::Elements.
+  using Raw = detail::ImportPathBase<ImportPath>::Raw;
+
+  /// A helper type which encapsulates a temporary vector and can produce an
+  /// import path from it. In addition to the obvious use in a temporary
+  /// variable, this type can be used mid-expression to produce an import path
+  /// that is valid until the end of the expression.
+  using Builder = detail::ImportPathBuilder<ImportPath>;
+
+  /// Represents an access path--the portion of an \c ImportPath which describes
+  /// the name of a declaration to scope the import to.
+  ///
+  /// \c ImportPath::Access is used in scoped imports to designate a specific
+  /// declaration inside the module. The import will only* cover this
+  /// declaration, and will import it with a higher "priority" than usual, so
+  /// name lookup will prefer it over identically-named declarations visible
+  /// through other imports.
+  ///
+  /// (* Not actually only--e.g. extensions will be imported too. The primary
+  /// use case for scoped imports is actually to resolve name conflicts, not to
+  /// reduce the set of visible declarations.)
+  ///
+  /// When \c ImportPath::Access is empty, this means the import covers all
+  /// declarations in the module.
+  ///
+  /// Although in theory Swift could support scoped imports of nested
+  /// declarations, in practice it currently only supports scoped imports of
+  /// top-level declarations. Reflecting this, \c ImportPath::Access is backed
+  /// by an \c ArrayRef, but it asserts that the access path has zero or one
+  /// elements.
+  ///
+  /// \c ImportPath::Access is essentially a wrapper around \c ArrayRef and does
+  /// not own its elements, so something else needs to manage their lifetime.
+  /// \c ImportDecl owns the memory backing \c ImportDecl::getDeclPath().
+  class Access : public detail::ImportPathBase<Access> {
+  public:
+    /// A helper type which encapsulates a temporary vector and can produce a
+    /// scope path from it. In addition to the obvious use in a temporary
+    /// variable, this type can be used mid-expression to produce a scope path
+    /// that is valid until the end of the expression.
+    using Builder = detail::ImportPathBuilder<Access>;
+
+    Access(ImportPath::Raw raw) : ImportPathBase(raw) {
+      assert(size() <= 1 && "nested scoped imports are not supported");
+    }
+
+    Access() : ImportPathBase({}) { }
+
+    /// Returns \c true if the scope of this import includes \c name. An empty
+    /// scope matches all names.
+    bool matches(DeclName name) const {
+      return empty() || DeclName(front().Item).matchesRef(name);
+    }
+  };
+
+  /// Represents a module path--the portion of an \c ImportPath which describes
+  /// the name of the module being imported, possibly including submodules.
+  ///
+  /// \c ImportPath::Module contains one or more identifiers. The first
+  /// identiifer names a top-level module. The second and subsequent
+  /// identifiers, if present, chain together to name a specific submodule to
+  /// import. (Although Swift modules cannot currently contain submodules, Swift
+  /// can import Clang submodules.)
+  ///
+  /// \c ImportPath::Module is essentially a wrapper around \c ArrayRef and
+  /// does not own its elements, so something else needs to manage their
+  /// lifetime. \c ImportDecl owns the memory backing
+  /// \c ImportDecl::getModulePath().
+  class Module : public detail::ImportPathBase<Module> {
+  public:
+    /// A helper type which encapsulates a temporary vector and can produce a
+    /// module path from it. In addition to the obvious use in a temporary
+    /// variable, this type can be used mid-expression to produce a module path
+    /// that is valid until the end of the expression.
+    using Builder = detail::ImportPathBuilder<Module>;
+
+    Module(ImportPath::Raw raw) : ImportPathBase(raw) {
+      assert(size() >= 1 && "must have a top-level module");
+    }
+
+    // Note: This type does not have a constructor which just takes an
+    // `Identifier` because it would not be able to create a temporary
+    // `ImportPath::Element` with a long enough lifetime to return. Use
+    // `ImportPath::Module::Builder` to create a temporary module path.
+
+    bool hasSubmodule() const {
+      return size() != 1;
+    }
+
+    ImportPath::Raw getSubmodulePath() const {
+      return getRaw().drop_front();
+    }
+  };
+
+  ImportPath(Raw raw) : ImportPathBase(raw) {
+    assert(raw.size() >= 1 && "ImportPath must contain a module name");
+  }
+
+  /// Extracts the portion of the \c ImportPath which represents a module name,
+  /// including submodules if appropriate.
+  Module getModulePath(bool isScoped) const {
+    if (isScoped)
+      return Module(getRaw().drop_back());
+
+    return Module(getRaw());
+  }
+
+  /// Extracts the portion of the \c ImportPath which represents a scope for the
+  /// import.
+  Access getAccessPath(bool isScoped) const {
+    if (isScoped) {
+      assert(size() >= 2 && "scoped ImportPath must contain a decl name");
+      return Access(getRaw().take_back());
+    }
+
+    return Access();
+  }
+
+  /// Extracts the portion of the \c ImportPath which represents a module name,
+  /// including submodules, assuming the \c ImportDecl has the indicated
+  /// \c importKind.
+  Module getModulePath(ImportKind importKind) const {
+    return getModulePath(importKind != ImportKind::Module);
+  }
+
+  /// Extracts the portion of the \c ImportPath which represents a scope for the
+  /// import, assuming the \c ImportDecl has the indicated \c importKind.
+  Access getAccessPath(ImportKind importKind) const {
+    return getAccessPath(importKind != ImportKind::Module);
+  }
 };
 
 }

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -1,0 +1,40 @@
+//===-- Import.h - Representation of imports --------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains types used to represent information about imports
+/// throughout the AST.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IMPORT_H
+#define SWIFT_IMPORT_H
+
+namespace swift {
+/// Describes what kind of name is being imported.
+///
+/// If the enumerators here are changed, make sure to update all diagnostics
+/// using ImportKind as a select index.
+enum class ImportKind : uint8_t {
+  Module = 0,
+  Type,
+  Struct,
+  Class,
+  Enum,
+  Protocol,
+  Var,
+  Func
+};
+
+}
+
+#endif

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -229,7 +229,7 @@ public:
   ///
   /// \c ImportPath::Access is essentially a wrapper around \c ArrayRef and does
   /// not own its elements, so something else needs to manage their lifetime.
-  /// \c ImportDecl owns the memory backing \c ImportDecl::getDeclPath().
+  /// \c ImportDecl owns the memory backing \c ImportDecl::getAccessPath().
   class Access : public detail::ImportPathBase<Access> {
   public:
     /// A helper type which encapsulates a temporary vector and can produce a

--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -108,17 +108,17 @@ class alignas(ModuleDecl::ImportedModule) ImportCache {
   llvm::DenseMap<const DeclContext *, ImportSet *> ImportSetForDC;
   llvm::DenseMap<std::tuple<const ModuleDecl *,
                             const DeclContext *>,
-                 ArrayRef<ModuleDecl::AccessPathTy>> VisibilityCache;
+                 ArrayRef<ImportPath::Access>> VisibilityCache;
   llvm::DenseMap<std::tuple<const ModuleDecl *,
                             const ModuleDecl *,
                             const DeclContext *>,
-                 ArrayRef<ModuleDecl::AccessPathTy>> ShadowCache;
+                 ArrayRef<ImportPath::Access>> ShadowCache;
 
-  ModuleDecl::AccessPathTy EmptyAccessPath;
+  ImportPath::Access EmptyAccessPath;
 
-  ArrayRef<ModuleDecl::AccessPathTy> allocateArray(
+  ArrayRef<ImportPath::Access> allocateArray(
       ASTContext &ctx,
-      SmallVectorImpl<ModuleDecl::AccessPathTy> &results);
+      SmallVectorImpl<ImportPath::Access> &results);
 
   ImportSet &getImportSet(ASTContext &ctx,
                           ArrayRef<ModuleDecl::ImportedModule> topLevelImports);
@@ -132,7 +132,7 @@ public:
 
   /// Returns all access paths into 'mod' that are visible from 'dc',
   /// including transitively, via re-exports.
-  ArrayRef<ModuleDecl::AccessPathTy>
+  ArrayRef<ImportPath::Access>
   getAllVisibleAccessPaths(const ModuleDecl *mod, const DeclContext *dc);
 
   bool isImportedBy(const ModuleDecl *mod,
@@ -142,7 +142,7 @@ public:
 
   /// Returns all access paths in 'mod' that are visible from 'dc' if we
   /// subtract imports of 'other'.
-  ArrayRef<ModuleDecl::AccessPathTy>
+  ArrayRef<ImportPath::Access>
   getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
                                  const ModuleDecl *other,
                                  const DeclContext *dc);

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/Import.h"
 #include "swift/AST/LookupKinds.h"
 #include "swift/AST/RawComment.h"
 #include "swift/AST/Type.h"

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -203,8 +203,6 @@ class ModuleDecl : public DeclContext, public TypeDecl {
   friend class DirectPrecedenceGroupLookupRequest;
 
 public:
-  LLVM_ATTRIBUTE_DEPRECATED(typedef ArrayRef<Located<Identifier>> AccessPathTy,
-                            "use ImportPath types instead");
   /// Convenience struct to keep track of a module along with its access path.
   struct alignas(uint64_t) ImportedModule {
     /// The access path from an import: `import Foo.Bar` -> `Foo.Bar`.
@@ -225,16 +223,6 @@ public:
              (this->accessPath == other.accessPath);
     }
   };
-
-  LLVM_ATTRIBUTE_DEPRECATED(
-    static bool matchesAccessPath(AccessPathTy AccessPath, DeclName Name),
-    "use ImportPath::Access::matches() instead")
-  {
-    assert(AccessPath.size() <= 1 && "can only refer to top-level decls");
-  
-    return AccessPath.empty()
-      || DeclName(AccessPath.front().Item).matchesRef(Name);
-  }
 
   /// Arbitrarily orders ImportedModule records, for inclusion in sets and such.
   class OrderImportedModules {
@@ -756,14 +744,6 @@ public:
   /// Generate the list of libraries needed to link this module, based on its
   /// imports.
   void collectLinkLibraries(LinkLibraryCallback callback) const;
-
-  /// Returns true if the two access paths contain the same chain of
-  /// identifiers.
-  ///
-  /// Source locations are ignored here.
-  LLVM_ATTRIBUTE_DEPRECATED(
-    static bool isSameAccessPath(AccessPathTy lhs, AccessPathTy rhs),
-    "use ImportPath::Access::isSameAs() instead");
 
   /// Get the path for the file that this module came from, or an empty
   /// string if this is not applicable.

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_MODULE_LOADER_H
 
 #include "swift/AST/Identifier.h"
+#include "swift/AST/Import.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/SourceLoc.h"
@@ -143,7 +144,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(Located<Identifier> named) = 0;
+  virtual bool canImportModule(ImportPath::Element named) = 0;
 
   /// Import a module with the given module path.
   ///
@@ -155,8 +156,7 @@ public:
   /// \returns the module referenced, if it could be loaded. Otherwise,
   /// emits a diagnostic and returns NULL.
   virtual
-  ModuleDecl *loadModule(SourceLoc importLoc,
-                         ArrayRef<Located<Identifier>> path) = 0;
+  ModuleDecl *loadModule(SourceLoc importLoc, ImportPath::Module path) = 0;
 
   /// Load extensions to the given nominal type.
   ///

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -65,7 +65,7 @@ void lookupInModule(const DeclContext *moduleOrFile,
 /// reexports, observing proper shadowing rules.
 void
 lookupVisibleDeclsInModule(const DeclContext *moduleOrFile,
-                           ModuleDecl::AccessPathTy accessPath,
+                           ImportPath::Access accessPath,
                            SmallVectorImpl<ValueDecl *> &decls,
                            NLKind lookupKind,
                            ResolutionKind resolutionKind,

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -407,14 +407,14 @@ public:
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &result) const override;
 
-  virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupVisibleDecls(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override;
 
-  virtual void lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupClassMembers(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer) const override;
   virtual void
-  lookupClassMember(ModuleDecl::AccessPathTy accessPath, DeclName name,
+  lookupClassMember(ImportPath::Access accessPath, DeclName name,
                     SmallVectorImpl<ValueDecl*> &results) const override;
 
   void lookupObjCMethods(

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -186,7 +186,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(Located<Identifier> named) override;
+  virtual bool canImportModule(ImportPath::Element named) override;
 
   /// Import a module with the given module path.
   ///
@@ -202,7 +202,7 @@ public:
   /// emits a diagnostic and returns NULL.
   virtual ModuleDecl *loadModule(
                         SourceLoc importLoc,
-                        ArrayRef<Located<Identifier>> path)
+                        ImportPath::Module path)
                       override;
 
   /// Determine whether \c overlayDC is within an overlay module for the
@@ -440,7 +440,7 @@ public:
   /// Given the path of a Clang module, collect the names of all its submodules.
   /// Calling this function does not load the module.
   void collectSubModuleNames(
-      ArrayRef<Located<Identifier>> path,
+      ImportPath::Module path,
       std::vector<std::string> &names) const;
 
   /// Given a Clang module, decide whether this module is imported already.

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -72,15 +72,15 @@ public:
   lookupNestedType(Identifier name,
                    const NominalTypeDecl *baseType) const override;
 
-  virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupVisibleDecls(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override;
 
-  virtual void lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupClassMembers(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer) const override;
 
   virtual void
-  lookupClassMember(ModuleDecl::AccessPathTy accessPath, DeclName name,
+  lookupClassMember(ImportPath::Access accessPath, DeclName name,
                     SmallVectorImpl<ValueDecl*> &decls) const override;
 
   void lookupObjCMethods(

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -134,7 +134,7 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                                      ModuleLoadingMode loadMode,
                                      bool IgnoreSwiftSourceInfoFile);
 
-  bool findModule(AccessPathElem moduleID,
+  bool findModule(ImportPath::Element moduleID,
                   SmallVectorImpl<char> *moduleInterfacePath,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
@@ -142,7 +142,7 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   bool &isFramework, bool &isSystemModule) override;
 
   std::error_code findModuleFilesInDirectory(
-                  AccessPathElem ModuleID,
+                  ImportPath::Element ModuleID,
                   const SerializedModuleBaseName &BaseName,
                   SmallVectorImpl<char> *ModuleInterfacePath,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -150,7 +150,7 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
                   bool IsFramework) override;
 
-  bool canImportModule(Located<Identifier> mID) override;
+  bool canImportModule(ImportPath::Element mID) override;
 
   bool isCached(StringRef DepPath) override { return false; };
 
@@ -332,7 +332,7 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   ModuleInterfaceLoaderOptions Opts;
 
   std::error_code findModuleFilesInDirectory(
-     AccessPathElem ModuleID,
+     ImportPath::Element ModuleID,
      const SerializedModuleBaseName &BaseName,
      SmallVectorImpl<char> *ModuleInterfacePath,
      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -190,7 +190,7 @@ public:
 
   /// Complete the import decl with importable modules.
   virtual void
-  completeImportDecl(std::vector<Located<Identifier>> &Path) {};
+  completeImportDecl(ImportPath::Builder &Path) {};
 
   /// Complete unresolved members after dot.
   virtual void completeUnresolvedMember(CodeCompletionExpr *E,

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -57,7 +57,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(Located<Identifier> named) override;
+  virtual bool canImportModule(ImportPath::Element named) override;
 
   /// Import a module with the given module path.
   ///
@@ -70,7 +70,7 @@ public:
   /// returns NULL.
   virtual ModuleDecl *
   loadModule(SourceLoc importLoc,
-             ArrayRef<Located<Identifier>> path) override;
+             ImportPath::Module path) override;
 
   /// Load extensions to the given nominal type.
   ///

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -54,7 +54,7 @@ namespace swift {
             dependencyKind(dependencyKind) {}
 
       std::error_code findModuleFilesInDirectory(
-          AccessPathElem ModuleID,
+          ImportPath::Element ModuleID,
           const SerializedModuleBaseName &BaseName,
           SmallVectorImpl<char> *ModuleInterfacePath,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -117,7 +117,8 @@ namespace swift {
       }
 
       std::error_code findModuleFilesInDirectory(
-          AccessPathElem ModuleID, const SerializedModuleBaseName &BaseName,
+          ImportPath::Element ModuleID,
+          const SerializedModuleBaseName &BaseName,
           SmallVectorImpl<char> *ModuleInterfacePath,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -72,8 +72,7 @@ protected:
   void collectVisibleTopLevelModuleNamesImpl(SmallVectorImpl<Identifier> &names,
                                              StringRef extension) const;
 
-  using AccessPathElem = Located<Identifier>;
-  virtual bool findModule(AccessPathElem moduleID,
+  virtual bool findModule(ImportPath::Element moduleID,
                           SmallVectorImpl<char> *moduleInterfacePath,
                           std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                           std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
@@ -93,7 +92,7 @@ protected:
   ///   modules and will defer to the remaining module loaders to look up this
   ///   module.
   virtual std::error_code findModuleFilesInDirectory(
-      AccessPathElem ModuleID,
+      ImportPath::Element ModuleID,
       const SerializedModuleBaseName &BaseName,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -103,19 +102,19 @@ protected:
 
   std::error_code
   openModuleFile(
-       AccessPathElem ModuleID,
+       ImportPath::Element ModuleID,
        const SerializedModuleBaseName &BaseName,
        std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer);
 
   std::error_code
   openModuleDocFileIfPresent(
-      AccessPathElem ModuleID,
+      ImportPath::Element ModuleID,
       const SerializedModuleBaseName &BaseName,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer);
 
   std::error_code
   openModuleSourceInfoFileIfPresent(
-      AccessPathElem ModuleID,
+      ImportPath::Element ModuleID,
       const SerializedModuleBaseName &BaseName,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
 
@@ -167,7 +166,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(Located<Identifier> named) override;
+  virtual bool canImportModule(ImportPath::Element named) override;
 
   /// Import a module with the given module path.
   ///
@@ -180,7 +179,7 @@ public:
   /// emits a diagnostic and returns a FailedImportModule object.
   virtual ModuleDecl *
   loadModule(SourceLoc importLoc,
-             ArrayRef<Located<Identifier>> path) override;
+             ImportPath::Module path) override;
 
 
   virtual void loadExtensions(NominalTypeDecl *nominal,
@@ -225,7 +224,7 @@ class ImplicitSerializedModuleLoader : public SerializedModuleLoaderBase {
   {}
 
   std::error_code findModuleFilesInDirectory(
-      AccessPathElem ModuleID,
+      ImportPath::Element ModuleID,
       const SerializedModuleBaseName &BaseName,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -271,7 +270,7 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
                                    IgnoreSwiftSourceInfo) {}
 
   std::error_code findModuleFilesInDirectory(
-      AccessPathElem ModuleID,
+      ImportPath::Element ModuleID,
       const SerializedModuleBaseName &BaseName,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -287,20 +286,20 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
 public:
   virtual ~MemoryBufferSerializedModuleLoader();
 
-  bool canImportModule(Located<Identifier> named) override;
+  bool canImportModule(ImportPath::Element named) override;
   ModuleDecl *
   loadModule(SourceLoc importLoc,
-             ArrayRef<Located<Identifier>> path) override;
+             ImportPath::Module path) override;
 
   /// Register a memory buffer that contains the serialized module for the given
   /// access path. This API is intended to be used by LLDB to add swiftmodules
   /// discovered in the __swift_ast section of a Mach-O file (or the .swift_ast
   /// section of an ELF file) to the search path.
   ///
-  /// FIXME: make this an actual access *path* once submodules are designed.
-  void registerMemoryBuffer(StringRef AccessPath,
+  /// FIXME: make this an actual import *path* once submodules are designed.
+  void registerMemoryBuffer(StringRef importPath,
                             std::unique_ptr<llvm::MemoryBuffer> input) {
-    MemoryBuffers[AccessPath] = std::move(input);
+    MemoryBuffers[importPath] = std::move(input);
   }
 
   void collectVisibleTopLevelModuleNames(
@@ -370,15 +369,15 @@ protected:
       TinyPtrVector<PrecedenceGroupDecl *> &results) const override;
 
 public:
-  virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupVisibleDecls(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override;
 
-  virtual void lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupClassMembers(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer) const override;
 
   virtual void
-  lookupClassMember(ModuleDecl::AccessPathTy accessPath, DeclName name,
+  lookupClassMember(ImportPath::Access accessPath, DeclName name,
                     SmallVectorImpl<ValueDecl*> &decls) const override;
 
   /// Find all Objective-C methods with the given selector.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -648,6 +648,12 @@ llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
   llvm_unreachable("bad AllocationArena");
 }
 
+ImportPath::Raw
+swift::detail::ImportPathBuilder_copyToImpl(ASTContext &ctx,
+                                            ImportPath::Raw raw) {
+  return ctx.AllocateCopy(raw);
+}
+
 /// Set a new stats reporter.
 void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
   if (stats) {
@@ -1602,7 +1608,7 @@ ModuleLoader *ASTContext::getModuleInterfaceLoader() const {
 }
 
 ModuleDecl *ASTContext::getLoadedModule(
-    ArrayRef<Located<Identifier>> ModulePath) const {
+    ImportPath::Module ModulePath) const {
   assert(!ModulePath.empty());
 
   // TODO: Swift submodules.
@@ -1867,28 +1873,28 @@ bool ASTContext::shouldPerformTypoCorrection() {
   return NumTypoCorrections <= LangOpts.TypoCorrectionLimit;
 }
 
-bool ASTContext::canImportModule(Located<Identifier> ModulePath) {
+bool ASTContext::canImportModule(ImportPath::Element ModuleName) {
   // If this module has already been successfully imported, it is importable.
-  if (getLoadedModule(ModulePath) != nullptr)
+  if (getLoadedModule(ImportPath::Module::Builder(ModuleName).get()) != nullptr)
     return true;
 
   // If we've failed loading this module before, don't look for it again.
-  if (FailedModuleImportNames.count(ModulePath.Item))
+  if (FailedModuleImportNames.count(ModuleName.Item))
     return false;
 
   // Otherwise, ask the module loaders.
   for (auto &importer : getImpl().ModuleLoaders) {
-    if (importer->canImportModule(ModulePath)) {
+    if (importer->canImportModule(ModuleName)) {
       return true;
     }
   }
 
-  FailedModuleImportNames.insert(ModulePath.Item);
+  FailedModuleImportNames.insert(ModuleName.Item);
   return false;
 }
 
 ModuleDecl *
-ASTContext::getModule(ArrayRef<Located<Identifier>> ModulePath) {
+ASTContext::getModule(ImportPath::Module ModulePath) {
   assert(!ModulePath.empty());
 
   if (auto *M = getLoadedModule(ModulePath))
@@ -1905,14 +1911,13 @@ ASTContext::getModule(ArrayRef<Located<Identifier>> ModulePath) {
 }
 
 ModuleDecl *ASTContext::getModuleByName(StringRef ModuleName) {
-  SmallVector<Located<Identifier>, 4>
-  AccessPath;
+  ImportPath::Module::Builder builder;
   while (!ModuleName.empty()) {
     StringRef SubModuleName;
     std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    AccessPath.push_back({ getIdentifier(SubModuleName), SourceLoc() });
+    builder.push_back(getIdentifier(SubModuleName));
   }
-  return getModule(AccessPath);
+  return getModule(builder.get());
 }
 
 ModuleDecl *ASTContext::getStdlibModule(bool loadIfAbsent) {
@@ -1922,7 +1927,8 @@ ModuleDecl *ASTContext::getStdlibModule(bool loadIfAbsent) {
   if (loadIfAbsent) {
     auto mutableThis = const_cast<ASTContext*>(this);
     TheStdlibModule =
-      mutableThis->getModule({ Located<Identifier>(StdlibModuleName, SourceLoc()) });
+      mutableThis->getModule(
+                           ImportPath::Module::Builder(StdlibModuleName).get());
   } else {
     TheStdlibModule = getLoadedModule(StdlibModuleName);
   }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -654,6 +654,12 @@ swift::detail::ImportPathBuilder_copyToImpl(ASTContext &ctx,
   return ctx.AllocateCopy(raw);
 }
 
+Identifier
+swift::detail::ImportPathBuilder_getIdentifierImpl(ASTContext &ctx,
+                                                   StringRef string) {
+  return ctx.getIdentifier(string);
+}
+
 /// Set a new stats reporter.
 void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
   if (stats) {
@@ -1911,12 +1917,7 @@ ASTContext::getModule(ImportPath::Module ModulePath) {
 }
 
 ModuleDecl *ASTContext::getModuleByName(StringRef ModuleName) {
-  ImportPath::Module::Builder builder;
-  while (!ModuleName.empty()) {
-    StringRef SubModuleName;
-    std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    builder.push_back(getIdentifier(SubModuleName));
-  }
+  ImportPath::Module::Builder builder(*this, ModuleName, /*separator=*/'.');
   return getModule(builder.get());
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1921,15 +1921,18 @@ ModuleDecl *ASTContext::getModuleByName(StringRef ModuleName) {
   return getModule(builder.get());
 }
 
+ModuleDecl *ASTContext::getModuleByIdentifier(Identifier ModuleID) {
+  ImportPath::Module::Builder builder(ModuleID);
+  return getModule(builder.get());
+}
+
 ModuleDecl *ASTContext::getStdlibModule(bool loadIfAbsent) {
   if (TheStdlibModule)
     return TheStdlibModule;
 
   if (loadIfAbsent) {
     auto mutableThis = const_cast<ASTContext*>(this);
-    TheStdlibModule =
-      mutableThis->getModule(
-                           ImportPath::Module::Builder(StdlibModuleName).get());
+    TheStdlibModule = mutableThis->getModuleByIdentifier(StdlibModuleName);
   } else {
     TheStdlibModule = getLoadedModule(StdlibModuleName);
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -619,11 +619,11 @@ namespace {
         OS << " kind=" << getImportKindString(ID->getImportKind());
 
       OS << " '";
-      interleave(ID->getFullAccessPath(),
-                 [&](const ImportDecl::AccessPathElement &Elem) {
-                   OS << Elem.Item;
-                 },
-                 [&] { OS << '.'; });
+      llvm::interleave(ID->getImportPath(),
+                       [&](const ImportPath::Element &Elem) {
+                         OS << Elem.Item;
+                       },
+                       [&] { OS << '.'; });
       OS << "')";
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2199,25 +2199,25 @@ void PrintAST::visitImportDecl(ImportDecl *decl) {
   getModuleEntities(decl, ModuleEnts);
 
   ArrayRef<ModuleEntity> Mods = ModuleEnts;
-  interleave(decl->getFullAccessPath(),
-             [&](const ImportDecl::AccessPathElement &Elem) {
-               if (!Mods.empty()) {
-                 Identifier Name = Elem.Item;
-                 if (Options.MapCrossImportOverlaysToDeclaringModule) {
-                   if (auto *MD = Mods.front().getAsSwiftModule()) {
-                     ModuleDecl *Declaring = const_cast<ModuleDecl*>(MD)
-                       ->getDeclaringModuleIfCrossImportOverlay();
-                     if (Declaring)
-                       Name = Declaring->getName();
-                   }
-                 }
-                 Printer.printModuleRef(Mods.front(), Name);
-                 Mods = Mods.slice(1);
-               } else {
-                 Printer << Elem.Item.str();
-               }
-             },
-             [&] { Printer << "."; });
+  llvm::interleave(decl->getImportPath(),
+                   [&](const ImportPath::Element &Elem) {
+                     if (!Mods.empty()) {
+                       Identifier Name = Elem.Item;
+                       if (Options.MapCrossImportOverlaysToDeclaringModule) {
+                         if (auto *MD = Mods.front().getAsSwiftModule()) {
+                           ModuleDecl *Declaring = const_cast<ModuleDecl*>(MD)
+                             ->getDeclaringModuleIfCrossImportOverlay();
+                           if (Declaring)
+                             Name = Declaring->getName();
+                         }
+                       }
+                       Printer.printModuleRef(Mods.front(), Name);
+                       Mods = Mods.slice(1);
+                     } else {
+                       Printer << Elem.Item.str();
+                     }
+                   },
+                   [&] { Printer << "."; });
 }
 
 static void printExtendedTypeName(Type ExtendedType, ASTPrinter &Printer,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1054,13 +1054,13 @@ SourceRange GenericContext::getGenericTrailingWhereClauseSourceRange() const {
 ImportDecl *ImportDecl::create(ASTContext &Ctx, DeclContext *DC,
                                SourceLoc ImportLoc, ImportKind Kind,
                                SourceLoc KindLoc,
-                               ArrayRef<AccessPathElement> Path,
+                               ImportPath Path,
                                ClangNode ClangN) {
   assert(!Path.empty());
   assert(Kind == ImportKind::Module || Path.size() > 1);
   assert(ClangN.isNull() || ClangN.getAsModule() ||
          isa<clang::ImportDecl>(ClangN.getAsDecl()));
-  size_t Size = totalSizeToAlloc<AccessPathElement>(Path.size());
+  size_t Size = totalSizeToAlloc<ImportPath::Element>(Path.size());
   void *ptr = allocateMemoryForDecl<ImportDecl>(Ctx, Size, !ClangN.isNull());
   auto D = new (ptr) ImportDecl(DC, ImportLoc, Kind, KindLoc, Path);
   if (ClangN)
@@ -1069,14 +1069,14 @@ ImportDecl *ImportDecl::create(ASTContext &Ctx, DeclContext *DC,
 }
 
 ImportDecl::ImportDecl(DeclContext *DC, SourceLoc ImportLoc, ImportKind K,
-                       SourceLoc KindLoc, ArrayRef<AccessPathElement> Path)
+                       SourceLoc KindLoc, ImportPath Path)
   : Decl(DeclKind::Import, DC), ImportLoc(ImportLoc), KindLoc(KindLoc) {
   Bits.ImportDecl.NumPathElements = Path.size();
   assert(Bits.ImportDecl.NumPathElements == Path.size() && "Truncation error");
   Bits.ImportDecl.ImportKind = static_cast<unsigned>(K);
   assert(getImportKind() == K && "not enough bits for ImportKind");
   std::uninitialized_copy(Path.begin(), Path.end(),
-                          getTrailingObjects<AccessPathElement>());
+                          getTrailingObjects<ImportPath::Element>());
 }
 
 ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1221,17 +1221,6 @@ void ModuleDecl::getImportedModulesForLookup(
   FORWARD(getImportedModulesForLookup, (modules));
 }
 
-bool ModuleDecl::isSameAccessPath(AccessPathTy lhs, AccessPathTy rhs) {
-  using AccessPathElem = Located<Identifier>;
-  if (lhs.size() != rhs.size())
-    return false;
-  return std::equal(lhs.begin(), lhs.end(), rhs.begin(),
-                    [](const AccessPathElem &lElem,
-                       const AccessPathElem &rElem) {
-    return lElem.Item == rElem.Item;
-  });
-}
-
 ModuleDecl::ReverseFullNameIterator::ReverseFullNameIterator(
     const ModuleDecl *M) {
   assert(M);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -170,8 +170,6 @@ class swift::SourceLookupCache {
   template<typename Range>
   void addToMemberCache(Range decls);
 public:
-  typedef ModuleDecl::AccessPathTy AccessPathTy;
-  
   SourceLookupCache(const SourceFile &SF);
   SourceLookupCache(const ModuleDecl &Mod);
 
@@ -202,17 +200,17 @@ public:
   void lookupPrecedenceGroup(Identifier name,
                              TinyPtrVector<PrecedenceGroupDecl *> &results);
 
-  void lookupVisibleDecls(AccessPathTy AccessPath,
+  void lookupVisibleDecls(ImportPath::Access AccessPath,
                           VisibleDeclConsumer &Consumer,
                           NLKind LookupKind);
   
   void populateMemberCache(const SourceFile &SF);
   void populateMemberCache(const ModuleDecl &Mod);
 
-  void lookupClassMembers(AccessPathTy AccessPath,
+  void lookupClassMembers(ImportPath::Access AccessPath,
                           VisibleDeclConsumer &consumer);
                           
-  void lookupClassMember(AccessPathTy accessPath,
+  void lookupClassMember(ImportPath::Access accessPath,
                          DeclName name,
                          SmallVectorImpl<ValueDecl*> &results);
 
@@ -372,7 +370,7 @@ void SourceLookupCache::lookupPrecedenceGroup(
     results.push_back(group);
 }
 
-void SourceLookupCache::lookupVisibleDecls(AccessPathTy AccessPath,
+void SourceLookupCache::lookupVisibleDecls(ImportPath::Access AccessPath,
                                            VisibleDeclConsumer &Consumer,
                                            NLKind LookupKind) {
   assert(AccessPath.size() <= 1 && "can only refer to top-level decls");
@@ -397,7 +395,7 @@ void SourceLookupCache::lookupVisibleDecls(AccessPathTy AccessPath,
   }
 }
 
-void SourceLookupCache::lookupClassMembers(AccessPathTy accessPath,
+void SourceLookupCache::lookupClassMembers(ImportPath::Access accessPath,
                                            VisibleDeclConsumer &consumer) {
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
   
@@ -430,7 +428,7 @@ void SourceLookupCache::lookupClassMembers(AccessPathTy accessPath,
   }
 }
 
-void SourceLookupCache::lookupClassMember(AccessPathTy accessPath,
+void SourceLookupCache::lookupClassMember(ImportPath::Access accessPath,
                                           DeclName name,
                                           SmallVectorImpl<ValueDecl*> &results) {
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
@@ -704,7 +702,7 @@ void SourceFile::lookupValue(DeclName name, NLKind lookupKind,
   getCache().lookupValue(name, lookupKind, result);
 }
 
-void ModuleDecl::lookupVisibleDecls(AccessPathTy AccessPath,
+void ModuleDecl::lookupVisibleDecls(ImportPath::Access AccessPath,
                                     VisibleDeclConsumer &Consumer,
                                     NLKind LookupKind) const {
   if (isParsedModule(this))
@@ -714,13 +712,13 @@ void ModuleDecl::lookupVisibleDecls(AccessPathTy AccessPath,
   FORWARD(lookupVisibleDecls, (AccessPath, Consumer, LookupKind));
 }
 
-void SourceFile::lookupVisibleDecls(ModuleDecl::AccessPathTy AccessPath,
+void SourceFile::lookupVisibleDecls(ImportPath::Access AccessPath,
                                     VisibleDeclConsumer &Consumer,
                                     NLKind LookupKind) const {
   getCache().lookupVisibleDecls(AccessPath, Consumer, LookupKind);
 }
 
-void ModuleDecl::lookupClassMembers(AccessPathTy accessPath,
+void ModuleDecl::lookupClassMembers(ImportPath::Access accessPath,
                                     VisibleDeclConsumer &consumer) const {
   if (isParsedModule(this)) {
     auto &cache = getSourceLookupCache();
@@ -732,14 +730,14 @@ void ModuleDecl::lookupClassMembers(AccessPathTy accessPath,
   FORWARD(lookupClassMembers, (accessPath, consumer));
 }
 
-void SourceFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+void SourceFile::lookupClassMembers(ImportPath::Access accessPath,
                                     VisibleDeclConsumer &consumer) const {
   auto &cache = getCache();
   cache.populateMemberCache(*this);
   cache.lookupClassMembers(accessPath, consumer);
 }
 
-void ModuleDecl::lookupClassMember(AccessPathTy accessPath,
+void ModuleDecl::lookupClassMember(ImportPath::Access accessPath,
                                    DeclName name,
                                    SmallVectorImpl<ValueDecl*> &results) const {
   auto *stats = getASTContext().Stats;
@@ -758,7 +756,7 @@ void ModuleDecl::lookupClassMember(AccessPathTy accessPath,
   FORWARD(lookupClassMember, (accessPath, name, results));
 }
 
-void SourceFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
+void SourceFile::lookupClassMember(ImportPath::Access accessPath,
                                    DeclName name,
                                    SmallVectorImpl<ValueDecl*> &results) const {
   FrontendStatsTracer tracer(getASTContext().Stats,
@@ -1294,11 +1292,10 @@ ModuleDecl::removeDuplicateImports(SmallVectorImpl<ImportedModule> &imports) {
           lhs.importedModule->getReverseFullModuleName(), {},
           rhs.importedModule->getReverseFullModuleName(), {});
     }
-    using AccessPathElem = Located<Identifier>;
     return std::lexicographical_compare(
         lhs.accessPath.begin(), lhs.accessPath.end(), rhs.accessPath.begin(),
         rhs.accessPath.end(),
-        [](const AccessPathElem &lElem, const AccessPathElem &rElem) {
+        [](const ImportPath::Element &lElem, const ImportPath::Element &rElem) {
           return lElem.Item.str() < rElem.Item.str();
         });
   });
@@ -1307,7 +1304,7 @@ ModuleDecl::removeDuplicateImports(SmallVectorImpl<ImportedModule> &imports) {
       [](const ImportedModule &lhs, const ImportedModule &rhs) -> bool {
         if (lhs.importedModule != rhs.importedModule)
           return false;
-        return ModuleDecl::isSameAccessPath(lhs.accessPath, rhs.accessPath);
+        return lhs.accessPath.isSameAs(rhs.accessPath);
       });
   imports.erase(last, imports.end());
 }
@@ -1471,7 +1468,7 @@ SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 
   // Make sure the top-level module is first; we want pre-order-ish traversal.
   auto topLevelModule =
-      ModuleDecl::ImportedModule{ModuleDecl::AccessPathTy(), topLevel};
+      ModuleDecl::ImportedModule{ImportPath::Access(), topLevel};
   stack.emplace_back(topLevelModule);
 
   while (!stack.empty()) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -267,20 +267,20 @@ static void recordShadowedDeclsAfterTypeMatch(
 
     auto name = firstDecl->getBaseName();
 
-    auto isShadowed = [&](ArrayRef<ModuleDecl::AccessPathTy> paths) {
+    auto isShadowed = [&](ArrayRef<ImportPath::Access> paths) {
       for (auto path : paths) {
-        if (ModuleDecl::matchesAccessPath(path, name))
+        if (path.matches(name))
           return false;
       }
 
       return true;
     };
 
-    auto isScopedImport = [&](ArrayRef<ModuleDecl::AccessPathTy> paths) {
+    auto isScopedImport = [&](ArrayRef<ImportPath::Access> paths) {
       for (auto path : paths) {
         if (path.empty())
           continue;
-        if (ModuleDecl::matchesAccessPath(path, name))
+        if (path.matches(name))
           return true;
       }
 
@@ -1765,9 +1765,8 @@ ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     auto accessPaths = ctx.getImportCache().getAllVisibleAccessPaths(
         module, topLevelScope);
     if (llvm::any_of(accessPaths,
-                     [&](ModuleDecl::AccessPathTy accessPath) {
-                       return ModuleDecl::matchesAccessPath(accessPath,
-                                                            member.getFullName());
+                     [&](ImportPath::Access accessPath) {
+                       return accessPath.matches(member.getFullName());
                      })) {
       lookupInModule(module, member.getFullName(), decls,
                      NLKind::QualifiedLookup, kind, topLevelScope);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1685,7 +1685,7 @@ void ClangImporter::collectVisibleTopLevelModuleNames(
 }
 
 void ClangImporter::collectSubModuleNames(
-    ArrayRef<Located<Identifier>> path,
+    ImportPath::Module path,
     std::vector<std::string> &names) const {
   auto &clangHeaderSearch = Impl.getClangPreprocessor().getHeaderSearchInfo();
 
@@ -1696,7 +1696,7 @@ void ClangImporter::collectSubModuleNames(
   if (!clangModule)
     return;
   clang::Module *submodule = clangModule;
-  for (auto component : path.slice(1)) {
+  for (auto component : path.getSubmodulePath()) {
     submodule = submodule->findSubmodule(component.Item.str());
     if (!submodule)
       return;
@@ -1709,7 +1709,7 @@ bool ClangImporter::isModuleImported(const clang::Module *M) {
   return M->NameVisibility == clang::Module::NameVisibilityKind::AllVisible;
 }
 
-bool ClangImporter::canImportModule(Located<Identifier> moduleID) {
+bool ClangImporter::canImportModule(ImportPath::Element moduleID) {
   // Look up the top-level module to see if it exists.
   // FIXME: This only works with top-level modules.
   auto &clangHeaderSearch = Impl.getClangPreprocessor().getHeaderSearchInfo();
@@ -1728,7 +1728,7 @@ bool ClangImporter::canImportModule(Located<Identifier> moduleID) {
 }
 
 ModuleDecl *ClangImporter::Implementation::loadModuleClang(
-    SourceLoc importLoc, ArrayRef<Located<Identifier>> path) {
+    SourceLoc importLoc, ImportPath::Module path) {
   auto &clangHeaderSearch = getClangPreprocessor().getHeaderSearchInfo();
 
   // Look up the top-level module first, to see if it exists at all.
@@ -1798,7 +1798,7 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
 
   // Verify that the submodule exists.
   clang::Module *submodule = clangModule;
-  for (auto &component : path.slice(1)) {
+  for (auto &component : path.getSubmodulePath()) {
     submodule = submodule->findSubmodule(component.Item.str());
 
     // Special case: a submodule named "Foo.Private" can be moved to a top-level
@@ -1806,7 +1806,7 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
     // We're limiting this to just submodules named "Private" because this will
     // put the Clang AST in a fatal error state if it /doesn't/ exist.
     if (!submodule && component.Item.str() == "Private" &&
-        (&component) == (&path[1])) {
+        (&component) == (&path.getRaw()[1])) {
       submodule = loadModule(llvm::makeArrayRef(clangPath).slice(0, 2),
                              clang::Module::Hidden);
     }
@@ -1827,12 +1827,12 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
 
 ModuleDecl *
 ClangImporter::loadModule(SourceLoc importLoc,
-                          ArrayRef<Located<Identifier>> path) {
+                          ImportPath::Module path) {
   return Impl.loadModule(importLoc, path);
 }
 
 ModuleDecl *ClangImporter::Implementation::loadModule(
-    SourceLoc importLoc, ArrayRef<Located<Identifier>> path) {
+    SourceLoc importLoc, ImportPath::Module path) {
   ModuleDecl *MD = nullptr;
   if (!DisableSourceImport)
     MD = loadModuleClang(importLoc, path);
@@ -2743,7 +2743,7 @@ void ClangImporter::lookupRelatedEntity(
   }
 }
 
-void ClangModuleUnit::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+void ClangModuleUnit::lookupVisibleDecls(ImportPath::Access accessPath,
                                          VisibleDeclConsumer &consumer,
                                          NLKind lookupKind) const {
   // FIXME: Ignore submodules, which are empty for now.
@@ -2864,13 +2864,14 @@ ImportDecl *swift::createImportDecl(ASTContext &Ctx,
                                     ArrayRef<clang::Module *> Exported) {
   auto *ImportedMod = ClangN.getClangModule();
   assert(ImportedMod);
-  SmallVector<Located<Identifier>, 4> AccessPath;
+
+  ImportPath::Builder importPath;
   auto *TmpMod = ImportedMod;
   while (TmpMod) {
-    AccessPath.push_back({ Ctx.getIdentifier(TmpMod->Name), SourceLoc() });
+    importPath.push_back(Ctx.getIdentifier(TmpMod->Name));
     TmpMod = TmpMod->Parent;
   }
-  std::reverse(AccessPath.begin(), AccessPath.end());
+  std::reverse(importPath.begin(), importPath.end());
 
   bool IsExported = false;
   for (auto *ExportedMod : Exported) {
@@ -2881,8 +2882,8 @@ ImportDecl *swift::createImportDecl(ASTContext &Ctx,
   }
 
   auto *ID = ImportDecl::create(Ctx, DC, SourceLoc(),
-                                ImportKind::Module, SourceLoc(), AccessPath,
-                                ClangN);
+                                ImportKind::Module, SourceLoc(),
+                                importPath.get(), ClangN);
   if (IsExported)
     ID->getAttrs().add(new (Ctx) ExportedAttr(/*IsImplicit=*/false));
   return ID;
@@ -3125,7 +3126,7 @@ void ClangImporter::loadObjCMethods(
 }
 
 void
-ClangModuleUnit::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
+ClangModuleUnit::lookupClassMember(ImportPath::Access accessPath,
                                    DeclName name,
                                    SmallVectorImpl<ValueDecl*> &results) const {
   // FIXME: Ignore submodules, which are empty for now.
@@ -3141,7 +3142,7 @@ ClangModuleUnit::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
   }
 }
 
-void ClangModuleUnit::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+void ClangModuleUnit::lookupClassMembers(ImportPath::Access accessPath,
                                          VisibleDeclConsumer &consumer) const {
   // FIXME: Ignore submodules, which are empty for now.
   if (clangModule && clangModule->isSubModule())
@@ -3413,8 +3414,8 @@ ModuleDecl *ClangModuleUnit::getOverlayModule() const {
     // FIXME: Include proper source location.
     ModuleDecl *M = getParentModule();
     ASTContext &Ctx = M->getASTContext();
-    auto overlay = Ctx.getModule(ModuleDecl::AccessPathTy({M->getName(),
-                                                           SourceLoc()}));
+    auto overlay = Ctx.getModule(
+                       ImportPath::Module::Builder(M->getName()).get());
     if (overlay == M) {
       overlay = nullptr;
     } else {
@@ -3445,7 +3446,7 @@ void ClangModuleUnit::getImportedModules(
   // Needed for implicitly synthesized conformances.
   if (filter.contains(ModuleDecl::ImportFilterKind::Private))
     if (auto stdlib = owner.getStdlibModule())
-      imports.push_back({ModuleDecl::AccessPathTy(), stdlib});
+      imports.push_back({ImportPath::Access(), stdlib});
 
   SmallVector<clang::Module *, 8> imported;
   if (!clangModule) {
@@ -3490,7 +3491,7 @@ void ClangModuleUnit::getImportedModules(
       if (importTopLevel != importMod) {
         if (!clangModule || importTopLevel != clangModule->getTopLevelModule()){
           auto topLevelWrapper = owner.getWrapperForModule(importTopLevel);
-          imports.push_back({ ModuleDecl::AccessPathTy(),
+          imports.push_back({ ImportPath::Access(),
                               topLevelWrapper->getParentModule() });
         }
       }
@@ -3500,7 +3501,7 @@ void ClangModuleUnit::getImportedModules(
     }
 
     assert(actualMod && "Missing imported overlay");
-    imports.push_back({ModuleDecl::AccessPathTy(), actualMod});
+    imports.push_back({ImportPath::Access(), actualMod});
   }
 }
 
@@ -3576,7 +3577,7 @@ void ClangModuleUnit::getImportedModulesForLookup(
       actualMod = wrapper->getParentModule();
 
     assert(actualMod && "Missing imported overlay");
-    imports.push_back({ModuleDecl::AccessPathTy(), actualMod});
+    imports.push_back({ImportPath::Access(), actualMod});
   }
 
   // Cache our results for use next time.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3414,8 +3414,7 @@ ModuleDecl *ClangModuleUnit::getOverlayModule() const {
     // FIXME: Include proper source location.
     ModuleDecl *M = getParentModule();
     ASTContext &Ctx = M->getASTContext();
-    auto overlay = Ctx.getModule(
-                       ImportPath::Module::Builder(M->getName()).get());
+    auto overlay = Ctx.getModuleByIdentifier(M->getName());
     if (overlay == M) {
       overlay = nullptr;
     } else {

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -44,16 +44,16 @@ public:
     return nullptr;
   }
 
-  virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+  virtual void lookupVisibleDecls(ImportPath::Access accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override {}
 
   virtual void
-  lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+  lookupClassMembers(ImportPath::Access accessPath,
                      VisibleDeclConsumer &consumer) const override {}
 
   virtual void
-  lookupClassMember(ModuleDecl::AccessPathTy accessPath, DeclName name,
+  lookupClassMember(ImportPath::Access accessPath, DeclName name,
                     SmallVectorImpl<ValueDecl *> &decls) const override {}
 
   void lookupObjCMethods(
@@ -99,7 +99,7 @@ static_assert(IsTriviallyDestructible<DWARFModuleUnit>::value,
               "DWARFModuleUnits are BumpPtrAllocated; the d'tor is not called");
 
 ModuleDecl *ClangImporter::Implementation::loadModuleDWARF(
-    SourceLoc importLoc, ArrayRef<Located<Identifier>> path) {
+    SourceLoc importLoc, ImportPath::Module path) {
   // There's no importing from debug info if no importer is installed.
   if (!DWARFImporter)
     return nullptr;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2441,7 +2441,7 @@ static ModuleDecl *tryLoadModule(ASTContext &C,
   if (importForwardDeclarations)
     module = C.getLoadedModule(moduleName);
   else
-    module = C.getModule({ {moduleName, SourceLoc()} });
+    module = C.getModule(ImportPath::Module::Builder(moduleName).get());
 
   checkedModules[moduleName] = module;
   return module;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2441,7 +2441,7 @@ static ModuleDecl *tryLoadModule(ASTContext &C,
   if (importForwardDeclarations)
     module = C.getLoadedModule(moduleName);
   else
-    module = C.getModule(ImportPath::Module::Builder(moduleName).get());
+    module = C.getModuleByIdentifier(moduleName);
 
   checkedModules[moduleName] = module;
   return module;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -622,17 +622,17 @@ private:
 
   /// Load a module using the clang::CompilerInstance.
   ModuleDecl *loadModuleClang(SourceLoc importLoc,
-                              ArrayRef<Located<Identifier>> path);
+                              ImportPath::Module path);
   
   /// "Load" a module from debug info. Because debug info types are read on
   /// demand, this doesn't really do any work.
   ModuleDecl *loadModuleDWARF(SourceLoc importLoc,
-                              ArrayRef<Located<Identifier>> path);
+                              ImportPath::Module path);
 
 public:
   /// Load a module using either method.
   ModuleDecl *loadModule(SourceLoc importLoc,
-                         ArrayRef<Located<Identifier>> path);
+                         ImportPath::Module path);
 
   void recordImplicitUnwrapForDecl(ValueDecl *decl, bool isIUO) {
     if (!isIUO)

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -334,7 +334,6 @@ struct ModuleRebuildInfo {
 /// normal cache, the prebuilt cache, a module adjacent to the interface, or
 /// a module that we'll build from a module interface.
 class ModuleInterfaceLoaderImpl {
-  using AccessPathElem = Located<Identifier>;
   friend class swift::ModuleInterfaceLoader;
   ASTContext &ctx;
   llvm::vfs::FileSystem &fs;
@@ -953,7 +952,7 @@ bool ModuleInterfaceLoader::isCached(StringRef DepPath) {
 /// cache or by converting it in a subordinate \c CompilerInstance, caching
 /// the results.
 std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
-  AccessPathElem ModuleID,
+  ImportPath::Element ModuleID,
   const SerializedModuleBaseName &BaseName,
   SmallVectorImpl<char> *ModuleInterfacePath,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -1520,7 +1519,7 @@ ExplicitSwiftModuleLoader::ExplicitSwiftModuleLoader(
 
 ExplicitSwiftModuleLoader::~ExplicitSwiftModuleLoader() { delete &Impl; }
 
-bool ExplicitSwiftModuleLoader::findModule(AccessPathElem ModuleID,
+bool ExplicitSwiftModuleLoader::findModule(ImportPath::Element ModuleID,
            SmallVectorImpl<char> *ModuleInterfacePath,
            std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
            std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -1596,7 +1595,7 @@ bool ExplicitSwiftModuleLoader::findModule(AccessPathElem ModuleID,
 }
 
 std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
-  AccessPathElem ModuleID,
+  ImportPath::Element ModuleID,
   const SerializedModuleBaseName &BaseName,
   SmallVectorImpl<char> *ModuleInterfacePath,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -1608,7 +1607,7 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
 }
 
 bool ExplicitSwiftModuleLoader::canImportModule(
-    Located<Identifier> mID) {
+    ImportPath::Element mID) {
   StringRef moduleName = mID.Item.str();
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no provided explicit module matches the name, then it cannot be imported.

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -66,9 +66,9 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
     if (!ID)
       continue;
 
-    auto accessPath = ID->getModulePath();
+    auto modulePath = ID->getModulePath();
     // only the top-level name is needed (i.e. A in A.B.C)
-    Modules.insert(accessPath[0].Item.str());
+    Modules.insert(modulePath[0].Item.str());
   }
 
   // And now look in the C code we're possibly using.
@@ -97,7 +97,7 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
 
   if (opts.ImportUnderlyingModule) {
     auto underlyingModule = clangImporter->loadModule(SourceLoc(),
-      { Located<Identifier>(mainModule->getName(), SourceLoc()) });
+      ImportPath::Module::Builder(mainModule->getName()).get());
     if (!underlyingModule) {
       Context.Diags.diagnose(SourceLoc(),
                              diag::error_underlying_module_not_found,

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -374,8 +374,10 @@ static bool printModuleInterfaceDecl(Decl *D,
 
 /// Sorts import declarations for display.
 static bool compareImports(ImportDecl *LHS, ImportDecl *RHS) {
-  auto LHSPath = LHS->getFullAccessPath();
-  auto RHSPath = RHS->getFullAccessPath();
+  // TODO(SR-13490): Probably buggy--thinks "import Foo" == "import Foo.Bar".
+  // ImportPathBase should provide universal comparison functions to avoid this.
+  auto LHSPath = LHS->getImportPath();
+  auto RHSPath = RHS->getImportPath();
   for (unsigned i: range(std::min(LHSPath.size(), RHSPath.size()))) {
     if (int Ret = LHSPath[i].Item.str().compare(RHSPath[i].Item.str()))
       return Ret < 0;

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -68,13 +68,13 @@ private:
 
   bool handleImports(ImportDecl *Import);
   bool handleCustomAttributes(Decl *D);
-  bool passModulePathElements(ArrayRef<ImportDecl::AccessPathElement> Path,
+  bool passModulePathElements(ImportPath::Module Path,
                               const clang::Module *ClangMod);
 
   bool passReference(ValueDecl *D, Type Ty, SourceLoc Loc, SourceRange Range,
                      ReferenceMetaData Data);
   bool passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data);
-  bool passReference(ModuleEntity Mod, Located<Identifier> IdLoc);
+  bool passReference(ModuleEntity Mod, ImportPath::Element IdLoc);
 
   bool passSubscriptReference(ValueDecl *D, SourceLoc Loc,
                               ReferenceMetaData Data, bool IsOpenBracket);
@@ -644,14 +644,15 @@ bool SemaAnnotator::handleImports(ImportDecl *Import) {
 }
 
 bool SemaAnnotator::passModulePathElements(
-    ArrayRef<ImportDecl::AccessPathElement> Path,
+    ImportPath::Module Path,
     const clang::Module *ClangMod) {
 
-  if (Path.empty() || !ClangMod)
-    return true;
+  assert(ClangMod && "can't passModulePathElements of null ClangMod");
 
-  if (!passModulePathElements(Path.drop_back(1), ClangMod->Parent))
-    return false;
+  // Visit parent, if any, first.
+  if (ClangMod->Parent && Path.hasSubmodule())
+    if (!passModulePathElements(Path.getParentPath(), ClangMod->Parent))
+      return false;
 
   return passReference(ClangMod, Path.back());
 }
@@ -732,7 +733,7 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
 }
 
 bool SemaAnnotator::passReference(ModuleEntity Mod,
-                                  Located<Identifier> IdLoc) {
+                                  ImportPath::Element IdLoc) {
   if (IdLoc.Loc.isInvalid())
     return true;
   unsigned NameLen = IdLoc.Item.getLength();

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -252,7 +252,7 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
       tryResolve(ASTWalker::ParentTy(D), D->getLoc());
     }
   } else if (ImportDecl *ID = dyn_cast<ImportDecl>(D)) {
-    for(const ImportDecl::AccessPathElement &Element: ID->getFullAccessPath()) {
+    for(const ImportPath::Element &Element: ID->getImportPath()) {
       tryResolve(ASTWalker::ParentTy(D), Element.Loc);
       if (isDone())
         break;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1132,7 +1132,7 @@ void IRGenModule::finishEmitAfterTopLevel() {
   if (DebugInfo) {
     if (ModuleDecl *TheStdlib = Context.getStdlibModule()) {
       if (TheStdlib != getSwiftModule()) {
-        Located<swift::Identifier> AccessPath[] = {
+        Located<swift::Identifier> moduleName[] = {
           { Context.StdlibModuleName, swift::SourceLoc() }
         };
 
@@ -1140,7 +1140,7 @@ void IRGenModule::finishEmitAfterTopLevel() {
                                       getSwiftModule(),
                                       SourceLoc(),
                                       ImportKind::Module, SourceLoc(),
-                                      AccessPath);
+                                      llvm::makeArrayRef(moduleName));
         Imp->setModule(TheStdlib);
         DebugInfo->emitImport(Imp);
       }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2089,7 +2089,7 @@ void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
     return;
 
   assert(D->getModule() && "compiler-synthesized ImportDecl is incomplete");
-  ModuleDecl::ImportedModule Imported = { D->getDeclPath(), D->getModule() };
+  ModuleDecl::ImportedModule Imported = { D->getAccessPath(), D->getModule() };
   auto DIMod = getOrCreateModule(Imported);
   auto L = getDebugLoc(*this, D);
   auto *File = getOrCreateFile(L.Filename);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -550,7 +550,7 @@ private:
 
     case DeclContextKind::Module:
       return getOrCreateModule(
-          {ModuleDecl::AccessPathTy(), cast<ModuleDecl>(DC)});
+          {ImportPath::Access(), cast<ModuleDecl>(DC)});
     case DeclContextKind::FileUnit:
       // A module may contain multiple files.
       return getOrCreateContext(DC->getParent());
@@ -2089,7 +2089,7 @@ void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
     return;
 
   assert(D->getModule() && "compiler-synthesized ImportDecl is incomplete");
-  ModuleDecl::ImportedModule Imported = {D->getModulePath(), D->getModule()};
+  ModuleDecl::ImportedModule Imported = { D->getDeclPath(), D->getModule() };
   auto DIMod = getOrCreateModule(Imported);
   auto L = getDebugLoc(*this, D);
   auto *File = getOrCreateFile(L.Filename);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -564,12 +564,13 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     // be imported.
     ASTContext &ctx = getASTContext();
     
-    Located<Identifier> UIKitName =
+    ImportPath::Element UIKitName =
       {ctx.getIdentifier("UIKit"), SourceLoc()};
     
     ModuleDecl *UIKit = ctx
       .getClangModuleLoader()
-      ->loadModule(SourceLoc(), UIKitName);
+      ->loadModule(SourceLoc(),
+                   ImportPath::Module(llvm::makeArrayRef(UIKitName)));
     assert(UIKit && "couldn't find UIKit objc module?!");
     SmallVector<ValueDecl *, 1> results;
     UIKit->lookupQualified(UIKit,

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -447,8 +447,7 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
 
   // Add any modules we were asked to implicitly import.
   for (auto moduleName : importInfo.ModuleNames) {
-    auto *importModule = ctx.getModule(
-        ImportPath::Module::Builder(moduleName).get());
+    auto *importModule = ctx.getModuleByIdentifier(moduleName);
     if (!importModule) {
       ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import, moduleName.str());
       if (ctx.SearchPathOpts.SDKPath.empty() &&

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -624,7 +624,7 @@ static void lookupVisibleMemberDeclsImpl(
   // special and can't have extensions.
   if (ModuleType *MT = BaseTy->getAs<ModuleType>()) {
     AccessFilteringDeclConsumer FilteringConsumer(CurrDC, Consumer);
-    MT->getModule()->lookupVisibleDecls(ModuleDecl::AccessPathTy(),
+    MT->getModule()->lookupVisibleDecls(ImportPath::Access(),
                                         FilteringConsumer,
                                         NLKind::QualifiedLookup);
     return;

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -62,7 +62,7 @@ void SourceLoader::collectVisibleTopLevelModuleNames(
   // TODO: Implement?
 }
 
-bool SourceLoader::canImportModule(Located<Identifier> ID) {
+bool SourceLoader::canImportModule(ImportPath::Element ID) {
   // Search the memory buffers to see if we can find this file on disk.
   FileOrError inputFileOrError = findModule(Ctx, ID.Item.str(),
                                             ID.Loc);
@@ -79,7 +79,7 @@ bool SourceLoader::canImportModule(Located<Identifier> ID) {
 }
 
 ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
-                                     ArrayRef<Located<Identifier>> path) {
+                                     ImportPath::Module path) {
   // FIXME: Swift submodules?
   if (path.size() > 1)
     return nullptr;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2014,35 +2014,31 @@ ModuleDecl *ModuleFile::getModule(ModuleID MID) {
       llvm_unreachable("implementation detail only");
     }
   }
-  return getModule(getIdentifier(MID),
+  return getModule(ImportPath::Module::Builder(getIdentifier(MID)).get(),
                    getContext().LangOpts.AllowDeserializingImplementationOnly);
 }
 
-ModuleDecl *ModuleFile::getModule(ArrayRef<Identifier> name,
+ModuleDecl *ModuleFile::getModule(ImportPath::Module name,
                                   bool allowLoading) {
-  if (name.empty() || name.front().empty())
+  if (name.empty() || name.front().Item.empty())
     return getContext().TheBuiltinModule;
 
   // FIXME: duplicated from ImportResolver::getModule
   if (name.size() == 1 &&
-      name.front() == FileContext->getParentModule()->getName()) {
+      name.front().Item == FileContext->getParentModule()->getName()) {
     if (!UnderlyingModule && allowLoading) {
       auto importer = getContext().getClangModuleLoader();
       assert(importer && "no way to import shadowed module");
-      UnderlyingModule = importer->loadModule(SourceLoc(),
-                                              {{name.front(), SourceLoc()}});
+      UnderlyingModule =
+          importer->loadModule(SourceLoc(), name.getTopLevelPath());
     }
 
     return UnderlyingModule;
   }
 
-  SmallVector<ImportDecl::AccessPathElement, 4> importPath;
-  for (auto pathElem : name)
-    importPath.push_back({ pathElem, SourceLoc() });
-
   if (allowLoading)
-    return getContext().getModule(importPath);
-  return getContext().getLoadedModule(importPath);
+    return getContext().getModule(name);
+  return getContext().getLoadedModule(name);
 }
 
 

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -26,7 +26,7 @@ using llvm::ErrorOr;
 
 
 std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
-                                      AccessPathElem ModuleID,
+                                      ImportPath::Element ModuleID,
                                       const SerializedModuleBaseName &BaseName,
                                       SmallVectorImpl<char> *ModuleInterfacePath,
                                       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -71,7 +71,7 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
 
 
 std::error_code PlaceholderSwiftModuleScanner::findModuleFilesInDirectory(
-    AccessPathElem ModuleID, const SerializedModuleBaseName &BaseName,
+    ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -530,7 +530,7 @@ public:
   void getImportDecls(SmallVectorImpl<Decl *> &Results);
 
   /// Reports all visible top-level members in this module.
-  void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+  void lookupVisibleDecls(ImportPath::Access accessPath,
                           VisibleDeclConsumer &consumer,
                           NLKind lookupKind);
 
@@ -567,13 +567,13 @@ public:
   /// Reports all class members in the module to the given consumer.
   ///
   /// This is intended for use with id-style lookup and code completion.
-  void lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+  void lookupClassMembers(ImportPath::Access accessPath,
                           VisibleDeclConsumer &consumer);
 
   /// Adds class members in the module with the given name to the given vector.
   ///
   /// This is intended for use with id-style lookup.
-  void lookupClassMember(ModuleDecl::AccessPathTy accessPath,
+  void lookupClassMember(ImportPath::Access accessPath,
                          DeclName name,
                          SmallVectorImpl<ValueDecl*> &results);
 
@@ -751,7 +751,7 @@ public:
   ///
   /// If the name matches the name of the current module, a shadowed module
   /// is loaded instead.
-  ModuleDecl *getModule(ArrayRef<Identifier> name, bool allowLoading = false);
+  ModuleDecl *getModule(ImportPath::Module name, bool allowLoading = false);
 
   /// Returns the generic signature for the given ID.
   GenericSignature getGenericSignature(serialization::GenericSignatureID ID);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1044,7 +1044,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());
   ModuleDecl *bridgingHeaderModule = clangImporter->getImportedHeaderModule();
-  ModuleDecl::ImportedModule bridgingHeaderImport{ModuleDecl::AccessPathTy(),
+  ModuleDecl::ImportedModule bridgingHeaderImport{ImportPath::Access(),
                                                   bridgingHeaderModule};
 
   // Make sure the bridging header module is always at the top of the import

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -251,7 +251,7 @@ void ImplicitSerializedModuleLoader::collectVisibleTopLevelModuleNames(
 }
 
 std::error_code SerializedModuleLoaderBase::openModuleDocFileIfPresent(
-  AccessPathElem ModuleID,
+  ImportPath::Element ModuleID,
   const SerializedModuleBaseName &BaseName,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) {
 
@@ -285,7 +285,7 @@ SerializedModuleLoaderBase::getModuleName(ASTContext &Ctx, StringRef modulePath,
 
 std::error_code
 SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(
-    AccessPathElem ModuleID,
+    ImportPath::Element ModuleID,
     const SerializedModuleBaseName &BaseName,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
   if (IgnoreSwiftSourceInfoFile || !ModuleSourceInfoBuffer)
@@ -324,7 +324,7 @@ SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(
 }
 
 std::error_code SerializedModuleLoaderBase::openModuleFile(
-    AccessPathElem ModuleID, const SerializedModuleBaseName &BaseName,
+    ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer) {
   llvm::vfs::FileSystem &FS = *Ctx.SourceMgr.getFileSystem();
 
@@ -416,7 +416,7 @@ llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
 }
 
 std::error_code ImplicitSerializedModuleLoader::findModuleFilesInDirectory(
-    AccessPathElem ModuleID,
+    ImportPath::Element ModuleID,
     const SerializedModuleBaseName &BaseName,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -510,7 +510,7 @@ std::string SerializedModuleBaseName::getName(file_types::ID fileTy) const {
 }
 
 bool
-SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
+SerializedModuleLoaderBase::findModule(ImportPath::Element moduleID,
            SmallVectorImpl<char> *moduleInterfacePath,
            std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
            std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
@@ -930,7 +930,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
 }
 
 bool SerializedModuleLoaderBase::canImportModule(
-    Located<Identifier> mID) {
+    ImportPath::Element mID) {
   // Look on disk.
   SmallVector<char, 0> *unusedModuleInterfacePath = nullptr;
   std::unique_ptr<llvm::MemoryBuffer> *unusedModuleBuffer = nullptr;
@@ -944,14 +944,14 @@ bool SerializedModuleLoaderBase::canImportModule(
 }
 
 bool MemoryBufferSerializedModuleLoader::canImportModule(
-    Located<Identifier> mID) {
+    ImportPath::Element mID) {
   // See if we find it in the registered memory buffers.
   return MemoryBuffers.count(mID.Item.str());
 }
 
 ModuleDecl *
 SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
-                                       ModuleDecl::AccessPathTy path) {
+                                       ImportPath::Module path) {
   // FIXME: Swift submodules?
   if (path.size() > 1)
     return nullptr;
@@ -1000,7 +1000,7 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
 ModuleDecl *
 MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
-                                               ModuleDecl::AccessPathTy path) {
+                                               ImportPath::Module path) {
   // FIXME: Swift submodules?
   if (path.size() > 1)
     return nullptr;
@@ -1070,7 +1070,7 @@ void SerializedModuleLoaderBase::loadDerivativeFunctionConfigurations(
 }
 
 std::error_code MemoryBufferSerializedModuleLoader::findModuleFilesInDirectory(
-    AccessPathElem ModuleID,
+    ImportPath::Element ModuleID,
     const SerializedModuleBaseName &BaseName,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -1179,19 +1179,19 @@ void SerializedASTFile::lookupPrecedenceGroupDirect(
     results.push_back(group);
 }
 
-void SerializedASTFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
+void SerializedASTFile::lookupVisibleDecls(ImportPath::Access accessPath,
                                            VisibleDeclConsumer &consumer,
                                            NLKind lookupKind) const {
   File.lookupVisibleDecls(accessPath, consumer, lookupKind);
 }
 
-void SerializedASTFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
+void SerializedASTFile::lookupClassMembers(ImportPath::Access accessPath,
                                            VisibleDeclConsumer &consumer) const{
   File.lookupClassMembers(accessPath, consumer);
 }
 
 void
-SerializedASTFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
+SerializedASTFile::lookupClassMember(ImportPath::Access accessPath,
                                      DeclName name,
                                      SmallVectorImpl<ValueDecl*> &decls) const {
   File.lookupClassMember(accessPath, name, decls);

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -40,10 +40,6 @@ using namespace SourceKit;
 using namespace swift;
 using namespace ide;
 
-static ModuleDecl *getModuleByFullName(ASTContext &Ctx, Identifier ModuleName) {
-  return Ctx.getModule(ImportPath::Module::Builder(ModuleName).get());
-}
-
 namespace {
 struct TextRange {
   unsigned Offset;
@@ -1012,7 +1008,7 @@ static void reportSourceAnnotations(const SourceTextInfo &IFaceInfo,
 static bool getModuleInterfaceInfo(ASTContext &Ctx, StringRef ModuleName,
                                    SourceTextInfo &Info) {
   // Load standard library so that Clang importer can use it.
-  auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
+  auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
   if (!Stdlib)
     return true;
 
@@ -1539,7 +1535,7 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
 
   // Load standard library so that Clang importer can use it.
   ASTContext &Ctx = CI.getASTContext();
-  auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
+  auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
   if (!Stdlib) {
     Error = "Cannot load stdlib.";
     Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -40,16 +40,6 @@ using namespace SourceKit;
 using namespace swift;
 using namespace ide;
 
-static ModuleDecl *getModuleByFullName(ASTContext &Ctx, StringRef ModuleName) {
-  ImportPath::Module::Builder modulePath;
-  while (!ModuleName.empty()) {
-    StringRef SubModuleName;
-    std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    modulePath.push_back(Ctx.getIdentifier(SubModuleName));
-  }
-  return Ctx.getModule(modulePath.get());
-}
-
 static ModuleDecl *getModuleByFullName(ASTContext &Ctx, Identifier ModuleName) {
   return Ctx.getModule(ImportPath::Module::Builder(ModuleName).get());
 }
@@ -1026,7 +1016,7 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx, StringRef ModuleName,
   if (!Stdlib)
     return true;
 
-  auto *M = getModuleByFullName(Ctx, ModuleName);
+  auto *M = Ctx.getModuleByName(ModuleName);
   if (!M)
     return true;
 
@@ -1555,7 +1545,7 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
     Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
-  auto *M = getModuleByFullName(Ctx, ModuleName);
+  auto *M = Ctx.getModuleByName(ModuleName);
   if (!M) {
     Error = "Cannot find the module.";
     Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -41,18 +41,17 @@ using namespace swift;
 using namespace ide;
 
 static ModuleDecl *getModuleByFullName(ASTContext &Ctx, StringRef ModuleName) {
-  SmallVector<Located<Identifier>, 4>
-      AccessPath;
+  ImportPath::Module::Builder modulePath;
   while (!ModuleName.empty()) {
     StringRef SubModuleName;
     std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    AccessPath.push_back({ Ctx.getIdentifier(SubModuleName), SourceLoc() });
+    modulePath.push_back(Ctx.getIdentifier(SubModuleName));
   }
-  return Ctx.getModule(AccessPath);
+  return Ctx.getModule(modulePath.get());
 }
 
 static ModuleDecl *getModuleByFullName(ASTContext &Ctx, Identifier ModuleName) {
-  return Ctx.getModule({ Located<Identifier>(ModuleName, SourceLoc()) });
+  return Ctx.getModule(ImportPath::Module::Builder(ModuleName).get());
 }
 
 namespace {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -91,16 +91,6 @@ typedef SwiftInterfaceGenContext::Implementation::TextReference TextReference;
 typedef SwiftInterfaceGenContext::Implementation::TextDecl TextDecl;
 typedef SwiftInterfaceGenContext::Implementation::SourceTextInfo SourceTextInfo;
 
-static ModuleDecl *getModuleByFullName(ASTContext &Ctx, StringRef ModuleName) {
-  ImportPath::Module::Builder builder;
-  while (!ModuleName.empty()) {
-    StringRef SubModuleName;
-    std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    builder.push_back(Ctx.getIdentifier(SubModuleName));
-  }
-  return Ctx.getModule(builder.get());
-}
-
 static ModuleDecl *getModuleByFullName(ASTContext &Ctx, Identifier ModuleName) {
   return Ctx.getModule(ImportPath::Module::Builder(ModuleName).get());
 }
@@ -293,7 +283,7 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx,
   }
 
   // Get the (sub)module to generate.
-  Mod = getModuleByFullName(Ctx, ModuleName);
+  Mod = Ctx.getModuleByName(ModuleName);
   if (!Mod) {
     ErrMsg = "Could not load module: ";
     ErrMsg += ModuleName;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -91,10 +91,6 @@ typedef SwiftInterfaceGenContext::Implementation::TextReference TextReference;
 typedef SwiftInterfaceGenContext::Implementation::TextDecl TextDecl;
 typedef SwiftInterfaceGenContext::Implementation::SourceTextInfo SourceTextInfo;
 
-static ModuleDecl *getModuleByFullName(ASTContext &Ctx, Identifier ModuleName) {
-  return Ctx.getModule(ImportPath::Module::Builder(ModuleName).get());
-}
-
 namespace {
 class AnnotatingPrinter : public StreamPrinter {
   SourceTextInfo &Info;
@@ -383,7 +379,7 @@ SwiftInterfaceGenContext::create(StringRef DocumentName,
   CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
 
   // Load standard library so that Clang importer can use it.
-  auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
+  auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
   if (!Stdlib) {
     ErrMsg = "Could not load the stdlib module";
     return nullptr;
@@ -443,7 +439,7 @@ SwiftInterfaceGenContext::createForTypeInterface(CompilerInvocation Invocation,
   CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
 
   // Load standard library so that Clang importer can use it.
-  auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
+  auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
   if (!Stdlib) {
     ErrorMsg = "Could not load the stdlib module";
     return nullptr;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -92,18 +92,17 @@ typedef SwiftInterfaceGenContext::Implementation::TextDecl TextDecl;
 typedef SwiftInterfaceGenContext::Implementation::SourceTextInfo SourceTextInfo;
 
 static ModuleDecl *getModuleByFullName(ASTContext &Ctx, StringRef ModuleName) {
-  SmallVector<Located<Identifier>, 4>
-      AccessPath;
+  ImportPath::Module::Builder builder;
   while (!ModuleName.empty()) {
     StringRef SubModuleName;
     std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    AccessPath.push_back({ Ctx.getIdentifier(SubModuleName), SourceLoc() });
+    builder.push_back(Ctx.getIdentifier(SubModuleName));
   }
-  return Ctx.getModule(AccessPath);
+  return Ctx.getModule(builder.get());
 }
 
 static ModuleDecl *getModuleByFullName(ASTContext &Ctx, Identifier ModuleName) {
-  return Ctx.getModule({ Located<Identifier>(ModuleName, SourceLoc()) });
+  return Ctx.getModule(ImportPath::Module::Builder(ModuleName).get());
 }
 
 namespace {

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -214,8 +214,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
   std::unique_ptr<ImplicitSerializedModuleLoader> Loader;
   ModuleDecl *Mod = nullptr;
   if (ModuleName == Ctx.StdlibModuleName.str()) {
-    Mod = Ctx.getModule(ImportPath::Module::Builder(Ctx.StdlibModuleName)
-                          .get());
+    Mod = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
   } else {
     Loader = ImplicitSerializedModuleLoader::create(Ctx);
     auto Buf = std::unique_ptr<llvm::MemoryBuffer>(

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -214,7 +214,8 @@ static void indexModule(llvm::MemoryBuffer *Input,
   std::unique_ptr<ImplicitSerializedModuleLoader> Loader;
   ModuleDecl *Mod = nullptr;
   if (ModuleName == Ctx.StdlibModuleName.str()) {
-    Mod = Ctx.getModule({ {Ctx.StdlibModuleName, SourceLoc()} });
+    Mod = Ctx.getModule(ImportPath::Module::Builder(Ctx.StdlibModuleName)
+                          .get());
   } else {
     Loader = ImplicitSerializedModuleLoader::create(Ctx);
     auto Buf = std::unique_ptr<llvm::MemoryBuffer>(

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -335,20 +335,17 @@ int main(int argc, char **argv) {
     if (Verbose)
       llvm::outs() << "Importing " << path << "... ";
 
+    swift::ImportPath::Module::Builder modulePath;
 #ifdef SWIFT_SUPPORTS_SUBMODULES
-    std::vector<swift::Located<swift::Identifier>> AccessPath;
     for (auto i = llvm::sys::path::begin(path);
          i != llvm::sys::path::end(path); ++i)
       if (!llvm::sys::path::is_separator((*i)[0]))
-          AccessPath.push_back({ CI.getASTContext().getIdentifier(*i),
-                                 swift::SourceLoc() });
+          modulePath.push_back(CI.getASTContext().getIdentifier(*i));
 #else
-    std::vector<swift::Located<swift::Identifier>> AccessPath;
-    AccessPath.push_back({ CI.getASTContext().getIdentifier(path),
-                           swift::SourceLoc() });
+    modulePath.push_back(CI.getASTContext().getIdentifier(path));
 #endif
 
-    auto Module = CI.getASTContext().getModule(AccessPath);
+    auto Module = CI.getASTContext().getModule(modulePath.get());
     if (!Module) {
       if (Verbose)
         llvm::errs() << "FAIL!\n";

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2111,13 +2111,7 @@ static int doInputCompletenessTest(StringRef SourceFilename) {
 //===----------------------------------------------------------------------===//
 
 static ModuleDecl *getModuleByFullName(ASTContext &Context, StringRef ModuleName) {
-  ImportPath::Module::Builder builder;
-  while (!ModuleName.empty()) {
-    StringRef SubModuleName;
-    std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    builder.push_back(Context.getIdentifier(SubModuleName));
-  }
-  ModuleDecl *Result = Context.getModule(builder.get());
+  ModuleDecl *Result = Context.getModuleByName(ModuleName);
   if (!Result || Result->failedToLoad())
     return nullptr;
   return Result;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2118,8 +2118,7 @@ static ModuleDecl *getModuleByFullName(ASTContext &Context, StringRef ModuleName
 }
 
 static ModuleDecl *getModuleByFullName(ASTContext &Context, Identifier ModuleName) {
-  ModuleDecl *Result = Context.getModule(
-                             ImportPath::Module::Builder(ModuleName).get());
+  ModuleDecl *Result = Context.getModuleByIdentifier(ModuleName);
   if (!Result || Result->failedToLoad())
     return nullptr;
   return Result;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2111,22 +2111,21 @@ static int doInputCompletenessTest(StringRef SourceFilename) {
 //===----------------------------------------------------------------------===//
 
 static ModuleDecl *getModuleByFullName(ASTContext &Context, StringRef ModuleName) {
-  SmallVector<Located<Identifier>, 4>
-      AccessPath;
+  ImportPath::Module::Builder builder;
   while (!ModuleName.empty()) {
     StringRef SubModuleName;
     std::tie(SubModuleName, ModuleName) = ModuleName.split('.');
-    AccessPath.push_back(
-        { Context.getIdentifier(SubModuleName), SourceLoc() });
+    builder.push_back(Context.getIdentifier(SubModuleName));
   }
-  ModuleDecl *Result = Context.getModule(AccessPath);
+  ModuleDecl *Result = Context.getModule(builder.get());
   if (!Result || Result->failedToLoad())
     return nullptr;
   return Result;
 }
 
 static ModuleDecl *getModuleByFullName(ASTContext &Context, Identifier ModuleName) {
-  ModuleDecl *Result = Context.getModule({ Located<Identifier>(ModuleName,SourceLoc()) });
+  ModuleDecl *Result = Context.getModule(
+                             ImportPath::Module::Builder(ModuleName).get());
   if (!Result || Result->failedToLoad())
     return nullptr;
   return Result;

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -480,12 +480,14 @@ DECL_NODES = [
                    is_optional=True),
          ]),
 
+    # FIXME: technically misnamed; should be "ImportPathComponent"
     Node('AccessPathComponent', kind='Syntax',
          children=[
             Child('Name', kind='IdentifierToken'),
             Child('TrailingDot', kind='PeriodToken', is_optional=True),
          ]),
 
+    # FIXME: technically misnamed; should be "ImportPath"
     Node('AccessPath', kind='SyntaxCollection', element='AccessPathComponent'),
 
     Node('ImportDecl', kind='Decl',


### PR DESCRIPTION
Currently, the use of the term "access path" in relation to imports is inconsistent. It sometimes refers to the entire chain of dotted identifiers, sometimes just to the part scoping an import to a declaration, and occasionally refers to the part that *doesn't* scope an import to a declaration. This is made worse by the use of `typedef` and `using` in many places, making semantics and invariants unclear.

This PR reforms the terminology surrounding the dotted chain of identifiers used in `import` statements, and introduces new, strong, better-documented types to avoid mistakes or confusion about them. Specifically:

* An import path (the `ImportPath` type) represents an undifferentiated chain of identifiers in an `import` statement. By providing additional information about the `ImportKind`, it can be split into its constituent parts.
* A module path (the `ImportPath::Module` type) represents the part of an import path that identifies the module or submodule being imported.
* An access path (the `ImportPath::Access` type) represents the part of the import path that identifies the declaration targeted by a scoped import.

Each of these types has appropriate invariants about its length enforced, and a corresponding `::Builder` type can be used to create a temporary. I have also added a constructor to split apart strings into `Builder` types, and refactored away some code in SourceKit that used to duplicate the `ASTContext` method for handling dotted module names.