### PR TITLE
Un-XFAIL a test that now passes

### DIFF
--- a/test/Interpreter/SDK/protocol_lookup_foreign.swift
+++ b/test/Interpreter/SDK/protocol_lookup_foreign.swift
@@ -4,11 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
-// rdar://20990451 is tracking the fix for compiling this test optimized.
-// XFAIL: swift_test_mode_optimize
-// XFAIL: swift_test_mode_optimize_size
-// XFAIL: swift_test_mode_optimize_unchecked
-
 import Foundation
 import StdlibUnittest
 


### PR DESCRIPTION
protocol_lookup_foreign exercises CF casting that used to
be broken, but now works with the new dynamic casting implementation.
