### PR TITLE
[Constraint solver] Fix backward trailing closures with ".member" expressions

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5592,9 +5592,7 @@ Expr *ExprRewriter::coerceCallArguments(
     SmallVector<LocatorPathElt, 4> path;
     auto anchor = locator.getLocatorParts(path);
     if (!path.empty() && path.back().is<LocatorPathElt::ApplyArgument>() &&
-        (anchor.isExpr(ExprKind::Call) ||
-         anchor.isExpr(ExprKind::Subscript) ||
-         anchor.isExpr(ExprKind::UnresolvedMember))) {
+        !anchor.isExpr(ExprKind::UnresolvedDot)) {
       auto locatorPtr = cs.getConstraintLocator(locator);
       assert(solution.trailingClosureMatchingChoices.count(locatorPtr) == 1);
       trailingClosureMatching = solution.trailingClosureMatchingChoices.find(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5592,7 +5592,9 @@ Expr *ExprRewriter::coerceCallArguments(
     SmallVector<LocatorPathElt, 4> path;
     auto anchor = locator.getLocatorParts(path);
     if (!path.empty() && path.back().is<LocatorPathElt::ApplyArgument>() &&
-        (anchor.isExpr(ExprKind::Call) || anchor.isExpr(ExprKind::Subscript))) {
+        (anchor.isExpr(ExprKind::Call) ||
+         anchor.isExpr(ExprKind::Subscript) ||
+         anchor.isExpr(ExprKind::UnresolvedMember))) {
       auto locatorPtr = cs.getConstraintLocator(locator);
       assert(solution.trailingClosureMatchingChoices.count(locatorPtr) == 1);
       trailingClosureMatching = solution.trailingClosureMatchingChoices.find(

--- a/test/expr/postfix/call/forward_trailing_closure_unresolved_member.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_unresolved_member.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// rdar://problem/67781123 - crash in SILGen
+
+struct Foo {
+  var title: String
+  var handler1: ((Int, String) -> Void)?
+  var handler2: (() -> Void)?
+}
+
+func take(foo: Foo) { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s42forward_trailing_closure_unresolved_member4testyy
+func test() {
+  // CHECK: function_ref @$s42forward_trailing_closure_unresolved_member4testyyFyycfU_ : $@convention(thin) () -> ()
+  take(foo: .init(title: "") {
+      print("handler2 is called")
+    })
+}


### PR DESCRIPTION
The introduction of forward-scan matching for trailing closures
(SE-0286) failed to account for unresolved member expressions,
sometimes causing a crash in SILGen. Fixes rdar://problem/67781123.
