### PR TITLE
Fix KnownSafety optimization bugs in ARCSequenceOpts

### DIFF
--- a/lib/SILOptimizer/ARC/ARCBBState.cpp
+++ b/lib/SILOptimizer/ARC/ARCBBState.cpp
@@ -137,6 +137,34 @@ void ARCBBState::initPredTopDown(ARCBBState &PredBBState) {
   PtrToTopDownState = PredBBState.PtrToTopDownState;
 }
 
+void ARCBBState::dumpBottomUpState() {
+  for (auto state : getBottomupStates()) {
+    if (!state.hasValue())
+      continue;
+    auto elem = state.getValue();
+    if (!elem.first)
+      continue;
+    llvm::dbgs() << "SILValue: ";
+    elem.first->dump();
+    llvm::dbgs() << "RefCountState: ";
+    elem.second.dump();
+  }
+}
+
+void ARCBBState::dumpTopDownState() {
+  for (auto state : getTopDownStates()) {
+    if (!state.hasValue())
+      continue;
+    auto elem = state.getValue();
+    if (!elem.first)
+      continue;
+    llvm::dbgs() << "SILValue: ";
+    elem.first->dump();
+    llvm::dbgs() << "RefCountState: ";
+    elem.second.dump();
+  }
+}
+
 //===----------------------------------------------------------------------===//
 //                               ARCBBStateInfo
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/ARC/ARCBBState.h
+++ b/lib/SILOptimizer/ARC/ARCBBState.h
@@ -137,6 +137,9 @@ public:
   /// BB. Used to create an initial state before we merge in other
   /// predecessors. This is currently a stub.
   void initPredTopDown(ARCBBState &PredBB);
+
+  void dumpBottomUpState();
+  void dumpTopDownState();
 };
 
 class ARCSequenceDataflowEvaluator::ARCBBStateInfoHandle {

--- a/lib/SILOptimizer/ARC/ARCRegionState.cpp
+++ b/lib/SILOptimizer/ARC/ARCRegionState.cpp
@@ -208,7 +208,7 @@ static bool processBlockBottomUpInsts(
       if (Op && OtherState->first == Op)
         continue;
 
-      OtherState->second.updateForSameLoopInst(I, SetFactory, AA);
+      OtherState->second.updateForSameLoopInst(I, AA);
     }
   }
 
@@ -275,7 +275,7 @@ bool ARCRegionState::processLoopBottomUp(
       continue;
 
     for (auto *I : State->getSummarizedInterestingInsts())
-      OtherState->second.updateForDifferentLoopInst(I, SetFactory, AA);
+      OtherState->second.updateForDifferentLoopInst(I, AA);
   }
 
   return false;
@@ -361,7 +361,7 @@ bool ARCRegionState::processBlockTopDown(
       if (Op && OtherState->first == Op)
         continue;
 
-      OtherState->second.updateForSameLoopInst(I, SetFactory, AA);
+      OtherState->second.updateForSameLoopInst(I, AA);
     }
   }
 
@@ -394,7 +394,7 @@ bool ARCRegionState::processLoopTopDown(
       continue;
 
     for (auto *I : State->getSummarizedInterestingInsts())
-      OtherState->second.updateForDifferentLoopInst(I, SetFactory, AA);
+      OtherState->second.updateForDifferentLoopInst(I, AA);
   }
 
   return false;

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -219,9 +219,6 @@ public:
   void removeInterestingInst(SILInstruction *I);
 
 private:
-  void processBlockBottomUpPredTerminators(
-      const LoopRegion *R, AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
   bool processBlockBottomUp(
       const LoopRegion *R, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       EpilogueARCFunctionInfo *EAFI,

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -188,6 +188,7 @@ public:
   bool processTopDown(
       AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       LoopRegionFunctionInfo *LRFI,
+      llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts,
       BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &LoopRegionState,
       ImmutablePointerSetFactory<SILInstruction> &SetFactory);
@@ -200,6 +201,7 @@ public:
       AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       EpilogueARCFunctionInfo *EAFI, LoopRegionFunctionInfo *LRFI,
       bool FreezeOwnedArgEpilogueReleases,
+      llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts,
       BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
       ImmutablePointerSetFactory<SILInstruction> &SetFactory);
@@ -227,17 +229,18 @@ private:
       ImmutablePointerSetFactory<SILInstruction> &SetFactory);
   bool processLoopBottomUp(
       const LoopRegion *R, AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
+      RCIdentityFunctionInfo *RCIA,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts);
 
   bool processBlockTopDown(
       SILBasicBlock &BB, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
       ImmutablePointerSetFactory<SILInstruction> &SetFactory);
-  bool
-  processLoopTopDown(const LoopRegion *R, ARCRegionState *State,
-                     AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
-                     ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+  bool processLoopTopDown(
+      const LoopRegion *R, ARCRegionState *State, AliasAnalysis *AA,
+      LoopRegionFunctionInfo *LRFI, RCIdentityFunctionInfo *RCIA,
+      llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts);
 
   void summarizeLoop(
       const LoopRegion *R, LoopRegionFunctionInfo *LRFI,

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -156,6 +156,7 @@ bool LoopARCPairingContext::processRegion(const LoopRegion *Region,
     }
 
     MadeChange |= MatchedPair;
+    Evaluator.saveMatchingInfo(Region);
     Evaluator.clearLoopState(Region);
     Context.DecToIncStateMap.clear();
     Context.IncToDecStateMap.clear();

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -76,6 +76,12 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
     }
   }
 
+  std::function<bool(SILInstruction *)> checkIfRefCountInstIsMatched =
+      [&DecToIncStateMap = DecToIncStateMap](SILInstruction *Inst) {
+        assert(isa<StrongReleaseInst>(Inst) || isa<ReleaseValueInst>(Inst));
+        return DecToIncStateMap.find(Inst) != DecToIncStateMap.end();
+      };
+
   // For each instruction I in BB...
   for (auto &I : BB) {
 
@@ -94,7 +100,7 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
 
     // This SILValue may be null if we were unable to find a specific RCIdentity
     // that the instruction "visits".
-    SILValue Op = Result.RCIdentity;
+    SILValue CurrentRC = Result.RCIdentity;
 
     // For all other [(SILValue, TopDownState)] we are tracking...
     for (auto &OtherState : BBState.getTopDownStates()) {
@@ -105,10 +111,12 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
       // If we visited an increment or decrement successfully (and thus Op is
       // set), if this is the state for this operand, skip it. We already
       // processed it.
-      if (Op && OtherState->first == Op)
+      if (CurrentRC && OtherState->first == CurrentRC)
         continue;
 
       OtherState->second.updateForSameLoopInst(&I, AA);
+      OtherState->second.checkAndResetKnownSafety(
+          &I, OtherState->first, checkIfRefCountInstIsMatched, RCIA, AA);
     }
   }
 
@@ -221,6 +229,12 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
       RCIA, EAFI, BBState, FreezeOwnedArgEpilogueReleases, IncToDecStateMap,
       SetFactory);
 
+  std::function<bool(SILInstruction *)> checkIfRefCountInstIsMatched =
+      [&IncToDecStateMap = IncToDecStateMap](SILInstruction *Inst) {
+        assert(isa<StrongRetainInst>(Inst) || isa<RetainValueInst>(Inst));
+        return IncToDecStateMap.find(Inst) != IncToDecStateMap.end();
+      };
+
   auto II = BB.rbegin();
   if (!isARCSignificantTerminator(&cast<TermInst>(*II))) {
     II++;
@@ -246,7 +260,7 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
 
     // This SILValue may be null if we were unable to find a specific RCIdentity
     // that the instruction "visits".
-    SILValue Op = Result.RCIdentity;
+    SILValue CurrentRC = Result.RCIdentity;
 
     // For all other (reference counted value, ref count state) we are
     // tracking...
@@ -257,10 +271,12 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
 
       // If this is the state associated with the instruction that we are
       // currently visiting, bail.
-      if (Op && OtherState->first == Op)
+      if (CurrentRC && OtherState->first == CurrentRC)
         continue;
 
       OtherState->second.updateForSameLoopInst(&I, AA);
+      OtherState->second.checkAndResetKnownSafety(
+          &I, OtherState->first, checkIfRefCountInstIsMatched, RCIA, AA);
     }
   }
 

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -363,7 +363,34 @@ ARCSequenceDataflowEvaluator::ARCSequenceDataflowEvaluator(
 bool ARCSequenceDataflowEvaluator::run(bool FreezeOwnedReleases) {
   bool NestingDetected = processBottomUp(FreezeOwnedReleases);
   NestingDetected |= processTopDown();
+
+  LLVM_DEBUG(
+      llvm::dbgs() << "*** Bottom-Up and Top-Down analysis results ***\n");
+  LLVM_DEBUG(dumpDataflowResults());
+
   return NestingDetected;
+}
+
+void ARCSequenceDataflowEvaluator::dumpDataflowResults() {
+  llvm::dbgs() << "IncToDecStateMap:\n";
+  for (auto it : IncToDecStateMap) {
+    if (!it.hasValue())
+      continue;
+    auto instAndState = it.getValue();
+    llvm::dbgs() << "Increment: ";
+    instAndState.first->dump();
+    instAndState.second.dump();
+  }
+
+  llvm::dbgs() << "DecToIncStateMap:\n";
+  for (auto it : DecToIncStateMap) {
+    if (!it.hasValue())
+      continue;
+    auto instAndState = it.getValue();
+    llvm::dbgs() << "Decrement: ";
+    instAndState.first->dump();
+    instAndState.second.dump();
+  }
 }
 
 // We put the destructor here so we don't need to expose the type of

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -108,7 +108,7 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
       if (Op && OtherState->first == Op)
         continue;
 
-      OtherState->second.updateForSameLoopInst(&I, SetFactory, AA);
+      OtherState->second.updateForSameLoopInst(&I, AA);
     }
   }
 
@@ -260,7 +260,7 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
       if (Op && OtherState->first == Op)
         continue;
 
-      OtherState->second.updateForSameLoopInst(&I, SetFactory, AA);
+      OtherState->second.updateForSameLoopInst(&I, AA);
     }
   }
 

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
@@ -108,6 +108,8 @@ private:
 
   llvm::Optional<ARCBBStateInfoHandle> getBottomUpBBState(SILBasicBlock *BB);
   llvm::Optional<ARCBBStateInfoHandle> getTopDownBBState(SILBasicBlock *BB);
+
+  void dumpDataflowResults();
 };
 
 } // end swift namespace

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -110,7 +110,8 @@ bool LoopARCSequenceDataflowEvaluator::processLoopTopDown(const LoopRegion *R) {
 
     // Then perform the dataflow.
     NestingDetected |= SubregionData.processTopDown(
-        AA, RCFI, LRFI, DecToIncStateMap, RegionStateInfo, SetFactory);
+        AA, RCFI, LRFI, UnmatchedRefCountInsts, DecToIncStateMap,
+        RegionStateInfo, SetFactory);
   }
 
   return NestingDetected;
@@ -214,8 +215,9 @@ bool LoopARCSequenceDataflowEvaluator::processLoopBottomUp(
 
     // Then perform the region optimization.
     NestingDetected |= SubregionData.processBottomUp(
-        AA, RCFI, EAFI, LRFI, FreezeOwnedArgEpilogueReleases, IncToDecStateMap,
-        RegionStateInfo, SetFactory);
+        AA, RCFI, EAFI, LRFI, FreezeOwnedArgEpilogueReleases,
+        UnmatchedRefCountInsts, IncToDecStateMap, RegionStateInfo,
+        SetFactory);
   }
 
   return NestingDetected;
@@ -284,8 +286,7 @@ void LoopARCSequenceDataflowEvaluator::dumpDataflowResults() {
   }
 }
 
-void LoopARCSequenceDataflowEvaluator::summarizeLoop(
-    const LoopRegion *R) {
+void LoopARCSequenceDataflowEvaluator::summarizeLoop(const LoopRegion *R) {
   RegionStateInfo[R]->summarize(LRFI, RegionStateInfo);
 }
 
@@ -313,4 +314,35 @@ void LoopARCSequenceDataflowEvaluator::removeInterestingInst(
     SILInstruction *I) {
   auto *Region = LRFI->getRegion(I->getParent());
   RegionStateInfo[Region]->removeInterestingInst(I);
+}
+
+// Compute if a RefCountInst was unmatched and populate in the persistent
+// UnmatchedRefCountInsts.
+// This can be done by looking up the RefCountInst in IncToDecStateMap or
+// DecToIncStateMap. If the StrongIncrement was matched to a StrongDecrement,
+// it will be found in IncToDecStateMap. If the StrongDecrement was matched to
+// a StrongIncrement, it will be found in DecToIncStateMap.
+void LoopARCSequenceDataflowEvaluator::saveMatchingInfo(const LoopRegion *R) {
+  if (R->isFunction())
+    return;
+  for (unsigned SubregionID : R->getSubregions()) {
+    auto *Subregion = LRFI->getRegion(SubregionID);
+    if (!Subregion->isBlock())
+      continue;
+    auto *RegionState = RegionStateInfo[Subregion];
+    for (auto Inst : RegionState->getSummarizedInterestingInsts()) {
+      if (isa<StrongRetainInst>(Inst) || isa<RetainValueInst>(Inst)) {
+        // unmatched if not found in IncToDecStateMap
+        if (IncToDecStateMap.find(Inst) == IncToDecStateMap.end())
+          UnmatchedRefCountInsts.insert(Inst);
+        continue;
+      }
+      if (isa<StrongReleaseInst>(Inst) || isa<ReleaseValueInst>(Inst)) {
+        // unmatched if not found in DecToIncStateMap
+        if (DecToIncStateMap.find(Inst) == DecToIncStateMap.end())
+          UnmatchedRefCountInsts.insert(Inst);
+        continue;
+      }
+    }
+  }
 }

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -252,9 +252,36 @@ LoopARCSequenceDataflowEvaluator::~LoopARCSequenceDataflowEvaluator() {
 bool LoopARCSequenceDataflowEvaluator::runOnLoop(
     const LoopRegion *R, bool FreezeOwnedArgEpilogueReleases,
     bool RecomputePostDomReleases) {
+  LLVM_DEBUG(llvm::dbgs() << "Run on region:\n");
+  LLVM_DEBUG(R->dump(true));
   bool NestingDetected = processLoopBottomUp(R, FreezeOwnedArgEpilogueReleases);
   NestingDetected |= processLoopTopDown(R);
+  LLVM_DEBUG(
+      llvm::dbgs() << "*** Bottom-Up and Top-Down analysis results ***\n");
+  LLVM_DEBUG(dumpDataflowResults());
   return NestingDetected;
+}
+
+void LoopARCSequenceDataflowEvaluator::dumpDataflowResults() {
+  llvm::dbgs() << "IncToDecStateMap:\n";
+  for (auto it : IncToDecStateMap) {
+    if (!it.hasValue())
+      continue;
+    auto instAndState = it.getValue();
+    llvm::dbgs() << "Increment: ";
+    instAndState.first->dump();
+    instAndState.second.dump();
+  }
+
+  llvm::dbgs() << "DecToIncStateMap:\n";
+  for (auto it : DecToIncStateMap) {
+    if (!it.hasValue())
+      continue;
+    auto instAndState = it.getValue();
+    llvm::dbgs() << "Decrement: ";
+    instAndState.first->dump();
+    instAndState.second.dump();
+  }
 }
 
 void LoopARCSequenceDataflowEvaluator::summarizeLoop(

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -134,6 +134,8 @@ private:
   bool processLoopTopDown(const LoopRegion *R);
   bool processLoopBottomUp(const LoopRegion *R,
                            bool FreezeOwnedArgEpilogueReleases);
+
+  void dumpDataflowResults();
 };
 
 } // end swift namespace

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -72,6 +72,9 @@ class LoopARCSequenceDataflowEvaluator {
   /// Stashed information for each region.
   llvm::DenseMap<const LoopRegion *, ARCRegionState *> RegionStateInfo;
 
+  /// Set of unmatched RefCountInsts
+  llvm::DenseSet<SILInstruction *> UnmatchedRefCountInsts;
+
 public:
   LoopARCSequenceDataflowEvaluator(
       SILFunction &F, AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
@@ -107,6 +110,10 @@ public:
 
   /// Remove \p I from the interesting instruction list of its parent block.
   void removeInterestingInst(SILInstruction *I);
+
+  /// Compute if a RefCountInst was unmatched and populate the persistent
+  /// UnmatchedRefCountInsts set.
+  void saveMatchingInfo(const LoopRegion *R);
 
   /// Clear the folding node set of the set factory we have stored internally.
   void clearSetFactory() {

--- a/lib/SILOptimizer/ARC/RCStateTransition.h
+++ b/lib/SILOptimizer/ARC/RCStateTransition.h
@@ -126,7 +126,6 @@ public:
   /// Returns a Range of Mutators. Asserts if this transition is not a mutator
   /// transition.
   mutator_range getMutators() const {
-    assert(isMutator() && "This should never be called given mutators");
     return {Mutators->begin(), Mutators->end()};
   }
 

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -903,6 +903,27 @@ void TopDownRefCountState::updateForDifferentLoopInst(
 //                             Printing Utilities
 //===----------------------------------------------------------------------===//
 
+void BottomUpRefCountState::dump() {
+  llvm::dbgs() << LatState << " "
+               << (isKnownSafe() ? "KnownSafe" : "NotKnownSafe") << " "
+               << (isCodeMotionSafe() ? "CodeMotionSafe" : "NotCodeMotionSafe")
+               << "\n";
+  llvm::dbgs() << "Matching Instructions:\n";
+  for (auto it : getInstructions()) {
+    it->dump();
+  }
+}
+void TopDownRefCountState::dump() {
+  llvm::dbgs() << LatState << " "
+               << (isKnownSafe() ? "KnownSafe" : "NotKnownSafe") << " "
+               << (isCodeMotionSafe() ? "CodeMotionSafe" : "NotCodeMotionSafe")
+               << "\n";
+  llvm::dbgs() << "Matching Instructions:\n";
+  for (auto it : getInstructions()) {
+    it->dump();
+  }
+}
+
 namespace llvm {
 
 raw_ostream &operator<<(raw_ostream &OS,
@@ -938,5 +959,4 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 
   llvm_unreachable("Unhandled LatticeState in switch.");
 }
-
 } // end namespace llvm

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -195,9 +195,7 @@ bool BottomUpRefCountState::valueCanBeUsedGivenLatticeState() const {
 
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
-bool BottomUpRefCountState::handleUser(
-    SILValue RCIdentity,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+bool BottomUpRefCountState::handleUser() {
   assert(valueCanBeUsedGivenLatticeState() &&
          "Must be able to be used at this point of the lattice.");
 
@@ -233,9 +231,7 @@ valueCanBeGuaranteedUsedGivenLatticeState() const {
 
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
-bool BottomUpRefCountState::handleGuaranteedUser(
-    SILValue RCIdentity,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+bool BottomUpRefCountState::handleGuaranteedUser() {
   assert(valueCanBeGuaranteedUsedGivenLatticeState() &&
          "Must be able to be used at this point of the lattice.");
 
@@ -270,14 +266,12 @@ bool BottomUpRefCountState::isRefCountInstMatchedToTrackedInstruction(
   if (!Transition.matchingInst(RefCountInst))
     return false;
 
-  return handleRefCountInstMatch(RefCountInst);
+  return handleRefCountInstMatch();
 }
 
 /// We have a matching ref count inst. Return true if we advance the sequence
 /// and false otherwise.
-bool
-BottomUpRefCountState::
-handleRefCountInstMatch(SILInstruction *RefCountInst) {
+bool BottomUpRefCountState::handleRefCountInstMatch() {
   // Otherwise modify the state appropriately in preparation for removing the
   // increment, decrement pair.
   switch (LatState) {
@@ -340,8 +334,7 @@ bool BottomUpRefCountState::merge(const BottomUpRefCountState &Other) {
 // the value we are tracking. If so advance the state's sequence appropriately
 // and return true. Otherwise return false.
 bool BottomUpRefCountState::handlePotentialGuaranteedUser(
-    SILInstruction *PotentialGuaranteedUser,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+    SILInstruction *PotentialGuaranteedUser, AliasAnalysis *AA) {
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
     return false;
@@ -375,7 +368,7 @@ bool BottomUpRefCountState::handlePotentialGuaranteedUser(
       FoundNonARCUser = true;
 
   // Otherwise, update the ref count state given the guaranteed user.
-  return handleGuaranteedUser(getRCRoot(), SetFactory, AA);
+  return handleGuaranteedUser();
 }
 
 /// Check if PotentialDecrement can decrement the reference count associated
@@ -408,9 +401,8 @@ bool BottomUpRefCountState::handlePotentialDecrement(
 // Check if PotentialUser could be a use of the reference counted value that
 // requires user to be alive. If so advance the state's sequence
 // appropriately and return true. Otherwise return false.
-bool BottomUpRefCountState::handlePotentialUser(
-    SILInstruction *PotentialUser,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+bool BottomUpRefCountState::handlePotentialUser(SILInstruction *PotentialUser,
+                                                AliasAnalysis *AA) {
 
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
@@ -434,12 +426,11 @@ bool BottomUpRefCountState::handlePotentialUser(
     if (mustUseValue(PotentialUser, getRCRoot(), AA))
       FoundNonARCUser = true;
 
-  return handleUser(getRCRoot(), SetFactory, AA);
+  return handleUser();
 }
 
-void BottomUpRefCountState::updateForSameLoopInst(
-    SILInstruction *I,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+void BottomUpRefCountState::updateForSameLoopInst(SILInstruction *I,
+                                                  AliasAnalysis *AA) {
   // If this state is not tracking anything, there is nothing to update.
   if (!isTrackingRefCount())
     return;
@@ -448,7 +439,7 @@ void BottomUpRefCountState::updateForSameLoopInst(
   // instruction in a way that requires us to guarantee the lifetime of the
   // pointer up to this point. This has the effect of performing a use and a
   // decrement.
-  if (handlePotentialGuaranteedUser(I, SetFactory, AA)) {
+  if (handlePotentialGuaranteedUser(I, AA)) {
     LLVM_DEBUG(llvm::dbgs() << "    Found Potential Guaranteed Use:\n        "
                             << getRCRoot());
     return;
@@ -465,15 +456,14 @@ void BottomUpRefCountState::updateForSameLoopInst(
 
   // Otherwise check if the reference counted value we are tracking
   // could be used by the given instruction.
-  if (!handlePotentialUser(I, SetFactory, AA))
+  if (!handlePotentialUser(I, AA))
     return;
   LLVM_DEBUG(llvm::dbgs() << "    Found Potential Use:\n        "
                           << getRCRoot());
 }
 
-void BottomUpRefCountState::updateForDifferentLoopInst(
-    SILInstruction *I,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+void BottomUpRefCountState::updateForDifferentLoopInst(SILInstruction *I,
+                                                       AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
     return;
@@ -483,7 +473,7 @@ void BottomUpRefCountState::updateForDifferentLoopInst(
         mayDecrementRefCount(I, getRCRoot(), AA)) {
       LLVM_DEBUG(llvm::dbgs() << "    Found potential guaranteed use:\n        "
                               << getRCRoot());
-      handleGuaranteedUser(getRCRoot(), SetFactory, AA);
+      handleGuaranteedUser();
       return;
     }
   }
@@ -491,7 +481,7 @@ void BottomUpRefCountState::updateForDifferentLoopInst(
   // We can just handle potential users normally, since if we handle the user we
   // already saw a decrement implying that we will treat this like a guaranteed
   // use.
-  if (!handlePotentialUser(I, SetFactory, AA))
+  if (!handlePotentialUser(I, AA))
     return;
   LLVM_DEBUG(llvm::dbgs() << "    Found Potential Use:\n        "
                           << getRCRoot());
@@ -585,9 +575,7 @@ bool TopDownRefCountState::valueCanBeDecrementedGivenLatticeState() const {
 
 /// If advance the state's sequence appropriately for a decrement. If we do
 /// advance return true. Otherwise return false.
-bool TopDownRefCountState::handleDecrement(
-    SILInstruction *PotentialDecrement,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory) {
+bool TopDownRefCountState::handleDecrement() {
   switch (LatState) {
   case LatticeState::Incremented:
     LatState = LatticeState::MightBeDecremented;
@@ -618,9 +606,7 @@ bool TopDownRefCountState::valueCanBeUsedGivenLatticeState() const {
 
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
-bool TopDownRefCountState::handleUser(SILInstruction *PotentialUser,
-                                      SILValue RCIdentity,
-                                      AliasAnalysis *AA) {
+bool TopDownRefCountState::handleUser() {
   assert(valueCanBeUsedGivenLatticeState() &&
          "Must be able to be used at this point of the lattice.");
 
@@ -657,10 +643,7 @@ valueCanBeGuaranteedUsedGivenLatticeState() const {
 
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
-bool TopDownRefCountState::handleGuaranteedUser(
-    SILInstruction *PotentialGuaranteedUser,
-    SILValue RCIdentity, ImmutablePointerSetFactory<SILInstruction> &SetFactory,
-    AliasAnalysis *AA) {
+bool TopDownRefCountState::handleGuaranteedUser() {
   assert(valueCanBeGuaranteedUsedGivenLatticeState() &&
          "Must be able to be used at this point of the lattice.");
   // Advance the sequence...
@@ -694,13 +677,12 @@ bool TopDownRefCountState::isRefCountInstMatchedToTrackedInstruction(
   if (!Transition.matchingInst(RefCountInst))
     return false;
 
-  return handleRefCountInstMatch(RefCountInst);
+  return handleRefCountInstMatch();
 }
 
 /// We have a matching ref count inst. Return true if we advance the sequence
 /// and false otherwise.
-bool TopDownRefCountState::
-handleRefCountInstMatch(SILInstruction *RefCountInst) {
+bool TopDownRefCountState::handleRefCountInstMatch() {
   // Otherwise modify the state appropriately in preparation for removing the
   // increment, decrement pair.
   switch (LatState) {
@@ -762,8 +744,7 @@ bool TopDownRefCountState::merge(const TopDownRefCountState &Other) {
 // the value we are tracking. If so advance the state's sequence appropriately
 // and return true. Otherwise return false.
 bool TopDownRefCountState::handlePotentialGuaranteedUser(
-    SILInstruction *PotentialGuaranteedUser,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+    SILInstruction *PotentialGuaranteedUser, AliasAnalysis *AA) {
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
     return false;
@@ -789,16 +770,14 @@ bool TopDownRefCountState::handlePotentialGuaranteedUser(
    }
 
   // Otherwise, update our step given that we have a potential decrement.
-  return handleGuaranteedUser(PotentialGuaranteedUser, getRCRoot(),
-                              SetFactory, AA);
+   return handleGuaranteedUser();
 }
 
 // Check if PotentialDecrement can decrement the reference count associated with
 // the value we are tracking. If so advance the state's sequence appropriately
 // and return true. Otherwise return false.
 bool TopDownRefCountState::handlePotentialDecrement(
-    SILInstruction *PotentialDecrement,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+    SILInstruction *PotentialDecrement, AliasAnalysis *AA) {
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
     return false;
@@ -817,7 +796,7 @@ bool TopDownRefCountState::handlePotentialDecrement(
     return false;
 
   // Otherwise, update our state given the potential decrement.
-  return handleDecrement(PotentialDecrement, SetFactory);
+  return handleDecrement();
 }
 
 // Check if PotentialUser could be a use of the reference counted value that
@@ -840,12 +819,11 @@ bool TopDownRefCountState::handlePotentialUser(SILInstruction *PotentialUser,
   if (!mayHaveSymmetricInterference(PotentialUser, getRCRoot(), AA))
     return false;
 
-  return handleUser(PotentialUser, getRCRoot(), AA);
+  return handleUser();
 }
 
-void TopDownRefCountState::updateForSameLoopInst(
-    SILInstruction *I, 
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+void TopDownRefCountState::updateForSameLoopInst(SILInstruction *I,
+                                                 AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
     return;
@@ -854,7 +832,7 @@ void TopDownRefCountState::updateForSameLoopInst(
   // instruction in a way that requires us to guarantee the lifetime of the
   // pointer up to this point. This has the effect of performing a use and a
   // decrement.
-  if (handlePotentialGuaranteedUser(I, SetFactory, AA)) {
+  if (handlePotentialGuaranteedUser(I, AA)) {
     LLVM_DEBUG(llvm::dbgs() << "    Found Potential Guaranteed Use:\n        "
                             << getRCRoot());
     return;
@@ -863,7 +841,7 @@ void TopDownRefCountState::updateForSameLoopInst(
   // Check if the instruction we are visiting could potentially decrement
   // the reference counted value we are tracking in a manner that could
   // cause us to change states. If we do change states continue...
-  if (handlePotentialDecrement(I, SetFactory, AA)) {
+  if (handlePotentialDecrement(I, AA)) {
     LLVM_DEBUG(llvm::dbgs() << "    Found Potential Decrement:\n        "
                             << getRCRoot());
     return;
@@ -877,9 +855,8 @@ void TopDownRefCountState::updateForSameLoopInst(
                           << getRCRoot());
 }
 
-void TopDownRefCountState::updateForDifferentLoopInst(
-    SILInstruction *I,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
+void TopDownRefCountState::updateForDifferentLoopInst(SILInstruction *I,
+                                                      AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
     return;
@@ -888,7 +865,7 @@ void TopDownRefCountState::updateForDifferentLoopInst(
     if (mayGuaranteedUseValue(I, getRCRoot(), AA) ||
         mayDecrementRefCount(I, getRCRoot(), AA)) {
       LLVM_DEBUG(llvm::dbgs() << "    Found potential guaranteed use!\n");
-      handleGuaranteedUser(I, getRCRoot(), SetFactory, AA);
+      handleGuaranteedUser();
       return;
     }
   }

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -188,7 +188,6 @@ public:
   /// Update this reference count's state given the instruction \p I.
   void
   updateForSameLoopInst(SILInstruction *I,
-                        ImmutablePointerSetFactory<SILInstruction> &SetFactory,
                         AliasAnalysis *AA);
 
   /// Update this reference count's state given the instruction \p I.
@@ -198,7 +197,6 @@ public:
   /// guaranteed used. We treat any uses as regular uses.
   void updateForDifferentLoopInst(
       SILInstruction *I,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory,
       AliasAnalysis *AA);
 
   /// Attempt to merge \p Other into this ref count state. Return true if we
@@ -243,16 +241,13 @@ private:
 
   /// Given the current lattice state, if we have seen a use, advance the
   /// lattice state. Return true if we do so and false otherwise.
-  bool handleUser(SILValue RCIdentity,
-                  ImmutablePointerSetFactory<SILInstruction> &SetFactory,
-                  AliasAnalysis *AA);
+  bool handleUser();
 
   /// Check if PotentialUser could be a use of the reference counted value that
   /// requires user to be alive. If so advance the state's sequence
   /// appropriately and return true. Otherwise return false.
   bool
   handlePotentialUser(SILInstruction *PotentialUser,
-                      ImmutablePointerSetFactory<SILInstruction> &SetFactory,
                       AliasAnalysis *AA);
 
   /// Returns true if given the current lattice state, do we care if the value
@@ -261,22 +256,18 @@ private:
 
   /// Given the current lattice state, if we have seen a use, advance the
   /// lattice state. Return true if we do so and false otherwise.
-  bool
-  handleGuaranteedUser(SILValue RCIdentity,
-                       ImmutablePointerSetFactory<SILInstruction> &SetFactory,
-                       AliasAnalysis *AA);
+  bool handleGuaranteedUser();
 
   /// Check if PotentialGuaranteedUser can use the reference count associated
   /// with the value we are tracking. If so advance the state's sequence
   /// appropriately and return true. Otherwise return false.
   bool handlePotentialGuaranteedUser(
       SILInstruction *User,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory,
       AliasAnalysis *AA);
 
   /// We have a matching ref count inst. Return true if we advance the sequence
   /// and false otherwise.
-  bool handleRefCountInstMatch(SILInstruction *RefCountInst);
+  bool handleRefCountInstMatch();
 };
 
 //===----------------------------------------------------------------------===//
@@ -335,7 +326,6 @@ public:
   /// Update this reference count's state given the instruction \p I.
   void
   updateForSameLoopInst(SILInstruction *I,
-                        ImmutablePointerSetFactory<SILInstruction> &SetFactory,
                         AliasAnalysis *AA);
 
   /// Update this reference count's state given the instruction \p I.
@@ -345,7 +335,6 @@ public:
   /// guaranteed used. We treat any uses as regular uses.
   void updateForDifferentLoopInst(
       SILInstruction *I,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory,
       AliasAnalysis *AA);
 
   /// Returns true if the passed in ref count inst matches the ref count inst
@@ -368,15 +357,13 @@ private:
 
   /// If advance the state's sequence appropriately for a decrement. If we do
   /// advance return true. Otherwise return false.
-  bool handleDecrement(SILInstruction *PotentialDecrement,
-                       ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+  bool handleDecrement();
 
   /// Check if PotentialDecrement can decrement the reference count associated
   /// with the value we are tracking. If so advance the state's sequence
   /// appropriately and return true. Otherwise return false.
   bool handlePotentialDecrement(
       SILInstruction *PotentialDecrement,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory,
       AliasAnalysis *AA);
 
   /// Returns true if given the current lattice state, do we care if the value
@@ -385,8 +372,7 @@ private:
 
   /// Given the current lattice state, if we have seen a use, advance the
   /// lattice state. Return true if we do so and false otherwise.
-  bool handleUser(SILInstruction *PotentialUser,
-                  SILValue RCIdentity, AliasAnalysis *AA);
+  bool handleUser();
 
   /// Check if PotentialUser could be a use of the reference counted value that
   /// requires user to be alive. If so advance the state's sequence
@@ -399,23 +385,18 @@ private:
 
   /// Given the current lattice state, if we have seen a use, advance the
   /// lattice state. Return true if we do so and false otherwise.
-  bool
-  handleGuaranteedUser(SILInstruction *PotentialGuaranteedUser,
-                       SILValue RCIdentity,
-                       ImmutablePointerSetFactory<SILInstruction> &SetFactory,
-                       AliasAnalysis *AA);
+  bool handleGuaranteedUser();
 
   /// Check if PotentialGuaranteedUser can use the reference count associated
   /// with the value we are tracking. If so advance the state's sequence
   /// appropriately and return true. Otherwise return false.
   bool handlePotentialGuaranteedUser(
       SILInstruction *PotentialGuaranteedUser,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory,
       AliasAnalysis *AA);
 
   /// We have a matching ref count inst. Return true if we advance the sequence
   /// and false otherwise.
-  bool handleRefCountInstMatch(SILInstruction *RefCountInst);
+  bool handleRefCountInstMatch();
 };
 
 // These static asserts are here for performance reasons.

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -212,6 +212,8 @@ public:
   /// Uninitialize the current state.
   void clear();
 
+  void dump();
+
 private:
   /// Return true if we *might* remove this instruction.
   ///
@@ -353,6 +355,8 @@ public:
   /// Attempt to merge \p Other into this ref count state. Return true if we
   /// succeed and false otherwise.
   bool merge(const TopDownRefCountState &Other);
+
+  void dump();
 
 private:
   /// Can we guarantee that the given reference counted value has been modified?

--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -126,6 +126,7 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-NEXT: bitcast %TSo7NSArrayC* %0 to i8*
     // CHECK-NEXT: tail call i8* @llvm.objc.retain
     // CHECK-NEXT: [[NSARRAY_ARG:%.+]] = tail call i8* @llvm.objc.retain
+    // CHECK: tail call %swift.refcounted* @swift_retain
     // CHECK: tail call swiftcc i1 @"${{.*}}isLoggingEnabled{{.*}}"()
     // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
 
@@ -136,6 +137,7 @@ func testNSObjectInterpolation(nsArray: NSArray) {
 
     // CHECK: [[EXIT]]:
     // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
+    // CHECK-NEXT: tail call void @swift_release
     // CHECK-NEXT: ret void
 
     // CHECK: [[ENABLED]]:

--- a/test/SILOptimizer/arcsequenceopts_knownsafebugs.sil
+++ b/test/SILOptimizer/arcsequenceopts_knownsafebugs.sil
@@ -1,0 +1,205 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+final class ChildCls {
+  var id: Int
+  init(_ i:Int)
+}
+
+struct S {
+  var child1 : ChildCls
+  var child2 : ChildCls
+  init()
+}
+
+class Cls {
+  var child1 : ChildCls
+  var child2 : ChildCls
+  init()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_subobject :
+// CHECK: bb0(%0 : $S):
+// CHECK:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK-LABEL: } // end sil function '$unmatched_rr_subobject'
+sil hidden @$unmatched_rr_subobject : $@convention(thin) (@owned S) -> () {
+bb0(%0 : $S):
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  %1 = struct_extract %0 : $S, #S.child1
+  strong_release %1 : $ChildCls
+  strong_retain %1 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$matched_rr_subobject :
+// CHECK: bb0(%0 : $S):
+// CHECK-NOT:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK-NEXT:   release_value %0 : $S
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]]
+// CHECK-LABEL: } // end sil function '$matched_rr_subobject'
+sil hidden @$matched_rr_subobject : $@convention(thin) (@owned S) -> () {
+bb0(%0 : $S):
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  %1 = struct_extract %0 : $S, #S.child1
+  strong_retain %1 : $ChildCls
+  strong_release %1 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_aliasing :
+// CHECK: bb0(%0 : $S, %1 : $ChildCls):
+// CHECK:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK-LABEL: } // end sil function '$unmatched_rr_aliasing'
+sil hidden @$unmatched_rr_aliasing : $@convention(thin) (@owned S, ChildCls) -> () {
+bb0(%0 : $S, %1 : $ChildCls):
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  strong_release %1 : $ChildCls
+  strong_retain %1 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$matched_rr_aliasing :
+// CHECK: bb0(%0 : $S, %1 : $ChildCls):
+// CHECK-NOT:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK-NEXT:   release_value %0 : $S
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]]
+// CHECK-LABEL: } // end sil function '$matched_rr_aliasing'
+sil hidden @$matched_rr_aliasing : $@convention(thin) (@owned S, ChildCls) -> () {
+bb0(%0 : $S, %1 : $ChildCls):
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  strong_retain %1 : $ChildCls
+  strong_release %1 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_cls_subobject :
+// CHECK: bb0(%0 : $Cls):
+// CHECK:   retain_value %0 : $Cls
+// CHECK: bb2:
+// CHECK:   release_value %0 : $Cls
+// CHECK:   release_value %0 : $Cls
+// CHECK-LABEL: } // end sil function '$unmatched_rr_cls_subobject'
+sil hidden @$unmatched_rr_cls_subobject : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  retain_value %0 : $Cls
+  br bb1
+
+bb1:
+  %1 = ref_element_addr %0 : $Cls, #Cls.child1
+  %2 = load %1 : $*ChildCls
+  strong_release %2 : $ChildCls
+  strong_retain %2 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $Cls
+  release_value %0 : $Cls
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$matched_rr_cls_subobject :
+// CHECK: bb0(%0 : $Cls):
+// CHECK-NOT:   retain_value %0 : $Cls
+// CHECK: bb2:
+// CHECK-NEXT:   release_value %0 : $Cls
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]]
+// CHECK-LABEL: } // end sil function '$matched_rr_cls_subobject'
+sil hidden @$matched_rr_cls_subobject : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  retain_value %0 : $Cls
+  br bb1
+
+bb1:
+  %1 = ref_element_addr %0 : $Cls, #Cls.child1
+  %2 = load %1 : $*ChildCls
+  strong_retain %2 : $ChildCls
+  strong_release %2 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $Cls
+  release_value %0 : $Cls
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_subobject_nested_knownsafety :
+// CHECK: bb0(%0 : $S):
+// CHECK:   retain_value %0 : $S
+// CHECK:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK-LABEL: } // end sil function '$unmatched_rr_subobject_nested_knownsafety'
+sil hidden @$unmatched_rr_subobject_nested_knownsafety : $@convention(thin) (@owned S) -> () {
+bb0(%0 : $S):
+  retain_value %0 : $S
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  %1 = struct_extract %0 : $S, #S.child1
+  strong_release %1 : $ChildCls
+  strong_retain %1 : $ChildCls
+  br bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+

--- a/test/SILOptimizer/arcsequenceopts_knownsafebugs_loop.sil
+++ b/test/SILOptimizer/arcsequenceopts_knownsafebugs_loop.sil
@@ -1,0 +1,323 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+final class ChildCls {
+  var id: Int
+  init(_ i:Int)
+}
+struct S {
+  var child1 : ChildCls
+  var child2 : ChildCls
+  init()
+}
+class Cls {
+  var child1 : ChildCls
+  var child2 : ChildCls
+  init()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_loop :
+// CHECK: bb0(%0 : $Cls):
+// CHECK:   strong_retain %0 : $Cls
+// CHECK: bb2:
+// CHECK:   strong_release %0 : $Cls
+// CHECK:   strong_release %0 : $Cls
+// CHECK-LABEL: } // end sil function '$unmatched_rr_loop'
+sil hidden @$unmatched_rr_loop : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  strong_retain %0 : $Cls
+  br bb1
+  
+bb1:
+  strong_release %0 : $Cls
+  strong_retain %0 : $Cls
+  cond_br undef, bb1, bb2
+  
+bb2:
+  strong_release %0 : $Cls
+  strong_release %0 : $Cls
+  %4 = tuple()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil hidden @$matched_rr_loop :
+// CHECK: bb0(%0 : $Cls):
+// CHECK-NOT:   strong_retain %0 : $Cls
+// CHECK: bb2:
+// CHECK-NEXT:   strong_release %0 : $Cls
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]]
+// CHECK-LABEL: } // end sil function '$matched_rr_loop'
+sil hidden @$matched_rr_loop : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  strong_retain %0 : $Cls
+  br bb1
+  
+bb1:
+  strong_retain %0 : $Cls
+  strong_release %0 : $Cls
+  cond_br undef, bb1, bb2
+  
+bb2:
+  strong_release %0 : $Cls
+  strong_release %0 : $Cls
+  %4 = tuple()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_aliasing_loop :
+// CHECK: bb0(%0 : $S, %1 : $ChildCls):
+// CHECK:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK-LABEL: } // end sil function '$unmatched_rr_aliasing_loop'
+sil hidden @$unmatched_rr_aliasing_loop : $@convention(thin) (@owned S, ChildCls) -> () {
+bb0(%0 : $S, %1 : $ChildCls):
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  strong_release %1 : $ChildCls
+  strong_retain %1 : $ChildCls
+  cond_br undef, bb1, bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$matched_rr_aliasing_loop :
+// CHECK: bb0(%0 : $S, %1 : $ChildCls):
+// CHECK-NOT:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK-NEXT:   release_value %0 : $S
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]]
+// CHECK-LABEL: } // end sil function '$matched_rr_aliasing_loop'
+sil hidden @$matched_rr_aliasing_loop : $@convention(thin) (@owned S, ChildCls) -> () {
+bb0(%0 : $S, %1 : $ChildCls):
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  strong_retain %1 : $ChildCls
+  strong_release %1 : $ChildCls
+  cond_br undef, bb1, bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_subobject_loop :
+// CHECK: bb0(%0 : $Cls):
+// CHECK:   retain_value %0 : $Cls
+// CHECK: bb2:
+// CHECK:   release_value %0 : $Cls
+// CHECK:   release_value %0 : $Cls
+// CHECK-LABEL: } // end sil function '$unmatched_rr_subobject_loop'
+sil hidden @$unmatched_rr_subobject_loop : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  retain_value %0 : $Cls
+  br bb1
+
+bb1:
+  %1 = ref_element_addr %0 : $Cls, #Cls.child1
+  %2 = load %1 : $*ChildCls
+  strong_release %2 : $ChildCls
+  strong_retain %2 : $ChildCls
+  cond_br undef, bb1, bb2
+
+bb2:
+  release_value %0 : $Cls
+  release_value %0 : $Cls
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$matched_rr_subobject_loop :
+// CHECK: bb0(%0 : $Cls):
+// CHECK-NOT:   retain_value %0 : $Cls
+// CHECK: bb2:
+// CHECK-NEXT:   release_value %0 : $Cls
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]]
+// CHECK-LABEL: } // end sil function '$matched_rr_subobject_loop'
+sil hidden @$matched_rr_subobject_loop : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  retain_value %0 : $Cls
+  br bb1
+
+bb1:
+  %1 = ref_element_addr %0 : $Cls, #Cls.child1
+  %2 = load %1 : $*ChildCls
+  strong_retain %2 : $ChildCls
+  strong_release %2 : $ChildCls
+  cond_br undef, bb1, bb2
+
+bb2:
+  release_value %0 : $Cls
+  release_value %0 : $Cls
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_subobject_nested_knownsafety_loop :
+// CHECK: bb0(%0 : $S):
+// CHECK:   retain_value %0 : $S
+// CHECK:   retain_value %0 : $S
+// CHECK: bb2:
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK:   release_value %0 : $S
+// CHECK-LABEL: } // end sil function '$unmatched_rr_subobject_nested_knownsafety_loop'
+sil hidden @$unmatched_rr_subobject_nested_knownsafety_loop : $@convention(thin) (@owned S) -> () {
+bb0(%0 : $S):
+  retain_value %0 : $S
+  retain_value %0 : $S
+  br bb1
+
+bb1:
+  %1 = struct_extract %0 : $S, #S.child1
+  strong_release %1 : $ChildCls
+  strong_retain %1 : $ChildCls
+  cond_br undef, bb1, bb2
+
+bb2:
+  release_value %0 : $S
+  release_value %0 : $S
+  release_value %0 : $S
+  %ret = tuple()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_loop_early_exit :
+// CHECK: bb1
+// CHECK:   strong_release %0 : $Cls
+// CHECK:   cond_br undef, bb3, bb2
+// CHECK: bb3:
+// CHECK:   strong_retain %0 : $Cls
+// CHECK:   cond_br undef, bb1, bb4
+// CHECK-LABEL: } // end sil function '$unmatched_rr_loop_early_exit'
+sil hidden @$unmatched_rr_loop_early_exit : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  strong_retain %0 : $Cls
+  br bb1
+  
+bb1:
+  strong_release %0 : $Cls
+  cond_br undef, bb2, bb3
+
+bb2:
+  strong_retain %0 : $Cls
+  cond_br undef, bb1, bb3
+  
+bb3:
+  strong_release %0 : $Cls
+  strong_release %0 : $Cls
+  %4 = tuple()
+  return %4 : $()
+}
+
+// This case does not get optimized by KnownSafety as well.
+// This is because the ref count state gets cleared due to non local successors while merging successors of bb1.
+// So the retain/release within the loop do not get matched. And KnownSafety outside the loop gets cleared.
+// CHECK-LABEL: sil hidden @$matched_rr_loop_early_exit :
+// CHECK: bb1
+// CHECK:   strong_retain %0 : $Cls
+// CHECK:   cond_br undef, bb3, bb2
+// CHECK: bb3:
+// CHECK:   strong_release %0 : $Cls
+// CHECK:   cond_br undef, bb1, bb4
+// CHECK-LABEL: } // end sil function '$matched_rr_loop_early_exit'
+sil hidden @$matched_rr_loop_early_exit : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  strong_retain %0 : $Cls
+  br bb1
+  
+bb1:
+  strong_retain %0 : $Cls
+  cond_br undef, bb2, bb3
+
+bb2:
+  strong_release %0 : $Cls
+  cond_br undef, bb1, bb3
+  
+bb3:
+  strong_release %0 : $Cls
+  strong_release %0 : $Cls
+  %4 = tuple()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil hidden @$unmatched_rr_loop_early_exit_allowsleaks :
+// CHECK: bb1
+// CHECK:   strong_release %0 : $Cls
+// CHECK:   cond_br undef, bb2, bb3
+// CHECK: bb2:
+// CHECK:   strong_retain %0 : $Cls
+// CHECK:   cond_br undef, bb1, bb4
+// CHECK-LABEL: } // end sil function '$unmatched_rr_loop_early_exit_allowsleaks'
+sil hidden @$unmatched_rr_loop_early_exit_allowsleaks : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  strong_retain %0 : $Cls
+  br bb1
+  
+bb1:
+  strong_release %0 : $Cls
+  cond_br undef, bb2, bb3
+
+bb2:
+  strong_retain %0 : $Cls
+  cond_br undef, bb1, bb4
+  
+bb3:
+  unreachable
+
+bb4:
+  strong_release %0 : $Cls
+  strong_release %0 : $Cls
+  %4 = tuple()
+  return %4 : $()
+}
+
+// Unlike $matched_rr_loop_early_exit this case gets optimized due to KnownSafety
+// Since AllowsLeaks is set, we do not clear ref count state on seeing the non local successor in bb1
+// CHECK-LABEL: sil hidden @$matched_rr_loop_early_exit_allowsleaks :
+// CHECK: bb1
+// CHECK-NOT:   strong_release %0 : $Cls
+// CHECK:   cond_br undef, bb2, bb3
+// CHECK: bb2:
+// CHECK-NOT:   strong_retain %0 : $Cls
+// CHECK:   cond_br undef, bb1, bb4
+// CHECK-LABEL: } // end sil function '$matched_rr_loop_early_exit_allowsleaks'
+sil hidden @$matched_rr_loop_early_exit_allowsleaks : $@convention(thin) (@owned Cls) -> () {
+bb0(%0 : $Cls):
+  strong_retain %0 : $Cls
+  br bb1
+  
+bb1:
+  strong_retain %0 : $Cls
+  cond_br undef, bb2, bb3
+
+bb2:
+  strong_release %0 : $Cls
+  cond_br undef, bb1, bb4
+  
+bb3:
+  unreachable
+
+bb4:
+  strong_release %0 : $Cls
+  strong_release %0 : $Cls
+  %4 = tuple()
+  return %4 : $()
+}


### PR DESCRIPTION
ARCSequenceOpts does KnownSafety optimization where 'KnownSafe' retain/release pairs are deleted.
A retain is 'KnownSafe' if during top down dataflow, it is preceded by another retain or non-arc use on the same RCIdentity.
A release is 'KnownSafe' if during bottom up dataflow, it is preceded by another release or non-arc use on the same RCIdentity.
This PR fixes the following two bugs in KnownSafety optimization.

a) KnownSafety bug in ARCSequenceOpts without loop support

    1: retain_value S
    2: retain_value S

    3: strong_release S.subobject
    4: strong_retain S.subobject
    5: release_value S
    6: release_value S

2 and 5 are marked as 'KnownSafe'. And currently they get paired and optimized away. 2 and 5 pairing is incorrect, this can be seen clearly expanding retain_value and release_value.
   
    1e: strong_retain S.subobject
    2e: strong_retain S.subobject
    3: strong_release S.subobject
    4: strong_retain S.subobject
    5e: strong_release S.subobject
    6e: strong_release S.subobject

The correct pairings are 2e and 3, 4 and 5e. Since RCIdentity distinguishes between S and S.subobject we can end
up with incorrect pairings and optimization with KnownSafety. This is true for any aliasing RCIdentities.

b) KnownSafety bug in ARCSequenceOpts with loop support

    bb0:
       1: strong_retain S
       2: strong_retain S
    loop:
        3: strong_release S
        4: strong_retain S
        5: cond_br undef, loop, bb2
    bb2:
       6: strong_release S
       7: strong_release S

2 and 6 are marked as 'KnownSafe'. And currently get paired and optimized away. This is incorrect and the correct pairings are 2 and 3 and 4 and 6. ARCLoopOpts computes loop summaries and uses it to only compute refcount states for CodeMotionSafe optimization in ARCSequenceOpts. The instructions in the loop have no effect on the already computed 'KnownSafe' states outside the loop.

With this PR, while doing bottom up dataflow, if we encounter an unmatched retain instruction, that can pair with a 'KnownSafe' already visited release instruction, we turn off KnownSafety if the two
RCIdentities mayAlias.
Similarly, during top down dataflow, if we encounter an unmatched release instruction, that can pair with a 'KnownSafe' already visited retain instruction, we turn off KnownSafety if the two RCIdentities mayAlias. This fixes the bugs in both ARCSequenceOpts without loop support and with loop support.

Fixes rdar://67720198 and rdar://27775427