### PR TITLE
Update VarDecl to store a potentially-compound name

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -328,7 +328,7 @@ protected:
                                 const ValueDecl *forDecl = nullptr);
 
   void appendTypeList(Type listTy, const ValueDecl *forDecl = nullptr);
-  void appendTypeListElement(Identifier name, Type elementType,
+  void appendTypeListElement(DeclName name, Type elementType,
                              ParameterTypeFlags flags,
                              const ValueDecl *forDecl = nullptr);
 

--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -233,7 +233,7 @@ public:
 
   void printEscapedStringLiteral(StringRef str);
 
-  void printName(Identifier Name,
+  void printName(DeclName Name,
                  PrintNameContext Context = PrintNameContext::Normal);
 
   void setIndent(unsigned NumSpaces) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2330,7 +2330,7 @@ class OpaqueTypeDecl;
 /// have a type, etc.
 class ValueDecl : public Decl {
   DeclName Name;
-  SourceLoc NameLoc;
+  DeclNameLoc NameLoc;
   llvm::PointerIntPair<Type, 3, OptionalEnum<AccessLevel>> TypeAndAccess;
   unsigned LocalDiscriminator = 0;
 
@@ -2380,11 +2380,11 @@ class ValueDecl : public Decl {
   friend class InterfaceTypeRequest;
   friend class CheckRedeclarationRequest;
   friend class Decl;
-  SourceLoc getLocFromSource() const { return NameLoc; }
+  SourceLoc getLocFromSource() const { return NameLoc.getBaseNameLoc(); }
 protected:
   ValueDecl(DeclKind K,
             llvm::PointerUnion<DeclContext *, ASTContext *> context,
-            DeclName name, SourceLoc NameLoc)
+            DeclName name, DeclNameLoc NameLoc)
     : Decl(K, context), Name(name), NameLoc(NameLoc) {
     Bits.ValueDecl.AlreadyInLookupTable = false;
     Bits.ValueDecl.CheckedRedeclaration = false;
@@ -2461,7 +2461,7 @@ public:
   /// Objective-C name, if used to satisfy the given requirement.
   bool canInferObjCFromRequirement(ValueDecl *requirement);
 
-  SourceLoc getNameLoc() const { return NameLoc; }
+  DeclNameLoc getNameLoc() const { return NameLoc; }
 
   bool isUsableFromInline() const;
 
@@ -2798,7 +2798,7 @@ protected:
   TypeDecl(DeclKind K, llvm::PointerUnion<DeclContext *, ASTContext *> context,
            Identifier name, SourceLoc NameLoc,
            MutableArrayRef<TypeLoc> inherited) :
-    ValueDecl(K, context, name, NameLoc), Inherited(inherited) {}
+    ValueDecl(K, context, name, DeclNameLoc(NameLoc)), Inherited(inherited) {}
 
 public:
   Identifier getName() const { return getBaseIdentifier(); }
@@ -2806,6 +2806,10 @@ public:
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
     return hasName() ? getBaseIdentifier().str() : "_";
+  }
+
+  SourceLoc getNameLoc() const {
+    return ValueDecl::getNameLoc().getBaseNameLoc();
   }
 
   /// The type of this declaration's values. For the type of the
@@ -4601,7 +4605,7 @@ private:
 
 protected:
   AbstractStorageDecl(DeclKind Kind, bool IsStatic, DeclContext *DC,
-                      DeclName Name, SourceLoc NameLoc,
+                      DeclName Name, DeclNameLoc NameLoc,
                       StorageIsMutable_t supportsMutation)
     : ValueDecl(Kind, DC, Name, NameLoc),
       ImplInfo(StorageImplInfo::getSimpleStored(supportsMutation)) {
@@ -4907,22 +4911,20 @@ protected:
   PointerUnion<PatternBindingDecl *, Stmt *, VarDecl *> Parent;
 
   VarDecl(DeclKind kind, bool isStatic, Introducer introducer,
-          bool isCaptureList, SourceLoc nameLoc, Identifier name,
+          bool isCaptureList, DeclNameLoc nameLoc, DeclName name,
           DeclContext *dc, StorageIsMutable_t supportsMutation);
 
 public:
   VarDecl(bool isStatic, Introducer introducer, bool isCaptureList,
-          SourceLoc nameLoc, Identifier name, DeclContext *dc)
+          DeclNameLoc nameLoc, DeclName name, DeclContext *dc)
     : VarDecl(DeclKind::Var, isStatic, introducer, isCaptureList, nameLoc,
               name, dc, StorageIsMutable_t(introducer == Introducer::Var)) {}
 
   SourceRange getSourceRange() const;
 
-  Identifier getName() const { return getBaseIdentifier(); }
-
-  /// Returns the string for the base name, or "_" if this is unnamed.
-  StringRef getNameStr() const {
-    return hasName() ? getBaseIdentifier().str() : "_";
+  /// Returns the string for the name, or "_" if this is unnamed.
+  StringRef getNameStr(llvm::SmallVectorImpl<char> &scratch) const {
+    return hasName() ? getName().getString(scratch) : "_";
   }
 
   /// Get the type of the variable within its context. If the context is generic,
@@ -5315,7 +5317,7 @@ class ParamDecl : public VarDecl {
   friend class DefaultArgumentExprRequest;
 
   llvm::PointerIntPair<Identifier, 1, bool> ArgumentNameAndDestructured;
-  SourceLoc ParameterNameLoc;
+  DeclNameLoc ParameterNameLoc;
   SourceLoc ArgumentNameLoc;
   SourceLoc SpecifierLoc;
 
@@ -5352,8 +5354,8 @@ class ParamDecl : public VarDecl {
 
 public:
   ParamDecl(SourceLoc specifierLoc, SourceLoc argumentNameLoc,
-            Identifier argumentName, SourceLoc parameterNameLoc,
-            Identifier parameterName, DeclContext *dc);
+            Identifier argumentName, DeclNameLoc parameterNameLoc,
+            DeclName parameterName, DeclContext *dc);
 
   /// Create a new ParamDecl identical to the first except without the interface type.
   static ParamDecl *cloneWithoutType(const ASTContext &Ctx, ParamDecl *PD);
@@ -5364,7 +5366,7 @@ public:
   }
 
   /// Retrieve the parameter (local) name for this function parameter.
-  Identifier getParameterName() const { return getName(); }
+  DeclName getParameterName() const { return getName(); }
 
   /// Retrieve the source location of the argument (API) name.
   ///
@@ -5372,7 +5374,7 @@ public:
   /// was specified separately from the parameter name.
   SourceLoc getArgumentNameLoc() const { return ArgumentNameLoc; }
 
-  SourceLoc getParameterNameLoc() const { return ParameterNameLoc; }
+  DeclNameLoc getParameterNameLoc() const { return ParameterNameLoc; }
 
   SourceLoc getSpecifierLoc() const { return SpecifierLoc; }
 
@@ -5652,7 +5654,7 @@ class SubscriptDecl : public GenericContext, public AbstractStorageDecl {
     : GenericContext(DeclContextKind::SubscriptDecl, Parent, GenericParams),
       AbstractStorageDecl(DeclKind::Subscript,
                           StaticSpelling != StaticSpellingKind::None,
-                          Parent, Name, SubscriptLoc,
+                          Parent, Name, DeclNameLoc(SubscriptLoc),
                           /*will be overwritten*/ StorageIsNotMutable),
       StaticLoc(StaticLoc), ArrowLoc(ArrowLoc),
       Indices(nullptr), ElementTy(ElementTyR) {
@@ -5687,7 +5689,7 @@ public:
   }
   
   SourceLoc getStaticLoc() const { return StaticLoc; }
-  SourceLoc getSubscriptLoc() const { return getNameLoc(); }
+  SourceLoc getSubscriptLoc() const { return getNameLoc().getBaseNameLoc(); }
   
   SourceLoc getStartLoc() const {
     return getStaticLoc().isValid() ? getStaticLoc() : getSubscriptLoc();
@@ -5876,7 +5878,7 @@ protected:
                        bool HasImplicitSelfDecl,
                        GenericParamList *GenericParams)
       : GenericContext(DeclContextKind::AbstractFunctionDecl, Parent, GenericParams),
-        ValueDecl(Kind, Parent, Name, NameLoc),
+        ValueDecl(Kind, Parent, Name, DeclNameLoc(NameLoc)),
         Body(nullptr), AsyncLoc(AsyncLoc), ThrowsLoc(ThrowsLoc) {
     setBodyKind(BodyKind::None);
     Bits.AbstractFunctionDecl.HasImplicitSelfDecl = HasImplicitSelfDecl;
@@ -5908,6 +5910,12 @@ public:
     assert(!getName().isSpecial() && "Cannot get string for special names");
     return hasName() ? getBaseIdentifier().str() : "_";
   }
+
+  /// Returns the location of the function's base name.
+  SourceLoc getBaseNameLoc() const {
+      return ValueDecl::getNameLoc().getBaseNameLoc();
+  }
+  DeclNameLoc getNameLoc() const = delete;
 
   /// Should this declaration be treated as if annotated with transparent
   /// attribute.
@@ -6692,9 +6700,13 @@ public:
   EnumCaseDecl *getParentCase() const;
 
   SourceLoc getStartLoc() const {
-    return getNameLoc();
+    return getBaseNameLoc();
   }
   SourceRange getSourceRange() const;
+  SourceLoc getBaseNameLoc() const {
+    return ValueDecl::getNameLoc().getBaseNameLoc();
+  }
+  DeclName getNameLoc() const = delete;
   
   bool hasAssociatedValues() const {
     return getParameterList() != nullptr;
@@ -6800,7 +6812,9 @@ public:
                   GenericParamList *GenericParams, 
                   DeclContext *Parent);
 
-  SourceLoc getConstructorLoc() const { return getNameLoc(); }
+  SourceLoc getConstructorLoc() const {
+      return ValueDecl::getNameLoc().getBaseNameLoc();
+  }
   SourceLoc getStartLoc() const { return getConstructorLoc(); }
   SourceRange getSourceRange() const;
 
@@ -6964,7 +6978,9 @@ public:
 
   ParamDecl **getImplicitSelfDeclStorage() { return &SelfDecl; }
 
-  SourceLoc getDestructorLoc() const { return getNameLoc(); }
+  SourceLoc getDestructorLoc() const {
+      return ValueDecl::getNameLoc().getBaseNameLoc();
+  }
   SourceLoc getStartLoc() const { return getDestructorLoc(); }
   SourceRange getSourceRange() const;
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -738,7 +738,7 @@ ERROR(expected_type_after_arrow,none,
       "expected type after '->'", ())
 ERROR(function_type_argument_label,none,
       "function types cannot have argument labels; use '_' before %0",
-      (Identifier))
+      (DeclName))
 ERROR(expected_dynamic_func_attr,none,
       "expected a dynamically_replaceable function", ())
 ERROR(async_after_throws,none,
@@ -867,7 +867,7 @@ ERROR(var_pattern_in_var,none,
       "'%select{var|let}0' cannot appear nested inside another 'var' or "
       "'let' pattern", (unsigned))
 ERROR(extra_var_in_multiple_pattern_list,none,
-      "%0 must be bound in every pattern", (Identifier))
+      "%0 must be bound in every pattern", (DeclName))
 ERROR(let_pattern_in_immutable_context,none,
       "'let' pattern cannot appear nested in an already immutable context", ())
 ERROR(specifier_must_have_type,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -114,18 +114,18 @@ NOTE(captured_value_declared_here,none,
 ERROR(escaping_inout_capture,none,
       SELECT_ESCAPING_CLOSURE_KIND
       " captures 'inout' parameter %1",
-      (unsigned, Identifier))
+      (unsigned, DeclName))
 NOTE(inout_param_defined_here,none,
-     "parameter %0 is declared 'inout'", (Identifier))
+     "parameter %0 is declared 'inout'", (DeclName))
 ERROR(escaping_mutable_self_capture,none,
       SELECT_ESCAPING_CLOSURE_KIND
       " captures mutating 'self' parameter", (unsigned))
 
 ERROR(escaping_noescape_param_capture,none,
       SELECT_ESCAPING_CLOSURE_KIND
-      " captures non-escaping parameter %1", (unsigned, Identifier))
+      " captures non-escaping parameter %1", (unsigned, DeclName))
 NOTE(noescape_param_defined_here,none,
-     "parameter %0 is implicitly non-escaping", (Identifier))
+     "parameter %0 is implicitly non-escaping", (DeclName))
 
 ERROR(escaping_noescape_var_capture,none,
       SELECT_ESCAPING_CLOSURE_KIND
@@ -133,7 +133,7 @@ ERROR(escaping_noescape_var_capture,none,
 
 NOTE(value_captured_here,none,"captured here", ())
 
-NOTE(copy_inout_captured_by_autoclosure,none, "pass a copy of %0", (Identifier))
+NOTE(copy_inout_captured_by_autoclosure,none, "pass a copy of %0", (DeclName))
 
 NOTE(copy_self_captured_by_autoclosure,none, "pass a copy of 'self'", ())
 
@@ -180,7 +180,7 @@ ERROR(self_use_before_fully_init,none,
       "'self' used in %select{method call|property access}1 %0 before "
       "%select{all stored properties are initialized|"
       "'super.init' call|"
-      "'self.init' call}2", (DeclBaseName, bool, unsigned))
+      "'self.init' call}2", (DeclName, bool, unsigned))
 ERROR(use_of_self_before_fully_init,none,
       "'self' used before all stored properties are initialized", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -250,7 +250,7 @@ ERROR(cannot_pass_rvalue_inout,none,
       "cannot pass immutable value of type %0 as inout argument",
       (Type))
 ERROR(cannot_provide_default_value_inout,none,
-      "cannot provide default value to inout parameter %0", (Identifier))
+      "cannot provide default value to inout parameter %0", (DeclName))
 
 ERROR(cannot_call_with_params, none,
       "cannot invoke %select{|initializer for type }2'%0' with an argument list"
@@ -558,11 +558,11 @@ ERROR(expression_unused_keypath_result,none,
       "result of key path is unused", ())
 ERROR(expr_keypath_non_objc_property,none,
       "argument of '#keyPath' refers to non-'@objc' property %0",
-      (Identifier))
+      (DeclName))
 WARNING(expr_keypath_swift3_objc_inference,none,
         "argument of '#keyPath' refers to property %0 in %1 that depends on "
         "'@objc' inference deprecated in Swift 4",
-        (Identifier, Identifier))
+        (DeclName, Identifier))
 ERROR(expr_keypath_type_of_property,none,
       "cannot refer to type member %0 within instance of type %1",
       (DeclNameRef, Type))
@@ -1140,7 +1140,7 @@ ERROR(cannot_pass_inout_arg_to_subscript,none,
 ERROR(incorrect_property_wrapper_reference,none,
       "cannot convert value %0 of type %1 to expected type %2, "
       "use %select{wrapper|wrapped value}3 instead",
-      (Identifier, Type, Type, bool))
+      (DeclName, Type, Type, bool))
 ERROR(incorrect_property_wrapper_reference_member,none,
       "referencing %0 %1 requires %select{wrapper|wrapped value of type}2 %3",
       (DescriptiveDeclKind, DeclName, bool, Type))
@@ -1461,15 +1461,15 @@ ERROR(unavailable_method_non_objc_protocol,none,
       ())
 ERROR(missing_in_class_init_1,none,
       "stored property %0 requires an initial value%select{| or should be "
-      "@NSManaged}1", (Identifier, bool))
+      "@NSManaged}1", (DeclName, bool))
 ERROR(missing_in_class_init_2,none,
       "stored properties %0 and %1 require initial values%select{| or should "
       "be @NSManaged}2",
-      (Identifier, Identifier, bool))
+      (DeclName, DeclName, bool))
 ERROR(missing_in_class_init_3plus,none,
       "stored properties %0, %1, %select{and %2|%2, and others}3 "
       "require initial values%select{| or should be @NSManaged}4",
-      (Identifier, Identifier, Identifier, bool, bool))
+      (DeclName, DeclName, DeclName, bool, bool))
 NOTE(requires_stored_property_inits_here,none,
      "%select{superclass|class}1 %0 requires all stored properties to have "
      "initial values%select{| or use @NSManaged}2", (Type, bool, bool))
@@ -1478,15 +1478,15 @@ ERROR(class_without_init,none,
 NOTE(note_no_in_class_init_1,none,
      "stored property %0 without initial value prevents synthesized "
      "initializers",
-     (Identifier))
+     (DeclName))
 NOTE(note_no_in_class_init_2,none,
      "stored properties %0 and %1 without initial values prevent synthesized "
      "initializers",
-     (Identifier, Identifier))
+     (DeclName, DeclName))
 NOTE(note_no_in_class_init_3plus,none,
      "stored properties %0, %1, %select{and %2|%2, and others}3 "
      "without initial values prevent synthesized initializers",
-     (Identifier, Identifier, Identifier, bool))
+     (DeclName, DeclName, DeclName, bool))
 ERROR(missing_unimplemented_init_runtime,none,
       "standard library error: missing _unimplementedInitializer", ())
 ERROR(missing_undefined_runtime,none,
@@ -1512,7 +1512,7 @@ NOTE(inherited_default_param_here,none,
 
 WARNING(option_set_zero_constant,none,
         "static property %0 produces an empty option set",
-        (Identifier))
+        (DeclName))
 NOTE(option_set_empty_set_init,none,
      "use [] to silence this warning", ())
 
@@ -1803,7 +1803,7 @@ ERROR(extension_specialization,none,
 ERROR(extension_stored_property,none,
       "extensions must not contain stored properties", ())
 NOTE(extension_stored_property_fixit,none,
-     "Remove '=' to make %0 a computed property", (Identifier))
+     "Remove '=' to make %0 a computed property", (DeclName))
 ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0",
       (Identifier))
@@ -2461,7 +2461,7 @@ ERROR(override_accessor_less_available,none,
 
 ERROR(override_let_property,none,
       "cannot override immutable 'let' property %0 with the getter of a 'var'",
-      (Identifier))
+      (DeclName))
 
 
 ERROR(override_not_accessible,none,
@@ -2508,7 +2508,7 @@ ERROR(nonoverride_and_override_attr,none,
       "'override' cannot be combined with '@_nonoverride'", ())
 ERROR(override_property_type_mismatch,none,
       "property %0 with type %1 cannot override a property with type %2",
-      (Identifier, Type, Type))
+      (DeclName, Type, Type))
 ERROR(override_with_stored_property,none,
       "cannot override with a stored property %0", (Identifier))
 WARNING(override_with_stored_property_warn,none,
@@ -2566,7 +2566,7 @@ NOTE(override_unnecessary_IUO_silence,none,
 
 ERROR(override_mutable_covariant_property,none,
       "cannot override mutable property %0 of type %1 with covariant type %2",
-      (Identifier, Type, Type))
+      (DeclName, Type, Type))
 ERROR(override_mutable_covariant_subscript,none,
       "cannot override mutable subscript of type %0 with covariant type %1",
       (Type, Type))
@@ -2822,7 +2822,7 @@ WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
       "stored property %0 has no derivative because %1 does not conform to "
       "'Differentiable'; add an explicit '@noDerivative' attribute"
       "%select{|, or conform %2 to 'AdditiveArithmetic'}3",
-      (/*propName*/ Identifier, /*propType*/ Type, /*nominalName*/ Identifier,
+      (/*propName*/ DeclName, /*propType*/ Type, /*nominalName*/ DeclName,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_immutable_wrapper_implicit_noderivative_fixit,none,
       "synthesis of the 'Differentiable.move(along:)' requirement for %1 "
@@ -3135,9 +3135,9 @@ ERROR(derivative_attr_result_value_not_differentiable,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
       "tuple; first element type %0 must conform to 'Differentiable'", (Type))
 ERROR(derivative_attr_result_func_type_mismatch,none,
-      "function result's %0 type does not match %1", (Identifier, DeclName))
+      "function result's %0 type does not match %1", (DeclName, DeclName))
 NOTE(derivative_attr_result_func_type_mismatch_note,none,
-     "%0 does not have expected type %1", (Identifier, Type))
+     "%0 does not have expected type %1", (DeclName, Type))
 NOTE(derivative_attr_result_func_original_note,none,
      "%0 defined here", (DeclName))
 ERROR(derivative_attr_not_in_same_file_as_original,none,
@@ -3551,12 +3551,12 @@ ERROR(implicit_use_of_self_in_closure,none,
 
 WARNING(recursive_accessor_reference,none,
         "attempting to %select{access|modify}1 %0 within its own "
-        "%select{getter|setter}1", (Identifier, bool))
+        "%select{getter|setter}1", (DeclName, bool))
 NOTE(recursive_accessor_reference_silence,none,
      "access 'self' explicitly to silence this warning", ())
 WARNING(store_in_willset,none,
         "attempting to store to property %0 within its own willSet, which is "
-        "about to be overwritten by the new value", (Identifier))
+        "about to be overwritten by the new value", (DeclName))
 
 ERROR(value_of_module_type,none,
       "expected module member name after module name", ())
@@ -3684,22 +3684,22 @@ NOTE(silence_debug_description_in_interpolation_segment_call,none,
 
 NOTE(noescape_parameter,none,
     "parameter %0 is implicitly non-escaping",
-     (Identifier))
+     (DeclName))
 NOTE(generic_parameters_always_escaping,none,
      "generic parameters are always considered '@escaping'", ())
 
 ERROR(passing_noescape_to_escaping,none,
       "passing non-escaping parameter %0 to function expecting an @escaping closure",
-      (Identifier))
+      (DeclName))
 ERROR(converting_noespace_param_to_generic_type,none,
       "converting non-escaping parameter %0 to generic parameter %1 may allow it to escape",
-      (Identifier, Type))
+      (DeclName, Type))
 ERROR(assigning_noescape_to_escaping,none,
       "assigning non-escaping parameter %0 to an @escaping closure",
-      (Identifier))
+      (DeclName))
 ERROR(general_noescape_to_escaping,none,
       "using non-escaping parameter %0 in a context expecting an @escaping closure",
-      (Identifier))
+      (DeclName))
 ERROR(converting_noescape_to_type,none,
       "converting non-escaping value to %0 may allow it to escape",
       (Type))
@@ -3828,7 +3828,7 @@ ERROR(fallthrough_from_last_case,none,
       "'fallthrough' without a following 'case' or 'default' block", ())
 ERROR(fallthrough_into_case_with_var_binding,none,
       "'fallthrough' from a case which doesn't bind variable %0",
-      (Identifier))
+      (DeclName))
 
 ERROR(unnecessary_cast_over_optionset,none,
       "unnecessary cast over raw value of %0", (Type))
@@ -3944,7 +3944,7 @@ NOTE(enum_element_pattern_assoc_values_remove,none,
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))
 ERROR(tuple_pattern_label_mismatch,none,
-      "tuple pattern element label %0 must be %1", (Identifier, Identifier))
+      "tuple pattern element label %0 must be %1", (DeclName, DeclName))
 ERROR(enum_element_pattern_member_not_found,none,
       "enum case %0 not found in type %1", (DeclNameRef, Type))
 ERROR(optional_element_pattern_not_valid_type,none,
@@ -3959,20 +3959,20 @@ ERROR(ambiguous_enum_pattern_type,none,
       "when matching value of type %1", (Type, Type))
 WARNING(type_inferred_to_undesirable_type,none,
         "%select{variable|constant}2 %0 inferred to have type %1, "
-        "which may be unexpected", (Identifier, Type, bool))
+        "which may be unexpected", (DeclName, Type, bool))
 WARNING(type_inferred_to_uninhabited_type,none,
         "%select{variable|constant}2 %0 inferred to have type %1, "
-        "which is an enum with no cases", (Identifier, Type, bool))
+        "which is an enum with no cases", (DeclName, Type, bool))
 WARNING(type_inferred_to_uninhabited_tuple_type,none,
         "%select{variable|constant}2 %0 inferred to have type %1, "
-        "which contains an enum with no cases", (Identifier, Type, bool))
+        "which contains an enum with no cases", (DeclName, Type, bool))
 NOTE(add_explicit_type_annotation_to_silence,none,
      "add an explicit type annotation to silence this warning", ())
 
 WARNING(unowned_assignment_immediate_deallocation,none,
         "instance will be immediately deallocated because "
         "%select{variable|property}2 %0 is %1",
-        (Identifier, ReferenceOwnership, /*Is Property*/unsigned))
+        (DeclName, ReferenceOwnership, /*Is Property*/unsigned))
 NOTE(unowned_assignment_requires_strong,none,
      "a strong reference is required to prevent the instance from being "
      "deallocated", ())
@@ -4999,37 +4999,37 @@ ERROR(specialize_attr_unsupported_kind_of_req,none,
 WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
-        (Identifier))
+        (DeclName))
 WARNING(unused_setter_parameter, none,
         "setter argument %0 was never used, but the property was accessed",
-        (Identifier))
+        (DeclName))
 NOTE(fixit_for_unused_setter_parameter, none,
-     "did you mean to use %0 instead of accessing the property's current value?", (Identifier))
+     "did you mean to use %0 instead of accessing the property's current value?", (DeclName))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"
         "; consider replacing with assignment to '_' or removing it",
-        (Identifier, unsigned))
+        (DeclName, unsigned))
 
 
 WARNING(capture_never_used, none,
         "capture %0 was never used",
-        (Identifier))
+        (DeclName))
 
 WARNING(variable_never_used, none,
         "%select{variable|immutable value}1 %0 was never used; "
         "consider replacing with '_' or removing it",
-        (Identifier, unsigned))
+        (DeclName, unsigned))
 WARNING(immutable_value_never_used_but_assigned, none,
         "immutable value %0 was never used; consider removing it",
-        (Identifier))
+        (DeclName))
 WARNING(variable_never_mutated, none,
         "variable %0 was never mutated; "
         "consider %select{removing 'var' to make it|changing to 'let'}1 constant",
-        (Identifier, bool))
+        (DeclName, bool))
 WARNING(variable_never_read, none,
         "variable %0 was written to, but never read",
-        (Identifier))
+        (DeclName))
 WARNING(observe_keypath_property_not_objc_dynamic, none,
         "passing reference to non-'@objc dynamic' property %0 to KVO method %1 "
         "may lead to unexpected behavior or runtime trap", (DeclName, DeclName))
@@ -5037,10 +5037,10 @@ WARNING(observe_keypath_property_not_objc_dynamic, none,
 WARNING(default_magic_identifier_mismatch, none,
         "parameter %0 with default argument '%1' passed to parameter %2, whose "
         "default argument is '%3'",
-        (Identifier, StringRef, Identifier, StringRef))
+        (DeclName, StringRef, DeclName, StringRef))
 NOTE(change_caller_default_to_match_callee, none,
      "did you mean for parameter %0 to default to '%1'?",
-     (Identifier, StringRef))
+     (DeclName, StringRef))
 NOTE(silence_default_magic_identifier_mismatch, none,
      "add parentheses to silence this warning", ())
 
@@ -5157,16 +5157,16 @@ ERROR(property_wrapper_computed, none,
 ERROR(property_with_wrapper_conflict_attribute,none,
       "property %0 with a wrapper cannot also be "
       "%select{lazy|@NSCopying|@NSManaged|weak|unowned|unmanaged}1",
-      (Identifier, int))
+      (DeclName, int))
 ERROR(property_wrapper_not_single_var, none,
       "property wrapper can only apply to a single variable", ())
 ERROR(property_with_wrapper_in_bad_context,none,
       "%select{|non-static |non-static }1property %0 declared inside "
       "%select{a protocol|an extension|an enum}1 cannot have a wrapper",
-      (Identifier, int))
+      (DeclName, int))
 ERROR(property_with_wrapper_overrides,none,
       "property %0 with attached wrapper cannot override another property",
-      (Identifier))
+      (DeclName))
 
 NOTE(property_wrapper_direct_init,none,
      "initialize the property wrapper type directly with "

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -526,6 +526,13 @@ public:
   bool isOperator() const {
     return getBaseName().isOperator();
   }
+
+  /// Determines whether the \c DeclName is empty. Note that if the name
+  /// contains argument labels it is always considered non-empty, even if the
+  /// labels themselves are all empty.
+  bool empty() const {
+    return isSimpleName() && getBaseName().empty();
+  }
   
   /// True if this name should be found by a decl ref or member ref under the
   /// name specified by 'refName'.

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -151,7 +151,7 @@ public:
 
   /// Returns the name directly bound by this pattern, or the null
   /// identifier if the pattern does not bind a name directly.
-  Identifier getBoundName() const;
+  DeclName getBoundName() const;
 
   /// If this pattern binds a single variable without any
   /// destructuring or conditionalizing, return that variable.
@@ -270,21 +270,21 @@ public:
 /// The Init and DefArgKind fields are only used in argument lists for
 /// functions.  They are not parsed as part of normal pattern grammar.
 class TuplePatternElt {
-  Identifier Label;
-  SourceLoc LabelLoc;
+  DeclName Label;
+  DeclNameLoc LabelLoc;
   Pattern *ThePattern;
 
 public:
   TuplePatternElt() = default;
   explicit TuplePatternElt(Pattern *P) : ThePattern(P) {}
 
-  TuplePatternElt(Identifier Label, SourceLoc LabelLoc, Pattern *p)
+  TuplePatternElt(DeclName Label, DeclNameLoc LabelLoc, Pattern *p)
     : Label(Label), LabelLoc(LabelLoc), ThePattern(p) {}
 
-  Identifier getLabel() const { return Label; }
-  SourceLoc getLabelLoc() const { return LabelLoc; }
-  void setLabel(Identifier I, SourceLoc Loc) {
-    Label = I;
+  DeclName getLabel() const { return Label; }
+  DeclNameLoc getLabelLoc() const { return LabelLoc; }
+  void setLabel(DeclName N, DeclNameLoc Loc) {
+    Label = N;
     LabelLoc = Loc;
   }
 
@@ -364,8 +364,10 @@ public:
   }
 
   VarDecl *getDecl() const { return Var; }
-  Identifier getBoundName() const;
-  StringRef getNameStr() const { return Var->getNameStr(); }
+  DeclName getBoundName() const;
+  StringRef getNameStr(llvm::SmallVectorImpl<char> &scratch) const {
+      return Var->getNameStr(scratch);
+  }
 
   SourceLoc getLoc() const { return Var->getLoc(); }
   SourceRange getSourceRange() const { return Var->getSourceRange(); }

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -673,10 +673,10 @@ private:
 
 /// A parsed element within a tuple type.
 struct TupleTypeReprElement {
-  Identifier Name;
-  SourceLoc NameLoc;
-  Identifier SecondName;
-  SourceLoc SecondNameLoc;
+  DeclName Name;
+  DeclNameLoc NameLoc;
+  DeclName SecondName;
+  DeclNameLoc SecondNameLoc;
   SourceLoc UnderscoreLoc;
   SourceLoc ColonLoc;
   TypeRepr *Type;
@@ -737,17 +737,17 @@ public:
     return getElements()[i];
   }
 
-  void getElementNames(SmallVectorImpl<Identifier> &Names) {
+  void getElementNames(SmallVectorImpl<DeclName> &Names) {
     for (auto &Element : getElements()) {
       Names.push_back(Element.Name);
     }
   }
 
-  Identifier getElementName(unsigned i) const {
+  DeclName getElementName(unsigned i) const {
     return getElement(i).Name;
   }
 
-  SourceLoc getElementNameLoc(unsigned i) const {
+  DeclNameLoc getElementNameLoc(unsigned i) const {
     return getElement(i).NameLoc;
   }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2047,7 +2047,7 @@ public:
 /// TupleTypeElt - This represents a single element of a tuple.
 class TupleTypeElt {
   /// An optional name for the field.
-  Identifier Name;
+  DeclName Name;
 
   /// This is the type of the field.
   Type ElementType;
@@ -2059,11 +2059,11 @@ class TupleTypeElt {
   
 public:
   TupleTypeElt() = default;
-  TupleTypeElt(Type ty, Identifier name = Identifier(),
+  TupleTypeElt(Type ty, DeclName name = DeclName(),
                ParameterTypeFlags fl = {});
   
   bool hasName() const { return !Name.empty(); }
-  Identifier getName() const { return Name; }
+  DeclName getName() const { return Name; }
   
   Type getRawType() const { return ElementType; }
   Type getType() const;
@@ -2087,10 +2087,10 @@ public:
   TupleTypeElt getWithType(Type T) const;
 
   /// Retrieve a copy of this tuple type element with the name replaced.
-  TupleTypeElt getWithName(Identifier name) const;
+  TupleTypeElt getWithName(DeclName name) const;
 
   /// Retrieve a copy of this tuple type element with no name
-  TupleTypeElt getWithoutName() const { return getWithName(Identifier()); }
+  TupleTypeElt getWithoutName() const { return getWithName(DeclName()); }
 };
 
 inline Type getTupleEltType(const TupleTypeElt &elt) {
@@ -2143,7 +2143,7 @@ public:
   
   /// getNamedElementId - If this tuple has an element with the specified name,
   /// return the element index, otherwise return -1.
-  int getNamedElementId(Identifier I) const;
+  int getNamedElementId(DeclName N) const;
   
   /// Returns true if this tuple has inout, __shared or __owned elements.
   bool hasElementWithOwnership() const {
@@ -5988,7 +5988,7 @@ inline Type TupleTypeElt::getVarargBaseTy() const {
   return T;
 }
 
-inline TupleTypeElt TupleTypeElt::getWithName(Identifier name) const {
+inline TupleTypeElt TupleTypeElt::getWithName(DeclName name) const {
   assert(getParameterFlags().isInOut() == getType()->is<InOutType>());
   return TupleTypeElt(getRawType(), name, getParameterFlags());
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1382,9 +1382,12 @@ public:
   Optional<SILDebugVariable> get(VarDecl *VD, const char *buf) const {
     if (!Bits.Data.HasValue)
       return None;
-    if (VD)
-      return SILDebugVariable(VD->getName().empty() ? "" : VD->getName().str(),
-                              VD->isLet(), getArgNo());
+    if (VD) {
+      // TODO(Compound variable names)
+      assert(VD->getName().isSimpleName());
+      auto nameStr = VD->getName().empty() ? "" : VD->getBaseIdentifier().str();
+      return SILDebugVariable(nameStr, VD->isLet(), getArgNo());
+    }
     else
       return SILDebugVariable(getName(buf), isLet(), getArgNo());
   }

--- a/include/swift/SILOptimizer/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Differentiation/Common.h
@@ -254,7 +254,8 @@ inline void createEntryArguments(SILFunction *f) {
     // Necessary to prevent crash during argument explosion optimization.
     auto loc = f->getLocation().getSourceLoc();
     auto *decl = new (ctx)
-        ParamDecl(loc, loc, Identifier(), loc, Identifier(), moduleDecl);
+        ParamDecl(loc, loc, Identifier(), DeclNameLoc(loc), Identifier(),
+                  moduleDecl);
     decl->setSpecifier(ParamDecl::Specifier::Default);
     entry->createFunctionArgument(type, decl);
   };

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2454,7 +2454,8 @@ void TupleType::Profile(llvm::FoldingSetNodeID &ID,
                         ArrayRef<TupleTypeElt> Fields) {
   ID.AddInteger(Fields.size());
   for (const TupleTypeElt &Elt : Fields) {
-    ID.AddPointer(Elt.Name.get());
+    llvm::SmallString<32> scratch;
+    ID.AddString(Elt.Name.getString(scratch));
     ID.AddPointer(Elt.getType().getPointer());
     ID.AddInteger(Elt.Flags.toRaw());
   }
@@ -2515,7 +2516,7 @@ Type TupleType::get(ArrayRef<TupleTypeElt> Fields, const ASTContext &C) {
   return New;
 }
 
-TupleTypeElt::TupleTypeElt(Type ty, Identifier name,
+TupleTypeElt::TupleTypeElt(Type ty, DeclName name,
                            ParameterTypeFlags fl)
   : Name(name), ElementType(ty), Flags(fl) {
   if (fl.isInOut())
@@ -3045,10 +3046,11 @@ void AnyFunctionType::decomposeInput(
   case TypeKind::Tuple: {
     auto tupleTy = cast<TupleType>(type.getPointer());
     for (auto &elt : tupleTy->getElements()) {
+      assert(elt.getName().isSimpleName());
       result.emplace_back((elt.isVararg()
                            ? elt.getVarargBaseTy()
                            : elt.getRawType()),
-                          elt.getName(),
+                          elt.getName().getBaseIdentifier(),
                           elt.getParameterFlags());
     }
     return;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2347,7 +2347,8 @@ void ASTMangler::appendTypeList(Type listTy, const ValueDecl *forDecl) {
     bool firstField = true;
     for (auto &field : tuple->getElements()) {
       assert(field.getParameterFlags().isNone());
-      appendTypeListElement(field.getName(), field.getRawType(),
+      appendTypeListElement(field.getName().getBaseIdentifier(),
+                            field.getRawType(),
                             ParameterTypeFlags(),
                             forDecl);
       appendListSeparator(firstField);
@@ -2358,7 +2359,7 @@ void ASTMangler::appendTypeList(Type listTy, const ValueDecl *forDecl) {
   }
 }
 
-void ASTMangler::appendTypeListElement(Identifier name, Type elementType,
+void ASTMangler::appendTypeListElement(DeclName name, Type elementType,
                                        ParameterTypeFlags flags,
                                        const ValueDecl *forDecl) {
   if (auto *fnType = elementType->getAs<FunctionType>())
@@ -2380,8 +2381,11 @@ void ASTMangler::appendTypeListElement(Identifier name, Type elementType,
     appendOperator("n");
     break;
   }
+  // TODO(Compound variable names): Need to decide whether and how to mangle
+  // compound names in type lists (e.g., compound-named tuple elements)
+  assert(name.isSimpleName());
   if (!name.empty())
-    appendIdentifier(name.str());
+    appendIdentifier(name.getBaseIdentifier().str());
   if (flags.isVariadic())
     appendOperator("d");
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -473,7 +473,8 @@ static bool escapeKeywordInContext(StringRef keyword, PrintNameContext context){
   llvm_unreachable("Unhandled PrintNameContext in switch.");
 }
 
-void ASTPrinter::printName(Identifier Name, PrintNameContext Context) {
+void ASTPrinter::printName(DeclName Name, PrintNameContext Context) {
+  assert(!Name.isSpecial());
   callPrintNamePre(Context);
 
   if (Name.empty()) {
@@ -482,11 +483,15 @@ void ASTPrinter::printName(Identifier Name, PrintNameContext Context) {
     return;
   }
 
-  bool shouldEscapeKeyword = escapeKeywordInContext(Name.str(), Context);
+  // TODO(Compound variable names): We'll need to handle escaped keywords
+  // differently...
+  assert(Name.isSimpleName());
+  auto nameStr = Name.getBaseIdentifier().str();
+  bool shouldEscapeKeyword = escapeKeywordInContext(nameStr, Context);
 
   if (shouldEscapeKeyword)
     *this << "`";
-  *this << Name.str();
+  *this << nameStr;
   if (shouldEscapeKeyword)
     *this << "`";
 
@@ -5047,7 +5052,7 @@ void swift::printEnumElementsAsCases(
     for (auto i = PL->begin(); i != PL->end(); ++i) {
       auto *param = *i;
       if (param->hasName()) {
-        OS << tok::kw_let << " " << param->getName().str();
+        OS << tok::kw_let << " " << param->getName();
       } else {
         OS << "_";
       }

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -749,12 +749,12 @@ AbstractFunctionDeclScope::getParmsSourceLocOfAFD(AbstractFunctionDecl *decl) {
     return c->getParameters()->getLParenLoc();
 
   if (auto *dd = dyn_cast<DestructorDecl>(decl))
-    return dd->getNameLoc();
+    return dd->getDestructorLoc();
 
   auto *fd = cast<FuncDecl>(decl);
   // clang-format off
   return isa<AccessorDecl>(fd) ? fd->getLoc()
-       : fd->isDeferBody()     ? fd->getNameLoc()
+       : fd->isDeferBody()     ? fd->getBaseNameLoc()
        :                         fd->getParameters()->getLParenLoc();
   // clang-format on
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -485,7 +485,7 @@ static std::string getDifferentiationParametersClauseString(
       switch (parameterKind) {
       // Print differentiability parameters by name.
       case DifferentiationParameterKind::Differentiability:
-        printer << function->getParameters()->get(index)->getName().str();
+        printer << function->getParameters()->get(index)->getName();
         break;
       // Print linearity parameters by index.
       case DifferentiationParameterKind::Linearity:
@@ -514,7 +514,8 @@ static std::string getDifferentiationParametersClauseString(
         assert(param.getIndex() <= paramList->size() &&
                "wrt parameter is out of range");
         auto *funcParam = paramList->get(param.getIndex());
-        printer << funcParam->getNameStr();
+        llvm::SmallString<32> scratch;
+        printer << funcParam->getNameStr(scratch);
         break;
       }
     }, [&] { printer << ", "; });

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -158,7 +158,8 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType) {
   SmallVector<ParamDecl*, 4> params;
   for (Type argType : argTypes) {
     auto PD = new (Context) ParamDecl(SourceLoc(), SourceLoc(),
-                                      Identifier(), SourceLoc(), Identifier(), DC);
+                                      Identifier(), DeclNameLoc(), Identifier(),
+                                      DC);
     PD->setSpecifier(ParamSpecifier::Default);
     PD->setInterfaceType(argType);
     PD->setImplicit();
@@ -197,7 +198,7 @@ getBuiltinGenericFunction(Identifier Id,
       ParamDecl::getParameterSpecifierForValueOwnership(
         ArgParamTypes[i].getParameterFlags().getValueOwnership());
     auto PD = new (Context) ParamDecl(SourceLoc(), SourceLoc(),
-                                      Identifier(), SourceLoc(),
+                                      Identifier(), DeclNameLoc(),
                                       Identifier(), DC);
     PD->setSpecifier(specifier);
     PD->setInterfaceType(paramIfaceType);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -725,7 +725,8 @@ bool AbstractFunctionDecl::isTransparent() const {
 
 bool ParameterList::hasInternalParameter(StringRef Prefix) const {
   for (auto param : *this) {
-    if (param->hasName() && param->getNameStr().startswith(Prefix))
+    llvm::SmallString<32> scratch;
+    if (param->hasName() && param->getNameStr(scratch).startswith(Prefix))
       return true;
     auto argName = param->getArgumentName();
     if (!argName.empty() && argName.str().startswith(Prefix))
@@ -1444,8 +1445,9 @@ ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() const {
       ASTContext &C = DC->getASTContext();
       auto *mutableThis = const_cast<PatternBindingInitializer *>(this);
       auto *LazySelfParam = new (C) ParamDecl(SourceLoc(), SourceLoc(),
-                                    Identifier(), singleVar->getLoc(),
-                                    C.Id_self, mutableThis);
+                                              Identifier(),
+                                              DeclNameLoc(singleVar->getLoc()),
+                                              C.Id_self, mutableThis);
       LazySelfParam->setImplicit();
       LazySelfParam->setSpecifier(specifier);
       LazySelfParam->setInterfaceType(DC->getSelfInterfaceType());
@@ -5370,7 +5372,7 @@ Type AbstractStorageDecl::getValueInterfaceType() const {
 }
 
 VarDecl::VarDecl(DeclKind kind, bool isStatic, VarDecl::Introducer introducer,
-                 bool isCaptureList, SourceLoc nameLoc, Identifier name,
+                 bool isCaptureList, DeclNameLoc nameLoc, DeclName name,
                  DeclContext *dc, StorageIsMutable_t supportsMutation)
   : AbstractStorageDecl(kind, isStatic, dc, name, nameLoc, supportsMutation)
 {
@@ -5486,7 +5488,7 @@ bool VarDecl::isLazilyInitializedGlobal() const {
 SourceRange VarDecl::getSourceRange() const {
   if (auto Param = dyn_cast<ParamDecl>(this))
     return Param->getSourceRange();
-  return getNameLoc();
+  return getNameLoc().getSourceRange();
 }
 
 SourceRange VarDecl::getTypeSourceRangeForDiagnostics() const {
@@ -5802,7 +5804,12 @@ bool ParamDecl::isAnonClosureParam() const {
   if (name.empty())
     return false;
 
-  auto nameStr = name.str();
+
+  if (name.isSpecial() || !name.isSimpleName())
+    return false;
+
+  auto nameStr = name.getBaseIdentifier().str();
+
   if (nameStr.empty())
     return false;
 
@@ -5984,7 +5991,10 @@ Identifier VarDecl::getObjCPropertyName() const {
       return name->getSelectorPieces()[0];
   }
 
-  return getName();
+  // TODO(Compound variable names): Should this be allowed?
+  // @objc properties may not have compound names.
+  assert(getName().isSimpleName());
+  return getName().getBaseIdentifier();
 }
 
 ObjCSelector VarDecl::getDefaultObjCGetterSelector(ASTContext &ctx,
@@ -6062,7 +6072,7 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
 
 ParamDecl::ParamDecl(SourceLoc specifierLoc,
                      SourceLoc argumentNameLoc, Identifier argumentName,
-                     SourceLoc parameterNameLoc, Identifier parameterName,
+                     DeclNameLoc parameterNameLoc, DeclName parameterName,
                      DeclContext *dc)
     : VarDecl(DeclKind::Param,
               /*IsStatic*/ false,
@@ -6080,7 +6090,7 @@ ParamDecl::ParamDecl(SourceLoc specifierLoc,
 ParamDecl *ParamDecl::cloneWithoutType(const ASTContext &Ctx, ParamDecl *PD) {
   auto *Clone = new (Ctx) ParamDecl(
       SourceLoc(), SourceLoc(), PD->getArgumentName(),
-      SourceLoc(), PD->getParameterName(), PD->getDeclContext());
+      DeclNameLoc(), PD->getParameterName(), PD->getDeclContext());
   Clone->DefaultValueAndFlags.setPointerAndInt(
       nullptr, PD->DefaultValueAndFlags.getInt());
   Clone->Bits.ParamDecl.defaultArgumentKind =
@@ -6122,13 +6132,13 @@ Type DeclContext::getSelfInterfaceType() const {
 /// Return the full source range of this parameter.
 SourceRange ParamDecl::getSourceRange() const {
   SourceLoc APINameLoc = getArgumentNameLoc();
-  SourceLoc nameLoc = getNameLoc();
+  DeclNameLoc nameLoc = getNameLoc();
 
   SourceLoc startLoc;
   if (APINameLoc.isValid())
     startLoc = APINameLoc;
   else if (nameLoc.isValid())
-    startLoc = nameLoc;
+    startLoc = nameLoc.getStartLoc();
   else if (auto *repr = getTypeRepr())
     startLoc = repr->getStartLoc();
 
@@ -6153,7 +6163,7 @@ SourceRange ParamDecl::getSourceRange() const {
 
   // The name has a location we can use.
   if (nameLoc.isValid())
-    return SourceRange(startLoc, nameLoc);
+    return SourceRange(startLoc, nameLoc.getEndLoc());
 
   return startLoc;
 }
@@ -6387,9 +6397,8 @@ static void writeTupleOfNils(TupleType *type, llvm::raw_ostream &os) {
   os << '(';
   for (unsigned i = 0; i < type->getNumElements(); ++i) {
     auto &elt = type->getElement(i);
-    if (elt.hasName()) {
-      os << elt.getName().str() << ": ";
-    }
+    if (elt.hasName())
+      os << elt.getName() << ": ";
 
     if (elt.getType()->getOptionalObjectType()) {
       os << "nil";
@@ -6844,9 +6853,9 @@ SourceRange AbstractFunctionDecl::getSignatureSourceRange() const {
 
   auto endLoc = paramList->getSourceRange().End;
   if (endLoc.isValid())
-    return SourceRange(getNameLoc(), endLoc);
+    return SourceRange(getBaseNameLoc(), endLoc);
 
-  return getNameLoc();
+  return getBaseNameLoc();
 }
 
 ObjCSelector
@@ -7044,7 +7053,7 @@ ParamDecl *AbstractFunctionDecl::getImplicitSelfDecl(bool createIfNeeded) {
   // Create and save our 'self' parameter.
   auto &ctx = getASTContext();
   *selfDecl = new (ctx) ParamDecl(SourceLoc(), SourceLoc(), Identifier(),
-                                  getLoc(), ctx.Id_self, this);
+                                  DeclNameLoc(getLoc()), ctx.Id_self, this);
   (*selfDecl)->setImplicit();
 
   return *selfDecl;
@@ -7561,7 +7570,7 @@ EnumElementDecl::EnumElementDecl(SourceLoc IdentifierLoc, DeclName Name,
                                  LiteralExpr *RawValueExpr,
                                  DeclContext *DC)
   : DeclContext(DeclContextKind::EnumElementDecl, DC),
-    ValueDecl(DeclKind::EnumElement, DC, Name, IdentifierLoc),
+    ValueDecl(DeclKind::EnumElement, DC, Name, DeclNameLoc(IdentifierLoc)),
     EqualsLoc(EqualsLoc),
     RawValueExpr(RawValueExpr) {
   setParameterList(Params);
@@ -7572,7 +7581,7 @@ SourceRange EnumElementDecl::getSourceRange() const {
     return {getStartLoc(), RawValueExpr->getEndLoc()};
   if (auto *PL = getParameterList())
     return {getStartLoc(), PL->getSourceRange().End};
-  return {getStartLoc(), getNameLoc()};
+  return {getStartLoc(), getBaseNameLoc()};
 }
 
 Type EnumElementDecl::getArgumentInterfaceType() const {

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -353,13 +353,13 @@ void *Pattern::operator new(size_t numBytes, const ASTContext &C) {
 /// Find the name directly bound by this pattern.  When used as a
 /// tuple element in a function signature, such names become part of
 /// the type.
-Identifier Pattern::getBoundName() const {
+DeclName Pattern::getBoundName() const {
   if (auto *NP = dyn_cast<NamedPattern>(getSemanticsProvidingPattern()))
     return NP->getBoundName();
   return Identifier();
 }
 
-Identifier NamedPattern::getBoundName() const {
+DeclName NamedPattern::getBoundName() const {
   return Var->getName();
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2772,9 +2772,9 @@ bool TypeBase::matchesFunctionType(Type other, TypeMatchOptions matchMode,
 
 /// getNamedElementId - If this tuple has a field with the specified name,
 /// return the field index, otherwise return -1.
-int TupleType::getNamedElementId(Identifier I) const {
+int TupleType::getNamedElementId(DeclName N) const {
   for (unsigned i = 0, e = Bits.TupleType.Count; i != e; ++i) {
-    if (getTrailingObjects<TupleTypeElt>()[i].getName() == I)
+    if (getTrailingObjects<TupleTypeElt>()[i].getName() == N)
       return i;
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1726,7 +1726,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
   if (auto CMD = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
     if (clangDecl->isOverloadedOperator()) {
       auto param = new (SwiftContext)
-          ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+          ParamDecl(SourceLoc(), SourceLoc(), Identifier(), DeclNameLoc(),
                     SwiftContext.getIdentifier("lhs"), dc);
 
       auto parent = CMD->getParent();
@@ -1791,7 +1791,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     // imported header unit.
     auto paramInfo = createDeclWithClangNode<ParamDecl>(
         param, AccessLevel::Private, SourceLoc(), SourceLoc(), name,
-        importSourceLoc(param->getLocation()), bodyName,
+        DeclNameLoc(importSourceLoc(param->getLocation())), bodyName,
         ImportedHeaderUnit);
     paramInfo->setSpecifier(ParamSpecifier::Default);
     paramInfo->setInterfaceType(swiftParamTy);
@@ -1808,7 +1808,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
                               {SwiftContext.TheAnyType});
     auto name = SwiftContext.getIdentifier("varargs");
     auto param = new (SwiftContext) ParamDecl(SourceLoc(), SourceLoc(),
-                                              Identifier(), SourceLoc(),
+                                              Identifier(), DeclNameLoc(),
                                               name,
                                               ImportedHeaderUnit);
     param->setSpecifier(ParamSpecifier::Default);
@@ -2143,7 +2143,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     auto type = TupleType::getEmpty(SwiftContext);
     auto var = new (SwiftContext) ParamDecl(SourceLoc(),
                                             SourceLoc(), argName,
-                                            SourceLoc(), argName,
+                                            DeclNameLoc(), argName,
                                             ImportedHeaderUnit);
     var->setSpecifier(ParamSpecifier::Default);
     var->setInterfaceType(type);
@@ -2275,10 +2275,11 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     ++nameIndex;
 
     // Set up the parameter info.
+    auto nameLoc = importSourceLoc(param->getLocation());
     auto paramInfo
       = createDeclWithClangNode<ParamDecl>(param, AccessLevel::Private,
                                            SourceLoc(), SourceLoc(), name,
-                                           importSourceLoc(param->getLocation()),
+                                           DeclNameLoc(nameLoc),
                                            bodyName,
                                            ImportedHeaderUnit);
     paramInfo->setSpecifier(ParamSpecifier::Default);
@@ -2402,7 +2403,8 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
       = createDeclWithClangNode<ParamDecl>(param, AccessLevel::Private,
                                            /*let loc*/SourceLoc(),
                                            /*label loc*/SourceLoc(),
-                                           argLabel, nameLoc, bodyName,
+                                           argLabel, DeclNameLoc(nameLoc),
+                                           bodyName,
                                            /*dummy DC*/ImportedHeaderUnit);
     paramInfo->setSpecifier(ParamSpecifier::Default);
     paramInfo->setInterfaceType(propertyTy);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -379,7 +379,7 @@ public:
     });
   }
 
-  void addCallParameter(Identifier Name, Identifier LocalName, Type Ty,
+  void addCallParameter(Identifier Name, DeclName LocalName, Type Ty,
                         Type ContextTy, bool IsVarArg, bool IsInOut, bool IsIUO,
                         bool isAutoClosure, bool useUnderscoreLabel,
                         bool isLabeledTrailingClosure);

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -515,7 +515,8 @@ private:
       if (!handleBraces(ED->getBraces(), ContextLoc))
         return Stop;
     } else if (auto *VD = dyn_cast<VarDecl>(D)) {
-      if (!handleBraces(VD->getBracesRange(), VD->getNameLoc()))
+      if (!handleBraces(VD->getBracesRange(),
+                        VD->getNameLoc().getBaseNameLoc()))
         return Stop;
     } else if (isa<AbstractFunctionDecl>(D) || isa<SubscriptDecl>(D)) {
       if (isa<SubscriptDecl>(D)) {
@@ -2673,7 +2674,7 @@ private:
     ListAligner Aligner(SM, TargetLocation, ContextLoc, L, R);
     auto NumElems = TE->getNumElements() - TE->getNumTrailingElements();
     for (auto I : range(NumElems)) {
-      SourceRange ElemRange = TE->getElementNameLoc(I);
+      SourceRange ElemRange = TE->getElementNameLoc(I).getSourceRange();
       if (Expr *Elem = TE->getElement(I))
         widenOrSet(ElemRange, Elem->getSourceRange());
       assert(ElemRange.isValid());
@@ -2757,7 +2758,7 @@ private:
       SourceLoc R = getLocIfKind(SM, Parens.End, tok::r_paren);
       ListAligner Aligner(SM, TargetLocation, ContextLoc, L, R);
       for (auto &Elem: TT->getElements()) {
-        SourceRange ElemRange = Elem.NameLoc;
+        SourceRange ElemRange = Elem.NameLoc.getSourceRange();
         widenOrSet(ElemRange, Elem.UnderscoreLoc);
         if (auto *T = Elem.Type)
           widenOrSet(ElemRange, T->getSourceRange());
@@ -2873,7 +2874,7 @@ private:
 
       ListAligner Aligner(SM, TargetLocation, ContextLoc, L, R);
       for (auto &Elem: TP->getElements()) {
-        SourceRange ElemRange = Elem.getLabelLoc();
+        SourceRange ElemRange = Elem.getLabelLoc().getSourceRange();
         if (auto *P = Elem.getPattern())
           widenOrSet(ElemRange, P->getSourceRange());
         Aligner.updateAlignment(ElemRange, TP);

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -748,14 +748,14 @@ bool SemaAnnotator::passCallArgNames(Expr *Fn, TupleExpr *TupleE) {
   if (!D)
     return true; // continue.
 
-  ArrayRef<Identifier> ArgNames = TupleE->getElementNames();
-  ArrayRef<SourceLoc> ArgLocs = TupleE->getElementNameLocs();
+  ArrayRef<DeclName> ArgNames = TupleE->getElementNames();
+  ArrayRef<DeclNameLoc> ArgLocs = TupleE->getElementNameLocs();
   for (auto i : indices(ArgNames)) {
-    Identifier Name = ArgNames[i];
+    Identifier Name = ArgNames[i].getBaseIdentifier();
     if (Name.empty())
       continue;
 
-    SourceLoc Loc = ArgLocs[i];
+    SourceLoc Loc = ArgLocs[i].getBaseNameLoc();
     if (Loc.isInvalid())
       continue;
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -489,8 +489,10 @@ static OwnedAddress emitAddressAtOffset(IRGenFunction &IGF, SILType baseType,
                                         VarDecl *field) {
   auto &fieldTI = IGF.getTypeInfo(baseType.getFieldType(
       field, IGF.getSILModule(), IGF.IGM.getMaximalTypeExpansionContext()));
+  // TODO(Compound variable names)
+  assert(field->getName().isSimpleName());
   auto addr = IGF.emitByteOffsetGEP(base, offset, fieldTI,
-                              base->getName() + "." + field->getName().str());
+            base->getName() + "." + field->getName().getBaseIdentifier().str());
   return OwnedAddress(addr, base);
 }
 
@@ -1800,7 +1802,10 @@ namespace {
       fields.add(offsetPtr);
 
       // TODO: clang puts this in __TEXT,__objc_methname,cstring_literals
-      fields.add(IGM.getAddrOfGlobalString(ivar->getName().str()));
+      // TODO(Compound variable names)
+      assert(ivar->getName().isSimpleName());
+      fields.add(
+          IGM.getAddrOfGlobalString(ivar->getName().getBaseIdentifier().str()));
 
       // TODO: clang puts this in __TEXT,__objc_methtype,cstring_literals
       fields.add(IGM.getAddrOfGlobalString(""));

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2383,8 +2383,10 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
       Optional<SILLocation> loc;
       if (var->getDecl()) {
         // Use the VarDecl for more accurate debugging information.
+        // TODO(Compound variable names)
+        assert(var->getDecl()->getName().isSimpleName());
         loc = var->getDecl();
-        name = var->getDecl()->getName().str();
+        name = var->getDecl()->getName().getBaseIdentifier().str();
       } else {
         if (var->hasLocation())
           loc = var->getLocation();

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -44,9 +44,11 @@ void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
   if (ti.isKnownEmpty(expansion)) {
     if (DebugInfo && var->getDecl()) {
       auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, Size(0), Alignment(1));
+      // TODO(Compound variable names)
+      assert(var->getDecl()->getName().isSimpleName());
       DebugInfo->emitGlobalVariableDeclaration(
-          nullptr, var->getDecl()->getName().str(), "", DbgTy,
-          var->getLinkage() != SILLinkage::Public,
+          nullptr, var->getDecl()->getName().getBaseIdentifier().str(), "",
+          DbgTy, var->getLinkage() != SILLinkage::Public,
           IRGenDebugInfo::NotHeapAllocated, SILLocation(var->getDecl()));
     }
     return;

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -72,7 +72,7 @@ namespace {
     VarDecl * const Field;
 
     StringRef getFieldName() const {
-      return Field->getName().str();
+      return Field->getName().getBaseIdentifier().str();
     }
     
     SILType getType(IRGenModule &IGM, SILType T) const {
@@ -98,7 +98,7 @@ namespace {
     VarDecl * const Field;
 
     StringRef getFieldName() const {
-      if (Field) return Field->getName().str();
+      if (Field) return Field->getName().getBaseIdentifier().str();
       return "<unimported>";
     }
 

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -404,7 +404,10 @@ namespace {
     TupleFieldInfo getFieldInfo(unsigned index,
                                 const TupleTypeElt &field,
                                 const TypeInfo &fieldTI) {
-      StringRef name = field.hasName() ? field.getName().str() : "elt";
+      // TODO(Compound variable names)
+      assert(field.getName().isSimpleName());
+      StringRef name =
+          field.hasName() ? field.getName().getBaseIdentifier().str() : "elt";
       return TupleFieldInfo(index, name, fieldTI);
     }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -877,8 +877,11 @@ private:
           VD->getInterfaceType(),
           IGM.getTypeInfoForUnlowered(
               IGM.getSILTypes().getAbstractionPattern(VD), memberTy));
-      Elements.push_back(createMemberType(DbgTy, VD->getName().str(),
-                                          OffsetInBits, Scope, File, Flags));
+      // TODO(Compound variable names)
+      assert(VD->getName().isSimpleName());
+      Elements.push_back(
+          createMemberType(DbgTy, VD->getName().getBaseIdentifier().str(),
+                           OffsetInBits, Scope, File, Flags));
     }
     if (OffsetInBits > SizeInBits)
       SizeInBits = OffsetInBits;

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1412,7 +1412,7 @@ void LoadableStorageAllocation::insertIndirectReturnArgs() {
   auto &ctx = pass.F->getModule().getASTContext();
   auto var = new (ctx) ParamDecl(
       SourceLoc(), SourceLoc(),
-      ctx.getIdentifier("$return_value"), SourceLoc(),
+      ctx.getIdentifier("$return_value"), DeclNameLoc(),
       ctx.getIdentifier("$return_value"),
       pass.F->getDeclContext());
   var->setSpecifier(ParamSpecifier::InOut);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1089,7 +1089,9 @@ static llvm::Constant *getTupleLabelsString(IRGenModule &IGM,
   for (auto &elt : type->getElements()) {
     if (elt.hasName()) {
       hasLabels = true;
-      buffer.append(elt.getName().str());
+      // TODO(Compound variable names)
+      assert(elt.getName().isSimpleName());
+      buffer.append(elt.getName().getBaseIdentifier().str());
     }
 
     // Each label is space-terminated.

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -65,8 +65,8 @@ public:
         SourceLoc End = Init->getFailabilityLoc();
         bool Optional = End.isValid();
         if (!Optional)
-          End = Init->getNameLoc();
-        return {SourceRange(Init->getNameLoc(), End), Optional,
+          End = Init->getBaseNameLoc();
+        return {SourceRange(Init->getBaseNameLoc(), End), Optional,
           /*suffixable=*/true, /*suffixed=*/false};
       }
       return {SourceRange(), false, false, false};
@@ -1183,7 +1183,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
         // If the argument name is not specified, add the argument name before
         // the parameter name.
         if (ArgLoc.isInvalid())
-          Editor.insertBefore(PD->getNameLoc(),
+          Editor.insertBefore(PD->getNameLoc().getBaseNameLoc(),
                               (llvm::Twine(NewArg) + " ").str());
         else {
           // Otherwise, replace the argument name directly.
@@ -1253,7 +1253,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     case NodeAnnotation::GetterToProperty: {
       auto FuncLoc = FD->getFuncLoc();
       auto ReturnTyLoc = FD->getResultTypeSourceRange().Start;
-      auto NameLoc = FD->getNameLoc();
+      auto NameLoc = FD->getBaseNameLoc();
       if (FuncLoc.isInvalid() || ReturnTyLoc.isInvalid() || NameLoc.isInvalid())
         break;
 
@@ -1299,7 +1299,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       return;
 
     // Get the internal name of the changed paramter.
-    auto VariableName = Params[Idx]->getParameterName().str();
+    llvm::SmallString<32> scratch;
+    auto VariableName = Params[Idx]->getParameterName().getString(scratch);
 
     // Insert the helper function to convert the type back to raw types.
     auto &Info = insertHelperFunction(DiffItem->DiffKind, DiffItem->LeftComment,
@@ -1434,7 +1435,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
           // If the overriden property has been renamed, we should rename
           // this property decl as well.
           if (CD->isRename() && VD->getNameLoc().isValid()) {
-            Editor.replaceToken(VD->getNameLoc(), CD->getNewName());
+            Editor.replace(VD->getNameLoc().getSourceRange(), CD->getNewName());
           }
         }
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5234,9 +5234,9 @@ static ParamDecl *createSetterAccessorArgument(SourceLoc nameLoc,
     name = P.Context.getIdentifier(implName);
   }
 
-  auto result = new (P.Context)
-      ParamDecl(SourceLoc(), SourceLoc(),
-                Identifier(), nameLoc, name, P.CurDeclContext);
+  auto result = new (P.Context) ParamDecl(SourceLoc(), SourceLoc(),
+                                          Identifier(), DeclNameLoc(nameLoc),
+                                          name, P.CurDeclContext);
 
   if (isNameImplicit)
     result->setImplicit();
@@ -5718,7 +5718,7 @@ Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
     storage = new (Context) VarDecl(StaticLoc.isValid(),
                                     VarDecl::Introducer::Var,
                                     /*is capture list*/ false,
-                                    VarLoc, Identifier(),
+                                    DeclNameLoc(VarLoc), Identifier(),
                                     CurDeclContext);
     storage->setImplicit(true);
     storage->setInvalid();
@@ -5755,10 +5755,8 @@ Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
   if (!isa<TypedPattern>(pattern)) {
     if (accessors.Get || accessors.Set || accessors.Address ||
         accessors.MutableAddress) {
-      SourceLoc locAfterPattern = pattern->getLoc().getAdvancedLoc(
-        pattern->getBoundName().getLength());
       diagnose(pattern->getLoc(), diag::computed_property_missing_type)
-        .fixItInsert(locAfterPattern, ": <# Type #>");
+        .fixItInsertAfter(pattern->getEndLoc(), ": <# Type #>");
       Invalid = true;
     }
   }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1988,7 +1988,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     // Make the variable which will contain our temporary value.
     auto InterpolationVar =
       new (Context) VarDecl(/*IsStatic=*/false, VarDecl::Introducer::Var,
-                            /*IsCaptureList=*/false, /*NameLoc=*/SourceLoc(),
+                            /*IsCaptureList=*/false, /*NameLoc=*/DeclNameLoc(),
                             Context.Id_dollarInterpolation, CurDeclContext);
     InterpolationVar->setImplicit(true);
     InterpolationVar->setHasNonPatternBindingInit(true);
@@ -2572,7 +2572,8 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
                          : VarDecl::Introducer::Var);
       auto *VD = new (Context) VarDecl(/*isStatic*/false, introducer,
                                        /*isCaptureList*/true,
-                                       nameLoc, name, CurDeclContext);
+                                       DeclNameLoc(nameLoc), name,
+                                       CurDeclContext);
         
       // If we captured something under the name "self", remember that.
       if (name == Context.Id_self)
@@ -2640,7 +2641,7 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
         }
         auto var = new (Context)
             ParamDecl(SourceLoc(), SourceLoc(),
-                      Identifier(), nameLoc, name, nullptr);
+                      Identifier(), DeclNameLoc(nameLoc), name, nullptr);
         var->setSpecifier(ParamSpecifier::Default);
         elements.push_back(var);
 
@@ -2944,7 +2945,8 @@ Expr *Parser::parseExprAnonClosureArg() {
   // replacements.
   if (auto *params = closure->getParameters()) {
     if (ArgNo < params->size() && params->get(ArgNo)->hasName()) {
-      auto paramName = params->get(ArgNo)->getNameStr();
+      llvm::SmallString<32> scratch;
+      auto paramName = params->get(ArgNo)->getNameStr(scratch);
       diagnose(Loc, diag::anon_closure_arg_in_closure_with_args_typo, paramName)
         .fixItReplace(Loc, paramName);
       return new (Context) DeclRefExpr(params->get(ArgNo), DeclNameLoc(Loc),
@@ -2965,7 +2967,7 @@ Expr *Parser::parseExprAnonClosureArg() {
     SourceLoc varLoc = leftBraceLoc;
     auto *var = new (Context)
         ParamDecl(SourceLoc(), SourceLoc(),
-                  Identifier(), varLoc, ident, closure);
+                  Identifier(), DeclNameLoc(varLoc), ident, closure);
     var->setSpecifier(ParamSpecifier::Default);
     var->setImplicit();
     decls.push_back(var);
@@ -3012,10 +3014,18 @@ Parser::parseExprList(tok leftTok, tok rightTok, SyntaxKind Kind) {
                                         /*hasTrailingClosure=*/false));
   }
 
+  SmallVector<DeclName, 8> declNames;
+  SmallVector<DeclNameLoc, 8> declNameLocs;
+  assert(subExprNames.size() == subExprNameLocs.size());
+  for (size_t i = 0; i < subExprNames.size(); ++i) {
+    declNames.push_back(subExprNames[i]);
+    declNameLocs.push_back(DeclNameLoc(subExprNameLocs[i]));
+  }
+
   return makeParserResult(
       status,
-      TupleExpr::create(Context, leftLoc, subExprs, subExprNames,
-                        subExprNameLocs, rightLoc, /*HasTrailingClosure=*/false,
+      TupleExpr::create(Context, leftLoc, subExprs, declNames, declNameLocs,
+                        rightLoc, /*HasTrailingClosure=*/false,
                         /*Implicit=*/false));
 }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -492,7 +492,7 @@ mapParsedParameters(Parser &parser,
   -> ParamDecl * {
     auto param = new (ctx) ParamDecl(paramInfo.SpecifierLoc,
                                      argNameLoc, argName,
-                                     paramNameLoc, paramName,
+                                     DeclNameLoc(paramNameLoc), paramName,
                                      parser.CurDeclContext);
     param->getAttrs() = paramInfo.Attrs;
 
@@ -966,7 +966,7 @@ ParserResult<Pattern> Parser::parsePattern() {
       PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
       auto VD = new (Context) VarDecl(
         /*IsStatic*/false, introducer, /*IsCaptureList*/false,
-        consumeToken(tok::kw__), Identifier(), CurDeclContext);
+        DeclNameLoc(consumeToken(tok::kw__)), Identifier(), CurDeclContext);
       return makeParserResult(NamedPattern::createImplicit(Context, VD));
     }
     PatternCtx.setCreateSyntax(SyntaxKind::WildcardPattern);
@@ -1038,8 +1038,8 @@ ParserResult<Pattern> Parser::parsePattern() {
 Pattern *Parser::createBindingFromPattern(SourceLoc loc, Identifier name,
                                           VarDecl::Introducer introducer) {
   auto var = new (Context) VarDecl(/*IsStatic*/false, introducer,
-                                   /*IsCaptureList*/false, loc, name,
-                                   CurDeclContext);
+                                   /*IsCaptureList*/false, DeclNameLoc(loc),
+                                   name, CurDeclContext);
   return new (Context) NamedPattern(var);
 }
 
@@ -1066,7 +1066,7 @@ Parser::parsePatternTupleElement() {
   if (pattern.isNull())
     return std::make_pair(makeParserError(), None);
 
-  auto Elt = TuplePatternElt(Label, LabelLoc, pattern.get());
+  auto Elt = TuplePatternElt(Label, DeclNameLoc(LabelLoc), pattern.get());
   return std::make_pair(makeParserSuccess(), Elt);
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1083,8 +1083,8 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
     auto errorName = P.Context.Id_error;
     auto var = new (P.Context) VarDecl(/*IsStatic*/false,
                                        VarDecl::Introducer::Let,
-                                       /*IsCaptureList*/false, loc, errorName,
-                                       P.CurDeclContext);
+                                       /*IsCaptureList*/false, DeclNameLoc(loc),
+                                       errorName, P.CurDeclContext);
     var->setImplicit();
     auto namePattern = new (P.Context) NamedPattern(var);
     auto varPattern =
@@ -1151,7 +1151,8 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
       }
       if (!found) {
         // Diagnose a declaration that doesn't match a previous pattern.
-        P.diagnose(VD->getLoc(), diag::extra_var_in_multiple_pattern_list, VD->getName());
+        P.diagnose(VD->getLoc(), diag::extra_var_in_multiple_pattern_list,
+                   VD->getName());
         status.setIsParseError();
       }
       repeatedDecls.push_back(VD);

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -431,7 +431,7 @@ private:
     if (!param->hasName()) {
       os << "_";
     } else {
-      Identifier name = param->getName();
+      Identifier name = param->getName().getBaseIdentifier();
       os << name;
       if (isClangKeyword(name))
         os << "_";
@@ -752,7 +752,8 @@ private:
                    Type objTy;
                    std::tie(objTy, kind) = getObjectTypeAndOptionality(
                        param, param->getInterfaceType());
-                   print(objTy, kind, param->getName(), IsFunctionParam);
+                   print(objTy, kind, param->getName().getBaseIdentifier(),
+                         IsFunctionParam);
                  },
                  [&] { os << ", "; });
     } else {

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -215,9 +215,11 @@ private:
   /// Look for an instance property of the given nominal type that's
   /// known to be stored.
   VarDecl *findField(NominalTypeDecl *typeDecl, StringRef memberName) {
+    llvm::SmallString<32> scratch;
     for (auto field : typeDecl->getStoredProperties()) {
-      if (field->getName().str() == memberName)
+      if (field->getName().getString(scratch) == memberName)
         return field;
+      scratch.clear();
     }
     return nullptr;
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1782,18 +1782,18 @@ public:
   void visitStructExtractInst(StructExtractInst *EI) {
     *this << getIDAndType(EI->getOperand()) << ", #";
     printFullContext(EI->getField()->getDeclContext(), PrintState.OS);
-    *this << EI->getField()->getName().get();
+    EI->getField()->getName().print(PrintState.OS);
   }
   void visitStructElementAddrInst(StructElementAddrInst *EI) {
     *this << getIDAndType(EI->getOperand()) << ", #";
     printFullContext(EI->getField()->getDeclContext(), PrintState.OS);
-    *this << EI->getField()->getName().get();
+    EI->getField()->getName().print(PrintState.OS);
   }
   void visitRefElementAddrInst(RefElementAddrInst *EI) {
     *this << (EI->isImmutable() ? "[immutable] " : "")
           << getIDAndType(EI->getOperand()) << ", #";
     printFullContext(EI->getField()->getDeclContext(), PrintState.OS);
-    *this << EI->getField()->getName().get();
+    EI->getField()->getName().print(PrintState.OS);
   }
 
   void visitRefTailAddrInst(RefTailAddrInst *RTAI) {

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -43,7 +43,7 @@ static SILValue emitConstructorMetatypeArg(SILGenFunction &SGF,
   auto &AC = SGF.getASTContext();
   auto VD =
       new (AC) ParamDecl(SourceLoc(), SourceLoc(),
-                         AC.getIdentifier("$metatype"), SourceLoc(),
+                         AC.getIdentifier("$metatype"), DeclNameLoc(),
                          AC.getIdentifier("$metatype"), DC);
   VD->setSpecifier(ParamSpecifier::Default);
   VD->setInterfaceType(metatype);
@@ -73,7 +73,7 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &SGF,
   auto &AC = SGF.getASTContext();
   auto VD = new (AC) ParamDecl(SourceLoc(), SourceLoc(),
                                AC.getIdentifier("$implicit_value"),
-                               SourceLoc(),
+                               DeclNameLoc(),
                                AC.getIdentifier("$implicit_value"),
                                DC);
   VD->setSpecifier(ParamSpecifier::Default);
@@ -168,7 +168,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
     auto &AC = SGF.getASTContext();
     auto VD = new (AC) ParamDecl(SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
-                                 SourceLoc(),
+                                 DeclNameLoc(),
                                  AC.getIdentifier("$return_value"),
                                  ctor);
     VD->setSpecifier(ParamSpecifier::InOut);
@@ -493,7 +493,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
     auto &AC = getASTContext();
     auto VD = new (AC) ParamDecl(SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
-                                 SourceLoc(),
+                                 DeclNameLoc(),
                                  AC.getIdentifier("$return_value"),
                                  element->getDeclContext());  
     VD->setSpecifier(ParamSpecifier::InOut);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -824,7 +824,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
     auto &ctx = getASTContext();
     auto param = new (ctx) ParamDecl(SourceLoc(), SourceLoc(),
                                      ctx.getIdentifier("$input_value"),
-                                     SourceLoc(),
+                                     DeclNameLoc(),
                                      ctx.getIdentifier("$input_value"),
                                      dc);
     param->setSpecifier(ParamSpecifier::Owned);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -476,7 +476,8 @@ static void emitIndirectResultParameters(SILGenFunction &SGF, Type resultType,
   }
   auto &ctx = SGF.getASTContext();
   auto var = new (ctx) ParamDecl(SourceLoc(), SourceLoc(),
-                                 ctx.getIdentifier("$return_value"), SourceLoc(),
+                                 ctx.getIdentifier("$return_value"),
+                                 DeclNameLoc(),
                                  ctx.getIdentifier("$return_value"),
                                  DC);
   var->setSpecifier(ParamSpecifier::InOut);

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -575,7 +575,7 @@ std::string AccessSummaryAnalysis::getSubPathDescription(
     }
 
     if (auto tupleTy = containingType.getAs<TupleType>()) {
-      Identifier elementName = tupleTy->getElement(index).getName();
+      DeclName elementName = tupleTy->getElement(index).getName();
       if (elementName.empty())
         os << index;
       else

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -285,7 +285,9 @@ VarDecl *getTangentStoredProperty(ADContext &context, VarDecl *originalField,
   auto *parentDC = originalField->getDeclContext();
   assert(parentDC->isTypeContext());
   auto parentDeclName = parentDC->getSelfNominalTypeDecl()->getNameStr();
-  auto fieldName = originalField->getNameStr();
+  // TODO(Compound variable names)
+  assert(originalField->getName().isSimpleName());
+  auto fieldName = originalField->getName().getBaseIdentifier().str();
   auto sourceLoc = loc.getSourceLoc();
   switch (tanFieldInfo.error->kind) {
   case TangentPropertyInfo::Error::Kind::NoDerivativeOriginalProperty:

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -76,7 +76,7 @@ VarDecl *LinearMapInfo::addVarDecl(NominalTypeDecl *nominal, StringRef name,
   auto id = astCtx.getIdentifier(name);
   auto *varDecl = new (astCtx) VarDecl(
       /*IsStatic*/ false, VarDecl::Introducer::Var, /*IsCaptureList*/ false,
-      SourceLoc(), id, nominal);
+      DeclNameLoc(), id, nominal);
   varDecl->setAccess(nominal->getEffectiveAccess());
   if (type->hasArchetype())
     varDecl->setInterfaceType(type->mapTypeOutOfContext());
@@ -151,7 +151,8 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
         linearMapStruct->getDeclaredInterfaceType()->getCanonicalType();
     // Create dummy declaration representing enum case parameter.
     auto *decl = new (astCtx)
-        ParamDecl(loc, loc, Identifier(), loc, Identifier(), moduleDecl);
+        ParamDecl(loc, loc, Identifier(), DeclNameLoc(loc), Identifier(),
+                  moduleDecl);
     decl->setSpecifier(ParamDecl::Specifier::Default);
     if (linearMapStructTy->hasArchetype())
       decl->setInterfaceType(linearMapStructTy->mapTypeOutOfContext());

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -452,7 +452,7 @@ unsigned OpaqueStorageAllocation::insertIndirectReturnArgs() {
     auto bodyResultTy = pass.F->mapTypeIntoContext(resultTy);
     auto var = new (ctx)
         ParamDecl(SourceLoc(), SourceLoc(),
-                  ctx.getIdentifier("$return_value"), SourceLoc(),
+                  ctx.getIdentifier("$return_value"), DeclNameLoc(),
                   ctx.getIdentifier("$return_value"),
                   pass.F->getDeclContext());
     var->setSpecifier(ParamSpecifier::InOut);

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -327,8 +327,10 @@ static void getPathStringToElementRec(TypeExpansionContext context,
 
     if (EltNo < NumFieldElements) {
       Result += '.';
-      if (Field.hasName())
-        Result += Field.getName().str();
+      if (Field.hasName()) {
+        llvm::SmallString<32> scratch;
+        Result += Field.getName().getString(scratch);
+      }
       else
         Result += llvm::utostr(FieldNo);
       return getPathStringToElementRec(context, Module, FieldTy, EltNo, Result);
@@ -369,10 +371,11 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
         if (Element < NumFieldElements) {
           Result += '.';
           auto originalProperty = VD->getOriginalWrappedProperty();
+          llvm::SmallString<32> scratch;
           if (originalProperty) {
-            Result += originalProperty->getName().str();
+            Result += originalProperty->getName().getString(scratch);
           } else {
-            Result += VD->getName().str();
+            Result += VD->getName().getString(scratch);
           }
           getPathStringToElementRec(expansionContext, Module, FieldType,
                                     Element, Result);

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -348,7 +348,7 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
   }
   // First, diagnose the inout captures, if any.
   for (auto inoutCapture : inoutCaptures) {
-    Optional<Identifier> paramName = None;
+    Optional<DeclName> paramName = None;
     if (isUseOfSelfInInitializer(inoutCapture)) {
       diagnose(Context, PAI->getLoc(), diag::escaping_mutable_self_capture,
                functionKind);

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -1095,8 +1095,9 @@ static bool checkOSLogMessageIsConstant(SingleValueInstruction *osLogMessage,
   for (auto *propDecl : propertyDecls) {
     SymbolicValue propertyValue = *(propValueI++);
     if (!propertyValue.isConstant()) {
+      llvm::SmallString<32> scratch;
       diagnose(astContext, sourceLoc, diag::oslog_property_not_constant,
-               propDecl->getNameStr());
+               propDecl->getNameStr(scratch));
       errorDetected = true;
       break;
     }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -751,7 +751,7 @@ static bool isZeroLoadFromEmptyCollection(LoadInst *LI) {
         // is not defined in the ABI and could change in another version of the
         // runtime (the capacity must be 0, but the flags may be not 0).
         if (SEA->getStructDecl()->getName().is("_SwiftArrayBodyStorage") &&
-            !SEA->getField()->getName().is("count")) {
+            !SEA->getField()->getName().isSimpleName("count")) {
           return false;
         }
         addr = SEA->getOperand();
@@ -763,8 +763,9 @@ static bool isZeroLoadFromEmptyCollection(LoadInst *LI) {
         // For Dictionary and Set we support "count" and "capacity".
         if (className.is("__RawDictionaryStorage") ||
             className.is("__RawSetStorage")) {
-          Identifier fieldName = REA->getField()->getName();
-          if (!fieldName.is("_count") && !fieldName.is("_capacity"))
+          DeclName fieldName = REA->getField()->getName();
+          if (!fieldName.isSimpleName("_count") &&
+              !fieldName.isSimpleName("_capacity"))
             return false;
         }
         addr = REA->getOperand();

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -155,7 +155,8 @@ class BuilderClosureVisitor
     Identifier name = ctx.getIdentifier(
         ("$__builder" + Twine(varCounter++)).str());
     auto var = new (ctx) VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var,
-                                 /*isCaptureList=*/false, loc, name, dc);
+                                 /*isCaptureList=*/false, DeclNameLoc(loc),
+                                 name, dc);
     var->setImplicit();
     return var;
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -809,8 +809,8 @@ bool LabelingFailure::diagnoseAsNote() {
   if (isa<ParenExpr>(argExpr)) {
     argLabels.push_back(Identifier());
   } else if (auto *tuple = dyn_cast<TupleExpr>(argExpr)) {
-    argLabels.append(tuple->getElementNames().begin(),
-                     tuple->getElementNames().end());
+    for (auto name : tuple->getElementNames())
+      argLabels.push_back(name.getBaseIdentifier());
   } else {
     return false;
   }
@@ -1607,7 +1607,7 @@ bool AssignmentFailure::diagnoseAsError() {
     auto getKeyPathArgument = [](SubscriptExpr *expr) {
       auto *TE = dyn_cast<TupleExpr>(expr->getIndex());
       assert(TE->getNumElements() == 1);
-      assert(TE->getElementName(0).str() == "keyPath");
+      assert(TE->getElementName(0).isSimpleName("keyPath"));
       return TE->getElement(0);
     };
 
@@ -1634,7 +1634,8 @@ bool AssignmentFailure::diagnoseAsError() {
     // problematic decl, we can produce a nice tailored diagnostic.
     if (auto *VD = dyn_cast<VarDecl>(choice->getDecl())) {
       std::string message = "'";
-      message += VD->getName().str().str();
+      llvm::SmallString<32> scratch;
+      message += VD->getName().getString(scratch).str();
       message += "'";
 
       auto type = getType(immutableExpr);
@@ -3566,7 +3567,9 @@ bool MissingMemberFailure::diagnoseForSubscriptMemberWithTupleBase() const {
         dyn_cast<StringLiteralExpr>(index->getSemanticsProvidingExpr());
     if (stringLiteral && !stringLiteral->getValue().empty() &&
         llvm::any_of(tupleType->getElements(), [&](TupleTypeElt element) {
-          return element.getName().is(stringLiteral->getValue());
+          llvm::SmallString<32> scratch;
+          return element.getName().getString(scratch) ==
+                 stringLiteral->getValue();
         })) {
       llvm::SmallString<16> dotAccess;
       llvm::raw_svector_ostream OS(dotAccess);
@@ -4219,7 +4222,7 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
       insertLoc = Lexer::getLocForEndOfToken(
           ctx.SourceMgr, TE->getElement(argPos)->getEndLoc());
     } else {
-      insertLoc = TE->getElementNameLoc(0);
+      insertLoc = TE->getElementNameLoc(0).getStartLoc();
       if (insertLoc.isInvalid())
         insertLoc = TE->getElement(0)->getStartLoc();
     }
@@ -4614,7 +4617,10 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
   parameterOS << "(";
   interleave(
       params->getArray(),
-      [&](const ParamDecl *param) { parameterOS << param->getNameStr(); },
+      [&](const ParamDecl *param) {
+        llvm::SmallString<32> scratch;
+        parameterOS << param->getNameStr(scratch);
+      },
       [&] { parameterOS << ", "; });
   parameterOS << ")";
 
@@ -4692,8 +4698,8 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
 
   auto *tuple = cast<TupleExpr>(argExpr);
 
-  Identifier first = tuple->getElementName(ArgIdx);
-  Identifier second = tuple->getElementName(PrevArgIdx);
+  Identifier first = tuple->getElementName(ArgIdx).getBaseIdentifier();
+  Identifier second = tuple->getElementName(PrevArgIdx).getBaseIdentifier();
 
   // Build a mapping from arguments to parameters.
   SmallVector<unsigned, 4> argBindings(tuple->getNumElements());
@@ -4705,7 +4711,7 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
   auto argRange = [&](unsigned argIdx, Identifier label) -> SourceRange {
     auto range = tuple->getElement(argIdx)->getSourceRange();
     if (!label.empty())
-      range.Start = tuple->getElementNameLoc(argIdx);
+      range.Start = tuple->getElementNameLoc(argIdx).getStartLoc();
 
     unsigned paramIdx = argBindings[argIdx];
     if (Bindings[paramIdx].size() > 1)
@@ -5605,8 +5611,8 @@ bool InvalidTupleSplatWithSingleParameterFailure::diagnoseAsError() {
       // If the label of the first argument matches the one required
       // by the parameter it would be omitted from the fixed parameter type.
       if (!paramTuple->getElement(0).hasName())
-        newLeftParenLoc = Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
-                                                     TE->getElementNameLoc(0));
+        newLeftParenLoc = Lexer::getLocForEndOfToken(
+            getASTContext().SourceMgr, TE->getElementNameLoc(0).getEndLoc());
     }
   }
 
@@ -5700,7 +5706,7 @@ void InOutConversionFailure::fixItChangeArgumentType() const {
     startLoc = typeRange.Start;
     endLoc = typeRange.End;
   } else if (isSimpleTypelessPattern(VD->getParentPattern())) {
-    endLoc = VD->getNameLoc();
+    endLoc = VD->getNameLoc().getEndLoc();
     scratch += ": ";
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -985,7 +985,7 @@ public:
 
   VarDecl *getProperty() const { return Property; }
 
-  Identifier getPropertyName() const { return Property->getName(); }
+  DeclName getPropertyName() const { return Property->getName(); }
 
   bool usingProjection() const { return UsingProjection; }
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -837,7 +837,8 @@ class UseWrappedValue final : public ConstraintFix {
         PropertyWrapper(propertyWrapper), Base(base), Wrapper(wrapper) {}
 
   bool usingProjection() const {
-    auto nameStr = PropertyWrapper->getName().str();
+    assert(PropertyWrapper->getName().isSimpleName());
+    auto nameStr = PropertyWrapper->getName().getBaseIdentifier().str();
     return !nameStr.startswith("_");
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4218,8 +4218,8 @@ swift::getOriginalArgumentList(Expr *expr) {
     auto labelLocs = tupleExpr->getElementNameLocs();
     for (unsigned i = 0, e = args.size(); i != e; ++i) {
       // Implicit TupleExprs don't always store label locations.
-      add(args[i], labels[i],
-          labelLocs.empty() ? SourceLoc() : labelLocs[i]);
+      add(args[i], labels[i].getBaseIdentifier(),
+          labelLocs.empty() ? SourceLoc() : labelLocs[i].getBaseNameLoc());
     }
   } else {
     add(expr, Identifier(), SourceLoc());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1194,7 +1194,8 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
           synthesizedArgs;
       for (unsigned i = 0, n = argTuple->getNumElements(); i != n; ++i) {
         const auto &elt = argTuple->getElement(i);
-        AnyFunctionType::Param argument(elt.getType(), elt.getName());
+        AnyFunctionType::Param argument(elt.getType(),
+                                        elt.getName().getBaseIdentifier());
         synthesizedArgs.push_back(std::make_pair(i, argument));
         argsWithLabels.push_back(argument);
       }
@@ -1728,7 +1729,8 @@ static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
     if (auto *tuple = argType->getAs<TupleType>()) {
       args.pop_back();
       for (const auto &elt : tuple->getElements()) {
-        args.push_back(AnyFunctionType::Param(elt.getType(), elt.getName(),
+        args.push_back(AnyFunctionType::Param(elt.getType(),
+                                              elt.getName().getBaseIdentifier(),
                                               elt.getParameterFlags()));
       }
     } else if (auto *typeVar = argType->getAs<TypeVariableType>()) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -125,8 +125,9 @@ Expr *swift::buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
                                   /*hasTrailingClosure=*/false);
     argExpr->setImplicit();
   } else {
-    argExpr = TupleExpr::create(ctx, SourceLoc(), args, labels, labelLocs,
-                                SourceLoc(), false, IsImplicit);
+    argExpr = TupleExpr::createArgTuple(ctx, SourceLoc(), args, labels,
+                                        labelLocs, SourceLoc(), false,
+                                        IsImplicit);
   }
 
   auto argTy = AnyFunctionType::composeInput(ctx, elts, /*canonical*/false);
@@ -262,9 +263,9 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
       }
 
       // Create the parameter.
-      auto *arg = new (ctx)
-          ParamDecl(SourceLoc(), Loc,
-                    var->getName(), Loc, var->getName(), decl);
+      auto *arg = new (ctx) ParamDecl(SourceLoc(), Loc,
+                                      var->getName().getBaseIdentifier(),
+                                      DeclNameLoc(Loc), var->getName(), decl);
       arg->setSpecifier(ParamSpecifier::Default);
       arg->setInterfaceType(varInterfaceType);
       arg->setImplicit();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5102,7 +5102,7 @@ SourceLoc constraints::getLoc(ASTNode anchor) {
     return T->getLoc();
   } else if (auto *V = anchor.dyn_cast<Decl *>()) {
     if (auto VD = dyn_cast<VarDecl>(V))
-      return VD->getNameLoc();
+      return VD->getNameLoc().getBaseNameLoc();
     return anchor.getStartLoc();
   } else if (auto *S = anchor.dyn_cast<Stmt *>()) {
     return S->getStartLoc();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -582,8 +582,10 @@ public:
 
   /// \returns The label for the argument being applied.
   Identifier getArgLabel() const {
-    if (auto *te = dyn_cast<TupleExpr>(ArgListExpr))
-      return te->getElementName(ArgIdx);
+    if (auto *te = dyn_cast<TupleExpr>(ArgListExpr)) {
+      assert(!te->getElementName(ArgIdx).isSpecial());
+      return te->getElementName(ArgIdx).getBaseIdentifier();
+    }
 
     assert(isa<ParenExpr>(ArgListExpr));
     return Identifier();

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -156,7 +156,7 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
   llvm::SmallVector<Identifier, 2> memberNames;
   for (auto member : nominal->getStoredProperties()) {
     memberOpExprs.push_back(createMemberOpExpr(member));
-    memberNames.push_back(member->getName());
+    memberNames.push_back(member->getName().getBaseIdentifier());
   }
   // Call memberwise initializer with member operator call expressions.
   auto *callExpr =
@@ -177,7 +177,7 @@ static ValueDecl *deriveMathOperator(DerivedConformance &derived,
   // Create parameter declaration with the given name and type.
   auto createParamDecl = [&](StringRef name, Type type) -> ParamDecl * {
     auto *param =
-        new (C) ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+        new (C) ParamDecl(SourceLoc(), SourceLoc(), Identifier(), DeclNameLoc(),
                           C.getIdentifier(name), parentDC);
     param->setSpecifier(ParamDecl::Specifier::Default);
     param->setInterfaceType(type);
@@ -268,7 +268,7 @@ deriveBodyPropertyGetter(AbstractFunctionDecl *funcDecl, ProtocolDecl *proto,
   llvm::SmallVector<Identifier, 2> memberNames;
   for (auto member : nominal->getStoredProperties()) {
     memberPropExprs.push_back(createMemberPropertyExpr(member));
-    memberNames.push_back(member->getName());
+    memberNames.push_back(member->getName().getBaseIdentifier());
   }
   // Call memberwise initializer with member property expressions.
   auto *callExpr =

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -43,9 +43,9 @@ static bool superclassConformsTo(ClassDecl *target, KnownProtocolKind kpk) {
 /// Retrieve the variable name for the purposes of encoding/decoding.
 static Identifier getVarNameForCoding(VarDecl *var) {
   if (auto originalVar = var->getOriginalWrappedProperty())
-    return originalVar->getName();
+    return originalVar->getName().getBaseIdentifier();
 
-  return var->getName();
+  return var->getName().getBaseIdentifier();
 }
 
 /// Validates the given CodingKeys enum decl by ensuring its cases are a 1-to-1
@@ -342,7 +342,7 @@ static VarDecl *createKeyedContainer(ASTContext &C, DeclContext *DC,
 
   // let container : Keyed*Container<KeyType>
   auto *containerDecl = new (C) VarDecl(/*IsStatic=*/false, introducer,
-                                        /*IsCaptureList=*/false, SourceLoc(),
+                                        /*IsCaptureList=*/false, DeclNameLoc(),
                                         C.Id_container, DC);
   containerDecl->setImplicit();
   containerDecl->setInterfaceType(containerType);
@@ -368,7 +368,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
   // (keyedBy:)
   auto *keyedByDecl = new (C)
       ParamDecl(SourceLoc(), SourceLoc(),
-                C.Id_keyedBy, SourceLoc(), C.Id_keyedBy, DC);
+                C.Id_keyedBy, DeclNameLoc(), C.Id_keyedBy, DC);
   keyedByDecl->setImplicit();
   keyedByDecl->setSpecifier(ParamSpecifier::Default);
   keyedByDecl->setInterfaceType(returnType);
@@ -618,7 +618,7 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   // Params: (Encoder)
   auto *encoderParam = new (C)
       ParamDecl(SourceLoc(), SourceLoc(), C.Id_to,
-                SourceLoc(), C.Id_encoder, conformanceDC);
+                DeclNameLoc(), C.Id_encoder, conformanceDC);
   encoderParam->setSpecifier(ParamSpecifier::Default);
   encoderParam->setInterfaceType(encoderType);
 
@@ -942,7 +942,7 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
   auto decoderType = C.getDecoderDecl()->getDeclaredInterfaceType();
   auto *decoderParamDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_from,
-      SourceLoc(), C.Id_decoder, conformanceDC);
+      DeclNameLoc(), C.Id_decoder, conformanceDC);
   decoderParamDecl->setImplicit();
   decoderParamDecl->setSpecifier(ParamSpecifier::Default);
   decoderParamDecl->setInterfaceType(decoderType);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -77,7 +77,7 @@ deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
   // rawValue param to init(rawValue:)
   auto *rawValueDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_rawValue,
-      SourceLoc(), C.Id_rawValue, parentDC);
+      DeclNameLoc(), C.Id_rawValue, parentDC);
   rawValueDecl->setInterfaceType(C.getIntDecl()->getDeclaredInterfaceType());
   rawValueDecl->setSpecifier(ParamSpecifier::Default);
   rawValueDecl->setImplicit();
@@ -117,7 +117,7 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
   // rawValue
   auto *rawDecl =
       new (C) ParamDecl(SourceLoc(), SourceLoc(),
-                        paramName, SourceLoc(), paramName, parentDC);
+                        paramName, DeclNameLoc(), paramName, parentDC);
   rawDecl->setSpecifier(ParamSpecifier::Default);
   rawDecl->setInterfaceType(paramType);
   rawDecl->setImplicit();

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -232,7 +232,7 @@ deriveComparable_lt(
 
   auto getParamDecl = [&](StringRef s) -> ParamDecl * {
     auto *param = new (C) ParamDecl(SourceLoc(),
-                                    SourceLoc(), Identifier(), SourceLoc(),
+                                    SourceLoc(), Identifier(), DeclNameLoc(),
                                     C.getIdentifier(s), parentDC);
     param->setSpecifier(ParamSpecifier::Default);
     param->setInterfaceType(selfIfaceTy);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -381,7 +381,7 @@ deriveEquatable_eq(
 
   auto getParamDecl = [&](StringRef s) -> ParamDecl * {
     auto *param = new (C) ParamDecl(SourceLoc(),
-                                    SourceLoc(), Identifier(), SourceLoc(),
+                                    SourceLoc(), Identifier(), DeclNameLoc(),
                                     C.getIdentifier(s), parentDC);
     param->setSpecifier(ParamSpecifier::Default);
     param->setInterfaceType(selfIfaceTy);
@@ -531,8 +531,9 @@ deriveHashable_hashInto(
 
   // Params: self (implicit), hasher
   auto *hasherParamDecl = new (C) ParamDecl(SourceLoc(),
-                                            SourceLoc(), C.Id_into, SourceLoc(),
-                                            C.Id_hasher, parentDC);
+                                            SourceLoc(), C.Id_into,
+                                            DeclNameLoc(), C.Id_hasher,
+                                            parentDC);
   hasherParamDecl->setSpecifier(ParamSpecifier::InOut);
   hasherParamDecl->setInterfaceType(hasherType);
 
@@ -877,7 +878,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
 
   VarDecl *hashValueDecl =
     new (C) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Var,
-                    /*IsCaptureList*/false, SourceLoc(),
+                    /*IsCaptureList*/false, DeclNameLoc(),
                     C.Id_hashValue, parentDC);
   hashValueDecl->setInterfaceType(intType);
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -411,7 +411,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
 
   auto *rawDecl = new (C)
       ParamDecl(SourceLoc(), SourceLoc(),
-                C.Id_rawValue, SourceLoc(), C.Id_rawValue, parentDC);
+                C.Id_rawValue, DeclNameLoc(), C.Id_rawValue, parentDC);
   rawDecl->setSpecifier(ParamSpecifier::Default);
   rawDecl->setInterfaceType(rawInterfaceType);
   rawDecl->setImplicit();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -456,7 +456,7 @@ DerivedConformance::declareDerivedProperty(Identifier name,
 
   VarDecl *propDecl = new (Context)
       VarDecl(/*IsStatic*/ isStatic, VarDecl::Introducer::Var,
-              /*IsCaptureList*/ false, SourceLoc(), name, parentDC);
+              /*IsCaptureList*/ false, DeclNameLoc(), name, parentDC);
   propDecl->setImplicit();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);
@@ -629,7 +629,7 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
   Type intType = C.getIntDecl()->getDeclaredInterfaceType();
 
   auto indexVar = new (C) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Var,
-                                  /*IsCaptureList*/false, SourceLoc(),
+                                  /*IsCaptureList*/false, DeclNameLoc(),
                                   C.getIdentifier(indexName),
                                   funcDecl);
   indexVar->setInterfaceType(intType);
@@ -760,7 +760,7 @@ DerivedConformance::enumElementPayloadSubpattern(EnumElementDecl *enumElementDec
       auto letPattern =
           BindingPattern::createImplicit(C, /*isLet*/ true, namedPattern);
       elementPatterns.push_back(TuplePatternElt(tupleElement.getName(),
-                                                SourceLoc(), letPattern));
+                                                DeclNameLoc(), letPattern));
     }
 
     auto pat = TuplePattern::createImplicit(C, elementPatterns);
@@ -800,7 +800,7 @@ VarDecl *DerivedConformance::indexedVarDecl(char prefixChar, int index, Type typ
   auto indexStrRef = StringRef(indexStr.data(), indexStr.size());
 
   auto varDecl = new (C) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Let,
-                                 /*IsCaptureList*/true, SourceLoc(),
+                                 /*IsCaptureList*/true, DeclNameLoc(),
                                  C.getIdentifier(indexStrRef),
                                  varContext);
   varDecl->setInterfaceType(type);

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -295,7 +295,7 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
     const DeclContext *CurrDC;
     llvm::DenseSet<std::pair<DeclBaseName, CanType>> FunctionsReported;
     llvm::DenseSet<CanType> SubscriptsReported;
-    llvm::DenseSet<std::pair<Identifier, CanType>> PropertiesReported;
+    llvm::DenseSet<std::pair<DeclName, CanType>> PropertiesReported;
 
   public:
     explicit DynamicLookupConsumer(VisibleDeclConsumer &ChainedConsumer,

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -510,7 +510,7 @@ public:
 
     VarDecl *VD =
         new (Context) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Let,
-                              /*IsCaptureList*/false, SourceLoc(),
+                              /*IsCaptureList*/false, DeclNameLoc(),
                               Context.getIdentifier(NameBuf),
                               TypeCheckDC);
     VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
@@ -594,7 +594,7 @@ public:
 
     llvm::SmallVector<Expr *, 3> TupleArgs{};
     TupleArgs.append({*AddedBeforeLogger, E, *AddedAfterLogger});
-    SmallVector<Identifier, 3> ThreeArgLabels(TupleArgs.size(), Identifier());
+    SmallVector<DeclName, 3> ThreeArgLabels(TupleArgs.size(), Identifier());
     TupleExpr *Tup =
         TupleExpr::createImplicit(Context, TupleArgs, ThreeArgLabels);
     SmallVector<TupleTypeElt, 3> TupleTypes{};

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1385,7 +1385,8 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
         index->getArgumentNameLoc().isInvalid()) {
       diagnose(SD, diag::invalid_dynamic_member_subscript)
           .highlight(index->getSourceRange())
-          .fixItInsert(index->getParameterNameLoc(), "dynamicMember ");
+          .fixItInsert(index->getParameterNameLoc().getBaseNameLoc(),
+                       "dynamicMember ");
     }
   }
 
@@ -4476,14 +4477,14 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   auto funcResultElt = derivativeResultTupleType->getElement(1);
   // Get derivative kind and derivative function identifier.
   AutoDiffDerivativeFunctionKind kind;
-  if (valueResultElt.getName().str() != "value") {
+  if (!valueResultElt.getName().isSimpleName("value")) {
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_invalid_result_tuple_value_label);
     return true;
   }
-  if (funcResultElt.getName().str() == "differential") {
+  if (funcResultElt.getName().isSimpleName("differential")) {
     kind = AutoDiffDerivativeFunctionKind::JVP;
-  } else if (funcResultElt.getName().str() == "pullback") {
+  } else if (funcResultElt.getName().isSimpleName("pullback")) {
     kind = AutoDiffDerivativeFunctionKind::VJP;
   } else {
     diags.diagnose(attr->getLocation(),

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2082,7 +2082,8 @@ void swift::diagnoseUnavailableOverride(ValueDecl *override,
     }
 
     if (!parsedName.IsFunctionName) {
-      diag.fixItReplace(override->getNameLoc(), parsedName.BaseName);
+      diag.fixItReplace(override->getNameLoc().getBaseNameLoc(),
+                        parsedName.BaseName);
       return;
     }
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -84,7 +84,7 @@ static bool isKeyPathCurriedThunkCallExpr(Expr *E) {
   if (!thunk)
     return false;
   if (thunk->getParameters()->size() != 1 ||
-      thunk->getParameters()->get(0)->getParameterName().str() != "$kp$")
+      !thunk->getParameters()->get(0)->getParameterName().isSimpleName("$kp$"))
     return false;
 
   auto PE = dyn_cast<ParenExpr>(CE->getArg());
@@ -288,14 +288,14 @@ public:
       return result;
     }
 
-    return TupleExpr::create(C,
-                             argList.lParenLoc,
-                             argList.args,
-                             argList.labels,
-                             argList.labelLocs,
-                             argList.rParenLoc,
-                             argList.hasTrailingClosure,
-                             /*implicit=*/true);
+    return TupleExpr::createArgTuple(C,
+                                     argList.lParenLoc,
+                                     argList.args,
+                                     argList.labels,
+                                     argList.labelLocs,
+                                     argList.rParenLoc,
+                                     argList.hasTrailingClosure,
+                                     /*implicit=*/true);
   }
 
   Expr *walkToExprPost(Expr *expr) override {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1611,7 +1611,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
 
       // If the tuple element has a label, propagate it.
       elt.Type = eltTE->getTypeRepr();
-      Identifier name = TE->getElementName(EltNo);
+      DeclName name = TE->getElementName(EltNo);
       if (!name.empty()) {
         elt.Name = name;
         elt.NameLoc = TE->getElementNameLoc(EltNo);
@@ -2449,7 +2449,7 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
   auto *matchVar = new (Context) VarDecl(/*IsStatic*/false,
                                          VarDecl::Introducer::Let,
                                          /*IsCaptureList*/false,
-                                         EP->getLoc(),
+                                         DeclNameLoc(EP->getLoc()),
                                          Context.getIdentifier("$match"),
                                          DC);
   matchVar->setInterfaceType(rhsType->mapTypeOutOfContext());
@@ -2738,7 +2738,7 @@ TypeChecker::coerceToRValue(ASTContext &Context, Expr *expr,
       elements.reserve(tuple->getElements().size());
       for (unsigned i = 0, n = tuple->getNumElements(); i != n; ++i) {
         Type type = getType(tuple->getElement(i));
-        Identifier name = tuple->getElementName(i);
+        DeclName name = tuple->getElementName(i);
         elements.push_back(TupleTypeElt(type, name));
       }
       setType(tuple, TupleType::get(elements, Context));

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -941,7 +941,7 @@ bool swift::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
   SourceRange TypeRange = VD->getTypeSourceRangeForDiagnostics();
   // TypeRange can be invalid; e.g. '@objc let foo = SwiftType()'
   if (TypeRange.isInvalid())
-    TypeRange = VD->getNameLoc();
+    TypeRange = VD->getNameLoc().getSourceRange();
 
   VD->diagnose(diag::objc_invalid_on_var, getObjCDiagnosticAttrKind(Reason))
       .highlight(TypeRange);
@@ -1902,7 +1902,8 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
   if (auto var = dyn_cast<VarDecl>(decl)) {
     // Replace the name.
     SmallString<64> scratch;
-    diag.fixItReplace(var->getNameLoc(), targetName.getString(scratch));
+    diag.fixItReplace(var->getNameLoc().getSourceRange(),
+                      targetName.getString(scratch));
     return false;
   }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1001,7 +1001,7 @@ static void checkOverrideAccessControl(ValueDecl *baseDecl, ValueDecl *decl,
     // override NSObject.hash instead.
     if (isNSObjectHashValue(baseDecl)) {
       diags.diagnose(decl, diag::override_nsobject_hashvalue_error)
-        .fixItReplace(SourceRange(decl->getNameLoc()), "hash");
+        .fixItReplace(decl->getNameLoc().getSourceRange(), "hash");
     } else {
       diags.diagnose(decl, diag::override_of_non_open,
                      decl->getDescriptiveKind());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1347,12 +1347,13 @@ public:
           (VD->getName().isSimpleName(Context.Id_Type) ||
            VD->getName().isSimpleName(Context.Id_Protocol)) &&
           VD->getNameLoc().isValid() &&
-          Context.SourceMgr.extractText({VD->getNameLoc(), 1}) != "`") {
+          Context.SourceMgr.extractText({VD->getNameLoc().getBaseNameLoc(), 1})
+            != "`") {
         auto &DE = getASTContext().Diags;
         DE.diagnose(VD->getNameLoc(), diag::reserved_member_name,
                     VD->getName(), VD->getBaseIdentifier().str());
         DE.diagnose(VD->getNameLoc(), diag::backticks_to_escape)
-            .fixItReplace(VD->getNameLoc(),
+            .fixItReplace(VD->getNameLoc().getBaseNameLoc(),
                           "`" + VD->getBaseName().userFacingName().str() + "`");
       }
     }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -640,8 +640,9 @@ noteTypoCorrection(DeclNameLoc loc, ValueDecl *decl,
       }
 
       auto &Diags = decl->getASTContext().Diags;
+      llvm::SmallString<32> scratch;
       return Diags.diagnose(loc.getBaseNameLoc(), diag::note_typo_candidate,
-                            var->getName().str());
+                            var->getName().getString(scratch));
     }
   }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1125,7 +1125,8 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       diags.diagnose(NP->getLoc(), diag, NP->getDecl()->getName(), type,
                      NP->getDecl()->isLet());
       diags.diagnose(NP->getLoc(), diag::add_explicit_type_annotation_to_silence)
-          .fixItInsertAfter(var->getNameLoc(), ": " + type->getWithoutParens()->getString());
+          .fixItInsertAfter(var->getNameLoc().getEndLoc(),
+                            ": " + type->getWithoutParens()->getString());
     }
 
     return P;
@@ -1198,7 +1199,8 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       // the label for the tuple type being matched.
       if (!hadError && !elt.getLabel().empty() &&
           elt.getLabel() != tupleTy->getElement(i).getName()) {
-        diags.diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+        diags.diagnose(elt.getLabelLoc().getBaseNameLoc(),
+                       diag::tuple_pattern_label_mismatch,
                        elt.getLabel(), tupleTy->getElement(i).getName());
         hadError = true;
       }
@@ -1534,7 +1536,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       if (auto *TTy = dyn_cast<TupleType>(elementType.getPointer())) {
         for (auto &elt : TTy->getElements()) {
           auto *subPattern = AnyPattern::createImplicit(Context);
-          elements.push_back(TuplePatternElt(elt.getName(), SourceLoc(),
+          elements.push_back(TuplePatternElt(elt.getName(), DeclNameLoc(),
                                              subPattern));
         }
       } else {
@@ -1543,7 +1545,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
         (void)parenTy;
         
         auto *subPattern = AnyPattern::createImplicit(Context);
-        elements.push_back(TuplePatternElt(Identifier(), SourceLoc(),
+        elements.push_back(TuplePatternElt(Identifier(), DeclNameLoc(),
                                            subPattern));
       }
       Pattern *sub = TuplePattern::createSimple(Context, SourceLoc(),

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -361,7 +361,7 @@ PropertyWrapperTypeInfoRequest::evaluate(
     if (result.projectedValueVar &&
         result.projectedValueVar->getLoc().isValid()) {
       result.projectedValueVar->diagnose(diag::property_wrapper_wrapperValue)
-        .fixItReplace(result.projectedValueVar->getNameLoc(),
+        .fixItReplace(result.projectedValueVar->getNameLoc().getBaseNameLoc(),
                       "projectedValue");
     }
   }
@@ -662,8 +662,8 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
     if (auto tuple = dyn_cast<TupleExpr>(attr->getArg())) {
       for (unsigned i : range(tuple->getNumElements())) {
         elements.push_back(tuple->getElement(i));
-        elementNames.push_back(tuple->getElementName(i));
-        elementLocs.push_back(tuple->getElementNameLoc(i));
+        elementNames.push_back(tuple->getElementName(i).getBaseIdentifier());
+        elementLocs.push_back(tuple->getElementNameLoc(i).getBaseNameLoc());
       }
     } else {
       auto paren = cast<ParenExpr>(attr->getArg());

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2099,7 +2099,7 @@ void swift::checkUnknownAttrRestrictions(
 }
 
 void swift::bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *caseStmt) {
-  llvm::SmallDenseMap<Identifier, std::pair<VarDecl *, bool>, 4> latestVars;
+  llvm::SmallDenseMap<DeclName, std::pair<VarDecl *, bool>, 4> latestVars;
   auto recordVar = [&](Pattern *pattern, VarDecl *var) {
     if (!var->hasName())
       return;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3491,7 +3491,7 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   SmallVector<TupleTypeElt, 8> elements;
   elements.reserve(repr->getNumElements());
 
-  llvm::SmallDenseSet<Identifier> seenEltNames;
+  llvm::SmallDenseSet<DeclName> seenEltNames;
   seenEltNames.reserve(repr->getNumElements());
 
   auto elementOptions = options;
@@ -3539,7 +3539,7 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
       && !(options & TypeResolutionFlags::SILType)) {
     if (!complained) {
       diagnose(repr->getElementNameLoc(0), diag::tuple_single_element)
-        .fixItRemoveChars(repr->getElementNameLoc(0),
+        .fixItRemoveChars(repr->getElementNameLoc(0).getStartLoc(),
                           repr->getElementType(0)->getStartLoc());
     }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -338,7 +338,7 @@ Expected<Pattern *> ModuleFile::readPattern(DeclContext *owningDC) {
       Identifier label = getIdentifier(labelID);
 
       Pattern *subPattern = readPatternUnchecked(owningDC);
-      elements.push_back(TuplePatternElt(label, SourceLoc(), subPattern));
+      elements.push_back(TuplePatternElt(label, DeclNameLoc(), subPattern));
     }
 
     auto result = TuplePattern::createImplicit(getContext(), elements);
@@ -2825,7 +2825,7 @@ public:
       MF.fatal();
 
     auto var = MF.createDecl<VarDecl>(/*IsStatic*/ isStatic, *introducer,
-                                      /*IsCaptureList*/ false, SourceLoc(),
+                                      /*IsCaptureList*/ false, DeclNameLoc(),
                                       name, DC);
     var->setHasNonPatternBindingInit(hasNonPatternBindingInit);
     var->setIsGetterMutating(isGetterMutating);
@@ -2956,7 +2956,7 @@ public:
       MF.fatal();
 
     auto param = MF.createDecl<ParamDecl>(SourceLoc(), SourceLoc(), argName,
-                                          SourceLoc(), paramName, DC);
+                                          DeclNameLoc(), paramName, DC);
     param->setSpecifier(*specifier);
 
     declOrOffset = param;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2690,8 +2690,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       abbrCode = S.DeclTypeAbbrCodes[TuplePatternEltLayout::Code];
       for (auto &elt : tuple->getElements()) {
         // FIXME: Default argument expressions?
-        TuplePatternEltLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                          S.addDeclBaseNameRef(elt.getLabel()));
+        // TODO(Compound variable names)
+        assert(elt.getLabel().isSimpleName());
+        auto id = S.addDeclBaseNameRef(elt.getLabel().getBaseName());
+        TuplePatternEltLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode, id);
         writePattern(elt.getPattern());
       }
       break;
@@ -3331,8 +3333,10 @@ public:
     unsigned numVTableEntries = getNumberOfRequiredVTableEntries(var);
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[VarLayout::Code];
+    // TODO(Compound variable names)
+    assert(var->getName().isSimpleName());
     VarLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                          S.addDeclBaseNameRef(var->getName()),
+                          S.addDeclBaseNameRef(var->getName().getBaseName()),
                           contextID.getOpaqueValue(),
                           var->isImplicit(),
                           var->isObjC(),
@@ -3377,9 +3381,11 @@ public:
         param->getDefaultValueStringRepresentation(scratch);
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[ParamLayout::Code];
+    // TODO(Compound variable names)
+    assert(param->getName().isSimpleName());
     ParamLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
         S.addDeclBaseNameRef(param->getArgumentName()),
-        S.addDeclBaseNameRef(param->getName()),
+        S.addDeclBaseNameRef(param->getName().getBaseName()),
         contextID.getOpaqueValue(),
         getRawStableParamDeclSpecifier(param->getSpecifier()),
         S.addTypeRef(interfaceType),
@@ -4004,9 +4010,11 @@ public:
     abbrCode = S.DeclTypeAbbrCodes[TupleTypeEltLayout::Code];
     for (auto &elt : tupleTy->getElements()) {
       assert(elt.getParameterFlags().isNone());
+      // TODO(Compound variable names)
+      assert(elt.getName().isSimpleName());
       TupleTypeEltLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode,
-          S.addDeclBaseNameRef(elt.getName()),
+          S.addDeclBaseNameRef(elt.getName().getBaseName()),
           S.addTypeRef(elt.getType()));
     }
   }

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -230,7 +230,8 @@ void Symbol::serializeFunctionSignature(llvm::json::OStream &OS) const {
           OS.attributeArray("parameters", [&](){
             for (const auto *Param : *ParamList) {
               auto ExternalName = Param->getArgumentName().str();
-              auto InternalName = Param->getParameterName().str();
+              llvm::SmallString<32> scratch;
+              auto InternalName = Param->getParameterName().getString(scratch);
 
               OS.object([&](){
                 if (ExternalName.empty()) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1525,9 +1525,10 @@ private:
         for (auto &ArgElt : FTR->getArgsTypeRepr()->getElements()) {
           CharSourceRange NR;
           CharSourceRange TR;
-          auto name = ArgElt.Name;
+          assert(ArgElt.Name.isSimpleName());
+          auto name = ArgElt.Name.getBaseIdentifier();
           if (!name.empty()) {
-            NR = CharSourceRange(ArgElt.NameLoc,
+            NR = CharSourceRange(ArgElt.NameLoc.getBaseNameLoc(),
                                  name.getLength());
           }
           SourceLoc SRE = Lexer::getLocForEndOfToken(SM,
@@ -2263,7 +2264,12 @@ void SwiftEditorDocument::expandPlaceholder(unsigned Offset, unsigned Length,
             OS << "{ ";
           } else {
             auto label = args->getElementName(argI);
-            OS << " " << (label.empty() ? "_" : label.str()) << ": { ";
+            OS << " ";
+            if (label.empty())
+              OS << "_";
+            else
+              OS << label;
+            OS << ": { ";
           }
           printClosureBody(closure, OS, SM);
           OS << "}";

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -716,10 +716,10 @@ getParamParentNameOffset(const ValueDecl *VD, SourceLoc Cursor) {
     auto *DC = PD->getDeclContext();
     switch (DC->getContextKind()) {
       case DeclContextKind::SubscriptDecl:
-        Loc = cast<SubscriptDecl>(DC)->getNameLoc();
+        Loc = cast<SubscriptDecl>(DC)->getNameLoc().getBaseNameLoc();
         break;
       case DeclContextKind::AbstractFunctionDecl:
-        Loc = cast<AbstractFunctionDecl>(DC)->getNameLoc();
+        Loc = cast<AbstractFunctionDecl>(DC)->getBaseNameLoc();
         break;
       default:
         break;

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -155,7 +155,7 @@ TEST(SourceLoc, StmtConditionElement) {
   auto vardecl = new (C.Ctx) VarDecl(/*IsStatic*/false,
                                      VarDecl::Introducer::Let,
                                      /*IsCaptureList*/false,
-                                     start.getAdvancedLoc(7)
+                                     DeclNameLoc(start.getAdvancedLoc(7))
                                     , C.Ctx.getIdentifier("x")
                                     , nullptr);
   auto pattern = new (C.Ctx) NamedPattern(vardecl);
@@ -247,7 +247,7 @@ TEST(SourceLoc, TupleExpr) {
   
   // a tuple with only invalid elements
   SmallVector<Expr *, 2> subExprsInvalid({ two, three });
-  SmallVector<Identifier, 2> subExprNamesInvalid(2, Identifier());
+  SmallVector<DeclName, 2> subExprNamesInvalid(2, DeclName());
   auto allInvalid = TupleExpr::createImplicit(C.Ctx, subExprsInvalid, subExprNamesInvalid);
   
   EXPECT_EQ(SourceLoc(), allInvalid->getStartLoc());
@@ -256,7 +256,7 @@ TEST(SourceLoc, TupleExpr) {
   
   // the tuple from the example
   SmallVector<Expr *, 2> subExprsRight({ one, two });
-  SmallVector<Identifier, 2> subExprNamesRight(2, Identifier());
+  SmallVector<DeclName, 2> subExprNamesRight(2, DeclName());
   auto rightInvalidTuple = TupleExpr::createImplicit(C.Ctx, subExprsRight, subExprNamesRight);
   
   EXPECT_EQ(start, rightInvalidTuple->getStartLoc());
@@ -264,7 +264,7 @@ TEST(SourceLoc, TupleExpr) {
   EXPECT_EQ(SourceRange(start, start), rightInvalidTuple->getSourceRange());
 
   SmallVector<Expr *, 2> subExprsLeft({ two, one });
-  SmallVector<Identifier, 2> subExprNamesLeft(2, Identifier());
+  SmallVector<DeclName, 2> subExprNamesLeft(2, DeclName());
   auto leftInvalidTuple = TupleExpr::createImplicit(C.Ctx, subExprsLeft, subExprNamesLeft);
   
   EXPECT_EQ(start, leftInvalidTuple->getStartLoc());
@@ -274,7 +274,7 @@ TEST(SourceLoc, TupleExpr) {
   // Some TupleExprs are triples. If only the middle expr has a valid SourceLoc
   // then the TupleExpr's SourceLoc should point at that.
   SmallVector<Expr *, 3> subExprsTriple({ two, one, two });
-  SmallVector<Identifier, 3> subExprNamesTriple(3, Identifier());
+  SmallVector<DeclName, 3> subExprNamesTriple(3, DeclName());
   auto tripleValidMid = TupleExpr::createImplicit(C.Ctx, subExprsTriple, subExprNamesTriple);
   EXPECT_EQ(start, tripleValidMid->getStartLoc());
   EXPECT_EQ(start, tripleValidMid->getEndLoc());
@@ -283,7 +283,7 @@ TEST(SourceLoc, TupleExpr) {
   // Some TupleExprs are quadruples. Quadruples should point at the range from
   // the first to the last valid exprs.
   SmallVector<Expr *, 4> subExprsQuad({ one, two, four, three });
-  SmallVector<Identifier, 4> subExprNamesQuad(4, Identifier());
+  SmallVector<DeclName, 4> subExprNamesQuad(4, DeclName());
   auto quadValidMids = TupleExpr::createImplicit(C.Ctx, subExprsQuad, subExprNamesQuad);
   EXPECT_EQ(start, quadValidMids->getStartLoc());
   EXPECT_EQ(start.getAdvancedLoc(4), quadValidMids->getEndLoc());


### PR DESCRIPTION
This PR is an incremental step towards supporting compound names for function-typed variables. Separating this initial work from the more meaningful changes was discussed on the forums [here](https://forums.swift.org/t/incremental-development-for-compound-variable-names/39011/3).

This does not include any changes to parsing, so it’s still an error to declare a variable like `var foo(x:y:)`, and the overall behavior of the compiler should remain unchanged.

This is mainly a refactor to update various parts of the compiler to expect a `DeclName` as the name of a `VarDecl` rather than an `Identifier`.

Where the change necessary to support compound names was obvious/trivial, the change has been made inline. In places where more refactoring or further thought is required, an appropriate assertion was added in addition to a “TODO(Compound variable names)”, and support will be added in a later PR.
