### PR TITLE
[Statement checking] Fix "old" fallthrough source.

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -725,12 +725,16 @@ public:
   
   struct AddSwitchNest {
     StmtChecker &SC;
+    CaseStmt *OuterFallthroughSource;
     CaseStmt *OuterFallthroughDest;
-    AddSwitchNest(StmtChecker &SC) : SC(SC),
+    AddSwitchNest(StmtChecker &SC)
+      : SC(SC),
+        OuterFallthroughSource(SC.FallthroughSource),
         OuterFallthroughDest(SC.FallthroughDest) {
     }
     
     ~AddSwitchNest() {
+      SC.FallthroughSource = OuterFallthroughSource;
       SC.FallthroughDest = OuterFallthroughDest;
     }
   };

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -165,3 +165,20 @@ func test5() {
   e()
 }
 
+// rdar://problem/67704651 - crash due to nested fallthrough
+func testNestedFallthrough(x: (Int, String), y: (Int, Int)) {
+  switch x {
+  case (17, let s):
+    switch y {
+    case (42, let i):
+      print("the answer")
+    default:
+      print("nope")
+    }
+    fallthrough
+  case (42, let s):
+    print("42 and \(s)")
+  default:
+    print("done")
+  }
+}


### PR DESCRIPTION
Fallthrough statement sources have always been incorrectly computed
when there are nested switch statements. The recent refactoring to
switch fallthrough source/destination computation over to ASTScope
fixed the computation. Amusingly, the assertion that ensures that the
old and new implementations produce the same result fires on these
cases, but it's the old implementation that's wrong. Fix up the old
implementation so the assertion does not trigger. The new test case
crashes in Swift 5.3 and earlier, asserts prior to this change.

Fixes rdar://problem/67704651.
