### PR TITLE
[5.3] [Constraint application] Find trailing closure direction more carefully.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5703,7 +5703,7 @@ Expr *ExprRewriter::coerceCallArguments(
     SmallVector<LocatorPathElt, 4> path;
     auto anchor = locator.getLocatorParts(path);
     if (!path.empty() && path.back().is<LocatorPathElt::ApplyArgument>() &&
-        (isa<CallExpr>(anchor) || isa<SubscriptExpr>(anchor))) {
+        !isa<UnresolvedDotExpr>(anchor)) {
       auto locatorPtr = cs.getConstraintLocator(locator);
       assert(solution.trailingClosureMatchingChoices.count(locatorPtr) == 1);
       trailingClosureMatching = solution.trailingClosureMatchingChoices.find(


### PR DESCRIPTION
Rather than trying to include each expression kind, which leaves us
open to errors of omission, exclude only the case where we don't record
locators for trailing closure directions.

Original #33721 reviewed by @xedin 

Fixes rdar://problem/67781123