### PR TITLE
[Docs] Rework educational note on protocol type non-conformance

### DIFF
--- a/userdocs/diagnostics/protocol-type-non-conformance.md
+++ b/userdocs/diagnostics/protocol-type-non-conformance.md
@@ -28,7 +28,7 @@ Notice that it is possible to invoke the method `makeNoise()` on a value of type
 ```swift
 print(Dog.species)    // Prints "Canus familiaris"
 print(Cat.species)    // Prints "Felis catus"
-print(Animal.species) // Error
+print(Animal.species) // error: static member 'species' cannot be used...
 ```
 
 Since a type conforms to a protocol only when it satisfies _all_ of that protocol's requirements, the existential type `Animal` does not conform to the protocol `Animal` because it cannot satisfy the protocol's requirement for the static property `species`:
@@ -45,7 +45,7 @@ declareAnimalSpecies(dog)
 // "Woof"
 // "My species is known as Canus familiaris"
 declareAnimalSpecies(animal)
-// Error: protocol type 'Animal' cannot conform to 'Animal'...
+// error: protocol type 'Animal' cannot conform to 'Animal'...
 ```
 
 In general, any initializers, static members, and associated types required by a protocol can be used only via conforming concrete types. Although Swift allows a protocol that requires initializers or static members to be used as a type, that type _does not and cannot_ conform to the protocol itself.
@@ -58,4 +58,4 @@ For more on using existential types, see [Protocols as Types](https://docs.swift
 
 ## Exceptions
 
-The Swift protocol `Error` has no requirements and, when used as a type, conforms to itself; `@objc` protocols with no static requirements can also be used as types that conform to themselves.
+The Swift protocol `Error` has no required members and, when used as a type, conforms to itself; `@objc` protocols with no static requirements can also be used as types that conform to themselves.

--- a/userdocs/diagnostics/protocol-type-non-conformance.md
+++ b/userdocs/diagnostics/protocol-type-non-conformance.md
@@ -1,46 +1,59 @@
-# Protocol type not conforming to itself
-Protocols in Swift may be used as types. Protocols as types are sometimes called existential types.
+# Protocol Types Cannot Conform to Protocols
 
+In Swift, a protocol that does not have `Self` or associated type requirements can be used as a type. You can use a variable or constant of a protocol type, also called an __existential type__, to hold a value of any conforming type:
 
 ```swift 
-protocol P {}
+protocol Animal {
+    func makeNoise()
+    static var species: String { get }
+}
+struct Dog: Animal {
+    func makeNoise() { print("Woof") }
+    static var species: String = "Canus familiaris"
+}
+struct Cat: Animal {
+    func makeNoise() { print("Meow") }
+    static var species: String = "Felis catus"
+}
 
-struct S: P {}
-
-var s: P = S() // This creates existential type because the protocol P is used as a type
+var animal: Animal // `Animal` is used here as a type.
+animal = Dog()
+animal.makeNoise() // Prints "Woof".
+animal = Cat()
+animal.makeNoise() // Prints "Meow".
 ```
 
-However, a protocol type does not conform to protocols - not even the protocol itself. 
-Allowing existential types to conform to protocols is unsound. For protocols with static method, initializer, or associated type requirements, the implementation of these requirements cannot be accessed from the protocol type - accessing these kinds of requirements must be done using a concrete type.
-
-Let's walk through the example below:
+Notice that it is possible to invoke the method `makeNoise()` on a value of type `Animal`, just as it is possible to do so on a value of concrete type `Dog` or `Cat`. However, the static property `species` is not available for the existential type:
 
 ```swift
-protocol Word: Hashable {
-    var word: String { get }
-}
-
-struct Singular: Word {
-    var word: String
-}
-
-struct Plural: Word {
-    var word: String
-}
-
-let singularWord = Singular(word: "mango")
-let pluralWord = Plural(word: "mangoes")
-
-let wordPairDict: [Word: Word] = [singularWord: pluralWord] // Error
+print(Dog.species)    // Prints "Canus familiaris"
+print(Cat.species)    // Prints "Felis catus"
+print(Animal.species) // Error
 ```
 
-One workaround to fix this problem is to use type erasure for the protocol `Word`. Think of type erasure as a way to hide an object's type. Since `Word` is of type `Hashable`, we already have `AnyHashable` type erasure available in the standard library which we can easily use here.
+Since a type conforms to a protocol only when it satisfies _all_ of that protocol's requirements, the existential type `Animal` does not conform to the protocol `Animal` because it cannot satisfy its own requirement for the static property `species`:
 
-```swift 
-// The fix
-let wordPairDict: [AnyHashable: AnyHashable] = [singularWord: pluralWord]
+```swift
+func declareAnimalSpecies<T: Animal>(_ animal: T) {
+    animal.makeNoise()
+    print("My species is known as \(T.species)")
+}
+
+let dog = Dog()
+declareAnimalSpecies(dog)
+// Prints:
+// "Woof"
+// "My species is known as Canus familiaris"
+declareAnimalSpecies(animal)
+// Error: protocol type 'Animal' cannot conform to 'Animal'...
 ```
 
-# Exceptions
-`@objc` protocol type with no static requirements however do conform to its own protocol. Another exception is the `Error` Swift protocol.
+In general, any initializers, static members, and associated types required by a protocol can be used only via conforming concrete types. Although Swift allows a protocol that requires initializers or static members to be used as a type, that type _does not and cannot_ conform to the protocol itself.
 
+Currently, even if a protocol `P` requires no initializers or static members, the existential type `P` does not conform to `P` (with exceptions below). This restriction allows library authors to add such requirements (initializers or static members) to an existing protocol without breaking their users' source code.
+
+Concrete types that _do_ conform to protocols can provide functionality similar to that of existential types. For example, the standard library provides the `AnyHashable` type for `Hashable` values. Manual implementation of such __type erasure__ can require specific knowledge of the semantic requirements for each protocol involved and is beyond the scope of this discussion.
+
+## Exceptions
+
+The Swift protocol `Error` has no requirements and, when used as a type, conforms to itself; `@objc` protocols with no static requirements can also be used as types that conform to themselves.

--- a/userdocs/diagnostics/protocol-type-non-conformance.md
+++ b/userdocs/diagnostics/protocol-type-non-conformance.md
@@ -31,7 +31,7 @@ print(Cat.species)    // Prints "Felis catus"
 print(Animal.species) // Error
 ```
 
-Since a type conforms to a protocol only when it satisfies _all_ of that protocol's requirements, the existential type `Animal` does not conform to the protocol `Animal` because it cannot satisfy its own requirement for the static property `species`:
+Since a type conforms to a protocol only when it satisfies _all_ of that protocol's requirements, the existential type `Animal` does not conform to the protocol `Animal` because it cannot satisfy the protocol's requirement for the static property `species`:
 
 ```swift
 func declareAnimalSpecies<T: Animal>(_ animal: T) {
@@ -53,6 +53,8 @@ In general, any initializers, static members, and associated types required by a
 Currently, even if a protocol `P` requires no initializers or static members, the existential type `P` does not conform to `P` (with exceptions below). This restriction allows library authors to add such requirements (initializers or static members) to an existing protocol without breaking their users' source code.
 
 Concrete types that _do_ conform to protocols can provide functionality similar to that of existential types. For example, the standard library provides the `AnyHashable` type for `Hashable` values. Manual implementation of such __type erasure__ can require specific knowledge of the semantic requirements for each protocol involved and is beyond the scope of this discussion.
+
+For more on using existential types, see [Protocols as Types](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID275) in _The Swift Programming Language_.
 
 ## Exceptions
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
The current educational note on protocol type non-conformance has been [insufficient to explain the situation](https://forums.swift.org/t/very-confused-about-some-compiler-warnings-related-to-protocols-bugs-or-intended/39754) to a user encountering the diagnostic in question.

This is an attempt to rework the text to incorporate more of the necessary discussion; it includes an example with intuitive protocol semantics which illustrates why existential types cannot conform to their own protocols in the general case, and it gives a brief explanation why it is not permitted currently in situations where it might be possible to relax the restriction.

Moreover, since [_The Swift Programming Language_](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID275) and [Apple documentation](https://developer.apple.com/documentation/swift/swift_standard_library/type_casting_and_existential_types) now pervasively use the term, this reworking elevates the term "existential type" and uses it more consistently throughout the text to contrast the type from the protocol with which it is associated.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
