### PR TITLE
[CSBindings] Delay binding chain result if type is an optional of a…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -743,6 +743,24 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
       return None;
   }
 
+  // If subtyping is allowed and this is a result of an implicit member chain,
+  // let's delay binding it to an optional until its object type resolved too or
+  // it has been determined that there is no possibility to resolve it. Otherwise
+  // we might end up missing solutions since it's allowed to implicitly unwrap
+  // base type of the chain but it can't be done early - type variable
+  // representing chain's result type has a different l-valueness comparing
+  // to generic parameter of the optional.
+  if (kind == AllowedBindingKind::Subtypes) {
+    auto *locator = typeVar->getImpl().getLocator();
+    if (locator &&
+        locator->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>()) {
+      auto objectType = type->getOptionalObjectType();
+      if (objectType && objectType->isTypeVariableOrMember()) {
+        result.PotentiallyIncomplete = true;
+      }
+    }
+  }
+
   if (type->is<InOutType>() && !typeVar->getImpl().canBindToInOut())
     type = LValueType::get(type->getInOutObjectType());
   if (type->is<LValueType>() && !typeVar->getImpl().canBindToLValue())

--- a/test/expr/delayed-ident/member_chains.swift
+++ b/test/expr/delayed-ident/member_chains.swift
@@ -344,3 +344,30 @@ extension CurriedGeneric where T == Int {
 
 let _: CurriedGeneric = .createInt(CurriedGeneric())()
 let _: CurriedGeneric = .create(CurriedGeneric())(Int.self)
+
+// rdar://problem/68094328 - failed to compile unresolved member with implicit optional promotion
+func rdar68094328() {
+  struct S {
+    init(string: String) {}
+
+    var value: S {
+      get { S(string: "") }
+    }
+
+    func baz(str: String) -> S {
+      S(string: str)
+    }
+  }
+
+  class C {
+    func bar(_: S) {}
+  }
+
+  func foo<T>(_: (C) -> (T) -> Void, _: T?) {}
+
+  func test(str: String) {
+    foo(C.bar, .init(string: str)) // Ok
+    foo(C.bar, .init(string: str).value) // Ok
+    foo(C.bar, .init(string: str).baz(str: "")) // Ok
+  }
+}


### PR DESCRIPTION
… type variable

If subtyping is allowed for a result type of an implicit member chain,
let's delay binding it to an optional until its object type resolved too or
it has been determined that there is no possibility to resolve it.
Otherwise we might end up missing solutions since it's allowed to
implicitly unwrap base type but it can't be done early - type variable
representing chain's result type has a different l-valueness comparing
to generic parameter of an optional.

This used to work before due to a hack in constraint generator where
unresolved member with arguments would return base type (which
doesn't allow l-value) instead of a result type.

Resolves: rdar://problem/68094328

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
