### PR TITLE
SILCombine: fix an assertion crash in SILCombine when casting AnyClass to Any

### DIFF
--- a/include/swift/SILOptimizer/Utils/Existential.h
+++ b/include/swift/SILOptimizer/Utils/Existential.h
@@ -49,6 +49,8 @@ struct OpenedArchetypeInfo {
     assert(!OpenedArchetype || (OpenedArchetypeValue && ExistentialValue));
     return OpenedArchetype;
   }
+  
+  void dump() const;
 };
 
 /// Record conformance and concrete type info derived from an init_existential
@@ -102,6 +104,8 @@ struct ConcreteExistentialInfo {
     CanType selfTy = P->getSelfInterfaceType()->getCanonicalType();
     return ExistentialSubs.lookupConformance(selfTy, P);
   }
+  
+  void dump() const;
 
 private:
   void initializeSubstitutionMap(
@@ -131,6 +135,8 @@ struct ConcreteOpenedExistentialInfo {
     assert(CEI->isValid());
     return true;
   }
+  
+  void dump() const;
 };
 
 } // end namespace swift

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -806,6 +806,8 @@ void SILCombiner::buildConcreteOpenedExistentialInfos(
       // BuilderContext before rewriting any uses of the ConcreteType.
       OpenedArchetypesTracker.addOpenedArchetypeDef(
           cast<ArchetypeType>(CEI.ConcreteType), CEI.ConcreteTypeDef);
+    } else if (auto *I = CEI.ConcreteValue->getDefiningInstruction()) {
+      OpenedArchetypesTracker.registerUsedOpenedArchetypes(I);
     }
   }
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -554,7 +554,8 @@ SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
   // Be careful with open archetypes, because they cannot be moved before
   // their definitions.
   if (IEI && !OEI &&
-      !IEI->getLoweredConcreteType().isOpenedExistential()) {
+      !IEI->getLoweredConcreteType().hasOpenedExistential()) {
+    assert(!IEI->getLoweredConcreteType().isOpenedExistential());
     auto *ConcAlloc = Builder.createAllocStack(
         AS->getLoc(), IEI->getLoweredConcreteType(), AS->getVarInfo());
     IEI->replaceAllUsesWith(ConcAlloc);

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -433,3 +433,40 @@ ConcreteOpenedExistentialInfo::ConcreteOpenedExistentialInfo(
   }
   CEI->isConcreteValueCopied |= OAI.isOpenedValueCopied;
 }
+
+void LLVM_ATTRIBUTE_USED OpenedArchetypeInfo::dump() const {
+  if (!isValid()) {
+    llvm::dbgs() << "invalid OpenedArchetypeInfo\n";
+    return;
+  }
+  llvm::dbgs() << "OpendArchetype: ";
+  OpenedArchetype->dump(llvm::dbgs());
+  llvm::dbgs() << "OpendArchetypeValue: ";
+  OpenedArchetypeValue->dump();
+  llvm::dbgs() << (isOpenedValueCopied ? "copied " : "") << "ExistentialValue: ";
+  ExistentialValue->dump();
+}
+
+void LLVM_ATTRIBUTE_USED ConcreteExistentialInfo::dump() const {
+  llvm::dbgs() << "ExistentialType: ";
+  ExistentialType->dump(llvm::dbgs());
+  llvm::dbgs() << "ConcreteType: ";
+  ConcreteType->dump(llvm::dbgs());
+  llvm::dbgs() << (isConcreteValueCopied ? "copied " : "") << "ConcreteValue: ";
+  ConcreteValue->dump();
+  if (ConcreteTypeDef) {
+    llvm::dbgs() << "ConcreteTypeDef: ";
+    ConcreteTypeDef->dump();
+  }
+  ExistentialSubs.dump(llvm::dbgs());
+  llvm::dbgs() << '\n';
+}
+
+void LLVM_ATTRIBUTE_USED ConcreteOpenedExistentialInfo::dump() const {
+  OAI.dump();
+  if (CEI) {
+    CEI->dump();
+  } else {
+    llvm::dbgs() << "no ConcreteExistentialInfo\n";
+  }
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3508,6 +3508,33 @@ bb0(%0 : $VV):
   return %26 : $()
 }
 
+sil @any_to_object : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+
+// CHECK-LABEL: sil @dont_crash_when_propagating_existentials
+// CHECK:   [[EM:%[0-9]+]] = init_existential_metatype %0
+// CHECK:   [[S:%[0-9]+]] = alloc_stack $Any
+// CHECK:   [[M:%[0-9]+]] = open_existential_metatype [[EM]]
+// CHECK:   [[E:%[0-9]+]] = init_existential_addr [[S]]
+// CHECK:   store [[M]] to [[E]]
+// CHECK:   apply {{%[0-9]+}}<(@opened("5F99B72C-EC40-11EA-9534-8C8590A6A134") AnyObject).Type>([[E]])
+// CHECK: } // end sil function 'dont_crash_when_propagating_existentials'
+sil @dont_crash_when_propagating_existentials : $@convention(thin) () -> @owned AnyObject {
+bb0:
+  %0 = metatype $@thick C.Type
+  %1 = init_existential_metatype %0 : $@thick C.Type, $@thick AnyObject.Type
+  %3 = alloc_stack $Any, let, name "object"
+  %4 = open_existential_metatype %1 : $@thick AnyObject.Type to $@thick (@opened("5F99B72C-EC40-11EA-9534-8C8590A6A134") AnyObject).Type
+  %5 = init_existential_addr %3 : $*Any, $(@opened("5F99B72C-EC40-11EA-9534-8C8590A6A134") AnyObject).Type
+  store %4 to %5 : $*@thick (@opened("5F99B72C-EC40-11EA-9534-8C8590A6A134") AnyObject).Type
+  %7 = open_existential_addr immutable_access %3 : $*Any to $*@opened("5F9F1B04-EC40-11EA-9534-8C8590A6A134") Any
+  %8 = function_ref @any_to_object : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+  %9 = apply %8<@opened("5F9F1B04-EC40-11EA-9534-8C8590A6A134") Any>(%7) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+  destroy_addr %3 : $*Any
+  dealloc_stack %3 : $*Any
+  return %9 : $AnyObject
+}
+
+
 // CHECK-LABEL: sil @remove_unused_alloc_ref
 // CHECK-NEXT: bb0
 // CHECK-NEXT: %0 = tuple ()


### PR DESCRIPTION
This caused a problem when propagating the concrete type of an existential: if the concrete type is itself an opened existential, it was not added to the OpenedArchetypeTracker.

https://bugs.swift.org/browse/SR-13444
rdar://problem/68077098