### PR TITLE
IRGen: Ignore local variable declaration in inline c functions

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -76,6 +76,12 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
 
   ClangDeclRefFinder refFinder([&](const clang::DeclRefExpr *DRE) {
     const clang::Decl *D = DRE->getDecl();
+
+    // Ignore local declarations.
+    if (auto varDecl = dyn_cast<clang::VarDecl>(D))
+      if (!varDecl->isFileVarDecl() && !varDecl->isStaticDataMember())
+        return;
+
     // Check that this is a file-level declaration and not inside a function.
     // If it's a member of a file-level decl, like a C++ static member variable,
     // we want to add the entire file-level declaration because Clang doesn't

--- a/test/IRGen/Inputs/c_functions.h
+++ b/test/IRGen/Inputs/c_functions.h
@@ -24,3 +24,8 @@ static inline void log_a_thing(const a_thing thing) {
 static inline unsigned int return7(void) {
   return 7;
 }
+
+static inline int getExternGlobal() {
+  extern int global;
+  return global;
+}

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -35,3 +35,8 @@ func test_indirect_by_val_alignment() {
 // i386: define hidden swiftcc void  @"$s11c_functions30test_indirect_by_val_alignmentyyF"()
 // s390x: define hidden swiftcc void  @"$s11c_functions30test_indirect_by_val_alignmentyyF"()
 // powerpc64le: define hidden swiftcc void  @"$s11c_functions30test_indirect_by_val_alignmentyyF"()
+
+
+func dontAssertOnExternLocal() {
+  let x = getExternGlobal()
+}


### PR DESCRIPTION
The existing code that walks back the declcontext parents did not work
for local declarations:

```
static inline void func() {
  extern int global;
  ...
}
```
The global's declaration context is the file context.

We would end up in code generation for the global decl and assert that
it is not a `isFileVarDecl()`.

rdar://67951491
