### PR TITLE
[NFC] Avoid repeatedly instantiating std::function in header files

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -380,10 +380,13 @@ struct PrintOptions {
   /// has no associated doc-comment by itself.
   bool CascadeDocComment = false;
 
+  static const std::function<bool(const ExtensionDecl *)>
+      defaultPrintExtensionContentAsMembers;
+
   /// Whether to print the content of an extension decl inside the type decl where it
   /// extends from.
   std::function<bool(const ExtensionDecl *)> printExtensionContentAsMembers =
-    [] (const ExtensionDecl *) { return false; };
+    PrintOptions::defaultPrintExtensionContentAsMembers;
 
   /// How to print the keyword argument and parameter name in functions.
   ArgAndParamPrintingMode ArgAndParamPrinting =

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -58,6 +58,11 @@
 
 using namespace swift;
 
+// Defined here to avoid repeatedly paying the price of template instantiation.
+const std::function<bool(const ExtensionDecl *)>
+    PrintOptions::defaultPrintExtensionContentAsMembers
+        = [] (const ExtensionDecl *) { return false; };
+
 void PrintOptions::setBaseType(Type T) {
   if (T->is<ErrorType>())
     return;

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -48,6 +48,27 @@ static llvm::cl::opt<bool> KeepWillThrowCall(
     llvm::cl::desc(
       "Keep calls to swift_willThrow, even if the throw is optimized away"));
 
+// Defined here to avoid repeatedly paying the price of template instantiation.
+const std::function<void(SILInstruction *)>
+    InstModCallbacks::defaultDeleteInst
+        = [](SILInstruction *inst) {
+          inst->eraseFromParent();
+        };
+const std::function<void(SILInstruction *)>
+    InstModCallbacks::defaultCreatedNewInst
+        = [](SILInstruction *) {};
+const std::function<void(SILValue, SILValue)>
+    InstModCallbacks::defaultReplaceValueUsesWith
+        = [](SILValue oldValue, SILValue newValue) {
+          oldValue->replaceAllUsesWith(newValue);
+        };
+const std::function<void(SingleValueInstruction *, SILValue)>
+    InstModCallbacks::defaultEraseAndRAUWSingleValueInst
+        = [](SingleValueInstruction *i, SILValue newValue) {
+          i->replaceAllUsesWith(newValue);
+          i->eraseFromParent();
+        };
+
 /// Creates an increment on \p Ptr before insertion point \p InsertPt that
 /// creates a strong_retain if \p Ptr has reference semantics itself or a
 /// retain_value if \p Ptr is a non-trivial value without reference-semantics.


### PR DESCRIPTION
Analysis of a build-script-based build with `-ftime-trace` showed that clang was spending a lot of time—at least 783.2 seconds of CPU time on my Xeon W—instantiating various templates. More than half of this time (466.6 sec) was associated with certain conversions of lambdas to `std::function` in header files:

1. 247.8 sec: llvm-project/llvm/include/llvm/Support/Error.h:1306:21
2. 226.6 sec: swift/include/swift/AST/PrintOptions.h:386:5
3. 48.0 sec: swift/include/swift/SILOptimizer/Utils/InstOptUtils.h:311, 314, 317, 322, 333 (various uses in `InstModCallbacks`)
4. 36.6 sec: swift/include/swift/SILOptimizer/Utils/InstOptUtils.h:45:17

This PR addresses 2 and 3, the easiest ones to avoid, by introducing `std::function` constants for the initial values of these fields. The lambdas, therefore, are only in one compilation unit, rather than e.g. 585 for PrintOptions.h. We can expect this to result in a small but noticeable reduction in the time needed for contributors to rebuild swiftc.

(llvm/Support/Error.h would be another good target, but we can't change that file in an apple/swift patch.)

I'll need to performance-test this to make sure that hiding these lambdas from the optimizer doesn't cause regressions.
