### PR TITLE
Sema: Fix cycle between closure type computation and EmittedMembersRequest

### DIFF
--- a/test/multifile/Inputs/rdar67842221-other.swift
+++ b/test/multifile/Inputs/rdar67842221-other.swift
@@ -1,0 +1,4 @@
+let closureValue = { () -> () in
+   class DummyClass {}
+   return ()
+}()

--- a/test/multifile/rdar67842221.swift
+++ b/test/multifile/rdar67842221.swift
@@ -1,0 +1,17 @@
+// Test both orderings, and single-file vs WMO
+
+// RUN: %target-swift-frontend -emit-ir -primary-file %s %S/Inputs/rdar67842221-other.swift -module-name main
+// RUN: %target-swift-frontend -emit-ir %s -primary-file %S/Inputs/rdar67842221-other.swift -module-name main
+
+// RUN: %target-swift-frontend -emit-ir -primary-file %S/Inputs/rdar67842221-other.swift %s -module-name main
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/rdar67842221-other.swift -primary-file %s -module-name main
+
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/rdar67842221-other.swift %s -module-name main
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/rdar67842221-other.swift %s -module-name main
+
+// The closure defines a local class; we want to make sure there is no cycle
+// between computing the semantic members of the local class (which requires
+// sorting) and computing the type of the closure value
+public func force() {
+  _ = closureValue
+}


### PR DESCRIPTION
EmittedMembersRequest needs a stable order for synthesized members
to ensure that vtable layout is computed consistently across frontend
jobs. This used to use the mangled name as the sort key.

However, the mangling includes the type of all outer contexts, and if
an outer type is a closure, we would need to compute the type of the
closure. Computing the type of a closure might require type checking
its body though, which would in turn type check the local class, which
would invoke EmittedMembersRequest, introducing a cycle.

Instead, let's use the DeclName and string-ified type as the sort key.
This is simpler to compute than th mangled name, and breaks the cycle.

Fixes <rdar://problem/67842221>.