### PR TITLE
[stdlib] NFC: Fix typo in comment.

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -293,7 +293,7 @@ extension _StringObject.CountAndFlags {
  on arm64.
 */
 extension _StringObject.Nibbles {
-  // The canonical empty sting is an empty small string
+  // The canonical empty string is an empty small string
   @inlinable @inline(__always)
   internal static var emptyString: UInt64 {
     return _StringObject.Nibbles.small(isASCII: true)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a comment typo in `stdlib/public/core/StringObject.swift`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
