### PR TITLE
[Sanitizer] Symbolication test no inline

### DIFF
--- a/test/Sanitizers/symbolication-linux.swift
+++ b/test/Sanitizers/symbolication-linux.swift
@@ -11,23 +11,25 @@
 // symbolication.  Note that `llvm-symbolizer` does not demangle Swift symbol
 // names, so we use `swift demangle`.
 
+@inline(never)
 func foo() {
   let x = UnsafeMutablePointer<Int>.allocate(capacity: 1)
   x.deallocate()
   print(x.pointee)
 }
 
+@inline(never)
 func bar() {
   foo()
+  print("Prevent tail call optimization")
 }
 
 bar()
 
-
 // Out-of-process
-// OOP:      #0 0x{{[0-9a-f]+}} in main.foo() -> () {{.*}}symbolication-linux.swift:[[@LINE-11]]
+// OOP:      #0 0x{{[0-9a-f]+}} in main.foo() -> () {{.*}}symbolication-linux.swift:[[@LINE-12]]
 // OOP-NEXT: #1 0x{{[0-9a-f]+}} in main.bar() -> () {{.*}}symbolication-linux.swift:[[@LINE-8]]
-// OOP-NEXT: #2 0x{{[0-9a-f]+}} in main {{.*}}symbolication-linux.swift:[[@LINE-6]]
+// OOP-NEXT: #2 0x{{[0-9a-f]+}} in main {{.*}}symbolication-linux.swift:[[@LINE-5]]
 
 // In-process
 // IP:      #0 0x{{[0-9a-f]+}} in main.foo() -> ()+0x

--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -9,23 +9,25 @@
 // both out-of-process (via `atos`) and when falling back to in-process
 // symbolication.  Note that `atos` also demangles Swift symbol names.
 
+@inline(never)
 func foo() {
   let x = UnsafeMutablePointer<Int>.allocate(capacity: 1)
   x.deallocate()
   print(x.pointee)
 }
 
+@inline(never)
 func bar() {
   foo()
+  print("Prevent tail call optimization")
 }
 
 bar()
 
-
 // Out-of-process
-// OOP:      #0 0x{{[0-9a-f]+}} in foo() symbolication.swift:[[@LINE-11]]
+// OOP:      #0 0x{{[0-9a-f]+}} in foo() symbolication.swift:[[@LINE-12]]
 // OOP-NEXT: #1 0x{{[0-9a-f]+}} in bar() symbolication.swift:[[@LINE-8]]
-// OOP-NEXT: #2 0x{{[0-9a-f]+}} in main symbolication.swift:[[@LINE-6]]
+// OOP-NEXT: #2 0x{{[0-9a-f]+}} in main symbolication.swift:[[@LINE-5]]
 
 // In-process
 // IP:      #0 0x{{[0-9a-f]+}} in main.foo() -> ()+0x


### PR DESCRIPTION
This test checks that Sanitizer reports contain properly symbolicated
stacks.  Let's make sure that all of the expected frames appear in the
stack by disabling inlining.

rdar://68171463

