### PR TITLE
Disable the PruneVTables optimization pass

### DIFF
--- a/lib/SILOptimizer/Transforms/PruneVTables.cpp
+++ b/lib/SILOptimizer/Transforms/PruneVTables.cpp
@@ -98,6 +98,8 @@ class PruneVTables : public SILModuleTransform {
   }
   
   void run() override {
+    return;
+
     SILModule *M = getModule();
     
     for (auto &vtable : M->getVTables()) {

--- a/lib/SILOptimizer/Transforms/PruneVTables.cpp
+++ b/lib/SILOptimizer/Transforms/PruneVTables.cpp
@@ -98,7 +98,9 @@ class PruneVTables : public SILModuleTransform {
   }
   
   void run() override {
+    // SWIFT_ENABLE_TENSORFLOW
     return;
+    // SWIFT_ENABLE_TENSORFLOW END
 
     SILModule *M = getModule();
     


### PR DESCRIPTION
This change disables the PruneVTables optimization pass introduced in #32359, because it caused issues uncovered by the use of `FoundationNetworking` described in [TF-1314](https://bugs.swift.org/browse/TF-1314). This patch is a temporary fix pending resolution of [SR-13449](https://bugs.swift.org/browse/SR-13449).

Resolves [TF-1314](https://bugs.swift.org/browse/TF-1314).

