### PR TITLE
Revert "build-script: remove dead CMake options for Swift"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1623,6 +1623,12 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_ENABLE_PROJECTS="$(join ";" ${llvm_enable_projects[@]})"
                 )
 
+                # NOTE: This is not a dead option! It is relied upon for certain
+                # bots/build-configs!
+                #
+                # TODO: In the future when we are always cross compiling and
+                # using Toolchain files, we should put this in either a
+                # toolchain file or a cmake cache.
                 if [[ "${BUILD_TOOLCHAIN_ONLY}" ]]; then
                     cmake_options+=(
                     -DLLVM_BUILD_TOOLS=NO
@@ -1796,6 +1802,23 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
                     "${swift_cmake_options[@]}"
                 )
+
+                if [[ "${BUILD_TOOLCHAIN_ONLY}" ]]; then
+                    cmake_options+=(
+                    -DSWIFT_TOOL_SIL_OPT_BUILD=FALSE
+                    -DSWIFT_TOOL_SWIFT_IDE_TEST_BUILD=FALSE
+                    -DSWIFT_TOOL_SWIFT_REMOTEAST_TEST_BUILD=FALSE
+                    -DSWIFT_TOOL_LLDB_MODULEIMPORT_TEST_BUILD=FALSE
+                    -DSWIFT_TOOL_SIL_EXTRACT_BUILD=FALSE
+                    -DSWIFT_TOOL_SWIFT_LLVM_OPT_BUILD=FALSE
+                    -DSWIFT_TOOL_SWIFT_SDK_ANALYZER_BUILD=FALSE
+                    -DSWIFT_TOOL_SWIFT_SDK_DIGESTER_BUILD=FALSE
+                    -DSWIFT_TOOL_SOURCEKITD_TEST_BUILD=FALSE
+                    -DSWIFT_TOOL_SOURCEKITD_REPL_BUILD=FALSE
+                    -DSWIFT_TOOL_COMPLETE_TEST_BUILD=FALSE
+                    -DSWIFT_TOOL_SWIFT_REFLECTION_DUMP_BUILD=FALSE
+                    )
+                fi
 
                 cmake_options=(
                     "${cmake_options[@]}"


### PR DESCRIPTION
This reverts commit 95102bc258a6b30ba2349d561ef56ea48c601cae.

This is actually a dead option that is relied upon for some configurations. I am
going to add a note to not touch the option.

I talked with compnerd about this and they are cool with this.

I think that we can redo this in a nicer way when we are further into the
build-script-impl refactoring.

I added a note to the code to explain that it isn't dead.
