### PR TITLE
[DynamicCast] Rely on runtime when casts can't be optimized

### DIFF
--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -522,12 +522,7 @@ class ClassInt: Equatable, Hashable {
   static func == (lhs: ClassInt, rhs: ClassInt) -> Bool {return true}
   func hash(into hasher: inout Hasher) {}
 }
-CastsTests.test("AnyHashable(Class) -> Obj-C -> Class")
-.skip(.custom({
-      !_isDebugAssertConfiguration()
-    },
-    reason: "Cast optimizer breaks this test"))
-.code {
+CastsTests.test("AnyHashable(Class) -> Obj-C -> Class") {
   let a = ClassInt()
   let b = runtimeCast(a, to: AnyHashable.self)!
   let c = _bridgeAnythingToObjectiveC(b)

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -298,9 +298,9 @@ bb3(%9 : $Optional<CP>):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checked_metatype_to_object_casts
 sil @checked_metatype_to_object_casts : $@convention(thin) <T> (@thick Any.Type) -> () {
 entry(%e : $@thick Any.Type):
-  %a = metatype $@thin NotClass.Type
-  // CHECK: br i1 false
-  checked_cast_br %a : $@thin NotClass.Type to AnyObject, a_yea, a_nay
+  %a = metatype $@thick NotClass.Type
+  // CHECK: call i1 @swift_dynamicCast({{.*}})
+  checked_cast_br %a : $@thick NotClass.Type to AnyObject, a_yea, a_nay
 a_yea(%1 : $AnyObject):
   %b = metatype $@thick A.Type
   // CHECK: bitcast %swift.type* {{%.*}} to %objc_object*

--- a/validation-test/Casting/BoxingCasts.swift.gyb
+++ b/validation-test/Casting/BoxingCasts.swift.gyb
@@ -16,16 +16,27 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/BoxingCasts.swift
-// RUN: %line-directive %t/BoxingCasts.swift -- %target-build-swift -g -module-name a -swift-version 5 -Onone %t/BoxingCasts.swift -o %t/a.swift5.Onone.out
+//
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-build-swift -g -module-name a -Onone -swift-version 5 %t/BoxingCasts.swift -o %t/a.swift5.Onone.out
 // RUN: %target-codesign %t/a.swift5.Onone.out
 // RUN: %line-directive %t/BoxingCasts.swift -- %target-run %t/a.swift5.Onone.out
 //
-// Note: The RUN directives above override the default test optimizations.
-// This test is deliberately run non-optimized in order to verify the
-// behavior of runtime methods that may not be called for optimized casts.
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-build-swift -g -O -module-name a -O -swift-version 5 %t/BoxingCasts.swift -o %t/a.swift5.O.out
+// RUN: %target-codesign %t/a.swift5.O.out
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-run %t/a.swift5.O.out
 //
-// XXX FIXME XXX TODO XXX  _Also_ build this with optimizations in order to
-// verify compiler behaviors.
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-build-swift -g -module-name a -Onone -swift-version 4 %t/BoxingCasts.swift -o %t/a.swift4.Onone.out
+// RUN: %target-codesign %t/a.swift4.Onone.out
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-run %t/a.swift4.Onone.out
+//
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-build-swift -g -O -module-name a -O -swift-version 4 %t/BoxingCasts.swift -o %t/a.swift4.O.out
+// RUN: %target-codesign %t/a.swift4.O.out
+// RUN: %line-directive %t/BoxingCasts.swift -- %target-run %t/a.swift4.O.out
+//
+// Note: The RUN directives above override the default test optimizations.
+// This test is deliberately run both ways:
+//  * optimized to verify compiler cast optimizations, and
+//  * non-optimized to verify the runtime methods used for non-optimized casts.
 //
 // REQUIRES: executable_test
 


### PR DESCRIPTION
The Swift compiler renders `as?` operations in Swift into variations of the `checked_cast_br` instructions in SIL.  Subsequent optimization passes may alter or eliminate these instructions.  Any remaining cast instructions after optimization are translated by IRGen into runtime calls.

At least, that's the theory.  Unfortunately, the current IRGen logic does not recognize all of the casting instruction variants and translates one particular unrecognized variant into a simple nil load.  This effectively converts an `as?` operation into one that will always fail.  Specifically, this occurs for optimized casts of metatypes to AnyObject:
```
  let a = Int.self
  let b = a as? AnyObject
  // b should not be nil here
```
(Ironically, in this particular case, the frontend issues a diagnostic warning that the cast will always succeed.)

This PR changes this case in IRGen to instead generate a call to `swift_dynamicCast`, deferring this case to the runtime.  (Yes, this particular example should get optimized into a simple store, but that's a future project.)

Test suite changes:
* With this change, the "BoxingCasts" test suite (which exercises a variety of boxing and unboxing casts) now passes in both optimized and non-optimized builds, so I've enabled those versions.
* There was a SIL test previously that constructed a `checked_cast_br` instruction with a thin metatype.  The IRGen pass should never see instructions of this form, so I've changed that particular test to exercise a thick metatype instead.