### PR TITLE
[NFC] Remove uses of 'nominal' from diagnostic text

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -21,6 +21,7 @@
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/AST/Types.h"
 #include "swift/Localization/LocalizationFormat.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -93,6 +94,7 @@ namespace swift {
     DeclAttribute,
     VersionTuple,
     LayoutConstraint,
+    TypeKind,
   };
 
   namespace diag {
@@ -122,6 +124,7 @@ namespace swift {
       const DeclAttribute *DeclAttributeVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
+      TypeKind TypeKindVal;
     };
     
   public:
@@ -209,6 +212,9 @@ namespace swift {
     DiagnosticArgument(LayoutConstraint L)
       : Kind(DiagnosticArgumentKind::LayoutConstraint), LayoutConstraintVal(L) {
     }
+
+    DiagnosticArgument(TypeKind K)
+        : Kind(DiagnosticArgumentKind::TypeKind), TypeKindVal(K) {}
     /// Initializes a diagnostic argument using the underlying type of the
     /// given enum.
     template<
@@ -298,6 +304,11 @@ namespace swift {
     LayoutConstraint getAsLayoutConstraint() const {
       assert(Kind == DiagnosticArgumentKind::LayoutConstraint);
       return LayoutConstraintVal;
+    }
+
+    TypeKind getAsTypeKind() const {
+      assert(Kind == DiagnosticArgumentKind::TypeKind);
+      return TypeKindVal;
     }
   };
   

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1783,7 +1783,7 @@ ERROR(inferred_opaque_type,none,
 
 // Extensions
 ERROR(non_nominal_extension,none,
-      "non-nominal type %0 cannot be extended", (Type))
+      "%0 %1 cannot be extended", (TypeKind, Type))
 WARNING(composition_in_extended_type,none,
         "extending a protocol composition is not supported; extending %0 "
         "instead", (Type))
@@ -2127,7 +2127,7 @@ NOTE(associated_type_deduction_witness_failed,none,
      (Identifier, Type, Type, bool))
 NOTE(associated_type_witness_conform_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
-     "is not a nominal type and so can't conform to %2",
+     "is not a struct, class or enum type and so can't conform to %2",
      (Identifier, Type, Type))
 NOTE(associated_type_witness_inherit_impossible,none,
      "candidate can not infer %0 = %1 because %1 "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1223,9 +1223,6 @@ NOTE(candidate_with_extraneous_args,none,
 ERROR(no_accessible_initializers,none,
       "%0 cannot be constructed because it has no accessible initializers",
       (Type))
-ERROR(non_nominal_no_initializers,none,
-      "non-nominal type %0 does not support explicit initialization",
-      (Type))
 ERROR(unbound_generic_parameter,none,
       "generic parameter %0 could not be inferred", (Type))
 ERROR(unbound_generic_parameter_cast,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2128,9 +2128,9 @@ NOTE(associated_type_deduction_witness_failed,none,
      "%select{inherited from|conformed to}3 %2",
      (Identifier, Type, Type, bool))
 NOTE(associated_type_witness_conform_impossible,none,
-     "candidate can not infer %0 = %1 because %1 "
-     "is not a struct, class or enum type and so can't conform to %2",
-     (Identifier, Type, Type))
+     "candidate can not infer %0 = %1 because %select{%1 "
+     "is a protocol used as a type and|%2 %1}3 can't conform to %4",
+     (Identifier, Type, TypeKind, bool, Type))
 NOTE(associated_type_witness_inherit_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a class type and so can't inherit from %2",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1784,6 +1784,8 @@ ERROR(inferred_opaque_type,none,
 // Extensions
 ERROR(non_nominal_extension,none,
       "%0 %1 cannot be extended", (TypeKind, Type))
+ERROR(anyobject_extension,none,
+      "'AnyObject' cannot be extended", ())
 WARNING(composition_in_extended_type,none,
         "extending a protocol composition is not supported; extending %0 "
         "instead", (Type))

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -35,9 +35,6 @@ EDUCATIONAL_NOTES(cannot_construct_dangling_pointer, "temporary-pointers.md")
 EDUCATIONAL_NOTES(cannot_construct_dangling_pointer_warning,
                   "temporary-pointers.md")
 
-
-
-EDUCATIONAL_NOTES(non_nominal_no_initializers, "nominal-types.md")
 EDUCATIONAL_NOTES(non_nominal_extension, "nominal-types.md")
 EDUCATIONAL_NOTES(associated_type_witness_conform_impossible,
                   "nominal-types.md")

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -452,6 +452,9 @@ public:
   /// getKind - Return what kind of type this is.
   TypeKind getKind() const { return static_cast<TypeKind>(Bits.TypeBase.Kind); }
 
+  // Return a descriptive name for this type.
+  static StringRef getKindName(TypeKind K);
+
   /// isCanonical - Return true if this is a canonical type.
   bool isCanonical() const { return Bits.TypeBase.IsCanonical; }
   

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -662,7 +662,21 @@ static void formatDiagnosticArgument(StringRef Modifier,
     break;
   case DiagnosticArgumentKind::TypeKind:
     assert(Modifier.empty() && "Improper modifier for TypeKind argument");
-    Out << TypeBase::getKindName(Arg.getAsTypeKind());
+    auto kind = Arg.getAsTypeKind();
+    switch (kind) {
+    case TypeKind::Hole:
+    case TypeKind::TypeVariable:
+    case TypeKind::WeakStorage:
+    case TypeKind::UnownedStorage:
+    case TypeKind::UnmanagedStorage:
+    case TypeKind::LValue:
+    case TypeKind::InOut:
+    case TypeKind::Paren:
+      assert(false && "These types should never appear in diagnostics!");
+    default:
+      break;
+    }
+    Out << TypeBase::getKindName(kind);
     break;
   }
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -660,6 +660,10 @@ static void formatDiagnosticArgument(StringRef Modifier,
     Out << FormatOpts.OpeningQuotationMark << Arg.getAsLayoutConstraint()
         << FormatOpts.ClosingQuotationMark;
     break;
+  case DiagnosticArgumentKind::TypeKind:
+    assert(Modifier.empty() && "Improper modifier for TypeKind argument");
+    Out << TypeBase::getKindName(Arg.getAsTypeKind());
+    break;
   }
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1137,6 +1137,79 @@ getCanonicalParams(AnyFunctionType *funcType,
   }
 }
 
+StringRef TypeBase::getKindName(TypeKind K) {
+#define ENTRY(Kind, String)                                                    \
+  case TypeKind::Kind:                                                         \
+    return String
+  switch (K) {
+    ENTRY(Error, "error type");
+    ENTRY(Unresolved, "unresolved type");
+    ENTRY(Hole, "hole type");
+    ENTRY(TypeVariable, "type variable type");
+
+    ENTRY(BuiltinInteger, "builtin type");
+    ENTRY(BuiltinIntegerLiteral, "builtin type");
+    ENTRY(BuiltinFloat, "builtin type");
+    ENTRY(BuiltinRawPointer, "builtin type");
+    ENTRY(BuiltinNativeObject, "builtin type");
+    ENTRY(BuiltinUnsafeValueBuffer, "builtin type");
+    ENTRY(BuiltinVector, "builtin type");
+    ENTRY(BuiltinBridgeObject, "builtin type");
+
+    ENTRY(Tuple, "tuple type");
+
+    ENTRY(WeakStorage, "reference storage type");
+    ENTRY(UnownedStorage, "reference storage type");
+    ENTRY(UnmanagedStorage, "reference storage type");
+
+    ENTRY(Enum, "enum type");
+    ENTRY(Struct, "struct type");
+    ENTRY(Class, "class type");
+    ENTRY(Protocol, "protocol type");
+
+    ENTRY(BoundGenericClass, "class type");
+    ENTRY(BoundGenericEnum, "enum type");
+    ENTRY(BoundGenericStruct, "struct type");
+
+    ENTRY(UnboundGeneric, "generic type");
+
+    ENTRY(Metatype, "metatype type");
+    ENTRY(ExistentialMetatype, "metatype type");
+
+    ENTRY(Module, "module type");
+
+    ENTRY(DynamicSelf, "dynamic self type");
+
+    ENTRY(PrimaryArchetype, "archetype type");
+    ENTRY(OpaqueTypeArchetype, "archetype type");
+    ENTRY(OpenedArchetype, "archetype type");
+    ENTRY(NestedArchetype, "archetype type");
+
+    ENTRY(GenericTypeParam, "generic parameter type");
+    ENTRY(DependentMember, "dependent member type");
+
+    ENTRY(Function, "function type");
+    ENTRY(GenericFunction, "function type");
+
+    ENTRY(SILFunction, "SIL function type");
+    ENTRY(SILBlockStorage, "SIL block storage type");
+    ENTRY(SILBox, "SIL box type");
+    ENTRY(SILToken, "SIL token type");
+
+    ENTRY(ProtocolComposition, "protocol composition type");
+    ENTRY(LValue, "lvalue type");
+    ENTRY(InOut, "inout type");
+
+    ENTRY(Paren, "paren type");
+    ENTRY(TypeAlias, "typealias type");
+    ENTRY(ArraySlice, "array slice type");
+    ENTRY(Optional, "optional type");
+    ENTRY(Dictionary, "dictionary type");
+  }
+#undef ENTRY
+  llvm_unreachable("bad TypeKind");
+}
+
 CanType TypeBase::computeCanonicalType() {
   assert(!hasCanonicalTypeComputed() && "called unnecessarily");
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1138,19 +1138,6 @@ getCanonicalParams(AnyFunctionType *funcType,
 }
 
 StringRef TypeBase::getKindName(TypeKind K) {
-  switch (K) {
-  case TypeKind::Hole:
-  case TypeKind::TypeVariable:
-  case TypeKind::WeakStorage:
-  case TypeKind::UnownedStorage:
-  case TypeKind::UnmanagedStorage:
-  case TypeKind::LValue:
-  case TypeKind::InOut:
-  case TypeKind::Paren:
-    assert(false && "These types should never appear in diagnostics!");
-  default:
-    break;
-  }
 #define ENTRY(Kind, String)                                                    \
   case TypeKind::Kind:                                                         \
     return String

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1138,6 +1138,19 @@ getCanonicalParams(AnyFunctionType *funcType,
 }
 
 StringRef TypeBase::getKindName(TypeKind K) {
+  switch (K) {
+  case TypeKind::Hole:
+  case TypeKind::TypeVariable:
+  case TypeKind::WeakStorage:
+  case TypeKind::UnownedStorage:
+  case TypeKind::UnmanagedStorage:
+  case TypeKind::LValue:
+  case TypeKind::InOut:
+  case TypeKind::Paren:
+    assert(false && "These types should never appear in diagnostics!");
+  default:
+    break;
+  }
 #define ENTRY(Kind, String)                                                    \
   case TypeKind::Kind:                                                         \
     return String
@@ -1158,9 +1171,9 @@ StringRef TypeBase::getKindName(TypeKind K) {
 
     ENTRY(Tuple, "tuple type");
 
-    ENTRY(WeakStorage, "reference storage type");
-    ENTRY(UnownedStorage, "reference storage type");
-    ENTRY(UnmanagedStorage, "reference storage type");
+    ENTRY(WeakStorage, "weak storage type");
+    ENTRY(UnownedStorage, "unowned storage type");
+    ENTRY(UnmanagedStorage, "unmanaged storage type");
 
     ENTRY(Enum, "enum type");
     ENTRY(Struct, "struct type");
@@ -1173,17 +1186,20 @@ StringRef TypeBase::getKindName(TypeKind K) {
 
     ENTRY(UnboundGeneric, "generic type");
 
-    ENTRY(Metatype, "metatype type");
-    ENTRY(ExistentialMetatype, "metatype type");
+    ENTRY(Metatype, "metatype");
+    ENTRY(ExistentialMetatype, "protocol metatype");
 
-    ENTRY(Module, "module type");
+    // Calling this 'module' instead of 'module type'
+    // because we don't want users to think of
+    // module as types.
+    ENTRY(Module, "module");
 
     ENTRY(DynamicSelf, "dynamic self type");
 
-    ENTRY(PrimaryArchetype, "archetype type");
-    ENTRY(OpaqueTypeArchetype, "archetype type");
-    ENTRY(OpenedArchetype, "archetype type");
-    ENTRY(NestedArchetype, "archetype type");
+    ENTRY(PrimaryArchetype, "generic parameter type");
+    ENTRY(OpaqueTypeArchetype, "opaque type");
+    ENTRY(OpenedArchetype, "protocol type");
+    ENTRY(NestedArchetype, "associated type");
 
     ENTRY(GenericTypeParam, "generic parameter type");
     ENTRY(DependentMember, "dependent member type");
@@ -1197,12 +1213,15 @@ StringRef TypeBase::getKindName(TypeKind K) {
     ENTRY(SILToken, "SIL token type");
 
     ENTRY(ProtocolComposition, "protocol composition type");
+
     ENTRY(LValue, "lvalue type");
     ENTRY(InOut, "inout type");
-
     ENTRY(Paren, "paren type");
-    ENTRY(TypeAlias, "typealias type");
-    ENTRY(ArraySlice, "array slice type");
+
+    // 'typealias' sounds better than 'typealias type'.
+    ENTRY(TypeAlias, "typealias");
+
+    ENTRY(ArraySlice, "array type");
     ENTRY(Optional, "optional type");
     ENTRY(Dictionary, "dictionary type");
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1205,8 +1205,8 @@ StringRef TypeBase::getKindName(TypeKind K) {
     ENTRY(InOut, "inout type");
     ENTRY(Paren, "paren type");
 
-    // 'typealias' sounds better than 'typealias type'.
-    ENTRY(TypeAlias, "typealias");
+    // 'type alias' sounds better than 'type alias type'.
+    ENTRY(TypeAlias, "type alias");
 
     ENTRY(ArraySlice, "array type");
     ENTRY(Optional, "optional type");

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2694,6 +2694,14 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
 
   // Cannot extend function types, tuple types, etc.
   if (!extendedType->getAnyNominal()) {
+    // Emit tailored diagnostic for 'AnyObject' since we don't want to
+    // mention "typealias" or "protocol composition type" in the
+    // diagnostic.
+    if (extendedType->isAnyObject()) {
+      diags.diagnose(ext->getLoc(), diag::anyobject_extension)
+          .highlight(extendedRepr->getSourceRange());
+      return error();
+    }
     diags
         .diagnose(ext->getLoc(), diag::non_nominal_extension,
                   extendedType->getCanonicalType()->getKind(), extendedType)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2694,8 +2694,10 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
 
   // Cannot extend function types, tuple types, etc.
   if (!extendedType->getAnyNominal()) {
-    diags.diagnose(ext->getLoc(), diag::non_nominal_extension, extendedType)
-         .highlight(extendedRepr->getSourceRange());
+    diags
+        .diagnose(ext->getLoc(), diag::non_nominal_extension,
+                  extendedType->getKind(), extendedType)
+        .highlight(extendedRepr->getSourceRange());
     return error();
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2696,7 +2696,7 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
   if (!extendedType->getAnyNominal()) {
     diags
         .diagnose(ext->getLoc(), diag::non_nominal_extension,
-                  extendedType->getKind(), extendedType)
+                  extendedType->getCanonicalType()->getKind(), extendedType)
         .highlight(extendedRepr->getSourceRange());
     return error();
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2432,7 +2432,7 @@ public:
                         canExtType->getString());
       } else if (!wasAlreadyInvalid) {
         // If nothing else applies, fall back to a generic diagnostic.
-        ED->diagnose(diag::non_nominal_extension, extType);
+        ED->diagnose(diag::non_nominal_extension, extType->getKind(), extType);
       }
       return;
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2432,7 +2432,8 @@ public:
                         canExtType->getString());
       } else if (!wasAlreadyInvalid) {
         // If nothing else applies, fall back to a generic diagnostic.
-        ED->diagnose(diag::non_nominal_extension, extType->getKind(), extType);
+        ED->diagnose(diag::non_nominal_extension,
+                     extType->getCanonicalType()->getKind(), extType);
       }
       return;
     }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1760,6 +1760,8 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_conform_impossible,
                            assocType->getName(), failed.TypeWitness,
+                           failed.TypeWitness->getCanonicalType()->getKind(),
+                           !failed.TypeWitness->isExistentialType(),
                            failed.Result.getRequirement());
             continue;
           }

--- a/test/SourceKit/Sema/educational_note_diags.swift
+++ b/test/SourceKit/Sema/educational_note_diags.swift
@@ -2,14 +2,14 @@ extension (Int, Int) {}
 
 // RUN: %sourcekitd-test -req=sema %s -- %s | %FileCheck %s -check-prefix=NO_OVERRIDE
 
-// NO_OVERRIDE:      key.description: "non-nominal type
+// NO_OVERRIDE:      key.description: "tuple type
 // NO_OVERRIDE:      key.educational_note_paths: [
 // NO_OVERRIDE-NEXT:   share{{[/\\]+}}doc{{[/\\]+}}swift{{[/\\]+}}diagnostics{{[/\\]+}}nominal-types.md"
 // NO_OVERRIDE-NEXT: ]
 
 // RUN: %sourcekitd-test -req=sema %s -- -Xfrontend -diagnostic-documentation-path -Xfrontend /educational/notes/path/prefix %s | %FileCheck %s -check-prefix=OVERRIDE
 
-// OVERRIDE:      key.description: "non-nominal type
+// OVERRIDE:      key.description: "tuple type
 // OVERRIDE:      key.educational_note_paths: [
 // OVERRIDE-NEXT:   "{{[/\\]+}}educational{{[/\\]+}}notes{{[/\\]+}}path{{[/\\]+}}prefix{{[/\\]+}}nominal-types.md"
 // OVERRIDE-NEXT: ]

--- a/test/attr/ApplicationMain/attr_main_tuple_extension.swift
+++ b/test/attr/ApplicationMain/attr_main_tuple_extension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s
 
 @main
-extension (Int, String) { // expected-error {{non-nominal type '(Int, String)' cannot be extended}}
+extension (Int, String) { // expected-error {{tuple type '(Int, String)' cannot be extended}}
   static func main() {
   }
 }

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -81,10 +81,10 @@ protocol P1 {}
 
 protocol P2 {}
 
-extension () {} // expected-error {{type '()' cannot be extended}} {{educational-notes=nominal-types}}
+extension () {} // expected-error {{tuple type '()' cannot be extended}} {{educational-notes=nominal-types}}
 
 typealias TupleAlias = (x: Int, y: Int)
-extension TupleAlias {} // expected-error{{typealias type 'TupleAlias' (aka '(x: Int, y: Int)') cannot be extended}} {{educational-notes=nominal-types}}
+extension TupleAlias {} // expected-error{{tuple type 'TupleAlias' (aka '(x: Int, y: Int)') cannot be extended}} {{educational-notes=nominal-types}}
 
 // Test property accessors in extended types
 class C {}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -81,10 +81,10 @@ protocol P1 {}
 
 protocol P2 {}
 
-extension () {} // expected-error {{non-nominal type '()' cannot be extended}} {{educational-notes=nominal-types}}
+extension () {} // expected-error {{type '()' cannot be extended}} {{educational-notes=nominal-types}}
 
 typealias TupleAlias = (x: Int, y: Int)
-extension TupleAlias {} // expected-error{{non-nominal type 'TupleAlias' (aka '(x: Int, y: Int)') cannot be extended}} {{educational-notes=nominal-types}}
+extension TupleAlias {} // expected-error{{typealias type 'TupleAlias' (aka '(x: Int, y: Int)') cannot be extended}} {{educational-notes=nominal-types}}
 
 // Test property accessors in extended types
 class C {}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -971,7 +971,7 @@ extension BadProto4 { } // okay
 typealias RawRepresentableAlias = RawRepresentable
 extension RawRepresentableAlias { } // okay
 
-extension AnyObject { } // expected-error{{non-nominal type 'AnyObject' cannot be extended}}
+extension AnyObject { } // expected-error{{builtin type 'AnyObject' cannot be extended}}
 
 // Members of protocol extensions cannot be overridden.
 // rdar://problem/21075287

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -971,7 +971,7 @@ extension BadProto4 { } // okay
 typealias RawRepresentableAlias = RawRepresentable
 extension RawRepresentableAlias { } // okay
 
-extension AnyObject { } // expected-error{{builtin type 'AnyObject' cannot be extended}}
+extension AnyObject { } // expected-error{{'AnyObject' cannot be extended}}
 
 // Members of protocol extensions cannot be overridden.
 // rdar://problem/21075287

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -78,7 +78,7 @@ protocol P8 {
 }
 
 struct B : P8 { // expected-error {{type 'B' does not conform to protocol 'P8'}}
-    func g(t: (Int, String)) {} // expected-note {{candidate can not infer 'T' = '(Int, String)' because '(Int, String)' is not a nominal type and so can't conform to 'P7'}}
+    func g(t: (Int, String)) {} // expected-note {{candidate can not infer 'T' = '(Int, String)' because '(Int, String)' is not a struct, class or enum type and so can't conform to 'P7'}}
 }
 
 protocol P9 {
@@ -107,7 +107,7 @@ protocol P12 {
 extension Int : P11 {}
 struct S3 : P12 { // expected-error {{type 'S3' does not conform to protocol 'P12'}}
     func bar() -> P11 { return 0 }
-    // expected-note@-1 {{candidate can not infer 'A' = 'P11' because 'P11' is not a nominal type and so can't conform to 'P11'}}
+    // expected-note@-1 {{candidate can not infer 'A' = 'P11' because 'P11' is not a struct, class or enum type and so can't conform to 'P11'}}
 }
 
 // SR-12759

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -78,7 +78,7 @@ protocol P8 {
 }
 
 struct B : P8 { // expected-error {{type 'B' does not conform to protocol 'P8'}}
-    func g(t: (Int, String)) {} // expected-note {{candidate can not infer 'T' = '(Int, String)' because '(Int, String)' is not a struct, class or enum type and so can't conform to 'P7'}}
+    func g(t: (Int, String)) {} // expected-note {{candidate can not infer 'T' = '(Int, String)' because tuple type '(Int, String)' can't conform to 'P7'}}
 }
 
 protocol P9 {
@@ -107,7 +107,7 @@ protocol P12 {
 extension Int : P11 {}
 struct S3 : P12 { // expected-error {{type 'S3' does not conform to protocol 'P12'}}
     func bar() -> P11 { return 0 }
-    // expected-note@-1 {{candidate can not infer 'A' = 'P11' because 'P11' is not a struct, class or enum type and so can't conform to 'P11'}}
+    // expected-note@-1 {{candidate can not infer 'A' = 'P11' because 'P11' is a protocol used as a type and can't conform to 'P11'}}
 }
 
 // SR-12759

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -328,7 +328,7 @@ typealias Y = ErrorA<ErrorB>
 
 typealias Id<T> = T
 
-extension Id {} // expected-error {{non-nominal type 'Id' cannot be extended}}
+extension Id {} // expected-error {{generic type 'Id' cannot be extended}}
 
 class OuterGeneric<T> {
   typealias Alias<T> = AnotherGeneric<T>

--- a/test/diagnostics/educational-notes.swift
+++ b/test/diagnostics/educational-notes.swift
@@ -12,7 +12,7 @@ let x = 1 +
 
 // A diagnostic with an educational note using supported markdown features
 extension (Int, Int) {}
-// CHECK:{{.*}}[0m[0;1;31merror: [0m[1mnon-nominal type '(Int, Int)' cannot be extended
+// CHECK:{{.*}}[0m[0;1;31merror: [0m[1mtuple type '(Int, Int)' cannot be extended
 // CHECK-NEXT:[0mextension (Int, Int) {}
 // CHECK-NEXT:[0;1;32m^         ~~~~~~~~~~
 // CHECK-NEXT:[0m[0m[1mNominal Types[0m
@@ -40,7 +40,7 @@ extension (Int, Int) {}
 // CHECK-NEXT:[0m[1mHeader 1[0m
 // CHECK-NEXT:[0m[1mHeader 3[0m
 
-// NO-COLOR:{{.*}}error: non-nominal type '(Int, Int)' cannot be extended
+// NO-COLOR:{{.*}}error: tuple type '(Int, Int)' cannot be extended
 // NO-COLOR-NEXT:extension (Int, Int) {}
 // NO-COLOR-NEXT:^         ~~~~~~~~~~
 // NO-COLOR-NEXT:Nominal Types
@@ -78,7 +78,7 @@ extension (Int, Int) {}
 // CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
 // CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
 // CHECK-DESCRIPTIVE-NEXT:  |           ~~~~~~~~~~
-// CHECK-DESCRIPTIVE-NEXT:  | ^ error: non-nominal type '(Int, Int)' cannot be extended
+// CHECK-DESCRIPTIVE-NEXT:  | ^ error: tuple type '(Int, Int)' cannot be extended
 // CHECK-DESCRIPTIVE-NEXT:  |
 // CHECK-DESCRIPTIVE-NEXT: Nominal Types
 // CHECK-DESCRIPTIVE-NEXT: -------------

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -33,13 +33,13 @@ func b() {
 // CHECK: unexpected warning produced: initialization of immutable value 'c' was never used
 // CHECK-WARNINGS-AS-ERRORS: unexpected error produced: initialization of immutable value 'c' was never used
 
-extension (Int, Int) {} // expected-error {{non-nominal type '(Int, Int)' cannot be extended}} {{educational-notes=foo-bar-baz}}
+extension (Int, Int) {} // expected-error {{tuple type '(Int, Int)' cannot be extended}} {{educational-notes=foo-bar-baz}}
 // CHECK: error: expected educational note(s) not seen; actual educational note(s): {{[{][{]}}educational-notes=nominal-types{{[}][}]}}
 
-extension (Bool, Int) {} // expected-error {{non-nominal type '(Bool, Int)' cannot be extended}} {{educational-notes=nominal-types}} {{educational-notes=nominal-types}}
+extension (Bool, Int) {} // expected-error {{tuple type '(Bool, Int)' cannot be extended}} {{educational-notes=nominal-types}} {{educational-notes=nominal-types}}
 // CHECK: error: each verified diagnostic may only have one {{[{][{]}}educational-notes=<#notes#>{{[}][}]}} declaration
 
-extension (Bool, Bool) {} // expected-error {{non-nominal type '(Bool, Bool)' cannot be extended}} {{educational-notes=nominal-types,foo-bar-baz}}
+extension (Bool, Bool) {} // expected-error {{tuple type '(Bool, Bool)' cannot be extended}} {{educational-notes=nominal-types,foo-bar-baz}}
 // CHECK: error: expected educational note(s) not seen; actual educational note(s): {{[{][{]}}educational-notes=nominal-types{{[}][}]}}
 
 // Verify the serialized diags have the right magic at the top.

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -17,7 +17,7 @@ func bad_containers_2(bc: BadContainer2) {
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
-  func makeIterator() { } // expected-note{{candidate can not infer 'Iterator' = '()' because '()' is not a nominal type and so can't conform to 'IteratorProtocol'}}
+  func makeIterator() { } // expected-note{{candidate can not infer 'Iterator' = '()' because '()' is not a struct, class or enum type and so can't conform to 'IteratorProtocol'}}
 }
 
 func bad_containers_3(bc: BadContainer3) {

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -17,7 +17,7 @@ func bad_containers_2(bc: BadContainer2) {
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
-  func makeIterator() { } // expected-note{{candidate can not infer 'Iterator' = '()' because '()' is not a struct, class or enum type and so can't conform to 'IteratorProtocol'}}
+  func makeIterator() { } // expected-note{{candidate can not infer 'Iterator' = '()' because tuple type '()' can't conform to 'IteratorProtocol'}}
 }
 
 func bad_containers_3(bc: BadContainer3) {


### PR DESCRIPTION
This PR removes uses of the word `nominal` from diagnostic text. This word is quite jargon-y and not meant to be used outside of compiler internals. Let's replace this word with a more (user-friendly) description of the type.