### PR TITLE
[Serialization] Local allocate ModuleFileSharedCore.ModuleInterfacePath

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -461,8 +461,11 @@ public:
     auto *core = new ModuleFileSharedCore(
         std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
         std::move(moduleSourceInfoInputBuffer), isFramework, info, extInfo);
-    if (!moduleInterfacePath.empty())
-      core->ModuleInterfacePath = moduleInterfacePath;
+    if (!moduleInterfacePath.empty()) {
+      ArrayRef<char> path;
+      core->allocateBuffer(path, moduleInterfacePath);
+      core->ModuleInterfacePath = StringRef(path.data(), path.size());
+    }
     theModule.reset(core);
     return info;
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -990,10 +990,8 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
   Ctx.addLoadedModule(M);
   SWIFT_DEFER { M->setHasResolvedImports(); };
 
-  StringRef moduleInterfacePathStr =
-    Ctx.AllocateCopy(moduleInterfacePath.str());
   auto *file =
-      loadAST(*M, moduleID.Loc, moduleInterfacePathStr,
+      loadAST(*M, moduleID.Loc, moduleInterfacePath,
               std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
               std::move(moduleSourceInfoInputBuffer), isFramework);
   if (file) {


### PR DESCRIPTION
`ModuleInterfacePath` is passed as `StringRef` that memory used to reside in `ASTContext`. But `ModuleFileSharedCore` should be `ASTContext` independent. So copy it using its own allocator.

