### PR TITLE
[udpate-checkout] Add --quiet flag

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -64,10 +64,8 @@ MOCK_CONFIG = {
 
 
 def call_quietly(*args, **kwargs):
-    with open(os.devnull, 'w') as f:
-        kwargs['stdout'] = f
-        kwargs['stderr'] = f
-        subprocess.check_call(*args, **kwargs)
+    result = subprocess.run(*args, capture_output=True, **kwargs)
+    return (result.stdout, result.stderr)
 
 
 def create_dir(d):
@@ -156,4 +154,4 @@ class SchemeMockTestCase(unittest.TestCase):
 
     def call(self, *args, **kwargs):
         kwargs['cwd'] = self.source_root
-        call_quietly(*args, **kwargs)
+        return call_quietly(*args, **kwargs)

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -23,3 +23,11 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
                    '--config', self.config_path,
                    '--source-root', self.source_root,
                    '--clone'])
+
+    def test_quiet_clone(self):
+        _, stderr = self.call([self.update_checkout_path,
+                               '--quiet',
+                               '--config', self.config_path,
+                               '--source-root', self.source_root,
+                               '--clone'])
+        self.assertRegex(stderr.decode(), 'git fetch .*--quiet')


### PR DESCRIPTION
Add a `--quiet` (and `-q`) flag to `update-checkout` to generate less terminal output.

This `--quiet` flag is currently only threaded through to the `git fetch` which is the most noisiest operation.