### PR TITLE
[TF] build: update checkout for swift-driver.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -355,7 +355,7 @@
                 "swift-tools-support-core": "0.1.8",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2020-08-31-a",
                 "swift-argument-parser": "0.3.0",
-                "swift-driver": "b590b0c8e8a26c68602af7224af1bb203f23c31a",
+                "swift-driver": "7a441561a176f6eac2953aea2c395cc4e683f820",
                 "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2020-08-31-a",
                 "swift-stress-tester": "swift-DEVELOPMENT-SNAPSHOT-2020-08-31-a",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2020-08-31-a",


### PR DESCRIPTION
`apple/swift-driver` does not have `swift-DEVELOPMENT-SNAPSHOT-*` tags, so its commit hash needs to be manually updated with every `master -> tensorflow` merge.

---

Fixes a build error due to outdated `apple/swift-driver` version:

```
+ swift-driver/Utilities/build-script-helper.py clean --package-path /Users/swiftninjas/s4tf/swi
ft-driver --build-path /Users/swiftninjas/s4tf/build/buildbot_osx/swiftdriver-macosx-x86_64 --configuration release --to
olchain /Users/swiftninjas/s4tf/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-20
20-09-02-a.xctoolchain/usr --ninja-bin /Users/swiftninjas/s4tf/build/buildbot_osx/ninja-build/ninja --verbose
usage: build-script-helper.py [-h] action ...
build-script-helper.py: error: argument action: invalid choice: 'clean' (choose from 'build', 'test', 'install')
```