### PR TITLE
utils: add a timeout to the integration tests

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3124,8 +3124,11 @@ function build_and_test_installable_package() {
             with_pushd "${PKG_TESTS_SANDBOX_PARENT}" \
                 call tar xzf "${package_for_host}"
 
+            if python -c import psutil ; then
+              TIMEOUT_ARGS=--timeout=3000 # 50 minutes
+            fi
             with_pushd "${PKG_TESTS_SOURCE_DIR}" \
-                call python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}"
+                call python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}" ${TIMEOUT_ARGS}
         fi
     fi
 }

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3125,7 +3125,7 @@ function build_and_test_installable_package() {
                 call tar xzf "${package_for_host}"
 
             if python -c import psutil ; then
-              TIMEOUT_ARGS=--timeout=3000 # 50 minutes
+              TIMEOUT_ARGS=--timeout=1200 # 20 minutes
             fi
             with_pushd "${PKG_TESTS_SOURCE_DIR}" \
                 call python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}" ${TIMEOUT_ARGS}

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3124,7 +3124,7 @@ function build_and_test_installable_package() {
             with_pushd "${PKG_TESTS_SANDBOX_PARENT}" \
                 call tar xzf "${package_for_host}"
 
-            if python -c import psutil ; then
+            if python -c "import psutil" ; then
               TIMEOUT_ARGS=--timeout=1200 # 20 minutes
             fi
             with_pushd "${PKG_TESTS_SOURCE_DIR}" \


### PR DESCRIPTION
This will allow us to add test cases which may hang.  The timeout here
is taken from the value we use in the regular test suite (along with the
check for the timeout requirements).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
