### PR TITLE
Adopt getParsedMembers()/getSemanticMembers() to squash nondeterminism

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -386,7 +386,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
 
@@ -404,10 +404,6 @@ protected:
 
     /// Whether the function body throws.
     Throws : 1,
-
-    /// Whether this member was synthesized as part of a derived
-    /// protocol conformance.
-    Synthesized : 1,
 
     /// Whether this member's body consists of a single expression.
     HasSingleExpressionBody : 1
@@ -5862,7 +5858,6 @@ protected:
     Bits.AbstractFunctionDecl.Overridden = false;
     Bits.AbstractFunctionDecl.Async = Async;
     Bits.AbstractFunctionDecl.Throws = Throws;
-    Bits.AbstractFunctionDecl.Synthesized = false;
     Bits.AbstractFunctionDecl.HasSingleExpressionBody = false;
   }
 
@@ -6047,14 +6042,6 @@ public:
   /// For a method of a class, checks whether it will require a new entry in the
   /// vtable.
   bool needsNewVTableEntry() const;
-
-  bool isSynthesized() const {
-    return Bits.AbstractFunctionDecl.Synthesized;
-  }
-
-  void setSynthesized(bool value = true) {
-    Bits.AbstractFunctionDecl.Synthesized = value;
-  }
 
 public:
   /// Retrieve the source range of the function body.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4406,7 +4406,7 @@ public:
   /// This can occur, for example, if the protocol is an Objective-C protocol
   /// with requirements that cannot be represented in Swift.
   bool hasMissingRequirements() const {
-    (void)getMembers();
+    (void)getSemanticMembers();
     return Bits.ProtocolDecl.HasMissingRequirements;
   }
 

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -322,6 +322,12 @@ public:
     cache.insert({AnyRequest(request), std::move(output)});
   }
 
+  template<typename Request,
+           typename std::enable_if<!Request::hasExternalCache>::type* = nullptr>
+  void clearCachedOutput(const Request &request) {
+    cache.erase(AnyRequest(request));
+  }
+
   /// Clear the cache stored within this evaluator.
   ///
   /// Note that this does not clear the caches of requests that use external

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -207,7 +207,7 @@ public:
   template<typename F>
   void forEachNonWitnessedRequirement(F f) const {
     const ProtocolDecl *protocol = getProtocol();
-    for (auto req : protocol->getMembers()) {
+    for (auto req : protocol->getSemanticMembers()) {
       auto valueReq = dyn_cast<ValueDecl>(req);
       if (!valueReq || valueReq->isInvalid())
         continue;
@@ -361,7 +361,7 @@ public:
   template<typename F>
   void forEachValueWitness(F f, bool useResolver=false) const {
     const ProtocolDecl *protocol = getProtocol();
-    for (auto req : protocol->getMembers()) {
+    for (auto req : protocol->getSemanticMembers()) {
       auto valueReq = dyn_cast<ValueDecl>(req);
       if (!valueReq || isa<AssociatedTypeDecl>(valueReq) ||
           valueReq->isInvalid())

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -53,9 +53,9 @@ public:
     return RetTy();
   }
 
-  /// A convenience method to visit all the members.
+  /// A convenience method to visit all the semantic members.
   void visitMembers(NominalTypeDecl *D) {
-    for (Decl *member : D->getMembers()) {
+    for (Decl *member : D->getSemanticMembers()) {
       asImpl().visit(member);
     }
   }

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -104,7 +104,7 @@ public:
       return;
 
     // Visit the witnesses for the direct members of a protocol.
-    for (Decl *member : protocol->getMembers()) {
+    for (Decl *member : protocol->getSemanticMembers()) {
       ASTVisitor<T>::visit(member);
     }
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -179,7 +179,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(bool preferTypeRepr,
             localModule->isImportedImplementationOnly(nominalModule)) {
 
           bool shouldPrintMembers = llvm::any_of(
-                                      ED->getMembers(),
+                                      ED->getSemanticMembers(),
                                       [&](const Decl *member) -> bool {
             return shouldPrint(member, options);
           });
@@ -1734,7 +1734,7 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
     getInheritedForPrinting(Ext, Options, ProtocolsToPrint);
     if (ProtocolsToPrint.empty()) {
       bool HasMemberToPrint = false;
-      for (auto Member : Ext->getMembers()) {
+      for (auto Member : Ext->getSemanticMembers()) {
         if (shouldPrint(Member, Options)) {
           HasMemberToPrint = true;
           break;
@@ -2034,24 +2034,24 @@ void PrintAST::printMembersOfDecl(Decl *D, bool needComma,
                                   bool openBracket,
                                   bool closeBracket) {
   llvm::SmallVector<Decl *, 3> Members;
-  auto AddDeclFunc = [&](DeclRange Range) {
+  auto AddDeclFunc = [&](ArrayRef<Decl *> Range) {
     for (auto RD : Range)
       Members.push_back(RD);
   };
 
   if (auto Ext = dyn_cast<ExtensionDecl>(D)) {
-    AddDeclFunc(Ext->getMembers());
+    AddDeclFunc(Ext->getSemanticMembers());
   } else if (auto NTD = dyn_cast<NominalTypeDecl>(D)) {
-    AddDeclFunc(NTD->getMembers());
+    AddDeclFunc(NTD->getSemanticMembers());
     for (auto Ext : NTD->getExtensions()) {
       if (Options.printExtensionContentAsMembers(Ext))
-        AddDeclFunc(Ext->getMembers());
+        AddDeclFunc(Ext->getSemanticMembers());
     }
     if (Options.PrintExtensionFromConformingProtocols) {
       for (auto Conf : NTD->getAllConformances()) {
         for (auto Ext : Conf->getProtocol()->getExtensions()) {
           if (Options.printExtensionContentAsMembers(Ext))
-            AddDeclFunc(Ext->getMembers());
+            AddDeclFunc(Ext->getSemanticMembers());
         }
       }
     }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2620,7 +2620,7 @@ public:
       }
 
       // Check that a normal protocol conformance is complete.
-      for (auto member : proto->getMembers()) {
+      for (auto member : proto->getSemanticMembers()) {
         if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
           if (!normal->hasTypeWitness(assocType)) {
             dumpRef(decl);
@@ -3173,7 +3173,7 @@ public:
       
       if (!CD->hasLazyMembers()) {
         unsigned NumDestructors = 0;
-        for (auto Member : CD->getMembers()) {
+        for (auto Member : CD->getSemanticMembers()) {
           if (isa<DestructorDecl>(Member)) {
             ++NumDestructors;
           }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4208,10 +4208,6 @@ GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   if (ctx.LangOpts.EnableObjCInterop)
     CD->recordObjCMethod(DD, DD->getObjCSelector());
 
-  // Mark it as synthesized to make its location in getEmittedMembers()
-  // deterministic.
-  DD->setSynthesized(true);
-
   return DD;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4419,7 +4419,7 @@ static ValueDecl *findOverridingDecl(const ClassDecl *C,
                                      const ValueDecl *Base) {
   // FIXME: This is extremely inefficient. The SILOptimizer should build a
   // reverse lookup table to answer these types of queries.
-  for (auto M : C->getMembers()) {
+  for (auto M : C->getSemanticMembers()) {
     if (auto *Derived = dyn_cast<ValueDecl>(M))
       if (::isOverridingDecl(Derived, Base))
         return Derived;
@@ -4647,7 +4647,7 @@ ProtocolDecl::getAssociatedTypeMembers() const {
     return result;
 
   // Find the associated type declarations.
-  for (auto member : getMembers()) {
+  for (auto member : getParsedMembers()) {
     if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
       result.push_back(ATD);
     }
@@ -7957,7 +7957,7 @@ Type TypeBase::getSwiftNewtypeUnderlyingType() {
     return {};
 
   // Underlying type is the type of rawValue
-  for (auto member : structDecl->getMembers())
+  for (auto member : structDecl->getSemanticMembers())
     if (auto varDecl = dyn_cast<VarDecl>(member))
       if (varDecl->getName() == getASTContext().Id_rawValue)
         return varDecl->getType();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -804,10 +804,12 @@ ArrayRef<Decl *> IterableDeclContext::getParsedMembers() const {
 
 ArrayRef<Decl *> IterableDeclContext::getSemanticMembers() const {
   ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(
+  auto result = evaluateOrDefault(
       ctx.evaluator,
       SemanticMembersRequest{const_cast<IterableDeclContext *>(this)},
       ArrayRef<Decl *>());
+  assert(result.size() <= getMemberCount());
+  return result;
 }
 
 /// Add a member to this context.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3895,7 +3895,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
         [&](ProtocolDecl *inheritedProto) -> TypeWalker::Action {
       if (inheritedProto == proto) return TypeWalker::Action::Continue;
 
-      for (auto req : inheritedProto->getMembers()) {
+      for (auto req : inheritedProto->getSemanticMembers()) {
         if (auto typeReq = dyn_cast<TypeDecl>(req)) {
           // Ignore generic types
           if (auto genReq = dyn_cast<GenericTypeDecl>(req))

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -320,7 +320,7 @@ bool ide::printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS) {
 
   // We make up a unique usr for each extension by combining a prefix
   // and the USR of the first value member of the extension.
-  for (auto D : ED->getMembers()) {
+  for (auto D : ED->getParsedMembers()) {
     if (auto VD = dyn_cast<ValueDecl>(D)) {
       OS << getUSRSpacePrefix() << "e:";
       return printValueDeclUSR(VD, OS);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7213,7 +7213,7 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
 
     } else {
       // Otherwise, import all mirrored members.
-      for (auto *member : proto->getMembers())
+      for (auto *member : proto->getSemanticMembers())
         importProtocolRequirement(member);
     }
   }
@@ -8020,7 +8020,7 @@ static void finishMissingOptionalWitnesses(
     NormalProtocolConformance *conformance) {
   auto *proto = conformance->getProtocol();
 
-  for (auto req : proto->getMembers()) {
+  for (auto req : proto->getSemanticMembers()) {
     auto valueReq = dyn_cast<ValueDecl>(req);
     if (!valueReq)
       continue;
@@ -8807,7 +8807,8 @@ static void loadMembersOfBaseImportedFromClang(ExtensionDecl *ext) {
   // loading the original class's members. Right now we only check if this
   // happens on the first member.
   if (auto *clangContainer = dyn_cast<clang::ObjCContainerDecl>(clangBase))
-    assert((clangContainer->decls_empty() || !base->getMembers().empty()) &&
+    assert((clangContainer->decls_empty() ||
+            !base->getParsedMembers().empty()) &&
            "can't load extension members before base has finished");
 }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -361,7 +361,7 @@ public:
     }
 
     // Recurse to find any nested types.
-    for (const Decl *member : memberContext->getMembers())
+    for (const Decl *member : memberContext->getSemanticMembers())
       collectProtocols(map, member);
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5085,7 +5085,7 @@ public:
     if (!CD->hasSuperclass())
       return;
     CD = CD->getSuperclassDecl();
-    for (const auto *Member : CD->getMembers()) {
+    for (const auto *Member : CD->getSemanticMembers()) {
       const auto *Constructor = dyn_cast<ConstructorDecl>(Member);
       if (!Constructor)
         continue;

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -118,7 +118,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
       N = findIndexInRange(D, parentSF->getTopLevelDecls());
     } else if (auto parentIDC = dyn_cast_or_null<IterableDeclContext>(
                    parentDC->getAsDecl())) {
-      N = findIndexInRange(D, parentIDC->getMembers());
+      N = findIndexInRange(D, parentIDC->getParsedMembers());
     } else {
 #ifndef NDEBUG
       llvm_unreachable("invalid DC kind for finding equivalent DC (indexpath)");
@@ -146,7 +146,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
     if (auto parentSF = dyn_cast<SourceFile>(newDC))
       D = getElementAt(parentSF->getTopLevelDecls(), N);
     else if (auto parentIDC = dyn_cast<IterableDeclContext>(newDC->getAsDecl()))
-      D = getElementAt(parentIDC->getMembers(), N);
+      D = getElementAt(parentIDC->getParsedMembers(), N);
     else
       llvm_unreachable("invalid DC kind for finding equivalent DC (query)");
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -104,9 +104,10 @@ struct SynthesizedExtensionAnalyzer::Implementation {
 
   static bool isExtensionFavored(const NominalTypeDecl* Target,
                                  const ExtensionDecl *ED) {
-    return std::find_if(ED->getMembers().begin(), ED->getMembers().end(),
+    return std::find_if(
+      ED->getParsedMembers().begin(), ED->getParsedMembers().end(),
       [&](DeclIterator It) {
-        return isMemberFavored(Target, *It);}) != ED->getMembers().end();
+        return isMemberFavored(Target, *It);}) != ED->getParsedMembers().end();
   }
 
   struct SynthesizedExtensionInfo {
@@ -571,7 +572,7 @@ hasMergeGroup(MergeGroupKind Kind) {
 void swift::
 collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
                     llvm::SmallDenseMap<ValueDecl*, ValueDecl*> &DefaultMap) {
-  auto HandleMembers = [&](DeclRange Members) {
+  auto HandleMembers = [&](ArrayRef<Decl *> Members) {
     for (Decl *D : Members) {
       auto *VD = dyn_cast<ValueDecl>(D);
 
@@ -592,12 +593,12 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
   };
 
   // Collect the default implementations for the members in this given protocol.
-  HandleMembers(PD->getMembers());
+  HandleMembers(PD->getSemanticMembers());
 
   // Collect the default implementations for the members in the inherited
   // protocols.
   for (auto *IP : PD->getInheritedProtocols())
-    HandleMembers(IP->getMembers());
+    HandleMembers(IP->getSemanticMembers());
 }
 
 /// This walker will traverse the AST and report types for every expression.

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -277,7 +277,7 @@ static bool printModuleInterfaceDecl(Decl *D,
         SubDecls.pop();
 
         // Add sub-types of NTD.
-        for (auto Sub : NTD->getMembers())
+        for (auto Sub : NTD->getSemanticMembers())
           if (auto N = dyn_cast<NominalTypeDecl>(Sub))
             SubDecls.push(N);
 
@@ -296,7 +296,7 @@ static bool printModuleInterfaceDecl(Decl *D,
             Ext->print(Printer, Options);
             Printer << "\n";
           }
-          for (auto Sub : Ext->getMembers())
+          for (auto Sub : Ext->getSemanticMembers())
             if (auto N = dyn_cast<NominalTypeDecl>(Sub))
               SubDecls.push(N);
         }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3275,7 +3275,7 @@ class AddEquatableContext {
   ArrayRef<VarDecl *> StoredProperties;
 
   /// Range of internal members in declaration
-  DeclRange Range;
+  ArrayRef<Decl *> Range;
 
   bool conformsToEquatableProtocol() {
     for (ProtocolDecl *Protocol : Protocols) {
@@ -3312,14 +3312,16 @@ public:
   Adopter(Decl->getDeclaredType()), StartLoc(Decl->getBraces().Start),
   ProtocolsLocations(Decl->getInherited()),
   Protocols(Decl->getAllProtocols()), ProtInsertStartLoc(Decl->getNameLoc()),
-  StoredProperties(Decl->getStoredProperties()), Range(Decl->getMembers()) {};
+  StoredProperties(Decl->getStoredProperties()),
+  Range(Decl->getSemanticMembers()) {};
 
   AddEquatableContext(ExtensionDecl *Decl) : DC(Decl),
   Adopter(Decl->getExtendedType()), StartLoc(Decl->getBraces().Start),
   ProtocolsLocations(Decl->getInherited()),
   Protocols(Decl->getExtendedNominal()->getAllProtocols()),
   ProtInsertStartLoc(Decl->getExtendedTypeRepr()->getEndLoc()),
-  StoredProperties(Decl->getExtendedNominal()->getStoredProperties()), Range(Decl->getMembers()) {};
+  StoredProperties(Decl->getExtendedNominal()->getStoredProperties()),
+  Range(Decl->getSemanticMembers()) {};
 
   AddEquatableContext() : DC(nullptr), Adopter(), ProtocolsLocations(),
   Protocols(), StoredProperties(), Range(nullptr, nullptr) {};
@@ -3427,7 +3429,7 @@ std::vector<ValueDecl *> AddEquatableContext::
 getProtocolRequirements() {
   std::vector<ValueDecl *> Collection;
   auto Proto = DC->getASTContext().getProtocol(KnownProtocolKind::Equatable);
-  for (auto Member : Proto->getMembers()) {
+  for (auto Member : Proto->getSemanticMembers()) {
     auto Req = dyn_cast<ValueDecl>(Member);
     if (!Req || Req->isInvalid() || !Req->isProtocolRequirement()) {
       continue;

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1155,7 +1155,7 @@ ClangNode swift::ide::extensionGetClangNode(const ExtensionDecl *ext) {
     return ClangNode();
 
   // It may have a global imported as a member.
-  for (auto member : ext->getMembers()) {
+  for (auto member : ext->getParsedMembers()) {
     if (auto clangNode = getEffectiveClangNode(member))
       return clangNode;
   }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -920,7 +920,7 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
 
   IRGen.addClassForEagerInitialization(D);
 
-  emitNestedTypeDecls(D->getMembers());
+  emitNestedTypeDecls(D->getSemanticMembers());
 }
 
 namespace {
@@ -1083,7 +1083,7 @@ namespace {
 
       visitConformances(theExtension);
 
-      for (Decl *member : TheExtension->getMembers())
+      for (Decl *member : TheExtension->getSemanticMembers())
         visit(member);
     }
 
@@ -1109,7 +1109,7 @@ namespace {
         Protocols.push_back(proto);
       }
 
-      for (Decl *member : theProtocol->getMembers())
+      for (Decl *member : theProtocol->getSemanticMembers())
         visit(member);
     }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -133,7 +133,7 @@ public:
   }
   
   void visitMembers(ExtensionDecl *ext) {
-    for (Decl *member : ext->getMembers())
+    for (Decl *member : ext->getSemanticMembers())
       visit(member);
   }
 
@@ -319,7 +319,7 @@ public:
     }
     
     // Add the members.
-    for (Decl *member : proto->getMembers())
+    for (Decl *member : proto->getSemanticMembers())
       visit(member);
     
     // Register it.
@@ -4468,7 +4468,7 @@ Address IRGenModule::getAddrOfEnumCase(EnumElementDecl *Case,
   return addr;
 }
 
-void IRGenModule::emitNestedTypeDecls(DeclRange members) {
+void IRGenModule::emitNestedTypeDecls(ArrayRef<Decl *> members) {
   for (Decl *member : members) {
     switch (member->getKind()) {
     case DeclKind::Import:
@@ -4532,7 +4532,7 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
       return true;
   }
 
-  for (auto member : ext->getMembers()) {
+  for (auto member : ext->getSemanticMembers()) {
     if (auto func = dyn_cast<FuncDecl>(member)) {
       if (requiresObjCMethodDescriptor(func))
         return true;
@@ -4552,7 +4552,7 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 }
 
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
-  emitNestedTypeDecls(ext->getMembers());
+  emitNestedTypeDecls(ext->getSemanticMembers());
 
   addLazyConformances(ext);
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6946,7 +6946,7 @@ void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
     emitFieldDescriptor(theEnum);
   }
 
-  emitNestedTypeDecls(theEnum->getMembers());
+  emitNestedTypeDecls(theEnum->getSemanticMembers());
 
   if (!isResilient(theEnum, ResilienceExpansion::Minimal))
     return;

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -984,7 +984,7 @@ void IRGenModule::emitStructDecl(StructDecl *st) {
     emitFieldDescriptor(st);
   }
 
-  emitNestedTypeDecls(st->getMembers());
+  emitNestedTypeDecls(st->getSemanticMembers());
 }
 
 void IRGenModule::maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *opaque) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1357,7 +1357,7 @@ public:
   void emitSILStaticInitializers();
   llvm::Constant *emitFixedTypeLayout(CanType t, const FixedTypeInfo &ti);
   void emitProtocolConformance(const ConformanceDescription &record);
-  void emitNestedTypeDecls(DeclRange members);
+  void emitNestedTypeDecls(ArrayRef<Decl *> members);
   void emitClangDecl(const clang::Decl *decl);
   void finalizeClangCodeGen();
   void finishEmitAfterTopLevel();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -399,7 +399,7 @@ private:
       return;
 
     unsigned CurLabel = 0;
-    for (auto Member : TypeContext->getMembers()) {
+    for (auto Member : TypeContext->getSemanticMembers()) {
       auto Prop = dyn_cast<VarDecl>(Member);
       if (!Prop)
         continue;

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -157,7 +157,7 @@ public:
   }
 
   bool isEmptyExtensionDecl(const ExtensionDecl *ED) {
-    auto members = ED->getMembers();
+    auto members = ED->getSemanticMembers();
     auto hasMembers = std::any_of(members.begin(), members.end(),
                                   [this](const Decl *D) -> bool {
       if (auto VD = dyn_cast<ValueDecl>(D))
@@ -327,7 +327,7 @@ private:
       os << " : " << getNameForObjC(superDecl);
     printProtocols(CD->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
-    printMembers(CD->getMembers());
+    printMembers(CD->getSemanticMembers());
     os << "@end\n";
   }
 
@@ -344,7 +344,7 @@ private:
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
-    printMembers(ED->getMembers());
+    printMembers(ED->getSemanticMembers());
     os << "@end\n";
   }
 
@@ -365,7 +365,7 @@ private:
 
     printProtocols(PD->getInheritedProtocols());
     os << "\n";
-    printMembers(PD->getMembers());
+    printMembers(PD->getSemanticMembers());
     os << "@end\n";
   }
 

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -235,7 +235,8 @@ public:
     });
   }
 
-  bool forwardDeclareMemberTypes(DeclRange members, const Decl *container) {
+  bool forwardDeclareMemberTypes(
+      ArrayRef<Decl *> members, const Decl *container) {
     PrettyStackTraceDecl
         entry("printing forward declarations needed by members of", container);
     switch (container->getKind()) {
@@ -368,7 +369,7 @@ public:
     if (!allRequirementsSatisfied)
       return false;
 
-    (void)forwardDeclareMemberTypes(CD->getMembers(), CD);
+    (void)forwardDeclareMemberTypes(CD->getSemanticMembers(), CD);
     seenTypes[CD] = { EmissionState::Defined, true };
     os << '\n';
     printer.print(CD);
@@ -400,7 +401,7 @@ public:
     if (!allRequirementsSatisfied)
       return false;
 
-    if (!forwardDeclareMemberTypes(PD->getMembers(), PD))
+    if (!forwardDeclareMemberTypes(PD->getSemanticMembers(), PD))
       return false;
 
     seenTypes[PD] = { EmissionState::Defined, true };
@@ -427,7 +428,7 @@ public:
     // This isn't rolled up into the previous set of requirements because
     // it /also/ prints forward declarations, and the header is a little
     // prettier if those are as close as possible to the necessary extension.
-    if (!forwardDeclareMemberTypes(ED->getMembers(), ED))
+    if (!forwardDeclareMemberTypes(ED->getSemanticMembers(), ED))
       return false;
 
     os << '\n';
@@ -519,8 +520,8 @@ public:
       // Break ties in extensions by putting smaller extensions last (in reverse
       // order).
       // FIXME: This will end up taking linear time.
-      auto lhsMembers = cast<ExtensionDecl>(*lhs)->getMembers();
-      auto rhsMembers = cast<ExtensionDecl>(*rhs)->getMembers();
+      auto lhsMembers = cast<ExtensionDecl>(*lhs)->getSemanticMembers();
+      auto rhsMembers = cast<ExtensionDecl>(*rhs)->getSemanticMembers();
       unsigned numLHSMembers = std::distance(lhsMembers.begin(),
                                              lhsMembers.end());
       unsigned numRHSMembers = std::distance(rhsMembers.begin(),

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1191,7 +1191,7 @@ static bool requiresIVarInitialization(SILGenModule &SGM, ClassDecl *cd) {
   if (!cd->requiresStoredPropertyInits())
     return false;
 
-  for (Decl *member : cd->getMembers()) {
+  for (Decl *member : cd->getSemanticMembers()) {
     auto pbd = dyn_cast<PatternBindingDecl>(member);
     if (!pbd) continue;
 
@@ -1204,7 +1204,7 @@ static bool requiresIVarInitialization(SILGenModule &SGM, ClassDecl *cd) {
 }
 
 bool SILGenModule::hasNonTrivialIVars(ClassDecl *cd) {
-  for (Decl *member : cd->getMembers()) {
+  for (Decl *member : cd->getSemanticMembers()) {
     auto *vd = dyn_cast<VarDecl>(member);
     if (!vd || !vd->hasStorage()) continue;
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -974,7 +974,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
                                             NominalTypeDecl *nominal) {
   auto subs = getSubstitutionsForPropertyInitializer(dc, nominal);
 
-  for (auto member : nominal->getMembers()) {
+  for (auto member : nominal->getSemanticMembers()) {
     // Find instance pattern binding declarations that have initializers.
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
       if (pbd->isStatic()) continue;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2543,7 +2543,7 @@ RValue RValueEmitter::visitObjCSelectorExpr(ObjCSelectorExpr *e, SGFContext C) {
 
   // Dig out the type of its pointer.
   Type selectorMemberTy;
-  for (auto member : selectorDecl->getMembers()) {
+  for (auto member : selectorDecl->getSemanticMembers()) {
     if (auto var = dyn_cast<VarDecl>(member)) {
       if (!var->isStatic() && var->hasStorage()) {
         selectorMemberTy = var->getInterfaceType();

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1036,16 +1036,13 @@ public:
   void emitType() {
     SGM.emitLazyConformancesForType(theType);
 
+    for (Decl *member : theType->getSemanticMembers())
+      visit(member);
+
     // Build a vtable if this is a class.
     if (auto theClass = dyn_cast<ClassDecl>(theType)) {
-      for (Decl *member : theClass->getSemanticMembers())
-        visit(member);
-
       SILGenVTable genVTable(SGM, theClass);
       genVTable.emitVTable();
-    } else {
-      for (Decl *member : theType->getMembers())
-        visit(member);
     }
 
     // Build a default witness table if this is a protocol that needs one.
@@ -1181,7 +1178,7 @@ public:
 
   /// Emit SIL functions for all the members of the extension.
   void emitExtension(ExtensionDecl *e) {
-    for (Decl *member : e->getMembers())
+    for (Decl *member : e->getSemanticMembers())
       visit(member);
 
     if (!isa<ProtocolDecl>(e->getExtendedNominal())) {

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -110,7 +110,7 @@ void CalleeCache::computeClassMethodCallees() {
   for (auto &VTable : M.getVTables()) {
     assert(!VTable->getClass()->hasClangNode());
 
-    for (Decl *member : VTable->getClass()->getMembers()) {
+    for (Decl *member : VTable->getClass()->getSemanticMembers()) {
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(member)) {
         // If a method implementation might be overridden in another translation
         // unit, also mark all the base methods as 'unknown'.

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -886,7 +886,7 @@ HasUserDefinedDesignatedInitRequest::evaluate(Evaluator &evaluator,
 
   for (auto *member : decl->getMembers())
     if (auto *ctor = dyn_cast<ConstructorDecl>(member))
-      if (ctor->isDesignatedInit() && !ctor->isSynthesized())
+      if (ctor->isDesignatedInit())
         return true;
   return false;
 }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -631,7 +631,6 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
       /*Async=*/false,
       /*Throws=*/true, /*GenericParams=*/nullptr, params, returnType,
       conformanceDC);
-  encodeDecl->setSynthesized();
   encodeDecl->setBodySynthesizer(deriveBodyEncodable_encode);
 
   // This method should be marked as 'override' for classes inheriting Encodable
@@ -958,7 +957,6 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
                               /*Throws=*/true, SourceLoc(), paramList,
                               /*GenericParams=*/nullptr, conformanceDC);
   initDecl->setImplicit();
-  initDecl->setSynthesized();
   initDecl->setBodySynthesizer(&deriveBodyDecodable_init);
 
   // This constructor should be marked as `required` for non-final classes.

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -358,7 +358,7 @@ public:
         }
       }
     } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
-      for (Decl *Member : NTD->getMembers()) {
+      for (Decl *Member : NTD->getSemanticMembers()) {
         transformDecl(Member);
       }
     }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -298,7 +298,7 @@ public:
         }
       }
     } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
-      for (Decl *Member : NTD->getMembers()) {
+      for (Decl *Member : NTD->getSemanticMembers()) {
         transformDecl(Member);
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1921,7 +1921,6 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
       /*Throws=*/mainFunction->hasThrows(),
       /*GenericParams=*/nullptr, ParameterList::createEmpty(context),
       /*FnRetType=*/TupleType::getEmpty(context), declContext);
-  func->setSynthesized(true);
 
   auto *params = context.Allocate<MainTypeAttrParams>();
   params->mainFunction = mainFunction;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -446,7 +446,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
     // If we implement the ability for extensions defined in the same module
     // (or the same file) to add vtable entries, we can re-evaluate this
     // restriction.
-    if (isa<ClassDecl>(nominal) && !decl->isSynthesized() &&
+    if (isa<ClassDecl>(nominal) && !decl->isImplicit() &&
         isa<ExtensionDecl>(decl->getDeclContext()) &&
         !(decl->getAttrs().hasAttribute<DynamicReplacementAttr>())) {
       if (cast<ClassDecl>(nominal)->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2646,8 +2646,10 @@ SemanticMembersRequest::evaluate(Evaluator &evaluator,
     TypeChecker::addImplicitConstructors(nominal);
   }
 
-  // Force any derivable conformances in this context. This ensures that any
-  // synthesized members will approach in the member list.
+  // Look through the conformances in this context. Both derivable conformances
+  // and associated type inference can introduce additional members that
+  // need to be part of the set of semantic members, so force those to be
+  // created now.
   using AssociatedTypeEntry =
       std::pair<ProtocolConformance *, AssociatedTypeDecl *>;
   SmallVector<AssociatedTypeEntry, 4> associatedTypes;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -513,7 +513,7 @@ ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
     return decl->requiresSelfConformanceWitnessTable();
 
   // Check whether this protocol conforms to itself.
-  for (auto member : decl->getMembers()) {
+  for (auto member : decl->getSemanticMembers()) {
     if (member->isInvalid()) continue;
 
     if (auto vd = dyn_cast<ValueDecl>(member)) {
@@ -539,7 +539,7 @@ ExistentialTypeSupportedRequest::evaluate(Evaluator &evaluator,
   if (decl->isObjC())
     return true;
 
-  for (auto member : decl->getMembers()) {
+  for (auto member : decl->getSemanticMembers()) {
     // Existential types cannot be used if the protocol has an associated type.
     if (isa<AssociatedTypeDecl>(member))
       return false;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1567,7 +1567,7 @@ void MultiConformanceChecker::checkAllConformances() {
       continue;
     // Check whether there are any unsatisfied requirements.
     auto proto = conformance->getProtocol();
-    for (auto member : proto->getMembers()) {
+    for (auto member : proto->getSemanticMembers()) {
       auto req = dyn_cast<ValueDecl>(member);
       if (!req || !req->isProtocolRequirement()) continue;
 
@@ -4146,7 +4146,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
 #pragma mark Protocol conformance checking
 
 void ConformanceChecker::resolveValueWitnesses() {
-  for (auto member : Proto->getMembers()) {
+  for (auto member : Proto->getSemanticMembers()) {
     auto requirement = dyn_cast<ValueDecl>(member);
     if (!requirement)
       continue;
@@ -5343,7 +5343,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
       // Complain about any declarations in this extension whose names match
       // a requirement in that protocol.
       SmallPtrSet<DeclName, 4> diagnosedNames;
-      for (auto decl : idc->getMembers()) {
+      for (auto decl : idc->getParsedMembers()) {
         if (decl->isImplicit())
           continue;
 
@@ -5856,7 +5856,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     return {defaultType, defaultedAssocType};
   };
 
-  for (auto *requirement : proto->getMembers()) {
+  for (auto *requirement : proto->getSemanticMembers()) {
     if (requirement->isInvalid())
       continue;
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -439,7 +439,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
   const llvm::SetVector<AssociatedTypeDecl *> &assocTypes)
 {
   InferredAssociatedTypes result;
-  for (auto member : proto->getMembers()) {
+  for (auto member : proto->getSemanticMembers()) {
     auto req = dyn_cast<ValueDecl>(member);
     if (!req || !req->isProtocolRequirement())
       continue;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1000,7 +1000,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   //- (id)copyWithZone:(NSZone *)zone;
   DeclName copyWithZoneName(Ctx, Ctx.getIdentifier("copy"), { Ctx.Id_with });
   FuncDecl *copyMethod = nullptr;
-  for (auto member : conformance.getRequirement()->getMembers()) {
+  for (auto member : conformance.getRequirement()->getSemanticMembers()) {
     if (auto func = dyn_cast<FuncDecl>(member)) {
       if (func->getName() == copyWithZoneName) {
         copyMethod = func;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6240,7 +6240,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   
   // Fill in opaque value witnesses if we need to.
   if (needToFillInOpaqueValueWitnesses) {
-    for (auto member : proto->getMembers()) {
+    for (auto member : proto->getSemanticMembers()) {
       // We only care about non-associated-type requirements.
       auto valueMember = dyn_cast<ValueDecl>(member);
       if (!valueMember || !valueMember->isProtocolRequirement()

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2609,7 +2609,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
   /// \param members The decls within the context.
   /// \param isClass True if the context could be a class context (class,
   ///        class extension, or protocol).
-  void writeMembers(DeclID parentID, DeclRange members, bool isClass) {
+  void writeMembers(DeclID parentID, ArrayRef<Decl *> members, bool isClass) {
     using namespace decls_block;
 
     SmallVector<DeclID, 16> memberIDs;
@@ -2744,7 +2744,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
     SmallVector<DeclID, 16> witnessIDs;
 
-    for (auto member : proto->getMembers()) {
+    for (auto member : proto->getSemanticMembers()) {
       if (auto *value = dyn_cast<ValueDecl>(member)) {
         auto witness = proto->getDefaultWitness(value);
         if (!witness)
@@ -2905,7 +2905,7 @@ public:
     for (auto *genericParams : llvm::reverse(allGenericParams))
       writeGenericParams(genericParams);
 
-    writeMembers(id, extension->getMembers(), isClassExtension);
+    writeMembers(id, extension->getSemanticMembers(), isClassExtension);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3121,7 +3121,7 @@ public:
 
 
     writeGenericParams(theStruct->getGenericParams());
-    writeMembers(id, theStruct->getMembers(), false);
+    writeMembers(id, theStruct->getSemanticMembers(), false);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3178,7 +3178,7 @@ public:
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theEnum->getGenericParams());
-    writeMembers(id, theEnum->getMembers(), false);
+    writeMembers(id, theEnum->getSemanticMembers(), false);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3237,7 +3237,7 @@ public:
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theClass->getGenericParams());
-    writeMembers(id, theClass->getMembers(), true);
+    writeMembers(id, theClass->getSemanticMembers(), true);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3286,7 +3286,7 @@ public:
     writeGenericParams(proto->getGenericParams());
     S.writeGenericRequirements(
       proto->getRequirementSignature(), S.DeclTypeAbbrCodes);
-    writeMembers(id, proto->getMembers(), true);
+    writeMembers(id, proto->getSemanticMembers(), true);
     writeDefaultWitnessTable(proto);
   }
 
@@ -4985,7 +4985,7 @@ static void collectInterestingNestedDeclarations(
 
     // Recurse into nested declarations.
     if (auto iterable = dyn_cast<IterableDeclContext>(member)) {
-      collectInterestingNestedDeclarations(S, iterable->getMembers(),
+      collectInterestingNestedDeclarations(S, iterable->getSemanticMembers(),
                                            operatorMethodDecls,
                                            objcMethods, nestedTypeDecls,
                                            derivativeConfigs,
@@ -5061,7 +5061,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
       // derived conformance (for example, ==), force them to be
       // serialized.
       if (auto IDC = dyn_cast<IterableDeclContext>(D)) {
-        collectInterestingNestedDeclarations(*this, IDC->getMembers(),
+        collectInterestingNestedDeclarations(*this, IDC->getSemanticMembers(),
                                              operatorMethodDecls, objcMethods,
                                              nestedTypeDecls,
                                              uniquedDerivativeConfigs);
@@ -5091,7 +5091,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
       localTypeGenerator.insert(MangledName, addDeclRef(TD));
 
       if (auto IDC = dyn_cast<IterableDeclContext>(TD)) {
-        collectInterestingNestedDeclarations(*this, IDC->getMembers(),
+        collectInterestingNestedDeclarations(*this, IDC->getSemanticMembers(),
                                              operatorMethodDecls, objcMethods,
                                              nestedTypeDecls,
                                              uniquedDerivativeConfigs,

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -254,7 +254,7 @@ void SymbolGraph::recordSuperclassSynthesizedMemberRelationships(Symbol S) {
     SmallPtrSet<const ValueDecl *, 32> SuperClassMembers;
     const auto *Super = C->getSuperclassDecl();
     while (Super) {
-      for (const auto *SuperMember : Super->getMembers()) {
+      for (const auto *SuperMember : Super->getSemanticMembers()) {
         if (const auto *SuperMemberVD = dyn_cast<ValueDecl>(SuperMember)) {
           SuperClassMembers.insert(SuperMemberVD);
         }
@@ -262,7 +262,7 @@ void SymbolGraph::recordSuperclassSynthesizedMemberRelationships(Symbol S) {
       Super = Super->getSuperclassDecl();
     }
     // Remove any that are overridden by this class.
-    for (const auto *DerivedMember : C->getMembers()) {
+    for (const auto *DerivedMember : C->getSemanticMembers()) {
       if (const auto *DerivedMemberVD = dyn_cast<ValueDecl>(DerivedMember)) {
         if (const auto *Overridden = DerivedMemberVD->getOverriddenDecl()) {
           SuperClassMembers.erase(Overridden);
@@ -345,7 +345,7 @@ void SymbolGraph::recordConformanceSynthesizedMemberRelationships(Symbol S) {
         continue;
       }
 
-      for (const auto ExtensionMember : Info.Ext->getMembers()) {
+      for (const auto ExtensionMember : Info.Ext->getSemanticMembers()) {
         if (const auto SynthMember = dyn_cast<ValueDecl>(ExtensionMember)) {
           if (SynthMember->isObjC()) {
             continue;
@@ -408,7 +408,7 @@ void SymbolGraph::recordDefaultImplementationRelationships(Symbol S) {
   /// Claim a protocol `P`'s members as default implementation targets
   /// for `VD`.
   auto HandleProtocol = [=](const ProtocolDecl *P) {
-    for (const auto *Member : P->getMembers()) {
+    for (const auto *Member : P->getSemanticMembers()) {
       if (const auto *MemberVD = dyn_cast<ValueDecl>(Member)) {
         if (MemberVD->getName().compare(VD->getName()) == 0) {
           recordEdge(Symbol(this, VD, nullptr),

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -820,7 +820,7 @@ void TBDGenVisitor::visitNominalTypeDecl(NominalTypeDecl *NTD) {
   // There are symbols associated with any protocols this type conforms to.
   addConformances(NTD);
 
-  for (auto member : NTD->getMembers())
+  for (auto member : NTD->getSemanticMembers())
     visit(member);
 }
 
@@ -947,7 +947,7 @@ void TBDGenVisitor::visitExtensionDecl(ExtensionDecl *ED) {
     addConformances(ED);
   }
 
-  for (auto member : ED->getMembers())
+  for (auto member : ED->getSemanticMembers())
     visit(member);
 }
 
@@ -1044,7 +1044,7 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
   // individual protocols, each conforming type has to handle them individually
   // (NB. anything within an active IfConfigDecls also appears outside). Let's
   // assert this fact:
-  for (auto *member : PD->getMembers()) {
+  for (auto *member : PD->getSemanticMembers()) {
     assert(isValidProtocolMemberForTBDGen(member) &&
            "unexpected member of protocol during TBD generation");
   }

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -122,11 +122,7 @@ void addImageCallback2Sections(const mach_header *mh, intptr_t vmaddr_slide) {
 
 #if OBJC_ADDLOADIMAGEFUNC_DEFINED && SWIFT_OBJC_INTEROP
 #define REGISTER_FUNC(...)                                               \
-  if (__builtin_available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)) { \
-    objc_addLoadImageFunc(__VA_ARGS__);                                  \
-  } else {                                                               \
-    _dyld_register_func_for_add_image(__VA_ARGS__);                      \
-  }
+    _dyld_register_func_for_add_image(__VA_ARGS__);
 #else
 #define REGISTER_FUNC(...) _dyld_register_func_for_add_image(__VA_ARGS__)
 #endif

--- a/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
@@ -10,12 +10,12 @@ struct GenericTangentVectorMember<T: Differentiable>: Differentiable,
 
 // CHECK-AST-LABEL: internal struct GenericTangentVectorMember<T> : Differentiable, AdditiveArithmetic where T : Differentiable
 // CHECK-AST:   internal var x: T.TangentVector
-// CHECK-AST:   internal init(x: T.TangentVector)
 // CHECK-AST:   internal typealias TangentVector = GenericTangentVectorMember<T>
+// CHECK-AST:   internal init(x: T.TangentVector)
 // CHECK-AST:   internal static var zero: GenericTangentVectorMember<T> { get }
+// CHECK-AST:   @_implements(Equatable, ==(_:_:)) internal static func __derived_struct_equals(_ a: GenericTangentVectorMember<T>, _ b: GenericTangentVectorMember<T>) -> Bool
 // CHECK-AST:   internal static func + (lhs: GenericTangentVectorMember<T>, rhs: GenericTangentVectorMember<T>) -> GenericTangentVectorMember<T>
 // CHECK-AST:   internal static func - (lhs: GenericTangentVectorMember<T>, rhs: GenericTangentVectorMember<T>) -> GenericTangentVectorMember<T>
-// CHECK-AST:   @_implements(Equatable, ==(_:_:)) internal static func __derived_struct_equals(_ a: GenericTangentVectorMember<T>, _ b: GenericTangentVectorMember<T>) -> Bool
 
 public struct ConditionallyDifferentiable<T> {
   public var x: T
@@ -69,17 +69,17 @@ final class AdditiveArithmeticClass<T: AdditiveArithmetic & Differentiable>: Add
 public struct FrozenStruct: Differentiable {}
 
 // CHECK-AST-LABEL: @frozen public struct FrozenStruct : Differentiable {
-// CHECK-AST:   internal init()
 // CHECK-AST:   @frozen public struct TangentVector : Differentiable, AdditiveArithmetic {
+// CHECK-AST:   internal init()
 
 @usableFromInline
 struct UsableFromInlineStruct: Differentiable {}
 
 // CHECK-AST-LABEL: @usableFromInline
 // CHECK-AST: struct UsableFromInlineStruct : Differentiable {
-// CHECK-AST:   internal init()
 // CHECK-AST:   @usableFromInline
 // CHECK-AST:   struct TangentVector : Differentiable, AdditiveArithmetic {
+// CHECK-AST:   internal init()
 
 // Test property wrappers.
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -199,8 +199,8 @@ struct d0100_FooStruct {
 
   class NestedClass {}
 // PASS_COMMON-NEXT: {{^}}  class NestedClass {{{$}}
-// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}    init(){{$}}
+// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   enum NestedEnum {}
@@ -241,8 +241,8 @@ struct d0100_FooStruct {
   static func overloadedStaticFunc2(x: Double) -> Int { return 0 }
 // PASS_COMMON-NEXT: {{^}}  static func overloadedStaticFunc2(x: Double) -> Int{{$}}
 }
-// PASS_COMMON-NEXT: {{^}}  init(instanceVar1: Int = 0){{$}}
 // PASS_COMMON-NEXT: {{^}}  init(){{$}}
+// PASS_COMMON-NEXT: {{^}}  init(instanceVar1: Int = 0){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
 extension d0100_FooStruct {
@@ -275,8 +275,8 @@ extension d0100_FooStruct {
 
   class ExtNestedClass {}
 // PASS_COMMON-NEXT: {{^}}  class ExtNestedClass {{{$}}
-// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}    init(){{$}}
+// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   enum ExtNestedEnum {
@@ -595,15 +595,15 @@ struct d0200_EscapedIdentifiers {
   }
 // PASS_COMMON-NEXT: {{^}}  enum `enum` {{{$}}
 // PASS_COMMON-NEXT: {{^}}    case `case`{{$}}
-// PASS_COMMON-NEXT: {{^}}    {{.*}}static func __derived_enum_equals(_ a: d0200_EscapedIdentifiers.`enum`, _ b: d0200_EscapedIdentifiers.`enum`) -> Bool
 // PASS_COMMON-NEXT: {{^}}    var hashValue: Int { get }{{$}}
+// PASS_COMMON-NEXT: {{^}}    {{.*}}static func __derived_enum_equals(_ a: d0200_EscapedIdentifiers.`enum`, _ b: d0200_EscapedIdentifiers.`enum`) -> Bool
 // PASS_COMMON-NEXT: {{^}}    func hash(into hasher: inout Hasher)
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   class `class` {}
 // PASS_COMMON-NEXT: {{^}}  class `class` {{{$}}
-// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}    init(){{$}}
+// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   typealias `protocol` = `class`
@@ -613,8 +613,8 @@ struct d0200_EscapedIdentifiers {
   class `extension` : `class` {}
 // PASS_ONE_LINE_TYPE-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : d0200_EscapedIdentifiers.`class` {{{$}}
 // PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : `class` {{{$}}
-// PASS_COMMON:      {{^}}    @objc deinit{{$}}
-// PASS_COMMON-NEXT: {{^}}    {{(override )?}}init(){{$}}
+// PASS_COMMON: {{^}}    {{(override )?}}init(){{$}}
+// PASS_COMMON-NEXT:      {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   func `func`<`let`: `protocol`, `where`>(
@@ -1024,8 +1024,8 @@ enum d2000_EnumDecl1 {
 // PASS_COMMON: {{^}}enum d2000_EnumDecl1 {{{$}}
 // PASS_COMMON-NEXT: {{^}}  case ED1_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case ED1_Second{{$}}
-// PASS_COMMON-NEXT: {{^}}  {{.*}}static func __derived_enum_equals(_ a: d2000_EnumDecl1, _ b: d2000_EnumDecl1) -> Bool
 // PASS_COMMON-NEXT: {{^}}  var hashValue: Int { get }{{$}}
+// PASS_COMMON-NEXT: {{^}}  {{.*}}static func __derived_enum_equals(_ a: d2000_EnumDecl1, _ b: d2000_EnumDecl1) -> Bool
 // PASS_COMMON-NEXT: {{^}}  func hash(into hasher: inout Hasher)
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
@@ -1179,8 +1179,8 @@ struct d2800_ProtocolWithAssociatedType1Impl : d2700_ProtocolWithAssociatedType1
 
 // PASS_COMMON: {{^}}struct d2800_ProtocolWithAssociatedType1Impl : d2700_ProtocolWithAssociatedType1 {{{$}}
 // PASS_COMMON-NEXT: {{^}}  func returnsTA1() -> Int{{$}}
-// PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}  typealias TA1 = Int
+// PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
 //===---

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -15,13 +15,6 @@ enum E {
   case E3
 }
 
-// Check if the == comparison can be compiled to a simple icmp instruction.
-
-// CHECK-NORMAL-LABEL:define hidden swiftcc i1 @"$s12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8 %0, i8 %1)
-// CHECK-TESTABLE-LABEL:define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$s12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8 %0, i8 %1)
-// CHECK: %2 = icmp eq i8 %0, %1
-// CHECK: ret i1 %2
-
 // Check for the presence of the hashValue getter, calling Hasher.init() and
 // Hasher.finalize().
 
@@ -31,6 +24,14 @@ enum E {
 // CHECK: call swiftcc i{{[0-9]+}} @"$ss6HasherV9_finalizeSiyF"(%Ts6HasherV* {{.*}})
 // CHECK: ret i{{[0-9]+}} %{{[0-9]+}}
 
+// Check if the == comparison can be compiled to a simple icmp instruction.
+
+// CHECK-NORMAL-LABEL:define hidden swiftcc i1 @"$s12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8 %0, i8 %1)
+// CHECK-TESTABLE-LABEL:define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$s12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8 %0, i8 %1)
+// CHECK: %2 = icmp eq i8 %0, %1
+// CHECK: ret i1 %2
+
+// Derived conformances from extensions
 // Check if the hash(into:) method can be compiled to a simple zext instruction
 // followed by a call to Hasher._combine(_:).
 
@@ -40,7 +41,6 @@ enum E {
 // CHECK: tail call swiftcc void @"$ss6HasherV8_combineyySuF"(i{{.*}} [[V]], %Ts6HasherV*
 // CHECK: ret void
 
-// Derived conformances from extensions
 // The actual enums are in Inputs/def_enum.swift
 
 extension def_enum.TrafficLight : Error {}

--- a/test/IRGen/objc_attr_NSManaged.sil
+++ b/test/IRGen/objc_attr_NSManaged.sil
@@ -17,7 +17,9 @@ import Foundation
 sil_vtable X {}
 
 // The getter/setter should not show up in the Objective-C metadata.
-// CHECK: @_INSTANCE_METHODS__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] } { i32 24, i32 2, {{.*}} @"\01L_selector_data(initWithBellsOn:)", {{.*}} @"\01L_selector_data(init)",
+// CHECK: @_INSTANCE_METHODS__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] }
+// CHECK-SAME: @"\01L_selector_data(init)
+// CHECK-SAME: @"\01L_selector_data(initWithBellsOn:)"
 
 // CHECK: [[X:@[0-9]+]] = private unnamed_addr constant [2 x i8] c"x\00"
 

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -26,10 +26,10 @@ public class Base<In, Out> {
 
 // CHECK: public class Derived<T> : {{(main.)?}}Base<T, T> {
 public class Derived<T> : Base<T, T> {
-// CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
-// CHECK-NEXT: override public init<A>(_ argument: A, _ argument: A)
 // CHECK-NEXT: override public init<C>(_ argument: C) where C : main.Base<T, T>
+// CHECK-NEXT: override public init<A>(_ argument: A, _ argument: A)
+// CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: }
 }
 

--- a/test/ModuleInterface/modifiers.swift
+++ b/test/ModuleInterface/modifiers.swift
@@ -68,9 +68,9 @@ public class Base {
 
 // CHECK-LABEL: public class SubImplicit : {{(Test[.])?Base}} {
 public class SubImplicit: Base {
-  // CHECK-NEXT: @objc deinit{{$}}
   // CHECK-NEXT: @objc override public init(){{$}}
   // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
+  // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 
 

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -19,18 +19,18 @@ public struct Wrapper<T> {
 @propertyWrapper
 public struct WrapperWithInitialValue<T> {
   private var value: T
-  
+
   public var wrappedValue: T {
     get { value }
     set { value = newValue }
   }
 
-  public init(initialValue: T) {
-    self.value = initialValue
-  }
-
   public init(alternate value: T) {
     self.value = value
+  }
+
+  public init(initialValue: T) {
+    self.value = initialValue
   }
 
   public var projectedValue: Wrapper<T> {
@@ -44,23 +44,23 @@ public struct HasWrappers {
   // CHECK: @TestResilient.Wrapper public var x: {{(Swift.)?}}Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
-  // CHECK-NEXT: _modify  
-  // CHECK-NEXT: }  
+  // CHECK-NEXT: _modify
+  // CHECK-NEXT: }
   @Wrapper public var x: Int
 
   // CHECK: @TestResilient.WrapperWithInitialValue @_projectedValueProperty($y) public var y: Swift.Int {
   // CHECK-NEXT: get
-  // CHECK-NEXT: }  
+  // CHECK-NEXT: }
   @WrapperWithInitialValue public private(set) var y = 17
-
-  // CHECK: public var $y: TestResilient.Wrapper<{{(Swift.)?}}Int> {
-  // CHECK-NEXT: get
-  // CHECK-NEXT: }  
 
   // CHECK: @TestResilient.WrapperWithInitialValue @_projectedValueProperty($z) public var z: Swift.Bool {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
   // CHECK-NEXT: _modify
-  // CHECK-NEXT: }  
+  // CHECK-NEXT: }
   @WrapperWithInitialValue(alternate: false) public var z
+
+  // CHECK: public var $y: TestResilient.Wrapper<{{(Swift.)?}}Int> {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
 }

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -45,8 +45,8 @@
 // CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSPropertyInFavorOfCount' has been renamed to 'count': This property is unavailable in favor to the old count property");
 
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nonnull instancetype)initWithObjects:(id _Nonnull const * _Nullable)objects count:(NSUInteger)cnt OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nullable instancetype)initWithCoder:(NSCoder * _Nonnull){{[a-zA-Z]+}} OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithObjects:(id _Nonnull const * _Nullable)objects count:(NSUInteger)cnt OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -176,9 +176,9 @@
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)x SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedZ:(NSInteger)deprecatedZ OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_MSG("init(deprecatedZ:) was deprecated. Use the new one instead", "initWithNewZ:")
 // CHECK-NEXT: - (nonnull instancetype)initWithNewZ:(NSInteger)z OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedOnMacOSFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE;
 // CHECK: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -175,8 +175,8 @@ class DiscardableResult : NSObject {
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithFloat:(float)f SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithMoreFun SWIFT_UNAVAILABLE;
-// CHECK-NEXT: - (nonnull instancetype)initForFun SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initWithEvenMoreFun SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initForFun SWIFT_UNAVAILABLE;
 // CHECK-NEXT: @end
 @objc class InheritedInitializers : Initializers {
   override init() {

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -84,16 +84,6 @@ func forceHasMemberwiseInit() {
 // CHECK: function_ref @$sSb22_builtinBooleanLiteralSbBi1__tcfC : $@convention(method) (Builtin.Int1, @thin Bool.Type) -> Bool
 // CHECK: return {{%.*}} : $Bool
 
-// default argument 0 of HasMemberwiseInit.init(x:y:z:)
-// CHECK: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitV1x1y1zACyxGAA7WrapperVySbG_xAA0F16WithInitialValueVySiGtcfcfA_ : $@convention(thin) <T where T : DefaultInit> () -> Wrapper<Bool> 
-
-// default argument 1 of HasMemberwiseInit.init(x:y:z:)
-// CHECK: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitV1x1y1zACyxGAA7WrapperVySbG_xAA0F16WithInitialValueVySiGtcfcfA0_ : $@convention(thin) <T where T : DefaultInit> () -> @out T {
-
-// default argument 2 of HasMemberwiseInit.init(x:y:z:)
-// CHECK: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitV1x1y1zACyxGAA7WrapperVySbG_xAA0F16WithInitialValueVySiGtcfcfA1_ : $@convention(thin) <T where T : DefaultInit> () -> WrapperWithInitialValue<Int> {
-
-
 // HasMemberwiseInit.init()
 // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitVACyxGycfC : $@convention(method) <T where T : DefaultInit> (@thin HasMemberwiseInit<T>.Type) -> @out HasMemberwiseInit<T> {
 
@@ -116,6 +106,15 @@ func forceHasMemberwiseInit() {
 // CHECK: function_ref @$s17property_wrappers17HasMemberwiseInitV2_p33_{{.*}}23WrapperWithInitialValueVySbGvpfi : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> () -> Bool
 // CHECK-NOT: return
 // CHECK: function_ref @$s17property_wrappers17HasMemberwiseInitV1p33_{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : DefaultInit> (Bool) -> WrapperWithInitialValue<Bool>
+
+// default argument 0 of HasMemberwiseInit.init(x:y:z:)
+// CHECK: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitV1x1y1zACyxGAA7WrapperVySbG_xAA0F16WithInitialValueVySiGtcfcfA_ : $@convention(thin) <T where T : DefaultInit> () -> Wrapper<Bool> 
+
+// default argument 1 of HasMemberwiseInit.init(x:y:z:)
+// CHECK: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitV1x1y1zACyxGAA7WrapperVySbG_xAA0F16WithInitialValueVySiGtcfcfA0_ : $@convention(thin) <T where T : DefaultInit> () -> @out T {
+
+// default argument 2 of HasMemberwiseInit.init(x:y:z:)
+// CHECK: sil hidden [ossa] @$s17property_wrappers17HasMemberwiseInitV1x1y1zACyxGAA7WrapperVySbG_xAA0F16WithInitialValueVySiGtcfcfA1_ : $@convention(thin) <T where T : DefaultInit> () -> WrapperWithInitialValue<Int> {
 
 // CHECK: return
 
@@ -412,9 +411,9 @@ struct CompositionMembers {
   // CHECK-LABEL: sil hidden [transparent] [ossa] @$s17property_wrappers18CompositionMembersV3_p233_{{.*}}8WrapperAVyAA0N1BVyAA0N1CVySSGGGvpfi : $@convention(thin) () -> @owned Optional<String> {
   // CHECK: %0 = string_literal utf8 "Hello"
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p12p2ACSiSg_SSSgtcfC : $@convention(method) (Optional<Int>, @owned Optional<String>, @thin CompositionMembers.Type) -> @owned CompositionMembers
   // CHECK: s17property_wrappers18CompositionMembersV3_p233_{{.*}}8WrapperAVyAA0N1BVyAA0N1CVySSGGGvpfi
 
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p12p2ACSiSg_SSSgtcfC : $@convention(method) (Optional<Int>, @owned Optional<String>, @thin CompositionMembers.Type) -> @owned CompositionMembers
 }
 
 func testComposition() {

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -8,7 +8,6 @@ final class Final<T> {
 // CHECK-LABEL: final class Final<T> {
 // CHECK:   @_hasStorage final var x: T { get set }
 // CHECK:   init(x: T)
-// CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
 // CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
@@ -19,6 +18,7 @@ final class Final<T> {
 // CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
 // CHECK:   }
+// CHECK:   deinit
 // CHECK: }
 
 class Nonfinal<T> {
@@ -28,7 +28,6 @@ class Nonfinal<T> {
 // CHECK-LABEL: class Nonfinal<T> {
 // CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   init(x: T)
-// CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
 // CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
@@ -39,6 +38,7 @@ class Nonfinal<T> {
 // CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
 // CHECK:   }
+// CHECK:   deinit
 // CHECK: }
 
 // CHECK-LABEL: extension Final : Encodable where T : Encodable {

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -10,13 +10,13 @@ final class Final<T> {
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
-// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var stringValue: String { get }
-// CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
+// CHECK:     init?(stringValue: String)
+// CHECK:     var hashValue: Int { get }
+// CHECK:     var intValue: Int? { get }
+// CHECK:     var stringValue: String { get }
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
+// CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:   }
 // CHECK:   deinit
 // CHECK: }
@@ -30,13 +30,13 @@ class Nonfinal<T> {
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
-// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var stringValue: String { get }
-// CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
+// CHECK:     init?(stringValue: String)
+// CHECK:     var hashValue: Int { get }
+// CHECK:     var intValue: Int? { get }
+// CHECK:     var stringValue: String { get }
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
+// CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:   }
 // CHECK:   deinit
 // CHECK: }
@@ -54,13 +54,13 @@ class Nonfinal<T> {
 
 // Make sure that CodingKeys members are actually emitted.
 
-// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}21__derived_enum_equalsySbAFyx_G_AHtFZ : $@convention(method) <T> (Final<T>.CodingKeys, Final<T>.CodingKeys, @thin Final<T>.CodingKeys.Type) -> Bool {
-// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}9hashValueSivg : $@convention(method) <T> (Final<T>.CodingKeys) -> Int {
-// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}4hash4intoys6HasherVz_tF : $@convention(method) <T> (@inout Hasher, Final<T>.CodingKeys) -> () {
-// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}11stringValueSSvg : $@convention(method) <T> (Final<T>.CodingKeys) -> @owned String {
-// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}11stringValueAFyx_GSgSS_tcfC : $@convention(method) <T> (@owned String, @thin Final<T>.CodingKeys.Type) -> Optional<Final<T>.CodingKeys> {
-// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}8intValueSiSgvg : $@convention(method) <T> (Final<T>.CodingKeys) -> Optional<Int> {
 // CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}8intValueAFyx_GSgSi_tcfC : $@convention(method) <T> (Int, @thin Final<T>.CodingKeys.Type) -> Optional<Final<T>.CodingKeys> {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}11stringValueAFyx_GSgSS_tcfC : $@convention(method) <T> (@owned String, @thin Final<T>.CodingKeys.Type) -> Optional<Final<T>.CodingKeys> {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}9hashValueSivg : $@convention(method) <T> (Final<T>.CodingKeys) -> Int {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}8intValueSiSgvg : $@convention(method) <T> (Final<T>.CodingKeys) -> Optional<Int> {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}11stringValueSSvg : $@convention(method) <T> (Final<T>.CodingKeys) -> @owned String {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}21__derived_enum_equalsySbAFyx_G_AHtFZ : $@convention(method) <T> (Final<T>.CodingKeys, Final<T>.CodingKeys, @thin Final<T>.CodingKeys.Type) -> Bool {
+// CHECK-LABEL: sil private [ossa] @$s29synthesized_conformance_class5FinalC10CodingKeys{{.*}}4hash4intoys6HasherVz_tF : $@convention(method) <T> (@inout Hasher, Final<T>.CodingKeys) -> () {
 
 extension Final: Encodable where T: Encodable {}
 // CHECK-LABEL: // Final<A>.encode(to:)

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -13,10 +13,10 @@ enum NoValues {
 }
 // CHECK-LABEL: enum NoValues {
 // CHECK:   case a, b
-// CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: NoValues, _ b: NoValues) -> Bool
-// CHECK-RESILIENT: static func == (a: NoValues, b: NoValues) -> Bool
 // CHECK:   var hashValue: Int { get }
+// CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: NoValues, _ b: NoValues) -> Bool
 // CHECK:   func hash(into hasher: inout Hasher)
+// CHECK-RESILIENT: static func == (a: NoValues, b: NoValues) -> Bool
 // CHECK: }
 
 // CHECK-LABEL: extension Enum : Equatable where T : Equatable {

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -7,18 +7,18 @@ struct Struct<T> {
 
 // CHECK-LABEL: struct Struct<T> {
 // CHECK:   @_hasStorage var x: T { get set }
-// CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
-// CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Struct<T>.CodingKeys, _ b: Struct<T>.CodingKeys) -> Bool
-// CHECK-RESILIENT: static func == (a: Struct<T>.CodingKeys, b: Struct<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var stringValue: String { get }
-// CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
+// CHECK:     init?(stringValue: String)
+// CHECK:     var hashValue: Int { get }
+// CHECK:     var intValue: Int? { get }
+// CHECK:     var stringValue: String { get }
+// CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Struct<T>.CodingKeys, _ b: Struct<T>.CodingKeys) -> Bool
+// CHECK:     func hash(into hasher: inout Hasher)
+// CHECK-RESILIENT: static func == (a: Struct<T>.CodingKeys, b: Struct<T>.CodingKeys) -> Bool
 // CHECK:   }
+// CHECK:   init(x: T)
 // CHECK: }
 // CHECK-LABEL: extension Struct : Equatable where T : Equatable {
 // CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_struct_equals(_ a: Struct<T>, _ b: Struct<T>) -> Bool

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -382,14 +382,14 @@ public class E2_InitializerStub : InitializerWithDisappearingType {
 
 // CHECK-LABEL: class E2_InitializerStub : InitializerWithDisappearingType {
 // CHECK-NEXT: init(unrelatedValue: Int)
-// CHECK-NEXT: init(boxedInt box: BoxedInt)
 // CHECK-NEXT: init()
+// CHECK-NEXT: init(boxedInt box: BoxedInt)
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class E2_InitializerStub : InitializerWithDisappearingType {
 // CHECK-RECOVERY-NEXT: init(unrelatedValue: Int)
-// CHECK-RECOVERY-NEXT: /* placeholder for init(boxedInt:) */
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(boxedInt:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 #endif // TEST

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -29,8 +29,8 @@ struct BA_DefaultStruct {
 private struct BB_PrivateStruct {
   // CHECK: internal var x
   var x = 0
-  // CHECK: internal init(x: Int = 0)
   // CHECK: internal init()
+  // CHECK: internal init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: internal{{(\*/)?}} struct BC_InternalStruct {
@@ -44,24 +44,24 @@ internal struct BC_InternalStruct {
 public struct BD_PublicStruct {
   // CHECK: internal var x
   var x = 0
-  // CHECK: internal init(x: Int = 0)
   // CHECK: internal init()
+  // CHECK: internal init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: public{{(\*/)?}} struct BE_PublicStructPrivateMembers {
 public struct BE_PublicStructPrivateMembers {
   // CHECK: private{{(\*/)?}} var x
   private var x = 0
-  // CHECK: private init(x: Int = 0)
   // CHECK: internal init()
+  // CHECK: private init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: {{^}}fileprivate{{(\*/)?}} struct BF_FilePrivateStruct {
 fileprivate struct BF_FilePrivateStruct {
   // CHECK: {{^}} internal var x
   var x = 0
-  // CHECK: {{^}} internal init(x: Int = 0)
   // CHECK: {{^}} internal init()
+  // CHECK: {{^}} internal init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1171,7 +1171,7 @@ static Optional<uint8_t> getSimilarMemberCount(NominalTypeDecl *NTD,
                                         llvm::function_ref<bool(Decl*)> Check) {
   if (!Check(VD))
     return None;
-  auto Members = NTD->getMembers();
+  auto Members = NTD->getSemanticMembers();
   auto End = std::find(Members.begin(), Members.end(), VD);
   assert(End != Members.end());
   return std::count_if(Members.begin(), End, Check);
@@ -1749,7 +1749,7 @@ SwiftDeclCollector::constructSubscriptDeclNode(SubscriptDecl *SD) {
 
 void swift::ide::api::
 SwiftDeclCollector::addMembersToRoot(SDKNode *Root, IterableDeclContext *Context) {
-  for (auto *Member : Context->getMembers()) {
+  for (auto *Member : Context->getSemanticMembers()) {
     if (Ctx.shouldIgnore(Member, Context->getDecl()))
       continue;
     if (auto Func = dyn_cast<FuncDecl>(Member)) {


### PR DESCRIPTION
Adopt `getParsedMembers()` and `getSemanticMembers()` liberally throughout the code base, eliminating most uses of the non-deterministic and ever-shifting `getMembers()`. Both of these queries provide deterministic results, so their adoption will eliminate a known sources of nondeterminism that affects Swift interface file generation, Swift module generation, the generated header, etc.

Addresses rdar://problem/59513440 and likely a number of other nondeterminism issues. 