### PR TITLE
Turn off PruneVTables tests on tensorflow toolchains

### DIFF
--- a/test/SILOptimizer/prune-vtables.sil
+++ b/test/SILOptimizer/prune-vtables.sil
@@ -1,5 +1,6 @@
 // RUN: %target-sil-opt -prune-vtables %s | %FileCheck --check-prefix=NOWMO %s
 // RUN: %target-sil-opt -wmo -prune-vtables %s | %FileCheck --check-prefix=WMO %s
+// UNSUPPORTED: tensorflow
 
 sil_stage canonical
 


### PR DESCRIPTION
This is a follow-up PR to #33757 that disables tests affected by the disabled PruneVTables pass.