### PR TITLE
Make waiting on condition variables error out on SWIFT_STDLIB_SINGLE_THREADED_RUNTIME

### DIFF
--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -214,7 +214,11 @@ public:
   ///
   /// Precondition: Mutex held by this thread, undefined otherwise.
   void wait(ConditionVariable &condition) {
+#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+    fatalError(0, "cannot wait for condition");
+#else
     ConditionPlatformHelper::wait(condition.Handle, Handle);
+#endif
   }
 
   /// Acquires lock before calling the supplied critical section and releases
@@ -613,7 +617,11 @@ public:
 
   /// See Mutex::wait
   void wait(StaticConditionVariable &condition) {
+#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+    fatalError(0, "cannot wait for condition");
+#else
     ConditionPlatformHelper::wait(condition.Handle, Handle);
+#endif
   }
 
   /// See Mutex::lock

--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -214,11 +214,7 @@ public:
   ///
   /// Precondition: Mutex held by this thread, undefined otherwise.
   void wait(ConditionVariable &condition) {
-#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-    fatalError(0, "cannot wait for condition");
-#else
     ConditionPlatformHelper::wait(condition.Handle, Handle);
-#endif
   }
 
   /// Acquires lock before calling the supplied critical section and releases
@@ -617,11 +613,7 @@ public:
 
   /// See Mutex::wait
   void wait(StaticConditionVariable &condition) {
-#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-    fatalError(0, "cannot wait for condition");
-#else
     ConditionPlatformHelper::wait(condition.Handle, Handle);
-#endif
   }
 
   /// See Mutex::lock

--- a/include/swift/Runtime/MutexSingleThreaded.h
+++ b/include/swift/Runtime/MutexSingleThreaded.h
@@ -38,7 +38,7 @@ struct ConditionPlatformHelper {
   static void notifyOne(ConditionHandle &condition) {}
   static void notifyAll(ConditionHandle &condition) {}
   static void wait(ConditionHandle &condition, MutexHandle &mutex) {
-    fatalError(0, "cannot wait for condition");
+    fatalError(0, "single-threaded runtime cannot wait for condition");
   }
 };
 

--- a/include/swift/Runtime/MutexSingleThreaded.h
+++ b/include/swift/Runtime/MutexSingleThreaded.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_RUNTIME_MUTEX_SINGLE_THREADED_H
 #define SWIFT_RUNTIME_MUTEX_SINGLE_THREADED_H
 
+#include "swift/Runtime/Debug.h"
+
 namespace swift {
 
 typedef void* ConditionHandle;
@@ -35,7 +37,9 @@ struct ConditionPlatformHelper {
   static void destroy(ConditionHandle &condition) {}
   static void notifyOne(ConditionHandle &condition) {}
   static void notifyAll(ConditionHandle &condition) {}
-  static void wait(ConditionHandle &condition, MutexHandle &mutex);
+  static void wait(ConditionHandle &condition, MutexHandle &mutex) {
+    fatalError(0, "cannot wait for condition");
+  }
 };
 
 struct MutexPlatformHelper {


### PR DESCRIPTION
...instead of having an undefined symbol.