### PR TITLE
[Serialization] Minor ModuleFile/ModuleFileSharedCore improvements

### DIFF
--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -177,9 +177,8 @@ ValidationInfo validateSerializedAST(
 /// - \p ModuleName is the name used to refer to the module in diagnostics.
 void diagnoseSerializedASTLoadFailure(
     ASTContext &Ctx, SourceLoc diagLoc, const ValidationInfo &loadInfo,
-    const ExtendedValidationInfo &extendedInfo, StringRef moduleBufferID,
-    StringRef moduleDocBufferID, ModuleFile *loadedModuleFile,
-    Identifier ModuleName);
+    StringRef moduleBufferID, StringRef moduleDocBufferID,
+    ModuleFile *loadedModuleFile, Identifier ModuleName);
 
 } // end namespace serialization
 } // end namespace swift

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -349,15 +349,13 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
     llvm::MemoryBuffer::getMemBuffer(llvm::MemoryBufferRef(*moduleBuf.get()),
     /*RequiresNullTerminator=*/false);
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
-  ExtendedValidationInfo ExtInfo;
   bool isFramework = false;
   serialization::ValidationInfo loadInfo =
      ModuleFileSharedCore::load(modulePath.str(),
                       std::move(newBuf),
                       nullptr,
                       nullptr,
-                      /*isFramework*/isFramework, loadedModuleFile,
-                      ExtInfo);
+                      /*isFramework*/isFramework, loadedModuleFile);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -357,7 +357,7 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
                       nullptr,
                       nullptr,
                       /*isFramework*/isFramework, loadedModuleFile,
-                      &ExtInfo);
+                      ExtInfo);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());
 }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -438,11 +438,31 @@ public:
     return Core->CompatibilityVersion;
   }
 
+  /// Whether this module is compiled with `-enable-private-imports`.
+  bool arePrivateImportsEnabled() const {
+    return Core->Bits.ArePrivateImportsEnabled;
+  }
+
   /// Is this module file actually a .sib file? .sib files are serialized SIL at
   /// arbitrary granularity and arbitrary stage; unlike serialized Swift
   /// modules, which are assumed to contain canonical SIL for an entire module.
   bool isSIB() const {
-    return Core->IsSIB;
+    return Core->Bits.IsSIB;
+  }
+
+  /// Whether this module file is compiled with '-enable-testing'.
+  bool isTestable() const {
+    return Core->Bits.IsTestable;
+  }
+
+  /// Whether the module is resilient. ('-enable-library-evolution')
+  ResilienceStrategy getResilienceStrategy() const {
+    return ResilienceStrategy(Core->Bits.ResilienceStrategy);
+  }
+
+  /// Whether this module is compiled with implicit dynamic.
+  bool isImplicitDynamicEnabled() const {
+    return Core->Bits.IsImplicitDynamicEnabled;
   }
 
   /// Associates this module file with the AST node representing it.

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1087,8 +1087,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
     std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
     std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
     std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-    bool isFramework, serialization::ValidationInfo &info,
-    serialization::ExtendedValidationInfo &extInfo)
+    bool isFramework, serialization::ValidationInfo &info)
     : ModuleInputBuffer(std::move(moduleInputBuffer)),
       ModuleDocInputBuffer(std::move(moduleDocInputBuffer)),
       ModuleSourceInfoInputBuffer(std::move(moduleSourceInfoInputBuffer)) {
@@ -1134,6 +1133,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
         return;
       }
 
+      ExtendedValidationInfo extInfo;
       info = validateControlBlock(cursor, scratch,
                                   {SWIFTMODULE_VERSION_MAJOR,
                                    SWIFTMODULE_VERSION_MINOR},

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1088,7 +1088,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
     std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
     std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
     bool isFramework, serialization::ValidationInfo &info,
-    serialization::ExtendedValidationInfo *extInfo)
+    serialization::ExtendedValidationInfo &extInfo)
     : ModuleInputBuffer(std::move(moduleInputBuffer)),
       ModuleDocInputBuffer(std::move(moduleDocInputBuffer)),
       ModuleSourceInfoInputBuffer(std::move(moduleSourceInfoInputBuffer)) {
@@ -1137,7 +1137,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       info = validateControlBlock(cursor, scratch,
                                   {SWIFTMODULE_VERSION_MAJOR,
                                    SWIFTMODULE_VERSION_MINOR},
-                                  extInfo);
+                                  &extInfo);
       if (info.status != Status::Valid) {
         error(info.status);
         return;
@@ -1145,7 +1145,11 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Name = info.name;
       TargetTriple = info.targetTriple;
       CompatibilityVersion = info.compatibilityVersion;
-      IsSIB = extInfo->isSIB();
+      Bits.ArePrivateImportsEnabled = extInfo.arePrivateImportsEnabled();
+      Bits.IsSIB = extInfo.isSIB();
+      Bits.IsTestable = extInfo.isTestable();
+      Bits.ResilienceStrategy = unsigned(extInfo.getResilienceStrategy());
+      Bits.IsImplicitDynamicEnabled = extInfo.isImplicitDynamicEnabled();
       MiscVersion = info.miscVersion;
 
       hasValidControlBlock = true;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -69,11 +69,6 @@ class ModuleFileSharedCore {
   /// The data blob containing all of the module's identifiers.
   StringRef IdentifierData;
 
-  /// Is this module file actually a .sib file? .sib files are serialized SIL at
-  /// arbitrary granularity and arbitrary stage; unlike serialized Swift
-  /// modules, which are assumed to contain canonical SIL for an entire module.
-  bool IsSIB = false;
-
   // Full blob from the misc. version field of the metadata block. This should
   // include the version string of the compiler that built the module.
   StringRef MiscVersion;
@@ -307,6 +302,21 @@ private:
     /// Whether an error has been detected setting up this module file.
     unsigned HasError : 1;
 
+    /// Whether this module is `-enable-private-imports`.
+    unsigned ArePrivateImportsEnabled : 1;
+
+    /// Whether this module file is actually a .sib file.
+    unsigned IsSIB: 1;
+
+    /// Whether this module file is compiled with '-enable-testing'.
+    unsigned IsTestable : 1;
+
+    /// Discriminator for resilience strategy.
+    unsigned ResilienceStrategy : 2;
+
+    /// Whether this module is compiled with implicit dynamic.
+    unsigned IsImplicitDynamicEnabled: 1;
+
     // Explicitly pad out to the next word boundary.
     unsigned : 0;
   } Bits = {};
@@ -327,7 +337,7 @@ private:
                  std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
                  bool isFramework, serialization::ValidationInfo &info,
-                 serialization::ExtendedValidationInfo *extInfo);
+                 serialization::ExtendedValidationInfo &extInfo);
 
   /// Change the status of the current module.
   Status error(Status issue) {
@@ -456,7 +466,7 @@ public:
        std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
        bool isFramework, std::shared_ptr<const ModuleFileSharedCore> &theModule,
-       serialization::ExtendedValidationInfo *extInfo = nullptr) {
+       serialization::ExtendedValidationInfo &extInfo) {
     serialization::ValidationInfo info;
     auto *core = new ModuleFileSharedCore(
         std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -336,8 +336,7 @@ private:
   ModuleFileSharedCore(std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-                 bool isFramework, serialization::ValidationInfo &info,
-                 serialization::ExtendedValidationInfo &extInfo);
+                 bool isFramework, serialization::ValidationInfo &info);
 
   /// Change the status of the current module.
   Status error(Status issue) {
@@ -465,12 +464,12 @@ public:
        std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-       bool isFramework, std::shared_ptr<const ModuleFileSharedCore> &theModule,
-       serialization::ExtendedValidationInfo &extInfo) {
+       bool isFramework,
+       std::shared_ptr<const ModuleFileSharedCore> &theModule) {
     serialization::ValidationInfo info;
     auto *core = new ModuleFileSharedCore(
         std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
-        std::move(moduleSourceInfoInputBuffer), isFramework, info, extInfo);
+        std::move(moduleSourceInfoInputBuffer), isFramework, info);
     if (!moduleInterfacePath.empty()) {
       ArrayRef<char> path;
       core->allocateBuffer(path, moduleInterfacePath);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -394,7 +394,7 @@ llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
                        nullptr,
                        nullptr,
                        isFramework, loadedModuleFile,
-                       &extInfo);
+                       extInfo);
 
   // Map the set of dependencies over to the "module dependencies".
   auto dependencies = ModuleDependencies::forSwiftModule(modulePath.str(), isFramework);
@@ -704,19 +704,19 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
                        std::move(moduleDocInputBuffer),
                        std::move(moduleSourceInfoInputBuffer),
                        isFramework, loadedModuleFileCore,
-                       &extendedInfo);
+                       extendedInfo);
   if (loadInfo.status == serialization::Status::Valid) {
     loadedModuleFile =
         std::make_unique<ModuleFile>(std::move(loadedModuleFileCore));
-    M.setResilienceStrategy(extendedInfo.getResilienceStrategy());
+    M.setResilienceStrategy(loadedModuleFile->getResilienceStrategy());
 
     // We've loaded the file. Now try to bring it into the AST.
     auto fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile);
-    if (extendedInfo.isTestable())
+    if (loadedModuleFile->isTestable())
       M.setTestingEnabled();
-    if (extendedInfo.arePrivateImportsEnabled())
+    if (loadedModuleFile->arePrivateImportsEnabled())
       M.setPrivateImportsEnabled();
-    if (extendedInfo.isImplicitDynamicEnabled())
+    if (loadedModuleFile->isImplicitDynamicEnabled())
       M.setImplicitDynamicEnabled();
 
     auto diagLocOrInvalid = diagLoc.getValueOr(SourceLoc());


### PR DESCRIPTION
* Add properties to `ModuleFile` that hold some informations from the control block.
* ~`ExtendedValidationInfo` parameter for `ModuleFileSharedCore::load()` cannot be `nullptr`. Make it non-defaulted Rvalue reference.~
* Remove `ExtendedValidationInfo` parameter from `ModuleFileSharedCore::load()`. Now that all required information can be fetched from `ModuleFile`.
