### PR TITLE
[AutoDiff] NFC: improve debug log output.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Differentiation/ADContext.h
@@ -273,7 +273,8 @@ ADContext::emitNondifferentiabilityError(SILValue value,
                                          Diag<T...> diag, U &&... args) {
   LLVM_DEBUG({
     getADDebugStream() << "Diagnosing non-differentiability.\n";
-    getADDebugStream() << "For value:\n" << value;
+    auto &s = getADDebugStream() << "For value:\n";
+    value->printInContext(s);
     getADDebugStream() << "With invoker:\n" << invoker << '\n';
   });
   // If instruction does not have a valid location, use the function location
@@ -290,7 +291,8 @@ ADContext::emitNondifferentiabilityError(SILInstruction *inst,
                                          Diag<T...> diag, U &&... args) {
   LLVM_DEBUG({
     getADDebugStream() << "Diagnosing non-differentiability.\n";
-    getADDebugStream() << "For instruction:\n" << *inst;
+    auto &s = getADDebugStream() << "For instruction:\n";
+    inst->printInContext(s);
     getADDebugStream() << "With invoker:\n" << invoker << '\n';
   });
   // If instruction does not have a valid location, use the function location


### PR DESCRIPTION
Print value/instruction with context in non-differentiability error debug log.

---

Before: the source of some non-differentiability issues isn't clear.

```console
$ swiftc test.swift
...
[AD] Diagnosing non-differentiability.
[AD] For value:
  %10 = partial_apply [callee_guaranteed] %9<τ_0_0, τ_1_0>() : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1 // user: %11
[AD] With invoker:
(differentiation_invoker differentiable_function_inst=(  %11 = differentiable_function [parameters 0] [results 0] %10 : $@callee_guaranteed (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_1_0>) -> @out τ_1_0 // users: %16, %12
))
```

After:
```console
$ swiftc test.swift
...
[AD] Diagnosing non-differentiability.
[AD] For value:
     // function_ref swift_getAtKeyPath
  %9 = function_ref @swift_getAtKeyPath : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1 // user: %10
->   %10 = partial_apply [callee_guaranteed] %9<τ_0_0, τ_1_0>() : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1 // user: %11
     %11 = differentiable_function [parameters 0] [results 0] %10 : $@callee_guaranteed (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_1_0>) -> @out τ_1_0 // users: %16, %12
[AD] With invoker:
(differentiation_invoker differentiable_function_inst=(  %11 = differentiable_function [parameters 0] [results 0] %10 : $@callee_guaranteed (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_1_0>) -> @out τ_1_0 // users: %16, %12
))
```