### PR TITLE
[5.3][ConstraintSystem] Extend invalid function body fix to cover constrai…

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1025,10 +1025,19 @@ namespace swift {
       }
     }
 
-    bool hasDiagnostics() const {
-      return std::distance(Engine.TentativeDiagnostics.begin() +
-                               PrevDiagnostics,
-                           Engine.TentativeDiagnostics.end()) > 0;
+    bool hasErrors() const {
+      ArrayRef<Diagnostic> diagnostics(Engine.TentativeDiagnostics.begin() +
+                                           PrevDiagnostics,
+                                       Engine.TentativeDiagnostics.end());
+
+      for (auto &diagnostic : diagnostics) {
+        auto behavior = Engine.state.determineBehavior(diagnostic.getID());
+        if (behavior == DiagnosticState::Behavior::Fatal ||
+            behavior == DiagnosticState::Behavior::Error)
+          return true;
+      }
+
+      return false;
     }
 
     /// Abort and close this transaction and erase all diagnostics

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1844,9 +1844,17 @@ class SpecifyKeyPathRootType final : public ConstraintFix {
 };
 
 class IgnoreInvalidFunctionBuilderBody final : public ConstraintFix {
-  IgnoreInvalidFunctionBuilderBody(ConstraintSystem &cs,
+  enum class ErrorInPhase {
+    PreCheck,
+    ConstraintGeneration,
+  };
+
+  ErrorInPhase Phase;
+
+  IgnoreInvalidFunctionBuilderBody(ConstraintSystem &cs, ErrorInPhase phase,
                                    ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::IgnoreInvalidFunctionBuilderBody, locator) {}
+      : ConstraintFix(cs, FixKind::IgnoreInvalidFunctionBuilderBody, locator),
+        Phase(phase) {}
 
 public:
   std::string getName() const override {
@@ -1859,8 +1867,19 @@ public:
     return diagnose(*commonFixes.front().first);
   }
 
-  static IgnoreInvalidFunctionBuilderBody *create(ConstraintSystem &cs,
-                                                  ConstraintLocator *locator);
+  static IgnoreInvalidFunctionBuilderBody *
+  duringPreCheck(ConstraintSystem &cs, ConstraintLocator *locator) {
+    return create(cs, ErrorInPhase::PreCheck, locator);
+  }
+
+  static IgnoreInvalidFunctionBuilderBody *
+  duringConstraintGeneration(ConstraintSystem &cs, ConstraintLocator *locator) {
+    return create(cs, ErrorInPhase::ConstraintGeneration, locator);
+  }
+
+private:
+  static IgnoreInvalidFunctionBuilderBody *
+  create(ConstraintSystem &cs, ErrorInPhase phase, ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1727,6 +1727,13 @@ private:
   /// from declared parameters/result and body.
   llvm::MapVector<const ClosureExpr *, FunctionType *> ClosureTypes;
 
+  /// This is a *global* list of all function builder bodies that have
+  /// been determined to be incorrect by failing constraint generation.
+  ///
+  /// Tracking this information is useful to avoid producing duplicate
+  /// diagnostics when function builder has multiple overloads.
+  llvm::SmallDenseSet<AnyFunctionRef> InvalidFunctionBuilderBodies;
+
   /// Maps node types used within all portions of the constraint
   /// system, instead of directly using the types on the
   /// nodes themselves. This allows us to typecheck and

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -606,6 +606,14 @@ struct MyView {
     } // expected-error {{expected identifier after '.' expression}}
   }
 
+  @TupleBuilder var invalidCaseWithoutDot: some P {
+    switch Optional.some(1) {
+    case none: 42 // expected-error {{cannot find 'none' in scope}}
+    case .some(let x):
+      0
+    }
+  }
+
   @TupleBuilder var invalidConversion: Int {
     "" // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
   }


### PR DESCRIPTION
…nt generation failures

Cherry-pick of https://github.com/apple/swift/pull/33762

----

- Explanation: Ignore function builder body if it emits at least one diagnostic during constraint generation.

- Scope: Limited to invalid function builder bodies which fail constraint generation due to structural or other issues.

- Resolves:  rdar://problem/65983237

- Risk: Low

- Testing: Added regression tests

- Reviewer: @hborla, @DougGregor 

Resolves: rdar://problem/65983237

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
