### PR TITLE
[Sema] Require function builders to have at least one buildBlock method

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5250,6 +5250,16 @@ WARNING(function_builder_missing_limited_availability, none,
         "function builder %0 does not implement 'buildLimitedAvailability'; "
         "this code may crash on earlier versions of the OS",
         (Type))
+ERROR(function_builder_static_buildblock, none,
+      "function builder must provide at least one static 'buildBlock' "
+      "method", ())
+NOTE(function_builder_non_static_buildblock, none,
+     "did you mean to make instance method 'buildBlock' static?", ())
+NOTE(function_builder_buildblock_enum_case, none,
+     "enum case 'buildBlock' cannot be used to satisfy the function builder "
+     "requirement", ())
+NOTE(function_builder_buildblock_not_static_method, none,
+     "potential match 'buildBlock' is not a static method", ())
 
 //------------------------------------------------------------------------------
 // MARK: Tuple Shuffle Diagnostics

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1221,6 +1221,13 @@ bool requireArrayLiteralIntrinsics(ASTContext &ctx, SourceLoc loc);
 /// If \c expr is not part of a member chain or the base is something other than
 /// an \c UnresolvedMemberExpr, \c nullptr is returned.
 UnresolvedMemberExpr *getUnresolvedMemberChainBase(Expr *expr);
+
+/// Checks whether a function builder type has a well-formed function builder
+/// method with the given name. If provided and non-empty, the argument labels
+/// are verified against any candidates.
+bool typeSupportsBuilderOp(Type builderType, DeclContext *dc, Identifier fnName,
+                           ArrayRef<Identifier> argLabels = {},
+                           SmallVectorImpl<ValueDecl *> *allResults = nullptr);
 }; // namespace TypeChecker
 
 /// Temporary on-stack storage and unescaping for encoded diagnostic

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -28,7 +28,9 @@ public func returnsAlias() -> Alias<Int> {
 }
 
 @_functionBuilder
-struct BridgeBuilder {}
+struct BridgeBuilder {
+    static func buildBlock(_: Any...) {}
+}
 
 public struct City {
   public init(@BridgeBuilder builder: () -> ()) {}


### PR DESCRIPTION
If the supplied method is not static, offer a fix-it to make it static

This is technically source breaking, though AFAICT any function builders which don't have at least one valid `buildBlock` member aren't usable anyway, so maybe okay? If necessary, could downgrade this to a warning.
