### PR TITLE
[stdlib] Dispatch to concrete implementations of known types for generic BinaryFloatingPoint and FixedWidthInteger initialisers

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -82,7 +82,6 @@ set(SWIFTLIB_ESSENTIAL
   Indices.swift
   InputStream.swift
   IntegerParsing.swift
-  Integers.swift
   Join.swift
   KeyPath.swift
   KeyValuePairs.swift
@@ -197,6 +196,7 @@ set(SWIFTLIB_ESSENTIAL_GYB_SOURCES
   FloatingPointTypes.swift.gyb
   FloatingPoint.swift.gyb
   IntegerTypes.swift.gyb
+  Integers.swift.gyb
   UnsafeBufferPointer.swift.gyb
   UnsafeRawBufferPointer.swift.gyb
   )

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -69,7 +69,6 @@ set(SWIFTLIB_ESSENTIAL
   FixedArray.swift
   FlatMap.swift
   Flatten.swift
-  FloatingPoint.swift
   Hashable.swift
   # WORKAROUND: This file name is not sorted alphabetically in the list because
   # if we do so, the compiler crashes.
@@ -196,6 +195,7 @@ set(SWIFTLIB_ESSENTIAL_GYB_SOURCES
   AtomicInt.swift.gyb
   FloatingPointParsing.swift.gyb
   FloatingPointTypes.swift.gyb
+  FloatingPoint.swift.gyb
   IntegerTypes.swift.gyb
   UnsafeBufferPointer.swift.gyb
   UnsafeRawBufferPointer.swift.gyb

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1,4 +1,4 @@
-//===--- FloatingPoint.swift ----------------------------------*- swift -*-===//
+//===--- FloatingPoint.swift.gyb ------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -9,6 +9,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+%{
+from __future__ import division
+from SwiftIntTypes import all_integer_types
+from SwiftFloatingPointTypes import all_floating_point_types
+}%
 
 /// A floating-point numeric type.
 ///
@@ -1890,6 +1896,38 @@ extension BinaryFloatingPoint {
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
   public init<Source: BinaryFloatingPoint>(_ value: Source) {
+%   for float_type in all_floating_point_types():
+%     if float_type.bits == 16:
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+%     elif float_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%     end
+      if let source = value as? ${float_type.stdlib_name} {
+%     if float_type.stdlib_name in ['Float', 'Double', 'Float80']:
+        self = Self(source)
+        return
+%     else:
+%       for self_float_type in all_floating_point_types():
+%         if self_float_type.bits == 16:
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+%         elif self_float_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%         end
+        if ${self_float_type.stdlib_name}.self == Self.self {
+          self = ${self_float_type.stdlib_name}(source) as! Self
+          return
+        }
+%         if self_float_type.bits == 16 or self_float_type.bits == 80:
+#endif
+%         end
+%       end
+%     end
+    }
+%     if float_type.bits == 16 or float_type.bits == 80:
+#endif
+%     end
+%   end
+
     self = Self._convert(from: value).value
   }
 
@@ -1902,6 +1940,37 @@ extension BinaryFloatingPoint {
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
   public init?<Source: BinaryFloatingPoint>(exactly value: Source) {
+%     for self_float_type in all_floating_point_types():
+%       if self_float_type.bits == 16:
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+%       elif self_float_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%       end
+      if ${self_float_type.stdlib_name}.self == Self.self {
+%       for float_type in all_floating_point_types():
+%         if float_type.bits == 16:
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+%         elif float_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%         end
+    if let source = value as? ${float_type.stdlib_name} {
+        if let converted = ${self_float_type.stdlib_name}(exactly: source) {
+          self = converted as! Self
+          return
+        } else {
+          return nil
+        }
+      }
+%       if float_type.bits == 16 or float_type.bits == 80:
+#endif
+%       end
+%     end
+    }
+%     if self_float_type.bits == 16 or self_float_type.bits == 80:
+#endif
+%     end
+%   end
+
     let (value_, exact) = Self._convert(from: value)
     guard exact else { return nil }
     self = value_

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1,4 +1,4 @@
-//===--- Integers.swift ---------------------------------------------------===//
+//===--- Integers.swift.gyb ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -9,6 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+
+%{
+from __future__ import division
+from SwiftIntTypes import all_integer_types
+from SwiftFloatingPointTypes import all_floating_point_types
+
+word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+}%
 
 //===----------------------------------------------------------------------===//
 //===--- Bits for the Stdlib ----------------------------------------------===//
@@ -3051,6 +3060,25 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
   public init<T: BinaryFloatingPoint>(_ source: T) {
+%   for float_type in all_floating_point_types():
+%   if float_type.bits == 16:
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+%   elif float_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%end
+    if let source = source as? ${float_type.stdlib_name} {
+%   for int_type in all_integer_types(word_bits):
+      if ${int_type.stdlib_name}.self == Self.self {
+        self = ${int_type.stdlib_name}(source) as! Self
+        return
+      }
+%     end
+    }
+%   if float_type.bits == 16 or float_type.bits == 80:
+#endif
+%end
+%   end
+
     guard let value = Self._convert(from: source).value else {
       fatalError("""
         \(T.self) value cannot be converted to \(Self.self) because it is \
@@ -3077,6 +3105,29 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable
   public init?<T: BinaryFloatingPoint>(exactly source: T) {
+%   for float_type in all_floating_point_types():
+%   if float_type.bits == 16:
+#if !os(macOS) && !targetEnvironment(macCatalyst)
+%   elif float_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%end
+    if let source = source as? ${float_type.stdlib_name} {
+%   for int_type in all_integer_types(word_bits):
+      if ${int_type.stdlib_name}.self == Self.self {
+        if let converted = ${int_type.stdlib_name}(exactly: source) {
+          self = converted as! Self
+          return
+        } else {
+          return nil
+        }
+      }
+%     end
+    }
+%   if float_type.bits == 16 or float_type.bits == 80:
+#endif
+%end
+%   end
+
     let (temporary, exact) = Self._convert(from: source)
     guard exact, let value = temporary else {
       return nil


### PR DESCRIPTION
Since generic functions in Swift cannot behave differently under specialisation, a number of numeric conversion behaviours were producing poor assembly (calling out to the generic `_convert` methods) in a generic context. This can be seen in scenarios like the following:

```
@inlinable
func processGeneric<T: BinaryFloatingPoint>(_ x: T) -> Double {
    return Double(x)
}

public func process(_ x: Double) -> Double {
    return processGeneric(x)
}
```

which produces [this](https://godbolt.org/z/Kb7Erf) when optimised and fully specialised.

This PR explicitly branches and specialises where necessary within the generic conversion methods for both `init()` and `init?(exactly:)` for `FixedWidthInteger` and `BinaryFloatingPoint` by GYBing the checks for all known types. This ensures that fully specialised code is able to call the concrete conversions, resulting in much better assembly.

This PR will regress performance slightly for non-stdlib types that pass through these generic initialisers and may negatively impact code-size. These are unfortunate consequences of this approach. An alternative approach might be to mark the concrete initialisers as being somehow substitutable for the generic initialiser such that the optimiser is able to substitute in the more-specific conversion in fully specialised code; however, that comes at the cost of potential behaviour differences between specialised and unspecialised code. Both of these options are discussed in the context of this thread: https://forums.swift.org/t/numeric-type-conversion-marking-functions-as-equivalent-for-generic-specialisation/39810

I'm not sure whether the existing benchmarks cover this, since I couldn't see clear differences locally. If it turns out they don't, I'll write and submit a benchmark in a separate PR.

cc @xwu – you mentioned taking a look at this, but hopefully this covers what you were thinking of.