### PR TITLE
[AutoDiff] [Sema] Fix missing access-level mismatch diagnostic in `-enable-testing` builds.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4653,7 +4653,8 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
     if (originalAFD->getFormalAccess() == derivative->getFormalAccess())
       return true;
     return originalAFD->getFormalAccess() == AccessLevel::Public &&
-           derivative->getEffectiveAccess() == AccessLevel::Public;
+           (derivative->getFormalAccess() == AccessLevel::Public ||
+            derivative->isUsableFromInline());
   };
 
   // Check access level compatibility for original and derivative functions.

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend-typecheck -verify -disable-availability-checking %s
+// RUN: %target-swift-frontend-typecheck -enable-testing -verify -disable-availability-checking %s
 
 // Swift.AdditiveArithmetic:3:17: note: cannot yet register derivative default implementation for protocol requirements
 

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend-typecheck -verify -disable-availability-checking %s
+// RUN: %target-swift-frontend-typecheck -enable-testing -verify -disable-availability-checking %s
 
 import _Differentiation
 

--- a/test/AutoDiff/Sema/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/transpose_attr_type_checking.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend-typecheck -verify %s
+// RUN: %target-swift-frontend-typecheck -enable-testing -verify %s
 
 import _Differentiation
 


### PR DESCRIPTION
When a derivative function is internal and its original function is public, there should be an error when the derivative is not `@usableFromInline`. This patch fixes a bug where the error does not appear in SwiftPM debug build configurations (or any configurations with `-enable-testing`).

`ValueDecl::getEffectiveAccess()` should not be used when we perform formal access checking for AutoDiff-related declaration attributes because it will treat all internal declarations as public when `-enable-testing` is enabled. Instead, we should use a combination of `ValueDecl::getFormalAccess()` and `ValueDecl::isUsableFromInline()`.

Also, add a `RUN` line with `-enable-testing` to all AutoDiff declaration attribute test files.

Resolves SR-13500 (rdar://68336300).