### PR TITLE
ModuleInterface: remark potential version differences between SDK and prebuilt modules

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -366,6 +366,9 @@ ERROR(error_extracting_flags_from_module_interface,none,
       "error extracting flags from module interface", ())
 REMARK(rebuilding_module_from_interface,none,
        "rebuilding module '%0' from interface '%1'", (StringRef, StringRef))
+NOTE(sdk_version_pbm_version,none,
+     "SDK build version is '%0'; prebuilt modules were "
+     "built using SDK build version: '%1'", (StringRef, StringRef))
 NOTE(out_of_date_module_here,none,
      "%select{compiled|cached|forwarding|prebuilt}0 module is out of date: '%1'",
      (unsigned, StringRef))

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -106,6 +106,13 @@ namespace swift {
   /// Retrieve the target SDK version for the given SDKInfo and target triple.
   llvm::VersionTuple getTargetSDKVersion(clang::driver::DarwinSDKInfo &SDKInfo,
                                          const llvm::Triple &triple);
+
+  /// Get SDK build version.
+  std::string getSDKBuildVersion(StringRef SDKPath);
+  std::string getSDKBuildVersionFromPlist(StringRef Path);
+
+  /// Get SDK name.
+  std::string getSDKName(StringRef SDKPath);
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PLATFORM_H

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -101,10 +101,6 @@ void walkOverriddenDecls(const ValueDecl *VD,
 
 void collectModuleNames(StringRef SDKPath, std::vector<std::string> &Modules);
 
-std::string getSDKName(StringRef Path);
-
-std::string getSDKVersion(StringRef Path);
-
 struct PlaceholderOccurrence {
   /// The complete placeholder string.
   StringRef FullPlaceholder;

--- a/test/ModuleInterface/ModuleCache/Inputs/sdk-build-ver.1.plist
+++ b/test/ModuleInterface/ModuleCache/Inputs/sdk-build-ver.1.plist
@@ -1,0 +1,6 @@
+<plist version="1.0">
+<dict>
+	<key>ProductBuildVersion</key>
+	<string>11111</string>
+</dict>
+</plist>

--- a/test/ModuleInterface/ModuleCache/Inputs/sdk-build-ver.2.plist
+++ b/test/ModuleInterface/ModuleCache/Inputs/sdk-build-ver.2.plist
@@ -1,0 +1,6 @@
+<plist version="1.0">
+<dict>
+	<key>ProductBuildVersion</key>
+	<string>22222</string>
+</dict>
+</plist>

--- a/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-forwarding-module.swift
+++ b/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-forwarding-module.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t/ModuleCache)
 // RUN: %empty-directory(%t/Build)
 // RUN: %empty-directory(%t/PrebuiltCache)
+// RUN: %empty-directory(%t/System/Library/CoreServices)
+
+// RUN: cp %S/../Inputs/sdk-build-ver.1.plist %t/System/Library/CoreServices/SystemVersion.plist
+// RUN: cp %S/../Inputs/sdk-build-ver.2.plist %t/PrebuiltCache/SystemVersion.plist
 
 // 1. Create a dummy module
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
@@ -30,3 +34,4 @@ import TestModule // expected-remark {{rebuilding module 'TestModule' from inter
 // expected-note @-2 {{dependency is out of date}}
 // expected-note @-3 {{prebuilt module is out of date}}
 // expected-note @-4 {{dependency is out of date}}
+// expected-note @-5 {{SDK build version is '11111'; prebuilt modules were built using SDK build version: '22222'}}

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -26,6 +26,7 @@
 // can be reflected as source-breaking changes for API users. If they are,
 // the output of api-digester will include such changes.
 
+#include "swift/Basic/Platform.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "swift/AST/DiagnosticsModuleDiffer.h"
@@ -2704,7 +2705,7 @@ static CheckerOptions getCheckOpts(int argc, char *argv[]) {
     Opts.ToolArgs.push_back(argv[i]);
 
   if (!options::SDK.empty()) {
-    auto Ver = getSDKVersion(options::SDK);
+    auto Ver = getSDKBuildVersion(options::SDK);
     if (!Ver.empty()) {
       Opts.ToolArgs.push_back("-sdk-version");
       Opts.ToolArgs.push_back(Ver);


### PR DESCRIPTION
Prebuilt-module directory now contains a SystemVersion.plist file copied from the SDK
it's built from. This patch teaches the compiler to remark this version and the SDK version
when -Rmodule-interface-rebuild is specified. The difference between these versions could
help us debug unusable prebuilt modules.