### PR TITLE
[stdlib] Make use of protocol requirements to convert from concrete floating-point types

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1890,11 +1890,15 @@ extension BinaryFloatingPoint {
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
   public init<Source: BinaryFloatingPoint>(_ value: Source) {
-    switch value {
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
-    case let value_ as Float16:
-      self = Self(Float(value_))
+    if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+      if case let value_ as Float16 = value {
+        self = Self(Float(value_))
+        return
+      }
+    }
 #endif
+    switch value {
     case let value_ as Float:
       self = Self(value_)
     case let value_ as Double:

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1891,6 +1891,10 @@ extension BinaryFloatingPoint {
   @inlinable
   public init<Source: BinaryFloatingPoint>(_ value: Source) {
     switch value {
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+    case let value_ as Float16:
+      self = Self(Float(value_))
+#endif
     case let value_ as Float:
       self = Self(value_)
     case let value_ as Double:

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1890,7 +1890,18 @@ extension BinaryFloatingPoint {
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
   public init<Source: BinaryFloatingPoint>(_ value: Source) {
-    self = Self._convert(from: value).value
+    switch value {
+    case let value_ as Float:
+      self = Self(value_)
+    case let value_ as Double:
+      self = Self(value_)
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+    case let value_ as Float80:
+      self = Self(value_)
+#endif
+    default:
+      self = Self._convert(from: value).value
+    }
   }
 
   /// Creates a new instance from the given value, if it can be represented


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR is about picking the low-hanging fruit in terms of recovering performance during generic floating-point conversion. It is _so_ low-hanging, in fact, it's actually partly a reversion to the original placeholder implementation of generic floating-point conversion.

In brief, we never removed the requirements for `init(_: Float)`, `init(_: Double)`, and `init(_: Float80)` from the protocol, and now that we have ABI stability, these requirements will be present forever. So, we can call them from the generic implementation.

There is one caveat to be highlighted: As in other situations (see #30417), the compiler regards the generic initializer itself as a suitable default implementation of `init(_: Float)` and friends, and therefore it will not warn if a concrete type does not provide its own implementations of the latter. Currently, this means that the concrete type will unwittingly have a very slow implementation; with this change, the concrete type will have an implementation that crashes at runtime due to infinite recursion. I think it's arguable as to which one is the worse outcome; this PR doesn't cause or otherwise change the underlying issue.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
