### PR TITLE
[Concurrency] Fix nested await/try parsing and effects checking.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -394,7 +394,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
   if (shouldParseExperimentalConcurrency() && Tok.isContextualKeyword("await")) {
     SourceLoc awaitLoc = consumeToken();
-    ParserResult<Expr> sub = parseExprUnary(message, isExprBasic);
+    ParserResult<Expr> sub =
+      parseExprSequenceElement(diag::expected_expr_after_await, isExprBasic);
     if (!sub.hasCodeCompletion() && !sub.isNull()) {
       ElementContext.setCreateSyntax(SyntaxKind::AwaitExpr);
       sub = makeParserResult(new (Context) AwaitExpr(awaitLoc, sub.get()));
@@ -428,7 +429,9 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     }
   }
 
-  ParserResult<Expr> sub = parseExprUnary(message, isExprBasic);
+  ParserResult<Expr> sub = hadTry
+      ? parseExprSequenceElement(message, isExprBasic)
+      : parseExprUnary(message, isExprBasic);
 
   if (hadTry && !sub.hasCodeCompletion() && !sub.isNull()) {
     ElementContext.setCreateSyntax(SyntaxKind::TryExpr);

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,16 +1,14 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify
 
 // REQUIRES: objc_interop
 import Foundation
 import ObjCConcurrency
 
-func testSlowServer(slowServer: SlowServer) async {
+func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
   let _: Bool = await slowServer.checkAvailability()
-  let _: String = await slowServer.findAnswer() ?? "nope"
-  let _: String = await slowServer.findAnswerFailingly() ?? "nope"
-  // FIXME: expected-error@-2{{call can throw, but it is not marked with 'try'}}
-  // FIXME: expected-error@-2{{call can throw, but it is not marked with 'try'}}
+  let _: String = try await slowServer.findAnswer() ?? "nope"
+  let _: String = await try slowServer.findAnswerFailingly() ?? "nope"
   let _: Void = await slowServer.doSomethingFun("jump")
   let _: (Int) -> Void = slowServer.completionHandler
 }


### PR DESCRIPTION
Fix the parsing of await/try/try?/try! so that the two can be nested
(e.g., `await try f()` or `try await f()`).

Then, fix the effects checking logic to preserve all throws-related
information under an `await`, and preserve all async/await-related
information under `try`/`try?`/`try!`.

Add a number of tests, and fix 'await' handling for string
interpolations as well.
