### PR TITLE
SILOptimizer: correct accidental `>=` to `>`

### DIFF
--- a/lib/SILOptimizer/Transforms/PruneVTables.cpp
+++ b/lib/SILOptimizer/Transforms/PruneVTables.cpp
@@ -31,7 +31,7 @@ class PruneVTables : public SILModuleTransform {
     LLVM_DEBUG(llvm::dbgs() << "PruneVTables inspecting table:\n";
                vtable->print(llvm::dbgs()));
     if (!M->isWholeModule() &&
-        vtable->getClass()->getEffectiveAccess() >= AccessLevel::FilePrivate) {
+        vtable->getClass()->getEffectiveAccess() > AccessLevel::FilePrivate) {
       LLVM_DEBUG(llvm::dbgs() << "Ignoring visible table: ";
                  vtable->print(llvm::dbgs()));
       return;


### PR DESCRIPTION
This should be enabled for `fileprivate` classes.  Thanks to
@slavapestov for pointing out the mistake in the condition!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
