### PR TITLE
ARCSequenceOpts: Add LoopSummary verifier 

### DIFF
--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -493,6 +493,8 @@ void BottomUpRefCountState::checkAndResetKnownSafety(
   clearKnownSafe();
 }
 
+// This function is conservative enough that the flow sensitive nature of
+// loop summarized instructions does not matter.
 void BottomUpRefCountState::updateForDifferentLoopInst(SILInstruction *I,
                                                        AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
@@ -500,6 +502,8 @@ void BottomUpRefCountState::updateForDifferentLoopInst(SILInstruction *I,
     return;
 
   if (valueCanBeGuaranteedUsedGivenLatticeState()) {
+    // Any instruction that may need guaranteed use or may decrement the
+    // refcount will turn off CodeMotionSafety
     if (mayGuaranteedUseValue(I, getRCRoot(), AA) ||
         mayDecrementRefCount(I, getRCRoot(), AA)) {
       LLVM_DEBUG(llvm::dbgs() << "    Found potential guaranteed use:\n        "
@@ -917,12 +921,16 @@ void TopDownRefCountState::checkAndResetKnownSafety(
   clearKnownSafe();
 }
 
+// This function is conservative enough that the flow sensitive nature of
+// loop summarized instructions does not matter.
 void TopDownRefCountState::updateForDifferentLoopInst(SILInstruction *I,
                                                       AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
     return;
 
+  // Any instruction that may need guaranteed use or may decrement the
+  // refcount will turn off CodeMotionSafety
   if (valueCanBeGuaranteedUsedGivenLatticeState()) {
     if (mayGuaranteedUseValue(I, getRCRoot(), AA) ||
         mayDecrementRefCount(I, getRCRoot(), AA)) {

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -178,6 +178,9 @@ public:
   BottomUpRefCountState(BottomUpRefCountState &&) = default;
   BottomUpRefCountState &operator=(BottomUpRefCountState &&) = default;
 
+  /// Getter for LatticeState
+  LatticeState getLatticeState() const {return LatState;}
+
   /// Return true if the release can be moved to the retain.
   bool isCodeMotionSafe() const {
     return LatState != LatticeState::MightBeDecremented;
@@ -205,6 +208,8 @@ public:
   /// The main difference in between this routine and update for same loop inst
   /// is that if we see any decrements on a value, we treat it as being
   /// guaranteed used. We treat any uses as regular uses.
+  /// This function is conservative enough that the flow sensitive nature of
+  /// loop summarized instructions does not matter.
   void updateForDifferentLoopInst(
       SILInstruction *I,
       AliasAnalysis *AA);
@@ -312,6 +317,9 @@ public:
   TopDownRefCountState(TopDownRefCountState &&) = default;
   TopDownRefCountState &operator=(TopDownRefCountState &&) = default;
 
+  /// Getter for LatticeState
+  LatticeState getLatticeState() const {return LatState;}
+
   /// Return true if the retain can be moved to the release.
   bool isCodeMotionSafe() const {
     return LatState != LatticeState::MightBeUsed;
@@ -350,6 +358,8 @@ public:
   /// The main difference in between this routine and update for same loop inst
   /// is that if we see any decrements on a value, we treat it as being
   /// guaranteed used. We treat any uses as regular uses.
+  /// This function is conservative enough that the flow sensitive nature of
+  /// loop summarized instructions does not matter.
   void updateForDifferentLoopInst(
       SILInstruction *I,
       AliasAnalysis *AA);


### PR DESCRIPTION
ARCSequenceOpts with loop support works on regions inside out. While processing an outer region, it uses summary from
the inner loop region to compute RefCountState transitions used for CodeMotionSafe optimization.

We do not compute the loop summary by iterating over it twice or iterating until a fixed point is reached.
Instead loop summary is just a list of refcount affecting instructions. And BottomUpRefCountState::updateForDifferentLoopInst and TopDownRefCountState::updateForDifferentLoopInst are used to compute the RefCountState transition when processing the inner loop region. These functions are very conservative and the flow sensitive nature of the summarized instructions do no matter.
This PR adds a verifying assert to confirm this.
