### PR TITLE
[SourceKit] Reorganize code completion options

### DIFF
--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -37,8 +37,10 @@ makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
 
 /// Manages \c CompilerInstance for completion like operations.
 class CompletionInstance {
-  unsigned MaxASTReuseCount = 100;
-  unsigned DependencyCheckIntervalSecond = 5;
+  struct Options {
+    unsigned MaxASTReuseCount = 100;
+    unsigned DependencyCheckIntervalSecond = 5;
+  } Opts;
 
   std::mutex mtx;
 
@@ -59,7 +61,7 @@ class CompletionInstance {
   /// argument has changed, primary file is not the same, the \c Offset is not
   /// in function bodies, or the interface hash of the file has changed.
   bool performCachedOperationIfPossible(
-      const swift::CompilerInvocation &Invocation, llvm::hash_code ArgsHash,
+      llvm::hash_code ArgsHash,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
@@ -78,7 +80,9 @@ class CompletionInstance {
       llvm::function_ref<void(CompilerInstance &, bool)> Callback);
 
 public:
-  void setDependencyCheckIntervalSecond(unsigned Value);
+  CompletionInstance() {}
+
+  void setOptions(Options NewOpts);
 
   /// Calls \p Callback with a \c CompilerInstance which is prepared for the
   /// second pass. \p Callback is resposible to perform the second pass on it.
@@ -94,7 +98,7 @@ public:
       swift::CompilerInvocation &Invocation, llvm::ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
-      bool EnableASTCaching, std::string &Error, DiagnosticConsumer *DiagC,
+      std::string &Error, DiagnosticConsumer *DiagC,
       llvm::function_ref<void(CompilerInstance &, bool)> Callback);
 };
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -40,7 +40,7 @@ func foo() {
 // RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 // RUN:   -shell -- echo '### Checking dependencies' == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -29,7 +29,7 @@ func foo() {
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -29,7 +29,7 @@ func foo() {
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -29,7 +29,7 @@ func foo() {
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -46,7 +46,7 @@ func foo(val: MyStruct) {
 // RUN: cp %t/State1.swift %t/test.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -29,7 +29,7 @@ func foo() {
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -12,7 +12,7 @@ func foo(value: MyStruct) {
 // RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -12,7 +12,7 @@ func foo(value: MyStruct) {
 // RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -completion-check-dependency-interval ${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \

--- a/test/SourceKit/CodeComplete/complete_sequence.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence.swift
@@ -19,8 +19,9 @@ func bar(arg: Bar) {
 
 // Disabled.
 // RUN: %sourcekitd-test \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=12:11 %s -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=15:11 %s -- %s > %t.response
+// RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=0 ==\
+// RUN:   -req=complete -pos=12:11 %s -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -- %s > %t.response
 // RUN: %FileCheck --check-prefix=RESULT_SLOW %s < %t.response
 
 // Enabled.

--- a/test/SourceKit/CodeComplete/complete_sequence_race.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_race.swift
@@ -19,21 +19,23 @@ func bar(arg: Bar) {
 
 // ReuseASTContext disabled.
 // RUN: %sourcekitd-test \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=12:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=15:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=12:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=15:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=17:1 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=12:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=15:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=12:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=15:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=17:1 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=12:11 %s -async -- %s == \
-// RUN:   -req=complete -req-opts=reuseastcontext=0 -pos=15:11 %s -async -- %s
+// RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=0 \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=17:1 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=17:1 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s
 
 // ReuseASTContext enabled.
 // RUN: %sourcekitd-test \
+// RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=5 \
 // RUN:   -req=complete -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=15:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=12:11 %s -async -- %s == \

--- a/test/SourceKit/CodeComplete/complete_without_stdlib.swift
+++ b/test/SourceKit/CodeComplete/complete_without_stdlib.swift
@@ -10,10 +10,11 @@ class Str {
 // RUN: %empty-directory(%t/sdk)
 
 // RUN: %sourcekitd-test \
+// RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=0 \
 // RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
 // RUN: %sourcekitd-test \
-// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk == \
-// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
+// RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk == \
+// RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
 
 // CHECK: key.results: [
 // CHECK-NOT: key.description:

--- a/test/SourceKit/ConformingMethods/basic.swift
+++ b/test/SourceKit/ConformingMethods/basic.swift
@@ -26,9 +26,12 @@ func testing(obj: C) {
   let _ = obj.
 }
 
-// RUN: %sourcekitd-test -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s > %t.response
+// RUN: %sourcekitd-test \
+// RUN:   -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s > %t.response
 // RUN: %diff -u %s.response %t.response
-// RUN: %sourcekitd-test -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD',reuseastcontext=0 -- -module-name MyModule %s | %FileCheck %s --check-prefix=DISABLED
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=0 == \
+// RUN:   -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s | %FileCheck %s --check-prefix=DISABLED
 
 // DISABLED-NOT: key.reuseastcontext
 // DISABLED: key.members: [

--- a/test/SourceKit/CursorInfo/use-swift-source-info.swift
+++ b/test/SourceKit/CursorInfo/use-swift-source-info.swift
@@ -12,10 +12,10 @@ func bar() {
 // RUN: %target-swift-frontend -enable-batch-mode -emit-module -emit-module-doc -emit-module-path %t/Foo.swiftmodule %t/Foo.swift -module-name Foo -emit-module-source-info-path %t/Foo.swiftsourceinfo -emit-module-doc-path %t/Foo.swiftdoc
 //
 // Test setting optimize for ide to false
-// RUN: %sourcekitd-test -req=global-config -for-ide=0 == -req=cursor -pos=3:3 %s -- -I %t -target %target-triple %s | %FileCheck --check-prefixes=BOTH,WITH %s
+// RUN: %sourcekitd-test -req=global-config -req-opts=optimize_for_ide=0 == -req=cursor -pos=3:3 %s -- -I %t -target %target-triple %s | %FileCheck --check-prefixes=BOTH,WITH %s
 //
 // Test setting optimize for ide to true
-// RUN: %sourcekitd-test -req=global-config -for-ide=1 == -req=cursor -pos=3:3 %s -- -I %t -target %target-triple %s | %FileCheck --check-prefixes=BOTH,WITHOUT %s
+// RUN: %sourcekitd-test -req=global-config -req-opts=optimize_for_ide=1 == -req=cursor -pos=3:3 %s -- -I %t -target %target-triple %s | %FileCheck --check-prefixes=BOTH,WITHOUT %s
 //
 // Test sourcekitd-test's default global configuration request (optimize for ide is true)
 // RUN: %sourcekitd-test -req=cursor -pos=3:3 %s -- -I %t -target %target-triple %s | %FileCheck --check-prefixes=BOTH,WITHOUT %s

--- a/test/SourceKit/TypeContextInfo/typecontext_basic.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_basic.swift
@@ -25,9 +25,12 @@ func test(obj: C) {
   let _ = obj.foo(x: 
 }
 
-// RUN: %sourcekitd-test -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -- %s > %t.response
+// RUN: %sourcekitd-test \
+// RUN:   -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -- %s > %t.response
 // RUN: %diff -u %s.response %t.response
-// RUN: %sourcekitd-test -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -req-opts=reuseastcontext=0 -- %s | %FileCheck %s --check-prefix=DISABLED
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=0 == \
+// RUN:   -req=typecontextinfo -repeat-request=2 -pos=25:22 %s -- %s | %FileCheck %s --check-prefix=DISABLED
 
 // DISABLED-NOT: key.reuseastcontext
 // DISABLED: key.results: [

--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -31,14 +31,20 @@ namespace SourceKit {
 class GlobalConfig {
 public:
   struct Settings {
-    /// When true, the default compiler options and other configuration flags will be chosen to optimize for
-    /// usage from an IDE.
+    /// When true, the default compiler options and other configuration flags
+    /// will be chosen to optimize for usage from an IDE.
     ///
     /// At the time of writing this just means ignoring .swiftsourceinfo files.
     bool OptimizeForIDE = false;
 
-    /// Interval second for checking dependencies in fast code completion.
-    unsigned CompletionCheckDependencyInterval = 5;
+    struct CompletionOptions {
+
+      /// Max count of reusing ASTContext for cached code completion.
+      unsigned MaxASTContextReuseCount = 100;
+
+      /// Interval second for checking dependencies in cached code completion.
+      unsigned CheckDependencyInterval = 5;
+    } CompletionOpts;
   };
 
 private:
@@ -47,9 +53,10 @@ private:
 
 public:
   Settings update(Optional<bool> OptimizeForIDE,
+                  Optional<unsigned> CompletionMaxASTContextReuseCount,
                   Optional<unsigned> CompletionCheckDependencyInterval);
   bool shouldOptimizeForIDE() const;
-  unsigned getCompletionCheckDependencyInterval() const;
+  Settings::CompletionOptions getCompletionOpts() const;
 };
 
 class Context {

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -18,12 +18,17 @@ using namespace SourceKit;
 
 GlobalConfig::Settings
 GlobalConfig::update(Optional<bool> OptimizeForIDE,
+                     Optional<unsigned> CompletionMaxASTContextReuseCount,
                      Optional<unsigned> CompletionCheckDependencyInterval) {
   llvm::sys::ScopedLock L(Mtx);
   if (OptimizeForIDE.hasValue())
     State.OptimizeForIDE = *OptimizeForIDE;
+  if (CompletionMaxASTContextReuseCount.hasValue())
+    State.CompletionOpts.MaxASTContextReuseCount =
+        *CompletionMaxASTContextReuseCount;
   if (CompletionCheckDependencyInterval.hasValue())
-    State.CompletionCheckDependencyInterval = *CompletionCheckDependencyInterval;
+    State.CompletionOpts.CheckDependencyInterval =
+        *CompletionCheckDependencyInterval;
   return State;
 };
 
@@ -31,9 +36,10 @@ bool GlobalConfig::shouldOptimizeForIDE() const {
   llvm::sys::ScopedLock L(Mtx);
   return State.OptimizeForIDE;
 }
-unsigned GlobalConfig::getCompletionCheckDependencyInterval() const {
+GlobalConfig::Settings::CompletionOptions
+GlobalConfig::getCompletionOpts() const {
   llvm::sys::ScopedLock L(Mtx);
-  return State.CompletionCheckDependencyInterval;
+  return State.CompletionOpts;
 }
 
 SourceKit::Context::Context(

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -42,7 +42,6 @@ struct Options {
   bool hideLowPriority = true;
   bool hideByNameStyle = true;
   bool fuzzyMatching = true;
-  bool reuseASTContextIfPossible = true;
   bool annotatedDescription = false;
   unsigned minFuzzyLength = 2;
   unsigned showTopNonLiteralResults = 3;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -121,9 +121,9 @@ static bool swiftCodeCompleteImpl(
     unsigned Offset, SwiftCodeCompletionConsumer &SwiftConsumer,
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    bool EnableASTCaching, bool annotateDescription, std::string &Error) {
+    bool annotateDescription, std::string &Error) {
   return Lang.performCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
+      UnresolvedInputFile, Offset, Args, FileSystem, Error,
       [&](CompilerInstance &CI, bool reusingASTContext) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
@@ -215,7 +215,6 @@ void SwiftLangSupport::codeComplete(
   std::string Error;
   if (!swiftCodeCompleteImpl(*this, UnresolvedInputFile, Offset, SwiftConsumer,
                              Args, fileSystem,
-                             CCOpts.reuseASTContextIfPossible,
                              CCOpts.annotatedDescription, Error)) {
     SKConsumer.failed(Error);
   }
@@ -734,7 +733,6 @@ static void translateCodeCompletionOptions(OptionsDictionary &from,
   static UIdent KeyContextWeight("key.codecomplete.sort.contextweight");
   static UIdent KeyFuzzyWeight("key.codecomplete.sort.fuzzyweight");
   static UIdent KeyPopularityBonus("key.codecomplete.sort.popularitybonus");
-  static UIdent KeyReuseASTContext("key.codecomplete.reuseastcontext");
   static UIdent KeyAnnotatedDescription("key.codecomplete.annotateddescription");
 
   from.valueForOption(KeySortByName, to.sortByName);
@@ -760,7 +758,6 @@ static void translateCodeCompletionOptions(OptionsDictionary &from,
   from.valueForOption(KeyPopularityBonus, to.popularityBonus);
   from.valueForOption(KeyHideByName, to.hideByNameStyle);
   from.valueForOption(KeyTopNonLiteral, to.showTopNonLiteralResults);
-  from.valueForOption(KeyReuseASTContext, to.reuseASTContextIfPossible);
   from.valueForOption(KeyAnnotatedDescription, to.annotatedDescription);
 }
 
@@ -1032,7 +1029,6 @@ static void transformAndForwardResults(
     std::string error;
     if (!swiftCodeCompleteImpl(lang, buffer.get(), str.size(), swiftConsumer,
                                cargs, session->getFileSystem(),
-                               options.reuseASTContextIfPossible,
                                options.annotatedDescription, error)) {
       consumer.failed(error);
       return;
@@ -1134,7 +1130,6 @@ void SwiftLangSupport::codeCompleteOpen(
   // Invoke completion.
   if (!swiftCodeCompleteImpl(*this, inputBuf, offset, swiftConsumer,
                              extendedArgs, fileSystem,
-                             CCOpts.reuseASTContextIfPossible,
                              CCOpts.annotatedDescription, error)) {
     consumer.failed(error);
     return;

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -26,11 +26,10 @@ using namespace SourceKit;
 using namespace swift;
 using namespace ide;
 
-static void translateConformingMethodListOptions(OptionsDictionary &from,
-                                                 ConformingMethodList::Options &to) {
-  static UIdent KeyReuseASTContext("key.conformingmethods.reuseastcontext");
-
-  from.valueForOption(KeyReuseASTContext, to.reuseASTContextIfPossible);
+static void
+translateConformingMethodListOptions(OptionsDictionary &from,
+                                     ConformingMethodList::Options &to) {
+  // ConformingMethodList doesn't receive any options at this point.
 }
 
 static bool swiftConformingMethodListImpl(
@@ -39,9 +38,9 @@ static bool swiftConformingMethodListImpl(
     ArrayRef<const char *> ExpectedTypeNames,
     ide::ConformingMethodListConsumer &Consumer,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    bool EnableASTCaching, std::string &Error) {
+    std::string &Error) {
   return Lang.performCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
+      UnresolvedInputFile, Offset, Args, FileSystem, Error,
       [&](CompilerInstance &CI, bool reusingASTContext) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
@@ -194,7 +193,7 @@ void SwiftLangSupport::getConformingMethodList(
 
   if (!swiftConformingMethodListImpl(*this, UnresolvedInputFile, Offset, Args,
                                      ExpectedTypeNames, Consumer, fileSystem,
-                                     options.reuseASTContextIfPossible, error)) {
+                                     error)) {
     SKConsumer.failed(error);
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -264,8 +264,11 @@ class InMemoryFileSystemProvider: public SourceKit::FileSystemProvider {
 static void
 configureCompletionInstance(std::shared_ptr<CompletionInstance> CompletionInst,
                             std::shared_ptr<GlobalConfig> GlobalConfig) {
-  CompletionInst->setDependencyCheckIntervalSecond(
-      GlobalConfig->getCompletionCheckDependencyInterval());
+  auto Opts = GlobalConfig->getCompletionOpts();
+  CompletionInst->setOptions({
+    Opts.MaxASTContextReuseCount,
+    Opts.CheckDependencyInterval
+  });
 }
 
 SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
@@ -986,7 +989,7 @@ bool SwiftLangSupport::performCompletionLikeOperation(
     llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    bool EnableASTCaching, std::string &Error,
+    std::string &Error,
     llvm::function_ref<void(CompilerInstance &, bool)> Callback) {
   assert(FileSystem);
 
@@ -1042,8 +1045,7 @@ bool SwiftLangSupport::performCompletionLikeOperation(
 
   return CompletionInst->performOperation(Invocation, Args, FileSystem,
                                           newBuffer.get(), Offset,
-                                          EnableASTCaching, Error,
-                                          &CIDiags, Callback);
+                                          Error, &CIDiags, Callback);
 }
 
 CloseClangModuleFiles::~CloseClangModuleFiles() {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -222,13 +222,13 @@ public:
 
 namespace TypeContextInfo {
 struct Options {
-  bool reuseASTContextIfPossible = true;
+  // TypeContextInfo doesn't receive any options at this point.
 };
 } // namespace TypeContextInfo
 
 namespace ConformingMethodList {
 struct Options {
-  bool reuseASTContextIfPossible = true;
+  // ConformingMethodList doesn't receive any options at this point.
 };
 } // namespace ConformingMethodList
 
@@ -465,7 +465,7 @@ public:
       llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
       ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-      bool EnableASTCaching, std::string &Error,
+      std::string &Error,
       llvm::function_ref<void(swift::CompilerInstance &, bool)> Callback);
 
   //==========================================================================//

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -27,9 +27,7 @@ using namespace ide;
 
 static void translateTypeContextInfoOptions(OptionsDictionary &from,
                                             TypeContextInfo::Options &to) {
-  static UIdent KeyReuseASTContext("key.typecontextinfo.reuseastcontext");
-
-  from.valueForOption(KeyReuseASTContext, to.reuseASTContextIfPossible);
+  // TypeContextInfo doesn't receive any options at this point.
 }
 
 static bool swiftTypeContextInfoImpl(
@@ -37,9 +35,9 @@ static bool swiftTypeContextInfoImpl(
     unsigned Offset, ide::TypeContextInfoConsumer &Consumer,
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    bool EnableASTCaching, std::string &Error) {
+    std::string &Error) {
   return Lang.performCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
+      UnresolvedInputFile, Offset, Args, FileSystem, Error,
       [&](CompilerInstance &CI, bool reusingASTContext) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
@@ -168,8 +166,7 @@ void SwiftLangSupport::getExpressionContextInfo(
   } Consumer(SKConsumer);
 
   if (!swiftTypeContextInfoImpl(*this, UnresolvedInputFile, Offset, Consumer,
-                                Args, fileSystem,
-                                options.reuseASTContextIfPossible, error)) {
+                                Args, fileSystem, error)) {
     SKConsumer.failed(error);
   }
 }

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -140,14 +140,6 @@ def vfs_files : CommaJoined<["-"], "vfs-files=">,
 def vfs_name : Separate<["-"], "vfs-name">,
   HelpText<"Specify a virtual filesystem name">;
 
-def optimize_for_ide : Joined<["-"], "for-ide=">,
-  HelpText<"Value for the OptimizeForIde global configuration setting">;
-
-def completion_check_dependency_interval : Separate<["-"], "completion-check-dependency-interval">,
-  HelpText<"Inteval seconds for checking dependencies in fast completion">;
-def completion_check_dependency_interval_EQ : Joined<["-"], "completion-check-dependency-interval=">,
-  Alias<completion_check_dependency_interval>;
-
 def suppress_config_request : Flag<["-"], "suppress-config-request">,
   HelpText<"Suppress the default global configuration request, that is otherwise sent before any other request (except for the global-config request itself)">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -371,29 +371,6 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       VFSName = InputArg->getValue();
       break;
 
-    case OPT_optimize_for_ide: {
-      bool Value;
-      if (StringRef(InputArg->getValue()).getAsInteger(10, Value)) {
-        llvm::errs() << "error: expected 0 or 1 for 'for-ide'\n";
-        return true;
-      }
-      OptimizeForIde = Value;
-      break;
-    }
-
-    case OPT_completion_check_dependency_interval: {
-      int64_t Value;
-      if (StringRef(InputArg->getValue()).getAsInteger(10, Value)) {
-        llvm::errs() << "error: expected number for inteval\n";
-        return true;
-      } else if (Value < 0) {
-        llvm::errs() << "error: completion-check-dependency-interval must be > 0\n";
-        return true;
-      }
-      CompletionCheckDependencyInterval = Value;
-      break;
-    }
-
     case OPT_suppress_config_request:
       SuppressDefaultConfigRequest = true;
       break;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -538,15 +538,17 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
 
   case SourceKitRequest::GlobalConfiguration:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestGlobalConfiguration);
-    if (Opts.OptimizeForIde.hasValue())
-      sourcekitd_request_dictionary_set_int64(
-          Req, KeyOptimizeForIDE,
-          static_cast<int64_t>(Opts.OptimizeForIde.getValue()));
-    if (Opts.CompletionCheckDependencyInterval.hasValue())
-      sourcekitd_request_dictionary_set_int64(
-          Req, KeyCompletionCheckDependencyInterval,
-          static_cast<int64_t>(
-              Opts.CompletionCheckDependencyInterval.getValue()));
+
+    for (auto &Opt : Opts.RequestOptions) {
+      auto KeyValue = StringRef(Opt).split('=');
+      std::string KeyStr("key.");
+      KeyStr.append(KeyValue.first.str());
+      sourcekitd_uid_t Key = sourcekitd_uid_get_from_cstr(KeyStr.c_str());
+
+      int64_t Value = 0;
+      KeyValue.second.getAsInteger(0, Value);
+      sourcekitd_request_dictionary_set_int64(Req, Key, Value);
+    }
     break;
 
   case SourceKitRequest::ProtocolVersion:

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -437,23 +437,27 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     ResponseBuilder RB;
     auto dict = RB.getDictionary();
 
-    Optional<bool> OptimizeForIDE;
-    int64_t EditorMode = true;
-    if (!Req.getInt64(KeyOptimizeForIDE, EditorMode, true)) {
-      OptimizeForIDE = EditorMode;
-    }
+    Optional<bool> OptimizeForIDE =
+        Req.getOptionalInt64(KeyOptimizeForIDE)
+            .map([](int64_t v) -> bool { return v; });
+    Optional<unsigned> CompletionMaxASTContextReuseCount =
+        Req.getOptionalInt64(KeyCompletionMaxASTContextReuseCount)
+            .map([](int64_t v) -> unsigned { return v; });
     Optional<unsigned> CompletionCheckDependencyInterval =
-      Req.getOptionalInt64(KeyCompletionCheckDependencyInterval)
-        .map([](int64_t v)->unsigned{return v;});
+        Req.getOptionalInt64(KeyCompletionCheckDependencyInterval)
+            .map([](int64_t v) -> unsigned { return v; });
 
-    GlobalConfig::Settings UpdatedConfig = Config->update(
-        OptimizeForIDE, CompletionCheckDependencyInterval);
+    GlobalConfig::Settings UpdatedConfig =
+        Config->update(OptimizeForIDE, CompletionMaxASTContextReuseCount,
+                       CompletionCheckDependencyInterval);
 
     getGlobalContext().getSwiftLangSupport().globalConfigurationUpdated(Config);
 
     dict.set(KeyOptimizeForIDE, UpdatedConfig.OptimizeForIDE);
+    dict.set(KeyCompletionMaxASTContextReuseCount,
+             UpdatedConfig.CompletionOpts.MaxASTContextReuseCount);
     dict.set(KeyCompletionCheckDependencyInterval,
-             UpdatedConfig.CompletionCheckDependencyInterval);
+             UpdatedConfig.CompletionOpts.CheckDependencyInterval);
 
     return Rec(RB.createResponse());
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -829,7 +829,7 @@ static bool doCodeCompletionImpl(
   CompletionInstance CompletionInst;
   auto isSuccess = CompletionInst.performOperation(
       Invocation, /*Args=*/{}, llvm::vfs::getRealFileSystem(), CleanFile.get(),
-      Offset, /*EnableASTCaching=*/false, Error,
+      Offset, Error,
       CodeCompletionDiagnostics ? &PrintDiags : nullptr,
       [&](CompilerInstance &CI, bool reusingASTContext) {
         assert(!reusingASTContext && "reusing AST context without enabling it");
@@ -1207,8 +1207,7 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
     bool wasASTContextReused = false;
     bool isSuccess = CompletionInst.performOperation(
         Invocation, /*Args=*/{}, FileSystem, completionBuffer.get(), Offset,
-        /*EnableASTCaching=*/true, Error,
-        CodeCompletionDiagnostics ? &PrintDiags : nullptr,
+        Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr,
         [&](CompilerInstance &CI, bool reusingASTContext) {
           // Create a CodeCompletionConsumer.
           std::unique_ptr<ide::CodeCompletionConsumer> Consumer(

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -181,6 +181,8 @@ UID_KEYS = [
     KEY('OptimizeForIDE', 'key.optimize_for_ide'),
     KEY('RequiredBystanders', 'key.required_bystanders'),
     KEY('ReusingASTContext', 'key.reusingastcontext'),
+    KEY('CompletionMaxASTContextReuseCount',
+        'key.completion_max_astcontext_reuse_count'),
     KEY('CompletionCheckDependencyInterval',
         'key.completion_check_dependency_interval'),
     KEY('AnnotatedTypename', 'key.annotated.typename'),


### PR DESCRIPTION
* Abolish `reuseastcontext` per-request option. Reusing ASTContext is essentially *non* per-request functionality. 
* Add `MaxASTContextReuseCount` global configuration instead.
