### PR TITLE
ARCSequenceOpts: Improve handling of release instructions in swift::mayDecrementRefCount

### DIFF
--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -81,6 +81,10 @@ bool swift::mayDecrementRefCount(SILInstruction *User,
     return AA->canApplyDecrementRefCount(TAI, Ptr);
   if (auto *BI = dyn_cast<BuiltinInst>(User))
     return AA->canBuiltinDecrementRefCount(BI, Ptr);
+  if (auto *SRI = dyn_cast<StrongReleaseInst>(User))
+    return !AA->isNoAlias(SRI->getOperand(), Ptr);
+  if (auto *RVI = dyn_cast<ReleaseValueInst>(User))
+    return !AA->isNoAlias(RVI->getOperand(), Ptr);
 
   // We cannot conservatively prove that this instruction cannot decrement the
   // ref count of Ptr. So assume that it does.

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -87,6 +87,9 @@ public protocol Error {
   var _code: Builtin.Int32 { get }
 }
 
+class EmptyCls {
+}
+
 sil [serialized] @use : $@convention(thin) (Builtin.NativeObject) -> ()
 sil [serialized] @guaranteed_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
@@ -2380,4 +2383,34 @@ bb0:
   end_access %12 : $*UnsafeMutablePointer<UInt8>
   %15 = tuple ()
   return %15 : $()
+}
+
+sil @userg : $@convention(thin) (EmptyCls) -> () {
+bb0(%0 : $EmptyCls):
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// %0 and %1 are not aliasing. Both RR pairs on %0 and %1 should be optimized away in a single iteration of ASO.
+// ASO should not transition the bottom up RefCountState of %0 to MightBeDecremented on seeing a non aliasing strong_release %1.
+// Same for top down processing as well.
+// CHECK-LABEL: sil hidden @$test_handle_decrement_nonaliasing :
+// CHECK-NOT: strong_retain
+// CHECK-NOT: strong_release
+// CHECK-LABEL: } // end sil function '$test_handle_decrement_nonaliasing'
+sil hidden @$test_handle_decrement_nonaliasing : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] $EmptyCls
+  %1 = alloc_ref [stack] $EmptyCls
+  strong_retain %0 : $EmptyCls
+  strong_retain %1 : $EmptyCls
+  strong_release %1 : $EmptyCls
+  %funcref = function_ref @userg : $@convention(thin) (EmptyCls) -> ()
+  apply %funcref (%0) : $@convention(thin) (EmptyCls) -> ()
+  strong_release %0 : $EmptyCls
+  dealloc_ref %1 : $EmptyCls
+  dealloc_ref [stack] %1 : $EmptyCls
+  dealloc_ref %0 : $EmptyCls
+  dealloc_ref [stack] %0 : $EmptyCls
+  return undef : $()
 }


### PR DESCRIPTION
While doing bottom up or top down traversal ASO calls `swift::mayDecrementRefCount` to compute refcount transition state. This function conservatively returned `true` on seeing release instructions for even non aliasing RCIdentities.
Use `AliasAnalysis::isNoAlias` to return better results for release instructions

