### PR TITLE
Remove old unqualified lookup implementation

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -254,9 +254,6 @@ namespace swift {
     /// Should  we stress ASTScope-based resolution for debugging?
     bool StressASTScopeLookup = false;
 
-    /// Build the ASTScope tree lazily
-    bool LazyASTScopes = true;
-
     /// Whether to enable the new operator decl and precedencegroup lookup
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -160,9 +160,6 @@ def crosscheck_unqualified_lookup : Flag<["-"], "crosscheck-unqualified-lookup">
 def stress_astscope_lookup : Flag<["-"], "stress-astscope-lookup">,
   HelpText<"Stress ASTScope-based unqualified name lookup (for testing)">;
   
-def lazy_astscopes : Flag<["-"], "lazy-astscopes">,
-  HelpText<"Build ASTScopes lazily">;
-
 def use_clang_function_types : Flag<["-"], "use-clang-function-types">,
   HelpText<"Use stored Clang function types for computing canonical types.">;
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -526,8 +526,6 @@ void ASTScopeImpl::computeAndCacheSourceRangeOfScope(
 }
 
 bool ASTScopeImpl::checkLazySourceRange(const ASTContext &ctx) const {
-  if (!ctx.LangOpts.LazyASTScopes)
-    return true;
   const auto unexpandedRange = sourceRangeForDeferredExpansion();
   const auto expandedRange = computeSourceRangeOfScopeWithChildASTNodes();
   if (unexpandedRange.isInvalid() || expandedRange.isInvalid())

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -17,17 +17,11 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTVisitor.h"
-#include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DebuggerClient.h"
-#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ImportCache.h"
-#include "swift/AST/Initializer.h"
-#include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
-#include "swift/AST/ParameterList.h"
-#include "swift/AST/SourceFile.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceManager.h"
@@ -42,58 +36,6 @@
 using namespace swift;
 using namespace swift::namelookup;
 
-
-namespace {
-  
-  /// Determine whether unqualified lookup should look at the members of the
-  /// given nominal type or extension, vs. only looking at type parameters.
-  template <typename D> bool shouldLookupMembers(D *decl, SourceLoc loc) {
-    // Only look at members of this type (or its inherited types) when
-    // inside the body or a protocol's top-level 'where' clause. (Why the
-    // 'where' clause? Because that's where you put constraints on
-    // inherited associated types.)
-    
-    // When we have no source-location information, we have to perform member
-    // lookup.
-    if (loc.isInvalid() || decl->getBraces().isInvalid())
-      return true;
-
-    SourceManager &SM = decl->getASTContext().SourceMgr;
-
-    // If a code completion happens inside a function body, some lookups may
-    // happen from the 'loc' that is in a different buffer from the 'decl'.
-    // In such cases, look for members of the 'decl' because we know 'loc' is
-    // inside a function body in the 'decl'.
-    if (SM.hasCodeCompletionBuffer()) {
-      auto completionBufferID = SM.getCodeCompletionBufferID();
-      if (SM.getRangeForBuffer(completionBufferID).contains(loc)) {
-        auto declBufferID =
-            decl->getDeclContext()->getParentSourceFile()->getBufferID();
-        if (completionBufferID != declBufferID)
-          return true;
-      }
-    }
-
-    // Within the braces, always look for members.
-    auto braces = decl->getBraces();
-    if (braces.Start != braces.End &&
-        SM.rangeContainsTokenLoc(braces, loc))
-      return true;
-    
-    // Within 'where' clause, we can also look for members.
-    if (auto *whereClause = decl->getTrailingWhereClause()) {
-      SourceRange whereClauseRange = whereClause->getSourceRange();
-      if (whereClauseRange.isValid() &&
-          SM.rangeContainsTokenLoc(whereClauseRange, loc)) {
-        return true;
-      }
-    }
-    
-    // Don't look at the members.
-    return false;
-  }
-} // end anonymous namespace
-
 namespace {
   class UnqualifiedLookupFactory {
 
@@ -105,11 +47,6 @@ namespace {
     using ResultsVector = SmallVector<LookupResultEntry, 4>;
     
   private:
-    struct ContextAndResolvedIsCascadingUse {
-      DeclContext *const DC;
-      const bool isCascadingUse;
-    };
-    
     /// Finds lookup results based on the types that self conforms to.
     /// For instance, self always conforms to a struct, enum or class.
     /// But in addition, self could conform to any number of protocols.
@@ -207,8 +144,6 @@ namespace {
 #endif
 
   public: // for exp debugging
-    SourceFile const *recordedSF = nullptr;
-    bool recordedIsCascadingUse = false;
     unsigned resultsSizeBeforeLocalsPass = ~0;
 
   public:
@@ -224,17 +159,6 @@ namespace {
     void performUnqualifiedLookup();
     
   private:
-    struct ContextAndUnresolvedIsCascadingUse {
-      DeclContext *whereToLook;
-      Optional<bool> isCascadingUse;
-      ContextAndResolvedIsCascadingUse resolve(const bool resolution) const {
-        return ContextAndResolvedIsCascadingUse{
-          whereToLook, isCascadingUse.getValueOr(resolution)};
-      }
-    };
-
-    bool useASTScopesForLookup() const;
-
     void lookUpTopLevelNamesInModuleScopeContext(DeclContext *);
 
     void lookInASTScopes();
@@ -247,109 +171,15 @@ namespace {
     /// to record the dividing line between results from first fruitful scope and
     /// the result.
     void recordCompletionOfAScope();
-    
-    template <typename Fn> void ifNotDoneYet(Fn fn) {
-      recordCompletionOfAScope();
-      if (!isFirstResultEnough())
-        fn();
-    }
-    
-    template <typename Fn1, typename Fn2> void ifNotDoneYet(Fn1 fn1, Fn2 fn2) {
-      ifNotDoneYet(fn1);
-      ifNotDoneYet(fn2);
-    }
-    
+
 #pragma mark context-based lookup declarations
-    
-    void lookupOperatorInDeclContexts(ContextAndUnresolvedIsCascadingUse);
-    
-    /// When performing a lookup, we may come across a capture of 'self'. We
-    /// will need to remember the DeclContext of the innermost captured self so
-    /// that it can be used as the base DeclContext if we find a lookup result
-    /// in the enclosing type. \c capturedSelfContext tracks this.
-    void lookupNamesIntroducedBy(const ContextAndUnresolvedIsCascadingUse,
-                                 DeclContext *capturedSelfContext);
-    
-    void finishLookingInContext(
-                                AddGenericParameters addGenericParameters,
-                                DeclContext *lookupContextForThisContext,
-                                Optional<ResultFinderForTypeContext> &&resultFinderForTypeContext,
-                                Optional<bool> isCascadingUse,
-                                DeclContext *capturedSelfContext);
-    
-    void lookupInModuleScopeContext(DeclContext *, Optional<bool> isCascadingUse);
-    
-    void lookupNamesIntroducedByPatternBindingInitializer(
-                                                          PatternBindingInitializer *PBI,
-                                                          Optional<bool> isCascadingUse,
-                                                          DeclContext *capturedSelfContext);
-    
-    void
-    lookupNamesIntroducedByLazyVariableInitializer(PatternBindingInitializer *PBI,
-                                                   ParamDecl *selfParam,
-                                                   Optional<bool> isCascadingUse,
-                                                   DeclContext *capturedSelfContext);
-    
-    void lookupNamesIntroducedByInitializerOfStoredPropertyOfAType(
-                                                                   PatternBindingInitializer *PBI, Optional<bool> isCascadingUse);
-    
-    /// An initializer of a global name, or a function-likelocal name.
-    void lookupNamesIntroducedByInitializerOfGlobalOrLocal(
-                                                           PatternBindingInitializer *PBI,
-                                                           Optional<bool> isCascadingUse,
-                                                           DeclContext *capturedSelfContext);
-    
-    void lookupNamesIntroducedByFunctionDecl(AbstractFunctionDecl *AFD,
-                                             Optional<bool> isCascadingUse,
-                                             DeclContext *capturedSelfContext);
-    
-    void lookupNamesIntroducedByMemberFunction(AbstractFunctionDecl *AFD,
-                                               bool isCascadingUse,
-                                               DeclContext *capturedSelfContext);
-    
-    void lookupNamesIntroducedByPureFunction(AbstractFunctionDecl *AFD,
-                                             bool isCascadingUse,
-                                             DeclContext *capturedSelfContext);
-    
-    void lookupNamesIntroducedByClosure(AbstractClosureExpr *ACE,
-                                        Optional<bool> isCascadingUse,
-                                        DeclContext *capturedSelfContext);
-    
-    template <typename NominalTypeDeclOrExtensionDecl>
-    void lookupNamesIntroducedByNominalTypeOrExtension(
-                                                       NominalTypeDeclOrExtensionDecl *D, Optional<bool> isCascadingUse);
-    
-    void lookupNamesIntroducedByDefaultArgumentInitializer(
-                                                           DefaultArgumentInitializer *I,
-                                                           Optional<bool> isCascadingUse,
-                                                           DeclContext *capturedSelfContext);
-    
-    void lookupNamesIntroducedByMiscContext(DeclContext *dc,
-                                            Optional<bool> isCascadingUse,
-                                            DeclContext *capturedSelfContext);
-    
-    void lookForLocalVariablesIn(AbstractFunctionDecl *AFD,
-                                 Optional<bool> isCascadingUse);
-    void lookForLocalVariablesIn(ClosureExpr *);
-    void lookForLocalVariablesIn(SourceFile *);
-    
+
     bool isOutsideBodyOfFunction(const AbstractFunctionDecl *const AFD) const;
-    
-    void addGenericParametersForContext(DeclContext *dc);
-    void addGenericParametersForContext(GenericParamList *);
-    
-    /// Consume generic parameters
-    void addGenericParametersForFunction(AbstractFunctionDecl *AFD);
-    
-    static GenericParamList *getGenericParams(const DeclContext *const dc);
     
     /// For diagnostic purposes, move aside the unavailables, and put
     /// them back as a last-ditch effort.
     /// Could be cleaner someday with a richer interface to UnqualifiedLookup.
     void setAsideUnavailableResults(size_t firstPossiblyUnavailableResult);
-    
-    void recordDependencyOnTopLevelName(DeclContext *topLevelContext,
-                                        DeclNameRef name, bool isCascadingUse);
     
     void addImportedResults(DeclContext *const dc);
     
@@ -369,19 +199,6 @@ namespace {
                                                    : None;
     }
 
-    static bool resolveIsCascadingUse(const DeclContext *const dc,
-                                      Optional<bool> isCascadingUse,
-                                      bool onlyCareAboutFunctionBody) {
-      return isCascadingUse.getValueOr(dc->isCascadingContextForLookup(
-                                                                       /*functionsAreNonCascading=*/onlyCareAboutFunctionBody));
-    }
-    
-    static bool resolveIsCascadingUse(ContextAndUnresolvedIsCascadingUse x,
-                                      bool onlyCareAboutFunctionBody) {
-      return resolveIsCascadingUse(x.whereToLook, x.isCascadingUse,
-                                   onlyCareAboutFunctionBody);
-    }
-    
     void findResultsAndSaveUnavailables(
                                         DeclContext *lookupContextForThisContext,
                                         ResultFinderForTypeContext &&resultFinderForTypeContext,
@@ -483,21 +300,24 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
                                   "performUnqualifedLookup",
                                   DC->getParentSourceFile());
 
-  const Optional<bool> initialIsCascadingUse = getInitialIsCascadingUse();
-
-  ContextAndUnresolvedIsCascadingUse contextAndIsCascadingUse{
-      DC, initialIsCascadingUse};
-  if (useASTScopesForLookup()) {
+  if (Loc.isValid()) {
     lookInASTScopes();
   } else {
+    assert(DC->isModuleScopeContext() &&
+           "Unqualified lookup without a source location must start from "
+           "a module-scope context");
+
 #ifndef NDEBUG
     stopForDebuggingIfStartingTargetLookup(false);
 #endif
+  }
 
-    if (Name.isOperator())
-      lookupOperatorInDeclContexts(contextAndIsCascadingUse);
-    else
-      lookupNamesIntroducedBy(contextAndIsCascadingUse, NULL);
+  recordCompletionOfAScope();
+  if (!isFirstResultEnough()) {
+    // If no result has been found yet, the dependency must be on a top-level
+    // name, since up to now, the search has been for non-top-level names.
+    auto *moduleScopeContext = DC->getModuleScopeContext();
+    lookUpTopLevelNamesInModuleScopeContext(moduleScopeContext);
   }
 }
 
@@ -522,427 +342,13 @@ void UnqualifiedLookupFactory::lookUpTopLevelNamesInModuleScopeContext(
   recordCompletionOfAScope();
 }
 
-bool UnqualifiedLookupFactory::useASTScopesForLookup() const {
-  if (!Loc.isValid())
-    return false;
-  return (bool) DC->getParentSourceFile();
-}
-
 #pragma mark context-based lookup definitions
-
-void UnqualifiedLookupFactory::lookupOperatorInDeclContexts(
-    const ContextAndUnresolvedIsCascadingUse contextAndUseArg) {
-  ContextAndResolvedIsCascadingUse contextAndResolvedIsCascadingUse{
-      // Operators are global
-      contextAndUseArg.whereToLook->getModuleScopeContext(),
-      resolveIsCascadingUse(contextAndUseArg,
-                            /*onlyCareAboutFunctionBody*/ true)};
-  lookupInModuleScopeContext(contextAndResolvedIsCascadingUse.DC,
-                             contextAndResolvedIsCascadingUse.isCascadingUse);
-}
-
-// TODO: Unify with LookupVisibleDecls.cpp::lookupVisibleDeclsImpl
-void UnqualifiedLookupFactory::lookupNamesIntroducedBy(
-    const ContextAndUnresolvedIsCascadingUse contextAndIsCascadingUseArg,
-    DeclContext *capturedSelfContext) {
-#ifndef NDEBUG
-  stopForDebuggingIfDuringTargetLookup(false);
-#endif
-  DeclContext *const dc = contextAndIsCascadingUseArg.whereToLook;
-  const auto isCascadingUseSoFar = contextAndIsCascadingUseArg.isCascadingUse;
-  if (dc->isModuleScopeContext()) {
-    assert(capturedSelfContext == NULL && "By the time we reach module scope,"
-           " there should be no 'self'.");
-    lookupInModuleScopeContext(dc, isCascadingUseSoFar);
-  }
-  else if (auto *PBI = dyn_cast<PatternBindingInitializer>(dc))
-    lookupNamesIntroducedByPatternBindingInitializer(PBI, isCascadingUseSoFar,
-                                                     capturedSelfContext);
-  else if (auto *AFD = dyn_cast<AbstractFunctionDecl>(dc))
-    lookupNamesIntroducedByFunctionDecl(AFD, isCascadingUseSoFar,
-                                        capturedSelfContext);
-  else if (auto *ACE = dyn_cast<AbstractClosureExpr>(dc))
-    lookupNamesIntroducedByClosure(ACE, isCascadingUseSoFar,
-                                   capturedSelfContext);
-  else if (auto *ED = dyn_cast<ExtensionDecl>(dc)) {
-    assert(capturedSelfContext == NULL && "When we recurse into type context,"
-           " 'self' should be forgotten.");
-    lookupNamesIntroducedByNominalTypeOrExtension(ED, isCascadingUseSoFar);
-  }
-  else if (auto *ND = dyn_cast<NominalTypeDecl>(dc)) {
-    assert(capturedSelfContext == NULL && "When we recurse into type context,"
-           " 'self' should be forgotten.");
-    lookupNamesIntroducedByNominalTypeOrExtension(ND, isCascadingUseSoFar);
-  }
-  else if (auto I = dyn_cast<DefaultArgumentInitializer>(dc))
-    lookupNamesIntroducedByDefaultArgumentInitializer(I, isCascadingUseSoFar,
-                                                      capturedSelfContext);
-  else
-    lookupNamesIntroducedByMiscContext(dc, isCascadingUseSoFar,
-                                       capturedSelfContext);
-}
-
-void UnqualifiedLookupFactory::lookupInModuleScopeContext(
-    DeclContext *dc, Optional<bool> isCascadingUse) {
-  if (auto SF = dyn_cast<SourceFile>(dc)) {
-    resultsSizeBeforeLocalsPass = Results.size();
-    lookForLocalVariablesIn(SF);
-  }
-  ifNotDoneYet([&] {
-    // If no result has been found yet, the dependency must be on a top-level
-    // name, since up to now, the search has been for non-top-level names.
-    recordDependencyOnTopLevelName(dc, Name, isCascadingUse.getValueOr(true));
-    lookUpTopLevelNamesInModuleScopeContext(dc);
-  });
-}
-
-void UnqualifiedLookupFactory::lookupNamesIntroducedByPatternBindingInitializer(
-    PatternBindingInitializer *PBI, Optional<bool> isCascadingUse,
-    DeclContext *capturedSelfContext) {
-  // Lazy variable initializer contexts have a 'self' parameter for
-  // instance member lookup.
-  if (auto *selfParam = PBI->getImplicitSelfDecl())
-    lookupNamesIntroducedByLazyVariableInitializer(PBI, selfParam,
-                                                   isCascadingUse,
-                                                   capturedSelfContext);
-  else if (PBI->getParent()->isTypeContext()) {
-    assert(capturedSelfContext == NULL && "If we were in a type's property"
-           " initializer, there should be no 'self' to have been captured.");
-    lookupNamesIntroducedByInitializerOfStoredPropertyOfAType(
-                                                              PBI,
-                                                              isCascadingUse);
-  }
-  else
-    lookupNamesIntroducedByInitializerOfGlobalOrLocal(PBI, isCascadingUse,
-                                                      capturedSelfContext);
-}
-
-  void UnqualifiedLookupFactory::lookupNamesIntroducedByLazyVariableInitializer(
-      PatternBindingInitializer *PBI, ParamDecl *selfParam,
-      Optional<bool> isCascadingUse, DeclContext *capturedSelfContext) {
-    Consumer.foundDecl(selfParam, DeclVisibilityKind::FunctionParameter);
-    ifNotDoneYet([&] {
-      DeclContext *const patternContainer = PBI->getParent();
-      // clang-format off
-    finishLookingInContext(
-      AddGenericParameters::Yes,
-      patternContainer,
-      ResultFinderForTypeContext(this, PBI, patternContainer),
-      resolveIsCascadingUse(PBI, isCascadingUse,
-                           /*onlyCareAboutFunctionBody=*/false),
-      capturedSelfContext);
-      // clang-format on
-    });
-}
-
-void UnqualifiedLookupFactory::
-    lookupNamesIntroducedByInitializerOfStoredPropertyOfAType(
-        PatternBindingInitializer *PBI, Optional<bool> isCascadingUse) {
-  // Initializers for stored properties of types perform static
-  // lookup into the surrounding context.
-  DeclContext *const storedPropertyContainer = PBI->getParent();
-  // clang-format off
-  finishLookingInContext(
-    AddGenericParameters::Yes,
-    storedPropertyContainer,
-    ResultFinderForTypeContext(
-      this, storedPropertyContainer, storedPropertyContainer),
-    resolveIsCascadingUse(storedPropertyContainer, None,
-                          /*onlyCareAboutFunctionBody=*/false),
-    /*capturedSelfContext=*/NULL);
-  // clang-format on
-}
-
-void UnqualifiedLookupFactory::
-    lookupNamesIntroducedByInitializerOfGlobalOrLocal(
-        PatternBindingInitializer *PBI, Optional<bool> isCascadingUse,
-        DeclContext *capturedSelfContext) {
-  // There's not much to find here, we'll keep going up to a parent
-  // context.
-  // clang-format off
-  finishLookingInContext(
-                         AddGenericParameters::Yes,
-                         PBI,
-                         None, // not looking in the partic type
-                         resolveIsCascadingUse(PBI, isCascadingUse,
-                                               /*onlyCareAboutFunctionBody=*/false),
-                         capturedSelfContext);
-  // clang-format on
-}
-
-void UnqualifiedLookupFactory::lookupNamesIntroducedByFunctionDecl(
-    AbstractFunctionDecl *AFD, Optional<bool> isCascadingUseArg,
-    DeclContext *capturedSelfContext) {
-
-  // DOUG: how does this differ from isOutsideBodyOfFunction below?
-  const bool isCascadingUse =
-      AFD->isCascadingContextForLookup(false) &&
-      (isCascadingUseArg.getValueOr(
-          Loc.isInvalid() || AFD->getBodySourceRange().isInvalid() ||
-          !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc)));
-
-  if (AFD->getDeclContext()->isTypeContext())
-    lookupNamesIntroducedByMemberFunction(AFD, isCascadingUse,
-                                          capturedSelfContext);
-  else
-    lookupNamesIntroducedByPureFunction(AFD, isCascadingUse,
-                                        capturedSelfContext);
-}
-
-void UnqualifiedLookupFactory::lookupNamesIntroducedByMemberFunction(
-    AbstractFunctionDecl *AFD, bool isCascadingUse,
-    DeclContext *capturedSelfContext) {
-  lookForLocalVariablesIn(AFD, isCascadingUse);
-  ifNotDoneYet(
-      [&] {
-        // If we're inside a function context, we're about to move to
-        // the parent DC, so we have to check the function's generic
-        // parameters first.
-        // Cannot start here in finishLookingInContext because AFD's
-        // getOuterParameters may be null even when AFD's parent has generics.
-        addGenericParametersForFunction(AFD);
-      },
-      [&] {
-        DeclContext *const fnDeclContext = AFD->getDeclContext();
-        // If we're not in the body of the function (for example, we
-        // might be type checking a default argument expression and
-        // performing name lookup from there), the base declaration
-        // is the nominal type, not 'self'. If we've captured self
-        // somewhere down the tree, we should use that as the context
-        // for lookup.
-        DeclContext *const BaseDC =
-            isOutsideBodyOfFunction(AFD) ? fnDeclContext
-            : capturedSelfContext ? capturedSelfContext
-            :  AFD;
-        // If we are inside of a method, check to see if there are any ivars in
-        // scope, and if so, whether this is a reference to one of them.
-        // FIXME: We should persist this information between lookups.
-        // clang-format off
-      finishLookingInContext(
-        AddGenericParameters::Yes,
-        AFD->getParent(),
-        ResultFinderForTypeContext(this, BaseDC, fnDeclContext),
-        isCascadingUse,
-        NULL);
-        // clang-format on
-      });
-}
-
-void UnqualifiedLookupFactory::lookupNamesIntroducedByPureFunction(
-    AbstractFunctionDecl *AFD, bool isCascadingUse,
-    DeclContext *capturedSelfContext) {
-  lookForLocalVariablesIn(AFD, isCascadingUse);
-  ifNotDoneYet([&] {
-    // clang-format off
-    finishLookingInContext(
-                           AddGenericParameters::Yes,
-                           AFD,
-                           None,
-                           isCascadingUse,
-                           capturedSelfContext);
-  });
-}
-
-
-void UnqualifiedLookupFactory::lookupNamesIntroducedByClosure(
-    AbstractClosureExpr *ACE, Optional<bool> isCascadingUse,
-    DeclContext *capturedSelfContext) {
-  if (auto *CE = dyn_cast<ClosureExpr>(ACE)) {
-    lookForLocalVariablesIn(CE);
-    // If we don't already have a captured self context, and this closure
-    // captures the self param (not weakly, so that implicit self is available),
-    // remember that.
-    if (capturedSelfContext == nullptr)
-      if (CE->capturesSelfEnablingImplictSelf())
-        capturedSelfContext = CE;
-  }
-  ifNotDoneYet([&] {
-    // clang-format off
-    finishLookingInContext(
-      AddGenericParameters::Yes,
-      ACE,
-      None,
-      resolveIsCascadingUse(ACE, isCascadingUse,
-                           /*onlyCareAboutFunctionBody=*/false),
-      capturedSelfContext);
-    // clang-format on
-  });
-}
-
-template <typename NominalTypeDeclOrExtensionDecl>
-void UnqualifiedLookupFactory::lookupNamesIntroducedByNominalTypeOrExtension(
-    NominalTypeDeclOrExtensionDecl *D, Optional<bool> isCascadingUse) {
-  // clang-format off
-  finishLookingInContext(
-    AddGenericParameters::Yes,
-    D,
-    shouldLookupMembers(D, Loc)
-    ? Optional<ResultFinderForTypeContext>(
-                ResultFinderForTypeContext(this, D, D))
-    : None,
-    resolveIsCascadingUse(D, isCascadingUse,
-                          /*onlyCareAboutFunctionBody=*/false),
-    /*capturedSelfContext=*/NULL);
-
-  // clang-format on
-}
-
-void UnqualifiedLookupFactory::
-    lookupNamesIntroducedByDefaultArgumentInitializer(
-        DefaultArgumentInitializer *I, Optional<bool> isCascadingUse,
-        DeclContext *capturedSelfContext) {
-  // In a default argument, skip immediately out of both the
-  // initializer and the function.
-  finishLookingInContext(AddGenericParameters::No, I->getParent(), None, false,
-                         capturedSelfContext);
-}
-
-void UnqualifiedLookupFactory::lookupNamesIntroducedByMiscContext(
-    DeclContext *dc, Optional<bool> isCascadingUse,
-    DeclContext *capturedSelfContext) {
-  // clang-format off
-  assert(isa<TopLevelCodeDecl>(dc) ||
-         isa<Initializer>(dc) ||
-         isa<TypeAliasDecl>(dc) ||
-         isa<SubscriptDecl>(dc) ||
-         isa<EnumElementDecl>(dc));
-  finishLookingInContext(
-    AddGenericParameters::Yes,
-    dc,
-    None,
-    resolveIsCascadingUse(DC, isCascadingUse,
-                          /*onlyCareAboutFunctionBody=*/false),
-    capturedSelfContext);
-  // clang-format on
-}
-
-
-void UnqualifiedLookupFactory::finishLookingInContext(
-       const AddGenericParameters addGenericParameters,
-       DeclContext *const lookupContextForThisContext,
-       Optional<ResultFinderForTypeContext> &&resultFinderForTypeContext,
-       const Optional<bool> isCascadingUse,
-       DeclContext *capturedSelfContext) {
-#ifndef NDEBUG
-  stopForDebuggingIfDuringTargetLookup(false);
-#endif
-  // When a generic has the same name as a member, Swift prioritizes the generic
-  // because the member could still be named by qualifying it. But there is no
-  // corresponding way to qualify a generic parameter.
-  // So, look for generics first.
-  if (addGenericParameters == AddGenericParameters::Yes)
-    addGenericParametersForContext(lookupContextForThisContext);
-  
-  ifNotDoneYet(
-    [&] {
-      if (resultFinderForTypeContext)
-        findResultsAndSaveUnavailables(lookupContextForThisContext,
-                                      std::move(*resultFinderForTypeContext),
-                                      *isCascadingUse, baseNLOptions);
-    },
-    // Recurse into the next context.
-    [&] {
-      lookupNamesIntroducedBy(ContextAndUnresolvedIsCascadingUse{
-        lookupContextForThisContext->getParentForLookup(), isCascadingUse},
-        capturedSelfContext);
-    });
-}
-
-
-void UnqualifiedLookupFactory::lookForLocalVariablesIn(
-    AbstractFunctionDecl *AFD, Optional<bool> isCascadingUse) {
-  // Look for local variables; normally, the parser resolves these
-  // for us, but it can't do the right thing inside local types.
-  // FIXME: when we can parse and typecheck the function body partially
-  // for code completion, AFD->getBody() check can be removed.
-
-  if (Loc.isInvalid() || AFD->getBodySourceRange().isInvalid() ||
-      !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc) ||
-      !AFD->getBody()) {
-    return;
-  }
-
-  namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-  localVal.visit(AFD->getBody());
-
-  ifNotDoneYet([&] {
-    if (auto *P = AFD->getImplicitSelfDecl())
-      localVal.checkValueDecl(P, DeclVisibilityKind::FunctionParameter);
-    localVal.checkParameterList(AFD->getParameters());
-  });
-}
-
-void UnqualifiedLookupFactory::lookForLocalVariablesIn(ClosureExpr *CE) {
-  // Look for local variables; normally, the parser resolves these
-  // for us, but it can't do the right thing inside local types.
-  if (Loc.isInvalid())
-    return;
-  namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-  if (auto body = CE->getBody())
-    localVal.visit(body);
-  ifNotDoneYet([&] {
-    if (auto params = CE->getParameters())
-      localVal.checkParameterList(params);
-  });
-}
-
-void UnqualifiedLookupFactory::lookForLocalVariablesIn(SourceFile *SF) {
-  if (Loc.isInvalid())
-    return;
-  // Look for local variables in top-level code; normally, the parser
-  // resolves these for us, but it can't do the right thing for
-  // local types.
-  namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-  localVal.checkSourceFile(*SF);
-}
 
 bool UnqualifiedLookupFactory::isOutsideBodyOfFunction(
     const AbstractFunctionDecl *const AFD) const {
   return !AFD->isImplicit() && Loc.isValid() &&
          AFD->getBodySourceRange().isValid() &&
          !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc);
-}
-
-GenericParamList *
-UnqualifiedLookupFactory::getGenericParams(const DeclContext *const dc) {
-  if (auto nominal = dyn_cast<NominalTypeDecl>(dc))
-    return nominal->getGenericParams();
-  if (auto ext = dyn_cast<ExtensionDecl>(dc))
-    return ext->getGenericParams();
-  if (auto subscript = dyn_cast<SubscriptDecl>(dc))
-    return subscript->getGenericParams();
-  if (auto func = dyn_cast<AbstractFunctionDecl>(dc))
-    return func->getGenericParams();
-  return nullptr;
-}
-
-void UnqualifiedLookupFactory::addGenericParametersForContext(
-    DeclContext *dc) {
-  // Generics can be nested, so visit the generic list, innermost first.
-  // Cannot use DeclContext::forEachGenericContext because this code breaks out
-  // if it finds a match and isFirstResultEnough()
-  addGenericParametersForContext(getGenericParams(dc));
-}
-
-void UnqualifiedLookupFactory::addGenericParametersForContext(
-    GenericParamList *dcGenericParams) {
-  if (!dcGenericParams)
-    return;
-  namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-  localVal.checkGenericParams(dcGenericParams);
-  ifNotDoneYet([&] {
-    addGenericParametersForContext(
-        dcGenericParams->getOuterParameters());
-  });
-}
-
-void UnqualifiedLookupFactory::addGenericParametersForFunction(
-    AbstractFunctionDecl *AFD) {
-  GenericParamList *GenericParams = AFD->getGenericParams();
-  if (GenericParams) {
-    namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-    localVal.checkGenericParams(GenericParams);
-  }
 }
 
 void UnqualifiedLookupFactory::ResultFinderForTypeContext::findResults(
@@ -996,13 +402,6 @@ void UnqualifiedLookupFactory::setAsideUnavailableResults(
   // in order to support lookup relative to the place where
   // execution is suspended.
   filterForDiscriminator(Results, DebugClient);
-}
-
-
-void UnqualifiedLookupFactory::recordDependencyOnTopLevelName(
-    DeclContext *topLevelContext, DeclNameRef name, bool isCascadingUse) {
-  recordedSF = dyn_cast<SourceFile>(topLevelContext);
-  recordedIsCascadingUse = isCascadingUse;
 }
 
 void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
@@ -1144,28 +543,8 @@ void UnqualifiedLookupFactory::lookInASTScopes() {
   stopForDebuggingIfStartingTargetLookup(true);
 #endif
 
-  const auto history = ASTScope::unqualifiedLookup(DC->getParentSourceFile(),
-                                                   Name, Loc, DC, consumer);
-
-  ifNotDoneYet([&] {
-    // Copied from lookupInModuleScopeContext
-    // If no result has been found yet, the dependency must be on a top-level
-    // name, since up to now, the search has been for non-top-level names.
-    auto *const moduleScopeContext = DC->getParentSourceFile();
-
-    const Optional<bool> isCascadingUseAtStartOfLookup =
-        !Name.isOperator()
-            ? getInitialIsCascadingUse()
-            : resolveIsCascadingUse(DC, getInitialIsCascadingUse(),
-                                    /*onlyCareAboutFunctionBody*/ true);
-
-    const Optional<bool> isCascadingUseAfterLookup =
-        ASTScope::computeIsCascadingUse(history, isCascadingUseAtStartOfLookup);
-
-    recordDependencyOnTopLevelName(moduleScopeContext, Name,
-                                   isCascadingUseAfterLookup.getValueOr(true));
-    lookUpTopLevelNamesInModuleScopeContext(moduleScopeContext);
-  });
+  ASTScope::unqualifiedLookup(DC->getParentSourceFile(),
+                              Name, Loc, DC, consumer);
 }
 
 bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -444,7 +444,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   
   Opts.DisableParserLookup |= Args.hasArg(OPT_disable_parser_lookup);
   Opts.StressASTScopeLookup |= Args.hasArg(OPT_stress_astscope_lookup);
-  Opts.LazyASTScopes |= Args.hasArg(OPT_lazy_astscopes);
   Opts.EnableNewOperatorLookup = Args.hasFlag(OPT_enable_new_operator_lookup,
                                               OPT_disable_new_operator_lookup,
                                               /*default*/ false);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -543,6 +543,9 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
   //       name/module qualifier to access top-level name.
   lookupOptions |= NameLookupFlags::IncludeOuterResults;
 
+  if (Loc.isInvalid())
+    DC = DC->getModuleScopeContext();
+
   auto Lookup = TypeChecker::lookupUnqualified(DC, Name, Loc, lookupOptions);
 
   auto &Context = DC->getASTContext();
@@ -2459,8 +2462,9 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   lookupOptions |= NameLookupFlags::KnownPrivate;
   auto matchLookup =
-      lookupUnqualified(DC, DeclNameRef(Context.Id_MatchOperator), SourceLoc(),
-                        lookupOptions);
+      lookupUnqualified(DC->getModuleScopeContext(),
+                        DeclNameRef(Context.Id_MatchOperator),
+                        SourceLoc(), lookupOptions);
   auto &diags = DC->getASTContext().Diags;
   if (!matchLookup) {
     diags.diagnose(EP->getLoc(), diag::no_match_operator);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -122,7 +122,7 @@ lookupUnqualifiedEnumMemberElement(DeclContext *DC, DeclNameRef name,
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   lookupOptions |= NameLookupFlags::KnownPrivate;
   auto lookup =
-      TypeChecker::lookupUnqualified(DC, name, SourceLoc(), lookupOptions);
+      TypeChecker::lookupUnqualified(DC, name, UseLoc, lookupOptions);
   return filterForEnumElement(DC, UseLoc,
                               /*unqualifiedLookup=*/true, lookup);
 }


### PR DESCRIPTION
The only remaining blocker to removing the old unqualified lookup implementation were a few places where we would perform an unqualified lookup from a non-top-level DeclContext, without a SourceLoc. This is no longer supported, since ASTScope always uses a SourceLoc to locate the innermost scope. First, this PR refactors these lookups to either start from a top-level context if there's no change in functionality, or perform a qualified lookup into a type if needed. With that out of the way, we can stick the right assertion in UnqualifiedLookup and remove the old code.

The next steps here are removing parse-time local variable lookup, since ASTScope can always find declarations in local scope, and refactoring LookupVisibleDecls to consult ASTScope instead of walking the AST directly. Once that is done, we'll finally have one canonical source of truth for unqualified lookups, concluding the ASTScope journey.