### PR TITLE
Platform: improve WinSDK modulemap to repair build

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -21,6 +21,10 @@ module WinSDK [system] {
     link "WS2_32.Lib"
   }
 
+  module WinSock {
+    header "winsock.h"
+  }
+
   module core {
     module acl {
       header "AclAPI.h"
@@ -206,6 +210,11 @@ module WinSDK [system] {
     export *
   }
 
+  module WinBase {
+    header "winbase.h"
+    export *
+  }
+
   module WinCrypt {
     header "wincrypt.h"
     export *
@@ -240,6 +249,13 @@ module WinSDK [system] {
     export *
 
     link "RpcRT4.Lib"
+  }
+
+  module WinSVC {
+    header "winsvc.h"
+    export *
+
+    link "AdvAPI32.Lib"
   }
 }
 


### PR DESCRIPTION
The WinSDK module failed to expose WinBase properly for reuse, which the
newer clang seems to object to (via an assertion).  Add a separate
module for WinBase which allows reuse of the definitions without causing
conflicts.  This caused some additional fallout requiring the creation
of the WinSVC submodule (service handling, part of security and
identity) and splitting up the legacy WinSock header from the WinSock2
module.  This allows building Foundation again on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
