### PR TITLE
[serialization] Rename ResultVal -> ResultInst.

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1179,7 +1179,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   // FIXME: validate
   SILInstructionKind OpCode = (SILInstructionKind) RawOpCode;
 
-  SILInstruction *ResultVal;
+  SILInstruction *ResultInst;
   switch (OpCode) {
   case SILInstructionKind::DebugValueInst:
   case SILInstructionKind::DebugValueAddrInst:
@@ -1187,19 +1187,19 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
   case SILInstructionKind::AllocBoxInst:
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");
-    ResultVal = Builder.createAllocBox(Loc,
-                       cast<SILBoxType>(MF->getType(TyID)->getCanonicalType()),
-                       None, /*bool hasDynamicLifetime*/ Attr != 0);
+    ResultInst = Builder.createAllocBox(
+        Loc, cast<SILBoxType>(MF->getType(TyID)->getCanonicalType()), None,
+        /*bool hasDynamicLifetime*/ Attr != 0);
     break;
   case SILInstructionKind::AllocStackInst:
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");
-    ResultVal = Builder.createAllocStack(
+    ResultInst = Builder.createAllocStack(
         Loc, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
         None, /*bool hasDynamicLifetime*/ Attr != 0);
     break;
   case SILInstructionKind::MetatypeInst:
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");
-    ResultVal = Builder.createMetatype(
+    ResultInst = Builder.createMetatype(
         Loc, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     break;
 
@@ -1207,7 +1207,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::ID##Inst:                                           \
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&                           \
            "Layout should be OneTypeOneOperand.");                             \
-    ResultVal = Builder.create##ID(                                            \
+    ResultInst = Builder.create##ID(                                           \
         Loc, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),  \
         getLocalValue(ValID, getSILType(MF->getType(TyID2),                    \
                                         (SILValueCategory)TyCategory2, Fn)));  \
@@ -1222,7 +1222,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DeallocBoxInst:
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    ResultVal = Builder.createDeallocBox(
+    ResultInst = Builder.createDeallocBox(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)));
@@ -1230,7 +1230,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::OpenExistentialAddrInst:
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    ResultVal = Builder.createOpenExistentialAddr(
+    ResultInst = Builder.createOpenExistentialAddr(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)),
@@ -1243,7 +1243,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::ID##Inst:                                           \
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&                           \
            "Layout should be OneTypeOneOperand.");                             \
-    ResultVal = Builder.create##ID(                                            \
+    ResultInst = Builder.create##ID(                                           \
         Loc,                                                                   \
         getLocalValue(ValID, getSILType(MF->getType(TyID2),                    \
                                         (SILValueCategory)TyCategory2, Fn)),   \
@@ -1283,7 +1283,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::ProjectBoxInst: {
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    ResultVal = Builder.createProjectBox(
+    ResultInst = Builder.createProjectBox(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)),
@@ -1294,7 +1294,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
     bool isLifetimeGuaranteed = Attr & 0x01;
-    ResultVal = Builder.createConvertEscapeToNoEscape(
+    ResultInst = Builder.createConvertEscapeToNoEscape(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)),
@@ -1306,7 +1306,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND
            && "Layout should be OneTypeOneOperand.");
     bool withoutActuallyEscaping = Attr & 0x01;
-    ResultVal = Builder.createConvertFunction(
+    ResultInst = Builder.createConvertFunction(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)),
@@ -1319,18 +1319,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");
     bool isStrict = Attr & 0x01;
     bool isInvariant = Attr & 0x02;
-    ResultVal = Builder.createPointerToAddress(
+    ResultInst = Builder.createPointerToAddress(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)),
-        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn), isStrict,
-        isInvariant);
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
+        isStrict, isInvariant);
     break;
   }
   case SILInstructionKind::DeallocExistentialBoxInst: {
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    ResultVal = Builder.createDeallocExistentialBox(
+    ResultInst = Builder.createDeallocExistentialBox(
         Loc, MF->getType(TyID)->getCanonicalType(),
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)));
@@ -1345,15 +1345,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto BitsTy =
         getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn);
     auto Bits = getLocalValue(ValID2, BitsTy);
-    
-    ResultVal = Builder.createRefToBridgeObject(Loc, Ref, Bits);
+
+    ResultInst = Builder.createRefToBridgeObject(Loc, Ref, Bits);
     break;
   }
 
   case SILInstructionKind::ObjCProtocolInst: {
     auto Ty = getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     auto Proto = MF->getDecl(ValID);
-    ResultVal = Builder.createObjCProtocol(Loc, cast<ProtocolDecl>(Proto), Ty);
+    ResultInst = Builder.createObjCProtocol(Loc, cast<ProtocolDecl>(Proto), Ty);
     break;
   }
 
@@ -1384,28 +1384,24 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     switch (OpCode) {
     default: llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::InitExistentialAddrInst:
-      ResultVal = Builder.createInitExistentialAddr(Loc, operand,
-                                                ConcreteTy,
-                                                Ty,
-                                                ctxConformances);
+      ResultInst = Builder.createInitExistentialAddr(Loc, operand, ConcreteTy,
+                                                     Ty, ctxConformances);
       break;
     case SILInstructionKind::InitExistentialValueInst:
-      ResultVal = Builder.createInitExistentialValue(Loc, Ty, ConcreteTy,
+      ResultInst = Builder.createInitExistentialValue(Loc, Ty, ConcreteTy,
                                                       operand, ctxConformances);
       break;
     case SILInstructionKind::InitExistentialMetatypeInst:
-      ResultVal = Builder.createInitExistentialMetatype(Loc, operand, Ty,
-                                                        ctxConformances);
+      ResultInst = Builder.createInitExistentialMetatype(Loc, operand, Ty,
+                                                         ctxConformances);
       break;
     case SILInstructionKind::InitExistentialRefInst:
-      ResultVal = Builder.createInitExistentialRef(Loc, Ty,
-                                         ConcreteTy,
-                                         operand,
-                                         ctxConformances);
+      ResultInst = Builder.createInitExistentialRef(Loc, Ty, ConcreteTy,
+                                                    operand, ctxConformances);
       break;
     case SILInstructionKind::AllocExistentialBoxInst:
-      ResultVal = Builder.createAllocExistentialBox(Loc, Ty, ConcreteTy,
-                                  ctxConformances);
+      ResultInst = Builder.createAllocExistentialBox(Loc, Ty, ConcreteTy,
+                                                     ctxConformances);
       break;
     }
     break;
@@ -1439,12 +1435,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       SILType MetadataType = getSILType(MF->getType(ListOfValues[i+1]),
                                         SILValueCategory::Object, Fn);
       SILValue MetadataOp = getLocalValue(ListOfValues[i], MetadataType);
-      ResultVal = Builder.createAllocRefDynamic(Loc, MetadataOp, ClassTy,
-                                                isObjC, TailTypes, Counts);
+      ResultInst = Builder.createAllocRefDynamic(Loc, MetadataOp, ClassTy,
+                                                 isObjC, TailTypes, Counts);
     } else {
       assert(i == NumVals);
-      ResultVal = Builder.createAllocRef(Loc, ClassTy, isObjC, canAllocOnStack,
-                                         TailTypes, Counts);
+      ResultInst = Builder.createAllocRef(Loc, ClassTy, isObjC, canAllocOnStack,
+                                          TailTypes, Counts);
     }
     break;
   }
@@ -1469,13 +1465,13 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
 
     if (OpCode == SILInstructionKind::ApplyInst) {
-      ResultVal = Builder.createApply(Loc, getLocalValue(ValID, FnTy),
-                                      Substitutions, Args,
-                                      IsNonThrowingApply != 0);
+      ResultInst =
+          Builder.createApply(Loc, getLocalValue(ValID, FnTy), Substitutions,
+                              Args, IsNonThrowingApply != 0);
     } else {
-      ResultVal = Builder.createBeginApply(Loc, getLocalValue(ValID, FnTy),
-                                           Substitutions, Args,
-                                           IsNonThrowingApply != 0);
+      ResultInst = Builder.createBeginApply(Loc, getLocalValue(ValID, FnTy),
+                                            Substitutions, Args,
+                                            IsNonThrowingApply != 0);
     }
     break;
   }
@@ -1505,9 +1501,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                        I, Builder.getTypeExpansionContext())));
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
 
-    ResultVal = Builder.createTryApply(Loc, getLocalValue(ValID, FnTy),
-                                       Substitutions, Args, normalBB,
-                                       errorBB);
+    ResultInst = Builder.createTryApply(Loc, getLocalValue(ValID, FnTy),
+                                        Substitutions, Args, normalBB, errorBB);
     break;
   }
   case SILInstructionKind::PartialApplyInst: {
@@ -1541,7 +1536,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                        ? PartialApplyInst::OnStackKind::OnStack
                        : PartialApplyInst::OnStackKind::NotOnStack;
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    ResultVal = Builder.createPartialApply(
+    ResultInst = Builder.createPartialApply(
         Loc, FnVal, Substitutions, Args,
         closureTy.castTo<SILFunctionType>()->getCalleeConvention(), onStack);
     break;
@@ -1558,9 +1553,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     }
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
     Identifier Name = MF->getIdentifier(ValID);
-    
-    ResultVal = Builder.createBuiltin(Loc, Name, ResultTy, Substitutions,
-                                      Args);
+
+    ResultInst =
+        Builder.createBuiltin(Loc, Name, ResultTy, Substitutions, Args);
     break;
   }
   case SILInstructionKind::AllocGlobalInst: {
@@ -1571,7 +1566,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILGlobalVariable *g = getGlobalForReference(Name);
     assert(g && "Can't deserialize global variable");
 
-    ResultVal = Builder.createAllocGlobal(Loc, g);
+    ResultInst = Builder.createAllocGlobal(Loc, g);
     break;
   }
   case SILInstructionKind::GlobalAddrInst:
@@ -1593,20 +1588,20 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     (void)Ty;
     (void)expectedType;
     if (OpCode == SILInstructionKind::GlobalAddrInst) {
-      ResultVal = Builder.createGlobalAddr(Loc, g);
+      ResultInst = Builder.createGlobalAddr(Loc, g);
     } else {
-      ResultVal = Builder.createGlobalValue(Loc, g);
+      ResultInst = Builder.createGlobalValue(Loc, g);
     }
     break;
   }
   case SILInstructionKind::BaseAddrForOffsetInst:
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");
-    ResultVal = Builder.createBaseAddrForOffset(Loc,
-              getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+    ResultInst = Builder.createBaseAddrForOffset(
+        Loc, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     break;
   case SILInstructionKind::DeallocStackInst: {
     auto Ty = MF->getType(TyID);
-    ResultVal = Builder.createDeallocStack(
+    ResultInst = Builder.createDeallocStack(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
@@ -1614,7 +1609,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DeallocRefInst: {
     auto Ty = MF->getType(TyID);
     bool OnStack = (bool)Attr;
-    ResultVal = Builder.createDeallocRef(
+    ResultInst = Builder.createDeallocRef(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         OnStack);
@@ -1623,17 +1618,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DeallocPartialRefInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    ResultVal = Builder.createDeallocPartialRef(Loc,
-        getLocalValue(ValID,
-                      getSILType(Ty,  (SILValueCategory)TyCategory, Fn)),
+    ResultInst = Builder.createDeallocPartialRef(
+        Loc,
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
-                      getSILType(Ty2,  (SILValueCategory)TyCategory2, Fn)));
+                      getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
     break;
   }
   case SILInstructionKind::FunctionRefInst: {
     auto Ty = MF->getType(TyID);
     StringRef FuncName = MF->getIdentifierText(ValID);
-    ResultVal = Builder.createFunctionRef(
+    ResultInst = Builder.createFunctionRef(
         Loc,
         getFuncForReference(
             FuncName, getSILType(Ty, (SILValueCategory)TyCategory, nullptr)));
@@ -1642,7 +1637,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DynamicFunctionRefInst: {
     auto Ty = MF->getType(TyID);
     StringRef FuncName = MF->getIdentifierText(ValID);
-    ResultVal = Builder.createDynamicFunctionRef(
+    ResultInst = Builder.createDynamicFunctionRef(
         Loc,
         getFuncForReference(
             FuncName, getSILType(Ty, (SILValueCategory)TyCategory, nullptr)));
@@ -1651,7 +1646,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::PreviousDynamicFunctionRefInst: {
     auto Ty = MF->getType(TyID);
     StringRef FuncName = MF->getIdentifierText(ValID);
-    ResultVal = Builder.createPreviousDynamicFunctionRef(
+    ResultInst = Builder.createPreviousDynamicFunctionRef(
         Loc,
         getFuncForReference(
             FuncName, getSILType(Ty, (SILValueCategory)TyCategory, nullptr)));
@@ -1660,7 +1655,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::MarkDependenceInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    ResultVal = Builder.createMarkDependence(
+    ResultInst = Builder.createMarkDependence(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
@@ -1670,7 +1665,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::CopyBlockWithoutEscapingInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    ResultVal = Builder.createCopyBlockWithoutEscaping(
+    ResultInst = Builder.createCopyBlockWithoutEscaping(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
@@ -1680,7 +1675,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::IndexAddrInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    ResultVal = Builder.createIndexAddr(
+    ResultInst = Builder.createIndexAddr(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
@@ -1691,7 +1686,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
     auto ResultTy = MF->getType(TyID3);
-    ResultVal = Builder.createTailAddr(
+    ResultInst = Builder.createTailAddr(
         Loc,
         getLocalValue(ValID, getSILType(Ty, SILValueCategory::Address, Fn)),
         getLocalValue(ValID2, getSILType(Ty2, SILValueCategory::Object, Fn)),
@@ -1701,7 +1696,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::IndexRawPointerInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    ResultVal = Builder.createIndexRawPointer(
+    ResultInst = Builder.createIndexRawPointer(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
@@ -1715,7 +1710,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool negate = text[0] == '-';
     if (negate) text = text.drop_front();
     APInt value = intTy->getWidth().parse(text, 10, negate);
-    ResultVal = Builder.createIntegerLiteral(
+    ResultInst = Builder.createIntegerLiteral(
         Loc, getSILType(Ty, (SILValueCategory)TyCategory, Fn), value);
     break;
   }
@@ -1730,7 +1725,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
     APFloat value(floatTy->getAPFloatSemantics(), bits);
 
-    ResultVal = Builder.createFloatLiteral(
+    ResultInst = Builder.createFloatLiteral(
         Loc, getSILType(Ty, (SILValueCategory)TyCategory, Fn), value);
     break;
   }
@@ -1738,15 +1733,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     StringRef StringVal = MF->getIdentifierText(ValID);
     auto encoding = fromStableStringEncoding(Attr);
     if (!encoding) return true;
-    ResultVal = Builder.createStringLiteral(Loc, StringVal,
-                                            encoding.getValue());
+    ResultInst =
+        Builder.createStringLiteral(Loc, StringVal, encoding.getValue());
     break;
   }
   case SILInstructionKind::CondFailInst: {
     SILValue Op = getLocalValue(
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     StringRef StringVal = MF->getIdentifierText(ValID2);
-    ResultVal = Builder.createCondFail(Loc, Op, StringVal);
+    ResultInst = Builder.createCondFail(Loc, Op, StringVal);
     break;
   }
   case SILInstructionKind::MarkFunctionEscapeInst: {
@@ -1759,7 +1754,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
           ListOfValues[I + 2],
           getSILType(EltTy, (SILValueCategory)ListOfValues[I + 1], Fn)));
     }
-    ResultVal = Builder.createMarkFunctionEscape(Loc, OpList);
+    ResultInst = Builder.createMarkFunctionEscape(Loc, OpList);
     break;
   }
   // Checked Conversion instructions.
@@ -1772,7 +1767,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     CanType targetFormalType =
         MF->getType(ListOfValues[3])->getCanonicalType();
-    ResultVal = Builder.createUnconditionalCheckedCast(
+    ResultInst = Builder.createUnconditionalCheckedCast(
         Loc, src, targetLoweredType, targetFormalType);
     break;
   }
@@ -1780,7 +1775,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 #define UNARY_INSTRUCTION(ID)                                                  \
   case SILInstructionKind::ID##Inst:                                           \
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");   \
-    ResultVal = Builder.create##ID(                                            \
+    ResultInst = Builder.create##ID(                                           \
         Loc,                                                                   \
         getLocalValue(ValID, getSILType(MF->getType(TyID),                     \
                                         (SILValueCategory)TyCategory, Fn)));   \
@@ -1789,7 +1784,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 #define REFCOUNTING_INSTRUCTION(ID)                                            \
   case SILInstructionKind::ID##Inst:                                           \
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");   \
-    ResultVal = Builder.create##ID(                                            \
+    ResultInst = Builder.create##ID(                                           \
         Loc,                                                                   \
         getLocalValue(ValID, getSILType(MF->getType(TyID),                     \
                                         (SILValueCategory)TyCategory, Fn)),    \
@@ -1839,7 +1834,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::IsEscapingClosureInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     unsigned verificationType = Attr;
-    ResultVal = Builder.createIsEscapingClosure(
+    ResultInst = Builder.createIsEscapingClosure(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID),
                                         (SILValueCategory)TyCategory, Fn)),
@@ -1850,10 +1845,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::BeginCOWMutationInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     unsigned isNative = Attr;
-    ResultVal = Builder.createBeginCOWMutation(
+    ResultInst = Builder.createBeginCOWMutation(
         Loc,
-        getLocalValue(ValID,
-            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(ValID, getSILType(MF->getType(TyID),
+                                        (SILValueCategory)TyCategory, Fn)),
         isNative != 0);
     break;
   }
@@ -1861,7 +1856,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::EndCOWMutationInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     unsigned keepUnique = Attr;
-    ResultVal = Builder.createEndCOWMutation(
+    ResultInst = Builder.createEndCOWMutation(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID),
                                         (SILValueCategory)TyCategory, Fn)),
@@ -1873,20 +1868,20 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     SILValue Operand = getLocalValue(
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
-    ResultVal = Builder.createDestructureTuple(Loc, Operand);
+    ResultInst = Builder.createDestructureTuple(Loc, Operand);
     break;
   }
   case SILInstructionKind::DestructureStructInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     SILValue Operand = getLocalValue(
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
-    ResultVal = Builder.createDestructureStruct(Loc, Operand);
+    ResultInst = Builder.createDestructureStruct(Loc, Operand);
     break;
   }
   case SILInstructionKind::UncheckedOwnershipConversionInst: {
     auto Ty = MF->getType(TyID);
     auto ResultKind = ValueOwnershipKind(Attr);
-    ResultVal = Builder.createUncheckedOwnershipConversion(
+    ResultInst = Builder.createUncheckedOwnershipConversion(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         ResultKind);
@@ -1896,7 +1891,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::LoadInst: {
     auto Ty = MF->getType(TyID);
     auto Qualifier = LoadOwnershipQualifier(Attr);
-    ResultVal = Builder.createLoad(
+    ResultInst = Builder.createLoad(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         Qualifier);
@@ -1909,7 +1904,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isTake = (Attr > 0);                                                  \
     auto Val = getLocalValue(                                                  \
         ValID, getSILType(Ty, SILValueCategory(TyCategory), Fn));              \
-    ResultVal = Builder.createLoad##Name(Loc, Val, IsTake_t(isTake));          \
+    ResultInst = Builder.createLoad##Name(Loc, Val, IsTake_t(isTake));         \
     break;                                                                     \
   }                                                                            \
   case SILInstructionKind::Store##Name##Inst: {                                \
@@ -1918,9 +1913,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto refType = addrType.castTo<Name##StorageType>();                       \
     auto ValType = SILType::getPrimitiveObjectType(refType.getReferentType()); \
     bool isInit = (Attr > 0);                                                  \
-    ResultVal = Builder.createStore##Name(Loc, getLocalValue(ValID, ValType),  \
-                                          getLocalValue(ValID2, addrType),     \
-                                          IsInitialization_t(isInit));         \
+    ResultInst = Builder.createStore##Name(Loc, getLocalValue(ValID, ValType), \
+                                           getLocalValue(ValID2, addrType),    \
+                                           IsInitialization_t(isInit));        \
     break;                                                                     \
   }
 #include "swift/AST/ReferenceStorage.def"
@@ -1928,7 +1923,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty = getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     auto Kind = (MarkUninitializedInst::Kind)Attr;
     auto Val = getLocalValue(ValID, Ty);
-    ResultVal = Builder.createMarkUninitialized(Loc, Val, Kind);
+    ResultInst = Builder.createMarkUninitialized(Loc, Val, Kind);
     break;
   }
   case SILInstructionKind::StoreInst: {
@@ -1936,16 +1931,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     SILType ValType = addrType.getObjectType();
     auto Qualifier = StoreOwnershipQualifier(Attr);
-    ResultVal = Builder.createStore(Loc, getLocalValue(ValID, ValType),
-                                    getLocalValue(ValID2, addrType), Qualifier);
+    ResultInst =
+        Builder.createStore(Loc, getLocalValue(ValID, ValType),
+                            getLocalValue(ValID2, addrType), Qualifier);
     break;
   }
   case SILInstructionKind::StoreBorrowInst: {
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     SILType ValType = addrType.getObjectType();
-    ResultVal = Builder.createStoreBorrow(Loc, getLocalValue(ValID, ValType),
-                                          getLocalValue(ValID2, addrType));
+    ResultInst = Builder.createStoreBorrow(Loc, getLocalValue(ValID, ValType),
+                                           getLocalValue(ValID2, addrType));
     break;
   }
   case SILInstructionKind::BeginAccessInst: {
@@ -1955,16 +1951,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x3);
     bool noNestedConflict = (Attr >> 4) & 0x01;
     bool fromBuiltin = (Attr >> 5) & 0x01;
-    ResultVal =
-        Builder.createBeginAccess(Loc, op, accessKind, enforcement,
-                                  noNestedConflict, fromBuiltin);
+    ResultInst = Builder.createBeginAccess(Loc, op, accessKind, enforcement,
+                                           noNestedConflict, fromBuiltin);
     break;
   }
   case SILInstructionKind::EndAccessInst: {
     SILValue op = getLocalValue(
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     bool aborted = Attr & 0x1;
-    ResultVal = Builder.createEndAccess(Loc, op, aborted);
+    ResultInst = Builder.createEndAccess(Loc, op, aborted);
     break;
   }
   case SILInstructionKind::BeginUnpairedAccessInst: {
@@ -1977,9 +1972,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x03);
     bool noNestedConflict = (Attr >> 4) & 0x01;
     bool fromBuiltin = (Attr >> 5) & 0x01;
-    ResultVal = Builder.createBeginUnpairedAccess(
-      Loc, source, buffer, accessKind, enforcement, noNestedConflict,
-      fromBuiltin);
+    ResultInst = Builder.createBeginUnpairedAccess(
+        Loc, source, buffer, accessKind, enforcement, noNestedConflict,
+        fromBuiltin);
     break;
   }
   case SILInstructionKind::EndUnpairedAccessInst: {
@@ -1988,8 +1983,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool aborted = Attr & 0x1;
     auto enforcement = SILAccessEnforcement((Attr >> 1) & 0x03);
     bool fromBuiltin = (Attr >> 3) & 0x01;
-    ResultVal = Builder.createEndUnpairedAccess(Loc, op, enforcement, aborted,
-                                                fromBuiltin);
+    ResultInst = Builder.createEndUnpairedAccess(Loc, op, enforcement, aborted,
+                                                 fromBuiltin);
     break;
   }
   case SILInstructionKind::CopyAddrInst: {
@@ -1997,11 +1992,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     bool isInit = (Attr & 0x2) > 0;
     bool isTake = (Attr & 0x1) > 0;
-    ResultVal = Builder.createCopyAddr(Loc,
-                    getLocalValue(ValID, addrType),
-                    getLocalValue(ValID2, addrType),
-                    IsTake_t(isTake),
-                    IsInitialization_t(isInit));
+    ResultInst = Builder.createCopyAddr(
+        Loc, getLocalValue(ValID, addrType), getLocalValue(ValID2, addrType),
+        IsTake_t(isTake), IsInitialization_t(isInit));
     break;
   }
   case SILInstructionKind::AssignInst: {
@@ -2009,10 +2002,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     SILType valType = addrType.getObjectType();
     auto qualifier = AssignOwnershipQualifier(Attr);
-    ResultVal = Builder.createAssign(Loc,
-                    getLocalValue(ValID, valType),
-                    getLocalValue(ValID2, addrType),
-                    qualifier);
+    ResultInst =
+        Builder.createAssign(Loc, getLocalValue(ValID, valType),
+                             getLocalValue(ValID2, addrType), qualifier);
     break;
   }
   case SILInstructionKind::AssignByWrapperInst:
@@ -2021,7 +2013,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_TYPE_VALUES &&
            "Layout should be OneTypeValues.");
     auto Ty = MF->getType(TyID);   // BoundTy
-    ResultVal = Builder.createBindMemory(
+    ResultInst = Builder.createBindMemory(
         Loc,
         getLocalValue(ListOfValues[2],
                       getSILType(MF->getType(ListOfValues[0]),
@@ -2042,11 +2034,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto ResultTy = Val->getType().getFieldType(
         Field, SILMod, Builder.getTypeExpansionContext());
     if (OpCode == SILInstructionKind::StructElementAddrInst)
-      ResultVal = Builder.createStructElementAddr(Loc, Val, Field,
-                                                  ResultTy.getAddressType());
+      ResultInst = Builder.createStructElementAddr(Loc, Val, Field,
+                                                   ResultTy.getAddressType());
     else
-      ResultVal = Builder.createStructExtract(Loc, Val, Field,
-                                              ResultTy.getObjectType());
+      ResultInst = Builder.createStructExtract(Loc, Val, Field,
+                                               ResultTy.getObjectType());
     break;
   }
   case SILInstructionKind::StructInst: {
@@ -2060,7 +2052,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
           ListOfValues[I + 2],
           getSILType(EltTy, (SILValueCategory)ListOfValues[I + 1], Fn)));
     }
-    ResultVal = Builder.createStruct(
+    ResultInst = Builder.createStruct(
         Loc, getSILType(Ty, (SILValueCategory)TyCategory, Fn), OpList);
     break;
   }
@@ -2075,12 +2067,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     switch (OpCode) {
     default: llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::TupleElementAddrInst:
-      ResultVal = Builder.createTupleElementAddr(
+      ResultInst = Builder.createTupleElementAddr(
           Loc, getLocalValue(ValID, ST), TyID,
           getSILType(ResultTy, SILValueCategory::Address, Fn));
       break;
     case SILInstructionKind::TupleExtractInst:
-      ResultVal = Builder.createTupleExtract(
+      ResultInst = Builder.createTupleExtract(
           Loc, getLocalValue(ValID, ST), TyID,
           getSILType(ResultTy, SILValueCategory::Object, Fn));
       break;
@@ -2100,7 +2092,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getLocalValue(ListOfValues[I],
                       getSILType(EltTy, SILValueCategory::Object, Fn)));
     }
-    ResultVal = Builder.createTuple(
+    ResultInst = Builder.createTuple(
         Loc, getSILType(Ty, (SILValueCategory)TyCategory, Fn), OpList);
     break;
   }
@@ -2119,7 +2111,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       SILValue elementVal = getLocalValue(ListOfValues[i], elementType);
       elements.push_back(elementVal);
     }
-    ResultVal = Builder.createObject(Loc, ClassTy, elements, numBaseElements);
+    ResultInst = Builder.createObject(Loc, ClassTy, elements, numBaseElements);
     break;
   }
   case SILInstructionKind::BranchInst: {
@@ -2130,8 +2122,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                         getSILType(MF->getType(ListOfValues[I]),
                                    (SILValueCategory)ListOfValues[I + 1], Fn)));
 
-    ResultVal = Builder.createBranch(Loc, getBBForReference(Fn, TyID),
-                    Args);
+    ResultInst = Builder.createBranch(Loc, getBBForReference(Fn, TyID), Args);
     break;
   }
   case SILInstructionKind::CondBranchInst: {
@@ -2161,9 +2152,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                         getSILType(MF->getType(ListOfValues[I]),
                                    (SILValueCategory)ListOfValues[I + 1], Fn)));
 
-    ResultVal = Builder.createCondBranch(Loc, Cond,
-                    getBBForReference(Fn, ListOfValues[1]), TrueArgs,
-                    getBBForReference(Fn, ListOfValues[2]), FalseArgs);
+    ResultInst = Builder.createCondBranch(
+        Loc, Cond, getBBForReference(Fn, ListOfValues[1]), TrueArgs,
+        getBBForReference(Fn, ListOfValues[2]), FalseArgs);
     break;
   }
   case SILInstructionKind::SwitchEnumInst:
@@ -2186,10 +2177,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                             getBBForReference(Fn, ListOfValues[I+1])} );
     }
     if (OpCode == SILInstructionKind::SwitchEnumInst)
-      ResultVal = Builder.createSwitchEnum(Loc, Cond, DefaultBB, CaseBBs);
+      ResultInst = Builder.createSwitchEnum(Loc, Cond, DefaultBB, CaseBBs);
     else
-      ResultVal = Builder.createSwitchEnumAddr(Loc, Cond,
-                      DefaultBB, CaseBBs);
+      ResultInst = Builder.createSwitchEnumAddr(Loc, Cond, DefaultBB, CaseBBs);
     break;
   }
   case SILInstructionKind::SelectEnumInst:
@@ -2218,11 +2208,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                          Value});
     }
     if (OpCode == SILInstructionKind::SelectEnumInst)
-      ResultVal = Builder.createSelectEnum(Loc, Cond, ResultTy,
-                                           DefaultVal, CaseVals);
+      ResultInst =
+          Builder.createSelectEnum(Loc, Cond, ResultTy, DefaultVal, CaseVals);
     else
-      ResultVal = Builder.createSelectEnumAddr(Loc, Cond, ResultTy,
-                                               DefaultVal, CaseVals);
+      ResultInst = Builder.createSelectEnumAddr(Loc, Cond, ResultTy, DefaultVal,
+                                                CaseVals);
     break;
   }
   case SILInstructionKind::SwitchValueInst: {
@@ -2245,7 +2235,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       auto value = getLocalValue(ListOfValues[I], ResultTy);
       CaseBBs.push_back( {value, getBBForReference(Fn, ListOfValues[I+1])} );
     }
-    ResultVal = Builder.createSwitchValue(Loc, Cond, DefaultBB, CaseBBs);
+    ResultInst = Builder.createSwitchValue(Loc, Cond, DefaultBB, CaseBBs);
     break;
   }
   case SILInstructionKind::SelectValueInst: {
@@ -2273,8 +2263,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       CaseValuesAndResults.push_back({CaseValue, Result});
     }
 
-    ResultVal = Builder.createSelectValue(Loc, Cond, ResultTy,
-                                          DefaultVal, CaseValuesAndResults);
+    ResultInst = Builder.createSelectValue(Loc, Cond, ResultTy, DefaultVal,
+                                           CaseValuesAndResults);
     break;
   }  
   case SILInstructionKind::EnumInst: {
@@ -2285,7 +2275,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       Operand =
           getLocalValue(ValID2, getSILType(MF->getType(TyID2),
                                            (SILValueCategory)TyCategory2, Fn));
-    ResultVal = Builder.createEnum(
+    ResultInst = Builder.createEnum(
         Loc, Operand, cast<EnumElementDecl>(MF->getDecl(ValID)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     break;
@@ -2297,9 +2287,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                    (SILValueCategory) TyCategory, Fn);
     SILType ResultTy = OperandTy.getEnumElementType(
         Elt, SILMod, Builder.getTypeExpansionContext());
-    ResultVal = Builder.createInitEnumDataAddr(Loc,
-                    getLocalValue(ValID2, OperandTy),
-                    Elt, ResultTy);
+    ResultInst = Builder.createInitEnumDataAddr(
+        Loc, getLocalValue(ValID2, OperandTy), Elt, ResultTy);
     break;
   }
   case SILInstructionKind::UncheckedEnumDataInst: {
@@ -2309,9 +2298,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     SILType ResultTy = OperandTy.getEnumElementType(
         Elt, SILMod, Builder.getTypeExpansionContext());
-    ResultVal = Builder.createUncheckedEnumData(Loc,
-                    getLocalValue(ValID2, OperandTy),
-                    Elt, ResultTy);
+    ResultInst = Builder.createUncheckedEnumData(
+        Loc, getLocalValue(ValID2, OperandTy), Elt, ResultTy);
     break;
   }
   case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
@@ -2321,16 +2309,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     SILType ResultTy = OperandTy.getEnumElementType(
         Elt, SILMod, Builder.getTypeExpansionContext());
-    ResultVal = Builder.createUncheckedTakeEnumDataAddr(Loc,
-                    getLocalValue(ValID2, OperandTy),
-                    Elt, ResultTy);
+    ResultInst = Builder.createUncheckedTakeEnumDataAddr(
+        Loc, getLocalValue(ValID2, OperandTy), Elt, ResultTy);
     break;
   }
   case SILInstructionKind::InjectEnumAddrInst: {
     // Use SILOneValueOneOperandLayout.
     EnumElementDecl *Elt = cast<EnumElementDecl>(MF->getDecl(ValID));
     auto Ty = MF->getType(TyID);
-    ResultVal = Builder.createInjectEnumAddr(
+    ResultInst = Builder.createInjectEnumAddr(
         Loc,
         getLocalValue(ValID2, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         Elt);
@@ -2344,15 +2331,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                              getSILType(Ty, (SILValueCategory)TyCategory, Fn));
     auto ResultTy = Val->getType().getFieldType(
         Field, SILMod, Builder.getTypeExpansionContext());
-    ResultVal = Builder.createRefElementAddr(Loc, Val, Field,
-                                          ResultTy, /*Immutable*/ Attr & 0x1);
+    ResultInst = Builder.createRefElementAddr(Loc, Val, Field, ResultTy,
+                                              /*Immutable*/ Attr & 0x1);
     break;
   }
   case SILInstructionKind::RefTailAddrInst: {
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
     assert((SILValueCategory)TyCategory == SILValueCategory::Address);
-    ResultVal = Builder.createRefTailAddr(
+    ResultInst = Builder.createRefTailAddr(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID2),
                                         (SILValueCategory)TyCategory2, Fn)),
@@ -2380,24 +2367,24 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     switch (OpCode) {
     default: llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::ClassMethodInst:
-      ResultVal = Builder.createClassMethod(Loc,
-                    getLocalValue(ListOfValues[NextValueIndex], operandTy),
-                    DRef, Ty);
+      ResultInst = Builder.createClassMethod(
+          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
+          Ty);
       break;
     case SILInstructionKind::SuperMethodInst:
-      ResultVal = Builder.createSuperMethod(Loc,
-                    getLocalValue(ListOfValues[NextValueIndex], operandTy),
-                    DRef, Ty);
+      ResultInst = Builder.createSuperMethod(
+          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
+          Ty);
       break;
     case SILInstructionKind::ObjCMethodInst:
-      ResultVal = Builder.createObjCMethod(Loc,
-                    getLocalValue(ListOfValues[NextValueIndex], operandTy),
-                    DRef, Ty);
+      ResultInst = Builder.createObjCMethod(
+          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
+          Ty);
       break;
     case SILInstructionKind::ObjCSuperMethodInst:
-      ResultVal = Builder.createObjCSuperMethod(Loc,
-                    getLocalValue(ListOfValues[NextValueIndex], operandTy),
-                    DRef, Ty);
+      ResultInst = Builder.createObjCSuperMethod(
+          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
+          Ty);
       break;
     }
     break;
@@ -2421,8 +2408,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       if (ValID3)
         ExistentialOperand = getLocalValue(ValID3, ExistentialOperandTy);
     }
-    ResultVal = Builder.createWitnessMethod(
-        Loc, Ty, Conformance, DRef, OperandTy);
+    ResultInst =
+        Builder.createWitnessMethod(Loc, Ty, Conformance, DRef, OperandTy);
     break;
   }
   case SILInstructionKind::DynamicMethodBranchInst: {
@@ -2432,7 +2419,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILDeclRef DRef = getSILDeclRef(MF, ListOfValues, NextValueIndex);
     assert(ListOfValues.size() == NextValueIndex + 2 &&
            "Wrong number of entries for DynamicMethodBranchInst");
-    ResultVal = Builder.createDynamicMethodBranch(
+    ResultInst = Builder.createDynamicMethodBranch(
         Loc,
         getLocalValue(
             ListOfValues[0],
@@ -2455,9 +2442,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto *successBB = getBBForReference(Fn, ListOfValues[5]);
     auto *failureBB = getBBForReference(Fn, ListOfValues[6]);
 
-    ResultVal = Builder.createCheckedCastBranch(
-        Loc, isExact, op, targetLoweredType, targetFormalType,
-        successBB, failureBB);
+    ResultInst =
+        Builder.createCheckedCastBranch(Loc, isExact, op, targetLoweredType,
+                                        targetFormalType, successBB, failureBB);
     break;
   }
   case SILInstructionKind::CheckedCastValueBranchInst: {
@@ -2472,9 +2459,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto *successBB = getBBForReference(Fn, ListOfValues[5]);
     auto *failureBB = getBBForReference(Fn, ListOfValues[6]);
 
-    ResultVal = Builder.createCheckedCastValueBranch(
-        Loc, op, srcFormalType, targetLoweredType, targetFormalType,
-        successBB, failureBB);
+    ResultInst = Builder.createCheckedCastValueBranch(
+        Loc, op, srcFormalType, targetLoweredType, targetFormalType, successBB,
+        failureBB);
     break;
   }
   case SILInstructionKind::UnconditionalCheckedCastValueInst: {
@@ -2486,9 +2473,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType targetLoweredType =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     CanType targetFormalType = MF->getType(ListOfValues[4])->getCanonicalType();
-    ResultVal = Builder.createUnconditionalCheckedCastValue(Loc, src, srcFormalType,
-                                                            targetLoweredType,
-                                                            targetFormalType);
+    ResultInst = Builder.createUnconditionalCheckedCastValue(
+        Loc, src, srcFormalType, targetLoweredType, targetFormalType);
     break;
   }
   case SILInstructionKind::UnconditionalCheckedCastAddrInst: {
@@ -2503,8 +2489,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     SILValue dest = getLocalValue(ListOfValues[5], targetLoweredType);
 
-    ResultVal = Builder.createUnconditionalCheckedCastAddr(Loc, src, srcFormalType,
-                                                           dest, targetFormalType);
+    ResultInst = Builder.createUnconditionalCheckedCastAddr(
+        Loc, src, srcFormalType, dest, targetFormalType);
     break;
   }
   case SILInstructionKind::CheckedCastAddrBranchInst: {
@@ -2523,10 +2509,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
     auto *successBB = getBBForReference(Fn, ListOfValues[7]);
     auto *failureBB = getBBForReference(Fn, ListOfValues[8]);
-    ResultVal = Builder.createCheckedCastAddrBranch(Loc, consumption,
-                                                    src, srcFormalType,
-                                                    dest, targetFormalType,
-                                                    successBB, failureBB);
+    ResultInst = Builder.createCheckedCastAddrBranch(
+        Loc, consumption, src, srcFormalType, dest, targetFormalType, successBB,
+        failureBB);
     break;
   }
   case SILInstructionKind::UncheckedRefCastAddrInst: {
@@ -2541,8 +2526,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     SILValue dest = getLocalValue(ListOfValues[5], destAddrTy);
 
-    ResultVal = Builder.createUncheckedRefCastAddr(Loc, src, sourceType,
-                                                   dest, targetType);
+    ResultInst = Builder.createUncheckedRefCastAddr(Loc, src, sourceType, dest,
+                                                    targetType);
     break;
   }
   case SILInstructionKind::InitBlockStorageHeaderInst: {
@@ -2563,16 +2548,16 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     
     auto SubMap = MF->getSubstitutionMap(ListOfValues[4]);
 
-    ResultVal = Builder.createInitBlockStorageHeader(Loc, storage, invoke,
-                                                     blockTy, SubMap);
+    ResultInst = Builder.createInitBlockStorageHeader(Loc, storage, invoke,
+                                                      blockTy, SubMap);
     break;
   }
   case SILInstructionKind::UnreachableInst: {
-    ResultVal = Builder.createUnreachable(Loc);
+    ResultInst = Builder.createUnreachable(Loc);
     break;
   }
   case SILInstructionKind::UnwindInst: {
-    ResultVal = Builder.createUnwind(Loc);
+    ResultInst = Builder.createUnwind(Loc);
     break;
   }
   case SILInstructionKind::YieldInst: {
@@ -2589,7 +2574,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
           ListOfValues[I + 2], getSILType(valueTy, valueCategory, Fn)));
     }
 
-    ResultVal = Builder.createYield(Loc, yieldedValues, resumeBB, unwindBB);
+    ResultInst = Builder.createYield(Loc, yieldedValues, resumeBB, unwindBB);
     break;
   }
   case SILInstructionKind::KeyPathInst: {
@@ -2640,8 +2625,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       auto opCat = (SILValueCategory)ListOfValues[nextValue++];
       operands.push_back(getLocalValue(opValue, getSILType(opTy, opCat, Fn)));
     }
-    
-    ResultVal = Builder.createKeyPath(Loc, pattern, subMap, operands, kpTy);
+
+    ResultInst = Builder.createKeyPath(Loc, pattern, subMap, operands, kpTy);
     break;
   }
   case SILInstructionKind::DifferentiableFunctionInst: {
@@ -2674,7 +2659,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     Optional<std::pair<SILValue, SILValue>> derivativeFunctions = None;
     if (hasDerivativeFunctions)
       derivativeFunctions = std::make_pair(operands[1], operands[2]);
-    ResultVal = Builder.createDifferentiableFunction(
+    ResultInst = Builder.createDifferentiableFunction(
         Loc, paramIndices, resultIndices, operands[0], derivativeFunctions);
     break;
   }
@@ -2699,8 +2684,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     Optional<SILValue> transposeFunction = None;
     if (hasLinearFunction)
       transposeFunction = operands[1];
-    ResultVal = Builder.createLinearFunction(
-        Loc, paramIndices, operands[0], transposeFunction);
+    ResultInst = Builder.createLinearFunction(Loc, paramIndices, operands[0],
+                                              transposeFunction);
     break;
   }
   case SILInstructionKind::DifferentiableFunctionExtractInst: {
@@ -2711,7 +2696,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     Optional<SILType> explicitExtracteeType = None;
     if (Attr2)
       explicitExtracteeType = silTy;
-    ResultVal = Builder.createDifferentiableFunctionExtract(
+    ResultInst = Builder.createDifferentiableFunctionExtract(
         Loc, extractee, val, explicitExtracteeType);
     break;
   }
@@ -2720,7 +2705,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto silTy = getSILType(astTy, SILValueCategory::Object, Fn);
     auto val = getLocalValue(ValID, silTy);
     LinearDifferentiableFunctionTypeComponent extractee(Attr);
-    ResultVal = Builder.createLinearFunctionExtract(Loc, extractee, val);
+    ResultInst = Builder.createLinearFunctionExtract(Loc, extractee, val);
     break;
   }
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {
@@ -2732,13 +2717,13 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto astTy = MF->getType(TyID);
     if (TyID)
       explicitFnTy = getSILType(astTy, SILValueCategory::Object, Fn);
-    ResultVal = Builder.createDifferentiabilityWitnessFunction(
+    ResultInst = Builder.createDifferentiabilityWitnessFunction(
         Loc, witnessKind, witness, explicitFnTy);
     break;
   }
   }
 
-  for (auto result : ResultVal->getResults()) {
+  for (auto result : ResultInst->getResults()) {
     LastValueID = LastValueID + 1;
     setLocalValue(result, LastValueID);
   }


### PR DESCRIPTION
This is a misnomer from when SILInstructions were always single valued.

NFC.
