### PR TITLE
[stdlib] Add another fast path for generic floating-point conversion

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1896,85 +1896,47 @@ extension BinaryFloatingPoint {
     switch (Source.exponentBitCount, Source.significandBitCount) {
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
     case (5, 10):
-      if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
-        if case let value_ as Float16 = value {
-          self = Self(Float(value_))
-          return
-        }
-        if !value.isNaN {
-          let value_ = Float16(
-            sign: value.sign,
-            exponentBitPattern:
-              UInt(truncatingIfNeeded: value.exponentBitPattern),
-            significandBitPattern:
-              UInt16(truncatingIfNeeded: value.significandBitPattern))
-          self = Self(Float(value_))
-          return
-        }
+      guard #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
+        self = Self._convert(from: value).value
+        break
       }
+      let value_ = value as? Float16 ?? Float16(
+        sign: value.sign,
+        exponentBitPattern:
+          UInt(truncatingIfNeeded: value.exponentBitPattern),
+        significandBitPattern:
+          UInt16(truncatingIfNeeded: value.significandBitPattern))
+      self = Self(Float(value_))
 #endif
-    case (8, 7):
-      if !value.isNaN {
-        let value_ = Float(
-          sign: value.sign,
-          exponentBitPattern:
-            UInt(truncatingIfNeeded: value.exponentBitPattern),
-          significandBitPattern:
-            UInt32(truncatingIfNeeded: value.significandBitPattern) &<< 16)
-        self = Self(value_)
-        return
-      }
     case (8, 23):
-      if case let value_ as Float = value {
-        self = Self(value_)
-        return
-      }
-      if !value.isNaN {
-        let value_ = Float(
-          sign: value.sign,
-          exponentBitPattern:
-            UInt(truncatingIfNeeded: value.exponentBitPattern),
-          significandBitPattern:
-            UInt32(truncatingIfNeeded: value.significandBitPattern))
-        self = Self(value_)
-        return
-      }
+      let value_ = value as? Float ?? Float(
+        sign: value.sign,
+        exponentBitPattern:
+          UInt(truncatingIfNeeded: value.exponentBitPattern),
+        significandBitPattern:
+          UInt32(truncatingIfNeeded: value.significandBitPattern))
+      self = Self(value_)
     case (11, 52):
-      if case let value_ as Double = value {
-        self = Self(value_)
-        return
-      }
-      if !value.isNaN {
-        let value_ = Double(
-          sign: value.sign,
-          exponentBitPattern:
-            UInt(truncatingIfNeeded: value.exponentBitPattern),
-          significandBitPattern:
-            UInt64(truncatingIfNeeded: value.significandBitPattern))
-        self = Self(value_)
-        return
-      }
+      let value_ = value as? Double ?? Double(
+        sign: value.sign,
+        exponentBitPattern:
+          UInt(truncatingIfNeeded: value.exponentBitPattern),
+        significandBitPattern:
+          UInt64(truncatingIfNeeded: value.significandBitPattern))
+      self = Self(value_)
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     case (15, 63):
-      if case let value_ as Float80 = value {
-        self = Self(value_)
-        return
-      }
-      if !value.isNaN {
-        let value_ = Float80(
-          sign: value.sign,
-          exponentBitPattern:
-            UInt(truncatingIfNeeded: value.exponentBitPattern),
-          significandBitPattern:
-            UInt64(truncatingIfNeeded: value.significandBitPattern))
-        self = Self(value_)
-        return
-      }
+      let value_ = value as? Float80 ?? Float80(
+        sign: value.sign,
+        exponentBitPattern:
+          UInt(truncatingIfNeeded: value.exponentBitPattern),
+        significandBitPattern:
+          UInt64(truncatingIfNeeded: value.significandBitPattern))
+      self = Self(value_)
 #endif
     default:
-      break
+      self = Self._convert(from: value).value
     }
-    self = Self._convert(from: value).value
   }
 
   /// Creates a new instance from the given value, if it can be represented

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1904,8 +1904,10 @@ extension BinaryFloatingPoint {
         if !value.isNaN {
           let value_ = Float16(
             sign: value.sign,
-            exponentBitPattern: UInt(value.exponentBitPattern),
-            significandBitPattern: UInt16(value.significandBitPattern))
+            exponentBitPattern:
+              UInt(truncatingIfNeeded: value.exponentBitPattern),
+            significandBitPattern:
+              UInt16(truncatingIfNeeded: value.significandBitPattern))
           self = Self(Float(value_))
           return
         }
@@ -1915,8 +1917,10 @@ extension BinaryFloatingPoint {
       if !value.isNaN {
         let value_ = Float(
           sign: value.sign,
-          exponentBitPattern: UInt(value.exponentBitPattern),
-          significandBitPattern: UInt32(value.significandBitPattern) &<< 16)
+          exponentBitPattern:
+            UInt(truncatingIfNeeded: value.exponentBitPattern),
+          significandBitPattern:
+            UInt32(truncatingIfNeeded: value.significandBitPattern) &<< 16)
         self = Self(value_)
         return
       }
@@ -1928,8 +1932,10 @@ extension BinaryFloatingPoint {
       if !value.isNaN {
         let value_ = Float(
           sign: value.sign,
-          exponentBitPattern: UInt(value.exponentBitPattern),
-          significandBitPattern: UInt32(value.significandBitPattern))
+          exponentBitPattern:
+            UInt(truncatingIfNeeded: value.exponentBitPattern),
+          significandBitPattern:
+            UInt32(truncatingIfNeeded: value.significandBitPattern))
         self = Self(value_)
         return
       }
@@ -1941,8 +1947,10 @@ extension BinaryFloatingPoint {
       if !value.isNaN {
         let value_ = Double(
           sign: value.sign,
-          exponentBitPattern: UInt(value.exponentBitPattern),
-          significandBitPattern: UInt64(value.significandBitPattern))
+          exponentBitPattern:
+            UInt(truncatingIfNeeded: value.exponentBitPattern),
+          significandBitPattern:
+            UInt64(truncatingIfNeeded: value.significandBitPattern))
         self = Self(value_)
         return
       }
@@ -1955,8 +1963,10 @@ extension BinaryFloatingPoint {
       if !value.isNaN {
         let value_ = Float80(
           sign: value.sign,
-          exponentBitPattern: UInt(value.exponentBitPattern),
-          significandBitPattern: UInt64(value.significandBitPattern))
+          exponentBitPattern:
+            UInt(truncatingIfNeeded: value.exponentBitPattern),
+          significandBitPattern:
+            UInt64(truncatingIfNeeded: value.significandBitPattern))
         self = Self(value_)
         return
       }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Based on my reading of IEEE 754, for any given _w_ (exponent bit width) and _p_ (precision, or significand bit width + 1), there can be one and only one encoding of any finite value **[edit: or ±∞]** in a binary interchange format with those parameters.

Therefore, we can use `init(sign:exponentBitPattern:significandBitPattern:)` to convert from _any_ binary floating-point type with _w_ and _p_ parameters that match a known standard library type's parameters to the latter type. From there, we can use the existing protocol requirements to convert to `Self`.

In a perfect world, since everything is inlinable, the compiler would be able to see that essentially the whole conversion involves bit shifting values in opposite directions and converting between unsigned integer types that are type aliases of each other, turning everything into no-ops. But I would imagine that there is some overhead here that can't quite be eliminated.

There is a companion PR (#33821) with benchmarks which **[edit: has been merged]** to test how well this fast path does the job. **[edit: Either the benchmarks are too-good-to-be-true, or the compiler is really doing a fantastic job of inlining.]**

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
