### PR TITLE
[sil-opt] Fix covering all-case of trapping instruction of mayTrap in sil-opt

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1266,6 +1266,7 @@ bool SILInstruction::mayTrap() const {
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::UnconditionalCheckedCastInst:
   case SILInstructionKind::UnconditionalCheckedCastAddrInst:
+  case SILInstructionKind::UnconditionalCheckedCastValueInst:
     return true;
   default:
     return false;


### PR DESCRIPTION
Hi, I found that the function which checking trapping SIL instruction may have an issue, so I want to fix by this PR.

# Abstract
Making `SILInstruction:: mayTrap ` covering all cases of trapping instruction.

# Issue
Having no issue-report

# Description
It seems that `SILInstruction::mayTrap()` is checking that the instruction may trap or not. 

And, according to the [sil.rst](https://github.com/apple/swift/blob/master/docs/SIL.rst#checked-conversions), there are 4 instruction may trap (runtime-failure). 

- `cond_fail`
- `unconditional_checked_cast`
- `unconditional_checked_cast_addr`
- `unconditional_checked_cast_value`

ref: https://github.com/apple/swift/blob/master/docs/SIL.rst#cond_fail and https://github.com/apple/swift/blob/master/docs/SIL.rst#checked-conversions 

However, `unconditional_checked_cast_value` is missed on `mayTrap ` case in current implementation so this commit added it to cover all-case.
