### PR TITLE
AST: align `ImportedModule` to 64-bits

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -204,7 +204,7 @@ class ModuleDecl : public DeclContext, public TypeDecl {
 public:
   typedef ArrayRef<Located<Identifier>> AccessPathTy;
   /// Convenience struct to keep track of a module along with its access path.
-  struct ImportedModule {
+  struct alignas(uint64_t) ImportedModule {
     /// The access path from an import: `import Foo.Bar` -> `Foo.Bar`.
     ModuleDecl::AccessPathTy accessPath;
     /// The actual module corresponding to the import.


### PR DESCRIPTION
Align `ImportedModule` to 64-bits as it is used in other types which
force the 8-byte alignment for the layout.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
