### PR TITLE
[Driver] Don't test for null source locations in driver diagnostics

### DIFF
--- a/test/Frontend/unknown-arguments.swift
+++ b/test/Frontend/unknown-arguments.swift
@@ -1,14 +1,14 @@
 // RUN: not %swift -fake-argument -abcdef -c %s -o %t.o 2>&1 | %FileCheck %s
 
-// CHECK: <unknown>:0: error: unknown argument: '-fake-argument'
-// CHECK-NEXT: <unknown>:0: error: unknown argument: '-abcdef'
+// CHECK: error: unknown argument: '-fake-argument'
+// CHECK-NEXT: error: unknown argument: '-abcdef'
 
 // RUN: not %swiftc_driver -c %s -o %t.o -Xfrontend -fake-frontend-arg -Xfrontend fakevalue 2>&1 | %FileCheck -check-prefix=XFRONTEND %s
 
-// XFRONTEND: <unknown>:0: error: unknown argument: '-fake-frontend-arg'
+// XFRONTEND: error: unknown argument: '-fake-frontend-arg'
 
 // RUN: not %swiftc_driver -D Correct -DAlsoCorrect -D@#%! -D Swift=Cool -D-D -c %s -o %t.o 2>&1 | %FileCheck -check-prefix=INVALID-COND %s
-// INVALID-COND: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '@#%!')
-// INVALID-COND-NEXT: <unknown>:0: warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'Swift=Cool')
-// INVALID-COND-NEXT: <unknown>:0: error: invalid argument '-D-D'; did you provide a redundant '-D' in your build settings?
+// INVALID-COND: error: conditional compilation flags must be valid Swift identifiers (rather than '@#%!')
+// INVALID-COND-NEXT: warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'Swift=Cool')
+// INVALID-COND-NEXT: error: invalid argument '-D-D'; did you provide a redundant '-D' in your build settings?
 

--- a/test/Misc/serialized-diagnostics-batch-mode.swift
+++ b/test/Misc/serialized-diagnostics-batch-mode.swift
@@ -2,7 +2,7 @@
 
 // The `-serialize-diagnostics-path` flag is not allowed for batch mode invoked by swiftc
 // RUN: not %target-swiftc_driver -serialize-diagnostics-path %t.notexpected.dia %s %S/Inputs/serialized-diagnostics-batch-mode-helper.swift -c -o %t.o 2>&1 | %FileCheck %s
-// CHECK: <unknown>:0: error: option '-serialize-diagnostics-path' is not supported by 'swiftc'; did you mean to use 'swift'?
+// CHECK: error: option '-serialize-diagnostics-path' is not supported by 'swiftc'; did you mean to use 'swift'?
 // RUN: not ls %t.notexpected.dia > /dev/null
 // RUN: not ls %t.o > /dev/null
 


### PR DESCRIPTION
swift-driver doesn't emit these, and there's no reason to check that they're present when using the integrated driver.