### PR TITLE
[Concurrency] Enable support for @objc async methods

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4129,6 +4129,8 @@ NOTE(objc_ambiguous_async_convention_candidate,none,
 ERROR(satisfy_async_objc,none,
       "satisfying an asychronous @objc %select{method|initializer}0 with "
       "a synchronous %select{method|initializer}0 is not supported", (bool))
+ERROR(async_objc_dynamic_self,none,
+      "asynchronous method returning 'Self' cannot be '@objc'", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Types

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1384,6 +1384,8 @@ ERROR(cdecl_empty_name,none,
       "@_cdecl symbol name cannot be empty", ())
 ERROR(cdecl_throws,none,
       "raising errors from @_cdecl functions is not supported", ())
+ERROR(cdecl_async,none,
+      "@_cdecl functions cannot be asynchronous", ())
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))
@@ -4116,6 +4118,17 @@ ERROR(asynchandler_inout_parameter,none,
 ERROR(asynchandler_mutating,none,
       "'@asyncHandler' function cannot be 'mutating'",
       ())
+
+ERROR(objc_ambiguous_async_convention,none,
+      "%0 overrides or implements protocol requirements for Objective-C "
+      "declarations with incompatible async conventions",
+      (DeclName))
+NOTE(objc_ambiguous_async_convention_candidate,none,
+     "%0 provides async here", (DeclName))
+
+ERROR(satisfy_async_objc,none,
+      "satisfying an asychronous @objc %select{method|initializer}0 with "
+      "a synchronous %select{method|initializer}0 is not supported", (bool))
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Types

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
@@ -953,6 +954,16 @@ namespace {
       if (!D->getCaptureInfo().isTrivial()) {
         OS << " ";
         D->getCaptureInfo().print(OS);
+      }
+
+      if (auto fac = D->getForeignAsyncConvention()) {
+        OS << " foreign_async=";
+        if (auto type = fac->completionHandlerType())
+          type.print(OS);
+        OS << ",completion_handler_param="
+           << fac->completionHandlerParamIndex();
+        if (auto errorParamIndex = fac->completionHandlerErrorParamIndex())
+          OS << ",error_param=" << *errorParamIndex;
       }
 
       if (auto fec = D->getForeignErrorConvention()) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
@@ -2994,8 +2995,23 @@ public:
         }
       }
 
-      // Throwing @objc methods must have a foreign error convention.
+      // Asynchronous @objc methods must have a foreign async convention.
       if (AFD->isObjC() &&
+          static_cast<bool>(AFD->getForeignAsyncConvention())
+            != AFD->hasAsync()) {
+        if (AFD->hasAsync())
+          Out << "@objc method async but does not have a foreign async "
+              << "convention";
+        else
+          Out << "@objc method has a foreign async convention but is not "
+              << "async";
+        abort();
+      }
+
+      // Synchronous throwing @objc methods must have a foreign error
+      // convention.
+      if (AFD->isObjC() &&
+          !AFD->hasAsync() &&
           static_cast<bool>(AFD->getForeignErrorConvention())
             != AFD->hasThrows()) {
         if (AFD->hasThrows())

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1185,7 +1185,7 @@ static bool isNullableNSErrorType(
   return true;
 }
 
-Optional<ForeignAsyncConvention>
+Optional<ForeignAsyncConvention::Info>
 NameImporter::considerAsyncImport(
     const clang::ObjCMethodDecl *clangDecl,
     StringRef &baseName,
@@ -1211,7 +1211,8 @@ NameImporter::considerAsyncImport(
   // Determine whether the naming indicates that this is a completion
   // handler.
   Optional<StringRef> newBaseName;
-  if (isCompletionHandlerParamName(paramNames[completionHandlerParamNameIndex])) {
+  if (isCompletionHandlerParamName(
+          paramNames[completionHandlerParamNameIndex])) {
     // The argument label itself has an appropriate name.
   } else if (!hasCustomName && completionHandlerParamIndex == 0 &&
              (newBaseName = isCompletionHandlerInBaseName(baseName))) {
@@ -1226,7 +1227,8 @@ NameImporter::considerAsyncImport(
   // Used for returns once we've determined that the method cannot be
   // imported as async, even though it has what looks like a completion handler
   // parameter.
-  auto notAsync = [&](const char *reason) -> Optional<ForeignAsyncConvention> {
+  auto notAsync = [&](const char *reason) ->
+      Optional<ForeignAsyncConvention::Info> {
 #ifdef ASYNC_IMPORT_DEBUG
     llvm::errs() << "*** failed async import: " << reason << "\n";
     clangDecl->dump(llvm::errs());
@@ -1306,7 +1308,7 @@ NameImporter::considerAsyncImport(
   if (newBaseName && !hasCustomName)
     baseName = *newBaseName;
 
-  return ForeignAsyncConvention(
+  return ForeignAsyncConvention::Info(
       completionHandlerParamIndex, completionHandlerErrorParamIndex);
 }
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -200,7 +200,7 @@ class ImportedName {
 
     /// For names that map Objective-C completion handlers into async
     /// Swift methods, describes how the mapping is performed.
-    ForeignAsyncConvention asyncInfo;
+    ForeignAsyncConvention::Info asyncInfo;
 
     /// For a declaration name that makes the declaration into an
     /// instance member, the index of the "Self" parameter.
@@ -270,7 +270,7 @@ public:
 
   /// For names that map Objective-C methods with completion handlers into
   /// async Swift methods, describes how the mapping is performed.
-  Optional<ForeignAsyncConvention> getAsyncInfo() const {
+  Optional<ForeignAsyncConvention::Info> getAsyncInfo() const {
     if (info.hasAsyncInfo)
       return info.asyncInfo;
     return None;
@@ -453,7 +453,7 @@ private:
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName);
 
-  Optional<ForeignAsyncConvention>
+  Optional<ForeignAsyncConvention::Info>
   considerAsyncImport(const clang::ObjCMethodDecl *clangDecl,
                       StringRef &baseName,
                       SmallVectorImpl<StringRef> &paramNames,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1997,7 +1997,7 @@ static Type mapGenericArgs(const DeclContext *fromDC,
 /// Decompose the type of a completion handler parameter in a function
 /// imported as 'async' and produce the result type of the 'async' function.
 static Type decomposeCompletionHandlerType(
-   Type paramTy, ForeignAsyncConvention info) {
+   Type paramTy, ForeignAsyncConvention::Info info) {
   auto fnType = paramTy->lookThroughAllOptionalTypes()->getAs<FunctionType>();
   if (!fnType)
     return Type();
@@ -2035,6 +2035,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
     bool isFromSystemModule, ParameterList **bodyParams,
     ImportedName importedName,
+    Optional<ForeignAsyncConvention> &asyncConvention,
     Optional<ForeignErrorConvention> &foreignErrorInfo,
     SpecialMethodKind kind) {
 
@@ -2129,6 +2130,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   swiftResultTy = mapGenericArgs(origDC, dc, swiftResultTy);
 
   CanType errorParamType;
+  CanType completionHandlerType;
 
   SmallBitVector nonNullArgs = getNonNullArgs(clangDecl, params);
 
@@ -2166,7 +2168,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     }
 
     bool paramIsCompletionHandler =
-        asyncInfo && paramIndex == asyncInfo->completionHandlerParamIndex();
+        asyncInfo && paramIndex == asyncInfo->CompletionHandlerParamIndex;
 
     // Import the parameter type into Swift.
 
@@ -2243,9 +2245,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
       if (Type replacedSwiftResultTy =
               decomposeCompletionHandlerType(swiftParamTy, *asyncInfo)) {
         swiftResultTy = replacedSwiftResultTy;
-
-        // FIXME: We will need an equivalent to "error parameter is replaced"
-        // for asynchronous functions. Perhaps add "async: ()"?
+        completionHandlerType = swiftParamTy->getCanonicalType();
         continue;
       }
 
@@ -2338,6 +2338,12 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   if (clangDecl->hasAttr<clang::NoReturnAttr>()) {
     origSwiftResultTy = SwiftContext.getNeverType();
     swiftResultTy = SwiftContext.getNeverType();
+  }
+
+  if (asyncInfo) {
+    asyncConvention = ForeignAsyncConvention(
+        completionHandlerType, asyncInfo->CompletionHandlerParamIndex,
+        asyncInfo->CompletionHandlerErrorParamIndex);
   }
 
   if (errorInfo) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1159,6 +1159,7 @@ public:
                                   bool isFromSystemModule,
                                   ParameterList **bodyParams,
                                   importer::ImportedName importedName,
+                                  Optional<ForeignAsyncConvention> &asyncConv,
                                   Optional<ForeignErrorConvention> &errorConv,
                                   SpecialMethodKind kind);
 

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/Comment.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/PrettyStackTrace.h"
@@ -464,6 +465,7 @@ private:
 
   Type getForeignResultType(AbstractFunctionDecl *AFD,
                             FunctionType *methodTy,
+                            Optional<ForeignAsyncConvention> asyncConvention,
                             Optional<ForeignErrorConvention> errorConvention) {
     // A foreign error convention can affect the result type as seen in
     // Objective-C.
@@ -482,6 +484,11 @@ private:
       case ForeignErrorConvention::ZeroPreservedResult:
         break;
       }
+    }
+
+    // Asynchronous methods return their results via completion handler.
+    if (asyncConvention) {
+      return getASTContext().TheEmptyTupleType;
     }
 
     auto result = methodTy->getResult();
@@ -513,16 +520,20 @@ private:
       }
     }
 
+    Optional<ForeignAsyncConvention> asyncConvention
+      = AFD->getForeignAsyncConvention();
     Optional<ForeignErrorConvention> errorConvention
       = AFD->getForeignErrorConvention();
     Type rawMethodTy = AFD->getMethodInterfaceType();
     auto methodTy = rawMethodTy->castTo<FunctionType>();
-    auto resultTy = getForeignResultType(AFD, methodTy, errorConvention);
+    auto resultTy = getForeignResultType(
+        AFD, methodTy, asyncConvention, errorConvention);
 
     // Constructors and methods returning DynamicSelf return
     // instancetype.
     if (isa<ConstructorDecl>(AFD) ||
-        (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->hasDynamicSelfResult())) {
+        (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->hasDynamicSelfResult() &&
+         !AFD->hasAsync())) {
       if (errorConvention && errorConvention->stripsResultOptionality()) {
         printNullability(OTK_Optional, NullabilityPrintKind::ContextSensitive);
       } else if (auto ctor = dyn_cast<ConstructorDecl>(AFD)) {
@@ -577,6 +588,16 @@ private:
       // Retrieve the selector piece.
       StringRef piece = selectorPieces[i].empty() ? StringRef("")
                                                   : selectorPieces[i].str();
+
+      // If we have an async convention and this is the completion handler
+      // parameter, print it.
+      if (asyncConvention &&
+          i == asyncConvention->completionHandlerParamIndex()) {
+        os << piece << ":(";
+        print(asyncConvention->completionHandlerType(), None);
+        os << ")completionHandler";
+        continue;
+      }
 
       // If we have an error convention and this is the error
       // parameter, print it.
@@ -660,7 +681,9 @@ private:
       if (looksLikeInitMethod(AFD->getObjCSelector())) {
         os << " SWIFT_METHOD_FAMILY(none)";
       }
-      if (methodTy->getResult()->isUninhabited()) {
+      if (asyncConvention) {
+        // Async methods don't have result types to annotate.
+      } else if (methodTy->getResult()->isUninhabited()) {
         os << " SWIFT_NORETURN";
       } else if (!methodTy->getResult()->isVoid() &&
                  !AFD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
@@ -697,12 +720,15 @@ private:
 
   void printAbstractFunctionAsFunction(FuncDecl *FD) {
     printDocumentationComment(FD);
+    Optional<ForeignAsyncConvention> asyncConvention
+      = FD->getForeignAsyncConvention();
     Optional<ForeignErrorConvention> errorConvention
       = FD->getForeignErrorConvention();
     assert(!FD->getGenericSignature() &&
            "top-level generic functions not supported here");
     auto funcTy = FD->getInterfaceType()->castTo<FunctionType>();
-    auto resultTy = getForeignResultType(FD, funcTy, errorConvention);
+    auto resultTy = getForeignResultType(
+        FD, funcTy, asyncConvention, errorConvention);
 
     // The result type may be a partial function type we need to close
     // up later.

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -550,10 +550,11 @@ configureInheritedDesignatedInitAttributes(ClassDecl *classDecl,
 
   // If the superclass constructor is @objc but the subclass constructor is
   // not representable in Objective-C, add @nonobjc implicitly.
+  Optional<ForeignAsyncConvention> asyncConvention;
   Optional<ForeignErrorConvention> errorConvention;
   if (superclassCtor->isObjC() &&
       !isRepresentableInObjC(ctor, ObjCReason::MemberOfObjCSubclass,
-                             errorConvention))
+                             asyncConvention, errorConvention))
     ctor->getAttrs().add(new (ctx) NonObjCAttr(/*isImplicit=*/true));
 }
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -660,10 +660,11 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
         AFD->diagnose(diag::objc_generic_extension_using_type_parameter);
 
         // If it's possible, suggest adding @objc.
+        Optional<ForeignAsyncConvention> asyncConvention;
         Optional<ForeignErrorConvention> errorConvention;
         if (!AFD->isObjC() &&
             isRepresentableInObjC(AFD, ObjCReason::MemberOfObjCMembersClass,
-                                  errorConvention)) {
+                                  asyncConvention, errorConvention)) {
           AFD->diagnose(
                    diag::objc_generic_extension_using_type_parameter_try_objc)
             .fixItInsert(AFD->getAttributeInsertionLoc(false), "@objc ");

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -494,8 +494,11 @@ static bool isValidObjectiveCErrorResultType(DeclContext *dc, Type type) {
 bool swift::isRepresentableInObjC(
        const AbstractFunctionDecl *AFD,
        ObjCReason Reason,
+       Optional<ForeignAsyncConvention> &asyncConvention,
        Optional<ForeignErrorConvention> &errorConvention) {
-  // Clear out the error convention. It will be added later if needed.
+  // Clear out the async and error conventions. They will be added later if
+  // needed.
+  asyncConvention = None;
   errorConvention = None;
 
   // If you change this function, you must add or modify a test in PrintAsObjC.
@@ -596,7 +599,8 @@ bool swift::isRepresentableInObjC(
 
   if (auto FD = dyn_cast<FuncDecl>(AFD)) {
     Type ResultType = FD->mapTypeIntoContext(FD->getResultInterfaceType());
-    if (!ResultType->hasError() &&
+    if (!FD->hasAsync() &&
+        !ResultType->hasError() &&
         !ResultType->isVoid() &&
         !ResultType->isUninhabited() &&
         !ResultType->isRepresentableIn(ForeignLanguage::ObjectiveC,
@@ -612,18 +616,83 @@ bool swift::isRepresentableInObjC(
     }
   }
 
-  // Async functions cannot be mapped into Objective-C.
   if (AFD->hasAsync()) {
-    if (Diagnose) {
-      AFD->diagnose(diag::not_objc_function_async)
-        .highlight(AFD->getAsyncLoc());
-      describeObjCReason(AFD, Reason);
-    }
-    return false;
-  }
+    // Asynchronous functions move all of the result value and thrown error
+    // information into a completion handler.
+    auto FD = dyn_cast<FuncDecl>(AFD);
+    if (!FD) {
+      if (Diagnose) {
+        AFD->diagnose(diag::not_objc_function_async)
+          .highlight(AFD->getAsyncLoc());
+        describeObjCReason(AFD, Reason);
+      }
 
-  // Throwing functions must map to a particular error convention.
-  if (AFD->hasThrows()) {
+      return false;
+    }
+
+    // The completion handler parameter always goes at the end.
+    unsigned completionHandlerParamIndex = AFD->getParameters()->size();
+
+    // Decompose the return type to form the parameter type of the completion
+    // handler.
+    SmallVector<AnyFunctionType::Param, 2> completionHandlerParams;
+    auto addCompletionHandlerParam = [&](Type type) {
+      // For a throwing asynchronous function, make each parameter type optional
+      // if that's representable in Objective-C.
+      if (AFD->hasThrows() &&
+          !type->getOptionalObjectType() &&
+          isValidObjectiveCErrorResultType(const_cast<FuncDecl *>(FD), type)) {
+        type = OptionalType::get(type);
+      }
+
+      completionHandlerParams.push_back(AnyFunctionType::Param(type));
+
+      // Make sure that the paraneter type is representable in Objective-C.
+      if (!type->isRepresentableIn(
+              ForeignLanguage::ObjectiveC, const_cast<FuncDecl *>(FD))) {
+        if (Diagnose) {
+          AFD->diagnose(diag::objc_invalid_on_func_result_type,
+                        getObjCDiagnosticAttrKind(Reason));
+          diagnoseTypeNotRepresentableInObjC(FD, type,
+                                             FD->getResultTypeSourceRange());
+          describeObjCReason(FD, Reason);
+        }
+
+        return true;
+      }
+
+      return false;
+    };
+
+    // Translate the result type of the function into parameters for the
+    // completion handler parameter, exploding one level of tuple if needed.
+    Type resultType = FD->mapTypeIntoContext(FD->getResultInterfaceType());
+    if (auto tupleType = resultType->getAs<TupleType>()) {
+      for (const auto &tupleElt : tupleType->getElements()) {
+        addCompletionHandlerParam(tupleElt.getType());
+      }
+    } else {
+      addCompletionHandlerParam(resultType);
+    }
+
+    // For a throwing asynchronous function, an Error? parameter is added
+    // to the completion handler parameter, and will be non-nil to signal
+    // a thrown error.
+    Optional<unsigned> completionHandlerErrorParamIndex;
+    if (FD->hasThrows()) {
+      completionHandlerErrorParamIndex = completionHandlerParams.size();
+      addCompletionHandlerParam(OptionalType::get(ctx.getExceptionType()));
+    }
+
+    Type completionHandlerType = FunctionType::get(
+        completionHandlerParams, TupleType::getEmpty(ctx),
+        ASTExtInfoBuilder(FunctionTypeRepresentation::Block, false).build());
+
+    asyncConvention = ForeignAsyncConvention(
+        completionHandlerType->getCanonicalType(), completionHandlerParamIndex,
+        completionHandlerErrorParamIndex);
+  } else if (AFD->hasThrows()) {
+    // Synchronous throwing functions must map to a particular error convention.
     DeclContext *dc = const_cast<AbstractFunctionDecl *>(AFD);
     SourceLoc throwsLoc;
     Type resultType;
@@ -947,9 +1016,10 @@ bool swift::canBeRepresentedInObjC(const ValueDecl *decl) {
     return false;
 
   if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    Optional<ForeignAsyncConvention> asyncConvention;
     Optional<ForeignErrorConvention> errorConvention;
     return isRepresentableInObjC(func, ObjCReason::MemberOfObjCMembersClass,
-                                 errorConvention);
+                                 asyncConvention, errorConvention);
   }
 
   if (auto var = dyn_cast<VarDecl>(decl))
@@ -1306,6 +1376,7 @@ static bool isEnumObjC(EnumDecl *enumDecl) {
 
 /// Record that a declaration is @objc.
 static void markAsObjC(ValueDecl *D, ObjCReason reason,
+                       Optional<ForeignAsyncConvention> asyncConvention,
                        Optional<ForeignErrorConvention> errorConvention);
 
 
@@ -1393,6 +1464,7 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   }
 
   // If needed, check whether this declaration is representable in Objective-C.
+  Optional<ForeignAsyncConvention> asyncConvention;
   Optional<ForeignErrorConvention> errorConvention;
   if (auto var = dyn_cast<VarDecl>(VD)) {
     if (!isRepresentableInObjC(var, *isObjC)) {
@@ -1407,14 +1479,15 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   } else if (isa<DestructorDecl>(VD)) {
     // Destructors need no additional checking.
   } else if (auto func = dyn_cast<AbstractFunctionDecl>(VD)) {
-    if (!isRepresentableInObjC(func, *isObjC, errorConvention)) {
+    if (!isRepresentableInObjC(
+            func, *isObjC, asyncConvention, errorConvention)) {
       makeNotObjC();
       return false;
     }
   }
 
   // Note that this declaration is exposed to Objective-C.
-  markAsObjC(VD, *isObjC, errorConvention);
+  markAsObjC(VD, *isObjC, asyncConvention, errorConvention);
 
   return true;
 }
@@ -1570,6 +1643,7 @@ static ObjCSelector inferObjCName(ValueDecl *decl) {
 /// If the declaration has a @nonobjc attribute, diagnose an error
 /// using the given Reason, if present.
 void markAsObjC(ValueDecl *D, ObjCReason reason,
+                Optional<ForeignAsyncConvention> asyncConvention,
                 Optional<ForeignErrorConvention> errorConvention) {
   ASTContext &ctx = D->getASTContext();
 
@@ -1587,19 +1661,28 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
   }
 
   if (auto method = dyn_cast<AbstractFunctionDecl>(D)) {
-    // Determine the foreign error convention.
-    Optional<ForeignErrorConvention> inheritedConvention;
-    AbstractFunctionDecl *declProvidingInheritedConvention = nullptr;
+    // Determine the foreign async and error conventions.
+    Optional<ForeignAsyncConvention> inheritedAsyncConvention;
+    AbstractFunctionDecl *declProvidingInheritedAsyncConvention = nullptr;
+    Optional<ForeignErrorConvention> inheritedErrorConvention;
+    AbstractFunctionDecl *declProvidingInheritedErrorConvention = nullptr;
     if (auto baseMethod = method->getOverriddenDecl()) {
-      // If the overridden method has a foreign error convention,
-      // adopt it.  Set the foreign error convention for a throwing
-      // method.  Note that the foreign error convention affects the
+      // If the overridden method has a foreign async or error convention,
+      // adopt it. Note that the foreign async or error convention affects the
       // selector, so we perform this before inferring a selector.
+      if (method->hasAsync()) {
+        if (auto baseAsyncConvention
+              = baseMethod->getForeignAsyncConvention()) {
+          inheritedAsyncConvention = baseAsyncConvention;
+          declProvidingInheritedAsyncConvention = baseMethod;
+        }
+      }
+
       if (method->hasThrows()) {
         if (auto baseErrorConvention
               = baseMethod->getForeignErrorConvention()) {
-          inheritedConvention = baseErrorConvention;
-          declProvidingInheritedConvention = baseMethod;
+          inheritedErrorConvention = baseErrorConvention;
+          declProvidingInheritedErrorConvention = baseMethod;
         }
       }
     }
@@ -1607,42 +1690,78 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
     for (auto req : findWitnessedObjCRequirements(method)) {
       auto reqMethod = dyn_cast<AbstractFunctionDecl>(req);
       if (!reqMethod) continue;
-      
+
+      // If the method witnesses an ObjC requirement that is async, adopt its
+      // async convention.
+      if (reqMethod->hasAsync()) {
+        if (auto reqAsyncConvention = reqMethod->getForeignAsyncConvention()) {
+          // Check for a conflict among protocol conformances or inherited
+          // methods.
+          if (declProvidingInheritedAsyncConvention
+              && inheritedAsyncConvention != reqAsyncConvention) {
+            method->diagnose(diag::objc_ambiguous_async_convention,
+                             method->getName());
+            declProvidingInheritedAsyncConvention->diagnose(
+                diag::objc_ambiguous_async_convention_candidate,
+                declProvidingInheritedAsyncConvention->getName());
+            reqMethod->diagnose(diag::objc_ambiguous_async_convention_candidate,
+                                reqMethod->getName());
+            break;
+          }
+
+          inheritedAsyncConvention = reqAsyncConvention;
+          declProvidingInheritedAsyncConvention = reqMethod;
+        }
+      }
+
       // If the method witnesses an ObjC requirement that throws, adopt its
       // error convention.
       if (reqMethod->hasThrows()) {
         if (auto reqErrorConvention = reqMethod->getForeignErrorConvention()) {
           // Check for a conflict among protocol conformances or inherited
           // methods.
-          if (declProvidingInheritedConvention
-              && inheritedConvention != reqErrorConvention) {
+          if (declProvidingInheritedErrorConvention
+              && inheritedErrorConvention != reqErrorConvention) {
             method->diagnose(diag::objc_ambiguous_error_convention,
                              method->getName());
-            declProvidingInheritedConvention->diagnose(
-                             diag::objc_ambiguous_error_convention_candidate,
-                             declProvidingInheritedConvention->getName());
+            declProvidingInheritedErrorConvention->diagnose(
+                diag::objc_ambiguous_error_convention_candidate,
+                declProvidingInheritedErrorConvention->getName());
             reqMethod->diagnose(diag::objc_ambiguous_error_convention_candidate,
                                 reqMethod->getName());
             break;
           }
 
-          inheritedConvention = reqErrorConvention;
-          declProvidingInheritedConvention = reqMethod;
+          inheritedErrorConvention = reqErrorConvention;
+          declProvidingInheritedErrorConvention = reqMethod;
         }
       }
     }
 
+    // Attach the foreign async convention.
+    if (inheritedAsyncConvention) {
+      if (!method->hasAsync())
+        method->diagnose(diag::satisfy_async_objc,
+                         isa<ConstructorDecl>(method));
+      else
+        method->setForeignAsyncConvention(*inheritedAsyncConvention);
+
+    } else if (method->hasAsync()) {
+      assert(asyncConvention && "Missing async convention");
+      method->setForeignAsyncConvention(*asyncConvention);
+    }
+
     // Attach the foreign error convention.
-    if (inheritedConvention) {
+    if (inheritedErrorConvention) {
       // Diagnose if this is a method that does not throw
-      // but inherits an ObjC error convention.
+      // but inherits an ObjC error convention.
       if (!method->hasThrows())
         method->diagnose(diag::satisfy_throws_objc,
                          isa<ConstructorDecl>(method));
       else
-        method->setForeignErrorConvention(*inheritedConvention);
+        method->setForeignErrorConvention(*inheritedErrorConvention);
 
-    } else if (method->hasThrows()) {
+    } else if (method->hasThrows() && !method->hasAsync()) {
       assert(errorConvention && "Missing error convention");
       method->setForeignErrorConvention(*errorConvention);
     }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -630,6 +630,18 @@ bool swift::isRepresentableInObjC(
       return false;
     }
 
+    // The completion handler transformation cannot properly represent a
+    // dynamic 'Self' type, so disallow @objc for such methods.
+    if (FD->hasDynamicSelfResult()) {
+      if (Diagnose) {
+        AFD->diagnose(diag::async_objc_dynamic_self)
+            .highlight(AFD->getAsyncLoc());
+        describeObjCReason(AFD, Reason);
+      }
+
+      return false;
+    }
+
     // The completion handler parameter always goes at the end.
     unsigned completionHandlerParamIndex = AFD->getParameters()->size();
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2347,10 +2347,15 @@ public:
     // FIXME: This needs to be moved to its own request if we want to
     // productize @_cdecl.
     if (auto CDeclAttr = FD->getAttrs().getAttribute<swift::CDeclAttr>()) {
+      Optional<ForeignAsyncConvention> asyncConvention;
       Optional<ForeignErrorConvention> errorConvention;
       if (isRepresentableInObjC(FD, ObjCReason::ExplicitlyCDecl,
-                                errorConvention)) {
-        if (FD->hasThrows()) {
+                                asyncConvention, errorConvention)) {
+        if (FD->hasAsync()) {
+          FD->setForeignAsyncConvention(*asyncConvention);
+          getASTContext().Diags.diagnose(CDeclAttr->getLocation(),
+                                         diag::cdecl_async);
+        } else if (FD->hasThrows()) {
           FD->setForeignErrorConvention(*errorConvention);
           getASTContext().Diags.diagnose(CDeclAttr->getLocation(),
                                          diag::cdecl_throws);

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SEMA_TYPE_CHECK_OBJC_H
 #define SWIFT_SEMA_TYPE_CHECK_OBJC_H
 
+#include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "llvm/ADT/Optional.h"
 
@@ -123,6 +124,7 @@ unsigned getObjCDiagnosticAttrKind(ObjCReason reason);
 /// and figure out its foreign error convention (if any).
 bool isRepresentableInObjC(const AbstractFunctionDecl *AFD,
                            ObjCReason Reason,
+                           Optional<ForeignAsyncConvention> &asyncConvention,
                            Optional<ForeignErrorConvention> &errorConvention);
 
 /// Determine whether the given variable can be represented in Objective-C.

--- a/test/PrintAsObjC/async.swift
+++ b/test/PrintAsObjC/async.swift
@@ -1,0 +1,30 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
+// FIXME: END -enable-source-import hackaround
+
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/async.h -import-objc-header %S/../Inputs/empty.h  -enable-experimental-concurrency -typecheck
+// RUN: %FileCheck %s < %t/async.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/async.h
+
+import Foundation
+
+// CHECK-LABEL: @interface BarClass : NSObject
+@objc @objcMembers class BarClass: NSObject {
+  // CHECK: (void)doSomethingBigWithCompletionHandler:(void (^)(NSInteger))completionHandler;
+  func doSomethingBig() async -> Int { 0 }
+
+  // CHECK: - (void)longRunningWithString:(NSString * _Nonnull)string completionHandler:(void (^)(BarClass * _Nullable, NSError * _Nullable))completionHandler;
+  func longRunning(string: String) async throws -> BarClass { return self }
+
+  // CHECK: - (void)magicTupleReturnWithCompletionHandler:(void (^)(BarClass * _Nonnull, NSInteger))completionHandler;
+  func magicTupleReturn() async -> (BarClass, Int) { return (self, 0) }
+}
+// CHECK: @end

--- a/test/attr/attr_cdecl_async.swift
+++ b/test/attr/attr_cdecl_async.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -enable-experimental-concurrency
+
+@_cdecl("async") // expected-error{{@_cdecl functions cannot be asynchronous}}
+func asynchronous() async { }
+

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency
-// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency > %t.ast
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t.ast
 // RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.ast
 // REQUIRES: objc_interop
 
@@ -2380,12 +2380,4 @@ class SR_9035_C {}
 class SR12801 {
   @objc subscript<T>(foo : [T]) -> Int { return 0 }
   // expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
-}
-
-// async cannot be compiled with @objc.
-class Concurrency {
-  @objc func doBigJob() async -> Int { return 0 } // expected-error{{'async' function cannot be represented in Objective-C}}
-
-  @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
-  // expected-note@-1{{'async' function types cannot be represented in Objective-C}}
 }

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -1,13 +1,19 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency
-// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency > %t.ast
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 5 -enable-source-import -I %S/Inputs -enable-experimental-concurrency
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 5 -enable-source-import -I %S/Inputs -enable-experimental-concurrency | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 5 -enable-source-import -I %S/Inputs -enable-experimental-concurrency > %t.ast
 // RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.ast
 // REQUIRES: objc_interop
+import Foundation
 
-// async cannot be compiled with @objc.
-// CHECK-DUMP: class Concurrency
+// CHECK: class Concurrency
 class Concurrency {
-  @objc func doBigJob() async -> Int { return 0 } // expected-error{{'async' function cannot be represented in Objective-C}}
+  // CHECK: @objc func doBigJob() async -> Int
+  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}foreign_async=@convention(block) (Int) -> (),completion_handler_param=0
+  @objc func doBigJob() async -> Int { return 0 }
+
+  // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
+  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}foreign_async=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> (),completion_handler_param=1,error_param=2
+  @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
 
   @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-1{{'async' function types cannot be represented in Objective-C}}

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference -enable-experimental-concurrency > %t.ast
+// RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.ast
+// REQUIRES: objc_interop
+
+// async cannot be compiled with @objc.
+// CHECK-DUMP: class Concurrency
+class Concurrency {
+  @objc func doBigJob() async -> Int { return 0 } // expected-error{{'async' function cannot be represented in Objective-C}}
+
+  @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-1{{'async' function types cannot be represented in Objective-C}}
+}

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -17,4 +17,7 @@ class Concurrency {
 
   @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-1{{'async' function types cannot be represented in Objective-C}}
+
+  @objc class func createAsynchronously() async -> Self? { nil }
+  // expected-error@-1{{asynchronous method returning 'Self' cannot be '@objc'}}
 }

--- a/test/decl/async/objc.swift
+++ b/test/decl/async/objc.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 5 -enable-experimental-concurrency
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 5 -enable-experimental-concurrency | %FileCheck %s
+// REQUIRES: objc_interop
+import Foundation
+import ObjectiveC
+
+@objc protocol P {
+  func doBigJob() async -> Int
+}
+
+// Infer @objc from protocol conformance
+// CHECK: class ConformsToP
+class ConformsToP: P {
+  // CHECK: @objc func doBigJob() async -> Int
+  func doBigJob() async -> Int { 5 }
+}
+
+// Infer @objc from superclass
+class Super {
+  @objc func longRunningRequest() async throws -> [String] { [] }
+}
+
+// CHECK: class Sub
+class Sub : Super {
+  // CHECK-NEXT: @objc override func longRunningRequest() async throws -> [String]
+  override func longRunningRequest() async throws -> [String] { [] }
+}
+
+// Check selector computation.
+@objc protocol MakeSelectors {
+  func selectorAsync() async -> Int
+  func selector(value: Int) async -> Int
+}
+
+func testSelectors() {
+  // expected-warning@+1{{use '#selector' instead of explicitly constructing a 'Selector'}}
+  _ = Selector("selectorAsyncWithCompletionHandler:")
+
+  // expected-warning@+1{{use '#selector' instead of explicitly constructing a 'Selector'}}
+  _ = Selector("selectorWithValue:completionHandler:")
+
+  _ = Selector("canary:") // expected-warning{{no method declared with Objective-C selector 'canary:'}}
+  // expected-note@-1{{wrap the selector name in parentheses to suppress this warning}}
+}


### PR DESCRIPTION
Allow `@objc` functions to be `async` as well, using the inverse of the transformation applied to take Objective-C completion-handler-based methods and turn them into `async` functions in Swift. This covers most of the checking and semantics within the type checker and related tools:
* Declaring `@objc async` methods and checking their parameter/result types
* Determining the default Objective-C selector by adding `completionHandler`/`WithCompletionHandler` as appropriate
* Determining the type of the completion handler parameter
* Inferring `@objc` from protocol requirements
* Inferring `@objc` from an overridden method
* Printing `@objc async` methods into the generated header with the right signature and attributes.