### PR TITLE
Add missing SWIFT_FALLTHROUGH to the tryCastToString

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -862,8 +862,8 @@ tryCastToString(
       destFailureType, srcFailureType,
       takeOnSuccess, mayDeferChecks);
 #endif
-  }
     SWIFT_FALLTHROUGH;
+  }
   default:
     return DynamicCastResult::Failure;
   }

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -863,6 +863,7 @@ tryCastToString(
       takeOnSuccess, mayDeferChecks);
 #endif
   }
+    SWIFT_FALLTHROUGH;
   default:
     return DynamicCastResult::Failure;
   }


### PR DESCRIPTION
This change fixes a warning in tryCastToString, that can break the build if `-Werror`, `-Wimplicit-fallthrough` flags are enabled:

```
swift/stdlib/public/runtime/DynamicCast.cpp:866:3: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  default:
```