### PR TITLE
[ConstraintSystem] Record `unable to infer base` only if hole origina…

### DIFF
--- a/test/Constraints/valid_pointer_conversions.swift
+++ b/test/Constraints/valid_pointer_conversions.swift
@@ -45,5 +45,4 @@ SR12382(&i) // expected-error {{cannot convert value of type 'UnsafeMutablePoint
 //problem/68254165 - Bad diagnostic when using String init(decodingCString:) with an incorrect pointer type
 func rdar68254165(ptr: UnsafeMutablePointer<Int8>) {
   _ = String(decodingCString: ptr, as: .utf8) // expected-error {{generic parameter 'Encoding' could not be inferred}}
-  // expected-error@-1 {{type '_.Type' has no member 'utf8'}}
 }

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -100,8 +100,7 @@ func test3a(_ a: ZeroOneTwoThree) {
   var h = ZeroOneTwoThree(1)
   
   var i = 0 > 3 ? .none : .some(3) // expected-error {{cannot infer contextual base in reference to member 'none'}}
-  // expected-error@-1 {{cannot infer contextual base in reference to member 'some'}}
-  
+
   test3a;  // expected-error {{unused function}}
   .Zero   // expected-error {{reference to member 'Zero' cannot be resolved without a contextual type}}
   test3a   // expected-error {{unused function}}


### PR DESCRIPTION
…ted from affected reference

This is a follow up to https://github.com/apple/swift/pull/33809

If base type of a unresolved member reference couldn't be determined
(represented as a hole type), before recording a fix about lack of
contextual information, let's make sure that hole originated in either
base or result type of this reference, otherwise the problem is
contextual e.g. generic parameter, which supposed to act as contextual
type for a reference, couldn't be inferred.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
