### PR TITLE
caches: add a cache for building just the runtime on Windows

### DIFF
--- a/cmake/caches/Runtime-Windows-x86_64.cmake
+++ b/cmake/caches/Runtime-Windows-x86_64.cmake
@@ -1,0 +1,20 @@
+
+set(SWIFT_HOST_VARIANT_SDK WINDOWS CACHE STRING "")
+set(SWIFT_HOST_VARIANT_ARCH x86_64 CACHE STRING "")
+
+# NOTE(compnerd) disable the tools, we are trying to build just the standard
+# library.
+set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build tests since the tests require the toolchain
+set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build docs since that requires perl
+set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+
+# NOTE(compnerd) these are part of the toolchain, not the runtime.
+set(SWIFT_BUILD_SYNTAXPARSERLIB NO CACHE BOOL "")
+set(SWIFT_BUILD_SOURCEKIT NO CACHE BOOL "")
+
+# NOTE(compnerd) build with the compiler specified, not a just built compiler.
+set(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER YES CACHE BOOL "")


### PR DESCRIPTION
This allows configuration of a build for just the runtime/SDK components
rather than a complete toolchain.  It allows for more effective
iteration when working on just the runtime aspect of the toolchain.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
