### PR TITLE
Avoid using a resilient offset in swift_readAtKeyPath

### DIFF
--- a/stdlib/public/runtime/KeyPaths.cpp
+++ b/stdlib/public/runtime/KeyPaths.cpp
@@ -119,9 +119,6 @@ void _destroy_temporary_continuation(YieldOnceBuffer *buffer, bool forUnwind) {
   YieldOnceTemporary::destroyAndDeallocateIn(buffer);
 }
 
-// The resilient offset to the start of KeyPath's class-specific data.
-extern "C" size_t MANGLE_SYM(s7KeyPathCMo);
-
 YieldOnceResult<const OpaqueValue*>
 swift::swift_readAtKeyPath(YieldOnceBuffer *buffer,
                            const OpaqueValue *root, void *keyPath) {
@@ -129,17 +126,7 @@ swift::swift_readAtKeyPath(YieldOnceBuffer *buffer,
   // KeyPath is a native class, so we can just load its metadata directly
   // even on ObjC-interop targets.
   const Metadata *keyPathType = static_cast<HeapObject*>(keyPath)->metadata;
-
-  // To find the generic arguments, we just have to find the class-specific
-  // data section of the class; the generic arguments are always at the start
-  // of that.
-  //
-  // We use the resilient access pattern because it's easy; since we're within
-  // KeyPath's resilience domain, that's not really necessary, and it would
-  // be totally valid to hard-code an offset.
-  auto keyPathGenericArgs =
-    reinterpret_cast<const Metadata * const *>(
-      reinterpret_cast<const char*>(keyPathType) + MANGLE_SYM(s7KeyPathCMo));
+  auto keyPathGenericArgs = keyPathType->getGenericArgs();
   const Metadata *valueTy = keyPathGenericArgs[1];
 
   // Allocate the buffer.


### PR DESCRIPTION
This is motivated by https://github.com/apple/swift/pull/33535, where I'd like to start supporting the standard library with Library Evolution turned off.

It seems that there's no real reason for using the resilient offset in swift_readAtKeyPath, unless I'm missing something?