### PR TITLE
Don't use resilient getter for playgroundPrintHook when resilience is off

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -298,7 +298,7 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_OBJC_INTEROP=0")
   endif()
 
-  # TODO(mracek): This should turned off for non-ABI-stable environments.
+  # TODO(mracek): This should get turned off for non-ABI-stable environments.
   list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=1")
 
   if(NOT SWIFT_ENABLE_COMPATIBILITY_OVERRIDES)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -298,6 +298,9 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_OBJC_INTEROP=0")
   endif()
 
+  # TODO(mracek): This should turned off for non-ABI-stable environments.
+  list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=1")
+
   if(NOT SWIFT_ENABLE_COMPATIBILITY_OVERRIDES)
     list(APPEND result "-DSWIFT_RUNTIME_NO_COMPATIBILITY_OVERRIDES")
   endif()

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -328,8 +328,13 @@ struct swift_closure {
   void *fptr;
   HeapObject *context;
 };
+#if SWIFT_LIBRARY_EVOLUTION
 SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
 MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+#else
+SWIFT_RUNTIME_STDLIB_API swift_closure
+MANGLE_SYM(s20_playgroundPrintHookySScSgvp);
+#endif
 
 static bool _shouldReportMissingReflectionMetadataWarnings() {
   // Missing metadata warnings noise up playground sessions and aren't really
@@ -339,7 +344,11 @@ static bool _shouldReportMissingReflectionMetadataWarnings() {
   // Guesstimate whether we're in a playground by looking at the
   // _playgroundPrintHook variable in the standard library, which is set during
   // playground execution.
+  #if SWIFT_LIBRARY_EVOLUTION
   auto hook = MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+  #else
+  auto hook = MANGLE_SYM(s20_playgroundPrintHookySScSgvp);
+  #endif
   if (hook.fptr) {
     swift_release(hook.context);
     return false;


### PR DESCRIPTION
While the stdlib doesn't yet have a way of turning Library Evolution off, I'm exploring that in <https://github.com/apple/swift/pull/33535>. Let's fix the code in `_shouldReportMissingReflectionMetadataWarnings` to be able to handle both cases (resilience on, or off).