### PR TITLE
WinSDK: add Shell32

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -180,9 +180,11 @@ module WinSDK [system] {
   }
 
   module ShellAPI {
+    header "shellapi.h"
     header "Shlwapi.h"
     export *
 
+    link "Shell32.Lib"
     link "ShLwApi.Lib"
   }
 


### PR DESCRIPTION
This header and .lib features useful APIs such as [SHFileOperation](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shfileoperationw), which seems to be the preferred way to manipulate file systems for certain things.