### PR TITLE
[sil-opt] Fix covering all-case of trapping instruction of SILInstruction::mayTrap

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1266,6 +1266,7 @@ bool SILInstruction::mayTrap() const {
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::UnconditionalCheckedCastInst:
   case SILInstructionKind::UnconditionalCheckedCastAddrInst:
+  case SILInstructionKind::UnconditionalCheckedCastValueInst:
     return true;
   default:
     return false;

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -210,6 +210,23 @@ bb0(%0 : $Builtin.NativeObject):
   return %r : $()
 }
 
+// CHECK-LABEL: sil @checkedaddr
+// CHECK: <func=rw+-,param0=,param1=;alloc;trap;readrc>
+sil @checkedaddr : $@convention(thin) (Builtin.NativeObject, X) -> () {
+bb0(%0 : $Builtin.NativeObject, %1 : $X):
+  unconditional_checked_cast_addr Builtin.NativeObject in %0 : $Builtin.NativeObject to X in %1 : $X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @checkedcastvalue
+// CHECK: <func=r,param0=;trap>
+sil @checkedcastvalue : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = unconditional_checked_cast_value Builtin.NativeObject in %0 : $Builtin.NativeObject to X
+  %r = tuple ()
+  return %r : $()
+}
 
 sil_global public @sil_global1 : $Int32
 


### PR DESCRIPTION
Hi, I found that the function which checking trapping SIL instruction may have an issue, so I want to fix by this PR.
(moved from https://github.com/apple/swift/pull/33830 to fix commit comment)

# Abstract
Making `SILInstruction:: mayTrap ` covering all cases of trapping instruction.

# Issue
Having no issue-report

# Description
It seems that `SILInstruction::mayTrap()` is checking that the instruction may trap or not. 

And, according to the [sil.rst](https://github.com/apple/swift/blob/master/docs/SIL.rst#checked-conversions), there are 4 instruction may trap (runtime-failure). 

- `cond_fail`
- `unconditional_checked_cast`
- `unconditional_checked_cast_addr`
- `unconditional_checked_cast_value`

ref: https://github.com/apple/swift/blob/master/docs/SIL.rst#cond_fail and https://github.com/apple/swift/blob/master/docs/SIL.rst#checked-conversions 

However, `unconditional_checked_cast_value` is missed on `mayTrap ` case in current implementation so this commit added it to cover all-case.

This missing case has a risk to remove instruction which should be marked as side-effect, on like Dead Code Elimination, so should be fixed