### PR TITLE
[benchmark] Delete two benchmarks and add generic floating-point conversion lit tests

### DIFF
--- a/benchmark/single-source/FloatingPointConversion.swift
+++ b/benchmark/single-source/FloatingPointConversion.swift
@@ -14,16 +14,6 @@ import TestsUtils
 
 public let FloatingPointConversion = [
   BenchmarkInfo(
-    name: "ConvertFloatingPoint.ConcreteDoubleToDouble",
-    runFunction: run_ConvertFloatingPoint_ConcreteDoubleToDouble,
-    tags: [.validation, .api],
-    setUpFunction: { blackHole(doubles) }),
-  BenchmarkInfo(
-    name: "ConvertFloatingPoint.GenericDoubleToDouble",
-    runFunction: run_ConvertFloatingPoint_GenericDoubleToDouble,
-    tags: [.validation, .api],
-    setUpFunction: { blackHole(doubles) }),
-  BenchmarkInfo(
     name: "ConvertFloatingPoint.MockFloat64ToDouble",
     runFunction: run_ConvertFloatingPoint_MockFloat64ToDouble,
     tags: [.validation, .api],
@@ -61,9 +51,9 @@ extension MockBinaryFloatingPoint {
   init(_ value: Int) { self.init(_Value(value)) }
   init(_ value: Float) { self.init(_Value(value)) }
   init(_ value: Double) { self.init(_Value(value)) }
-  #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-    init(_ value: Float80) { self.init(_Value(value)) }
-  #endif
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+  init(_ value: Float80) { self.init(_Value(value)) }
+#endif
   init(integerLiteral value: _Value.IntegerLiteralType) {
     self.init(_Value(integerLiteral: value))
   }
@@ -159,25 +149,7 @@ func convert<
   U(value)
 }
 
-@inline(never)
-public func run_ConvertFloatingPoint_ConcreteDoubleToDouble(_ N: Int) {
-  for _ in 0..<(N * 100) {
-    for element in doubles {
-      let f = Double(identity(element))
-      blackHole(f)
-    }
-  }
-}
-
-@inline(never)
-public func run_ConvertFloatingPoint_GenericDoubleToDouble(_ N: Int) {
-  for _ in 0..<(N * 100) {
-    for element in doubles {
-      let f = convert(identity(element), to: Double.self)
-      blackHole(f)
-    }
-  }
-}
+// See also: test/SILOptimizer/floating_point_conversion.swift
 
 @inline(never)
 public func run_ConvertFloatingPoint_MockFloat64ToDouble(_ N: Int) {

--- a/test/SILOptimizer/floating_point_conversion.swift
+++ b/test/SILOptimizer/floating_point_conversion.swift
@@ -1,12 +1,36 @@
 // RUN: %target-swift-frontend -O -module-name=test -emit-sil %s | %FileCheck %s
 
 func convert<
-   T: BinaryFloatingPoint, U: BinaryFloatingPoint
- >(_ value: T, to: U.Type) -> U {
-   U(value)
+  T: BinaryFloatingPoint, U: BinaryFloatingPoint
+>(_ value: T, to: U.Type) -> U {
+  U(value)
 }
 
-// Check that the follwing functions can be optimized to no-ops.
+// Check that the following functions can be optimized to concrete conversions.
+
+// CHECK-LABEL: sil @$s4test0A13DoubleToFloatySfSdF
+// CHECK:      bb0(%0 : $Double):
+// CHECK:        struct_extract %0 : $Double, #Double._value
+// CHECK-NEXT:   builtin "fptrunc_FPIEEE64_FPIEEE32"
+// CHECK-NEXT:   struct $Float
+// CHECK-NEXT:   return
+// CHECK-NEXT: } // end sil function '$s4test0A13DoubleToFloatySfSdF'
+public func testDoubleToFloat(_ x: Double) -> Float {
+  return convert(x, to: Float.self)
+}
+
+// CHECK-LABEL: sil @$s4test0A13FloatToDoubleySdSfF
+// CHECK:      bb0(%0 : $Float):
+// CHECK:        struct_extract %0 : $Float, #Float._value
+// CHECK-NEXT:   builtin "fpext_FPIEEE32_FPIEEE64"
+// CHECK-NEXT:   struct $Double
+// CHECK-NEXT:   return
+// CHECK-NEXT: } // end sil function '$s4test0A13FloatToDoubleySdSfF'
+public func testFloatToDouble(_ x: Float) -> Double {
+  return convert(x, to: Double.self)
+}
+
+// Check that the following functions can be optimized to no-ops.
 
 // CHECK-LABEL: sil @$s4test0A6DoubleyS2dF
 // CHECK:   return %0
@@ -21,5 +45,3 @@ public func testDouble(_ x: Double) -> Double {
 public func testFloat(_ x: Float) -> Float {
   return convert(x, to: Float.self)
 }
-
-


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR follows up on #33801 and #33839 by removing benchmarks that are unnecessary now that lit tests check that the optimization is, well, optimal for generic `Double`-to-`Double` conversion.

In addition, I have added two additional checks to floating_point_conversion.swift to ensure that generic `Double`-to-`Float` and `Float`-to-`Double` conversions are also optimized as expected.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
