### PR TITLE
[Sema] Fix availability checking in inlinable code

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2455,10 +2455,16 @@ NOTE(suggest_removing_override, none,
 ERROR(override_less_available,none,
       "overriding %0 must be as available as declaration it overrides",
       (DeclBaseName))
+WARNING(override_less_available_warn,none,
+        "overriding %0 must be as available as declaration it overrides",
+        (DeclBaseName))
 
 ERROR(override_accessor_less_available,none,
       "overriding %0 for %1 must be as available as declaration it overrides",
       (DescriptiveDeclKind, DeclBaseName))
+WARNING(override_accessor_less_available_warn,none,
+        "overriding %0 for %1 must be as available as declaration it overrides",
+        (DescriptiveDeclKind, DeclBaseName))
 
 ERROR(override_let_property,none,
       "cannot override immutable 'let' property %0 with the getter of a 'var'",

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -154,16 +154,23 @@ private:
 
   SourceRange SrcRange;
 
+  /// Runtime availability information for the code in this context.
   AvailabilityContext AvailabilityInfo;
+
+  /// Runtime availability information as explicitly declared by attributes
+  /// for the inlinable code in this context. Compared to AvailabilityInfo,
+  /// this is not bounded to the minimum deployment OS version.
+  AvailabilityContext AvailabilityInfoExplicit;
 
   std::vector<TypeRefinementContext *> Children;
 
   TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
                         TypeRefinementContext *Parent, SourceRange SrcRange,
-                        const AvailabilityContext &Info);
+                        const AvailabilityContext &Info,
+                        const AvailabilityContext &InfoExplicit);
 
 public:
-  
+
   /// Create the root refinement context for the given SourceFile.
   static TypeRefinementContext *createRoot(SourceFile *SF,
                                            const AvailabilityContext &Info);
@@ -172,8 +179,9 @@ public:
   static TypeRefinementContext *createForDecl(ASTContext &Ctx, Decl *D,
                                               TypeRefinementContext *Parent,
                                               const AvailabilityContext &Info,
+                                              const AvailabilityContext &InfoExplicit,
                                               SourceRange SrcRange);
-  
+
   /// Create a refinement context for the Then branch of the given IfStmt.
   static TypeRefinementContext *
   createForIfStmtThen(ASTContext &Ctx, IfStmt *S, TypeRefinementContext *Parent,
@@ -240,9 +248,17 @@ public:
   SourceRange getSourceRange() const { return SrcRange; }
 
   /// Returns the information on what can be assumed present at run time when
-  /// running code contained in this context.
+  /// running code contained in this context, taking into account the minimum
+  /// deployment target.
   const AvailabilityContext &getAvailabilityInfo() const {
     return AvailabilityInfo;
+  }
+
+  /// Returns the information on what can be assumed present at run time when
+  /// running code contained in this context if it were to be inlined,
+  /// without considering the minimum deployment target.
+  const AvailabilityContext &getAvailabilityInfoExplicit() const {
+    return AvailabilityInfoExplicit;
   }
 
   /// Adds a child refinement context.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -144,8 +144,13 @@ static bool isBetterThan(const AvailableAttr *newAttr,
     return true;
 
   // If they belong to the same platform, the one that introduces later wins.
-  if (prevAttr->Platform == newAttr->Platform)
+  if (prevAttr->Platform == newAttr->Platform) {
+    if (newAttr->isUnconditionallyUnavailable())
+      return true;
+    if (prevAttr->isUnconditionallyUnavailable())
+      return false;
     return prevAttr->Introduced.getValue() < newAttr->Introduced.getValue();
+  }
 
   // If the new attribute's platform inherits from the old one, it wins.
   return inheritsAvailabilityFromPlatform(newAttr->Platform,
@@ -158,10 +163,12 @@ AvailabilityInference::annotatedAvailableRange(const Decl *D, ASTContext &Ctx) {
 
   for (auto Attr : D->getAttrs()) {
     auto *AvailAttr = dyn_cast<AvailableAttr>(Attr);
-    if (AvailAttr == nullptr || !AvailAttr->Introduced.hasValue() ||
+    if (AvailAttr == nullptr ||
         !AvailAttr->isActivePlatform(Ctx) ||
         AvailAttr->isLanguageVersionSpecific() ||
-        AvailAttr->isPackageDescriptionVersionSpecific()) {
+        AvailAttr->isPackageDescriptionVersionSpecific() ||
+        (!AvailAttr->Introduced.hasValue() &&
+         !AvailAttr->isUnconditionallyUnavailable())) {
       continue;
     }
 
@@ -171,6 +178,9 @@ AvailabilityInference::annotatedAvailableRange(const Decl *D, ASTContext &Ctx) {
 
   if (!bestAvailAttr)
     return None;
+
+  if (bestAvailAttr->isUnconditionallyUnavailable())
+      return AvailabilityContext(VersionRange::empty());
 
   return AvailabilityContext{
     VersionRange::allGTE(bestAvailAttr->Introduced.getValue())};

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -28,12 +28,14 @@ using namespace swift;
 TypeRefinementContext::TypeRefinementContext(ASTContext &Ctx, IntroNode Node,
                                              TypeRefinementContext *Parent,
                                              SourceRange SrcRange,
-                                             const AvailabilityContext &Info)
-    : Node(Node), SrcRange(SrcRange), AvailabilityInfo(Info) {
+                                             const AvailabilityContext &Info,
+                                             const AvailabilityContext &InfoExplicit)
+    : Node(Node), SrcRange(SrcRange), AvailabilityInfo(Info),
+      AvailabilityInfoExplicit(InfoExplicit) {
   if (Parent) {
     assert(SrcRange.isValid());
     Parent->addChild(this);
-    assert(Info.isContainedIn(Parent->getAvailabilityInfo()));
+    assert(InfoExplicit.isContainedIn(Parent->getAvailabilityInfoExplicit()));
   }
   Ctx.addDestructorCleanup(Children);
 }
@@ -46,18 +48,20 @@ TypeRefinementContext::createRoot(SourceFile *SF,
   ASTContext &Ctx = SF->getASTContext();
   return new (Ctx)
       TypeRefinementContext(Ctx, SF,
-                            /*Parent=*/nullptr, SourceRange(), Info);
+                            /*Parent=*/nullptr, SourceRange(), Info,
+                            AvailabilityContext::alwaysAvailable());
 }
 
 TypeRefinementContext *
 TypeRefinementContext::createForDecl(ASTContext &Ctx, Decl *D,
                                      TypeRefinementContext *Parent,
                                      const AvailabilityContext &Info,
+                                     const AvailabilityContext &InfoExplicit,
                                      SourceRange SrcRange) {
   assert(D);
   assert(Parent);
   return new (Ctx)
-      TypeRefinementContext(Ctx, D, Parent, SrcRange, Info);
+      TypeRefinementContext(Ctx, D, Parent, SrcRange, Info, InfoExplicit);
 }
 
 TypeRefinementContext *
@@ -68,7 +72,7 @@ TypeRefinementContext::createForIfStmtThen(ASTContext &Ctx, IfStmt *S,
   assert(Parent);
   return new (Ctx)
       TypeRefinementContext(Ctx, IntroNode(S, /*IsThen=*/true), Parent,
-                            S->getThenStmt()->getSourceRange(), Info);
+                            S->getThenStmt()->getSourceRange(), Info, Info);
 }
 
 TypeRefinementContext *
@@ -79,7 +83,7 @@ TypeRefinementContext::createForIfStmtElse(ASTContext &Ctx, IfStmt *S,
   assert(Parent);
   return new (Ctx)
       TypeRefinementContext(Ctx, IntroNode(S, /*IsThen=*/false), Parent,
-                            S->getElseStmt()->getSourceRange(), Info);
+                            S->getElseStmt()->getSourceRange(), Info, Info);
 }
 
 TypeRefinementContext *
@@ -92,7 +96,7 @@ TypeRefinementContext::createForConditionFollowingQuery(ASTContext &Ctx,
   assert(Parent);
   SourceRange Range(PAI->getEndLoc(), LastElement.getEndLoc());
   return new (Ctx) TypeRefinementContext(Ctx, PAI, Parent, Range,
-                                         Info);
+                                         Info, Info);
 }
 
 TypeRefinementContext *
@@ -107,7 +111,7 @@ TypeRefinementContext::createForGuardStmtFallthrough(ASTContext &Ctx,
   SourceRange Range(RS->getEndLoc(), ContainingBraceStmt->getEndLoc());
   return new (Ctx) TypeRefinementContext(Ctx,
                                          IntroNode(RS, /*IsFallthrough=*/true),
-                                         Parent, Range, Info);
+                                         Parent, Range, Info, Info);
 }
 
 TypeRefinementContext *
@@ -118,7 +122,7 @@ TypeRefinementContext::createForGuardStmtElse(ASTContext &Ctx, GuardStmt *RS,
   assert(Parent);
   return new (Ctx)
       TypeRefinementContext(Ctx, IntroNode(RS, /*IsFallthrough=*/false), Parent,
-                            RS->getBody()->getSourceRange(), Info);
+                            RS->getBody()->getSourceRange(), Info, Info);
 }
 
 TypeRefinementContext *
@@ -128,7 +132,7 @@ TypeRefinementContext::createForWhileStmtBody(ASTContext &Ctx, WhileStmt *S,
   assert(S);
   assert(Parent);
   return new (Ctx) TypeRefinementContext(
-      Ctx, S, Parent, S->getBody()->getSourceRange(), Info);
+      Ctx, S, Parent, S->getBody()->getSourceRange(), Info, Info);
 }
 
 // Only allow allocation of TypeRefinementContext using the allocator in

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -300,6 +300,7 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
   OS << "(" << getReasonName(getReason());
 
   OS << " versions=" << AvailabilityInfo.getOSVersion().getAsString();
+  OS << " explicit=" << AvailabilityInfoExplicit.getOSVersion().getAsString();
 
   if (getReason() == Reason::Decl) {
     Decl *D = Node.getAsDecl();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1817,18 +1817,27 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
   if (info.isAlwaysAvailable())
     return;
 
+  PlatformAgnosticAvailabilityKind platformAgnosticAvailability;
+  llvm::VersionTuple introducedVersion;
+  if (info.isKnownUnreachable()) {
+    platformAgnosticAvailability = PlatformAgnosticAvailabilityKind::Unavailable;
+  } else {
+    platformAgnosticAvailability = PlatformAgnosticAvailabilityKind::None;
+    introducedVersion = info.getOSVersion().getLowerEndpoint();
+  }
+
   llvm::VersionTuple noVersion;
   auto AvAttr = new (C) AvailableAttr(SourceLoc(), SourceRange(),
                                       targetPlatform(C.LangOpts),
                                       /*Message=*/StringRef(),
                                       /*Rename=*/StringRef(),
-                                      info.getOSVersion().getLowerEndpoint(),
+                                      introducedVersion,
                                       /*IntroducedRange*/SourceRange(),
                                       /*Deprecated=*/noVersion,
                                       /*DeprecatedRange*/SourceRange(),
                                       /*Obsoleted=*/noVersion,
                                       /*ObsoletedRange*/SourceRange(),
-                                      PlatformAgnosticAvailabilityKind::None,
+                                      platformAgnosticAvailability,
                                       /*Implicit=*/false);
 
   decl->getAttrs().add(AvAttr);

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2638,7 +2638,8 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   if (isAlwaysWeakImported())
     OS << "[weak_imported] ";
   auto availability = getAvailabilityForLinkage();
-  if (!availability.isAlwaysAvailable()) {
+  if (!availability.isAlwaysAvailable() &&
+      !availability.isKnownUnreachable()) {
     auto version = availability.getOSVersion().getLowerEndpoint();
     OS << "[available " << version.getAsString() << "] ";
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1530,9 +1530,16 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       VersionRange::allGTE(attr->Introduced.getValue())};
 
   if (!AttrRange.isContainedIn(EnclosingAnnotatedRange.getValue())) {
-    diagnose(attr->getLocation(), diag::availability_decl_more_than_enclosing);
-    diagnose(EnclosingDecl->getLoc(),
-             diag::availability_decl_more_than_enclosing_enclosing_here);
+    // Don't show this error in swiftinterfaces if it is about a context that
+    // is unavailable, this was in the stdlib at Swift 5.3.
+    SourceFile *Parent = D->getDeclContext()->getParentSourceFile();
+    if (!Parent || Parent->Kind != SourceFileKind::Interface ||
+        !EnclosingAnnotatedRange.getValue().isKnownUnreachable()) {
+      diagnose(attr->getLocation(),
+               diag::availability_decl_more_than_enclosing);
+      diagnose(EnclosingDecl->getLoc(),
+               diag::availability_decl_more_than_enclosing_enclosing_here);
+    }
   }
 }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -179,9 +179,13 @@ private:
     // When the body is inlinable consider only the explicitly declared range
     // for checking availability. Otherwise, use the parent range which may
     // begin at the minimum deployment target.
+    //
+    // Also use the parent range when reading swiftinterfaces for
+    // retrocompatibility.
     bool isInlinable = D->getAttrs().hasAttribute<InlinableAttr>() ||
                        D->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>();
-    if (!isInlinable)) {
+    SourceFile *SF = D->getDeclContext()->getParentSourceFile();
+    if (!isInlinable || (SF && SF->Kind == SourceFileKind::Interface)) {
       DeclInfo.intersectWith(
           getCurrentTRC()->getAvailabilityInfo());
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -720,6 +720,14 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
     }
   }
 
+  // If we still don't have an introduction version, use the current deployment
+  // target. This covers cases where an inlinable function and its parent
+  // contexts don't have explicit availability attributes.
+  if (!OverApproximateContext.getOSVersion().hasLowerEndpoint()) {
+    auto currentOS = AvailabilityContext::forDeploymentTarget(Context);
+    OverApproximateContext.constrainWith(currentOS);
+  }
+
   return OverApproximateContext;
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1687,7 +1687,8 @@ static bool diagnoseOverrideForAvailability(ValueDecl *override,
   if (isRedundantAccessorOverrideAvailabilityDiagnostic(override, base))
     return false;
 
-  auto &diags = override->getASTContext().Diags;
+  auto &ctx = override->getASTContext();
+  auto &diags = ctx.Diags;
   if (auto *accessor = dyn_cast<AccessorDecl>(override)) {
     diags.diagnose(override, diag::override_accessor_less_available,
                    accessor->getDescriptiveKind(),
@@ -1695,6 +1696,15 @@ static bool diagnoseOverrideForAvailability(ValueDecl *override,
     diags.diagnose(base, diag::overridden_here);
     return true;
   }
+
+  // Don't report constructors that are marked unavailable as being less
+  // available than their introduction. This was previously allowed and
+  // can be used to forbid the direct use of a constructor in a subclass.
+  // Note that even when marked unavailable the constructor could be called
+  // by other inherited constructors.
+  if (isa<ConstructorDecl>(override) &&
+      override->getAttrs().isUnavailable(ctx))
+    return false;
 
   diags.diagnose(override, diag::override_less_available,
                  override->getBaseName());

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1690,23 +1690,34 @@ static bool diagnoseOverrideForAvailability(ValueDecl *override,
   auto &ctx = override->getASTContext();
   auto &diags = ctx.Diags;
   if (auto *accessor = dyn_cast<AccessorDecl>(override)) {
-    diags.diagnose(override, diag::override_accessor_less_available,
+    bool downgradeToWarning = override->getAttrs().isUnavailable(ctx);
+    diags.diagnose(override,
+                   downgradeToWarning?
+                     diag::override_accessor_less_available_warn :
+                     diag::override_accessor_less_available,
                    accessor->getDescriptiveKind(),
                    accessor->getStorage()->getBaseName());
     diags.diagnose(base, diag::overridden_here);
     return true;
   }
 
-  // Don't report constructors that are marked unavailable as being less
-  // available than their introduction. This was previously allowed and
-  // can be used to forbid the direct use of a constructor in a subclass.
-  // Note that even when marked unavailable the constructor could be called
-  // by other inherited constructors.
-  if (isa<ConstructorDecl>(override) &&
-      override->getAttrs().isUnavailable(ctx))
-    return false;
+  bool downgradeToWarning = false;
+  if (override->getAttrs().isUnavailable(ctx)) {
+    // Don't report constructors that are marked unavailable as being less
+    // available than their introduction. This was previously allowed and
+    // can be used to forbid the direct use of a constructor in a subclass.
+    // Note that even when marked unavailable the constructor could be called
+    // by other inherited constructors.
+    if (isa<ConstructorDecl>(override))
+      return false;
 
-  diags.diagnose(override, diag::override_less_available,
+    // Report as a warning other unavailable overrides.
+    downgradeToWarning = true;
+  }
+
+  diags.diagnose(override,
+                 downgradeToWarning? diag::override_less_available_warn :
+                                     diag::override_less_available,
                  override->getBaseName());
   diags.diagnose(base, diag::overridden_here);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1469,6 +1469,11 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
       return CheckKind::UsableFromInline;
   }
 
+  if (match.Witness->getAttrs().isUnavailable(getASTContext()) &&
+      !requirement->getAttrs().isUnavailable(getASTContext())) {
+    return CheckKind::WitnessUnavailable;
+  }
+
   auto requiredAvailability = AvailabilityContext::alwaysAvailable();
   if (checkWitnessAvailability(requirement, match.Witness,
                                &requiredAvailability)) {
@@ -1496,11 +1501,6 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
         }
       }
     }
-  }
-
-  if (match.Witness->getAttrs().isUnavailable(getASTContext()) &&
-      !requirement->getAttrs().isUnavailable(getASTContext())) {
-    return CheckKind::WitnessUnavailable;
   }
 
   return CheckKind::Success;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -430,7 +430,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
   Optional<llvm::VersionTuple> available;
   auto availability = F.getAvailabilityForLinkage();
-  if (!availability.isAlwaysAvailable()) {
+  if (!availability.isAlwaysAvailable() &&
+      !availability.isKnownUnreachable()) {
     available = availability.getOSVersion().getLowerEndpoint();
   }
   ENCODE_VER_TUPLE(available, available)

--- a/test/SILGen/vtables.swift
+++ b/test/SILGen/vtables.swift
@@ -21,7 +21,6 @@ class C : B {
 // CHECK:   #A.bar: {{.*}} : @$s7vtables1CC3bar{{[_0-9a-zA-Z]*}}F
 // CHECK:   #A.bas: {{.*}} : @$s7vtables1AC3bas{{[_0-9a-zA-Z]*}}F
 // CHECK:   #A.qux: {{.*}} : @$s7vtables1CC3qux{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.flux: {{.*}} : @$s7vtables1BC4flux{{[_0-9a-zA-Z]*}}F
 // CHECK:   #B.init!allocator: {{.*}} : @$s7vtables1CC{{[_0-9a-zA-Z]*}}fC
 // CHECK:   #B.zim: {{.*}} : @$s7vtables1BC3zim{{[_0-9a-zA-Z]*}}F
 // CHECK:   #B.zang: {{.*}} : @$s7vtables1CC4zang{{[_0-9a-zA-Z]*}}F
@@ -35,7 +34,7 @@ class A {
   func bar() {}
   func bas() {}
   func qux() {}
-  func flux() {}
+  @available(*, unavailable) func flux() {}
 }
 
 // CHECK: sil_vtable A {
@@ -54,7 +53,6 @@ class B : A {
   // bar inherited from A
   // bas inherited from A
   override func qux() {}
-  @available(*, unavailable) override func flux() {}
 
   func zim() {}
   func zang() {}
@@ -65,7 +63,6 @@ class B : A {
 // CHECK:   #A.bar: {{.*}} : @$s7vtables1AC3bar{{[_0-9a-zA-Z]*}}F
 // CHECK:   #A.bas: {{.*}} : @$s7vtables1AC3bas{{[_0-9a-zA-Z]*}}F
 // CHECK:   #A.qux: {{.*}} : @$s7vtables1BC3qux{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.flux: {{.*}} : @$s7vtables1BC4flux{{[_0-9a-zA-Z]*}}F
 // CHECK:   #B.init!allocator: {{.*}} : @$s7vtables1BC{{[_0-9a-zA-Z]*}}fC
 // CHECK:   #B.zim: {{.*}} : @$s7vtables1BC3zim{{[_0-9a-zA-Z]*}}F
 // CHECK:   #B.zang: {{.*}} : @$s7vtables1BC4zang{{[_0-9a-zA-Z]*}}F

--- a/test/Sema/availability_inlinable.swift
+++ b/test/Sema/availability_inlinable.swift
@@ -1,0 +1,48 @@
+/// Inlinable functions should check availability by ignoring the current
+/// deployment target as clients could inline the function in a lower target.
+
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.0
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.10
+
+// REQUIRES: OS=macosx
+
+@available(macOS 10.10, *)
+@inlinable
+public func availMacOS10() {
+  availMacOS11() // expected-error {{'availMacOS11()' is only available in macOS 11.0 or newer}}
+  // expected-note @-1 {{add 'if #available' version check}}
+
+  if #available(macOS 11.0, *) {
+    availMacOS11()
+  } else {
+    availMacOS11() // expected-error {{'availMacOS11()' is only available in macOS 11.0 or newer}}
+    // expected-note @-1 {{add 'if #available' version check}}
+  }
+
+  if #available(macOS 10.15, *) {
+    availMacOS11() // expected-error {{'availMacOS11()' is only available in macOS 11.0 or newer}}
+    // expected-note @-1 {{add 'if #available' version check}}
+  }
+
+  func nestedFunc() {
+    availMacOS11() // expected-error {{'availMacOS11()' is only available in macOS 11.0 or newer}}
+    // expected-note @-1 {{add 'if #available' version check}}
+  }
+}
+
+@available(macOS 11.0, *)
+public func availMacOS11() { }
+
+@available(macOS 10.10, *)
+public struct StructAvailMacOS10 {
+  @inlinable
+  public func availabilityFromTheContextInlinable() {
+  // expected-note @-1 {{add @available attribute to enclosing instance method}}
+    availMacOS11() // expected-error {{'availMacOS11()' is only available in macOS 11.0 or newer}}
+    // expected-note @-1 {{add 'if #available' version check}}
+
+    availabilityFromContext()
+  }
+
+  public func availabilityFromContext() {}
+}

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -1,18 +1,18 @@
-// RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s > %t.dump 2>&1
+// RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts -target %target-cpu-apple-macosx10.50 %s > %t.dump 2>&1
 // RUN: %FileCheck --strict-whitespace %s < %t.dump
 
 // REQUIRES: OS=macosx
 
-// CHECK: {{^}}(root versions=[10.{{[0-9]+}}.0,+Inf)
+// CHECK: {{^}}(root versions=[10.50.0,+Inf) explicit=all
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someMethod()
-// CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) decl=someInnerFunc()
-// CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) decl=InnerClass
-// CHECK-NEXT: {{^}}        (decl versions=[10.54,+Inf) decl=innerClassMethod
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someStaticProperty
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someComputedProperty
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someOtherMethod()
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=someMethod()
+// CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) explicit=[10.53,+Inf) decl=someInnerFunc()
+// CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) explicit=[10.53,+Inf) decl=InnerClass
+// CHECK-NEXT: {{^}}        (decl versions=[10.54,+Inf) explicit=[10.54,+Inf) decl=innerClassMethod
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=someStaticProperty
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=someComputedProperty
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=someOtherMethod()
 @available(OSX 10.51, *)
 class SomeClass {
   @available(OSX 10.52, *)
@@ -43,13 +43,13 @@ class SomeClass {
   func someOtherMethod() { }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=someFunction()
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=someFunction()
 @available(OSX 10.51, *)
 func someFunction() { }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeProtocol
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=protoMethod()
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=protoProperty
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=SomeProtocol
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=protoMethod()
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=protoProperty
 @available(OSX 10.51, *)
 protocol SomeProtocol {
   @available(OSX 10.52, *)
@@ -59,26 +59,26 @@ protocol SomeProtocol {
   var protoProperty: Int { get }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someExtensionFunction()
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) explicit=[10.52,+Inf) decl=someExtensionFunction()
 @available(OSX 10.51, *)
 extension SomeClass {
   @available(OSX 10.52, *)
   func someExtensionFunction() { }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}      (if_then versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.55,+Inf)
-// CHECK-NEXT: {{^}}        (decl versions=[10.55,+Inf) decl=funcInGuardElse()
-// CHECK-NEXT: {{^}}        (guard_fallthrough versions=[10.55,+Inf)
-// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.56,+Inf)
-// CHECK-NEXT: {{^}}          (guard_fallthrough versions=[10.56,+Inf)
-// CHECK-NEXT: {{^}}      (decl versions=[10.57,+Inf) decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=functionWithStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.52,+Inf) explicit=[10.52,+Inf)
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.53,+Inf) explicit=[10.53,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[10.53,+Inf) explicit=[10.53,+Inf)
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.54,+Inf) explicit=[10.54,+Inf)
+// CHECK-NEXT: {{^}}      (if_then versions=[10.54,+Inf) explicit=[10.54,+Inf)
+// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.55,+Inf) explicit=[10.55,+Inf)
+// CHECK-NEXT: {{^}}        (decl versions=[10.55,+Inf) explicit=[10.55,+Inf) decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}        (guard_fallthrough versions=[10.55,+Inf) explicit=[10.55,+Inf)
+// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.56,+Inf) explicit=[10.56,+Inf)
+// CHECK-NEXT: {{^}}          (guard_fallthrough versions=[10.56,+Inf) explicit=[10.56,+Inf)
+// CHECK-NEXT: {{^}}      (decl versions=[10.57,+Inf) explicit=[10.57,+Inf) decl=funcInInnerIfElse()
 @available(OSX 10.51, *)
 func functionWithStmtCondition() {
   if #available(OSX 10.52, *),
@@ -97,11 +97,11 @@ func functionWithStmtCondition() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithUnnecessaryStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[10.53,+Inf)
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}    (if_then versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=functionWithUnnecessaryStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.53,+Inf) explicit=[10.53,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[10.53,+Inf) explicit=[10.53,+Inf)
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.54,+Inf) explicit=[10.54,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[10.54,+Inf) explicit=[10.54,+Inf)
 
 @available(OSX 10.51, *)
 func functionWithUnnecessaryStmtCondition() {
@@ -127,13 +127,13 @@ func functionWithUnnecessaryStmtCondition() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
-// CHECK-NEXT: {{^}}    (if_else versions=empty
-// CHECK-NEXT: {{^}}      (decl versions=empty decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}    (if_else versions=empty
-// CHECK-NEXT: {{^}}    (guard_else versions=empty
-// CHECK-NEXT: {{^}}    (guard_else versions=empty
-// CHECK-NEXT: {{^}}    (if_else versions=empty
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
+// CHECK-NEXT: {{^}}    (if_else versions=empty explicit=empty
+// CHECK-NEXT: {{^}}      (decl versions=empty explicit=empty decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}    (if_else versions=empty explicit=empty
+// CHECK-NEXT: {{^}}    (guard_else versions=empty explicit=empty
+// CHECK-NEXT: {{^}}    (guard_else versions=empty explicit=empty
+// CHECK-NEXT: {{^}}    (if_else versions=empty explicit=empty
 
 @available(OSX 10.51, *)
 func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
@@ -180,10 +180,10 @@ func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
 
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=functionWithWhile()
-// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}    (while_body versions=[10.52,+Inf)
-// CHECK-NEXT: {{^}}      (decl versions=[10.54,+Inf) decl=funcInWhileBody()
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) explicit=[10.51,+Inf) decl=functionWithWhile()
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.52,+Inf) explicit=[10.52,+Inf)
+// CHECK-NEXT: {{^}}    (while_body versions=[10.52,+Inf) explicit=[10.52,+Inf)
+// CHECK-NEXT: {{^}}      (decl versions=[10.54,+Inf) explicit=[10.54,+Inf) decl=funcInWhileBody()
 @available(OSX 10.51, *)
 func functionWithWhile() {
   while #available(OSX 10.52, *),
@@ -191,4 +191,45 @@ func functionWithWhile() {
     @available(OSX 10.54, *)
     func funcInWhileBody() { }
   }
+}
+
+// CHECK-NEXT: {{^}}  (decl versions=[10.50.0,+Inf) explicit=[10.10,+Inf) decl=olderFunction()
+@available(macOS 10.10, *)
+public func olderFunction() {
+}
+
+// CHECK-NEXT: {{^}}  (decl versions=[10.10,+Inf) explicit=[10.10,+Inf) decl=inlinableFunction()
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.55,+Inf) explicit=[10.55,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[10.55,+Inf) explicit=[10.55,+Inf)
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.15,+Inf)
+// CHECK-NEXT: {{^}}    (if_then versions=[10.15,+Inf) explicit=[10.15,+Inf)
+// CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.15,+Inf) explicit=[10.15,+Inf)
+// CHECK-NEXT: {{^}}    (guard_fallthrough versions=[10.15,+Inf) explicit=[10.15,+Inf)
+@available(macOS 10.10, *)
+@inlinable
+public func inlinableFunction() {
+  if #available(macOS 10.55, *) { } else { }
+
+  if #available(macOS 10.15, *) { }
+
+  guard #available(macOS 10.15, *) else { }
+
+  func nestedFunc() { }
+}
+
+// CHECK-NEXT: {{^}}  (decl versions=[10.50.0,+Inf) explicit=[10.10,+Inf) decl=SomeOlderClass
+// CHECK-NEXT: {{^}}    (decl versions=[10.10,+Inf) explicit=[10.10,+Inf) decl=someInlinableMethod()
+// CHECK-NEXT: {{^}}    (decl versions=[10.15,+Inf) explicit=[10.15,+Inf) decl=someOtherInlinableMethod()
+// CHECK-NEXT: {{^}}    (decl versions=[10.50.0,+Inf) explicit=[10.15,+Inf) decl=someMethod()
+@available(OSX 10.10, *)
+class SomeOlderClass {
+  @inlinable
+  func someInlinableMethod() { }
+
+  @available(OSX 10.15, *)
+  @inlinable
+  func someOtherInlinableMethod() { }
+
+  @available(OSX 10.15, *)
+  func someMethod() { }
 }

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -198,6 +198,11 @@ func functionWithWhile() {
 public func olderFunction() {
 }
 
+// CHECK-NEXT: {{^}}  (decl versions=empty explicit=empty decl=unavailableFunction()
+@available(macOS, unavailable)
+public func unavailableFunction() {
+}
+
 // CHECK-NEXT: {{^}}  (decl versions=[10.10,+Inf) explicit=[10.10,+Inf) decl=inlinableFunction()
 // CHECK-NEXT: {{^}}    (condition_following_availability versions=[10.55,+Inf) explicit=[10.55,+Inf)
 // CHECK-NEXT: {{^}}    (if_then versions=[10.55,+Inf) explicit=[10.55,+Inf)

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -788,21 +788,21 @@ class UnavailableClassExtendingUnavailableClass : ClassAvailableOn10_51 {
 // Method availability is contravariant
 
 class SuperWithAlwaysAvailableMembers {
-  func shouldAlwaysBeAvailableMethod() { // expected-note {{overridden declaration is here}}
+  func shouldAlwaysBeAvailableMethod() { // expected-note 2 {{overridden declaration is here}}
   }
   
-  var shouldAlwaysBeAvailableProperty: Int { // expected-note {{overridden declaration is here}}
+  var shouldAlwaysBeAvailableProperty: Int { // expected-note 2 {{overridden declaration is here}}
     get { return 9 }
     set(newVal) {}
   }
 
   var setterShouldAlwaysBeAvailableProperty: Int {
     get { return 9 }
-    set(newVal) {} // expected-note {{overridden declaration is here}}
+    set(newVal) {} // expected-note 2 {{overridden declaration is here}}
   }
 
   var getterShouldAlwaysBeAvailableProperty: Int {
-    get { return 9 } // expected-note {{overridden declaration is here}}
+    get { return 9 } // expected-note 2 {{overridden declaration is here}}
     set(newVal) {}
   }
 }
@@ -827,6 +827,31 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
 
   override var getterShouldAlwaysBeAvailableProperty: Int {
     @available(OSX, introduced: 10.51)
+    get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
+    set(newVal) {}
+  }
+}
+
+class SubWithUnavailableMembers : SuperWithAlwaysAvailableMembers {
+  @available(OSX, unavailable)
+  override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
+  }
+
+  @available(OSX, unavailable)
+  override var shouldAlwaysBeAvailableProperty: Int { // expected-error {{overriding 'shouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
+    get { return 10 }
+    set(newVal) {}
+  }
+
+  override var setterShouldAlwaysBeAvailableProperty: Int {
+    get { return 9 }
+    @available(OSX, unavailable)
+    set(newVal) {} // expected-error {{overriding setter for 'setterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
+    // This is a terrible diagnostic. rdar://problem/20427938
+  }
+
+  override var getterShouldAlwaysBeAvailableProperty: Int {
+    @available(OSX, unavailable)
     get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     set(newVal) {}
   }

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -788,6 +788,9 @@ class UnavailableClassExtendingUnavailableClass : ClassAvailableOn10_51 {
 // Method availability is contravariant
 
 class SuperWithAlwaysAvailableMembers {
+
+  required init() {} // expected-note {{overridden declaration is here}}
+
   func shouldAlwaysBeAvailableMethod() { // expected-note 2 {{overridden declaration is here}}
   }
   
@@ -808,6 +811,10 @@ class SuperWithAlwaysAvailableMembers {
 }
 
 class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
+
+  @available(OSX, introduced: 10.51)
+  required init() {} // expected-error {{overriding 'init' must be as available as declaration it overrides}}
+
   @available(OSX, introduced: 10.51)
   override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
   }
@@ -833,6 +840,10 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
 }
 
 class SubWithUnavailableMembers : SuperWithAlwaysAvailableMembers {
+
+  @available(OSX, unavailable)
+  required init() {}
+
   @available(OSX, unavailable)
   override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
   }

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -845,11 +845,11 @@ class SubWithUnavailableMembers : SuperWithAlwaysAvailableMembers {
   required init() {}
 
   @available(OSX, unavailable)
-  override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
+  override func shouldAlwaysBeAvailableMethod() { // expected-warning {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
   }
 
   @available(OSX, unavailable)
-  override var shouldAlwaysBeAvailableProperty: Int { // expected-error {{overriding 'shouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
+  override var shouldAlwaysBeAvailableProperty: Int { // expected-warning {{overriding 'shouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     get { return 10 }
     set(newVal) {}
   }
@@ -857,13 +857,13 @@ class SubWithUnavailableMembers : SuperWithAlwaysAvailableMembers {
   override var setterShouldAlwaysBeAvailableProperty: Int {
     get { return 9 }
     @available(OSX, unavailable)
-    set(newVal) {} // expected-error {{overriding setter for 'setterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
+    set(newVal) {} // expected-warning {{overriding setter for 'setterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     // This is a terrible diagnostic. rdar://problem/20427938
   }
 
   override var getterShouldAlwaysBeAvailableProperty: Int {
     @available(OSX, unavailable)
-    get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
+    get { return 9 } // expected-warning {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     set(newVal) {}
   }
 }

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -typecheck -verify -parse-stdlib -target x86_64-apple-ios51.0-macabi %s
 
-// REQUIRES: OS=maccatalyst
+// REQUIRES: VENDOR=apple
 
 @available(macCatalyst, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
            message: "you don't want to do that anyway")
@@ -52,6 +52,16 @@ func introducedLaterOnMacCatalyst() {
 func introducedLaterOnIOS() {
 }
 
+@available(iOS, introduced: 1.0)
+@available(macCatalyst, unavailable)
+func unavailableOnMacCatalyst() { // expected-note 3 {{'unavailableOnMacCatalyst()' has been explicitly marked unavailable here}}
+}
+
+@available(iOS, unavailable)
+@available(macCatalyst, introduced: 1.0)
+func unavailableOnIOS() {
+}
+
 // expected-note@+1 *{{add @available attribute to enclosing global function}}
 func testPoundAvailable() {
 
@@ -60,6 +70,9 @@ func testPoundAvailable() {
     // expected-note@-1 {{add 'if #available' version check}}
     introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
+
+    unavailableOnMacCatalyst() // expected-error {{'unavailableOnMacCatalyst()' is unavailable in Mac Catalyst}}
+    unavailableOnIOS()
   }
 
   // macCatalyst should win over iOS when present
@@ -69,6 +82,9 @@ func testPoundAvailable() {
     // expected-note@-1 {{add 'if #available' version check}}
     introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
+
+    unavailableOnMacCatalyst() // expected-error {{'unavailableOnMacCatalyst()' is unavailable in Mac Catalyst}}
+    unavailableOnIOS()
   }
 
   if #available(iOS 55.0, macCatalyst 56.0, *) {
@@ -88,6 +104,9 @@ func testPoundAvailable() {
     // expected-note@-1 {{add 'if #available' version check}}
     introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
+
+    unavailableOnMacCatalyst() // expected-error {{'unavailableOnMacCatalyst()' is unavailable in Mac Catalyst}}
+    unavailableOnIOS()
   }
 
   if #available(iOS 56.0, *) {


### PR DESCRIPTION
Inlinable and `@_alwaysEmitIntoClient` functions can be inlined in clients with a lower OS target version than the framework defining the function. For this reason, the availability in inlinable functions should always be checked by using the introduction OS version specified by the explicit attributes as lower bound and not the minimum deployment version of the framework.

A side-effect of this change is rejecting unavailable overrides to available methods, in a similar way as overrides that are less available than the introduction are rejected. I believe this is the intended behavior as it provided inconsistent diagnostics and surprising behaviors.

rdar://problem/67975153