### PR TITLE
[CodeCompletion] Reuse loaded ModuleFileSharedCore across ASTContexts

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -133,6 +133,9 @@ namespace swift {
     /// Only used by lldb-moduleimport-test.
     bool EnableMemoryBufferImporter = false;
 
+    /// Enable the ModuleFileSharedCoreRegistryImporter.
+    bool EnableModuleFileSharedCoreRegistryImporter = false;
+
     /// Allows using identifiers with a leading dollar.
     bool EnableDollarIdentifiers = false;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -54,6 +54,7 @@ namespace swift {
 
 class SerializedModuleLoaderBase;
 class MemoryBufferSerializedModuleLoader;
+class ModuleFileSharedCoreRegistryModuleLoader;
 class SILModule;
 
 namespace Lowering {
@@ -434,6 +435,7 @@ class CompilerInstance {
   mutable ModuleDecl *MainModule = nullptr;
   SerializedModuleLoaderBase *DefaultSerializedLoader = nullptr;
   MemoryBufferSerializedModuleLoader *MemoryBufferLoader = nullptr;
+  ModuleFileSharedCoreRegistryModuleLoader *ModuleFileSharedCoreLoader = nullptr;
 
   /// Contains buffer IDs for input source code files.
   std::vector<unsigned> InputSourceCodeBufferIDs;
@@ -511,6 +513,11 @@ public:
   MemoryBufferSerializedModuleLoader *
   getMemoryBufferSerializedModuleLoader() const {
     return MemoryBufferLoader;
+  }
+
+  ModuleFileSharedCoreRegistryModuleLoader *
+  getModuleFileSharedCoreRegistryModuleLoader() const {
+    return ModuleFileSharedCoreLoader;
   }
 
   ArrayRef<unsigned> getInputBufferIDs() const {

--- a/include/swift/Serialization/ModuleFileSharedCoreRegistryModuleLoader.h
+++ b/include/swift/Serialization/ModuleFileSharedCoreRegistryModuleLoader.h
@@ -1,0 +1,95 @@
+//===--- ModuleFileSharedCoreRegistryModuleLoader.h -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_MODULE_FILE_SHARED_CORE_REGISTRY_MODULE_LOADER_H
+#define SWIFT_MODULE_FILE_SHARED_CORE_REGISTRY_MODULE_LOADER_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace swift {
+class ModuleDecl;
+class ModuleFileSharedCore;
+
+class ModuleFileSharedCoreRegistry {
+public:
+  struct Value {
+    std::shared_ptr<const ModuleFileSharedCore> ModuleFileCore;
+    bool IsSystemModule;
+
+    Value(std::shared_ptr<const ModuleFileSharedCore> ModuleFileCore,
+          bool IsSystemModule)
+        : ModuleFileCore(ModuleFileCore), IsSystemModule(IsSystemModule) {}
+
+    Value() : Value(nullptr, false) {}
+  };
+
+private:
+  llvm::StringMap<Value> Storage;
+
+public:
+  ModuleFileSharedCoreRegistry() {}
+
+  /// Clear the registry.
+  void clear();
+
+  /// Add a module to the registry.
+  void registerModule(ModuleDecl *M);
+
+  /// Lookup a module by name in the registry.
+  Value lookup(StringRef name) const;
+};
+
+class ModuleFileSharedCoreRegistryModuleLoader
+    : public SerializedModuleLoaderBase {
+  std::shared_ptr<ModuleFileSharedCoreRegistry> Registry;
+
+  ModuleFileSharedCoreRegistryModuleLoader(ASTContext &ctx,
+                                           DependencyTracker *tracker,
+                                           ModuleLoadingMode loadMode,
+                                           bool IgnoreSwiftSourceInfo)
+      : SerializedModuleLoaderBase(ctx, tracker, loadMode,
+                                   IgnoreSwiftSourceInfo) {}
+
+public:
+  void
+  setRegistry(const std::shared_ptr<ModuleFileSharedCoreRegistry> &Registry) {
+    this->Registry = Registry;
+  }
+
+  void collectVisibleTopLevelModuleNames(
+      SmallVectorImpl<Identifier> &names) const override{};
+  std::error_code findModuleFilesInDirectory(
+      AccessPathElem ModuleID, const SerializedModuleBaseName &BaseName,
+      SmallVectorImpl<char> *ModuleInterfacePath,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsFramework) override;
+
+  bool canImportModule(Located<Identifier> named) override;
+  ModuleDecl *loadModule(SourceLoc importLoc,
+                         ArrayRef<Located<Identifier>> path) override;
+
+  static std::unique_ptr<ModuleFileSharedCoreRegistryModuleLoader>
+  create(ASTContext &ctx, DependencyTracker *tracker) {
+    return std::unique_ptr<ModuleFileSharedCoreRegistryModuleLoader>{
+        new ModuleFileSharedCoreRegistryModuleLoader(
+            ctx, tracker, ModuleLoadingMode::OnlySerialized,
+            /*IgnoreSwiftSourceInfo=*/true)};
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -16,10 +16,14 @@
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
+#include "swift/Serialization/Validation.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 namespace swift {
 class ModuleFile;
+class ModuleFileSharedCore;
+class ModuleFileSharedCoreRegistry;
+
 namespace file_types {
   enum ID : uint8_t;
 }
@@ -149,6 +153,10 @@ public:
   SerializedModuleLoaderBase(SerializedModuleLoaderBase &&) = delete;
   SerializedModuleLoaderBase &operator=(const SerializedModuleLoaderBase &) = delete;
   SerializedModuleLoaderBase &operator=(SerializedModuleLoaderBase &&) = delete;
+
+  serialization::Status loadAST(ModuleDecl &M, Optional<SourceLoc> diagLoc,
+                                std::unique_ptr<ModuleFile> &loadedModuleFile,
+                                FileUnit *&fileUnit);
 
   /// Attempt to load a serialized AST into the given module.
   ///
@@ -324,6 +332,7 @@ class SerializedASTFile final : public LoadedFile {
   friend class SerializedModuleLoaderBase;
   friend class SerializedSILLoader;
   friend class ModuleFile;
+  friend class ModuleFileSharedCoreRegistry;
 
   ModuleFile &File;
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -31,6 +31,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
+#include "swift/Serialization/ModuleFileSharedCoreRegistryModuleLoader.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/ModuleDependencyScanner.h"
@@ -477,6 +478,13 @@ bool CompilerInstance::setUpModuleLoaders() {
         *Context, getDependencyTracker(), MLM, IgnoreSourceInfoFile);
     this->MemoryBufferLoader = MemoryBufferLoader.get();
     Context->addModuleLoader(std::move(MemoryBufferLoader));
+  }
+
+  if (Invocation.getLangOptions().EnableModuleFileSharedCoreRegistryImporter) {
+    auto SharedCoreLoader = ModuleFileSharedCoreRegistryModuleLoader::create(
+        *Context, getDependencyTracker());
+    this->ModuleFileSharedCoreLoader = SharedCoreLoader.get();
+    Context->addModuleLoader(std::move(SharedCoreLoader));
   }
 
   // Wire up the Clang importer. If the user has specified an SDK, use it.

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_host_library(swiftSerialization STATIC
   ModuleDependencyScanner.cpp
   ModuleFile.cpp
   ModuleFileSharedCore.cpp
+  ModuleFileSharedCoreRegistryModuleLoader.cpp
   Serialization.cpp
   SerializedModuleLoader.cpp
   SerializedSILLoader.cpp

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -428,6 +428,10 @@ public:
   // Out of line to avoid instantiation OnDiskChainedHashTable here.
   ~ModuleFile();
 
+  std::shared_ptr<const ModuleFileSharedCore> getCore() const {
+    return Core;
+  }
+
   /// The name of the module.
   StringRef getName() const {
     return Core->Name;
@@ -622,10 +626,7 @@ public:
   void getDisplayDecls(SmallVectorImpl<Decl*> &results);
 
   StringRef getModuleFilename() const {
-    if (!Core->ModuleInterfacePath.empty())
-      return Core->ModuleInterfacePath;
-    // FIXME: This seems fragile, maybe store the filename separately ?
-    return Core->ModuleInputBuffer->getBufferIdentifier();
+    return Core->getModuleFilename();
   }
 
   StringRef getTargetTriple() const {

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -491,6 +491,13 @@ public:
   ArrayRef<Dependency> getDependencies() const {
     return Dependencies;
   }
+
+  StringRef getModuleFilename() const {
+    if (!ModuleInterfacePath.empty())
+      return ModuleInterfacePath;
+    // FIXME: This seems fragile, maybe store the filename separately ?
+    return ModuleInputBuffer->getBufferIdentifier();
+  }
 };
 
 template <typename T, typename RawData>

--- a/lib/Serialization/ModuleFileSharedCoreRegistryModuleLoader.cpp
+++ b/lib/Serialization/ModuleFileSharedCoreRegistryModuleLoader.cpp
@@ -1,0 +1,105 @@
+//===--- ModuleFileSharedCoreRegistryModuleLoader.cpp -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Serialization/ModuleFileSharedCoreRegistryModuleLoader.h"
+
+#include "ModuleFile.h"
+#include "ModuleFileSharedCore.h"
+#include "Serialization.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ModuleLoader.h"
+
+using namespace swift;
+
+void ModuleFileSharedCoreRegistry::clear() { Storage.clear(); }
+
+void ModuleFileSharedCoreRegistry::registerModule(ModuleDecl *M) {
+  if (M->failedToLoad() || M->getFiles().empty())
+    return;
+
+  std::shared_ptr<const ModuleFileSharedCore> moduleCore;
+
+  if (M->isNonSwiftModule()) {
+    // TODO: Support clang modules.
+    return;
+  } else if (auto ASTFile =
+                 dyn_cast<SerializedASTFile>(M->getFiles().front())) {
+    moduleCore = ASTFile->File.getCore();
+  } else {
+    return;
+  }
+
+  //  llvm::errs() << "RegisterModule: " << M->getName() << "\n";
+  Storage.insert({M->getName().str(), {moduleCore, M->isSystemModule()}});
+}
+
+ModuleFileSharedCoreRegistry::Value
+ModuleFileSharedCoreRegistry::lookup(StringRef name) const {
+  return Storage.lookup(name);
+}
+
+std::error_code
+ModuleFileSharedCoreRegistryModuleLoader::findModuleFilesInDirectory(
+    AccessPathElem ModuleID, const SerializedModuleBaseName &BaseName,
+    SmallVectorImpl<char> *ModuleInterfacePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsFramework) {
+  // This is a soft error instead of an llvm_unreachable because this API is
+  // primarily used by LLDB which makes it more likely that unwitting changes to
+  // the Swift compiler accidentally break the contract.
+  assert(false && "not supported");
+  return std::make_error_code(std::errc::not_supported);
+}
+
+bool ModuleFileSharedCoreRegistryModuleLoader::canImportModule(
+    Located<Identifier> named) {
+  assert(Registry);
+  return bool(Registry->lookup(named.Item.str()).ModuleFileCore);
+}
+
+ModuleDecl *ModuleFileSharedCoreRegistryModuleLoader::loadModule(
+    SourceLoc importLoc, ArrayRef<Located<Identifier>> path) {
+  assert(Registry);
+
+  // TODO: How to support submodules?
+  if (path.size() > 1)
+    return nullptr;
+
+  const auto &moduleID = path[0];
+
+  auto cached = Registry->lookup(moduleID.Item.str());
+  if (!cached.ModuleFileCore)
+    return nullptr;
+
+  if (dependencyTracker)
+    dependencyTracker->addDependency(cached.ModuleFileCore->getModuleFilename(),
+                                     cached.IsSystemModule);
+
+  auto *M = ModuleDecl::create(moduleID.Item, Ctx);
+  M->setIsSystemModule(cached.IsSystemModule);
+  Ctx.addLoadedModule(M);
+  SWIFT_DEFER { M->setHasResolvedImports(); };
+
+  std::unique_ptr<ModuleFile> loadedModuleFile =
+      std::make_unique<ModuleFile>(cached.ModuleFileCore);
+  FileUnit *file = nullptr;
+  auto status = loadAST(*M, importLoc, loadedModuleFile, file);
+  if (status == serialization::Status::Valid) {
+    M->addFile(*file);
+  } else {
+    M->setFailedToLoad();
+  }
+
+  return M;
+}

--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -38,6 +38,9 @@ public:
     bool OptimizeForIDE = false;
 
     struct CompletionOptions {
+      /// When true, code completion tries to reuse loaded modules across
+      /// ASTContext sessions.
+      bool ReuseLoadedModules = false;
 
       /// Max count of reusing ASTContext for cached code completion.
       unsigned MaxASTContextReuseCount = 100;
@@ -53,6 +56,7 @@ private:
 
 public:
   Settings update(Optional<bool> OptimizeForIDE,
+                  Optional<bool> CompletionReuseLoadedModules,
                   Optional<unsigned> CompletionMaxASTContextReuseCount,
                   Optional<unsigned> CompletionCheckDependencyInterval);
   bool shouldOptimizeForIDE() const;

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -18,11 +18,14 @@ using namespace SourceKit;
 
 GlobalConfig::Settings
 GlobalConfig::update(Optional<bool> OptimizeForIDE,
+                     Optional<bool> CompletionReuseLoadedModules,
                      Optional<unsigned> CompletionMaxASTContextReuseCount,
                      Optional<unsigned> CompletionCheckDependencyInterval) {
   llvm::sys::ScopedLock L(Mtx);
   if (OptimizeForIDE.hasValue())
     State.OptimizeForIDE = *OptimizeForIDE;
+  if (CompletionReuseLoadedModules.hasValue())
+    State.CompletionOpts.ReuseLoadedModules = *CompletionReuseLoadedModules;
   if (CompletionMaxASTContextReuseCount.hasValue())
     State.CompletionOpts.MaxASTContextReuseCount =
         *CompletionMaxASTContextReuseCount;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -266,6 +266,7 @@ configureCompletionInstance(std::shared_ptr<CompletionInstance> CompletionInst,
                             std::shared_ptr<GlobalConfig> GlobalConfig) {
   auto Opts = GlobalConfig->getCompletionOpts();
   CompletionInst->setOptions({
+    Opts.ReuseLoadedModules,
     Opts.MaxASTContextReuseCount,
     Opts.CheckDependencyInterval
   });

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -440,6 +440,9 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     Optional<bool> OptimizeForIDE =
         Req.getOptionalInt64(KeyOptimizeForIDE)
             .map([](int64_t v) -> bool { return v; });
+    Optional<bool> CompletionReuseLoadedModules =
+        Req.getOptionalInt64(KeyCompletionReuseLoadedModules)
+            .map([](int64_t v) -> bool { return v; });
     Optional<unsigned> CompletionMaxASTContextReuseCount =
         Req.getOptionalInt64(KeyCompletionMaxASTContextReuseCount)
             .map([](int64_t v) -> unsigned { return v; });
@@ -447,13 +450,15 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
         Req.getOptionalInt64(KeyCompletionCheckDependencyInterval)
             .map([](int64_t v) -> unsigned { return v; });
 
-    GlobalConfig::Settings UpdatedConfig =
-        Config->update(OptimizeForIDE, CompletionMaxASTContextReuseCount,
-                       CompletionCheckDependencyInterval);
+    GlobalConfig::Settings UpdatedConfig = Config->update(
+        OptimizeForIDE, CompletionReuseLoadedModules,
+        CompletionMaxASTContextReuseCount, CompletionCheckDependencyInterval);
 
     getGlobalContext().getSwiftLangSupport().globalConfigurationUpdated(Config);
 
     dict.set(KeyOptimizeForIDE, UpdatedConfig.OptimizeForIDE);
+    dict.set(KeyCompletionReuseLoadedModules,
+             UpdatedConfig.CompletionOpts.ReuseLoadedModules);
     dict.set(KeyCompletionMaxASTContextReuseCount,
              UpdatedConfig.CompletionOpts.MaxASTContextReuseCount);
     dict.set(KeyCompletionCheckDependencyInterval,

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -181,6 +181,8 @@ UID_KEYS = [
     KEY('OptimizeForIDE', 'key.optimize_for_ide'),
     KEY('RequiredBystanders', 'key.required_bystanders'),
     KEY('ReusingASTContext', 'key.reusingastcontext'),
+    KEY('CompletionReuseLoadedModules',
+        'key.completion_reuse_loaded_modules'),
     KEY('CompletionMaxASTContextReuseCount',
         'key.completion_max_astcontext_reuse_count'),
     KEY('CompletionCheckDependencyInterval',


### PR DESCRIPTION
Loading module files and initializing `ModuleFileSharedCore` have some cost. Since `ModuleFileSharedCore` is ASTContext-independent, we can reuse initialized `ModuleFileSharedCore` across multiple ASTContext sessions.

Introduce `ModuleFileSharedCoreRegistryModuleLoader` which loads modules from cached `ModuleFileSharedCore` objects, and enable it in code completion.

rdar://problem/65895681

