### PR TITLE
GSB: Watch out for a concrete ResolvedType in ArchetypeType::resolveNestedType

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr13519.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13519.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+// https://bugs.swift.org/browse/SR-13519
+
+class Class: P {
+  typealias A = Bool
+}
+protocol P {
+  associatedtype A
+}
+protocol Q: P {
+  func takesA(arg: A)
+}
+
+func test<T: Class & Q>(arg: T) {
+  arg.takesA(arg: true)
+}
+


### PR DESCRIPTION
Resolves SR-13519

The regression was caused by 653fa07260497ab736c7667158e9e59226723af4, apparently. Under certain conditions, `maybeResolveEquivalenceClass` would look into the superclass of the base equiv. class to find a nested type, resulting in a concrete `ResolvedType` that is not associated with an equivalence class. `resolveEquivalenceClass` and at least one of its clients were not expecting this to happen.