### PR TITLE
[Diagnostics] Diagnose comparisons with '.nan' and suggest using '.isNan' instead

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3350,13 +3350,15 @@ ERROR(missing_builtin_precedence_group,none,
       "broken standard library: missing builtin precedence group %0",
       (Identifier))
 WARNING(nan_comparison, none, 
-       "comparison with '.nan' may lead to unexpected result, use "
-       "%select{'%0.isNan'|'.isNan'}1 to check for %select{presence|"
-       "absence|presence or absence}2 of NaN", 
-       (StringRef, bool, unsigned))
-WARNING(nan_comparison_constant, none, 
-       "'.nan' %select{==|!=}0 '.nan' is always %select{false|true}0", 
-       (bool))
+       "comparison with '.nan' using %0 is always %select{false|true}1, use "
+       "'%2.isNan' to check if '%3' %select{is not a number|is a number}1",
+       (Identifier, bool, StringRef, StringRef))
+WARNING(nan_comparison_without_isnan, none, 
+       "comparison with '.nan' using %0 is always %select{false|true}1", 
+       (Identifier, bool))
+WARNING(nan_comparison_both_nan, none, 
+       "'.nan' %0 '.nan' is always %select{false|true}1", 
+       (StringRef, bool))
 
 // If you change this, also change enum TryKindForDiagnostics.
 #define TRY_KIND_SELECT(SUB) "%select{try|try!|try?|await}" #SUB

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3349,6 +3349,14 @@ ERROR(unordered_adjacent_operators,none,
 ERROR(missing_builtin_precedence_group,none,
       "broken standard library: missing builtin precedence group %0",
       (Identifier))
+WARNING(nan_comparison, none, 
+       "comparison with '.nan' may lead to unexpected result, use "
+       "%select{'%0.isNan'|'.isNan'}1 to check for %select{presence|"
+       "absence|presence or absence}2 of NaN", 
+       (StringRef, bool, unsigned))
+WARNING(nan_comparison_constant, none, 
+       "'.nan' %select{==|!=}0 '.nan' is always %select{false|true}0", 
+       (bool))
 
 // If you change this, also change enum TryKindForDiagnostics.
 #define TRY_KIND_SELECT(SUB) "%select{try|try!|try?|await}" #SUB

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3351,7 +3351,7 @@ ERROR(missing_builtin_precedence_group,none,
       (Identifier))
 WARNING(nan_comparison, none, 
        "comparison with '.nan' using %0 is always %select{false|true}1, use "
-       "'%2.isNan' to check if '%3' %select{is not a number|is a number}1",
+       "'%2.isNaN' to check if '%3' %select{is not a number|is a number}1",
        (Identifier, bool, StringRef, StringRef))
 WARNING(nan_comparison_without_isnan, none, 
        "comparison with '.nan' using %0 is always %select{false|true}1", 

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -109,7 +109,14 @@ public:
     // Handle the high unicode case out of line.
     return isOperatorSlow();
   }
-  
+
+  // Returns whether this is a standard comparison operator,
+  // such as '==', '>=' or '!=='.
+  bool isStandardComparisonOperator() const {
+    return is("==") || is("!=") || is("===") || is("!==") || is("<") ||
+           is(">") || is("<=") || is(">=");
+  }
+
   /// isOperatorStartCodePoint - Return true if the specified code point is a
   /// valid start of an operator.
   static bool isOperatorStartCodePoint(uint32_t C) {

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -87,6 +87,8 @@ PROTOCOL(StringInterpolationProtocol)
 PROTOCOL(AdditiveArithmetic)
 PROTOCOL(Differentiable)
 
+PROTOCOL(FloatingPoint)
+
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByDictionaryLiteral, "Dictionary", false)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5044,6 +5044,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::StringInterpolationProtocol:
   case KnownProtocolKind::AdditiveArithmetic:
   case KnownProtocolKind::Differentiable:
+  case KnownProtocolKind::FloatingPoint:
     return SpecialProtocol::None;
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -165,7 +165,7 @@ Type FailureDiagnostic::restoreGenericParameters(
 bool FailureDiagnostic::conformsToKnownProtocol(
     Type type, KnownProtocolKind protocol) const {
   auto &cs = getConstraintSystem();
-  return constraints::conformsToKnownProtocol(cs, type, protocol);
+  return constraints::conformsToKnownProtocol(cs.DC, type, protocol);
 }
 
 Type RequirementFailure::getOwnerType() const {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1767,11 +1767,11 @@ namespace {
 
         auto type = contextualType->lookThroughAllOptionalTypes();
         if (conformsToKnownProtocol(
-                CS, type, KnownProtocolKind::ExpressibleByArrayLiteral))
+                CS.DC, type, KnownProtocolKind::ExpressibleByArrayLiteral))
           return false;
 
         return conformsToKnownProtocol(
-            CS, type, KnownProtocolKind::ExpressibleByDictionaryLiteral);
+            CS.DC, type, KnownProtocolKind::ExpressibleByDictionaryLiteral);
       };
 
       if (isDictionaryContextualType(contextualType)) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3930,11 +3930,11 @@ bool constraints::hasAppliedSelf(const OverloadChoice &choice,
          doesMemberRefApplyCurriedSelf(baseType, decl);
 }
 
-bool constraints::conformsToKnownProtocol(ConstraintSystem &cs, Type type,
+bool constraints::conformsToKnownProtocol(DeclContext *dc, Type type,
                                           KnownProtocolKind protocol) {
   if (auto *proto =
-          TypeChecker::getProtocol(cs.getASTContext(), SourceLoc(), protocol))
-    return (bool)TypeChecker::conformsToProtocol(type, proto, cs.DC);
+          TypeChecker::getProtocol(dc->getASTContext(), SourceLoc(), protocol))
+    return (bool)TypeChecker::conformsToProtocol(type, proto, dc);
   return false;
 }
 
@@ -3959,7 +3959,8 @@ Type constraints::isRawRepresentable(
     ConstraintSystem &cs, Type type,
     KnownProtocolKind rawRepresentableProtocol) {
   Type rawTy = isRawRepresentable(cs, type);
-  if (!rawTy || !conformsToKnownProtocol(cs, rawTy, rawRepresentableProtocol))
+  if (!rawTy ||
+      !conformsToKnownProtocol(cs.DC, rawTy, rawRepresentableProtocol))
     return Type();
 
   return rawTy;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4253,9 +4253,7 @@ bool constraints::isStandardComparisonOperator(ASTNode node) {
   if (!expr) return false;
 
   if (auto opName = getOperatorName(expr)) {
-    return opName->is("==") || opName->is("!=") || opName->is("===") ||
-           opName->is("!==") || opName->is("<") || opName->is(">") ||
-           opName->is("<=") || opName->is(">=");
+    return opName->isStandardComparisonOperator();
   }
   return false;
 }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5505,7 +5505,7 @@ bool hasAppliedSelf(const OverloadChoice &choice,
                     llvm::function_ref<Type(Type)> getFixedType);
 
 /// Check whether type conforms to a given known protocol.
-bool conformsToKnownProtocol(ConstraintSystem &cs, Type type,
+bool conformsToKnownProtocol(DeclContext *dc, Type type,
                              KnownProtocolKind protocol);
 
 /// Check whether given type conforms to `RawPepresentable` protocol

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4450,12 +4450,12 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
     void tryDiagnoseComparisonWithNaN(BinaryExpr *BE) {
       ValueDecl *comparisonDecl = nullptr;
 
-      // The == and != methods take two arguments.
+      // Comparison functions like == or <= take two arguments.
       if (BE->getArg()->getNumElements() != 2) {
         return;
       }
 
-      // Dig out the function the arguments are being passed to.
+      // Dig out the function declaration.
       if (auto Fn = BE->getFn()) {
         if (auto DSCE = dyn_cast<DotSyntaxCallExpr>(Fn)) {
           comparisonDecl = DSCE->getCalledValue();
@@ -4489,7 +4489,7 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
       };
 
       if (!conformsToFpProto(firstArg->getType()) ||
-          !conformsToFpProto(firstArg->getType())) {
+          !conformsToFpProto(secondArg->getType())) {
         return;
       }
 
@@ -4525,7 +4525,7 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
       // the result is always false. If the comparison is done using '!=',
       // then the result is always true.
       //
-      // Emit a different diagnostic which doesn't mention using '.isNan' if
+      // Emit a different diagnostic which doesn't mention using '.isNaN' if
       // the comparison isn't done using '==' or '!=' or if both sides are
       // '.nan'.
       if (isNanDecl(firstVal) && isNanDecl(secondVal)) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4469,7 +4469,7 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
         return;
       }
 
-      // We're only interested in == and != functions.
+      // We're only interested in comparison functions like == or <=.
       auto comparisonDeclName = comparisonDecl->getBaseIdentifier();
       if (!(comparisonDeclName.is("==") || comparisonDeclName.is("!=") ||
             comparisonDeclName.is("<=") || comparisonDeclName.is("<") ||
@@ -4508,9 +4508,9 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
         secondVal = MRE->getMember().getDecl();
       }
 
-      // One of them has to be '.nan', so if we don't have declarations
-      // for both, then bail out.
-      if (!firstVal && !secondVal) {
+      // If we can't find declarations for both arguments, bail out,
+      // because one of them has to be '.nan'.
+      if (!firstArg && !secondArg) {
         return;
       }
 
@@ -4531,7 +4531,7 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
       if (isNanDecl(firstVal) && isNanDecl(secondVal)) {
         C.Diags.diagnose(BE->getLoc(), diag::nan_comparison_both_nan,
                          comparisonDeclName.str(), comparisonDeclName.is("!="));
-      } else {
+      } else if (isNanDecl(firstVal) || isNanDecl(secondVal)) {
         if (comparisonDeclName.is("==") || comparisonDeclName.is("!=")) {
           auto exprStr =
               C.SourceMgr

--- a/test/decl/var/nan_comparisons.swift
+++ b/test/decl/var/nan_comparisons.swift
@@ -1,10 +1,30 @@
 // RUN: %target-typecheck-verify-swift
 
-// Comparison with '.nan' static property instead of using '.isNan' instance property.
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/////// Comparison with '.nan' static property instead of using '.isNan' instance property ///////
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+// MARK: One side is '.nan' and the other isn't. Using '==' or '!=' for comparison should suggest
 
 let double: Double = 0.0
-_ = double == .nan // expected-warning {{comparison with '.nan' may lead to unexpected result, use 'double.isNan' to check for presence of NaN}}
-_ = double != .nan // expected-warning {{comparison with '.nan' may lead to unexpected result, use '!double.isNan' to check for absence of NaN}}
-_ = 0.0 == .nan // // expected-warning {{comparison with '.nan' may lead to unexpected result, use '.isNan' to check for presence or absence of NaN}}
+_ = double == .nan // expected-warning {{comparison with '.nan' using '==' is always false, use 'double.isNan' to check if 'double' is not a number}}
+_ = double != .nan // expected-warning {{comparison with '.nan' using '!=' is always true, use '!double.isNan' to check if 'double' is a number}}
+_ = 0.0 == .nan // // expected-warning {{comparison with '.nan' using '==' is always false, use '0.0.isNan' to check if '0.0' is not a number}}
+
+// MARK: One side is '.nan' and the other isn't. Using '>=', '>', '<', '<=' for comparison:
+// We can't suggest using '.isNan' here.
+
+_ = 0.0 >= .nan // expected-warning {{comparison with '.nan' using '>=' is always false}}
+_ = .nan > 1.1 // expected-warning {{comparison with '.nan' using '>' is always false}}
+_ = .nan < 2.2 // expected-warning {{comparison with '.nan' using '<' is always false}}
+_ = 3.3 <= .nan // expected-warning {{comparison with '.nan' using '<=' is always false}}
+
+// MARK: Both sides are '.nan':
+// We can't suggest using '.isNan' here.
+
 _ = Double.nan == Double.nan // expected-warning {{'.nan' == '.nan' is always false}}
 _ = Double.nan != Double.nan // expected-warning {{'.nan' != '.nan' is always true}}
+_ = Double.nan < Double.nan // expected-warning {{'.nan' < '.nan' is always false}}
+_ = Double.nan <= Double.nan // expected-warning {{'.nan' <= '.nan' is always false}}
+_ = Double.nan > Double.nan // expected-warning {{'.nan' > '.nan' is always false}}
+_ = Double.nan >= Double.nan // expected-warning {{'.nan' >= '.nan' is always false}}

--- a/test/decl/var/nan_comparisons.swift
+++ b/test/decl/var/nan_comparisons.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+// Comparison with '.nan' static property instead of using '.isNan' instance property.
+
+let double: Double = 0.0
+_ = double == .nan // expected-warning {{comparison with '.nan' may lead to unexpected result, use 'double.isNan' to check for presence of NaN}}
+_ = double != .nan // expected-warning {{comparison with '.nan' may lead to unexpected result, use '!double.isNan' to check for absence of NaN}}
+_ = 0.0 == .nan // // expected-warning {{comparison with '.nan' may lead to unexpected result, use '.isNan' to check for presence or absence of NaN}}
+_ = Double.nan == Double.nan // expected-warning {{'.nan' == '.nan' is always false}}
+_ = Double.nan != Double.nan // expected-warning {{'.nan' != '.nan' is always true}}

--- a/test/decl/var/nan_comparisons.swift
+++ b/test/decl/var/nan_comparisons.swift
@@ -4,14 +4,15 @@
 /////// Comparison with '.nan' static property instead of using '.isNan' instance property ///////
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-// MARK: One side is '.nan' and the other isn't. Using '==' or '!=' for comparison should suggest
+// One side is '.nan' and the other isn't.
+// Using '==' or '!=' for comparison should suggest using '.isNan'.
 
 let double: Double = 0.0
 _ = double == .nan // expected-warning {{comparison with '.nan' using '==' is always false, use 'double.isNan' to check if 'double' is not a number}}
 _ = double != .nan // expected-warning {{comparison with '.nan' using '!=' is always true, use '!double.isNan' to check if 'double' is a number}}
 _ = 0.0 == .nan // // expected-warning {{comparison with '.nan' using '==' is always false, use '0.0.isNan' to check if '0.0' is not a number}}
 
-// MARK: One side is '.nan' and the other isn't. Using '>=', '>', '<', '<=' for comparison:
+// One side is '.nan' and the other isn't. Using '>=', '>', '<', '<=' for comparison:
 // We can't suggest using '.isNan' here.
 
 _ = 0.0 >= .nan // expected-warning {{comparison with '.nan' using '>=' is always false}}
@@ -19,7 +20,7 @@ _ = .nan > 1.1 // expected-warning {{comparison with '.nan' using '>' is always 
 _ = .nan < 2.2 // expected-warning {{comparison with '.nan' using '<' is always false}}
 _ = 3.3 <= .nan // expected-warning {{comparison with '.nan' using '<=' is always false}}
 
-// MARK: Both sides are '.nan':
+// Both sides are '.nan':
 // We can't suggest using '.isNan' here.
 
 _ = Double.nan == Double.nan // expected-warning {{'.nan' == '.nan' is always false}}

--- a/test/decl/var/nan_comparisons.swift
+++ b/test/decl/var/nan_comparisons.swift
@@ -1,19 +1,19 @@
 // RUN: %target-typecheck-verify-swift
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-/////// Comparison with '.nan' static property instead of using '.isNan' instance property ///////
+/////// Comparison with '.nan' static property instead of using '.isNaN' instance property ///////
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 // One side is '.nan' and the other isn't.
-// Using '==' or '!=' for comparison should suggest using '.isNan'.
+// Using '==' or '!=' for comparison should suggest using '.isNaN'.
 
 let double: Double = 0.0
-_ = double == .nan // expected-warning {{comparison with '.nan' using '==' is always false, use 'double.isNan' to check if 'double' is not a number}}
-_ = double != .nan // expected-warning {{comparison with '.nan' using '!=' is always true, use '!double.isNan' to check if 'double' is a number}}
-_ = 0.0 == .nan // // expected-warning {{comparison with '.nan' using '==' is always false, use '0.0.isNan' to check if '0.0' is not a number}}
+_ = double == .nan // expected-warning {{comparison with '.nan' using '==' is always false, use 'double.isNaN' to check if 'double' is not a number}}
+_ = double != .nan // expected-warning {{comparison with '.nan' using '!=' is always true, use '!double.isNaN' to check if 'double' is a number}}
+_ = 0.0 == .nan // // expected-warning {{comparison with '.nan' using '==' is always false, use '0.0.isNaN' to check if '0.0' is not a number}}
 
 // One side is '.nan' and the other isn't. Using '>=', '>', '<', '<=' for comparison:
-// We can't suggest using '.isNan' here.
+// We can't suggest using '.isNaN' here.
 
 _ = 0.0 >= .nan // expected-warning {{comparison with '.nan' using '>=' is always false}}
 _ = .nan > 1.1 // expected-warning {{comparison with '.nan' using '>' is always false}}
@@ -21,7 +21,7 @@ _ = .nan < 2.2 // expected-warning {{comparison with '.nan' using '<' is always 
 _ = 3.3 <= .nan // expected-warning {{comparison with '.nan' using '<=' is always false}}
 
 // Both sides are '.nan':
-// We can't suggest using '.isNan' here.
+// We can't suggest using '.isNaN' here.
 
 _ = Double.nan == Double.nan // expected-warning {{'.nan' == '.nan' is always false}}
 _ = Double.nan != Double.nan // expected-warning {{'.nan' != '.nan' is always true}}


### PR DESCRIPTION
This is based on a suggestion from @stephentyrone on Twitter: https://twitter.com/stephentyrone/status/1302702935831384071

---

It is a pretty common mistake to compare values to the `.nan` static property, instead of using the `.isNaN` instance property when checking for the presence or absence of NaN.

According to [isNaN documentation](https://developer.apple.com/documentation/swift/floatingpoint/1641763-isnan):

> Because NaN is not equal to any value, including NaN, use this property instead of the equal-to operator (==) or not-equal-to operator (!=) to test whether a value is or is not NaN.

So, diagnose comparisons using `==`, `>=` and etc when either of the arguments is `.nan` from `FloatingPoint` protocol. For example:

```swift
2.0 >= .nan // warning

let value = 0.1
value == .nan // warning
```

and suggest using `isNaN` when applicable.