### PR TITLE
[Sema] Evaluate SPI groups for all decls, not only public ones

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2049,10 +2049,8 @@ bool Decl::isSPI() const {
 }
 
 ArrayRef<Identifier> Decl::getSPIGroups() const {
-  if (auto vd = dyn_cast<ValueDecl>(this)) {
-    if (vd->getFormalAccess() < AccessLevel::Public)
-      return ArrayRef<Identifier>();
-  } else if (!isa<ExtensionDecl>(this))
+  if (!isa<ValueDecl>(this) &&
+      !isa<ExtensionDecl>(this))
     return ArrayRef<Identifier>();
 
   return evaluateOrDefault(getASTContext().evaluator,
@@ -2063,10 +2061,8 @@ ArrayRef<Identifier> Decl::getSPIGroups() const {
 llvm::ArrayRef<Identifier>
 SPIGroupsRequest::evaluate(Evaluator &evaluator, const Decl *decl) const {
   // Applies only to public ValueDecls and ExtensionDecls.
-  if (auto vd = dyn_cast<ValueDecl>(decl))
-    assert(vd->getFormalAccess() >= AccessLevel::Public);
-  else
-    assert(isa<ExtensionDecl>(decl));
+  assert (isa<ValueDecl>(decl) ||
+          isa<ExtensionDecl>(decl));
 
   // First, look for local attributes.
   llvm::SetVector<Identifier> spiGroups;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -885,7 +885,8 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     // VD must be public or open to use an @_spi attribute.
     auto declAccess = VD->getFormalAccess();
-    if (declAccess < AccessLevel::Public) {
+    if (declAccess < AccessLevel::Public &&
+        !VD->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
       diagnoseAndRemoveAttr(attr,
                             diag::spi_attribute_on_non_public,
                             declAccess,

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -1,7 +1,10 @@
-// Checks for SPI declarations and limited exposability
+// Checks for SPI declarations and limited exportability.
 
 // RUN: %empty-directory(%t)
 // RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown -enable-library-evolution -swift-version 5
+
+// Without -enable-library-evolution the exportability check looks at struct internal properties.
+// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown -swift-version 5
 
 // SPI declarations
 @_spi(MySPI) public func spiFunc() {} // expected-note {{global function 'spiFunc()' is not '@usableFromInline' or public}}
@@ -54,4 +57,27 @@ public func genFuncBad<T: SPIProtocol>(_ t: T) {} // expected-error {{cannot use
 public struct PublicStructWithProperties {
   public var a: SPIClass // expected-error {{cannot use class 'SPIClass' here; it is SPI}}
   public var b = SPIClass() // expected-error {{cannot use class 'SPIClass' here; it is SPI}}
+}
+
+@_spi(S)
+@usableFromInline
+func usableFromInlineFunc(_ a: SPIStruct) -> SPIStruct {
+  fatalError()
+}
+
+@_spi(S)
+public final class ClassWithUsables {
+    @usableFromInline
+    var usableFromInlineVar = SPIClass()
+
+    @usableFromInline
+    func usableFromInlineFunc(_ a: SPIStruct) -> SPIStruct {
+      fatalError()
+    }
+}
+
+@_spi(S)
+public struct NestedParent {
+    public struct Nested { }
+    let nested: Nested
 }

--- a/test/Sema/spi-inlinable-conformances.swift
+++ b/test/Sema/spi-inlinable-conformances.swift
@@ -241,9 +241,8 @@ extension NormalProtoAssocHolder {
 
 @_spi(AcceptInSPI)
 @inlinable public func SPIlocalTypeAlias() {
-  // FIXME these should be accepted.
-  typealias LocalUser = NormalProtoAssocHolder<NormalStruct> // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
-  typealias LocalGenericUser<T> = (T, NormalProtoAssocHolder<NormalStruct>) // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
+  typealias LocalUser = NormalProtoAssocHolder<NormalStruct>
+  typealias LocalGenericUser<T> = (T, NormalProtoAssocHolder<NormalStruct>)
 
   typealias LocalProtoAssoc<T: NormalProto> = T.Assoc
   _ = LocalProtoAssoc<NormalStruct>()
@@ -258,9 +257,8 @@ extension NormalProtoAssocHolder {
 
 @_spi(AcceptInSPI)
 @inlinable public func SPIlocalFunctions() {
-  // FIXME these should be accepted.
-  func local(_: NormalProtoAssocHolder<NormalStruct>) {} // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
-  func localReturn() -> NormalProtoAssocHolder<NormalStruct> { fatalError() } // expected-error{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
+  func local(_: NormalProtoAssocHolder<NormalStruct>) {}
+  func localReturn() -> NormalProtoAssocHolder<NormalStruct> { fatalError() }
   let _ = { (_: NormalProtoAssocHolder<NormalStruct>) in return }
   let _ = { () -> NormalProtoAssocHolder<NormalStruct> in fatalError() }
 }


### PR DESCRIPTION
Remove the fast path skipping evaluating SPI groups for non-public decls. This knowledge is still required to allow the use of SPI types in the signatures of `@usableFromInline` declarations and in internal properties of structs in non library evolution compilation.

rdar://68530659
rdar://68527580