### PR TITLE
[stdlib] Silence a few assert related warnings

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -733,6 +733,7 @@ MetadataResponse swift::swift_getCanonicalSpecializedMetadata(
       auto key = MetadataCacheKey(cache.NumKeyParameters, cache.NumWitnessTables,
                                   arguments);
       auto result = cache.getOrInsert(key, MetadataRequest(MetadataState::Complete, /*isNonBlocking*/true), canonicalMetadata);
+      (void)result;
       assert(result.second.Value == canonicalMetadata);
     }
   } else {
@@ -744,6 +745,7 @@ MetadataResponse swift::swift_getCanonicalSpecializedMetadata(
       auto key = MetadataCacheKey(cache.NumKeyParameters, cache.NumWitnessTables,
                                   arguments);
       auto result = cache.getOrInsert(key, MetadataRequest(MetadataState::Complete, /*isNonBlocking*/true), canonicalMetadata);
+      (void)result;
       assert(result.second.Value == canonicalMetadata);
     }
   }

--- a/stdlib/public/stubs/OptionalBridgingHelper.mm
+++ b/stdlib/public/stubs/OptionalBridgingHelper.mm
@@ -48,6 +48,7 @@ using namespace swift;
   int fmtResult = asprintf(&str, "<%s %p depth = %u>", clsName,
                                                        (void*)self,
                                                        self->depth);
+  (void)fmtResult;
   assert(fmtResult != -1 && "unable to format description of null");
   id result = swift_stdlib_NSStringFromUTF8(str, strlen(str));
   free(str);


### PR DESCRIPTION
Silences warnings on variables that used only to check asserts. These variables appear unused to the compiler in no-assert builds.