### PR TITLE
[cxx-interop] Replace inline member "operator+" with "operator-".

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -3,7 +3,7 @@
 
 struct IntBox {
   int value;
-  IntBox operator+(IntBox rhs) { return IntBox{.value = value + rhs.value}; }
+  IntBox operator-(IntBox rhs) { return IntBox{.value = value - rhs.value}; }
 };
 
 #endif

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -5,7 +5,7 @@
 
 import MemberInline
 
-public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+public func sub(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs - rhs }
 
-// CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN6IntBoxplES_|"\?\?HIntBox@@QEAA\?AU0@U0@@Z")]](%struct.IntBox* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval align 4}} {{%[0-9]+}})
+// CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN6IntBoxmiES_|"\?\?GIntBox@@QEAA\?AU0@U0@@Z")]](%struct.IntBox* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval align 4}} {{%[0-9]+}})
 // CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.IntBox* %this, {{i32 %rhs.coerce|\[1 x i32\] %rhs.coerce|i64 %rhs.coerce|%struct.IntBox\* byval\(%struct.IntBox\) align 4 %rhs}})

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK: struct IntBox {
-// CHECK:   static func + (lhs: inout IntBox, rhs: IntBox) -> IntBox
+// CHECK:   static func - (lhs: inout IntBox, rhs: IntBox) -> IntBox
 // CHECK: }

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -2,13 +2,13 @@
 
 import MemberInline
 
-public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+public func sub(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs - rhs }
 
 // CHECK: bb0([[SELF:%.*]] : $*IntBox, [[RHS:%.*]] : $IntBox):
 
 // CHECK: [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*IntBox
-// CHECK: [[OP:%.*]] = function_ref [[NAME:@(_ZN6IntBoxplES_|\?\?HIntBox@@QEAA\?AU0@U0@@Z)]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK: [[OP:%.*]] = function_ref [[NAME:@(_ZN6IntBoxmiES_|\?\?GIntBox@@QEAA\?AU0@U0@@Z)]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
 // CHECK: apply [[OP]]([[SELFACCESS]], [[RHS]]) : $@convention(c) (@inout IntBox, IntBox) -> IntBox
 // CHECK: end_access [[SELFACCESS]] : $*IntBox
 
-// CHECK: sil [clang IntBox."+"] [[NAME]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK: sil [clang IntBox."-"] [[NAME]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -5,4 +5,4 @@ import MemberInline
 var lhs = IntBox(value: 42)
 let rhs = IntBox(value: 23)
 
-let resultPlus = lhs + rhs
+let resultPlus = lhs - rhs

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -14,9 +14,9 @@ OperatorsTestSuite.test("plus") {
   var lhs = IntBox(value: 42)
   let rhs = IntBox(value: 23)
 
-  let result = lhs + rhs
+  let result = lhs - rhs
 
-  expectEqual(65, result.value)
+  expectEqual(19, result.value)
 }
 
 runAllTests()


### PR DESCRIPTION
Adding integers is a commutative operation meaning the old tests would fail to detect an error if the arguments were passed in the wrong order. Testing inline member operators using subtraction ensures that arguments are passed in the correct order.

[Refs](https://github.com/apple/swift/pull/32869/files#r457349610).