### PR TITLE
[ConstraintSystem] Adjust impact of a missing member fix

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7168,17 +7168,18 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
                                MemberLookupResult::ErrorAlreadyDiagnosed);
       auto *fix = DefineMemberBasedOnUse::create(*this, baseTy, member,
                                                  alreadyDiagnosed, locator);
-      // Impact is higher if the base is expected to be inferred from context,
-      // because a failure to find a member ultimately means that base type is
-      // not a match in this case.
-      auto impact =
-          locator->findLast<LocatorPathElt::UnresolvedMember>() ? 2 : 1;
 
+      auto instanceTy = baseObjTy->getMetatypeInstanceType();
+
+      auto impact = 2;
       // Impact is higher if the the base type is any function type
       // because function types can't have any members other than self
-      if (baseObjTy->is<AnyFunctionType>()) {
-          impact += 10;
+      if (instanceTy->is<AnyFunctionType>()) {
+        impact += 10;
       }
+
+      if (instanceTy->isAny() || instanceTy->isAnyObject())
+        impact += 5;
 
       if (recordFix(fix, impact))
         return SolutionKind::Error;

--- a/test/Constraints/rdar68155466.swift
+++ b/test/Constraints/rdar68155466.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class A : NSObject {
+  func uniqueID() -> Int {
+    42
+  }
+}
+
+struct Loop< // expected-note {{required by generic struct 'Loop' where 'ID' = '() -> Int'}}
+  Data : RandomAccessCollection,
+  ID : Hashable,
+  Content
+> {
+  public init(
+    _ data: Data,
+    id: KeyPath<Data.Element, ID>,
+    content: @escaping (Data.Element) -> Content) {}
+}
+
+func data() -> [A] {
+  return []
+}
+
+_ = Loop(data(), id: \.uniqueID) { $0 } // expected-error {{key path cannot refer to instance method 'uniqueID()'}}
+// expected-error@-1 {{type '() -> Int' cannot conform to 'Hashable'; only concrete types such as structs, enums and classes can conform to protocols}}


### PR DESCRIPTION
Currently its impact is set to be less than that of a conversion fix,
which is incorrect. Let's adjust that and increase it even farther for
cases where base is `Any` or `AnyObject`. We couldn't do it for `Any`
before because it was used to represent type holes, but it's no longer
the case.

Resolves: rdar://problem/68155466

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
