### PR TITLE
Stop ReplaceOpaqueTypesWithUnderlyingTypes recursion if it hits a fixpoint.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3063,8 +3063,8 @@ operator()(SubstitutableType *maybeOpaqueType) const {
           }))
     return maybeOpaqueType;
 
-  // If the type still contains opaque types, recur.
-  if (substTy->hasOpaqueArchetype()) {
+  // If the type changed, but still contains opaque types, recur.
+  if (!substTy->isEqual(maybeOpaqueType) && substTy->hasOpaqueArchetype()) {
     return ::substOpaqueTypesWithUnderlyingTypes(
         substTy, inContext, contextExpansion, isContextWholeModule);
   }

--- a/test/SILGen/Inputs/replace_opaque_type_public_assoc_type_m.swift
+++ b/test/SILGen/Inputs/replace_opaque_type_public_assoc_type_m.swift
@@ -1,0 +1,11 @@
+public protocol Gesture {
+    associatedtype Body: Gesture
+    var body: Body { get }
+
+    associatedtype Value
+    var value: Value { get }
+}
+
+extension Gesture {
+    public var value: Body.Value { return body.value }
+}

--- a/test/SILGen/replace_opaque_type_public_assoc_type.swift
+++ b/test/SILGen/replace_opaque_type_public_assoc_type.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module-path %t/replace_opaque_type_public_assoc_type_m.swiftmodule %S/Inputs/replace_opaque_type_public_assoc_type_m.swift
+// RUN: %target-swift-emit-silgen -disable-availability-checking -I %t %s -verify
+
+import replace_opaque_type_public_assoc_type_m
+
+struct PiggyBack: Gesture {
+    var action: () -> Void
+
+    var body: some Gesture {
+        action()
+        return self
+    }
+}


### PR DESCRIPTION
This can happen when a non-substitutable opaque type appears in structural position, such as the root of an associated
type archetype. Fixes rdar://problem/67040429.