### PR TITLE
ModuleInterface: avoid verifying textual interfaces without -enable-library-evolution

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2217,6 +2217,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
 #endif
 
   if (MergeModuleAction
+      && Args.hasArg(options::OPT_enable_library_evolution)
       && Args.hasFlag(options::OPT_verify_emitted_module_interface,
                       options::OPT_no_verify_emitted_module_interface,
                       verifyInterfacesByDefault)) {

--- a/test/Driver/verify-module-interface.swift
+++ b/test/Driver/verify-module-interface.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
+
+// RUN: %swiftc_driver -driver-print-jobs -driver-skip-execution -j 3 -emit-module -module-name foo -emit-module-interface %t/file-01.swift %t/file-02.swift %t/file-03.swift -verify-emitted-module-interface -enable-library-evolution >%t/evolution.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -driver-skip-execution -j 3 -emit-module -module-name foo -emit-module-interface %t/file-01.swift %t/file-02.swift %t/file-03.swift -verify-emitted-module-interface >%t/no-evolution.txt
+
+// RUN: %FileCheck %s --check-prefix=CHECK_EVOLUTION <%t/evolution.txt
+// RUN: %FileCheck %s --check-prefix=CHECK_NO_EVOLUTION <%t/no-evolution.txt
+
+// CHECK_EVOLUTION: -typecheck-module-from-interface
+// CHECK_NO_EVOLUTION-NOT: -typecheck-module-from-interface


### PR DESCRIPTION
Textual interfaces without -enable-library-evolution aren't properly supported. We should
avoid verifying them too.

rdar://68223978