### PR TITLE
[AutoDiff] Add missing `REQUIRES: asserts` to test.

### DIFF
--- a/test/AutoDiff/validation-test/optional-property.swift
+++ b/test/AutoDiff/validation-test/optional-property.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -o /dev/null 2>&1 %s | %FileCheck %s
 // REQUIRES: executable_test
+// REQUIRES: asserts
 
 // Test differentiation of `Optional` properties.
 


### PR DESCRIPTION
`test/AutoDiff/validation-test/optional-property.swift` uses `-Xllvm -debug-only=differentiation`, which requires assertions enabled.

---

This should fix test failure: https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/5402

```
/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-R_stdlib-RD_test-simulator/swift/test/AutoDiff/validation-test/optional-property.swift:36:17: error: CHECK-LABEL: expected string not found in input
11:32:16 // CHECK-LABEL: [AD] Activity info for ${{.*}}Struct{{.*}}method{{.*}} at (parameters=(0) results=(0))
11:32:16                 ^
11:32:16 <stdin>:1:1: note: scanning from here
11:32:16 swift (LLVM option parsing): Unknown command line argument '-debug-only=differentiation'. Try: 'swift (LLVM option parsing) --help'
11:32:16 ^
11:32:16 
11:32:16 Input file: <stdin>
11:32:16 Check file: /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-R_stdlib-RD_test-simulator/swift/test/AutoDiff/validation-test/optional-property.swift
11:32:16 
11:32:16 -dump-input=help explains the following input dump.
11:32:16 
11:32:16 Input was:
11:32:16 <<<<<<
11:32:16           1: swift (LLVM option parsing): Unknown command line argument '-debug-only=differentiation'. Try: 'swift (LLVM option parsing) --help'
11:32:16 label:36     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
11:32:16           2: swift (LLVM option parsing): Did you mean '--debug-pass=differentiation'?
11:32:16 label:36     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
11:32:16 >>>>>>
11:32:16 
11:32:16 --
11:32:16 
11:32:16 ********************
```