### PR TITLE
[ClangImporter] NFC: XFAIL two tests due to rdar://problem/67721506

### DIFF
--- a/test/ClangImporter/availability_ios.swift
+++ b/test/ClangImporter/availability_ios.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension %s
 
 // REQUIRES: OS=ios
+// REQUIRES: rdar67721506
 
 import Foundation
 import AvailabilityExtras

--- a/test/ClangImporter/availability_macosx_canonical_versions.swift
+++ b/test/ClangImporter/availability_macosx_canonical_versions.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -target x86_64-apple-macosx10.15 %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: rdar67721506
 
 import MacOSVersionCanonicalization
 


### PR DESCRIPTION


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
