### PR TITLE
[5.3] Stop ReplaceOpaqueTypesWithUnderlyingTypes recursion if it hits a fixpoint

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3059,8 +3059,8 @@ operator()(SubstitutableType *maybeOpaqueType) const {
           }))
     return maybeOpaqueType;
 
-  // If the type still contains opaque types, recur.
-  if (substTy->hasOpaqueArchetype()) {
+  // If the type changed, but still contains opaque types, recur.
+  if (!substTy->isEqual(maybeOpaqueType) && substTy->hasOpaqueArchetype()) {
     return ::substOpaqueTypesWithUnderlyingTypes(
         substTy, inContext, contextExpansion, isContextWholeModule);
   }

--- a/test/SILGen/Inputs/replace_opaque_type_public_assoc_type_m.swift
+++ b/test/SILGen/Inputs/replace_opaque_type_public_assoc_type_m.swift
@@ -1,0 +1,11 @@
+public protocol Gesture {
+    associatedtype Body: Gesture
+    var body: Body { get }
+
+    associatedtype Value
+    var value: Value { get }
+}
+
+extension Gesture {
+    public var value: Body.Value { return body.value }
+}

--- a/test/SILGen/replace_opaque_type_public_assoc_type.swift
+++ b/test/SILGen/replace_opaque_type_public_assoc_type.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module-path %t/replace_opaque_type_public_assoc_type_m.swiftmodule %S/Inputs/replace_opaque_type_public_assoc_type_m.swift
+// RUN: %target-swift-emit-silgen -disable-availability-checking -I %t %s -verify
+
+import replace_opaque_type_public_assoc_type_m
+
+struct PiggyBack: Gesture {
+    var action: () -> Void
+
+    var body: some Gesture {
+        action()
+        return self
+    }
+}


### PR DESCRIPTION
Explanation: The compiler would get stuck in an infinite loop when trying to substitute opaque types with associated types, such as `some Gesture` in SwiftUI.

Scope: Crash when trying to write custom `Gesture` types in SwiftUI.

Issue: rdar://problem/67040429

Reviewed by: @aschwaighofer 

Risk: Low