### PR TITLE
[Serialization] Remove documentation for the extInfo parameter

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -456,7 +456,6 @@ public:
   /// \param isFramework If true, this is treated as a framework module for
   /// linking purposes.
   /// \param[out] theModule The loaded module.
-  /// \param[out] extInfo Optionally, extra info serialized about the module.
   /// \returns Whether the module was successfully loaded, or what went wrong
   ///          if it was not.
   static serialization::ValidationInfo


### PR DESCRIPTION
Remove the documentation for a parameter removed in #33789 to silence a warning.