### PR TITLE
[Sema] Check that at least one `buildBlock` is callable given arg labels

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5309,6 +5309,9 @@ NOTE(function_builder_non_static_buildblock, none,
 NOTE(function_builder_buildblock_enum_case, none,
      "enum case 'buildBlock' cannot be used to satisfy the function builder "
      "requirement", ())
+NOTE(function_builder_buildblock_arg_labels, none,
+     "potential match 'buildBlock' can never be called implicitly because it "
+     "has at least one labeled argument", ())
 NOTE(function_builder_buildblock_not_static_method, none,
      "potential match 'buildBlock' is not a static method", ())
 

--- a/test/decl/var/function_builders.swift
+++ b/test/decl/var/function_builders.swift
@@ -199,6 +199,11 @@ enum InvalidBuilder11 { // expected-error {{function builder must provide at lea
     case buildBlock(Any) // expected-note {{enum case 'buildBlock' cannot be used to satisfy the function builder requirement}}
 }
 
+@_functionBuilder
+struct InvalidBuilder12 { // expected-error {{function builder must provide at least one static 'buildBlock' method}}
+  static func buildBlock(exprs: Any...) -> Int { return exprs.count } // expected-note {{potential match 'buildBlock' can never be called implicitly because it has at least one labeled argument}}
+}
+
 struct S {
   @ValidBuilder1 var v1: Int { 1 }
   @ValidBuilder2 var v2: Int { 1 }
@@ -216,4 +221,5 @@ struct S {
   @InvalidBuilder9 var i9: Int { 1 }
   @InvalidBuilder10 var i10: Int { 1 }
   @InvalidBuilder11 var i11: InvalidBuilder11 { 1 }
+  @InvalidBuilder12 var i12: Int { 1 } // expected-error {{missing argument label 'exprs:' in call}}
 }


### PR DESCRIPTION
When validating an @_functionBuilder type, reject types which only provide `buildBlock` declarations with argument labels (which don't have default values). These declarations will never be callable by the `buildBlock` calls produced by the function builder transformation, which does not insert any argument labels for `buildBlock` calls.