### PR TITLE
AssociatedTypeInference: Generalize computeFixedTypeWitness to consider type parameters

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -873,8 +873,7 @@ private:
     const llvm::SetVector<AssociatedTypeDecl *> &assocTypes);
 
   /// Compute a "fixed" type witness for an associated type, e.g.,
-  /// if the refined protocol requires it to be equivalent to some other
-  /// concrete type.
+  /// if the refined protocol requires it to be equivalent to some other type.
   Type computeFixedTypeWitness(AssociatedTypeDecl *assocType);
 
   /// Compute the default type witness from an associated type default,

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -809,33 +809,37 @@ AssociatedTypeDecl *AssociatedTypeInference::findDefaultedAssociatedType(
 
 Type AssociatedTypeInference::computeFixedTypeWitness(
                                             AssociatedTypeDecl *assocType) {
+  Type resultType;
+  auto *const structuralTy = DependentMemberType::get(
+      proto->getSelfInterfaceType(), assocType->getName());
+
   // Look at all of the inherited protocols to determine whether they
   // require a fixed type for this associated type.
-  Type resultType;
   for (auto conformedProto : adoptee->getAnyNominal()->getAllProtocols()) {
     if (conformedProto != assocType->getProtocol() &&
         !conformedProto->inheritsFrom(assocType->getProtocol()))
       continue;
 
-    const auto genericSig = conformedProto->getGenericSignature();
-    if (!genericSig) return Type();
+    const auto ty =
+        conformedProto->getGenericSignature()->getCanonicalTypeInContext(
+            structuralTy);
 
-    const auto nestedType = genericSig->getCanonicalTypeInContext(
-        DependentMemberType::get(conformedProto->getSelfInterfaceType(),
-                                 assocType->getName()));
-    if (nestedType->isEqual(conformedProto->getSelfInterfaceType())) {
-      // Self is a valid fixed type witness.
-    } else if (nestedType->isTypeParameter()) {
-      continue;
+    // A dependent member type with an identical base and name indicates that
+    // the protocol does not same-type constrain it in any way; move on to
+    // the next protocol.
+    if (auto *const memberTy = ty->getAs<DependentMemberType>()) {
+      if (memberTy->getBase()->isEqual(structuralTy->getBase()) &&
+          memberTy->getName() == structuralTy->getName())
+        continue;
     }
 
     if (!resultType) {
-      resultType = nestedType;
+      resultType = ty;
       continue;
     }
 
     // FIXME: Bailing out on ambiguity.
-    if (!resultType->isEqual(nestedType))
+    if (!resultType->isEqual(ty))
       return Type();
   }
 

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -99,3 +99,24 @@ protocol Q11 {
 // expected-error@+2 {{type 'S11' does not conform to protocol 'P11a'}}
 // expected-error@+1 {{type 'S11' does not conform to protocol 'P11b'}}
 struct S11: Q11, P11b {}
+
+protocol P12 where A == B {
+  associatedtype A
+  associatedtype B
+  func foo(arg: A)
+}
+struct S12: P12 { // OK, A == B == Never
+  func foo(arg: Never) {}
+}
+
+protocol P13a {
+  associatedtype A
+  func foo(arg: A)
+}
+protocol P13b {
+  associatedtype B
+}
+protocol P13c: P13a, P13b where A == B {}
+struct S13: P13c { // OK, A == B == Never
+  func foo(arg: Never) {}
+}


### PR DESCRIPTION
While we're here, remove the return on a null generic signature. The request for
the generic signature of a protocol is a trivial computation that is never expected
to fail.