### PR TITLE
SIL: fix some memory leaks and add verification for leaked instructions

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -76,6 +76,9 @@ public:
   /// This method unlinks 'self' from the containing SILFunction and deletes it.
   void eraseFromParent();
 
+  /// Remove all instructions of a SILGlobalVariable's static initializer block.
+  void clearStaticInitializerBlock(SILModule &module);
+
   //===--------------------------------------------------------------------===//
   // SILInstruction List Inspection and Manipulation
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -141,11 +141,11 @@ private:
   CanSILFunctionType LoweredType;
 
   /// The context archetypes of the function.
-  GenericEnvironment *GenericEnv;
+  GenericEnvironment *GenericEnv = nullptr;
 
   /// The information about specialization.
   /// Only set if this function is a specialization of another function.
-  const GenericSpecializationInformation *SpecializationInfo;
+  const GenericSpecializationInformation *SpecializationInfo = nullptr;
 
   /// The forwarding substitution map, lazily computed.
   SubstitutionMap ForwardingSubMap;
@@ -158,10 +158,10 @@ private:
   ValueDecl *ClangNodeOwner = nullptr;
 
   /// The source location and scope of the function.
-  const SILDebugScope *DebugScope;
+  const SILDebugScope *DebugScope = nullptr;
 
   /// The AST decl context of the function.
-  DeclContext *DeclCtxt;
+  DeclContext *DeclCtxt = nullptr;
 
   /// The profiler for instrumentation based profiling, or null if profiling is
   /// disabled.
@@ -315,8 +315,7 @@ private:
               IsTransparent_t isTrans, IsSerialized_t isSerialized,
               ProfileCounter entryCount, IsThunk_t isThunk,
               SubclassScope classSubclassScope, Inline_t inlineStrategy,
-              EffectsKind E, SILFunction *insertBefore,
-              const SILDebugScope *debugScope,
+              EffectsKind E, const SILDebugScope *debugScope,
               IsDynamicallyReplaceable_t isDynamic,
               IsExactSelfClass_t isExactSelfClass);
 
@@ -333,6 +332,18 @@ private:
          EffectsKind EffectsKindAttr = EffectsKind::Unspecified,
          SILFunction *InsertBefore = nullptr,
          const SILDebugScope *DebugScope = nullptr);
+
+  void init(SILLinkage Linkage, StringRef Name,
+                         CanSILFunctionType LoweredType,
+                         GenericEnvironment *genericEnv,
+                         Optional<SILLocation> Loc, IsBare_t isBareSILFunction,
+                         IsTransparent_t isTrans, IsSerialized_t isSerialized,
+                         ProfileCounter entryCount, IsThunk_t isThunk,
+                         SubclassScope classSubclassScope,
+                         Inline_t inlineStrategy, EffectsKind E,
+                         const SILDebugScope *DebugScope,
+                         IsDynamicallyReplaceable_t isDynamic,
+                         IsExactSelfClass_t isExactSelfClass);
 
   /// Set has ownership to the given value. True means that the function has
   /// ownership, false means it does not.

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -233,7 +233,7 @@ public ilist_node_traits<::swift::SILGlobalVariable> {
   using SILGlobalVariable = ::swift::SILGlobalVariable;
 
 public:
-  static void deleteNode(SILGlobalVariable *V) {}
+  static void deleteNode(SILGlobalVariable *V) { V->~SILGlobalVariable(); }
   
 private:
   void createNode(const SILGlobalVariable &);

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -650,6 +650,19 @@ public:
   /// invariants.
   void verify() const;
 
+  /// Check if there are any leaking instructions.
+  ///
+  /// Aborts with an error if more instructions are allocated than contained in
+  /// the module.
+  void checkForLeaks() const;
+
+  /// Check if there are any leaking instructions after the SILModule is
+  /// destructed.
+  ///
+  /// The SILModule destructor already calls checkForLeaks(). This function is
+  /// useful to check if the destructor itself destroys all data structures.
+  static void checkForLeaksAfterDestruction();
+
   /// Pretty-print the module.
   void dump(bool Verbose = false) const;
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -340,7 +340,7 @@ public:
   /// Specialization can cause a function that was erased before by dead function
   /// elimination to become alive again. If this happens we need to remove it
   /// from the list of zombies.
-  void removeFromZombieList(StringRef Name);
+  SILFunction *removeFromZombieList(StringRef Name);
 
   /// Erase a global SIL variable from the module.
   void eraseGlobalVariable(SILGlobalVariable *G);

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -171,9 +171,6 @@ private:
   /// but kept alive for debug info generation.
   FunctionListType zombieFunctions;
 
-  /// Stores the names of zombie functions.
-  llvm::BumpPtrAllocator zombieFunctionNames;
-
   /// Lookup table for SIL vtables from class decls.
   llvm::DenseMap<const ClassDecl *, SILVTable *> VTableMap;
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1009,7 +1009,10 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
 
   // Free the memory occupied by the SILModule.
   // Execute this task in parallel to the embedding of bitcode.
-  auto SILModuleRelease = [&SILMod]() { SILMod.reset(nullptr); };
+  auto SILModuleRelease = [&SILMod]() {
+    SILMod.reset(nullptr);
+    SILModule::checkForLeaksAfterDestruction();
+  };
   auto Thread = std::thread(SILModuleRelease);
   // Wait for the thread to terminate.
   SWIFT_DEFER { Thread.join(); };
@@ -1307,7 +1310,10 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
 
   // Free the memory occupied by the SILModule.
   // Execute this task in parallel to the LLVM compilation.
-  auto SILModuleRelease = [&SILMod]() { SILMod.reset(nullptr); };
+  auto SILModuleRelease = [&SILMod]() {
+    SILMod.reset(nullptr);
+    SILModule::checkForLeaksAfterDestruction();
+  };
   auto releaseModuleThread = std::thread(SILModuleRelease);
 
   codeGenThreads.runMainThread();

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -112,10 +112,10 @@ void SILBasicBlock::eraseInstructions() {
 /// Returns the iterator following the erased instruction.
 SILBasicBlock::iterator SILBasicBlock::erase(SILInstruction *I) {
   // Notify the delete handlers that this instruction is going away.
-  getModule().notifyDeleteHandlers(&*I);
-  auto *F = getParent();
+  SILModule &module = getModule();
+  module.notifyDeleteHandlers(&*I);
   auto nextIter = InstList.erase(I);
-  F->getModule().deallocateInst(I);
+  module.deallocateInst(I);
   return nextIter;
 }
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -72,13 +72,29 @@ SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
     name = entry->getKey();
   }
 
-  auto fn = new (M) SILFunction(M, linkage, name, loweredType, genericEnv, loc,
+  SILFunction *fn = M.removeFromZombieList(name);
+  if (fn) {
+    // Resurrect a zombie function.
+    // This happens for example if a specialized function gets dead and gets
+    // deleted. And afterwards the same specialization is created again.
+    fn->init(linkage, name, loweredType, genericEnv, loc, isBareSILFunction,
+             isTrans, isSerialized, entryCount, isThunk, classSubclassScope,
+             inlineStrategy, E, debugScope, isDynamic, isExactSelfClass);
+    assert(fn->empty());
+  } else {
+    fn = new (M) SILFunction(M, linkage, name, loweredType, genericEnv, loc,
                                 isBareSILFunction, isTrans, isSerialized,
                                 entryCount, isThunk, classSubclassScope,
-                                inlineStrategy, E, insertBefore, debugScope,
+                                inlineStrategy, E, debugScope,
                                 isDynamic, isExactSelfClass);
-
+  }
   if (entry) entry->setValue(fn);
+
+  if (insertBefore)
+    M.functions.insert(SILModule::iterator(insertBefore), fn);
+  else
+    M.functions.push_back(fn);
+
   return fn;
 }
 
@@ -90,39 +106,58 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          ProfileCounter entryCount, IsThunk_t isThunk,
                          SubclassScope classSubclassScope,
                          Inline_t inlineStrategy, EffectsKind E,
-                         SILFunction *InsertBefore,
                          const SILDebugScope *DebugScope,
                          IsDynamicallyReplaceable_t isDynamic,
                          IsExactSelfClass_t isExactSelfClass)
-    : Module(Module), Name(Name), LoweredType(LoweredType),
-      GenericEnv(genericEnv), SpecializationInfo(nullptr),
-      EntryCount(entryCount),
-      Availability(AvailabilityContext::alwaysAvailable()),
-      Bare(isBareSILFunction), Transparent(isTrans),
-      Serialized(isSerialized), Thunk(isThunk),
-      ClassSubclassScope(unsigned(classSubclassScope)), GlobalInitFlag(false),
-      InlineStrategy(inlineStrategy), Linkage(unsigned(Linkage)),
-      HasCReferences(false), IsWeakImported(false),
-      IsDynamicReplaceable(isDynamic),
-      ExactSelfClass(isExactSelfClass),
-      Inlined(false), Zombie(false), HasOwnership(true),
-      WasDeserializedCanonical(false), IsWithoutActuallyEscapingThunk(false),
-      OptMode(unsigned(OptimizationMode::NotSet)),
-      EffectsKindAttr(unsigned(E)) {
-  assert(!Transparent || !IsDynamicReplaceable);
-  validateSubclassScope(classSubclassScope, isThunk, nullptr);
-  setDebugScope(DebugScope);
-
-  if (InsertBefore)
-    Module.functions.insert(SILModule::iterator(InsertBefore), this);
-  else
-    Module.functions.push_back(this);
-
-  Module.removeFromZombieList(Name);
-
+    : Module(Module), Availability(AvailabilityContext::alwaysAvailable())  {
+  init(Linkage, Name, LoweredType, genericEnv, Loc, isBareSILFunction, isTrans,
+       isSerialized, entryCount, isThunk, classSubclassScope, inlineStrategy,
+       E, DebugScope, isDynamic, isExactSelfClass);
+  
   // Set our BB list to have this function as its parent. This enables us to
   // splice efficiently basic blocks in between functions.
   BlockList.Parent = this;
+}
+
+void SILFunction::init(SILLinkage Linkage, StringRef Name,
+                         CanSILFunctionType LoweredType,
+                         GenericEnvironment *genericEnv,
+                         Optional<SILLocation> Loc, IsBare_t isBareSILFunction,
+                         IsTransparent_t isTrans, IsSerialized_t isSerialized,
+                         ProfileCounter entryCount, IsThunk_t isThunk,
+                         SubclassScope classSubclassScope,
+                         Inline_t inlineStrategy, EffectsKind E,
+                         const SILDebugScope *DebugScope,
+                         IsDynamicallyReplaceable_t isDynamic,
+                         IsExactSelfClass_t isExactSelfClass) {
+  this->Name = Name;
+  this->LoweredType = LoweredType;
+  this->GenericEnv = genericEnv;
+  this->SpecializationInfo = nullptr;
+  this->EntryCount = entryCount;
+  this->Availability = AvailabilityContext::alwaysAvailable();
+  this->Bare = isBareSILFunction;
+  this->Transparent = isTrans;
+  this->Serialized = isSerialized;
+  this->Thunk = isThunk;
+  this->ClassSubclassScope = unsigned(classSubclassScope);
+  this->GlobalInitFlag = false;
+  this->InlineStrategy = inlineStrategy;
+  this->Linkage = unsigned(Linkage);
+  this->HasCReferences = false;
+  this->IsWeakImported = false;
+  this->IsDynamicReplaceable = isDynamic;
+  this->ExactSelfClass = isExactSelfClass;
+  this->Inlined = false;
+  this->Zombie = false;
+  this->HasOwnership = true,
+  this->WasDeserializedCanonical = false;
+  this->IsWithoutActuallyEscapingThunk = false;
+  this->OptMode = unsigned(OptimizationMode::NotSet);
+  this->EffectsKindAttr = unsigned(E);
+  assert(!Transparent || !IsDynamicReplaceable);
+  validateSubclassScope(classSubclassScope, isThunk, nullptr);
+  setDebugScope(DebugScope);
 }
 
 SILFunction::~SILFunction() {

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -58,7 +58,8 @@ SILGlobalVariable::SILGlobalVariable(SILModule &Module, SILLinkage Linkage,
 }
 
 SILGlobalVariable::~SILGlobalVariable() {
-  getModule().GlobalVariableMap.erase(Name);
+  StaticInitializerBlock.dropAllReferences();
+  StaticInitializerBlock.clearStaticInitializerBlock(Module);
 }
 
 /// Get this global variable's fragile attribute.

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5277,6 +5277,11 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     return true;
   }
 
+  if (!B.hasValidInsertionPoint()) {
+    P.diagnose(P.Tok, diag::expected_sil_block_name);
+    return true;
+  }
+
   SmallVector<Located<StringRef>, 4> resultNames;
   SourceLoc resultClauseBegin;
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5559,6 +5559,8 @@ void SILModule::verify() const {
   if (!verificationEnabled(*this))
     return;
 
+  checkForLeaks();
+
   // Uniquing set to catch symbol name collisions.
   llvm::DenseSet<StringRef> symbolNames;
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -52,14 +52,6 @@ using namespace swift::silverifier;
 
 using Lowering::AbstractionPattern;
 
-// This flag is used only to check that sil-combine can properly
-// remove any code after unreachable, thus bringing SIL into
-// its canonical form which may get temporarily broken during
-// intermediate transformations.
-static llvm::cl::opt<bool> SkipUnreachableMustBeLastErrors(
-                              "verify-skip-unreachable-must-be-last",
-                              llvm::cl::init(false));
-
 // This flag controls the default behaviour when hitting a verification
 // failure (abort/exit).
 static llvm::cl::opt<bool> AbortOnFailure(
@@ -1026,10 +1018,8 @@ public:
                 "Non-terminators cannot be the last in a block");
       }
     } else {
-      // Skip the check for UnreachableInst, if explicitly asked to do so.
-      if (!isa<UnreachableInst>(I) || !SkipUnreachableMustBeLastErrors)
-        require(&*BB->rbegin() == I,
-                "Terminator must be the last in block");
+      require(&*BB->rbegin() == I,
+              "Terminator must be the last in block");
     }
 
     // Verify that all of our uses are in this function.

--- a/test/SIL/Parser/errors.sil
+++ b/test/SIL/Parser/errors.sil
@@ -56,3 +56,11 @@ sil @test_formal_substituted_type : $@convention(thin) <X> (@owned Array<@substi
 entry(%0 : $Array<X>):
   return undef : $()
 }
+
+sil @instructions_after_terminator : $@convention(thin) () -> () {
+bb0:
+  unreachable
+  %0 = tuple () // expected-error {{expected basic block name or '}'}}
+  return %0 : $()
+}
+

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2413,19 +2413,6 @@ bb0:
 }
 
 
-// CHECK-LABEL:   sil @remove_dead_code_after_unreachable
-// CHECK-NEXT:      bb0
-// CHECK-NEXT:      unreachable
-// CHECK-NEXT:      } // end sil function 'remove_dead_code_after_unreachable'
-sil @remove_dead_code_after_unreachable : $@convention(thin) () -> (Int32) {
-bb0:
-  unreachable
-  %2 = integer_literal $Builtin.Int32, -2
-  %3 = struct $Int32 (%2 : $Builtin.Int32)
-  return %3 : $Int32
-}
-
-
 // CHECK-LABEL:   sil @dont_remove_code_after_cond_fail
 // CHECK:         bb0([[Cond:%.*]] : $Builtin.Int1):
 // CHECK-NEXT:      [[Ref:%.*]] = integer_literal $Builtin.Int32, -2

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
 
 import Swift
 import Builtin

--- a/test/SILOptimizer/sil_combine_global_addr.sil
+++ b/test/SILOptimizer/sil_combine_global_addr.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -devirtualizer | %FileCheck %s
 
 // Test to see if concrete type can be propagated from
 // global_addr in sil_combiner.

--- a/test/SILOptimizer/sil_combine_objc.sil
+++ b/test/SILOptimizer/sil_combine_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 // REQUIRES: objc_interop
 
 // See https://bugs.swift.org/browse/SR-5065, rdar://32511494

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -27,7 +27,6 @@ _swift_complete()
       -view-cfg-remove-use-list-comments \
       -view-cfg-only-for-function \
       -sil-print-no-color \
-      -verify-skip-unreachable-must-be-last \
       -aa \
       -cache-aa-results \
       -sil-dump-call-graph \


### PR DESCRIPTION
Fixing some memory leaks:

#### 1. related to zombie functions

The leak happened in this scenario:
1. A function becomes dead and gets deleted (which means: it gets added to the zombie-list)
2. A function with the same name is created again. This can happen with specializations.

In such a case we just removed the zombie function from the zombie-list without deleting it.
But we cannot delete zombie functions, because they might still be referenced by metadata, like debug-info.

Therefore the right fix is to resurrect the zombie function if a new function is created with the same name.

#### 2. Let SILGlobalVariables be destroyed

Instructions of the static initializer block were not be freed.

#### 3. Leaks in SILParser

#### Also: check for leaked instructions in the SILVerifier and in the SILModule destructor.

rdar://problem/66931238