### PR TITLE
[stdlib] Add fast paths for generic floating-point-to-integer conversion

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1257,6 +1257,7 @@ public struct ${Self}
     self = Self._convert(from: source).value!
   }
   
+  @_alwaysEmitIntoClient
   @inlinable
   @inline(__always)
   public init<T: BinaryFloatingPoint>(_ source: T) {
@@ -1276,6 +1277,7 @@ public struct ${Self}
     self.init(_unchecked: source)
   }
 
+  @_alwaysEmitIntoClient
   @inlinable
   @inline(__always)
   public init?<T: BinaryFloatingPoint>(exactly source: T) {

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1225,12 +1225,10 @@ public struct ${Self}
 %   end
 
   @_alwaysEmitIntoClient
-  @usableFromInline
   internal init<T: BinaryFloatingPoint>(_unchecked source: T) {
     switch (T.exponentBitCount, T.significandBitCount) {
 %   for (FloatType, FloatBits, FloatExponentBits, FloatSignificandBits) in [
-%     ('Float16', 16, 5, 10), ('Float', 32, 8, 23),
-%     ('Double', 64, 11, 52), ('Float80', 80, 15, 63)]:
+%     ('Float16',16,5,10), ('Float',32,8,23), ('Double',64,11,52), ('Float80',80,15,63)]:
 %     if FloatType == 'Float16':
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     elif FloatType == 'Float80':
@@ -1260,7 +1258,6 @@ public struct ${Self}
   }
   
   @_alwaysEmitIntoClient
-  @inlinable
   @inline(__always)
   public init<T: BinaryFloatingPoint>(_ source: T) {
     _precondition(source.isFinite,
@@ -1273,7 +1270,6 @@ public struct ${Self}
   }
 
   @_alwaysEmitIntoClient
-  @inlinable
   @inline(__always)
   public init?<T: BinaryFloatingPoint>(exactly source: T) {
     // The value passed as `source` must not be infinite, NaN, or exceed the

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1265,17 +1265,10 @@ public struct ${Self}
   public init<T: BinaryFloatingPoint>(_ source: T) {
     _precondition(source.isFinite,
       "Floating-point value cannot be converted to ${Self} because it is either infinite or NaN")
-%   if bits >= 32:
-    // Float16 is always in-range.
-    if T.exponentBitCount > 5 {
-%   else:
-    do {
-%   end
-      _precondition(source > ${str(lower)}.0,
-        "Floating-point value cannot be converted to ${Self} because the result would be less than ${Self}.min")
-      _precondition(source < ${str(upper)}.0,
-        "Floating-point value cannot be converted to ${Self} because the result would be greater than ${Self}.max")
-    }
+    _precondition(source > ${str(lower)}.0,
+      "Floating-point value cannot be converted to ${Self} because the result would be less than ${Self}.min")
+    _precondition(source < ${str(upper)}.0,
+      "Floating-point value cannot be converted to ${Self} because the result would be greater than ${Self}.max")
     self.init(_unchecked: source)
   }
 
@@ -1286,13 +1279,7 @@ public struct ${Self}
     // The value passed as `source` must not be infinite, NaN, or exceed the
     // bounds of the integer type; the result of `fptosi` or `fptoui` is
     // undefined if it overflows.
-%   if bits >= 32:
-    // Float16 is always in-range.
-    guard (T.exponentBitCount <= 5 && source.isFinite)
-      || (source > ${str(lower)}.0 && source < ${str(upper)}.0) else {
-%   else:
     guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
-%   end
       return nil
     }
     guard source == source.rounded(.towardZero) else {

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1224,6 +1224,79 @@ public struct ${Self}
 
 %   end
 
+  @_alwaysEmitIntoClient
+  @usableFromInline
+  internal init<T: BinaryFloatingPoint>(_unchecked source: T) {
+    switch (T.exponentBitCount, T.significandBitCount) {
+%   for (FloatType, FloatBits, FloatExponentBits, FloatSignificandBits) in [
+%     ('Float16', 16, 5, 10), ('Float', 32, 8, 23),
+%     ('Double', 64, 11, 52), ('Float80', 80, 15, 63)]:
+%     if FloatType == 'Float16':
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+%     elif FloatType == 'Float80':
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%     end
+    case (${FloatExponentBits}, ${FloatSignificandBits}):
+%     if FloatType == 'Float16':
+      guard #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) else { break }
+%     end
+      let source_ = source as? ${FloatType} ?? ${FloatType}(
+        sign: source.sign,
+        exponentBitPattern:
+          ${FloatType}.RawExponent(truncatingIfNeeded: source.exponentBitPattern),
+        significandBitPattern:
+          ${FloatType}.RawSignificand(truncatingIfNeeded: source.significandBitPattern))
+      self._value = Builtin.fpto${u}i_FPIEEE${FloatBits}_${BuiltinName}(source_._value)
+      return
+%     if FloatType == 'Float16' or FloatType == 'Float80':
+#endif
+%     end
+%   end
+    default: break
+    }
+    self = Self._convert(from: source).value!
+  }
+  
+  @inlinable
+  @inline(__always)
+  public init<T: BinaryFloatingPoint>(_ source: T) {
+    _precondition(source.isFinite,
+      "Floating-point value cannot be converted to ${Self} because it is either infinite or NaN")
+%   if bits >= 32:
+    // Float16 is always in-range.
+    if T.exponentBitCount > 5 {
+%   else:
+    do {
+%   end
+      _precondition(source > ${str(lower)}.0,
+        "Floating-point value cannot be converted to ${Self} because the result would be less than ${Self}.min")
+      _precondition(source < ${str(upper)}.0,
+        "Floating-point value cannot be converted to ${Self} because the result would be greater than ${Self}.max")
+    }
+    self.init(_unchecked: source)
+  }
+
+  @inlinable
+  @inline(__always)
+  public init?<T: BinaryFloatingPoint>(exactly source: T) {
+    // The value passed as `source` must not be infinite, NaN, or exceed the
+    // bounds of the integer type; the result of `fptosi` or `fptoui` is
+    // undefined if it overflows.
+%   if bits >= 32:
+    // Float16 is always in-range.
+    guard (T.exponentBitCount <= 5 && source.isFinite)
+      || (source > ${str(lower)}.0 && source < ${str(upper)}.0) else {
+%   else:
+    guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
+%   end
+      return nil
+    }
+    guard source == source.rounded(.towardZero) else {
+      return nil
+    }
+    self.init(_unchecked: source)
+  }
+
   @_transparent
   public static func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_eq_Int${bits}(lhs._value, rhs._value))

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1232,13 +1232,15 @@ public struct ${Self}
 %     ('Float16', 16, 5, 10), ('Float', 32, 8, 23),
 %     ('Double', 64, 11, 52), ('Float80', 80, 15, 63)]:
 %     if FloatType == 'Float16':
-#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     elif FloatType == 'Float80':
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %     end
     case (${FloatExponentBits}, ${FloatSignificandBits}):
 %     if FloatType == 'Float16':
-      guard #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) else { break }
+      guard #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
+        break
+      }
 %     end
       let source_ = source as? ${FloatType} ?? ${FloatType}(
         sign: source.sign,

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -648,7 +648,7 @@ let arr = [BottleLayout]()
 let layout = BottleLayout(count:1)
 let ix = arr.firstIndex(of:layout) // expected-error {{referencing instance method 'firstIndex(of:)' on 'Collection' requires that 'BottleLayout' conform to 'Equatable'}}
 
-let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{initializer 'init(_:)' requires that 'Unicode.Scalar' conform to 'BinaryInteger'}}
+let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{initializer 'init(_:)' requires that 'Unicode.Scalar' conform to }}
 
 // https://bugs.swift.org/browse/SR-9068
 func compare<C: Collection, Key: Hashable, Value: Equatable>(c: C)

--- a/test/SILOptimizer/floating_point_conversion.swift
+++ b/test/SILOptimizer/floating_point_conversion.swift
@@ -62,5 +62,3 @@ public func testDouble(_ x: Double) -> Double {
 public func testFloat(_ x: Float) -> Float {
   return convert(x, to: Float.self)
 }
-
-

--- a/test/SILOptimizer/floating_point_conversion.swift
+++ b/test/SILOptimizer/floating_point_conversion.swift
@@ -6,6 +6,12 @@ func convert<
   U(value)
 }
 
+func convert<
+  T: BinaryFloatingPoint, U: BinaryInteger
+>(_ value: T, to: U.Type) -> U {
+  U(value)
+}
+
 // Check that the following functions can be optimized to concrete conversions.
 
 // CHECK-LABEL: sil @$s4test0A13DoubleToFloatySfSdF
@@ -30,6 +36,17 @@ public func testFloatToDouble(_ x: Float) -> Double {
   return convert(x, to: Double.self)
 }
 
+// CHECK-LABEL: sil @$s4test0A13DoubleToInt64ys0D0VSdF
+// CHECK:      bb0(%0 : $Double):
+// CHECK:        [[ARG:%[0-9]+]] = struct_extract %0
+// CHECK:        [[CNV:%[0-9]+]] = builtin "fptosi_FPIEEE64_Int64"([[ARG]] : $Builtin.FPIEEE64)
+// CHECK-NEXT:   [[RET:%[0-9]+]] = struct $Int64 ([[CNV]] : $Builtin.Int64)
+// CHECK-NEXT:   return [[RET]]
+// CHECK-NEXT: } // end sil function '$s4test0A13DoubleToInt64ys0D0VSdF'
+public func testDoubleToInt64(_ x: Double) -> Int64 {
+  return convert(x, to: Int64.self)
+}
+
 // Check that the following functions can be optimized to no-ops.
 
 // CHECK-LABEL: sil @$s4test0A6DoubleyS2dF
@@ -45,3 +62,5 @@ public func testDouble(_ x: Double) -> Double {
 public func testFloat(_ x: Float) -> Float {
   return convert(x, to: Float.self)
 }
+
+


### PR DESCRIPTION
Here, we use a similar approach as that in #33826 to create some fast paths for conversion of generic floating-point values to integers.

With the slightly different design of the integer protocols, it's necessary to create concrete implementations of the required initializer (hence their addition to `IntegerTypes.swift.gyb`). These ultimately call the protocol extension method `Self._convert` as a fallback; for conversion from any floating-point values of known format, however, the fast paths here would apply.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
