### PR TITLE
[stdlib] Correct shell32 casing

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -184,7 +184,7 @@ module WinSDK [system] {
     header "Shlwapi.h"
     export *
 
-    link "Shell32.Lib"
+    link "shell32.lib"
     link "ShLwApi.Lib"
   }
 


### PR DESCRIPTION
This allows links to succeed on a case-sensitive file system.