### PR TITLE
[Sema] Add a tailored diagnostic for default implementations of '@objc' protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4681,6 +4681,10 @@ NOTE(objc_optional_requirement_swift_rename,none,
      "rename %select{method|initializer|property|subscript}0 to match "
      "requirement %1", (bool, DeclName))
 
+ERROR(witness_objc_default_implementation, none, 
+      "default implementations cannot be used to satisfy requirements of "
+      "'@objc' protocols, such as %0 in '@objc' protocol %1", (DeclName, DeclName))
+
 ERROR(witness_non_objc,none,
       "non-'@objc' " OBJC_DIAG_SELECT " does not satisfy requirement "
       "of '@objc' protocol %2",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4681,9 +4681,8 @@ NOTE(objc_optional_requirement_swift_rename,none,
      "rename %select{method|initializer|property|subscript}0 to match "
      "requirement %1", (bool, DeclName))
 
-ERROR(witness_objc_default_implementation, none, 
-      "default implementations cannot be used to satisfy requirements of "
-      "'@objc' protocols, such as %0 in '@objc' protocol %1", (DeclName, DeclName))
+NOTE(witness_objc_default_implementation, none, 
+     "default implementations cannot be used to satisfy requirements of '@objc' protocols", ())
 
 ERROR(witness_non_objc,none,
       "non-'@objc' " OBJC_DIAG_SELECT " does not satisfy requirement "

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -1,9 +1,6 @@
-// RUN: %target-typecheck-verify-swift
-// REQUIRES: objc_interop
+// RUN: %target-typecheck-verify-swift -enable-objc-interop
 
 // Test requirements and conformance for Objective-C protocols.
-
-import Foundation
 
 @objc class ObjCClass { }
 
@@ -261,25 +258,3 @@ class C8SubRW: C8Base {
 class C8SubRW2: C8Base {
   var prop: Int = 0
 }
-
-// SR-13515
-// Default implementations of requirements should not suggest adding '@objc'
-// to the witness and should clarify that default implementations are not
-// allowed.
-
-@objc protocol ObjCProtocol {
-  @objc func requiredMethod() // expected-note {{requirement 'requiredMethod()' declared here}}
-  @objc var requiredProperty: Int { get } // expected-note {{requirement 'requiredProperty' declared here}}
-  @objc subscript(required: Int) -> Int { get } // expected-note {{requirement 'subscript(_:)' declared here}}
-}
-
-extension ObjCProtocol {
-  func requiredMethod() {}
-  var requiredProperty: Int { 0 }
-  subscript(required: Int) -> Int { 1 }
-}
-
-class ConformingClass: NSObject, ObjCProtocol {}
-// expected-error@-1 {{default implementations cannot be used to satisfy requirements of '@objc' protocols, such as 'requiredMethod()' in '@objc' protocol 'ObjCProtocol'}}
-// expected-error@-2 {{default implementations cannot be used to satisfy requirements of '@objc' protocols, such as 'requiredProperty' in '@objc' protocol 'ObjCProtocol'}}
-// expected-error@-3 {{default implementations cannot be used to satisfy requirements of '@objc' protocols, such as 'subscript(_:)' in '@objc' protocol 'ObjCProtocol'}}

--- a/test/decl/protocol/objc_witness_default_implementation.swift
+++ b/test/decl/protocol/objc_witness_default_implementation.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -diagnostics-editor-mode -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+// SR-13515
+// Tailored diagnostic when there are witnesses to '@objc'
+// requirements which are default implementations.
+
+@objc protocol ObjCProtocol {
+  @objc func requiredMethod() // expected-note {{requirement 'requiredMethod()' declared here}}
+  @objc var requiredProperty: Int { get } // expected-note {{requirement 'requiredProperty' declared here}}
+  @objc subscript(required: Int) -> Int { get } // expected-note {{requirement 'subscript(_:)' declared here}}
+}
+
+extension ObjCProtocol {
+  func requiredMethod() {}
+  var requiredProperty: Int { 0 }
+  subscript(required: Int) -> Int { 1 }
+}
+
+class ConformingClass: NSObject, ObjCProtocol {} 
+// expected-error@-1 {{type 'ConformingClass' does not conform to protocol 'ObjCProtocol'}}
+// expected-note@-2 {{default implementations cannot be used to satisfy requirements of '@objc' protocols}}
+// expected-note@-3 {{do you want to add protocol stubs?}} {{47-47=\n    func requiredMethod() {\n        <#code#>\n    \}\n\n    var requiredProperty: Int\n\n    subscript(required: Int) -> Int {\n        <#code#>\n    \}\n}}


### PR DESCRIPTION
Default implementations cannot be used to satisfy a `@objc` protocol requirement. Add a tailored diagnostic to emphasise this and also omit the "add `@objc`" fix-it because it will not work (and instead it will trigger another diagnostic).

```swift
@objc protocol ObjCProtocol {
  @objc func requiredMethod()

extension ObjCProtocol {
  func requiredMethod() { // this is not allowed and adding '@objc' will not work
    print("Default implementation")
  }
}

class ConformingClass: NSObject, ObjCProtocol {} // cannot use 'requiredMethod' default implementation
```

Resolves SR-13515