### PR TITLE
[Sema] Improve -require-explicit-availability precision

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2866,7 +2866,9 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
       return false;
   }
 
-  if (decl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
+  // Skip functions emitted into clients or SPI.
+  if (decl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>() ||
+      decl->isSPI())
     return false;
 
   // Warn on decls without an introduction version.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1685,6 +1685,8 @@ public:
 
     checkAccessControl(SD);
 
+    checkExplicitAvailability(SD);
+
     if (!checkOverrides(SD)) {
       // If a subscript has an override attribute but does not override
       // anything, complain.
@@ -2643,6 +2645,8 @@ public:
     }
 
     checkAccessControl(CD);
+
+    checkExplicitAvailability(CD);
 
     if (requiresDefinition(CD) && !CD->hasBody()) {
       // Complain if we should have a body.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1629,6 +1629,8 @@ public:
 
     checkAccessControl(PBD);
 
+    checkExplicitAvailability(PBD);
+
     // If the initializers in the PBD aren't checked yet, do so now.
     for (auto i : range(PBD->getNumPatternEntries())) {
       if (!PBD->isInitialized(i))

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -79,3 +79,15 @@ public protocol PublicProtocol { }
 
 @available(macOS 10.1, *)
 extension S : PublicProtocol { }
+
+@_spi(SPIsAreOK)
+public func spiFunc() { }
+
+@_spi(SPIsAreOK)
+public struct spiStruct {
+  public func spiMethod() {}
+}
+
+extension spiStruct {
+  public func spiExtensionMethod() {}
+}

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,8 +1,7 @@
 // Test the -require-explicit-availability flag
 // REQUIRES: OS=macosx
 
-// RUN: %swiftc_driver -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -Xfrontend -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
-// RUN: %swiftc_driver -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
+// RUN: %swiftc_driver -typecheck -parse-as-library -target x86_64-apple-macosx10.10 -Xfrontend -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
 
 public struct S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}}
   public func method() { }
@@ -90,4 +89,51 @@ public struct spiStruct {
 
 extension spiStruct {
   public func spiExtensionMethod() {}
+}
+
+public var publicVar = S() // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+@available(macOS 10.10, *)
+public var publicVarOk = S()
+
+public var (a, b) = (S(), S()) // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+@available(macOS 10.10, *)
+public var (c, d) = (S(), S())
+
+public var _ = S() // expected-error {{global variable declaration does not bind any variables}}
+
+public var implicitGet: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  return S()
+}
+
+@available(macOS 10.10, *)
+public var implicitGetOk: S {
+  return S()
+}
+
+public var computed: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  get { return S() }
+  set { }
+}
+
+public var computedHalf: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  @available(macOS 10.10, *)
+  get { return S() }
+  set { }
+}
+
+// FIXME the following warning is not needed.
+public var computedOk: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  @available(macOS 10.10, *)
+  get { return S() }
+
+  @available(macOS 10.10, *)
+  set { }
+}
+
+@available(macOS 10.10, *)
+public var computedOk1: S {
+  get { return S() }
+  set { }
 }

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -137,3 +137,30 @@ public var computedOk1: S {
   get { return S() }
   set { }
 }
+
+public class SomeClass { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  public init () {}
+
+  public subscript(index: String) -> Int {
+    get { return 42; }
+    set(newValue) { }
+  }
+}
+
+extension SomeClass { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  public convenience init(s : S) {} // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
+
+  @available(macOS 10.10, *)
+  public convenience init(s : SomeClass) {}
+
+  public subscript(index: Int) -> Int { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
+    get { return 42; }
+    set(newValue) { }
+  }
+
+  @available(macOS 10.10, *)
+  public subscript(index: S) -> Int {
+    get { return 42; }
+    set(newValue) { }
+  }
+}

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -52,6 +52,11 @@ extension S { // expected-warning {{public declarations should have an availabil
   public func warnForPublicMembers() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
 }
 
+@available(macOS 10.1, *)
+extension S {
+  public func okWhenTheExtensionHasAttribute() { }
+}
+
 extension S {
   internal func dontWarnWithoutPublicMembers() { }
   private func dontWarnWithoutPublicMembers1() { }
@@ -68,3 +73,9 @@ open class OpenClass { } // expected-warning {{public declarations should have a
 private class PrivateClass { }
 
 extension PrivateClass { }
+
+@available(macOS 10.1, *)
+public protocol PublicProtocol { }
+
+@available(macOS 10.1, *)
+extension S : PublicProtocol { }


### PR DESCRIPTION
Fix a few issues where `-require-explicit-availability` raised superfluous warnings or would ignore type members declared in extensions:

- Correctly detect availability attributes on extensions and pattern binding decls.
- Don't require availability on `@_spi` declarations.
- Report missing availability attributes on constructors and subscripts in extensions.