### PR TITLE
[stdlib] Fix a Float16-to-integer conversion bug

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1195,9 +1195,11 @@ public struct ${Self}
     // undefined if it overflows.
 %     if not (FloatBits == 16 and bits >= 32): # Float16 is always in-range for 32- and 64-bit ints.
     guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
+%     else:
+    guard source.isFinite else {
+%     end
       return nil
     }
-%     end
     guard source == source.rounded(.towardZero) else {
       return nil
     }

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -260,6 +260,16 @@ FloatingPoint.test("Float/staticProperties") {
 }
 
 // Tests the float and int conversions work correctly. Each case is special.
+
+#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  FloatingPoint.test("Float16/Int") {
+    expectNil(Int(exactly: Float16.infinity))
+    expectNil(Int(exactly: -Float16.infinity))
+  }
+}
+#endif
+
 FloatingPoint.test("Float/UInt8") {
   expectEqual(UInt8.min, UInt8(Float(UInt8.min)))
   expectEqual(UInt8.max, UInt8(Float(UInt8.max)))


### PR DESCRIPTION
LLVM intrinsics to convert floating-point values to integers have undefined behavior if the value isn't finite.

Here, the original logic tested if a value was within range, which also excludes infinities and NaNs; this was bypassed for `Float16` values that are converted to integers with bit widths 32 or greater, since all finite values are within range. However, no subsequent check then excludes infinities as it does NaNs.

As a fix, we check `source.isFinite` for such conversions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
