### PR TITLE
Fix incorrect build type regression from ef89b0dc51d

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -244,7 +244,7 @@ function(_add_target_variant_swift_compile_flags
       "-F${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/../../../Developer/Library/Frameworks")
   endif()
 
-  swift_optimize_flag_for_build_type("${CMAKE_BUILD_TYPE}" optimize_flag)
+  swift_optimize_flag_for_build_type("${build_type}" optimize_flag)
   list(APPEND result "${optimize_flag}")
 
   is_build_type_with_debuginfo("${build_type}" debuginfo)


### PR DESCRIPTION
Unfortunately, this is a regression introduced in https://github.com/apple/swift/commit/ef89b0dc51ddd731f90fcf0f71738e9190f767db:
```is_build_type_optimized("${build_type}" optimized)```
changed to CMAKE_BUILD_TYPE but should have kept "build_type":
```swift_optimize_flag_for_build_type("${CMAKE_BUILD_TYPE}" optimize_flag)```
