### PR TITLE
[benchmark] Add benchmark for generic floating-point to integer conversion

### DIFF
--- a/benchmark/single-source/FloatingPointConversion.swift
+++ b/benchmark/single-source/FloatingPointConversion.swift
@@ -168,7 +168,7 @@ public func run_ConvertFloatingPoint_MockFloat64ToDouble(_ N: Int) {
 
 @inline(never)
 public func run_ConvertFloatingPoint_MockFloat64ToInt64(_ N: Int) {
-  for _ in 0..<(N * 100) {
+  for _ in 0..<(N * 1000) {
     for element in mockFloat64s {
       let i = Int64(identity(element))
       blackHole(i)

--- a/benchmark/single-source/FloatingPointConversion.swift
+++ b/benchmark/single-source/FloatingPointConversion.swift
@@ -18,6 +18,11 @@ public let FloatingPointConversion = [
     runFunction: run_ConvertFloatingPoint_MockFloat64ToDouble,
     tags: [.validation, .api],
     setUpFunction: { blackHole(mockFloat64s) }),
+  BenchmarkInfo(
+    name: "ConvertFloatingPoint.MockFloat64ToInt64",
+    runFunction: run_ConvertFloatingPoint_MockFloat64ToInt64,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(mockFloat64s) }),
 ]
 
 protocol MockBinaryFloatingPoint: BinaryFloatingPoint {
@@ -157,6 +162,16 @@ public func run_ConvertFloatingPoint_MockFloat64ToDouble(_ N: Int) {
     for element in mockFloat64s {
       let f = Double(identity(element))
       blackHole(f)
+    }
+  }
+}
+
+@inline(never)
+public func run_ConvertFloatingPoint_MockFloat64ToInt64(_ N: Int) {
+  for _ in 0..<(N * 100) {
+    for element in mockFloat64s {
+      let i = Int64(identity(element))
+      blackHole(i)
     }
   }
 }


### PR DESCRIPTION
This PR adds another benchmark, this time for generic floating-point to integer conversion, in anticipation of assessing the fast path to be added in #33889.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
