### PR TITLE
[5.3] Fix glibc.modulemap generation

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -102,6 +102,8 @@ foreach(sdk ${SWIFT_SDKS})
             "-DGLIBC_INCLUDE_PATH=${SWIFT_SDK_${sdk}_ARCH_${arch}_LIBC_INCLUDE_DIRECTORY}"
             "-DGLIBC_ARCH_INCLUDE_PATH=${SWIFT_SDK_${sdk}_ARCH_${arch}_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY}")
 
+    list(APPEND glibc_modulemap_target_list ${glibc_modulemap_target})
+
     if(SWIFT_BUILD_STATIC_STDLIB)
       add_custom_command_target(
         copy_glibc_modulemap_static


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/33311

- **Explanation**: https://github.com/apple/swift/pull/33678 has accidentally removed a line to generate the glibc modulemap, this PR adds it back.
- **Scope**: build
- **Risk**: Low
- **Testing**: Clean build works again
- **Issue**: rdar://problem/68674537
- **Reviewer**: @rintaro 