### PR TITLE
[CI] Re-enable test

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,7 +5,13 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
-// REQUIRES: rdar68353068
+// We copy the binary but not the corresponding .dSYM for remote runs (e.g.,
+// on-device testing), and hence online symbolication fails.
+// UNSUPPORTED: remote_run
+
+// The 32-bit iOS simulator is old and has an outdated version of atos that
+// can't demangle current Swift symbol names (the mangling scheme has changed).
+// UNSUPPORTED: CPU=i386 && OS=ios
 
 // Check that Sanitizer reports are properly symbolicated on Apple platforms,
 // both out-of-process (via `atos`) and when falling back to in-process


### PR DESCRIPTION
Disable for "remote runs".  We don't copy the corresponding `.dSYM`
with the test binary, and hence symbolication (source info) does not
succeed.

Also explicitly mark this test unsupported on for the 32-bit iOS
simulator.  It has an outdated version of `atos` that can't demangle
Swift symbol names.

Enable on other platforms.

rdar://68353068

