### PR TITLE
build: begin wiring up swift-argument-parser

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -579,6 +579,10 @@ def create_argument_parser():
     option(['--swiftevolve'], toggle_true('build_swiftevolve'),
            help='build the swift-evolve tool')
 
+    option(['--swift-argument-parser'],
+           toggle_true('build_swift_argument_parser'),
+           help='build swift-argument-parser')
+
     option(['--swift-driver'], toggle_true('build_swift_driver'),
            help='build swift-driver')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -88,6 +88,7 @@ EXPECTED_DEFAULTS = {
     'build_swift_static_stdlib': False,
     'build_swift_stdlib_unittest_extra': False,
     'build_swiftpm': False,
+    'build_argument_parser': False,
     'build_swift_driver': False,
     'build_swiftsyntax': False,
     'build_libparser_only': False,
@@ -472,6 +473,7 @@ EXPECTED_OPTIONS = [
                   dest='install_playgroundsupport'),
     SetTrueOption('--skip-build'),
     SetTrueOption('--swiftpm', dest='build_swiftpm'),
+    SetTrueOption('--swift-argument-parser', dest='build_swift_argument_parser')
     SetTrueOption('--swift-driver', dest='build_swift_driver'),
     SetTrueOption('--swiftsyntax', dest='build_swiftsyntax'),
     SetTrueOption('--build-libparser-only', dest='build_libparser_only'),

--- a/utils/swift_build_support/swift_build_support/products/argumentparser.py
+++ b/utils/swift_build_support/swift_build_support/products/argumentparser.py
@@ -1,0 +1,71 @@
+# swift_build_support/products/argumentparser.py -----------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from . import foundation
+from . import libdispatch
+from . import swift
+from . import xctest
+
+
+class ArgumentParser(product.Product):
+    @classmethod
+    def product_source_name(cls):
+        return "swift-argument-parser"
+
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    def should_build(self, host_target):
+        return self.args.build_swift_argument_parser
+
+    def get_dependencies(cls):
+        return [
+            foundation.Foundation,
+            libdispatch.LibDispatch,
+            swift.Swift,
+            xctest.XCTest,
+        ]
+
+    def build(self, host_target):
+        toolchain_path = targets.toolchain_path(self.args.install_destdir,
+                                                self.args.install_prefix)
+        swiftc = os.path.join(toolchain_path, 'bin', 'swiftc')
+
+        # FIXME: this is a workaround for CMake <3.16 which does not correctly
+        # generate the build rules if you are not in the build directory.
+        try:
+            shell.makedirs(self.build_dir)
+        except OSError:
+            pass
+
+        with shell.pushd(self.build_dir):
+            build_root = os.path.dirname(self.build_dir)
+            dispatch_build_dir = \
+                    os.path.join(build_root, "{}-{}".format("dispatch", host_target)
+            foundation_build_dir = \
+                    os.path.join(build_root, "{}-{}".format("foundation", host_target)
+            xctest_build_Dir = \
+                    os.path.join(build_root, "{}-{}".format("xctest", host_target)
+
+            shell.call([
+                self.toolchain.cmake,
+                '-B', self.build_dir,
+                '-D', "CMAKE_MAKE_PROGRAM={}".format(self.toolchain.ninja),
+                '-D', "CMAKE_Swift_COMPILER={}".format(swiftc),
+                '-D', "dispatch_DIR={}".format(dispatch_build_dir),
+                '-D', "Foundation_DIR={}".format(foundation_build_dir),
+                '-D', "XCTest_DIR={}".format(xctest_build_dir)
+            shell.call([
+                self.toolchain.cmake,
+                "--build", self.build_dir,
+            ])

--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -37,15 +37,18 @@ class SwiftDriver(product.Product):
 
     @classmethod
     def get_dependencies(cls):
-        return [cmark.CMark,
-                llvm.LLVM,
-                libcxx.LibCXX,
-                libicu.LibICU,
-                swift.Swift,
-                libdispatch.LibDispatch,
-                foundation.Foundation,
-                xctest.XCTest,
-                llbuild.LLBuild]
+        return [
+            cmark.CMark,
+            llvm.LLVM,
+            libcxx.LibCXX,
+            libicu.LibICU,
+            swift.Swift,
+            libdispatch.LibDispatch,
+            foundation.Foundation,
+            xctest.XCTest,
+            llbuild.LLBuild,
+            argumentparser.ArgumentParser,
+        ]
 
     def should_clean(self, host_target):
         return self.args.clean_swift_driver


### PR DESCRIPTION
swift-driver requires swift-argument-parser, add the build
infrastructure for building swift-argument-parser.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
