### PR TITLE
[stdlib] Silence signaling NaN in generic conversions

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1897,7 +1897,8 @@ extension BinaryFloatingPoint {
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
     case (5, 10):
       guard #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
-        self = Self._convert(from: value).value
+        // Convert signaling NaN to quiet NaN by multiplying by 1.
+        self = Self._convert(from: value).value * 1
         break
       }
       let value_ = value as? Float16 ?? Float16(
@@ -1935,7 +1936,8 @@ extension BinaryFloatingPoint {
       self = Self(value_)
 #endif
     default:
-      self = Self._convert(from: value).value
+      // Convert signaling NaN to quiet NaN by multiplying by 1.
+      self = Self._convert(from: value).value * 1
     }
   }
 


### PR DESCRIPTION
This PR is a follow-up to #33826, using a cheap operation (multiplying by one) to silence signaling NaN in generic conversions.

(Mostly I'm proud of the branch name.)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
