### PR TITLE
[build-script] Cleanup source directory layout help

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1190,16 +1190,13 @@ SWIFT_SOURCE_ROOT: a directory containing the source for LLVM, Clang, Swift.
 
 'build-script' expects the sources to be laid out in the following way:
 
-   $SWIFT_SOURCE_ROOT/llvm
-                     /clang
+   $SWIFT_SOURCE_ROOT/llvm-project
                      /swift
-                     /lldb                       (optional)
                      /llbuild                    (optional)
                      /swiftpm                    (optional, requires llbuild)
                      /swift-syntax               (optional, requires swiftpm)
                      /swift-stress-tester        (optional,
                                                    requires swift-syntax)
-                     /compiler-rt                (optional)
                      /swift-corelibs-xctest      (optional)
                      /swift-corelibs-foundation  (optional)
                      /swift-corelibs-libdispatch (optional)


### PR DESCRIPTION
Update the source directory layout help string that is embedded in `build-script` to represent how `llvm-project` has changed things.