### PR TITLE
[Concurrency] Basic support for actor classes and actor isolation

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -566,6 +566,12 @@ SIMPLE_DECL_ATTR(asyncHandler, AsyncHandler,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   101)
 
+CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
+  OnClass | ConcurrencyOnly |
+  ABIBreakingToAdd | ABIBreakingToRemove |
+  APIBreakingToAdd | APIBreakingToRemove,
+  102)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -418,6 +418,9 @@ public:
 
     /// The opposite of ABIBreakingToRemove
     ABIStableToRemove = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 15),
+
+    /// Whether this attribute is only valid when concurrency is enabled.
+    ConcurrencyOnly = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 16),
   };
 
   LLVM_READNONE
@@ -494,6 +497,10 @@ public:
 
   static bool isSilOnly(DeclAttrKind DK) {
     return getOptions(DK) & SILOnly;
+  }
+
+  static bool isConcurrencyOnly(DeclAttrKind DK) {
+    return getOptions(DK) & ConcurrencyOnly;
   }
 
   static bool isUserInaccessible(DeclAttrKind DK) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4007,6 +4007,9 @@ public:
     return getForeignClassKind() != ForeignKind::Normal;
   }
 
+  /// Whether the class is an actor.
+  bool isActor() const;
+
   /// Returns true if the class has designated initializers that are not listed
   /// in its members.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4141,10 +4141,14 @@ ERROR(actor_isolated_non_self_reference,none,
         "actor-isolated %0 %1 can only be referenced "
         "%select{inside the actor|on 'self'}2",
         (DescriptiveDeclKind, DeclName, bool))
-WARNING(concurrent_access,none,
-        "%select{local|actor-isolated}0 %1 %2 is unsafe to reference in code "
+WARNING(concurrent_access_local,none,
+        "local %0 %1 is unsafe to reference in code that may execute "
+        "concurrently",
+        (DescriptiveDeclKind, DeclName))
+ERROR(actor_isolated_concurrent_access,none,
+        "actor-isolated %0 %1 is unsafe to reference in code "
         "that may execute concurrently",
-        (bool, DescriptiveDeclKind, DeclName))
+        (DescriptiveDeclKind, DeclName))
 NOTE(actor_isolated_method,none,
      "only asynchronous methods can be used outside the actor instance; "
      "do you want to add 'async'?", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4137,6 +4137,23 @@ ERROR(actor_without_concurrency,none,
 ERROR(actor_with_nonactor_superclass,none,
       "actor class cannot inherit from non-actor class %0", (DeclName))
 
+ERROR(actor_isolated_non_self_reference,none,
+        "actor-isolated %0 %1 can only be referenced "
+        "%select{inside the actor|on 'self'}2",
+        (DescriptiveDeclKind, DeclName, bool))
+WARNING(concurrent_access,none,
+        "%select{local|actor-isolated}0 %1 %2 is unsafe to reference in code "
+        "that may execute concurrently",
+        (bool, DescriptiveDeclKind, DeclName))
+NOTE(actor_isolated_method,none,
+     "only asynchronous methods can be used outside the actor instance; "
+     "do you want to add 'async'?", ())
+NOTE(actor_mutable_state,none,
+     "mutable state is only available within the actor instance", ())
+WARNING(shared_mutable_state_access,none,
+        "reference to %0 %1 is not concurrency-safe because it involves "
+        "shared mutable state", (DescriptiveDeclKind, DeclName))
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Types
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4132,6 +4132,11 @@ ERROR(satisfy_async_objc,none,
 ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
 
+ERROR(actor_without_concurrency,none,
+      "'actor' classes require experimental concurrency support", ())
+ERROR(actor_with_nonactor_superclass,none,
+      "actor class cannot inherit from non-actor class %0", (DeclName))
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Types
 //------------------------------------------------------------------------------

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -799,6 +799,24 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Determine whether the given class is an actor.
+class IsActorRequest :
+    public SimpleRequest<IsActorRequest,
+                         bool(ClassDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 /// Request whether the storage has a mutating getter.
 class IsGetterMutatingRequest :
     public SimpleRequest<IsGetterMutatingRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -83,6 +83,8 @@ SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest, Type(ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsAsyncHandlerRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(ClassDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, GenericSignatureRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4222,6 +4222,13 @@ GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   return DD;
 }
 
+bool ClassDecl::isActor() const {
+  auto mutableThis = const_cast<ClassDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           IsActorRequest{mutableThis},
+                           false);
+}
+
 bool ClassDecl::hasMissingDesignatedInitializers() const {
   return evaluateOrDefault(
       getASTContext().evaluator,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3079,6 +3079,7 @@ ParserStatus Parser::parseDeclAttributeList(DeclAttributes &Attributes) {
 //      'nonmutating'
 //      '__consuming'
 //      'convenience'
+//      'actor'
 bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
                                    SourceLoc &StaticLoc,
                                    StaticSpellingKind &StaticSpelling) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4461,6 +4461,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   if (ctx.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(DC, E);
   diagnoseConstantArgumentRequirement(E, DC);
+  checkActorIsolation(E, DC);
 }
 
 void swift::performStmtDiagnostics(ASTContext &ctx, const Stmt *S) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -273,6 +273,14 @@ public:
     // Trigger the request to check for @asyncHandler.
     (void)func->isAsyncHandler();
   }
+
+  void visitActorAttr(ActorAttr *attr) {
+    auto classDecl = dyn_cast<ClassDecl>(D);
+    if (!classDecl)
+      return; // already diagnosed
+
+    (void)classDecl->isActor();
+  }
 };
 } // end anonymous namespace
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -551,7 +551,7 @@ void swift::checkActorIsolation(const Expr *expr, const DeclContext *dc) {
         if (mayExecuteConcurrentlyWith(
                 getDeclContext(), isolation.getLocalContext())) {
           ctx.Diags.diagnose(
-              loc, diag::concurrent_access, false,
+              loc, diag::concurrent_access_local,
               value->getDescriptiveKind(), value->getName());
           value->diagnose(
               diag::kind_declared_here, value->getDescriptiveKind());
@@ -593,7 +593,7 @@ void swift::checkActorIsolation(const Expr *expr, const DeclContext *dc) {
         if (mayExecuteConcurrentlyWith(
                 getDeclContext(), selfVar->getDeclContext())) {
           ctx.Diags.diagnose(
-              memberLoc, diag::concurrent_access, true,
+              memberLoc, diag::actor_isolated_concurrent_access,
               member->getDescriptiveKind(), member->getName());
           noteIsolatedActorMember(member);
           return true;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "TypeChecker.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -193,4 +194,425 @@ bool IsActorRequest::evaluate(
   }
 
   return actorAttr != nullptr;
+}
+
+namespace {
+
+/// The isolation restriction in effect for a given declaration that is
+/// referenced from source.
+class IsolationRestriction {
+public:
+  enum Kind {
+    /// There is no restriction on references to the given declaration,
+    /// e.g., because it's immutable.
+    Unrestricted,
+
+    /// Access to the declaration is unsafe in a concurrent context.
+    Unsafe,
+
+    /// The declaration can only be referenced from the given local context,
+    /// or a context that cannot execute concurrently with code in that
+    /// context.
+    Local,
+
+    /// References to this local variable that can only be made from the
+    /// References to this member of an actor are only permitted on 'self'.
+    ActorSelf,
+  };
+
+private:
+  /// The kind of restriction
+  Kind kind;
+
+  union {
+    /// The local context that an entity is tied to.
+    DeclContext *localContext;
+
+    /// The actor class that the entity is declared in.
+    ClassDecl *actorClass;
+  } data;
+
+  explicit IsolationRestriction(Kind kind) : kind(kind) { }
+
+  /// Determine whether the given value is an instance member of an actor
+  /// class that is isolated to the current actor instance.
+  ///
+  /// \returns the type of the actor.
+  static ClassDecl *getActorIsolatingInstanceMEmber(ValueDecl *value) {
+    // Only instance members are isolated.
+    if (!value->isInstanceMember())
+      return nullptr;
+
+    // Are we within an actor class?
+    auto classDecl = value->getDeclContext()->getSelfClassDecl();
+    if (!classDecl || !classDecl->isActor())
+      return nullptr;
+
+    // Functions that are an asynchronous context can be accessed from anywhere.
+    if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
+      if (func->isAsyncContext())
+        return nullptr;
+    }
+
+    // This member is part of the isolated state.
+    return classDecl;
+  }
+
+public:
+  Kind getKind() const { return kind; }
+
+  /// Retrieve the declaration context in which a local was defined.
+  DeclContext *getLocalContext() const {
+    assert(kind == Local);
+    return data.localContext;
+  }
+
+  /// Retrieve the actor class that the declaration is within.
+  ClassDecl *getActorClass() const {
+    assert(kind == ActorSelf);
+    return data.actorClass;
+  }
+
+  /// There are no restrictions on the use of the entity.
+  static IsolationRestriction forUnrestricted() {
+    return IsolationRestriction(Unrestricted);
+  }
+
+  /// Accesses to the given declaration are unsafe.
+  static IsolationRestriction forUnsafe() {
+    return IsolationRestriction(Unsafe);
+  }
+
+  /// Accesses to the given declaration can only be made via the 'self' of
+  /// the current actor.
+  static IsolationRestriction forActorSelf(ClassDecl *actorClass) {
+    IsolationRestriction result(ActorSelf);
+    result.data.actorClass = actorClass;
+    return result;
+  }
+
+  /// Access is restricted to code running within the given local context.
+  static IsolationRestriction forLocal(DeclContext *dc) {
+    IsolationRestriction result(Local);
+    result.data.localContext = dc;
+    return result;
+  }
+
+  /// Determine the isolation rules for a given declaration.
+  static IsolationRestriction forDeclaration(Decl *decl) {
+    switch (decl->getKind()) {
+    case DeclKind::AssociatedType:
+    case DeclKind::Class:
+    case DeclKind::Enum:
+    case DeclKind::Extension:
+    case DeclKind::GenericTypeParam:
+    case DeclKind::OpaqueType:
+    case DeclKind::Protocol:
+    case DeclKind::Struct:
+    case DeclKind::TypeAlias:
+      // Types are always available.
+      return forUnrestricted();
+
+    case DeclKind::Constructor:
+    case DeclKind::EnumCase:
+    case DeclKind::EnumElement:
+      // Type-level entities don't require isolation.
+      return forUnrestricted();
+
+    case DeclKind::IfConfig:
+    case DeclKind::Import:
+    case DeclKind::InfixOperator:
+    case DeclKind::MissingMember:
+    case DeclKind::Module:
+    case DeclKind::PatternBinding:
+    case DeclKind::PostfixOperator:
+    case DeclKind::PoundDiagnostic:
+    case DeclKind::PrecedenceGroup:
+    case DeclKind::PrefixOperator:
+    case DeclKind::TopLevelCode:
+      // Non-value entities don't require isolation.
+      return forUnrestricted();
+
+    case DeclKind::Destructor:
+      // Destructors don't require isolation.
+      return forUnrestricted();
+
+    case DeclKind::Param:
+    case DeclKind::Var:
+      // 'let' declarations are immutable, so there are no restrictions on
+      // their access.
+      if (cast<VarDecl>(decl)->isLet())
+        return forUnrestricted();
+
+      LLVM_FALLTHROUGH;
+
+    case DeclKind::Accessor:
+    case DeclKind::Func:
+    case DeclKind::Subscript:
+      // Local captures can only be referenced in their local context or a
+      // context that is guaranteed not to run concurrently with it.
+      if (cast<ValueDecl>(decl)->isLocalCapture())
+        return forLocal(decl->getDeclContext());
+
+      // Protected actor instance members can only be accessed on 'self'.
+      if (auto actorClass = getActorIsolatingInstanceMEmber(
+              cast<ValueDecl>(decl)))
+        return forActorSelf(actorClass);
+
+      // All other accesses are unsafe.
+      return forUnsafe();
+    }
+  }
+
+  operator Kind() const { return kind; };
+};
+
+}
+
+void swift::checkActorIsolation(const Expr *expr, const DeclContext *dc) {
+  class ActorIsolationWalker : public ASTWalker {
+    ASTContext &ctx;
+    SmallVector<const DeclContext *, 4> contextStack;
+
+    const DeclContext *getDeclContext() const {
+      return contextStack.back();
+    }
+
+  public:
+    ActorIsolationWalker(const DeclContext *dc) : ctx(dc->getASTContext()) {
+      contextStack.push_back(dc);
+    }
+
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
+    }
+
+    bool shouldWalkCaptureInitializerExpressions() override { return true; }
+
+    bool shouldWalkIntoTapExpression() override { return false; }
+
+    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      if (auto *closure = dyn_cast<AbstractClosureExpr>(expr)) {
+        contextStack.push_back(closure);
+        return { true, expr };
+      }
+
+      if (auto lookup = dyn_cast<LookupExpr>(expr)) {
+        checkMemberReference(lookup->getBase(), lookup->getMember().getDecl(),
+                             lookup->getLoc());
+        return { true, expr };
+      }
+
+      if (auto declRef = dyn_cast<DeclRefExpr>(expr)) {
+        checkNonMemberReference(declRef->getDecl(), declRef->getLoc());
+        return { true, expr };
+      }
+
+      if (auto call = dyn_cast<SelfApplyExpr>(expr)) {
+        Expr *fn = call->getFn()->getValueProvidingExpr();
+        if (auto declRef = dyn_cast<DeclRefExpr>(fn)) {
+          checkMemberReference(
+              call->getArg(), declRef->getDecl(), declRef->getLoc());
+          call->getArg()->walk(*this);
+          return { false, expr };
+        }
+
+        if (auto otherCtor = dyn_cast<OtherConstructorDeclRefExpr>(fn)) {
+          checkMemberReference(
+              call->getArg(), otherCtor->getDecl(), otherCtor->getLoc());
+          call->getArg()->walk(*this);
+          return { false, expr };
+        }
+      }
+
+      return { true, expr };
+    }
+
+    Expr *walkToExprPost(Expr *expr) override {
+      if (auto *closure = dyn_cast<AbstractClosureExpr>(expr)) {
+        assert(contextStack.back() == closure);
+        contextStack.pop_back();
+      }
+
+      return expr;
+    }
+
+  private:
+    /// If the expression is a reference to `self`, return the 'self' parameter.
+    static VarDecl *getSelfReference(Expr *expr) {
+      // Look through identity expressions and implicit conversions.
+      Expr *prior;
+      do {
+        prior = expr;
+
+        expr = expr->getSemanticsProvidingExpr();
+
+        if (auto conversion = dyn_cast<ImplicitConversionExpr>(expr))
+          expr = conversion->getSubExpr();
+      } while (prior != expr);
+
+      // 'super' references always act on self.
+      if (auto super = dyn_cast<SuperRefExpr>(expr))
+        return super->getSelf();
+
+      // Declaration references to 'self'.
+      if (auto declRef = dyn_cast<DeclRefExpr>(expr)) {
+        if (auto var = dyn_cast<VarDecl>(declRef->getDecl()))
+          if (var->isSelfParameter())
+            return var;
+      }
+
+      // Not a self reference.
+      return nullptr;
+    }
+
+    /// Note that the given actor member is isolated.
+    static void noteIsolatedActorMember(ValueDecl *decl) {
+      if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+        // FIXME: We'd like to insert 'async' at the appropriate place, but
+        // FuncDecl/AbstractFunctionDecl doesn't have the right source-location
+        // information to do so.
+        func->diagnose(diag::actor_isolated_method);
+      } else if (isa<VarDecl>(decl)) {
+        decl->diagnose(diag::actor_mutable_state);
+      } else {
+        decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
+      }
+    }
+
+    /// Determine whether code in the given use context might execute
+    /// concurrently with code in the definition context.
+    bool mayExecuteConcurrentlyWith(
+        const DeclContext *useContext, const DeclContext *defContext) {
+      // If it's the same context, it won't execute concurrently.
+      if (useContext == defContext)
+        return false;
+
+      // Assume all child contexts can execute concurrently.
+      return true;
+    }
+
+    // Retrieve the nearest enclosing actor context.
+    static ClassDecl *getNearestEnclosingActorContext(const DeclContext *dc) {
+      while (!dc->isModuleScopeContext()) {
+        if (dc->isTypeContext()) {
+          if (auto classDecl = dc->getSelfClassDecl()) {
+            if (classDecl->isActor())
+              return classDecl;
+          }
+        }
+
+        dc = dc->getParent();
+      }
+
+      return nullptr;
+    }
+
+    /// Diagnose a reference to an unsafe entity.
+    ///
+    /// \returns true if we diagnosed the entity, \c false otherwise.
+    bool diagnoseReferenceToUnsafe(ValueDecl *value, SourceLoc loc) {
+      // Only diagnose unsafe concurrent accesses within the context of an
+      // actor. This is globally unsafe, but locally enforceable.
+      if (!getNearestEnclosingActorContext(getDeclContext()))
+        return false;
+
+      // Only diagnose direct references to mutable shared state. This is
+      // globally unsafe, but reduces the noise.
+      if (!isa<VarDecl>(value) || !cast<VarDecl>(value)->hasStorage())
+        return false;
+
+      ctx.Diags.diagnose(
+          loc, diag::shared_mutable_state_access,
+          value->getDescriptiveKind(), value->getName());
+      value->diagnose(diag::kind_declared_here, value->getDescriptiveKind());
+      return true;
+    }
+
+    /// Check a reference to a local or global.
+    bool checkNonMemberReference(ValueDecl *value, SourceLoc loc) {
+      if (!value)
+        return false;
+
+      switch (auto isolation = IsolationRestriction::forDeclaration(value)) {
+      case IsolationRestriction::Unrestricted:
+        return false;
+
+      case IsolationRestriction::ActorSelf:
+        llvm_unreachable("non-member reference into an actor");
+
+      case IsolationRestriction::Local:
+        // Only diagnose unsafe concurrent accesses within the context of an
+        // actor. This is globally unsafe, but locally enforceable.
+        if (!getNearestEnclosingActorContext(getDeclContext()))
+          return false;
+
+        // Check whether we are in a context that will not execute concurrently
+        // with the context of 'self'.
+        if (mayExecuteConcurrentlyWith(
+                getDeclContext(), isolation.getLocalContext())) {
+          ctx.Diags.diagnose(
+              loc, diag::concurrent_access, false,
+              value->getDescriptiveKind(), value->getName());
+          value->diagnose(
+              diag::kind_declared_here, value->getDescriptiveKind());
+          return true;
+        }
+
+        return false;
+
+      case IsolationRestriction::Unsafe:
+        return diagnoseReferenceToUnsafe(value, loc);
+      }
+    }
+
+    /// Check a reference with the given base expression to the given member.
+    bool checkMemberReference(
+        Expr *base, ValueDecl *member, SourceLoc memberLoc) {
+      if (!base || !member)
+        return false;
+
+      switch (auto isolation = IsolationRestriction::forDeclaration(member)) {
+      case IsolationRestriction::Unrestricted:
+        return false;
+
+      case IsolationRestriction::ActorSelf: {
+        auto selfVar = getSelfReference(base);
+        if (!selfVar) {
+          ctx.Diags.diagnose(
+              memberLoc, diag::actor_isolated_non_self_reference,
+              member->getDescriptiveKind(),
+              member->getName(),
+              isolation.getActorClass() ==
+                getNearestEnclosingActorContext(getDeclContext()));
+          noteIsolatedActorMember(member);
+          return true;
+        }
+
+        // Check whether we are in a context that will not execute concurrently
+        // with the context of 'self'.
+        if (mayExecuteConcurrentlyWith(
+                getDeclContext(), selfVar->getDeclContext())) {
+          ctx.Diags.diagnose(
+              memberLoc, diag::concurrent_access, true,
+              member->getDescriptiveKind(), member->getName());
+          noteIsolatedActorMember(member);
+          return true;
+        }
+
+        // It's fine.
+        return false;
+      }
+
+      case IsolationRestriction::Local:
+        llvm_unreachable("Locals cannot be referenced with member syntax");
+
+      case IsolationRestriction::Unsafe:
+        return diagnoseReferenceToUnsafe(member, memberLoc);
+      }
+    }
+  };
+
+  ActorIsolationWalker walker(dc);
+  const_cast<Expr *>(expr)->walk(walker);
 }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1512,6 +1512,7 @@ namespace  {
     UNINTERESTING_ATTR(FunctionBuilder)
     UNINTERESTING_ATTR(ProjectedValueProperty)
     UNINTERESTING_ATTR(OriginallyDefinedIn)
+    UNINTERESTING_ATTR(Actor)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1132,8 +1132,7 @@ void checkTopLevelEffects(TopLevelCodeDecl *D);
 void checkFunctionEffects(AbstractFunctionDecl *D);
 void checkInitializerEffects(Initializer *I, Expr *E);
 void checkEnumElementEffects(EnumElementDecl *D, Expr *expr);
-void checkPropertyWrapperEffects(PatternBindingDecl *binding,
-                                       Expr *expr);
+void checkPropertyWrapperEffects(PatternBindingDecl *binding, Expr *expr);
 
 /// If an expression references 'self.init' or 'super.init' in an
 /// initializer context, returns the implicit 'self' decl of the constructor.
@@ -1387,6 +1386,9 @@ void bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *stmt);
 /// Add notes suggesting the addition of 'async' or '@asyncHandler', as
 /// appropriate, to a diagnostic for a function that isn't an async context.
 void addAsyncNotes(FuncDecl *func);
+
+/// Check actor isolation rules.
+void checkActorIsolation(const Expr *expr, const DeclContext *dc);
 
 } // end namespace swift
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -14,9 +14,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
 }
 
 func testSlowServerOldSchool(slowServer: SlowServer) {
-  var i1: Int = 0
   slowServer.doSomethingSlow("mail") { i in
-    i1 = i
+    _ = i
   }
-  print(i1)
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1,0 +1,109 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+
+let immutableGlobal: String = "hello"
+var mutableGlobal: String = "can't touch this" // expected-note{{var declared here}}
+
+func globalFunc() { }
+func acceptClosure<T>(_: () -> T) { }
+func acceptEscapingClosure<T>(_: @escaping () -> T) { }
+
+// ----------------------------------------------------------------------
+// Actor state isolation restrictions
+// ----------------------------------------------------------------------
+actor class MySuperActor {
+  var superState: Int = 25
+
+  func superMethod() { }
+  func superAsyncMethod() async { }
+
+  subscript (index: Int) -> String { // expected-note{{subscript declared here}}
+    "\(index)"
+  }
+}
+
+actor class MyActor: MySuperActor {
+  let immutable: Int = 17
+  var text: [String] = [] // expected-note 4{{mutable state is only available within the actor instance}}
+
+  class func synchronousClass() { }
+  static func synchronousStatic() { }
+
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 3{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func asynchronous() async -> String { synchronous() }
+}
+
+extension MyActor {
+  func testAsynchronous(otherActor: MyActor) async {
+    _ = immutable
+    _ = synchronous()
+    _ = text[0]
+
+    // Accesses on 'self' are okay.
+    _ = self.immutable
+    _ = self.synchronous()
+    _ = await self.asynchronous()
+    _ = self.text[0]
+    _ = self[0]
+
+    // Accesses on 'super' are okay.
+    _ = super.superState
+    super.superMethod()
+    await super.superAsyncMethod()
+    _ = super[0]
+
+    // Accesses on other actors can only reference immutable data or
+    // call asychronous methods
+    _ = otherActor.immutable // okay
+    _ = otherActor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced on 'self'}}
+    _ = await otherActor.asynchronous()
+    _ = otherActor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced on 'self'}}
+
+    // Global data is okay if it is immutable.
+    _ = immutableGlobal
+    _ = mutableGlobal // expected-warning{{reference to var 'mutableGlobal' is not concurrency-safe because it involves shared mutable state}}
+
+    // Global functions are not actually safe, but we allow them for now.
+    globalFunc()
+
+    // Class methods are okay.
+    Self.synchronousClass()
+    Self.synchronousStatic()
+
+    // Closures.
+    let localConstant = 17
+    var localVar = 17 // expected-note 2{{var declared here}}
+    acceptClosure {
+      _ = text[0] // expected-warning{{actor-isolated property 'text' is unsafe to reference in code that may execute concurrently}}
+      _ = self.synchronous() // expected-warning{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
+      _ = localVar // expected-warning{{local var 'localVar' is unsafe to reference in code that may execute concurrently}}
+      _ = localConstant
+    }
+
+    acceptEscapingClosure {
+      _ = self.text[0] // expected-warning{{actor-isolated property 'text' is unsafe to reference in code that may execute concurrently}}
+      _ = localVar // expected-warning{{local var 'localVar' is unsafe to reference in code that may execute concurrently}}
+      _ = localConstant
+    }
+    localVar = 0
+  }
+}
+
+// ----------------------------------------------------------------------
+// Non-actor code isolation restrictions
+// ----------------------------------------------------------------------
+func testGlobalRestrictions(actor: MyActor) async {
+  let _ = MyActor()
+
+  // Asynchronous functions and immutable state are permitted.
+  _ = await actor.asynchronous()
+  _ = actor.immutable
+
+  // Synchronous operations and mutable state references are not.
+  _ = actor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced inside the actor}}
+  _ = actor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced inside the actor}}
+  _ = actor[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can only be referenced inside the actor}}
+
+  // Operations on non-instances are permitted.
+  MyActor.synchronousStatic()
+  MyActor.synchronousClass()
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -28,7 +28,7 @@ actor class MyActor: MySuperActor {
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 3{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 4{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
   func asynchronous() async -> String { synchronous() }
 }
 
@@ -73,14 +73,15 @@ extension MyActor {
     let localConstant = 17
     var localVar = 17 // expected-note 2{{var declared here}}
     acceptClosure {
-      _ = text[0] // expected-warning{{actor-isolated property 'text' is unsafe to reference in code that may execute concurrently}}
-      _ = self.synchronous() // expected-warning{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
+      _ = text[0] // expected-error{{actor-isolated property 'text' is unsafe to reference in code that may execute concurrently}}
+      _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
       _ = localVar // expected-warning{{local var 'localVar' is unsafe to reference in code that may execute concurrently}}
       _ = localConstant
     }
 
     acceptEscapingClosure {
-      _ = self.text[0] // expected-warning{{actor-isolated property 'text' is unsafe to reference in code that may execute concurrently}}
+      _ = self.text[0] // expected-error{{actor-isolated property 'text' is unsafe to reference in code that may execute concurrently}}
+      _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
       _ = localVar // expected-warning{{local var 'localVar' is unsafe to reference in code that may execute concurrently}}
       _ = localConstant
     }

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD2 | %FileCheck %s -check-prefix=KEYWORD2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD3 | %FileCheck %s -check-prefix=KEYWORD3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD3_2 | %FileCheck %s -check-prefix=KEYWORD3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD3 -enable-experimental-concurrency | %FileCheck %s -check-prefix=KEYWORD3_ASYNC
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD4 | %FileCheck %s -check-prefix=KEYWORD4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD5 | %FileCheck %s -check-prefix=KEYWORD5
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_GLOBALVAR | %FileCheck %s -check-prefix=ON_GLOBALVAR
@@ -89,6 +90,8 @@ struct MyStruct {}
 // KEYWORD3-NEXT:             Keyword/None:                       usableFromInline[#Class Attribute#]; name=usableFromInline
 // KEYWORD3-NEXT:             Keyword/None:                       propertyWrapper[#Class Attribute#]; name=propertyWrapper
 // KEYWORD3-NEXT:             End completions
+
+// KEYWORD3_ASYNC: Keyword/None: actor[#Class Attribute#]; name=actor
 
 @#^KEYWORD3_2^#IB class C2 {}
 // Same as KEYWORD3.

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+
+actor class MyActor { }
+
+class MyActorSubclass1: MyActor { }
+
+actor class MyActorSubclass2: MyActor { }
+
+class NonActor { }
+
+actor class NonActorSubclass : NonActor { } // expected-error{{actor class cannot inherit from non-actor class 'NonActor'}}

--- a/test/decl/class/actor/noconcurrency.swift
+++ b/test/decl/class/actor/noconcurrency.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift
+
+actor class C { } // expected-error{{'actor' classes require experimental concurrency support}}
+

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -170,7 +170,8 @@ DECL_NODES = [
                        'lazy', 'optional', 'override', 'postfix', 'prefix',
                        'required', 'static', 'unowned', 'weak', 'private',
                        'fileprivate', 'internal', 'public', 'open',
-                       'mutating', 'nonmutating', 'indirect', '__consuming'
+                       'mutating', 'nonmutating', 'indirect', '__consuming',
+                       'actor'
                    ]),
              Child('DetailLeftParen', kind='LeftParenToken', is_optional=True),
              Child('Detail', kind='IdentifierToken', is_optional=True),


### PR DESCRIPTION
Introduce the "actor class" syntax. Ensure that it is only used for
root classes or classes that inherit from other actor classes. Within
actors, implement a basic set of isolation rules for actors, which includes:

* Asynchronous actor methods can be invoked on any actor instance.
* All mutable instance properties and synchronous instance methods are
only accessible via "self" or "super" within the context of the actor.
* Closures defined within an actor method are considered to be a
context distinct from the actor itself, are therefore are subject to
the same restrictions as above.

Together with a scheduler that ensures that asynchronous invocations
for a particular actor are serialized (at least up until they hit a
suspension point or return), this serves to isolate the actor's
instance state in a shallow manner: references to shared mutable state
can still be passed among actors, code can access global variables,
and one can still form and pass around unsafe pointers.

Pair this with some basic checking within actor contexts that
identifies a few obvious potential kinds of race conditions:

* References to captured mutable local variables from within closures.
* References to mutable global and static/class variables.

The latter are warnings, for which we currently don't have a great
suppression mechanism. That, and a lot of tuning, are still to come.