### PR TITLE
[Parse][CodeCompletion] Stop code completion within a closure causing parser recovery after the closure.

### DIFF
--- a/include/swift/Parse/SyntaxParserResult.h
+++ b/include/swift/Parse/SyntaxParserResult.h
@@ -44,11 +44,16 @@ public:
 
   bool isNull() const { return ASTResult.isNull(); }
   bool isNonNull() const { return ASTResult.isNonNull(); }
-  bool isParseError() const { return ASTResult.isParseError(); }
+  bool isParseError() const {
+    return ASTResult.isParseError();
+  }
+  bool isParseErrorOrHasCompletion() const {
+    return ASTResult.isParseErrorOrHasCompletion();
+  }
   bool hasCodeCompletion() const { return ASTResult.hasCodeCompletion(); }
 
   void setIsParseError() { return ASTResult.setIsParserError(); }
-  void setHasCodeCompletion() { return ASTResult.setHasCodeCompletion(); }
+  void setHasCodeCompletionAndIsError() { return ASTResult.setHasCodeCompletionAndIsError(); }
 
   const ParserResult<AST> &getASTResult() { return ASTResult; }
 
@@ -92,7 +97,7 @@ makeSyntaxCodeCompletionResult(AST *Result = nullptr) {
   SyntaxParserResult<Syntax, AST> SR;
   if (Result)
     SR = SyntaxParserResult<Syntax, AST>(None, Result);
-  SR.setHasCodeCompletion();
+  SR.setHasCodeCompletionAndIsError();
   return SR;
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -597,7 +597,7 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
                                   /*isBasic=*/true);
     parseStatus = rootResult;
 
-    if (rootResult.isParseError())
+    if (rootResult.isParseErrorOrHasCompletion())
       return rootResult;
   }
 
@@ -725,7 +725,7 @@ ParserResult<Expr> Parser::parseExprKeyPathObjC() {
 
   // Parse the closing ')'.
   SourceLoc rParenLoc;
-  if (status.isError()) {
+  if (status.isErrorOrHasCompletion()) {
     skipUntilDeclStmtRBrace(tok::r_paren);
     if (Tok.is(tok::r_paren))
       rParenLoc = consumeToken();
@@ -738,7 +738,7 @@ ParserResult<Expr> Parser::parseExprKeyPathObjC() {
 
   // If we cannot build a useful expression, just return an error
   // expression.
-  if (components.empty() || status.isError()) {
+  if (components.empty() || status.isErrorOrHasCompletion()) {
     return makeParserResult<Expr>(
              new (Context) ErrorExpr(SourceRange(keywordLoc, rParenLoc)));
   }
@@ -809,7 +809,7 @@ ParserResult<Expr> Parser::parseExprSelector() {
 
   // Parse the closing ')'.
   SourceLoc rParenLoc;
-  if (subExpr.isParseError()) {
+  if (subExpr.isParseErrorOrHasCompletion()) {
     skipUntilDeclStmtRBrace(tok::r_paren);
     if (Tok.is(tok::r_paren))
       rParenLoc = consumeToken();
@@ -821,7 +821,7 @@ ParserResult<Expr> Parser::parseExprSelector() {
   }
 
   // If the subexpression was in error, just propagate the error.
-  if (subExpr.isParseError() && !subExpr.hasCodeCompletion())
+  if (subExpr.isParseErrorOrHasCompletion() && !subExpr.hasCodeCompletion())
     return makeParserResult<Expr>(
       new (Context) ErrorExpr(SourceRange(keywordLoc, rParenLoc)));
 
@@ -1190,7 +1190,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         SmallVector<TypeRepr *, 8> args;
         SourceLoc LAngleLoc, RAngleLoc;
         auto argStat = parseGenericArguments(args, LAngleLoc, RAngleLoc);
-        if (argStat.isError())
+        if (argStat.isErrorOrHasCompletion())
           diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
 
         SyntaxContext->createNodeInPlace(SyntaxKind::SpecializeExpr);
@@ -1321,7 +1321,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       }
       // Eat the code completion token because we handled it.
       consumeToken(tok::code_complete);
-      Result.setHasCodeCompletion();
+      Result.setHasCodeCompletionAndIsError();
       return Result;
     }
 
@@ -1390,7 +1390,7 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
   Result = parseExprPostfixSuffix(Result, isExprBasic,
                                   /*periodHasKeyPathBehavior=*/InSwiftKeyPath,
                                   hasBindOptional);
-  if (Result.isParseError() || Result.hasCodeCompletion())
+  if (Result.isParseErrorOrHasCompletion() || Result.hasCodeCompletion())
     return Result;
 
   // If we had a ? suffix expression, bind the entire postfix chain
@@ -1601,7 +1601,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     if (Tok.is(tok::code_complete)) {
       auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
       auto Result = makeParserResult(CCE);
-      Result.setHasCodeCompletion();
+      Result.setHasCodeCompletionAndIsError();
       if (CodeCompletion) {
         CodeCompletion->completeUnresolvedMember(CCE, DotLoc);
       }
@@ -1642,7 +1642,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     auto res = parseStmtConditionPoundAvailable();
     if (res.hasCodeCompletion())
       return makeParserCodeCompletionStatus();
-    if (res.isParseError() || res.isNull())
+    if (res.isParseErrorOrHasCompletion() || res.isNull())
       return nullptr;
     return makeParserResult(new (Context)
                                 ErrorExpr(res.get()->getSourceRange()));
@@ -1656,7 +1656,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   case tok::code_complete: {
     auto Result =
         makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
-    Result.setHasCodeCompletion();
+    Result.setHasCodeCompletionAndIsError();
     if (CodeCompletion &&
         // We cannot code complete anything after var/let.
         (!InVarOrLetPattern || InVarOrLetPattern == IVOLP_InMatchingPattern)) {
@@ -2223,7 +2223,7 @@ Expr *Parser::parseExprIdentifier() {
     SyntaxContext->createNodeInPlace(SyntaxKind::IdentifierExpr);
     SyntaxContext->setCreateSyntax(SyntaxKind::SpecializeExpr);
     auto argStat = parseGenericArguments(args, LAngleLoc, RAngleLoc);
-    if (argStat.isError())
+    if (argStat.isErrorOrHasCompletion())
       diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
     
     // The result can be empty in error cases.
@@ -2829,7 +2829,7 @@ ParserResult<Expr> Parser::parseExprClosure() {
     // be considered top-level completions.
     if (State->hasCodeCompletionDelayedDeclState())
       (void)State->takeCodeCompletionDelayedDeclState();
-    Status.setHasCodeCompletion();
+    Status.setHasCodeCompletionAndIsError();
   }
 
   // Parse the closing '}'.
@@ -2837,8 +2837,13 @@ ParserResult<Expr> Parser::parseExprClosure() {
   bool missingRBrace = parseMatchingToken(tok::r_brace, rightBrace,
                                           diag::expected_closure_rbrace,
                                           leftBrace);
-  if (missingRBrace)
+  if (missingRBrace) {
     Status.setIsParseError();
+  } else {
+    // We recovered so don't propagate any error status (but still preserve
+    // HasCodeCompletion).
+    Status.clearIsError();
+  }
 
   // If we didn't have any parameters, create a parameter list from the
   // anonymous closure arguments.
@@ -3086,7 +3091,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
         CodeCompletion->completeCallArg(CCExpr, PreviousLoc == leftLoc);
       consumeIf(tok::code_complete);
       SubExpr = CCExpr;
-      Status.setHasCodeCompletion();
+      Status.setHasCodeCompletionAndIsError();
     } else {
       auto ParsedSubExpr = parseExpr(diag::expected_expr_in_expr_list);
       SubExpr = ParsedSubExpr.getPtrOrNull();
@@ -3218,7 +3223,7 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
       if (CodeCompletion)
         CodeCompletion->completeLabeledTrailingClosure(CCExpr, Tok.isAtStartOfLine());
       consumeToken(tok::code_complete);
-      result.setHasCodeCompletion();
+      result.setHasCodeCompletionAndIsError();
       closures.push_back({Identifier(), SourceLoc(), CCExpr});
       continue;
     }
@@ -3293,7 +3298,7 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
                                       SyntaxKind::TupleExprElementList);
   if (status.hasCodeCompletion())
     return makeParserCodeCompletionResult<Expr>();
-  if (status.isError())
+  if (status.isErrorOrHasCompletion())
     return makeParserError();
 
   return makeParserResult(
@@ -3334,7 +3339,7 @@ ParserResult<Expr> Parser::parseExprPoundUnknown(SourceLoc LSquareLoc) {
                       trailingClosures, SyntaxKind::TupleExprElementList);
     if (status.hasCodeCompletion())
       return makeParserCodeCompletionResult<Expr>();
-    if (status.isError())
+    if (status.isErrorOrHasCompletion())
       return makeParserError();
   }
 
@@ -3435,7 +3440,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
     CodeCompletion->completePostfixExprParen(fn.get(), CCE);
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);
-    Result.setHasCodeCompletion();
+    Result.setHasCodeCompletionAndIsError();
     return Result;
   }
 
@@ -3527,7 +3532,7 @@ ParserResult<Expr> Parser::parseExprCollection() {
       // Skip to ']' or ',' in case of error.
       // NOTE: This checks 'Status' instead of 'Element' to silence excessive
       // diagnostics.
-      if (Status.isError()) {
+      if (Status.isErrorOrHasCompletion()) {
         skipUntilDeclRBrace(tok::r_square, tok::comma);
         if (Tok.isNot(tok::comma))
           break;
@@ -3567,7 +3572,7 @@ ParserResult<Expr> Parser::parseExprCollection() {
   ArrayOrDictContext.setCreateSyntax(*isDictionary ? SyntaxKind::DictionaryExpr
                                                    : SyntaxKind::ArrayExpr);
 
-  if (Status.isError()) {
+  if (Status.isErrorOrHasCompletion()) {
     // If we've already got errors, don't emit missing RightK diagnostics.
     RSquareLoc = Tok.is(tok::r_square) ? consumeToken()
                                        : getLocForMissingMatchingToken();

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -135,7 +135,7 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
   // Return early if there was code completion token.
   if (Result.hasCodeCompletion())
     return Result;
-  auto Invalid = Result.isError();
+  auto Invalid = Result.isErrorOrHasCompletion();
 
   // Parse the optional where-clause.
   SourceLoc WhereLoc;
@@ -143,7 +143,7 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
   bool FirstTypeInComplete;
   if (Tok.is(tok::kw_where) &&
       parseGenericWhereClause(WhereLoc, Requirements,
-                              FirstTypeInComplete).isError()) {
+                              FirstTypeInComplete).isErrorOrHasCompletion()) {
     Invalid = true;
   }
   
@@ -283,7 +283,7 @@ ParserStatus Parser::parseGenericWhereClause(
       if (CodeCompletion)
         CodeCompletion->completeGenericRequirement();
       consumeToken(tok::code_complete);
-      Status.setHasCodeCompletion();
+      Status.setHasCodeCompletionAndIsError();
       break;
     }
 
@@ -293,7 +293,7 @@ ParserStatus Parser::parseGenericWhereClause(
 
     if (FirstType.hasCodeCompletion()) {
       BodyContext->setTransparent();
-      Status.setHasCodeCompletion();
+      Status.setHasCodeCompletionAndIsError();
       FirstTypeInComplete = true;
     }
 
@@ -399,7 +399,7 @@ parseFreestandingGenericWhereClause(GenericContext *genCtx) {
   bool FirstTypeInComplete;
   auto result = parseGenericWhereClause(WhereLoc, Requirements,
                                         FirstTypeInComplete);
-  if (result.shouldStopParsing() || Requirements.empty())
+  if (result.isErrorOrHasCompletion() || Requirements.empty())
     return result;
 
   genCtx->setTrailingWhereClause(
@@ -417,7 +417,7 @@ ParserStatus Parser::parseProtocolOrAssociatedTypeWhereClause(
   bool firstTypeInComplete;
   auto whereStatus =
       parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete);
-  if (whereStatus.isSuccess()) {
+  if (whereStatus.isSuccess() && !whereStatus.hasCodeCompletion()) {
     trailingWhere =
         TrailingWhereClause::create(Context, whereLoc, requirements);
   } else if (whereStatus.hasCodeCompletion()) {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -228,7 +228,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       if (AttrStatus.hasCodeCompletion()) {
         if (CodeCompletion)
           CodeCompletion->setAttrTargetDeclKind(DeclKind::Param);
-        status.setHasCodeCompletion();
+        status.setHasCodeCompletionAndIsError();
       }
     }
     
@@ -808,7 +808,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
         parseDeclResultType(diag::expected_type_function_result);
     retType = ResultType.getPtrOrNull();
     Status |= ResultType;
-    if (Status.isError())
+    if (Status.isErrorOrHasCompletion())
       return Status;
 
     // Check for 'throws' and 'rethrows' after the type and correct it.
@@ -919,7 +919,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
                                             argLabelLocs, rParenLoc,
                                             trailingClosures,
                                             SyntaxKind::Unknown);
-        if (status.isSuccess()) {
+        if (status.isSuccess() && !status.hasCodeCompletion()) {
           backtrack.cancelBacktrack();
           
           // Suggest replacing ':' with '='
@@ -1133,11 +1133,11 @@ parseOptionalPatternTypeAnnotation(ParserResult<Pattern> result) {
   Pattern *P = result.get();
   ParserStatus status;
   if (result.hasCodeCompletion())
-    status.setHasCodeCompletion();
+    status.setHasCodeCompletionAndIsError();
 
   ParserResult<TypeRepr> Ty = parseType();
   if (Ty.hasCodeCompletion()) {
-    result.setHasCodeCompletion();
+    result.setHasCodeCompletionAndIsError();
     return result;
   }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -388,11 +388,11 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
     } else if (Tok.is(tok::pound_line)) {
       ParserStatus Status = parseLineDirective(true);
       BraceItemsStatus |= Status;
-      NeedParseErrorRecovery = Status.isError();
+      NeedParseErrorRecovery = Status.isErrorOrHasCompletion();
     } else if (Tok.is(tok::pound_sourceLocation)) {
       ParserStatus Status = parseLineDirective(false);
       BraceItemsStatus |= Status;
-      NeedParseErrorRecovery = Status.isError();
+      NeedParseErrorRecovery = Status.isErrorOrHasCompletion();
     } else if (isStartOfSwiftDecl()) {
       SmallVector<Decl*, 8> TmpDecls;
       ParserResult<Decl> DeclResult = 
@@ -411,7 +411,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                           FD->setHasTopLevelLocalContextCaptures();
                     });
       BraceItemsStatus |= DeclResult;
-      if (DeclResult.isParseError()) {
+      if (DeclResult.isParseErrorOrHasCompletion()) {
         NeedParseErrorRecovery = true;
         if (DeclResult.hasCodeCompletion() && IsTopLevel &&
             isCodeCompletionFirstPass()) {
@@ -443,7 +443,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
         Entries.push_back(TLCD);
         return Status;
       }
-      if (Status.isError())
+      if (Status.isErrorOrHasCompletion())
         NeedParseErrorRecovery = true;
       else if (!allowTopLevelCode()) {
         diagnose(StartLoc,
@@ -674,6 +674,10 @@ ParserResult<BraceStmt> Parser::parseBraceItemList(Diag<> ID) {
                          diag::expected_rbrace_in_brace_stmt, LBLoc)) {
     // Synthesize a r-brace if the source doesn't have any.
     LocalContext.synthesize(tok::r_brace, LBLoc.getAdvancedLoc(1));
+  } else {
+    // We recovered do don't propagate any error status (but still preserve
+    // HasCodeCompletion).
+    Status.clearIsError();
   }
 
   return makeParserResult(Status,
@@ -756,7 +760,7 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
     if (CodeCompletion) {
       CodeCompletion->completeReturnStmt(CCE);
     }
-    Result.setHasCodeCompletion();
+    Result.setHasCodeCompletionAndIsError();
     consumeToken();
     return Result;
   }
@@ -825,7 +829,7 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
     if (CodeCompletion) {
       CodeCompletion->completeYieldStmt(cce, /*index=*/ None);
     }
-    result.setHasCodeCompletion();
+    result.setHasCodeCompletionAndIsError();
     consumeToken();
     return result;
   }
@@ -872,7 +876,7 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
     auto expr = parseExpr(diag::expected_expr_yield);
     if (expr.hasCodeCompletion())
       return makeParserCodeCompletionResult<Stmt>();
-    if (expr.isParseError()) {
+    if (expr.isParseErrorOrHasCompletion()) {
       auto endLoc = (Tok.getLoc() == beginLoc ? beginLoc : PreviousLoc);
       yields.push_back(
         new (Context) ErrorExpr(SourceRange(beginLoc, endLoc)));
@@ -915,7 +919,7 @@ ParserResult<Stmt> Parser::parseStmtThrow(SourceLoc tryLoc) {
   }
 
   if (hasCodeCompletion)
-    Result.setHasCodeCompletion();
+    Result.setHasCodeCompletionAndIsError();
 
   return makeParserResult(Result,
               new (Context) ThrowStmt(throwLoc, Result.get()));
@@ -1071,7 +1075,7 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
       }
     }
     P.consumeToken(tok::code_complete);
-    status.setHasCodeCompletion();
+    status.setHasCodeCompletionAndIsError();
     return;
   }
 
@@ -1365,7 +1369,7 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
     }
   }
 
-  if (Status.isSuccess())
+  if (Status.isSuccess() && !Status.hasCodeCompletion())
     validateAvailabilitySpecList(*this, Specs);
 
   return Status;
@@ -1498,7 +1502,7 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
 
   ThePattern = parseOptionalPatternTypeAnnotation(ThePattern);
   if (ThePattern.hasCodeCompletion()) {
-    Status.setHasCodeCompletion();
+    Status.setHasCodeCompletionAndIsError();
 
     // Skip to '=' so that the completion can see the expected type of the
     // pattern which is determined by the initializer. 
@@ -1524,7 +1528,7 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
   }
 
   if (Init.hasCodeCompletion())
-    Status.setHasCodeCompletion();
+    Status.setHasCodeCompletionAndIsError();
 
   if (Init.isNull()) {
     // Recover by creating ErrorExpr.
@@ -1578,7 +1582,7 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
                                               SyntaxKind::ConditionElement);
     Status |= parseStmtConditionElement(result, DefaultID, ParentKind,
                                         BindingKindStr);
-    if (Status.shouldStopParsing())
+    if (Status.isErrorOrHasCompletion())
       break;
 
     // If a comma exists consume it and succeed.
@@ -1664,7 +1668,7 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
     } else {
       Status |= parseStmtCondition(Condition, diag::expected_condition_if,
                                    StmtKind::If);
-      if (Status.isError() || Status.hasCodeCompletion())
+      if (Status.isErrorOrHasCompletion())
         return recoverWithCond(Status, Condition);
     }
 
@@ -1708,7 +1712,7 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
     } else if (Tok.is(tok::code_complete)) {
       if (CodeCompletion)
         CodeCompletion->completeAfterIfStmt(/*hasElse*/true);
-      Status.setHasCodeCompletion();
+      Status.setHasCodeCompletionAndIsError();
       consumeToken(tok::code_complete);
     } else {
       ElseBody = parseBraceItemList(diag::expected_lbrace_or_if_after_else);
@@ -1717,7 +1721,7 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
   } else if (Tok.is(tok::code_complete)) {
     if (CodeCompletion)
       CodeCompletion->completeAfterIfStmt(/*hasElse*/false);
-    Status.setHasCodeCompletion();
+    Status.setHasCodeCompletionAndIsError();
     consumeToken(tok::code_complete);
   }
 
@@ -1763,7 +1767,7 @@ ParserResult<Stmt> Parser::parseStmtGuard() {
   } else {
     Status |= parseStmtCondition(Condition, diag::expected_condition_guard,
                                  StmtKind::Guard);
-    if (Status.isError() || Status.hasCodeCompletion()) {
+    if (Status.isErrorOrHasCompletion()) {
       // FIXME: better recovery
       return recoverWithCond(Status, Condition);
     }
@@ -1840,7 +1844,7 @@ ParserResult<Stmt> Parser::parseStmtWhile(LabeledStmtInfo LabelInfo) {
   } else {
     Status |= parseStmtCondition(Condition, diag::expected_condition_while,
                                  StmtKind::While);
-    if (Status.isError() || Status.hasCodeCompletion())
+    if (Status.isErrorOrHasCompletion())
       return recoverWithCond(Status, Condition);
   }
 
@@ -1942,7 +1946,7 @@ ParserResult<Stmt> Parser::parseStmtDo(LabeledStmtInfo labelInfo,
     // Recover from all of the clauses failing to parse by returning a
     // normal do-statement.
     if (allClauses.empty()) {
-      assert(status.isError());
+      assert(status.isErrorOrHasCompletion());
       return makeParserResult(status,
                         new (Context) DoStmt(labelInfo, doLoc, body.get()));
     }
@@ -2170,7 +2174,7 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
   } else if (Tok.is(tok::code_complete)) {
     Container =
         makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
-    Container.setHasCodeCompletion();
+    Container.setHasCodeCompletionAndIsError();
     Status |= Container;
     if (CodeCompletion)
       CodeCompletion->completeForEachSequenceBeginning(
@@ -2181,7 +2185,7 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
     Status |= Container;
     if (Container.isNull())
       Container = makeParserErrorResult(new (Context) ErrorExpr(Tok.getLoc()));
-    if (Container.isParseError())
+    if (Container.isParseErrorOrHasCompletion())
       // Recover.
       skipUntilDeclStmtRBrace(tok::l_brace, tok::kw_where);
   }
@@ -2541,7 +2545,7 @@ ParserResult<CaseStmt> Parser::parseStmtCase(bool IsActive) {
   SourceLoc StartOfBody = Tok.getLoc();
   if (Tok.isNot(tok::r_brace) && !isAtStartOfSwitchCase(*this)) {
     Status |= parseBraceItems(BodyItems, BraceItemListKind::Case);
-  } else if (Status.isSuccess()) {
+  } else if (Status.isSuccess() && !Status.hasCodeCompletion()) {
     diagnose(CaseLoc, diag::case_stmt_without_body,
              CaseLabelItems.back().isDefault())
         .highlight(SourceRange(CaseLoc, ColonLoc))
@@ -2578,7 +2582,7 @@ ParserResult<Stmt> Parser::parseStmtPoundAssert() {
   SourceLoc LBLoc = consumeToken(tok::l_paren);
 
   auto conditionExprResult = parseExpr(diag::pound_assert_expected_expression);
-  if (conditionExprResult.isParseError())
+  if (conditionExprResult.isParseErrorOrHasCompletion())
     return ParserStatus(conditionExprResult);
 
   StringRef message;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -624,19 +624,19 @@ ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
 
   auto result = parseType(MessageID);
 
-  if (!result.isParseError() && Tok.is(tok::r_square)) {
+  if (!result.isParseErrorOrHasCompletion() && Tok.is(tok::r_square)) {
     auto diag = diagnose(Tok, diag::extra_rbracket);
     diag.fixItInsert(result.get()->getStartLoc(), getTokenText(tok::l_square));
     consumeToken();
     return makeParserErrorResult(new (Context)
                                      ErrorTypeRepr(getTypeErrorLoc()));
-  } else if (!result.isParseError() && Tok.is(tok::colon)) {
+  } else if (!result.isParseErrorOrHasCompletion() && Tok.is(tok::colon)) {
     auto colonTok = consumeToken();
     auto secondType = parseType(diag::expected_dictionary_value_type);
 
     auto diag = diagnose(colonTok, diag::extra_colon);
     diag.fixItInsert(result.get()->getStartLoc(), getTokenText(tok::l_square));
-    if (!secondType.isParseError()) {
+    if (!secondType.isParseErrorOrHasCompletion()) {
       if (Tok.is(tok::r_square)) {
         consumeToken();
       } else {
@@ -750,7 +750,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
       SmallVector<TypeRepr*, 8> GenericArgs;
       if (startsWithLess(Tok)) {
         auto genericArgsStatus = parseGenericArguments(GenericArgs, LAngle, RAngle);
-        if (genericArgsStatus.isError())
+        if (genericArgsStatus.isErrorOrHasCompletion())
           return genericArgsStatus;
       }
       EndLoc = Loc.getEndLoc();
@@ -771,7 +771,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
     // unless <anything> is 'Type'.
     if ((Tok.is(tok::period) || Tok.is(tok::period_prefix))) {
       if (peekToken().is(tok::code_complete)) {
-        Status.setHasCodeCompletion();
+        Status.setHasCodeCompletionAndIsError();
         break;
       }
       if (!peekToken().isContextualKeyword("Type")
@@ -793,7 +793,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
       }
     } else if (Tok.is(tok::code_complete)) {
       if (!Tok.isAtStartOfLine())
-        Status.setHasCodeCompletion();
+        Status.setHasCodeCompletionAndIsError();
       break;
     }
     break;
@@ -983,7 +983,7 @@ ParserResult<TypeRepr> Parser::parseOldStyleProtocolComposition() {
   if (startsWithGreater(Tok)) {
     RAngleLoc = consumeStartingGreater();
   } else {
-    if (Status.isSuccess()) {
+    if (Status.isSuccess() && !Status.hasCodeCompletion()) {
       diagnose(Tok, diag::expected_rangle_protocol);
       diagnose(LAngleLoc, diag::opening_angle);
       Status.setIsParseError();
@@ -996,7 +996,7 @@ ParserResult<TypeRepr> Parser::parseOldStyleProtocolComposition() {
   auto composition = CompositionTypeRepr::create(
     Context, Protocols, ProtocolLoc, {LAngleLoc, RAngleLoc});
 
-  if (Status.isSuccess()) {
+  if (Status.isSuccess() && !Status.hasCodeCompletion()) {
     // Only if we have complete protocol<...> construct, diagnose deprecated.
     SmallString<32> replacement;
     if (Protocols.empty()) {
@@ -1323,7 +1323,7 @@ SyntaxParserResult<ParsedTypeSyntax, TypeRepr> Parser::parseTypeCollection() {
     return Status;
 
   // If we couldn't parse anything for one of the types, propagate the error.
-  if (Status.isError())
+  if (Status.isErrorOrHasCompletion())
     return makeParserError();
 
   TypeRepr *TyR;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1102,8 +1102,8 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
       return Status;
     }
     // If we haven't made progress, or seeing any error, skip ahead.
-    if (Tok.getLoc() == StartLoc || Status.isError()) {
-      assert(Status.isError() && "no progress without error");
+    if (Tok.getLoc() == StartLoc || Status.isErrorOrHasCompletion()) {
+      assert(Status.isErrorOrHasCompletion() && "no progress without error");
       skipListUntilDeclRBrace(LeftLoc, RightK, tok::comma);
       if (Tok.is(RightK) || Tok.isNot(tok::comma))
         break;
@@ -1136,7 +1136,7 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
 
   ListContext.reset();
 
-  if (Status.isError()) {
+  if (Status.isErrorOrHasCompletion()) {
     // If we've already got errors, don't emit missing RightK diagnostics.
     if (Tok.is(RightK)) {
       RightLoc = consumeToken();

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1637,7 +1637,7 @@ bool SILParser::parseSILBBArgsAtBranch(SmallVector<SILValue, 6> &Args,
                       }
                       Args.push_back(Arg);
                       return makeParserSuccess();
-                    }).isError() || HasError)
+                    }).isErrorOrHasCompletion() || HasError)
       return true;
   }
   return false;

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -10,6 +10,8 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=CLOSURE_NORETURN | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=CLOSURE_FUNCBUILDER | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER | %FileCheck %s --check-prefix=POINT_MEMBER
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_ERROR | %FileCheck %s --check-prefix=POINT_MEMBER
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_FIXME | %FileCheck %s --check-prefix=NORESULTS
 
 struct A {
   func doAThings() -> A { return self }
@@ -143,5 +145,27 @@ CreateThings {
       point.#^MULTICLOSURE_FUNCBUILDER^#
     }
     Thing { _ in }
+}
+
+// In multi-statement closure with unpropagated errors
+CreateThings {
+    Thing { point in
+      print("hello")
+      point. // ErrorExpr
+      point.#^MULTICLOSURE_FUNCBUILDER_ERROR^#
+    }
+    Thing { point in 
+      print("hello")
+      point. // ErrorExpr
+    }
+}
+
+// FIXME: No results in multi-statement closure with erroreous sibling function builder element
+CreateThings {
+    Thing { point in
+      print("hello")
+      point.#^MULTICLOSURE_FUNCBUILDER_FIXME^#
+    }
+    Thing. // ErrorExpr
 }
 

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -9,6 +9,7 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=CLOSURE_MISSINGARG | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=CLOSURE_NORETURN | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=CLOSURE_FUNCBUILDER | %FileCheck %s --check-prefix=POINT_MEMBER
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER | %FileCheck %s --check-prefix=POINT_MEMBER
 
 struct A {
   func doAThings() -> A { return self }
@@ -127,10 +128,19 @@ struct ThingBuilder {
 }
 func CreateThings(@ThingBuilder makeThings: () -> [Thing]) {}
 
-// FIXME: only works if the first call to Thing is passed a single expression closure
+// In single statement closure
 CreateThings {
     Thing { point in
       point.#^CLOSURE_FUNCBUILDER^#
+    }
+    Thing { _ in }
+}
+
+// In multi-statement closure
+CreateThings {
+    Thing { point in
+      print("hello")
+      point.#^MULTICLOSURE_FUNCBUILDER^#
     }
     Thing { _ in }
 }


### PR DESCRIPTION
For example, the completion below would trigger error recovery within the first closure, which we recover from by skipping to that closure's right brace. The fact that we recovered though, wasn't being recorded. The closure was treated as still being in error, triggering another recovery after it that skips over the `Thing` token, giving a lone closure expression, rather than a
call as the next expression.
```
CreateThings {
    Thing { point in
      print("hello")
      point.#^HERE^#
    }
    Thing { _ in }
}
```
This isn't an issue for code completion when the outer closure is a regular closure, but when it's a function builder, invalid elements result in no types being applied (no valid solutions) and we end up with no completion results. We should have a fallback to handle when the other elements are legitimately invalid (rather than from parser recovery skipping things), but when the other elements *are* valid this fix gets us results in the meantime and should still give more accurate results compared to a single-function-builder-element fallback once we have one.

The fix here is removing the error status from the parser result after the initial parser recovery. We still needed to propagate the fact that the parsed AST node contained a code completion token though, so that the code completion callbacks still happen. This required dropping the invariant that `ParserResult::hasCodeCompletion()` implies `ParserResult::isError()`. To ensure there was no unintended behavior change, this updates existing checks of `ParserResult::isError()` that weren't directly related to this fix to use `ParserResult::isErrorOrHasCompletion()` instead (which is equivalent to the behavior of `isError()` prior to this change).