### PR TITLE
[stdlib] Simplify 'BinaryFloatingPoint.init?<T: BinaryFloatingPoint>(exactly: T)'

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1948,9 +1948,30 @@ extension BinaryFloatingPoint {
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
   public init?<Source: BinaryFloatingPoint>(exactly value: Source) {
-    let (value_, exact) = Self._convert(from: value)
-    guard exact else { return nil }
-    self = value_
+    // We define exactness by equality after roundtripping; since NaN is never
+    // equal to itself, it can never be converted exactly.
+    if value.isNaN { return nil }
+    
+    if (Source.exponentBitCount > Self.exponentBitCount
+        || Source.significandBitCount > Self.significandBitCount)
+      && value.isFinite && !value.isZero {
+      let exponent = value.exponent
+      if exponent < Self.leastNormalMagnitude.exponent {
+        if exponent < Self.leastNonzeroMagnitude.exponent { return nil }
+        if value.significandWidth >
+          Int(Self.Exponent(exponent) - Self.leastNonzeroMagnitude.exponent) {
+          return nil
+        }
+      } else {
+        if exponent > Self.greatestFiniteMagnitude.exponent { return nil }
+        if value.significandWidth >
+          Self.greatestFiniteMagnitude.significandWidth {
+          return nil
+        }
+      }
+    }
+    
+    self = Self(value)
   }
   
   @inlinable

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -116,6 +116,47 @@ FloatingPoint.test("BinaryFloatingPoint/genericIntegerConversion") {
 }
 
 FloatingPoint.test("BinaryFloatingPoint/genericFloatingPointConversion") {
+  func convert<
+    T: BinaryFloatingPoint, U: BinaryFloatingPoint
+  >(exactly value: T, to: U.Type) -> U { U(exactly: value) }
+  
+  expectEqual(convert(exactly: 0 as Float, to: Double.self), 0.0)
+  expectEqual(convert(exactly: -0.0 as Float, to: Double.self), -0.0)
+  expectEqual(
+    convert(exactly: -0.0 as Float, to: Double.self).sign,
+    FloatingPointSign.minus)
+  expectEqual(convert(exactly: 0 as Double, to: Float.self), 0.0 as Float)
+  expectEqual(convert(exactly: -0.0 as Double, to: Float.self), -0.0 as Float)
+  expectEqual(
+    convert(exactly: -0.0 as Double, to: Float.self).sign,
+    FloatingPointSign.minus)
+  expectEqual(convert(exactly: 1 as Float, to: Double.self), 1.0)
+  expectEqual(convert(exactly: -1 as Float, to: Double.self), -1.0)
+  expectEqual(convert(exactly: 1 as Double, to: Float.self), 1.0 as Float)
+  expectEqual(convert(exactly: -1 as Double, to: Float.self), -1.0 as Float)
+  expectEqual(
+    convert(exactly: Float.infinity, to: Double.self), Double.infinity)
+  expectEqual(
+    convert(exactly: -Float.infinity, to: Double.self), -Double.infinity)
+  expectEqual(
+    convert(exactly: Double.infinity, to: Float.self), Float.infinity)
+  expectEqual(
+    convert(exactly: -Double.infinity, to: Float.self), -Float.infinity)
+  expectEqual(convert(exactly: Float.nan, to: Double.self), nil)
+  expectEqual(convert(exactly: Double.nan, to: Float.self), nil)
+  expectEqual(convert(exactly: Float.nan, to: Float.self), nil)
+  expectEqual(convert(exactly: Double.nan, to: Double.self), nil)
+  expectEqual(
+    convert(exactly: Double.leastNonzeroMagnitude, to: Float.self), nil)
+  expectEqual(
+    convert(exactly: Float.leastNonzeroMagnitude, to: Double.self),
+    Double(Float.leastNonzeroMagnitude))
+  expectEqual(
+    convert(exactly: Double.greatestFiniteMagnitude, to: Float.self), nil)
+  expectEqual(
+    convert(exactly: Float.greatestFiniteMagnitude, to: Double.self),
+    Double(Float.greatestFiniteMagnitude))
+  
   expectTrue(Double._convert(from: 0 as Float) == (value: 0, exact: true))
   expectTrue(Double._convert(from: -0.0 as Float) == (value: -0.0, exact: true))
   expectTrue(Double._convert(from: 1 as Float) == (value: 1, exact: true))


### PR DESCRIPTION
This PR replaces an unconditional invocation of the generic `BinaryFloatingPoint._convert` in the default implementation of `BinaryFloatingPoint.init?<T: BinaryFloatingPoint>(exactly: T)` with a more thoughtful alternative to take advantage of fast paths introduced in #33803 and #33826.

Specifically, the logic for determining if a value can be exactly represented is extracted from `BinaryFloatingPoint._convert` to enable early exits returning `nil`. If the value can be represented exactly, then we invoke `BinaryFloatingPoint.init<T: BinaryFloatingPoint>(T)`, which has the aforementioned fast paths.

A test is updated to correspond with this change.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
