### PR TITLE
[runtime] Silence unreachable code warning

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -864,8 +864,9 @@ tryCastToString(
       destLocation, destType, srcValue, srcType,
       destFailureType, srcFailureType,
       takeOnSuccess, mayDeferChecks);
-#endif
+#else
     SWIFT_FALLTHROUGH;
+#endif
   }
   default:
     return DynamicCastResult::Failure;


### PR DESCRIPTION
PR #33838 fixed a warning about unannotated fallthrough on platforms without Obj-C interop; however, this introduces an unreachable code warning on platforms _with_ Obj-C interop. We silence the warning here.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
