### PR TITLE
Drop assert(Atomicity::Atomic) from visitRetainValueAddrInst+visitReleaseValueAddrInst

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1020,10 +1020,10 @@ public:
                         bool setIsNoInline = false);
 
   llvm::Constant *getOrCreateRetainFunction(const TypeInfo &objectTI, SILType t,
-                                            llvm::Type *llvmType);
+                              llvm::Type *llvmType, Atomicity atomicity);
 
   llvm::Constant *getOrCreateReleaseFunction(const TypeInfo &objectTI, SILType t,
-                                             llvm::Type *llvmType);
+                              llvm::Type *llvmType, Atomicity atomicity);
 
   llvm::Constant *getOrCreateOutlinedInitializeWithTakeFunction(
                               SILType objectType, const TypeInfo &objectTI,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3629,8 +3629,6 @@ void IRGenSILFunction::visitRetainValueInst(swift::RetainValueInst *i) {
 }
 
 void IRGenSILFunction::visitRetainValueAddrInst(swift::RetainValueAddrInst *i) {
-  assert(i->getAtomicity() == RefCountingInst::Atomicity::Atomic &&
-         "Non atomic retains are not supported");
   SILValue operandValue = i->getOperand();
   Address addr = getLoweredAddress(operandValue);
   SILType addrTy = operandValue->getType();
@@ -3704,8 +3702,6 @@ void IRGenSILFunction::visitReleaseValueInst(swift::ReleaseValueInst *i) {
 
 void IRGenSILFunction::visitReleaseValueAddrInst(
     swift::ReleaseValueAddrInst *i) {
-  assert(i->getAtomicity() == RefCountingInst::Atomicity::Atomic &&
-         "Non atomic retains are not supported");
   SILValue operandValue = i->getOperand();
   Address addr = getLoweredAddress(operandValue);
   SILType addrTy = operandValue->getType();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3635,7 +3635,9 @@ void IRGenSILFunction::visitRetainValueAddrInst(swift::RetainValueAddrInst *i) {
   SILType objectT = addrTy.getObjectType();
   llvm::Type *llvmType = addr.getAddress()->getType();
   const TypeInfo &addrTI = getTypeInfo(addrTy);
-  auto *outlinedF = IGM.getOrCreateRetainFunction(addrTI, objectT, llvmType);
+  auto atomicity = i->isAtomic() ? Atomicity::Atomic : Atomicity::NonAtomic;
+  auto *outlinedF = IGM.getOrCreateRetainFunction(
+      addrTI, objectT, llvmType, atomicity);
   llvm::Value *args[] = {addr.getAddress()};
   llvm::CallInst *call = Builder.CreateCall(outlinedF, args);
   call->setCallingConv(IGM.DefaultCC);
@@ -3708,8 +3710,9 @@ void IRGenSILFunction::visitReleaseValueAddrInst(
   SILType objectT = addrTy.getObjectType();
   llvm::Type *llvmType = addr.getAddress()->getType();
   const TypeInfo &addrTI = getTypeInfo(addrTy);
+  auto atomicity = i->isAtomic() ? Atomicity::Atomic : Atomicity::NonAtomic;
   auto *outlinedF = IGM.getOrCreateReleaseFunction(
-      addrTI, objectT, llvmType);
+      addrTI, objectT, llvmType, atomicity);
   llvm::Value *args[] = {addr.getAddress()};
   llvm::CallInst *call = Builder.CreateCall(outlinedF, args);
   call->setCallingConv(IGM.DefaultCC);

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -396,7 +396,8 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedDestroyFunction(
 
 llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &ti,
                                                        SILType t,
-                                                       llvm::Type *llvmType) {
+                                                       llvm::Type *llvmType,
+                                                       Atomicity atomicity) {
   auto *loadableTI = cast<LoadableTypeInfo>(&ti);
   IRGenMangler mangler;
   auto manglingBits =
@@ -412,7 +413,7 @@ llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &ti,
         Explosion loaded;
         loadableTI->loadAsTake(IGF, addr, loaded);
         Explosion out;
-        loadableTI->copy(IGF, loaded, out, irgen::Atomicity::Atomic);
+        loadableTI->copy(IGF, loaded, out, atomicity);
         (void)out.claimAll();
         IGF.Builder.CreateRet(addr.getAddress());
       },
@@ -422,7 +423,8 @@ llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &ti,
 llvm::Constant *
 IRGenModule::getOrCreateReleaseFunction(const TypeInfo &ti,
                                         SILType t,
-                                        llvm::Type *llvmType) {
+                                        llvm::Type *llvmType,
+                                        Atomicity atomicity) {
   auto *loadableTI = cast<LoadableTypeInfo>(&ti);
   IRGenMangler mangler;
   auto manglingBits =
@@ -437,7 +439,7 @@ IRGenModule::getOrCreateReleaseFunction(const TypeInfo &ti,
         Address addr(&*it++, loadableTI->getFixedAlignment());
         Explosion loaded;
         loadableTI->loadAsTake(IGF, addr, loaded);
-        loadableTI->consume(IGF, loaded, irgen::Atomicity::Atomic);
+        loadableTI->consume(IGF, loaded, atomicity);
         IGF.Builder.CreateRet(addr.getAddress());
       },
       true /*setIsNoInline*/);


### PR DESCRIPTION
The "minimal" stdlib currently fails to build with this assertion, <https://ci.swift.org/view/all/job/oss-swift-test-stdlib-with-toolchain-minimal/2/console>:

```
Assertion failed: (i->getAtomicity() == RefCountingInst::Atomicity::Atomic && "Non atomic retains are not supported"), function visitReleaseValueAddrInst, file /Users/buildnode/jenkins/workspace/oss-swift-package-osx/swift/lib/IRGen/IRGenSIL.cpp, line 3708.
...
08:11:18 3.	While evaluating request IRGenRequest(IR Generation for module Swift)
08:11:18 4.	While emitting IR SIL function "@$sSDsSQR_rlE2eeoiySbSDyxq_G_ABtFZ".
08:11:18  for '==(_:_:)' (at /Users/buildnode/jenkins/workspace/oss-swift-test-stdlib-with-toolchain-minimal/swift/stdlib/public/core/Dictionary.swift:1575:10)
...
08:11:18 7  swift-frontend           0x00000001129a8a13 swift::SILInstructionVisitor<(anonymous namespace)::IRGenSILFunction, void>::visit(swift::SILInstruction*) (.cold.631) + 35
08:11:18 8  swift-frontend           0x000000010e83cd98 swift::SILInstructionVisitor<(anonymous namespace)::IRGenSILFunction, void>::visit(swift::SILInstruction*) + 73816
08:11:18 9  swift-frontend           0x000000010e82718c swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 7340
08:11:18 10 swift-frontend           0x000000010e715042 swift::irgen::IRGenerator::emitGlobalTopLevel(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 818
08:11:18 11 swift-frontend           0x000000010e7f8acf swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const + 991
08:11:18 12 swift-frontend           0x000000010e8253c5 swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)9>::evaluateRequest(swift::IRGenRequest const&, swift::Evaluator&) + 37
08:11:18 13 swift-frontend           0x000000010e7fee9e llvm::Expected<swift::IRGenRequest::OutputType> swift::Evaluator::getResultUncached<swift::IRGenRequest>(swift::IRGenRequest const&) + 446
08:11:18 14 swift-frontend           0x000000010e7faf9d llvm::Expected<swift::IRGenRequest::OutputType> swift::Evaluator::operator()<swift::IRGenRequest, (void*)0>(swift::IRGenRequest const&) + 61
08:11:18 15 swift-frontend           0x000000010e7f9a4d swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::StringRef, swift::PrimarySpecificPaths const&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, llvm::GlobalVariable**) + 669
08:11:18 16 swift-frontend           0x000000010e560f01 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 2209
08:11:18 17 swift-frontend           0x000000010e56043c performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 636
08:11:18 18 swift-frontend           0x000000010e558450 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 4864
08:11:18 19 swift-frontend           0x000000010e4f17e1 main + 881
```

The non-atomic retains and releases get produced by the AssumeSingleThreaded pass, which is triggered by the -Xfrontend -assume-single-threaded flag used when building with SWIFT_STDLIB_SINGLE_THREADED_RUNTIME. @gottesmm, are you aware of anything actually not working with non-atomic retains and releases here, or is this assert just being too aggressive?