### PR TITLE
(Re)-Disable End Of Pipeline Actions for ObjC Actions

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -169,7 +169,7 @@ public:
 
   /// Returns a buffer ID for a previously added buffer with the given
   /// buffer identifier, or None if there is no such buffer.
-  Optional<unsigned> getIDForBufferIdentifier(StringRef BufIdentifier);
+  Optional<unsigned> getIDForBufferIdentifier(StringRef BufIdentifier) const;
 
   /// Returns the identifier for the buffer with the given ID.
   ///

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -153,6 +153,7 @@ public:
   bool shouldTreatAsLLVM() const;
   bool shouldTreatAsSIL() const;
   bool shouldTreatAsModuleInterface() const;
+  bool shouldTreatAsObjCHeader() const;
 
   bool areAllNonPrimariesSIB() const;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -304,6 +304,9 @@ public:
   /// \return true if the given action requires input files to be provided.
   static bool doesActionRequireInputs(ActionType action);
 
+  /// \return true if the given action requires input files to be provided.
+  static bool doesActionPerformEndOfPipelineActions(ActionType action);
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -26,7 +26,8 @@ enum class InputFileKind {
   SwiftLibrary,
   SwiftModuleInterface,
   SIL,
-  LLVM
+  LLVM,
+  ObjCHeader,
 };
 
 // Inputs may include buffers that override contents, and eventually should

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -152,9 +152,8 @@ SourceManager::getVirtualFile(SourceLoc Loc) const {
   return nullptr;
 }
 
-
-Optional<unsigned> SourceManager::getIDForBufferIdentifier(
-    StringRef BufIdentifier) {
+Optional<unsigned>
+SourceManager::getIDForBufferIdentifier(StringRef BufIdentifier) const {
   auto It = BufIdentIDMap.find(BufIdentifier);
   if (It == BufIdentIDMap.end())
     return None;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -423,6 +423,8 @@ bool ArgsToFrontendOptionsConverter::setUpInputKindAndImmediateArgs() {
     Opts.InputKind = InputFileKind::SIL;
   else if (Opts.InputsAndOutputs.shouldTreatAsLLVM())
     Opts.InputKind = InputFileKind::LLVM;
+  else if (Opts.InputsAndOutputs.shouldTreatAsObjCHeader())
+    Opts.InputKind = InputFileKind::ObjCHeader;
   else if (Opts.InputsAndOutputs.shouldTreatAsModuleInterface())
     Opts.InputKind = InputFileKind::SwiftModuleInterface;
   else if (Args.hasArg(OPT_parse_as_library))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -238,6 +238,7 @@ SourceFileKind CompilerInvocation::getSourceFileKind() const {
     return SourceFileKind::SIL;
   case InputFileKind::None:
   case InputFileKind::LLVM:
+  case InputFileKind::ObjCHeader:
     llvm_unreachable("Trying to convert from unsupported InputFileKind");
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -586,6 +586,7 @@ static bool shouldTreatSingleInputAsMain(InputFileKind inputKind) {
     return true;
   case InputFileKind::SwiftLibrary:
   case InputFileKind::LLVM:
+  case InputFileKind::ObjCHeader:
   case InputFileKind::None:
     return false;
   }

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -199,6 +199,19 @@ bool FrontendInputsAndOutputs::shouldTreatAsSIL() const {
   llvm_unreachable("Either all primaries or none must end with .sil");
 }
 
+bool FrontendInputsAndOutputs::shouldTreatAsObjCHeader() const {
+  if (hasSingleInput()) {
+    StringRef InputExt = llvm::sys::path::extension(getFilenameOfFirstInput());
+    switch (file_types::lookupTypeForExtension(InputExt)) {
+    case file_types::TY_ObjCHeader:
+      return true;
+    default:
+      return false;
+    }
+  }
+  return false;
+}
+
 bool FrontendInputsAndOutputs::areAllNonPrimariesSIB() const {
   for (const InputFile &input : AllInputs) {
     if (input.isPrimary())

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -42,8 +42,8 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpPCM:
-    return false;
   case ActionType::EmitPCH:
+    return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIL:
   case ActionType::EmitSIBGen:
@@ -146,6 +146,47 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   case ActionType::EmitPCH:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
+  case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
+  case ActionType::ResolveImports:
+  case ActionType::Typecheck:
+  case ActionType::DumpAST:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitModuleOnly:
+  case ActionType::MergeModules:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::Immediate:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+  case ActionType::DumpTypeInfo:
+    return true;
+  }
+  llvm_unreachable("Unknown ActionType");
+}
+
+bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
+  switch (action) {
+  case ActionType::NoneAction:
+  case ActionType::PrintVersion:
+  case ActionType::EmitPCH:
+  case ActionType::EmitPCM:
+  case ActionType::DumpPCM:
+    return false;
+  case ActionType::REPL:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::EmitImportedModules:
+  case ActionType::ScanDependencies:
+  case ActionType::ScanClangDependencies:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
   case ActionType::ResolveImports:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1876,8 +1876,6 @@ static bool performAction(CompilerInstance &Instance,
                              "removed; use the LLDB-enhanced REPL instead.");
 
   // MARK: Actions for Clang and Clang Modules
-  // We've been asked to precompile a bridging header or module; we want to
-  // avoid touching any other inputs and just parse, emit and exit.
   case FrontendOptions::ActionType::EmitPCH:
     return precompileBridgingHeader(Instance);
   case FrontendOptions::ActionType::EmitPCM:
@@ -1983,7 +1981,7 @@ static bool performCompile(CompilerInstance &Instance,
   const FrontendOptions::ActionType Action = opts.RequestedAction;
 
   // To compile LLVM IR, just pass it off unmodified.
-  if (Instance.getInvocation().getInputKind() == InputFileKind::LLVM)
+  if (Invocation.getInputKind() == InputFileKind::LLVM)
     return compileLLVMIR(Instance);
 
   // If we aren't in a parse-only context and expect an implicit stdlib import,
@@ -2014,7 +2012,7 @@ static bool performCompile(CompilerInstance &Instance,
   // We might have freed the ASTContext already, but in that case we would
   // have already performed these actions.
   if (Instance.hasASTContext() &&
-      FrontendOptions::doesActionRequireInputs(Action)) {
+      FrontendOptions::doesActionPerformEndOfPipelineActions(Action)) {
     performEndOfPipelineActions(Instance);
     hadError |= Instance.getASTContext().hadError();
   }

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -69,6 +69,7 @@ bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
   case InputFileKind::None:
   case InputFileKind::SIL:
   case InputFileKind::LLVM:
+  case InputFileKind::ObjCHeader:
     return false;
   }
   llvm_unreachable("unhandled kind");


### PR DESCRIPTION
This restores the behavior of the old frontend - which would skip these post-pipeline actions wholesale. #33672 tried turning it on, but it turns out we were modeling ObjC header inputs as Swift files, and so the first post-pipeline action to build the main module would suck in the bridging header and try to parse it as Swift code.

To tackle that last one, explicitly model ObjCHeader as an input kind. This is just plumbing I'll need for later.

rdar://68587228