### PR TITLE
SILParser: Fix for removal of parse-time name lookup

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1332,6 +1332,8 @@ public:
 
   void print(raw_ostream &OS) const;
   SWIFT_DEBUG_DUMP;
+
+  bool walk(ASTWalker &walker);
 };
   
 /// A trailing where clause.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1334,6 +1334,10 @@ public:
   SWIFT_DEBUG_DUMP;
 
   bool walk(ASTWalker &walker);
+
+  /// Finds a generic parameter declaration by name. This should only
+  /// be used from the SIL parser.
+  GenericTypeParamDecl *lookUpGenericParam(Identifier name) const;
 };
   
 /// A trailing where clause.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2501,7 +2501,8 @@ public:
 
 class ResolveTypeRequest
     : public SimpleRequest<ResolveTypeRequest,
-                           Type(const TypeResolution *, TypeRepr *),
+                           Type(const TypeResolution *, TypeRepr *,
+                                GenericParamList *),
                            RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2515,7 +2516,7 @@ private:
 
   // Evaluation.
   Type evaluate(Evaluator &evaluator, const TypeResolution *resolution,
-                TypeRepr *repr) const;
+                TypeRepr *repr, GenericParamList *silParams) const;
 };
 
 void simple_display(llvm::raw_ostream &out, const TypeResolution *resolution);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -243,7 +243,7 @@ SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,
               Type(ProtocolDecl *, TypeEraserAttr *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeRequest,
-              Type (const TypeResolution *, TypeRepr *),
+              Type (const TypeResolution *, TypeRepr *, GenericParamList *),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SPIGroupsRequest,
               llvm::ArrayRef<Identifier>(Decl *),

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -149,7 +149,9 @@ namespace swift {
   ///
   /// \returns A well-formed type on success, or an \c ErrorType.
   Type performTypeResolution(TypeRepr *TyR, ASTContext &Ctx, bool isSILMode,
-                             bool isSILType, GenericEnvironment *GenericEnv,
+                             bool isSILType,
+                             GenericEnvironment *GenericEnv,
+                             GenericParamList *GenericParams,
                              DeclContext *DC, bool ProduceDiagnostics = true);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -130,7 +130,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     // Must check this first in case extensions have not been bound yet
     if (Walker.shouldWalkIntoGenericParams()) {
       if (auto *params = GC->getParsedGenericParams()) {
-        visitGenericParamList(params);
+        doIt(params);
       }
       return true;
     }
@@ -252,7 +252,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   
   bool visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
     if (Walker.shouldWalkIntoGenericParams() && OTD->getGenericParams()) {
-      if (visitGenericParamList(OTD->getGenericParams()))
+      if (doIt(OTD->getGenericParams()))
         return true;
     }
     return false;
@@ -436,22 +436,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         return true;
       }
     }
-    return false;
-  }
-
-  bool visitGenericParamList(GenericParamList *GPL) {
-    // Visit generic params
-    for (auto &P : GPL->getParams()) {
-      if (doIt(P))
-        return true;
-    }
-
-    // Visit param conformance
-    for (auto Req : GPL->getRequirements()) {
-      if (doIt(Req))
-        return true;
-    }
-
     return false;
   }
 
@@ -1342,10 +1326,26 @@ public:
         return true;
       break;
     case RequirementReprKind::LayoutConstraint:
-      if (doIt(Req.getFirstTypeRepr()))
+      if (doIt(Req.getSubjectRepr()))
         return true;
       break;
     }
+    return false;
+  }
+
+  bool doIt(GenericParamList *GPL) {
+    // Visit generic params
+    for (auto &P : GPL->getParams()) {
+      if (doIt(P))
+        return true;
+    }
+
+    // Visit param conformance
+    for (auto Req : GPL->getRequirements()) {
+      if (doIt(Req))
+        return true;
+    }
+
     return false;
   }
 };
@@ -1875,5 +1875,9 @@ StmtConditionElement *StmtConditionElement::walk(ASTWalker &walker) {
 }
 
 bool Decl::walk(ASTWalker &walker) {
+  return Traversal(walker).doIt(this);
+}
+
+bool GenericParamList::walk(ASTWalker &walker) {
   return Traversal(walker).doIt(this);
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -960,6 +960,21 @@ void GenericParamList::setDeclContext(DeclContext *dc) {
     param->setDeclContext(dc);
 }
 
+GenericTypeParamDecl *GenericParamList::lookUpGenericParam(
+    Identifier name) const {
+  for (const auto *innerParams = this;
+       innerParams != nullptr;
+       innerParams = innerParams->getOuterParameters()) {
+    for (auto *paramDecl : *innerParams) {
+      if (name == paramDecl->getName()) {
+        return const_cast<GenericTypeParamDecl *>(paramDecl);
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 TrailingWhereClause::TrailingWhereClause(
                        SourceLoc whereLoc,
                        ArrayRef<RequirementRepr> requirements)

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1617,7 +1617,9 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
     const auto ty = swift::performTypeResolution(
         ParsedTypeLoc.getTypeRepr(), P.Context,
         /*isSILMode=*/false,
-        /*isSILType=*/false, CurDeclContext->getGenericEnvironmentOfContext(),
+        /*isSILType=*/false,
+        CurDeclContext->getGenericEnvironmentOfContext(),
+        /*GenericParams=*/nullptr,
         CurDeclContext,
         /*ProduceDiagnostics=*/false);
     ParsedTypeLoc.setType(ty);

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -336,7 +336,7 @@ void swift::ide::collectPossibleReturnTypesFromContext(
           const auto type = swift::performTypeResolution(
               CE->getExplicitResultTypeRepr(), DC->getASTContext(),
               /*isSILMode=*/false, /*isSILType=*/false,
-              DC->getGenericEnvironmentOfContext(),
+              DC->getGenericEnvironmentOfContext(), /*GenericParams=*/nullptr,
               const_cast<DeclContext *>(DC), /*diagnostics=*/false);
 
           if (!type->hasError()) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -138,16 +138,6 @@ namespace {
     SILSpecializeAttr::SpecializationKind kind;
   };
 
-  enum class ConformanceContext {
-    /// A normal conformance parse.
-    Ordinary,
-
-    /// We're parsing this for a SIL witness table.
-    /// Leave any generic parameter clauses in scope, and use an explicit
-    /// self-conformance instead of an abstract one.
-    WitnessTable,
-  };
-
   class SILParser {
     friend SILParserState;
   public:
@@ -156,6 +146,7 @@ namespace {
     SILParserState &TUState;
     SILFunction *F = nullptr;
     GenericEnvironment *ContextGenericEnv = nullptr;
+    GenericParamList *ContextGenericParams = nullptr;
 
   private:
     /// HadError - Have we seen an error parsing this function?
@@ -174,14 +165,16 @@ namespace {
     std::function<void(Type)> ParsedTypeCallback;
 
     Type performTypeResolution(TypeRepr *TyR, bool IsSILType,
-                               GenericEnvironment *GenericEnv);
+                               GenericEnvironment *GenericEnv,
+                               GenericParamList *GenericParams);
 
     void convertRequirements(SILFunction *F, ArrayRef<RequirementRepr> From,
                              SmallVectorImpl<Requirement> &To);
 
     ProtocolConformanceRef parseProtocolConformanceHelper(
-        ProtocolDecl *&proto, GenericEnvironment *GenericEnv,
-        ConformanceContext context, ProtocolDecl *defaultForProto);
+        ProtocolDecl *&proto,
+        GenericEnvironment *GenericEnv,
+        GenericParamList *WitnessParams);
 
   public:
     SILParser(Parser &P)
@@ -307,16 +300,14 @@ namespace {
 
     /// @{ Type parsing.
     bool parseASTType(CanType &result,
-                      GenericEnvironment *environment = nullptr);
-    bool parseASTType(CanType &result, SourceLoc &TypeLoc) {
-      TypeLoc = P.Tok.getLoc();
-      return parseASTType(result);
-    }
+                      GenericEnvironment *genericEnv=nullptr,
+                      GenericParamList *genericParams=nullptr);
     bool parseASTType(CanType &result,
                       SourceLoc &TypeLoc,
-                      GenericEnvironment *env) {
+                      GenericEnvironment *genericEnv=nullptr,
+                      GenericParamList *genericParams=nullptr) {
       TypeLoc = P.Tok.getLoc();
-      return parseASTType(result, env);
+      return parseASTType(result, genericEnv, genericParams);
     }
     bool parseSILOwnership(ValueOwnershipKind &OwnershipKind) {
       // We parse here @ <identifier>.
@@ -332,13 +323,17 @@ namespace {
       return parseSILIdentifierSwitch(OwnershipKind, AllOwnershipKinds,
                                       diag::expected_sil_value_ownership_kind);
     }
+    void bindSILGenericParams(TypeRepr *TyR);
     bool parseSILType(SILType &Result,
                       GenericEnvironment *&parsedGenericEnv,
-                      bool IsFuncDecl = false,
-                      GenericEnvironment *parentGenericEnv = nullptr);
+                      GenericParamList *&parsedGenericParams,
+                      bool IsFuncDecl=false,
+                      GenericEnvironment *parentGenericEnv=nullptr,
+                      GenericParamList *parentGenericParams=nullptr);
     bool parseSILType(SILType &Result) {
-      GenericEnvironment *IgnoredEnv;
-      return parseSILType(Result, IgnoredEnv);
+      GenericEnvironment *IgnoredEnv = nullptr;
+      GenericParamList *IgnoredParams = nullptr;
+      return parseSILType(Result, IgnoredEnv, IgnoredParams);
     }
     bool parseSILType(SILType &Result, SourceLoc &TypeLoc) {
       TypeLoc = P.Tok.getLoc();
@@ -346,9 +341,12 @@ namespace {
     }
     bool parseSILType(SILType &Result, SourceLoc &TypeLoc,
                       GenericEnvironment *&parsedGenericEnv,
-                      GenericEnvironment *parentGenericEnv = nullptr) {
+                      GenericParamList *&parsedGenericParams,
+                      GenericEnvironment *parentGenericEnv = nullptr,
+                      GenericParamList *parentGenericParams = nullptr) {
       TypeLoc = P.Tok.getLoc();
-      return parseSILType(Result, parsedGenericEnv, false, parentGenericEnv);
+      return parseSILType(Result, parsedGenericEnv, parsedGenericParams,
+                          false, parentGenericEnv, parentGenericParams);
     }
     /// @}
 
@@ -411,22 +409,24 @@ namespace {
                                       SourceLoc componentLoc,
                                       Identifier componentKind,
                                       SILLocation InstLoc,
-                                      GenericEnvironment *patternEnv);
+                                      GenericEnvironment *patternEnv,
+                                      GenericParamList *patternParams);
     bool isStartOfSILInstruction();
 
     bool parseSubstitutions(SmallVectorImpl<ParsedSubstitution> &parsed,
                             GenericEnvironment *GenericEnv=nullptr,
-                            ProtocolDecl *defaultForProto = nullptr);
+                            GenericParamList *GenericParams=nullptr);
 
     ProtocolConformanceRef parseProtocolConformance(
-        ProtocolDecl *&proto, GenericEnvironment *&genericEnv,
-        ConformanceContext context, ProtocolDecl *defaultForProto);
+        ProtocolDecl *&proto,
+        GenericEnvironment *&genericEnv,
+        GenericParamList *&genericParams);
     ProtocolConformanceRef
-    parseProtocolConformance(ProtocolDecl *defaultForProto,
-                             ConformanceContext context) {
-      ProtocolDecl *dummy;
-      GenericEnvironment *env;
-      return parseProtocolConformance(dummy, env, context, defaultForProto);
+    parseProtocolConformance() {
+      ProtocolDecl *dummy = nullptr;
+      GenericEnvironment *genericEnv = nullptr;
+      GenericParamList *genericParams = nullptr;
+      return parseProtocolConformance(dummy, genericEnv, genericParams);
     }
 
     Optional<llvm::coverage::Counter>
@@ -846,6 +846,8 @@ static bool parseSILOptional(bool &Result, SILParser &SP, StringRef Expected) {
 }
 
 namespace {
+  // FIXME: Nuke this.
+
   /// A helper class to perform lookup of IdentTypes in the
   /// current parser scope.
   class IdentTypeReprLookup : public ASTWalker {
@@ -884,7 +886,8 @@ void SILParser::convertRequirements(SILFunction *F,
   // to the generic parameters.
   auto ResolveToInterfaceType = [&](TypeRepr *TyR) -> Type {
     TyR->walk(PerformLookup);
-    return performTypeResolution(TyR, /*IsSILType=*/false, ContextGenericEnv)
+    return performTypeResolution(TyR, /*IsSILType=*/false,
+                                 ContextGenericEnv, nullptr)
         ->mapTypeOutOfContext();
   };
 
@@ -1110,12 +1113,14 @@ static bool parseDeclSILOptional(bool *isTransparent,
 }
 
 Type SILParser::performTypeResolution(TypeRepr *TyR, bool IsSILType,
-                                      GenericEnvironment *GenericEnv) {
+                                      GenericEnvironment *GenericEnv,
+                                      GenericParamList *GenericParams) {
   if (GenericEnv == nullptr)
     GenericEnv = ContextGenericEnv;
 
   return swift::performTypeResolution(TyR, P.Context,
-                                      /*isSILMode=*/true, IsSILType, GenericEnv,
+                                      /*isSILMode=*/true, IsSILType,
+                                      GenericEnv, GenericParams,
                                       &P.SF);
 }
 
@@ -1167,15 +1172,29 @@ static ValueDecl *lookupMember(Parser &P, Type Ty, DeclBaseName Name,
   return Lookup[0];
 }
 
-bool SILParser::parseASTType(CanType &result, GenericEnvironment *env) {
+bool SILParser::parseASTType(CanType &result,
+                             GenericEnvironment *genericEnv,
+                             GenericParamList *genericParams) {
   ParserResult<TypeRepr> parsedType = P.parseType();
   if (parsedType.isNull()) return true;
+
+  bool wantInterfaceType = true;
+  if (genericEnv == nullptr) {
+    genericEnv = ContextGenericEnv;
+    wantInterfaceType = false;
+  }
+  if (genericParams == nullptr)
+    genericParams = ContextGenericParams;
+
+  bindSILGenericParams(parsedType.get());
+
   const auto resolvedType =
-      performTypeResolution(parsedType.get(), /*isSILType=*/false, env);
+      performTypeResolution(parsedType.get(), /*isSILType=*/false,
+                            genericEnv, genericParams);
   if (resolvedType->hasError())
     return true;
 
-  if (env)
+  if (wantInterfaceType)
     result = resolvedType->mapTypeOutOfContext()->getCanonicalType();
   else
     result = resolvedType->getCanonicalType();
@@ -1185,14 +1204,57 @@ bool SILParser::parseASTType(CanType &result, GenericEnvironment *env) {
   return false;
 }
 
+void SILParser::bindSILGenericParams(TypeRepr *TyR) {
+  // Resolve the generic environments for parsed generic function and box types.
+  class HandleSILGenericParamsWalker : public ASTWalker {
+    SourceFile *SF;
+
+  public:
+    HandleSILGenericParamsWalker(SourceFile *SF) : SF(SF) {}
+
+    bool walkToTypeReprPre(TypeRepr *T) override {
+      if (auto fnType = dyn_cast<FunctionTypeRepr>(T)) {
+        if (auto *genericParams = fnType->getGenericParams()) {
+          auto *env = handleSILGenericParams(genericParams, SF);
+          fnType->setGenericEnvironment(env);
+        }
+
+        if (auto *genericParams = fnType->getPatternGenericParams()) {
+          auto *env = handleSILGenericParams(genericParams, SF);
+          fnType->setPatternGenericEnvironment(env);
+        }
+      }
+
+      if (auto boxType = dyn_cast<SILBoxTypeRepr>(T)) {
+        if (auto *genericParams = boxType->getGenericParams()) {
+          auto *env = handleSILGenericParams(genericParams, SF);
+          boxType->setGenericEnvironment(env);
+        }
+      }
+
+      return true;
+    }
+  };
+
+  TyR->walk(HandleSILGenericParamsWalker(&P.SF));
+}
+
 ///   sil-type:
 ///     '$' '*'? attribute-list (generic-params)? type
 ///
 bool SILParser::parseSILType(SILType &Result,
                              GenericEnvironment *&ParsedGenericEnv,
+                             GenericParamList *&ParsedGenericParams,
                              bool IsFuncDecl,
-                             GenericEnvironment *OuterGenericEnv) {
+                             GenericEnvironment *OuterGenericEnv,
+                             GenericParamList *OuterGenericParams) {
   ParsedGenericEnv = nullptr;
+  ParsedGenericParams = nullptr;
+
+  if (OuterGenericEnv == nullptr)
+    OuterGenericEnv = ContextGenericEnv;
+  if (OuterGenericParams == nullptr)
+    OuterGenericParams = ContextGenericParams;
 
   if (P.parseToken(tok::sil_dollar, diag::expected_sil_type))
     return true;
@@ -1224,48 +1286,25 @@ bool SILParser::parseSILType(SILType &Result,
 
   if (TyR.isNull())
     return true;
-  
-  // Resolve the generic environments for parsed generic function and box types.
-  class HandleSILGenericParamsWalker : public ASTWalker {
-    SourceFile *SF;
-  public:
-    HandleSILGenericParamsWalker(SourceFile *SF) : SF(SF) {}
 
-    bool walkToTypeReprPre(TypeRepr *T) override {
-      if (auto fnType = dyn_cast<FunctionTypeRepr>(T)) {
-        if (auto generics = fnType->getGenericParams()) {
-          auto env = handleSILGenericParams(generics, SF);
-          fnType->setGenericEnvironment(env);
-        }
-        if (auto generics = fnType->getPatternGenericParams()) {
-          auto env = handleSILGenericParams(generics, SF);
-          fnType->setPatternGenericEnvironment(env);
-        }
-      }
-      if (auto boxType = dyn_cast<SILBoxTypeRepr>(T)) {
-        if (auto generics = boxType->getGenericParams()) {
-          auto env = handleSILGenericParams(generics, SF);
-          boxType->setGenericEnvironment(env);
-        }
-      }
-      return true;
-    }
-  };
-
-  TyR.get()->walk(HandleSILGenericParamsWalker(&P.SF));
-
-  // Save the top-level function generic environment if there was one.
-  if (auto fnType = dyn_cast<FunctionTypeRepr>(TyR.get()))
-    if (auto env = fnType->getGenericEnvironment())
-      ParsedGenericEnv = env;
+  bindSILGenericParams(TyR.get());
   
   // Apply attributes to the type.
   auto *attrRepr =
       P.applyAttributeToType(TyR.get(), attrs, specifier, specifierLoc);
   const auto Ty =
-      performTypeResolution(attrRepr, /*IsSILType=*/true, OuterGenericEnv);
+      performTypeResolution(attrRepr, /*IsSILType=*/true,
+                            OuterGenericEnv, OuterGenericParams);
   if (Ty->hasError())
     return true;
+
+  // Save the top-level function generic environment if there was one.
+  if (auto fnType = dyn_cast<FunctionTypeRepr>(TyR.get())) {
+    if (auto *genericEnv = fnType->getGenericEnvironment())
+      ParsedGenericEnv = genericEnv;
+    if (auto *genericParams = fnType->getGenericParams())
+      ParsedGenericParams = genericParams;
+  }
 
   Result = SILType::getPrimitiveType(Ty->getCanonicalType(),
                                      category);
@@ -1658,50 +1697,20 @@ bool SILParser::parseSILBBArgsAtBranch(SmallVector<SILValue, 6> &Args,
   return false;
 }
 
-/// Bind any unqualified 'Self' references to the given protocol's 'Self'
-/// generic parameter.
-///
-/// FIXME: This is a hack to work around the lack of a DeclContext for
-/// witness tables.
-static void bindProtocolSelfInTypeRepr(TypeRepr *typeRepr, ProtocolDecl *proto) {
-  assert(typeRepr);
-
-  // AST walker to update 'Self' references.
-  class BindProtocolSelf : public ASTWalker {
-    ProtocolDecl *proto;
-    GenericTypeParamDecl *selfParam;
-    Identifier selfId;
-
-  public:
-    BindProtocolSelf(ProtocolDecl *proto)
-      : proto(proto),
-        selfParam(proto->getProtocolSelfType()->getDecl()),
-        selfId(proto->getASTContext().Id_Self) {
-    }
-
-    virtual bool walkToTypeReprPre(TypeRepr *T) override {
-      if (auto ident = dyn_cast<IdentTypeRepr>(T)) {
-        auto firstComponent = ident->getComponentRange().front();
-        if (firstComponent->getNameRef().isSimpleName(selfId))
-          firstComponent->setValue(selfParam, proto);
-      }
-
-      return true;
-    }
-  };
-
-  typeRepr->walk(BindProtocolSelf(proto));
-}
-
 /// Parse the substitution list for an apply instruction or
 /// specialized protocol conformance.
 bool SILParser::parseSubstitutions(SmallVectorImpl<ParsedSubstitution> &parsed,
                                    GenericEnvironment *GenericEnv,
-                                   ProtocolDecl *defaultForProto) {
+                                   GenericParamList *GenericParams) {
   // Check for an opening '<' bracket.
   if (!P.startsWithLess(P.Tok))
     return false;
   
+  if (GenericEnv == nullptr)
+    GenericEnv = ContextGenericEnv;
+  if (GenericParams == nullptr)
+    GenericParams = ContextGenericParams;
+
   P.consumeStartingLess();
   
   // Parse a list of Substitutions.
@@ -1712,11 +1721,10 @@ bool SILParser::parseSubstitutions(SmallVectorImpl<ParsedSubstitution> &parsed,
     ParserResult<TypeRepr> TyR = P.parseType();
     if (TyR.isNull())
       return true;
-    if (defaultForProto)
-      bindProtocolSelfInTypeRepr(TyR.get(), defaultForProto);
 
     const auto Ty =
-        performTypeResolution(TyR.get(), /*IsSILType=*/false, GenericEnv);
+        performTypeResolution(TyR.get(), /*IsSILType=*/false,
+                              GenericEnv, GenericParams);
     if (Ty->hasError())
       return true;
     parsed.push_back({Loc, Ty});
@@ -2112,21 +2120,19 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Member, bool FnTypeRequired) {
     if (TyR.isNull())
       return true;
 
+    bindSILGenericParams(TyR.get());
+
     // The type can be polymorphic.
     GenericEnvironment *genericEnv = nullptr;
-    if (auto fnType = dyn_cast<FunctionTypeRepr>(TyR.get())) {
-      if (auto generics = fnType->getGenericParams()) {
-        genericEnv = handleSILGenericParams(generics, &P.SF);
-        fnType->setGenericEnvironment(genericEnv);
-      }
-      if (auto generics = fnType->getPatternGenericParams()) {
-        genericEnv = handleSILGenericParams(generics, &P.SF);
-        fnType->setPatternGenericEnvironment(genericEnv);
-      }
+    GenericParamList *genericParams = nullptr;
+    if (auto *fnType = dyn_cast<FunctionTypeRepr>(TyR.get())) {
+      genericEnv = fnType->getGenericEnvironment();
+      genericParams = fnType->getGenericParams();
     }
 
     const auto Ty =
-        performTypeResolution(TyR.get(), /*IsSILType=*/false, genericEnv);
+        performTypeResolution(TyR.get(), /*IsSILType=*/false,
+                              genericEnv, genericParams);
     if (Ty->hasError())
       return true;
 
@@ -2165,7 +2171,8 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
                                         SourceLoc componentLoc,
                                         Identifier componentKind,
                                         SILLocation InstLoc,
-                                        GenericEnvironment *patternEnv) {
+                                        GenericEnvironment *patternEnv,
+                                        GenericParamList *patternParams) {
    auto parseComponentIndices =
      [&](SmallVectorImpl<KeyPathPatternComponent::Index> &indexes) -> bool {
        while (true) {
@@ -2186,16 +2193,19 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
          
          SourceLoc formalTyLoc;
          SourceLoc loweredTyLoc;
-         GenericEnvironment *ignoredParsedEnv;
+         GenericEnvironment *ignoredParsedEnv = nullptr;
+         GenericParamList *ignoredParsedParams = nullptr;
          if (P.parseToken(tok::colon,
                           diag::expected_tok_in_sil_instr, ":")
              || P.parseToken(tok::sil_dollar,
                              diag::expected_tok_in_sil_instr, "$")
-             || parseASTType(formalTy, formalTyLoc, patternEnv)
+             || parseASTType(formalTy, formalTyLoc,
+                             patternEnv, patternParams)
              || P.parseToken(tok::colon,
                              diag::expected_tok_in_sil_instr, ":")
              || parseSILType(loweredTy, loweredTyLoc,
-                             ignoredParsedEnv, patternEnv))
+                             ignoredParsedEnv, ignoredParsedParams,
+                             patternEnv, patternParams))
            return true;
          
          if (patternEnv)
@@ -2249,7 +2259,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
         || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
         || P.parseToken(tok::sil_dollar,
                         diag::expected_tok_in_sil_instr, "$")
-        || parseASTType(ty, patternEnv))
+        || parseASTType(ty, patternEnv, patternParams))
       return true;
     component =
       KeyPathPatternComponent::forStoredProperty(cast<VarDecl>(prop), ty);
@@ -2260,7 +2270,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
     
     CanType componentTy;
     if (P.parseToken(tok::sil_dollar,diag::expected_tok_in_sil_instr,"$")
-        || parseASTType(componentTy, patternEnv)
+        || parseASTType(componentTy, patternEnv, patternParams)
         || P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
     
@@ -2323,7 +2333,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
         SmallVector<ParsedSubstitution, 4> parsedSubs;
 
         if (parseSILDottedPath(parsedExternalDecl)
-            || parseSubstitutions(parsedSubs, patternEnv))
+            || parseSubstitutions(parsedSubs, patternEnv, patternParams))
           return true;
 
         externalDecl = cast<AbstractStorageDecl>(parsedExternalDecl);
@@ -2409,7 +2419,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
     CanType ty;
     if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
         || P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$")
-        || parseASTType(ty, patternEnv))
+        || parseASTType(ty, patternEnv, patternParams))
       return true;
     KeyPathPatternComponent::Kind kind;
     
@@ -2433,7 +2443,7 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
         || parseInteger(tupleIndex, diag::expected_sil_tuple_index)
         || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
         || P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$")
-        || parseASTType(ty, patternEnv))
+        || parseASTType(ty, patternEnv, patternParams))
       return true;
       
     component = KeyPathPatternComponent::forTupleElement(tupleIndex, ty);
@@ -3131,15 +3141,15 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
 
-    GenericParamList *generics = nullptr;
+    GenericParamList *patternParams = nullptr;
     GenericEnvironment *patternEnv = nullptr;
     CanType rootType;
     StringRef objcString;
     SmallVector<SILType, 4> operandTypes;
     {
       Scope genericsScope(&P, ScopeKind::Generics);
-      generics = P.maybeParseGenericParams().getPtrOrNull();
-      patternEnv = handleSILGenericParams(generics, &P.SF);
+      patternParams = P.maybeParseGenericParams().getPtrOrNull();
+      patternEnv = handleSILGenericParams(patternParams, &P.SF);
 
       if (P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
         return true;
@@ -3154,7 +3164,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         if (componentKind.str() == "root") {
           if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr,
                            "$") ||
-              parseASTType(rootType, patternEnv))
+              parseASTType(rootType, patternEnv, patternParams))
             return true;
         } else if (componentKind.str() == "objc") {
           auto tok = P.Tok;
@@ -3171,7 +3181,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
           KeyPathPatternComponent component;
           if (parseKeyPathPatternComponent(component, operandTypes,
                                            componentLoc, componentKind, InstLoc,
-                                           patternEnv))
+                                           patternEnv, patternParams))
             return true;
           components.push_back(component);
         }
@@ -3189,7 +3199,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       P.diagnose(InstLoc.getSourceLoc(), diag::sil_keypath_no_root);
 
     SmallVector<ParsedSubstitution, 4> parsedSubs;
-    if (parseSubstitutions(parsedSubs, ContextGenericEnv))
+    if (parseSubstitutions(parsedSubs, ContextGenericEnv, ContextGenericParams))
       return true;
 
     SubstitutionMap subMap;
@@ -5024,7 +5034,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
 
       UnresolvedValueName invokeName;
       SILType invokeTy;
-      GenericEnvironment *invokeGenericEnv;
+      GenericEnvironment *invokeGenericEnv = nullptr;
+      GenericParamList *invokeGenericParams = nullptr;
 
       SILType blockType;
       SmallVector<ParsedSubstitution, 4> parsedSubs;
@@ -5035,7 +5046,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
                              "invoke") ||
           parseValueName(invokeName) || parseSubstitutions(parsedSubs) ||
           P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-          parseSILType(invokeTy, invokeGenericEnv) ||
+          parseSILType(invokeTy, invokeGenericEnv, invokeGenericParams) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
           parseSILIdentifier(type, typeLoc, diag::expected_tok_in_sil_instr,
                              "type") ||
@@ -5392,9 +5403,10 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
   SILType Ty;
   SourceLoc TypeLoc;
   GenericEnvironment *GenericEnv = nullptr;
+  GenericParamList *GenericParams = nullptr;
   if (P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")") ||
       P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-      parseSILType(Ty, TypeLoc, GenericEnv))
+      parseSILType(Ty, TypeLoc, GenericEnv, GenericParams))
     return true;
 
   auto FTI = Ty.getAs<SILFunctionType>();
@@ -5725,8 +5737,10 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     // Construct a Scope for the function body so TypeAliasDecl can be added to
     // the scope.
     Scope Body(&P, ScopeKind::FunctionBody);
-    GenericEnvironment *GenericEnv;
-    if (FunctionState.parseSILType(FnType, GenericEnv, true /*IsFuncDecl*/))
+    GenericEnvironment *GenericEnv = nullptr;
+    GenericParamList *GenericParams = nullptr;
+    if (FunctionState.parseSILType(FnType, GenericEnv, GenericParams,
+                                   true /*IsFuncDecl*/))
       return true;
     auto SILFnType = FnType.getAs<SILFunctionType>();
     if (!SILFnType || !FnType.isObject()) {
@@ -5771,6 +5785,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
       isDefinition = true;
 
       FunctionState.ContextGenericEnv = GenericEnv;
+      FunctionState.ContextGenericParams = GenericParams;
       FunctionState.F->setGenericEnvironment(GenericEnv);
 
       if (GenericEnv && !SpecAttrs.empty()) {
@@ -5999,12 +6014,12 @@ bool SILParserState::parseSILProperty(Parser &P) {
   if (SP.parseSILDottedPath(VD))
     return true;
   
-  GenericParamList *generics;
+  GenericParamList *patternParams;
   GenericEnvironment *patternEnv;
   Scope toplevelScope(&P, ScopeKind::TopLevel);
   Scope genericsScope(&P, ScopeKind::Generics);
-  generics = P.maybeParseGenericParams().getPtrOrNull();
-  patternEnv = handleSILGenericParams(generics, &P.SF);
+  patternParams = P.maybeParseGenericParams().getPtrOrNull();
+  patternEnv = handleSILGenericParams(patternParams, &P.SF);
 
   if (patternEnv) {
     if (patternEnv->getGenericSignature().getCanonicalSignature() !=
@@ -6035,7 +6050,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
                           diag::expected_tok_in_sil_instr, "component kind")
         || SP.parseKeyPathPatternComponent(parsedComponent, OperandTypes,
                  ComponentLoc, ComponentKind, InstLoc,
-                 patternEnv)
+                 patternEnv, patternParams)
         || P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")"))
       return true;
     
@@ -6251,15 +6266,9 @@ static CanType parseAssociatedTypePath(Parser &P, SILParser &SP,
   return CanType();
 }
 
-static bool isSelfConformance(Type conformingType, ProtocolDecl *protocol) {
-  if (auto protoTy = conformingType->getAs<ProtocolType>())
-    return protoTy->getDecl() == protocol;
-  return false;
-}
-
 static ProtocolConformanceRef
 parseRootProtocolConformance(Parser &P, SILParser &SP, Type ConformingTy,
-                             ProtocolDecl *&proto, ConformanceContext context) {
+                             ProtocolDecl *&proto) {
   Identifier ModuleKeyword, ModuleName;
   SourceLoc Loc, KeywordLoc;
   proto = parseProtocolDecl(P, SP);
@@ -6288,12 +6297,6 @@ parseRootProtocolConformance(Parser &P, SILParser &SP, Type ConformingTy,
     return ProtocolConformanceRef();
   }
 
-  // Use a concrete self-conformance if we're parsing this for a witness table.
-  if (context == ConformanceContext::WitnessTable && !lookup.isConcrete() &&
-      isSelfConformance(ConformingTy, proto)) {
-    lookup = ProtocolConformanceRef(P.Context.getSelfConformance(proto));
-  }
-
   return lookup;
 }
 
@@ -6307,46 +6310,41 @@ parseRootProtocolConformance(Parser &P, SILParser &SP, Type ConformingTy,
 ///    generic-parameter-list? type: protocolName module ModuleName
 /// Note that generic-parameter-list is already parsed before calling this.
 ProtocolConformanceRef SILParser::parseProtocolConformance(
-    ProtocolDecl *&proto, GenericEnvironment *&genericEnv,
-    ConformanceContext context, ProtocolDecl *defaultForProto) {
+    ProtocolDecl *&proto,
+    GenericEnvironment *&genericEnv,
+    GenericParamList *&genericParams) {
   // Parse generic params for the protocol conformance. We need to make sure
   // they have the right scope.
-  Optional<Scope> GenericsScope;
-  if (context == ConformanceContext::Ordinary)
-    GenericsScope.emplace(&P, ScopeKind::Generics);
+  Scope GenericsScope(&P, ScopeKind::Generics);
 
   // Make sure we don't leave it uninitialized in the caller
   genericEnv = nullptr;
 
-  auto *genericParams = P.maybeParseGenericParams().getPtrOrNull();
+  genericParams = P.maybeParseGenericParams().getPtrOrNull();
   if (genericParams) {
     genericEnv = handleSILGenericParams(genericParams, &P.SF);
-  } else if (defaultForProto) {
-    genericEnv = defaultForProto->getGenericEnvironment();
   }
 
-  auto retVal = parseProtocolConformanceHelper(proto, genericEnv, context,
-                                               defaultForProto);
-
-  if (GenericsScope) {
-    GenericsScope.reset();
-  }
-  return retVal;
+  return parseProtocolConformanceHelper(proto, genericEnv, genericParams);
 }
 
 ProtocolConformanceRef SILParser::parseProtocolConformanceHelper(
-    ProtocolDecl *&proto, GenericEnvironment *witnessEnv,
-    ConformanceContext context, ProtocolDecl *defaultForProto) {
+    ProtocolDecl *&proto,
+    GenericEnvironment *witnessEnv,
+    GenericParamList *witnessParams) {
   // Parse AST type.
   ParserResult<TypeRepr> TyR = P.parseType();
   if (TyR.isNull())
     return ProtocolConformanceRef();
-  if (defaultForProto) {
-    bindProtocolSelfInTypeRepr(TyR.get(), defaultForProto);
-  }
+
+  if (witnessEnv == nullptr)
+    witnessEnv = ContextGenericEnv;
+  if (witnessParams == nullptr)
+    witnessParams = ContextGenericParams;
 
   const auto ConformingTy =
-      performTypeResolution(TyR.get(), /*IsSILType=*/false, witnessEnv);
+      performTypeResolution(TyR.get(), /*IsSILType=*/false,
+                            witnessEnv, witnessParams);
   if (ConformingTy->hasError())
     return ProtocolConformanceRef();
 
@@ -6358,17 +6356,16 @@ ProtocolConformanceRef SILParser::parseProtocolConformanceHelper(
 
     // Parse substitutions for specialized conformance.
     SmallVector<ParsedSubstitution, 4> parsedSubs;
-    if (parseSubstitutions(parsedSubs, witnessEnv, defaultForProto))
+    if (parseSubstitutions(parsedSubs, witnessEnv, witnessParams))
       return ProtocolConformanceRef();
 
     if (P.parseToken(tok::l_paren, diag::expected_sil_witness_lparen))
       return ProtocolConformanceRef();
     ProtocolDecl *dummy;
-    GenericEnvironment *specializedEnv;
+    GenericEnvironment *specializedEnv = nullptr;
+    GenericParamList *specializedParams = nullptr;
     auto genericConform =
-        parseProtocolConformance(dummy, specializedEnv,
-                                 ConformanceContext::Ordinary,
-                                 defaultForProto);
+        parseProtocolConformance(dummy, specializedEnv, specializedParams);
     if (genericConform.isInvalid() || !genericConform.isConcrete())
       return ProtocolConformanceRef();
     if (P.parseToken(tok::r_paren, diag::expected_sil_witness_rparen))
@@ -6389,8 +6386,7 @@ ProtocolConformanceRef SILParser::parseProtocolConformanceHelper(
 
     if (P.parseToken(tok::l_paren, diag::expected_sil_witness_lparen))
       return ProtocolConformanceRef();
-    auto baseConform = parseProtocolConformance(defaultForProto,
-                                                ConformanceContext::Ordinary);
+    auto baseConform = parseProtocolConformance();
     if (baseConform.isInvalid() || !baseConform.isConcrete())
       return ProtocolConformanceRef();
     if (P.parseToken(tok::r_paren, diag::expected_sil_witness_rparen))
@@ -6402,23 +6398,22 @@ ProtocolConformanceRef SILParser::parseProtocolConformanceHelper(
   }
 
   auto retVal =
-    parseRootProtocolConformance(P, *this, ConformingTy, proto, context);
+    parseRootProtocolConformance(P, *this, ConformingTy, proto);
   return retVal;
 }
 
 /// Parser a single SIL vtable entry and add it to either \p witnessEntries
 /// or \c conditionalConformances.
-static bool parseSILVTableEntry(
+static bool parseSILWitnessTableEntry(
          Parser &P,
          SILModule &M,
          ProtocolDecl *proto,
          GenericEnvironment *witnessEnv,
+         GenericParamList *witnessParams,
          SILParser &witnessState,
-         bool isDefaultWitnessTable,
          std::vector<SILWitnessTable::Entry> &witnessEntries,
          std::vector<SILWitnessTable::ConditionalConformance>
            &conditionalConformances) {
-  ProtocolDecl *defaultForProto = isDefaultWitnessTable ? proto : nullptr;
   Identifier EntryKeyword;
   SourceLoc KeywordLoc;
   if (P.parseIdentifier(EntryKeyword, KeywordLoc,
@@ -6439,8 +6434,7 @@ static bool parseSILVTableEntry(
     if (P.parseToken(tok::colon, diag::expected_sil_witness_colon))
       return true;
     auto conform =
-      witnessState.parseProtocolConformance(defaultForProto,
-                                            ConformanceContext::Ordinary);
+      witnessState.parseProtocolConformance();
     // Ignore invalid and abstract witness entries.
     if (conform.isInvalid() || !conform.isConcrete())
       return false;
@@ -6463,13 +6457,13 @@ static bool parseSILVTableEntry(
       if (TyR.isNull())
         return true;
 
-      if (isDefaultWitnessTable)
-        bindProtocolSelfInTypeRepr(TyR.get(), proto);
-
       const auto Ty =
           swift::performTypeResolution(TyR.get(), P.Context,
                                        /*isSILMode=*/false,
-                                       /*isSILType=*/false, witnessEnv, &P.SF);
+                                       /*isSILType=*/false,
+                                       witnessEnv,
+                                       witnessParams,
+                                       &P.SF);
       if (Ty->hasError())
         return true;
 
@@ -6489,8 +6483,7 @@ static bool parseSILVTableEntry(
     ProtocolConformanceRef conformance(proto);
     if (P.Tok.getText() != "dependent") {
       auto concrete =
-        witnessState.parseProtocolConformance(defaultForProto,
-                                              ConformanceContext::Ordinary);
+        witnessState.parseProtocolConformance();
       // Ignore invalid and abstract witness entries.
       if (concrete.isInvalid() || !concrete.isConcrete())
         return false;
@@ -6525,13 +6518,12 @@ static bool parseSILVTableEntry(
     if (TyR.isNull())
       return true;
 
-    if (isDefaultWitnessTable)
-      bindProtocolSelfInTypeRepr(TyR.get(), proto);
-
     const auto Ty =
         swift::performTypeResolution(TyR.get(), P.Context,
                                      /*isSILMode=*/false,
-                                     /*isSILType=*/false, witnessEnv, &P.SF);
+                                     /*isSILType=*/false,
+                                     witnessEnv, witnessParams,
+                                     &P.SF);
     if (Ty->hasError())
       return true;
 
@@ -6610,12 +6602,13 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
 
   // Parse the protocol conformance.
   ProtocolDecl *proto;
-  GenericEnvironment *witnessEnv;
+  GenericEnvironment *witnessEnv = nullptr;
+  GenericParamList *witnessParams = nullptr;
   auto conf = WitnessState.parseProtocolConformance(proto,
                                                     witnessEnv,
-                                              ConformanceContext::WitnessTable,
-                                                    nullptr);
+                                                    witnessParams);
   WitnessState.ContextGenericEnv = witnessEnv;
+  WitnessState.ContextGenericParams = witnessParams;
 
   // FIXME: should we really allow a specialized or inherited conformance here?
   RootProtocolConformance *theConformance = nullptr;
@@ -6657,8 +6650,9 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
 
   if (P.Tok.isNot(tok::r_brace)) {
     do {
-      if (parseSILVTableEntry(P, M, proto, witnessEnv, WitnessState, false,
-                              witnessEntries, conditionalConformances))
+      if (parseSILWitnessTableEntry(P, M, proto, witnessEnv, witnessParams,
+                                    WitnessState, witnessEntries,
+                                    conditionalConformances))
         return true;
     } while (P.Tok.isNot(tok::r_brace) && P.Tok.isNot(tok::eof));
   }
@@ -6708,6 +6702,9 @@ bool SILParserState::parseSILDefaultWitnessTable(Parser &P) {
   if (!protocol)
     return true;
 
+  WitnessState.ContextGenericEnv = protocol->getGenericEnvironment();
+  WitnessState.ContextGenericParams = protocol->getGenericParams();
+
   // Parse the body.
   SourceLoc LBraceLoc = P.Tok.getLoc();
   P.consumeToken(tok::l_brace);
@@ -6721,9 +6718,11 @@ bool SILParserState::parseSILDefaultWitnessTable(Parser &P) {
 
   if (P.Tok.isNot(tok::r_brace)) {
     do {
-      if (parseSILVTableEntry(P, M, protocol, protocol->getGenericEnvironment(),
-                              WitnessState, true, witnessEntries,
-                              conditionalConformances))
+      if (parseSILWitnessTableEntry(P, M, protocol,
+                                    protocol->getGenericEnvironment(),
+                                    protocol->getGenericParams(),
+                                    WitnessState, witnessEntries,
+                                    conditionalConformances))
         return true;
     } while (P.Tok.isNot(tok::r_brace) && P.Tok.isNot(tok::eof));
   }
@@ -7028,12 +7027,13 @@ bool SILParserState::parseSILScope(Parser &P) {
     SourceLoc FnLoc = P.Tok.getLoc();
     // We need to turn on InSILBody to parse the function reference.
     Lexer::SILBodyRAII Tmp(*P.L);
-    GenericEnvironment *IgnoredEnv;
+    GenericEnvironment *IgnoredEnv = nullptr;
+    GenericParamList *IgnoredParams = nullptr;
     Scope S(&P, ScopeKind::TopLevel);
     Scope Body(&P, ScopeKind::FunctionBody);
     if ((ScopeState.parseGlobalName(FnName)) ||
         P.parseToken(tok::colon, diag::expected_sil_colon_value_ref) ||
-        ScopeState.parseSILType(Ty, IgnoredEnv, true))
+        ScopeState.parseSILType(Ty, IgnoredEnv, IgnoredParams, true))
       return true;
 
     // The function doesn't exist yet. Create a zombie forward declaration.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -43,6 +43,7 @@
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Strings.h"
+#include "swift/Subsystems.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -670,6 +671,7 @@ static void diagnoseUnboundGenericType(Type ty, SourceLoc loc);
 ///
 /// \param type The generic type to which to apply arguments.
 /// \param resolution The type resolution to perform.
+/// \param silParams Used to look up generic parameters in SIL mode.
 /// \param comp The arguments to apply with the angle bracket range for
 /// diagnostics.
 ///
@@ -678,6 +680,7 @@ static void diagnoseUnboundGenericType(Type ty, SourceLoc loc);
 ///
 /// \see applyUnboundGenericArguments
 static Type applyGenericArguments(Type type, TypeResolution resolution,
+                                  GenericParamList *silParams,
                                   ComponentIdentTypeRepr *comp) {
   const auto options = resolution.getOptions();
   auto dc = resolution.getDeclContext();
@@ -775,7 +778,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
       if (nominal->isOptionalDecl()) {
         // Validate the generic argument.
-        Type objectType = resolution.resolveType(genericArgs[0]);
+        Type objectType = resolution.resolveType(genericArgs[0], silParams);
         if (objectType->hasError()) {
           return ErrorType::get(ctx);
         }
@@ -800,7 +803,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
   SmallVector<Type, 2> args;
   for (auto tyR : genericArgs) {
     // Propagate failure.
-    Type substTy = genericResolution.resolveType(tyR);
+    Type substTy = genericResolution.resolveType(tyR, silParams);
     if (!substTy || substTy->hasError())
       return ErrorType::get(ctx);
 
@@ -1010,6 +1013,7 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
 /// Returns a valid type or ErrorType in case of an error.
 static Type resolveTypeDecl(TypeDecl *typeDecl, DeclContext *foundDC,
                             TypeResolution resolution,
+                            GenericParamList *silParams,
                             ComponentIdentTypeRepr *comp) {
   // Resolve the type declaration to a specific type. How this occurs
   // depends on the current context and where the type was found.
@@ -1025,7 +1029,7 @@ static Type resolveTypeDecl(TypeDecl *typeDecl, DeclContext *foundDC,
                                    typeDecl);
   }
 
-  return applyGenericArguments(type, resolution, comp);
+  return applyGenericArguments(type, resolution, silParams, comp);
 }
 
 static std::string getDeclNameFromContext(DeclContext *dc,
@@ -1287,6 +1291,7 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 /// \returns Either the resolved type or a null type, the latter of
 /// which indicates that some dependencies were unsatisfied.
 static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
+                                              GenericParamList *silParams,
                                               ComponentIdentTypeRepr *comp) {
   const auto options = resolution.getOptions();
   ASTContext &ctx = resolution.getASTContext();
@@ -1299,13 +1304,26 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   // that now.
   if (auto *typeDecl = comp->getBoundDecl()) {
     // Resolve the type declaration within this context.
-    return resolveTypeDecl(typeDecl, comp->getDeclContext(), resolution, comp);
+    return resolveTypeDecl(typeDecl, comp->getDeclContext(), resolution,
+                           silParams, comp);
   }
 
   // Resolve the first component, which is the only one that requires
   // unqualified name lookup.
   auto DC = resolution.getDeclContext();
   auto id = comp->getNameRef();
+
+  // In SIL mode, we bind generic parameters here, since name lookup
+  // won't find them.
+  if (silParams != nullptr) {
+    auto name = id.getBaseIdentifier();
+    if (auto *paramDecl = silParams->lookUpGenericParam(name)) {
+      comp->setValue(paramDecl, DC);
+
+      return resolveTypeDecl(paramDecl, DC, resolution,
+                             silParams, comp);
+    }
+  }
 
   NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
   if (options.contains(TypeResolutionFlags::KnownNonCascadingDependency))
@@ -1322,7 +1340,7 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
     auto *foundDC = entry.getDeclContext();
     auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
 
-    Type type = resolveTypeDecl(typeDecl, foundDC, resolution, comp);
+    Type type = resolveTypeDecl(typeDecl, foundDC, resolution, silParams, comp);
     if (type->is<ErrorType>())
       return type;
 
@@ -1417,7 +1435,9 @@ static void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
 /// Resolve the given identifier type representation as a qualified
 /// lookup within the given parent type, returning the type it
 /// references.
+/// \param silParams Used to look up generic parameters in SIL mode.
 static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
+                                            GenericParamList *silParams,
                                             Type parentTy,
                                             SourceRange parentRange,
                                             ComponentIdentTypeRepr *comp) {
@@ -1473,7 +1493,8 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
     }
 
     // If there are generic arguments, apply them now.
-    return applyGenericArguments(memberType, resolution, comp);
+    return applyGenericArguments(memberType, resolution,
+                                 silParams, comp);
   };
 
   // Short-circuiting.
@@ -1490,7 +1511,7 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
       // type later on.
       if (!memberType->is<DependentMemberType>() ||
           memberType->castTo<DependentMemberType>()->getAssocType()) {
-        return applyGenericArguments(memberType, resolution, comp);
+        return applyGenericArguments(memberType, resolution, silParams, comp);
       }
 
       return memberType;
@@ -1558,28 +1579,33 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
   return maybeDiagnoseBadMemberType(member, memberType, inferredAssocType);
 }
 
+/// \param silParams Used to look up generic parameters in SIL mode.
 static Type
 resolveIdentTypeComponent(TypeResolution resolution,
+                          GenericParamList *silParams,
                           ArrayRef<ComponentIdentTypeRepr *> components) {
   auto comp = components.back();
 
   // The first component uses unqualified lookup.
   const auto parentComps = components.drop_back();
   if (parentComps.empty()) {
-    return resolveTopLevelIdentTypeComponent(resolution, comp);
+    return resolveTopLevelIdentTypeComponent(resolution, silParams,
+                                             comp);
   }
 
   // All remaining components use qualified lookup.
 
   // Resolve the parent type.
-  Type parentTy = resolveIdentTypeComponent(resolution, parentComps);
+  Type parentTy = resolveIdentTypeComponent(resolution, silParams,
+                                            parentComps);
   if (!parentTy || parentTy->hasError()) return parentTy;
   
   SourceRange parentRange(parentComps.front()->getStartLoc(),
                           parentComps.back()->getEndLoc());
 
   // Resolve the nested type.
-  return resolveNestedIdentTypeComponent(resolution, parentTy, parentRange,
+  return resolveNestedIdentTypeComponent(resolution, silParams,
+                                         parentTy, parentRange,
                                          comp);
 }
 
@@ -1720,9 +1746,13 @@ namespace {
   class TypeResolver {
     const TypeResolution &resolution;
 
+    /// Used in SIL mode.
+    GenericParamList *genericParams;
+
   public:
-    explicit TypeResolver(const TypeResolution &resolution)
-        : resolution(resolution) {}
+    explicit TypeResolver(const TypeResolution &resolution,
+                          GenericParamList *genericParams = nullptr)
+        : resolution(resolution), genericParams(genericParams) {}
 
     NeverNullType resolveType(TypeRepr *repr, TypeResolutionOptions options);
 
@@ -1828,10 +1858,12 @@ namespace {
   };
 } // end anonymous namespace
 
-Type TypeResolution::resolveType(TypeRepr *TyR) const {
+Type TypeResolution::resolveType(TypeRepr *TyR,
+                                 GenericParamList *silParams) const {
   auto &ctx = getASTContext();
   auto Ty =
-      evaluateOrDefault(ctx.evaluator, ResolveTypeRequest{this, TyR}, Type());
+      evaluateOrDefault(ctx.evaluator,
+                        ResolveTypeRequest{this, TyR, silParams}, Type());
   if (!Ty)
     return ErrorType::get(ctx);
   return Ty;
@@ -1839,11 +1871,13 @@ Type TypeResolution::resolveType(TypeRepr *TyR) const {
 
 Type ResolveTypeRequest::evaluate(Evaluator &evaluator,
                                   const TypeResolution *resolution,
-                                  TypeRepr *TyR) const {
+                                  TypeRepr *TyR,
+                                  GenericParamList *silParams) const {
   const auto options = resolution->getOptions();
   auto &ctx = resolution->getASTContext();
   auto result =
-      TypeResolver(*resolution).resolveType(TyR, resolution->getOptions());
+      TypeResolver(*resolution, silParams)
+          .resolveType(TyR, resolution->getOptions());
 
   // If we resolved down to an error, make sure to mark the typeRepr as invalid
   // so we don't produce a redundant diagnostic.
@@ -2677,6 +2711,23 @@ Type TypeResolver::resolveASTFunctionType(
     const clang::Type *parsedClangFunctionType,
     DifferentiabilityKind diffKind) {
 
+  Optional<llvm::SaveAndRestore<GenericParamList *>> saveGenericParams;
+
+  if (auto *genericParams = repr->getGenericParams())
+    saveGenericParams.emplace(this->genericParams, genericParams);
+
+  // Diagnose a couple of things that we can parse in SIL mode but we don't
+  // allow in formal types.
+  if (auto patternParams = repr->getPatternGenericParams()) {
+    diagnose(patternParams->getLAngleLoc(),
+             diag::ast_subst_function_type);
+    return ErrorType::get(getASTContext());
+  } else if (!repr->getInvocationSubstitutions().empty()) {
+    diagnose(repr->getInvocationSubstitutions()[0]->getStartLoc(),
+             diag::ast_subst_function_type);
+    return ErrorType::get(getASTContext());
+  }
+
   TypeResolutionOptions options = None;
   options |= parentOptions.withoutContext().getFlags();
   auto params = resolveASTFunctionTypeParams(
@@ -2723,16 +2774,6 @@ Type TypeResolver::resolveASTFunctionType(
                      .withAsync(repr->isAsync())
                      .withClangFunctionType(clangFnType)
                      .build();
-
-  // Diagnose a couple of things that we can parse in SIL mode but we don't
-  // allow in formal types.
-  if (auto patternParams = repr->getPatternGenericParams()) {
-    diagnose(patternParams->getLAngleLoc(),
-             diag::ast_subst_function_type);
-  } else if (!repr->getInvocationSubstitutions().empty()) {
-    diagnose(repr->getInvocationSubstitutions()[0]->getStartLoc(),
-             diag::ast_subst_function_type);
-  }
 
   // SIL uses polymorphic function types to resolve overloaded member functions.
   if (auto genericEnv = repr->getGenericEnvironment()) {
@@ -2809,12 +2850,18 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
     // has one. (TODO: Field types should never refer to generic parameters
     // outside the box's own environment; we should really validate that...)
     TypeResolution fieldResolution{resolution};
-    if (auto env = repr->getGenericEnvironment()) {
+
+    auto *genericEnv = repr->getGenericEnvironment();
+    auto *genericParams = repr->getGenericParams();
+
+    if (genericParams) {
       fieldResolution = TypeResolution::forContextual(
-          getDeclContext(), env, options, resolution.getUnboundTypeOpener());
+          getDeclContext(), genericEnv, options,
+          resolution.getUnboundTypeOpener());
     }
 
-    TypeResolver fieldResolver{fieldResolution};
+    TypeResolver fieldResolver{fieldResolution,
+                               genericParams};
     for (auto &fieldRepr : repr->getFields()) {
       auto fieldTy = fieldResolver.resolveType(fieldRepr.getFieldType(), options);
       fields.push_back({fieldTy->getCanonicalType(), fieldRepr.isMutable()});
@@ -2878,6 +2925,13 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
 
   // Resolve generic params in the pattern environment, if present, or
   // else the function's generic environment, if it has one.
+  GenericParamList *genericParams = repr->getGenericParams();
+  if (genericParams == nullptr)
+    genericParams = this->genericParams;
+  GenericParamList *componentGenericParams = repr->getPatternGenericParams();
+  if (componentGenericParams == nullptr)
+    componentGenericParams = genericParams;
+
   GenericEnvironment *genericEnv = repr->getGenericEnvironment();
   GenericEnvironment *componentTypeEnv =
     repr->getPatternGenericEnvironment()
@@ -2903,7 +2957,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
         diagnose(element.UnderscoreLoc, diag::sil_function_input_label);
     }
 
-    TypeResolver silResolver{functionResolution};
+    TypeResolver silResolver{functionResolution, componentGenericParams};
     for (auto elt : argsTuple->getElements()) {
       auto elementOptions = options;
       elementOptions.setContext(TypeResolverContext::FunctionInput);
@@ -2915,7 +2969,6 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     }
 
     {
-      // FIXME: Deal with unsatisfied dependencies.
       if (silResolver.resolveSILResults(repr->getResultTypeRepr(),
                                         options, yields,
                                         results, errorResult)) {
@@ -2957,11 +3010,13 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
                                         resolution.getUnboundTypeOpener());
       patternSubs = resolveSubstitutions(repr->getPatternGenericEnvironment(),
                                          repr->getPatternSubstitutions(),
-                                         TypeResolver{resolveSILParameters});
+                                         TypeResolver{resolveSILParameters,
+                                                      genericParams});
     } else {
       patternSubs = resolveSubstitutions(repr->getPatternGenericEnvironment(),
                                          repr->getPatternSubstitutions(),
-                                         TypeResolver{resolution});
+                                         TypeResolver{resolution,
+                                                      genericParams});
     }
   }
 
@@ -2970,7 +3025,8 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
   if (!repr->getInvocationSubstitutions().empty()) {
     invocationSubs = resolveSubstitutions(repr->getGenericEnvironment(),
                                           repr->getInvocationSubstitutions(),
-                                          TypeResolver{resolution});
+                                          TypeResolver{resolution,
+                                                       genericParams});
   }
 
   if (hasError) {
@@ -3261,7 +3317,7 @@ Type TypeResolver::resolveIdentifierType(IdentTypeRepr *IdType,
   auto Components = llvm::makeArrayRef(ComponentRange.begin(),
                                        ComponentRange.end());
   Type result = resolveIdentTypeComponent(resolution.withOptions(options),
-                                          Components);
+                                          genericParams, Components);
   if (!result || result->hasError()) {
     return ErrorType::get(getASTContext());
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -371,9 +371,11 @@ public:
   /// to create a well-formed type.
   ///
   /// \param TyR The type representation to check.
+  /// \param silParams Used to look up generic parameters in SIL mode.
   ///
   /// \returns A well-formed type that is never null, or an \c ErrorType in case of an error.
-  Type resolveType(TypeRepr *TyR) const;
+  Type resolveType(TypeRepr *TyR,
+                   GenericParamList *silParams=nullptr) const;
 
   /// Whether this type resolution uses archetypes (vs. generic parameters).
   bool usesArchetypes() const;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -365,11 +365,11 @@ bool swift::isAdditiveArithmeticConformanceDerivationEnabled(SourceFile &SF) {
 Type swift::performTypeResolution(TypeRepr *TyR, ASTContext &Ctx,
                                   bool isSILMode, bool isSILType,
                                   GenericEnvironment *GenericEnv,
+                                  GenericParamList *GenericParams,
                                   DeclContext *DC, bool ProduceDiagnostics) {
   TypeResolutionOptions options = None;
-  if (isSILMode) {
+  if (isSILMode)
     options |= TypeResolutionFlags::SILMode;
-  }
   if (isSILType)
     options |= TypeResolutionFlags::SILType;
 
@@ -385,8 +385,31 @@ Type swift::performTypeResolution(TypeRepr *TyR, ASTContext &Ctx,
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
 
-  return resolution.resolveType(TyR);
+  return resolution.resolveType(TyR, GenericParams);
 }
+
+namespace {
+  class BindGenericParamsWalker : public ASTWalker {
+    DeclContext *dc;
+    GenericParamList *params;
+
+  public:
+    BindGenericParamsWalker(DeclContext *dc,
+                            GenericParamList *params)
+        : dc(dc), params(params) {}
+
+    bool walkToTypeReprPre(TypeRepr *T) override {
+      if (auto *ident = dyn_cast<IdentTypeRepr>(T)) {
+        auto firstComponent = ident->getComponentRange().front();
+        auto name = firstComponent->getNameRef().getBaseIdentifier();
+        if (auto *paramDecl = params->lookUpGenericParam(name))
+          firstComponent->setValue(paramDecl, dc);
+      }
+
+      return true;
+    }
+  };
+};
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
 GenericEnvironment *
@@ -396,15 +419,21 @@ swift::handleSILGenericParams(GenericParamList *genericParams,
     return nullptr;
 
   SmallVector<GenericParamList *, 2> nestedList;
-  for (; genericParams; genericParams = genericParams->getOuterParameters()) {
-    nestedList.push_back(genericParams);
+  for (auto *innerParams = genericParams;
+       innerParams != nullptr;
+       innerParams = innerParams->getOuterParameters()) {
+    nestedList.push_back(innerParams);
   }
 
   std::reverse(nestedList.begin(), nestedList.end());
 
+  BindGenericParamsWalker walker(DC, genericParams);
+
   for (unsigned i = 0, e = nestedList.size(); i < e; ++i) {
     auto genericParams = nestedList[i];
     genericParams->setDepth(i);
+
+    genericParams->walk(walker);
   }
 
   auto sig =


### PR DESCRIPTION
The SIL parser parses "dismebodied" `GenericParamList`s that are not associated with a `Decl`, and do not appear in the ASTScope tree. The parser would bind `IdentTypeRepr`s that referenced these generic parameter lists using parse-time lookup.

In order to make this work when parse-time lookup is disabled, we have to plumb `GenericParamList`s through the SIL parser in various places, and also teach Sema's `resolveType()` to handle them.