### PR TITLE
Revert "Start using optimization (-O0/-O2/-O3/-Os) and debug (-g) flags from CMAKE_CXX_FLAGS_${CFLAGS_BUILD_TYPE} (#33388)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,22 +629,6 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_SIMULATE_ID}" STREQU
   set(SWIFT_COMPILER_IS_MSVC_LIKE TRUE)
 endif()
 
-if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
-  # CMake's default for CMAKE_CXX_FLAGS_RELEASE is "-O3 -DNDEBUG". Let's avoid "-O3" for consistency
-  # between Release and RelWithDebInfo. Dropping -DNDEBUG from this setting is blocked by triggering
-  # a test failure of Swift-Unit :: Syntax/./SwiftSyntaxTests/TypeSyntaxTests.MetatypeTypeWithAPIs
-  # because unit tests don't currently explicitly set -DNDEBUG/-UNDEBUG.
-  set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
-
-  _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
-  if(_lto_flag_out)
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_RELEASE} -gline-tables-only")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -gline-tables-only")
-  endif()
-else()
-  
-endif()
-
 #
 # Configure SDKs.
 #

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -164,18 +164,17 @@ function(_add_target_variant_c_compile_flags)
     MACCATALYST_BUILD_FLAVOR "${CFLAGS_MACCATALYST_BUILD_FLAVOR}")
 
   is_build_type_optimized("${CFLAGS_BUILD_TYPE}" optimized)
-  is_build_type_with_debuginfo("${CFLAGS_BUILD_TYPE}" debuginfo)
-
-  # Add -O0/-O2/-O3/-Os/-g/... based on CFLAGS_BUILD_TYPE.
-  list(APPEND result "${CMAKE_CXX_FLAGS_${CFLAGS_BUILD_TYPE}}")
-
   if(optimized)
+    if("${CFLAGS_BUILD_TYPE}" STREQUAL "MinSizeRel")
+      list(APPEND result "-Os")
+    else()
+      list(APPEND result "-O2")
+    endif()
+
     # Omit leaf frame pointers on x86 production builds (optimized, no debug
     # info, and no asserts).
-    if(NOT debuginfo AND NOT CFLAGS_ENABLE_ASSERTIONS)
-      # Unfortunately, this cannot be folded into the standard
-      # CMAKE_CXX_FLAGS_... because Apple multi-SDK builds use different
-      # architectures for different SDKs (CFLAGS_ARCH isn't constant here).
+    is_build_type_with_debuginfo("${CFLAGS_BUILD_TYPE}" debug)
+    if(NOT debug AND NOT CFLAGS_ENABLE_ASSERTIONS)
       if("${CFLAGS_ARCH}" STREQUAL "i386" OR "${CFLAGS_ARCH}" STREQUAL "i686")
         if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
           list(APPEND result "-momit-leaf-frame-pointer")
@@ -183,6 +182,27 @@ function(_add_target_variant_c_compile_flags)
           list(APPEND result "/Oy")
         endif()
       endif()
+    endif()
+  else()
+    if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+      list(APPEND result "-O0")
+    else()
+      list(APPEND result "/Od")
+    endif()
+  endif()
+
+  # CMake automatically adds the flags for debug info if we use MSVC/clang-cl.
+  if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+    is_build_type_with_debuginfo("${CFLAGS_BUILD_TYPE}" debuginfo)
+    if(debuginfo)
+      _compute_lto_flag("${CFLAGS_ENABLE_LTO}" _lto_flag_out)
+      if(_lto_flag_out)
+        list(APPEND result "-gline-tables-only")
+      else()
+        list(APPEND result "-g")
+      endif()
+    else()
+      list(APPEND result "-g0")
     endif()
   endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1768,6 +1768,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")


### PR DESCRIPTION
Reverting because of https://github.com/apple/swift/pull/33896 which is a big oversight. Better re-try landing the whole thing.