### PR TITLE
[NFC] Refactor InputFile

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -458,7 +458,7 @@ public:
 
   /// Convenience accessor for clients that know what kind of file they're
   /// dealing with.
-  SourceFile &getMainSourceFile(SourceFileKind expectedKind) const;
+  SourceFile &getMainSourceFile() const;
 
   /// Convenience accessor for clients that know what kind of file they're
   /// dealing with.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -624,10 +624,8 @@ inline SourceFile::ParsingOptions operator|(SourceFile::ParsingFlags lhs,
   return SourceFile::ParsingOptions(lhs) | rhs;
 }
 
-inline SourceFile &
-ModuleDecl::getMainSourceFile(SourceFileKind expectedKind) const {
+inline SourceFile &ModuleDecl::getMainSourceFile() const {
   assert(!Files.empty() && "No files added yet");
-  assert(cast<SourceFile>(Files.front())->Kind == expectedKind);
   return *cast<SourceFile>(Files.front());
 }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -287,13 +287,6 @@ public:
     return FrontendOpts.ParseStdlib;
   }
 
-  void setInputKind(InputFileKind K) {
-    FrontendOpts.InputKind = K;
-  }
-
-  InputFileKind getInputKind() const {
-    return FrontendOpts.InputKind;
-  }
   void setModuleName(StringRef Name) {
     FrontendOpts.ModuleName = Name.str();
     IRGenOpts.ModuleName = Name.str();
@@ -332,7 +325,7 @@ public:
 
   /// Retrieve the stdlib kind to implicitly import.
   ImplicitStdlibKind getImplicitStdlibKind() const {
-    if (getInputKind() == InputFileKind::SIL) {
+    if (FrontendOpts.InputMode == FrontendOptions::ParseInputMode::SIL) {
       return ImplicitStdlibKind::None;
     }
     if (getParseStdlib()) {

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -351,9 +351,6 @@ public:
   setUpInputForSILTool(StringRef inputFilename, StringRef moduleNameArg,
                        bool alwaysSetModuleToMain, bool bePrimary,
                        serialization::ExtendedValidationInfo &extendedInfo);
-  bool hasSerializedAST() {
-    return FrontendOpts.InputKind == InputFileKind::SwiftLibrary;
-  }
 
   const PrimarySpecificPaths &
   getPrimarySpecificPathsForAtMostOnePrimary() const;
@@ -562,13 +559,6 @@ private:
   void setUpLLVMArguments();
   void setUpDiagnosticOptions();
   bool setUpModuleLoaders();
-  bool isInputSwift() {
-    return Invocation.getInputKind() == InputFileKind::Swift;
-  }
-  bool isInSILMode() {
-    return Invocation.getInputKind() == InputFileKind::SIL;
-  }
-
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -576,10 +576,6 @@ private:
   void setupDependencyTrackerIfNeeded();
   Optional<unsigned> setUpCodeCompletionBuffer();
 
-  /// Set up all state in the CompilerInstance to process the given input file.
-  /// Return true on error.
-  bool setUpForInput(const InputFile &input);
-
   /// Find a buffer for a given input file and ensure it is recorded in
   /// SourceMgr, PartialModules, or InputSourceCodeBufferIDs as appropriate.
   /// Return the buffer ID if it is not already compiled, or None if so.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -430,9 +430,6 @@ class CompilerInstance {
   /// \c mutable as it is consumed by \c loadPartialModulesAndImplicitImports.
   mutable std::vector<ModuleBuffers> PartialModules;
 
-  enum : unsigned { NO_SUCH_BUFFER = ~0U };
-  unsigned MainBufferID = NO_SUCH_BUFFER;
-
   /// Identifies the set of input buffers in the SourceManager that are
   /// considered primaries.
   llvm::SetVector<unsigned> PrimaryBufferIDs;
@@ -602,12 +599,14 @@ private:
   /// Creates a new source file for the main module.
   SourceFile *createSourceFileForMainModule(ModuleDecl *mod,
                                             SourceFileKind FileKind,
-                                            Optional<unsigned> BufferID) const;
+                                            Optional<unsigned> BufferID,
+                                            bool isMainBuffer = false) const;
 
   /// Creates all the files to be added to the main module, appending them to
   /// \p files. If a loading error occurs, returns \c true.
   bool createFilesForMainModule(ModuleDecl *mod,
                                 SmallVectorImpl<FileUnit *> &files) const;
+  SourceFile *computeMainSourceFileForModule(ModuleDecl *mod) const;
 
 public:
   void freeASTContext();

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -294,9 +294,6 @@ public:
   InputFileKind getInputKind() const {
     return FrontendOpts.InputKind;
   }
-
-  SourceFileKind getSourceFileKind() const;
-
   void setModuleName(StringRef Name) {
     FrontendOpts.ModuleName = Name.str();
     IRGenOpts.ModuleName = Name.str();

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -39,9 +39,6 @@ class FrontendOptions {
 public:
   FrontendInputsAndOutputs InputsAndOutputs;
 
-  /// The kind of input on which the frontend should operate.
-  InputFileKind InputKind = InputFileKind::Swift;
-
   void forAllOutputPaths(const InputFile &input,
                          llvm::function_ref<void(StringRef)> fn) const;
 
@@ -142,6 +139,14 @@ public:
 
   /// Indicates the action the user requested that the frontend perform.
   ActionType RequestedAction = ActionType::NoneAction;
+
+  enum class ParseInputMode {
+    Swift,
+    SwiftLibrary,
+    SwiftModuleInterface,
+    SIL,
+  };
+  ParseInputMode InputMode = ParseInputMode::Swift;
 
   /// Indicates that the input(s) should be parsed as the Swift stdlib.
   bool ParseStdlib = false;
@@ -316,8 +321,8 @@ public:
   StringRef determineFallbackModuleName() const;
 
   bool isCompilingExactlyOneSwiftFile() const {
-    return InputKind == InputFileKind::Swift &&
-           InputsAndOutputs.hasSingleInput();
+    return InputsAndOutputs.hasSingleInput() &&
+           InputMode == ParseInputMode::Swift;
   }
 
   const PrimarySpecificPaths &

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -33,6 +33,25 @@ enum class InputFileKind {
 // Inputs may include buffers that override contents, and eventually should
 // always include a buffer.
 class InputFile {
+/// An \c InputFile encapsulates information about an input passed to the
+/// frontend.
+///
+/// Compiler inputs are usually passed on the command line without a leading
+/// flag. However, there are clients that use the \c CompilerInvocation as
+/// a library like LLDB and SourceKit that generate their own \c InputFile
+/// instances programmatically. Note that an \c InputFile need not actually be
+/// backed by a physical file, nor does its file name actually reflect its
+/// contents. \c InputFile has a constructor that will try to figure out the file
+/// type from the file name if none is provided, but many clients that
+/// construct \c InputFile instances themselves may provide bogus file names
+/// with pre-computed kinds. It is imperative that \c InputFile::getType be used
+/// as a source of truth for this information.
+///
+/// \warning \c InputFile takes an unfortunately lax view of the ownership of
+/// its primary data. It currently only owns the file name and a copy of any
+/// assigned \c PrimarySpecificPaths outright. It is the responsibility of the
+/// caller to ensure that an associated memory buffer outlives the \c InputFile.
+class InputFile final {
   std::string Filename;
   bool IsPrimary;
   /// Points to a buffer overriding the file's contents, or nullptr if there is

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -20,19 +20,6 @@
 
 namespace swift {
 
-enum class InputFileKind {
-  None,
-  Swift,
-  SwiftLibrary,
-  SwiftModuleInterface,
-  SIL,
-  LLVM,
-  ObjCHeader,
-};
-
-// Inputs may include buffers that override contents, and eventually should
-// always include a buffer.
-class InputFile {
 /// An \c InputFile encapsulates information about an input passed to the
 /// frontend.
 ///

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -143,6 +143,16 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.InputsAndOutputs = std::move(inputsAndOutputs).getValue();
   }
 
+  if (Args.hasArg(OPT_parse_sil) || Opts.InputsAndOutputs.shouldTreatAsSIL()) {
+    Opts.InputMode = FrontendOptions::ParseInputMode::SIL;
+  } else if (Opts.InputsAndOutputs.shouldTreatAsModuleInterface()) {
+    Opts.InputMode = FrontendOptions::ParseInputMode::SwiftModuleInterface;
+  } else if (Args.hasArg(OPT_parse_as_library)) {
+    Opts.InputMode = FrontendOptions::ParseInputMode::SwiftLibrary;
+  } else {
+    Opts.InputMode = FrontendOptions::ParseInputMode::Swift;
+  }
+
   if (Opts.RequestedAction == FrontendOptions::ActionType::NoneAction) {
     Opts.RequestedAction = determineRequestedAction(Args);
   }
@@ -163,7 +173,7 @@ bool ArgsToFrontendOptionsConverter::convert(
     return true;
   }
 
-  if (setUpInputKindAndImmediateArgs())
+  if (setUpImmediateArgs())
     return true;
 
   if (computeModuleName())
@@ -398,7 +408,7 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
   llvm_unreachable("Unhandled mode option");
 }
 
-bool ArgsToFrontendOptionsConverter::setUpInputKindAndImmediateArgs() {
+bool ArgsToFrontendOptionsConverter::setUpImmediateArgs() {
   using namespace options;
   bool treatAsSIL =
       Args.hasArg(OPT_parse_sil) || Opts.InputsAndOutputs.shouldTreatAsSIL();
@@ -418,19 +428,6 @@ bool ArgsToFrontendOptionsConverter::setUpInputKindAndImmediateArgs() {
       }
     }
   }
-
-  if (treatAsSIL)
-    Opts.InputKind = InputFileKind::SIL;
-  else if (Opts.InputsAndOutputs.shouldTreatAsLLVM())
-    Opts.InputKind = InputFileKind::LLVM;
-  else if (Opts.InputsAndOutputs.shouldTreatAsObjCHeader())
-    Opts.InputKind = InputFileKind::ObjCHeader;
-  else if (Opts.InputsAndOutputs.shouldTreatAsModuleInterface())
-    Opts.InputKind = InputFileKind::SwiftModuleInterface;
-  else if (Args.hasArg(OPT_parse_as_library))
-    Opts.InputKind = InputFileKind::SwiftLibrary;
-  else
-    Opts.InputKind = InputFileKind::Swift;
 
   return false;
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.h
@@ -47,7 +47,7 @@ private:
   void computePrintStatsOptions();
   void computeTBDOptions();
 
-  bool setUpInputKindAndImmediateArgs();
+  bool setUpImmediateArgs();
 
   bool checkUnusedSupplementaryOutputPaths() const;
 

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -183,7 +183,7 @@ OutputFilesComputer::computeOutputFile(StringRef outputArg,
 
 Optional<std::string>
 OutputFilesComputer::deriveOutputFileFromInput(const InputFile &input) const {
-  if (input.file() == "-" || HasTextualOutput)
+  if (input.getFileName() == "-" || HasTextualOutput)
     return std::string("-");
 
   std::string baseName = determineBaseNameOfOutput(input);
@@ -210,7 +210,7 @@ std::string
 OutputFilesComputer::determineBaseNameOfOutput(const InputFile &input) const {
   std::string nameToStem =
       input.isPrimary()
-          ? input.file()
+          ? input.getFileName()
           : ModuleNameArg ? ModuleNameArg->getValue() : FirstInput;
   return llvm::sys::path::stem(nameToStem).str();
 }
@@ -474,8 +474,8 @@ StringRef SupplementaryOutputPathsComputer::
   if (!outputFilename.empty() && outputFilename != "-")
     return outputFilename;
 
-  if (input.isPrimary() && input.file() != "-")
-    return llvm::sys::path::filename(input.file());
+  if (input.isPrimary() && input.getFileName() != "-")
+    return llvm::sys::path::filename(input.getFileName());
 
   return ModuleName;
 }
@@ -600,12 +600,12 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
   InputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {
         const TypeToPathMap *mapForInput =
-            OFM->getOutputMapForInput(input.file());
+            OFM->getOutputMapForInput(input.getFileName());
         if (!mapForInput) {
           Diags.diagnose(
               SourceLoc(),
               diag::error_missing_entry_in_supplementary_output_file_map,
-              supplementaryFileMapPath, input.file());
+              supplementaryFileMapPath, input.getFileName());
           hadError = true;
         }
         outputPaths.push_back(createFromTypeToPathMap(mapForInput));

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1859,7 +1859,7 @@ CompilerInvocation::setUpInputForSILTool(
   // If it looks like we have an AST, set the source file kind to SIL and the
   // name of the module to the file's name.
   getFrontendOptions().InputsAndOutputs.addInput(
-      InputFile(inputFilename, bePrimary, fileBufOrErr.get().get()));
+      InputFile(inputFilename, bePrimary, fileBufOrErr.get().get(), file_types::TY_SIL));
 
   auto result = serialization::validateSerializedAST(
       fileBufOrErr.get()->getBuffer(), &extendedInfo);
@@ -1870,13 +1870,14 @@ CompilerInvocation::setUpInputForSILTool(
                                ? moduleNameArg
                                : llvm::sys::path::stem(inputFilename);
     setModuleName(stem);
-    setInputKind(InputFileKind::SwiftLibrary);
+    getFrontendOptions().InputMode =
+        FrontendOptions::ParseInputMode::SwiftLibrary;
   } else {
     const StringRef name = (alwaysSetModuleToMain || moduleNameArg.empty())
                                ? "main"
                                : moduleNameArg;
     setModuleName(name);
-    setInputKind(InputFileKind::SIL);
+    getFrontendOptions().InputMode = FrontendOptions::ParseInputMode::SIL;
   }
   return fileBufOrErr;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -387,9 +387,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
 
-  if (FrontendOpts.InputKind == InputFileKind::SIL)
-    Opts.DisableAvailabilityChecking = true;
-  
   if (auto A = Args.getLastArg(OPT_enable_access_control,
                                OPT_disable_access_control)) {
     Opts.EnableAccessControl
@@ -675,8 +672,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
 
   // If we're parsing SIL, access control doesn't make sense to enforce.
-  if (FrontendOpts.InputKind == InputFileKind::SIL) {
+  if (Args.hasArg(OPT_parse_sil) ||
+      FrontendOpts.InputsAndOutputs.shouldTreatAsSIL()) {
     Opts.EnableAccessControl = false;
+    Opts.DisableAvailabilityChecking = true;
   }
 
   return HadError || UnsupportedOS || UnsupportedArch;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -226,25 +226,6 @@ void CompilerInvocation::setSDKPath(const std::string &Path) {
   updateRuntimeLibraryPaths(SearchPathOpts, LangOpts.Target);
 }
 
-SourceFileKind CompilerInvocation::getSourceFileKind() const {
-  switch (getInputKind()) {
-  case InputFileKind::Swift:
-    return SourceFileKind::Main;
-  case InputFileKind::SwiftLibrary:
-    return SourceFileKind::Library;
-  case InputFileKind::SwiftModuleInterface:
-    return SourceFileKind::Interface;
-  case InputFileKind::SIL:
-    return SourceFileKind::SIL;
-  case InputFileKind::None:
-  case InputFileKind::LLVM:
-  case InputFileKind::ObjCHeader:
-    llvm_unreachable("Trying to convert from unsupported InputFileKind");
-  }
-
-  llvm_unreachable("Unhandled InputFileKind in switch.");
-}
-
 static bool ParseFrontendArgs(
     FrontendOptions &opts, ArgList &args, DiagnosticEngine &diags,
     SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> *buffers) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -783,8 +783,6 @@ bool CompilerInstance::createFilesForMainModule(
     ModuleDecl *mod, SmallVectorImpl<FileUnit *> &files) const {
   // Make sure the main file is the first file in the module.
   if (MainBufferID != NO_SUCH_BUFFER) {
-    auto *mainFile = createSourceFileForMainModule(
-        mod, Invocation.getSourceFileKind(), MainBufferID);
     files.push_back(mainFile);
   }
 

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -54,7 +54,7 @@ operator=(const FrontendInputsAndOutputs &other) {
 std::vector<std::string> FrontendInputsAndOutputs::getInputFilenames() const {
   std::vector<std::string> filenames;
   for (auto &input : AllInputs) {
-    filenames.push_back(input.file());
+    filenames.push_back(input.getFileName());
   }
   return filenames;
 }
@@ -66,7 +66,7 @@ bool FrontendInputsAndOutputs::isReadingFromStdin() const {
 const std::string &FrontendInputsAndOutputs::getFilenameOfFirstInput() const {
   assert(hasInputs());
   const InputFile &inp = AllInputs[0];
-  const std::string &f = inp.file();
+  const std::string &f = inp.getFileName();
   assert(!f.empty());
   return f;
 }
@@ -135,7 +135,7 @@ FrontendInputsAndOutputs::getRequiredUniquePrimaryInput() const {
 std::string FrontendInputsAndOutputs::getStatsFileMangledInputName() const {
   // Use the first primary, even if there are multiple primaries.
   // That's enough to keep the file names unique.
-  return isWholeModule() ? "all" : firstPrimaryInput().file();
+  return isWholeModule() ? "all" : firstPrimaryInput().getFileName();
 }
 
 bool FrontendInputsAndOutputs::isInputPrimary(StringRef file) const {
@@ -146,7 +146,7 @@ unsigned FrontendInputsAndOutputs::numberOfPrimaryInputsEndingWith(
     StringRef extension) const {
   unsigned n = 0;
   (void)forEachPrimaryInput([&](const InputFile &input) -> bool {
-    if (llvm::sys::path::extension(input.file()).endswith(extension))
+    if (llvm::sys::path::extension(input.getFileName()).endswith(extension))
       ++n;
     return false;
   });
@@ -216,7 +216,7 @@ bool FrontendInputsAndOutputs::areAllNonPrimariesSIB() const {
   for (const InputFile &input : AllInputs) {
     if (input.isPrimary())
       continue;
-    StringRef extension = llvm::sys::path::extension(input.file());
+    StringRef extension = llvm::sys::path::extension(input.getFileName());
     if (file_types::lookupTypeForExtension(extension) != file_types::TY_SIB) {
       return false;
     }
@@ -269,7 +269,7 @@ void FrontendInputsAndOutputs::addInput(const InputFile &input) {
   AllInputs.push_back(input);
   if (input.isPrimary()) {
     PrimaryInputsInOrder.push_back(index);
-    PrimaryInputsByName.insert(std::make_pair(AllInputs.back().file(), index));
+    PrimaryInputsByName.insert({AllInputs.back().getFileName(), index});
   }
 }
 
@@ -330,7 +330,7 @@ void FrontendInputsAndOutputs::setMainAndSupplementaryOutputs(
     for (auto &input : AllInputs) {
       if (input.isPrimary()) {
         input.setPrimarySpecificPaths(PrimarySpecificPaths(
-            outputFiles[i], input.file(), supplementaryOutputs[i]));
+            outputFiles[i], input.getFileName(), supplementaryOutputs[i]));
         ++i;
       }
     }
@@ -340,7 +340,7 @@ void FrontendInputsAndOutputs::setMainAndSupplementaryOutputs(
          "WMO only ever produces one set of supplementary outputs");
   if (outputFiles.size() == 1) {
     AllInputs.front().setPrimarySpecificPaths(PrimarySpecificPaths(
-        outputFiles.front(), firstInputProducingOutput().file(),
+        outputFiles.front(), firstInputProducingOutput().getFileName(),
         supplementaryOutputs.front()));
     return;
   }

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -179,7 +179,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     bool isTypeChecking =
         (FEOpts.RequestedAction == FrontendOptions::ActionType::Typecheck);
     const auto &InputInfo = FEOpts.InputsAndOutputs.firstInput();
-    StringRef InPath = InputInfo.file();
+    StringRef InPath = InputInfo.getFileName();
     const auto &OutputInfo =
     InputInfo.getPrimarySpecificPaths().SupplementaryOutputs;
     StringRef OutPath = OutputInfo.ModuleOutputPath;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1142,6 +1142,8 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.setSDKPath(SearchPathOpts.SDKPath);
   }
 
+  genericSubInvocation.getFrontendOptions().InputMode
+      = FrontendOptions::ParseInputMode::SwiftModuleInterface;
   if (!SearchPathOpts.RuntimeResourcePath.empty()) {
     genericSubInvocation.setRuntimeResourcePath(SearchPathOpts.RuntimeResourcePath);
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1142,7 +1142,6 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.setSDKPath(SearchPathOpts.SDKPath);
   }
 
-  genericSubInvocation.setInputKind(InputFileKind::SwiftModuleInterface);
   if (!SearchPathOpts.RuntimeResourcePath.empty()) {
     genericSubInvocation.setRuntimeResourcePath(SearchPathOpts.RuntimeResourcePath);
   }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2104,7 +2104,10 @@ static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
 
     // If we can't validate the given input file, bail early. This covers cases
     // like passing raw SIL as a primary file.
-    if (!inputFileKindCanHaveTBDValidated(Invocation.getInputKind())) {
+    const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
+    // FIXME: This would be a good test of the interface format.
+    if (IO.shouldTreatAsModuleInterface() || IO.shouldTreatAsSIL() ||
+        IO.shouldTreatAsLLVM() || IO.shouldTreatAsObjCHeader()) {
       return false;
     }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2414,7 +2414,7 @@ createDispatchingDiagnosticConsumerIfNeeded(
   inputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {
         if (auto consumer = maybeCreateConsumerForDiagnosticsFrom(input))
-          subconsumers.emplace_back(input.file(), std::move(consumer));
+          subconsumers.emplace_back(input.getFileName(), std::move(consumer));
         return false;
       });
   // For batch mode, the compiler must sometimes swallow diagnostics pertaining
@@ -2431,7 +2431,7 @@ createDispatchingDiagnosticConsumerIfNeeded(
   if (!subconsumers.empty() && inputsAndOutputs.hasMultiplePrimaryInputs()) {
     inputsAndOutputs.forEachNonPrimaryInput(
         [&](const InputFile &input) -> bool {
-          subconsumers.emplace_back(input.file(), nullptr);
+          subconsumers.emplace_back(input.getFileName(), nullptr);
           return false;
         });
   }

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -56,25 +56,6 @@ bool swift::writeTBD(ModuleDecl *M, StringRef OutputFilename,
   return false;
 }
 
-bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
-  // Only things that involve an AST can have a TBD file computed, at the
-  // moment.
-  switch (kind) {
-  case InputFileKind::Swift:
-  case InputFileKind::SwiftLibrary:
-    return true;
-  case InputFileKind::SwiftModuleInterface:
-    // FIXME: This would be a good test of the interface format.
-    return false;
-  case InputFileKind::None:
-  case InputFileKind::SIL:
-  case InputFileKind::LLVM:
-  case InputFileKind::ObjCHeader:
-    return false;
-  }
-  llvm_unreachable("unhandled kind");
-}
-
 static bool validateSymbols(DiagnosticEngine &diags,
                             const std::vector<std::string> &symbols,
                             const llvm::Module &IRModule,

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -27,7 +27,6 @@ struct TBDGenOptions;
 
 bool writeTBD(ModuleDecl *M, StringRef OutputFilename,
               const TBDGenOptions &Opts);
-bool inputFileKindCanHaveTBDValidated(InputFileKind kind);
 bool validateTBD(ModuleDecl *M,
                  const llvm::Module &IRModule,
                  const TBDGenOptions &opts,

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1172,7 +1172,7 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
   CompilerInvocation Invocation{};
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
-      InputFile("<extract>", true, InputBuffer.get()));
+      InputFile("<extract>", true, InputBuffer.get(), file_types::TY_Swift));
   Invocation.getFrontendOptions().ModuleName = "extract";
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -206,8 +206,8 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
   FrontendInputsAndOutputs replacementInputsAndOutputs;
   for (const InputFile &input : inputsAndOutputs.getAllInputs()) {
     llvm::SmallString<128> newFilename;
-    if (auto err = FileSystem->getRealPath(input.file(), newFilename))
-      newFilename = input.file();
+    if (auto err = FileSystem->getRealPath(input.getFileName(), newFilename))
+      newFilename = input.getFileName();
     llvm::sys::path::native(newFilename);
     bool newIsPrimary = input.isPrimary() ||
                         (!PrimaryFile.empty() && PrimaryFile == newFilename);
@@ -216,7 +216,7 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
     }
     assert(primaryCount < 2 && "cannot handle multiple primaries");
     replacementInputsAndOutputs.addInput(
-        InputFile(newFilename.str(), newIsPrimary, input.buffer()));
+        InputFile(newFilename.str(), newIsPrimary, input.getBuffer()));
   }
 
   if (PrimaryFile.empty() || primaryCount == 1) {

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -435,5 +435,5 @@ const MigratorOptions &Migrator::getMigratorOptions() const {
 const StringRef Migrator::getInputFilename() const {
   auto &PrimaryInput = StartInvocation.getFrontendOptions()
                            .InputsAndOutputs.getRequiredUniquePrimaryInput();
-  return PrimaryInput.file();
+  return PrimaryInput.getFileName();
 }

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -142,8 +142,9 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
          "Migration must have a primary");
   for (const auto &input : OrigFrontendOpts.InputsAndOutputs.getAllInputs()) {
     Invocation.getFrontendOptions().InputsAndOutputs.addInput(
-        InputFile(input.file(), input.isPrimary(),
-                  input.isPrimary() ? InputBuffer.get() : input.buffer()));
+        InputFile(input.getFileName(), input.isPrimary(),
+                  input.isPrimary() ? InputBuffer.get() : input.getBuffer(),
+                  input.getType()));
   }
 
   auto Instance = std::make_unique<swift::CompilerInstance>();

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -711,7 +711,7 @@ bool ASTProducer::shouldRebuild(
       Invok.Opts.Invok.getFrontendOptions().InputsAndOutputs.inputCount());
   for (const auto &input :
        Invok.Opts.Invok.getFrontendOptions().InputsAndOutputs.getAllInputs()) {
-    const std::string &File = input.file();
+    const std::string &File = input.getFileName();
     bool FoundSnapshot = false;
     for (auto &Snap : Snapshots) {
       if (Snap->getFilename() == File) {
@@ -906,7 +906,7 @@ void ASTProducer::findSnapshotAndOpenFiles(
   const InvocationOptions &Opts = InvokRef->Impl.Opts;
   for (const auto &input :
        Opts.Invok.getFrontendOptions().InputsAndOutputs.getAllInputs()) {
-    const std::string &File = input.file();
+    const std::string &File = input.getFileName();
     bool IsPrimary = input.isPrimary();
     bool FoundSnapshot = false;
     for (auto &Snap : Snapshots) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -856,7 +856,8 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
-      InputFile(Buf.get()->getBufferIdentifier(), false, Buf.get()));
+      InputFile(Buf.get()->getBufferIdentifier(), /*isPrimary*/false, Buf.get(),
+                file_types::TY_Swift));
   return CI.setup(Invocation);
 }
 
@@ -1441,7 +1442,8 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
   }
   Invocation.setInputKind(InputFileKind::Swift);
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
-      InputFile(InputBuf->getBufferIdentifier(), false, InputBuf));
+      InputFile(InputBuf->getBufferIdentifier(), /*isPrimary*/false, InputBuf,
+                file_types::TY_Swift));
 
   if (ParseCI.setup(Invocation)) {
     Error = "Compiler invocation set up failed";

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -850,7 +850,6 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
                           CompilerInvocation Invocation) {
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
-  Invocation.setInputKind(InputFileKind::Swift);
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
@@ -1440,7 +1439,6 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     Error = "Compiler invocation init failed";
     return nullptr;
   }
-  Invocation.setInputKind(InputFileKind::Swift);
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(InputBuf->getBufferIdentifier(), /*isPrimary*/false, InputBuf,
                 file_types::TY_Swift));

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -218,7 +218,6 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
                           CompilerInvocation Invocation) {
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
-  Invocation.setInputKind(InputFileKind::Swift);
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -224,7 +224,8 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
-      InputFile(Buf.get()->getBufferIdentifier(), false, Buf.get()));
+      InputFile(Buf.get()->getBufferIdentifier(), /*isPrimary*/false, Buf.get(),
+                file_types::TY_Swift));
   return CI.setup(Invocation);
 }
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -931,8 +931,7 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
   PrintOptions Options = PrintOptions::printEverything();
 
   ModuleDecl *M = CI.getMainModule();
-  M->getMainSourceFile(Invocation.getSourceFileKind()).print(llvm::outs(),
-                                                             Options);
+  M->getMainSourceFile().print(llvm::outs(), Options);
 
   auto SMAModel = createSMAModel(M);
   llvm::yaml::Output YOut(llvm::outs());

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1322,8 +1322,6 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
     BufferText = BufferText.drop_back(1);
 
   CompilerInvocation Invocation(InitInvok);
-  Invocation.setInputKind(InputFileKind::Swift);
-
   CompilerInstance CI;
 
   // Display diagnostics to stderr.
@@ -3790,8 +3788,6 @@ int main(int argc, char *argv[]) {
 
   for (auto &File : options::InputFilenames)
     InitInvok.getFrontendOptions().InputsAndOutputs.addInputFile(File);
-  if (!options::InputFilenames.empty())
-    InitInvok.setInputKind(InputFileKind::SwiftLibrary);
 
   InitInvok.setMainExecutablePath(
       llvm::sys::fs::getMainExecutable(argv[0],

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2158,8 +2158,7 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
 
   if (MangledNameToFind.empty()) {
     ModuleDecl *M = CI.getMainModule();
-    M->getMainSourceFile(Invocation.getSourceFileKind()).print(llvm::outs(),
-                                                               Options);
+    M->getMainSourceFile().print(llvm::outs(), Options);
     return EXIT_SUCCESS;
   }
 

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -613,8 +613,6 @@ int parseFile(
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
 
-  if (InputFileName.endswith(".swiftinterface"))
-    Invocation.setInputKind(InputFileKind::SwiftModuleInterface);
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(MainExecutablePath,
       reinterpret_cast<void *>(&anchorForGetMainExecutable)));


### PR DESCRIPTION
Refactor `InputFile` by expanding its documentation, normalizing its accessors and constructors, and scrubbing the frontend of the legacy of `InputFileKind`, which incorrectly constricted the "kinds" of input files the frontend could accept. 