### PR TITLE
WinSDK: extract several submodules

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -337,6 +337,11 @@ module WinSDK [system] {
     link "Gdi32.Lib"
   }
 
+  module WinNT {
+    header "winnt.h"
+    export *
+  }
+
   module WinReg {
     header "winreg.h"
     export *


### PR DESCRIPTION
Currently `WinSDK.WinSock2` includes several headers which aren't specific to sockets, for example, `windef.h` which includes typedefs for `DWORD`, `HKEY`, etc.

This PR extracts some of these headers into separate `WinSDK` submodules, making it cleaner and easier to navigate.
It also reduces the size of the generated Swift interface for `WinSDK.WinSock2` which used to exceed 2.7 MB.