### PR TITLE
[test] diff --strip-trailing-cr is non-standard.

### DIFF
--- a/test/Migrator/double_fixit_ok.swift
+++ b/test/Migrator/double_fixit_ok.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 4
-// RUN: diff --strip-trailing-cr -u %s.expected %t/double_fixit_ok.result
+// RUN: %diff -u %s.expected %t/double_fixit_ok.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 @available(swift, obsoleted: 4, renamed: "Thing.constant___renamed")

--- a/test/Migrator/double_fixit_ok.swift.expected
+++ b/test/Migrator/double_fixit_ok.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 4
-// RUN: diff --strip-trailing-cr -u %s.expected %t/double_fixit_ok.result
+// RUN: %diff -u %s.expected %t/double_fixit_ok.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 @available(swift, obsoleted: 4, renamed: "Thing.constant___renamed")

--- a/test/Migrator/insert_replace_fixit.swift
+++ b/test/Migrator/insert_replace_fixit.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4
-// RUN: diff --strip-trailing-cr -u %s.expected %t/result.swift
+// RUN: %diff -u %s.expected %t/result.swift
 
 import TestMyTime
 

--- a/test/Migrator/insert_replace_fixit.swift.expected
+++ b/test/Migrator/insert_replace_fixit.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4
-// RUN: diff --strip-trailing-cr -u %s.expected %t/result.swift
+// RUN: %diff -u %s.expected %t/result.swift
 
 import TestMyTime
 

--- a/test/Migrator/no_extraneous_argument_labels.swift
+++ b/test/Migrator/no_extraneous_argument_labels.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 4
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null
-// RUN: diff --strip-trailing-cr -u %s.expected %t/no_extraneous_argument_labels.result
+// RUN: %diff -u %s.expected %t/no_extraneous_argument_labels.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 func foo(_ oc: [String]) {

--- a/test/Migrator/no_extraneous_argument_labels.swift.expected
+++ b/test/Migrator/no_extraneous_argument_labels.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 4
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null
-// RUN: diff --strip-trailing-cr -u %s.expected %t/no_extraneous_argument_labels.result
+// RUN: %diff -u %s.expected %t/no_extraneous_argument_labels.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 func foo(_ oc: [String]) {

--- a/test/Migrator/no_var_to_let.swift
+++ b/test/Migrator/no_var_to_let.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 4
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null
-// RUN: diff --strip-trailing-cr -u %s %t/no_var_to_let.swift.result
+// RUN: %diff -u %s %t/no_var_to_let.swift.result
 // RUN: %target-swift-frontend -typecheck %s -swift-version 5
 
 // Note that the diff run line indicates that there should be no change.

--- a/test/Migrator/null_migration.swift
+++ b/test/Migrator/null_migration.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/migrated_null_migration.swift -emit-remap-file-path %t/null_migration.remap -o /dev/null
-// RUN: diff --strip-trailing-cr -u %s %t/migrated_null_migration.swift
+// RUN: %diff -u %s %t/migrated_null_migration.swift
 
 // This file tests that, if all migration passes are no-op,
 // there are no changes to the file.

--- a/test/Migrator/optional_try_migration.swift
+++ b/test/Migrator/optional_try_migration.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift
-// RUN: diff --strip-trailing-cr -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
+// RUN: %diff -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
 
 func fetchOptInt() throws -> Int? {
     return 3

--- a/test/Migrator/optional_try_migration.swift.expected
+++ b/test/Migrator/optional_try_migration.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift
-// RUN: diff --strip-trailing-cr -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
+// RUN: %diff -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
 
 func fetchOptInt() throws -> Int? {
     return 3

--- a/test/Migrator/post_fixit_pass.swift
+++ b/test/Migrator/post_fixit_pass.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4
-// RUN: diff --strip-trailing-cr -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
+// RUN: %diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
 
 #if swift(>=4.2)
   public struct SomeAttribute: RawRepresentable {

--- a/test/Migrator/post_fixit_pass.swift.expected
+++ b/test/Migrator/post_fixit_pass.swift.expected
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4
-// RUN: diff --strip-trailing-cr -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
+// RUN: %diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
 
 #if swift(>=4.2)
   public struct SomeAttribute: RawRepresentable {

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -20,4 +20,3 @@ else:
     config.substitutions.append( ('%swiftlib_dir', config.swiftlib_dir) )
     config.substitutions.append( ('%sed_clean', '%s %s' % (pipes.quote(sys.executable), sk_path_sanitize) ) )
 
-config.substitutions.append( ('%diff', 'diff --strip-trailing-cr') )

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2034,3 +2034,8 @@ else:
     num_extra_inhabitants_64bit = 4096
 add_num_extra_inhabitants = "-D#num_extra_inhabitants_64bit={} ".format(num_extra_inhabitants_64bit)
 config.substitutions.append(('%add_num_extra_inhabitants', add_num_extra_inhabitants))
+
+if kIsWindows:
+  config.substitutions.append( ('%diff', 'diff --strip-trailing-cr') )
+else:
+  config.substitutions.append( ('%diff', 'diff') )


### PR DESCRIPTION
Since we're saving command output to file and then comparing, we can use
sed to convert the inputs to the same line ending convention when
comparing. This has the same effect as the --strip-trailing-cr flag.
Since this flag is a nonstandard extension, it won't be available on
other platforms, and the absence of this flag will cause misleading test
failures.