### PR TITLE
WinSDK: extract Internationalization submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -174,6 +174,20 @@ module WinSDK [system] {
     link "Cabinet.Lib"
   }
 
+  module Internationalization {
+    module WinNLS {
+      header "winnls.h"
+      export *
+    }
+
+    module IMM {
+      header "immdev.h"
+      export *
+
+      link "Imm32.lib"
+    }
+  }
+
   module Shell {
     header "ShlObj.h"
     export *


### PR DESCRIPTION
Currently winnls.h & imm.h get included into `WinSDK.WinSock2`, however their usages might not be related to sockets.

MSDN groups these headers together in https://docs.microsoft.com/en-us/windows/win32/api/_intl/.
I initially thought about merging these submodules into one, but decided against it, since `imm.h` requires special linking.

This PR emerged from the discussion in https://github.com/apple/swift/pull/33929.