### PR TITLE
test: Replace _silgen_name w/ _cdecl in CommandLineStressTest

### DIFF
--- a/test/stdlib/Inputs/CommandLineStressTest/CommandLineStressTest.swift
+++ b/test/stdlib/Inputs/CommandLineStressTest/CommandLineStressTest.swift
@@ -1,5 +1,5 @@
 // Do not change the SIL name for this without also changing CommandLineStressTest.c
-@_silgen_name("swift_commandline_test_getProcessArgs")
+@_cdecl("swift_commandline_test_getProcessArgs")
 public func runTest() {
   let CommandLineRaceTestSuite = TestSuite("CommandLine Race")
 


### PR DESCRIPTION
This test abuses @_silgen_name unnecessarily according to https://forums.swift.org/t/how-can-my-c-main-function-call-swift/40244/2

