### PR TITLE
[build-script] Disable pkg-config for Darwin hosts (NFC)

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -655,9 +655,12 @@ class BuildScriptInvocation(object):
             ]
 
             # Isolate build from the system; Darwin toolchains build against SDKs.
-            args.extra_cmake_options.append(
-                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib'
-            )
+            # For additional isolation, disable pkg-config. Homebrew's pkg-config
+            # prioritizes CommandLineTools paths, resulting in compile errors.
+            args.extra_cmake_options += [
+                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib',
+                '-DPKG_CONFIG_EXECUTABLE=/usr/bin/true',
+            ]
 
         if toolchain.libtool is not None:
             impl_args += [

--- a/utils/build-script
+++ b/utils/build-script
@@ -659,7 +659,7 @@ class BuildScriptInvocation(object):
             # prioritizes CommandLineTools paths, resulting in compile errors.
             args.extra_cmake_options += [
                 '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib',
-                '-DPKG_CONFIG_EXECUTABLE=/usr/bin/true',
+                '-DPKG_CONFIG_EXECUTABLE=/usr/bin/false',
             ]
 
         if toolchain.libtool is not None:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -632,17 +632,6 @@ function set_build_options_for_host() {
 
             cmake_os_sysroot="$(xcrun --sdk ${platform} --show-sdk-path)"
 
-            # Customize the CMake `find_*` search paths to search the SDK
-            # sysroot before searching `pkg-config` paths. This prevents compile
-            # failures caused when `pkg-config` returns CommandLineTools paths
-            # instead of Xcode paths.
-            #
-            # These search paths can be user customized either by setting the
-            # `CMAKE_PREFIX_PATH` environment variable, or by setting the same
-            # CMake variable via the command line (`-DCMAKE_PREFIX_PATH`).
-            # See https://cmake.org/cmake/help/latest/command/find_path.html
-            export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${cmake_os_sysroot}/usr"
-
             cmark_cmake_options=(
                 -DCMAKE_C_FLAGS="$(cmark_c_flags ${host})"
                 -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${host})"


### PR DESCRIPTION
Disable `pkg-config` on Darwin to prevent compilation issues.

This is an NFC follow up to https://github.com/apple/swift/pull/32436 and https://github.com/apple/swift/pull/32437.

The benefits are:

1. Prevents the `pkg-config` issues directly, instead of a roundabout way
2. Centralize two related pieces of build isolation config to a single place

For 1, the original issue was that CMake `find_` functions would search `pkg-config` before the SDK. Homebrew `pkg-config` hardcodes CommandLineTools, even when Xcode is installed, and this caused problems. See [SR-12726](https://bugs.swift.org/browse/SR-12726).

Disabling `pkg-config` gives better isolation, and it removes the use of `CMAKE_PREFIX_PATH` which I see as a bigger hammer than disabling `pkg-config`.

Before any of these changes, if `pkg-config` is installed, the effective search order was:

1. Try `CMAKE_PREFIX_PATH` (empty)
2. Try `HINTS` paths (CommandLineTools via `pkg-config`)
3. Try SDK paths

After #32436, the relevant search order became:

1. Try `CMAKE_PREFIX_PATH` (SDK)
2. Try `HINTS` paths (CommandLineTools via `pkg-config`)
3. Try SDK paths

Now with this change, the relevant search order is:

1. Try `CMAKE_PREFIX_PATH` (empty)
2. Try `HINTS` paths (empty)
3. Try SDK paths