### PR TITLE
ABI checker: when invoking via build system, explicitly mention ABI breakge in diagnostics

### DIFF
--- a/test/api-digester/breakage-allowlist.swift
+++ b/test/api-digester/breakage-allowlist.swift
@@ -10,9 +10,9 @@
 // RUN: echo "public func foo() {}" > %t.mod1/Foo.swift
 // RUN: echo "public func bar() {}" > %t.mod2/Foo.swift
 
-// RUN: echo "Foo: func foo() has been removed" > %t/incomplete-allowlist.txt
-// RUN: echo "Foo: func foo() has been removed" > %t/complete-allowlist.txt
-// RUN: echo "Foo: func bar() is a new API without @available attribute" >> %t/complete-allowlist.txt
+// RUN: echo "ABI breakage: func foo() has been removed" > %t/incomplete-allowlist.txt
+// RUN: echo "ABI breakage: func foo() has been removed" > %t/complete-allowlist.txt
+// RUN: echo "ABI breakage: func bar() is a new API without @available attribute" >> %t/complete-allowlist.txt
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t.mod1/Foo.swiftmodule  %t.mod1/Foo.swift -parse-as-library -enable-library-evolution -emit-module-source-info -emit-module-source-info-path %t.mod1/Foo.swiftsourceinfo -emit-module-interface-path %t.mod1/Foo.swiftinterface -module-name Foo -swift-version 5
 
@@ -20,19 +20,19 @@
 
 // RUN: %api-digester -dump-sdk -module Foo -output-dir %t.baseline -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -abi -use-interface-for-module Foo
 
-// RUN: %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -breakage-allowlist-path %t/complete-allowlist.txt -o %t/expected-diags.txt
+// RUN: %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -breakage-allowlist-path %t/complete-allowlist.txt -o %t/expected-diags.txt
 
-// RUN: not %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -compiler-style-diags
+// RUN: not %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -compiler-style-diags
 
-// RUN: not %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -compiler-style-diags -breakage-allowlist-path %t/incomplete-allowlist.txt
+// RUN: not %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -compiler-style-diags -breakage-allowlist-path %t/incomplete-allowlist.txt
 
-// RUN: %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -compiler-style-diags -breakage-allowlist-path %t/complete-allowlist.txt
+// RUN: %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -compiler-style-diags -breakage-allowlist-path %t/complete-allowlist.txt
 
-// RUN: not %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -serialize-diagnostics-path %t/serialized-diag.dia
+// RUN: not %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -serialize-diagnostics-path %t/serialized-diag.dia
 // RUN: ls %t/serialized-diag.dia
 
-// RUN: not %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -serialize-diagnostics-path %t/serialized-diag.dia -breakage-allowlist-path %t/incomplete-allowlist.txt
+// RUN: not %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -serialize-diagnostics-path %t/serialized-diag.dia -breakage-allowlist-path %t/incomplete-allowlist.txt
 // RUN: ls %t/serialized-diag.dia
 
-// RUN: %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -serialize-diagnostics-path %t/serialized-diag.dia -breakage-allowlist-path %t/complete-allowlist.txt
+// RUN: %api-digester -diagnose-sdk -baseline-dir %t.baseline -module Foo -I %t.mod2 -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -serialize-diagnostics-path %t/serialized-diag.dia -breakage-allowlist-path %t/complete-allowlist.txt
 // RUN: ls %t/serialized-diag.dia

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -18,5 +18,5 @@
 // RUN: not %api-digester -diagnose-sdk -print-module -baseline-dir %t.baseline -module cake -I %t.mod2 -I %S/Inputs/APINotesLeft -module-cache-path %t.module-cache %clang-importer-sdk-nosource -abi -o %t.result -compiler-style-diags 2> %t.abi.compiler.diags
 // RUN: %FileCheck %s < %t.abi.compiler.diags
 
-// CHECK: cake_current/cake.swift:39:15: error: cake: struct C6 is now with @frozen
-// CHECK: cake_current/cake.swift:41:13: error: cake: enum IceKind is now without @frozen
+// CHECK: cake_current/cake.swift:39:15: error: ABI breakage: struct C6 is now with @frozen
+// CHECK: cake_current/cake.swift:41:13: error: ABI breakage: enum IceKind is now without @frozen

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -409,10 +409,16 @@ StringRef SDKNodeDecl::getScreenInfo() const {
   auto &Ctx = getSDKContext();
   llvm::SmallString<64> SS;
   llvm::raw_svector_ostream OS(SS);
-  if (Ctx.getOpts().PrintModule)
-    OS << ModuleName;
-  if (!HeaderName.empty())
-    OS << "(" << HeaderName << ")";
+  if (Ctx.getOpts().CompilerStyle) {
+    // Compiler style we don't need source info
+    OS << (Ctx.checkingABI() ? "ABI breakage" : "API breakage");
+  } else {
+    // Print more source info.
+    if (Ctx.getOpts().PrintModule)
+      OS << ModuleName;
+    if (!HeaderName.empty())
+      OS << "(" << HeaderName << ")";
+  }
   if (!OS.str().empty())
     OS << ": ";
   bool IsExtension = false;


### PR DESCRIPTION
The error messages emitted from the ABI checker are mostly explanations of breakages. We should
explicitly mention why they are emitted to differentiate them from other compiler diagnostics.

rdar://68864860