### PR TITLE
[ClangImporter] Objective-C import decision remarks

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -127,7 +127,7 @@ If you run into any issues or have questions while following the steps above, fe
 
 - `%0`, `%1`, etc - Formats the specified diagnostic argument based on its type.
 
-- `%select{a|b|c}0` - Chooses from a list of alternatives, separated by vertical bars, based on the value of the given argument. In this example, a value of 2 in diagnostic argument 0 would result in "c" being output. The argument to the %select may be an integer, enum, or StringRef. If it's a StringRef, the specifier acts as an emptiness check.
+- `%select{a|b|c}0` - Chooses from a list of alternatives, separated by vertical bars, based on the value of the given argument. In this example, a value of 2 in diagnostic argument 0 would result in "c" being output. Any argument may be used in `%select`. For integer types, the first alternative is used for `0`, the second for `1`, and so on. For enums, the raw values are mapped to integers and the integer logic is applied. For other types, the first alternative is used for that type's "empty" or "null" value and the second for any other value.
 
 - `%s0` - Produces an "s" if the given argument is anything other than 1, as meant for an English plural. This isn't particularly localizable without a more general `%plural` form, but most diagnostics try to avoid cases where a plural/singular distinction would be necessary in the first place.
 

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -121,6 +121,7 @@ public:
   virtual clang::Sema &getClangSema() const = 0;
   virtual const clang::CompilerInstance &getClangInstance() const = 0;
   virtual void printStatistics() const = 0;
+  virtual void emitImportRemarks() = 0;
 
   /// Returns the module that contains imports and declarations from all loaded
   /// Objective-C header files.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -229,6 +229,8 @@ namespace swift {
 
     DiagnosticArgumentKind getKind() const { return Kind; }
 
+    unsigned getSelection() const;
+
     StringRef getAsString() const {
       assert(Kind == DiagnosticArgumentKind::String);
       return StringVal;

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -29,6 +29,8 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VersionTuple.h"
 
+namespace clang { class NamedDecl; }
+
 namespace swift {
   class Decl;
   class DeclAttribute;
@@ -93,6 +95,7 @@ namespace swift {
     DeclAttribute,
     VersionTuple,
     LayoutConstraint,
+    ClangDecl,
   };
 
   namespace diag {
@@ -122,6 +125,7 @@ namespace swift {
       const DeclAttribute *DeclAttributeVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
+      const clang::NamedDecl *ClangDecl;
     };
     
   public:
@@ -209,6 +213,11 @@ namespace swift {
     DiagnosticArgument(LayoutConstraint L)
       : Kind(DiagnosticArgumentKind::LayoutConstraint), LayoutConstraintVal(L) {
     }
+
+    DiagnosticArgument(const clang::NamedDecl *ND)
+      : Kind(DiagnosticArgumentKind::ClangDecl), ClangDecl(ND) {
+    }
+
     /// Initializes a diagnostic argument using the underlying type of the
     /// given enum.
     template<
@@ -298,6 +307,11 @@ namespace swift {
     LayoutConstraint getAsLayoutConstraint() const {
       assert(Kind == DiagnosticArgumentKind::LayoutConstraint);
       return LayoutConstraintVal;
+    }
+
+    const clang::NamedDecl *getAsClangDecl() const {
+      assert(Kind == DiagnosticArgumentKind::ClangDecl);
+      return ClangDecl;
     }
   };
   
@@ -1155,6 +1169,10 @@ namespace swift {
     parentDiag.flush();
     builder();
   }
+
+  /// Prints the qualified name of a Clang declaration in a form suitable for
+  /// diagnostics or debug logging.
+  void printClangDeclName(const clang::NamedDecl *D, llvm::raw_ostream &os);
 
 } // end namespace swift
 

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -81,32 +81,45 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         (StringRef, Identifier))
 
 REMARK(imported_clang_decl_as,none,
-       "imported as %select{|unavailable }0%1 '%2'",
-       (bool, DescriptiveDeclKind, StringRef))
+       "%0%select{| %1}1 imported as "
+       "%select{|unavailable }2%3 '%4'",
+       (StringRef, const clang::NamedDecl *, bool, DescriptiveDeclKind,
+        StringRef))
 REMARK(also_imported_clang_decl_as,none,
-       "also imported as %select{|unavailable }0%1 '%2",
-       (bool, DescriptiveDeclKind, StringRef))
+       "%0%select{| %1}1 also imported as "
+       "%select{|unavailable }2%3 '%4",
+       (StringRef, const clang::NamedDecl *, bool, DescriptiveDeclKind,
+        StringRef))
 REMARK(did_not_import_clang_decl,none,
-       "did not import",
-       ())
+       "could not import %0%select{| %1}1",
+       (StringRef, const clang::NamedDecl *))
 REMARK(did_not_import_clang_decl_because,none,
-       "could not import: %select{%error|%error|Swift cannot import forward "
-       "declarations|Swift cannot import instance variables|the "
-       "declaration it belongs to cannot be imported|it uses a type that "
-       "can't be imported|initializer can't be imported as an accessor|its "
-       "name can't be imported; it may have an invalid Swift name attribute|"
+       "could not import %0%select{| %1}1: %select{%error|%error|"
+       "Swift cannot import forward declarations|"
+       "Swift cannot import instance variables|"
+       "the declaration it belongs to cannot be imported|"
+       "it uses a type that can't be imported|"
+       "Swift can't import an '-init' method as an accessor|"
+       "its name can't be imported; it may have an invalid Swift name "
+           "attribute|"
        "methods with the name 'print()' in older language versions are not "
-       "imported|could not find property corresponding to accessor|the method "
-       "is marked as an accessor, but a matching property wasn't found|the "
-       "parameter list could not be imported|the raw type could not be "
-       "imported|property was redeclared in a potentially invalid way|"
+           "imported|"
+       "could not find the property corresponding to this accessor|"
+       "the method is marked as an accessor, but a matching property wasn't "
+            "found|"
+       "the parameter list could not be imported|"
+       "the raw type could not be imported|"
+       "property is being redeclared in a potentially invalid way|"
        "overriding a method with a property is not valid in Swift|"
        "property will not be imported, but its accessors will be imported as "
-       "methods|Swift cannot import '@implementation' blocks|its Objective-C "
-       "generic signature could not be imported|the 'NSObject' type could not "
-       "be found|the class being extended could not be imported|a different "
-       "initializer with the same Swift name is being imported instead}0",
-       (uint8_t))
+           "methods|"
+       "Swift cannot import '@implementation' blocks|"
+       "its Objective-C generic signature could not be imported|"
+       "the 'NSObject' type could not be found|"
+       "the class being extended could not be imported|"
+       "a different initializer with the same Swift name is being imported "
+           "instead}2",
+       (StringRef, const clang::NamedDecl *, uint8_t))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -80,17 +80,15 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         "is deprecated and will be removed in a later version of Swift",
         (StringRef, Identifier))
 
-// Note the unusual order in these remarks: version is %0 even though it's
-// printed at the end.
 REMARK(imported_clang_decl_as,none,
-       "imported as %1 '%2' in Swift %0",
-       (llvm::VersionTuple, DescriptiveDeclKind, StringRef))
+       "imported as %select{|unavailable }0%1 '%2'",
+       (bool, DescriptiveDeclKind, StringRef))
 REMARK(also_imported_clang_decl_as,none,
-       "also imported as %1 '%2' in Swift %0",
-       (llvm::VersionTuple, DescriptiveDeclKind, StringRef))
+       "also imported as %select{|unavailable }0%1 '%2",
+       (bool, DescriptiveDeclKind, StringRef))
 REMARK(did_not_import_clang_decl,none,
-       "did not import in Swift %0",
-       (llvm::VersionTuple))
+       "did not import",
+       ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -89,6 +89,24 @@ REMARK(also_imported_clang_decl_as,none,
 REMARK(did_not_import_clang_decl,none,
        "did not import",
        ())
+REMARK(did_not_import_clang_decl_because,none,
+       "could not import: %select{%error|%error|Swift cannot import forward "
+       "declarations|Swift cannot import instance variables|the "
+       "declaration it belongs to cannot be imported|it uses a type that "
+       "can't be imported|initializer can't be imported as an accessor|its "
+       "name can't be imported; it may have an invalid Swift name attribute|"
+       "methods with the name 'print()' in older language versions are not "
+       "imported|could not find property corresponding to accessor|the method "
+       "is marked as an accessor, but a matching property wasn't found|the "
+       "parameter list could not be imported|the raw type could not be "
+       "imported|property was redeclared in a potentially invalid way|"
+       "overriding a method with a property is not valid in Swift|"
+       "property will not be imported, but its accessors will be imported as "
+       "methods|Swift cannot import '@implementation' blocks|its Objective-C "
+       "generic signature could not be imported|the 'NSObject' type could not "
+       "be found|the class being extended could not be imported|a different "
+       "initializer with the same Swift name is being imported instead}0",
+       (uint8_t))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -80,5 +80,17 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         "is deprecated and will be removed in a later version of Swift",
         (StringRef, Identifier))
 
+// Note the unusual order in these remarks: version is %0 even though it's
+// printed at the end.
+REMARK(imported_clang_decl_as,none,
+       "imported as %1 '%2' in Swift %0",
+       (llvm::VersionTuple, DescriptiveDeclKind, StringRef))
+REMARK(also_imported_clang_decl_as,none,
+       "also imported as %1 '%2' in Swift %0",
+       (llvm::VersionTuple, DescriptiveDeclKind, StringRef))
+REMARK(did_not_import_clang_decl,none,
+       "did not import in Swift %0",
+       (llvm::VersionTuple))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -81,45 +81,112 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         (StringRef, Identifier))
 
 REMARK(imported_clang_decl_as,none,
-       "%0%select{| %1}1 imported as "
-       "%select{|unavailable }2%3 '%4'",
-       (StringRef, const clang::NamedDecl *, bool, DescriptiveDeclKind,
-        StringRef))
-REMARK(also_imported_clang_decl_as,none,
-       "%0%select{| %1}1 also imported as "
-       "%select{|unavailable }2%3 '%4",
-       (StringRef, const clang::NamedDecl *, bool, DescriptiveDeclKind,
-        StringRef))
+       "%0%select{| %1}1"
+       "%select{| also}2 imported as %select{|unavailable }3"
+       "%4%select{| %5}5",
+       (/*clangDescriptiveKind=*/StringRef, const clang::NamedDecl *,
+        /*isAlternative=*/bool, /*isUnavailable=*/bool,
+        DescriptiveDeclKind, ValueDecl *))
+REMARK(imported_clang_decl_as_accessor,none,
+       "%0%select{| %1}1"
+       "%select{| also}2 imported as %select{|unavailable }3"
+       "%4 for %5 %6",
+       (/*clangDescriptiveKind=*/StringRef, const clang::NamedDecl *,
+        /*isAlternative=*/bool, /*isUnavailable=*/bool,
+        DescriptiveDeclKind, DescriptiveDeclKind, ValueDecl *))
+REMARK(imported_clang_decl_as_extension,none,
+       "%0%select{| %1}1"
+       "%select{| also}2 imported as %select{|unavailable }3"
+       "extension of %4",
+       (/*clangDescriptiveKind=*/StringRef, const clang::NamedDecl *,
+        /*isAlternative=*/bool, /*isUnavailable=*/bool,
+        Type))
+       
 REMARK(did_not_import_clang_decl,none,
        "could not import %0%select{| %1}1",
        (StringRef, const clang::NamedDecl *))
-REMARK(did_not_import_clang_decl_because,none,
-       "could not import %0%select{| %1}1: %select{%error|%error|"
-       "Swift cannot import forward declarations|"
-       "Swift cannot import instance variables|"
-       "the declaration it belongs to cannot be imported|"
-       "it uses a type that can't be imported|"
-       "Swift can't import an '-init' method as an accessor|"
-       "its name can't be imported; it may have an invalid Swift name "
-           "attribute|"
-       "methods with the name 'print()' in older language versions are not "
-           "imported|"
-       "could not find the property corresponding to this accessor|"
-       "the method is marked as an accessor, but a matching property wasn't "
-            "found|"
-       "the parameter list could not be imported|"
-       "the raw type could not be imported|"
-       "property is being redeclared in a potentially invalid way|"
-       "overriding a method with a property is not valid in Swift|"
-       "property will not be imported, but its accessors will be imported as "
-           "methods|"
-       "Swift cannot import '@implementation' blocks|"
-       "its Objective-C generic signature could not be imported|"
-       "the 'NSObject' type could not be found|"
-       "the class being extended could not be imported|"
-       "a different initializer with the same Swift name is being imported "
-           "instead}2",
-       (StringRef, const clang::NamedDecl *, uint8_t))
+
+NOTE(note_cannot_import_forward_declaration,none,
+     "found only forward declarations of %0 %1; incomplete types cannot be "
+     "imported into Swift",
+     (StringRef, const clang::NamedDecl *))
+NOTE(note_cannot_import_objc_ivars,none,
+     "use a property to access this instance variable",
+     ())
+NOTE(note_cannot_import_context,none,
+     "its context could not be imported",                       // FIXME improve
+     ())
+NOTE(note_cannot_import_type,none,
+     "type could not be imported",                              // FIXME improve
+     ())
+NOTE(note_cannot_import_name,none,
+     "could not import Swift name",                             // FIXME improve
+     ())
+NOTE(note_cannot_import_parameter_list,none,
+     "its parameter list could not be imported",                // FIXME improve
+     ())
+NOTE(note_cannot_import_init_as_accessor,none,
+     "methods starting with '-init' cannot be imported as accessors because "
+     "they have special memory management behavior",
+     ())
+NOTE(note_cannot_import_method_named_print_into_old_version,none,
+     "methods with the name 'print' are not imported in inactive language "
+     "versions to avoid conflicting with the 'print()' function",
+     ())
+NOTE(note_cannot_import_clang_ast_inconsistent,none,
+     "clang AST is in an inconsistent state; please file a compiler bug report "
+     "with your code and this message: '%0'",
+     (StringRef))
+NOTE(note_cannot_import_not_an_accessor,none,
+     "%0 %1 cannot be imported as an accessor because it doesn't belong to a "
+     "property in Objective-C",
+     (StringRef, const clang::NamedDecl *))
+NOTE(note_cannot_import_raw_type,none,
+     "its raw value type could not be imported",
+     ())
+NOTE(note_cannot_import_property_redeclaration_merged,none,
+     "its attributes have been merged with previous declaration imported as "
+     "%0 %1",
+     (DescriptiveDeclKind, ValueDecl *))
+NOTE(note_cannot_import_property_redeclaration,none,
+     "it is declared elsewhere with different accessors",
+     ())
+NOTE(note_cannot_import_property_overriding_method,none,
+     "property overrides %0 %1; this is valid in Objective-C, but not in Swift",
+     (StringRef, const clang::NamedDecl *))
+NOTE(note_cannot_import_property_broken_up,none,
+     "the maintainer of %0 %1 has chosen to import this property's accessors "
+     "as methods instead",
+     (StringRef, const clang::NamedDecl *))
+NOTE(note_cannot_import_at_implementation,none,
+     "header files should not include '@implementation' declarations",
+     ())
+NOTE(note_cannot_import_generic_signature,none,
+     "its Objective-C generic signature could not be imported",
+     ())
+NOTE(note_cannot_import_known_type_not_found,none,
+     "importing this %0 requires the type '%1', but it could not be found",
+     (StringRef, StringRef))
+NOTE(note_cannot_import_class_of_category,none,
+     "the class it extends could not be imported",
+     ())
+NOTE(note_cannot_import_property_accessor,none,
+     "its %select{getter|setter}0 could not be imported",
+     (bool))
+NOTE(note_cannot_import_see_other_decl,none,
+     "%0 %1 may have remarks describing why it could not be imported",
+     (StringRef, const clang::NamedDecl *))
+NOTE(note_cannot_import_is_worse_than_named_alternative,none,
+     "a better candidate, %0 %1, is already being imported with the name %2 "
+     "and the same signature",
+     (StringRef, const clang::NamedDecl *, ValueDecl *))
+NOTE(note_cannot_import_is_worse_than_alternative,none,
+     "a better candidate is already being imported with the name %2 and the "
+     "same signature",
+     (ValueDecl *))
+NOTE(note_cannot_import_alias_for_unavailable_case,none,
+     "cannot import alias %0 for %1 %2 because it is unavailable",
+     (Identifier, DescriptiveDeclKind, ValueDecl *))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -187,6 +187,13 @@ NOTE(note_cannot_import_is_worse_than_alternative,none,
 NOTE(note_cannot_import_alias_for_unavailable_case,none,
      "cannot import alias %0 for %1 %2 because it is unavailable",
      (Identifier, DescriptiveDeclKind, ValueDecl *))
+NOTE(note_cannot_import_subscript_setter_type_mismatch,none,
+     "cannot import %0 %1 as a subscript setter matching getter %3 %4 because "
+     "the setter's %select{element|index}6 type, %2, does not match the "
+     "getter's, %5",
+     (/*setterInfo=*/StringRef, const clang::NamedDecl *, Type,
+      /*getterInfo=*/StringRef, const clang::NamedDecl *, Type,
+      /*isParamType=*/bool))
 
 NOTE(note_imported_from_swift_part,none,
      "replaced by definition for %0 %1 from the Swift %select{part of|overlay "

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -188,5 +188,10 @@ NOTE(note_cannot_import_alias_for_unavailable_case,none,
      "cannot import alias %0 for %1 %2 because it is unavailable",
      (Identifier, DescriptiveDeclKind, ValueDecl *))
 
+NOTE(note_imported_from_swift_part,none,
+     "replaced by definition for %0 %1 from the Swift %select{part of|overlay "
+     "for}2 this module",
+     (DescriptiveDeclKind, ValueDecl *, /*overlay=*/bool))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -859,6 +859,8 @@ public:
   /// \param scratch Scratch space to use.
   StringRef getString(llvm::SmallVectorImpl<char> &scratch) const;
 
+  SWIFT_DEBUG_HELPER(bool isString(StringRef str) const);
+
   ObjCSelectorFamily getSelectorFamily() const;
 
   void *getOpaqueValue() const { return Storage.getOpaqueValue(); }

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -41,6 +41,10 @@ public:
   /// Indicates whether diagnostic passes should be skipped.
   bool SkipDiagnosticPasses = false;
 
+  /// Additional non-source files which will have diagnostics emitted in them,
+  /// and which should be scanned for expectations by the diagnostic verifier.
+  std::vector<std::string> AdditionalVerifierFiles;
+
   /// Keep emitting subsequent diagnostics after a fatal error.
   bool ShowDiagnosticsAfterFatalError = false;
 
@@ -54,22 +58,23 @@ public:
   /// Treat all warnings as errors
   bool WarningsAsErrors = false;
 
-  // When printing diagnostics, include the diagnostic name at the end
+  /// When printing diagnostics, include the diagnostic name (diag::whatever) at
+  /// the end.
   bool PrintDiagnosticNames = false;
 
   /// If set to true, include educational notes in printed output if available.
   /// Educational notes are documentation which supplement diagnostics.
   bool PrintEducationalNotes = false;
 
-  // If set to true, use the more descriptive experimental formatting style for
-  // diagnostics.
+  /// Whether to emit diagnostics in the terse LLVM style or in a more
+  /// descriptive style that's specific to Swift (currently experimental).
   FormattingStyle PrintedFormattingStyle = FormattingStyle::LLVM;
 
   std::string DiagnosticDocumentationPath = "";
 
   std::string LocalizationCode = "";
 
-  // Diagnostic messages directory path.
+  /// Path to a directory of diagnostic localization tables.
   std::string LocalizationPath = "";
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Version.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -592,6 +593,10 @@ namespace swift {
     /// The optimizaton setting.  This doesn't typically matter for
     /// import, but it can affect Clang's IR generation of static functions.
     std::string Optimization;
+
+    /// Swift should emit remarks describing import decisions in these modules.
+    /// If true, emit for all decisions; if false, emit only for failures.
+    std::vector<std::tuple<std::string, bool>> EmitImportDecisionRemarks;
 
     /// Disable validating the persistent PCH.
     bool PCHDisableValidation = false;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -598,6 +598,10 @@ namespace swift {
     /// If true, emit for all decisions; if false, emit only for failures.
     std::vector<std::tuple<std::string, bool>> EmitImportDecisionRemarks;
 
+    /// If true, deliberately import as many declarations as possible in the
+    /// modules listed in \c EmitImportDecisionRemarks.
+    bool ForceImportDecisions = false;
+
     /// Disable validating the persistent PCH.
     bool PCHDisableValidation = false;
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -434,6 +434,9 @@ public:
   // Print statistics from the Clang AST reader.
   void printStatistics() const override;
 
+  /// Emit remarks about decisions made while importing.
+  void emitImportRemarks() override;
+
   /// Dump Swift lookup tables.
   void dumpSwiftLookupTables();
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -65,6 +65,7 @@ class DiagnosticVerifier : public DiagnosticConsumer {
   SourceManager &SM;
   std::vector<CapturedDiagnosticInfo> CapturedDiagnostics;
   ArrayRef<unsigned> BufferIDs;
+  SmallVector<unsigned, 4> AdditionalBufferIDs;
   bool AutoApplyFixes;
   bool IgnoreUnknown;
 
@@ -73,6 +74,10 @@ public:
                               bool AutoApplyFixes, bool IgnoreUnknown)
       : SM(SM), BufferIDs(BufferIDs), AutoApplyFixes(AutoApplyFixes),
         IgnoreUnknown(IgnoreUnknown) {}
+
+  void appendAdditionalBufferID(unsigned bufferID) {
+    AdditionalBufferIDs.push_back(bufferID);
+  }
 
   virtual void handleDiagnostic(SourceManager &SM,
                                 const DiagnosticInfo &Info) override;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -552,8 +552,11 @@ private:
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();
-  void setupDiagnosticVerifierIfNeeded();
   void setupDependencyTrackerIfNeeded();
+
+  /// \return false if successsful, true on error.
+  bool setupDiagnosticVerifierIfNeeded();
+
   Optional<unsigned> setUpCodeCompletionBuffer();
 
   /// Find a buffer for a given input file and ensure it is recorded in

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -168,6 +168,16 @@ def use_clang_function_types : Flag<["-"], "use-clang-function-types">,
 def print_clang_stats : Flag<["-"], "print-clang-stats">,
   HelpText<"Print Clang importer statistics">;
 
+def Robjc_imports : Separate<["-"], "Robjc-imports">,
+  MetaVarName<"<module-or-submodule-name>">,
+  HelpText<"Emit remarks describing whether, why, and how Objective-C "
+           "declarations from this module can be imported">;
+
+def Robjc_import_failures : Separate<["-"], "Robjc-import-failures">,
+  MetaVarName<"<module-or-submodule-name>">,
+  HelpText<"Emit remarks describing which Objective-C declarations in this "
+           "module cannot be imported and why">;
+
 def serialize_debugging_options : Flag<["-"], "serialize-debugging-options">,
   HelpText<"Always serialize options for debugging (default: only for apps)">;
 def no_serialize_debugging_options :

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -112,6 +112,8 @@ def tbd_is_installapi: Flag<["-"], "tbd-is-installapi">,
 def verify : Flag<["-"], "verify">,
   HelpText<"Verify diagnostics against expected-{error|warning|note} "
            "annotations">;
+def verify_additional_file : Separate<["-"], "verify-additional-file">,
+  HelpText<"Verify diagnostics in this file in addition to source files">;
 def verify_apply_fixes : Flag<["-"], "verify-apply-fixes">,
   HelpText<"Like -verify, but updates the original source file">;
 def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -178,6 +178,10 @@ def Robjc_import_failures : Separate<["-"], "Robjc-import-failures">,
   HelpText<"Emit remarks describing which Objective-C declarations in this "
            "module cannot be imported and why">;
 
+def Robjc_imports_natural_only : Flag<["-"], "Robjc-imports-natural-only">,
+  HelpText<"Don't force unnecessary imports of Objective-C declarations just "
+           "to get remarks from -Robjc-imports or -Robjc-import-failures">;
+
 def serialize_debugging_options : Flag<["-"], "serialize-debugging-options">,
   HelpText<"Always serialize options for debugging (default: only for apps)">;
 def no_serialize_debugging_options :

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -34,6 +34,9 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclObjC.h"
 
 using namespace swift;
 
@@ -465,6 +468,41 @@ static bool typeSpellingIsAmbiguous(Type type,
   return false;
 }
 
+void swift::printClangDeclName(const clang::NamedDecl *D, llvm::raw_ostream &os) {
+  if (auto *category = dyn_cast<clang::ObjCCategoryDecl>(D)) {
+    printClangDeclName(category->getClassInterface(), os);
+    os << '(';
+    category->printName(os);
+    os << ')';
+    return;
+  }
+
+  if (auto *method = dyn_cast<clang::ObjCMethodDecl>(D)) {
+    os << (method->isClassMethod() ? '+' : '-');
+    os << '[';
+    printClangDeclName(cast<clang::NamedDecl>(method->getDeclContext()), os);
+    os << ' ';
+    method->printName(os);
+    os << ']';
+    return;
+  }
+
+  if (auto *prop = dyn_cast<clang::ObjCPropertyDecl>(D)) {
+    os << (prop->isClassProperty() ? '+' : '-');
+    printClangDeclName(cast<clang::NamedDecl>(prop->getDeclContext()), os);
+    os << '.';
+    prop->printName(os);
+    return;
+  }
+
+  // If this is an anonymous tag declaration with a typedef name, use that.
+  if (auto tag = dyn_cast<clang::TagDecl>(D))
+    if (auto typedefName = tag->getTypedefNameForAnonDecl())
+      D = typedefName;
+
+  D->getNameForDiagnostic(os, D->getASTContext().getPrintingPolicy(), true);
+}
+
 /// Format a single diagnostic argument and write it to the given
 /// stream.
 static void formatDiagnosticArgument(StringRef Modifier, 
@@ -659,6 +697,12 @@ static void formatDiagnosticArgument(StringRef Modifier,
     assert(Modifier.empty() && "Improper modifier for LayoutConstraint argument");
     Out << FormatOpts.OpeningQuotationMark << Arg.getAsLayoutConstraint()
         << FormatOpts.ClosingQuotationMark;
+    break;
+
+  case DiagnosticArgumentKind::ClangDecl:
+    Out << FormatOpts.OpeningQuotationMark;
+    printClangDeclName(Arg.getAsClangDecl(), Out);
+    Out << FormatOpts.ClosingQuotationMark;
     break;
   }
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -503,6 +503,46 @@ void swift::printClangDeclName(const clang::NamedDecl *D, llvm::raw_ostream &os)
   D->getNameForDiagnostic(os, D->getASTContext().getPrintingPolicy(), true);
 }
 
+unsigned DiagnosticArgument::getSelection() const {
+  switch (getKind()) {
+  case DiagnosticArgumentKind::Integer:
+    assert(getAsInteger() >= 0 && "Negative selection index");
+    return unsigned(getAsInteger());
+  case DiagnosticArgumentKind::Unsigned:
+    return getAsUnsigned();
+  case DiagnosticArgumentKind::String:
+    return getAsString().empty() ? 0 : 1;
+  case DiagnosticArgumentKind::Identifier:
+    return !getAsIdentifier() ? 0 : 1;
+  case DiagnosticArgumentKind::ObjCSelector:
+    return !getAsObjCSelector() ? 0 : 1;
+  case DiagnosticArgumentKind::ValueDecl:
+    return !getAsValueDecl() ? 0 : 1;
+  case DiagnosticArgumentKind::Type:
+    return !getAsType() ? 0 : 1;
+  case DiagnosticArgumentKind::TypeRepr:
+    return !getAsTypeRepr() ? 0 : 1;
+  case DiagnosticArgumentKind::PatternKind:
+    return unsigned(getAsPatternKind());
+  case DiagnosticArgumentKind::SelfAccessKind:
+    return unsigned(getAsSelfAccessKind());
+  case DiagnosticArgumentKind::ReferenceOwnership:
+    return unsigned(getAsReferenceOwnership());
+  case DiagnosticArgumentKind::StaticSpellingKind:
+    return unsigned(getAsStaticSpellingKind());
+  case DiagnosticArgumentKind::DescriptiveDeclKind:
+    return unsigned(getAsDescriptiveDeclKind());
+  case DiagnosticArgumentKind::DeclAttribute:
+    return !getAsDeclAttribute() ? 0 : 1;
+  case DiagnosticArgumentKind::VersionTuple:
+    return getAsVersionTuple().empty() ? 0 : 1;
+  case DiagnosticArgumentKind::LayoutConstraint:
+    return getAsLayoutConstraint().isNull() ? 0 : 1;
+  case DiagnosticArgumentKind::ClangDecl:
+    return !getAsClangDecl() ? 0 : 1;
+  }
+}
+
 /// Format a single diagnostic argument and write it to the given
 /// stream.
 static void formatDiagnosticArgument(StringRef Modifier, 
@@ -512,54 +552,46 @@ static void formatDiagnosticArgument(StringRef Modifier,
                                      DiagnosticFormatOptions FormatOpts,
                                      llvm::raw_ostream &Out) {
   const DiagnosticArgument &Arg = Args[ArgIndex];
+
+  if (Modifier == "select") {
+    unsigned selection = Arg.getSelection();
+    formatSelectionArgument(ModifierArguments, Args, selection, FormatOpts,
+                            Out);
+    return;
+  }
+  else if (Modifier == "s") {
+    unsigned selection = Arg.getSelection();
+    if (selection != 1)
+      Out << 's';
+    return;
+  }
+
+  if (!Modifier.empty()) {
+    Out << "<<INTERNAL ERROR: improper modifier '" << Modifier
+        << "' for arugment #" << ArgIndex << " in diagnostic string>>";
+    assert(false && "Unknown modifier for argument");
+  }
+
   switch (Arg.getKind()) {
   case DiagnosticArgumentKind::Integer:
-    if (Modifier == "select") {
-      assert(Arg.getAsInteger() >= 0 && "Negative selection index");
-      formatSelectionArgument(ModifierArguments, Args, Arg.getAsInteger(),
-                              FormatOpts, Out);
-    } else if (Modifier == "s") {
-      if (Arg.getAsInteger() != 1)
-        Out << 's';
-    } else {
-      assert(Modifier.empty() && "Improper modifier for integer argument");
-      Out << Arg.getAsInteger();
-    }
+    Out << Arg.getAsInteger();
     break;
 
   case DiagnosticArgumentKind::Unsigned:
-    if (Modifier == "select") {
-      formatSelectionArgument(ModifierArguments, Args, Arg.getAsUnsigned(),
-                              FormatOpts, Out);
-    } else if (Modifier == "s") {
-      if (Arg.getAsUnsigned() != 1)
-        Out << 's';
-    } else {
-      assert(Modifier.empty() && "Improper modifier for unsigned argument");
-      Out << Arg.getAsUnsigned();
-    }
+    Out << Arg.getAsUnsigned();
     break;
 
   case DiagnosticArgumentKind::String:
-    if (Modifier == "select") {
-      formatSelectionArgument(ModifierArguments, Args,
-                              Arg.getAsString().empty() ? 0 : 1, FormatOpts,
-                              Out);
-    } else {
-      assert(Modifier.empty() && "Improper modifier for string argument");
-      Out << Arg.getAsString();
-    }
+    Out << Arg.getAsString();
     break;
 
   case DiagnosticArgumentKind::Identifier:
-    assert(Modifier.empty() && "Improper modifier for identifier argument");
     Out << FormatOpts.OpeningQuotationMark;
     Arg.getAsIdentifier().printPretty(Out);
     Out << FormatOpts.ClosingQuotationMark;
     break;
 
   case DiagnosticArgumentKind::ObjCSelector:
-    assert(Modifier.empty() && "Improper modifier for selector argument");
     Out << FormatOpts.OpeningQuotationMark << Arg.getAsObjCSelector()
         << FormatOpts.ClosingQuotationMark;
     break;
@@ -571,8 +603,6 @@ static void formatDiagnosticArgument(StringRef Modifier,
     break;
 
   case DiagnosticArgumentKind::Type: {
-    assert(Modifier.empty() && "Improper modifier for Type argument");
-    
     // Strip extraneous parentheses; they add no value.
     auto type = Arg.getAsType()->getWithoutParens();
 
@@ -624,62 +654,32 @@ static void formatDiagnosticArgument(StringRef Modifier,
   }
 
   case DiagnosticArgumentKind::TypeRepr:
-    assert(Modifier.empty() && "Improper modifier for TypeRepr argument");
     assert(Arg.getAsTypeRepr() && "TypeRepr argument is null");
     Out << FormatOpts.OpeningQuotationMark << Arg.getAsTypeRepr()
         << FormatOpts.ClosingQuotationMark;
     break;
 
   case DiagnosticArgumentKind::PatternKind:
-    assert(Modifier.empty() && "Improper modifier for PatternKind argument");
     Out << Arg.getAsPatternKind();
     break;
 
   case DiagnosticArgumentKind::SelfAccessKind:
-    if (Modifier == "select") {
-      formatSelectionArgument(ModifierArguments, Args,
-                              unsigned(Arg.getAsSelfAccessKind()),
-                              FormatOpts, Out);
-    } else {
-      assert(Modifier.empty() &&
-             "Improper modifier for SelfAccessKind argument");
-      Out << Arg.getAsSelfAccessKind();
-    }
+    Out << Arg.getAsSelfAccessKind();
     break;
 
   case DiagnosticArgumentKind::ReferenceOwnership:
-    if (Modifier == "select") {
-      formatSelectionArgument(ModifierArguments, Args,
-                              unsigned(Arg.getAsReferenceOwnership()),
-                              FormatOpts, Out);
-    } else {
-      assert(Modifier.empty() &&
-             "Improper modifier for ReferenceOwnership argument");
-      Out << Arg.getAsReferenceOwnership();
-    }
+    Out << Arg.getAsReferenceOwnership();
     break;
 
   case DiagnosticArgumentKind::StaticSpellingKind:
-    if (Modifier == "select") {
-      formatSelectionArgument(ModifierArguments, Args,
-                              unsigned(Arg.getAsStaticSpellingKind()),
-                              FormatOpts, Out);
-    } else {
-      assert(Modifier.empty() &&
-             "Improper modifier for StaticSpellingKind argument");
-      Out << Arg.getAsStaticSpellingKind();
-    }
+    Out << Arg.getAsStaticSpellingKind();
     break;
 
   case DiagnosticArgumentKind::DescriptiveDeclKind:
-    assert(Modifier.empty() &&
-           "Improper modifier for DescriptiveDeclKind argument");
     Out << Decl::getDescriptiveKindName(Arg.getAsDescriptiveDeclKind());
     break;
 
   case DiagnosticArgumentKind::DeclAttribute:
-    assert(Modifier.empty() &&
-           "Improper modifier for DeclAttribute argument");
     if (Arg.getAsDeclAttribute()->isDeclModifier())
       Out << FormatOpts.OpeningQuotationMark
           << Arg.getAsDeclAttribute()->getAttrName()
@@ -689,12 +689,10 @@ static void formatDiagnosticArgument(StringRef Modifier,
     break;
 
   case DiagnosticArgumentKind::VersionTuple:
-    assert(Modifier.empty() &&
-           "Improper modifier for VersionTuple argument");
     Out << Arg.getAsVersionTuple().getAsString();
     break;
+
   case DiagnosticArgumentKind::LayoutConstraint:
-    assert(Modifier.empty() && "Improper modifier for LayoutConstraint argument");
     Out << FormatOpts.OpeningQuotationMark << Arg.getAsLayoutConstraint()
         << FormatOpts.ClosingQuotationMark;
     break;

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -267,6 +267,11 @@ StringRef ObjCSelector::getString(llvm::SmallVectorImpl<char> &scratch) const {
   return os.str();
 }
 
+bool ObjCSelector::isString(StringRef str) const {
+  SmallString<64> scratch;
+  return getString(scratch) == str;
+}
+
 void ObjCSelector::dump() const {
   llvm::errs() << *this << "\n";
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4093,7 +4093,8 @@ shouldEmitImportRemark(const ImportRemark &remark) {
   if (remark.version != CurrentVersion)
     return false;
 
-  bool success = remark.swiftDecl != nullptr || remark.alreadyDecided;
+  bool success = remark.swiftDecl != nullptr
+              || remark.reason == ImportReason::AlreadyDecided;
   auto &opts = SwiftContext.ClangImporterOpts;
 
   // FIXME: String comparison is a pretty silly way to check for membership in a
@@ -4175,22 +4176,34 @@ static std::string getDeclName(Decl *decl) {
 }
 
 void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
-  if (swiftDecl) {
-    auto name = getDeclName(swiftDecl);
-    if (!name.empty())
-      ::diagnose(impl, clangDecl, version, diag::imported_clang_decl_as,
-                 swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
-                 swiftDecl->getDescriptiveKind(), name);
-  }
-  else if (!alreadyDecided) {
-    ::diagnose(impl, clangDecl, version, diag::did_not_import_clang_decl);
-  }
+  switch (reason) {
+  case ImportReason::Unspecified:
+    if (swiftDecl) {
+      auto name = getDeclName(swiftDecl);
+      if (!name.empty())
+        ::diagnose(impl, clangDecl, version, diag::imported_clang_decl_as,
+                   swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
+                   swiftDecl->getDescriptiveKind(), name);
 
-  for (auto *altDecl : alternateSwiftDecls) {
-    auto name = getDeclName(altDecl);
-    if (!name.empty())
-      ::diagnose(impl, clangDecl, version, diag::also_imported_clang_decl_as,
-                 altDecl->getAttrs().isUnavailable(impl.SwiftContext),
-                 altDecl->getDescriptiveKind(), name);
+      for (auto *altDecl : alternateSwiftDecls) {
+        auto name = getDeclName(altDecl);
+        if (!name.empty())
+          ::diagnose(impl, clangDecl, version,
+                     diag::also_imported_clang_decl_as,
+                     altDecl->getAttrs().isUnavailable(impl.SwiftContext),
+                     altDecl->getDescriptiveKind(), name);
+      }
+    } else {
+      ::diagnose(impl, clangDecl, version, diag::did_not_import_clang_decl);
+    }
+    break;
+
+  case ImportReason::AlreadyDecided:
+    // Emit nothing.
+    break;
+
+  default:
+    ::diagnose(impl, clangDecl, version,
+               diag::did_not_import_clang_decl_because, (uint8_t)reason);
   }
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3845,7 +3845,8 @@ ClangImporter::Implementation::loadNamedMembers(
   auto table = findLookupTable(*CMO);
   assert(table && "clang module without lookup table");
 
-  assert(isa<clang::ObjCContainerDecl>(CD) || isa<clang::NamespaceDecl>(CD));
+  assert(isa<clang::ObjCContainerDecl>(CD) || isa<clang::NamespaceDecl>(CD) ||
+         isa<clang::EnumDecl>(CD));
 
   // Force the members of the entire inheritance hierarchy to be loaded and
   // deserialized before loading the named member of a class. This warms up

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4132,7 +4132,7 @@ template<typename ...ArgTypes>
 static void diagnose(ClangImporter::Implementation &impl,
                      const clang::Decl *clangDecl,
                      importer::ImportNameVersion version,
-                     Diag<llvm::VersionTuple, ArgTypes...> id,
+                     Diag<ArgTypes...> id,
                      typename detail::PassArgument<ArgTypes>::type... args) {
   if (version == importer::ImportNameVersion::raw()) return;
 
@@ -4141,8 +4141,7 @@ static void diagnose(ClangImporter::Implementation &impl,
                              clangDecl->getLocation());
   if (!loc.isValid()) return;
 
-  impl.SwiftContext.Diags.diagnose(loc, id, version.asClangVersionTuple(),
-                                   std::move(args)...);
+  impl.SwiftContext.Diags.diagnose(loc, id, std::move(args)...);
 }
 
 static std::string getDeclName(Decl *decl) {
@@ -4158,6 +4157,7 @@ void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
     auto name = getDeclName(swiftDecl);
     if (!name.empty())
       ::diagnose(impl, clangDecl, version, diag::imported_clang_decl_as,
+                 swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
                  swiftDecl->getDescriptiveKind(), name);
   }
   else if (!alreadyDecided) {
@@ -4168,6 +4168,7 @@ void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
     auto name = getDeclName(altDecl);
     if (!name.empty())
       ::diagnose(impl, clangDecl, version, diag::also_imported_clang_decl_as,
+                 altDecl->getAttrs().isUnavailable(impl.SwiftContext),
                  altDecl->getDescriptiveKind(), name);
   }
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4082,3 +4082,66 @@ swift::getModuleCachePathFromClang(const clang::CompilerInstance &Clang) {
   return llvm::sys::path::parent_path(SpecificModuleCachePath).str();
 }
 
+void
+ClangImporter::Implementation::addImportRemark(const ImportRemark &remark) {
+  ImportRemarks.push_back(remark);
+}
+
+void ClangImporter::Implementation::emitImportRemarks() {
+  // Move list to a local variable so that, if emitting these remarks somehow
+  // causes additional imports, they don't affect us.
+  std::vector<ImportRemark> remarks;
+  std::swap(remarks, ImportRemarks);
+
+  // Emit.
+  for (auto &remark : remarks)
+    remark.diagnose(*this);
+}
+
+void ClangImporter::emitImportRemarks() {
+  Impl.emitImportRemarks();
+}
+
+template<typename ...ArgTypes>
+static void diagnose(ClangImporter::Implementation &impl,
+                     const clang::Decl *clangDecl,
+                     importer::ImportNameVersion version,
+                     Diag<llvm::VersionTuple, ArgTypes...> id,
+                     typename detail::PassArgument<ArgTypes>::type... args) {
+  if (version == importer::ImportNameVersion::raw()) return;
+
+  SourceLoc loc = impl.getBufferImporterForDiagnostics()
+      .resolveSourceLocation(impl.getClangASTContext().getSourceManager(),
+                             clangDecl->getLocation());
+  if (!loc.isValid()) return;
+
+  impl.SwiftContext.Diags.diagnose(loc, id, version.asClangVersionTuple(),
+                                   std::move(args)...);
+}
+
+static std::string getDeclName(Decl *decl) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  if (auto *VD = dyn_cast<ValueDecl>(decl))
+    VD->getName().printPretty(os);        // FIXME: do better
+  return str;
+}
+
+void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
+  if (swiftDecl) {
+    auto name = getDeclName(swiftDecl);
+    if (!name.empty())
+      ::diagnose(impl, clangDecl, version, diag::imported_clang_decl_as,
+                 swiftDecl->getDescriptiveKind(), name);
+  }
+  else if (!alreadyDecided) {
+    ::diagnose(impl, clangDecl, version, diag::did_not_import_clang_decl);
+  }
+
+  for (auto *altDecl : alternateSwiftDecls) {
+    auto name = getDeclName(altDecl);
+    if (!name.empty())
+      ::diagnose(impl, clangDecl, version, diag::also_imported_clang_decl_as,
+                 altDecl->getDescriptiveKind(), name);
+  }
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4120,11 +4120,11 @@ static void diagnose(ClangImporter::Implementation &impl,
 }
 
 static std::string getDeclName(Decl *decl) {
-  std::string str;
-  llvm::raw_string_ostream os(str);
   if (auto *VD = dyn_cast<ValueDecl>(decl))
-    VD->getName().printPretty(os);        // FIXME: do better
-  return str;
+    return VD->printRef();
+  if (auto *ED = dyn_cast<ExtensionDecl>(decl))
+    return "extension " + ED->getExtendedType().getString();
+  return "";
 }
 
 void ImportRemark::diagnose(ClangImporter::Implementation &impl) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4125,6 +4125,28 @@ void ClangImporter::Implementation::emitImportRemarks() {
 }
 
 void ClangImporter::emitImportRemarks() {
+  auto &opts = Impl.SwiftContext.ClangImporterOpts;
+  if (opts.ForceImportDecisions) {
+    for (auto pair : opts.EmitImportDecisionRemarks) {
+      ImportPath::Module::Builder modulePath(Impl.SwiftContext,
+                                             std::get<0>(pair), '.');
+      auto module = loadModule(SourceLoc(), modulePath.get());
+
+      // FIXME: I'm not convinced this actually touches everything. Is there a
+      // better way to do this?
+      class CuriousDeclConsumer : public VisibleDeclConsumer {
+        virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
+                               DynamicLookupInfo dynamicLookupInfo = {}) override {
+
+          if (auto *IDC = dyn_cast<IterableDeclContext>(VD))
+            (void)IDC->getMembers();
+        }
+      };
+      CuriousDeclConsumer consumer;
+      module->lookupVisibleDecls({}, consumer, NLKind::QualifiedLookup);
+    }
+  }
+
   Impl.emitImportRemarks();
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4175,13 +4175,50 @@ static std::string getDeclName(Decl *decl) {
   return "";
 }
 
+StringRef getClangDeclDescription(const clang::Decl *D) {
+  switch (D->getKind()) {
+  case clang::Decl::Kind::Record:
+    return "C struct";
+  case clang::Decl::Kind::Typedef:
+    return "C typedef";
+  case clang::Decl::Kind::ObjCInterface:
+    return "Objective-C class interface";
+  case clang::Decl::Kind::ObjCMethod:
+    return "Objective-C method";
+  case clang::Decl::Kind::ObjCIvar:
+    return "Objective-C instance variable";
+  case clang::Decl::Kind::ObjCProperty:
+    return "Objective-C property";
+  case clang::Decl::Kind::ObjCProtocol:
+    return "Objective-C protocol";
+  case clang::Decl::Kind::ObjCCategory:
+    return "Objective-C category";
+  case clang::Decl::Kind::Function:
+    return "C function";
+  case clang::Decl::Kind::Field:
+    return "C field";
+  case clang::Decl::Kind::Enum:
+    return "C enum";
+  case clang::Decl::Kind::EnumConstant:
+    return "C enum constant";
+  case clang::Decl::Kind::Var:
+    return "C variable";
+  default:
+    return D->getDeclKindName();
+  }
+}
+
 void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
+  StringRef clangDeclKind = getClangDeclDescription(clangDecl);
+  const clang::NamedDecl *namedClangDecl = dyn_cast<clang::NamedDecl>(clangDecl);
+
   switch (reason) {
   case ImportReason::Unspecified:
     if (swiftDecl) {
       auto name = getDeclName(swiftDecl);
       if (!name.empty())
         ::diagnose(impl, clangDecl, version, diag::imported_clang_decl_as,
+                   clangDeclKind, namedClangDecl,
                    swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
                    swiftDecl->getDescriptiveKind(), name);
 
@@ -4190,11 +4227,13 @@ void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
         if (!name.empty())
           ::diagnose(impl, clangDecl, version,
                      diag::also_imported_clang_decl_as,
+                     clangDeclKind, namedClangDecl,
                      altDecl->getAttrs().isUnavailable(impl.SwiftContext),
                      altDecl->getDescriptiveKind(), name);
       }
     } else {
-      ::diagnose(impl, clangDecl, version, diag::did_not_import_clang_decl);
+      ::diagnose(impl, clangDecl, version, diag::did_not_import_clang_decl,
+                 clangDeclKind, namedClangDecl);
     }
     break;
 
@@ -4204,6 +4243,7 @@ void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
 
   default:
     ::diagnose(impl, clangDecl, version,
-               diag::did_not_import_clang_decl_because, (uint8_t)reason);
+               diag::did_not_import_clang_decl_because,
+               clangDeclKind, namedClangDecl, (uint8_t)reason);
   }
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4011,10 +4011,11 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
 }
 
 void ClangImporter::dumpSwiftLookupTables() {
-  Impl.dumpSwiftLookupTables();
+  Impl.dumpSwiftLookupTables(llvm::dbgs());
 }
 
-void ClangImporter::Implementation::dumpSwiftLookupTables() {
+void ClangImporter::Implementation::
+dumpSwiftLookupTables(llvm::raw_ostream &os) const {
   // Sort the module names so we can print in a deterministic order.
   SmallVector<StringRef, 4> moduleNames;
   for (const auto &lookupTable : LookupTables) {
@@ -4024,13 +4025,16 @@ void ClangImporter::Implementation::dumpSwiftLookupTables() {
 
   // Print out the lookup tables for the various modules.
   for (auto moduleName : moduleNames) {
-    llvm::errs() << "<<" << moduleName << " lookup table>>\n";
-    LookupTables[moduleName]->deserializeAll();
-    LookupTables[moduleName]->dump(llvm::errs());
+    os << "<<" << moduleName << " lookup table>>\n";
+    auto iter = LookupTables.find(moduleName);
+    if (iter != LookupTables.end()) {
+      iter->getSecond()->deserializeAll();
+      iter->getSecond()->dump(os);
+    }
   }
 
-  llvm::errs() << "<<Bridging header lookup table>>\n";
-  BridgingHeaderLookupTable->dump(llvm::errs());
+  os << "<<Bridging header lookup table>>\n";
+  BridgingHeaderLookupTable->dump(os);
 }
 
 DeclName ClangImporter::

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4093,8 +4093,7 @@ shouldEmitImportRemark(const ImportRemark &remark) {
   if (remark.version != CurrentVersion)
     return false;
 
-  bool success = remark.swiftDecl != nullptr
-              || remark.reason == ImportReason::AlreadyDecided;
+  bool success = remark.getSwiftDecl() != nullptr || !remark.getShouldEmit();
   auto &opts = SwiftContext.ClangImporterOpts;
 
   // FIXME: String comparison is a pretty silly way to check for membership in a
@@ -4151,31 +4150,7 @@ void ClangImporter::emitImportRemarks() {
   Impl.emitImportRemarks();
 }
 
-template<typename ...ArgTypes>
-static void diagnose(ClangImporter::Implementation &impl,
-                     const clang::Decl *clangDecl,
-                     importer::ImportNameVersion version,
-                     Diag<ArgTypes...> id,
-                     typename detail::PassArgument<ArgTypes>::type... args) {
-  if (version == importer::ImportNameVersion::raw()) return;
-
-  SourceLoc loc = impl.getBufferImporterForDiagnostics()
-      .resolveSourceLocation(impl.getClangASTContext().getSourceManager(),
-                             clangDecl->getLocation());
-  if (!loc.isValid()) return;
-
-  impl.SwiftContext.Diags.diagnose(loc, id, std::move(args)...);
-}
-
-static std::string getDeclName(Decl *decl) {
-  if (auto *VD = dyn_cast<ValueDecl>(decl))
-    return VD->printRef();
-  if (auto *ED = dyn_cast<ExtensionDecl>(decl))
-    return "extension " + ED->getExtendedType().getString();
-  return "";
-}
-
-StringRef getClangDeclDescription(const clang::Decl *D) {
+StringRef swift::importer::getClangDescriptiveKind(const clang::Decl *D) {
   switch (D->getKind()) {
   case clang::Decl::Kind::Record:
     return "C struct";
@@ -4196,6 +4171,7 @@ StringRef getClangDeclDescription(const clang::Decl *D) {
   case clang::Decl::Kind::Function:
     return "C function";
   case clang::Decl::Kind::Field:
+  case clang::Decl::Kind::IndirectField:
     return "C field";
   case clang::Decl::Kind::Enum:
     return "C enum";
@@ -4209,41 +4185,79 @@ StringRef getClangDeclDescription(const clang::Decl *D) {
 }
 
 void ImportRemark::diagnose(ClangImporter::Implementation &impl) {
-  StringRef clangDeclKind = getClangDeclDescription(clangDecl);
-  const clang::NamedDecl *namedClangDecl = dyn_cast<clang::NamedDecl>(clangDecl);
+  if (version == importer::ImportNameVersion::raw()) return;
 
-  switch (reason) {
-  case ImportReason::Unspecified:
-    if (swiftDecl) {
-      auto name = getDeclName(swiftDecl);
-      if (!name.empty())
-        ::diagnose(impl, clangDecl, version, diag::imported_clang_decl_as,
-                   clangDeclKind, namedClangDecl,
-                   swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
-                   swiftDecl->getDescriptiveKind(), name);
+  auto getSourceLoc = [&](clang::SourceLocation clangLoc) -> SourceLoc {
+    return impl.getBufferImporterForDiagnostics()
+        .resolveSourceLocation(impl.getClangASTContext().getSourceManager(),
+                               clangLoc);
+  };
+  
+  SourceLoc remarkLoc = getSourceLoc(clangDecl->getLocation());
+  if (!remarkLoc.isValid()) return;
 
-      for (auto *altDecl : alternateSwiftDecls) {
-        auto name = getDeclName(altDecl);
-        if (!name.empty())
-          ::diagnose(impl, clangDecl, version,
-                     diag::also_imported_clang_decl_as,
-                     clangDeclKind, namedClangDecl,
-                     altDecl->getAttrs().isUnavailable(impl.SwiftContext),
-                     altDecl->getDescriptiveKind(), name);
-      }
+  auto &diags = impl.SwiftContext.Diags;
+  StringRef clangDeclKind = getClangDescriptiveKind(clangDecl);
+  const clang::NamedDecl *namedClangDecl =
+      dyn_cast<clang::NamedDecl>(clangDecl);
+
+  auto diagnoseImport =
+      [&](Decl *swiftDecl, bool isAlternate) -> InFlightDiagnostic {
+    if (auto *ED = dyn_cast<ExtensionDecl>(swiftDecl))
+      return diags
+          .diagnose(remarkLoc, diag::imported_clang_decl_as_extension,
+                    clangDeclKind, namedClangDecl, isAlternate,
+                    swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
+                    ED->getExtendedType());
+    else if (auto *AD = dyn_cast<AccessorDecl>(swiftDecl))
+      return diags
+          .diagnose(remarkLoc, diag::imported_clang_decl_as_accessor,
+                    clangDeclKind, namedClangDecl, isAlternate,
+                    swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
+                    AD->getDescriptiveKind(),
+                    AD->getStorage()->getDescriptiveKind(), AD->getStorage());
+
+    // Any other decl. If it's not a ValueDecl, we'll pass nullptr and end up
+    // not showing an identifier.
+    return diags
+        .diagnose(remarkLoc, diag::imported_clang_decl_as,
+                  clangDeclKind, namedClangDecl, isAlternate,
+                  swiftDecl->getAttrs().isUnavailable(impl.SwiftContext),
+                  swiftDecl->getDescriptiveKind(),
+                  dyn_cast<ValueDecl>(swiftDecl));
+  };
+
+  if (getShouldEmit()) {
+    Optional<InFlightDiagnostic> remarkDiag;
+
+    if (getOutcome() == Outcome::Imported) {
+      remarkDiag.emplace(diagnoseImport(getSwiftDecl(), false));
     } else {
-      ::diagnose(impl, clangDecl, version, diag::did_not_import_clang_decl,
-                 clangDeclKind, namedClangDecl);
+      remarkDiag.emplace(
+          diags.diagnose(remarkLoc, diag::did_not_import_clang_decl,
+                         clangDeclKind, namedClangDecl));
     }
-    break;
 
-  case ImportReason::AlreadyDecided:
-    // Emit nothing.
-    break;
-
-  default:
-    ::diagnose(impl, clangDecl, version,
-               diag::did_not_import_clang_decl_because,
-               clangDeclKind, namedClangDecl, (uint8_t)reason);
+    diags.diagnoseWithNotes(std::move(*remarkDiag), [&] {
+      // Typically, a note is added after observing a failure, so the earlier
+      // notes have more specifics while the later ones have more context. This
+      // is most understandable if they're read in the opposite order, so we
+      // emit them in reverse.
+      for (auto &note : llvm::reverse(notes)) {
+        if (!note.conditions.contains(getOutcome()))
+          continue;
+        
+        SourceLoc noteLoc = remarkLoc;
+        if (note.location)
+          noteLoc = getSourceLoc(*note.location);
+        diags.diagnose(noteLoc, note.diagnostic);
+      }
+    });
   }
+
+  // Emit even when getShouldEmit() is false, because alreadyDecided() is
+  // sometimes used when we need to add alternative declarations to a main
+  // declaration that we've already imported.
+  for (auto *altDecl : alternateSwiftDecls)
+    diagnoseImport(altDecl, true);
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2241,8 +2241,12 @@ namespace {
   /// Convert Clang declarations into the corresponding Swift
   /// declarations.
   class SwiftDeclConverter
-    : public clang::ConstDeclVisitor<SwiftDeclConverter, Decl *>
+    : private clang::ConstDeclVisitor<SwiftDeclConverter, Decl *>
   {
+    friend class clang::ConstDeclVisitor<SwiftDeclConverter, Decl *>;
+    friend class clang::declvisitor::Base<llvm::make_const_ptr,
+                                          SwiftDeclConverter, Decl *>;
+
     ClangImporter::Implementation &Impl;
     bool forwardDeclaration = false;
     ImportNameVersion version;
@@ -2418,7 +2422,6 @@ namespace {
               name.getInitKind() == CtorInitializerKind::ConvenienceFactory);
     }
 
-  public:
     explicit SwiftDeclConverter(ClangImporter::Implementation &impl,
                                 ImportNameVersion vers)
       : Impl(impl), version(vers) { }
@@ -3107,7 +3110,12 @@ namespace {
             return true;
           });
           break;
-        case EnumKind::Options:
+        case EnumKind::Options: {
+          clang::PrettyStackTraceDecl(
+              constant, clang::SourceLocation(),
+              Impl.getClangASTContext().getSourceManager(),
+              "importing clang OptionSet constant");
+
           Impl.forEachDistinctName(constant,
                                    [&](ImportedName newName,
                                        ImportNameVersion nameVersion) -> bool {
@@ -3125,8 +3133,14 @@ namespace {
             return true;
           });
           break;
+        }
         case EnumKind::NonFrozenEnum:
         case EnumKind::FrozenEnum: {
+          clang::PrettyStackTraceDecl(
+              constant, clang::SourceLocation(),
+              Impl.getClangASTContext().getSourceManager(),
+              "importing clang enum case");
+
           auto canonicalCaseIter =
             canonicalEnumConstants.find(&constant->getInitVal());
 
@@ -3607,7 +3621,7 @@ namespace {
                                           clang::APValue(decl->getInitVal()),
                                           ConstantConvertKind::Construction,
                                           /*static*/ false, decl);
-        Impl.cacheImportedDecl(result, decl, getVersion());
+        Impl.cacheImportedDecl(result, decl, version);
 
         // If this is a compatibility stub, mark it as such.
         if (correctSwiftName)
@@ -4525,6 +4539,7 @@ namespace {
       // FIXME: Is there an IBSegueAction equivalent?
 
       // Check whether there's some special method to import.
+      // (If we're forcing a class method, one of our callers will do it.)
       if (!forceClassMethod) {
         if (dc == Impl.importDeclContextOf(decl, decl->getDeclContext()) &&
             !Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}])
@@ -4548,7 +4563,6 @@ namespace {
       return result;
     }
 
-  public:
     /// Record the function or initializer overridden by the given Swift method.
     void recordObjCOverride(AbstractFunctionDecl *decl);
 
@@ -4614,8 +4628,6 @@ namespace {
                                  AccessorKind accessorKind,
                                  DeclContext *dc);
 
-  public:
-
     /// Recursively add the given protocol and its inherited protocols to the
     /// given vector, guarded by the known set of protocols.
     void addProtocols(ProtocolDecl *protocol,
@@ -4635,31 +4647,6 @@ namespace {
     Optional<GenericParamList *>
     importObjCGenericParams(const clang::ObjCInterfaceDecl *decl,
                             DeclContext *dc);
-
-    /// Import the members of all of the protocols to which the given
-    /// Objective-C class, category, or extension explicitly conforms into
-    /// the given list of members, so long as the method was not already
-    /// declared in the class.
-    ///
-    /// FIXME: This whole thing is a hack, because name lookup should really
-    /// just find these members when it looks in the protocol. Unfortunately,
-    /// that's not something the name lookup code can handle right now, and
-    /// it may still be necessary when the protocol's instance methods become
-    /// class methods on a root class (e.g. NSObject-the-protocol's instance
-    /// methods become class methods on NSObject).
-    void importMirroredProtocolMembers(const clang::ObjCContainerDecl *decl,
-                                       DeclContext *dc,
-                                       Optional<DeclBaseName> name,
-                                       SmallVectorImpl<Decl *> &newMembers);
-
-    void importNonOverriddenMirroredMethods(DeclContext *dc,
-                                  MutableArrayRef<MirroredMethodEntry> entries,
-                                  SmallVectorImpl<Decl *> &newMembers);
-
-    /// Import constructors from our superclasses (and their
-    /// categories/extensions), effectively "inheriting" constructors.
-    void importInheritedConstructors(const ClassDecl *classDecl,
-                                     SmallVectorImpl<Decl *> &newMembers);
 
     Decl *VisitObjCCategoryDecl(const clang::ObjCCategoryDecl *decl) {
       // If the declaration is invalid, fail.
@@ -5386,6 +5373,59 @@ namespace {
       // Rather, they are understood from the module itself.
       return nullptr;
     }
+
+  public:
+    /// Perform an ordinary import of a clang declaration.
+    static std::tuple<Decl *, /*hadForwardDeclaration=*/bool>
+    importDecl(ClangImporter::Implementation &Impl,
+               ImportNameVersion version,
+               const clang::Decl *ClangDecl) {
+      SwiftDeclConverter converter(Impl, version);
+      auto Result = converter.Visit(ClangDecl);
+      return std::make_tuple(Result, converter.hadForwardDeclaration());
+    }
+
+    /// Import the members of all of the protocols to which the given
+    /// Objective-C class, category, or extension explicitly conforms into
+    /// the given list of members, so long as the method was not already
+    /// declared in the class.
+    ///
+    /// FIXME: This whole thing is a hack, because name lookup should really
+    /// just find these members when it looks in the protocol. Unfortunately,
+    /// that's not something the name lookup code can handle right now, and
+    /// it may still be necessary when the protocol's instance methods become
+    /// class methods on a root class (e.g. NSObject-the-protocol's instance
+    /// methods become class methods on NSObject).
+    static void
+    importMirroredProtocolMembers(ClangImporter::Implementation &Impl,
+                                  ImportNameVersion version,
+                                  const clang::ObjCContainerDecl *decl,
+                                  DeclContext *dc,
+                                  Optional<DeclBaseName> name,
+                                  SmallVectorImpl<Decl *> &newMembers);
+
+    static void
+    importNonOverriddenMirroredMethods(ClangImporter::Implementation &Impl,
+                                       ImportNameVersion version,
+                                       DeclContext *dc,
+                                  MutableArrayRef<MirroredMethodEntry> entries,
+                                       SmallVectorImpl<Decl *> &newMembers);
+
+    static std::tuple<Decl *, /*hadForwardDeclaration=*/bool>
+    importMirroredDecl(ClangImporter::Implementation &Impl,
+                       ImportNameVersion version,
+                       const clang::NamedDecl *decl,
+                       DeclContext *dc,
+                       ProtocolDecl *proto);
+
+    /// Import constructors from our superclasses (and their
+    /// categories/extensions), effectively "inheriting" constructors.
+    static void
+    importInheritedConstructors(ClangImporter::Implementation &Impl,
+                                ImportNameVersion version,
+                                const ClassDecl *classDecl,
+                                SmallVectorImpl<Decl *> &newMembers);
+
   };
 } // end anonymous namespace
 
@@ -7090,11 +7130,12 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
 void ClangImporter::Implementation::importMirroredProtocolMembers(
     const clang::ObjCContainerDecl *decl, DeclContext *dc,
     Optional<DeclBaseName> name, SmallVectorImpl<Decl *> &members) {
-  SwiftDeclConverter converter(*this, CurrentVersion);
-  converter.importMirroredProtocolMembers(decl, dc, name, members);
+  SwiftDeclConverter::importMirroredProtocolMembers(*this, CurrentVersion,
+                                                    decl, dc, name, members);
 }
 
 void SwiftDeclConverter::importMirroredProtocolMembers(
+    ClangImporter::Implementation &Impl, ImportNameVersion version,
     const clang::ObjCContainerDecl *decl, DeclContext *dc,
     Optional<DeclBaseName> name, SmallVectorImpl<Decl *> &members) {
   assert(dc);
@@ -7158,7 +7199,7 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         bool inNearbyCategory =
             std::any_of(interfaceDecl->known_categories_begin(),
                         interfaceDecl->known_categories_end(),
-                        [=](const clang::ObjCCategoryDecl *category) -> bool {
+                  [=, &Impl](const clang::ObjCCategoryDecl *category) -> bool {
                           if (!Impl.getClangSema().isVisible(category)) {
                             return false;
                           }
@@ -7176,7 +7217,7 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
           return;
 
         if (auto imported =
-                Impl.importMirroredDecl(objcProp, dc, getVersion(), proto)) {
+                Impl.importMirroredDecl(objcProp, dc, version, proto)) {
           members.push_back(imported);
           // FIXME: We should mirror properties of the root class onto the
           // metatype.
@@ -7224,7 +7265,8 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
 
   // Process all the methods, now that we've arranged them by selector.
   for (auto &mapEntry : methodsByName) {
-    importNonOverriddenMirroredMethods(dc, mapEntry.second, members);
+    importNonOverriddenMirroredMethods(Impl, version, dc, mapEntry.second,
+                                       members);
   }
 }
 
@@ -7317,9 +7359,11 @@ static bool suppressOverriddenMethods(ClangImporter::Implementation &importer,
 /// It's possible that we'll end up selecting multiple methods to import
 /// here, in the cases where there's no hierarchical relationship between
 /// two methods.  The importer already has code to handle this case.
-void SwiftDeclConverter::importNonOverriddenMirroredMethods(DeclContext *dc,
-                               MutableArrayRef<MirroredMethodEntry> entries,
-                                           SmallVectorImpl<Decl *> &members) {
+void SwiftDeclConverter::
+importNonOverriddenMirroredMethods(ClangImporter::Implementation &Impl,
+                                   ImportNameVersion version, DeclContext *dc,
+                                   MutableArrayRef<MirroredMethodEntry> entries,
+                                   SmallVectorImpl<Decl *> &members) {
   for (size_t i = 0, e = entries.size(); i != e; ++i) {
     auto objcMethod = entries[i].first;
 
@@ -7339,7 +7383,13 @@ void SwiftDeclConverter::importNonOverriddenMirroredMethods(DeclContext *dc,
     // When mirroring an initializer, make it designated and required.
     if (isInitMethod(objcMethod)) {
       // Import the constructor.
-      if (auto imported = importConstructor(objcMethod, dc, /*implicit=*/true,
+      clang::PrettyStackTraceDecl trace(objcMethod, clang::SourceLocation(),
+                                        Impl.getClangASTContext()
+                                            .getSourceManager(),
+                                        "import (mirrored) initializer");
+      SwiftDeclConverter converter(Impl, version);
+      if (auto imported = converter.importConstructor(
+                                            objcMethod, dc, /*implicit=*/true,
                                             CtorInitializerKind::Designated,
                                             /*required=*/true)) {
         members.push_back(imported);
@@ -7350,7 +7400,7 @@ void SwiftDeclConverter::importNonOverriddenMirroredMethods(DeclContext *dc,
     // Import the method.
     auto proto = entries[i].second;
     if (auto imported =
-            Impl.importMirroredDecl(objcMethod, dc, getVersion(), proto)) {
+            Impl.importMirroredDecl(objcMethod, dc, version, proto)) {
       members.push_back(imported);
 
       for (auto alternate : Impl.getAlternateDecls(imported))
@@ -7361,6 +7411,7 @@ void SwiftDeclConverter::importNonOverriddenMirroredMethods(DeclContext *dc,
 }
 
 void SwiftDeclConverter::importInheritedConstructors(
+    ClangImporter::Implementation &Impl, ImportNameVersion version,
     const ClassDecl *classDecl, SmallVectorImpl<Decl *> &newMembers) {
   auto superclassDecl = classDecl->getSuperclassDecl();
   if (!superclassDecl)
@@ -7415,6 +7466,7 @@ void SwiftDeclConverter::importInheritedConstructors(
     clang::PrettyStackTraceDecl trace(objcMethod, clang::SourceLocation(),
                                       clangSourceMgr,
                                       "importing (inherited)");
+    SwiftDeclConverter converter(Impl, version);
 
     // If this initializer came from a factory method, inherit
     // it as an initializer.
@@ -7423,21 +7475,21 @@ void SwiftDeclConverter::importInheritedConstructors(
 
       Optional<ImportedName> correctSwiftName;
       ImportedName importedName =
-          importFullName(objcMethod, correctSwiftName);
+          converter.importFullName(objcMethod, correctSwiftName);
       assert(
           !correctSwiftName &&
           "Import inherited initializers never references correctSwiftName");
       importedName.setHasCustomName();
       ConstructorDecl *existing;
       if (auto newCtor =
-              importConstructor(objcMethod, classDecl,
-                                /*implicit=*/true, ctor->getInitKind(),
-                                /*required=*/false, ctor->getObjCSelector(),
-                                importedName, objcMethod->parameters(),
-                                objcMethod->isVariadic(), existing)) {
+          converter.importConstructor(objcMethod, classDecl, /*implicit=*/true,
+                                      ctor->getInitKind(), /*required=*/false,
+                                      ctor->getObjCSelector(), importedName,
+                                      objcMethod->parameters(),
+                                      objcMethod->isVariadic(), existing)) {
         // If this is a compatibility stub, mark it as such.
         if (correctSwiftName)
-          markAsVariant(newCtor, *correctSwiftName);
+          converter.markAsVariant(newCtor, *correctSwiftName);
 
         Impl.importAttributes(objcMethod, newCtor, curObjCClass);
         newMembers.push_back(newCtor);
@@ -7469,8 +7521,8 @@ void SwiftDeclConverter::importInheritedConstructors(
 
     // Import the constructor into this context.
     if (auto newCtor =
-            importConstructor(objcMethod, classDecl,
-                              /*implicit=*/true, myKind, isRequired)) {
+        converter.importConstructor(objcMethod, classDecl,
+                                    /*implicit=*/true, myKind, isRequired)) {
       Impl.importAttributes(objcMethod, newCtor, curObjCClass);
       newMembers.push_back(newCtor);
     }
@@ -7849,9 +7901,8 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
   }
 
   if (!Result) {
-    SwiftDeclConverter converter(*this, version);
-    Result = converter.Visit(ClangDecl);
-    HadForwardDeclaration = converter.hadForwardDeclaration();
+    std::tie(Result, HadForwardDeclaration) =
+      SwiftDeclConverter::importDecl(*this, version, ClangDecl);
   }
   if (!Result && version == CurrentVersion) {
     // If we couldn't import this Objective-C entity, determine
@@ -8119,12 +8170,32 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   }
 
   if (!HadForwardDeclaration)
+    // FIXME: may have been called earlier; decide if that's okay
     cacheImportedDecl(Result, Canon, version);
 
   if (!SuperfluousTypedefsAreTransparent && TypedefIsSuperfluous)
     return nullptr;
 
   return Result;
+}
+
+std::tuple<Decl *, /*hadForwardDeclaration=*/bool>
+SwiftDeclConverter::importMirroredDecl(ClangImporter::Implementation &Impl,
+                                       ImportNameVersion version,
+                                       const clang::NamedDecl *decl,
+                                       DeclContext *dc, ProtocolDecl *proto) {
+  SwiftDeclConverter converter(Impl, version);
+
+  Decl *result;
+  if (auto method = dyn_cast<clang::ObjCMethodDecl>(decl)) {
+    result = converter.importObjCMethodDecl(method, dc, /*accessor*/None);
+  } else if (auto prop = dyn_cast<clang::ObjCPropertyDecl>(decl)) {
+    result = converter.importObjCPropertyDecl(prop, dc);
+  } else {
+    llvm_unreachable("unexpected mirrored decl");
+  }
+
+  return std::make_tuple(result, converter.hadForwardDeclaration());
 }
 
 Decl *
@@ -8145,15 +8216,10 @@ ClangImporter::Implementation::importMirroredDecl(const clang::NamedDecl *decl,
   if (known != ImportedProtocolDecls.end())
     return known->second;
 
-  SwiftDeclConverter converter(*this, version);
   Decl *result;
-  if (auto method = dyn_cast<clang::ObjCMethodDecl>(decl)) {
-    result = converter.importObjCMethodDecl(method, dc, /*accessor*/None);
-  } else if (auto prop = dyn_cast<clang::ObjCPropertyDecl>(decl)) {
-    result = converter.importObjCPropertyDecl(prop, dc);
-  } else {
-    llvm_unreachable("unexpected mirrored decl");
-  }
+  bool hadForwardDeclaration;
+  std::tie(result, hadForwardDeclaration) =
+      SwiftDeclConverter::importMirroredDecl(*this, version, decl, dc, proto);
 
   if (result) {
     assert(result->getClangDecl() && result->getClangDecl() == canon);
@@ -8183,7 +8249,7 @@ ClangImporter::Implementation::importMirroredDecl(const clang::NamedDecl *decl,
     for (auto alternate : getAlternateDecls(result))
       updateMirroredDecl(alternate);
   }
-  if (result || !converter.hadForwardDeclaration())
+  if (result || !hadForwardDeclaration)
     ImportedProtocolDecls[std::make_tuple(canon, dc, version)] = result;
   return result;
 }
@@ -8872,8 +8938,8 @@ void ClangImporter::Implementation::importInheritedConstructors(
      const clang::ObjCInterfaceDecl *curObjCClass,
      const ClassDecl *classDecl, SmallVectorImpl<Decl *> &newMembers) {
   if (curObjCClass->getName() != "Protocol") {
-    SwiftDeclConverter converter(*this, CurrentVersion);
-    converter.importInheritedConstructors(classDecl, newMembers);
+    SwiftDeclConverter::importInheritedConstructors(*this, CurrentVersion,
+                                                    classDecl, newMembers);
   }
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1665,8 +1665,9 @@ static void makeStructRawValuedWithBridge(
 /// Build a declaration for an Objective-C subscript getter.
 static AccessorDecl *
 buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
-                         SubscriptDecl *subscript, const FuncDecl *getter,
-                         Type elementTy, DeclContext *dc, ParamDecl *index) {
+                         SubscriptDecl *subscript, FuncDecl *getter,
+                         Type elementTy, DeclContext *dc, ParamDecl *index,
+                         ImportDecision &decision) {
   auto &C = Impl.SwiftContext;
   auto loc = getter->getLoc();
 
@@ -1694,15 +1695,18 @@ buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
   thunk->setIsDynamic(getter->isDynamic());
   // FIXME: Should we record thunks?
 
+  decision.importAlternate(getter, thunk);
+
   return thunk;
 }
 
 /// Build a declaration for an Objective-C subscript setter.
 static AccessorDecl *
 buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
-                         SubscriptDecl *subscript, const FuncDecl *setter,
+                         SubscriptDecl *subscript, FuncDecl *setter,
                          Type elementInterfaceTy,
-                         DeclContext *dc, ParamDecl *index) {
+                         DeclContext *dc, ParamDecl *index,
+                         ImportDecision &decision) {
   auto &C = Impl.SwiftContext;
   auto loc = setter->getLoc();
 
@@ -1744,6 +1748,8 @@ buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
     thunk->getAttrs().add(objcAttr->clone(C));
   thunk->setIsObjC(setter->isObjC());
   thunk->setIsDynamic(setter->isDynamic());
+
+  decision.importAlternate(setter, thunk);
 
   return thunk;
 }
@@ -4670,7 +4676,7 @@ namespace {
         if (importedName.isSubscriptAccessor()) {
           // If this was a subscript accessor, try to create a
           // corresponding subscript declaration.
-          (void)importSubscript(result, decl);
+          (void)importSubscript(result, decl, decision);
         } else if (shouldAlsoImportAsClassMethod(result)) {
           // If we should import this instance method also as a class
           // method, do so and mark the result as an alternate
@@ -4745,7 +4751,8 @@ namespace {
     /// Given either the getter or setter for a subscript operation,
     /// create the Swift subscript declaration.
     SubscriptDecl *importSubscript(Decl *decl,
-                                   const clang::ObjCMethodDecl *objcMethod);
+                                   const clang::ObjCMethodDecl *objcMethod,
+                                   ImportDecision &decision);
 
     // FIXME: Should be static, as it uses a separate decision.
     /// Import the accessor and its attributes.
@@ -7022,7 +7029,8 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
 /// create the Swift subscript declaration.
 SubscriptDecl *
 SwiftDeclConverter::importSubscript(Decl *decl,
-                                    const clang::ObjCMethodDecl *objcMethod) {
+                                    const clang::ObjCMethodDecl *objcMethod,
+                                    ImportDecision &decision) {
   assert(objcMethod->isInstanceMethod() && "Caller must filter");
 
   // If the method we're attempting to import has the
@@ -7082,26 +7090,38 @@ SwiftDeclConverter::importSubscript(Decl *decl,
         Impl.importDecl(counterpart, getActiveSwiftVersion()));
   };
 
-  // Determine the selector of the counterpart.
+  clang::Selector counterpartSelector;
+  // If we find a counterpart, an ImportDecision for it will be constructed
+  // here.
+  Optional<ImportDecision> counterpartDecision;
+
   FuncDecl *getter = nullptr, *setter = nullptr;
   const clang::ObjCMethodDecl *getterObjCMethod = nullptr,
                               *setterObjCMethod = nullptr;
-  clang::Selector counterpartSelector;
+  // One will point to `decision`; the other will remain null or point to
+  // `counterpartDecision`.
+  ImportDecision *getterDecision = nullptr, *setterDecision = nullptr;
+
+  // Determine the selector of the counterpart.
   if (objcMethod->getSelector() == Impl.objectAtIndexedSubscript) {
     getter = cast<FuncDecl>(decl);
     getterObjCMethod = objcMethod;
+    getterDecision = &decision;
     counterpartSelector = Impl.setObjectAtIndexedSubscript;
   } else if (objcMethod->getSelector() == Impl.setObjectAtIndexedSubscript) {
     setter = cast<FuncDecl>(decl);
     setterObjCMethod = objcMethod;
+    setterDecision = &decision;
     counterpartSelector = Impl.objectAtIndexedSubscript;
   } else if (objcMethod->getSelector() == Impl.objectForKeyedSubscript) {
     getter = cast<FuncDecl>(decl);
     getterObjCMethod = objcMethod;
+    getterDecision = &decision;
     counterpartSelector = Impl.setObjectForKeyedSubscript;
   } else if (objcMethod->getSelector() == Impl.setObjectForKeyedSubscript) {
     setter = cast<FuncDecl>(decl);
     setterObjCMethod = objcMethod;
+    setterDecision = &decision;
     counterpartSelector = Impl.objectForKeyedSubscript;
   } else {
     llvm_unreachable("Unknown getter/setter selector");
@@ -7124,6 +7144,11 @@ SwiftDeclConverter::importSubscript(Decl *decl,
       if (optionalMethods)
         optionalMethods = (counterpartMethod->getImplementationControl() ==
                            clang::ObjCMethodDecl::Optional);
+
+      counterpartDecision.emplace(Impl, counterpartMethod, version);
+      // The original import decision has already been made; we're just adding
+      // alternates.
+      counterpartDecision->alreadyDecided();
     }
 
     assert(!counterpart || !counterpart->isStatic());
@@ -7131,9 +7156,11 @@ SwiftDeclConverter::importSubscript(Decl *decl,
     if (getter) {
       setter = counterpart;
       setterObjCMethod = counterpartMethod;
+      setterDecision = counterpartDecision.getPointer();
     } else {
       getter = counterpart;
       getterObjCMethod = counterpartMethod;
+      getterDecision = counterpartDecision.getPointer();
     }
   }
 
@@ -7144,6 +7171,8 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   // Check whether we've already created a subscript operation for
   // this getter/setter pair.
   if (auto subscript = Impl.Subscripts[{getter, setter}]) {
+    // Not marking decision as alreadyDecided() because we are only deciding
+    // alternates in this method.
     return subscript->getDeclContext() == decl->getDeclContext() ? subscript
                                                                  : nullptr;
   }
@@ -7152,8 +7181,19 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   ParamDecl *getterIndex;
   {
     auto params = getter->getParameters();
-    if (params->size() != 1)
+    if (params->size() != 1) {
+      // Note on `decision`, rather than `getterDecision`, so that the user will
+      // actually see it even if the getter is the counterpart.
+      //
+      // FIXME: This feels like a flaw in ImportDecision's handling of alternate
+      // decls. Perhaps we ought to model alternate decls as their own
+      // ImportDecisions with their own success or failure outcomes.
+      decision.note(getterObjCMethod->getLocation(),
+                    diag::note_cannot_import_clang_ast_inconsistent,
+                    "would-be subscript getter has a one-argument selector, "
+                    "but its arity != 1");
       return nullptr;
+    }
     getterIndex = params->get(0);
   }
 
@@ -7173,6 +7213,27 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   bool getterAndSetterInSameType = false;
   bool isIUO = getter->isImplicitlyUnwrappedOptional();
   if (setter) {
+    auto noteTypeMismatch =
+        [&](bool isParamType, Type getterType, Type setterType) {
+          // Even if we import something, we didn't import this alternate, and
+          // we want ot make the reason known.
+          ImportRemark::Note::Conditions either{
+            ImportRemark::Outcome::Imported, ImportRemark::Outcome::NotImported
+          };
+          // We note on the setter so that we report subclasses that try to add
+          // a setter, but fail. We note *only* on the setter so we don't
+          // double-report if we also notice this condition while we're
+          // importing the getter.
+          setterDecision->
+              noteIf(either, getterObjCMethod->getLocation(),
+                     diag::note_cannot_import_subscript_setter_type_mismatch,
+                     getClangDescriptiveKind(setterObjCMethod),
+                     setterObjCMethod, setterType,
+                     getClangDescriptiveKind(getterObjCMethod),
+                     getterObjCMethod, getterType,
+                     isParamType);
+        };
+
     // Whether there is an existing read-only subscript for which
     // we have now found a setter.
     SubscriptDecl *existingSubscript = Impl.Subscripts[{getter, nullptr}];
@@ -7196,8 +7257,10 @@ SwiftDeclConverter::importSubscript(Decl *decl,
     // type.
     auto importedType = rectifySubscriptTypes(elementTy, isIUO, setterElementTy,
                                               canUpdateSubscriptType);
-    if (!importedType)
+    if (!importedType) {
+      noteTypeMismatch(false, elementTy, setterElementTy);
       return decl == getter ? existingSubscript : nullptr;
+    }
 
     isIUO = importedType.isImplicitlyUnwrapped();
 
@@ -7207,6 +7270,8 @@ SwiftDeclConverter::importSubscript(Decl *decl,
     // Make sure that the index types are equivalent.
     // FIXME: Rectify these the same way we do for element types.
     if (!setterIndex->getType()->isEqual(getterIndex->getType())) {
+      noteTypeMismatch(true, getterIndex->getType(), setterIndex->getType());
+
       // If there is an existing subscript operation, we're done.
       if (existingSubscript)
         return decl == getter ? existingSubscript : nullptr;
@@ -7216,6 +7281,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
       setter = nullptr;
       setterObjCMethod = nullptr;
       setterIndex = nullptr;
+      setterDecision = nullptr;
     }
 
     // If there is an existing subscript within this context, we
@@ -7227,7 +7293,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
         // Create the setter thunk.
         auto setterThunk = buildSubscriptSetterDecl(
             Impl, existingSubscript, setter, elementTy,
-            setter->getDeclContext(), setterIndex);
+            setter->getDeclContext(), setterIndex, *setterDecision);
 
         // Set the computed setter.
         existingSubscript->setComputedSetter(setterThunk);
@@ -7270,16 +7336,17 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   // Build the thunks.
   AccessorDecl *getterThunk =
       buildSubscriptGetterDecl(Impl, subscript, getter, elementTy,
-                               dc, getterIndex);
+                               dc, getterIndex, *getterDecision);
 
   AccessorDecl *setterThunk = nullptr;
   if (setter)
     setterThunk =
         buildSubscriptSetterDecl(Impl, subscript, setter, elementTy,
-                                 dc, setterIndex);
+                                 dc, setterIndex, *setterDecision);
 
   // Record the subscript as an alternative declaration.
-  Impl.addAlternateDecl(associateWithSetter ? setter : getter, subscript);
+  (associateWithSetter ? setterDecision : getterDecision)
+    ->importAndCacheAlternate(associateWithSetter ? setter : getter, subscript);
 
   // Import attributes for the accessors if there is a pair.
   Impl.importAttributes(getterObjCMethod, getterThunk);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8229,8 +8229,6 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
                                   "import-clang-decl", ClangDecl);
   clang::PrettyStackTraceDecl trace(ClangDecl, clang::SourceLocation(),
                                     Instance->getSourceManager(), "importing");
-  ImportDecision decision(*this, ClangDecl, version);
-
   assert((UseCanonicalDecl || isa<clang::ObjCCategoryDecl>(ClangDecl)) &&
          "should always UseCanonicalDecl for non-categories");
   auto Canon = cast<clang::NamedDecl>(UseCanonicalDecl? ClangDecl->getCanonicalDecl(): ClangDecl);
@@ -8239,7 +8237,6 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
     if (!SuperfluousTypedefsAreTransparent &&
         SuperfluousTypedefs.count(Canon))
       return nullptr;
-    decision.alreadyDecided();
     return Known;
   }
 
@@ -8247,6 +8244,8 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   bool HadForwardDeclaration = false;
 
   startedImportingEntity();
+  ImportDecision decision(*this, ClangDecl, version);
+
   Decl *Result = importDeclImpl(ClangDecl, version, TypedefIsSuperfluous,
                                 HadForwardDeclaration, decision);
   if (!Result)
@@ -8259,7 +8258,6 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   }
 
   if (!HadForwardDeclaration)
-    // FIXME: may have been called earlier; decide if that's okay
     decision.importAndCache(Result);
 
   if (!SuperfluousTypedefsAreTransparent && TypedefIsSuperfluous)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2825,6 +2825,176 @@ namespace {
       }
     };
 
+    static void
+    importEnumConstant(ClangImporter::Implementation &Impl,
+                       const clang::EnumConstantDecl *constant,
+                       const clang::EnumDecl *clangEnum,
+                       NominalTypeDecl *swiftEnum,
+                       NominalTypeDecl *errorWrapper,
+                       EnumKind enumKind,
+                       CaseCanonicalizer &canonicalEnumConstants) {
+      const clang::EnumDecl *canonicalClangDecl = clangEnum->getCanonicalDecl();
+      auto contextIsEnum = [&](const ImportedName &name) -> bool {
+        EffectiveClangContext importContext = name.getEffectiveContext();
+        switch (importContext.getKind()) {
+        case EffectiveClangContext::DeclContext:
+          return importContext.getAsDeclContext() == canonicalClangDecl;
+        case EffectiveClangContext::TypedefContext: {
+          auto *typedefName = importContext.getTypedefName();
+          clang::QualType underlyingTy = typedefName->getUnderlyingType();
+          return underlyingTy->getAsTagDecl() == canonicalClangDecl;
+        }
+        case EffectiveClangContext::UnresolvedContext:
+          // Assume this is a context other than the enum.
+          return false;
+        }
+        llvm_unreachable("unhandled kind");
+      };
+
+      // Declarations to add to the type as members. Note that we don't fill
+      // these in when we import a case as a free constant.
+      Decl *enumeratorDecl = nullptr;       ///< Primary member to add to type
+      TinyPtrVector<Decl *> variantDecls;   ///< Other members to add to type
+
+      switch (enumKind) {
+      case EnumKind::Constants:
+      case EnumKind::Unknown:
+        // We can import these via VisitEnumConstantDecl().
+        // FIXME: Could we just let that happen on demand, or do we need to
+        // force it here?
+        Impl.forEachDistinctName(constant,
+                                 [&](ImportedName newName,
+                                     ImportNameVersion nameVersion) -> bool {
+          return Impl.importDecl(constant, nameVersion);
+        });
+        break;
+
+      case EnumKind::Options: {
+        clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
+            Impl.getClangASTContext().getSourceManager(),
+            "importing option enum constant");
+        Impl.forEachDistinctName(constant,
+                                 [&](ImportedName newName,
+                                     ImportNameVersion nameVersion) -> bool {
+          if (!contextIsEnum(newName))
+            return true;
+
+          SwiftDeclConverter converter(Impl, nameVersion);
+          Decl *imported =
+              converter.importOptionConstant(constant, clangEnum, swiftEnum);
+          if (!imported)
+            return false;
+
+          Impl.cacheImportedDecl(imported, constant, nameVersion);
+          if (nameVersion == Impl.CurrentVersion)
+            enumeratorDecl = imported;
+          else
+            variantDecls.push_back(imported);
+          return true;
+        });
+        break;
+      }
+
+      case EnumKind::NonFrozenEnum:
+      case EnumKind::FrozenEnum: {
+        // Make sure we first import for the active version.
+        auto canonResult = canonicalEnumConstants.canonicalize(
+            constant, [&](auto unimported) -> auto {
+          clang::PrettyStackTraceDecl(unimported, clang::SourceLocation(),
+              Impl.getClangASTContext().getSourceManager(),
+              "importing canonical enum constant");
+          SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
+
+          auto imported = converter.importEnumCase(unimported, clangEnum,
+                                                   cast<EnumDecl>(swiftEnum));
+          return imported;
+        });
+        enumeratorDecl = canonResult.swiftCase;
+
+        // If this decl was non-canonical, and if we were able to import the
+        // canonical decl, add an alias for this decl.
+        if (canonResult.clangCase != constant && enumeratorDecl) {
+          ImportedName importedName =
+              Impl.importFullName(constant, Impl.CurrentVersion);
+          Identifier name = importedName.getDeclName().getBaseIdentifier();
+          if (name.empty()) {
+            // Clear the existing declaration so we don't try to process it
+            // twice later.
+            enumeratorDecl = nullptr;
+          } else {
+            auto original = cast<ValueDecl>(enumeratorDecl);
+
+            clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
+                Impl.getClangASTContext().getSourceManager(),
+                "importing alias enum constant");
+            SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
+            enumeratorDecl =
+                converter.importEnumCaseAlias(name, constant, original,
+                                              clangEnum, swiftEnum);
+          }
+        }
+
+        Impl.forEachDistinctName(constant,
+                                 [&](ImportedName newName,
+                                     ImportNameVersion nameVersion) -> bool {
+          if (nameVersion == Impl.CurrentVersion)
+            return true;
+          if (!contextIsEnum(newName))
+            return true;
+
+          clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
+              Impl.getClangASTContext().getSourceManager(),
+              "importing previous version enum constant");
+          SwiftDeclConverter converter(Impl, nameVersion);
+          Decl *imported = converter.importEnumCase(constant, clangEnum,
+                                                    cast<EnumDecl>(swiftEnum),
+                                                    enumeratorDecl);
+          if (!imported)
+            return false;
+          variantDecls.push_back(imported);
+          return true;
+        });
+        break;
+      }
+      }
+
+      if (!enumeratorDecl)
+        return;
+
+      // Add a member enumerator to the given nominal type.
+      auto addDecl = [&](NominalTypeDecl *nominal, Decl *decl) {
+        if (!decl) return;
+        nominal->addMember(decl);
+      };
+
+      addDecl(swiftEnum, enumeratorDecl);
+      for (auto *variant : variantDecls)
+        addDecl(swiftEnum, variant);
+
+      // If there is an error wrapper, add an alias within the
+      // wrapper to the corresponding value within the enumerator
+      // context.
+      if (!errorWrapper)
+        return;
+
+      auto enumeratorValue = cast<ValueDecl>(enumeratorDecl);
+      auto name = enumeratorValue->getBaseIdentifier();
+
+      clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
+          Impl.getClangASTContext().getSourceManager(),
+          "importing error wrapper alias constant");
+      SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
+
+      auto alias = converter.importEnumCaseAlias(name, constant,
+                                                 enumeratorValue,
+                                                 clangEnum, swiftEnum,
+                                                 errorWrapper);
+      if (!alias)
+        return;
+
+      addDecl(errorWrapper, alias);
+    }
+
     Decl *VisitEnumDecl(const clang::EnumDecl *decl) {
       decl = decl->getDefinition();
       if (!decl) {
@@ -3092,168 +3262,16 @@ namespace {
 
       Impl.cacheImportedDecl(result, decl, getVersion());
 
-      // Import each of the enumerators.
-      
-      bool addEnumeratorsAsMembers;
-      switch (enumKind) {
-      case EnumKind::Constants:
-      case EnumKind::Unknown:
-        addEnumeratorsAsMembers = false;
-        break;
-      case EnumKind::Options:
-      case EnumKind::NonFrozenEnum:
-      case EnumKind::FrozenEnum:
-        addEnumeratorsAsMembers = true;
-        break;
-      }
-
       // For NonFrozenEnum and FrozenEnum, we precompute this table and share it
       // between all cases we want to import. (The others don't use it, and the
       // CaseCanonicalizer knows to not bother building itself.)
       CaseCanonicalizer canonicalEnumConstants(Impl, enumKind, decl);
 
-      const clang::EnumDecl *canonicalClangDecl = decl->getCanonicalDecl();
-      auto contextIsEnum = [&](const ImportedName &name) -> bool {
-        EffectiveClangContext importContext = name.getEffectiveContext();
-        switch (importContext.getKind()) {
-        case EffectiveClangContext::DeclContext:
-          return importContext.getAsDeclContext() == canonicalClangDecl;
-        case EffectiveClangContext::TypedefContext: {
-          auto *typedefName = importContext.getTypedefName();
-          clang::QualType underlyingTy = typedefName->getUnderlyingType();
-          return underlyingTy->getAsTagDecl() == canonicalClangDecl;
-        }
-        case EffectiveClangContext::UnresolvedContext:
-          // Assume this is a context other than the enum.
-          return false;
-        }
-        llvm_unreachable("unhandled kind");
-      };
-
-      for (auto constant : decl->enumerators()) {
-        Decl *enumeratorDecl = nullptr;
-        TinyPtrVector<Decl *> variantDecls;
-        switch (enumKind) {
-        case EnumKind::Constants:
-        case EnumKind::Unknown:
-          Impl.forEachDistinctName(constant,
-                                   [&](ImportedName newName,
-                                       ImportNameVersion nameVersion) -> bool {
-            Decl *imported = Impl.importDecl(constant, nameVersion);
-            if (!imported)
-              return false;
-            if (nameVersion == getActiveSwiftVersion())
-              enumeratorDecl = imported;
-            else
-              variantDecls.push_back(imported);
-            return true;
-          });
-          break;
-        case EnumKind::Options: {
-          clang::PrettyStackTraceDecl(
-              constant, clang::SourceLocation(),
-              Impl.getClangASTContext().getSourceManager(),
-              "importing clang OptionSet constant");
-
-          Impl.forEachDistinctName(constant,
-                                   [&](ImportedName newName,
-                                       ImportNameVersion nameVersion) -> bool {
-            if (!contextIsEnum(newName))
-              return true;
-            SwiftDeclConverter converter(Impl, nameVersion);
-            Decl *imported =
-                converter.importOptionConstant(constant, decl, result);
-            if (!imported)
-              return false;
-            if (nameVersion == getActiveSwiftVersion())
-              enumeratorDecl = imported;
-            else
-              variantDecls.push_back(imported);
-            return true;
-          });
-          break;
-        }
-        case EnumKind::NonFrozenEnum:
-        case EnumKind::FrozenEnum: {
-          clang::PrettyStackTraceDecl(
-              constant, clang::SourceLocation(),
-              Impl.getClangASTContext().getSourceManager(),
-              "importing clang enum case");
-
-          auto canonResult = canonicalEnumConstants.canonicalize(
-              constant,
-              [&](auto unimported) -> auto {
-            return SwiftDeclConverter(Impl, getActiveSwiftVersion())
-                .importEnumCase(unimported, decl, cast<EnumDecl>(result));
-          });
-          enumeratorDecl = canonResult.swiftCase;
-
-          // If this decl was non-canonical, and if we were able to import the
-          // canonical decl, add an alias for this decl.
-          if (canonResult.clangCase != constant && enumeratorDecl) {
-            ImportedName importedName =
-                Impl.importFullName(constant, getActiveSwiftVersion());
-            Identifier name = importedName.getDeclName().getBaseIdentifier();
-            if (name.empty()) {
-              // Clear the existing declaration so we don't try to process it
-              // twice later.
-              enumeratorDecl = nullptr;
-            } else {
-              auto original = cast<ValueDecl>(enumeratorDecl);
-              enumeratorDecl = importEnumCaseAlias(name, constant, original,
-                                                   decl, result);
-            }
-          }
-
-          Impl.forEachDistinctName(constant,
-                                   [&](ImportedName newName,
-                                       ImportNameVersion nameVersion) -> bool {
-            if (nameVersion == getActiveSwiftVersion())
-              return true;
-            if (!contextIsEnum(newName))
-              return true;
-            SwiftDeclConverter converter(Impl, nameVersion);
-            Decl *imported =
-                converter.importEnumCase(constant, decl, cast<EnumDecl>(result),
-                                         enumeratorDecl);
-            if (!imported)
-              return false;
-            variantDecls.push_back(imported);
-            return true;
-          });
-          break;
-        }
-        }
-        if (!enumeratorDecl)
-          continue;
-
-        if (addEnumeratorsAsMembers) {
-          // Add a member enumerator to the given nominal type.
-          auto addDecl = [&](NominalTypeDecl *nominal, Decl *decl) {
-            if (!decl) return;
-            nominal->addMember(decl);
-          };
-
-          addDecl(result, enumeratorDecl);
-          for (auto *variant : variantDecls)
-            addDecl(result, variant);
-          
-          // If there is an error wrapper, add an alias within the
-          // wrapper to the corresponding value within the enumerator
-          // context.
-          if (errorWrapper) {
-            auto enumeratorValue = cast<ValueDecl>(enumeratorDecl);
-            auto name = enumeratorValue->getBaseIdentifier();
-            auto alias = importEnumCaseAlias(name,
-                                             constant,
-                                             enumeratorValue,
-                                             decl,
-                                             result,
-                                             errorWrapper);
-            addDecl(errorWrapper, alias);
-          }
-        }
-      }
+      // Import each of the enumerators.
+      for (auto constant : decl->enumerators())
+        SwiftDeclConverter::importEnumConstant(Impl, constant, decl, result,
+                                               errorWrapper, enumKind,
+                                               canonicalEnumConstants);
 
       return result;
     }
@@ -3658,6 +3676,7 @@ namespace {
         // The enumeration was mapped to a high-level Swift type, and its
         // elements were created as children of that enum. They aren't available
         // independently.
+        // See importEnumConstant().
 
         // FIXME: This is gross. We shouldn't have to import
         // everything to get at the individual constants.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2109,6 +2109,24 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
   return true;
 }
 
+static bool contextIsEnum(const ImportedName &name,
+                          const clang::EnumDecl *canonicalClangDecl) {
+  EffectiveClangContext importContext = name.getEffectiveContext();
+  switch (importContext.getKind()) {
+  case EffectiveClangContext::DeclContext:
+    return importContext.getAsDeclContext() == canonicalClangDecl;
+  case EffectiveClangContext::TypedefContext: {
+    auto *typedefName = importContext.getTypedefName();
+    clang::QualType underlyingTy = typedefName->getUnderlyingType();
+    return underlyingTy->getAsTagDecl() == canonicalClangDecl;
+  }
+  case EffectiveClangContext::UnresolvedContext:
+    // Assume this is a context other than the enum.
+    return false;
+  }
+  llvm_unreachable("unhandled kind");
+}
+
 using MirroredMethodEntry =
   std::pair<const clang::ObjCMethodDecl*, ProtocolDecl*>;
 
@@ -2777,6 +2795,34 @@ namespace {
                                            Identifier name,
                                            const clang::EnumDecl *decl);
 
+    static void
+    importEnumConstantAsOption(ClangImporter::Implementation &Impl,
+                               const clang::EnumConstantDecl *constant,
+                               const clang::EnumDecl *clangEnum,
+                               NominalTypeDecl *swiftEnum) {
+      const clang::EnumDecl *canonicalClangEnum = clangEnum->getCanonicalDecl();
+
+      clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
+          Impl.getClangASTContext().getSourceManager(),
+          "importing option enum constant");
+      Impl.forEachDistinctName(constant,
+                               [&](ImportedName newName,
+                                   ImportNameVersion nameVersion) -> bool {
+        if (!contextIsEnum(newName, canonicalClangEnum))
+          return true;
+
+        SwiftDeclConverter converter(Impl, nameVersion);
+        Decl *imported =
+            converter.importOptionConstant(constant, clangEnum, swiftEnum);
+        if (!imported)
+          return false;
+
+        Impl.cacheImportedDecl(imported, constant, nameVersion);
+        swiftEnum->addMember(imported);
+        return true;
+      });
+    }
+
     class CaseCanonicalizer {
     public:
       struct Result {
@@ -2789,12 +2835,8 @@ namespace {
                           APSIntRefDenseMapInfo> canonicalEnumConstants;
 
     public:
-      CaseCanonicalizer(ClangImporter::Implementation &Impl, EnumKind enumKind,
+      CaseCanonicalizer(ClangImporter::Implementation &Impl,
                         const clang::EnumDecl *decl) {
-        if (enumKind != EnumKind::NonFrozenEnum &&
-            enumKind != EnumKind::FrozenEnum)
-          return;
-
         for (auto constant : decl->enumerators()) {
           if (Impl.isUnavailableInSwift(constant))
             continue;
@@ -2826,145 +2868,74 @@ namespace {
     };
 
     static void
-    importEnumConstant(ClangImporter::Implementation &Impl,
+    importEnumConstantAsCaseOrAlias(ClangImporter::Implementation &Impl,
                        const clang::EnumConstantDecl *constant,
                        const clang::EnumDecl *clangEnum,
                        NominalTypeDecl *swiftEnum,
                        NominalTypeDecl *errorWrapper,
-                       EnumKind enumKind,
                        CaseCanonicalizer &canonicalEnumConstants) {
-      const clang::EnumDecl *canonicalClangDecl = clangEnum->getCanonicalDecl();
-      auto contextIsEnum = [&](const ImportedName &name) -> bool {
-        EffectiveClangContext importContext = name.getEffectiveContext();
-        switch (importContext.getKind()) {
-        case EffectiveClangContext::DeclContext:
-          return importContext.getAsDeclContext() == canonicalClangDecl;
-        case EffectiveClangContext::TypedefContext: {
-          auto *typedefName = importContext.getTypedefName();
-          clang::QualType underlyingTy = typedefName->getUnderlyingType();
-          return underlyingTy->getAsTagDecl() == canonicalClangDecl;
-        }
-        case EffectiveClangContext::UnresolvedContext:
-          // Assume this is a context other than the enum.
-          return false;
-        }
-        llvm_unreachable("unhandled kind");
-      };
+      const clang::EnumDecl *canonicalClangEnum = clangEnum->getCanonicalDecl();
 
-      // Declarations to add to the type as members. Note that we don't fill
-      // these in when we import a case as a free constant.
-      Decl *enumeratorDecl = nullptr;       ///< Primary member to add to type
-      TinyPtrVector<Decl *> variantDecls;   ///< Other members to add to type
+      // Make sure we first import for the active version.
+      auto canonResult = canonicalEnumConstants.canonicalize(
+          constant, [&](auto unimported) -> auto {
+        clang::PrettyStackTraceDecl(unimported, clang::SourceLocation(),
+            Impl.getClangASTContext().getSourceManager(),
+            "importing canonical enum constant");
+        SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
 
-      switch (enumKind) {
-      case EnumKind::Constants:
-        llvm_unreachable("VisitEnumDecl should bail before we get here.");
+        auto imported = converter.importEnumCase(unimported, clangEnum,
+                                                 cast<EnumDecl>(swiftEnum));
+        return imported;
+      });
 
-      case EnumKind::Unknown:
-        // We can import these on demand via VisitEnumConstantDecl().
+      if (!canonResult.swiftCase)
         return;
 
-      case EnumKind::Options: {
+      Decl *enumeratorDecl;
+      if (canonResult.clangCase == constant) {
+        enumeratorDecl = canonResult.swiftCase;
+      } else {
+        // If this decl was non-canonical, add an alias for this decl.
+        ImportedName importedName =
+            Impl.importFullName(constant, Impl.CurrentVersion);
+        Identifier name = importedName.getDeclName().getBaseIdentifier();
+        if (name.empty())
+          return;
+
         clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
             Impl.getClangASTContext().getSourceManager(),
-            "importing option enum constant");
-        Impl.forEachDistinctName(constant,
-                                 [&](ImportedName newName,
-                                     ImportNameVersion nameVersion) -> bool {
-          if (!contextIsEnum(newName))
-            return true;
+            "importing alias enum constant");
+        SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
 
-          SwiftDeclConverter converter(Impl, nameVersion);
-          Decl *imported =
-              converter.importOptionConstant(constant, clangEnum, swiftEnum);
-          if (!imported)
-            return false;
+        auto original = cast<ValueDecl>(canonResult.swiftCase);
+        enumeratorDecl = converter.importEnumCaseAlias(name, constant, original,
+                                                       clangEnum, swiftEnum);
+        if (!enumeratorDecl)
+          return;
+      }
+      swiftEnum->addMember(enumeratorDecl);
 
-          Impl.cacheImportedDecl(imported, constant, nameVersion);
-          if (nameVersion == Impl.CurrentVersion)
-            enumeratorDecl = imported;
-          else
-            variantDecls.push_back(imported);
+      Impl.forEachDistinctName(constant,
+                               [&](ImportedName newName,
+                                   ImportNameVersion nameVersion) -> bool {
+        if (nameVersion == Impl.CurrentVersion)
           return true;
-        });
-        break;
-      }
-
-      case EnumKind::NonFrozenEnum:
-      case EnumKind::FrozenEnum: {
-        // Make sure we first import for the active version.
-        auto canonResult = canonicalEnumConstants.canonicalize(
-            constant, [&](auto unimported) -> auto {
-          clang::PrettyStackTraceDecl(unimported, clang::SourceLocation(),
-              Impl.getClangASTContext().getSourceManager(),
-              "importing canonical enum constant");
-          SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
-
-          auto imported = converter.importEnumCase(unimported, clangEnum,
-                                                   cast<EnumDecl>(swiftEnum));
-          return imported;
-        });
-        enumeratorDecl = canonResult.swiftCase;
-
-        // If this decl was non-canonical, and if we were able to import the
-        // canonical decl, add an alias for this decl.
-        if (canonResult.clangCase != constant && enumeratorDecl) {
-          ImportedName importedName =
-              Impl.importFullName(constant, Impl.CurrentVersion);
-          Identifier name = importedName.getDeclName().getBaseIdentifier();
-          if (name.empty()) {
-            // Clear the existing declaration so we don't try to process it
-            // twice later.
-            enumeratorDecl = nullptr;
-          } else {
-            auto original = cast<ValueDecl>(enumeratorDecl);
-
-            clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
-                Impl.getClangASTContext().getSourceManager(),
-                "importing alias enum constant");
-            SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
-            enumeratorDecl =
-                converter.importEnumCaseAlias(name, constant, original,
-                                              clangEnum, swiftEnum);
-          }
-        }
-
-        Impl.forEachDistinctName(constant,
-                                 [&](ImportedName newName,
-                                     ImportNameVersion nameVersion) -> bool {
-          if (nameVersion == Impl.CurrentVersion)
-            return true;
-          if (!contextIsEnum(newName))
-            return true;
-
-          clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
-              Impl.getClangASTContext().getSourceManager(),
-              "importing previous version enum constant");
-          SwiftDeclConverter converter(Impl, nameVersion);
-          Decl *imported = converter.importEnumCase(constant, clangEnum,
-                                                    cast<EnumDecl>(swiftEnum),
-                                                    enumeratorDecl);
-          if (!imported)
-            return false;
-          variantDecls.push_back(imported);
+        if (!contextIsEnum(newName, canonicalClangEnum))
           return true;
-        });
-        break;
-      }
-      }
 
-      if (!enumeratorDecl)
-        return;
-
-      // Add a member enumerator to the given nominal type.
-      auto addDecl = [&](NominalTypeDecl *nominal, Decl *decl) {
-        if (!decl) return;
-        nominal->addMember(decl);
-      };
-
-      addDecl(swiftEnum, enumeratorDecl);
-      for (auto *variant : variantDecls)
-        addDecl(swiftEnum, variant);
+        clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
+            Impl.getClangASTContext().getSourceManager(),
+            "importing previous version enum constant");
+        SwiftDeclConverter converter(Impl, nameVersion);
+        Decl *imported = converter.importEnumCase(constant, clangEnum,
+                                                  cast<EnumDecl>(swiftEnum),
+                                                  enumeratorDecl);
+        if (!imported)
+          return false;
+        swiftEnum->addMember(imported);
+        return true;
+      });
 
       // If there is an error wrapper, add an alias within the
       // wrapper to the corresponding value within the enumerator
@@ -2981,13 +2952,12 @@ namespace {
       SwiftDeclConverter converter(Impl, Impl.CurrentVersion);
 
       auto alias = converter.importEnumCaseAlias(name, constant,
-                                                 enumeratorValue,
-                                                 clangEnum, swiftEnum,
-                                                 errorWrapper);
+                                                 enumeratorValue, clangEnum,
+                                                 swiftEnum, errorWrapper);
       if (!alias)
         return;
 
-      addDecl(errorWrapper, alias);
+      errorWrapper->addMember(alias);
     }
 
     Decl *VisitEnumDecl(const clang::EnumDecl *decl) {
@@ -3257,16 +3227,32 @@ namespace {
 
       Impl.cacheImportedDecl(result, decl, getVersion());
 
-      // For NonFrozenEnum and FrozenEnum, we precompute this table and share it
-      // between all cases we want to import. (The others don't use it, and the
-      // CaseCanonicalizer knows to not bother building itself.)
-      CaseCanonicalizer canonicalEnumConstants(Impl, enumKind, decl);
-
       // Import each of the enumerators.
-      for (auto constant : decl->enumerators())
-        SwiftDeclConverter::importEnumConstant(Impl, constant, decl, result,
-                                               errorWrapper, enumKind,
-                                               canonicalEnumConstants);
+      switch (enumKind) {
+      case EnumKind::Constants:
+        llvm_unreachable("VisitEnumDecl should bail before we get here.");
+
+      case EnumKind::Unknown:
+        // We can import these on demand via VisitEnumConstantDecl().
+        break;
+
+      case EnumKind::Options:
+        for (auto constant : decl->enumerators())
+          SwiftDeclConverter::importEnumConstantAsOption(Impl, constant, decl,
+                                                         result);
+        break;
+
+      case EnumKind::NonFrozenEnum:
+      case EnumKind::FrozenEnum: {
+        CaseCanonicalizer canonicalEnumConstants(Impl, decl);
+        for (auto constant : decl->enumerators())
+          SwiftDeclConverter::
+              importEnumConstantAsCaseOrAlias(Impl, constant, decl, result,
+                                              errorWrapper,
+                                              canonicalEnumConstants);
+        break;
+      }
+      }
 
       return result;
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2795,34 +2795,6 @@ namespace {
                                            Identifier name,
                                            const clang::EnumDecl *decl);
 
-    static void
-    importEnumConstantAsOption(ClangImporter::Implementation &Impl,
-                               const clang::EnumConstantDecl *constant,
-                               const clang::EnumDecl *clangEnum,
-                               NominalTypeDecl *swiftEnum) {
-      const clang::EnumDecl *canonicalClangEnum = clangEnum->getCanonicalDecl();
-
-      clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),
-          Impl.getClangASTContext().getSourceManager(),
-          "importing option enum constant");
-      Impl.forEachDistinctName(constant,
-                               [&](ImportedName newName,
-                                   ImportNameVersion nameVersion) -> bool {
-        if (!contextIsEnum(newName, canonicalClangEnum))
-          return true;
-
-        SwiftDeclConverter converter(Impl, nameVersion);
-        Decl *imported =
-            converter.importOptionConstant(constant, clangEnum, swiftEnum);
-        if (!imported)
-          return false;
-
-        Impl.cacheImportedDecl(imported, constant, nameVersion);
-        swiftEnum->addMember(imported);
-        return true;
-      });
-    }
-
     class CaseCanonicalizer {
     public:
       struct Result {
@@ -2991,7 +2963,6 @@ namespace {
 
       // Create the enum declaration and record it.
       StructDecl *errorWrapper = nullptr;
-      NominalTypeDecl *result;
       auto enumInfo = Impl.getEnumInfo(decl);
       auto enumKind = enumInfo.getKind();
       switch (enumKind) {
@@ -3023,8 +2994,7 @@ namespace {
                              KnownProtocolKind::Equatable},
                             options, /*setterAccess=*/AccessLevel::Public);
 
-        result = structDecl;
-        break;
+        return structDecl;
       }
 
       case EnumKind::NonFrozenEnum:
@@ -3202,59 +3172,51 @@ namespace {
 
           // Add the 'Code' enum to the error wrapper.
           errorWrapper->addMember(enumDecl);
-          Impl.addAlternateDecl(enumDecl, errorWrapper);
 
           // Stash the 'Code' enum so we can find it later.
           Impl.ErrorCodeEnums[errorWrapper] = enumDecl;
         }
 
-        // The enumerators go into this enumeration.
-        result = enumDecl;
-        break;
-      }
+        // We will immediately import members (see below), so add to Impl's
+        // caches right away.
+        Impl.cacheImportedDecl(enumDecl, decl, getVersion());
+        if (errorWrapper)
+          Impl.addAlternateDecl(enumDecl, errorWrapper);
 
-      case EnumKind::Options: {
-        result = importAsOptionSetType(dc, name, decl);
-        if (!result)
-          return nullptr;
-
-        // HACK: Make sure PrintAsObjC always omits the 'enum' tag for
-        // option set enums.
-        Impl.DeclsWithSuperfluousTypedefs.insert(decl);
-        break;
-      }
-      }
-
-      Impl.cacheImportedDecl(result, decl, getVersion());
-
-      // Import each of the enumerators.
-      switch (enumKind) {
-      case EnumKind::Constants:
-        llvm_unreachable("VisitEnumDecl should bail before we get here.");
-
-      case EnumKind::Unknown:
-        // We can import these on demand via VisitEnumConstantDecl().
-        break;
-
-      case EnumKind::Options:
-        for (auto constant : decl->enumerators())
-          SwiftDeclConverter::importEnumConstantAsOption(Impl, constant, decl,
-                                                         result);
-        break;
-
-      case EnumKind::NonFrozenEnum:
-      case EnumKind::FrozenEnum: {
+        // In most EnumKinds, the enum constants are all imported as Swift
+        // constants in some DeclContext or another; this is done lazily via
+        // VisitEnumConstantDecl(). But in FrozenEnum and NonFrozenEnum, some
+        // constants (the "canonical" ones) are imported as cases instead, and
+        // some are also duplicated onto the errorWrapper.
+        //
+        // We handle these extra complications by computing which constants we
+        // will consider to be the "canonical" ones (the ones mapped to cases)
+        // and then adding all of these members up front.
+        //
+        // FIXME: This could be refactored to be lazy-loadable too.
         CaseCanonicalizer canonicalEnumConstants(Impl, decl);
         for (auto constant : decl->enumerators())
           SwiftDeclConverter::
-              importEnumConstantAsCaseOrAlias(Impl, constant, decl, result,
+              importEnumConstantAsCaseOrAlias(Impl, constant, decl, enumDecl,
                                               errorWrapper,
                                               canonicalEnumConstants);
-        break;
+
+        return enumDecl;
+      }
+
+      case EnumKind::Options: {
+        auto result = importAsOptionSetType(dc, name, decl);
+
+        // HACK: Make sure PrintAsObjC always omits the 'enum' tag for
+        // option set enums.
+        if (result)
+          Impl.DeclsWithSuperfluousTypedefs.insert(decl);
+
+        return result;
       }
       }
 
-      return result;
+      llvm_unreachable("unknown EnumKind");
     }
 
     Decl *VisitRecordDecl(const clang::RecordDecl *decl) {
@@ -3651,10 +3613,30 @@ namespace {
         return result;
       }
 
-      case EnumKind::NonFrozenEnum:
-      case EnumKind::FrozenEnum:
       case EnumKind::Options: {
-        // The enumeration was mapped to a high-level Swift type, and its
+        // The context where the constant will be introduced.
+        auto dc =
+            Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
+        if (!dc)
+          return nullptr;
+
+        // Get the parent type.
+        auto *swiftEnum = dc->getSelfStructDecl();
+        if (!swiftEnum)
+          return nullptr;
+
+        auto *result = importOptionConstant(decl, clangEnum, swiftEnum);
+        if (!result)
+          return nullptr;
+
+        Impl.cacheImportedDecl(result, decl, version);
+
+        return result;
+      }
+
+      case EnumKind::NonFrozenEnum:
+      case EnumKind::FrozenEnum: {
+        // The enumeration was mapped to a Swift enum, and its
         // elements were created as children of that enum. They aren't available
         // independently.
         // See importEnumConstant().
@@ -6006,6 +5988,9 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
   auto selfType = structDecl->getDeclaredInterfaceType();
   addSynthesizedTypealias(structDecl, ctx.Id_Element, selfType);
   addSynthesizedTypealias(structDecl, ctx.Id_ArrayLiteralElement, selfType);
+
+  structDecl->setMemberLoader(&Impl, 0);
+
   return structDecl;
 }
 
@@ -8405,6 +8390,13 @@ ClangImporter::Implementation::importDeclContextOf(
     decl->getDeclContext()->getRedeclContext()->isTranslationUnit();
   if (!isGlobal) return importedDC;
 
+  // Enum constants don't use import-as-member unless they belong to anonymous
+  // enums.
+  if (isa<clang::EnumConstantDecl>(decl) &&
+      cast<clang::EnumDecl>(decl->getDeclContext())->hasNameForLinkage()) {
+    return importedDC;
+  }
+
   // If the resulting declaration context is not a nominal type,
   // we're done.
   auto nominal = dyn_cast<NominalTypeDecl>(importedDC);
@@ -8769,11 +8761,16 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   // Check whether we're importing an Objective-C container of some sort.
   auto objcContainer =
     dyn_cast_or_null<clang::ObjCContainerDecl>(D->getClangDecl());
-
-  // If not, we're importing globals-as-members into an extension.
   if (objcContainer) {
     loadAllMembersOfSuperclassIfNeeded(dyn_cast<ClassDecl>(D));
     loadAllMembersOfObjcContainer(D, objcContainer);
+    return;
+  }
+
+  auto enumDecl =
+    dyn_cast_or_null<clang::EnumDecl>(D->getClangDecl());
+  if (enumDecl) {
+    loadAllMembersOfLazilyLoadedEnum(D, enumDecl);
     return;
   }
 
@@ -8798,6 +8795,7 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
     return;
   }
 
+  // If not, we're importing globals-as-members into an extension.
   loadAllMembersIntoExtension(D, extra);
 }
 
@@ -8921,6 +8919,30 @@ void ClangImporter::Implementation::loadAllMembersOfObjcContainer(
 
   SmallVector<Decl *, 16> members;
   collectMembersToAdd(objcContainer, D, cast<DeclContext>(D), members);
+
+  auto *IDC = cast<IterableDeclContext>(D);
+  for (auto member : members) {
+    if (!isa<AccessorDecl>(member))
+      IDC->addMember(member);
+  }
+}
+
+void ClangImporter::Implementation::loadAllMembersOfLazilyLoadedEnum(
+    Decl *D, const clang::EnumDecl *enumDecl) {
+  assert(isa<StructDecl>(D) &&
+         !D->getAttrs().hasAttribute<ClangImporterSynthesizedTypeAttr>() &&
+         "only OptionSets, not enums or their error wrappers, can have members "
+         "loaded lazily");
+
+  clang::PrettyStackTraceDecl trace(enumDecl, clang::SourceLocation(),
+                                    Instance->getSourceManager(),
+                                    "loading option constants for");
+
+  startedImportingEntity();
+
+  SmallVector<Decl *, 16> members;
+  for (auto constant : enumDecl->enumerators())
+    insertMembersAndAlternates(constant, members);
 
   auto *IDC = cast<IterableDeclContext>(D);
   for (auto member : members) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2858,16 +2858,11 @@ namespace {
 
       switch (enumKind) {
       case EnumKind::Constants:
+        llvm_unreachable("VisitEnumDecl should bail before we get here.");
+
       case EnumKind::Unknown:
-        // We can import these via VisitEnumConstantDecl().
-        // FIXME: Could we just let that happen on demand, or do we need to
-        // force it here?
-        Impl.forEachDistinctName(constant,
-                                 [&](ImportedName newName,
-                                     ImportNameVersion nameVersion) -> bool {
-          return Impl.importDecl(constant, nameVersion);
-        });
-        break;
+        // We can import these on demand via VisitEnumConstantDecl().
+        return;
 
       case EnumKind::Options: {
         clang::PrettyStackTraceDecl(constant, clang::SourceLocation(),

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2172,7 +2172,8 @@ namespace {
                                 DeclContext *dc,
                                 const clang::ObjCPropertyDecl *decl,
                                 Identifier name,
-                                ClassDecl *subject) {
+                                ClassDecl *subject,
+                                ImportDecision &decision) {
     bool foundMethod = false;
     for (; subject; (subject = subject->getSuperclassDecl())) {
       llvm::SmallVector<ValueDecl *, 8> lookup;
@@ -2195,6 +2196,11 @@ namespace {
             continue;
 
           foundMethod = true;
+          if (const auto *clangFD =
+                  dyn_cast<clang::NamedDecl>(fd->getClangDecl()))
+            decision.note(clangFD->getLocation(),
+                          diag::note_cannot_import_property_overriding_method,
+                          getClangDescriptiveKind(clangFD), clangFD);
         } else if (auto *var = dyn_cast<VarDecl>(result)) {
           if (var->isInstanceMember() != decl->isInstanceProperty())
             continue;
@@ -2322,6 +2328,8 @@ namespace {
               activeName.getDeclName() == canonicalName.getDeclName() &&
               activeName.getEffectiveContext().equalsWithoutResolving(
                   canonicalName.getEffectiveContext())) {
+            // Nothing to do
+            decision.alreadyDecided();
             return ImportedName();
           }
         }
@@ -2344,8 +2352,10 @@ namespace {
       if (getVersion().supportsConcurrency()) {
         // If the resulting name isn't special for concurrency, it's not
         // different.
-        if (!alternateName.getAsyncInfo())
+        if (!alternateName.getAsyncInfo()) {
+          decision.alreadyDecided();
           return ImportedName();
+        }
 
         // Otherwise, it's a legitimately different import.
         return alternateName;
@@ -2358,6 +2368,7 @@ namespace {
           assert(canonicalVersion != getActiveSwiftVersion());
           return alternateName;
         }
+        decision.alreadyDecided();
         return ImportedName();
       }
 
@@ -2452,7 +2463,11 @@ namespace {
 
     void setForwardDeclaration() {
       forwardDeclaration = true;
-      decision.dontImport(ImportReason::ForwardDeclaration);
+
+      auto decl = decision.getClangDecl();
+      decision.note(None, diag::note_cannot_import_forward_declaration,
+                    getClangDescriptiveKind(decl),
+                    dyn_cast<clang::NamedDecl>(decl));
     }
 
     Decl *VisitDecl(const clang::Decl *decl) {
@@ -2603,7 +2618,7 @@ namespace {
       auto importedName = importFullName(Decl, correctSwiftName);
       auto Name = importedName.getDeclName().getBaseIdentifier();
       if (Name.empty()) {
-        decision.dontImport(ImportReason::NameFailure);
+        decision.note(None, diag::note_cannot_import_name);
         return nullptr;
       }
 
@@ -2614,6 +2629,8 @@ namespace {
                                             *correctSwiftName,
                                             decision);
 
+      auto underlyingTypeLoc =
+          Decl->getTypeSourceInfo()->getTypeLoc().getBeginLoc();
       Type SwiftType;
       if (Decl->getDeclContext()->getRedeclContext()->isTranslationUnit()) {
         bool IsError;
@@ -2622,8 +2639,12 @@ namespace {
         std::tie(SwiftType, StdlibTypeName) =
             getSwiftStdlibType(Decl, Name, Impl, &IsError, NameMapping);
 
-        if (IsError)
+        if (IsError) {
+          decision.note(underlyingTypeLoc,
+                        diag::note_cannot_import_known_type_not_found,
+                        getClangDescriptiveKind(Decl), Name.str());
           return nullptr;
+        }
 
         // Import 'typedef struct __Blah *BlahRef;' and
         // 'typedef const void *FooRef;' as CF types if they have the
@@ -2632,7 +2653,7 @@ namespace {
           auto DC = Impl.importDeclContextOf(
               Decl, importedName.getEffectiveContext());
           if (!DC) {
-            decision.dontImport(ImportReason::ContextImportFailure);
+            decision.note(None, diag::note_cannot_import_context);
             return nullptr;
           }
 
@@ -2642,7 +2663,7 @@ namespace {
               auto swiftClass = importCFClassType(
                   Decl, Name, pointee, importedName.getEffectiveContext());
               if (!swiftClass) {
-                decision.dontImport(ImportReason::TypeImportFailure);
+                decision.note(underlyingTypeLoc, diag::note_cannot_import_type);
                 return nullptr;
               }
 
@@ -2657,7 +2678,7 @@ namespace {
               auto underlying = cast_or_null<TypeDecl>(Impl.importDecl(
                   pointee.getTypedef(), getActiveSwiftVersion()));
               if (!underlying) {
-                decision.dontImport(ImportReason::TypeImportFailure);
+                decision.note(underlyingTypeLoc, diag::note_cannot_import_type);
                 return nullptr;
               }
 
@@ -2735,7 +2756,7 @@ namespace {
       auto DC =
           Impl.importDeclContextOf(Decl, importedName.getEffectiveContext());
       if (!DC) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -2756,7 +2777,7 @@ namespace {
       }
 
       if (!SwiftType) {
-        decision.dontImport(ImportReason::TypeImportFailure);
+        decision.note(underlyingTypeLoc, diag::note_cannot_import_type);
         return nullptr;
       }
 
@@ -4066,7 +4087,7 @@ namespace {
 
     Decl *VisitObjCIvarDecl(const clang::ObjCIvarDecl *decl) {
       // Disallow direct ivar access (and avoid conflicts with property names).
-      decision.dontImport(ImportReason::InstanceVariable);
+      decision.note(None, diag::note_cannot_import_objc_ivars);
       return nullptr;
     }
 
@@ -4085,7 +4106,7 @@ namespace {
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -4095,6 +4116,7 @@ namespace {
       bool isAudited = decl->getType().isConstQualified();
 
       auto declType = decl->getType();
+      auto declTypeLoc = decl->getTypeSpecStartLoc();
 
       // Special case: NS Notifications
       if (isNSNotificationGlobal(decl))
@@ -4111,7 +4133,7 @@ namespace {
                           isInSystemModule(dc), Bridgeability::None);
 
       if (!importedType) {
-        decision.dontImport(ImportReason::TypeImportFailure);
+        decision.note(declTypeLoc, diag::note_cannot_import_type);
         return nullptr;
       }
 
@@ -4253,7 +4275,7 @@ namespace {
     Decl *VisitObjCMethodDecl(const clang::ObjCMethodDecl *decl) {
       auto dc = Impl.importDeclContextOf(decl, decl->getDeclContext());
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -4350,7 +4372,7 @@ namespace {
       if (isInitMethod(decl)) {
         // Cannot import initializers as accessors.
         if (accessorInfo) {
-          decision.dontImport(ImportReason::InitMethodWithAccessorInfo);
+          decision.note(None, diag::note_cannot_import_init_as_accessor);
           return nullptr;
         }
 
@@ -4383,7 +4405,7 @@ namespace {
       Optional<ImportedName> correctSwiftName;
       importedName = importFullName(decl, correctSwiftName);
       if (!importedName) {
-        decision.dontImport(ImportReason::NameFailure);
+        decision.note(None, diag::note_cannot_import_name);
         return nullptr;
       }
 
@@ -4416,7 +4438,7 @@ namespace {
 
       // We can't import a factory-initializer as an accessor.
       if (accessorInfo) {
-        decision.dontImport(ImportReason::InitMethodWithAccessorInfo);
+        decision.note(None, diag::note_cannot_import_init_as_accessor);
         return nullptr;
       }
 
@@ -4461,7 +4483,8 @@ namespace {
       // Swift.print in that case.
       if (!isActiveSwiftVersion() &&
           isPrintLikeMethod(importedName.getDeclName(), dc)) {
-        decision.dontImport(ImportReason::PrintLikeMethodName);
+        decision.note(None,
+                  diag::note_cannot_import_method_named_print_into_old_version);
         return nullptr;
       }
 
@@ -4479,20 +4502,29 @@ namespace {
       if (decl->isPropertyAccessor()) {
         prop = decl->findPropertyDecl();
         if (!prop) {
-          decision.dontImport(ImportReason::PropertyImportFailure);
+          decision.note(None, diag::note_cannot_import_clang_ast_inconsistent,
+                        "method is marked as an accessor, but clang couldn't "
+                        "find the property it belongs to");
           return nullptr;
         }
 
         // If we're importing just the accessors (not the property), ignore
         // the property.
-        if (shouldImportPropertyAsAccessors(prop))
+        if (shouldImportPropertyAsAccessors(prop)) {
+          decision.note(prop->getLocation(),
+                        diag::note_cannot_import_property_broken_up,
+                        getClangDescriptiveKind(prop), prop);
           prop = nullptr;
+        }
+      }
+      else if (accessorInfo) {
+        decision.note(None, diag::note_cannot_import_not_an_accessor,
+                      getClangDescriptiveKind(decl), decl);
       }
 
       // If we have an accessor-import request but didn't find a property,
       // reject the import request.
       if (accessorInfo && !prop) {
-        decision.dontImport(ImportReason::MethodWithAccessorInfoButNoProperty);
         return nullptr;
       }
 
@@ -4504,7 +4536,8 @@ namespace {
         // setter are redeclared in a potentially incompatible way, bail out.
         if (prop->getGetterMethodDecl() != decl &&
             prop->getSetterMethodDecl() != decl) {
-          decision.dontImport(ImportReason::PropertyRedeclarationIgnored);
+          decision.note(prop->getLocation(),
+                        diag::note_cannot_import_property_redeclaration);
           return nullptr;
         }
         importedType =
@@ -4518,7 +4551,9 @@ namespace {
             asyncConvention, errorConvention, kind);
       }
       if (!importedType) {
-        decision.dontImport(ImportReason::TypeImportFailure);
+        // FIXME: Thread decision into `importAccessorParamsAndReturnType()` and
+        // `importMethodParamsAndReturnType()` so we can give more detail.
+        decision.note(None, diag::note_cannot_import_type);
         return nullptr;
       }
 
@@ -4712,6 +4747,7 @@ namespace {
     SubscriptDecl *importSubscript(Decl *decl,
                                    const clang::ObjCMethodDecl *objcMethod);
 
+    // FIXME: Should be static, as it uses a separate decision.
     /// Import the accessor and its attributes.
     AccessorDecl *importAccessor(clang::ObjCMethodDecl *clangAccessor,
                                  AbstractStorageDecl *storage,
@@ -4749,16 +4785,22 @@ namespace {
       }
 
       // Find the Swift class being extended.
-      auto objcClass = castIgnoringCompatibilityAlias<ClassDecl>(
-          Impl.importDecl(decl->getClassInterface(), getActiveSwiftVersion()));
-      if (!objcClass) {
-        decision.dontImport(ImportReason::ExtendedClassImportFailure);
+      auto extendedObjCClass = decl->getClassInterface();
+      auto extendedSwiftClass = castIgnoringCompatibilityAlias<ClassDecl>(
+          Impl.importDecl(extendedObjCClass, getActiveSwiftVersion()));
+      if (!extendedSwiftClass) {
+        decision.note(extendedObjCClass->getLocation(),
+                      diag::note_cannot_import_see_other_decl,
+                      getClangDescriptiveKind(extendedObjCClass),
+                      extendedObjCClass);
+        decision.note(decl->getCategoryNameLoc(),
+                      diag::note_cannot_import_class_of_category);
         return nullptr;
       }
 
       auto dc = Impl.importDeclContextOf(decl, decl->getDeclContext());
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -4768,17 +4810,17 @@ namespace {
                       nullptr,
                       { }, dc, nullptr, decl);
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedTypeRequest{result},
-                                              objcClass->getDeclaredType());
+                                              extendedSwiftClass->getDeclaredType());
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedNominalRequest{result},
-                                              std::move(objcClass));
+                                              std::move(extendedSwiftClass));
       
       // Determine the type and generic args of the extension.
-      if (objcClass->getGenericParams()) {
-        result->setGenericSignature(objcClass->getGenericSignature());
+      if (extendedSwiftClass->getGenericParams()) {
+        result->setGenericSignature(extendedSwiftClass->getGenericSignature());
       }
 
       // Create the extension declaration and record it.
-      objcClass->addExtension(result);
+      extendedSwiftClass->addExtension(result);
       decision.importAndCache(result);
       SmallVector<TypeLoc, 4> inheritedTypes;
       importObjCProtocols(result, decl->getReferencedProtocols(),
@@ -4934,7 +4976,10 @@ namespace {
     Decl *VisitObjCProtocolDecl(const clang::ObjCProtocolDecl *decl) {
       Optional<ImportedName> correctSwiftName;
       auto importedName = importFullName(decl, correctSwiftName);
-      if (!importedName) return nullptr;
+      if (!importedName) {
+        decision.note(None, diag::note_cannot_import_name);
+        return nullptr;
+      }
 
       // If we've been asked to produce a compatibility stub, handle it via a
       // typealias.
@@ -4964,7 +5009,7 @@ namespace {
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -5041,7 +5086,8 @@ namespace {
           clangCtx.getObjCProtocolDecl()->getCanonicalDecl()) {
         Type nsObjectTy = Impl.getNSObjectType();
         if (!nsObjectTy) {
-          decision.dontImport(ImportReason::NSObjectNotFound);
+          decision.note(None, diag::note_cannot_import_known_type_not_found,
+                        getClangDescriptiveKind(decl), "NSObject");
           return nullptr;
         }
         const ClassDecl *nsObjectDecl =
@@ -5099,7 +5145,7 @@ namespace {
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -5130,7 +5176,7 @@ namespace {
           result->setGenericSignature(sig);
         }
       } else {
-        decision.dontImport(ImportReason::GenericSignatureImportFailure);
+        decision.note(None, diag::note_cannot_import_generic_signature);
         return nullptr;
       }
 
@@ -5188,14 +5234,14 @@ namespace {
     Decl *VisitObjCImplDecl(const clang::ObjCImplDecl *decl) {
       // Implementations of Objective-C classes and categories are not
       // reflected into Swift.
-      decision.dontImport(ImportReason::AtImplmentationBlocksUnimportable);
+      decision.note(None, diag::note_cannot_import_at_implementation);
       return nullptr;
     }
 
     Decl *VisitObjCPropertyDecl(const clang::ObjCPropertyDecl *decl) {
       auto dc = Impl.importDeclContextOf(decl, decl->getDeclContext());
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -5273,9 +5319,20 @@ namespace {
         return nullptr;
 
       if (shouldImportPropertyAsAccessors(decl)) {
-        decision.dontImport(ImportReason::ImportedAsAccessorMethods);
+        decision.note(None, diag::note_cannot_import_property_broken_up,
+                      getClangDescriptiveKind(decl), decl);
         return nullptr;
       }
+
+      auto diagnoseRedeclaration = [&](ValueDecl *existingDecl) {
+        Optional<clang::SourceLocation> loc;
+        if (auto *clangExistingDecl =
+                dyn_cast<clang::NamedDecl>(existingDecl->getClangDecl()))
+          loc = clangExistingDecl->getLocation();
+        decision.note(loc,
+                      diag::note_cannot_import_property_redeclaration_merged,
+                      existingDecl->getDescriptiveKind(), existingDecl);
+      };
 
       VarDecl *overridden = nullptr;
       // Check whether there is a function with the same name as this
@@ -5289,10 +5346,11 @@ namespace {
 
         bool foundMethod = false;
         std::tie(overridden, foundMethod)
-          = identifyNearestOverriddenDecl(Impl, dc, decl, name, subject);
+          = identifyNearestOverriddenDecl(Impl, dc, decl, name, subject,
+                                          decision);
 
         if (foundMethod && !overridden) {
-          decision.dontImport(ImportReason::OverridingMethodWithProperty);
+          // Note emitted in identifyNearestOverriddenDecl().
           return nullptr;
         }
 
@@ -5305,7 +5363,7 @@ namespace {
                 == dc->getSelfNominalTypeDecl()) {
             // We've encountered a redeclaration of the property.
             handlePropertyRedeclaration(overridden, decl, decision);
-            decision.dontImport(ImportReason::PropertyRedeclarationIgnored);
+            diagnoseRedeclaration(overridden);
             return nullptr;
           }
         }
@@ -5318,14 +5376,14 @@ namespace {
                                                  dc->getSelfClassDecl(), name);
         if (redecl) {
           handlePropertyRedeclaration(redecl, decl, decision);
-          decision.dontImport(ImportReason::PropertyRedeclarationIgnored);
+          diagnoseRedeclaration(redecl);
           return nullptr;
         }
       }
 
       auto importedType = Impl.importPropertyType(decl, isInSystemModule(dc));
       if (!importedType) {
-        decision.dontImport(ImportReason::TypeImportFailure);
+        decision.note(None, diag::note_cannot_import_type);
         return nullptr;
       }
 
@@ -5353,23 +5411,34 @@ namespace {
       // sure under what circumstances this occurs, but we shouldn't crash.
       auto clangGetter = decl->getGetterMethodDecl();
       assert(clangGetter && "ObjC property without getter");
-      if (!clangGetter)
+      if (!clangGetter) {
+        decision.note(None, diag::note_cannot_import_clang_ast_inconsistent,
+                      "ObjC property without setter");
         return nullptr;
+      }
 
       // Import the getter.
-      // FIXME: Should use a separate decision for this.
       AccessorDecl *getter = importAccessor(clangGetter, result,
                                             AccessorKind::Get, dc);
-      if (!getter)
+      if (!getter) {
+        decision.note(clangGetter->getLocation(),
+                      diag::note_cannot_import_see_other_decl,
+                      getClangDescriptiveKind(clangGetter), clangGetter);
+        decision.note(None, diag::note_cannot_import_property_accessor, false);
         return nullptr;
+      }
 
       // Import the setter, if there is one.
-      // FIXME: Should use a separate decision for this.
       AccessorDecl *setter = nullptr;
       if (auto clangSetter = decl->getSetterMethodDecl()) {
         setter = importAccessor(clangSetter, result, AccessorKind::Set, dc);
-        if (!setter)
+        if (!setter) {
+          decision.note(clangSetter->getLocation(),
+                        diag::note_cannot_import_see_other_decl,
+                        getClangDescriptiveKind(clangSetter), clangSetter);
+          decision.note(None, diag::note_cannot_import_property_accessor, true);
           return nullptr;
+        }
       }
 
       // Turn this into a computed property.
@@ -5413,7 +5482,7 @@ namespace {
       EffectiveClangContext effectiveContext(decl->getDeclContext()->getRedeclContext());
       auto dc = Impl.importDeclContextOf(decl, effectiveContext);
       if (!dc) {
-        decision.dontImport(ImportReason::ContextImportFailure);
+        decision.note(None, diag::note_cannot_import_context);
         return nullptr;
       }
 
@@ -5422,7 +5491,7 @@ namespace {
       auto name = importedName.getDeclName().getBaseIdentifier();
 
       if (name.empty()) {
-        decision.dontImport(ImportReason::NameFailure);
+        decision.note(None, diag::note_cannot_import_name);
         return nullptr;
       }
 
@@ -5430,7 +5499,12 @@ namespace {
           Impl.importDecl(decl->getClassInterface(), getActiveSwiftVersion());
       auto typeDecl = dyn_cast_or_null<TypeDecl>(importedDecl);
       if (!typeDecl) {
-        decision.dontImport(ImportReason::TypeImportFailure);
+        decision.note(decl->getClassInterface()->getLocation(),
+                      diag::note_cannot_import_see_other_decl,
+                      getClangDescriptiveKind(decl->getClassInterface()),
+                      decl->getClassInterface());
+        decision.note(decl->getClassInterfaceLoc(),
+                      diag::note_cannot_import_type);
         return nullptr;
       }
 
@@ -5652,7 +5726,7 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
                                       EffectiveClangContext effectiveContext) {
   auto dc = Impl.importDeclContextOf(decl, effectiveContext);
   if (!dc) {
-    decision.dontImport(ImportReason::ContextImportFailure);
+    decision.note(None, diag::note_cannot_import_context);
     return nullptr;
   }
 
@@ -5721,7 +5795,9 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
     importedDecl = Impl.importDecl(decl, getActiveSwiftVersion());
   auto typeDecl = dyn_cast_or_null<TypeDecl>(importedDecl);
   if (!typeDecl) {
-    decision.dontImport(ImportReason::TypeImportFailure);
+    decision.note(decl->getLocation(), diag::note_cannot_import_see_other_decl,
+                  getClangDescriptiveKind(decl), decl);
+    decision.note(None, diag::note_cannot_import_type);
     return nullptr;
   }
 
@@ -5729,7 +5805,7 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   auto dc = Impl.importDeclContextOf(decl,
                                      compatibilityName.getEffectiveContext());
   if (!dc) {
-    decision.dontImport(ImportReason::ContextImportFailure);
+    decision.note(None, diag::note_cannot_import_context);
     return nullptr;
   }
 
@@ -5841,7 +5917,8 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
       Bridgeability::None, OTK_None);
 
   if (!storedUnderlyingType) {
-    decision.dontImport(ImportReason::UnderlyingTypeImportFailure);
+    decision.note(decl->getTypeSourceInfo()->getTypeLoc().getBeginLoc(),
+                  diag::note_cannot_import_raw_type);
     return nullptr;
   }
 
@@ -5975,7 +6052,7 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
   auto name =
       importFullName(decl, correctSwiftName).getDeclName().getBaseIdentifier();
   if (name.empty()) {
-    decision.dontImport(ImportReason::NameFailure);
+    decision.note(None, diag::note_cannot_import_name);
     return nullptr;
   }
 
@@ -5983,12 +6060,20 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
     // We're creating a compatibility stub. Treat it as an enum case alias.
     auto correctCase = dyn_cast_or_null<EnumElementDecl>(correctDecl);
     if (!correctCase)
+      // FIXME: decision.note?
       return nullptr;
 
     // If the correct declaration was unavailable, don't map to it.
     // FIXME: This eliminates spurious errors, but affects QoI.
-    if (correctCase->getAttrs().isUnavailable(Impl.SwiftContext))
+    if (correctCase->getAttrs().isUnavailable(Impl.SwiftContext)) {
+      clang::SourceLocation initLoc = decl->getLocation();
+      if (decl->getInitExpr())
+        initLoc = decl->getInitExpr()->getExprLoc();
+      decision.note(initLoc,
+                    diag::note_cannot_import_alias_for_unavailable_case,
+                    name, correctCase->getDescriptiveKind(), correctCase);
       return nullptr;
+    }
 
     auto compatibilityCase =
         importEnumCaseAlias(name, decl, correctCase, clangEnum, theEnum);
@@ -6033,7 +6118,7 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
   ImportedName nameInfo = importFullName(decl, correctSwiftName);
   Identifier name = nameInfo.getDeclName().getBaseIdentifier();
   if (name.empty()) {
-    decision.dontImport(ImportReason::NameFailure);
+    decision.note(None, diag::note_cannot_import_name);
     return nullptr;
   }
 
@@ -6070,7 +6155,7 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
     const clang::EnumDecl *clangEnum, NominalTypeDecl *importedEnum,
     DeclContext *importIntoDC) {
   if (name.empty()) {
-    decision.dontImport(ImportReason::NameFailure);
+    decision.note(None, diag::note_cannot_import_name);
     return nullptr;
   }
 
@@ -6125,7 +6210,8 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
       decl->getIntegerType(), ImportTypeKind::Enum, isInSystemModule(dc),
       Bridgeability::None);
   if (!underlyingType) {
-    decision.dontImport(ImportReason::TypeImportFailure);
+    decision.note(decl->getIntegerTypeSourceInfo()->getTypeLoc().getBeginLoc(),
+                  diag::note_cannot_import_raw_type);
     return nullptr;
   }
 
@@ -6188,7 +6274,8 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
         allowNSUIntegerAsInt, argNames);
   }
   if (!parameterList) {
-    decision.dontImport(ImportReason::ParameterListImportFailure);
+    decision.note(decl->getParametersSourceRange().getBegin(),
+                  diag::note_cannot_import_parameter_list);
     return nullptr;
   }
 
@@ -6455,7 +6542,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
   Optional<ImportedName> correctSwiftName;
   auto importedName = importFullName(objcMethod, correctSwiftName);
   if (!importedName) {
-    decision.dontImport(ImportReason::NameFailure);
+    decision.note(None, diag::note_cannot_import_name);
     return nullptr;
   }
 
@@ -6617,7 +6704,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
       SpecialMethodKind::Constructor);
   assert(!asyncConvention && "Initializers don't have async conventions");
   if (!importedType) {
-    decision.dontImport(ImportReason::TypeImportFailure);
+    decision.note(None, diag::note_cannot_import_type);
     return nullptr;
   }
 
@@ -6708,7 +6795,15 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
     // it will be no better than the existing one.
     existing = ctor;
 
-    decision.dontImport(ImportReason::BetterInitializer);
+    if (auto objcCtor =
+            dyn_cast_or_null<clang::NamedDecl>(ctor->getClangDecl()))
+      decision.note(objcCtor->getLocation(),
+                    diag::note_cannot_import_is_worse_than_named_alternative,
+                    getClangDescriptiveKind(objcCtor), objcCtor,
+                    ctor);
+    else
+      decision.note(None, diag::note_cannot_import_is_worse_than_alternative,
+                    ctor);
     return nullptr;
   }
 
@@ -8377,8 +8472,6 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
 
   if (!HadForwardDeclaration)
     decision.importAndCache(Result);
-  else
-    decision.dontImport(ImportReason::ForwardDeclaration);
 
   if (!SuperfluousTypedefsAreTransparent && TypedefIsSuperfluous)
     return nullptr;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4934,16 +4934,31 @@ namespace {
     template <typename T, typename U>
     T *resolveSwiftDecl(const U *decl, Identifier name,
                         bool hasKnownSwiftName, ClangModuleUnit *clangModule) {
-      if (auto overlay = clangModule->getOverlayModule())
-        return resolveSwiftDeclImpl<T>(decl, name, hasKnownSwiftName, overlay);
+      ImportRemark::Note::Conditions either = {
+        ImportRemark::Outcome::Imported,
+        ImportRemark::Outcome::NotImported
+      };
+      if (auto overlay = clangModule->getOverlayModule()) {
+        if (T *result = resolveSwiftDeclImpl<T>(decl, name, hasKnownSwiftName,
+                                                overlay)) {
+          // FIXME: We'd like to diagnose this with a Swift SourceLoc.
+          decision.noteIf(either, None, diag::note_imported_from_swift_part,
+                          result->getDescriptiveKind(), result, true);
+          return result;
+        }
+      }
       if (clangModule == Impl.ImportedHeaderUnit) {
         // Use an index-based loop because new owners can come in as we're
         // iterating.
         for (size_t i = 0; i < Impl.ImportedHeaderOwners.size(); ++i) {
           ModuleDecl *owner = Impl.ImportedHeaderOwners[i];
           if (T *result = resolveSwiftDeclImpl<T>(decl, name,
-                                                  hasKnownSwiftName, owner))
+                                                  hasKnownSwiftName, owner)) {
+            // FIXME: We'd like to diagnose this with a Swift SourceLoc.
+            decision.noteIf(either, None, diag::note_imported_from_swift_part,
+                            result->getDescriptiveKind(), result, false);
             return result;
+          }
         }
       }
       return nullptr;
@@ -5015,10 +5030,8 @@ namespace {
 
       ProtocolDecl *nativeDecl;
       bool declaredNative = hasNativeSwiftDecl(decl, name, dc, nativeDecl);
-      if (declaredNative && nativeDecl) {
-        decision.alreadyDecided();
+      if (declaredNative && nativeDecl)
         return nativeDecl;
-      }
 
       // Create the protocol declaration and record it.
       auto result = Impl.createDeclWithClangNode<ProtocolDecl>(
@@ -5120,9 +5133,8 @@ namespace {
         if (auto clangModule = Impl.getClangModuleForDecl(decl, true)) {
           if (auto native = resolveSwiftDecl<ClassDecl>(decl, name,
                                                         hasKnownSwiftName,
-                                                        clangModule)) {
+                                                        clangModule))
             return native;
-          }
         }
 
         if (Impl.ImportForwardDeclarations) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2777,6 +2777,54 @@ namespace {
                                            Identifier name,
                                            const clang::EnumDecl *decl);
 
+    class CaseCanonicalizer {
+    public:
+      struct Result {
+        const clang::EnumConstantDecl *clangCase;
+        Decl *swiftCase;
+      };
+
+    private:
+      llvm::SmallDenseMap<const llvm::APSInt *, Result, 8,
+                          APSIntRefDenseMapInfo> canonicalEnumConstants;
+
+    public:
+      CaseCanonicalizer(ClangImporter::Implementation &Impl, EnumKind enumKind,
+                        const clang::EnumDecl *decl) {
+        if (enumKind != EnumKind::NonFrozenEnum &&
+            enumKind != EnumKind::FrozenEnum)
+          return;
+
+        for (auto constant : decl->enumerators()) {
+          if (Impl.isUnavailableInSwift(constant))
+            continue;
+          canonicalEnumConstants.insert({ &constant->getInitVal(),
+                                          { constant, nullptr} });
+        }
+      }
+
+      using CaseImporter =
+          llvm::function_ref<Decl *(const clang::EnumConstantDecl *)>;
+
+      Result canonicalize(const clang::EnumConstantDecl *noncanon,
+                          CaseImporter importCase) {
+        auto iter = canonicalEnumConstants.find(&noncanon->getInitVal());
+
+        // Unavailable declarations aren't in the table; they get imported
+        // without being canonicalized.
+        Result resultForUnavailable = { noncanon, nullptr };
+        Result &result = iter == canonicalEnumConstants.end()
+                       ? resultForUnavailable
+                       : iter->getSecond();
+
+        assert(result.clangCase);
+        if (!result.swiftCase)
+          result.swiftCase = importCase(result.clangCase);
+
+        return result;
+      }
+    };
+
     Decl *VisitEnumDecl(const clang::EnumDecl *decl) {
       decl = decl->getDefinition();
       if (!decl) {
@@ -3059,19 +3107,10 @@ namespace {
         break;
       }
 
-      llvm::SmallDenseMap<const llvm::APSInt *,
-                          PointerUnion<const clang::EnumConstantDecl *,
-                                       EnumElementDecl *>, 8,
-                          APSIntRefDenseMapInfo> canonicalEnumConstants;
-
-      if (enumKind == EnumKind::NonFrozenEnum ||
-          enumKind == EnumKind::FrozenEnum) {
-        for (auto constant : decl->enumerators()) {
-          if (Impl.isUnavailableInSwift(constant))
-            continue;
-          canonicalEnumConstants.insert({&constant->getInitVal(), constant});
-        }
-      }
+      // For NonFrozenEnum and FrozenEnum, we precompute this table and share it
+      // between all cases we want to import. (The others don't use it, and the
+      // CaseCanonicalizer knows to not bother building itself.)
+      CaseCanonicalizer canonicalEnumConstants(Impl, enumKind, decl);
 
       const clang::EnumDecl *canonicalClangDecl = decl->getCanonicalDecl();
       auto contextIsEnum = [&](const ImportedName &name) -> bool {
@@ -3141,45 +3180,28 @@ namespace {
               Impl.getClangASTContext().getSourceManager(),
               "importing clang enum case");
 
-          auto canonicalCaseIter =
-            canonicalEnumConstants.find(&constant->getInitVal());
+          auto canonResult = canonicalEnumConstants.canonicalize(
+              constant,
+              [&](auto unimported) -> auto {
+            return SwiftDeclConverter(Impl, getActiveSwiftVersion())
+                .importEnumCase(unimported, decl, cast<EnumDecl>(result));
+          });
+          enumeratorDecl = canonResult.swiftCase;
 
-          if (canonicalCaseIter == canonicalEnumConstants.end()) {
-            // Unavailable declarations get no special treatment.
-            enumeratorDecl =
-                SwiftDeclConverter(Impl, getActiveSwiftVersion())
-                    .importEnumCase(constant, decl, cast<EnumDecl>(result));
-          } else {
-            const clang::EnumConstantDecl *unimported =
-                canonicalCaseIter->
-                  second.dyn_cast<const clang::EnumConstantDecl *>();
-
-            // Import the canonical enumerator for this case first.
-            if (unimported) {
-              enumeratorDecl = SwiftDeclConverter(Impl, getActiveSwiftVersion())
-                  .importEnumCase(unimported, decl, cast<EnumDecl>(result));
-              if (enumeratorDecl) {
-                canonicalCaseIter->getSecond() =
-                    cast<EnumElementDecl>(enumeratorDecl);
-              }
+          // If this decl was non-canonical, and if we were able to import the
+          // canonical decl, add an alias for this decl.
+          if (canonResult.clangCase != constant && enumeratorDecl) {
+            ImportedName importedName =
+                Impl.importFullName(constant, getActiveSwiftVersion());
+            Identifier name = importedName.getDeclName().getBaseIdentifier();
+            if (name.empty()) {
+              // Clear the existing declaration so we don't try to process it
+              // twice later.
+              enumeratorDecl = nullptr;
             } else {
-              enumeratorDecl =
-                  canonicalCaseIter->second.get<EnumElementDecl *>();
-            }
-
-            if (unimported != constant && enumeratorDecl) {
-              ImportedName importedName =
-                  Impl.importFullName(constant, getActiveSwiftVersion());
-              Identifier name = importedName.getDeclName().getBaseIdentifier();
-              if (name.empty()) {
-                // Clear the existing declaration so we don't try to process it
-                // twice later.
-                enumeratorDecl = nullptr;
-              } else {
-                auto original = cast<ValueDecl>(enumeratorDecl);
-                enumeratorDecl = importEnumCaseAlias(name, constant, original,
-                                                     decl, result);
-              }
+              auto original = cast<ValueDecl>(enumeratorDecl);
+              enumeratorDecl = importEnumCaseAlias(name, constant, original,
+                                                   decl, result);
             }
           }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1273,6 +1273,9 @@ private:
                                   SmallVectorImpl<Decl *> &members);
   void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
 
+  void loadAllMembersOfLazilyLoadedEnum(Decl *D,
+                                        const clang::EnumDecl *enumDecl);
+
   /// Imports \p decl under \p nameVersion with the name \p newName, and adds
   /// it and its alternates to \p ext.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -403,11 +403,11 @@ public:
     assert(clangDecl && "can't cache swift decl for null clang decl!");
     assert(swiftDecl && "can't cache null swift decl!");
 
-    // I believe this invariant holds, and want to exploit it in the future if
-    // it does.
-    assert(isa<clang::ObjCCategoryDecl>(clangDecl)
-              || clangDecl->isCanonicalDecl()
-           && "all imported clang decls except for categories are canonical");
+    // Identically-named categories canonicalize to the first category with that
+    // name; this is not super-helpful in practice. All other decls should be
+    // canonicalized before caching.
+    if (!isa<clang::ObjCCategoryDecl>(clangDecl))
+      clangDecl = clangDecl->getCanonicalDecl();
 
     ImportedDecls[{clangDecl, version}] = swiftDecl;
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -308,41 +308,80 @@ public:
   explicit operator bool() const { return type.getPointer() != nullptr; }
 };
 
-enum class ImportReason : uint8_t {
-  Unspecified,          ///< Default; also used for successful imports.
-  AlreadyDecided,       ///< A previous ImportRemark should describe the decision. Not a real failure.
-  ForwardDeclaration,
-  InstanceVariable,
-  ContextImportFailure,
-  TypeImportFailure,
-  InitMethodWithAccessorInfo,
-  NameFailure,
-  PrintLikeMethodName,
-  PropertyImportFailure,
-  MethodWithAccessorInfoButNoProperty,
-  ParameterListImportFailure,
-  UnderlyingTypeImportFailure,
-  PropertyRedeclarationIgnored,
-  OverridingMethodWithProperty,
-  ImportedAsAccessorMethods,
-  AtImplmentationBlocksUnimportable,
-  GenericSignatureImportFailure,
-  NSObjectNotFound,
-  ExtendedClassImportFailure,
-  BetterInitializer
-};
-
+/// Information about a decision that was made to import, or not import, a
+/// clang declaration into Swift.
 struct ImportRemark {
-  const clang::Decl *clangDecl;
-  importer::ImportNameVersion version;
-  Decl *swiftDecl = nullptr;
-  TinyPtrVector<Decl *> alternateSwiftDecls;
-  ImportReason reason = ImportReason::Unspecified;
+  /// Represents the overall result of the import operation.
+  enum Outcome : uint8_t { Imported, NotImported };
 
+  /// A note that will be emitted alongside a given import remark under certain
+  /// conditions.
+  struct Note {
+    using Conditions = OptionSet<Outcome>;
+
+    /// The conditions under which this note should be emitted. Typically either
+    /// \c Outcome::Imported, \c Outcome::NotImported, or both.
+    Conditions conditions;
+
+    /// The diagnostic to emit.
+    Diagnostic diagnostic;
+
+    /// If present, the \c clang::SourceLocation which (after converting to a
+    /// \c SourceLoc) the diagnostic will be emitted at. If absent, the remark's
+    /// \c SourceLoc will be used instead.
+    Optional<clang::SourceLocation> location;
+  };
+
+  /// The Clang declaration being imported.
+  const clang::Decl *clangDecl;
+
+  /// The Swift version it's being imported for.
+  importer::ImportNameVersion version;
+
+private:
+  // Bool is stored negated so that this is all-zeros by default
+  llvm::PointerIntPair<Decl *, 1, bool> swiftDeclAndShouldNotEmit;
+
+public:
+  /// Alternate declarations which \c clangDecl was also imported for.
+  TinyPtrVector<Decl *> alternateSwiftDecls;
+
+  /// The diagnostics to emit along with the remark.
+  SmallVector<Note, 4> notes;
+
+  /// The main Swift declaration that \c clangDecl was imported as. Controls
+  /// the \c Outcome of the import.
+  Decl *getSwiftDecl() const {
+    return swiftDeclAndShouldNotEmit.getPointer();
+  }
+  void setSwiftDecl(Decl *newDecl) {
+    swiftDeclAndShouldNotEmit.setPointer(newDecl);
+  }
+
+  /// If \c true, we will emit the main success/failure remark and any
+  /// notes appropriate for the outcome, in addition to remarks for alternate
+  /// declarations. If \c false, we will only emit remarks for alternate
+  /// declarations.
+  bool getShouldEmit() const {
+    return !swiftDeclAndShouldNotEmit.getInt();
+  }
+  void setShouldEmit(bool newValue) {
+    swiftDeclAndShouldNotEmit.setInt(!newValue);
+  }
+
+  /// The result of this attempt to import.
+  Outcome getOutcome() const {
+    return getSwiftDecl() ? Outcome::Imported : Outcome::NotImported;
+  }
+
+  /// Construct an ImportRemark for a failed import with no notes. Only
+  /// ImportDecision should call this constructor.
   ImportRemark(const clang::Decl *clangDecl,
                importer::ImportNameVersion version)
     : clangDecl(clangDecl), version(version) { }
 
+  /// Generate and emit the diagnostics. Only ClangImporter::Implementation
+  /// should call this method.
   void diagnose(ClangImporter::Implementation &impl);
 };
 
@@ -1495,14 +1534,66 @@ public:
   }
 };
 
+/// An RAII class representing a pending decision about whether, why, and how to
+/// import a Clang declaration into Swift.
+///
+/// \c ImportDecision can be thought of as a builder for \c ImportRemark.
+/// Each remark starts its life indicating that it has failed to import the
+/// clang declaration in question, but with no details about why.
+/// \c ImportDecision can be used to:
+///
+/// \li Indicate that the decision about whether to import or not had already
+///     been made in the past: \c alreadyDecided()
+///
+/// \li Change the failure to success and indicate the resulting Swift
+///     declaration(s): \c import(), \c importAndCache(), \c importAlternate(),
+///     \c importAlternateAndCache()
+///
+/// \li Add notes explaining the import decision: \c noteIf(), \c note()
+///
+/// When \c ImportDecision is deallocated, the remark is given to
+/// \c ClangImporter::Implementation to either emit or drop based on its own
+/// criteria.
 class ImportDecision {
+  // Design note: Why are we using an RAII class for this?
+  //
+  // ClangImporter often uses early returns. It does not always communicate the
+  // meaning of an early return clearly; for instance, it may early-return from
+  // a `void` function, or it may use the same empty return value to mean "error
+  // occurred" and "no work to do". Adding import remarks to the existing code
+  // requires that we work within this framework, and within it, the most
+  // reliable indicator of a failure is simply "we started trying to import
+  // something, but we didn't end up doing it".
+  //
+  // In an ideal world, we might have something more like the `Swift.Result`
+  // enum where callees clearly communicate information directly to their
+  // callers by return value. But that is a larger and riskier refactoring than
+  // we're prepared to take on up front. And adding ImportDecisions is an
+  // incremental step in that direction, building up clear rationales directly
+  // in the code that we could communicate through ClangImporter in other ways
+  // in the future.
+  //
+  // An incrementally better world would be one in which `ImportDecision` and
+  // `SwiftDeclConverter` were basically synonymous. That will take more
+  // refactoring, though.
+
 public:
-  enum class Kind : uint8_t { Normal, Mirrored, Inherited };
+  /// What sort of import are we deciding? We usually only emit remarks about
+  /// normal imports; mirrored and inherited imports are implementation details.
+  enum class Kind : uint8_t {
+    /// A normal import of the primary declaration.
+    Normal,
+    /// A mirrored import of a protocol requirement into a conforming type.
+    Mirrored,
+    /// An inherited import of a superclass member into a subclass.
+    Inherited
+  };
 
 private:
   ClangImporter::Implementation &impl;
   Kind kind;
 
+  /// The remark we will emit (or not), along with its notes.
   ImportRemark remark;
 
 public:
@@ -1528,39 +1619,114 @@ public:
   }
 
 public:
+  /// Gets the clang declaration we're thinking about importing. Use this only
+  /// for assertions or when the original declaration is inaccessible.
+  const clang::Decl *getClangDecl() const { return remark.clangDecl; }
+
+  /// Change the remark to indicate that the Clang decl was imported into Swift
+  /// as \p decl.
   void import(Decl *decl) {
     assert(decl);
-    assert(!remark.swiftDecl || remark.swiftDecl == decl);
-    remark.swiftDecl = decl;
+    assert(!remark.getSwiftDecl() || remark.getSwiftDecl() == decl);
+    remark.setSwiftDecl(decl);
   }
 
+  /// Change the remark to indicate that the Clang decl was imported into Swift
+  /// as \p decl, and register this fact in the
+  /// \c ClangImporter::Implementation::ImportedDecls map.
   void importAndCache(Decl *decl) {
     import(decl);
     if (kind == Kind::Normal)
       impl.cacheImportedDecl(decl, remark.clangDecl, remark.version);
   }
 
+  /// Change the remark to indicate that the Clang decl was imported into Swift
+  /// as \p altDecl in addition to \p mainDecl.
+  ///
+  /// Additional remarks will be emitted for the alternate declarations; they
+  /// will say "also imported as" instead of just "imported as".
   void importAlternate(Decl *mainDecl, ValueDecl *altDecl) {
     assert(mainDecl && altDecl);
     // FIXME: assert(mainDecl == remark.swiftDecl);
     remark.alternateSwiftDecls.push_back(altDecl);
   }
 
+  /// Change the remark to indicate that the Clang decl was imported into Swift
+  /// as \p altDecl in addition to \p mainDecl, and register this declaration
+  /// in the \c ClangImporter::Implementation::AlternateDecls map.
+  ///
+  /// Additional remarks will be emitted for the alternate declarations; they
+  /// will say "also imported as" instead of just "imported as".
   void importAndCacheAlternate(Decl *mainDecl, ValueDecl *altDecl) {
     importAlternate(mainDecl, altDecl);
     impl.addAlternateDecl(mainDecl, altDecl);
   }
 
-  void dontImport(ImportReason newReason) {
-    remark.reason = newReason;
+  /// Add a diagnostic that will be emitted if \p conditions hold. If \c loc is
+  /// provided, it will be emitted at the indicated source location; otherwise,
+  /// it will be emitted at the same source location as the remark.
+  void noteIf(ImportRemark::Note::Conditions conditions,
+              Optional<clang::SourceLocation> loc,
+              Diagnostic diag) {
+    remark.notes.push_back({ conditions, diag, loc });
   }
 
+  /// Add a diagnostic that will be emitted if \p conditions hold. If \c loc is
+  /// provided, it will be emitted at the indicated source location; otherwise,
+  /// it will be emitted at the same source location as the remark.
+  template <class ...DiagArgs>
+  void noteIf(ImportRemark::Note::Conditions conditions,
+              Optional<clang::SourceLocation> loc,
+              Diag<DiagArgs...> diagID,
+              typename detail::PassArgument<DiagArgs>::type... args) {
+    noteIf(conditions, loc, Diagnostic(diagID, std::move(args)...));
+  }
+
+  /// Add a diagnostic that will be emitted if the declaration is not imported
+  /// (the most commonly needed condition). If \c loc is provided, it will be
+  /// emitted at the indicated source location; otherwise, it will be emitted at
+  /// the same source location as the remark.
+  template <class ...DiagArgs>
+  void note(Optional<clang::SourceLocation> loc,
+            Diag<DiagArgs...> diagID,
+            typename detail::PassArgument<DiagArgs>::type... args) {
+    noteIf(ImportRemark::Outcome::NotImported, loc, diagID, std::move(args)...);
+  }
+
+  /// Indicate that the decision to either import or not import this declaration
+  /// has been made previously. No remark will be emitted indicating whether the
+  /// declaration was imported, and none of the notes will be emitted either.
+  /// However, remarks for any alternate imports \em will still be emitted.
+  ///
+  /// Some situations where you might use this method:
+  ///
+  /// 1) While trying to import a declaration, you use \c importDeclCached() or
+  ///    look in one of \c Impl's maps and discover that this declaration has
+  ///    already been imported (or, perhaps, not imported). You want to just
+  ///    return that value instead of creating a new declaration.
+  ///
+  /// 2) While importing an alternate name for a particular version, you
+  ///    discover that it is synonymous with the active version's name. You
+  ///    don't want or need to do any more work.
+  ///
+  /// 3) You want to generate alternates for a main declaration, but the main
+  ///    declaration has already been imported and its \c ImportDecision is now
+  ///    gone, so you can't add the alternates to its original
+  ///    \c ImportDecision. Instead, you can create a new \c ImportDecision for
+  ///    the clang decl and immediately mark it as "already decided".
+  ///
+  /// The common theme is that you have discovered that some previous
+  /// \c ImportDecision should already indicate whether or not the clang
+  /// declaration was imported, and you are not changing that decision.
   void alreadyDecided() {
-    remark.reason = ImportReason::AlreadyDecided;
+    remark.setShouldEmit(false);
   }
 };
 
 namespace importer {
+
+/// Returns a string describing the declaration in the user's terms.
+StringRef getClangDescriptiveKind(const clang::Decl *decl);
 
 /// Whether we should suppress the import of the given Clang declaration.
 bool shouldSuppressDeclImport(const clang::Decl *decl);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -30,6 +30,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/Basic/FileTypes.h"
+#include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/StringExtras.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclVisitor.h"
@@ -396,6 +397,20 @@ private:
 public:
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;
+
+  void cacheImportedDecl(Decl *swiftDecl, const clang::Decl *clangDecl,
+                         Version version) {
+    assert(clangDecl && "can't cache swift decl for null clang decl!");
+    assert(swiftDecl && "can't cache null swift decl!");
+
+    // I believe this invariant holds, and want to exploit it in the future if
+    // it does.
+    assert(isa<clang::ObjCCategoryDecl>(clangDecl)
+              || clangDecl->isCanonicalDecl()
+           && "all imported clang decls except for categories are canonical");
+
+    ImportedDecls[{clangDecl, version}] = swiftDecl;
+  }
 
   /// The set of "special" typedef-name declarations, which are
   /// mapped to specific Swift types.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -481,7 +481,12 @@ public:
   // Mapping from imported types to their raw value types.
   llvm::DenseMap<const NominalTypeDecl *, Type> RawTypes;
 
-  void addImportRemark(const ImportRemark &remark);
+  bool shouldEmitImportRemark(const ImportRemark &remark);
+
+  void addImportRemark(const ImportRemark &remark) {
+    if (shouldEmitImportRemark(remark))
+      ImportRemarks.push_back(remark);
+  }
 
   void emitImportRemarks();
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -25,6 +25,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
@@ -264,6 +265,8 @@ private:
 };
 }
 
+class ImportDecision;
+
 using LookupTableMap =
     llvm::DenseMap<StringRef, std::unique_ptr<SwiftLookupTable>>;
 
@@ -305,12 +308,27 @@ public:
   explicit operator bool() const { return type.getPointer() != nullptr; }
 };
 
+struct ImportRemark {
+  const clang::Decl *clangDecl;
+  importer::ImportNameVersion version;
+  Decl *swiftDecl = nullptr;
+  TinyPtrVector<Decl *> alternateSwiftDecls;
+  bool alreadyDecided = false;
+
+  ImportRemark(const clang::Decl *clangDecl,
+               importer::ImportNameVersion version)
+    : clangDecl(clangDecl), version(version) { }
+
+  void diagnose(ClangImporter::Implementation &impl);
+};
+
 /// Implementation of the Clang importer.
 class LLVM_LIBRARY_VISIBILITY ClangImporter::Implementation 
   : public LazyMemberLoader,
     public LazyConformanceLoader
 {
   friend class ClangImporter;
+  friend class ImportDecision;
   using Version = importer::ImportNameVersion;
 
 public:
@@ -394,6 +412,9 @@ private:
   /// Clang arguments used to create the Clang invocation.
   std::vector<std::string> ClangArgs;
 
+  /// Remarks to emit about import decisions.
+  std::vector<ImportRemark> ImportRemarks;
+
 public:
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;
@@ -459,6 +480,10 @@ public:
 
   // Mapping from imported types to their raw value types.
   llvm::DenseMap<const NominalTypeDecl *, Type> RawTypes;
+
+  void addImportRemark(const ImportRemark &remark);
+
+  void emitImportRemarks();
 
   clang::CompilerInstance *getClangInstance() {
     return Instance.get();
@@ -792,7 +817,8 @@ public:
                          bool UseCanonicalDecl = true);
 
   Decl *importDeclImpl(const clang::NamedDecl *ClangDecl, Version version,
-                       bool &TypedefIsSuperfluous, bool &HadForwardDeclaration);
+                       bool &TypedefIsSuperfluous, bool &HadForwardDeclaration,
+                       ImportDecision &decision);
 
   Decl *importDeclAndCacheImpl(const clang::NamedDecl *ClangDecl,
                                Version version,
@@ -1437,6 +1463,66 @@ public:
     if (SinglePCHImport.hasValue())
       return *SinglePCHImport;
     return StringRef();
+  }
+};
+
+class ImportDecision {
+public:
+  enum class Kind : uint8_t { Normal, Mirrored, Inherited };
+
+private:
+  ClangImporter::Implementation &impl;
+  Kind kind;
+
+  ImportRemark remark;
+
+public:
+  ImportDecision(ClangImporter::Implementation &impl,
+                 const clang::Decl *clangDecl,
+                 importer::ImportNameVersion version,
+                 Kind kind = Kind::Normal)
+    : impl(impl), kind(kind), remark(clangDecl, version)
+  { }
+
+  // Uncopyable. Each decision is unique.
+  ImportDecision(const ImportDecision &other) = delete;
+  ImportDecision &operator=(const ImportDecision &other) = delete;
+
+  // Unmovable. (These could be implemented by setting the moved-from instance
+  // to AlreadyDecided.)
+  ImportDecision(const ImportDecision &&other) = delete;
+  ImportDecision &operator=(const ImportDecision &&other) = delete;
+
+  ~ImportDecision() {
+    impl.addImportRemark(remark);
+  }
+
+public:
+  void import(Decl *decl) {
+    assert(decl);
+    assert(!remark.swiftDecl || remark.swiftDecl == decl);
+    remark.swiftDecl = decl;
+  }
+
+  void importAndCache(Decl *decl) {
+    import(decl);
+    if (kind == Kind::Normal)
+      impl.cacheImportedDecl(decl, remark.clangDecl, remark.version);
+  }
+
+  void importAlternate(Decl *mainDecl, ValueDecl *altDecl) {
+    assert(mainDecl && altDecl);
+    // FIXME: assert(mainDecl == remark.swiftDecl);
+    remark.alternateSwiftDecls.push_back(altDecl);
+  }
+
+  void importAndCacheAlternate(Decl *mainDecl, ValueDecl *altDecl) {
+    importAlternate(mainDecl, altDecl);
+    impl.addAlternateDecl(mainDecl, altDecl);
+  }
+
+  void alreadyDecided() {
+    remark.alreadyDecided = true;
   }
 };
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1412,7 +1412,11 @@ public:
   }
 
   /// Dump the Swift-specific name lookup tables we generate.
-  void dumpSwiftLookupTables();
+  void dumpSwiftLookupTables(llvm::raw_ostream &os) const;
+
+  SWIFT_DEBUG_DUMPER(dumpSwiftLookupTables()) {
+    dumpSwiftLookupTables(llvm::dbgs());
+  }
 
   void setSinglePCHImport(Optional<std::string> PCHFilename) {
     if (PCHFilename.hasValue()) {

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -841,57 +841,6 @@ ArrayRef<clang::ObjCCategoryDecl *> SwiftLookupTable::categories() {
   return Categories;
 }
 
-static void printName(clang::NamedDecl *named, llvm::raw_ostream &out) {
-  // If there is a name, print it.
-  if (!named->getDeclName().isEmpty()) {
-    // If we have an Objective-C method, print the class name along
-    // with '+'/'-'.
-    if (auto objcMethod = dyn_cast<clang::ObjCMethodDecl>(named)) {
-      out << (objcMethod->isInstanceMethod() ? '-' : '+') << '[';
-      if (auto classDecl = objcMethod->getClassInterface()) {
-        classDecl->printName(out);
-        out << ' ';
-      } else if (auto proto = dyn_cast<clang::ObjCProtocolDecl>(
-                                objcMethod->getDeclContext())) {
-        proto->printName(out);
-        out << ' ';
-      }
-      named->printName(out);
-      out << ']';
-      return;
-    }
-
-    // If we have an Objective-C property, print the class name along
-    // with the property name.
-    if (auto objcProperty = dyn_cast<clang::ObjCPropertyDecl>(named)) {
-      auto dc = objcProperty->getDeclContext();
-      if (auto classDecl = dyn_cast<clang::ObjCInterfaceDecl>(dc)) {
-        classDecl->printName(out);
-        out << '.';
-      } else if (auto categoryDecl = dyn_cast<clang::ObjCCategoryDecl>(dc)) {
-        categoryDecl->getClassInterface()->printName(out);
-        out << '.';
-      } else if (auto proto = dyn_cast<clang::ObjCProtocolDecl>(dc)) {
-        proto->printName(out);
-        out << '.';
-      }
-      named->printName(out);
-      return;
-    }
-
-    named->printName(out);
-    return;
-  }
-
-  // If this is an anonymous tag declaration with a typedef name, use that.
-  if (auto tag = dyn_cast<clang::TagDecl>(named)) {
-    if (auto typedefName = tag->getTypedefNameForAnonDecl()) {
-      printName(typedefName, out);
-      return;
-    }
-  }
-}
-
 void SwiftLookupTable::deserializeAll() {
   if (!Reader) return;
 
@@ -966,7 +915,7 @@ static void printStoredEntry(const SwiftLookupTable *table, uint64_t entry,
     llvm::errs() << "Macro";
   } else {
     auto decl = const_cast<SwiftLookupTable *>(table)->mapStoredDecl(entry);
-    printName(decl, llvm::errs());
+    printClangDeclName(decl, llvm::errs());
   }
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -928,6 +928,9 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);
 
+  for (Arg *A : Args.filtered(OPT_verify_additional_file))
+    Opts.AdditionalVerifierFiles.push_back(A->getValue());
+
   Opts.UseColor |=
       Args.hasFlag(OPT_color_diagnostics,
                    OPT_no_color_diagnostics,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -776,6 +776,14 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   return HadError;
 }
 
+static void ParseRImportArg(std::vector<std::tuple<std::string, bool>> &list,
+                            bool value,
+                            ArgList &Args,
+                            OptSpecifier id) {
+  for (const Arg *A : Args.filtered(id))
+    list.emplace_back(A->getValue(), value);
+}
+
 static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
                                    ArgList &Args,
                                    DiagnosticEngine &Diags,
@@ -795,6 +803,11 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
   for (const Arg *A : Args.filtered(OPT_Xcc)) {
     Opts.ExtraArgs.push_back(A->getValue());
   }
+
+  ParseRImportArg(Opts.EmitImportDecisionRemarks, true, Args,
+                  OPT_Robjc_imports);
+  ParseRImportArg(Opts.EmitImportDecisionRemarks, false, Args,
+                  OPT_Robjc_import_failures);
 
   for (auto A : Args.getAllArgValues(OPT_debug_prefix_map)) {
     // Forward -debug-prefix-map arguments from Swift to Clang as

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -809,6 +809,10 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
   ParseRImportArg(Opts.EmitImportDecisionRemarks, false, Args,
                   OPT_Robjc_import_failures);
 
+  if (!Opts.EmitImportDecisionRemarks.empty()
+      && !Args.hasArg(OPT_Robjc_imports_natural_only))
+    Opts.ForceImportDecisions = true;
+
   for (auto A : Args.getAllArgValues(OPT_debug_prefix_map)) {
     // Forward -debug-prefix-map arguments from Swift to Clang as
     // -fdebug-prefix-map. This is required to ensure DIFiles created there,

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -978,11 +978,13 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
 bool DiagnosticVerifier::finishProcessing() {
   DiagnosticVerifier::Result Result = {false, false};
 
-  for (auto &BufferID : BufferIDs) {
-    DiagnosticVerifier::Result FileResult = verifyFile(BufferID);
-    Result.HadError |= FileResult.HadError;
-    Result.HadUnexpectedDiag |= FileResult.HadUnexpectedDiag;
-  }
+  ArrayRef<unsigned> BufferIDLists[2] = { BufferIDs, AdditionalBufferIDs };
+  for (ArrayRef<unsigned> BufferIDList : BufferIDLists)
+    for (auto &BufferID : BufferIDList) {
+      DiagnosticVerifier::Result FileResult = verifyFile(BufferID);
+      Result.HadError |= FileResult.HadError;
+      Result.HadUnexpectedDiag |= FileResult.HadUnexpectedDiag;
+    }
   if (!IgnoreUnknown) {
     bool HadError = verifyUnknown(SM, CapturedDiagnostics);
     Result.HadError |= HadError;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1757,6 +1757,8 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   // Verify generic signatures if we've been asked to.
   verifyGenericSignaturesIfNeeded(Invocation, ctx);
 
+  ctx.getClangModuleLoader()->emitImportRemarks();
+
   // Emit any additional outputs that we only need for a successful compilation.
   // We don't want to unnecessarily delay getting any errors back to the user.
   if (!ctx.hadError()) {

--- a/test/ClangImporter/import-decision-remarks.swift
+++ b/test/ClangImporter/import-decision-remarks.swift
@@ -1,0 +1,31 @@
+// Positive checks for all expected diagnostics. The actual expectations are in
+// Foundation.h, not here.
+//
+// TODO: Actually add all of the expectations to Foundation.h.
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -verify-additional-file %clang-importer-sdk-path/usr/include/Foundation.h -Robjc-imports Foundation
+
+import Foundation
+import ctypes
+import enums_using_attributes
+
+// The %t.txt file should contain failures (but not successes) in Foundation,
+// successes and failures in user_objc, and nothing in enums_using_attributes.
+//
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -Robjc-import-failures Foundation -Robjc-imports ctypes 2>%t.txt
+// RUN: %FileCheck --check-prefix POSITIVE %s <%t.txt
+// RUN: %FileCheck --check-prefix NEGATIVE %s <%t.txt
+
+// POSITIVE-DAG: ctypes.h:{{[0-9]+:[0-9]+}}: remark: could not import
+// POSITIVE-DAG: ctypes.h:{{[0-9]+:[0-9]+}}: remark: {{.* (also )?}}imported as
+// POSITIVE-DAG: Foundation.h:{{[0-9]+:[0-9]+}}: remark: could not import
+
+// NEGATIVE-NOT: Foundation.h:{{[0-9]+:[0-9]+}}: remark: {{.* (also )?}}imported as
+// NEGATIVE-NOT: enums_using_attributes.h:{{[0-9]+:[0-9]+}}: remark: {{.* (also )?}}imported as
+// NEGATIVE-NOT: enums_using_attributes.h:{{[0-9]+:[0-9]+}}: remark: could not import
+
+// Not mentioned in any of the flags, but imported by Foundation.
+// NEGATIVE-NOT: CoreGraphics.h:{{[0-9]+:[0-9]+}}: remark: {{.* (also )?}}imported as
+// NEGATIVE-NOT: CoreGraphics.h:{{[0-9]+:[0-9]+}}: remark: could not import
+
+// TODO: Test -Robjc-imports-natural-only
+// TODO: Test specifying a submodule

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -158,6 +158,8 @@ __attribute__((availability(ios,introduced=8.0)))
 // expected-note@-4 {{a better candidate, Objective-C method '-[NSArray initWithObjects:count:]', is already being imported with the name 'init(objects:count:)' and the same signature}}
 - (nonnull ObjectType)objectAtIndexedSubscript:(NSUInteger)idx;
 // expected-remark@-1 {{Objective-C method '-[NSArray objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
+// expected-remark@-2 {{Objective-C method '-[NSArray objectAtIndexedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[NSArray objectAtIndexedSubscript:]' also imported as subscript 'subscript(_:)'}}
 - description;
 // expected-remark@-1 {{Objective-C method '-[NSArray description]' imported as instance method 'description()'}}
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector;
@@ -187,7 +189,8 @@ __attribute__((availability(ios,introduced=8.0)))
 // expected-remark@-1 {{Objective-C class interface 'DummyClass' imported as class 'DummyClass'}}
 - (nonnull id)objectAtIndexedSubscript:(NSUInteger)idx;
 // expected-remark@-1 {{Objective-C method '-[DummyClass objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
-// FIXME: Subscript???
+// expected-remark@-2 {{Objective-C method '-[DummyClass objectAtIndexedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[DummyClass objectAtIndexedSubscript:]' also imported as subscript 'subscript(_:)'}}
 - description;
 // expected-remark@-1 {{Objective-C method '-[DummyClass description]' imported as instance method 'description()'}}
 
@@ -282,7 +285,8 @@ __attribute__((availability(ios,introduced=8.0)))
 // expected-remark@-1 {{Objective-C category 'NSDictionary(NSExtendedDictionary)' imported as extension of 'NSDictionary'}}
 - (nullable ObjectType)objectForKeyedSubscript:(nonnull KeyType)key;
 // expected-remark@-1 {{Objective-C method '-[NSDictionary(NSExtendedDictionary) objectForKeyedSubscript:]' imported as unavailable instance method 'objectForKeyedSubscript'}}
-// FIXME: Subscript?
+// expected-remark@-2 {{Objective-C method '-[NSDictionary(NSExtendedDictionary) objectForKeyedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[NSDictionary(NSExtendedDictionary) objectForKeyedSubscript:]' also imported as subscript 'subscript(_:)'}}
 @end
 
 @interface NSDictionary (Inits)
@@ -523,17 +527,21 @@ typedef NSPoint *NSPointArray;
 // expected-remark@-1 {{Objective-C class interface 'BadCollection' imported as class 'BadCollection'}}
 - (id)objectForKeyedSubscript:(id)key;
 // expected-remark@-1 {{Objective-C method '-[BadCollection objectForKeyedSubscript:]' imported as unavailable instance method 'objectForKeyedSubscript'}}
-// FIXME: Subscript?
+// expected-remark@-2 {{Objective-C method '-[BadCollection objectForKeyedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[BadCollection objectForKeyedSubscript:]' also imported as subscript 'subscript(_:)'}}
+// expected-note@-4 {{cannot import Objective-C method '-[BadCollection setObject:forKeyedSubscript:]' as a subscript setter matching getter Objective-C method '-[BadCollection objectForKeyedSubscript:]' because the setter's index type, 'String?', does not match the getter's, 'Any?'}}
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
 // expected-remark@-1 {{Objective-C method '-[BadCollection setObject:forKeyedSubscript:]' imported as instance method 'setObject(_:forKeyedSubscript:)'}}
-// FIXME: Subscript?
 @end
 
 @interface BadCollectionParent
 // expected-remark@-1 {{Objective-C class interface 'BadCollectionParent' imported as class 'BadCollectionParent'}}
 - (id)objectForKeyedSubscript:(NSString *)key;
 // expected-remark@-1 {{Objective-C method '-[BadCollectionParent objectForKeyedSubscript:]' imported as unavailable instance method 'objectForKeyedSubscript'}}
-// FIXME: Subscript?
+// expected-remark@-2 {{Objective-C method '-[BadCollectionParent objectForKeyedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[BadCollectionParent objectForKeyedSubscript:]' also imported as subscript 'subscript(_:)'}}
+// expected-note@-4 {{cannot import Objective-C method '-[BadCollectionChild setObject:forKeyedSubscript:]' as a subscript setter matching getter Objective-C method '-[BadCollectionParent objectForKeyedSubscript:]' because the setter's index type, 'Any?', does not match the getter's, 'String?'}}
+// expected-note@-5 {{cannot import Objective-C method '-[ReadOnlyCollectionChild setObject:forKeyedSubscript:]' as a subscript setter matching getter Objective-C method '-[BadCollectionParent objectForKeyedSubscript:]' because the setter's index type, 'Any?', does not match the getter's, 'String?'}}
 @end
 
 @interface BadCollectionChild : BadCollectionParent
@@ -1287,6 +1295,8 @@ typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOnOSXOptions) {
 
 - (id)objectAtIndexedSubscript:(NSUInteger)idx;
 // expected-remark@-1 {{Objective-C method '-[NSWobbling objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
+// expected-remark@-2 {{Objective-C method '-[NSWobbling objectAtIndexedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[NSWobbling objectAtIndexedSubscript:]' also imported as subscript 'subscript(_:)'}}
 @end
 
 @protocol NSMaybeInitWobble
@@ -2008,8 +2018,11 @@ void takeNullableId(_Nullable id);
 // expected-remark@-1 {{Objective-C class interface 'ColorArray' imported as class 'ColorArray'}}
 - (ColorDescriptor *)objectAtIndexedSubscript:(NSUInteger)attachmentIndex;
 // expected-remark@-1 {{Objective-C method '-[ColorArray objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
+// expected-remark@-2 {{Objective-C method '-[ColorArray objectAtIndexedSubscript:]' also imported as getter for subscript 'subscript(_:)'}}
+// expected-remark@-3 {{Objective-C method '-[ColorArray objectAtIndexedSubscript:]' also imported as subscript 'subscript(_:)'}}
 - (void)setObject:(nullable ColorDescriptor *)attachment atIndexedSubscript:(NSUInteger)attachmentIndex;
 // expected-remark@-1 {{Objective-C method '-[ColorArray setObject:atIndexedSubscript:]' imported as unavailable instance method 'setObject(_:atIndexedSubscript:)'}}
+// expected-remark@-2 {{Objective-C method '-[ColorArray setObject:atIndexedSubscript:]' also imported as setter for subscript 'subscript(_:)'}}
 @end
 
 @interface PaletteDescriptor : NSObject <NSCopying>

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1,3 +1,5 @@
+// expected-* lines in this file are used in test/ClangImporter/import-decision-remarks.swift.
+
 #if __has_feature(modules)
 @import ObjectiveC;
 @import CoreFoundation;
@@ -13,304 +15,537 @@
 #define NS_NOESCAPE CF_NOESCAPE
 
 typedef struct objc_object { void *isa; } *id;
+// expected-remark@-1:36 {{C field 'objc_object::isa' imported as property 'isa'}}
+// expected-remark@-2:16 {{C struct 'objc_object' imported as struct 'objc_object'}}
+// expected-remark@-3:44 {{C typedef 'id' imported as unavailable type alias 'id'}}
 
 typedef struct _NSZone NSZone;
+// expected-remark@-1 {{could not import C struct '_NSZone'}}
+// expected-note@-2 {{found only forward declarations of C struct '_NSZone'; incomplete types cannot be imported into Swift}}
+// expected-remark@-3 {{could not import C typedef 'NSZone'}}
+// expected-note@-4 {{type could not be imported}}
 void *allocate(NSZone *zone);
+// expected-remark@-1 {{C function 'allocate' imported as global function 'allocate'}}
 
 typedef double NSTimeInterval;
+// expected-remark@-1 {{C typedef 'NSTimeInterval' imported as type alias 'TimeInterval'}}
 
 typedef struct _NSRange {
+    // expected-remark@-1 {{C struct '_NSRange' imported as struct '_NSRange'}}
     NSUInteger location;
+    // expected-remark@-1 {{C field '_NSRange::location' imported as property 'location'}}
     NSUInteger length;
+    // expected-remark@-1 {{C field '_NSRange::length' imported as property 'length'}}
 } NSRange;
+// expected-remark@-1 {{C typedef 'NSRange' imported as type alias 'NSRange'}}
 
 
 extern NSUInteger NSRealMemoryAvailable(void) __attribute__((availability(macosx,introduced=10.0 ,deprecated=10.8,message="" ))) __attribute__((availability(ios,introduced=2.0 ,deprecated=6.0,message="" )));
+// expected-remark@-1 {{C function 'NSRealMemoryAvailable' imported as unavailable global function 'NSRealMemoryAvailable()'}}
 extern NSUInteger SomeCrazyAppExtensionForbiddenAPI(void)
   __attribute__((availability(macosx_app_extension,unavailable,message="Not available in App Extensions")))
   __attribute__((availability(ios_app_extension,unavailable,message="Not available in App Extensions")));
+// expected-remark@-3 {{C function 'SomeCrazyAppExtensionForbiddenAPI' imported as global function 'SomeCrazyAppExtensionForbiddenAPI()'}}
 
 extern NSString *const globalStringAvailableOn10_51 __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{C variable 'globalStringAvailableOn10_51' imported as let 'globalStringAvailableOn10_51'}}
 extern NSString *const globalStringAvailableOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{C variable 'globalStringAvailableOn10_52' imported as let 'globalStringAvailableOn10_52'}}
 
 __attribute__((availability(macosx,introduced=10.51)))
 @interface NSAvailableOn10_51 : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSAvailableOn10_51' imported as class 'NSAvailableOn10_51'}}
 - (instancetype)init;
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_51 init]' imported as initializer 'init()'}}
 - (instancetype)initWithStringOn10_52:(NSString *)s __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_51 initWithStringOn10_52:]' imported as initializer 'init(stringOn10_52:)'}}
 
 @property NSInteger propertyOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_51 propertyOn10_52]' imported as getter for property 'propertyOn10_52'}}
+// expected-remark@-2 {{Objective-C method '-[NSAvailableOn10_51 setPropertyOn10_52:]' imported as setter for property 'propertyOn10_52'}}
+// expected-remark@-3 {{Objective-C property '-NSAvailableOn10_51.propertyOn10_52' imported as property 'propertyOn10_52'}}
 
 - (void)methodAvailableOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_51 methodAvailableOn10_52]' imported as instance method 'methodAvailableOn10_52()'}}
 @end
 
 extern NSAvailableOn10_51 *const globalClassInstanceAvailableOn10_51 __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{C variable 'globalClassInstanceAvailableOn10_51' imported as let 'globalClassInstanceAvailableOn10_51'}}
 
 __attribute__((availability(macosx,introduced=10.51)))
 @protocol NSProtocolAvailableOn10_51
+// expected-remark@-1 {{Objective-C protocol 'NSProtocolAvailableOn10_51' imported as protocol 'NSProtocolAvailableOn10_51'}}
 
 @end
 
 __attribute__((availability(macosx,introduced=10.9)))
 @interface NSAvailableOn10_9 : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSAvailableOn10_9' imported as class 'NSAvailableOn10_9'}}
 
 @property NSInteger propertyOn10_9;
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 propertyOn10_9]' imported as getter for property 'propertyOn10_9'}}
+// expected-remark@-2 {{Objective-C method '-[NSAvailableOn10_9 setPropertyOn10_9:]' imported as setter for property 'propertyOn10_9'}}
+// expected-remark@-3 {{Objective-C property '-NSAvailableOn10_9.propertyOn10_9' imported as property 'propertyOn10_9'}}
 
 // Properties with unavailable accessors declared before property.
 - (void)setPropertyOn10_51WithSetterOn10_52Before:(NSInteger)prop __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 setPropertyOn10_51WithSetterOn10_52Before:]' imported as instance method 'setPropertyOn10_51WithSetterOn10_52Before'}}
+// expected-remark@-2 {{Objective-C method '-[NSAvailableOn10_9 setPropertyOn10_51WithSetterOn10_52Before:]' imported as setter for property 'propertyOn10_51WithSetterOn10_52Before'}}
 @property NSInteger propertyOn10_51WithSetterOn10_52Before __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 propertyOn10_51WithSetterOn10_52Before]' imported as getter for property 'propertyOn10_51WithSetterOn10_52Before'}}
+// expected-remark@-2 {{Objective-C property '-NSAvailableOn10_9.propertyOn10_51WithSetterOn10_52Before' imported as property 'propertyOn10_51WithSetterOn10_52Before'}}
 
 - (NSInteger)propertyOn10_51WithGetterOn10_52Before __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 propertyOn10_51WithGetterOn10_52Before]' imported as getter for property 'propertyOn10_51WithGetterOn10_52Before'}}
+// expected-remark@-2 {{Objective-C method '-[NSAvailableOn10_9 propertyOn10_51WithGetterOn10_52Before]' imported as instance method 'propertyOn10_51WithGetterOn10_52Before()'}}
 @property NSInteger propertyOn10_51WithGetterOn10_52Before __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 setPropertyOn10_51WithGetterOn10_52Before:]' imported as setter for property 'propertyOn10_51WithGetterOn10_52Before'}}
+// expected-remark@-2 {{Objective-C property '-NSAvailableOn10_9.propertyOn10_51WithGetterOn10_52Before' imported as property 'propertyOn10_51WithGetterOn10_52Before'}}
 
 // Properties with unavailable accessors declared after property.
 @property NSInteger propertyOn10_51WithSetterOn10_52After __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 propertyOn10_51WithSetterOn10_52After]' imported as getter for property 'propertyOn10_51WithSetterOn10_52After'}}
+// expected-remark@-2 {{Objective-C property '-NSAvailableOn10_9.propertyOn10_51WithSetterOn10_52After' imported as property 'propertyOn10_51WithSetterOn10_52After'}}
 - (void)setPropertyOn10_51WithSetterOn10_52After:(NSInteger)prop __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 setPropertyOn10_51WithSetterOn10_52After:]' imported as setter for property 'propertyOn10_51WithSetterOn10_52After'}}
 
 @property NSInteger propertyOn10_51WithGetterOn10_52After __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 setPropertyOn10_51WithGetterOn10_52After:]' imported as setter for property 'propertyOn10_51WithGetterOn10_52After'}}
+// expected-remark@-2 {{Objective-C property '-NSAvailableOn10_9.propertyOn10_51WithGetterOn10_52After' imported as property 'propertyOn10_51WithGetterOn10_52After'}}
 - (NSInteger)propertyOn10_51WithGetterOn10_52After __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 propertyOn10_51WithGetterOn10_52After]' imported as getter for property 'propertyOn10_51WithGetterOn10_52After'}}
 
 // Property with redeclared with a setter in a category
 @property(readonly) NSInteger readOnlyRedeclaredWithSetterInCategory __attribute__((availability(macosx,introduced=10.51)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 readOnlyRedeclaredWithSetterInCategory]' imported as getter for property 'readOnlyRedeclaredWithSetterInCategory'}}
+// expected-remark@-2 {{Objective-C property '-NSAvailableOn10_9.readOnlyRedeclaredWithSetterInCategory' imported as property 'readOnlyRedeclaredWithSetterInCategory'}}
 
 - (void)methodAvailableOn10_52 __attribute__((availability(macosx,introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSAvailableOn10_9 methodAvailableOn10_52]' imported as instance method 'methodAvailableOn10_52()'}}
 @end
 
 @interface NSAvailableOn10_9 (NSWithPropertyReclarationInACategory)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 
 @property(readwrite) NSInteger readOnlyRedeclaredWithSetterInCategory __attribute__((availability(macosx,introduced=10.51)));
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)setReadOnlyRedeclaredWithSetterInCategory:(NSInteger)prop __attribute__((availability(macosx,introduced=10.52)));
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 /// Aaa.  NSAvailableOnOSX10_51AndIOS8_0.  Bbb.
 __attribute__((availability(macosx,introduced=10.51)))
 __attribute__((availability(ios,introduced=8.0)))
 @interface NSAvailableOnOSX10_51AndIOS8_0 : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSAvailableOnOSX10_51AndIOS8_0' imported as class 'NSAvailableOnOSX10_51AndIOS8_0'}}
 
 @end
 
 @class NSString, NSArray, NSDictionary, NSSet, NSEnumerator;
+// FIXME: These are doubled for some reason.
+// expected-remark@-2:48 2 {{could not import Objective-C class interface 'NSEnumerator'}}
+// expected-note@-3:48 2 {{found only forward declarations of Objective-C class interface 'NSEnumerator'; incomplete types cannot be imported into Swift}}
 
 @class NSMutableArray<ObjectType>;
 
 /// Aaa.  NSArray.  Bbb.
 @interface NSArray<ObjectType> : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSArray' imported as class 'NSArray'}}
 - (instancetype)initWithObjects:(const ObjectType _Nonnull [_Nullable])objects
                           count:(NSUInteger)cnt NS_DESIGNATED_INITIALIZER;
+// expected-remark@-2 {{Objective-C method '-[NSArray initWithObjects:count:]' imported as initializer 'init(objects:count:)'}}
+// --- Emitted for +arrayWithObjects:count: ---
+// expected-note@-4 {{a better candidate, Objective-C method '-[NSArray initWithObjects:count:]', is already being imported with the name 'init(objects:count:)' and the same signature}}
 - (nonnull ObjectType)objectAtIndexedSubscript:(NSUInteger)idx;
+// expected-remark@-1 {{Objective-C method '-[NSArray objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
 - description;
+// expected-remark@-1 {{Objective-C method '-[NSArray description]' imported as instance method 'description()'}}
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector;
+// expected-remark@-1 {{Objective-C method '-[NSArray makeObjectsPerformSelector:]' imported as instance method 'makeObjectsPerform'}}
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector withObject:(nullable ObjectType)anObject;
+// expected-remark@-1 {{Objective-C method '-[NSArray makeObjectsPerformSelector:withObject:]' imported as instance method 'makeObjectsPerform(_:with:)'}}
 - (void)makeObjectsPerformSelector:(nonnull SEL)aSelector withObject:(nullable ObjectType)anObject withObject:(nullable ObjectType)anotherObject;
+// expected-remark@-1 {{Objective-C method '-[NSArray makeObjectsPerformSelector:withObject:withObject:]' imported as instance method 'makeObjectsPerform(_:with:with:)'}}
 - (nonnull NSMutableArray<ObjectType> *)mutableCopy;
+// expected-remark@-1 {{Objective-C method '-[NSArray mutableCopy]' imported as instance method 'mutableCopy()'}}
 @end
 
 @interface NSArray<ObjectType>(NSArrayCreation)
+// expected-remark@-1 {{Objective-C category 'NSArray(NSArrayCreation)' imported as extension of 'NSArray'}}
 + (instancetype)arrayWithObjects:(const ObjectType _Nonnull [_Nullable])objects
                            count:(NSUInteger)cnt;
+// expected-remark@-2 {{could not import Objective-C method '+[NSArray(NSArrayCreation) arrayWithObjects:count:]'}}
 @end
 
 @interface NSArray (AddingObject)
+// expected-remark@-1 {{Objective-C category 'NSArray(AddingObject)' imported as extension of 'NSArray'}}
 - (NSInteger)indexOfObject:(nonnull id)object;
+// expected-remark@-1 {{Objective-C method '-[NSArray(AddingObject) indexOfObject:]' imported as instance method 'index(of:)'}}
 @end
 
 @interface DummyClass : NSObject
+// expected-remark@-1 {{Objective-C class interface 'DummyClass' imported as class 'DummyClass'}}
 - (nonnull id)objectAtIndexedSubscript:(NSUInteger)idx;
+// expected-remark@-1 {{Objective-C method '-[DummyClass objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
+// FIXME: Subscript???
 - description;
+// expected-remark@-1 {{Objective-C method '-[DummyClass description]' imported as instance method 'description()'}}
 
 @property NSString *nsstringProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass nsstringProperty]' imported as getter for property 'nsstringProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setNsstringProperty:]' imported as setter for property 'nsstringProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.nsstringProperty' imported as property 'nsstringProperty'}}
 @property BOOL boolProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass boolProperty]' imported as getter for property 'boolProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setBoolProperty:]' imported as setter for property 'boolProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.boolProperty' imported as property 'boolProperty'}}
 @property NSArray *arrayProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass arrayProperty]' imported as getter for property 'arrayProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setArrayProperty:]' imported as setter for property 'arrayProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.arrayProperty' imported as property 'arrayProperty'}}
 @property NSDictionary *dictProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass dictProperty]' imported as getter for property 'dictProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setDictProperty:]' imported as setter for property 'dictProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.dictProperty' imported as property 'dictProperty'}}
 @property NSSet *setProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass setProperty]' imported as getter for property 'setProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setSetProperty:]' imported as setter for property 'setProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.setProperty' imported as property 'setProperty'}}
 
 - (nonnull NSString*) fetchNonnullString;
+// expected-remark@-1 {{Objective-C method '-[DummyClass fetchNonnullString]' imported as instance method 'fetchNonnullString()'}}
 - (nullable NSString*) fetchNullableString;
+// expected-remark@-1 {{Objective-C method '-[DummyClass fetchNullableString]' imported as instance method 'fetchNullableString()'}}
 - (null_unspecified NSString*) fetchNullproneString;
+// expected-remark@-1 {{Objective-C method '-[DummyClass fetchNullproneString]' imported as instance method 'fetchNullproneString()'}}
 
 - (void) takeNonnullString: (nonnull NSString*) string;
+// expected-remark@-1 {{Objective-C method '-[DummyClass takeNonnullString:]' imported as instance method 'takeNonnullString'}}
 - (void) takeNullableString: (nullable NSString*) string;
+// expected-remark@-1 {{Objective-C method '-[DummyClass takeNullableString:]' imported as instance method 'takeNullableString'}}
 - (void) takeNullproneString: (null_unspecified NSString*) string;
+// expected-remark@-1 {{Objective-C method '-[DummyClass takeNullproneString:]' imported as instance method 'takeNullproneString'}}
 
 @property(readwrite) _Nonnull NSString *nonnullStringProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass nonnullStringProperty]' imported as getter for property 'nonnullStringProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setNonnullStringProperty:]' imported as setter for property 'nonnullStringProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.nonnullStringProperty' imported as property 'nonnullStringProperty'}}
 @property(readwrite) _Nullable NSString *nullableStringProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass nullableStringProperty]' imported as getter for property 'nullableStringProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setNullableStringProperty:]' imported as setter for property 'nullableStringProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.nullableStringProperty' imported as property 'nullableStringProperty'}}
 @property(readwrite) _Null_unspecified NSString *nullproneStringProperty;
+// expected-remark@-1 {{Objective-C method '-[DummyClass nullproneStringProperty]' imported as getter for property 'nullproneStringProperty'}}
+// expected-remark@-2 {{Objective-C method '-[DummyClass setNullproneStringProperty:]' imported as setter for property 'nullproneStringProperty'}}
+// expected-remark@-3 {{Objective-C property '-DummyClass.nullproneStringProperty' imported as property 'nullproneStringProperty'}}
 
 @end
 
 @interface DummyClass (Extras)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @property NSString *nsstringProperty2;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSCoder : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSCoder' imported as class 'NSCoder'}}
 @end
 
 @protocol NSCoding
+// expected-remark@-1 {{Objective-C protocol 'NSCoding' imported as protocol 'NSCoding'}}
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aCoder;
+// expected-remark@-1 {{Objective-C method '-[NSCoding initWithCoder:]' imported as initializer 'init(coder:)'}}
 @end
 
 @protocol NSSecureCoding <NSCoding>
+// expected-remark@-1 {{Objective-C protocol 'NSSecureCoding' imported as protocol 'NSSecureCoding'}}
 @end
 
 @protocol NSCopying
+// expected-remark@-1 {{Objective-C protocol 'NSCopying' imported as protocol 'NSCopying'}}
 - (id)copyWithZone:(nullable NSZone *)zone;
+// expected-remark@-1 {{Objective-C method '-[NSCopying copyWithZone:]' imported as instance method 'copy(with:)'}}
 @end
 
 @interface NSDictionary<KeyType, ObjectType> : NSObject /*<NSCopying, NSMutableCopying, NSSecureCoding, NSFastEnumeration>*/
+// expected-remark@-1 {{Objective-C class interface 'NSDictionary' imported as class 'NSDictionary'}}
 @property (readonly) NSUInteger count;
+// expected-remark@-1 {{Objective-C method '-[NSDictionary count]' imported as getter for property 'count'}}
+// expected-remark@-2 {{Objective-C property '-NSDictionary.count' imported as property 'count'}}
 - (nullable ObjectType)objectForKey:(nonnull KeyType)aKey;
+// expected-remark@-1 {{Objective-C method '-[NSDictionary objectForKey:]' imported as instance method 'object(forKey:)'}}
 - (nonnull NSEnumerator *)keyEnumerator;
+// expected-remark@-1 {{could not import Objective-C method '-[NSDictionary keyEnumerator]'}}
+// expected-note@-2 {{type could not be imported}}
 @end
 @interface NSDictionary<KeyType, ObjectType> (NSExtendedDictionary)
+// expected-remark@-1 {{Objective-C category 'NSDictionary(NSExtendedDictionary)' imported as extension of 'NSDictionary'}}
 - (nullable ObjectType)objectForKeyedSubscript:(nonnull KeyType)key;
+// expected-remark@-1 {{Objective-C method '-[NSDictionary(NSExtendedDictionary) objectForKeyedSubscript:]' imported as unavailable instance method 'objectForKeyedSubscript'}}
+// FIXME: Subscript?
 @end
 
 @interface NSDictionary (Inits)
+// expected-remark@-1 {{Objective-C category 'NSDictionary(Inits)' imported as extension of 'NSDictionary'}}
 - (nonnull instancetype)init;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSMutableDictionary<KeyType : id<NSCopying>, ObjectType> : NSDictionary<KeyType, ObjectType>
+// expected-remark@-1 {{Objective-C class interface 'NSMutableDictionary' imported as class 'NSMutableDictionary'}}
 - (void)removeObjectForKey:(nonnull KeyType)aKey;
+// expected-remark@-1 {{Objective-C method '-[NSMutableDictionary removeObjectForKey:]' imported as instance method 'removeObject(forKey:)'}}
 - (void)setObject:(nonnull ObjectType)anObject forKey:(nonnull KeyType)aKey;
+// expected-remark@-1 {{Objective-C method '-[NSMutableDictionary setObject:forKey:]' imported as instance method 'setObject(_:forKey:)'}}
 @end
 
 @interface NSMutableDictionary<KeyType, ObjectType> (NSExtendedMutableDictionary)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)setObject:(nullable ObjectType)obj forKeyedSubscript:(nonnull KeyType)key;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSSet<KeyType> : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSSet' imported as class 'NSSet'}}
 - (nonnull instancetype)init;
+// expected-remark@-1 {{Objective-C method '-[NSSet init]' imported as initializer 'init()'}}
 - (NSUInteger)count;
+// expected-remark@-1 {{Objective-C method '-[NSSet count]' imported as instance method 'count()'}}
 - (nonnull KeyType)anyObject;
+// expected-remark@-1 {{Objective-C method '-[NSSet anyObject]' imported as instance method 'anyObject()'}}
 - (nonnull instancetype)initWithArray:(nonnull NSArray<KeyType> *)array;
+// expected-remark@-1 {{Objective-C method '-[NSSet initWithArray:]' imported as initializer 'init(array:)'}}
 @end
 
 @interface NSMutableSet<KeyType> : NSSet<KeyType>
+// expected-remark@-1 {{Objective-C class interface 'NSMutableSet' imported as class 'NSMutableSet'}}
 - (void)addObject:(KeyType)obj;
+// expected-remark@-1 {{Objective-C method '-[NSMutableSet addObject:]' imported as instance method 'add'}}
 - (void)removeObject:(KeyType)obj;
+// expected-remark@-1 {{Objective-C method '-[NSMutableSet removeObject:]' imported as instance method 'remove'}}
 @end
 
-@interface NSCountedSet<KeyType> : NSMutableSet<KeyType> 
+@interface NSCountedSet<KeyType> : NSMutableSet<KeyType>
+// expected-remark@-1 {{Objective-C class interface 'NSCountedSet' imported as class 'NSCountedSet'}}
 - (instancetype)initWithCapacity:(NSUInteger)numItems NS_DESIGNATED_INITIALIZER;
+// expected-remark@-1 {{Objective-C method '-[NSCountedSet initWithCapacity:]' imported as initializer 'init(capacity:)'}}
 - (instancetype)initWithArray:(NSArray<KeyType> *)array;
+// expected-remark@-1 {{Objective-C method '-[NSCountedSet initWithArray:]' imported as initializer 'init(array:)'}}
 @end
 
 @interface NSValue : NSObject <NSCopying>
+// expected-remark@-1 {{Objective-C class interface 'NSValue' imported as class 'NSValue'}}
 @end
 
 @interface NSValue (NSRange)
+// expected-remark@-1 {{Objective-C category 'NSValue(NSRange)' imported as extension of 'NSValue'}}
 - (NSValue *)valueWithRange:(NSRange)range;
+// expected-remark@-1 {{Objective-C method '-[NSValue(NSRange) valueWithRange:]' imported as instance method 'withRange'}}
 @property NSRange rangeValue;
+// expected-remark@-1 {{Objective-C method '-[NSValue(NSRange) rangeValue]' imported as getter for property 'rangeValue'}}
+// expected-remark@-2 {{Objective-C method '-[NSValue(NSRange) setRangeValue:]' imported as setter for property 'rangeValue'}}
+// expected-remark@-3 {{Objective-C property '-NSValue(NSRange).rangeValue' imported as property 'rangeValue'}}
 @end
 
 typedef __INT32_TYPE__ int32_t;
+// expected-remark@-1 {{C typedef 'int32_t' imported as struct 'Int32'}}
 
 @interface NSNumber : NSValue
+// expected-remark@-1 {{Objective-C class interface 'NSNumber' imported as class 'NSNumber'}}
+// FIXME: These are unavailable because of the initializers that follow; we should emit notes explaining this.
 + (nonnull NSNumber *)numberWithInt:(int)value;
+// expected-remark@-1 {{Objective-C method '+[NSNumber numberWithInt:]' imported as unavailable initializer 'init(int:)'}}
 + (nonnull NSNumber *)numberWithInteger:(NSInteger)value;
+// expected-remark@-1 {{Objective-C method '+[NSNumber numberWithInteger:]' imported as unavailable initializer 'init(integer:)'}}
 + (nonnull NSNumber *)numberWithUnsignedInteger:(NSUInteger)value;
+// expected-remark@-1 {{Objective-C method '+[NSNumber numberWithUnsignedInteger:]' imported as unavailable initializer 'init(unsignedInteger:)'}}
 + (nonnull NSNumber *)numberWithDouble:(double)value;
+// expected-remark@-1 {{Objective-C method '+[NSNumber numberWithDouble:]' imported as unavailable initializer 'init(double:)'}}
 
 - (nonnull NSNumber *)initWithInteger:(NSInteger)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber initWithInteger:]' imported as initializer 'init(value:)'}}
 - (nonnull NSNumber *)initWithUnsignedInteger:(NSUInteger)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber initWithUnsignedInteger:]' imported as initializer 'init(value:)'}}
 - (nonnull NSNumber *)initWithDouble:(double)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber initWithDouble:]' imported as initializer 'init(value:)'}}
 - (nonnull NSNumber *)addDouble:(double)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber addDouble:]' imported as instance method 'add'}}
 - (nonnull NSNumber *)addBool:(BOOL)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber addBool:]' imported as instance method 'add'}}
 
 - (nonnull NSNumber *)addUInt16:(unsigned short)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber addUInt16:]' imported as instance method 'add'}}
 - (nonnull NSNumber *)addInt:(int)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber addInt:]' imported as instance method 'add'}}
 - (nonnull NSNumber *)subtractInt32:(int32_t)value;
+// expected-remark@-1 {{Objective-C method '-[NSNumber subtractInt32:]' imported as instance method 'subtract'}}
 
 @property NSInteger integerValue;
+// expected-remark@-1 {{Objective-C method '-[NSNumber integerValue]' imported as getter for property 'intValue'}}
+// expected-remark@-2 {{Objective-C method '-[NSNumber setIntegerValue:]' imported as setter for property 'intValue'}}
+// expected-remark@-3 {{Objective-C property '-NSNumber.integerValue' imported as property 'intValue'}}
 @property NSUInteger unsignedIntegerValue;
+// expected-remark@-1 {{Objective-C method '-[NSNumber setUnsignedIntegerValue:]' imported as setter for property 'uintValue'}}
+// expected-remark@-2 {{Objective-C method '-[NSNumber unsignedIntegerValue]' imported as getter for property 'uintValue'}}
+// expected-remark@-3 {{Objective-C property '-NSNumber.unsignedIntegerValue' imported as property 'uintValue'}}
 @end
 
 @interface NSDecimalNumber : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSDecimalNumber' imported as class 'NSDecimalNumber'}}
 + (instancetype)initWithMantissa:(unsigned long long)mantissa exponent:(short)exponent isNegative:(BOOL)isNegative;
+// expected-remark@-1 {{Objective-C method '+[NSDecimalNumber initWithMantissa:exponent:isNegative:]' imported as class method 'initWithMantissa(_:exponent:isNegative:)'}}
 + (NSDecimalNumber *)decimalNumberWithMantissa:(unsigned long long)mantissa exponent:(short)exponent isNegative:(BOOL)isNegative;
+// expected-remark@-1 {{Objective-C method '+[NSDecimalNumber decimalNumberWithMantissa:exponent:isNegative:]' imported as initializer 'init(mantissa:exponent:isNegative:)'}}
 @end
 
 @interface NSError : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSError' imported as class 'NSError'}}
 @property (readonly, nonnull) NSString *domain;
+// expected-remark@-1 {{Objective-C method '-[NSError domain]' imported as getter for property 'domain'}}
+// expected-remark@-2 {{Objective-C property '-NSError.domain' imported as property 'domain'}}
 @property (readonly) NSInteger code;
+// expected-remark@-1 {{Objective-C method '-[NSError code]' imported as getter for property 'code'}}
+// expected-remark@-2 {{Objective-C property '-NSError.code' imported as property 'code'}}
 - (nonnull instancetype)initWithDomain:(nonnull NSString *)domain code:(NSInteger)code userInfo:(nullable NSDictionary *)userInfo;
+// expected-remark@-1 {{Objective-C method '-[NSError initWithDomain:code:userInfo:]' imported as initializer 'init(domain:code:userInfo:)'}}
 @end
 
 @interface NSString : NSObject <NSSecureCoding, NSCopying>
+// expected-remark@-1 {{Objective-C class interface 'NSString' imported as class 'NSString'}}
 - (void)onlyOnNSString;
+// expected-remark@-1 {{Objective-C method '-[NSString onlyOnNSString]' imported as instance method 'onlyOnNSString()'}}
 + (instancetype)stringWithContentsOfFile:(NSString*)path error:(NSError**)error;
+// expected-remark@-1 {{Objective-C method '+[NSString stringWithContentsOfFile:error:]' imported as initializer 'init(contentsOfFile:)'}}
 + (instancetype)stringWithContentsOfFile:(NSString*)path encoding:(int)encoding error:(NSError**)error;
+// expected-remark@-1 {{Objective-C method '+[NSString stringWithContentsOfFile:encoding:error:]' imported as initializer 'init(contentsOfFile:encoding:)'}}
 
 + (instancetype)stringWithPath:(NSString*)path;
+// expected-remark@-1 {{Objective-C method '+[NSString stringWithPath:]' imported as initializer 'init(path:)'}}
 + (nullable instancetype)stringWithPath:(NSString*)path encoding:(int)encoding;
+// expected-remark@-1 {{Objective-C method '+[NSString stringWithPath:encoding:]' imported as initializer 'init(path:encoding:)'}}
 @end
 
 __attribute__((warn_unused_result)) NSString *NSStringToNSString(NSString *str);
+// expected-remark@-1 {{C function 'NSStringToNSString' imported as global function 'NSStringToNSString'}}
 
 @interface Bee : NSObject
+// expected-remark@-1 {{Objective-C class interface 'Bee' imported as class 'Bee'}}
 -(void)buzz;
+// expected-remark@-1 {{Objective-C method '-[Bee buzz]' imported as instance method 'buzz()'}}
 @end
 
 @interface Hive : NSObject {
+// expected-remark@-1 {{Objective-C class interface 'Hive' imported as class 'Hive'}}
   Bee *queen;
+  // expected-remark@-1 {{could not import Objective-C instance variable 'Hive::queen'}}
+  // expected-note@-2 {{use a property to access this instance variable}}
 }
 - init;
+// expected-remark@-1 {{Objective-C method '-[Hive init]' imported as initializer 'init()'}}
 - (instancetype)initWithCoder:(NSCoder *)aDecoder;
+// expected-remark@-1 {{Objective-C method '-[Hive initWithCoder:]' imported as initializer 'init(coder:)'}}
 
 @property (nonnull) NSArray<Bee *> *bees;
+// expected-remark@-1 {{Objective-C method '-[Hive bees]' imported as getter for property 'bees'}}
+// expected-remark@-2 {{Objective-C method '-[Hive setBees:]' imported as setter for property 'bees'}}
+// expected-remark@-3 {{Objective-C property '-Hive.bees' imported as property 'bees'}}
 @property (nullable) NSDictionary<NSString *, Bee *> *beesByName;
+// expected-remark@-1 {{Objective-C method '-[Hive beesByName]' imported as getter for property 'beesByName'}}
+// expected-remark@-2 {{Objective-C method '-[Hive setBeesByName:]' imported as setter for property 'beesByName'}}
+// expected-remark@-3 {{Objective-C property '-Hive.beesByName' imported as property 'beesByName'}}
 @property (nonnull) NSSet<Bee *> *allBees;
+// expected-remark@-1 {{Objective-C method '-[Hive allBees]' imported as getter for property 'allBees'}}
+// expected-remark@-2 {{Objective-C method '-[Hive setAllBees:]' imported as setter for property 'allBees'}}
+// expected-remark@-3 {{Objective-C property '-Hive.allBees' imported as property 'allBees'}}
 @property (nonnull) NSDictionary<id <NSCopying>, Bee *> *anythingToBees;
+// expected-remark@-1 {{Objective-C method '-[Hive anythingToBees]' imported as getter for property 'anythingToBees'}}
+// expected-remark@-2 {{Objective-C method '-[Hive setAnythingToBees:]' imported as setter for property 'anythingToBees'}}
+// expected-remark@-3 {{Objective-C property '-Hive.anythingToBees' imported as property 'anythingToBees'}}
 
 @property(getter=isMakingHoney) BOOL makingHoney;
+// expected-remark@-1 {{Objective-C method '-[Hive isMakingHoney]' imported as getter for property 'isMakingHoney'}}
+// expected-remark@-2 {{Objective-C method '-[Hive setMakingHoney:]' imported as setter for property 'isMakingHoney'}}
+// expected-remark@-3 {{Objective-C property '-Hive.makingHoney' imported as property 'isMakingHoney'}}
 @property(setter=assignGuard:) id guard;
+// expected-remark@-1 {{Objective-C method '-[Hive assignGuard:]' imported as setter for property 'guard'}}
+// expected-remark@-2 {{Objective-C method '-[Hive guard]' imported as getter for property 'guard'}}
+// expected-remark@-3 {{Objective-C property '-Hive.guard' imported as property 'guard'}}
 
 + (instancetype)hiveWithQueen:(Bee *)queen;
+// expected-remark@-1 {{Objective-C method '+[Hive hiveWithQueen:]' imported as initializer 'init(queen:)'}}
 + (instancetype)hiveWithFlakyQueen:(Bee *)queen error:(NSError **)error;
+// expected-remark@-1 {{Objective-C method '+[Hive hiveWithFlakyQueen:error:]' imported as initializer 'init(flakyQueen:)'}}
 
 - (instancetype)visit;
+// expected-remark@-1 {{Objective-C method '-[Hive visit]' imported as instance method 'visit()'}}
 @end
 
 @interface NSMutableString : NSString
+// expected-remark@-1 {{Objective-C class interface 'NSMutableString' imported as class 'NSMutableString'}}
 @end
 
 @interface NSURL : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSURL' imported as class 'NSURL'}}
 - (instancetype)URLWithString:(NSString *)URLString;
+// expected-remark@-1 {{Objective-C method '-[NSURL URLWithString:]' imported as instance method 'withString'}}
 + (instancetype)URLWithString:(NSString *)URLString;
+// expected-remark@-1 {{Objective-C method '+[NSURL URLWithString:]' imported as initializer 'init(string:)'}}
 - (BOOL)getResourceValue:(out id _Nullable *)value
                   forKey:(NSString *)key
                    error:(out NSError *_Nullable *)error;
+// expected-remark@-3 {{Objective-C method '-[NSURL getResourceValue:forKey:error:]' imported as instance method 'getResourceValue(_:forKey:)'}}
 @end
 
 // An all-initials name like NSURL or NSUUID, but one that isn't bridged.
 @interface NSGUID : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSGUID' imported as class 'NSGUID'}}
 @end
 
 @interface NSAttributedString : NSString
+// expected-remark@-1 {{Objective-C class interface 'NSAttributedString' imported as class 'NSAttributedString'}}
 - (NSAttributedString *)sliceAttributedString:(NSInteger)startIndex;
+// expected-remark@-1 {{Objective-C method '-[NSAttributedString sliceAttributedString:]' imported as instance method 'sliceAttributedString'}}
 @end
 
 BOOL BOOLtoBOOL(BOOL b);
+// expected-remark@-1 {{C function 'BOOLtoBOOL' imported as global function 'BOOLtoBOOL'}}
 
 typedef CGPoint NSPoint;
+// expected-remark@-1 {{C typedef 'NSPoint' imported as type alias 'NSPoint'}}
 typedef CGSize NSSize;
+// expected-remark@-1 {{C typedef 'NSSize' imported as type alias 'NSSize'}}
 typedef CGRect NSRect;
+// expected-remark@-1 {{C typedef 'NSRect' imported as type alias 'NSRect'}}
 typedef NSPoint *NSPointArray;
+// expected-remark@-1 {{C typedef 'NSPointArray' imported as type alias 'NSPointArray'}}
 
 @interface BadCollection
+// expected-remark@-1 {{Objective-C class interface 'BadCollection' imported as class 'BadCollection'}}
 - (id)objectForKeyedSubscript:(id)key;
+// expected-remark@-1 {{Objective-C method '-[BadCollection objectForKeyedSubscript:]' imported as unavailable instance method 'objectForKeyedSubscript'}}
+// FIXME: Subscript?
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
+// expected-remark@-1 {{Objective-C method '-[BadCollection setObject:forKeyedSubscript:]' imported as instance method 'setObject(_:forKeyedSubscript:)'}}
+// FIXME: Subscript?
 @end
 
 @interface BadCollectionParent
+// expected-remark@-1 {{Objective-C class interface 'BadCollectionParent' imported as class 'BadCollectionParent'}}
 - (id)objectForKeyedSubscript:(NSString *)key;
+// expected-remark@-1 {{Objective-C method '-[BadCollectionParent objectForKeyedSubscript:]' imported as unavailable instance method 'objectForKeyedSubscript'}}
+// FIXME: Subscript?
 @end
 
 @interface BadCollectionChild : BadCollectionParent
+// expected-remark@-1 {{Objective-C class interface 'BadCollectionChild' imported as class 'BadCollectionChild'}}
 - (void)setObject:(id)object forKeyedSubscript:(id)key;
+// expected-remark@-1 {{Objective-C method '-[BadCollectionChild setObject:forKeyedSubscript:]' imported as instance method 'setObject(_:forKeyedSubscript:)'}}
 @end
 
 @interface ReadOnlyCollectionChild : BadCollectionParent
+// expected-remark@-1 {{Objective-C class interface 'ReadOnlyCollectionChild' imported as class 'ReadOnlyCollectionChild'}}
 - (void)setObject:(id)object forKeyedSubscript:(id)key;
+// expected-remark@-1 {{Objective-C method '-[ReadOnlyCollectionChild setObject:forKeyedSubscript:]' imported as instance method 'setObject(_:forKeyedSubscript:)'}}
 @end
 
 //===---
@@ -322,874 +557,1464 @@ typedef NSPoint *NSPointArray;
 
 /// Aaa.  NSRuncingMode.  Bbb.
 typedef NS_ENUM(NSUInteger, NSRuncingMode) {
+  // expected-remark@-1 {{C enum 'NSRuncingMode' imported as enum 'NSRuncingMode'}}
+  // expected-remark@-2 {{C typedef 'NSRuncingMode' imported as enum 'NSRuncingMode'}}
   NSRuncingMince,
+  // expected-remark@-1 {{C enum constant 'NSRuncingMince' imported as enum case 'mince'}}
   NSRuncingQuince
+  // expected-remark@-1 {{C enum constant 'NSRuncingQuince' imported as enum case 'quince'}}
 };
 
 typedef NS_ENUM(int, NSUnderlyingType) {
+  // expected-remark@-1 {{C enum 'NSUnderlyingType' imported as enum 'NSUnderlyingType'}}
+  // expected-remark@-2 {{C typedef 'NSUnderlyingType' imported as enum 'NSUnderlyingType'}}
   NSUnderlyingTypeZim,
+  // expected-remark@-1 {{C enum constant 'NSUnderlyingTypeZim' imported as enum case 'zim'}}
   NSUnderlyingTypeZang,
+  // expected-remark@-1 {{C enum constant 'NSUnderlyingTypeZang' imported as enum case 'zang'}}
   NSUnderlyingTypeFoo = 11,
+  // expected-remark@-1 {{C enum constant 'NSUnderlyingTypeFoo' imported as enum case 'foo'}}
   NSUnderlyingTypeBar = 22,
+  // expected-remark@-1 {{C enum constant 'NSUnderlyingTypeBar' imported as enum case 'bar'}}
   NSUnderlyingTypeBas
+  // expected-remark@-1 {{C enum constant 'NSUnderlyingTypeBas' imported as enum case 'bas'}}
 };
 
 typedef NS_ENUM(unsigned, NSUnsignedUnderlyingTypeNegativeValue) {
+  // expected-remark@-1 {{C enum 'NSUnsignedUnderlyingTypeNegativeValue' imported as enum 'NSUnsignedUnderlyingTypeNegativeValue'}}
+  // expected-remark@-2 {{C typedef 'NSUnsignedUnderlyingTypeNegativeValue' imported as enum 'NSUnsignedUnderlyingTypeNegativeValue'}}
   NSNegativeOne = -1,
+  // expected-remark@-1 {{C enum constant 'NSNegativeOne' imported as enum case 'negativeOne'}}
   NSNegativeTwo = -2,
+  // expected-remark@-1 {{C enum constant 'NSNegativeTwo' imported as enum case 'negativeTwo'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreak) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreak' imported as enum 'NSPrefixWordBreak'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreak' imported as enum 'NSPrefixWordBreak'}}
   NSPrefixWordBreakBanjo,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakBanjo' imported as enum case 'banjo'}}
   NSPrefixWordBreakBandana
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakBandana' imported as enum case 'bandana'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreak2) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreak2' imported as enum 'NSPrefixWordBreak2'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreak2' imported as enum 'NSPrefixWordBreak2'}}
   NSPrefixWordBreakBarBas,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakBarBas' imported as enum case 'breakBarBas'}}
   NSPrefixWordBreakBareBass,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakBareBass' imported as enum case 'breakBareBass'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreak3) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreak3' imported as enum 'NSPrefixWordBreak3'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreak3' imported as enum 'NSPrefixWordBreak3'}}
   NSPrefixWordBreak1Bob,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreak1Bob' imported as enum case 'break1Bob'}}
   NSPrefixWordBreak1Ben,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreak1Ben' imported as enum case 'break1Ben'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreakCustom) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreakCustom' imported as enum 'NSPrefixWordBreakCustom'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreakCustom' imported as enum 'NSPrefixWordBreakCustom'}}
   PrefixWordBreakProblemCase __attribute__((swift_name("problemCase"))),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreakProblemCase' imported as enum case 'problemCase'}}
   NSPrefixWordBreakDeprecatedGoodCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakDeprecatedGoodCase' imported as enum case 'deprecatedGoodCase'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreak2Custom) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreak2Custom' imported as enum 'NSPrefixWordBreak2Custom'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreak2Custom' imported as enum 'NSPrefixWordBreak2Custom'}}
   PrefixWordBreak2ProblemCase __attribute__((swift_name("problemCase"))),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreak2ProblemCase' imported as enum case 'problemCase'}}
   PrefixWordBreak2DeprecatedBadCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreak2DeprecatedBadCase' imported as enum case 'PrefixWordBreak2DeprecatedBadCase'}}
   NSPrefixWordBreak2DeprecatedGoodCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreak2DeprecatedGoodCase' imported as enum case 'deprecatedGoodCase'}}
   NSPrefixWordBreak2GoodCase,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreak2GoodCase' imported as enum case 'goodCase'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreakReversedCustom) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreakReversedCustom' imported as enum 'NSPrefixWordBreakReversedCustom'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreakReversedCustom' imported as enum 'NSPrefixWordBreakReversedCustom'}}
   NSPrefixWordBreakReversedDeprecatedGoodCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakReversedDeprecatedGoodCase' imported as enum case 'deprecatedGoodCase'}}
   PrefixWordBreakReversedProblemCase __attribute__((swift_name("problemCase"))),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreakReversedProblemCase' imported as enum case 'problemCase'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreakReorderedCustom) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreakReorderedCustom' imported as enum 'NSPrefixWordBreakReorderedCustom'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreakReorderedCustom' imported as enum 'NSPrefixWordBreakReorderedCustom'}}
   PrefixWordBreakReorderedProblemCase __attribute__((swift_name("problemCase"))),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreakReorderedProblemCase' imported as enum case 'problemCase'}}
   NSPrefixWordBreakReorderedGoodCase,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakReorderedGoodCase' imported as enum case 'goodCase'}}
   PrefixWordBreakReorderedDeprecatedBadCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreakReorderedDeprecatedBadCase' imported as enum case 'PrefixWordBreakReorderedDeprecatedBadCase'}}
   NSPrefixWordBreakReorderedDeprecatedGoodCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakReorderedDeprecatedGoodCase' imported as enum case 'deprecatedGoodCase'}}
 };
 
 typedef NS_ENUM(NSInteger, NSPrefixWordBreakReordered2Custom) {
+  // expected-remark@-1 {{C enum 'NSPrefixWordBreakReordered2Custom' imported as enum 'NSPrefixWordBreakReordered2Custom'}}
+  // expected-remark@-2 {{C typedef 'NSPrefixWordBreakReordered2Custom' imported as enum 'NSPrefixWordBreakReordered2Custom'}}
   PrefixWordBreakReordered2DeprecatedBadCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreakReordered2DeprecatedBadCase' imported as enum case 'PrefixWordBreakReordered2DeprecatedBadCase'}}
   PrefixWordBreakReordered2ProblemCase __attribute__((swift_name("problemCase"))),
+  // expected-remark@-1 {{C enum constant 'PrefixWordBreakReordered2ProblemCase' imported as enum case 'problemCase'}}
   NSPrefixWordBreakReordered2GoodCase,
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakReordered2GoodCase' imported as enum case 'goodCase'}}
   NSPrefixWordBreakReordered2DeprecatedGoodCase __attribute__((deprecated)),
+  // expected-remark@-1 {{C enum constant 'NSPrefixWordBreakReordered2DeprecatedGoodCase' imported as enum case 'deprecatedGoodCase'}}
 };
 
 typedef NS_ENUM(NSInteger, NSSwiftNameAllTheThings) {
+  // expected-remark@-1 {{C enum 'NSSwiftNameAllTheThings' imported as enum 'NSSwiftNameAllTheThings'}}
+  // expected-remark@-2 {{C typedef 'NSSwiftNameAllTheThings' imported as enum 'NSSwiftNameAllTheThings'}}
   NSSwiftNameAllTheThingsA __attribute__((swift_name("Foo"))),
+  // expected-remark@-1 {{C enum constant 'NSSwiftNameAllTheThingsA' imported as enum case 'Foo'}}
   NSSwiftNameAllTheThingsB __attribute__((swift_name("Bar"))),
+  // expected-remark@-1 {{C enum constant 'NSSwiftNameAllTheThingsB' imported as enum case 'Bar'}}
 };
 
 typedef NS_ENUM(NSInteger, NSSwiftNameBad) {
+  // expected-remark@-1 {{C enum 'NSSwiftNameBad' imported as enum 'NSSwiftNameBad'}}
+  // expected-remark@-2 {{C typedef 'NSSwiftNameBad' imported as enum 'NSSwiftNameBad'}}
   NSSwiftNameBadA __attribute__((swift_name("class"))),
+  // expected-remark@-1 {{C enum constant 'NSSwiftNameBadA' imported as enum case 'class'}}
 };
 
 
 typedef NS_ENUM(NSInteger, NSSingleConstantEnum) {
+  // expected-remark@-1 {{C enum 'NSSingleConstantEnum' imported as enum 'NSSingleConstantEnum'}}
+  // expected-remark@-2 {{C typedef 'NSSingleConstantEnum' imported as enum 'NSSingleConstantEnum'}}
   NSSingleConstantValue,
+  // expected-remark@-1 {{C enum constant 'NSSingleConstantValue' imported as enum case 'value'}}
 };
 
 typedef NS_ENUM(unsigned char, NSAliasesEnum) {
+  // expected-remark@-1 {{C enum 'NSAliasesEnum' imported as enum 'NSAliasesEnum'}}
+  // expected-remark@-2 {{C typedef 'NSAliasesEnum' imported as enum 'NSAliasesEnum'}}
   NSAliasesOriginal = 129,
+  // expected-remark@-1 {{C enum constant 'NSAliasesOriginal' imported as enum case 'original'}}
   NSAliasesBySameValue = 129,
+  // expected-remark@-1 {{C enum constant 'NSAliasesBySameValue' imported as static property 'bySameValue'}}
   NSAliasesByEquivalentValue = -127,
+  // expected-remark@-1 {{C enum constant 'NSAliasesByEquivalentValue' imported as static property 'byEquivalentValue'}}
   NSAliasesByName = NSAliasesOriginal,
+  // expected-remark@-1 {{C enum constant 'NSAliasesByName' imported as static property 'byName'}}
   NSAliasesDifferentValue = 2
+  // expected-remark@-1 {{C enum constant 'NSAliasesDifferentValue' imported as enum case 'differentValue'}}
 };
 
 typedef NS_ENUM(unsigned char, NSUnavailableAliasesEnum) {
+  // expected-remark@-1 {{C enum 'NSUnavailableAliasesEnum' imported as enum 'NSUnavailableAliasesEnum'}}
+  // expected-remark@-2 {{C typedef 'NSUnavailableAliasesEnum' imported as enum 'NSUnavailableAliasesEnum'}}
   NSUnavailableAliasesOriginalAU = 0,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableAliasesOriginalAU' imported as enum case 'originalAU'}}
   NSUnavailableAliasesAliasAU __attribute__((unavailable)) = 0,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableAliasesAliasAU' imported as unavailable static property 'aliasAU'}}
   NSUnavailableAliasesOriginalUA __attribute__((unavailable)) = 1,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableAliasesOriginalUA' imported as unavailable static property 'originalUA'}}
   NSUnavailableAliasesAliasUA = 1,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableAliasesAliasUA' imported as enum case 'aliasUA'}}
   NSUnavailableAliasesOriginalUU __attribute__((unavailable)) = 2,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableAliasesOriginalUU' imported as unavailable enum case 'originalUU'}}
   NSUnavailableAliasesAliasUU __attribute__((unavailable)) = 2,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableAliasesAliasUU' imported as unavailable enum case 'aliasUU'}}
 };
 
 NS_ENUM(NSInteger, NSMalformedEnumMissingTypedef) {
+  // expected-remark@-1 {{C enum 'NSMalformedEnumMissingTypedef' imported as enum 'NSMalformedEnumMissingTypedef'}}
+  // expected-remark@-2 {{C variable 'NSMalformedEnumMissingTypedef' imported as var 'NSMalformedEnumMissingTypedef'}}
   NSMalformedEnumMissingTypedefValue
+  // expected-remark@-1 {{C enum constant 'NSMalformedEnumMissingTypedefValue' imported as enum case 'value'}}
 };
 
 @interface NSNumberFormatter : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSNumberFormatter' imported as class 'NumberFormatter'}}
 @end
 
 typedef NS_ENUM(NSUInteger, NSNumberFormatterBehavior) {
+  // expected-remark@-1 {{C enum 'NSNumberFormatterBehavior' imported as enum 'Behavior'}}
+  // expected-remark@-2 {{C typedef 'NSNumberFormatterBehavior' imported as enum 'Behavior'}}
   NSNumberFormatterBehaviorDefault = 0,
+  // expected-remark@-1 {{C enum constant 'NSNumberFormatterBehaviorDefault' imported as enum case 'default'}}
   NSNumberFormatterBehavior10_0 = 1000,
+  // expected-remark@-1 {{C enum constant 'NSNumberFormatterBehavior10_0' imported as enum case 'behavior10_0'}}
   NSNumberFormatterBehavior10_4 = 1040,
+  // expected-remark@-1 {{C enum constant 'NSNumberFormatterBehavior10_4' imported as enum case 'behavior10_4'}}
 };
 
 @interface NSNotification : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSNotification' imported as class 'NSNotification'}}
 @end
 
 @interface NSNotificationQueue : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSNotificationQueue' imported as class 'NotificationQueue'}}
 @end
 
 typedef NS_ENUM(NSUInteger, NSPostingStyle) {
+  // expected-remark@-1 {{C enum 'NSPostingStyle' imported as enum 'PostingStyle'}}
+  // expected-remark@-2 {{C typedef 'NSPostingStyle' imported as enum 'PostingStyle'}}
   NSPostWhenIdle = 1,
+  // expected-remark@-1 {{C enum constant 'NSPostWhenIdle' imported as enum case 'whenIdle'}}
   NSPostASAP = 2,
+  // expected-remark@-1 {{C enum constant 'NSPostASAP' imported as enum case 'asap'}}
   NSPostNow = 3
+  // expected-remark@-1 {{C enum constant 'NSPostNow' imported as enum case 'now'}}
 };
 
 @interface NSXMLNode : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSXMLNode' imported as class 'XMLNode'}}
 @end
 
 typedef NS_ENUM(NSUInteger, NSXMLNodeKind) {
+  // expected-remark@-1 {{C enum 'NSXMLNodeKind' imported as enum 'Kind'}}
+  // expected-remark@-2 {{C typedef 'NSXMLNodeKind' imported as enum 'Kind'}}
   NSXMLInvalidKind = 0,
+  // expected-remark@-1 {{C enum constant 'NSXMLInvalidKind' imported as enum case 'invalid'}}
   NSXMLDocumentKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLDocumentKind' imported as enum case 'document'}}
   NSXMLElementKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLElementKind' imported as enum case 'element'}}
   NSXMLAttributeKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLAttributeKind' imported as enum case 'attribute'}}
   NSXMLNamespaceKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLNamespaceKind' imported as enum case 'namespace'}}
   NSXMLProcessingInstructionKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLProcessingInstructionKind' imported as enum case 'processingInstruction'}}
   NSXMLCommentKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLCommentKind' imported as enum case 'comment'}}
   NSXMLTextKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLTextKind' imported as enum case 'text'}}
   NSXMLDTDKind __attribute__((swift_name("DTDKind"))),
+  // expected-remark@-1 {{C enum constant 'NSXMLDTDKind' imported as enum case 'DTDKind'}}
   NSXMLEntityDeclarationKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLEntityDeclarationKind' imported as enum case 'entityDeclaration'}}
   NSXMLAttributeDeclarationKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLAttributeDeclarationKind' imported as enum case 'attributeDeclaration'}}
   NSXMLElementDeclarationKind,
+  // expected-remark@-1 {{C enum constant 'NSXMLElementDeclarationKind' imported as enum case 'elementDeclaration'}}
   NSXMLNotationDeclarationKind
+  // expected-remark@-1 {{C enum constant 'NSXMLNotationDeclarationKind' imported as enum case 'notationDeclaration'}}
 };
 
 // From CoreFoundation
 typedef CF_ENUM(NSInteger, CFURLPathStyle) {
+  // expected-remark@-1 {{C enum 'CFURLPathStyle' imported as enum 'CFURLPathStyle'}}
+  // expected-remark@-2 {{C typedef 'CFURLPathStyle' imported as enum 'CFURLPathStyle'}}
   kCFURLPOSIXPathStyle = 0,
+  // expected-remark@-1 {{C enum constant 'kCFURLPOSIXPathStyle' imported as enum case 'cfurlposixPathStyle'}}
   kCFURLHFSPathStyle /*CF_ENUM_DEPRECATED(10_0, 10_9, 2_0, 7_0)*/,
+  // expected-remark@-1 {{C enum constant 'kCFURLHFSPathStyle' imported as enum case 'cfurlhfsPathStyle'}}
   kCFURLWindowsPathStyle
+  // expected-remark@-1 {{C enum constant 'kCFURLWindowsPathStyle' imported as enum case 'cfurlWindowsPathStyle'}}
 };
 
 typedef CF_ENUM(NSInteger, CFURLOrUTI) {
+  // expected-remark@-1 {{C enum 'CFURLOrUTI' imported as enum 'CFURLOrUTI'}}
+  // expected-remark@-2 {{C typedef 'CFURLOrUTI' imported as enum 'CFURLOrUTI'}}
   kCFURLKind,
+  // expected-remark@-1 {{C enum constant 'kCFURLKind' imported as enum case 'cfurlKind'}}
   kCFUTIKind
+  // expected-remark@-1 {{C enum constant 'kCFUTIKind' imported as enum case 'cfutiKind'}}
 };
 
 typedef CF_ENUM(NSInteger, Magnitude) {
+  // expected-remark@-1 {{C enum 'Magnitude' imported as enum 'Magnitude'}}
+  // expected-remark@-2 {{C typedef 'Magnitude' imported as enum 'Magnitude'}}
   k0,
+  // expected-remark@-1 {{C enum constant 'k0' imported as enum case 'k0'}}
   k1,
+  // expected-remark@-1 {{C enum constant 'k1' imported as enum case 'k1'}}
   k2,
+  // expected-remark@-1 {{C enum constant 'k2' imported as enum case 'k2'}}
 };
 
 typedef CF_ENUM(NSInteger, MagnitudeWords) {
+  // expected-remark@-1 {{C enum 'MagnitudeWords' imported as enum 'MagnitudeWords'}}
+  // expected-remark@-2 {{C typedef 'MagnitudeWords' imported as enum 'MagnitudeWords'}}
   kZero,
+  // expected-remark@-1 {{C enum constant 'kZero' imported as enum case 'zero'}}
   kOne,
+  // expected-remark@-1 {{C enum constant 'kOne' imported as enum case 'one'}}
   kTwo,
+  // expected-remark@-1 {{C enum constant 'kTwo' imported as enum case 'two'}}
 };
 
 
 // Deliberately simple to test the overlay module.
 enum {
+  // FIXME: Indicate that the anonymous enum isn't imported?
   NSUTF8StringEncoding = 8
+  // expected-remark@-1 {{C enum constant 'NSUTF8StringEncoding' imported as var 'NSUTF8StringEncoding'}}
 };
 
 
 /// Aaa.  NSRuncingOptions.  Bbb.
 typedef NS_OPTIONS(NSUInteger, NSRuncingOptions) {
+  // expected-remark@-1 {{C enum 'NSRuncingOptions' imported as struct 'NSRuncingOptions'}}
+  // expected-remark@-2 {{C typedef 'NSRuncingOptions' imported as struct 'NSRuncingOptions'}}
   NSRuncingNone = 0,
+  // expected-remark@-1 {{C enum constant 'NSRuncingNone' imported as unavailable static property 'none'}}
   NSRuncingEnableMince = 1,
+  // expected-remark@-1 {{C enum constant 'NSRuncingEnableMince' imported as static property 'enableMince'}}
   NSRuncingEnableQuince = 2,
+  // expected-remark@-1 {{C enum constant 'NSRuncingEnableQuince' imported as static property 'enableQuince'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSSingleOptions) {
+  // expected-remark@-1 {{C enum 'NSSingleOptions' imported as struct 'NSSingleOptions'}}
+  // expected-remark@-2 {{C typedef 'NSSingleOptions' imported as struct 'NSSingleOptions'}}
   NSSingleValue = 1,
+  // expected-remark@-1 {{C enum constant 'NSSingleValue' imported as static property 'value'}}
 };
 
 // From CoreFoundation
 typedef CF_OPTIONS(unsigned long, CFCalendarUnit) {
+  // expected-remark@-1 {{C enum 'CFCalendarUnit' imported as struct 'CFCalendarUnit'}}
+  // expected-remark@-2 {{C typedef 'CFCalendarUnit' imported as struct 'CFCalendarUnit'}}
   kCFCalendarUnitEra = (1UL << 1),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitEra' imported as static property 'era'}}
   kCFCalendarUnitYear = (1UL << 2),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitYear' imported as static property 'year'}}
   kCFCalendarUnitMonth = (1UL << 3),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitMonth' imported as static property 'month'}}
   kCFCalendarUnitDay = (1UL << 4),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitDay' imported as static property 'day'}}
   kCFCalendarUnitHour = (1UL << 5),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitHour' imported as static property 'hour'}}
   kCFCalendarUnitMinute = (1UL << 6),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitMinute' imported as static property 'minute'}}
   kCFCalendarUnitSecond = (1UL << 7),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitSecond' imported as static property 'second'}}
   kCFCalendarUnitWeek /*CF_ENUM_DEPRECATED(10_4, 10_51, 2_0, 8_0)*/ = (1UL << 8),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitWeek' imported as static property 'week'}}
   kCFCalendarUnitWeekday = (1UL << 9),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitWeekday' imported as static property 'weekday'}}
   kCFCalendarUnitWeekdayOrdinal = (1UL << 10),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitWeekdayOrdinal' imported as static property 'weekdayOrdinal'}}
   kCFCalendarUnitQuarter /*CF_ENUM_AVAILABLE(10_6, 4_0)*/ = (1UL << 11),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitQuarter' imported as static property 'quarter'}}
   kCFCalendarUnitWeekOfMonth /*CF_ENUM_AVAILABLE(10_7, 5_0)*/ = (1UL << 12),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitWeekOfMonth' imported as static property 'weekOfMonth'}}
   kCFCalendarUnitWeekOfYear /*CF_ENUM_AVAILABLE(10_7, 5_0)*/ = (1UL << 13),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitWeekOfYear' imported as static property 'weekOfYear'}}
   kCFCalendarUnitYearForWeekOfYear /*CF_ENUM_AVAILABLE(10_7, 5_0)*/ = (1UL << 14),
+  // expected-remark@-1 {{C enum constant 'kCFCalendarUnitYearForWeekOfYear' imported as static property 'yearForWeekOfYear'}}
 };
 
 // From Foundation
 
 typedef NS_OPTIONS(NSUInteger, NSKeyValueObservingOptions) {
+  // expected-remark@-1 {{C enum 'NSKeyValueObservingOptions' imported as struct 'NSKeyValueObservingOptions'}}
+  // expected-remark@-2 {{C typedef 'NSKeyValueObservingOptions' imported as struct 'NSKeyValueObservingOptions'}}
   NSKeyValueObservingOptionNew = 0x01,
+  // expected-remark@-1 {{C enum constant 'NSKeyValueObservingOptionNew' imported as static property 'new'}}
   NSKeyValueObservingOptionOld = 0x02,
+  // expected-remark@-1 {{C enum constant 'NSKeyValueObservingOptionOld' imported as static property 'old'}}
   NSKeyValueObservingOptionInitial /*NS_ENUM_AVAILABLE(10_5, 2_0)*/ = 0x04,
+  // expected-remark@-1 {{C enum constant 'NSKeyValueObservingOptionInitial' imported as static property 'initial'}}
   NSKeyValueObservingOptionPrior /*NS_ENUM_AVAILABLE(10_5, 2_0)*/ = 0x08
+  // expected-remark@-1 {{C enum constant 'NSKeyValueObservingOptionPrior' imported as static property 'prior'}}
 };
 
 @interface NSCalendar : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSCalendar' imported as class 'NSCalendar'}}
 @end
 
 #define NS_CALENDAR_ENUM_DEPRECATED(osx_in, osx_out, ios_in, ios_out, msg) \
   __attribute__((availability(macosx, introduced=osx_in, deprecated=osx_out, message=msg))) \
   __attribute__((availability(iphoneos, introduced=ios_in, deprecated=ios_out, message=msg)))
 typedef NS_OPTIONS(NSUInteger, NSCalendarUnit) {
+  // expected-remark@-1 {{C enum 'NSCalendarUnit' imported as struct 'Unit'}}
+  // expected-remark@-2 {{C typedef 'NSCalendarUnit' imported as struct 'Unit'}}
   NSCalendarUnitEra                = kCFCalendarUnitEra,
+  // expected-remark@-1 {{C enum constant 'NSCalendarUnitEra' imported as static property 'era'}}
   NSCalendarUnitYear               = kCFCalendarUnitYear,
+  // expected-remark@-1 {{C enum constant 'NSCalendarUnitYear' imported as static property 'year'}}
   NSCalendarUnitMonth              = kCFCalendarUnitMonth,
+  // expected-remark@-1 {{C enum constant 'NSCalendarUnitMonth' imported as static property 'month'}}
+
   // snip
+
   NSCalendarUnitCalendar           = (1 << 20),
+  // expected-remark@-1 {{C enum constant 'NSCalendarUnitCalendar' imported as static property 'calendar'}}
 
   NSEraCalendarUnit NS_CALENDAR_ENUM_DEPRECATED(10_4, 10_9, 2_0, 7_0, "Use NSCalendarUnitEra instead") = NSCalendarUnitEra,
+  // expected-remark@-1 {{C enum constant 'NSEraCalendarUnit' imported as unavailable static property 'NSEraCalendarUnit'}}
   NSYearCalendarUnit NS_CALENDAR_ENUM_DEPRECATED(10_4, 10_9, 2_0, 7_0, "Use NSCalendarUnitYear instead") = NSCalendarUnitYear,
+  // expected-remark@-1 {{C enum constant 'NSYearCalendarUnit' imported as unavailable static property 'NSYearCalendarUnit'}}
   NSMonthCalendarUnit NS_CALENDAR_ENUM_DEPRECATED(10_4, 10_9, 2_0, 7_0, "Use NSCalendarUnitMonth instead") = NSCalendarUnitMonth,
+  // expected-remark@-1 {{C enum constant 'NSMonthCalendarUnit' imported as unavailable static property 'NSMonthCalendarUnit'}}
+
   // snip
+
   NSCalendarCalendarUnit NS_CALENDAR_ENUM_DEPRECATED(10_7, 10_9, 4_0, 7_0, "Use NSCalendarUnitCalendar instead") = NSCalendarUnitCalendar,
+  // expected-remark@-1 {{C enum constant 'NSCalendarCalendarUnit' imported as unavailable static property 'NSCalendarCalendarUnit'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSCalendarUnitDeprecated) {
+  // expected-remark@-1 {{C enum 'NSCalendarUnitDeprecated' imported as struct 'NSCalendarUnitDeprecated'}}
+  // expected-remark@-2 {{C typedef 'NSCalendarUnitDeprecated' imported as struct 'NSCalendarUnitDeprecated'}}
   NSEraCalendarUnitDeprecated NS_CALENDAR_ENUM_DEPRECATED(10_4, 10_9, 2_0, 7_0, "Use NSCalendarUnitEra instead") = NSCalendarUnitEra,
+  // expected-remark@-1 {{C enum constant 'NSEraCalendarUnitDeprecated' imported as unavailable static property 'eraCalendarUnitDeprecated'}}
   NSYearCalendarUnitDeprecated NS_CALENDAR_ENUM_DEPRECATED(10_4, 10_9, 2_0, 7_0, "Use NSCalendarUnitYear instead") = NSCalendarUnitYear,
+  // expected-remark@-1 {{C enum constant 'NSYearCalendarUnitDeprecated' imported as unavailable static property 'yearCalendarUnitDeprecated'}}
   NSMonthCalendarUnitDeprecated NS_CALENDAR_ENUM_DEPRECATED(10_4, 10_9, 2_0, 7_0, "Use NSCalendarUnitMonth instead") = NSCalendarUnitMonth,
+  // expected-remark@-1 {{C enum constant 'NSMonthCalendarUnitDeprecated' imported as unavailable static property 'monthCalendarUnitDeprecated'}}
+
   // snip
+
   NSCalendarCalendarUnitDeprecated NS_CALENDAR_ENUM_DEPRECATED(10_7, 10_9, 4_0, 7_0, "Use NSCalendarUnitCalendar instead") = NSCalendarUnitCalendar,
+  // expected-remark@-1 {{C enum constant 'NSCalendarCalendarUnitDeprecated' imported as unavailable static property 'calendarCalendarUnitDeprecated'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSOptionsAlsoGetSwiftName) {
+  // expected-remark@-1 {{C enum 'NSOptionsAlsoGetSwiftName' imported as struct 'NSOptionsAlsoGetSwiftName'}}
+  // expected-remark@-2 {{C typedef 'NSOptionsAlsoGetSwiftName' imported as struct 'NSOptionsAlsoGetSwiftName'}}
   ThisIsAnNSOptionsCaseWithSwiftName __attribute__((swift_name("Case"))) = 0x1
+  // expected-remark@-1 {{C enum constant 'ThisIsAnNSOptionsCaseWithSwiftName' imported as static property 'Case'}}
 };
 
 #define CF_SWIFT_UNAVAILABLE(_msg) __attribute__((availability(swift, unavailable, message=_msg)))
 #define NS_SWIFT_UNAVAILABLE(_msg) CF_SWIFT_UNAVAILABLE(_msg)
 
 typedef NS_ENUM(NSUInteger, NSRectEdge) {
+  // expected-remark@-1 {{C enum 'NSRectEdge' imported as enum 'NSRectEdge'}}
+  // expected-remark@-2 {{C typedef 'NSRectEdge' imported as enum 'NSRectEdge'}}
   NSRectEdgeMinX = 0,
+  // expected-remark@-1 {{C enum constant 'NSRectEdgeMinX' imported as enum case 'minX'}}
   NSRectEdgeMinY = 1,
+  // expected-remark@-1 {{C enum constant 'NSRectEdgeMinY' imported as enum case 'minY'}}
   NSRectEdgeMaxX = 2,
+  // expected-remark@-1 {{C enum constant 'NSRectEdgeMaxX' imported as enum case 'maxX'}}
   NSRectEdgeMaxY = 3,
+  // expected-remark@-1 {{C enum constant 'NSRectEdgeMaxY' imported as enum case 'maxY'}}
 
   NSMinXEdge NS_SWIFT_UNAVAILABLE("Use NSRectEdge.MinX instead") = NSRectEdgeMinX,
+  // expected-remark@-1 {{C enum constant 'NSMinXEdge' imported as unavailable static property 'NSMinXEdge'}}
   NSMinYEdge NS_SWIFT_UNAVAILABLE("Use NSRectEdge.MinY instead") = NSRectEdgeMinY,
+  // expected-remark@-1 {{C enum constant 'NSMinYEdge' imported as unavailable static property 'NSMinYEdge'}}
   NSMaxXEdge __attribute__((availability(swift, unavailable, message="Use NSRectEdge.MaxX instead"))) = NSRectEdgeMaxX,
+  // expected-remark@-1 {{C enum constant 'NSMaxXEdge' imported as unavailable static property 'NSMaxXEdge'}}
   NSMaxYEdge __attribute__((availability(swift, unavailable, message="Use NSRectEdge.MaxY instead"))) = NSRectEdgeMaxY,
+  // expected-remark@-1 {{C enum constant 'NSMaxYEdge' imported as unavailable static property 'NSMaxYEdge'}}
 };
 
 // From CoreBluetooth
 typedef NS_OPTIONS(NSInteger, CBCharacteristicProperties) {
+  // expected-remark@-1 {{C enum 'CBCharacteristicProperties' imported as struct 'CBCharacteristicProperties'}}
+  // expected-remark@-2 {{C typedef 'CBCharacteristicProperties' imported as struct 'CBCharacteristicProperties'}}
   CBCharacteristicPropertyBroadcast = 0x01,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyBroadcast' imported as static property 'broadcast'}}
   CBCharacteristicPropertyRead = 0x02,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyRead' imported as static property 'read'}}
   CBCharacteristicPropertyWriteWithoutResponse = 0x04,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyWriteWithoutResponse' imported as static property 'writeWithoutResponse'}}
   CBCharacteristicPropertyWrite = 0x08,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyWrite' imported as static property 'write'}}
   CBCharacteristicPropertyNotify = 0x10,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyNotify' imported as static property 'notify'}}
   CBCharacteristicPropertyIndicate = 0x20,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyIndicate' imported as static property 'indicate'}}
   CBCharacteristicPropertyAuthenticatedSignedWrites = 0x40,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyAuthenticatedSignedWrites' imported as static property 'authenticatedSignedWrites'}}
   CBCharacteristicPropertyExtendedProperties = 0x80,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyExtendedProperties' imported as static property 'extendedProperties'}}
   CBCharacteristicPropertyNotifyEncryptionRequired /*NS_ENUM_AVAILABLE(10_9, 6_0)*/ = 0x100,
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyNotifyEncryptionRequired' imported as static property 'notifyEncryptionRequired'}}
   CBCharacteristicPropertyIndicateEncryptionRequired /*NS_ENUM_AVAILABLE(10_9, 6_0)*/ = 0x200
+  // expected-remark@-1 {{C enum constant 'CBCharacteristicPropertyIndicateEncryptionRequired' imported as static property 'indicateEncryptionRequired'}}
 };
 
 // From CoreMedia
 typedef CF_OPTIONS(unsigned int, CMTimeFlags) {
+  // expected-remark@-1 {{C enum 'CMTimeFlags' imported as struct 'CMTimeFlags'}}
+  // expected-remark@-2 {{C typedef 'CMTimeFlags' imported as struct 'CMTimeFlags'}}
   kCMTimeFlags_Valid = 1UL<<0,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlags_Valid' imported as static property 'valid'}}
   kCMTimeFlags_HasBeenRounded = 1UL<<1,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlags_HasBeenRounded' imported as static property 'hasBeenRounded'}}
   kCMTimeFlags_PositiveInfinity = 1UL<<2,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlags_PositiveInfinity' imported as static property 'positiveInfinity'}}
   kCMTimeFlags_NegativeInfinity = 1UL<<3,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlags_NegativeInfinity' imported as static property 'negativeInfinity'}}
   kCMTimeFlags_Indefinite = 1UL<<4,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlags_Indefinite' imported as static property 'indefinite'}}
   kCMTimeFlags_ImpliedValueFlagsMask = kCMTimeFlags_PositiveInfinity | kCMTimeFlags_NegativeInfinity | kCMTimeFlags_Indefinite
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlags_ImpliedValueFlagsMask' imported as static property 'impliedValueFlagsMask'}}
 };
 typedef CF_OPTIONS(unsigned int, CMTimeFlagsWithNumber) {
+  // expected-remark@-1 {{C enum 'CMTimeFlagsWithNumber' imported as struct 'CMTimeFlagsWithNumber'}}
+  // expected-remark@-2 {{C typedef 'CMTimeFlagsWithNumber' imported as struct 'CMTimeFlagsWithNumber'}}
   kCMTimeFlagsWithNumber_Valid = 1UL<<0,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlagsWithNumber_Valid' imported as static property '_Valid'}}
   kCMTimeFlagsWithNumber_888 = 1UL<<1,
+  // expected-remark@-1 {{C enum constant 'kCMTimeFlagsWithNumber_888' imported as static property '_888'}}
 };
 
 
 // Contrived name with a plural "-es"...normally these are "beeps".
 typedef NS_OPTIONS(NSInteger, AlertBuzzes) {
+  // expected-remark@-1 {{C enum 'AlertBuzzes' imported as struct 'AlertBuzzes'}}
+  // expected-remark@-2 {{C typedef 'AlertBuzzes' imported as struct 'AlertBuzzes'}}
   AlertBuzzNone = 0,
+  // expected-remark@-1 {{C enum constant 'AlertBuzzNone' imported as unavailable static property 'none'}}
   AlertBuzzFunk = 1 << 0,
+  // expected-remark@-1 {{C enum constant 'AlertBuzzFunk' imported as static property 'funk'}}
   AlertBuzzHero = 1 << 1,
+  // expected-remark@-1 {{C enum constant 'AlertBuzzHero' imported as static property 'hero'}}
   AlertBuzzSosumi = 1 << 2
+  // expected-remark@-1 {{C enum constant 'AlertBuzzSosumi' imported as static property 'sosumi'}}
 };
 
 // From AppKit
 typedef NS_OPTIONS(NSUInteger, NSBitmapFormat) {
+  // expected-remark@-1 {{C enum 'NSBitmapFormat' imported as struct 'NSBitmapFormat'}}
+  // expected-remark@-2 {{C typedef 'NSBitmapFormat' imported as struct 'NSBitmapFormat'}}
   NSAlphaFirstBitmapFormat            = 1 << 0, // 0 means is alpha last (RGBA, CMYKA, etc.)
+  // expected-remark@-1 {{C enum constant 'NSAlphaFirstBitmapFormat' imported as static property 'NSAlphaFirstBitmapFormat'}}
   NSAlphaNonpremultipliedBitmapFormat = 1 << 1, // 0 means is premultiplied
+  // expected-remark@-1 {{C enum constant 'NSAlphaNonpremultipliedBitmapFormat' imported as static property 'NSAlphaNonpremultipliedBitmapFormat'}}
   NSFloatingPointSamplesBitmapFormat  = 1 << 2, // 0 is integer
+  // expected-remark@-1 {{C enum constant 'NSFloatingPointSamplesBitmapFormat' imported as static property 'NSFloatingPointSamplesBitmapFormat'}}
 
   NS16BitLittleEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 8),
+  // expected-remark@-1 {{C enum constant 'NS16BitLittleEndianBitmapFormat' imported as static property 'NS16BitLittleEndianBitmapFormat'}}
   NS32BitLittleEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 9),
+  // expected-remark@-1 {{C enum constant 'NS32BitLittleEndianBitmapFormat' imported as static property 'NS32BitLittleEndianBitmapFormat'}}
   NS16BitBigEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 10),
+  // expected-remark@-1 {{C enum constant 'NS16BitBigEndianBitmapFormat' imported as static property 'NS16BitBigEndianBitmapFormat'}}
   NS32BitBigEndianBitmapFormat /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 11)
+  // expected-remark@-1 {{C enum constant 'NS32BitBigEndianBitmapFormat' imported as static property 'NS32BitBigEndianBitmapFormat'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSBitmapFormatReversed) {
+  // expected-remark@-1 {{C enum 'NSBitmapFormatReversed' imported as struct 'NSBitmapFormatReversed'}}
+  // expected-remark@-2 {{C typedef 'NSBitmapFormatReversed' imported as struct 'NSBitmapFormatReversed'}}
   NS16BitLittleEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 8),
+  // expected-remark@-1 {{C enum constant 'NS16BitLittleEndianBitmapFormatR' imported as static property 'NS16BitLittleEndianBitmapFormatR'}}
   NS32BitLittleEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 9),
+  // expected-remark@-1 {{C enum constant 'NS32BitLittleEndianBitmapFormatR' imported as static property 'NS32BitLittleEndianBitmapFormatR'}}
   NS16BitBigEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 10),
+  // expected-remark@-1 {{C enum constant 'NS16BitBigEndianBitmapFormatR' imported as static property 'NS16BitBigEndianBitmapFormatR'}}
   NS32BitBigEndianBitmapFormatR /*NS_ENUM_AVAILABLE_MAC(10_51)*/ = (1 << 11),
+  // expected-remark@-1 {{C enum constant 'NS32BitBigEndianBitmapFormatR' imported as static property 'NS32BitBigEndianBitmapFormatR'}}
 
   NSAlphaFirstBitmapFormatR            = 1 << 0, // 0 means is alpha last (RGBA, CMYKA, etc.)
+  // expected-remark@-1 {{C enum constant 'NSAlphaFirstBitmapFormatR' imported as static property 'NSAlphaFirstBitmapFormatR'}}
   NSAlphaNonpremultipliedBitmapFormatR = 1 << 1, // 0 means is premultiplied
+  // expected-remark@-1 {{C enum constant 'NSAlphaNonpremultipliedBitmapFormatR' imported as static property 'NSAlphaNonpremultipliedBitmapFormatR'}}
   NSFloatingPointSamplesBitmapFormatR  = 1 << 2, // 0 is integer
+  // expected-remark@-1 {{C enum constant 'NSFloatingPointSamplesBitmapFormatR' imported as static property 'NSFloatingPointSamplesBitmapFormatR'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSBitmapFormat2) {
+  // expected-remark@-1 {{C enum 'NSBitmapFormat2' imported as struct 'NSBitmapFormat2'}}
+  // expected-remark@-2 {{C typedef 'NSBitmapFormat2' imported as struct 'NSBitmapFormat2'}}
   NSU16a = 1,
+  // expected-remark@-1 {{C enum constant 'NSU16a' imported as static property 'NSU16a'}}
   NSU32a = 2,
+  // expected-remark@-1 {{C enum constant 'NSU32a' imported as static property 'NSU32a'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSBitmapFormat3) {
+  // expected-remark@-1 {{C enum 'NSBitmapFormat3' imported as struct 'NSBitmapFormat3'}}
+  // expected-remark@-2 {{C typedef 'NSBitmapFormat3' imported as struct 'NSBitmapFormat3'}}
   NSU16b = 1,
+  // expected-remark@-1 {{C enum constant 'NSU16b' imported as static property 'NSU16b'}}
   NSU32b = 2,
+  // expected-remark@-1 {{C enum constant 'NSU32b' imported as static property 'NSU32b'}}
   NSS16b = 4,
+  // expected-remark@-1 {{C enum constant 'NSS16b' imported as static property 'NSS16b'}}
   NSS32b = 8,
+  // expected-remark@-1 {{C enum constant 'NSS32b' imported as static property 'NSS32b'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSUBitmapFormat4) {
+  // expected-remark@-1 {{C enum 'NSUBitmapFormat4' imported as struct 'NSUBitmapFormat4'}}
+  // expected-remark@-2 {{C typedef 'NSUBitmapFormat4' imported as struct 'NSUBitmapFormat4'}}
   NSU16c = 1,
+  // expected-remark@-1 {{C enum constant 'NSU16c' imported as static property 'NSU16c'}}
   NSU32c = 2,
+  // expected-remark@-1 {{C enum constant 'NSU32c' imported as static property 'NSU32c'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSABitmapFormat5) {
+  // expected-remark@-1 {{C enum 'NSABitmapFormat5' imported as struct 'NSABitmapFormat5'}}
+  // expected-remark@-2 {{C typedef 'NSABitmapFormat5' imported as struct 'NSABitmapFormat5'}}
   NSAA16d = 1,
+  // expected-remark@-1 {{C enum constant 'NSAA16d' imported as static property 'NSAA16d'}}
   NSAB32d = 2,
+  // expected-remark@-1 {{C enum constant 'NSAB32d' imported as static property 'NSAB32d'}}
 };
 
 /// Aaa.  NSPotentiallyUnavailableOptions.  Bbb.
 typedef NS_OPTIONS(NSUInteger, NSPotentiallyUnavailableOptions) {
+  // expected-remark@-1 {{C enum 'NSPotentiallyUnavailableOptions' imported as struct 'NSPotentiallyUnavailableOptions'}}
+  // expected-remark@-2 {{C typedef 'NSPotentiallyUnavailableOptions' imported as struct 'NSPotentiallyUnavailableOptions'}}
   NSPotentiallyUnavailableOptionsFirst   = (1 << 0),
+  // expected-remark@-1 {{C enum constant 'NSPotentiallyUnavailableOptionsFirst' imported as static property 'first'}}
   NSPotentiallyUnavailableOptionsSecond  = (1 << 1),
+  // expected-remark@-1 {{C enum constant 'NSPotentiallyUnavailableOptionsSecond' imported as static property 'second'}}
   NSPotentiallyUnavailableOptionsThird   = (1 << 2),
+  // expected-remark@-1 {{C enum constant 'NSPotentiallyUnavailableOptionsThird' imported as static property 'third'}}
 }  __attribute__((availability(macosx, introduced=10.51)));
 
 /// Aaa.  NSOptionsWithUnavailableElement.  Bbb.
 typedef NS_OPTIONS(NSUInteger, NSOptionsWithUnavailableElement) {
+  // expected-remark@-1 {{C enum 'NSOptionsWithUnavailableElement' imported as struct 'NSOptionsWithUnavailableElement'}}
+  // expected-remark@-2 {{C typedef 'NSOptionsWithUnavailableElement' imported as struct 'NSOptionsWithUnavailableElement'}}
   NSOptionsWithUnavailableElementFirst    = (1 << 0),
+  // expected-remark@-1 {{C enum constant 'NSOptionsWithUnavailableElementFirst' imported as static property 'first'}}
   NSOptionsWithUnavailableElementSecond   = (1 << 1),
+  // expected-remark@-1 {{C enum constant 'NSOptionsWithUnavailableElementSecond' imported as static property 'second'}}
   NSOptionsWithUnavailableElementThird __attribute__((availability(macosx, introduced=10.51))) = (1 << 2),
+  // expected-remark@-1 {{C enum constant 'NSOptionsWithUnavailableElementThird' imported as static property 'third'}}
 };
 
 /// Aaa.  NSUnavailableEnum.  Bbb.
 typedef NS_ENUM(NSUInteger, NSUnavailableEnum) {
+  // expected-remark@-1 {{C enum 'NSUnavailableEnum' imported as enum 'NSUnavailableEnum'}}
+  // expected-remark@-2 {{C typedef 'NSUnavailableEnum' imported as enum 'NSUnavailableEnum'}}
   NSUnavailableEnumFirst,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableEnumFirst' imported as enum case 'first'}}
   NSUnavailableEnumSecond,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableEnumSecond' imported as enum case 'second'}}
   NSUnavailableEnumThird,
+  // expected-remark@-1 {{C enum constant 'NSUnavailableEnumThird' imported as enum case 'third'}}
 }  __attribute__((availability(macosx, introduced=10.51)));
 
 /// Aaa.  NSEnumWithUnavailableElement.  Bbb.
 typedef NS_ENUM(NSUInteger, NSEnumWithUnavailableElement) {
+  // expected-remark@-1 {{C enum 'NSEnumWithUnavailableElement' imported as enum 'NSEnumWithUnavailableElement'}}
+  // expected-remark@-2 {{C typedef 'NSEnumWithUnavailableElement' imported as enum 'NSEnumWithUnavailableElement'}}
   NSEnumWithUnavailableElementFirst,
+  // expected-remark@-1 {{C enum constant 'NSEnumWithUnavailableElementFirst' imported as enum case 'first'}}
   NSEnumWithUnavailableElementSecond,
+  // expected-remark@-1 {{C enum constant 'NSEnumWithUnavailableElementSecond' imported as enum case 'second'}}
   NSEnumWithUnavailableElementThird __attribute__((availability(macosx, introduced=10.51))),
+  // expected-remark@-1 {{C enum constant 'NSEnumWithUnavailableElementThird' imported as enum case 'third'}}
 };
 
 typedef NS_OPTIONS(NSUInteger, NSDeprecatedOptions) {
+  // expected-remark@-1 {{C enum 'NSDeprecatedOptions' imported as struct 'NSDeprecatedOptions'}}
+  // expected-remark@-2 {{C typedef 'NSDeprecatedOptions' imported as struct 'NSDeprecatedOptions'}}
   NSDeprecatedOptionsNone = 0,
+  // expected-remark@-1 {{C enum constant 'NSDeprecatedOptionsNone' imported as unavailable static property 'none'}}
   NSDeprecatedOptionsFirst   = (1 << 0)
+  // expected-remark@-1 {{C enum constant 'NSDeprecatedOptionsFirst' imported as static property 'first'}}
 }  __attribute__((availability(macosx, introduced=10.51, deprecated=10.51, message="Use a different API")));
 
 typedef NS_ENUM(NSUInteger, NSDeprecatedEnum) {
+  // expected-remark@-1 {{C enum 'NSDeprecatedEnum' imported as enum 'NSDeprecatedEnum'}}
+  // expected-remark@-2 {{C typedef 'NSDeprecatedEnum' imported as enum 'NSDeprecatedEnum'}}
   NSDeprecatedEnumFirst
+  // expected-remark@-1 {{C enum constant 'NSDeprecatedEnumFirst' imported as enum case 'first'}}
 } __attribute__((availability(macosx, introduced=10.51, deprecated=10.51, message="Use a different API")));
 
 typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOptions) {
+  // expected-remark@-1 {{C enum 'NSExplicitlyUnavailableOptions' imported as unavailable struct 'NSExplicitlyUnavailableOptions'}}
+  // expected-remark@-2 {{C typedef 'NSExplicitlyUnavailableOptions' imported as unavailable struct 'NSExplicitlyUnavailableOptions'}}
   NSExplicitlyUnavailableOptionsNone = 0,
+  // expected-remark@-1 {{C enum constant 'NSExplicitlyUnavailableOptionsNone' imported as unavailable static property 'none'}}
   NSExplicitlyUnavailableOptionsFirst   = (1 << 0)
+  // expected-remark@-1 {{C enum constant 'NSExplicitlyUnavailableOptionsFirst' imported as static property 'first'}}
 } __attribute__((unavailable));
 
 typedef NS_OPTIONS(NSUInteger, NSExplicitlyUnavailableOnOSXOptions) {
+  // expected-remark@-1 {{C enum 'NSExplicitlyUnavailableOnOSXOptions' imported as unavailable struct 'NSExplicitlyUnavailableOnOSXOptions'}}
+  // expected-remark@-2 {{C typedef 'NSExplicitlyUnavailableOnOSXOptions' imported as unavailable struct 'NSExplicitlyUnavailableOnOSXOptions'}}
   NSExplicitlyUnavailableOnOSXOptionsNone = 0,
+  // expected-remark@-1 {{C enum constant 'NSExplicitlyUnavailableOnOSXOptionsNone' imported as unavailable static property 'none'}}
   NSExplicitlyUnavailableOnOSXOptionsFirst   = (1 << 0)
+  // expected-remark@-1 {{C enum constant 'NSExplicitlyUnavailableOnOSXOptionsFirst' imported as static property 'first'}}
 }  __attribute__((availability(macosx, unavailable, message="Use a different API")));
 
 
 @interface NSClassWithDeprecatedOptionsInMethodSignature : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSClassWithDeprecatedOptionsInMethodSignature' imported as class 'NSClassWithDeprecatedOptionsInMethodSignature'}}
 + (NSClassWithDeprecatedOptionsInMethodSignature *) sharedInstance;
+// expected-remark@-1 {{Objective-C method '+[NSClassWithDeprecatedOptionsInMethodSignature sharedInstance]' imported as class method 'sharedInstance()'}}
 @end
 
 @interface NSClassWithDeprecatedOptionsInMethodSignature (ActuallyUseOptions)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
   - (void)someMethodWithDeprecatedOptions:(NSDeprecatedOptions)options __attribute__((availability(macosx, introduced=10.51, deprecated=10.51, message="Use a different API")));
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSClassWithExplicitlyUnavailableOptionsInMethodSignature : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSClassWithExplicitlyUnavailableOptionsInMethodSignature' imported as class 'NSClassWithExplicitlyUnavailableOptionsInMethodSignature'}}
 + (NSClassWithExplicitlyUnavailableOptionsInMethodSignature *) sharedInstance;
+// expected-remark@-1 {{Objective-C method '+[NSClassWithExplicitlyUnavailableOptionsInMethodSignature sharedInstance]' imported as class method 'sharedInstance()'}}
 @end
 
 @interface NSClassWithExplicitlyUnavailableOptionsInMethodSignature (ActuallyUseOptions)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)someMethodWithUnavailableOptions:(NSExplicitlyUnavailableOptions)options __attribute__((unavailable));
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)someMethodWithUnavailableOptionsOnOSX:(NSExplicitlyUnavailableOnOSXOptions)options __attribute__((availability(macosx, unavailable, message="Use a different API")));
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSClassWithPotentiallyUnavailableOptionsInMethodSignature : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSClassWithPotentiallyUnavailableOptionsInMethodSignature' imported as class 'NSClassWithPotentiallyUnavailableOptionsInMethodSignature'}}
 + (NSClassWithPotentiallyUnavailableOptionsInMethodSignature *) sharedInstance;
+// expected-remark@-1 {{Objective-C method '+[NSClassWithPotentiallyUnavailableOptionsInMethodSignature sharedInstance]' imported as class method 'sharedInstance()'}}
 - (void)someMethodWithPotentiallyUnavailableOptions:(NSPotentiallyUnavailableOptions)options __attribute__((availability(macosx, introduced=10.52)));
+// expected-remark@-1 {{Objective-C method '-[NSClassWithPotentiallyUnavailableOptionsInMethodSignature someMethodWithPotentiallyUnavailableOptions:]' imported as instance method 'someMethod(potentiallyUnavailableOptions:)'}}
 @end
 
 @protocol NSWobbling
+// expected-remark@-1 {{Objective-C protocol 'NSWobbling' imported as protocol 'NSWobbling'}}
 -(void)wobble;
+// expected-remark@-1 {{Objective-C method '-[NSWobbling wobble]' imported as instance method 'wobble()'}}
 
-- (instancetype)returnMyself; 
+- (instancetype)returnMyself;
+// expected-remark@-1 {{Objective-C method '-[NSWobbling returnMyself]' imported as instance method 'returnMyself()'}}
 
 @optional
 -(void)wibble;
+// expected-remark@-1 {{Objective-C method '-[NSWobbling wibble]' imported as instance method 'wibble()'}}
 
 - (id)objectAtIndexedSubscript:(NSUInteger)idx;
+// expected-remark@-1 {{Objective-C method '-[NSWobbling objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
 @end
 
 @protocol NSMaybeInitWobble
+// expected-remark@-1 {{Objective-C protocol 'NSMaybeInitWobble' imported as protocol 'NSMaybeInitWobble'}}
 @optional
 - (id)initWithWobble:(int)wobble;
+// expected-remark@-1 {{Objective-C method '-[NSMaybeInitWobble initWithWobble:]' imported as initializer 'init(wobble:)'}}
 @end
 
 @interface NSURLRequest : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSURLRequest' imported as class 'NSURLRequest'}}
 - (instancetype)requestWithString:(NSString *)URLString;
+// expected-remark@-1 {{Objective-C method '-[NSURLRequest requestWithString:]' imported as instance method 'withString'}}
 + (instancetype)requestWithString:(NSString *)URLString;
+// expected-remark@-1 {{Objective-C method '+[NSURLRequest requestWithString:]' imported as initializer 'init(string:)'}}
 + (instancetype)URLRequestWithURL:(NSURL *)URL;
+// expected-remark@-1 {{Objective-C method '+[NSURLRequest URLRequestWithURL:]' imported as initializer 'init(url:)'}}
 @end
 
 NS_SWIFT_UNAVAILABLE("NSInvocation and related APIs not available")
 @interface NSInvocation : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSInvocation' imported as unavailable class 'NSInvocation'}}
 @end
 
 typedef NS_ENUM(NSInteger, NSByteCountFormatterCountStyle) {
+  // expected-remark@-1 {{C enum 'NSByteCountFormatterCountStyle' imported as enum 'CountStyle'}}
+  // expected-remark@-2 {{C typedef 'NSByteCountFormatterCountStyle' imported as enum 'CountStyle'}}
   NSByteCountFormatterCountStyleFile    = 0,
+  // expected-remark@-1 {{C enum constant 'NSByteCountFormatterCountStyleFile' imported as enum case 'file'}}
   NSByteCountFormatterCountStyleMemory  = 1,
+  // expected-remark@-1 {{C enum constant 'NSByteCountFormatterCountStyleMemory' imported as enum case 'memory'}}
   NSByteCountFormatterCountStyleDecimal = 2,
+  // expected-remark@-1 {{C enum constant 'NSByteCountFormatterCountStyleDecimal' imported as enum case 'decimal'}}
   NSByteCountFormatterCountStyleBinary  = 3
+  // expected-remark@-1 {{C enum constant 'NSByteCountFormatterCountStyleBinary' imported as enum case 'binary'}}
 };
 
 @interface NSByteCountFormatter : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSByteCountFormatter' imported as class 'ByteCountFormatter'}}
 
 @property NSByteCountFormatterCountStyle countStyle;
+// expected-remark@-1 {{Objective-C method '-[NSByteCountFormatter countStyle]' imported as getter for property 'countStyle'}}
+// expected-remark@-2 {{Objective-C method '-[NSByteCountFormatter setCountStyle:]' imported as setter for property 'countStyle'}}
+// expected-remark@-3 {{Objective-C property '-NSByteCountFormatter.countStyle' imported as property 'countStyle'}}
 
 @end
 
 NSArray *arrayToArray(NSArray *arr);
+// expected-remark@-1 {{C function 'arrayToArray' imported as global function 'arrayToArray'}}
 NSDictionary *dictToDict(NSDictionary *dict);
+// expected-remark@-1 {{C function 'dictToDict' imported as global function 'dictToDict'}}
 NSSet *setToSet(NSSet *dict);
+// expected-remark@-1 {{C function 'setToSet' imported as global function 'setToSet'}}
 
 @interface NSExtensionContext : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSExtensionContext' imported as class 'NSExtensionContext'}}
 - (void)openURL:(NSURL *)URL completionHandler:(void (^)(BOOL success))completionHandler;
+// expected-remark@-1 {{Objective-C method '-[NSExtensionContext openURL:completionHandler:]' imported as instance method 'open(_:completionHandler:)'}}
+
 // Fake API, for testing initialisms.
 - (void)openGUID:(NSGUID *)GUID completionHandler:(void (^)(BOOL success))completionHandler;
+// expected-remark@-1 {{Objective-C method '-[NSExtensionContext openGUID:completionHandler:]' imported as instance method 'open(_:completionHandler:)'}}
 @end
 
 @interface NSProcessInfo : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSProcessInfo' imported as class 'ProcessInfo'}}
 @property (class, readonly, strong, nonnull) NSProcessInfo *processInfo;
+// expected-remark@-1 {{Objective-C method '+[NSProcessInfo processInfo]' imported as getter for class property 'processInfo'}}
+// expected-remark@-2 {{Objective-C property '+NSProcessInfo.processInfo' imported as class property 'processInfo'}}
 @end
 
 @interface NSString(FoundationExts)
+// expected-remark@-1 {{Objective-C category 'NSString(FoundationExts)' imported as extension of 'NSString'}}
 - (void)notBridgedMethod;
+// expected-remark@-1 {{Objective-C method '-[NSString(FoundationExts) notBridgedMethod]' imported as instance method 'notBridgedMethod()'}}
 @end
 
 @interface NSString(FoundationExts)
+// expected-remark@-1 {{Objective-C category 'NSString(FoundationExts)' imported as extension of 'NSString'}}
 @property (nonatomic, copy) NSString *uppercaseString;
+// expected-remark@-1 {{Objective-C method '-[NSString(FoundationExts) setUppercaseString:]' imported as setter for property 'uppercased'}}
+// expected-remark@-2 {{Objective-C method '-[NSString(FoundationExts) uppercaseString]' imported as getter for property 'uppercased'}}
+// expected-remark@-3 {{Objective-C property '-NSString(FoundationExts).uppercaseString' imported as property 'uppercased'}}
 @end
 
 typedef struct {
+    // expected-remark@-1 {{C struct 'NSFastEnumerationState' imported as struct 'NSFastEnumerationState'}}
     unsigned long state;
+    // expected-remark@-1 {{C field '(anonymous struct)::state' imported as property 'state'}}
     id __unsafe_unretained *itemsPtr;
+    // expected-remark@-1 {{C field '(anonymous struct)::itemsPtr' imported as property 'itemsPtr'}}
     unsigned long *mutationsPtr;
+    // expected-remark@-1 {{C field '(anonymous struct)::mutationsPtr' imported as property 'mutationsPtr'}}
     unsigned long extra[5];
+    // expected-remark@-1 {{C field '(anonymous struct)::extra' imported as property 'extra'}}
 } NSFastEnumerationState;
+// expected-remark@-1 {{C typedef 'NSFastEnumerationState' imported as struct 'NSFastEnumerationState'}}
 
 @protocol NSFastEnumeration
+// expected-remark@-1 {{Objective-C protocol 'NSFastEnumeration' imported as protocol 'NSFastEnumeration'}}
 
 - (NSUInteger)countByEnumeratingWithState:(nonnull NSFastEnumerationState *)state objects:(id __unsafe_unretained [])buffer count:(NSUInteger)len;
+// expected-remark@-1 {{Objective-C method '-[NSFastEnumeration countByEnumeratingWithState:objects:count:]' imported as instance method 'countByEnumerating(with:objects:count:)'}}
 
 @end
 
 typedef const void * CFTypeRef;
+// expected-remark@-1 {{C typedef 'CFTypeRef' imported as type alias 'CFTypeRef'}}
 typedef const struct __attribute__((objc_bridge(NSString))) __CFString * CFStringRef;
+// expected-remark@-1 {{C typedef 'CFStringRef' imported as class 'CFString'}}
 typedef const struct __attribute__((objc_bridge(NSDictionary))) __CFDictionary * CFDictionaryRef;
+// expected-remark@-1 {{C typedef 'CFDictionaryRef' imported as class 'CFDictionary'}}
 typedef struct CGColor *CGColorRef;
+// expected-remark@-1 {{C typedef 'CGColorRef' imported as class 'CGColor'}}
 
 extern CFTypeRef CFRetain(CFTypeRef cf);
+// expected-remark@-1 {{C function 'CFRetain' imported as unavailable global function 'CFRetain'}}
 extern void CFRelease(CFTypeRef cf);
+// expected-remark@-1 {{C function 'CFRelease' imported as unavailable global function 'CFRelease'}}
 extern CFTypeRef CFAutorelease(CFTypeRef __attribute__((cf_consumed)) arg) __attribute__((availability(macosx,introduced=10.9)));
+// expected-remark@-1 {{C function 'CFAutorelease' imported as unavailable global function 'CFAutorelease'}}
 extern CGColorRef CGColorRetain(CGColorRef color) __attribute__((availability(macosx,introduced=10.3)));
+// expected-remark@-1 {{C function 'CGColorRetain' imported as unavailable global function 'CGColorRetain'}}
 extern void CGColorRelease(CGColorRef color) __attribute__((availability(macosx,introduced=10.3)));
+// expected-remark@-1 {{C function 'CGColorRelease' imported as unavailable global function 'CGColorRelease'}}
 
 @interface NSObject (NSDistributedObjects)
+// expected-remark@-1 {{Objective-C category 'NSObject(NSDistributedObjects)' imported as extension of 'NSObject'}}
 @property (readonly) Class classForPortCoder NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead");
+// FIXME: why not unavailable? expected-remark@-1 {{Objective-C method '-[NSObject(NSDistributedObjects) classForPortCoder]' also imported as class method 'classForPortCoder()'}}
+// expected-remark@-2 {{Objective-C method '-[NSObject(NSDistributedObjects) classForPortCoder]' imported as unavailable getter for property 'classForPortCoder'}}
+// expected-remark@-3 {{Objective-C property '-NSObject(NSDistributedObjects).classForPortCoder' imported as unavailable property 'classForPortCoder'}}
 @end
 
 typedef NSString *_Nonnull NSNotificationName
     __attribute((swift_newtype(struct)));
+// expected-remark@-2 {{C typedef 'NSNotificationName' imported as struct 'Name'}}
 
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 extern NSString * const NSConnectionReplyMode;
+// expected-remark@-1 {{C variable 'NSConnectionReplyMode' imported as unavailable let 'NSConnectionReplyMode'}}
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 extern NSString * const NSConnectionDidDieNotification;
+// expected-remark@-1 {{C variable 'NSConnectionDidDieNotification' imported as unavailable static property 'NSConnectionDidDie'}}
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSConnection : NSObject {
+  // expected-remark@-1 {{Objective-C class interface 'NSConnection' imported as unavailable class 'NSConnection'}}
 }
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSPortCoder : NSCoder
+// expected-remark@-1 {{Objective-C class interface 'NSPortCoder' imported as unavailable class 'NSPortCoder'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @protocol NSConnectionDelegate <NSObject>
+// expected-remark@-1 {{Objective-C protocol 'NSConnectionDelegate' imported as unavailable protocol 'NSConnectionDelegate'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSDistantObjectRequest : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSDistantObjectRequest' imported as unavailable class 'NSDistantObjectRequest'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSDistantObject
+// expected-remark@-1 {{Objective-C class interface 'NSDistantObject' imported as unavailable class 'NSDistantObject'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSPortNameServer : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSPortNameServer' imported as unavailable class 'NSPortNameServer'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSMachBootstrapServer : NSPortNameServer
+// expected-remark@-1 {{Objective-C class interface 'NSMachBootstrapServer' imported as unavailable class 'NSMachBootstrapServer'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSMessagePortNameServer : NSPortNameServer
+// expected-remark@-1 {{Objective-C class interface 'NSMessagePortNameServer' imported as unavailable class 'NSMessagePortNameServer'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSXPCConnection instead")
 @interface NSSocketPortNameServer : NSPortNameServer
+// expected-remark@-1 {{Objective-C class interface 'NSSocketPortNameServer' imported as unavailable class 'NSSocketPortNameServer'}}
 @end
 NS_SWIFT_UNAVAILABLE("Use NSCalendar and NSDateComponents and NSDateFormatter instead")
 @interface NSCalendarDate : NSDate
+// expected-remark@-1 {{Objective-C class interface 'NSCalendarDate' imported as unavailable class 'NSCalendarDate'}}
 @end
 NS_SWIFT_UNAVAILABLE("NSInvocation and related APIs not available")
 @interface NSInvocationOperation : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSInvocationOperation' imported as unavailable class 'NSInvocationOperation'}}
 @end
 NS_SWIFT_UNAVAILABLE("NSInvocation and related APIs not available")
 @interface NSMethodSignature : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSMethodSignature' imported as unavailable class 'NSMethodSignature'}}
 @end
 /// Unavailable Global Functions
 extern void NSSetZoneName(NSZone *_Nonnull zone, NSString *_Nonnull name)
     NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
+// expected-remark@-2 {{C function 'NSSetZoneName' imported as unavailable global function 'NSSetZoneName'}}
 extern NSString *NSZoneName(NSZone *zone) NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
+// expected-remark@-1 {{C function 'NSZoneName' imported as unavailable global function 'NSZoneName'}}
 extern NSZone *NSCreateZone(NSUInteger startSize, NSUInteger granularity, BOOL canFree) NS_SWIFT_UNAVAILABLE("Zone-based memory management is unavailable");
+// expected-remark@-1 {{C function 'NSCreateZone' imported as unavailable global function 'NSCreateZone'}}
 
 @interface NSXPCInterface : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSXPCInterface' imported as class 'NSXPCInterface'}}
 + (NSXPCInterface *)interfaceWithProtocol:(Protocol *)protocol;
+// expected-remark@-1 {{Objective-C method '+[NSXPCInterface interfaceWithProtocol:]' imported as initializer 'init(with:)'}}
 @end
 
 typedef struct NonNilableReferences {
+  // expected-remark@-1 {{C struct 'NonNilableReferences' imported as struct 'NonNilableReferences'}}
   NSObject *_Nonnull __unsafe_unretained obj;
+  // expected-remark@-1 {{C field 'NonNilableReferences::obj' imported as property 'obj'}}
 } NonNilableReferences;
+// expected-remark@-1 {{C typedef 'NonNilableReferences' imported as struct 'NonNilableReferences'}}
 
 
 @protocol NSProtocolWithOptionalRequirement
+// expected-remark@-1 {{Objective-C protocol 'NSProtocolWithOptionalRequirement' imported as protocol 'NSProtocolWithOptionalRequirement'}}
 @optional
 -(void)optionalRequirement;
+// expected-remark@-1 {{Objective-C method '-[NSProtocolWithOptionalRequirement optionalRequirement]' imported as instance method 'optionalRequirement()'}}
 -(DummyClass *)optionalRequirementMethodWithIUOResult;
+// expected-remark@-1 {{Objective-C method '-[NSProtocolWithOptionalRequirement optionalRequirementMethodWithIUOResult]' imported as instance method 'optionalRequirementMethodWithIUOResult()'}}
 @end
 
 @interface NSClassWithMethodFromNSProtocolWithOptionalRequirement
+// expected-remark@-1 {{Objective-C class interface 'NSClassWithMethodFromNSProtocolWithOptionalRequirement' imported as class 'NSClassWithMethodFromNSProtocolWithOptionalRequirement'}}
 -(void)optionalRequirement  __attribute__((availability(macosx, introduced=10.51)));
+// expected-remark@-1 {{Objective-C method '-[NSClassWithMethodFromNSProtocolWithOptionalRequirement optionalRequirement]' also imported as class method 'optionalRequirement()'}}
+// expected-remark@-2 {{Objective-C method '-[NSClassWithMethodFromNSProtocolWithOptionalRequirement optionalRequirement]' imported as instance method 'optionalRequirement()'}}
 @end
 
 __attribute__((availability(macosx, introduced = 10.51)))
 @interface AnnotatedFrameworkClass : NSObject
+// expected-remark@-1 {{Objective-C class interface 'AnnotatedFrameworkClass' imported as class 'AnnotatedFrameworkClass'}}
 @end
 
 __attribute__((availability(macosx, introduced = 10.52)))
 @interface AnnotatedLaterFrameworkClass : NSObject
+// expected-remark@-1 {{Objective-C class interface 'AnnotatedLaterFrameworkClass' imported as class 'AnnotatedLaterFrameworkClass'}}
 @end
 
 /// Aaa.  UnannotatedFrameworkProtocol.  Bbb.
 @protocol UnannotatedFrameworkProtocol
+// expected-remark@-1 {{Objective-C protocol 'UnannotatedFrameworkProtocol' imported as protocol 'UnannotatedFrameworkProtocol'}}
 - (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nullable)k;
+// expected-remark@-1 {{Objective-C method '-[UnannotatedFrameworkProtocol doSomethingWithClass:]' imported as instance method 'doSomething(with:)'}}
 - (void)doSomethingWithNonNullableClass:(AnnotatedFrameworkClass *_Nonnull)k;
+// expected-remark@-1 {{Objective-C method '-[UnannotatedFrameworkProtocol doSomethingWithNonNullableClass:]' imported as instance method 'doSomething(withNonNullableClass:)'}}
 - (void)doSomethingWithIUOClass:(AnnotatedFrameworkClass *_Null_unspecified)k;
+// expected-remark@-1 {{Objective-C method '-[UnannotatedFrameworkProtocol doSomethingWithIUOClass:]' imported as instance method 'doSomething(withIUOClass:)'}}
 - (AnnotatedFrameworkClass *_Nullable)returnSomething;
+// expected-remark@-1 {{Objective-C method '-[UnannotatedFrameworkProtocol returnSomething]' imported as instance method 'returnSomething()'}}
 
 -(void)noUnavailableTypesInSignature;
+// expected-remark@-1 {{Objective-C method '-[UnannotatedFrameworkProtocol noUnavailableTypesInSignature]' imported as instance method 'noUnavailableTypesInSignature()'}}
 
 - (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nonnull)k
                andLaterClass:(AnnotatedLaterFrameworkClass *_Nonnull)lk;
+// expected-remark@-2 {{Objective-C method '-[UnannotatedFrameworkProtocol doSomethingWithClass:andLaterClass:]' imported as instance method 'doSomething(with:andLaterClass:)'}}
 
 -(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=10.53)));
+// expected-remark@-1 {{Objective-C method '-[UnannotatedFrameworkProtocol someMethodWithAvailability]' imported as instance method 'someMethodWithAvailability()'}}
 
 @property(nonnull) AnnotatedFrameworkClass *someProperty;
+// FIXME: repeats expected-remark@-1 3 {{Objective-C method '-[UnannotatedFrameworkProtocol setSomeProperty:]' imported as setter for property 'someProperty'}}
+// FIXME: repeats expected-remark@-2 3 {{Objective-C method '-[UnannotatedFrameworkProtocol someProperty]' imported as getter for property 'someProperty'}}
+// expected-remark@-3 {{Objective-C property '-UnannotatedFrameworkProtocol.someProperty' imported as property 'someProperty'}}
 
 @end
 
 /// Aaa.  AnnotatedFrameworkProtocol.  Bbb.
 __attribute__((availability(macosx, introduced = 10.9)))
 @protocol AnnotatedFrameworkProtocol
+// expected-remark@-1 {{Objective-C protocol 'AnnotatedFrameworkProtocol' imported as protocol 'AnnotatedFrameworkProtocol'}}
 - (AnnotatedFrameworkClass * _Nullable) returnSomething;
+// expected-remark@-1 {{Objective-C method '-[AnnotatedFrameworkProtocol returnSomething]' imported as instance method 'returnSomething()'}}
 @end
 
 /// Aaa.  FrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
 @interface FrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject<UnannotatedFrameworkProtocol>
+// expected-remark@-1 {{Objective-C class interface 'FrameworkClassConformingToUnannotatedFrameworkProtocol' imported as class 'FrameworkClassConformingToUnannotatedFrameworkProtocol'}}
 @end
 
 /// Aaa.  LaterFrameworkClassConformingToUnannotatedFrameworkProtocol.  Bbb.
 __attribute__((availability(macosx, introduced = 10.52)))
 @interface LaterFrameworkClassConformingToUnannotatedFrameworkProtocol : NSObject<UnannotatedFrameworkProtocol>
+// expected-remark@-1 {{Objective-C class interface 'LaterFrameworkClassConformingToUnannotatedFrameworkProtocol' imported as class 'LaterFrameworkClassConformingToUnannotatedFrameworkProtocol'}}
 @end
 
 /// Aaa.  LaterAnnotatedFrameworkProtocol.  Bbb.
 __attribute__((availability(macosx, introduced = 10.52)))
 @protocol LaterAnnotatedFrameworkProtocol
+// expected-remark@-1 {{Objective-C protocol 'LaterAnnotatedFrameworkProtocol' imported as protocol 'LaterAnnotatedFrameworkProtocol'}}
 - (AnnotatedFrameworkClass * _Nullable) returnSomething;
+// expected-remark@-1 {{Objective-C method '-[LaterAnnotatedFrameworkProtocol returnSomething]' imported as instance method 'returnSomething()'}}
 - (void)doSomethingWithClass:(AnnotatedFrameworkClass *_Nonnull)k
                andLaterClass:(AnnotatedLaterFrameworkClass *_Nonnull)lk;
+// expected-remark@-2 {{Objective-C method '-[LaterAnnotatedFrameworkProtocol doSomethingWithClass:andLaterClass:]' imported as instance method 'doSomething(with:andLaterClass:)'}}
 -(void)noUnavailableTypesInSignature;
+// expected-remark@-1 {{Objective-C method '-[LaterAnnotatedFrameworkProtocol noUnavailableTypesInSignature]' imported as instance method 'noUnavailableTypesInSignature()'}}
 -(void)someMethodWithAvailability __attribute__((availability(macosx,introduced=10.53)));
+// expected-remark@-1 {{Objective-C method '-[LaterAnnotatedFrameworkProtocol someMethodWithAvailability]' imported as instance method 'someMethodWithAvailability()'}}
 @property(nonnull) AnnotatedFrameworkClass *someProperty;
+// FIXME: repeats expected-remark@-1 2 {{Objective-C method '-[LaterAnnotatedFrameworkProtocol setSomeProperty:]' imported as setter for property 'someProperty'}}
+// FIXME: repeats expected-remark@-2 2 {{Objective-C method '-[LaterAnnotatedFrameworkProtocol someProperty]' imported as getter for property 'someProperty'}}
+// expected-remark@-3 {{Objective-C property '-LaterAnnotatedFrameworkProtocol.someProperty' imported as property 'someProperty'}}
 @end
 
 /// Aaa.  FrameworkClassConformingToLaterAnnotatedFrameworkProtocol.  Bbb.
 @interface FrameworkClassConformingToLaterAnnotatedFrameworkProtocol : NSObject<LaterAnnotatedFrameworkProtocol>
+// expected-remark@-1 {{Objective-C class interface 'FrameworkClassConformingToLaterAnnotatedFrameworkProtocol' imported as class 'FrameworkClassConformingToLaterAnnotatedFrameworkProtocol'}}
 @end
 
 @interface UnusedResults : NSObject
+// expected-remark@-1 {{Objective-C class interface 'UnusedResults' imported as class 'UnusedResults'}}
 -(NSInteger)producesResult __attribute__((warn_unused_result));
+// expected-remark@-1 {{Objective-C method '-[UnusedResults producesResult]' imported as instance method 'producesResult()'}}
 @end
 
 @interface NSObject (Silly)
+// expected-remark@-1 {{Objective-C category 'NSObject(Silly)' imported as extension of 'NSObject'}}
 -(void)doSelector:(SEL)selector;
+// expected-remark@-1 {{Objective-C method '-[NSObject(Silly) doSelector:]' also imported as class method 'do'}}
+// expected-remark@-2 {{Objective-C method '-[NSObject(Silly) doSelector:]' imported as instance method 'do'}}
 @end
 
 @interface Bee (Gerunds)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)startSquashingBee:(nonnull Bee *)bee;
+//  expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)startSoothingBee:(nonnull Bee *)bee;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)startShoppingBee:(nonnull Bee *)bee;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSMutableArray<ObjectType> : NSArray
+// expected-remark@-1 {{Objective-C class interface 'NSMutableArray' imported as class 'NSMutableArray'}}
 - (void)addObjects:(nonnull NSArray<ObjectType> *)objects;
+// expected-remark@-1 {{Objective-C method '-[NSMutableArray addObjects:]' imported as instance method 'add'}}
 @end
 
 @interface NSString (Slicing)
+// expected-remark@-1 {{Objective-C category 'NSString(Slicing)' imported as extension of 'NSString'}}
 - (nonnull NSString *)sliceFromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex;
+// expected-remark@-1 {{Objective-C method '-[NSString(Slicing) sliceFromIndex:toIndex:]' imported as instance method 'slice(from:to:)'}}
 @end
 
 @interface NSString (Appending)
+// expected-remark@-1 {{Objective-C category 'NSString(Appending)' imported as extension of 'NSString'}}
 - (nonnull NSString *)stringByAppendingString:(nonnull NSString *)string;
+// expected-remark@-1 {{Objective-C method '-[NSString(Appending) stringByAppendingString:]' imported as instance method 'appending'}}
 - (nonnull NSString *)stringWithString:(nonnull NSString *)string;
+// expected-remark@-1 {{Objective-C method '-[NSString(Appending) stringWithString:]' imported as instance method 'withString'}}
 - (nullable NSURL *)URLWithAddedString:(nonnull NSString *)string;
+// expected-remark@-1 {{Objective-C method '-[NSString(Appending) URLWithAddedString:]' imported as instance method 'url(withAddedString:)'}}
+
 // Fake API for testing initialisms.
 - (nullable NSGUID *)GUIDWithAddedString:(nonnull NSString *)string;
+// expected-remark@-1 {{Objective-C method '-[NSString(Appending) GUIDWithAddedString:]' imported as instance method 'guid(withAddedString:)'}}
 - (NSString *)stringForCalendarUnits:(NSCalendarUnit)units;
+// expected-remark@-1 {{Objective-C method '-[NSString(Appending) stringForCalendarUnits:]' imported as instance method 'forCalendarUnits'}}
 @end
 
 @interface NSURL (Properties)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @property (readonly, nullable) NSURL *URLByDeletingLastPathComponent;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
+// expected-FIXME-remark@-2 {{<#diagnostic#>}}
 @property (readonly, nonnull) NSURL *URLWithHTTPS;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
+// expected-FIXME-remark@-2 {{<#diagnostic#>}}
 @end
 
 @interface NSGUID (Properties)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @property (readonly, nullable) NSGUID *GUIDByCanonicalizing;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
+// expected-FIXME-remark@-2 {{<#diagnostic#>}}
 @property (readonly, nonnull) NSGUID *GUIDWithContext;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
+// expected-FIXME-remark@-2 {{<#diagnostic#>}}
 @end
 
 typedef NS_OPTIONS(NSUInteger, NSEnumerationOptions) {
+   // expected-remark@-1 {{C enum 'NSEnumerationOptions' imported as struct 'NSEnumerationOptions'}}
+   // expected-remark@-2 {{C typedef 'NSEnumerationOptions' imported as struct 'NSEnumerationOptions'}}
    NSEnumerationConcurrent = (1UL << 0),
+   // expected-remark@-1 {{C enum constant 'NSEnumerationConcurrent' imported as static property 'concurrent'}}
    NSEnumerationReverse = (1UL << 1),
+   // expected-remark@-1 {{C enum constant 'NSEnumerationReverse' imported as static property 'reverse'}}
 };
 
 @interface NSArray (Enumeration)
+// expected-remark@-1 {{Objective-C category 'NSArray(Enumeration)' imported as extension of 'NSArray'}}
 - (void)enumerateObjectsUsingBlock:(void (^)(id obj,
                                              NSUInteger idx,
                                              BOOL *stop))block;
+// expected-remark@-3 {{Objective-C method '-[NSArray(Enumeration) enumerateObjectsUsingBlock:]' imported as instance method 'enumerateObjects'}}
 
 - (void)enumerateObjectsWithOptions:(NSEnumerationOptions)opts
                          usingBlock:(void (^)(id obj, NSUInteger idx,
                                               BOOL *stop))block;
+// expected-remark@-3 {{Objective-C method '-[NSArray(Enumeration) enumerateObjectsWithOptions:usingBlock:]' imported as instance method 'enumerateObjects(options:using:)'}}
 
 - (void)enumerateObjectsRandomlyWithBlock:
     (void (^_Nullable)(id obj, NSUInteger idx, BOOL *stop))block;
+// expected-remark@-2 {{Objective-C method '-[NSArray(Enumeration) enumerateObjectsRandomlyWithBlock:]' imported as instance method 'enumerateObjectsRandomly(block:)'}}
 
 - (void)enumerateObjectsHaphazardly:(void (^_Nullable)(id obj, NSUInteger idx,
                                                        BOOL *stop))block;
+// expected-remark@-2 {{Objective-C method '-[NSArray(Enumeration) enumerateObjectsHaphazardly:]' imported as instance method 'enumerateObjectsHaphazardly'}}
 
 - (void)optionallyEnumerateObjects:(NSEnumerationOptions)opts
                               body:(void (^)(id obj, NSUInteger idx,
                                              BOOL *stop))block;
+// expected-remark@-3 {{Objective-C method '-[NSArray(Enumeration) optionallyEnumerateObjects:body:]' imported as instance method 'optionallyEnumerateObjects(_:body:)'}}
 
 - (void)enumerateObjectsWhileOrderingPizza:(BOOL)pizza
                          withOptions:(NSEnumerationOptions)opts
                          usingBlock:(void (^)(id obj, NSUInteger idx,
                                               BOOL *stop))block;
+// expected-remark@-4 {{Objective-C method '-[NSArray(Enumeration) enumerateObjectsWhileOrderingPizza:withOptions:usingBlock:]' imported as instance method 'enumerateObjectsWhileOrderingPizza(_:with:using:)'}}
 
 - (void)doSomethingWithCopying:(nonnull id<NSCopying>)copying;
+// expected-remark@-1 {{Objective-C method '-[NSArray(Enumeration) doSomethingWithCopying:]' imported as instance method 'doSomething(with:)'}}
 - (void)doSomethingElseWithCopying:(nonnull NSObject<NSCopying> *)copying;
+// expected-remark@-1 {{Objective-C method '-[NSArray(Enumeration) doSomethingElseWithCopying:]' imported as instance method 'doSomethingElse(with:)'}}
 
 - (void)enumerateObjectsWithNullableBlock:
     (void (^_Nullable)(id obj, NSUInteger idx, BOOL *stop))block;
+// expected-remark@-2 {{Objective-C method '-[NSArray(Enumeration) enumerateObjectsWithNullableBlock:]' imported as instance method 'enumerateObjects(nullableBlock:)'}}
 @end
 
 @interface NSMutableArray (Sorting)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)sortUsingFunction:(NSInteger (*_Nonnull)(_Nonnull id,
                                                  _Nonnull id))fimctopn;
+// expected-FIXME-remark@-2 {{<#diagnostic#>}}
 @end
 
 @interface NSMutableArray (Removal)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)removeObjects:(nonnull NSArray *)objects;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSMutableArray (TypeSuffix)
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)doSomethingWithUnderlying:(NSUnderlyingType)underlying;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 - (void)setDefaultEnumerationOptions:(NSEnumerationOptions)options;
+// expected-FIXME-remark@-1 {{<#diagnostic#>}}
 @end
 
 @interface NSString ()
+// expected-remark@-1 {{Objective-C category 'NSString()' imported as extension of 'NSString'}}
 - (nonnull NSString *)stringByNormalizingXMLPreservingComments:(BOOL)preserveFlag;
+// expected-remark@-1 {{Objective-C method '-[NSString() stringByNormalizingXMLPreservingComments:]' imported as instance method 'normalizingXMLPreservingComments'}}
 @end
 
 @interface NSSet ()
+// expected-remark@-1 {{Objective-C category 'NSSet()' imported as extension of 'NSSet'}}
 - (nonnull NSSet *)setByAddingObject:(nonnull id)object;
+// expected-remark@-1 {{Objective-C method '-[NSSet() setByAddingObject:]' imported as instance method 'adding'}}
 @property (readonly) BOOL empty;
+// expected-remark@-1 {{Objective-C method '-[NSSet() empty]' imported as getter for property 'empty'}}
+// expected-remark@-2 {{Objective-C property '-NSSet().empty' imported as property 'empty'}}
 - (BOOL)nonEmpty;
+// expected-remark@-1 {{Objective-C method '-[NSSet() nonEmpty]' imported as instance method 'nonEmpty()'}}
 @property (readonly) BOOL isStringSet;
+// expected-remark@-1 {{Objective-C method '-[NSSet() isStringSet]' imported as getter for property 'isStringSet'}}
+// expected-remark@-2 {{Objective-C property '-NSSet().isStringSet' imported as property 'isStringSet'}}
 @property (readonly) BOOL wantsAUnion;
+// expected-remark@-1 {{Objective-C method '-[NSSet() wantsAUnion]' imported as getter for property 'wantsAUnion'}}
+// expected-remark@-2 {{Objective-C property '-NSSet().wantsAUnion' imported as property 'wantsAUnion'}}
 @property (readonly) BOOL watchesItsLanguage;
+// expected-remark@-1 {{Objective-C method '-[NSSet() watchesItsLanguage]' imported as getter for property 'watchesItsLanguage'}}
+// expected-remark@-2 {{Objective-C property '-NSSet().watchesItsLanguage' imported as property 'watchesItsLanguage'}}
 @property (readonly) BOOL appliesForAJob;
+// expected-remark@-1 {{Objective-C method '-[NSSet() appliesForAJob]' imported as getter for property 'appliesForAJob'}}
+// expected-remark@-2 {{Objective-C property '-NSSet().appliesForAJob' imported as property 'appliesForAJob'}}
 @property (readonly) BOOL setShouldBeInfinite;
+// expected-remark@-1 {{Objective-C method '-[NSSet() setShouldBeInfinite]' imported as getter for property 'setShouldBeInfinite'}}
+// expected-remark@-2 {{Objective-C property '-NSSet().setShouldBeInfinite' imported as property 'setShouldBeInfinite'}}
 @end
 
 int variadicFunc1(int A, ...);
+// expected-remark@-1 {{C function 'variadicFunc1' imported as unavailable global function 'variadicFunc1'}}
 
 int variadicFunc2(int A, ...);
+// expected-remark@-1 {{C function 'variadicFunc2' imported as unavailable global function 'variadicFunc2'}}
 
 @interface NSString (UTF8)
+// expected-remark@-1 {{Objective-C category 'NSString(UTF8)' imported as extension of 'NSString'}}
 -(nullable instancetype)initWithUTF8String:(const char *)bytes;
+// expected-remark@-1 {{Objective-C method '-[NSString(UTF8) initWithUTF8String:]' imported as initializer 'init(utf8String:)'}}
 @end
 
 extern NSString *NSGlobalConstant;
+// expected-remark@-1 {{C variable 'NSGlobalConstant' imported as let 'NSGlobalConstant'}}
 extern void NSGlobalFunction(void);
+// expected-remark@-1 {{C function 'NSGlobalFunction' imported as global function 'NSGlobalFunction()'}}
 
 extern void NS123(void);
+// expected-remark@-1 {{C function 'NS123' imported as global function 'NS123()'}}
 extern void NSYELLING(void);
+// expected-remark@-1 {{C function 'NSYELLING' imported as global function 'NSYELLING()'}}
 extern void NS_SCREAMING(void);
+// expected-remark@-1 {{C function 'NS_SCREAMING' imported as global function 'NS_SCREAMING()'}}
 extern void NS_(void);
+// expected-remark@-1 {{C function 'NS_' imported as global function 'NS_()'}}
 extern NSString *NSHTTPRequestKey;
+// expected-remark@-1 {{C variable 'NSHTTPRequestKey' imported as let 'NSHTTPRequestKey'}}
 
 @interface NSString (URLExtraction)
+// expected-remark@-1 {{Objective-C category 'NSString(URLExtraction)' imported as extension of 'NSString'}}
 @property (nonnull,copy,readonly) NSArray<NSURL *> *URLsInText;
+// expected-remark@-1 {{Objective-C method '-[NSString(URLExtraction) URLsInText]' imported as getter for property 'urlsInText'}}
+// expected-remark@-2 {{Objective-C property '-NSString(URLExtraction).URLsInText' imported as property 'urlsInText'}}
 @property (nonnull,copy,readonly) NSArray<NSGUID *> *GUIDsInText;
+// expected-remark@-1 {{Objective-C method '-[NSString(URLExtraction) GUIDsInText]' imported as getter for property 'guidsInText'}}
+// expected-remark@-2 {{Objective-C property '-NSString(URLExtraction).GUIDsInText' imported as property 'guidsInText'}}
 @end
 
 @interface NSObject (Selectors)
+// expected-remark@-1 {{Objective-C category 'NSObject(Selectors)' imported as extension of 'NSObject'}}
 -(void)messageSomeObject:(nonnull id)object selector:(SEL)selector;
+// expected-remark@-1 {{Objective-C method '-[NSObject(Selectors) messageSomeObject:selector:]' also imported as class method 'messageSomeObject(_:selector:)'}}
+// expected-remark@-2 {{Objective-C method '-[NSObject(Selectors) messageSomeObject:selector:]' imported as instance method 'messageSomeObject(_:selector:)'}}
 @end
 
 @interface NSOperation : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSOperation' imported as class 'Operation'}}
 @end
 
 @interface NSProgress : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSProgress' imported as class 'NSProgress'}}
 @end
 
 @protocol NSProgressReporting <NSObject>
+// expected-remark@-1 {{Objective-C protocol 'NSProgressReporting' imported as protocol 'ProgressReporting'}}
 @property (readonly) NSProgress *progress;
+// expected-remark@-1 {{Objective-C method '-[NSProgressReporting progress]' imported as getter for property 'progress'}}
+// expected-remark@-2 {{Objective-C property '-NSProgressReporting.progress' imported as property 'progress'}}
 @end
 
 @interface NSIdLover: NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSIdLover' imported as class 'NSIdLover'}}
 
 - (id _Nonnull)makesId;
+// expected-remark@-1 {{Objective-C method '-[NSIdLover makesId]' imported as instance method 'makesId()'}}
 - (void)takesId:(id _Nonnull)x;
+// expected-remark@-1 {{Objective-C method '-[NSIdLover takesId:]' imported as instance method 'takesId'}}
 - (void)takesArrayOfId:(const id _Nonnull * _Nonnull)x;
+// expected-remark@-1 {{Objective-C method '-[NSIdLover takesArrayOfId:]' imported as instance method 'takesArray(ofId:)'}}
 - (void)takesNullableId:(id _Nullable)x;
+// expected-remark@-1 {{Objective-C method '-[NSIdLover takesNullableId:]' imported as instance method 'takesNullableId'}}
 
 @property (strong) id propertyOfId;
+// expected-remark@-1 {{Objective-C method '-[NSIdLover propertyOfId]' imported as getter for property 'propertyOfId'}}
+// expected-remark@-2 {{Objective-C method '-[NSIdLover setPropertyOfId:]' imported as setter for property 'propertyOfId'}}
+// expected-remark@-3{{Objective-C property '-NSIdLover.propertyOfId' imported as property 'propertyOfId'}}
 
 @end
 
 @protocol NSIdLoving
+// expected-remark@-1 {{Objective-C protocol 'NSIdLoving' imported as protocol 'NSIdLoving'}}
 - (void)takesIdViaProtocol:(id _Nonnull)x;
+// expected-remark@-1 {{Objective-C method '-[NSIdLoving takesIdViaProtocol:]' imported as instance method 'takesId(viaProtocol:)'}}
 @end
 
 #define NSTimeIntervalSince1970 978307200.0
 #define NS_DO_SOMETHING 17
 
 typedef NS_ENUM(NSUInteger, NSClothingStyle) {
+  // expected-remark@-1 {{C enum 'NSClothingStyle' imported as enum 'NSClothingStyle'}}
+  // expected-remark@-2 {{C typedef 'NSClothingStyle' imported as enum 'NSClothingStyle'}}
+
   NSClothingStyleFormal = 0,
+  // expected-remark@-1 {{C enum constant 'NSClothingStyleFormal' imported as enum case 'formal'}}
   NSClothingStyleSemiFormal,
+  // expected-remark@-1 {{C enum constant 'NSClothingStyleSemiFormal' imported as enum case 'semiFormal'}}
   NSClothingStyleHipster,
+  // expected-remark@-1 {{C enum constant 'NSClothingStyleHipster' imported as enum case 'hipster'}}
   NSClothingStyleHippie
+  // expected-remark@-1 {{C enum constant 'NSClothingStyleHippie' imported as enum case 'hippie'}}
 };
 static const NSClothingStyle NSClothingStyleOfficeCasual __attribute__((availability(swift,unavailable,replacement="NSClothingStyleSemiFormal"))) = NSClothingStyleSemiFormal;
+// expected-remark@-1 {{C variable 'NSClothingStyleOfficeCasual' imported as unavailable let 'NSClothingStyleOfficeCasual'}}
 
 void acceptError(NSError * _Nonnull error);
+// expected-remark@-1 {{C function 'acceptError' imported as global function 'acceptError'}}
 NSError * _Nonnull produceError(void);
+// expected-remark@-1 {{C function 'produceError' imported as global function 'produceError()'}}
 NSError * _Nullable produceOptionalError(void);
+// expected-remark@-1 {{C function 'produceOptionalError' imported as global function 'produceOptionalError()'}}
 
 extern NSString * const FictionalServerErrorDomain;
+// expected-remark@-1 {{C variable 'FictionalServerErrorDomain' imported as let 'FictionalServerErrorDomain'}}
 
 typedef enum __attribute__((ns_error_domain(FictionalServerErrorDomain))) FictionalServerErrorCode : NSInteger {
+  // expected-remark@-1 {{C enum 'FictionalServerErrorCode' also imported as struct 'FictionalServerError'}}
+  // expected-remark@-2 {{C enum 'FictionalServerErrorCode' imported as enum 'Code'}}
   FictionalServerErrorMeltedDown = 1
+  // expected-remark@-1 {{C enum constant 'FictionalServerErrorMeltedDown' also imported as static property 'meltedDown'}}
+  // expected-remark@-2 {{C enum constant 'FictionalServerErrorMeltedDown' imported as enum case 'meltedDown'}}
 } FictionalServerErrorCode;
+// expected-remark@-1 {{C typedef 'FictionalServerErrorCode' imported as enum 'Code'}}
 
 @protocol Wearable
+// expected-remark@-1 {{Objective-C protocol 'Wearable' imported as protocol 'Wearable'}}
 - (void)wear;
+// expected-remark@-1 {{Objective-C method '-[Wearable wear]' imported as instance method 'wear()'}}
 @end
 
 @protocol Garment
+// expected-remark@-1 {{Objective-C protocol 'Garment' imported as protocol 'Garment'}}
 @end
 
 @protocol Cotton
+// expected-remark@-1 {{Objective-C protocol 'Cotton' imported as protocol 'Cotton'}}
 @end
 
 @interface Coat : NSObject<Wearable>
+// expected-remark@-1 {{Objective-C class interface 'Coat' imported as class 'Coat'}}
 
 - (void)wear;
+// expected-remark@-1 {{Objective-C method '-[Coat wear]' imported as instance method 'wear()'}}
 @property (class) Coat <Wearable> *fashionStatement;
+// expected-remark@-1 {{Objective-C method '+[Coat fashionStatement]' imported as getter for class property 'fashionStatement'}}
+// expected-remark@-2 {{Objective-C method '+[Coat setFashionStatement:]' imported as setter for class property 'fashionStatement'}}
+// expected-remark@-3 {{Objective-C property '+Coat.fashionStatement' imported as class property 'fashionStatement'}}
 
 @end
 
 @protocol NSLaundry
+// expected-remark@-1 {{Objective-C protocol 'NSLaundry' imported as protocol 'NSLaundry'}}
 - (void)wash:(Coat <Garment> * _Nonnull)garment;
+// expected-remark@-1 {{Objective-C method '-[NSLaundry wash:]' imported as instance method 'wash'}}
 - (void)bleach:(Coat <Garment, Cotton> * _Nonnull)garment;
+// expected-remark@-1 {{Objective-C method '-[NSLaundry bleach:]' imported as instance method 'bleach'}}
 - (Coat <Garment> * _Nonnull)dry;
+// expected-remark@-1 {{Objective-C method '-[NSLaundry dry]' imported as instance method 'dry()'}}
 @end
 
 @interface NSLaundromat : NSObject
+// expected-remark@-1 {{Objective-C class interface 'NSLaundromat' imported as class 'NSLaundromat'}}
 @end
 
 extern NSString * const NSLaundryErrorDomain;
+// expected-remark@-1 {{C variable 'NSLaundryErrorDomain' imported as let 'NSLaundryErrorDomain'}}
 
 typedef enum __attribute__((ns_error_domain(NSLaundryErrorDomain))) __attribute__((swift_name("NSLaundromat.Error"))) NSLaundryErrorCode {
+    // expected-remark@-1 {{C enum 'NSLaundryErrorCode' also imported as struct 'Error'}}
+    // expected-remark@-2 {{C enum 'NSLaundryErrorCode' imported as enum 'Code'}}
     NSLaundryErrorTooMuchSoap = 1,
+    // expected-remark@-1 {{C enum constant 'NSLaundryErrorTooMuchSoap' also imported as static property 'tooMuchSoap'}}
+    // expected-remark@-2 {{C enum constant 'NSLaundryErrorTooMuchSoap' imported as enum case 'tooMuchSoap'}}
     NSLaundryErrorCatInWasher = 2
+    // expected-remark@-1 {{C enum constant 'NSLaundryErrorCatInWasher' also imported as static property 'catInWasher'}}
+    // expected-remark@-2 {{C enum constant 'NSLaundryErrorCatInWasher' imported as enum case 'catInWasher'}}
 };
 
 typedef void (*event_handler)(_Nonnull id);
+// expected-remark@-1 {{C typedef 'event_handler' imported as type alias 'event_handler'}}
 void install_global_event_handler(_Nullable event_handler handler);
+// expected-remark@-1 {{C function 'install_global_event_handler' imported as global function 'install_global_event_handler'}}
 
 @interface NSObject ()
+// expected-remark@-1 {{Objective-C category 'NSObject()' imported as extension of 'NSObject'}}
 - (void) addObserver: (id) observer
          forKeyPath: (NSString*) keyPath
          options: (NSInteger) options
          context: (void*) context;
+// expected-remark@-4 {{Objective-C method '-[NSObject() addObserver:forKeyPath:options:context:]' also imported as class method 'addObserver(_:forKeyPath:options:context:)'}}
+// expected-remark@-5 {{Objective-C method '-[NSObject() addObserver:forKeyPath:options:context:]' imported as instance method 'addObserver(_:forKeyPath:options:context:)'}}
 - (void) removeObserver: (id) observer
          forKeyPath: (NSString*) keyPath
          context: (void*) options;
+// expected-remark@-3 {{Objective-C method '-[NSObject() removeObserver:forKeyPath:context:]' also imported as class method 'removeObserver(_:forKeyPath:context:)'}}
+// expected-remark@-4 {{Objective-C method '-[NSObject() removeObserver:forKeyPath:context:]' imported as instance method 'removeObserver(_:forKeyPath:context:)'}}
 @end
 
 _Nullable id returnNullableId(void);
+// expected-remark@-1 {{C function 'returnNullableId' imported as global function 'returnNullableId()'}}
 void takeNullableId(_Nullable id);
+// expected-remark@-1 {{C function 'takeNullableId' imported as global function 'takeNullableId'}}
 
 @interface I
+// expected-remark@-1 {{Objective-C class interface 'I' imported as class 'I'}}
 @end
 
 @protocol OptionalRequirements
+// expected-remark@-1 {{Objective-C protocol 'OptionalRequirements' imported as protocol 'OptionalRequirements'}}
 @optional
 - (Coat *)optional;
+// expected-remark@-1 {{Objective-C method '-[OptionalRequirements optional]' imported as instance method 'optional()'}}
 @property NSString *name;
+// expected-remark@-1 {{Objective-C method '-[OptionalRequirements name]' imported as getter for property 'name'}}
+// expected-remark@-2 {{Objective-C method '-[OptionalRequirements setName:]' imported as setter for property 'name'}}
+// expected-remark@-3 {{Objective-C property '-OptionalRequirements.name' imported as property 'name'}}
 @end
 
 @interface IUOProperty
+// expected-remark@-1 {{Objective-C class interface 'IUOProperty' imported as class 'IUOProperty'}}
 @property (readonly) id<OptionalRequirements> iuo;
+// expected-remark@-1 {{Objective-C method '-[IUOProperty iuo]' also imported as class method 'iuo()'}}
+// expected-remark@-2 {{Objective-C method '-[IUOProperty iuo]' imported as getter for property 'iuo'}}
+// expected-remark@-3 {{Objective-C property '-IUOProperty.iuo' imported as property 'iuo'}}
 @end
 
 @interface ColorDescriptor : NSObject <NSCopying>
+// expected-remark@-1 {{Objective-C class interface 'ColorDescriptor' imported as class 'ColorDescriptor'}}
 @end
 
 @interface ColorArray : NSObject
+// expected-remark@-1 {{Objective-C class interface 'ColorArray' imported as class 'ColorArray'}}
 - (ColorDescriptor *)objectAtIndexedSubscript:(NSUInteger)attachmentIndex;
+// expected-remark@-1 {{Objective-C method '-[ColorArray objectAtIndexedSubscript:]' imported as unavailable instance method 'objectAtIndexedSubscript'}}
 - (void)setObject:(nullable ColorDescriptor *)attachment atIndexedSubscript:(NSUInteger)attachmentIndex;
+// expected-remark@-1 {{Objective-C method '-[ColorArray setObject:atIndexedSubscript:]' imported as unavailable instance method 'setObject(_:atIndexedSubscript:)'}}
 @end
 
 @interface PaletteDescriptor : NSObject <NSCopying>
+// expected-remark@-1 {{Objective-C class interface 'PaletteDescriptor' imported as class 'PaletteDescriptor'}}
 @property (readonly, nonnull) ColorArray *colors;
+// expected-remark@-1 {{Objective-C property '-PaletteDescriptor.colors' imported as property 'colors'}}
+// expected-remark@-2 {{Objective-C method '-[PaletteDescriptor colors]' imported as getter for property 'colors'}}
 @end


### PR DESCRIPTION
Broadly, this PR can be divided into four parts:

1. **General `SwiftDeclConverter` refactoring.** This is trying to move towards a world where each `SwiftDeclConverter` instance is used to convert one and only one declaration, and where the reentrancy of `SwiftDeclConverter` is significantly better defined than it is today. Among other things, it ensures that `SwiftDeclConverter` is only entered from the outside through five specific entry points.

2. **Enum case import refactoring and laziness improvements.** This debrides several tangled code paths in `SwiftDeclConverter::VisitEnumDecl()` that previously were greedily importing the cases of most enums. Now, only clang enums that are actually imported as Swift enums (as opposed to those imported as OptionSet structs or global constants) have their cases imported immediately; the others are loaded lazily on demand. The code that remains is also better factored.

3. **`DiagnosticEngine` improvements.** `clang::NamedDecl*`s can now be used as arguments for diagnostics; `%select` is now compatible with all arguments (and does an "empty" or "null" check for ones that don't map to integers); and a new `-verify-additional-file` flag allows the diagnostic verifier to look for expectations in files outside of the module's actual source files, so that (for instance) we can check diagnostics emitted in header files.

4. **Objective-C import decision remarks.** The actual point of all of the above.

With import decision remarks enabled, ClangImporter will (try to) annotate either every clang declaration in a given module, or every declaration it fails to import, with remarks explaining:

* Whether it could import the declaration.
* If it could, what name(s) it was imported as.
* If it couldn't, why it couldn't. (This is the hard part—the reasons are currently pretty vague, occasionally misleading, and sometimes missing entirely.)

For example (using the Foundation.h from clang-importer-sdk in our test suite):

```
Foundation.h:161:33: remark: Objective-C method '-[NSDictionary count]' imported as getter 'Foundation.(file).NSDictionary._'
@property (readonly) NSUInteger count;
                                ^
Foundation.h:161:33: remark: Objective-C property 'NSDictionary::count' imported as property 'Foundation.(file).NSDictionary.count'
@property (readonly) NSUInteger count;
                                ^
Foundation.h:162:1: remark: Objective-C method '-[NSDictionary objectForKey:]' imported as instance method 'Foundation.(file).NSDictionary.object(forKey:)'
- (nullable ObjectType)objectForKey:(nonnull KeyType)aKey;
^
Foundation.h:93:48: remark: could not import Objective-C class interface 'NSEnumerator': Swift cannot import forward declarations
@class NSString, NSArray, NSDictionary, NSSet, NSEnumerator;
                                               ^
Foundation.h:163:1: remark: could not import Objective-C method '-[NSDictionary keyEnumerator]': it uses a type that can't be imported
- (nonnull NSEnumerator *)keyEnumerator;
^
```

-------

**To Do:**

- [x] Fully annotate Foundation.h with its import decision remarks and enable that part of the test
- [x] Fix lack of import remarks for subscripts 
- [ ] Fix forcing of categories
- [ ] Fix multiple emission of remarks for forward declarations
- [ ] Fix multiple emission of remarks for some accessors
- [ ] Fix lack of unavailable for `classForPortCoder` class method alternate
- [ ] Clean up the way we filter by module and make submodule filtering/forcing work correctly
- [ ] Add tests for `-verify-additional-file`
- [ ] Look for other interesting examples in the Swift test suite and test their import decision remarks, too