### PR TITLE
SILGen: Relax assertion that incorrectly tripped on lowered opaque capture types.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -124,8 +124,14 @@ SILGenFunction::emitGlobalFunctionRef(SILLocation loc, SILDeclRef constant,
   }
 
   auto f = SGM.getFunction(constant, NotForDefinition);
-  assert(f->getLoweredFunctionTypeInContext(B.getTypeExpansionContext()) ==
-         constantInfo.SILFnType);
+#ifndef NDEBUG
+  auto constantFnTypeInContext =
+    SGM.Types.getLoweredType(constantInfo.SILFnType,
+                             B.getTypeExpansionContext())
+             .castTo<SILFunctionType>();
+  assert(f->getLoweredFunctionTypeInContext(B.getTypeExpansionContext())
+          == constantFnTypeInContext);
+#endif
   if (callPreviousDynamicReplaceableImpl)
     return B.createPreviousDynamicFunctionRef(loc, f);
   else

--- a/test/SILGen/serialized-capture-opaque-type-subst.swift
+++ b/test/SILGen/serialized-capture-opaque-type-subst.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -verify %s
+
+public func foo() -> some Any { return 1 }
+
+public struct XY<X, Y> { public init(x: X, y: Y) { fatalError() } }
+
+@inlinable
+public func bar() -> () -> Any {
+    let xy = XY(x: 1, y: foo())
+
+    return { xy }
+}


### PR DESCRIPTION
When lowering the SILConstantInfo for a closure implementation type with captures, we are more conservative about
substituting opaque types in the capture, since the underlying types may only be available in the local context. This means
the SILConstantInfo type may not in fact be exactly what you get from `SILFunction::getFunctionTypeInContext` referencing
the implementation function from its originating context, since those opaque types will be substituted in the local context.

Fixes SR-13480 | rdar://problem/68159831.