### PR TITLE
Update GYB Files for SwiftSyntax Double and Int Convenience Properties

### DIFF
--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -208,7 +208,8 @@ EXPR_NODES = [
     Node('FloatLiteralExpr', kind='Expr',
          children=[
              Child('FloatingDigits', kind='FloatingLiteralToken'),
-         ]),
+         ],
+         must_uphold_invariant=True),
 
     Node('TupleExpr', kind='Expr',
          traits=['Parenthesized'],
@@ -282,7 +283,8 @@ EXPR_NODES = [
     Node('IntegerLiteralExpr', kind='Expr',
          children=[
              Child('Digits', kind='IntegerLiteralToken'),
-         ]),
+         ],
+         must_uphold_invariant=True),
 
     # true or false
     Node('BooleanLiteralExpr', kind='Expr',

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -19,7 +19,8 @@ class Node(object):
 
     def __init__(self, name, description=None, kind=None, traits=None,
                  children=None, element=None, element_name=None,
-                 element_choices=None, omit_when_empty=False):
+                 element_choices=None, omit_when_empty=False,
+                 must_uphold_invariant=False):
         self.syntax_kind = name
         self.swift_syntax_kind = lowercase_first_word(name)
         self.name = kind_to_type(self.syntax_kind)
@@ -39,6 +40,8 @@ class Node(object):
 
         self.omit_when_empty = omit_when_empty
         self.collection_element = element or ""
+        self.must_uphold_invariant = must_uphold_invariant
+
         # For SyntaxCollections make sure that the element_name is set.
         assert(not self.is_syntax_collection() or element_name or
                (element and element != 'Syntax'))


### PR DESCRIPTION
[This SwiftSyntax PR](https://github.com/apple/swift-syntax/pull/234) implements [SR-11580](https://bugs.swift.org/browse/SR-11580), whose goal is to add convenience properties to get `Double` and `Int` values from `FloatLiteralExprSyntax` and `IntegerLiteralExprSyntax`, respectively. The SwiftSyntax PR requires certain changes to `Node.py` and `ExprNodes.py` in the main Swift repo. I have been using these changes locally, but SwiftSyntax-PR reviewer @ahoppen recommended that I create this PR to the main Swift repo for the purpose of CI testing.
