### PR TITLE
[5.3] SILGen: Relax assertion that incorrectly tripped on lowered opaque capture types.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -144,8 +144,14 @@ SILGenFunction::emitGlobalFunctionRef(SILLocation loc, SILDeclRef constant,
   }
 
   auto f = SGM.getFunction(constant, NotForDefinition);
-  assert(f->getLoweredFunctionTypeInContext(B.getTypeExpansionContext()) ==
-         constantInfo.SILFnType);
+#ifndef NDEBUG
+  auto constantFnTypeInContext =
+    SGM.Types.getLoweredType(constantInfo.SILFnType,
+                             B.getTypeExpansionContext())
+             .castTo<SILFunctionType>();
+  assert(f->getLoweredFunctionTypeInContext(B.getTypeExpansionContext())
+          == constantFnTypeInContext);
+#endif
   if (callPreviousDynamicReplaceableImpl)
     return B.createPreviousDynamicFunctionRef(loc, f);
   else

--- a/test/SILGen/serialized-capture-opaque-type-subst.swift
+++ b/test/SILGen/serialized-capture-opaque-type-subst.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -verify %s
+
+public func foo() -> some Any { return 1 }
+
+public struct XY<X, Y> { public init(x: X, y: Y) { fatalError() } }
+
+@inlinable
+public func bar() -> () -> Any {
+    let xy = XY(x: 1, y: foo())
+
+    return { xy }
+}


### PR DESCRIPTION
Explanation: An assertion failure would trigger spuriously in some circumstances where a public inlinable function contained a closure that captured a value with an opaque result type.

Scope: Incorrect assertion failure; regression from 5.2

Risk: Low; no behavior change to asserts-disabled builds

Reviewed by: @aschwaighofer 

Issue: SR-13480 | rdar://problem/68159831