### PR TITLE
[build-script-impl] Add a comment explaining why an option isn't truly dead as per reviewers suggestion.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1808,6 +1808,12 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${swift_cmake_options[@]}"
                 )
 
+                # NOTE: This is not a dead option! It is relied upon for certain
+                # bots/build-configs!
+                #
+                # TODO: In the future when we are always cross compiling and
+                # using Toolchain files, we should put this in either a
+                # toolchain file or a cmake cache.
                 if [[ "${BUILD_TOOLCHAIN_ONLY}" ]]; then
                     cmake_options+=(
                     -DSWIFT_TOOL_SIL_OPT_BUILD=FALSE


### PR DESCRIPTION
In the original revert, this option was used in two places and I added a comment
only on the first one. This copies the comment onto the second usage of the
option.

Thanks to @edymtt and @compnerd for catching my careless error!
