### PR TITLE
Enable compiler-rt on Windows

### DIFF
--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -1,6 +1,7 @@
 set(LLVM_ENABLE_PROJECTS
       clang
       clang-tools-extra
+      compiler-rt
       lld
       lldb
     CACHE STRING "")


### PR DESCRIPTION
<!-- What's in this pull request? -->

Enable `compiler-rt` on Windows. It is required for `swift-driver` and other components to find `clang_rt` libs.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
