### PR TITLE
WinSDK: extract Controls submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -134,9 +134,18 @@ module WinSDK [system] {
     link "AuthZ.Lib"
   }
 
-  module CommCtrl {
-    header "CommCtrl.h"
-    export *
+  module Controls {
+    module CommCtrl {
+      header "CommCtrl.h"
+      export *
+    }
+
+    module CommDlg {
+      header "commdlg.h"
+      export *
+
+      link "Comdlg32.lib"
+    }
   }
 
   // FIXME(compnerd) this is a hack for the HWND typedef for DbgHelp


### PR DESCRIPTION
Currently commdlg.h gets included into `WinSDK.WinSock2`, however its usages might not be related to sockets.
This PR extracts `CommDlg` into a submodule of `WinSDK.Controls`.

This change was briefly discussed in https://github.com/apple/swift/pull/33929.
