### PR TITLE
Add required arg to `product.install_toolchain_path()`

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -65,7 +65,7 @@ class TensorFlowSwiftAPIs(product.Product):
                 '-G', 'Ninja',
                 '-D', 'BUILD_SHARED_LIBS=YES',
                 '-D', 'CMAKE_INSTALL_PREFIX={}'.format(
-                    self.install_toolchain_path()),
+                    self.install_toolchain_path(host_target)),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),
                 '-D', 'CMAKE_Swift_COMPILER={}'.format(swiftc),
                 # SWIFT_ENABLE_TENSORFLOW


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds the `host_target` argument to `product.install_toolchain_path()`,  required as of #33490.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
