### PR TITLE
Add an cplusplus_driver lit feature for use with tests not supported by swift-driver

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -617,6 +617,9 @@ else:
 if 'swift_evolve' in lit_config.params:
     config.available_features.add("swift_evolve")
 
+if not 'swift_driver' in lit_config.params:
+    config.available_features.add("cplusplus_driver")
+
 # Enable benchmark testing when the binary is found (has fully qualified path).
 if config.benchmark_o != 'Benchmark_O':
     config.available_features.add('benchmark')


### PR DESCRIPTION
This will be used to mark tests as REQUIRES: integrated_driver if they cannot be easily made to work with swift-driver due to architectural differences (for example, the lack of -driver-print-actions and -driver-print-bindings), and the test cases have been ported to XCTest in the swift-driver repo.

This feature is enabled if the swift_driver param is NOT passed to lit.py

Now that swift-driver only fails ~200 integration tests, I think it makes sense to put more effort into porting some of these test cases to XCTest and excluding them when using swift-driver, so we have a better measure of our progress towards parity with the integrated version.