### PR TITLE
Platform: correct linked import library name

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -144,7 +144,7 @@ module WinSDK [system] {
       header "commdlg.h"
       export *
 
-      link "Comdlg32.lib"
+      link "ComDlg32.Lib"
     }
   }
 


### PR DESCRIPTION
When linking on a case sensitive file system, the import library must be
named with the matching case.  The import library is named
`ComDlg32.Lib` in the SDK, adjust the case.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
