### PR TITLE
[AutoDiff] Fix pullback subset thunk generation crash.

### DIFF
--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -768,7 +768,8 @@ getOrCreateSubsetParametersThunkForLinearMap(
     if (!paramInfo.isIndirectMutating())
       continue;
     auto inoutArg = *std::next(ai->getInoutArguments().begin(), inoutArgIdx++);
-    allResults.insert(allResults.begin() + paramIdx, inoutArg);
+    unsigned mappedParamIdx = mapOriginalParameterIndex(paramIdx);
+    allResults.insert(allResults.begin() + mappedParamIdx, inoutArg);
   }
   assert(allResults.size() == actualIndices.parameters->getNumIndices() &&
          "Number of pullback results should match number of differentiability "

--- a/test/AutoDiff/compiler_crashers_fixed/tf1315-pullback-subset-parameter-thunk-generation.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1315-pullback-subset-parameter-thunk-generation.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-sil %s
+// REQUIRES: asserts
+
+// TF-1315: Pullback subset thunk generation crash due to unmapped parameter
+// index for `inout` differentiability parameters.
+
+import _Differentiation
+
+func foo(_ x: Int, _ y: Float, _ z: inout Float) {}
+
+@derivative(of: foo, wrt: (y, z))
+func vjpFoo(_ x: Int, _ y: Float, _ z: inout Float) -> (
+  value: Void, pullback: (inout Float) -> Float
+) {
+  fatalError()
+}
+
+@differentiable
+func TF_1315(_ x: Float) -> Float {
+  var x = x
+  // The call to `foo` below triggers pullback subset parameter thunk generation.
+  // `foo` original function type: `(Int, Float, inout Float) -> ()`
+  //     Actual parameter indices: 1, 2
+  //    Desired parameter indices: 2
+  foo(1, 2, &x)
+  return x
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/33968 to `tensorflow` branch.

---

Fix pullback subset thunk generation crash due to unmapped parameter index
for `inout` differentiability parameters.

Resolves TF-1315:

```
$ swiftc tf1315-pullback-subset-parameter-thunk-generation.swift 
Assertion failed: (I <= this->end() && "Inserting past the end of the vector."), function insert, file llvm-project/llvm/include/llvm/ADT/SmallVector.h, line 550.
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.	Program arguments: build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swift-frontend -target x86_64-apple-macosx10.9 -module-cache-path build/Ninja-ReleaseAssert/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.sdk -swift-version 4 -ignore-module-source-info -typo-correction-limit 10 -emit-sil test/AutoDiff/compiler_crashers_fixed/tf1315-pullback-subset-parameter-thunk-generation.swift
1.	Swift version 5.3-dev (LLVM 32ba33c87eb2475, Swift d90d0b390c96816)
2.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main.main)
3.	While running pass #33 SILModuleTransform "Differentiation".
4.	While canonicalizing `differentiable_function` SIL node   %17 = differentiable_function [parameters 2] [results 0] %13 : $@convention(thin) (Int, Float, @inout Float) -> () // users: %19, %18
5.	While ...in SIL function "@AD__$s4main7TF_1315yS2fF__vjp_src_0_wrt_0".
 for 'TF_1315(_:)' (at test/AutoDiff/compiler_crashers_fixed/tf1315-pullback-subset-parameter-thunk-generation.swift:19:1)
0  swift-frontend           0x0000000107be25a5 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
1  swift-frontend           0x0000000107be14e8 llvm::sys::RunSignalHandlers() + 248
2  swift-frontend           0x0000000107be2b86 SignalHandler(int) + 262
3  libsystem_platform.dylib 0x00007fff6e0115fd _sigtramp + 29
4  libsystem_platform.dylib 000000000000000000 _sigtramp + 18446603338670598688
5  libsystem_c.dylib        0x00007fff6dee7808 abort + 120
6  libsystem_c.dylib        0x00007fff6dee6ac6 err + 0
7  swift-frontend           0x0000000107de03a3 llvm::SmallVectorImpl<swift::SILValue>::insert(swift::SILValue*, swift::SILValue const&) (.cold.3) + 35
8  swift-frontend           0x00000001038e3594 llvm::SmallVectorImpl<swift::SILValue>::insert(swift::SILValue*, swift::SILValue const&) + 276
9  swift-frontend           0x00000001038e2e96 swift::autodiff::getOrCreateSubsetParametersThunkForLinearMap(swift::SILOptFunctionBuilder&, swift::SILFunction*, swift::CanTypeWrapper<swift::SILFunctionType>, swift::CanTypeWrapper<swift::SILFunctionType>, swift::CanTypeWrapper<swift::SILFunctionType>, swift::AutoDiffDerivativeFunctionKind, swift::SILAutoDiffI  1 [AutoDiff] Fix pullback subset thunk generation crash.
ndices, swift::SILAutoDiffIndices) + 8262
10 swift-frontend           0x00000001038e4eab swift::autodiff::getOrCreateSubsetParametersThunkForDerivativeFunction(swift::SILOptFunctionBuilder&, swift::SILValue, swift::SILValue, swift::AutoDiffDerivativeFunctionKind, swift::SILAutoDiffIndices, swift::SILAutoDiffIndices) + 6395
11 swift-frontend           0x0000000103a2ca32 (anonymous namespace)::DifferentiationTransformer::promoteToDifferentiableFunction(swift::DifferentiableFunctionInst*, swift::SILBuilder&, swift::SILLocation, swift::autodiff::DifferentiationInvoker) + 7842
```