### PR TITLE
[Sema] Accept the use of SPI in SPI inlinable code

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -481,6 +481,8 @@ public:
       return false;
     assert(nominal->isGenericContext());
 
+    if (printOptions.PrintSPIs)
+      out << "@_spi(" << DummyProtocolName << ")\n";
     out << "@available(*, unavailable)\nextension ";
     nominal->getDeclaredType().print(out, printOptions);
     out << " : ";

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -885,8 +885,10 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     // VD must be public or open to use an @_spi attribute.
     auto declAccess = VD->getFormalAccess();
+    auto DC = VD->getDeclContext()->getAsDecl();
     if (declAccess < AccessLevel::Public &&
-        !VD->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
+        !VD->getAttrs().hasAttribute<UsableFromInlineAttr>() &&
+        !(DC && DC->isSPI())) {
       diagnoseAndRemoveAttr(attr,
                             diag::spi_attribute_on_non_public,
                             declAccess,
@@ -896,7 +898,9 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
     // Forbid stored properties marked SPI in frozen types.
     if (auto property = dyn_cast<AbstractStorageDecl>(VD))
       if (auto DC = dyn_cast<NominalTypeDecl>(D->getDeclContext()))
-        if (property->hasStorage() && !DC->isFormallyResilient())
+        if (property->hasStorage() &&
+            !DC->isFormallyResilient() &&
+            !DC->isSPI())
           diagnoseAndRemoveAttr(attr,
                                 diag::spi_attribute_on_frozen_stored_properties,
                                 VD->getName());

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -50,6 +50,9 @@ func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' a
 @frozen public struct SPIFrozenStruct {
   var spiTypeInFrozen = SPIStruct()
   private var spiTypeInFrozen1: SPIClass
+
+  @_spi(S)
+  private var privateSPIInFrozenSPI = SPIStruct()
 }
 
 private protocol PrivateProtocol {} // expected-note {{type declared here}}

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -12,15 +12,19 @@
 // RUN: %target-swift-frontend -emit-module %t/SPIHelper.swiftinterface -emit-module-path %t/SPIHelper-from-public-swiftinterface.swiftmodule -swift-version 5 -module-name SPIHelper -enable-library-evolution
 
 /// Test the textual interfaces generated from this test.
-// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -emit-private-module-interface-path %t/main.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t
-// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/main.swiftinterface
-// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/main.private.swiftinterface
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/Main.swiftinterface -emit-private-module-interface-path %t/Main.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t -module-name Main
+// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/Main.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/Main.private.swiftinterface
+// RUN: %target-swift-frontend -typecheck-module-from-interface -I %t %t/Main.swiftinterface
+// RUN: %target-swift-frontend -typecheck-module-from-interface -I %t %t/Main.private.swiftinterface -module-name Main
 
 /// Serialize and deserialize this module, then print.
-// RUN: %target-swift-frontend -emit-module %s -emit-module-path %t/merged-partial.swiftmodule -swift-version 5 -I %t -module-name merged -enable-library-evolution
-// RUN: %target-swift-frontend -merge-modules %t/merged-partial.swiftmodule -module-name merged -emit-module -emit-module-path %t/merged.swiftmodule -I %t -emit-module-interface-path %t/merged.swiftinterface -emit-private-module-interface-path %t/merged.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t
-// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/merged.swiftinterface
-// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/merged.private.swiftinterface
+// RUN: %target-swift-frontend -emit-module %s -emit-module-path %t/Merged-partial.swiftmodule -swift-version 5 -I %t -module-name Merged -enable-library-evolution
+// RUN: %target-swift-frontend -merge-modules %t/Merged-partial.swiftmodule -module-name Merged -emit-module -emit-module-path %t/Merged.swiftmodule -I %t -emit-module-interface-path %t/Merged.swiftinterface -emit-private-module-interface-path %t/Merged.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t
+// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/Merged.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/Merged.private.swiftinterface
+// RUN: %target-swift-frontend -typecheck-module-from-interface -I %t %t/Merged.swiftinterface
+// RUN: %target-swift-frontend -typecheck-module-from-interface -I %t %t/Merged.private.swiftinterface -module-name Merged
 
 @_spi(HelperSPI) @_spi(OtherSPI) @_spi(OtherSPI) import SPIHelper
 // CHECK-PUBLIC: import SPIHelper

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -162,6 +162,18 @@ extension IOIPublicStruct : LocalPublicProto {}
 // CHECK-PRIVATE-NOT: IOIPublicStruct
 // CHECK-PUBLIC-NOT: IOIPublicStruct
 
+@_spi(S)
+@frozen public struct SPIFrozenStruct {
+// CHECK-PRIVATE: struct SPIFrozenStruct
+// CHECK-PUBLIC-NOT: SPIFrozenStruct
+
+  var spiTypeInFrozen = SPIStruct()
+  // CHECK-PRIVATE: @_spi(S) internal var spiTypeInFrozen
+
+  private var spiTypeInFrozen1: SPIClass
+  // CHECK-PRIVATE: @_spi(S) private var spiTypeInFrozen1
+}
+
 // The dummy conformance should be only in the private swiftinterface for
 // SPI extensions.
 @_spi(LocalSPI)

--- a/test/SPI/spi_client.swift
+++ b/test/SPI/spi_client.swift
@@ -53,8 +53,16 @@ public func publicUseOfSPI(param: SPIClass) -> SPIClass {} // expected-error 2{{
 public func publicUseOfSPI2() -> [SPIClass] {} // expected-error {{cannot use class 'SPIClass' here; it is an SPI imported from 'SPIHelper'}}
 
 @inlinable
-func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+public func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   _ = SPIClass() // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   _ = [SPIClass]() // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+}
+
+@_spi(S)
+@inlinable
+public func inlinable() -> SPIClass {
+  spiFunc()
+  _ = SPIClass()
+  _ = [SPIClass]()
 }


### PR DESCRIPTION
Allow the use of SPI declarations within SPI inlinable code, default values for arguments and frozen property initializers. This makes the compiler generate `@_spi` attributes where they would have previously been rejected so accept all explicit `@_spi` attributes in SPI contexts. To test all of this and more, we also check the swiftinterfaces generated by `SPI/private_swiftinterface.swift` with `-typecheck-module-from-interface`.

rdar://63978500&63189125