### PR TITLE
[Function builders] Fix-Its and code completion improvements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5312,6 +5312,16 @@ NOTE(function_builder_buildblock_enum_case, none,
 NOTE(function_builder_buildblock_not_static_method, none,
      "potential match 'buildBlock' is not a static method", ())
 
+NOTE(function_builder_missing_build_optional, none,
+     "add 'buildOptional(_:)' to the function builder %0 to add support for "
+     "'if' statements without an 'else'", (Type))
+NOTE(function_builder_missing_build_either, none,
+     "add 'buildEither(first:)' and `buildEither(second:)' to the function "
+     "builder %0 to add support for 'if'-'else' and 'switch'", (Type))
+NOTE(function_builder_missing_build_array, none,
+     "add 'buildArray(_:)' to the function builder %0 to add support for "
+     "'for'..'in' loops", (Type))
+
 //------------------------------------------------------------------------------
 // MARK: Tuple Shuffle Diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5321,6 +5321,9 @@ NOTE(function_builder_missing_build_either, none,
 NOTE(function_builder_missing_build_array, none,
      "add 'buildArray(_:)' to the function builder %0 to add support for "
      "'for'..'in' loops", (Type))
+NOTE(function_builder_missing_build_limited_availability, none,
+     "add 'buildLimitedAvailability(_:)' to the function "
+     "builder %0 to erase type information for less-available types", (Type))
 
 //------------------------------------------------------------------------------
 // MARK: Tuple Shuffle Diagnostics

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5316,7 +5316,7 @@ NOTE(function_builder_missing_build_optional, none,
      "add 'buildOptional(_:)' to the function builder %0 to add support for "
      "'if' statements without an 'else'", (Type))
 NOTE(function_builder_missing_build_either, none,
-     "add 'buildEither(first:)' and `buildEither(second:)' to the function "
+     "add 'buildEither(first:)' and 'buildEither(second:)' to the function "
      "builder %0 to add support for 'if'-'else' and 'switch'", (Type))
 NOTE(function_builder_missing_build_array, none,
      "add 'buildArray(_:)' to the function builder %0 to add support for "

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -81,4 +81,15 @@ EDUCATIONAL_NOTES(type_cannot_conform, "protocol-type-non-conformance.md")
 EDUCATIONAL_NOTES(unlabeled_trailing_closure_deprecated,
                   "trailing-closure-matching.md")
 
+EDUCATIONAL_NOTES(function_builder_static_buildblock,
+                  "function-builder-methods.md")
+EDUCATIONAL_NOTES(function_builder_missing_limited_availability,
+                  "function-builder-methods.md")
+EDUCATIONAL_NOTES(function_builder_missing_build_optional,
+                  "function-builder-methods.md")
+EDUCATIONAL_NOTES(function_builder_missing_build_either,
+                  "function-builder-methods.md")
+EDUCATIONAL_NOTES(function_builder_missing_build_array,
+                  "function-builder-methods.md")
+
 #undef EDUCATIONAL_NOTES

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -640,11 +640,13 @@ public:
                        CodeCompletionString *CompletionString,
                        ExpectedTypeRelation TypeDistance,
                        CodeCompletionOperatorKind KnownOperatorKind =
-                           CodeCompletionOperatorKind::None)
+                           CodeCompletionOperatorKind::None,
+                       StringRef BriefDocComment = StringRef())
       : Kind(Kind), KnownOperatorKind(unsigned(KnownOperatorKind)),
         SemanticContext(unsigned(SemanticContext)), NotRecommended(false),
         NotRecReason(NotRecommendedReason::NoReason),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
+        BriefDocComment(BriefDocComment),
         TypeDistance(TypeDistance) {
     assert(Kind != Declaration && "use the other constructor");
     assert(CompletionString);
@@ -664,12 +666,13 @@ public:
                        SemanticContextKind SemanticContext,
                        unsigned NumBytesToErase,
                        CodeCompletionString *CompletionString,
-                       ExpectedTypeRelation TypeDistance)
+                       ExpectedTypeRelation TypeDistance,
+                       StringRef BriefDocComment = StringRef())
       : Kind(Keyword), KnownOperatorKind(0),
         SemanticContext(unsigned(SemanticContext)), NotRecommended(false),
         NotRecReason(NotRecommendedReason::NoReason),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        TypeDistance(TypeDistance) {
+        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(CompletionString);
     AssociatedKind = static_cast<unsigned>(Kind);
     IsSystem = 0;

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -254,6 +254,29 @@ namespace swift {
                             bool IncludeProtocolRequirements = true,
                             bool Transitive = false);
 
+  /// Enumerates the various kinds of "build" functions within a function
+  /// builder.
+  enum class FunctionBuilderBuildFunction {
+    BuildBlock,
+    BuildExpression,
+    BuildOptional,
+    BuildEitherFirst,
+    BuildEitherSecond,
+    BuildArray,
+    BuildLimitedAvailability,
+    BuildFinalResult,
+  };
+
+  /// Try to infer the component type of a function builder from the type
+  /// of buildBlock or buildExpression, if it was there.
+  Type inferFunctionBuilderComponentType(NominalTypeDecl *builder);
+
+  /// Print the declaration for a function builder "build" function, for use
+  /// in Fix-Its, code completion, and so on.
+  void printFunctionBuilderBuildFunction(
+      NominalTypeDecl *builder, Type componentType,
+      FunctionBuilderBuildFunction function,
+      Optional<std::string> stubIndent, llvm::raw_ostream &out);
 }
 
 #endif

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -22,6 +22,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/SourceLoc.h"
 #include <memory>
+#include <tuple>
 
 namespace swift {
   class AbstractFunctionDecl;
@@ -277,6 +278,11 @@ namespace swift {
       NominalTypeDecl *builder, Type componentType,
       FunctionBuilderBuildFunction function,
       Optional<std::string> stubIndent, llvm::raw_ostream &out);
+
+  /// Compute the insertion location, indentation string, and component type
+  /// for a Fix-It that adds a new build* function to a function builder.
+  std::tuple<SourceLoc, std::string, Type>
+  determineFunctionBuilderBuildFixItInfo(NominalTypeDecl *builder);
 }
 
 #endif

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5170,7 +5170,7 @@ public:
           "outermost block statement to produce the final returned result";
 
     case FunctionBuilderBuildFunction::BuildLimitedAvailability:
-      return "If declaration, this will be called on the partial result of "
+      return "If declared, this will be called on the partial result of "
         "an 'if #available' block to allow the function builder to erase "
         "type information";
 
@@ -5195,9 +5195,9 @@ public:
         Builder.addAccessControlKeyword(AccessLevel::Public);
 
       if (!hasStaticOrClass)
-        Builder.addKeyword("static");
+        Builder.addTextChunk("static ");
 
-      Builder.addKeyword("func");
+      Builder.addTextChunk("func ");
     }
 
     std::string declStringWithoutFunc;

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -92,6 +92,7 @@ class CodeCompletionResultBuilder {
   bool IsNotRecommended = false;
   CodeCompletionResult::NotRecommendedReason NotRecReason =
     CodeCompletionResult::NotRecommendedReason::NoReason;
+  StringRef BriefDocComment = StringRef();
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
                         StringRef Text);
@@ -445,6 +446,10 @@ public:
   void addAnnotatedWhitespace(StringRef space) {
     addWhitespace(space);
     getLastChunk().setIsAnnotation();
+  }
+
+  void setBriefDocComment(StringRef comment) {
+    BriefDocComment = comment;
   }
 };
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1981,9 +1981,10 @@ void swift::printFunctionBuilderBuildFunction(
   }
 
   if (!printedResult)
-    printer << " -> " << componentTypeString << " {";
+    printer << " -> " << componentTypeString;
 
   if (stubIndent) {
+    printer << " {";
     printer.printNewline();
     printer << "  <#code#>";
     printer.printNewline();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5511,21 +5511,11 @@ void SkipUnhandledConstructInFunctionBuilderFailure::diagnosePrimary(
 
     // Emit custom notes to help the user introduce the appropriate 'build'
     // functions.
-    SourceLoc buildInsertionLoc = builder->getBraces().Start;
+    SourceLoc buildInsertionLoc;
     std::string stubIndent;
     Type componentType;
-    if (buildInsertionLoc.isValid()) {
-      buildInsertionLoc = Lexer::getLocForEndOfToken(
-          getASTContext().SourceMgr, buildInsertionLoc);
-
-      ASTContext &ctx = getASTContext();
-      StringRef extraIndent;
-      StringRef currentIndent = Lexer::getIndentationForLine(
-          ctx.SourceMgr, buildInsertionLoc, &extraIndent);
-      stubIndent = (currentIndent + extraIndent).str();
-
-      componentType = inferFunctionBuilderComponentType(builder);
-    }
+    std::tie(buildInsertionLoc, stubIndent, componentType) =
+        determineFunctionBuilderBuildFixItInfo(builder);
 
     if (buildInsertionLoc.isInvalid()) {
       // Do nothing.

--- a/test/Constraints/function_builder_availability.swift
+++ b/test/Constraints/function_builder_availability.swift
@@ -8,7 +8,7 @@ enum Either<T,U> {
 }
 
 @_functionBuilder
-struct TupleBuilder {
+struct TupleBuilder { // expected-note{{add 'buildLimitedAvailability(_:)' to the function builder 'TupleBuilder' to erase type information for less-available types}}{{22-22=\n    static func buildLimitedAvailability(_ component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}}}
   static func buildBlock<T1>(_ t1: T1) -> (T1) {
     return (t1)
   }

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -46,9 +46,9 @@ struct TupleBuilder { // expected-note 2 {{struct 'TupleBuilder' declared here}}
 
 @_functionBuilder
 struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf' declared here}}
-  // expected-note@-1{{add 'buildOptional(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if' statements without an 'else'}}{{31-31=\n    static func buildOptional(_ component: <#Component#>?) -> <#Component#> {\n      <#code#>\n    \}}}
-  // expected-note@-2{{add 'buildEither(first:)' and 'buildEither(second:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if'-'else' and 'switch'}}{{31-31=\n    static func buildEither(first component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}\n\n    static func buildEither(second component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}}}
-  // expected-note@-3{{add 'buildArray(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'for'..'in' loops}}{{31-31=\n    static func buildArray(_ components: [<#Component#>]) -> <#Component#> {\n      <#code#>\n    \}}}
+  // expected-note@-1{{add 'buildOptional(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if' statements without an 'else'}}
+  // expected-note@-2{{add 'buildEither(first:)' and 'buildEither(second:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if'-'else' and 'switch'}}
+  // expected-note@-3{{add 'buildArray(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'for'..'in' loops}}
   static func buildBlock() -> () { }
   
   static func buildBlock<T1>(_ t1: T1) -> T1 {

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -45,7 +45,10 @@ struct TupleBuilder { // expected-note 2 {{struct 'TupleBuilder' declared here}}
 }
 
 @_functionBuilder
-struct TupleBuilderWithoutIf { // expected-note {{struct 'TupleBuilderWithoutIf' declared here}}
+struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf' declared here}}
+  // expected-note@-1{{add 'buildOptional(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if' statements without an 'else'}}{{31-31=\n    static func buildOptional(_ component: <#Component#>?) -> <#Component#> {\n      <#code#>\n    \}}}
+  // expected-note@-2{{add 'buildEither(first:)' and `buildEither(second:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if'-'else' and 'switch'}}{{31-31=\n    static func buildEither(first component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}\n\n    static func buildEither(second component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}}}
+  // expected-note@-3{{add 'buildArray(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'for'..'in' loops}}{{31-31=\n    static func buildArray(_ components: [<#Component#>]) -> <#Component#> {\n      <#code#>\n    \}}}
   static func buildBlock() -> () { }
   
   static func buildBlock<T1>(_ t1: T1) -> T1 {
@@ -104,6 +107,19 @@ func testDiags() {
   tuplifyWithoutIf(true) {
     if $0 {    // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilderWithoutIf'}}
       "hello"
+    }
+  }
+
+  tuplifyWithoutIf(true) {
+    if $0 {    // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilderWithoutIf'}}
+      "hello"
+    } else {
+    }
+  }
+
+  tuplifyWithoutIf(true) { a in
+    for x in 0..<100 {    // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilderWithoutIf'}}
+      x
     }
   }
 }

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -47,7 +47,7 @@ struct TupleBuilder { // expected-note 2 {{struct 'TupleBuilder' declared here}}
 @_functionBuilder
 struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf' declared here}}
   // expected-note@-1{{add 'buildOptional(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if' statements without an 'else'}}{{31-31=\n    static func buildOptional(_ component: <#Component#>?) -> <#Component#> {\n      <#code#>\n    \}}}
-  // expected-note@-2{{add 'buildEither(first:)' and `buildEither(second:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if'-'else' and 'switch'}}{{31-31=\n    static func buildEither(first component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}\n\n    static func buildEither(second component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}}}
+  // expected-note@-2{{add 'buildEither(first:)' and 'buildEither(second:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if'-'else' and 'switch'}}{{31-31=\n    static func buildEither(first component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}\n\n    static func buildEither(second component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}}}
   // expected-note@-3{{add 'buildArray(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'for'..'in' loops}}{{31-31=\n    static func buildArray(_ components: [<#Component#>]) -> <#Component#> {\n      <#code#>\n    \}}}
   static func buildBlock() -> () { }
   

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_TOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_NONTOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FUNCTION_BUILDER_DECL | %FileCheck %s -check-prefix=IN_FUNCTION_BUILDER_DECL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FUNCTION_BUILDER_DECL -code-completion-comments=true | %FileCheck %s -check-prefix=IN_FUNCTION_BUILDER_DECL
 
 struct Tagged<Tag, Entity> {
   let tag: Tag
@@ -103,12 +103,12 @@ struct AnyBuilder {
 }
 
 // IN_FUNCTION_BUILDER_DECL: Begin completions, 8 items
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildBlock(_ components: Any...) -> Any { {|}; name=buildBlock(_ components: Any...) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildExpression(_ expression: <#Expression#>) -> Any { {|}; name=buildExpression(_ expression: <#Expression#>) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildOptional(_ component: Any?) -> Any { {|}; name=buildOptional(_ component: Any?) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(first component: Any) -> Any { {|}; name=buildEither(first component: Any) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(second component: Any) -> Any { {|}; name=buildEither(second component: Any) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildArray(_ components: [Any]) -> Any { {|}; name=buildArray(_ components: [Any]) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any { {|}; name=buildLimitedAvailability(_ component: Any) -> Any {
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildFinalResult(_ component: Any) -> <#Result#> {|}; name=buildFinalResult(_ component: Any) -> <#Result#>
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildBlock(_ components: Any...) -> Any { {|}; name=buildBlock(_ components: Any...) -> Any {; comment=Required by every
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildExpression(_ expression: <#Expression#>) -> Any { {|}; name=buildExpression(_ expression: <#Expression#>) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildOptional(_ component: Any?) -> Any { {|}; name=buildOptional(_ component: Any?) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(first component: Any) -> Any { {|}; name=buildEither(first component: Any) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(second component: Any) -> Any { {|}; name=buildEither(second component: Any) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildArray(_ components: [Any]) -> Any { {|}; name=buildArray(_ components: [Any]) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any { {|}; name=buildLimitedAvailability(_ component: Any) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildFinalResult(_ component: Any) -> <#Result#> {|}; name=buildFinalResult(_ component: Any) -> <#Result#>; comment=
 // IN_FUNCTION_BUILDER_DECL: End completions

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -103,12 +103,12 @@ struct AnyBuilder {
 }
 
 // IN_FUNCTION_BUILDER_DECL: Begin completions, 8 items
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildBlock(_ components: Any...) -> Any { {|}; name=buildBlock(_ components: Any...) -> Any {; comment=Required by every
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildExpression(_ expression: <#Expression#>) -> Any { {|}; name=buildExpression(_ expression: <#Expression#>) -> Any {; comment=
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildOptional(_ component: Any?) -> Any { {|}; name=buildOptional(_ component: Any?) -> Any {; comment=
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(first component: Any) -> Any { {|}; name=buildEither(first component: Any) -> Any {; comment=
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(second component: Any) -> Any { {|}; name=buildEither(second component: Any) -> Any {; comment=
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildArray(_ components: [Any]) -> Any { {|}; name=buildArray(_ components: [Any]) -> Any {; comment=
-// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any { {|}; name=buildLimitedAvailability(_ component: Any) -> Any {; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildBlock(_ components: Any...) -> Any {|}; name=buildBlock(_ components: Any...) -> Any; comment=Required by every
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildExpression(_ expression: <#Expression#>) -> Any {|}; name=buildExpression(_ expression: <#Expression#>) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildOptional(_ component: Any?) -> Any {|}; name=buildOptional(_ component: Any?) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(first component: Any) -> Any {|}; name=buildEither(first component: Any) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(second component: Any) -> Any {|}; name=buildEither(second component: Any) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildArray(_ components: [Any]) -> Any {|}; name=buildArray(_ components: [Any]) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any {|}; name=buildLimitedAvailability(_ component: Any) -> Any; comment=
 // IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildFinalResult(_ component: Any) -> <#Result#> {|}; name=buildFinalResult(_ component: Any) -> <#Result#>; comment=
 // IN_FUNCTION_BUILDER_DECL: End completions

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_NONTOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FUNCTION_BUILDER_DECL -code-completion-comments=true | %FileCheck %s -check-prefix=IN_FUNCTION_BUILDER_DECL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FUNCTION_BUILDER_DECL_PREFIX -code-completion-comments=true | %FileCheck %s -check-prefix=IN_FUNCTION_BUILDER_DECL_PREFIX
 
 struct Tagged<Tag, Entity> {
   let tag: Tag
@@ -99,6 +100,8 @@ func acceptBuilder(@EnumToVoidBuilder body: () -> Void) {}
 struct AnyBuilder {
   static func buildBlock(_ components: Any...) -> Any { 5 }
 
+  #^IN_FUNCTION_BUILDER_DECL_PREFIX^#
+
   static func #^IN_FUNCTION_BUILDER_DECL^#
 }
 
@@ -112,3 +115,14 @@ struct AnyBuilder {
 // IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any {|}; name=buildLimitedAvailability(_ component: Any) -> Any; comment=
 // IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildFinalResult(_ component: Any) -> <#Result#> {|}; name=buildFinalResult(_ component: Any) -> <#Result#>; comment=
 // IN_FUNCTION_BUILDER_DECL: End completions
+
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Begin completions
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildBlock(_ components: Any...) -> Any {|}; name=static func buildBlock(_ components: Any...) -> Any; comment=Required by every
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildExpression(_ expression: <#Expression#>) -> Any {|}; name=static func buildExpression(_ expression: <#Expression#>) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildOptional(_ component: Any?) -> Any {|}; name=static func buildOptional(_ component: Any?) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildEither(first component: Any) -> Any {|}; name=static func buildEither(first component: Any) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildEither(second component: Any) -> Any {|}; name=static func buildEither(second component: Any) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildArray(_ components: [Any]) -> Any {|}; name=static func buildArray(_ components: [Any]) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildLimitedAvailability(_ component: Any) -> Any {|}; name=static func buildLimitedAvailability(_ component: Any) -> Any; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildFinalResult(_ component: Any) -> <#Result#> {|}; name=static func buildFinalResult(_ component: Any) -> <#Result#>; comment=
+// IN_FUNCTION_BUILDER_DECL_PREFIX: End completions

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_TOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_NONTOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FUNCTION_BUILDER_DECL | %FileCheck %s -check-prefix=IN_FUNCTION_BUILDER_DECL
 
 struct Tagged<Tag, Entity> {
   let tag: Tag
@@ -93,3 +94,21 @@ struct EnumToVoidBuilder {
   static func buildBlock(_ :MyEnum, _: MyEnum, _: MyEnum) {}
 }
 func acceptBuilder(@EnumToVoidBuilder body: () -> Void) {}
+
+@_functionBuilder
+struct AnyBuilder {
+  static func buildBlock(_ components: Any...) -> Any { 5 }
+
+  static func #^IN_FUNCTION_BUILDER_DECL^#
+}
+
+// IN_FUNCTION_BUILDER_DECL: Begin completions, 8 items
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildBlock(_ components: Any...) -> Any { {|}; name=buildBlock(_ components: Any...) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildExpression(_ expression: <#Expression#>) -> Any { {|}; name=buildExpression(_ expression: <#Expression#>) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildOptional(_ component: Any?) -> Any { {|}; name=buildOptional(_ component: Any?) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(first component: Any) -> Any { {|}; name=buildEither(first component: Any) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildEither(second component: Any) -> Any { {|}; name=buildEither(second component: Any) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildArray(_ components: [Any]) -> Any { {|}; name=buildArray(_ components: [Any]) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any { {|}; name=buildLimitedAvailability(_ component: Any) -> Any {
+// IN_FUNCTION_BUILDER_DECL: Pattern/CurrNominal:                buildFinalResult(_ component: Any) -> <#Result#> {|}; name=buildFinalResult(_ component: Any) -> <#Result#>
+// IN_FUNCTION_BUILDER_DECL: End completions

--- a/test/decl/function_builder_fixits.swift
+++ b/test/decl/function_builder_fixits.swift
@@ -1,0 +1,64 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// UNSUPPORTED: windows
+// Line-feeds in Fix-Its fail to check on Windows.
+
+@_functionBuilder
+struct Maker {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}{{15-15=\n    static func buildBlock(_ components: <#Component#>...) -> <#Component#> {\n      <#code#>\n    \}}}
+
+@_functionBuilder
+struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf' declared here}}
+  // expected-note@-1{{add 'buildOptional(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if' statements without an 'else'}}{{31-31=\n    static func buildOptional(_ component: <#Component#>?) -> <#Component#> {\n      <#code#>\n    \}}}
+  // expected-note@-2{{add 'buildEither(first:)' and 'buildEither(second:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'if'-'else' and 'switch'}}{{31-31=\n    static func buildEither(first component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}\n\n    static func buildEither(second component: <#Component#>) -> <#Component#> {\n      <#code#>\n    \}}}
+  // expected-note@-3{{add 'buildArray(_:)' to the function builder 'TupleBuilderWithoutIf' to add support for 'for'..'in' loops}}{{31-31=\n    static func buildArray(_ components: [<#Component#>]) -> <#Component#> {\n      <#code#>\n    \}}}
+  static func buildBlock() -> () { }
+  
+  static func buildBlock<T1>(_ t1: T1) -> T1 {
+    return t1
+  }
+  
+  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
+    return (t1, t2)
+  }
+  
+  static func buildBlock<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
+      -> (T1, T2, T3) {
+    return (t1, t2, t3)
+  }
+
+  static func buildBlock<T1, T2, T3, T4>(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4)
+      -> (T1, T2, T3, T4) {
+    return (t1, t2, t3, t4)
+  }
+
+  static func buildBlock<T1, T2, T3, T4, T5>(
+    _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5
+  ) -> (T1, T2, T3, T4, T5) {
+    return (t1, t2, t3, t4, t5)
+  }
+}
+
+func tuplifyWithoutIf<T>(_ cond: Bool, @TupleBuilderWithoutIf body: (Bool) -> T) {
+  print(body(cond))
+}
+
+func testDiags() {
+  // Statements unsupported by the particular builder.
+  tuplifyWithoutIf(true) {
+    if $0 {    // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilderWithoutIf'}}
+      "hello"
+    }
+  }
+
+  tuplifyWithoutIf(true) {
+    if $0 {    // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilderWithoutIf'}}
+      "hello"
+    } else {
+    }
+  }
+
+  tuplifyWithoutIf(true) { a in
+    for x in 0..<100 {    // expected-error{{closure containing control flow statement cannot be used with function builder 'TupleBuilderWithoutIf'}}
+      x
+    }
+  }
+}

--- a/test/decl/var/function_builders.swift
+++ b/test/decl/var/function_builders.swift
@@ -7,7 +7,7 @@ var globalBuilder: Int
 func globalBuilderFunction() -> Int { return 0 }
 
 @_functionBuilder
-struct Maker {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}
+struct Maker {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}{{15-15=\n    static func buildBlock(_ components: <#Component#>...) -> <#Component#> {\n      <#code#>\n    \}}}
 
 @_functionBuilder
 class Inventor {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}

--- a/test/decl/var/function_builders.swift
+++ b/test/decl/var/function_builders.swift
@@ -7,7 +7,7 @@ var globalBuilder: Int
 func globalBuilderFunction() -> Int { return 0 }
 
 @_functionBuilder
-struct Maker {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}{{15-15=\n    static func buildBlock(_ components: <#Component#>...) -> <#Component#> {\n      <#code#>\n    \}}}
+struct Maker {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}
 
 @_functionBuilder
 class Inventor {} // expected-error {{function builder must provide at least one static 'buildBlock' method}}

--- a/userdocs/diagnostics/function-builder-methods.md
+++ b/userdocs/diagnostics/function-builder-methods.md
@@ -1,0 +1,56 @@
+# Function Builder Methods
+
+To be useful as a function builder, a function builder type must provide a
+sufficient subset of function-building methods that enable the transformation of
+various statement kinds (`if`, `switch`, `for`..`in`, etc.). The following
+example function builder illustrates the various function-building methods one
+can define:
+
+```swift
+@_functionBuilder
+struct ExampleFunctionBuilder {
+  /// The type of individual statement expressions in the transformed function,
+  /// which defaults to Component if buildExpression() is not provided.
+  typealias Expression = ...
+
+  /// The type of a partial result, which will be carried through all of the
+  /// build functions.
+  typealias Component = ...
+
+  /// The type of the final returned result, which defaults to Component if
+  /// buildFinalResult() is not provided.
+  typealias Result = ...
+
+  /// Required by every function builder to build combined results from
+  /// statement blocks.
+  static func buildBlock(_ components: Component...) -> Component { ... }
+
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  static func buildExpression(_ expression: Expression) -> Component { ... }
+
+  /// Enables support for `if` statements that do not have an `else`.
+  static func buildOptional(_ component: Component?) -> Component { ... }
+
+  /// With buildEither(second:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  static func buildEither(first component: Component) -> Component { ... }
+
+  /// With buildEither(first:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  static func buildEither(second component: Component) -> Component { ... }
+
+  /// Enables support for..in loops in a function builder by combining the
+  /// results of all iterations into a single result.
+  static func buildArray(_ components: [Component]) -> Component { ... }
+
+  /// If declaration, this will be called on the partial result of an 'if
+  /// #available' block to allow the function builder to erase type
+  /// information.
+  static func buildLimitedAvailability(_ component: Component) -> Component { ... }
+
+  /// If declared, this will be called on the partial result from the outermost
+  /// block statement to produce the final returned result.
+  static func buildFinalResult(_ component: Component) -> Result { ... }
+}
+```

--- a/userdocs/diagnostics/function-builder-methods.md
+++ b/userdocs/diagnostics/function-builder-methods.md
@@ -44,7 +44,7 @@ struct ExampleFunctionBuilder {
   /// results of all iterations into a single result.
   static func buildArray(_ components: [Component]) -> Component { ... }
 
-  /// If declaration, this will be called on the partial result of an 'if
+  /// If declared, this will be called on the partial result of an 'if
   /// #available' block to allow the function builder to erase type
   /// information.
   static func buildLimitedAvailability(_ component: Component) -> Component { ... }


### PR DESCRIPTION
Extend diagnostics and code completion to help guide developers toward implementing function builders. Specifically:
* When the function builder transformation cannot be applied because of a missing `build` method, e.g., because the body uses `if-else` but the function builder doesn't provide `buildEither(first:)` and `buildEither(second:)`, add a note + Fix-It to the error message that adds stubs for the functions needed to support those statements.
* When code-completing with the definition of a function builder type, provide a full set of completions for all of the `build` functions that function builders support.
* Add an educational note outlining the builder functions that a function builder can provide.

Fixes [SR-13536](https://bugs.swift.org/browse/SR-13536) / rdar://problem/68732123