### PR TITLE
[benchmark] Add another test to floating point conversion benchmark

### DIFF
--- a/benchmark/single-source/FloatingPointConversion.swift
+++ b/benchmark/single-source/FloatingPointConversion.swift
@@ -19,6 +19,11 @@ public let FloatingPointConversion = [
     tags: [.validation, .api],
     setUpFunction: { blackHole(mockFloat64s) }),
   BenchmarkInfo(
+    name: "ConvertFloatingPoint.MockFloat64Exactly",
+    runFunction: run_ConvertFloatingPoint_MockFloat64Exactly,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(mockFloat64s) }),
+  BenchmarkInfo(
     name: "ConvertFloatingPoint.MockFloat64ToInt64",
     runFunction: run_ConvertFloatingPoint_MockFloat64ToInt64,
     tags: [.validation, .api],
@@ -147,13 +152,6 @@ let doubles = [
 
 let mockFloat64s = doubles.map { MockFloat64($0) }
 
-@inline(__always)
-func convert<
-  T: BinaryFloatingPoint, U: BinaryFloatingPoint
->(_ value: T, to: U.Type) -> U {
-  U(value)
-}
-
 // See also: test/SILOptimizer/floating_point_conversion.swift
 
 @inline(never)
@@ -161,6 +159,23 @@ public func run_ConvertFloatingPoint_MockFloat64ToDouble(_ N: Int) {
   for _ in 0..<(N * 100) {
     for element in mockFloat64s {
       let f = Double(identity(element))
+      blackHole(f)
+    }
+  }
+}
+
+@inline(__always)
+func convert<
+  T: BinaryFloatingPoint, U: BinaryFloatingPoint
+>(exactly value: T, to: U.Type) -> U? {
+  U(exactly: value)
+}
+
+@inline(never)
+public func run_ConvertFloatingPoint_MockFloat64Exactly(_ N: Int) {
+  for _ in 0..<(N * 100) {
+    for element in mockFloat64s {
+      let f = convert(exactly: identity(element), to: Double.self)
       blackHole(f)
     }
   }

--- a/benchmark/single-source/FloatingPointConversion.swift
+++ b/benchmark/single-source/FloatingPointConversion.swift
@@ -24,8 +24,8 @@ public let FloatingPointConversion = [
     tags: [.validation, .api],
     setUpFunction: { blackHole(mockFloat64s) }),
   BenchmarkInfo(
-    name: "ConvertFloatingPoint.MockFloat64Exactly.bis",
-    runFunction: run_ConvertFloatingPoint_MockFloat64Exactly_bis,
+    name: "ConvertFloatingPoint.MockFloat64Exactly2",
+    runFunction: run_ConvertFloatingPoint_MockFloat64Exactly2,
     tags: [.validation, .api],
     setUpFunction: { blackHole(mockFloat64s) }),
   BenchmarkInfo(
@@ -183,7 +183,7 @@ func convert<
 
 @inline(never)
 public func run_ConvertFloatingPoint_MockFloat64Exactly(_ N: Int) {
-  for _ in 0..<(N * 100) {
+  for _ in 0..<(N * 25) {
     for element in mockFloat64s {
       let f = convert(exactly: identity(element), to: Double.self)
       blackHole(f)
@@ -192,8 +192,8 @@ public func run_ConvertFloatingPoint_MockFloat64Exactly(_ N: Int) {
 }
 
 @inline(never)
-public func run_ConvertFloatingPoint_MockFloat64Exactly_bis(_ N: Int) {
-  for _ in 0..<(N * 100) {
+public func run_ConvertFloatingPoint_MockFloat64Exactly2(_ N: Int) {
+  for _ in 0..<(N * 25) {
     for element in mockFloat64s {
       let f = convert(exactly: identity(element), to: MockFloat32.self)
       blackHole(f)

--- a/benchmark/single-source/FloatingPointConversion.swift
+++ b/benchmark/single-source/FloatingPointConversion.swift
@@ -24,6 +24,11 @@ public let FloatingPointConversion = [
     tags: [.validation, .api],
     setUpFunction: { blackHole(mockFloat64s) }),
   BenchmarkInfo(
+    name: "ConvertFloatingPoint.MockFloat64Exactly.bis",
+    runFunction: run_ConvertFloatingPoint_MockFloat64Exactly_bis,
+    tags: [.validation, .api],
+    setUpFunction: { blackHole(mockFloat64s) }),
+  BenchmarkInfo(
     name: "ConvertFloatingPoint.MockFloat64ToInt64",
     runFunction: run_ConvertFloatingPoint_MockFloat64ToInt64,
     tags: [.validation, .api],
@@ -135,6 +140,11 @@ struct MockFloat64: MockBinaryFloatingPoint {
   init(_ _value: Double) { self._value = _value }
 }
 
+struct MockFloat32: MockBinaryFloatingPoint {
+  var _value: Float
+  init(_ _value: Float) { self._value = _value }
+}
+
 let doubles = [
    1.8547832857295,  26.321549267719135, 98.9544480962058,    73.70286973782363,
   82.04918555938816, 76.38902969312758,  46.35647857011161,   64.0821426030317,
@@ -176,6 +186,16 @@ public func run_ConvertFloatingPoint_MockFloat64Exactly(_ N: Int) {
   for _ in 0..<(N * 100) {
     for element in mockFloat64s {
       let f = convert(exactly: identity(element), to: Double.self)
+      blackHole(f)
+    }
+  }
+}
+
+@inline(never)
+public func run_ConvertFloatingPoint_MockFloat64Exactly_bis(_ N: Int) {
+  for _ in 0..<(N * 100) {
+    for element in mockFloat64s {
+      let f = convert(exactly: identity(element), to: MockFloat32.self)
       blackHole(f)
     }
   }


### PR DESCRIPTION
This PR adds a benchmark to test the performance of the default implementation of `BinaryFloatingPoint.init<T>(exactly:) where T: BinaryFloatingPoint`.

It is a companion to #33910 and will need to be landed separately in order to demonstrate that the other PR produces the expected performance improvement.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
