### PR TITLE
Remove ASTScope starting DeclContext hack

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -411,8 +411,7 @@ public:
 
   /// Entry point into ASTScopeImpl-land for lookups
   static llvm::SmallVector<const ASTScopeImpl *, 0>
-  unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc,
-                    const DeclContext *startingContext, DeclConsumer);
+  unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc, DeclConsumer);
 
   /// Entry point into ASTScopeImpl-land for labeled statement lookups.
   static llvm::SmallVector<LabeledStmt *, 4>
@@ -429,11 +428,7 @@ public:
 private:
   static const ASTScopeImpl *findStartingScopeForLookup(SourceFile *,
                                                         const DeclNameRef name,
-                                                        const SourceLoc where,
-                                                        const DeclContext *ctx);
-
-protected:
-  virtual bool doesContextMatchStartingContext(const DeclContext *) const;
+                                                        const SourceLoc where);
 
 protected:
   /// Not const because may reexpand some scopes.
@@ -1006,7 +1001,6 @@ public:
 protected:
   bool lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
                              DeclConsumer) const override;
-  bool doesContextMatchStartingContext(const DeclContext *) const override;
   Optional<bool>
   resolveIsCascadingUseForThisScope(Optional<bool>) const override;
 };
@@ -1622,7 +1616,6 @@ protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &) override;
   bool lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
                              DeclConsumer) const override;
-  bool doesContextMatchStartingContext(const DeclContext *) const override;
 };
 
 class SubscriptDeclScope final : public ASTScopeImpl {

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -691,7 +691,6 @@ public:
   /// \return the scopes traversed
   static llvm::SmallVector<const ast_scope::ASTScopeImpl *, 0>
   unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc,
-                    const DeclContext *startingContext,
                     namelookup::AbstractASTScopeDeclConsumer &);
 
   static Optional<bool>

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -40,12 +40,10 @@ using namespace ast_scope;
 
 llvm::SmallVector<const ASTScopeImpl *, 0> ASTScope::unqualifiedLookup(
     SourceFile *SF, DeclNameRef name, SourceLoc loc,
-    const DeclContext *startingContext,
     namelookup::AbstractASTScopeDeclConsumer &consumer) {
   if (auto *s = SF->getASTContext().Stats)
     ++s->getFrontendCounters().NumASTScopeLookups;
-  return ASTScopeImpl::unqualifiedLookup(SF, name, loc, startingContext,
-                                         consumer);
+  return ASTScopeImpl::unqualifiedLookup(SF, name, loc, consumer);
 }
 
 Optional<bool> ASTScope::computeIsCascadingUse(

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -456,8 +456,7 @@ SourceRange ClosureParametersScope::getSourceRangeOfThisASTNode(
   if (!omitAssertions)
     ASTScopeAssert(closureExpr->getInLoc().isValid(),
                    "We don't create these if no in loc");
-  return SourceRange(getStartOfFirstParam(closureExpr),
-                     closureExpr->getInLoc());
+  return SourceRange(closureExpr->getInLoc(), closureExpr->getEndLoc());
 }
 
 SourceRange

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -544,7 +544,7 @@ void UnqualifiedLookupFactory::lookInASTScopes() {
 #endif
 
   ASTScope::unqualifiedLookup(DC->getParentSourceFile(),
-                              Name, Loc, DC, consumer);
+                              Name, Loc, consumer);
 }
 
 bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7289,8 +7289,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
           auto descriptor = UnqualifiedLookupDescriptor(
               DeclNameRef(param->getName()),
-              paramDecl->getDeclContext()->getParentForLookup(),
-              paramDecl->getStartLoc(),
+              paramDecl->getDeclContext()->getParentSourceFile(),
+              SourceLoc(),
               UnqualifiedLookupFlags::KnownPrivate |
                   UnqualifiedLookupFlags::TypeLookup);
           auto lookup = evaluateOrDefault(


### PR DESCRIPTION
ASTScope takes a SourceFile and a SourceLoc, and finds the innermost scope containing the SourceLoc.

It used to also take a DeclContext, and if the DeclContext didn't match the innermost scope's DeclContext, walk up to the parent scope. Let's remove this hack and have the callers do the right thing instead.