### PR TITLE
[semantic-arc] Extract out from the main visitor a context object for individual sub optimizations.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/CMakeLists.txt
+++ b/lib/SILOptimizer/SemanticARC/CMakeLists.txt
@@ -4,4 +4,6 @@ target_sources(swiftSILOptimizer PRIVATE
   LoadCopyToLoadBorrowOpt.cpp
   BorrowScopeOpts.cpp
   CopyValueOpts.cpp
-  OwnedToGuaranteedPhiOpt.cpp)
+  OwnedToGuaranteedPhiOpt.cpp
+  Context.cpp
+  )

--- a/lib/SILOptimizer/SemanticARC/Context.cpp
+++ b/lib/SILOptimizer/SemanticARC/Context.cpp
@@ -1,0 +1,166 @@
+//===--- Context.cpp ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-semantic-arc-opts"
+
+#include "Context.h"
+#include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/Projection.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+using namespace swift::semanticarc;
+
+static llvm::cl::opt<bool>
+    VerifyAfterTransformOption("sil-semantic-arc-opts-verify-after-transform",
+                               llvm::cl::Hidden, llvm::cl::init(false));
+
+void Context::verify() const {
+  if (VerifyAfterTransformOption)
+    fn.verify();
+}
+
+//===----------------------------------------------------------------------===//
+//                        Well Behaved Write Analysis
+//===----------------------------------------------------------------------===//
+
+/// Returns true if we were able to ascertain that either the initialValue has
+/// no write uses or all of the write uses were writes that we could understand.
+bool Context::constructCacheValue(
+    SILValue initialValue,
+    SmallVectorImpl<Operand *> &wellBehavedWriteAccumulator) {
+  SmallVector<Operand *, 8> worklist(initialValue->getUses());
+
+  while (!worklist.empty()) {
+    auto *op = worklist.pop_back_val();
+    SILInstruction *user = op->getUser();
+
+    if (Projection::isAddressProjection(user) ||
+        isa<ProjectBlockStorageInst>(user)) {
+      for (SILValue r : user->getResults()) {
+        llvm::copy(r->getUses(), std::back_inserter(worklist));
+      }
+      continue;
+    }
+
+    if (auto *oeai = dyn_cast<OpenExistentialAddrInst>(user)) {
+      // Mutable access!
+      if (oeai->getAccessKind() != OpenedExistentialAccess::Immutable) {
+        wellBehavedWriteAccumulator.push_back(op);
+      }
+
+      //  Otherwise, look through it and continue.
+      llvm::copy(oeai->getUses(), std::back_inserter(worklist));
+      continue;
+    }
+
+    if (auto *si = dyn_cast<StoreInst>(user)) {
+      // We must be the dest since addresses can not be stored.
+      assert(si->getDest() == op->get());
+      wellBehavedWriteAccumulator.push_back(op);
+      continue;
+    }
+
+    // Add any destroy_addrs to the resultAccumulator.
+    if (isa<DestroyAddrInst>(user)) {
+      wellBehavedWriteAccumulator.push_back(op);
+      continue;
+    }
+
+    // load_borrow and incidental uses are fine as well.
+    if (isa<LoadBorrowInst>(user) || isIncidentalUse(user)) {
+      continue;
+    }
+
+    // Look through begin_access and mark them/their end_borrow as users.
+    if (auto *bai = dyn_cast<BeginAccessInst>(user)) {
+      // If we do not have a read, mark this as a write. Also, insert our
+      // end_access as well.
+      if (bai->getAccessKind() != SILAccessKind::Read) {
+        wellBehavedWriteAccumulator.push_back(op);
+        transform(bai->getUsersOfType<EndAccessInst>(),
+                  std::back_inserter(wellBehavedWriteAccumulator),
+                  [](EndAccessInst *eai) { return &eai->getAllOperands()[0]; });
+      }
+
+      // And then add the users to the worklist and continue.
+      llvm::copy(bai->getUses(), std::back_inserter(worklist));
+      continue;
+    }
+
+    // If we have a load, we just need to mark the load [take] as a write.
+    if (auto *li = dyn_cast<LoadInst>(user)) {
+      if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
+        wellBehavedWriteAccumulator.push_back(op);
+      }
+      continue;
+    }
+
+    // If we have a FullApplySite, we need to do per convention/inst logic.
+    if (auto fas = FullApplySite::isa(user)) {
+      // Begin by seeing if we have an in_guaranteed use. If we do, we are done.
+      if (fas.getArgumentConvention(*op) ==
+          SILArgumentConvention::Indirect_In_Guaranteed) {
+        continue;
+      }
+
+      // Then see if we have an apply site that is not a coroutine apply
+      // site. In such a case, without further analysis, we can treat it like an
+      // instantaneous write and validate that it doesn't overlap with our load
+      // [copy].
+      if (!fas.beginsCoroutineEvaluation() &&
+          fas.getArgumentConvention(*op).isInoutConvention()) {
+        wellBehavedWriteAccumulator.push_back(op);
+        continue;
+      }
+
+      // Otherwise, be conservative and return that we had a write that we did
+      // not understand.
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Function: " << user->getFunction()->getName() << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "Value: " << op->get());
+      LLVM_DEBUG(llvm::dbgs() << "Unhandled apply site!: " << *user);
+
+      return false;
+    }
+
+    // Copy addr that read are just loads.
+    if (auto *cai = dyn_cast<CopyAddrInst>(user)) {
+      // If our value is the destination, this is a write.
+      if (cai->getDest() == op->get()) {
+        wellBehavedWriteAccumulator.push_back(op);
+        continue;
+      }
+
+      // Ok, so we are Src by process of elimination. Make sure we are not being
+      // taken.
+      if (cai->isTakeOfSrc()) {
+        wellBehavedWriteAccumulator.push_back(op);
+        continue;
+      }
+
+      // Otherwise, we are safe and can continue.
+      continue;
+    }
+
+    // If we did not recognize the user, just return conservatively that it was
+    // written to in a way we did not understand.
+    LLVM_DEBUG(llvm::dbgs()
+               << "Function: " << user->getFunction()->getName() << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Value: " << op->get());
+    LLVM_DEBUG(llvm::dbgs() << "Unknown instruction!: " << *user);
+    return false;
+  }
+
+  // Ok, we finished our worklist and this address is not being written to.
+  return true;
+}

--- a/lib/SILOptimizer/SemanticARC/Context.h
+++ b/lib/SILOptimizer/SemanticARC/Context.h
@@ -1,0 +1,100 @@
+//===--- Context.h --------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_SEMANTICARC_CONTEXT_H
+#define SWIFT_SILOPTIMIZER_SEMANTICARC_CONTEXT_H
+
+#include "OwnershipLiveRange.h"
+
+#include "swift/Basic/BlotSetVector.h"
+#include "swift/Basic/FrozenMultiMap.h"
+#include "swift/Basic/MultiMapCache.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/ValueLifetime.h"
+#include "llvm/Support/Compiler.h"
+
+namespace swift {
+namespace semanticarc {
+
+struct LLVM_LIBRARY_VISIBILITY Context {
+  SILFunction &fn;
+  Optional<DeadEndBlocks> deadEndBlocks;
+  ValueLifetimeAnalysis::Frontier lifetimeFrontier;
+  SmallMultiMapCache<SILValue, Operand *> addressToExhaustiveWriteListCache;
+
+  /// Are we assuming that we reached a fix point and are re-processing to
+  /// prepare to use the phiToIncomingValueMultiMap.
+  bool assumingAtFixedPoint = false;
+
+  /// A map from a value that acts as a "joined owned introducer" in the def-use
+  /// graph.
+  ///
+  /// A "joined owned introducer" is a value with owned ownership whose
+  /// ownership is derived from multiple non-trivial owned operands of a related
+  /// instruction. Some examples are phi arguments, tuples, structs. Naturally,
+  /// all of these instructions must be non-unary instructions and only have
+  /// this property if they have multiple operands that are non-trivial.
+  ///
+  /// In such a case, we can not just treat them like normal forwarding concepts
+  /// since we can only eliminate optimize such a value if we are able to reason
+  /// about all of its operands together jointly. This is not amenable to a
+  /// small peephole analysis.
+  ///
+  /// Instead, as we perform the peephole analysis, using the multimap, we map
+  /// each joined owned value introducer to the set of its @owned operands that
+  /// we thought we could convert to guaranteed only if we could do the same to
+  /// the joined owned value introducer. Then once we finish performing
+  /// peepholes, we iterate through the map and see if any of our joined phi
+  /// ranges had all of their operand's marked with this property by iterating
+  /// over the multimap. Since we are dealing with owned values and we know that
+  /// our LiveRange can not see through joined live ranges, we know that we
+  /// should only be able to have a single owned value introducer for each
+  /// consumed operand.
+  FrozenMultiMap<SILValue, Operand *> joinedOwnedIntroducerToConsumedOperands;
+
+  /// If set to true, then we should only run cheap optimizations that do not
+  /// build up data structures or analyze code in depth.
+  ///
+  /// As an example, we do not do load [copy] optimizations here since they
+  /// generally involve more complex analysis, but simple peepholes of
+  /// copy_values we /do/ allow.
+  bool onlyGuaranteedOpts;
+
+  using FrozenMultiMapRange =
+      decltype(joinedOwnedIntroducerToConsumedOperands)::PairToSecondEltRange;
+
+  DeadEndBlocks &getDeadEndBlocks() {
+    if (!deadEndBlocks)
+      deadEndBlocks.emplace(&fn);
+    return *deadEndBlocks;
+  }
+
+  Context(SILFunction &fn, bool onlyGuaranteedOpts)
+      : fn(fn), deadEndBlocks(), lifetimeFrontier(),
+        addressToExhaustiveWriteListCache(constructCacheValue),
+        onlyGuaranteedOpts(onlyGuaranteedOpts) {}
+
+  void verify() const;
+
+private:
+  static bool
+  constructCacheValue(SILValue initialValue,
+                      SmallVectorImpl<Operand *> &wellBehavedWriteAccumulator);
+};
+
+} // namespace semanticarc
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -61,7 +61,7 @@ using namespace swift::semanticarc;
 bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
     CopyValueInst *cvi) {
   // For now, do not run this optimization. This is just to be careful.
-  if (onlyGuaranteedOpts)
+  if (ctx.onlyGuaranteedOpts)
     return false;
 
   SmallVector<BorrowedValue, 4> borrowScopeIntroducers;
@@ -83,7 +83,7 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
   // (e.x. storing into memory).
   OwnershipLiveRange lr(cvi);
   auto hasUnknownConsumingUseState =
-      lr.hasUnknownConsumingUse(assumingAtFixedPoint);
+      lr.hasUnknownConsumingUse(ctx.assumingAtFixedPoint);
   if (hasUnknownConsumingUseState ==
       OwnershipLiveRange::HasConsumingUse_t::Yes) {
     return false;
@@ -222,8 +222,8 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
 
     if (canOptimizePhi) {
       opPhi.visitResults([&](SILValue value) {
-        joinedOwnedIntroducerToConsumedOperands.insert(value,
-                                                       opPhi.getOperand());
+        ctx.joinedOwnedIntroducerToConsumedOperands.insert(value,
+                                                           opPhi.getOperand());
         return true;
       });
     }

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -13,8 +13,8 @@
 #ifndef SWIFT_SILOPTIMIZER_SEMANTICARC_SEMANTICARCOPTVISITOR_H
 #define SWIFT_SILOPTIMIZER_SEMANTICARC_SEMANTICARCOPTVISITOR_H
 
+#include "Context.h"
 #include "OwnershipLiveRange.h"
-
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/Basic/MultiMapCache.h"
@@ -26,12 +26,6 @@
 
 namespace swift {
 namespace semanticarc {
-
-extern bool VerifyAfterTransform;
-
-bool constructCacheValue(
-    SILValue initialValue,
-    SmallVectorImpl<Operand *> &wellBehavedWriteAccumulator);
 
 /// A visitor that optimizes ownership instructions and eliminates any trivially
 /// dead code that results after optimization. It uses an internal worklist that
@@ -51,61 +45,12 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   /// when visiting phi nodes.
   SmallBlotSetVector<SILValue, 16> visitedSinceLastMutation;
 
-  SILFunction &F;
-  Optional<DeadEndBlocks> TheDeadEndBlocks;
-  ValueLifetimeAnalysis::Frontier lifetimeFrontier;
-  SmallMultiMapCache<SILValue, Operand *> addressToExhaustiveWriteListCache;
+  Context ctx;
 
-  /// Are we assuming that we reached a fix point and are re-processing to
-  /// prepare to use the phiToIncomingValueMultiMap.
-  bool assumingAtFixedPoint = false;
+  explicit SemanticARCOptVisitor(SILFunction &fn, bool onlyGuaranteedOpts)
+      : ctx(fn, onlyGuaranteedOpts) {}
 
-  /// A map from a value that acts as a "joined owned introducer" in the def-use
-  /// graph.
-  ///
-  /// A "joined owned introducer" is a value with owned ownership whose
-  /// ownership is derived from multiple non-trivial owned operands of a related
-  /// instruction. Some examples are phi arguments, tuples, structs. Naturally,
-  /// all of these instructions must be non-unary instructions and only have
-  /// this property if they have multiple operands that are non-trivial.
-  ///
-  /// In such a case, we can not just treat them like normal forwarding concepts
-  /// since we can only eliminate optimize such a value if we are able to reason
-  /// about all of its operands together jointly. This is not amenable to a
-  /// small peephole analysis.
-  ///
-  /// Instead, as we perform the peephole analysis, using the multimap, we map
-  /// each joined owned value introducer to the set of its @owned operands that
-  /// we thought we could convert to guaranteed only if we could do the same to
-  /// the joined owned value introducer. Then once we finish performing
-  /// peepholes, we iterate through the map and see if any of our joined phi
-  /// ranges had all of their operand's marked with this property by iterating
-  /// over the multimap. Since we are dealing with owned values and we know that
-  /// our LiveRange can not see through joined live ranges, we know that we
-  /// should only be able to have a single owned value introducer for each
-  /// consumed operand.
-  FrozenMultiMap<SILValue, Operand *> joinedOwnedIntroducerToConsumedOperands;
-
-  /// If set to true, then we should only run cheap optimizations that do not
-  /// build up data structures or analyze code in depth.
-  ///
-  /// As an example, we do not do load [copy] optimizations here since they
-  /// generally involve more complex analysis, but simple peepholes of
-  /// copy_values we /do/ allow.
-  bool onlyGuaranteedOpts;
-
-  using FrozenMultiMapRange =
-      decltype(joinedOwnedIntroducerToConsumedOperands)::PairToSecondEltRange;
-
-  explicit SemanticARCOptVisitor(SILFunction &F, bool onlyGuaranteedOpts)
-      : F(F), addressToExhaustiveWriteListCache(constructCacheValue),
-        onlyGuaranteedOpts(onlyGuaranteedOpts) {}
-
-  DeadEndBlocks &getDeadEndBlocks() {
-    if (!TheDeadEndBlocks)
-      TheDeadEndBlocks.emplace(&F);
-    return *TheDeadEndBlocks;
-  }
+  DeadEndBlocks &getDeadEndBlocks() { return ctx.getDeadEndBlocks(); }
 
   /// Given a single value instruction, RAUW it with newValue, add newValue to
   /// the worklist, and then call eraseInstruction on i.
@@ -238,8 +183,6 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   FORWARDING_TERM(CheckedCastBranch)
   FORWARDING_TERM(Branch)
 #undef FORWARDING_TERM
-
-  bool isWrittenTo(LoadInst *li, const OwnershipLiveRange &lr);
 
   bool processWorklist();
   bool optimize();


### PR DESCRIPTION
This patch moves state from the main SemanticARCOptVisitor struct to instead be
on a context object. Sub-transformations should not need to know about the
visitor since how it processes things is orthogonal from the transformations
themselves.
