### PR TITLE
[semantic-arc] Add support for specifying the specific sub-semantic arc transforms to perform from the command line.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/CMakeLists.txt
+++ b/lib/SILOptimizer/SemanticARC/CMakeLists.txt
@@ -6,4 +6,5 @@ target_sources(swiftSILOptimizer PRIVATE
   CopyValueOpts.cpp
   OwnedToGuaranteedPhiOpt.cpp
   Context.cpp
+  SemanticARCOptVisitor.cpp
   )

--- a/lib/SILOptimizer/SemanticARC/Context.h
+++ b/lib/SILOptimizer/SemanticARC/Context.h
@@ -72,6 +72,9 @@ struct LLVM_LIBRARY_VISIBILITY Context {
   /// copy_values we /do/ allow.
   bool onlyGuaranteedOpts;
 
+  /// Callbacks that we must use to remove or RAUW values.
+  InstModCallbacks instModCallbacks;
+
   using FrozenMultiMapRange =
       decltype(joinedOwnedIntroducerToConsumedOperands)::PairToSecondEltRange;
 
@@ -81,7 +84,7 @@ struct LLVM_LIBRARY_VISIBILITY Context {
     return *deadEndBlocks;
   }
 
-  Context(SILFunction &fn, bool onlyGuaranteedOpts)
+  Context(SILFunction &fn, bool onlyGuaranteedOpts, InstModCallbacks callbacks)
       : fn(fn), deadEndBlocks(), lifetimeFrontier(),
         addressToExhaustiveWriteListCache(constructCacheValue),
         onlyGuaranteedOpts(onlyGuaranteedOpts) {}

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
@@ -1,0 +1,112 @@
+//===--- SemanticARCOptVisitor.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// Implementation of the main optimize loop of the ARC visitor peephole
+/// optimizer.
+///
+//===----------------------------------------------------------------------===//
+
+#include "SemanticARCOptVisitor.h"
+#include "swift/SIL/DebugUtils.h"
+
+using namespace swift;
+using namespace swift::semanticarc;
+
+bool SemanticARCOptVisitor::optimize() {
+  bool madeChange = false;
+
+  // First process the worklist until we reach a fixed point.
+  madeChange |= processWorklist();
+
+  {
+    // If we made a change, set that we assume we are at fixed point and then
+    // re-run the worklist so that we can
+    // properly seeded the ARC peephole map.
+    ctx.assumingAtFixedPoint = true;
+    SWIFT_DEFER { ctx.assumingAtFixedPoint = false; };
+
+    // Add everything in visitedSinceLastMutation to the worklist so we
+    // recompute our fixed point.
+    drainVisitedSinceLastMutationIntoWorklist();
+
+    // Then re-run the worklist. We shouldn't modify anything since we are at a
+    // fixed point and are just using this to seed the
+    // joinedOwnedIntroducerToConsumedOperands after we have finished changing
+    // things. If we did change something, we did something weird, so assert!
+    bool madeAdditionalChanges = processWorklist();
+    (void)madeAdditionalChanges;
+    assert(!madeAdditionalChanges && "Should be at the fixed point");
+  }
+
+  return madeChange;
+}
+
+bool SemanticARCOptVisitor::processWorklist() {
+  // NOTE: The madeChange here is not strictly necessary since we only have
+  // items added to the worklist today if we have already made /some/ sort of
+  // change. That being said, I think there is a low cost to including this here
+  // and makes the algorithm more correct, visually and in the face of potential
+  // refactoring.
+  bool madeChange = false;
+
+  while (!worklist.empty()) {
+    // Pop the last element off the list. If we were returned None, we blotted
+    // this element, so skip it.
+    SILValue next = worklist.pop_back_val().getValueOr(SILValue());
+    if (!next)
+      continue;
+
+    // First check if this is a value that we have visited since the last time
+    // we erased an instruction. If we have visited it, skip it. Every time we
+    // modify something, we should be deleting an instruction, so we have not
+    // found any further information.
+    if (!visitedSinceLastMutation.insert(next).second) {
+      continue;
+    }
+
+    // First check if this is an instruction that is trivially dead. This can
+    // occur if we eliminate rr traffic resulting in dead projections and the
+    // like.
+    //
+    // If we delete, we first add all of our deleted instructions operands to
+    // the worklist and then remove all results (since we are going to delete
+    // the instruction).
+    if (auto *defInst = next->getDefiningInstruction()) {
+      if (isInstructionTriviallyDead(defInst)) {
+        assert(!ctx.assumingAtFixedPoint &&
+               "Assumed was at fixed point and recomputing state?!");
+        deleteAllDebugUses(defInst);
+        eraseInstruction(defInst);
+        madeChange = true;
+        ctx.verify();
+        continue;
+      }
+    }
+
+    // Otherwise, if we have a single value instruction (to be expanded later
+    // perhaps), try to visit that value recursively.
+    if (auto *svi = dyn_cast<SingleValueInstruction>(next)) {
+      bool madeSingleChange = visit(svi);
+      assert((!madeSingleChange || !ctx.assumingAtFixedPoint) &&
+             "Assumed was at fixed point and modified state?!");
+      madeChange |= madeSingleChange;
+      if (madeSingleChange) {
+        ctx.verify();
+      }
+      continue;
+    }
+  }
+
+  return madeChange;
+}

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -48,7 +48,13 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   Context ctx;
 
   explicit SemanticARCOptVisitor(SILFunction &fn, bool onlyGuaranteedOpts)
-      : ctx(fn, onlyGuaranteedOpts) {}
+      : ctx(fn, onlyGuaranteedOpts,
+            InstModCallbacks(
+                [this](SILInstruction *inst) { eraseInstruction(inst); },
+                [](SILInstruction *) {}, [](SILValue, SILValue) {},
+                [this](SingleValueInstruction *i, SILValue value) {
+                  eraseAndRAUWSingleValueInstruction(i, value);
+                })) {}
 
   DeadEndBlocks &getDeadEndBlocks() { return ctx.getDeadEndBlocks(); }
 
@@ -190,7 +196,6 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi);
   bool eliminateDeadLiveRangeCopyValue(CopyValueInst *cvi);
   bool tryJoiningCopyValueLiveRangeWithOperand(CopyValueInst *cvi);
-  bool performPostPeepholeOwnedArgElimination();
 };
 
 } // namespace semanticarc

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
@@ -12,130 +12,13 @@
 
 #define DEBUG_TYPE "sil-semantic-arc-opts"
 
-#include "OwnershipLiveRange.h"
-#include "OwnershipPhiOperand.h"
 #include "SemanticARCOptVisitor.h"
 #include "Transforms.h"
 
-#include "swift/Basic/LLVM.h"
-
-#include "swift/Basic/BlotSetVector.h"
-#include "swift/Basic/FrozenMultiMap.h"
-#include "swift/Basic/MultiMapCache.h"
-#include "swift/Basic/STLExtras.h"
-#include "swift/SIL/BasicBlockUtils.h"
-#include "swift/SIL/DebugUtils.h"
-#include "swift/SIL/LinearLifetimeChecker.h"
-#include "swift/SIL/MemAccessUtils.h"
-#include "swift/SIL/OwnershipUtils.h"
-#include "swift/SIL/Projection.h"
-#include "swift/SIL/SILArgument.h"
-#include "swift/SIL/SILBuilder.h"
-#include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/SILVisitor.h"
-#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
-#include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/InstOptUtils.h"
-#include "swift/SILOptimizer/Utils/ValueLifetime.h"
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/Statistic.h"
 
 using namespace swift;
 using namespace swift::semanticarc;
-
-//===----------------------------------------------------------------------===//
-//                               Implementation
-//===----------------------------------------------------------------------===//
-
-bool SemanticARCOptVisitor::optimize() {
-  bool madeChange = false;
-
-  // First process the worklist until we reach a fixed point.
-  madeChange |= processWorklist();
-
-  {
-    // If we made a change, set that we assume we are at fixed point and then
-    // re-run the worklist so that we can
-    // properly seeded the ARC peephole map.
-    ctx.assumingAtFixedPoint = true;
-    SWIFT_DEFER { ctx.assumingAtFixedPoint = false; };
-
-    // Add everything in visitedSinceLastMutation to the worklist so we
-    // recompute our fixed point.
-    drainVisitedSinceLastMutationIntoWorklist();
-
-    // Then re-run the worklist. We shouldn't modify anything since we are at a
-    // fixed point and are just using this to seed the
-    // joinedOwnedIntroducerToConsumedOperands after we have finished changing
-    // things. If we did change something, we did something weird, so assert!
-    bool madeAdditionalChanges = processWorklist();
-    (void)madeAdditionalChanges;
-    assert(!madeAdditionalChanges && "Should be at the fixed point");
-  }
-
-  return madeChange;
-}
-
-bool SemanticARCOptVisitor::processWorklist() {
-  // NOTE: The madeChange here is not strictly necessary since we only have
-  // items added to the worklist today if we have already made /some/ sort of
-  // change. That being said, I think there is a low cost to including this here
-  // and makes the algorithm more correct, visually and in the face of potential
-  // refactoring.
-  bool madeChange = false;
-
-  while (!worklist.empty()) {
-    // Pop the last element off the list. If we were returned None, we blotted
-    // this element, so skip it.
-    SILValue next = worklist.pop_back_val().getValueOr(SILValue());
-    if (!next)
-      continue;
-
-    // First check if this is a value that we have visited since the last time
-    // we erased an instruction. If we have visited it, skip it. Every time we
-    // modify something, we should be deleting an instruction, so we have not
-    // found any further information.
-    if (!visitedSinceLastMutation.insert(next).second) {
-      continue;
-    }
-
-    // First check if this is an instruction that is trivially dead. This can
-    // occur if we eliminate rr traffic resulting in dead projections and the
-    // like.
-    //
-    // If we delete, we first add all of our deleted instructions operands to
-    // the worklist and then remove all results (since we are going to delete
-    // the instruction).
-    if (auto *defInst = next->getDefiningInstruction()) {
-      if (isInstructionTriviallyDead(defInst)) {
-        assert(!ctx.assumingAtFixedPoint &&
-               "Assumed was at fixed point and recomputing state?!");
-        deleteAllDebugUses(defInst);
-        eraseInstruction(defInst);
-        madeChange = true;
-        ctx.verify();
-        continue;
-      }
-    }
-
-    // Otherwise, if we have a single value instruction (to be expanded later
-    // perhaps), try to visit that value recursively.
-    if (auto *svi = dyn_cast<SingleValueInstruction>(next)) {
-      bool madeSingleChange = visit(svi);
-      assert((!madeSingleChange || !ctx.assumingAtFixedPoint) &&
-             "Assumed was at fixed point and modified state?!");
-      madeChange |= madeSingleChange;
-      if (madeSingleChange) {
-        ctx.verify();
-      }
-      continue;
-    }
-  }
-
-  return madeChange;
-}
 
 //===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint
@@ -179,7 +62,7 @@ struct SemanticARCOpts : SILFunctionTransform {
     }
 
     // Then process the worklist, performing peepholes.
-    bool madeChange = visitor.optimize();
+    bool eliminatedARCInst = visitor.optimize();
 
     // Now that we have seeded the map of phis to incoming values that could be
     // converted to guaranteed, ignoring the phi, try convert those phis to be
@@ -191,7 +74,7 @@ struct SemanticARCOpts : SILFunctionTransform {
     }
 
     // Otherwise, we only deleted instructions and did not touch phis.
-    if (madeChange)
+    if (eliminatedARCInst)
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
   }
 };

--- a/lib/SILOptimizer/SemanticARC/Transforms.h
+++ b/lib/SILOptimizer/SemanticARC/Transforms.h
@@ -1,0 +1,41 @@
+//===--- Transforms.h -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// Top level transforms for SemanticARCOpts
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_SEMANTICARCOPT_TRANSFORMS_H
+#define SWIFT_SILOPTIMIZER_SEMANTICARCOPT_TRANSFORMS_H
+
+#include "llvm/Support/Compiler.h"
+
+namespace swift {
+namespace semanticarc {
+
+struct Context;
+
+/// Given the current map of owned phi arguments to consumed incoming values in
+/// ctx, attempt to convert these owned phi arguments to guaranteed phi
+/// arguments if the phi arguments are the only thing that kept us from
+/// converting these incoming values to be guaranteed.
+///
+/// \returns true if we converted atleast one phi from owned -> guaranteed and
+/// eliminated ARC traffic as a result.
+bool tryConvertOwnedPhisToGuaranteedPhis(Context &ctx) LLVM_LIBRARY_VISIBILITY;
+
+} // namespace semanticarc
+} // namespace swift
+
+#endif


### PR DESCRIPTION
This involved:

1. Refactoring the ARC peephole optimizer/Phi optimizer into separate transforms.
2. Moving the ARC peephole optimizer (SemanticARCOptVisitor) into its own file.
3. Adding support in SemanticARCOpts (the main place the actual transform is specified) for a compiler developer to specify with an asserts compiler the specific transforms to run.

This is in preparation for adding transforms like the coroutine lifetime extender that should be run after peepholes/guaranteed phi arg elimination, but that we want to also be able to test separately.