### PR TITLE
ASTScope: Simplify representation of closures

### DIFF
--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -96,10 +96,6 @@ NullablePtr<ClosureExpr> BraceStmtScope::parentClosureIfAny() const {
 NullablePtr<ClosureExpr> ASTScopeImpl::getClosureIfClosureScope() const {
   return nullptr;
 }
-NullablePtr<ClosureExpr>
-AbstractClosureScope::getClosureIfClosureScope() const {
-  return closureExpr;
-}
 
 // Conservative, because using precise info would be circular
 SourceRange
@@ -231,9 +227,7 @@ DEFINE_GET_CLASS_NAME(PatternEntryInitializerScope)
 DEFINE_GET_CLASS_NAME(ConditionalClauseScope)
 DEFINE_GET_CLASS_NAME(ConditionalClausePatternUseScope)
 DEFINE_GET_CLASS_NAME(CaptureListScope)
-DEFINE_GET_CLASS_NAME(WholeClosureScope)
 DEFINE_GET_CLASS_NAME(ClosureParametersScope)
-DEFINE_GET_CLASS_NAME(ClosureBodyScope)
 DEFINE_GET_CLASS_NAME(TopLevelCodeScope)
 DEFINE_GET_CLASS_NAME(SpecializeAttributeScope)
 DEFINE_GET_CLASS_NAME(DifferentiableAttributeScope)

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -424,18 +424,19 @@ bool PatternEntryInitializerScope::lookupLocalsOrMembers(
   return false;
 }
 
+bool CaptureListScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
+  for (auto &e : expr->getCaptureList()) {
+    if (consumer.consume(
+            {e.Var},
+            DeclVisibilityKind::LocalVariable)) // or FunctionParameter??
+      return true;
+  }
+  return false;
+}
+
 bool ClosureParametersScope::lookupLocalsOrMembers(
     ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
-  if (auto *cl = captureList.getPtrOrNull()) {
-    CaptureListExpr *mutableCL =
-        const_cast<CaptureListExpr *>(captureList.get());
-    for (auto &e : mutableCL->getCaptureList()) {
-      if (consumer.consume(
-              {e.Var},
-              DeclVisibilityKind::LocalVariable)) // or FunctionParameter??
-        return true;
-    }
-  }
   for (auto param : *closureExpr->getParameters())
     if (consumer.consume({param}, DeclVisibilityKind::FunctionParameter))
       return true;
@@ -699,10 +700,6 @@ DefaultArgumentInitializerScope::resolveIsCascadingUseForThisScope(
 }
 
 Optional<bool> ClosureParametersScope::resolveIsCascadingUseForThisScope(
-    Optional<bool> isCascadingUse) const {
-  return ifUnknownIsCascadingUseAccordingTo(isCascadingUse, closureExpr);
-}
-Optional<bool> ClosureBodyScope::resolveIsCascadingUseForThisScope(
     Optional<bool> isCascadingUse) const {
   return ifUnknownIsCascadingUseAccordingTo(isCascadingUse, closureExpr);
 }


### PR DESCRIPTION
Let's use a ClosureParametersScope for all closures, even those
without an 'in' keyword. This eliminates the need for the
ClosureBodyScope and WholeClosureScope.

Also, let's move the lookup of capture list bindings from
CaptureParametersScope to CaptureListScope. This eliminates the
need for CaptureParametersScope to store a reference to the
capture list, which allows us to remove the AbstractClosureScope
base class entirely.
