### PR TITLE
[NFC] Clarify import filtering logic and naming.

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -241,7 +241,7 @@ public:
   /// \see ModuleDecl::getImportedModulesForLookup
   virtual void getImportedModulesForLookup(
       SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const {
-    return getImportedModules(imports, ModuleDecl::ImportFilterKind::Public);
+    return getImportedModules(imports, ModuleDecl::ImportFilterKind::Exported);
   }
 
   /// Generates the list of libraries needed to link this file, based on its

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -648,17 +648,16 @@ public:
   /// \sa getImportedModules
   enum class ImportFilterKind {
     /// Include imports declared with `@_exported`.
-    Public = 1 << 0,
+    Exported = 1 << 0,
     /// Include "regular" imports with no special annotation.
-    Private = 1 << 1,
+    Default = 1 << 1,
     /// Include imports declared with `@_implementationOnly`.
     ImplementationOnly = 1 << 2,
     /// Include imports of SPIs declared with `@_spi`
     SPIAccessControl = 1 << 3,
-    /// Include imports shadowed by a separately-imported overlay (i.e. a
-    /// cross-import overlay). Unshadowed imports are included whether or not
-    /// this flag is specified.
-    ShadowedBySeparateOverlay = 1 << 4
+    /// Include imports shadowed by a cross-import overlay. Unshadowed imports
+    /// are included whether or not this flag is specified.
+    ShadowedByCrossImportOverlay = 1 << 4
   };
   /// \sa getImportedModules
   using ImportFilter = OptionSet<ImportFilterKind>;
@@ -668,7 +667,7 @@ public:
   /// \p filter controls whether public, private, or any imports are included
   /// in this list.
   void getImportedModules(SmallVectorImpl<ImportedModule> &imports,
-                          ImportFilter filter = ImportFilterKind::Public) const;
+                          ImportFilter filter = ImportFilterKind::Exported) const;
 
   /// Looks up which modules are imported by this module, ignoring any that
   /// won't contain top-level decls.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -653,7 +653,8 @@ public:
     Default = 1 << 1,
     /// Include imports declared with `@_implementationOnly`.
     ImplementationOnly = 1 << 2,
-    /// Include imports of SPIs declared with `@_spi`
+    /// Include imports of SPIs declared with `@_spi`. Non-SPI imports are
+    /// included whether or not this flag is specified.
     SPIAccessControl = 1 << 3,
     /// Include imports shadowed by a cross-import overlay. Unshadowed imports
     /// are included whether or not this flag is specified.
@@ -664,8 +665,33 @@ public:
 
   /// Looks up which modules are imported by this module.
   ///
-  /// \p filter controls whether public, private, or any imports are included
-  /// in this list.
+  /// \p filter controls which imports are included in the list.
+  ///
+  /// There are three axes for categorizing imports:
+  /// 1. Privacy: Exported/Private/ImplementationOnly (mutually exclusive).
+  /// 2. SPI/non-SPI: An import of any privacy level may be @_spi("SPIName").
+  /// 3. Shadowed/Non-shadowed: An import of any privacy level may be shadowed
+  ///    by a cross-import overlay.
+  ///
+  /// It is also possible for SPI imports to be shadowed by a cross-import
+  /// overlay.
+  ///
+  /// If \p filter contains multiple privacy levels, modules at all the privacy
+  /// levels are included.
+  ///
+  /// If \p filter contains \c ImportFilterKind::SPIAccessControl, then both
+  /// SPI and non-SPI imports are included. Otherwise, only non-SPI imports are
+  /// included.
+  ///
+  /// If \p filter contains \c ImportFilterKind::ShadowedByCrossImportOverlay,
+  /// both shadowed and non-shadowed imports are included. Otherwise, only
+  /// non-shadowed imports are included.
+  ///
+  /// Clang modules have some additional complexities; see the implementation of
+  /// \c ClangModuleUnit::getImportedModules for details.
+  ///
+  /// \pre \p filter must contain at least one privacy level, i.e. one of
+  ///      \c Exported or \c Private or \c ImplementationOnly.
   void getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                           ImportFilter filter = ImportFilterKind::Exported) const;
 

--- a/include/swift/Basic/OptionSet.h
+++ b/include/swift/Basic/OptionSet.h
@@ -19,6 +19,7 @@
 
 #include "llvm/ADT/None.h"
 
+#include <cassert>
 #include <type_traits>
 #include <cstdint>
 #include <initializer_list>
@@ -96,6 +97,14 @@ public:
   /// Check if this option set contains the exact same options as the given set.
   constexpr bool containsOnly(OptionSet set) const {
     return Storage == set.Storage;
+  }
+
+  /// Check if this option set contains any options from \p set.
+  ///
+  /// \pre \p set must be non-empty.
+  bool containsAny(OptionSet set) const {
+    assert((bool)set && "argument must be non-empty");
+    return (bool)((*this) & set);
   }
 
   // '==' and '!=' are deliberately not defined because they provide a pitfall

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -175,6 +175,7 @@ ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
       ModuleDecl::ImportedModule{ImportPath::Access(), mod});
 
   if (file) {
+    // Should include both SPI & non-SPI.
     file->getImportedModules(imports,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
@@ -260,6 +261,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
       ModuleDecl::ImportedModule{ImportPath::Access(), currentMod});
 
   if (auto *file = dyn_cast<FileUnit>(dc)) {
+    // Should include both SPI & non-SPI
     file->getImportedModules(stack,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -176,7 +176,7 @@ ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
 
   if (file) {
     file->getImportedModules(imports,
-                             {ModuleDecl::ImportFilterKind::Private,
+                             {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
                               ModuleDecl::ImportFilterKind::SPIAccessControl});
   }
@@ -261,7 +261,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
 
   if (auto *file = dyn_cast<FileUnit>(dc)) {
     file->getImportedModules(stack,
-                             {ModuleDecl::ImportFilterKind::Private,
+                             {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
                               ModuleDecl::ImportFilterKind::SPIAccessControl});
   }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1163,6 +1163,13 @@ void SourceFile::lookupPrecedenceGroupDirect(
 
 void ModuleDecl::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
                                     ModuleDecl::ImportFilter filter) const {
+  assert(filter.containsAny(ImportFilter({
+      ModuleDecl::ImportFilterKind::Exported,
+      ModuleDecl::ImportFilterKind::Default,
+      ModuleDecl::ImportFilterKind::ImplementationOnly}))
+    && "filter should have at least one of Exported|Private|ImplementationOnly"
+  );
+
   FORWARD(getImportedModules, (modules, filter));
 }
 
@@ -1187,10 +1194,11 @@ SourceFile::getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &modu
       requiredFilter |= ModuleDecl::ImportFilterKind::Exported;
     else if (desc.importOptions.contains(ImportFlags::ImplementationOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    else if (desc.importOptions.contains(ImportFlags::SPIAccessControl))
-      requiredFilter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
     else
       requiredFilter |= ModuleDecl::ImportFilterKind::Default;
+
+    if (desc.importOptions.contains(ImportFlags::SPIAccessControl))
+      requiredFilter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
 
     if (!separatelyImportedOverlays.lookup(desc.module.importedModule).empty())
       requiredFilter |= ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1184,16 +1184,16 @@ SourceFile::getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &modu
   for (auto desc : *Imports) {
     ModuleDecl::ImportFilter requiredFilter;
     if (desc.importOptions.contains(ImportFlags::Exported))
-      requiredFilter |= ModuleDecl::ImportFilterKind::Public;
+      requiredFilter |= ModuleDecl::ImportFilterKind::Exported;
     else if (desc.importOptions.contains(ImportFlags::ImplementationOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
     else if (desc.importOptions.contains(ImportFlags::SPIAccessControl))
       requiredFilter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
     else
-      requiredFilter |= ModuleDecl::ImportFilterKind::Private;
+      requiredFilter |= ModuleDecl::ImportFilterKind::Default;
 
     if (!separatelyImportedOverlays.lookup(desc.module.importedModule).empty())
-      requiredFilter |= ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay;
+      requiredFilter |= ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay;
 
     if (filter.contains(requiredFilter))
       modules.push_back(desc.module);
@@ -1445,8 +1445,8 @@ SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
   SmallVector<ModuleDecl::ImportedModule, 32> stack;
 
   ModuleDecl::ImportFilter filter = {
-      ModuleDecl::ImportFilterKind::Public,
-      ModuleDecl::ImportFilterKind::Private,
+      ModuleDecl::ImportFilterKind::Exported,
+      ModuleDecl::ImportFilterKind::Default,
       ModuleDecl::ImportFilterKind::SPIAccessControl};
 
   auto *topLevel = getParentModule();
@@ -1680,7 +1680,7 @@ ModuleDecl::getDeclaringModuleAndBystander() {
   SmallVector<ModuleDecl::ImportedModule, 16> furtherImported;
   ModuleDecl *overlayModule = this;
 
-  getImportedModules(imported, ModuleDecl::ImportFilterKind::Public);
+  getImportedModules(imported, ModuleDecl::ImportFilterKind::Exported);
   while (!imported.empty()) {
     ModuleDecl *importedModule = imported.back().importedModule;
     imported.pop_back();
@@ -1706,7 +1706,7 @@ ModuleDecl::getDeclaringModuleAndBystander() {
 
     furtherImported.clear();
     importedModule->getImportedModules(furtherImported,
-                                       ModuleDecl::ImportFilterKind::Public);
+                                       ModuleDecl::ImportFilterKind::Exported);
     imported.append(furtherImported.begin(), furtherImported.end());
   }
 
@@ -1988,10 +1988,10 @@ bool ModuleDecl::isImportedImplementationOnly(const ModuleDecl *module) const {
   // Look through non-implementation-only imports to see if module is imported
   // in some other way. Otherwise we assume it's implementation-only imported.
   ModuleDecl::ImportFilter filter = {
-    ModuleDecl::ImportFilterKind::Public,
-    ModuleDecl::ImportFilterKind::Private,
+    ModuleDecl::ImportFilterKind::Exported,
+    ModuleDecl::ImportFilterKind::Default,
     ModuleDecl::ImportFilterKind::SPIAccessControl,
-    ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay};
+    ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay};
   SmallVector<ModuleDecl::ImportedModule, 4> results;
   getImportedModules(results, filter);
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3443,14 +3443,14 @@ void ClangModuleUnit::getImportedModules(
 
   // [NOTE: Pure-Clang-modules-privately-import-stdlib]:
   // Needed for implicitly synthesized conformances.
-  if (filter.contains(ModuleDecl::ImportFilterKind::Private))
+  if (filter.contains(ModuleDecl::ImportFilterKind::Default))
     if (auto stdlib = owner.getStdlibModule())
       imports.push_back({ImportPath::Access(), stdlib});
 
   SmallVector<clang::Module *, 8> imported;
   if (!clangModule) {
     // This is the special "imported headers" module.
-    if (filter.contains(ModuleDecl::ImportFilterKind::Public)) {
+    if (filter.contains(ModuleDecl::ImportFilterKind::Exported)) {
       imported.append(owner.ImportedHeaderExports.begin(),
                       owner.ImportedHeaderExports.end());
     }
@@ -3458,11 +3458,11 @@ void ClangModuleUnit::getImportedModules(
   } else {
     clangModule->getExportedModules(imported);
 
-    if (filter.contains(ModuleDecl::ImportFilterKind::Private)) {
+    if (filter.contains(ModuleDecl::ImportFilterKind::Default)) {
       // Copy in any modules that are imported but not exported.
       llvm::SmallPtrSet<clang::Module *, 8> knownModules(imported.begin(),
                                                          imported.end());
-      if (!filter.contains(ModuleDecl::ImportFilterKind::Public)) {
+      if (!filter.contains(ModuleDecl::ImportFilterKind::Exported)) {
         // Remove the exported ones now that we're done with them.
         imported.clear();
       }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -116,7 +116,8 @@ static void printImports(raw_ostream &out,
 
     SmallVector<ModuleDecl::ImportedModule, 4> ioiImport;
     M->getImportedModules(ioiImport,
-                          ModuleDecl::ImportFilterKind::ImplementationOnly);
+                          {ModuleDecl::ImportFilterKind::ImplementationOnly,
+                           ModuleDecl::ImportFilterKind::SPIAccessControl});
     ioiImportSet.insert(ioiImport.begin(), ioiImport.end());
   }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -101,8 +101,8 @@ static void printImports(raw_ostream &out,
   // FIXME: This is very similar to what's in Serializer::writeInputBlock, but
   // it's not obvious what higher-level optimization would be factored out here.
   ModuleDecl::ImportFilter allImportFilter = {
-      ModuleDecl::ImportFilterKind::Public,
-      ModuleDecl::ImportFilterKind::Private,
+      ModuleDecl::ImportFilterKind::Exported,
+      ModuleDecl::ImportFilterKind::Default,
       ModuleDecl::ImportFilterKind::SPIAccessControl};
 
   // With -experimental-spi-imports:
@@ -128,7 +128,7 @@ static void printImports(raw_ostream &out,
   // Collect the public imports as a subset so that we can mark them with
   // '@_exported'.
   SmallVector<ModuleDecl::ImportedModule, 8> publicImports;
-  M->getImportedModules(publicImports, ModuleDecl::ImportFilterKind::Public);
+  M->getImportedModules(publicImports, ModuleDecl::ImportFilterKind::Exported);
   llvm::SmallSet<ModuleDecl::ImportedModule, 8,
                  ModuleDecl::OrderImportedModules> publicImportSet;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -305,11 +305,11 @@ static void getImmediateImports(
     ModuleDecl *module,
     SmallPtrSetImpl<ModuleDecl *> &imports,
     ModuleDecl::ImportFilter importFilter = {
-      ModuleDecl::ImportFilterKind::Public,
-      ModuleDecl::ImportFilterKind::Private,
+      ModuleDecl::ImportFilterKind::Exported,
+      ModuleDecl::ImportFilterKind::Default,
       ModuleDecl::ImportFilterKind::ImplementationOnly,
       ModuleDecl::ImportFilterKind::SPIAccessControl,
-      ModuleDecl::ImportFilterKind::ShadowedBySeparateOverlay
+      ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay
     }) {
   SmallVector<ModuleDecl::ImportedModule, 8> importList;
   module->getImportedModules(importList, importFilter);
@@ -507,7 +507,7 @@ bool ABIDependencyEvaluator::isOverlayOfClangModule(ModuleDecl *swiftModule) {
 
   llvm::SmallPtrSet<ModuleDecl *, 8> importList;
   ::getImmediateImports(swiftModule, importList,
-                        {ModuleDecl::ImportFilterKind::Public});
+                        {ModuleDecl::ImportFilterKind::Exported});
   bool isOverlay =
       llvm::any_of(importList, [&](ModuleDecl *importedModule) -> bool {
         return isClangOverlayOf(swiftModule, importedModule);
@@ -642,7 +642,7 @@ void ABIDependencyEvaluator::computeABIDependenciesForSwiftModule(
 
   SmallPtrSet<ModuleDecl *, 32> reexportedImports;
   ::getImmediateImports(module, reexportedImports,
-                        {ModuleDecl::ImportFilterKind::Public});
+                        {ModuleDecl::ImportFilterKind::Exported});
   for (auto reexportedImport: reexportedImports) {
     reexposeImportedABI(module, reexportedImport);
   }

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -80,8 +80,8 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
     if (!clangImporter->importBridgingHeader(implicitHeaderPath, mainModule)) {
       SmallVector<ModuleDecl::ImportedModule, 16> imported;
       clangImporter->getImportedHeaderModule()->getImportedModules(
-          imported, {ModuleDecl::ImportFilterKind::Public,
-                     ModuleDecl::ImportFilterKind::Private,
+          imported, {ModuleDecl::ImportFilterKind::Exported,
+                     ModuleDecl::ImportFilterKind::Default,
                      ModuleDecl::ImportFilterKind::ImplementationOnly,
                      ModuleDecl::ImportFilterKind::SPIAccessControl});
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2040,8 +2040,8 @@ public:
     SmallVector<ModuleDecl::ImportedModule, 16> FurtherImported;
     CurrDeclContext->getParentSourceFile()->getImportedModules(
         Imported,
-        {ModuleDecl::ImportFilterKind::Public,
-         ModuleDecl::ImportFilterKind::Private,
+        {ModuleDecl::ImportFilterKind::Exported,
+         ModuleDecl::ImportFilterKind::Default,
          ModuleDecl::ImportFilterKind::ImplementationOnly});
     while (!Imported.empty()) {
       ModuleDecl *MD = Imported.back().importedModule;
@@ -2050,7 +2050,7 @@ public:
         continue;
       FurtherImported.clear();
       MD->getImportedModules(FurtherImported,
-                             ModuleDecl::ImportFilterKind::Public);
+                             ModuleDecl::ImportFilterKind::Exported);
       Imported.append(FurtherImported.begin(), FurtherImported.end());
     }
   }
@@ -5993,8 +5993,8 @@ static void deliverCompletionResults(CodeCompletionContext &CompletionContext,
       // Add results for all imported modules.
       SmallVector<ModuleDecl::ImportedModule, 4> Imports;
       SF.getImportedModules(
-          Imports, {ModuleDecl::ImportFilterKind::Public,
-                    ModuleDecl::ImportFilterKind::Private,
+          Imports, {ModuleDecl::ImportFilterKind::Exported,
+                    ModuleDecl::ImportFilterKind::Default,
                     ModuleDecl::ImportFilterKind::ImplementationOnly});
 
       for (auto Imported : Imports) {

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -227,7 +227,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   // Carry over the private imports from the last module.
   SmallVector<ModuleDecl::ImportedModule, 8> imports;
   lastModule->getImportedModules(imports,
-                                 ModuleDecl::ImportFilterKind::Private);
+                                 ModuleDecl::ImportFilterKind::Default);
   for (auto &import : imports) {
     implicitImports.AdditionalModules.emplace_back(import.importedModule,
                                                    /*exported*/ false);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1843,8 +1843,8 @@ void IRGenDebugInfoImpl::finalize() {
   // from all ImportDecls).
   SmallVector<ModuleDecl::ImportedModule, 8> ModuleWideImports;
   IGM.getSwiftModule()->getImportedModules(
-      ModuleWideImports, {ModuleDecl::ImportFilterKind::Public,
-                          ModuleDecl::ImportFilterKind::Private,
+      ModuleWideImports, {ModuleDecl::ImportFilterKind::Exported,
+                          ModuleDecl::ImportFilterKind::Default,
                           ModuleDecl::ImportFilterKind::ImplementationOnly});
   for (auto M : ModuleWideImports)
     if (!ImportedModules.count(M.importedModule))

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -126,8 +126,8 @@ public:
   void
   getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &Modules) const {
     constexpr ModuleDecl::ImportFilter ImportFilter = {
-        ModuleDecl::ImportFilterKind::Public,
-        ModuleDecl::ImportFilterKind::Private,
+        ModuleDecl::ImportFilterKind::Exported,
+        ModuleDecl::ImportFilterKind::Default,
         ModuleDecl::ImportFilterKind::ImplementationOnly};
 
     if (auto *SF = SFOrMod.dyn_cast<SourceFile *>()) {
@@ -1599,9 +1599,9 @@ void IndexSwiftASTWalker::collectRecursiveModuleImports(
   }
 
   ModuleDecl::ImportFilter ImportFilter;
-  ImportFilter |= ModuleDecl::ImportFilterKind::Public;
-  ImportFilter |= ModuleDecl::ImportFilterKind::Private;
-  // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
+  ImportFilter |= ModuleDecl::ImportFilterKind::Exported;
+  ImportFilter |= ModuleDecl::ImportFilterKind::Default;
+  // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
   SmallVector<ModuleDecl::ImportedModule, 8> Imports;
   TopMod.getImportedModules(Imports);
 

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -581,8 +581,8 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   }
 
   SmallVector<ModuleDecl::ImportedModule, 8> imports;
-  module->getImportedModules(imports, {ModuleDecl::ImportFilterKind::Public,
-                                       ModuleDecl::ImportFilterKind::Private});
+  module->getImportedModules(imports, {ModuleDecl::ImportFilterKind::Exported,
+                                       ModuleDecl::ImportFilterKind::Default});
   StringScratchSpace moduleNameScratch;
   addModuleDependencies(imports, indexStorePath, indexSystemModules, skipStdlib,
                         targetTriple, clangCI, diags, unitWriter,
@@ -621,8 +621,8 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
   // Module dependencies.
   SmallVector<ModuleDecl::ImportedModule, 8> imports;
   primarySourceFile->getImportedModules(
-      imports, {ModuleDecl::ImportFilterKind::Public,
-                ModuleDecl::ImportFilterKind::Private,
+      imports, {ModuleDecl::ImportFilterKind::Exported,
+                ModuleDecl::ImportFilterKind::Default,
                 ModuleDecl::ImportFilterKind::ImplementationOnly});
   StringScratchSpace moduleNameScratch;
   addModuleDependencies(imports, indexStorePath, indexSystemModules, skipStdlib,

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1173,7 +1173,7 @@ void ImportResolver::addCrossImportableModules(ImportedModuleDesc importDesc) {
 
     // Add the module's re-exports to worklist.
     nextImport.importedModule->getImportedModules(
-        importsWorklist, ModuleDecl::ImportFilterKind::Public);
+        importsWorklist, ModuleDecl::ImportFilterKind::Exported);
   }
 }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -427,7 +427,7 @@ void ModuleFile::getImportedModules(
 
   for (auto &dep : Dependencies) {
     if (dep.isExported()) {
-      if (!filter.contains(ModuleDecl::ImportFilterKind::Public))
+      if (!filter.contains(ModuleDecl::ImportFilterKind::Exported))
         continue;
 
     } else if (dep.isImplementationOnly()) {
@@ -440,7 +440,7 @@ void ModuleFile::getImportedModules(
       }
 
     } else {
-      if (!filter.contains(ModuleDecl::ImportFilterKind::Private))
+      if (!filter.contains(ModuleDecl::ImportFilterKind::Default))
         continue;
     }
 

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -824,9 +824,9 @@ getActualImportControl(unsigned rawValue) {
   // values.
   switch (rawValue) {
   case static_cast<unsigned>(serialization::ImportControl::Normal):
-    return ModuleDecl::ImportFilterKind::Private;
+    return ModuleDecl::ImportFilterKind::Default;
   case static_cast<unsigned>(serialization::ImportControl::Exported):
-    return ModuleDecl::ImportFilterKind::Public;
+    return ModuleDecl::ImportFilterKind::Exported;
   case static_cast<unsigned>(serialization::ImportControl::ImplementationOnly):
     return ModuleDecl::ImportFilterKind::ImplementationOnly;
   default:

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -112,12 +112,12 @@ public:
 
    static Dependency forHeader(StringRef headerPath, bool exported) {
      auto importControl =
-         exported ? ImportFilterKind::Public : ImportFilterKind::Private;
+         exported ? ImportFilterKind::Exported : ImportFilterKind::Default;
      return Dependency(headerPath, StringRef(), true, importControl, false);
     }
 
     bool isExported() const {
-      return getImportControl() == ImportFilterKind::Public;
+      return getImportControl() == ImportFilterKind::Exported;
     }
     bool isImplementationOnly() const {
       return getImportControl() == ImportFilterKind::ImplementationOnly;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1039,7 +1039,11 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   ImportSet privateImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Default);
   ImportSet spiImportSet =
-      getImportsAsSet(M, ModuleDecl::ImportFilterKind::SPIAccessControl);
+      getImportsAsSet(M, {
+          ModuleDecl::ImportFilterKind::Exported,
+          ModuleDecl::ImportFilterKind::Default,
+          ModuleDecl::ImportFilterKind::SPIAccessControl
+      });
 
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1026,8 +1026,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
 
   SmallVector<ModuleDecl::ImportedModule, 8> allImports;
   M->getImportedModules(allImports,
-                        {ModuleDecl::ImportFilterKind::Public,
-                         ModuleDecl::ImportFilterKind::Private,
+                        {ModuleDecl::ImportFilterKind::Exported,
+                         ModuleDecl::ImportFilterKind::Default,
                          ModuleDecl::ImportFilterKind::ImplementationOnly,
                          ModuleDecl::ImportFilterKind::SPIAccessControl});
   ModuleDecl::removeDuplicateImports(allImports);
@@ -1035,9 +1035,9 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   // Collect the public and private imports as a subset so that we can
   // distinguish them.
   ImportSet publicImportSet =
-      getImportsAsSet(M, ModuleDecl::ImportFilterKind::Public);
+      getImportsAsSet(M, ModuleDecl::ImportFilterKind::Exported);
   ImportSet privateImportSet =
-      getImportsAsSet(M, ModuleDecl::ImportFilterKind::Private);
+      getImportsAsSet(M, ModuleDecl::ImportFilterKind::Default);
   ImportSet spiImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::SPIAccessControl);
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1110,8 +1110,8 @@ void SerializedASTFile::getImportedModules(
 void SerializedASTFile::collectLinkLibrariesFromImports(
     ModuleDecl::LinkLibraryCallback callback) const {
   llvm::SmallVector<ModuleDecl::ImportedModule, 8> Imports;
-  File.getImportedModules(Imports, {ModuleDecl::ImportFilterKind::Public,
-                                    ModuleDecl::ImportFilterKind::Private});
+  File.getImportedModules(Imports, {ModuleDecl::ImportFilterKind::Exported,
+                                    ModuleDecl::ImportFilterKind::Default});
 
   for (auto Import : Imports)
     Import.importedModule->collectLinkLibraries(callback);

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -353,10 +353,10 @@ ImportDepth::ImportDepth(ASTContext &context,
 
   // Private imports from this module.
   // FIXME: only the private imports from the current source file.
-  // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
+  // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
   SmallVector<ModuleDecl::ImportedModule, 16> mainImports;
   main->getImportedModules(mainImports,
-                           {ModuleDecl::ImportFilterKind::Private,
+                           {ModuleDecl::ImportFilterKind::Default,
                             ModuleDecl::ImportFilterKind::ImplementationOnly});
   for (auto &import : mainImports) {
     uint8_t depth = 1;

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -747,13 +747,13 @@ static void collectModuleDependencies(ModuleDecl *TopMod,
   auto ClangModuleLoader = TopMod->getASTContext().getClangModuleLoader();
 
   ModuleDecl::ImportFilter ImportFilter = {
-      ModuleDecl::ImportFilterKind::Public,
-      ModuleDecl::ImportFilterKind::Private};
+      ModuleDecl::ImportFilterKind::Exported,
+      ModuleDecl::ImportFilterKind::Default};
   if (Visited.empty()) {
     // Only collect implementation-only dependencies from the main module.
     ImportFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
   }
-  // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
+  // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
   SmallVector<ModuleDecl::ImportedModule, 8> Imports;
   TopMod->getImportedModules(Imports, ImportFilter);
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3185,8 +3185,8 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
 
       scratch.clear();
       next.importedModule->getImportedModules(
-          scratch, ModuleDecl::ImportFilterKind::Public);
-      // FIXME: ImportFilterKind::ShadowedBySeparateOverlay?
+          scratch, ModuleDecl::ImportFilterKind::Exported);
+      // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
       for (auto &import : scratch) {
         llvm::outs() << "\t" << import.importedModule->getName();
         for (auto accessPathPiece : import.accessPath) {


### PR DESCRIPTION
Ran into surprising behavior with `SourceFile::getImportedModules` when working on https://github.com/apple/swift/pull/33980, figured I should land this first.

I don't understand why `ModuleFile::getImportedModules` doesn't have handling for `SPI`/`ShadowedByCrossImportOverlay` though, so I haven't touched it.