### PR TITLE
Specify Float80 as supported on OpenBSD.

### DIFF
--- a/include/swift/Runtime/SwiftDtoa.h
+++ b/include/swift/Runtime/SwiftDtoa.h
@@ -33,7 +33,7 @@
  #undef SWIFT_DTOA_FLOAT80_SUPPORT
 #elif defined(__ANDROID__)
  // At least for now Float80 is disabled. See: https://github.com/apple/swift/pull/25502
-#elif defined(__APPLE__) || defined(__linux__)
+#elif defined(__APPLE__) || defined(__linux__) || defined(__OpenBSD__)
  // macOS and Linux support Float80 on X86 hardware but not on ARM
  #if defined(__x86_64__) || defined(__i386)
   #define SWIFT_DTOA_FLOAT80_SUPPORT 1


### PR DESCRIPTION
This fixes unit test `stdlib/PrintFloat.swift.gyb` on OpenBSD.