### PR TITLE
Adjust tabstop and shiftwidth on File Type Plugin for vim

### DIFF
--- a/utils/vim/ftplugin/swift.vim
+++ b/utils/vim/ftplugin/swift.vim
@@ -8,6 +8,6 @@
 
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
 setlocal expandtab
-setlocal ts=2
-setlocal sw=2
+setlocal ts=4
+setlocal sw=4
 setlocal smartindent


### PR DESCRIPTION
<!-- What's in this pull request? -->
The tabstop and shiftwidth configurations for vim are wrong. This PR fix those attributes.

Previous values
```
setlocal ts=2
setlocal sw=2
```

New values
```
setlocal ts=4
setlocal sw=4
```
