### PR TITLE
[Conformance checker] Capture potential matches for missing witnesses.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -197,6 +197,16 @@ public:
 
 class SILLayout; // From SIL
 
+/// A set of missing witnesses for a given conformance. These are temporarily
+/// stashed in the ASTContext so the type checker can get at them.
+///
+/// The only subclass is owned by the type checker, so it can hide its own
+/// data structures.
+class MissingWitnessesBase {
+public:
+  virtual ~MissingWitnessesBase();
+};
+
 /// ASTContext - This object creates and owns the AST objects.
 /// However, this class does more than just maintain context within an AST.
 /// It is the closest thing to thread-local or compile-local storage in this
@@ -943,12 +953,13 @@ public:
   takeDelayedConformanceDiags(NormalProtocolConformance *conformance);
 
   /// Add delayed missing witnesses for the given normal protocol conformance.
-  void addDelayedMissingWitnesses(NormalProtocolConformance *conformance,
-                                  ArrayRef<ValueDecl*> witnesses);
+  void addDelayedMissingWitnesses(
+      NormalProtocolConformance *conformance,
+      std::unique_ptr<MissingWitnessesBase> missingWitnesses);
 
   /// Retrieve the delayed missing witnesses for the given normal protocol
   /// conformance.
-  std::vector<ValueDecl*>
+  std::unique_ptr<MissingWitnessesBase>
   takeDelayedMissingWitnesses(NormalProtocolConformance *conformance);
 
   /// Produce a specialized conformance, which takes a generic

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -298,7 +298,8 @@ struct ASTContext::Implementation {
   /// Map from normal protocol conformances to missing witnesses that have
   /// been delayed until the conformance is fully checked, so that we can
   /// issue a fixit that fills the entire protocol stub.
-  llvm::DenseMap<NormalProtocolConformance *, std::vector<ValueDecl*>>
+  llvm::DenseMap<
+      NormalProtocolConformance *, std::unique_ptr<MissingWitnessesBase>>
     DelayedMissingWitnesses;
 
   /// Stores information about lazy deserialization of various declarations.
@@ -2129,22 +2130,24 @@ bool ASTContext::hasDelayedConformanceErrors() const {
   return false;
 }
 
+MissingWitnessesBase::~MissingWitnessesBase() { }
+
 void ASTContext::addDelayedConformanceDiag(
        NormalProtocolConformance *conformance,
        DelayedConformanceDiag fn) {
   getImpl().DelayedConformanceDiags[conformance].push_back(std::move(fn));
 }
 
-void ASTContext::
-addDelayedMissingWitnesses(NormalProtocolConformance *conformance,
-                           ArrayRef<ValueDecl*> witnesses) {
-  auto &bucket = getImpl().DelayedMissingWitnesses[conformance];
-  bucket.insert(bucket.end(), witnesses.begin(), witnesses.end());
+void ASTContext::addDelayedMissingWitnesses(
+    NormalProtocolConformance *conformance,
+    std::unique_ptr<MissingWitnessesBase> missingWitnesses) {
+  getImpl().DelayedMissingWitnesses[conformance] = std::move(missingWitnesses);
 }
 
-std::vector<ValueDecl*> ASTContext::
-takeDelayedMissingWitnesses(NormalProtocolConformance *conformance) {
-  std::vector<ValueDecl*> result;
+std::unique_ptr<MissingWitnessesBase>
+ASTContext::takeDelayedMissingWitnesses(
+    NormalProtocolConformance *conformance) {
+  std::unique_ptr<MissingWitnessesBase> result;
   auto known = getImpl().DelayedMissingWitnesses.find(conformance);
   if (known != getImpl().DelayedMissingWitnesses.end()) {
     result = std::move(known->second);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2864,7 +2864,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   {
     llvm::SmallString<128> Text;
     llvm::raw_svector_ostream SS(Text);
-    llvm::SetVector<ValueDecl *> missingWitnesses;
+    llvm::SetVector<MissingWitness> missingWitnesses;
     for (auto protocol : missingProtocols) {
       auto conformance = NormalProtocolConformance(
           nominal->getDeclaredType(), protocol, SourceLoc(), nominal,
@@ -2876,7 +2876,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
     }
 
     for (auto decl : missingWitnesses) {
-      swift::printRequirementStub(decl, nominal, nominal->getDeclaredType(),
+      swift::printRequirementStub(decl.requirement, nominal, nominal->getDeclaredType(),
                                   nominal->getStartLoc(), SS);
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3800,8 +3800,7 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDefault(
     recordOptionalWitness(requirement);
     return ResolveWitnessResult::Success;
   }
-  // Save the missing requirement for later diagnosis.
-  GlobalMissingWitnesses.insert({requirement, {}});
+
   return ResolveWitnessResult::ExplicitFailed;
 }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -643,6 +643,31 @@ enum class MissingWitnessDiagnosisKind {
 class AssociatedTypeInference;
 class MultiConformanceChecker;
 
+/// Describes a missing witness during conformance checking.
+class MissingWitness {
+public:
+  /// The requirement that is missing a witness.
+  ValueDecl *requirement;
+
+  /// The set of potential matching witnesses.
+  std::vector<RequirementMatch> matches;
+
+  MissingWitness(ValueDecl *requirement,
+                 ArrayRef<RequirementMatch> matches)
+    : requirement(requirement),
+      matches(matches.begin(), matches.end()) { }
+};
+
+/// Capture missing witnesses that have been delayed and will be stored
+/// in the ASTContext for later.
+class DelayedMissingWitnesses : public MissingWitnessesBase {
+public:
+  std::vector<MissingWitness> missingWitnesses;
+
+  DelayedMissingWitnesses(ArrayRef<MissingWitness> missingWitnesses)
+      : missingWitnesses(missingWitnesses.begin(), missingWitnesses.end()) { }
+};
+
 /// The protocol conformance checker.
 ///
 /// This helper class handles most of the details of checking whether a
@@ -665,7 +690,7 @@ class ConformanceChecker : public WitnessChecker {
   /// Keep track of missing witnesses, either type or value, for later
   /// diagnosis emits. This may contain witnesses that are external to the
   /// protocol under checking.
-  llvm::SetVector<ValueDecl*> &GlobalMissingWitnesses;
+  llvm::SetVector<MissingWitness> &GlobalMissingWitnesses;
 
   /// Keep track of the slice in GlobalMissingWitnesses that is local to
   /// this protocol under checking.
@@ -746,7 +771,7 @@ class ConformanceChecker : public WitnessChecker {
          ValueDecl *requirement, bool isError,
          std::function<void(NormalProtocolConformance *)> fn);
 
-  ArrayRef<ValueDecl*> getLocalMissingWitness() {
+  ArrayRef<MissingWitness> getLocalMissingWitness() {
     return GlobalMissingWitnesses.getArrayRef().
       slice(LocalMissingWitnessesStartIndex,
             GlobalMissingWitnesses.size() - LocalMissingWitnessesStartIndex);
@@ -764,7 +789,7 @@ public:
   void emitDelayedDiags();
 
   ConformanceChecker(ASTContext &ctx, NormalProtocolConformance *conformance,
-                     llvm::SetVector<ValueDecl *> &GlobalMissingWitnesses,
+                     llvm::SetVector<MissingWitness> &GlobalMissingWitnesses,
                      bool suppressDiagnostics = true);
 
   /// Resolve all of the type witnesses.
@@ -1030,4 +1055,26 @@ void diagnoseConformanceFailure(Type T,
 
 }
 
+namespace llvm {
+
+template<>
+struct DenseMapInfo<swift::MissingWitness> {
+  using MissingWitness = swift::MissingWitness;
+  using RequirementPointerTraits = DenseMapInfo<swift::ValueDecl *>;
+
+  static inline MissingWitness getEmptyKey() {
+    return MissingWitness(RequirementPointerTraits::getEmptyKey(), {});
+  }
+  static inline MissingWitness getTombstoneKey() {
+    return MissingWitness(RequirementPointerTraits::getTombstoneKey(), {});
+  }
+  static inline unsigned getHashValue(MissingWitness missing) {
+    return RequirementPointerTraits::getHashValue(missing.requirement);
+  }
+  static bool isEqual(MissingWitness a, MissingWitness b) {
+    return a.requirement == b.requirement;
+  }
+};
+
+}
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -2010,8 +2010,10 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
     return None;
 
   // Save the missing type witnesses for later diagnosis.
-  checker.GlobalMissingWitnesses.insert(unresolvedAssocTypes.begin(),
-                                        unresolvedAssocTypes.end());
+  for (auto assocType : unresolvedAssocTypes) {
+    checker.GlobalMissingWitnesses.insert({assocType, {}});
+  }
+
   return None;
 }
 


### PR DESCRIPTION
Rework the data structures we use in the conformance checker to talk
about missing witnesses, so they can capture the set of potential
matches. This will allow us to delay more diagnostics to later,
more uniformly.