### PR TITLE
[TF] Fix `Optional` completion tests.

### DIFF
--- a/test/IDE/complete_generic_optional.swift
+++ b/test/IDE/complete_generic_optional.swift
@@ -11,7 +11,7 @@ struct Foo<T> {
 // SR-642 Code completion does not instantiate generic arguments of a type wrapped in an optional
 let x: Foo<Bar>? = Foo<Bar>()
 x.#^FOO_OPTIONAL_1^#
-// FOO_OPTIONAL_1: Begin completions, 7 items
+// FOO_OPTIONAL_1: Begin completions, 13 items
 // FOO_OPTIONAL_1-DAG: Decl[InstanceMethod]/CurrNominal/Erase[1]: ?.myFunction({#(foobar): Bar#})[#Void#]; name=myFunction(foobar: Bar)
 // FOO_OPTIONAL_1-DAG: Keyword[self]/CurrNominal: self[#Foo<Bar>?#]; name=self
 // FOO_OPTIONAL_1: End completions

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -644,7 +644,7 @@ func testGuardCase(x:FooStruct?) {
 // FOOSTRUCT_LOCALVAL-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Convertible\])?}}: boundVal[#FooStruct#];
 // FOOSTRUCT_LOCALVAL: End completions
 
-// OPTIONAL_FOOSTRUCT: Begin completions, 9 items
+// OPTIONAL_FOOSTRUCT: Begin completions, 21 items
 // OPTIONAL_FOOSTRUCT-DAG: Keyword[nil]/None/Erase[1]:         nil[#FooStruct?#]; name=nil
 // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem: none[#Optional<FooStruct>#]; name=none
 // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem: some({#FooStruct#})[#Optional<FooStruct>#]; name=some(FooStruct)

--- a/test/IDE/complete_swift_key_path_optional_root.swift
+++ b/test/IDE/complete_swift_key_path_optional_root.swift
@@ -19,7 +19,7 @@ extension Optional {
 }
 
 let _ : KeyPath<Person?, String> = \.#^TYPE_INFER_DOT_OPTIONAL^#
-// PERSONTYPE-INFER-DOT-OPT: Begin completions, 9 items
+// PERSONTYPE-INFER-DOT-OPT: Begin completions, 11 items
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.name[#String#]; name=name
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.friends[#[Person]#]; name=friends
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.bestFriend[#Person?#]; name=bestFriend
@@ -27,11 +27,12 @@ let _ : KeyPath<Person?, String> = \.#^TYPE_INFER_DOT_OPTIONAL^#
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[Subscript]/CurrNominal:     ?[{#(index): Int#}][#Int#]; name=[index: Int]
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:            optMember[#String#]; name=optMember
+// PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem: allKeyPaths[#[PartialKeyPath<Optional<Person>>]#]; name=allKeyPaths
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   debugDescription[#String#]; name=debugDescription
 // PERSONTYPE-INFER-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   customMirror[#Mirror#]; name=customMirror
 
 let _ : KeyPath<Person?, String> = \Person?.#^TYPE_DOT_OPTIONAL^#
-// PERSONTYPE-DOT-OPT: Begin completions, 9 items
+// PERSONTYPE-DOT-OPT: Begin completions, 11 items
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.name[#String#]; name=name
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.friends[#[Person]#]; name=friends
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:   ?.bestFriend[#Person?#]; name=bestFriend
@@ -39,11 +40,12 @@ let _ : KeyPath<Person?, String> = \Person?.#^TYPE_DOT_OPTIONAL^#
 // PERSONTYPE-DOT-OPT-NEXT: Decl[Subscript]/CurrNominal:     ?[{#(index): Int#}][#Int#]; name=[index: Int]
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal:            optMember[#String#]; name=optMember
+// PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem: allKeyPaths[#[PartialKeyPath<Optional<Person>>]#]; name=allKeyPaths
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   debugDescription[#String#]; name=debugDescription
 // PERSONTYPE-DOT-OPT-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   customMirror[#Mirror#]; name=customMirror
 
 let _ : KeyPath<Person?, String> = \Person?. #^TYPE_DOT_OPTIONAL_SPACE^#
-// PERSONTYPE-DOT-OPT-SPACE: Begin completions, 9 items
+// PERSONTYPE-DOT-OPT-SPACE: Begin completions, 11 items
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.name[#String#]; name=name
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.friends[#[Person]#]; name=friends
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]:   ?.bestFriend[#Person?#]; name=bestFriend
@@ -51,5 +53,6 @@ let _ : KeyPath<Person?, String> = \Person?. #^TYPE_DOT_OPTIONAL_SPACE^#
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[Subscript]/CurrNominal/Erase[1]:     ?[{#(index): Int#}][#Int#]; name=[index: Int]
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   unsafelyUnwrapped[#Person#]; name=unsafelyUnwrapped
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal:            optMember[#String#]; name=optMember
+// PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem: allKeyPaths[#[PartialKeyPath<Optional<Person>>]#]; name=allKeyPaths
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   debugDescription[#String#]; name=debugDescription
 // PERSONTYPE-DOT-OPT-SPACE-NEXT: Decl[InstanceVar]/CurrNominal/IsSystem:   customMirror[#Mirror#]; name=customMirror

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -294,7 +294,7 @@ class C4 {
 // UNRESOLVED_3_NOTIDEAL-NOT: none
 // UNRESOLVED_3_NOTIDEAL-NOT: some(
 
-// UNRESOLVED_3_OPT: Begin completions, 9 items
+// UNRESOLVED_3_OPT: Begin completions, 21 items
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
@@ -307,7 +307,7 @@ class C4 {
 // UNRESOLVED_3_OPT-NOT: init({#nilLiteral:
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1>#})[#(into: inout Hasher) -> Void#];
 
-// UNRESOLVED_3_OPTOPTOPT: Begin completions, 9 items
+// UNRESOLVED_3_OPTOPTOPT: Begin completions, 21 items
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
@@ -329,7 +329,7 @@ extension Optional where Wrapped == Somewhere {
 }
 func testOptionalWithCustomExtension() {
   var _: Somewhere? = .#^UNRESOLVED_OPT_4^#
-// UNRESOLVED_OPT_4: Begin completions, 11 items
+// UNRESOLVED_OPT_4: Begin completions, 23 items
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]:     earth[#Somewhere#];
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]:     mars[#Somewhere#];
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Somewhere#})[#(into: inout Hasher) -> Void#];


### PR DESCRIPTION
Adding `KeyPathIterable` conformance to `Optional` changes the code completions for optional members.

---

Follow-up fix to https://github.com/apple/swift/pull/33992.