### PR TITLE
[windows] Use update-checkout in build-windows.bat

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -14,6 +14,7 @@
 :: Additionally, it needs the following variables:
 :: - CMAKE_BUILD_TYPE: Kind of build: Release, RelWithDebInfo, Debug.
 :: - PYTHON_HOME: The Python installation directory.
+:: - REPO_SCHEME: Optional. The scheme name to checkout.
 
 :: REQUIRED PERMISSIONS
 :: Practically, it is easier to be in the Adminstrators group to run the
@@ -24,6 +25,8 @@
 :: @echo off
 
 setlocal enableextensions enabledelayedexpansion
+
+PATH=%PATH%;%PYTHON_HOME%
 
 set icu_version_major=64
 set icu_version_minor=2
@@ -53,7 +56,7 @@ set install_directory=%build_root%\Library\Developer\Toolchains\unknown-Asserts-
 md %build_root%\tmp
 set TMPDIR=%build_root%\tmp
 
-md %build_root%\tmp\org.llvm.clang
+md %build_root%\tmp\org.llvm.clang.9999
 set CUSTOM_CLANG_MODULE_CACHE=%build_root%\tmp\org.llvm.clang.9999
 
 md %build_root%\tmp\org.swift.package-manager
@@ -89,20 +92,33 @@ endlocal
 :: It supposes the %CD% is the source root.
 setlocal enableextensions enabledelayedexpansion
 
+if defined REPO_SCHEME SET "scheme_arg=--scheme %REPO_SCHEME%"
+
 git -C "%source_root%\swift" config --local core.autocrlf input
 git -C "%source_root%\swift" config --local core.symlink true
 git -C "%source_root%\swift" checkout-index --force --all
 
-git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %exitOnError%
-git clone --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project llvm-project %exitOnError%
-mklink /D "%source_root%\clang" "%source_root%\llvm-project\clang"
-mklink /D "%source_root%\llvm" "%source_root%\llvm-project\llvm"
-mklink /D "%source_root%\lld" "%source_root%\llvm-project\lld"
-mklink /D "%source_root%\lldb" "%source_root%\llvm-project\lldb"
-mklink /D "%source_root%\compiler-rt" "%source_root%\llvm-project\compiler-rt"
-mklink /D "%source_root%\libcxx" "%source_root%\llvm-project\libcxx"
-mklink /D "%source_root%\clang-tools-extra" "%source_root%\llvm-project\clang-tools-extra"
-git clone --depth 1 --single-branch https://github.com/apple/swift-corelibs-libdispatch %exitOnError%
+:: Always skip Swift, since it is checked out by Jenkins
+@set "skip_repositories_arg=--skip-repository swift"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository llbuild"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository indexstore-db"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository ninja"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository sourcekit-lsp"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-argument-parser"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-corelibs-foundation"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-corelibs-xctest"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-driver"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-format"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-integration-tests"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swiftpm"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-stress-tester"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-syntax"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-tools-support-core"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository swift-xcode-playground-support"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository tensorflow-swift-apis"
+@set "skip_repositories_arg=%skip_repositories_arg% --skip-repository yams"
+
+call "%source_root%\swift\utils\update-checkout.cmd" %scheme_arg% %skip_repositories_arg% --clone --skip-history --github-comment "%ghprbCommentBody%" >NUL 2>NUL
 
 goto :eof
 endlocal
@@ -185,7 +201,7 @@ cmake^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
-    -S "%source_root%\llvm" %exitOnError%
+    -S "%source_root%\llvm-project\llvm" %exitOnError%
 
 cmake --build "%build_root%\llvm" %exitOnError%
 cmake --build "%build_root%\llvm" --target install %exitOnError%
@@ -294,7 +310,7 @@ cmake^
     -DLLDB_DISABLE_PYTHON=YES^
     -DLLDB_INCLUDE_TESTS:BOOL=NO^
     -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON^
-    -S "%source_root%\lldb" %exitOnError%
+    -S "%source_root%\llvm-project\lldb" %exitOnError%
 
 cmake --build "%build_root%\lldb" %exitOnError%
 cmake --build "%build_root%\lldb" --target install %exitOnError%


### PR DESCRIPTION
- Skip the creation of symlinks for the LLVM subprojects. Not needed anymore.
- Use `update-checkout.cmd` instead of manually checking out git repositories.
  - Instead of the focused subset of repositories, `update-checkout` will check all of them, which is not ideal, but the machine network connection is good, so it should not add a lot of delay.
  - The repositories, however, are cloned without history, which should improve download a little.
- Accept new environment variable `REPO_SCHEME` which is passed to update-checkout to be able to use this script for different branches by only changing an enironment variable in the CI server job configuration. By default uses `master` (which will need to be changed soon).
- Pass the environment variable `ghprbCommentBody` as a `--github-comment` argument of `update-checkout`, which should checkout the provided PR from GitHub.
- Fix the creation of the Clang module cache temporal directory.
- Add `PYTHON_HOME` to the path, just in case it is not already there.

@compnerd: check if the change around `CUSTOM_CLANG_MODULE_CACHE` makes sense, or was intentional. I can discard that line.

@shahmishal: This is difficult to check by myself, so accept my apologies if something goes wrong. The `REPO_SCHEME` change is something that would need to be changed in the Jenkins configuration (the same that we set `CMAKE_BUILD_TYPE` and `PYTHON_HOME`). With the current default no changes are necessary, but after the 22nd it should be provided (and/or default changed in the script). If I understand Jenkins documentation correctly `ghprbCommentBody` should be provided automatically to the PR builds (we can create a bogus PR in some other repository if we want to check before merging).

Deals with https://bugs.swift.org/browse/SR-13565