### PR TITLE
[Concurrency] Introduce `@actorIndependent` attribute.

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+SWIFT_TYPEID(ActorIsolation)
 SWIFT_TYPEID(AncestryFlags)
 SWIFT_TYPEID(CtorInitializerKind)
 SWIFT_TYPEID(FunctionBuilderBodyPreCheck)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -23,6 +23,7 @@
 namespace swift {
 
 class AbstractFunctionDecl;
+class ActorIsolation;
 class BraceStmt;
 class ClosureExpr;
 class CodeCompletionCallbacksFactory;

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -1,0 +1,111 @@
+//===--- ActorIsolation.h - Actor isolation ---------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides a description of actor isolation state.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_AST_ACTORISOLATIONSTATE_H
+#define SWIFT_AST_ACTORISOLATIONSTATE_H
+
+#include "llvm/ADT/Hashing.h"
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace swift {
+class ClassDecl;
+
+/// Describes the actor isolation of a given declaration, which determines
+/// the actors with which it can interact.
+class ActorIsolation {
+public:
+  enum Kind {
+    /// The actor isolation has not been specified. It is assumed to be
+    /// unsafe to interact with this declaration from any actor.
+    Unspecified = 0,
+    /// The declaration is isolated to the instance of an actor class.
+    /// For example, a mutable stored property or synchronous function within
+    /// the actor is isolated to the instance of that actor.
+    ActorInstance,
+    /// The declaration can refer to actor-isolated state, but can also be
+    //// referenced from outside the actor.
+    ActorPrivileged,
+    /// The declaration is explicitly specified to be independent of any actor,
+    /// meaning that it can be used from any actor but is also unable to
+    /// refer to the isolated state of any given actor.
+    Independent,
+  };
+
+private:
+  Kind kind;
+  ClassDecl *actor;
+
+  ActorIsolation(Kind kind, ClassDecl *actor) : kind(kind), actor(actor) { }
+
+public:
+  static ActorIsolation forUnspecified() {
+    return ActorIsolation(Unspecified, nullptr);
+  }
+
+  static ActorIsolation forIndependent() {
+    return ActorIsolation(Independent, nullptr);
+  }
+
+  static ActorIsolation forActorPrivileged(ClassDecl *actor) {
+    return ActorIsolation(ActorPrivileged, actor);
+  }
+
+  static ActorIsolation forActorInstance(ClassDecl *actor) {
+    return ActorIsolation(ActorInstance, actor);
+  }
+
+  Kind getKind() const { return kind; }
+
+  operator Kind() const { return getKind(); }
+
+  ClassDecl *getActor() const {
+    assert(getKind() == ActorInstance || getKind() == ActorPrivileged);
+    return actor;
+  }
+
+  friend bool operator==(const ActorIsolation &lhs,
+                         const ActorIsolation &rhs) {
+    if (lhs.kind != rhs.kind)
+      return false;
+
+    switch (lhs.kind) {
+    case Independent:
+    case Unspecified:
+      return true;
+
+    case ActorInstance:
+    case ActorPrivileged:
+      return lhs.actor == rhs.actor;
+    }
+  }
+
+  friend bool operator!=(const ActorIsolation &lhs,
+                         const ActorIsolation &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend llvm::hash_code hash_value(const ActorIsolation &state) {
+    return llvm::hash_combine(state.kind, state.actor);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out, const ActorIsolation &state);
+
+} // end namespace swift
+
+#endif /* SWIFT_AST_ACTORISOLATIONSTATE_H */

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -562,7 +562,7 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   100)
 
 SIMPLE_DECL_ATTR(asyncHandler, AsyncHandler,
-  OnFunc | UserInaccessible |
+  OnFunc | ConcurrencyOnly |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   101)
 

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -572,6 +572,12 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
   APIBreakingToAdd | APIBreakingToRemove,
   102)
 
+SIMPLE_DECL_ATTR(actorIndependent, ActorIndependent,
+  OnFunc | OnVar | OnSubscript | ConcurrencyOnly |
+  ABIStableToAdd | ABIStableToRemove |
+  APIStableToAdd | APIBreakingToRemove,
+  103)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1748,6 +1748,11 @@ ERROR(pound_available_package_description_not_allowed, none,
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))
 
+ERROR(attr_requires_concurrency,none,
+      "'%0' %select{attribute|modifier}1 is only valid when experimental "
+      "concurrency is enabled",
+      (StringRef, bool))
+
 //------------------------------------------------------------------------------
 // MARK: syntax parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4107,9 +4107,6 @@ NOTE(protocol_witness_async_conflict,none,
 ERROR(async_autoclosure_nonasync_function,none,
       "'async' autoclosure parameter in a non-'async' function", ())
 
-ERROR(asynchandler_attr_requires_concurrency,none,
-      "'@asyncHandler' is only valid when experimental concurrency is enabled",
-      ())
 ERROR(asynchandler_non_func,none,
       "'@asyncHandler' can only be applied to functions",
       ())
@@ -4142,8 +4139,6 @@ ERROR(satisfy_async_objc,none,
 ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
 
-ERROR(actor_without_concurrency,none,
-      "'actor' classes require experimental concurrency support", ())
 ERROR(actor_with_nonactor_superclass,none,
       "actor class cannot inherit from non-actor class %0", (DeclName))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4146,6 +4146,10 @@ ERROR(actor_isolated_non_self_reference,none,
         "actor-isolated %0 %1 can only be referenced "
         "%select{inside the actor|on 'self'}2",
         (DescriptiveDeclKind, DeclName, bool))
+ERROR(actor_isolated_self_independent_context,none,
+        "actor-isolated %0 %1 can not be referenced from an "
+        "'@actorIndependent' context",
+        (DescriptiveDeclKind, DeclName))
 WARNING(concurrent_access_local,none,
         "local %0 %1 is unsafe to reference in code that may execute "
         "concurrently",
@@ -4169,6 +4173,24 @@ NOTE(actor_isolated_witness_could_be_async_handler,none,
      "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement; "
      "did you mean to make it an asychronous handler?",
      (DescriptiveDeclKind, DeclName))
+
+ERROR(actorisolated_let,none,
+      "'@actorIsolated' is meaningless on 'let' declarations because "
+      "they are immutable",
+      ())
+ERROR(actorisolated_mutable_storage,none,
+      "'@actorIsolated' can not be applied to stored properties",
+      ())
+ERROR(actorisolated_local_var,none,
+      "'@actorIsolated' can not be applied to local variables",
+      ())
+ERROR(actorisolated_not_actor_member,none,
+      "'@actorIsolated' can only be applied to actor members and "
+      "global/static variables",
+      ())
+ERROR(actorisolated_not_actor_instance_member,none,
+      "'@actorIsolated' can only be applied to instance members of actors",
+      ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Types

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -16,6 +16,7 @@
 #ifndef SWIFT_TYPE_CHECK_REQUESTS_H
 #define SWIFT_TYPE_CHECK_REQUESTS_H
 
+#include "swift/AST/ActorIsolation.h"
 #include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/GenericSignature.h"
@@ -811,6 +812,24 @@ private:
   friend SimpleRequest;
 
   bool evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
+/// Determine the actor isolation for the given declaration.
+class ActorIsolationRequest :
+    public SimpleRequest<ActorIsolationRequest,
+                         ActorIsolation(ValueDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ActorIsolation evaluate(Evaluator &evaluator, ValueDecl *value) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -85,6 +85,9 @@ SWIFT_REQUEST(TypeChecker, IsAsyncHandlerRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(ClassDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ActorIsolationRequest,
+              ActorIsolationState(ValueDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, GenericSignatureRequest,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1496,3 +1496,25 @@ void CustomAttrTypeRequest::cacheResult(Type value) const {
   auto *attr = std::get<0>(getStorage());
   attr->setType(value);
 }
+
+
+void swift::simple_display(
+    llvm::raw_ostream &out, const ActorIsolation &state) {
+  switch (state) {
+    case ActorIsolation::ActorInstance:
+      out << "actor-isolated to instance of " << state.getActor()->getName();
+      break;
+
+    case ActorIsolation::ActorPrivileged:
+      out << "actor-privileged to instance of " << state.getActor()->getName();
+      break;
+
+    case ActorIsolation::Independent:
+      out << "actor-independent";
+      break;
+
+    case ActorIsolation::Unspecified:
+      out << "unspecified actor isolation";
+      break;
+  }
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1394,6 +1394,15 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     DiscardAttribute = true;
   }
 
+  // If this attribute is only permitted when concurrency is enabled, reject it.
+  if (DeclAttribute::isConcurrencyOnly(DK) &&
+      !shouldParseExperimentalConcurrency()) {
+    diagnose(
+        Loc, diag::attr_requires_concurrency, AttrName,
+        DeclAttribute::isDeclModifier(DK));
+    DiscardAttribute = true;
+  }
+
   if (Context.LangOpts.Target.isOSBinFormatCOFF()) {
     if (DK == DAK_WeakLinked) {
       diagnose(Loc, diag::attr_unsupported_on_target, AttrName,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -259,11 +259,6 @@ public:
   void visitTransposeAttr(TransposeAttr *attr);
 
   void visitAsyncHandlerAttr(AsyncHandlerAttr *attr) {
-    if (!Ctx.LangOpts.EnableExperimentalConcurrency) {
-      diagnoseAndRemoveAttr(attr, diag::asynchandler_attr_requires_concurrency);
-      return;
-    }
-
     auto func = dyn_cast<FuncDecl>(D);
     if (!func) {
       diagnoseAndRemoveAttr(attr, diag::asynchandler_non_func);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -161,14 +161,6 @@ bool IsActorRequest::evaluate(
     Evaluator &evaluator, ClassDecl *classDecl) const {
   // If concurrency is not enabled, we don't have actors.
   auto actorAttr = classDecl->getAttrs().getAttribute<ActorAttr>();
-  if (!classDecl->getASTContext().LangOpts.EnableExperimentalConcurrency) {
-    if (actorAttr) {
-      classDecl->diagnose(diag::actor_without_concurrency)
-          .highlight(actorAttr->getRange());
-    }
-
-    return false;
-  }
 
   // If there is a superclass, we can infer actor-ness from it.
   if (auto superclassDecl = classDecl->getSuperclassDecl()) {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -19,6 +19,7 @@
 
 namespace swift {
 
+class ActorIsolation;
 class ClassDecl;
 class DeclContext;
 class Expr;
@@ -41,11 +42,8 @@ void addAsyncNotes(FuncDecl *func);
 /// Check actor isolation rules.
 void checkActorIsolation(const Expr *expr, const DeclContext *dc);
 
-/// Determine whether the given value is an instance member of an actor
-/// class that is isolated to the current actor instance.
-///
-/// \returns the type of the actor.
-ClassDecl *getActorIsolatingMember(ValueDecl *value);
+/// Determine how the given value declaration is isolated.
+ActorIsolation getActorIsolation(ValueDecl *value);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1513,6 +1513,7 @@ namespace  {
     UNINTERESTING_ATTR(ProjectedValueProperty)
     UNINTERESTING_ATTR(OriginallyDefinedIn)
     UNINTERESTING_ATTR(Actor)
+    UNINTERESTING_ATTR(ActorIndependent)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -727,9 +727,17 @@ swift::matchWitness(
     }
   }
 
-  // Actor-isolated witnesses cannot conform to protocol requirements.
-  if (getActorIsolatingMember(witness))
+  // Check for actor-isolation consistency.
+  switch (getActorIsolation(witness)) {
+  case ActorIsolation::ActorInstance:
+    // Actor-isolated witnesses cannot conform to protocol requirements.
     return RequirementMatch(witness, MatchKind::ActorIsolatedWitness);
+
+  case ActorIsolation::ActorPrivileged:
+  case ActorIsolation::Independent:
+  case ActorIsolation::Unspecified:
+    break;
+  }
 
   // Now finalize the match.
   auto result = finalize(anyRenaming, optionalAdjustments);

--- a/test/attr/actorindependent.swift
+++ b/test/attr/actorindependent.swift
@@ -1,0 +1,77 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
+
+// expected-error@+1{{'@actorIsolated' can only be applied to actor members and global/static variables}}
+@actorIndependent func globalFunction() { }
+
+@actorIndependent var globalComputedProperty1: Int { 17 }
+
+@actorIndependent var globalComputedProperty2: Int {
+  get { 17 }
+  set { }
+}
+
+// expected-error@+1{{'@actorIsolated' can not be applied to stored properties}}
+@actorIndependent var globalStoredProperty: Int = 17
+
+struct X {
+  @actorIndependent
+  static var staticProperty1: Int {
+    return 5
+  }
+
+  @actorIndependent
+  static var staticProperty2: Int {
+    get { 5 }
+    set { }
+  }
+
+  // expected-error@+1{{'@actorIsolated' can not be applied to stored properties}}
+  @actorIndependent
+  static var storedStaticProperty: Int = 17
+}
+
+class C {
+  // expected-error@+1{{'@actorIsolated' can only be applied to actor members and global/static variables}}
+  @actorIndependent
+  var property3: Int { 5 }
+}
+
+actor class A {
+  var property: Int = 5
+
+  // expected-error@+1{{'@actorIsolated' can not be applied to stored properties}}
+  @actorIndependent
+  var property2: Int = 5
+
+  @actorIndependent
+  var property3: Int { 5 }
+
+  @actorIndependent
+  var property4: Int {
+    get { 5 }
+    set { }
+  }
+
+  @actorIndependent
+  static var staticProperty1: Int {
+    return 5
+  }
+
+  @actorIndependent
+  static var staticProperty2: Int {
+    get { 5 }
+    set { }
+  }
+
+  @actorIndependent
+  func synchronousFunc() { }
+
+  @actorIndependent
+  func asynchronousFunc() async { }
+
+  @actorIndependent
+  subscript(index: Int) -> String { "\(index)" }
+
+  // expected-error@+1{{'@actorIsolated' can only be applied to instance members of actors}}
+  @actorIndependent static func staticFunc() { }
+}

--- a/test/attr/asynchandler_noconcurrency.swift
+++ b/test/attr/asynchandler_noconcurrency.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
 @asyncHandler func asyncHandler1() { }
-// expected-error@-1{{'@asyncHandler' is only valid when experimental concurrency is enabled}}
+// expected-error@-1{{'asyncHandler' attribute is only valid when experimental concurrency is enabled}}

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -24,6 +24,8 @@ protocol SyncProtocol {
 
   func syncMethodB()
 
+  func syncMethodC() -> Int
+
   subscript (index: Int) -> String { get }
   // expected-note@-1{{do you want to add a stub}}
 
@@ -45,6 +47,10 @@ actor class OtherActor: SyncProtocol { // expected-error{{type 'OtherActor' does
   // Async handlers are okay.
   @asyncHandler
   func syncMethodB() { }
+
+  // @actorIndependent methods are okay.
+  // FIXME: Consider suggesting @actorIndependent if this didn't match.
+  @actorIndependent func syncMethodC() -> Int { 5 }
 
   subscript (index: Int) -> String { "\(index)" }
   // expected-note@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy a protocol requirement}}

--- a/test/decl/class/actor/noconcurrency.swift
+++ b/test/decl/class/actor/noconcurrency.swift
@@ -1,4 +1,4 @@
 // RUN: %target-typecheck-verify-swift
 
-actor class C { } // expected-error{{'actor' classes require experimental concurrency support}}
+actor class C { } // expected-error{{'actor' attribute is only valid when experimental concurrency is enabled}}
 


### PR DESCRIPTION
Introduce a new attribute `@actorIndependent` that specifies that a
given declaration is considered to be independent of any actor.
Actor-independent declarations do not have access to actor-isolated
state, even when they are declared as instance members of the actor.

On the other hand, actor-independent declarations can be used to
conform to (synchronous) requirements in protocols.