### PR TITLE
[CMake] Runtime unittests require loading just built standard library

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -96,5 +96,17 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     ${PLATFORM_TARGET_LINK_LIBRARIES}
     ${swift_runtime_test_extra_libraries}
     )
+
+  if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
+    # Because we link libswiftCore with the install_name_dir as /usr/lib/swift
+    # it gets installed as this name as a dependency for this unit test. This is
+    # incorrect because at load time we look at the system library vs. the
+    # just built stdlib that we statically link against. Use install_name_tool
+    # to change the dylib name in the unit test.
+    add_custom_command(TARGET SwiftRuntimeTests
+      POST_BUILD COMMAND
+      ${CMAKE_INSTALL_NAME_TOOL} -change /usr/lib/swift/libswiftCore.dylib @rpath/libswiftCore.dylib
+      $<TARGET_FILE:SwiftRuntimeTests>)
+  endif()
 endif()
 

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -57,5 +57,17 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     ${PLATFORM_TARGET_LINK_LIBRARIES}
     ${swift_runtime_test_extra_libraries}
     )
+
+  if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
+    # Because we link libswiftCore with the install_name_dir as /usr/lib/swift
+    # it gets installed as this name as a dependency for this unit test. This is
+    # incorrect because at load time we look at the system library vs. the
+    # just built stdlib that we statically link against. Use install_name_tool
+    # to change the dylib name in the unit test.
+    add_custom_command(TARGET SwiftRuntimeLongTests
+      POST_BUILD COMMAND
+      ${CMAKE_INSTALL_NAME_TOOL} -change /usr/lib/swift/libswiftCore.dylib @rpath/libswiftCore.dylib
+      $<TARGET_FILE:SwiftRuntimeLongTests>)
+  endif()
 endif()
 


### PR DESCRIPTION
Because we build the standard library with the install_name `/usr/lib/swift` on Darwin, it gets installed as this name as a dependency for these unittest executables. This is incorrect because we statically link against the locally built standard library, but at load time it sees the system library and loads that instead. Change the dependency name for these targets to the `@rpath` version.

@compnerd does this look like a good solution? It seems the compiler now relies on the standard library being installed as this name, so I don't think altering that name now is a solution.