### PR TITLE
[test] Erase SDKROOT since env -u is not portable.

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/early-exits.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/early-exits.test-sh
@@ -1,7 +1,7 @@
 RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt 2>&1 | %FileCheck -check-prefix NO-OUTPUT %s
 NO-OUTPUT: argument -o is required
 
-RUN: env -u SDKROOT SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -o %t 2>&1 | %FileCheck -check-prefix NO-SDK %s
+RUN: env SDKROOT='' SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -o %t 2>&1 | %FileCheck -check-prefix NO-SDK %s
 NO-SDK: SDKROOT must be set
 
 RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -o %t -sdk %S/nonexistent 2>&1 | %FileCheck -check-prefix BAD-SDK %s


### PR DESCRIPTION
The `env -u` flag is not portable and not available on all platforms, so
this unit test will fail when the feature is unavailable.  Instead of
trying to unset the field, just erase it instead, since trying to copy
the entire invoked environment is difficult.