### PR TITLE
[TypeCheckDeclOverride] Add Fix-Its to "override" mismatch

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -531,27 +531,22 @@ static bool fixMissingParameters(InFlightDiagnostic &diag, ValueDecl *decl,
       fixIt << ", ";
     }
     
+    auto paraNameStr = paraName.empty() ? " _" : paraName.str();
+    auto argNameStr = argName.empty() ? " _" : argName.str();
     if (paraName == argName) {
-      if (argName.empty()) {
-        fixIt << "_ : ";
-      } else {
-        fixIt << argName << ": ";
-      }
+      fixIt << argNameStr << ": ";
     } else {
-      // e.g. func foo(a _: Int) {}
-      // this doesn't make sense, maybe should be improve.
-      if (argName.empty()) {
-        fixIt << "_ " << paraName << ": ";
-      } else {
-        fixIt << argName << " " << paraName << ": ";
-      }
+      fixIt << argNameStr << " " << paraNameStr << ": ";
     }
     
     if (baseParam->isInOut())
       fixIt << "inout ";
     
-    if (!baseParamTy->isNoEscape()) {
-      fixIt << "@escaping ";
+    auto type = baseParamTy->getCanonicalType();
+    if (auto funcTy = dyn_cast<FunctionType>(type)) {
+      if (!funcTy->isNoEscape()) {
+        fixIt << "@escaping ";
+      }
     }
       
     if (baseParam->isVariadic()) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -549,6 +549,10 @@ static bool fixMissingParameters(InFlightDiagnostic &diag, ValueDecl *decl,
     
     if (baseParam->isInOut())
       fixIt << "inout ";
+    
+    if (!baseParamTy->isNoEscape()) {
+      fixIt << "@escaping ";
+    }
       
     if (baseParam->isVariadic()) {
       fixIt << baseParam->getVarargBaseTy() << "...";
@@ -556,14 +560,12 @@ static bool fixMissingParameters(InFlightDiagnostic &diag, ValueDecl *decl,
       fixIt << baseParamTy;
     }
       
-    
     if (i + 1 < n)
       fixIt << ", ";
   }
     
   // The location where to insert stubs.
   SourceLoc FixitLocation;
-  derivedParams->getArray().end();
   FixitLocation = derivedParams->get(derivedParams->size()-1)->getEndLoc();
   diag.fixItInsertAfter(FixitLocation, fixIt.str());
   

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -218,12 +218,6 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
 /// declaration in a superclass.
 static bool areOverrideCompatibleSimple(ValueDecl *decl,
                                         ValueDecl *parentDecl) {
-  // If the number of argument labels does not match, these overrides cannot
-  // be compatible.
-  if (decl->getName().getArgumentNames().size() !=
-        parentDecl->getName().getArgumentNames().size())
-    return false;
-
   // If the parent declaration is not in a class (or extension thereof) or
   // a protocol, we cannot override it.
   if (decl->getDeclContext()->getSelfClassDecl() &&
@@ -487,6 +481,95 @@ namespace {
   };
 }
 
+static bool fixMissingParameters(InFlightDiagnostic &diag, ValueDecl *decl,
+                                 ValueDecl *baseDecl) {
+  // Only check class override
+  if (!(decl->getDeclContext()->getSelfClassDecl() &&
+      baseDecl->getDeclContext()->getSelfClassDecl())) {
+    return false;
+  }
+  
+  const ParameterList *derivedParams = nullptr;
+  const ParameterList *baseParams = nullptr;
+  if ((isa<AbstractFunctionDecl>(decl) &&
+       isa<AbstractFunctionDecl>(baseDecl)) ||
+      isa<SubscriptDecl>(baseDecl)) {
+    derivedParams = getParameterList(const_cast<ValueDecl *>(decl));
+    baseParams = getParameterList(const_cast<ValueDecl *>(baseDecl));
+  }
+
+  if (!derivedParams && !baseParams) {
+    return false;
+  }
+
+  int diff = baseParams->size() - derivedParams->size();
+  if (diff <= 0)
+    return false;
+  
+  unsigned numMissing = abs(diff);
+  
+  SmallString<32> scratch;
+  llvm::raw_svector_ostream fixIt(scratch);
+
+  auto subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, decl,
+                                                        /*derivedSubs=*/None);
+  
+  bool isFirst = true;
+  for (unsigned i = baseParams->size() - numMissing, n = baseParams->size();
+       i != n; ++i) {
+    auto *baseParam = baseParams->get(i);
+    auto baseParamTy = baseParam->getInterfaceType();
+    if (baseParam->isInOut())
+      baseParamTy = baseParamTy->getInOutObjectType();
+    baseParamTy = baseParamTy.subst(subs);
+      
+    auto argName = baseParam->getArgumentName();
+    auto paraName = baseParam->getParameterName();
+    
+    if (isFirst) {
+      isFirst = false;
+      fixIt << ", ";
+    }
+    
+    if (paraName == argName) {
+      if (argName.empty()) {
+        fixIt << "_ : ";
+      } else {
+        fixIt << argName << ": ";
+      }
+    } else {
+      // e.g. func foo(a _: Int) {}
+      // this doesn't make sense, maybe should be improve.
+      if (argName.empty()) {
+        fixIt << "_ " << paraName << ": ";
+      } else {
+        fixIt << argName << " " << paraName << ": ";
+      }
+    }
+    
+    if (baseParam->isInOut())
+      fixIt << "inout ";
+      
+    if (baseParam->isVariadic()) {
+      fixIt << baseParam->getVarargBaseTy() << "...";
+    } else {
+      fixIt << baseParamTy;
+    }
+      
+    
+    if (i + 1 < n)
+      fixIt << ", ";
+  }
+    
+  // The location where to insert stubs.
+  SourceLoc FixitLocation;
+  derivedParams->getArray().end();
+  FixitLocation = derivedParams->get(derivedParams->size()-1)->getEndLoc();
+  diag.fixItInsertAfter(FixitLocation, fixIt.str());
+  
+  return true;
+}
+
 static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
                                            ArrayRef<OverrideMatch> matches,
                                            OverrideCheckingAttempt attempt) {
@@ -524,13 +607,84 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
       continue;
     }
 
-    auto diag = diags.diagnose(matchDecl, diag::overridden_near_match_here,
-                               matchDecl->getDescriptiveKind(),
-                               matchDecl->getName());
-    if (attempt == OverrideCheckingAttempt::BaseName) {
+    if (decl->getName().getArgumentNames().size()
+        < matchDecl->getName().getArgumentNames().size()) {
+      auto diag = diags.diagnose(matchDecl, diag::overridden_near_match_here,
+                                 matchDecl->getDescriptiveKind(),
+                                 matchDecl->getName());
+      fixMissingParameters(diag, decl, matchDecl);
+    } else {
+      auto diag = diags.diagnose(matchDecl, diag::overridden_near_match_here,
+                                 matchDecl->getDescriptiveKind(),
+                                 matchDecl->getName());
       fixDeclarationName(diag, decl, matchDecl->getName());
     }
   }
+}
+
+static bool partialParameterMatch(const ValueDecl *derivedDecl,
+                                  const ValueDecl *baseDecl,
+                                  TypeMatchOptions matchMode) {
+  const ParameterList *derivedParams = nullptr;
+  const ParameterList *baseParams = nullptr;
+  if ((isa<AbstractFunctionDecl>(derivedDecl) &&
+       isa<AbstractFunctionDecl>(baseDecl)) ||
+      isa<SubscriptDecl>(baseDecl)) {
+    derivedParams = getParameterList(const_cast<ValueDecl *>(derivedDecl));
+    baseParams = getParameterList(const_cast<ValueDecl *>(baseDecl));
+  }
+  
+  if (!derivedParams && !baseParams) {
+    return false;
+  }
+  
+  if (baseParams->size() == derivedParams->size())
+    return false;
+    
+  auto subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, derivedDecl,
+                                                        /*derivedSubs=*/None);
+  
+  for (auto i : indices(derivedParams->getArray())) {
+    auto *baseParam = baseParams->get(i);
+    auto *derivedParam = derivedParams->get(i);
+    // Make sure parameter name match
+    if (baseParam->getParameterName() != derivedParam->getParameterName())
+      return false;
+    
+    // Make sure inout-ness and varargs match.
+    if (baseParam->isInOut() != derivedParam->isInOut() ||
+        baseParam->isVariadic() != derivedParam->isVariadic()) {
+      return false;
+    }
+    
+    auto baseParamTy = baseParam->getInterfaceType();
+    baseParamTy = baseParamTy.subst(subs);
+    auto derivedParamTy = derivedParam->getInterfaceType();
+
+    if (baseParam->isInOut() || baseParam->isVariadic()) {
+      // Inout and vararg parameters must match exactly.
+      if (baseParamTy->isEqual(derivedParamTy))
+        continue;
+    } else {
+      // Attempt contravariant match.
+      if (baseParamTy->matchesParameter(derivedParamTy, matchMode))
+        continue;
+
+      // Try once more for a match, using the underlying type of an
+      // IUO if we're allowing that.
+      if (baseParam->isImplicitlyUnwrappedOptional() &&
+          matchMode.contains(TypeMatchFlags::AllowNonOptionalForIUOParam)) {
+        baseParamTy = baseParamTy->getOptionalObjectType();
+        if (baseParamTy->matches(derivedParamTy, matchMode))
+          continue;
+      }
+    }
+    
+    // If there is no match, then we're done.
+    return false;
+  }
+  
+  return true;
 }
 
 static bool parameterTypesMatch(const ValueDecl *derivedDecl,
@@ -925,6 +1079,25 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
       matches.push_back({parentDecl, false});
       continue;
     }
+    
+    // collect matches for method_does_not_override
+    if ((attempt == OverrideCheckingAttempt::BaseName) &&
+        (decl->getBaseName() == parentDecl->getBaseName() &&
+         (decl->getName().getArgumentNames().size() <
+          parentDecl->getName().getArgumentNames().size()) &&
+           (declFnTy && parentDeclFnTy))) {
+      auto partiaParamsAndResultMatch = [=]() -> bool {
+        return partialParameterMatch(decl, parentDecl, matchMode) &&
+               declFnTy->getResult()->matches(parentDeclFnTy->getResult(),
+                                              matchMode);
+      };
+
+      if (declFnTy->matchesFunctionType(parentDeclFnTy, matchMode,
+                                        partiaParamsAndResultMatch)) {
+        matches.push_back({parentDecl, false});
+        continue;
+      }
+    }
   }
 
   // If we have more than one match, and any of them was exact, remove all
@@ -1054,11 +1227,21 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
   // If the name of our match differs from the name we were looking for,
   // complain.
   if (decl->getName() != baseDecl->getName()) {
-    auto diag = diags.diagnose(decl, diag::override_argument_name_mismatch,
-                               isa<ConstructorDecl>(decl),
-                               decl->getName(),
-                               baseDecl->getName());
-    fixDeclarationName(diag, decl, baseDecl->getName());
+    if ((decl->getName().getArgumentNames().size()
+         < baseDecl->getName().getArgumentNames().size())
+        && attempt == OverrideCheckingAttempt::BaseName) {
+      auto diagKind = diag::method_does_not_override;
+      if (isa<ConstructorDecl>(decl))
+        diagKind = diag::initializer_does_not_override;
+      auto diag = diags.diagnose(decl, diagKind);
+      fixMissingParameters(diag, decl, baseDecl);
+    } else {
+      auto diag = diags.diagnose(decl, diag::override_argument_name_mismatch,
+                                 isa<ConstructorDecl>(decl),
+                                 decl->getName(),
+                                 baseDecl->getName());
+      fixDeclarationName(diag, decl, baseDecl->getName());
+    }
     emittedMatchError = true;
   }
 

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -161,15 +161,15 @@ class H : G {
 }
 
 class J {
-  func f1(_: Int, int1: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:)' here}} {{none}}
-  func f1(_: Int, int1: Int, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:int2:)' here}} {{none}}
-  func f1(_: Int, string1: String, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:sting1:int2:)' here}} {{none}}
+  func f1(_: Int, int1: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:)' here}} {{26-26=, int1: Int}}
+  func f1(_: Int, int1: Int, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:int2:)' here}} {{26-26=, int1: Int, int2: Int}}
+  func f1(_: Int, string1: String, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:sting1:int2:)' here}} {{26-26=, string1: String, int2: Int}}
   
-  func g1(_: Int, string1: String) { } // expected-note{{potential overridden instance method 'g1(_:string1:)' here}} {{none}}
-  func g1(_: Int, int1: inout Int, _ a: Int..., d: String, closure: ((Int, Int) -> Void)?) { } // expected-note{{potential overridden instance method 'g1(_:int1:_:d:closure:)' here}} {{none}}
+  func g1(_: Int, string1: String) { } // expected-note{{potential overridden instance method 'g1(_:string1:)' here}} {{26-26=, string1: String}}
+  func g1(_: Int, int1: inout Int, _ a: Int..., d: String) { } // expected-note{{potential overridden instance method 'g1(_:int1:_:d:closure:)' here}} {{26-26=, int1: inout Int, _ a: Int..., d: String}}
   
-  init(a: Int, int1: Int) {} // expected-note{{potential overridden instance method 'init(_:int1:)' here}} {{none}}
-  init(a: Int, string: String) {} // expected-note{{potential overridden instance method 'init(_:string:)' here}} {{none}}
+  init(a: Int, int1: Int) {} // expected-note{{potential overridden instance method 'init(_:int1:)' here}} {{23-23=, int1: Int}}
+  init(a: Int, string: String) {} // expected-note{{potential overridden instance method 'init(_:string:)' here}} {{23-23=, string: String}}
 }
 
 class K: J {
@@ -177,7 +177,7 @@ class K: J {
   
   override func g1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
   
-  init(a: Int) {} // expected-error{{declaration 'init(a:)' has different argument labels from any potential overrides}} {{none}}
+  override init(a: Int) {} // expected-error{{declaration 'init(a:)' has different argument labels from any potential overrides}} {{none}}
 }
 
 @objc class IUOTestBaseClass {

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -161,23 +161,19 @@ class H : G {
 }
 
 class J {
-  func f1(_: Int, int1: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:)' here}} {{26-26=, int1: Int}}
-  func f1(_: Int, int1: Int, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:int2:)' here}} {{26-26=, int1: Int, int2: Int}}
-  func f1(_: Int, string1: String, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:sting1:int2:)' here}} {{26-26=, string1: String, int2: Int}}
+  func f1(_: Int, int1: Int) { } //  expected-note * {{here}}
   
-  func g1(_: Int, string1: String) { } // expected-note{{potential overridden instance method 'g1(_:string1:)' here}} {{26-26=, string1: String}}
-  func g1(_: Int, int1: inout Int, _ a: Int..., d: String) { } // expected-note{{potential overridden instance method 'g1(_:int1:_:d:closure:)' here}} {{26-26=, int1: inout Int, _ a: Int..., d: String}}
+  func g1(_: Int, int1: inout Int, _ a: Int..., d: String) { } //  expected-note * {{here}}
   
-  init(a: Int, int1: Int) {} // expected-note{{potential overridden instance method 'init(_:int1:)' here}} {{23-23=, int1: Int}}
-  init(a: Int, string: String) {} // expected-note{{potential overridden instance method 'init(_:string:)' here}} {{23-23=, string: String}}
+  init(a: Int, string: String) {} //  expected-note * {{here}}
 }
 
 class K: J {
-  override func f1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
+  override func f1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{26-26=, int1: Int}}
   
-  override func g1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
+  override func g1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{26-26=, int1: inout Int, _ a: Int..., d: String}}
   
-  override init(a: Int) {} // expected-error{{declaration 'init(a:)' has different argument labels from any potential overrides}} {{none}}
+  override init(a: Int) {} // expected-error{{declaration 'init(a:)' has different argument labels from any potential overrides}} {{23-23=, string: String}}
 }
 
 @objc class IUOTestBaseClass {

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -160,6 +160,26 @@ class H : G {
   override init(b: Double) {} // expected-error{{initializer does not override a designated initializer from its superclass}} {{none}}
 }
 
+class J {
+  func f1(_: Int, int1: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:)' here}} {{none}}
+  func f1(_: Int, int1: Int, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:int1:int2:)' here}} {{none}}
+  func f1(_: Int, string1: String, int2: Int) { } // expected-note{{potential overridden instance method 'f1(_:sting1:int2:)' here}} {{none}}
+  
+  func g1(_: Int, string1: String) { } // expected-note{{potential overridden instance method 'g1(_:string1:)' here}} {{none}}
+  func g1(_: Int, int1: inout Int, _ a: Int..., d: String, closure: ((Int, Int) -> Void)?) { } // expected-note{{potential overridden instance method 'g1(_:int1:_:d:closure:)' here}} {{none}}
+  
+  init(a: Int, int1: Int) {} // expected-note{{potential overridden instance method 'init(_:int1:)' here}} {{none}}
+  init(a: Int, string: String) {} // expected-note{{potential overridden instance method 'init(_:string:)' here}} {{none}}
+}
+
+class K: J {
+  override func f1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
+  
+  override func g1(_: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
+  
+  init(a: Int) {} // expected-error{{declaration 'init(a:)' has different argument labels from any potential overrides}} {{none}}
+}
+
 @objc class IUOTestBaseClass {
   @objc func none() {}
 


### PR DESCRIPTION
Resolves [SR-13388](https://bugs.swift.org/browse/SR-13388?filter=-1)

Add Fix-Its to "override" mismatch

For code like this following:

```
class Base {
  func foo(a: Int, b: Int) {}
}
class C: Base {
  override func foo(a: Int) {} // error: method does not override any method from its superclass
}
```

we should provide a Fix-It that adds ", b: Int" to C.foo.