### PR TITLE
WinSDK: add console API headers

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -43,6 +43,8 @@ module WinSDK [system] {
 
     module console {
       header "consoleapi.h"
+      header "consoleapi2.h"
+      header "consoleapi3.h"
       export *
     }
 


### PR DESCRIPTION
`WinSDK.core.console` only specified `consoleapi.h` header, while `consoleapi2.h` & `consoleapi3.h` were included in the WinSock2 submodule since these headers are included by `windows.h`