### PR TITLE
[SR-13503] [Sema] Special InsertExplicitCall for nominal callable types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1064,7 +1064,9 @@ NOTE(note_call_to_initializer,none,
 NOTE(note_init_parameter,none,
      "in initialization of parameter %0", (Identifier))
 
-
+ERROR(missing_explicit_call_callable_value, none,
+      "value of callable type %0 can be called to produce expected type %1; "
+      "did you mean to call it with '()'?", (Type, Type))
 ERROR(missing_nullary_call,none,
      "function produces expected type %0; did you mean to call it with '()'?",
      (Type))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2145,7 +2145,8 @@ public:
 /// implementation of a \c callAsFunction method.
 class IsCallableNominalTypeRequest
     : public SimpleRequest<IsCallableNominalTypeRequest,
-                           bool(CanType, DeclContext *), RequestFlags::Cached> {
+                           bool(CanType, bool, DeclContext *),
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -2153,7 +2154,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool evaluate(Evaluator &evaluator, CanType ty, DeclContext *dc) const;
+  bool evaluate(Evaluator &evaluator, CanType ty, bool ignoreAccessControl,
+                DeclContext *dc) const;
 
 public:
   // Cached.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -135,7 +135,7 @@ SWIFT_REQUEST(TypeChecker, InterfaceTypeRequest,
 SWIFT_REQUEST(TypeChecker, IsAccessorTransparentRequest, bool(AccessorDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsCallableNominalTypeRequest,
-              bool(CanType, DeclContext *), Cached, NoLocationInfo)
+              bool(CanType, bool, DeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -840,9 +840,8 @@ public:
   }
 
   /// Checks whether this is a type that supports being called through the
-  /// implementation of a \c callAsFunction method. Note that this does not
-  /// check access control.
-  bool isCallableNominalType(DeclContext *dc);
+  /// implementation of a \c callAsFunction method.
+  bool isCallableNominalType(DeclContext *dc, bool ignoreAccessControl = true);
 
   /// Return true if the specified type or a super-class/super-protocol has the
   /// @dynamicMemberLookup attribute on it.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -789,8 +789,12 @@ public:
 };
 
 class InsertExplicitCall final : public ConstraintFix {
-  InsertExplicitCall(ConstraintSystem &cs, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::InsertCall, locator) {}
+  Type ResultType;
+
+  InsertExplicitCall(ConstraintSystem &cs, Type resultType,
+                     ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::InsertCall, locator),
+        ResultType(resultType) {}
 
 public:
   std::string getName() const override {
@@ -801,6 +805,9 @@ public:
 
   static InsertExplicitCall *create(ConstraintSystem &cs,
                                     ConstraintLocator *locator);
+  static InsertExplicitCall *createWithResult(ConstraintSystem &cs,
+                                              Type resultType,
+                                              ConstraintLocator *locator);
 };
 
 class UsePropertyWrapper final : public ConstraintFix {

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -868,6 +868,19 @@ public:
     return (getSummaryFlags() & ConstraintLocator::IsNonEphemeralParam);
   }
 
+  /// Checks whether this locator is describing an anchor produces a value of a
+  /// callable type that could be implicit called using "()" either by defining
+  /// a \c callAsFunction or by being a @dynamicCallable type.
+  bool isForImplicitCallableValue() const {
+    SmallVector<LocatorPathElt, 8> path;
+    getLocatorParts(path);
+
+    return std::any_of(
+        path.rbegin(), path.rend(), [](LocatorPathElt &elt) {
+      return elt.getKind() == ConstraintLocator::ImplicitCallableValue;
+    });
+  }
+
   /// Retrieve the base constraint locator, on which this builder's
   /// path is based.
   ConstraintLocator *getBaseLocator() const {

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -871,13 +871,12 @@ public:
   /// Checks whether this locator is describing an anchor that produces a value of a
   /// callable type that could be implicit called using "()" either by defining
   /// a \c callAsFunction or by being a @dynamicCallable type.
-  bool isForImplicitCallableValue() const {
+  bool isForImplicitCallOfCallableValue() const {
     SmallVector<LocatorPathElt, 8> path;
     getLocatorParts(path);
 
-    return std::any_of(
-        path.rbegin(), path.rend(), [](LocatorPathElt &elt) {
-      return elt.getKind() == ConstraintLocator::ImplicitCallableValue;
+    return std::any_of(path.rbegin(), path.rend(), [](LocatorPathElt &elt) {
+      return elt.getKind() == ConstraintLocator::ImplicitCallOfCallableValue;
     });
   }
 

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -868,7 +868,7 @@ public:
     return (getSummaryFlags() & ConstraintLocator::IsNonEphemeralParam);
   }
 
-  /// Checks whether this locator is describing an anchor produces a value of a
+  /// Checks whether this locator is describing an anchor that produces a value of a
   /// callable type that could be implicit called using "()" either by defining
   /// a \c callAsFunction or by being a @dynamicCallable type.
   bool isForImplicitCallableValue() const {

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -868,9 +868,9 @@ public:
     return (getSummaryFlags() & ConstraintLocator::IsNonEphemeralParam);
   }
 
-  /// Checks whether this locator is describing an anchor that produces a value of a
-  /// callable type that could be implicit called using "()" either by defining
-  /// a \c callAsFunction or by being a @dynamicCallable type.
+  /// Checks whether this locator is describing an anchor that produces a value
+  /// of a callable type that could be called using "()" either by defining a \c
+  /// callAsFunction or by being a @dynamicCallable type.
   bool isForImplicitCallOfCallableValue() const {
     SmallVector<LocatorPathElt, 8> path;
     getLocatorParts(path);

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -195,8 +195,8 @@ CUSTOM_LOCATOR_PATH_ELT(ArgumentAttribute)
 /// The result of a chain of member accesses off an UnresolvedMemberExpr
 SIMPLE_LOCATOR_PATH_ELT(UnresolvedMemberChainResult)
 
-/// A reference or expression that results in value of a callable type either @dynamicCallable
-/// or that defines one or more \c callAsFunction methods.
+/// A reference or expression that results in value of a callable type that is
+/// either @dynamicCallable or defines one or more \c callAsFunction methods.
 SIMPLE_LOCATOR_PATH_ELT(ImplicitCallOfCallableValue)
 
 #undef LOCATOR_PATH_ELT

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -195,6 +195,10 @@ CUSTOM_LOCATOR_PATH_ELT(ArgumentAttribute)
 /// The result of a chain of member accesses off an UnresolvedMemberExpr
 SIMPLE_LOCATOR_PATH_ELT(UnresolvedMemberChainResult)
 
+/// A reference or expression that results in value of a callable type either @dynamicCallable
+/// or that defines one or more \c callAsFunction methods.
+SIMPLE_LOCATOR_PATH_ELT(ImplicitCallableValue)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -197,7 +197,7 @@ SIMPLE_LOCATOR_PATH_ELT(UnresolvedMemberChainResult)
 
 /// A reference or expression that results in value of a callable type either @dynamicCallable
 /// or that defines one or more \c callAsFunction methods.
-SIMPLE_LOCATOR_PATH_ELT(ImplicitCallableValue)
+SIMPLE_LOCATOR_PATH_ELT(ImplicitCallOfCallableValue)
 
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1510,7 +1510,8 @@ bool TypeBase::satisfiesClassConstraint() {
   return mayHaveSuperclass() || isObjCExistentialType();
 }
 
-bool TypeBase::isCallableNominalType(DeclContext *dc) {
+bool TypeBase::isCallableNominalType(DeclContext *dc,
+                                     bool ignoreAccessControl) {
   // Don't allow callAsFunction to be used with dynamic lookup.
   if (isAnyObject())
     return false;
@@ -1521,8 +1522,9 @@ bool TypeBase::isCallableNominalType(DeclContext *dc) {
 
   auto canTy = getCanonicalType();
   auto &ctx = canTy->getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-                           IsCallableNominalTypeRequest{canTy, dc}, false);
+  return evaluateOrDefault(
+      ctx.evaluator,
+      IsCallableNominalTypeRequest{canTy, ignoreAccessControl, dc}, false);
 }
 
 bool TypeBase::hasDynamicMemberLookupAttribute() {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -974,7 +974,7 @@ public:
 
   bool diagnoseAsError() override;
 
-  /// Tailored diagnose insert an explicit call to a value of a type that
+  /// Tailored diagnostic to insert an explicit call to a value of a type that
   /// supports being called either by defining a \c callAsFunction method or by
   /// being a @dynamicCallable type.
   bool diagnoseForCallableValue() const;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -963,13 +963,21 @@ public:
 };
 
 class MissingCallFailure final : public FailureDiagnostic {
+  Type ResultType;
+
 public:
-  MissingCallFailure(const Solution &solution, ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator) {}
+  MissingCallFailure(const Solution &solution, Type resultType,
+                     ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), ResultType(resultType) {}
 
   ASTNode getAnchor() const override;
 
   bool diagnoseAsError() override;
+
+  /// Tailored diagnose insert an explicit call to a value of a type that
+  /// supports being called either by defining a \c callAsFunction method or by
+  /// being a @dynamicCallable type.
+  bool diagnoseForCallableValue() const;
 };
 
 class PropertyWrapperReferenceFailure : public ContextualFailure {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -523,13 +523,19 @@ RemoveUnwrap *RemoveUnwrap::create(ConstraintSystem &cs, Type baseType,
 }
 
 bool InsertExplicitCall::diagnose(const Solution &solution, bool asNote) const {
-  MissingCallFailure failure(solution, getLocator());
+  MissingCallFailure failure(solution, ResultType, getLocator());
   return failure.diagnose(asNote);
 }
 
 InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
                                                ConstraintLocator *locator) {
-  return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
+  return new (cs.getAllocator()) InsertExplicitCall(cs, Type(), locator);
+}
+
+InsertExplicitCall *
+InsertExplicitCall::createWithResult(ConstraintSystem &cs, Type resultType,
+                                     ConstraintLocator *locator) {
+  return new (cs.getAllocator()) InsertExplicitCall(cs, resultType, locator);
 }
 
 bool UsePropertyWrapper::diagnose(const Solution &solution, bool asNote) const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8958,7 +8958,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
       if (locator.isForImplicitCallOfCallableValue()) {
         // This overload can be trivially called to produce a value of expected
         // type record the insert explicit call fix.
-        if (recordFix(InsertCallableValueExplicitCall::create(
+        if (recordFix(InsertExplicitCall::createWithResult(
                 *this, func1->getResult(), getConstraintLocator(locator))))
           return SolutionKind::Error;
       }
@@ -9133,7 +9133,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
       if (locator.isForImplicitCallOfCallableValue()) {
         // If this overload can be called to produce a value of expected type
         // record the insert explicit call fix.
-        if (recordFix(InsertCallableValueExplicitCall::create(
+        if (recordFix(InsertExplicitCall::createWithResult(
                 *this, func1->getResult(), getConstraintLocator(locator))))
           return SolutionKind::Error;
       }
@@ -9428,7 +9428,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
     if (locator.isForImplicitCallOfCallableValue()) {
       // This overload of dynamicCall can be called to produce a value of
       // expected type, so we record the insert explicit call fix.
-      if (recordFix(InsertCallableValueExplicitCall::create(
+      if (recordFix(InsertExplicitCall::createWithResult(
               *this, func1->getResult(), getConstraintLocator(locator))))
         return SolutionKind::Error;
     }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -82,7 +82,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PatternMatch:
   case ConstraintLocator::ArgumentAttribute:
   case ConstraintLocator::UnresolvedMemberChainResult:
-  case ConstraintLocator::ImplicitCallableValue:
+  case ConstraintLocator::ImplicitCallOfCallableValue:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -481,7 +481,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       out << "unresolved chain result";
       break;
 
-    case ImplicitCallableValue:
+    case ImplicitCallOfCallableValue:
       out << "implicit callable value";
       break;
     }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -82,6 +82,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PatternMatch:
   case ConstraintLocator::ArgumentAttribute:
   case ConstraintLocator::UnresolvedMemberChainResult:
+  case ConstraintLocator::ImplicitCallableValue:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -478,6 +479,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
 
     case UnresolvedMemberChainResult:
       out << "unresolved chain result";
+      break;
+
+    case ImplicitCallableValue:
+      out << "implicit callable value";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -482,7 +482,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       break;
 
     case ImplicitCallOfCallableValue:
-      out << "implicit callable value";
+      out << "implicit call callable value";
       break;
     }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -456,11 +456,11 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
       return getConstraintLocator(anchor, newPath);
     }
   }
-  
-  // We checkinng if it's possible to make a nominal callAsFunction callable value an
-  // explicit call, we need to drop the inserted ApplyArgument and add the extra
-  // apply function and implicit call to match it as the callee locator recorded when
-  // resolving the overload.
+
+  // We checking if it's possible to make a nominal callAsFunction callable
+  // value an explicit call, we need to drop the inserted ApplyArgument and add
+  // the extra apply function and implicit call to match it as the callee
+  // locator recorded when resolving the overload.
   if (locator->findLast<LocatorPathElt::ImplicitCallOfCallableValue>() &&
       !locator->findLast<LocatorPathElt::DynamicCallable>()) {
     SmallVector<LocatorPathElt, 4> newPath;
@@ -4309,7 +4309,7 @@ ConstraintSystem::getArgumentInfo(ConstraintLocator *locator) {
     return None;
 
   // Since we are only attempting to check if it's possible to insert an
-  // explicit call in an anchor expr it doesn't explicitly have an argument
+  // explicit call in an anchor expr, it doesn't explicitly have an argument
   // info, so we just fake one for this situation.
   if (locator->findLast<LocatorPathElt::ImplicitCallOfCallableValue>())
     return ConstraintSystem::ArgumentInfo();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -456,6 +456,19 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
       return getConstraintLocator(anchor, newPath);
     }
   }
+  
+  // We checkinng if it's possible to make a nominal callAsFunction callable value an
+  // explicit call, we need to drop the inserted ApplyArgument and add the extra
+  // apply function and implicit call to match it as the callee locator recorded when
+  // resolving the overload.
+  if (locator->findLast<LocatorPathElt::ImplicitCallableValue>() &&
+      !locator->findLast<LocatorPathElt::DynamicCallable>()) {
+    SmallVector<LocatorPathElt, 4> newPath;
+    newPath.append(path.begin(), path.end() - 1);
+    newPath.append({ConstraintLocator::ApplyFunction,
+                    ConstraintLocator::ImplicitCallAsFunction});
+    return getConstraintLocator(anchor, newPath);
+  }
 
   if (locator->findLast<LocatorPathElt::DynamicCallable>()) {
     return getConstraintLocator(anchor, LocatorPathElt::ApplyFunction());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -461,7 +461,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   // explicit call, we need to drop the inserted ApplyArgument and add the extra
   // apply function and implicit call to match it as the callee locator recorded when
   // resolving the overload.
-  if (locator->findLast<LocatorPathElt::ImplicitCallableValue>() &&
+  if (locator->findLast<LocatorPathElt::ImplicitCallOfCallableValue>() &&
       !locator->findLast<LocatorPathElt::DynamicCallable>()) {
     SmallVector<LocatorPathElt, 4> newPath;
     newPath.append(path.begin(), path.end() - 1);
@@ -4307,6 +4307,12 @@ Optional<ConstraintSystem::ArgumentInfo>
 ConstraintSystem::getArgumentInfo(ConstraintLocator *locator) {
   if (!locator)
     return None;
+
+  // Since we are only attempting to check if it's possible to insert an
+  // explicit call in an anchor expr it doesn't explicitly have an argument
+  // info, so we just fake one for this situation.
+  if (locator->findLast<LocatorPathElt::ImplicitCallOfCallableValue>())
+    return ConstraintSystem::ArgumentInfo();
 
   if (auto *infoLocator = getArgumentInfoLocator(locator)) {
     auto known = ArgumentInfos.find(infoLocator);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2041,11 +2041,12 @@ ForcedCheckedCastExpr *swift::findForcedDowncast(ASTContext &ctx, Expr *expr) {
   return nullptr;
 }
 
-bool
-IsCallableNominalTypeRequest::evaluate(Evaluator &evaluator, CanType ty,
-                                       DeclContext *dc) const {
+bool IsCallableNominalTypeRequest::evaluate(Evaluator &evaluator, CanType ty,
+                                            bool ignoreAccessControl,
+                                            DeclContext *dc) const {
   auto options = defaultMemberLookupOptions;
-  options |= NameLookupFlags::IgnoreAccessControl;
+  if (ignoreAccessControl)
+    options |= NameLookupFlags::IgnoreAccessControl;
 
   // Look for a callAsFunction method.
   auto &ctx = ty->getASTContext();

--- a/test/Sema/diag_callable_types_mismatch_conversion.swift
+++ b/test/Sema/diag_callable_types_mismatch_conversion.swift
@@ -1,0 +1,171 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-13503
+class Root {}
+class Sub: Root {}
+
+// No callAsFunction overload
+struct SR13503No {}
+
+// A single callAsFunction overload
+struct SR13503Single {
+  func callAsFunction() -> Int { 0 }
+}
+
+// One overload matches one fail callAsFunction overload
+struct SR13503Match {
+  func callAsFunction() -> Int { 0 }
+  func callAsFunction() -> Double { 0.0 }
+}
+
+// A single overload with all parameters default matches.
+struct SR13503Default {
+  func callAsFunction(a: Int = 0) -> Int { 0 }
+}
+
+struct SR13503 {
+  func callAsFunction() -> Int { 0 }
+  func callAsFunction(a: Int = 0) -> Int { 0 }
+}
+
+struct SR13503A {
+  private func callAsFunction() -> Int { 0 }
+  private func callAsFunction(a: Int = 0) -> Int { 0 }
+}
+
+struct SR13503Sub {
+  func callAsFunction() -> Root { fatalError() }
+  func callAsFunction() -> Sub { fatalError() }
+}
+
+struct SR13503G<T> {
+  func callAsFunction() -> T { fatalError() }
+  func callAsFunction(a: Int = 0) -> T { fatalError() }
+}
+
+func testReturn() -> SR13503 { SR13503() }
+
+let value = SR13503()
+let valueSin = SR13503Single()
+let valueNo = SR13503No()
+let valueg = SR13503G<Int>()
+let valueg1 = SR13503G<String>()
+let valuesub = SR13503Sub()
+let valuea = SR13503A()
+let valueM = SR13503Match()
+let valueD = SR13503Default()
+
+func fSR13503(class: Root) {}
+
+func fSR13503(arg: Int) {}
+func fSR13503_S(arg: String) {}
+
+fSR13503(arg: valueNo) // expected-error {{cannot convert value of type 'SR13503No' to expected argument type 'Int'}}
+fSR13503(arg: valueSin) // expected-error {{value of callable type 'SR13503Single' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{23-23=()}}
+fSR13503_S(arg: valueSin) // expected-error {{cannot convert value of type 'SR13503Single' to expected argument type 'String'}}
+fSR13503(arg: value) // expected-error {{value of callable type 'SR13503' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{20-20=()}}
+fSR13503_S(arg: value) // expected-error {{cannot convert value of type 'SR13503' to expected argument type 'String'}}
+fSR13503(arg: valueg) // expected-error {{value of callable type 'SR13503G<Int>' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{21-21=()}}
+fSR13503(arg: valueg1) // expected-error {{cannot convert value of type 'SR13503G<String>' to expected argument type 'Int'}}
+fSR13503(arg: testReturn()) // expected-error {{value of callable type 'SR13503' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{27-27=()}}
+fSR13503_S(arg: testReturn()) // expected-error {{cannot convert value of type 'SR13503' to expected argument type 'String'}}
+fSR13503(arg: valueM) // expected-error {{value of callable type 'SR13503Match' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{21-21=()}}
+fSR13503_S(arg: valueM) // expected-error {{cannot convert value of type 'SR13503Match' to expected argument type 'String'}}
+fSR13503(arg: valueD) // expected-error {{value of callable type 'SR13503Default' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{21-21=()}}
+fSR13503_S(arg: valueD) // expected-error {{cannot convert value of type 'SR13503Default' to expected argument type 'String'}}
+
+// Access control no visible callAsFunction
+fSR13503(arg: valuea) // expected-error {{cannot convert value of type 'SR13503A' to expected argument type 'Int'}}
+// In case we have subtype callAsFunction overloads, suggest call with '()' may lead to ambiguity
+fSR13503(class: valuesub) // expected-error {{value of callable type 'SR13503Sub' can be called to produce expected type 'Root'; did you mean to call it with '()'?}} {{25-25=()}}
+
+let _ : Int = value // expected-error {{value of callable type 'SR13503' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{20-20=()}}
+let _ : String = value // expected-error {{cannot convert value of type 'SR13503' to specified type 'String'}}
+let _ : Int = valueg // expected-error {{value of callable type 'SR13503G<Int>' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{21-21=()}}
+let _ : Int = valueg1 // expected-error {{cannot convert value of type 'SR13503G<String>' to specified type 'Int'}}
+let _ : Int = testReturn() // expected-error {{value of callable type 'SR13503' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{27-27=()}}
+let _ : Void = value // expected-error {{cannot convert value of type 'SR13503' to specified type 'Void'}}
+
+// Access control no visible callAsFunction
+let _ : Int = valuea // expected-error {{cannot convert value of type 'SR13503A' to specified type 'Int'}}
+// In case we have subtype callAsFunction overloads, suggest call with '()' may lead to ambiguity
+let _ : Root = valuesub // expected-error {{value of callable type 'SR13503Sub' can be called to produce expected type 'Root'; did you mean to call it with '()'?}} {{24-24=()}}
+
+// @dynamicCallable
+
+// A single @dynamicCallable overload
+@dynamicCallable
+struct SR13503Single_DC {
+  func dynamicallyCall(withArguments: [Int]) -> Int { 0 }
+}
+
+@dynamicCallable
+struct SR13503_DC {
+  func dynamicallyCall(withArguments: [Int]) -> Int { 0 }
+  func dynamicallyCall(withArguments: [Int]) -> Double { 0 }
+}
+
+@dynamicCallable
+struct SR13503A_DC {
+  private func dynamicallyCall(withKeywordArguments: [String: Any]) -> Int { 0 }
+}
+
+@dynamicCallable
+struct SR13503Sub_DC {
+  func dynamicallyCall(withKeywordArguments: [String: Any]) -> Root { fatalError() }
+  func dynamicallyCall(withKeywordArguments: [String: Any]) -> Sub { fatalError() }
+}
+
+@dynamicCallable
+struct SR13503G_DC<T> {
+  func dynamicallyCall(withArguments: [Int]) -> T { fatalError() }
+  func dynamicallyCall(withKeywordArguments: [String: Any]) -> T { fatalError() }
+}
+
+func testReturn_DC() -> SR13503_DC { SR13503_DC() }
+
+let value_sin_dc = SR13503Single_DC()
+let value_dc = SR13503_DC()
+let valueg_dc = SR13503G_DC<Int>()
+let valueg1_dc = SR13503G_DC<String>()
+let valuesub_dc = SR13503Sub_DC()
+let valuea_dc = SR13503A_DC()
+
+fSR13503(arg: value_sin_dc) // expected-error {{value of callable type 'SR13503Single_DC' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{27-27=()}}
+fSR13503_S(arg: value_sin_dc) // expected-error {{cannot convert value of type 'SR13503Single_DC' to expected argument type 'String'}}
+fSR13503(arg: value_dc) // expected-error {{value of callable type 'SR13503_DC' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{23-23=()}}
+fSR13503_S(arg: value_dc) // expected-error {{cannot convert value of type 'SR13503_DC' to expected argument type 'String'}}
+fSR13503(arg: valueg_dc) // expected-error {{value of callable type 'SR13503G_DC<Int>' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{24-24=()}}
+fSR13503(arg: valueg1_dc) // expected-error {{cannot convert value of type 'SR13503G_DC<String>' to expected argument type 'Int'}}
+fSR13503(arg: testReturn_DC()) // expected-error {{value of callable type 'SR13503_DC' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{30-30=()}}
+fSR13503_S(arg: testReturn_DC()) // expected-error {{cannot convert value of type 'SR13503_DC' to expected argument type 'String'}}
+
+// Access control no visible dynamicallyCall
+fSR13503(arg: valuea_dc) // expected-error {{cannot convert value of type 'SR13503A_DC' to expected argument type 'Int'}}
+// In case we have subtype dynamicallyCall overloads, suggest call with '()' may lead to ambiguity
+fSR13503(class: valuesub_dc) // expected-error {{value of callable type 'SR13503Sub_DC' can be called to produce expected type 'Root'; did you mean to call it with '()'?}} {{28-28=()}}
+
+let _ : Int = value_dc // expected-error {{value of callable type 'SR13503_DC' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{23-23=()}}
+let _ : String = value_dc // expected-error {{cannot convert value of type 'SR13503_DC' to specified type 'String'}}
+let _ : Int = valueg_dc // expected-error {{value of callable type 'SR13503G_DC<Int>' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{24-24=()}}
+let _ : Int = valueg1_dc // expected-error {{cannot convert value of type 'SR13503G_DC<String>' to specified type 'Int'}}
+let _ : Int =  testReturn_DC() // expected-error {{value of callable type 'SR13503_DC' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{31-31=()}}
+let _ : String =  testReturn_DC()  // expected-error {{cannot convert value of type 'SR13503_DC' to specified type 'String'}}
+
+// Access control no visible dynamicallyCall
+let _ : Int = valuea_dc // expected-error {{cannot convert value of type 'SR13503A_DC' to specified type 'Int'}}
+// In case we have subtype dynamicallyCall overloads, suggest call with '()' may lead to ambiguity
+let _ : Root =  valuesub_dc // expected-error {{value of callable type 'SR13503Sub_DC' can be called to produce expected type 'Root'; did you mean to call it with '()'?}} {{28-28=()}}
+
+// Callable Literal
+extension String {
+  func dynamicallyCall(withArguments arguments: [Int]) -> Int {
+    return arguments.count
+  }
+
+  func callAsFunction() -> Int { 0 }
+}
+
+let strRef = "foo"
+let _: Int = "foo" // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
+let _: Int = strRef // expected-error {{value of callable type 'String' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{20-20=()}}

--- a/test/Sema/diag_callable_types_mismatch_conversion.swift
+++ b/test/Sema/diag_callable_types_mismatch_conversion.swift
@@ -23,6 +23,15 @@ struct SR13503Default {
   func callAsFunction(a: Int = 0) -> Int { 0 }
 }
 
+// A single overload with parameters.
+struct SR13503Param {
+  func callAsFunction(a: Int) -> Int { 0 }
+}
+struct SR13503Param2 {
+  func callAsFunction(a: Int, b: Int) -> Int { 0 }
+}
+
+
 struct SR13503 {
   func callAsFunction() -> Int { 0 }
   func callAsFunction(a: Int = 0) -> Int { 0 }
@@ -54,6 +63,8 @@ let valuesub = SR13503Sub()
 let valuea = SR13503A()
 let valueM = SR13503Match()
 let valueD = SR13503Default()
+let valueP = SR13503Param()
+let valueP2 = SR13503Param2()
 
 func fSR13503(class: Root) {}
 
@@ -73,6 +84,8 @@ fSR13503(arg: valueM) // expected-error {{value of callable type 'SR13503Match' 
 fSR13503_S(arg: valueM) // expected-error {{cannot convert value of type 'SR13503Match' to expected argument type 'String'}}
 fSR13503(arg: valueD) // expected-error {{value of callable type 'SR13503Default' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{21-21=()}}
 fSR13503_S(arg: valueD) // expected-error {{cannot convert value of type 'SR13503Default' to expected argument type 'String'}}
+fSR13503(arg: valueP) // expected-error {{cannot convert value of type 'SR13503Param' to expected argument type 'Int'}}
+fSR13503_S(arg: valueP) // expected-error {{cannot convert value of type 'SR13503Param' to expected argument type 'String'}}
 
 // Access control no visible callAsFunction
 fSR13503(arg: valuea) // expected-error {{cannot convert value of type 'SR13503A' to expected argument type 'Int'}}
@@ -139,6 +152,13 @@ fSR13503(arg: valueg_dc) // expected-error {{value of callable type 'SR13503G_DC
 fSR13503(arg: valueg1_dc) // expected-error {{cannot convert value of type 'SR13503G_DC<String>' to expected argument type 'Int'}}
 fSR13503(arg: testReturn_DC()) // expected-error {{value of callable type 'SR13503_DC' can be called to produce expected type 'Int'; did you mean to call it with '()'?}} {{30-30=()}}
 fSR13503_S(arg: testReturn_DC()) // expected-error {{cannot convert value of type 'SR13503_DC' to expected argument type 'String'}}
+
+// Values that cannot be called with () because they have only callAsFunction definitions that expect parameters.
+fSR13503(arg: valueP) // expected-error {{cannot convert value of type 'SR13503Param' to expected argument type 'Int'}}
+fSR13503_S(arg: valueP) // expected-error {{cannot convert value of type 'SR13503Param' to expected argument type 'String'}}
+
+fSR13503(arg: valueP2) // expected-error {{cannot convert value of type 'SR13503Param2' to expected argument type 'Int'}}
+fSR13503_S(arg: valueP2) // expected-error {{cannot convert value of type 'SR13503Param2' to expected argument type 'String'}}
 
 // Access control no visible dynamicallyCall
 fSR13503(arg: valuea_dc) // expected-error {{cannot convert value of type 'SR13503A_DC' to expected argument type 'Int'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Detect if a type mismatch we the source type is a callable nominal and has a `callAsFunction` that produces the destination type, so we can suggest making it an explicit call to it.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13503.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
