### PR TITLE
[test] Mark failing reflection tests XFAIL.

### DIFF
--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -5,6 +5,9 @@
 // SR-10758
 // UNSUPPORTED: linux
 
+// SR-12893
+// XFAIL: openbsd
+
 sil_stage canonical
 
 import Builtin

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -1,5 +1,9 @@
 
 // REQUIRES: no_asan
+
+// SR-12893
+// XFAIL: openbsd
+
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors%{target-shared-library-suffix} -L%t/../../.. -lBlocksRuntime
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,5 +1,8 @@
 // XFAIL: OS=windows-msvc
 
+// SR-12893
+// XFAIL: openbsd
+
 // UNSUPPORTED: CPU=arm64e
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
See [SR-12893](https://bugs.swift.org/browse/SR-12893). swift-reflection-dump does not properly handle offsets in
ELF executable images that, when interpreted as vaddrs, belong in
segments part of the image.

This just empirically XFAIL's the unit tests that are crashing or
failing, even though the other tests are just happening to pass anyway.
There's no clear workaround; disable the expected failures for the
moment.