### PR TITLE
stdlib: fix a back-deployment issue for array COW checks with a stdlib assert-build

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -190,7 +190,7 @@ void swift::runtime::environment::initialize(void *context) {
 #endif
 
 SWIFT_RUNTIME_EXPORT
-bool swift_COWSanityChecksEnabled() {
-  return runtime::environment::SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS();
+bool swift_COWChecksEnabled() {
+  return runtime::environment::SWIFT_DEBUG_ENABLE_COW_CHECKS();
 }
 

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -44,7 +44,7 @@ VARIABLE(SWIFT_ENABLE_MANGLED_NAME_VERIFICATION, bool, false,
 VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, bool, false,
          "Scribble on runtime allocations such as metadata allocations.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS, bool, false,
-         "Enable sanity checks for copy-on-write operations.")
+VARIABLE(SWIFT_DEBUG_ENABLE_COW_CHECKS, bool, false,
+         "Enable internal checks for copy-on-write operations.")
 
 #undef VARIABLE

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1993,7 +1993,7 @@ config.environment[TARGET_ENV_PREFIX + 'SWIFT_DETERMINISTIC_HASHING'] = '1'
 config.environment[TARGET_ENV_PREFIX + 'SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE'] = 'YES'
 
 # Enable COW sanity checks in the swift runtime by default.
-config.environment['SWIFT_DEBUG_ENABLE_COW_SANITY_CHECKS'] = 'true'
+config.environment['SWIFT_DEBUG_ENABLE_COW_CHECKS'] = 'true'
 
 # Run lsb_release on the target to be tested and return the results.
 def linux_get_lsb_release():


### PR DESCRIPTION
And rename COWSanityChecks -> COWChecks.

rdar://problem/68181747
