### PR TITLE
[leaks-checker] Add verbose flag to dump out raw output from runtime to help debug failures on bots.

### DIFF
--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -62,12 +62,13 @@ class LeaksRunnerResult(perf_test_driver.Result):
 
 
 class LeaksRunnerBenchmarkDriver(perf_test_driver.BenchmarkDriver):
-    def __init__(self, binary, xfail_list, num_samples, num_iters):
+    def __init__(self, binary, xfail_list, num_samples, num_iters, verbose):
         perf_test_driver.BenchmarkDriver.__init__(
             self, binary, xfail_list, enable_parallel=True
         )
         self.num_samples = num_samples
         self.num_iters = num_iters
+        self.verbose = verbose
 
     def print_data_header(self, max_test_len):
         fmt = "{:<%d}{:<10}{:}" % (max_test_len + 5)
@@ -120,6 +121,13 @@ class LeaksRunnerBenchmarkDriver(perf_test_driver.BenchmarkDriver):
             ]
             d["objc_count"] = len(d["objc_objects"])
 
+            # If we are asked to emit verbose output, do so now.
+            if self.verbose:
+                tmp = (data["path"], data["test_name"], d)
+                sys.stderr.write(
+                    "VERBOSE (%s,%s): %s" % tmp)
+                sys.stderr.flush()
+
             total_count = d["objc_count"] + d["swift_count"]
             return total_count
         except Exception:
@@ -156,13 +164,17 @@ def parse_args():
     )
     parser.add_argument("-num-samples", type=int, default=2)
     parser.add_argument("-num-iters", type=int, default=2)
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Upon failure, dump out raw result",
+                        dest="verbose")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
     driver = LeaksRunnerBenchmarkDriver(
-        SWIFT_BIN_DIR, XFAIL_LIST, args.num_samples, args.num_iters
+        SWIFT_BIN_DIR, XFAIL_LIST, args.num_samples, args.num_iters,
+        args.verbose
     )
     if driver.run(args.filter):
         sys.exit(0)


### PR DESCRIPTION
Just a quick hack to ease debugging on the bots.
