### PR TITLE
Sema: Fix crash on static -vs- non-static witness mismatch with deserialized witness

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2374,13 +2374,16 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
       if (auto FD = dyn_cast<FuncDecl>(witness)) {
         loc = FD->getStaticLoc();
       } else if (auto VD = dyn_cast<VarDecl>(witness)) {
-        loc = VD->getParentPatternBinding()->getStaticLoc();
+        if (auto PBD = VD->getParentPatternBinding()) {
+          loc = PBD->getStaticLoc();
+        }
       } else if (auto SD = dyn_cast<SubscriptDecl>(witness)) {
         loc = SD->getStaticLoc();
       } else {
         llvm_unreachable("Unexpected witness");
       }
-      diag.fixItRemove(loc);
+      if (loc.isValid())
+        diag.fixItRemove(loc);
     } else {
       diag.fixItInsert(witness->getAttributeInsertionLoc(true), "static ");
     }

--- a/test/decl/protocol/Inputs/deserialized_witness_mismatch_other.swift
+++ b/test/decl/protocol/Inputs/deserialized_witness_mismatch_other.swift
@@ -1,0 +1,3 @@
+public struct TimeZone {
+  public static var current: TimeZone { return TimeZone() }
+}

--- a/test/decl/protocol/deserialized_witness_mismatch.swift
+++ b/test/decl/protocol/deserialized_witness_mismatch.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/deserialized_witness_mismatch_other.swift -emit-module-path %t/deserialized_witness_mismatch_other.swiftmodule
+// RUN: %target-swift-frontend -I %t/ %s -typecheck -verify
+
+// Deserialized computed properties don't have a PatternBindingDecl, so
+// make sure we don't expect to find one.
+
+import deserialized_witness_mismatch_other
+
+protocol HasCurrent {
+  var current: Self { get }
+  // expected-note@-1 {{protocol requires property 'current' with type 'TimeZone'; do you want to add a stub?}}
+}
+
+extension TimeZone : HasCurrent {}
+// expected-error@-1 {{type 'TimeZone' does not conform to protocol 'HasCurrent'}}


### PR DESCRIPTION
Deserialized computed properties don't get a PatternBindingDecl apparently.

Fixes <rdar://problem/68241758>.