### PR TITLE
[Diagnostics] Allow "unknown base" fix to be diagnosed in ambiguity situ…

### DIFF
--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1763,6 +1763,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
 };

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -409,6 +409,7 @@ enum Color {
 
 let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) })
 // expected-error@-1 {{cannot convert value of type 'Array<(Int, _)>' to specified type '(Int, Color)'}}
+// expected-error@-2 {{cannot infer contextual base in reference to member 'Unknown'}}
 
 let _: [(Int, Color)] = [1,2].map({ ($0, .Unknown("")) })// expected-error {{missing argument label 'description:' in call}}
 

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -718,3 +718,11 @@ func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: I
   _ = labeled[""] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
 
 }
+
+// rdar://problem/66891544 - incorrect diagnostic ("type is ambiguous") when base type of a reference cannot be determined
+func rdar66891544() {
+  func foo<T>(_: T, defaultT: T? = nil) {}
+  func foo<U>(_: U, defaultU: U? = nil) {}
+
+  foo(.bar) // expected-error {{cannot infer contextual base in reference to member 'bar'}}
+}


### PR DESCRIPTION
…ations

If there are multiple overloads and all of them require explicit
base type for a member reference, let's diagnose it as a single
error since the problem is the same across the overload choices:

```swift
func foo<T>(_: T, defaultT: T? = nil) {}
func foo<U>(_: U, defaultU: U? = nil) {}

foo(.bar)
```

In this example there is not enough contextual information to
determine base type of `.bar` reference and hence both `foo`
overloads are a considered valid solutions until explicitly set
base type disambiguates them.

Resolves: rdar://problem/66891544

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
