### PR TITLE
[5.3][Property Wrappers] Refine assign_by_wrapper lowering

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3937,6 +3937,16 @@ class AssignByWrapperInst
     : public AssignInstBase<SILInstructionKind::AssignByWrapperInst, 4> {
   friend SILBuilder;
 
+public:
+  /// The assignment destination for the property wrapper
+  enum class Destination {
+    BackingWrapper,
+    WrappedValue,
+  };
+
+private:
+  Destination AssignDest = Destination::WrappedValue;
+
   AssignByWrapperInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest,
                        SILValue Initializer, SILValue Setter,
                        AssignOwnershipQualifier Qualifier =
@@ -3951,8 +3961,17 @@ public:
     return AssignOwnershipQualifier(
       SILInstruction::Bits.AssignByWrapperInst.OwnershipQualifier);
   }
-  void setOwnershipQualifier(AssignOwnershipQualifier qualifier) {
+
+  Destination getAssignDestination() const { return AssignDest; }
+
+  void setAssignInfo(AssignOwnershipQualifier qualifier, Destination dest) {
+    using Qualifier = AssignOwnershipQualifier;
+    assert(qualifier == Qualifier::Init && dest == Destination::BackingWrapper ||
+           qualifier == Qualifier::Reassign && dest == Destination::BackingWrapper ||
+           qualifier == Qualifier::Reassign && dest == Destination::WrappedValue);
+
     SILInstruction::Bits.AssignByWrapperInst.OwnershipQualifier = unsigned(qualifier);
+    AssignDest = dest;
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -254,6 +254,10 @@ enum DIUseKind {
   /// value.
   Assign,
 
+  /// The instruction is an assignment of a wrapped value with an already initialized
+  /// backing property wrapper.
+  AssignWrappedValue,
+
   /// The instruction is a store to a member of a larger struct value.
   PartialStore,
 

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -534,54 +534,6 @@ func testSR_12341() {
   _ = SR_12341(condition: true)
 }
 
-class TestLeak: CustomStringConvertible {
-  let val: Int
-  init(val: Int) { self.val = val }
-  deinit { print("    .. \(self).deinit") }
-  var description: String { "TestLeak(\(val))" }
-}
-
-struct SR_13495 {
-  @Wrapper var wrapped: TestLeak
-  var str: String
-
-  init() {
-     wrapped = TestLeak(val: 42)
-     str = ""
-     wrapped = TestLeak(val: 27)
-  }
-
-  init(conditionalInit: Bool) {
-    if (conditionalInit) {
-      wrapped = TestLeak(val: 42)
-    }
-    str = ""
-    wrapped = TestLeak(val: 27)
-  }
-}
-
-func testSR_13495() {
-  // CHECK: ## SR_13495
-  print("\n## SR_13495")
-
-  // CHECK-NEXT:   .. init TestLeak(42)
-  // CHECK-NEXT:     .. TestLeak(42).deinit
-  // CHECK-NEXT:   .. set TestLeak(27)
-  // CHECK-NEXT:     .. TestLeak(27).deinit
-  _ = SR_13495()
-
-  // CHECK-NEXT:   .. init TestLeak(42)
-  // CHECK-NEXT:     .. TestLeak(42).deinit
-  // CHECK-NEXT:   .. init TestLeak(27)
-  // CHECK-NEXT:     .. TestLeak(27).deinit
-  _ = SR_13495(conditionalInit: true)
-
-  // CHECK-NEXT:   .. init TestLeak(27)
-  // CHECK-NEXT:     .. TestLeak(27).deinit
-  _ = SR_13495(conditionalInit: false)
-}
-
-
 @propertyWrapper
 struct NonMutatingSetterWrapper<Value> {
     var value: Value
@@ -620,5 +572,4 @@ testDefaultNilOptIntStruct()
 testComposed()
 testWrapperInitWithDefaultArg()
 testSR_12341()
-testSR_13495()
 testNonMutatingSetterStruct()

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -534,6 +534,54 @@ func testSR_12341() {
   _ = SR_12341(condition: true)
 }
 
+class TestLeak: CustomStringConvertible {
+  let val: Int
+  init(val: Int) { self.val = val }
+  deinit { print("    .. \(self).deinit") }
+  var description: String { "TestLeak(\(val))" }
+}
+
+struct SR_13495 {
+  @Wrapper var wrapped: TestLeak
+  var str: String
+
+  init() {
+     wrapped = TestLeak(val: 42)
+     str = ""
+     wrapped = TestLeak(val: 27)
+  }
+
+  init(conditionalInit: Bool) {
+    if (conditionalInit) {
+      wrapped = TestLeak(val: 42)
+    }
+    str = ""
+    wrapped = TestLeak(val: 27)
+  }
+}
+
+func testSR_13495() {
+  // CHECK: ## SR_13495
+  print("\n## SR_13495")
+
+  // CHECK-NEXT:   .. init TestLeak(42)
+  // CHECK-NEXT:     .. TestLeak(42).deinit
+  // CHECK-NEXT:   .. set TestLeak(27)
+  // CHECK-NEXT:     .. TestLeak(27).deinit
+  _ = SR_13495()
+
+  // CHECK-NEXT:   .. init TestLeak(42)
+  // CHECK-NEXT:     .. TestLeak(42).deinit
+  // CHECK-NEXT:   .. init TestLeak(27)
+  // CHECK-NEXT:     .. TestLeak(27).deinit
+  _ = SR_13495(conditionalInit: true)
+
+  // CHECK-NEXT:   .. init TestLeak(27)
+  // CHECK-NEXT:     .. TestLeak(27).deinit
+  _ = SR_13495(conditionalInit: false)
+}
+
+
 @propertyWrapper
 struct NonMutatingSetterWrapper<Value> {
     var value: Value
@@ -572,4 +620,5 @@ testDefaultNilOptIntStruct()
 testComposed()
 testWrapperInitWithDefaultArg()
 testSR_12341()
+testSR_13495()
 testNonMutatingSetterStruct()

--- a/test/SILOptimizer/di_property_wrappers_leak.swift
+++ b/test/SILOptimizer/di_property_wrappers_leak.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+}
+
+struct TestWrappedValueLeak {
+  @Wrapper var wrapped: LifetimeTracked = LifetimeTracked(0)
+  var str: String
+
+  init() {
+    wrapped = LifetimeTracked(42)
+    str = ""
+    wrapped = LifetimeTracked(27)
+  }
+
+  init(conditionalInit: Bool) {
+    if (conditionalInit) {
+      wrapped = LifetimeTracked(42)
+    }
+    str = ""
+    wrapped = LifetimeTracked(27)
+  }
+}
+
+TestSuite("Property Wrapper DI").test("test wrapped value leak") {
+  _ = TestWrappedValueLeak()
+  _ = TestWrappedValueLeak(conditionalInit: true)
+  _ = TestWrappedValueLeak(conditionalInit: false)
+}
+
+runAllTests()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/33923

Reviewed by: @slavapestov

---
If all of `self` is not yet initialized but the backing property wrapper is, lower `assign_by_wrapper` to re-assignment of the backing storage.

Resolves: [SR-13495](https://bugs.swift.org/browse/SR-13495)
Resolves: rdar://problem/69023636