### PR TITLE
Add a SWIFT_FREESTANDING_MODULE_NAME CMake option

### DIFF
--- a/cmake/modules/DarwinSDKs.cmake
+++ b/cmake/modules/DarwinSDKs.cmake
@@ -32,11 +32,14 @@ if(swift_build_freestanding)
       "Which SDK to use when building the FREESTANDING stdlib")
   set(SWIFT_FREESTANDING_TRIPLE_NAME "" CACHE STRING
       "Which triple name (e.g. 'none-macho') to use when building the FREESTANDING stdlib")
+  set(SWIFT_FREESTANDING_MODULE_NAME "" CACHE STRING
+      "Which .swiftmodule name (e.g. 'freestanding') to use when building the FREESTANDING stdlib")
   set(SWIFT_FREESTANDING_ARCHS "" CACHE STRING
       "Which architectures to build when building the FREESTANDING stdlib")
   configure_sdk_darwin(
       FREESTANDING "FREESTANDING" ""
-      "${SWIFT_FREESTANDING_SDK}" freestanding "${SWIFT_FREESTANDING_TRIPLE_NAME}" freestanding "${SWIFT_FREESTANDING_ARCHS}")
+      "${SWIFT_FREESTANDING_SDK}" freestanding
+      "${SWIFT_FREESTANDING_TRIPLE_NAME}" "${SWIFT_FREESTANDING_MODULE_NAME}" "${SWIFT_FREESTANDING_ARCHS}")
   set(SWIFT_SDK_FREESTANDING_LIB_SUBDIR "freestanding")
   configure_target_variant(FREESTANDING-DA "FREESTANDING Debug+Asserts"   FREESTANDING DA "Debug+Asserts")
   configure_target_variant(FREESTANDING-RA "FREESTANDING Release+Asserts" FREESTANDING RA "Release+Asserts")

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2468,6 +2468,7 @@ swift-primary-variant-arch=x86_64
 swift-freestanding-sdk=macosx
 # For now, until clang/swiftc works correctly with "none-macho" as the OS part of target triple.
 swift-freestanding-triple-name=macosx11.0
+swift-freestanding-module-name=macos
 swift-freestanding-archs=x86_64
 
 #===----------------------------------------------------------------------===#

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -201,6 +201,7 @@ KNOWN_SETTINGS=(
     ## FREESTANDING Stdlib Options
     swift-freestanding-sdk                      ""                "which SDK to use when building the FREESTANDING stdlib"
     swift-freestanding-triple-name              ""                "which triple name (e.g. 'none-macho') to use when building the FREESTANDING stdlib"
+    swift-freestanding-module-name              ""                "which .swiftmodule name (e.g. 'freestanding') to use when building the FREESTANDING stdlib"
     swift-freestanding-archs                    ""                "space-separated list of which architectures to build when building the FREESTANDING stdlib"
 
     ## Uncategorised
@@ -1890,6 +1891,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_FREESTANDING_TRIPLE_NAME:STRING="${SWIFT_FREESTANDING_TRIPLE_NAME}"
+                    )
+                fi
+
+                if [ "${SWIFT_FREESTANDING_MODULE_NAME}" ] ; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_FREESTANDING_MODULE_NAME:STRING="${SWIFT_FREESTANDING_MODULE_NAME}"
                     )
                 fi
 


### PR DESCRIPTION
Add a SWIFT_FREESTANDING_MODULE_NAME CMake option to be able to select the last part of a .swiftmodule filename when building the "freestanding" variant of stdlib. This is needed to bringup building and testing infrastructure for "freestanding".

Eventually, these flags (SWIFT_FREESTANDING_MODULE_NAME, SWIFT_FREESTANDING_TRIPLE_NAME) should go away, but that can only happen once Clang and Swift actually accept "freestanding" or "none" as a target triple.