### PR TITLE
Avoid using extra-cmake-options in the stdlib standalone presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2369,9 +2369,10 @@ skip-build-cmark
 skip-build-benchmarks
 skip-test-cmark
 
-# Then we inject two cmake arguments that cause us not to build tools and to
+# This triggers the stdlib standalone build: Don't build tools (the compiler),
 # assume we are working with the host compiler.
-extra-cmake-options=-DSWIFT_INCLUDE_TOOLS=NO -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=YES
+build-swift-tools=0
+build-runtime-with-host-compiler=1
 
 # Then set the paths to our native tools. If compiling against a toolchain,
 # these should all be the ./usr/bin directory.


### PR DESCRIPTION
NFC. We have these flags exposed in build-script, no need to use extra-cmake-options.