### PR TITLE
ASTScope: Remove "re-expansion" mechanism

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -986,18 +986,11 @@ class AbstractFunctionBodyScope : public ASTScopeImpl {
 public:
   AbstractFunctionDecl *const decl;
 
-  /// \c Parser::parseAbstractFunctionBodyDelayed can call \c
-  /// AbstractFunctionDecl::setBody after the tree has been constructed. So if
-  /// this changes, have to rebuild body.
-  NullablePtr<BraceStmt> bodyWhenLastExpanded;
-
   AbstractFunctionBodyScope(AbstractFunctionDecl *e) : decl(e) {}
   virtual ~AbstractFunctionBodyScope() {}
 
 protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &scopeCreator) override;
-  void beCurrent() override;
-  bool isCurrentIfWasExpanded() const override;
 
 private:
   void expandAScopeThatDoesNotCreateANewInsertionPoint(ScopeCreator &);

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1321,20 +1321,16 @@ protected:
 class TopLevelCodeScope final : public ASTScopeImpl {
 public:
   TopLevelCodeDecl *const decl;
-  BraceStmt *bodyWhenLastExpanded;
 
   TopLevelCodeScope(TopLevelCodeDecl *e) : decl(e) {}
   virtual ~TopLevelCodeScope() {}
 
 protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &scopeCreator) override;
-  void beCurrent() override;
-  bool isCurrentIfWasExpanded() const override;
 
 private:
   AnnotatedInsertionPoint
   expandAScopeThatCreatesANewInsertionPoint(ScopeCreator &);
-  std::vector<ASTScopeImpl *> rescueBodyScopesToReuse();
 
 public:
   std::string getClassName() const override;

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -530,12 +530,6 @@ public:
   ScopeCreator *const scopeCreator;
   ASTScopeImpl *insertionPoint;
 
-  /// The number of \c Decls in the \c SourceFile that were already seen.
-  /// Since parsing can be interleaved with type-checking, on every
-  /// lookup, look at creating scopes for any \c Decls beyond this number.
-  /// TODO: Unify with numberOfChildrenWhenLastExpanded
-  size_t numberOfDeclsAlreadySeen = 0;
-
   ASTSourceFileScope(SourceFile *SF, ScopeCreator *scopeCreator);
 
   std::string getClassName() const override;
@@ -560,8 +554,6 @@ public:
 
 protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &scopeCreator) override;
-  bool isCurrentIfWasExpanded() const override;
-  void beCurrent() override;
   bool doesExpansionOnlyAddNewDeclsAtEnd() const override;
 
   ScopeCreator &getScopeCreator() override;

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -609,8 +609,6 @@ public:
   virtual const Decl *
   getReferrentOfScope(const GenericTypeOrExtensionScope *s) const;
 
-  virtual void beCurrent(IterableTypeScope *) const = 0;
-  virtual bool isCurrentIfWasExpanded(const IterableTypeScope *) const = 0;
   virtual NullablePtr<ASTScopeImpl>
   insertionPointForDeferredExpansion(IterableTypeScope *) const = 0;
   virtual SourceRange
@@ -635,19 +633,6 @@ public:
 
     const Decl *
     getReferrentOfScope(const GenericTypeOrExtensionScope *s) const override;
-
-    /// Make whole portion lazy to avoid circularity in lookup of generic
-    /// parameters of extensions. When \c bindExtension is called, it needs to
-    /// unqualifed-lookup the type being extended. That causes an \c
-    /// ExtensionScope
-    /// (\c GenericTypeOrExtensionWholePortion) to be built.
-    /// The building process needs the generic parameters, but that results in a
-    /// request for the extended nominal type of the \c ExtensionDecl, which is
-    /// an endless recursion. Although we only need to make \c ExtensionScope
-    /// lazy, might as well do it for all \c IterableTypeScopes.
-
-    void beCurrent(IterableTypeScope *) const override;
-    bool isCurrentIfWasExpanded(const IterableTypeScope *) const override;
 
     NullablePtr<ASTScopeImpl>
     insertionPointForDeferredExpansion(IterableTypeScope *) const override;
@@ -682,9 +667,6 @@ public:
   SourceRange getChildlessSourceRangeOf(const GenericTypeOrExtensionScope *,
                                         bool omitAssertions) const override;
 
-  void beCurrent(IterableTypeScope *) const override;
-  bool isCurrentIfWasExpanded(const IterableTypeScope *) const override;
-
   NullablePtr<ASTScopeImpl>
   insertionPointForDeferredExpansion(IterableTypeScope *) const override;
   SourceRange
@@ -704,8 +686,6 @@ public:
   SourceRange getChildlessSourceRangeOf(const GenericTypeOrExtensionScope *,
                                         bool omitAssertions) const override;
 
-  void beCurrent(IterableTypeScope *) const override;
-  bool isCurrentIfWasExpanded(const IterableTypeScope *) const override;
   NullablePtr<ASTScopeImpl>
   insertionPointForDeferredExpansion(IterableTypeScope *) const override;
   SourceRange
@@ -796,11 +776,6 @@ protected:
 };
 
 class IterableTypeScope : public GenericTypeScope {
-  /// Because of \c parseDelayedDecl members can get added after the tree is
-  /// constructed, and they can be out of order. Detect this happening by
-  /// remembering the member count.
-  unsigned memberCount = 0;
-
 public:
   IterableTypeScope(const Portion *p) : GenericTypeScope(p) {}
   virtual ~IterableTypeScope() {}
@@ -810,15 +785,7 @@ public:
   bool doesDeclHaveABody() const override;
   void expandBody(ScopeCreator &) override;
 
-protected:
-  void beCurrent() override;
-  bool isCurrentIfWasExpanded() const override;
-
 public:
-  void makeWholeCurrent();
-  bool isWholeCurrent() const;
-  void makeBodyCurrent();
-  bool isBodyCurrent() const;
   NullablePtr<ASTScopeImpl> insertionPointForDeferredExpansion() override;
   SourceRange sourceRangeForDeferredExpansion() const override;
 

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1133,9 +1133,6 @@ public:
 };
 
 class PatternEntryDeclScope final : public AbstractPatternEntryScope {
-  const Expr *initWhenLastExpanded;
-  unsigned varCountWhenLastExpanded = 0;
-
 public:
   PatternEntryDeclScope(PatternBindingDecl *pbDecl, unsigned entryIndex,
                         DeclVisibilityKind vis)
@@ -1144,8 +1141,6 @@ public:
 
 protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &scopeCreator) override;
-  void beCurrent() override;
-  bool isCurrentIfWasExpanded() const override;
 
 private:
   AnnotatedInsertionPoint

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1948,8 +1948,6 @@ private:
   CaptureInfo getCaptureInfo() const { return Captures; }
   void setCaptureInfo(CaptureInfo captures) { Captures = captures; }
 
-  unsigned getNumBoundVariables() const;
-
 private:
   SourceLoc getLastAccessorEndLoc() const;
 };

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -712,13 +712,6 @@ class IterableDeclContext {
   /// member loading, as a key when doing lookup in this IDC.
   serialization::DeclID SerialID;
 
-  /// Because \c parseDelayedDecl and lazy member adding can add members *after*
-  /// an \c ASTScope tree is created, there must be some way for the tree to
-  /// detect when a member has been added. A bit would suffice,
-  /// but would be more fragile, The scope code could count the members each
-  /// time, but I think it's a better trade to just keep a count here.
-  unsigned MemberCount : 29;
-
   /// Whether we have already added the parsed members into the context.
   unsigned AddedParsedMembers : 1;
 
@@ -741,7 +734,6 @@ class IterableDeclContext {
 public:
   IterableDeclContext(IterableDeclContextKind kind)
     : LastDeclAndKind(nullptr, kind) {
-    MemberCount = 0;
     AddedParsedMembers = 0;
     HasOperatorDeclarations = 0;
     HasNestedClassDeclarations = 0;
@@ -793,9 +785,6 @@ public:
   /// Add a member to this context. If the hint decl is specified, the new decl
   /// is inserted immediately after the hint.
   void addMember(Decl *member, Decl *hint = nullptr);
-
-  /// See \c MemberCount
-  unsigned getMemberCount() const;
 
   /// Check whether there are lazily-loaded members.
   bool hasLazyMembers() const {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -251,9 +251,6 @@ namespace swift {
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;
 
-    /// Should  we stress ASTScope-based resolution for debugging?
-    bool StressASTScopeLookup = false;
-
     /// Whether to enable the new operator decl and precedencegroup lookup
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -157,9 +157,6 @@ def disable_target_os_checking :
 def crosscheck_unqualified_lookup : Flag<["-"], "crosscheck-unqualified-lookup">,
   HelpText<"Compare legacy DeclContext- to ASTScope-based unqualified name lookup (for debugging)">;
 
-def stress_astscope_lookup : Flag<["-"], "stress-astscope-lookup">,
-  HelpText<"Stress ASTScope-based unqualified name lookup (for testing)">;
-  
 def use_clang_function_types : Flag<["-"], "use-clang-function-types">,
   HelpText<"Use stored Clang function types for computing canonical types.">;
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1695,27 +1695,6 @@ bool ASTSourceFileScope::isCurrentIfWasExpanded() const {
   return SF->getTopLevelDecls().size() == numberOfDeclsAlreadySeen;
 }
 
-// Try to avoid the work of counting
-static const bool assumeVarsDoNotGetAdded = true;
-
-void PatternEntryDeclScope::beCurrent() {
-  initWhenLastExpanded = getPatternEntry().getOriginalInit();
-  if (assumeVarsDoNotGetAdded && varCountWhenLastExpanded)
-    return;
-  varCountWhenLastExpanded = getPatternEntry().getNumBoundVariables();
-}
-bool PatternEntryDeclScope::isCurrentIfWasExpanded() const {
-  if (initWhenLastExpanded != getPatternEntry().getOriginalInit())
-    return false;
-  if (assumeVarsDoNotGetAdded && varCountWhenLastExpanded) {
-    ASTScopeAssert(varCountWhenLastExpanded ==
-                       getPatternEntry().getNumBoundVariables(),
-                   "Vars were not supposed to be added to a pattern entry.");
-    return true;
-  }
-  return getPatternEntry().getNumBoundVariables() == varCountWhenLastExpanded;
-}
-
 #pragma mark getParentOfASTAncestorScopesToBeRescued
 NullablePtr<ASTScopeImpl>
 ASTScopeImpl::getParentOfASTAncestorScopesToBeRescued() {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -330,14 +330,6 @@ public:
     return nullptr;
   }
 
-  template <typename Scope, typename... Args>
-  ASTScopeImpl *ensureUniqueThenConstructExpandAndInsert(ASTScopeImpl *parent,
-                                                         Args... args) {
-    if (auto s = ifUniqueConstructExpandAndInsert<Scope>(parent, args...))
-      return s.get();
-    ASTScope_unreachable("Scope should have been unique");
-  }
-
 private:
   template <typename Scope, typename... Args>
   ASTScopeImpl *constructExpandAndInsert(ASTScopeImpl *parent, Args... args) {
@@ -1701,46 +1693,6 @@ void ASTSourceFileScope::beCurrent() {
 }
 bool ASTSourceFileScope::isCurrentIfWasExpanded() const {
   return SF->getTopLevelDecls().size() == numberOfDeclsAlreadySeen;
-}
-
-void IterableTypeScope::beCurrent() { portion->beCurrent(this); }
-bool IterableTypeScope::isCurrentIfWasExpanded() const {
-  return portion->isCurrentIfWasExpanded(this);
-}
-
-void GenericTypeOrExtensionWholePortion::beCurrent(IterableTypeScope *s) const {
-  s->makeWholeCurrent();
-}
-bool GenericTypeOrExtensionWholePortion::isCurrentIfWasExpanded(
-    const IterableTypeScope *s) const {
-  return s->isWholeCurrent();
-}
-void GenericTypeOrExtensionWherePortion::beCurrent(IterableTypeScope *) const {}
-bool GenericTypeOrExtensionWherePortion::isCurrentIfWasExpanded(
-    const IterableTypeScope *) const {
-  return true;
-}
-void IterableTypeBodyPortion::beCurrent(IterableTypeScope *s) const {
-  s->makeBodyCurrent();
-}
-bool IterableTypeBodyPortion::isCurrentIfWasExpanded(
-    const IterableTypeScope *s) const {
-  return s->isBodyCurrent();
-}
-
-void IterableTypeScope::makeWholeCurrent() {
-  ASTScopeAssert(getWasExpanded(), "Should have been expanded");
-}
-bool IterableTypeScope::isWholeCurrent() const {
-  // Whole starts out unexpanded, and is lazily built but will have at least a
-  // body scope child
-  return getWasExpanded();
-}
-void IterableTypeScope::makeBodyCurrent() {
-  memberCount = getIterableDeclContext().get()->getMemberCount();
-}
-bool IterableTypeScope::isBodyCurrent() const {
-  return memberCount == getIterableDeclContext().get()->getMemberCount();
 }
 
 void AbstractFunctionBodyScope::beCurrent() {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1695,14 +1695,6 @@ bool ASTSourceFileScope::isCurrentIfWasExpanded() const {
   return SF->getTopLevelDecls().size() == numberOfDeclsAlreadySeen;
 }
 
-void AbstractFunctionBodyScope::beCurrent() {
-  bodyWhenLastExpanded = decl->getBody(false);
-}
-bool AbstractFunctionBodyScope::isCurrentIfWasExpanded() const {
-  // Pass in false to keep the compiler from synthesizing one.
-  return bodyWhenLastExpanded == decl->getBody(false);
-}
-
 // Try to avoid the work of counting
 static const bool assumeVarsDoNotGetAdded = true;
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1703,11 +1703,6 @@ bool AbstractFunctionBodyScope::isCurrentIfWasExpanded() const {
   return bodyWhenLastExpanded == decl->getBody(false);
 }
 
-void TopLevelCodeScope::beCurrent() { bodyWhenLastExpanded = decl->getBody(); }
-bool TopLevelCodeScope::isCurrentIfWasExpanded() const {
-  return bodyWhenLastExpanded == decl->getBody();
-}
-
 // Try to avoid the work of counting
 static const bool assumeVarsDoNotGetAdded = true;
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1056,8 +1056,7 @@ ASTSourceFileScope::expandAScopeThatCreatesANewInsertionPoint(
   ASTScopeAssert(SF, "Must already have a SourceFile.");
   ArrayRef<Decl *> decls = SF->getTopLevelDecls();
   // Assume that decls are only added at the end, in source order
-  ArrayRef<Decl *> newDecls = decls.slice(numberOfDeclsAlreadySeen);
-  std::vector<ASTNode> newNodes(newDecls.begin(), newDecls.end());
+  std::vector<ASTNode> newNodes(decls.begin(), decls.end());
   insertionPoint =
       scopeCreator.addSiblingsToScopeTree(insertionPoint, this, newNodes);
   // Too slow to perform all the time:
@@ -1687,13 +1686,6 @@ bool ASTScopeImpl::isCurrent() const {
 
 void ASTScopeImpl::beCurrent() {}
 bool ASTScopeImpl::isCurrentIfWasExpanded() const { return true; }
-
-void ASTSourceFileScope::beCurrent() {
-  numberOfDeclsAlreadySeen = SF->getTopLevelDecls().size();
-}
-bool ASTSourceFileScope::isCurrentIfWasExpanded() const {
-  return SF->getTopLevelDecls().size() == numberOfDeclsAlreadySeen;
-}
 
 #pragma mark getParentOfASTAncestorScopesToBeRescued
 NullablePtr<ASTScopeImpl>

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -938,6 +938,9 @@ ExpandASTScopeRequest::evaluate(Evaluator &evaluator, ASTScopeImpl *parent,
 }
 
 ASTScopeImpl *ASTScopeImpl::expandAndBeCurrent(ScopeCreator &scopeCreator) {
+  ASTScopeAssert(!getWasExpanded(),
+                 "Cannot expand the same scope twice");
+
   auto *insertionPoint = expandSpecifically(scopeCreator);
   ASTScopeAssert(!insertionPointForDeferredExpansion() ||
                      insertionPointForDeferredExpansion().get() ==

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1560,12 +1560,6 @@ VarDecl *PatternBindingEntry::getAnchoringVarDecl() const {
   return variables[0];
 }
 
-unsigned PatternBindingEntry::getNumBoundVariables() const {
-  unsigned varCount = 0;
-  getPattern()->forEachVariable([&](VarDecl *) { ++varCount; });
-  return varCount;
-}
-
 SourceLoc PatternBindingEntry::getLastAccessorEndLoc() const {
   SourceLoc lastAccessorEnd;
   getPattern()->forEachVariable([&](VarDecl *var) {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -768,7 +768,6 @@ ArrayRef<Decl *> IterableDeclContext::getSemanticMembers() const {
 void IterableDeclContext::addMember(Decl *member, Decl *Hint) {
   // Add the member to the list of declarations without notification.
   addMemberSilently(member, Hint);
-  ++MemberCount;
 
   // Notify our parent declaration that we have added the member, which can
   // be used to update the lookup tables.
@@ -845,12 +844,6 @@ bool IterableDeclContext::hasUnparsedMembers() const {
   }
 
   return true;
-}
-
-unsigned IterableDeclContext::getMemberCount() const {
-  if (hasUnparsedMembers())
-    loadAllMembers();
-  return MemberCount;
 }
 
 void IterableDeclContext::loadAllMembers() const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -426,7 +426,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   
   Opts.DisableParserLookup |= Args.hasArg(OPT_disable_parser_lookup);
-  Opts.StressASTScopeLookup |= Args.hasArg(OPT_stress_astscope_lookup);
   Opts.EnableNewOperatorLookup = Args.hasFlag(OPT_enable_new_operator_lookup,
                                               OPT_disable_new_operator_lookup,
                                               /*default*/ false);


### PR DESCRIPTION
The subset of the AST that participates in unqualified lookup should be effectively immutable. Delayed parsing can fill in members of nominal types and extensions, as well as function bodies, but since we lazily expand scopes, and the relevant getter methods on IterableDeclContext and AbstractFunctionBody trigger parsing, ASTScope should always see a consistent view of the world.