### PR TITLE
[linux] remove absolute rpath of /usr/lib/swift/linux added to many shared libraries

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -461,7 +461,7 @@ function(add_swift_host_library name)
       INSTALL_NAME_DIR "@rpath")
   elseif(SWIFT_HOST_VARIANT_SDK STREQUAL LINUX)
     set_target_properties(${name} PROPERTIES
-      INSTALL_RPATH "$ORIGIN:/usr/lib/swift/linux")
+      INSTALL_RPATH "$ORIGIN")
   elseif(SWIFT_HOST_VARIANT_SDK STREQUAL CYGWIN)
     set_target_properties(${name} PROPERTIES
       INSTALL_RPATH "$ORIGIN:/usr/lib/swift/cygwin")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -998,7 +998,7 @@ function(_add_swift_target_library_single target name)
   elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "LINUX")
     set_target_properties("${target}"
       PROPERTIES
-      INSTALL_RPATH "$ORIGIN:/usr/lib/swift/linux")
+      INSTALL_RPATH "$ORIGIN")
   elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "CYGWIN")
     set_target_properties("${target}"
       PROPERTIES

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -99,7 +99,7 @@ macro(add_sourcekit_library name)
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     if(SOURCEKITLIB_SHARED)
       set_target_properties(${name} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
-      set_target_properties(${name} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/swift/linux:/usr/lib/swift/linux")
+      set_target_properties(${name} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/swift/linux")
     endif()
   endif()
 


### PR DESCRIPTION
This was presumably added as a backup, in case the libraries in a toolchain couldn't be found, but will not work well, so take it out.

Here's a full list of shared library runpaths from the just-released official Swift 5.3 toolchain for linux:
```
> find swift-5.3-RELEASE-ubuntu20.04/ -name "lib*.so"| xargs readelf -d | ag "File:|runpath"
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/libsourcekitdInProc.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib/swift/linux:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/pm/4_2/libPackageDescription.so
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/swift-nightly-install/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/pm/4/libPackageDescription.so
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/swift-nightly-install/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/pm/llbuild/libllbuildSwift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../../linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/pm/llbuild/libllbuild.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicuucswift.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftRemoteMirror.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libdispatch.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libBlocksRuntime.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libFoundationNetworking.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicudataswift.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libXCTest.so
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftDispatch.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswift_Differentiation.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/lib_InternalSwiftSyntaxParser.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftGlibc.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libFoundationXML.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libFoundation.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftSwiftOnoneSupport.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicui18nswift.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/swift/linux/libswiftCore.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/liblldb.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/libIndexStore.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.hwasan-x86_64.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.scudo_minimal-x86_64.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.scudo-x86_64.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.ubsan_minimal-x86_64.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib]
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.dyndd-x86_64.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.so
File: swift-5.3-RELEASE-ubuntu20.04/usr/lib/libswiftDemangle.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/lib/swift/linux]
```
If there's any difference between the toolchain being used and the one installed in `/usr/lib/swift/linux`, say if you download this 5.3 toolchain for linux into your home directory but 5.2.5 is installed in `/usr/lib/swift/linux`, using that system runpath won't work properly. I checked and all these libraries already have a runpath relative to $ORIGIN, ie locally, so all this absolute path will do is supply the system Swift library if the local one is missing (obviously if the used toolchain is installed in the system, ie `/usr/lib/swift/linux`, this absolute path is redundant). But since using the system Swift libraries will not work properly if the Swift versions don't match, causing subtle bugs in the worst case, I think it's better not to add this absolute runpath at all.

It was added five years ago by @bitjammer, ad95b5f, and copied to SourceKit a couple years later, a93bddf. [I brought up this issue earlier this year](https://github.com/apple/swift/pull/30235#issuecomment-600429177), but got no response at the time, so I let it go. I think this is worth getting in and into the 5.3 branch for the next patch release.

@gottesmm and @compnerd, I think this should be removed, similar to the other ELF runpath issues we discussed. @tachoknight, let us know what you think from your Fedora packaging perspective.