### PR TITLE
Move the actual Obj-C parts of ReflectionMirror.mm into a separate file, make ReflectionMirror.mm a .cpp file

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -22,7 +22,7 @@ set(swift_runtime_objc_sources
     ErrorObject.mm
     SwiftObject.mm
     SwiftValue.mm
-    ReflectionMirror.mm
+    ReflectionMirrorObjC.mm
     ObjCRuntimeGetImageNameFromClass.mm)
 
 set(swift_runtime_sources
@@ -63,6 +63,7 @@ set(swift_runtime_sources
     Portability.cpp
     ProtocolConformance.cpp
     RefCount.cpp
+    ReflectionMirror.cpp
     RuntimeInvocationsTracking.cpp
     SwiftDtoa.cpp)
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -632,6 +632,13 @@ public:
                                   const Metadata *assocType,
                                   const ProtocolRequirement *reqBase,
                                   const ProtocolRequirement *assocConformance);
+
+#if SWIFT_OBJC_INTEROP
+  /// Returns a retained Quick Look representation object an Obj-C object.
+  SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+  id _quickLookObjectForPointer(void *value);
+#endif
+
 } // end namespace swift
 
 #endif /* SWIFT_RUNTIME_PRIVATE_H */

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -34,9 +34,6 @@
 #if SWIFT_OBJC_INTEROP
 #include "swift/Runtime/ObjCBridge.h"
 #include "SwiftObject.h"
-#include <Foundation/Foundation.h>
-#include <objc/objc.h>
-#include <objc/runtime.h>
 #endif
 
 #if defined(_WIN32)
@@ -79,13 +76,6 @@ char *strndup(const char *s, size_t n) {
 #endif
 
 using namespace swift;
-
-#if SWIFT_OBJC_INTEROP
-// Declare the debugQuickLookObject selector.
-@interface DeclareSelectors
-- (id)debugQuickLookObject;
-@end
-#endif
 
 namespace {
 
@@ -751,16 +741,8 @@ struct ClassImpl : ReflectionMirrorImpl {
   }
 
 #if SWIFT_OBJC_INTEROP
-  id quickLookObject() {
-    id object = [*reinterpret_cast<const id *>(value) retain];
-    if ([object respondsToSelector:@selector(debugQuickLookObject)]) {
-      id quickLookObject = [object debugQuickLookObject];
-      [quickLookObject retain];
-      [object release];
-      return quickLookObject;
-    }
-
-    return object;
+  id quickLookObject() override {
+    return _quickLookObjectForPointer(value);
   }
 #endif
 };

--- a/stdlib/public/runtime/ReflectionMirrorObjC.mm
+++ b/stdlib/public/runtime/ReflectionMirrorObjC.mm
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Config.h"
+
+#if SWIFT_OBJC_INTEROP
+
+#include "Private.h"
+#include <Foundation/Foundation.h>
+#include <objc/objc.h>
+#include <objc/runtime.h>
+
+using namespace swift;
+
+// Declare the debugQuickLookObject selector.
+@interface DeclareSelectors
+- (id)debugQuickLookObject;
+@end
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+id swift::_quickLookObjectForPointer(void *value) {
+  id object = [*reinterpret_cast<const id *>(value) retain];
+  if ([object respondsToSelector:@selector(debugQuickLookObject)]) {
+    id quickLookObject = [object debugQuickLookObject];
+    [quickLookObject retain];
+    [object release];
+    return quickLookObject;
+  }
+
+  return object;
+}
+
+#endif


### PR DESCRIPTION
Move the actual Obj-C parts of ReflectionMirror.mm into a separate file, make ReflectionMirror.mm a .cpp file.