### PR TITLE
ASTScope: Clean up IfConfigDecl handling and a couple of other things

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -298,9 +298,6 @@ protected:
   bool verifyThatChildrenAreContainedWithin(SourceRange) const;
   bool verifyThatThisNodeComeAfterItsPriorSibling() const;
 
-  virtual SourceRange
-  getSourceRangeOfEnclosedParamsOfASTNode(bool omitAssertions) const;
-
 private:
   bool checkSourceRangeAfterExpansion(const ASTContext &) const;
 
@@ -992,13 +989,6 @@ public:
   NullablePtr<const void> getReferrent() const override;
 
 protected:
-  SourceRange
-  getSourceRangeOfEnclosedParamsOfASTNode(bool omitAssertions) const override;
-
-private:
-  static SourceLoc getParmsSourceLocOfAFD(AbstractFunctionDecl *);
-
-protected:
   NullablePtr<const GenericParamList> genericParams() const override;
 };
 
@@ -1507,9 +1497,6 @@ public:
   NullablePtr<const void> getReferrent() const override;
 
 protected:
-  SourceRange
-  getSourceRangeOfEnclosedParamsOfASTNode(bool omitAssertions) const override;
-
   NullablePtr<const GenericParamList> genericParams() const override;
   NullablePtr<AbstractStorageDecl>
   getEnclosingAbstractStorageDecl() const override {
@@ -1565,10 +1552,6 @@ public:
   NullablePtr<DeclContext> getDeclContext() const override { return decl; }
   NullablePtr<Decl> getDeclIfAny() const override { return decl; }
   Decl *getDecl() const { return decl; }
-
-protected:
-  SourceRange
-  getSourceRangeOfEnclosedParamsOfASTNode(bool omitAssertions) const override;
 
 private:
   void expandAScopeThatDoesNotCreateANewInsertionPoint(ScopeCreator &);

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -681,10 +681,8 @@ public:
   /// Flesh out the tree for dumping
   void buildFullyExpandedTree();
 
-  /// \return the scopes traversed
-  static llvm::SmallVector<const ast_scope::ASTScopeImpl *, 0>
-  unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc,
-                    namelookup::AbstractASTScopeDeclConsumer &);
+  static void unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc,
+                                namelookup::AbstractASTScopeDeclConsumer &);
 
   /// Entry point to record the visible statement labels from the given
   /// point.

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -38,12 +38,12 @@ using namespace ast_scope;
 
 #pragma mark ASTScope
 
-llvm::SmallVector<const ASTScopeImpl *, 0> ASTScope::unqualifiedLookup(
+void ASTScope::unqualifiedLookup(
     SourceFile *SF, DeclNameRef name, SourceLoc loc,
     namelookup::AbstractASTScopeDeclConsumer &consumer) {
   if (auto *s = SF->getASTContext().Stats)
     ++s->getFrontendCounters().NumASTScopeLookups;
-  return ASTScopeImpl::unqualifiedLookup(SF, name, loc, consumer);
+  ASTScopeImpl::unqualifiedLookup(SF, name, loc, consumer);
 }
 
 llvm::SmallVector<LabeledStmt *, 4> ASTScope::lookupLabeledStmts(

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1298,24 +1298,23 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
             .ifUniqueConstructExpandAndInsert<DifferentiableAttributeScope>(
                 this, diffAttr, decl);
       });
+
   // Create scopes for generic and ordinary parameters.
   // For a subscript declaration, the generic and ordinary parameters are in an
   // ancestor scope, so don't make them here.
   ASTScopeImpl *leaf = this;
+
   if (!isa<AccessorDecl>(decl)) {
     leaf = scopeCreator.addNestedGenericParamScopesToTree(
         decl, decl->getGenericParams(), leaf);
-    if (isLocalizable(decl) && getParmsSourceLocOfAFD(decl).isValid()) {
-      // swift::createDesignatedInitOverride just clones the parameters, so they
-      // end up with a bogus SourceRange, maybe *before* the start of the
-      // function.
-      if (!decl->isImplicit()) {
-        leaf = scopeCreator
-                   .constructExpandAndInsertUncheckable<ParameterListScope>(
-                       leaf, decl->getParameters(), nullptr);
-      }
+
+    auto *params = decl->getParameters();
+    if (params->size() > 0) {
+      scopeCreator.constructExpandAndInsertUncheckable<ParameterListScope>(
+          leaf, params, nullptr);
     }
   }
+
   // Create scope for the body.
   // We create body scopes when there is no body for source kit to complete
   // erroneous code in bodies.

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -62,7 +62,7 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
 
   namelookup::ASTScopeDeclGatherer gatherer;
   // Print the local bindings introduced by this scope.
-  locScope->lookupLocalsOrMembers({this}, gatherer);
+  locScope->lookupLocalsOrMembers(gatherer);
   if (!gatherer.getDecls().empty()) {
     llvm::errs() << "Local bindings: ";
     llvm::interleave(

--- a/test/NameLookup/scope_map_top_level.swift
+++ b/test/NameLookup/scope_map_top_level.swift
@@ -8,7 +8,7 @@ let a: Int? = 1
 guard let b = a else {
 }
 
-func foo() {} // to interrupt the TopLevelCodeDecl
+func foo(x: Int) {} // to interrupt the TopLevelCodeDecl
 
 let c = b
 
@@ -40,10 +40,10 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:             `-ConditionalClausePatternUseScope, [8:22 - 8:22] let b{{\??}}
 // CHECK-EXPANDED-NEXT:           |-BraceStmtScope {{.*}}, [8:22 - 9:1]
 // CHECK-EXPANDED-NEXT:           `-LookupParentDiversionScope, [9:1 - 21:28]
-// CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [11:1 - 11:13] 'foo()'
-// CHECK-EXPANDED-NEXT:               `-ParameterListScope {{.*}}, [11:9 - 11:13]
-// CHECK-EXPANDED-NEXT:                 `-FunctionBodyScope {{.*}}, [11:12 - 11:13]
-// CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [11:12 - 11:13]
+// CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [11:1 - 11:19] 'foo(x:)'
+// CHECK-EXPANDED-NEXT:               |-ParameterListScope {{.*}}, [11:9 - 11:16]
+// CHECK-EXPANDED-NEXT:               `-FunctionBodyScope {{.*}}, [11:18 - 11:19]
+// CHECK-EXPANDED-NEXT:                 `-BraceStmtScope {{.*}}, [11:18 - 11:19]
 // CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 21:28]
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                 |-PatternEntryDeclScope {{.*}}, [13:5 - 13:9] entry 0 'c'
@@ -52,9 +52,8 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:                 |-ExtensionDeclScope {{.*}}, [17:14 - 19:1]
 // CHECK-EXPANDED-NEXT:                   `-ExtensionBodyScope {{.*}}, [17:15 - 19:1]
 // CHECK-EXPANDED-NEXT:                     `-AbstractFunctionDeclScope {{.*}}, [18:3 - 18:43] 'my_identity()'
-// CHECK-EXPANDED-NEXT:                       `-ParameterListScope {{.*}}, [18:19 - 18:43]
-// CHECK-EXPANDED-NEXT:                         `-FunctionBodyScope {{.*}}, [18:29 - 18:43]
-// CHECK-EXPANDED-NEXT:                           `-BraceStmtScope {{.*}}, [18:29 - 18:43]
+// CHECK-EXPANDED-NEXT:                       `-FunctionBodyScope {{.*}}, [18:29 - 18:43]
+// CHECK-EXPANDED-NEXT:                         `-BraceStmtScope {{.*}}, [18:29 - 18:43]
 // CHECK-EXPANDED-NEXT:                 `-TopLevelCodeScope {{.*}}, [21:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [21:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                     `-PatternEntryDeclScope {{.*}}, [21:5 - 21:28] entry 0 'i'


### PR DESCRIPTION
- The `history` vector passed down through lookup was only used for the `selfDC` and `isCascading` computations, both of which are now gone.
- Members of the active clause of an `IfConfigDecl` are visited as part of their parent, so we don't have to walk into `IfConfigDecl`s at all.
- The `ParameterListScope` is only used as a parent for default argument initializer scopes, and doesn't bind any names, so it can be a sibling rather a parent of the `FunctionBodyScope`, which simplifies some source range computations.