### PR TITLE
[Dependency Scanner] Add option to execute an import prescan

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -269,6 +269,10 @@ public:
   /// built and given to the compiler invocation.
   bool DisableImplicitModules = false;
 
+  /// When performing a dependency scanning action, only identify and output all imports
+  /// of the main Swift module's source files.
+  bool ImportPrescan = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -226,8 +226,11 @@ def placeholder_dependency_module_map
 def batch_scan_input_file
   : Separate<["-"], "batch-scan-input-file">, MetaVarName<"<path>">,
     HelpText<"Specify a JSON file containing modules to perform batch dependencies scanning">;
-}
 
+def import_prescan : Flag<["-"], "import-prescan">,
+   HelpText<"When performing a dependency scan, only dentify all imports of the main Swift module sources">;
+
+}
 
 // HIDDEN FLAGS
 let Flags = [FrontendOption, NoDriverOption, HelpHidden] in {

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -167,9 +167,14 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
                                            const ArgList &args) {
   const Arg *ExternalDependencyMap = args.getLastArg(options::OPT_placeholder_dependency_module_map);
   const Arg *ScanDependencies = args.getLastArg(options::OPT_scan_dependencies);
+  const Arg *Prescan = args.getLastArg(options::OPT_import_prescan);
   if (ExternalDependencyMap && !ScanDependencies) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
                    "-placeholder-dependency-module-map-file", "-scan-dependencies");
+  }
+  if (Prescan && !ScanDependencies) {
+    diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
+                   "-import-prescan", "-scan-dependencies");
   }
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -88,6 +88,8 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.DisableImplicitModules |= Args.hasArg(OPT_disable_implicit_swift_modules);
 
+  Opts.ImportPrescan |= Args.hasArg(OPT_import_prescan);
+
   // Always track system dependencies when scanning dependencies.
   if (const Arg *ModeArg = Args.getLastArg(OPT_modes_Group)) {
     if (ModeArg->getOption().matches(OPT_scan_dependencies)) {

--- a/test/ScanDependencies/batch_prescan.swift
+++ b/test/ScanDependencies/batch_prescan.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/outputs)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: echo "[{" > %/t/inputs/input.json
+// RUN: echo "\"swiftModuleName\": \"F\"," >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-target x86_64-apple-macosx10.9\"," >> %/t/inputs/input.json
+// RUN: echo "\"output\": \"%/t/outputs/F.swiftmodule.json\"" >> %/t/inputs/input.json
+// RUN: echo "}]" >> %/t/inputs/input.json
+
+// RUN: %target-swift-frontend -scan-dependencies -import-prescan -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s -check-prefix=CHECK-SWIFT < %t/outputs/F.swiftmodule.json
+
+// CHECK-SWIFT: {
+// CHECK-SWIFT-NEXT:"imports": [
+// CHECK-SWIFT-NEXT:  "Swift",
+// CHECK-SWIFT-NEXT:  "F",
+// CHECK-SWIFT-NEXT:  "SwiftOnoneSupport"
+// CHECK-SWIFT-NEXT:]

--- a/test/ScanDependencies/prescan_deps.swift
+++ b/test/ScanDependencies/prescan_deps.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: %target-swift-frontend -scan-dependencies -import-prescan -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s < %t/deps.json
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import C
+import E
+import G
+import SubE
+
+// CHECK: "imports": [
+// CHECK-NEXT:  "C",
+// CHECK-NEXT:  "E",
+// CHECK-NEXT:  "G",
+// CHECK-NEXT:  "SubE",
+// CHECK-NEXT:  "Swift",
+// CHECK-NEXT:  "SwiftOnoneSupport"
+// CHECK-NEXT: ]


### PR DESCRIPTION
With this option enabled, the dependency scanner gathers all import statements in source files of the main module (non-transitive) and outputs a list of imported modules.
This will be used by build systems and the swift-driver as a way to avoid redundant re-scanning in incremental contexts.
