### PR TITLE
Add module interface printing test with non-trivial pattern binding initializer

### DIFF
--- a/test/ModuleInterface/stored-properties.swift
+++ b/test/ModuleInterface/stored-properties.swift
@@ -83,6 +83,9 @@ public struct BagOfVariables {
   // COMMON: public let a: Swift.Int = 0
   public let a: Int = 0
 
+  // COMMON: public let (x, y): (Swift.Int, Swift.Int) = (0, 0)
+  public let (x, y) = (0, 0)
+
   // COMMON: public var b: Swift.Bool = false
   public var b: Bool = false
 


### PR DESCRIPTION
A stored property can be part of a pattern binding entry whose pattern
declares multiple bindings with a single initializer, for example:

    struct S {
      let (x, y) = (0, 0)
    }

Make sure these round-trip correctly.