### PR TITLE
[NFC] Remove a typealias from SILInstruction.h that's unused in noasserts builds.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3978,10 +3978,9 @@ public:
   Destination getAssignDestination() const { return AssignDest; }
 
   void setAssignInfo(AssignOwnershipQualifier qualifier, Destination dest) {
-    using Qualifier = AssignOwnershipQualifier;
-    assert(qualifier == Qualifier::Init && dest == Destination::BackingWrapper ||
-           qualifier == Qualifier::Reassign && dest == Destination::BackingWrapper ||
-           qualifier == Qualifier::Reassign && dest == Destination::WrappedValue);
+    assert(qualifier == AssignOwnershipQualifier::Init && dest == Destination::BackingWrapper ||
+           qualifier == AssignOwnershipQualifier::Reassign && dest == Destination::BackingWrapper ||
+           qualifier == AssignOwnershipQualifier::Reassign && dest == Destination::WrappedValue);
 
     SILInstruction::Bits.AssignByWrapperInst.OwnershipQualifier = unsigned(qualifier);
     AssignDest = dest;


### PR DESCRIPTION
This was only used to shorten the lines in the `assert`, but all of the lines are under 80 columns anyway.
