### PR TITLE
WinSDK: extract Printing submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -225,6 +225,13 @@ module WinSDK [system] {
     link "OleAut32.Lib"
   }
 
+  module Printing {
+    header "winspool.h"
+    export *
+
+    link "WinSpool.Lib"
+  }
+
   module RichEdit {
     header "Richedit.h"
     export *


### PR DESCRIPTION
Currently winspool.h gets included into `WinSDK.WinSock2` via windows.h.
However it is not directly related to sockets.
This change makes it a separate submodule.