### PR TITLE
LLVM-Passes: add pointer authentication to Swift's function merge pass.

### DIFF
--- a/include/swift/LLVMPasses/PassesFwd.h
+++ b/include/swift/LLVMPasses/PassesFwd.h
@@ -31,7 +31,8 @@ namespace swift {
   llvm::FunctionPass *createSwiftARCOptPass();
   llvm::FunctionPass *createSwiftARCContractPass();
   llvm::ModulePass *createInlineTreePrinterPass();
-  llvm::ModulePass *createSwiftMergeFunctionsPass();
+  llvm::ModulePass *createSwiftMergeFunctionsPass(bool ptrAuthEnabled,
+                                                  unsigned ptrAuthKey);
   llvm::ImmutablePass *createSwiftAAWrapperPass();
   llvm::ImmutablePass *createSwiftRCIdentityPass();
 } // end namespace swift

--- a/test/LLVMPasses/merge_func_ptrauth.ll
+++ b/test/LLVMPasses/merge_func_ptrauth.ll
@@ -1,0 +1,43 @@
+; RUN: %swift-llvm-opt -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
+; REQUIRES: CODEGENERATOR=AArch64
+
+target triple = "arm64e-apple-macosx11.0.0"
+
+; CHECK: [[RELOC1:@[0-9]+]] = private constant { i8*, i32, i64, i64 } { i8* bitcast (i32 (i32, i32)* @callee1 to i8*), i32 0, i64 0, i64 [[DISCR:[0-9]+]] }, section "llvm.ptrauth"
+; CHECK: [[RELOC2:@[0-9]+]] = private constant { i8*, i32, i64, i64 } { i8* bitcast (i32 (i32, i32)* @callee2 to i8*), i32 0, i64 0, i64 [[DISCR]] }, section "llvm.ptrauth"
+
+
+; CHECK-LABEL: define i32 @simple_func1(i32 %x)
+; CHECK: %1 = tail call i32 @simple_func1Tm(i32 %x, i32 27, i32 (i32, i32)* bitcast ({ i8*, i32, i64, i64 }* [[RELOC1]] to i32 (i32, i32)*))
+; CHECK: ret i32 %1
+define i32 @simple_func1(i32 %x) {
+  %sum = add i32 %x, 1
+  %sum2 = add i32 %sum, 2
+  %sum3 = add i32 %sum2, 3
+  %r = call i32 @callee1(i32 %sum3, i32 27)
+  ret i32 %r
+}
+
+; CHECK-LABEL: define i32 @simple_func2(i32 %x)
+; CHECK: %1 = tail call i32 @simple_func1Tm(i32 %x, i32 42, i32 (i32, i32)* bitcast ({ i8*, i32, i64, i64 }* [[RELOC2]] to i32 (i32, i32)*))
+; CHECK: ret i32 %1
+define i32 @simple_func2(i32 %x) {
+  %sum = add i32 %x, 1
+  %sum2 = add i32 %sum, 2
+  %sum3 = add i32 %sum2, 3
+  %r = call i32 @callee2(i32 %sum3, i32 42)
+  ret i32 %r
+}
+
+define i32 @caller2() {
+  %r = call i32 @simple_func2(i32 123)
+  ret i32 %r
+}
+
+; CHECK-LABEL: define internal i32 @simple_func1Tm(i32 %0, i32 %1, i32 (i32, i32)* %2) {
+; CHECK: [[R:%r[0-9]*]] = call i32 %2(i32 %sum3, i32 %1) [ "ptrauth"(i32 0, i64 [[DISCR]]) ]
+; CHECK: ret i32 [[R]]
+
+declare i32 @callee1(i32, i32)
+declare i32 @callee2(i32, i32)
+

--- a/test/LLVMPasses/merge_func_ptrauth.swift
+++ b/test/LLVMPasses/merge_func_ptrauth.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -O -Xllvm -swiftmergefunc-threshold=5 -module-name=test -emit-ir  %s | %FileCheck %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test
+// REQUIRES: CPU=arm64e
+
+// CHECK: [[RELOC1:@[0-9]+]] = private constant { i8*, i32, i64, i64 } { i8* bitcast (void (i64)* @"$s4test7callee1yySiF" to i8*), i32 0, i64 0, i64 [[DISCR:[0-9]+]] }, section "llvm.ptrauth"
+// CHECK: [[RELOC2:@[0-9]+]] = private constant { i8*, i32, i64, i64 } { i8* bitcast (void (i64)* @"$s4test7callee2yySiF" to i8*), i32 0, i64 0, i64 [[DISCR]] }, section "llvm.ptrauth"
+@inline(never)
+func callee1(_ i: Int) {
+  print(i)
+}
+
+@inline(never)
+func callee2(_ i: Int) {
+  print("abc", i)
+}
+
+// CHECK-LABEL: define {{.*}} @"$s4test7testit1yyF"()
+// CHECK: call {{.*}} @"$s4test7testit1yyFTm"(i64 27, void (i64)* bitcast ({ i8*, i32, i64, i64 }* [[RELOC1]] to void (i64)*))
+@inline(never)
+func testit1() {
+  for _ in 0..<10 {
+    callee1(27)
+  }
+}
+
+// CHECK-LABEL: define {{.*}} @"$s4test7testit2yyF"()
+// CHECK: call {{.*}} @"$s4test7testit1yyFTm"(i64 42, void (i64)* bitcast ({ i8*, i32, i64, i64 }* [[RELOC2]] to void (i64)*))
+@inline(never)
+public func testit2() {
+  for _ in 0..<10 {
+    callee2(42)
+  }
+}
+
+// CHECK-LABEL: define {{.*}} @"$s4test7testit1yyFTm"(i64 %0, void (i64)* %1)
+// CHECK: call {{.*}} %1(i64 %0) [ "ptrauth"(i32 0, i64 [[DISCR]]) ]
+
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+// CHECK-OUTPUT: 27
+testit1()
+
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+// CHECK-OUTPUT: abc 42
+testit2()


### PR DESCRIPTION
If during merging a function pointer is passed as a parameter to the merged function, it needs to be signed on arm64e.

rdar://problem/66797689
