### PR TITLE
WinSDK: extract Multimedia submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -197,6 +197,30 @@ module WinSDK [system] {
     }
   }
 
+  module Multimedia {
+    module DigitalVideo {
+      header "Digitalv.h"
+      export *
+    }
+
+    module Video {
+      header "Vfw.h"
+      export *
+
+      link "Vfw32.Lib"
+    }
+
+    header "mmeapi.h"
+    header "mmddk.h"
+    header "mmsystem.h"
+    header "mmiscapi.h"
+    header "timeapi.h"
+    header "joystickapi.h"
+    export *
+
+    link "WinMM.Lib"
+  }
+
   module Shell {
     header "ShlObj.h"
     export *


### PR DESCRIPTION
Some of the headers in the Multimedia subsystem were not included in any other submodule of WinSDK, while others were included into `WinSock2` via windows.h.
This change adds them to WinSDK as a separate submodule.
