### PR TITLE
[CSGen] Avoid failing on invalid declarations

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5736,19 +5736,19 @@ DEFINE_EMPTY_CAN_TYPE_WRAPPER(TypeVariableType, Type)
 /// because the expression is ambiguous. This type is only used by the
 /// constraint solver and transformed into UnresolvedType to be used in AST.
 class HoleType : public TypeBase {
-  using OriginatorType =
-      llvm::PointerUnion<TypeVariableType *, DependentMemberType *>;
+  using Originator = llvm::PointerUnion<TypeVariableType *,
+                                        DependentMemberType *, VarDecl *>;
 
-  OriginatorType Originator;
+  Originator O;
 
-  HoleType(ASTContext &C, OriginatorType originator,
+  HoleType(ASTContext &C, Originator originator,
            RecursiveTypeProperties properties)
-      : TypeBase(TypeKind::Hole, &C, properties), Originator(originator) {}
+      : TypeBase(TypeKind::Hole, &C, properties), O(originator) {}
 
 public:
-  static Type get(ASTContext &ctx, OriginatorType originatorType);
+  static Type get(ASTContext &ctx, Originator originator);
 
-  OriginatorType getOriginatorType() const { return Originator; }
+  Originator getOriginator() const { return O; }
 
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::Hole;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2400,13 +2400,9 @@ Type ErrorType::get(Type originalType) {
   return entry = new (mem) ErrorType(ctx, originalType, properties);
 }
 
-Type HoleType::get(ASTContext &ctx, OriginatorType originator) {
+Type HoleType::get(ASTContext &ctx, Originator originator) {
   assert(originator);
-  auto properties = reinterpret_cast<TypeBase *>(originator.getOpaqueValue())
-                        ->getRecursiveProperties();
-  properties |= RecursiveTypeProperties::HasTypeHole;
-
-  auto arena = getArena(properties);
+  auto arena = getArena(RecursiveTypeProperties::HasTypeHole);
   return new (ctx, arena)
       HoleType(ctx, originator, RecursiveTypeProperties::HasTypeHole);
 }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3512,12 +3512,14 @@ namespace {
 
     void visitHoleType(HoleType *T, StringRef label) {
       printCommon(label, "hole_type");
-      auto originatorTy = T->getOriginatorType();
-      if (auto *typeVar = originatorTy.dyn_cast<TypeVariableType *>()) {
+      auto originator = T->getOriginator();
+      if (auto *typeVar = originator.dyn_cast<TypeVariableType *>()) {
         printRec("type_variable", typeVar);
+      } else if (auto *VD = originator.dyn_cast<VarDecl *>()) {
+        VD->dumpRef(PrintWithColorRAII(OS, DeclColor).getOS());
       } else {
         printRec("dependent_member_type",
-                 originatorTy.get<DependentMemberType *>());
+                 originator.get<DependentMemberType *>());
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3822,8 +3822,15 @@ public:
   void visitHoleType(HoleType *T) {
     if (Options.PrintTypesForDebugging) {
       Printer << "<<hole for ";
-      auto originatorTy = T->getOriginatorType();
-      visit(Type(reinterpret_cast<TypeBase *>(originatorTy.getOpaqueValue())));
+      auto originator = T->getOriginator();
+      if (auto *typeVar = originator.dyn_cast<TypeVariableType *>()) {
+        visit(typeVar);
+      } else if (auto *VD = originator.dyn_cast<VarDecl *>()) {
+        Printer << "decl = ";
+        Printer << VD->getName();
+      } else {
+        visit(originator.get<DependentMemberType *>());
+      }
       Printer << ">>";
     } else {
       Printer << "<<hole>>";

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7016,7 +7016,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       // type but a hole.
       auto shouldRecordFixForHole = [&](HoleType *baseType) {
         auto *originator =
-            baseType->getOriginatorType().dyn_cast<TypeVariableType *>();
+            baseType->getOriginator().dyn_cast<TypeVariableType *>();
 
         if (!originator)
           return false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5213,3 +5213,21 @@ void ConstraintSystem::recordFixedRequirement(ConstraintLocator *reqLocator,
         std::make_tuple(GP, reqKind, requirementTy.getPointer()));
   }
 }
+
+// Replace any error types encountered with holes.
+Type ConstraintSystem::getVarType(const VarDecl *var) {
+  auto type = var->getType();
+
+  // If this declaration is used as part of a code completion
+  // expression, solver needs to glance over the fact that
+  // it might be invalid to avoid failing constraint generation
+  // and produce completion results.
+  if (!isForCodeCompletion())
+    return type;
+
+  return type.transform([&](Type type) {
+    if (!type->is<ErrorType>())
+      return type;
+    return HoleType::get(Context, const_cast<VarDecl *>(var));
+  });
+}

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1293,6 +1293,11 @@ enum class ConstraintSystemFlags {
   /// Don't try to type check closure bodies, and leave them unchecked. This is
   /// used for source tooling functionalities.
   LeaveClosureBodyUnchecked = 0x20,
+
+  /// If set, we are solving specifically to determine the type of a
+  /// CodeCompletionExpr, and should continue in the presence of errors wherever
+  /// possible.
+  ForCodeCompletion = 0x40,
 };
 
 /// Options that affect the constraint system as a whole.
@@ -3055,6 +3060,12 @@ public:
 
   bool shouldReusePrecheckedType() const {
     return Options.contains(ConstraintSystemFlags::ReusePrecheckedType);
+  }
+
+  /// Whether we are solving to determine the possible types of a
+  /// \c CodeCompletionExpr.
+  bool isForCodeCompletion() const {
+    return Options.contains(ConstraintSystemFlags::ForCodeCompletion);
   }
 
   /// Log and record the application of the fix. Return true iff any

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2839,6 +2839,11 @@ public:
     return known->second;
   }
 
+  /// Retrieve type type of the given declaration to be used in
+  /// constraint system, this is better than calling `getType()`
+  /// directly because it accounts of constraint system flags.
+  Type getVarType(const VarDecl *var);
+
   /// Cache the type of the expression argument and return that same
   /// argument.
   template <typename T>

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -1012,7 +1012,7 @@ sawSolution(const constraints::Solution &S) {
       return S.simplifyType(completionTy.transform([&](Type type) {
         if (auto *hole = type->getAs<HoleType>()) {
           if (auto *typeVar =
-                  hole->getOriginatorType().dyn_cast<TypeVariableType *>()) {
+                  hole->getOriginator().dyn_cast<TypeVariableType *>()) {
             if (auto *GP = typeVar->getImpl().getGenericParameter()) {
               // Code completion depends on generic parameter type being
               // represented in terms of `ArchetypeType` since it's easy


### PR DESCRIPTION
Solver needs to handle invalid declarations but only in
"code completion" mode since declaration in question might
not be associated with code completion, otherwise (if constraint
generation fails) there is going to be no completion results.

In order to make this work we need to:

- Extend `HoleType` to allow it to be originated from `VarDecl`;
- Add a special flag to constraint system which specifies that solving is for "code completion";
- Use special access for `VarDecl` types which respects constraint system flags
  and can convert any `ErrorTypes` into `HoleTypes`s.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
