### PR TITLE
Store Clang module imports in addition to Swift overlay. 

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -660,6 +660,24 @@ private:
            isa<ConstructorDecl>(DeclCtx);
   }
 
+  void createImportedModule(llvm::DIScope *Context,
+                            ModuleDecl::ImportedModule M, llvm::DIFile *File,
+                            unsigned Line) {
+    // For overlays of Clang modules also emit an import of the underlying Clang
+    // module. The helps the debugger resolve types that are present only in the
+    // underlying module.
+    if (const clang::Module *UnderlyingClangModule =
+            M.importedModule->findUnderlyingClangModule()) {
+      DBuilder.createImportedModule(
+          Context,
+          getOrCreateModule(
+              {*const_cast<clang::Module *>(UnderlyingClangModule)},
+              UnderlyingClangModule),
+          File, 0);
+    }
+    DBuilder.createImportedModule(Context, getOrCreateModule(M), File, Line);
+  }
+
   llvm::DIModule *getOrCreateModule(const void *Key, llvm::DIScope *Parent,
                                     StringRef Name, StringRef IncludePath,
                                     uint64_t Signature = ~1ULL,
@@ -1871,8 +1889,7 @@ void IRGenDebugInfoImpl::finalize() {
                           ModuleDecl::ImportFilterKind::ImplementationOnly});
   for (auto M : ModuleWideImports)
     if (!ImportedModules.count(M.importedModule))
-      DBuilder.createImportedModule(MainFile, getOrCreateModule(M), MainFile,
-                                    0);
+      createImportedModule(MainFile, M, MainFile, 0);
 
   // Finalize all replaceable forward declarations.
   for (auto &Ty : ReplaceMap) {
@@ -2113,10 +2130,9 @@ void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
 
   assert(D->getModule() && "compiler-synthesized ImportDecl is incomplete");
   ModuleDecl::ImportedModule Imported = { D->getAccessPath(), D->getModule() };
-  auto DIMod = getOrCreateModule(Imported);
   auto L = getDebugLoc(*this, D);
   auto *File = getOrCreateFile(L.Filename);
-  DBuilder.createImportedModule(File, DIMod, File, L.Line);
+  createImportedModule(File, Imported, File, L.Line);
   ImportedModules.insert(Imported.importedModule);
 }
 

--- a/test/DebugInfo/ImportClangSubmodule.swift
+++ b/test/DebugInfo/ImportClangSubmodule.swift
@@ -22,11 +22,9 @@
 // CHECK-SAME:                              {{..}}-DFOO=foo{{..}}
 // CHECK-SAME:                              {{..}}-UBAR{{..}}
 
-// CHECK: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]], file:
-// CHECK-SAME:              line: [[@LINE+1]])
+// CHECK: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]], file:{{.*}}line: [[@LINE+1]])
 import ClangModule.SubModule
-// CHECK: !DIImportedEntity({{.*}}, entity: ![[OTHERSUBMODULE]],
-// CHECK-SAME:              line: [[@LINE+1]])
+// CHECK: !DIImportedEntity({{.*}}, entity: ![[OTHERSUBMODULE]],{{.*}}line: [[@LINE+1]])
 import OtherClangModule.SubModule
 
 // The Swift compiler uses an ugly hack that auto-imports a

--- a/test/DebugInfo/overlay-import.swift
+++ b/test/DebugInfo/overlay-import.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-ir -g %s -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import Foundation
+let n = Notification(name: Notification.Name(rawValue: "test"))
+// Test that a skeleton CU for the Foundation module is emitted even though we are only using the overlay!
+// CHECK: !DICompileUnit(language: DW_LANG_ObjC, {{.*}}Foundation{{.*}}.pcm", {{.*}}dwoId:


### PR DESCRIPTION
This helps the debugger resolve types in the underlying Clang module.

<rdar://problem/69393097>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
