### PR TITLE
Fix SR-13520: return string instead of address of local temporary

### DIFF
--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -31,7 +31,7 @@ public:
     }
   }
 
-  static StringRef tokToString(swift::tok T) {
+  static std::string tokToString(swift::tok T) {
     switch (T) {
   #define KEYWORD(X) \
     case swift::tok::kw_##X: return "kw_" #X; break;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace return type to `std::string` to avoid returning address of local temporary variable.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13520.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
