### PR TITLE
[CSGen] Check whether parent has a contextual type before diagnosing …

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1020,8 +1020,35 @@ namespace {
       // `_ = nil`, let's diagnose it here because solver can't
       // attempt any types for it.
       auto *parentExpr = CS.getParentExpr(expr);
-      while (parentExpr && isa<ParenExpr>(parentExpr))
-        parentExpr = CS.getParentExpr(parentExpr);
+      bool hasContextualType = bool(CS.getContextualType(expr));
+
+      while (parentExpr) {
+        if (!isa<IdentityExpr>(parentExpr))
+          break;
+
+        // If there is a parent, use it, otherwise we need
+        // to check whether the last parent node in the chain
+        // had a contextual type associated with it because
+        // in situations like:
+        //
+        // \code
+        // func foo() -> Int? {
+        //   return (nil)
+        // }
+        // \endcode
+        //
+        // parentheses around `nil` are significant.
+        if (auto *nextParent = CS.getParentExpr(parentExpr)) {
+          parentExpr = nextParent;
+        } else {
+          hasContextualType |= bool(CS.getContextualType(parentExpr));
+          // Since current expression is an identity expr
+          // and there are no more parents, let's pretend
+          // that `nil`  don't have a parent since parens
+          // are not semantically significant for further checks.
+          parentExpr = nullptr;
+        }
+      }
 
       // In cases like `_ = nil?` AST would have `nil`
       // wrapped in `BindOptionalExpr`.
@@ -1056,7 +1083,7 @@ namespace {
         }
       }
 
-      if (!parentExpr && !CS.getContextualType(expr)) {
+      if (!parentExpr && !hasContextualType) {
         DE.diagnose(expr->getLoc(), diag::unresolved_nil_literal);
         return Type();
       }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -450,4 +450,12 @@ func sr_12309() {
   _ = (((nil))) // expected-error {{'nil' requires a contextual type}}
   _ = ((((((nil)))))) // expected-error {{'nil' requires a contextual type}}
   _ = (((((((((nil))))))))) // expected-error {{'nil' requires a contextual type}}
+
+  func test_with_contextual_type_one() -> Int? {
+    return (nil) // Ok
+  }
+
+  func test_with_contextual_type_many() -> Int? {
+    return (((nil))) // Ok
+  }
 }


### PR DESCRIPTION
…`nil` use

Before considering `nil` to be used without a context, let's
check whether parent expression (semantic significance of
which is not important) has a contextual type associated with it,
otherwise it's possible to misdiagnose cases like:

```swift
func test() -> Int? {
  return (nil)
}
```

Resolves: rdar://69454410

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
