### PR TITLE
Improve the error message that is emitted when trying to use a bridging header in a framework target

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -65,7 +65,8 @@ ERROR(error_unknown_target,none,
       "unknown target '%0'", (StringRef))
 
 ERROR(error_framework_bridging_header,none,
-      "using bridging headers with framework targets is unsupported", ())
+      "using bridging headers with framework targets is unsupported; use "
+      "the framework umbrella header instead", ())
 ERROR(error_bridging_header_module_interface,none,
       "using bridging headers with module interfaces is unsupported",
       ())

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -25,7 +25,7 @@
 // ASSERTCONFIG_DISABLEREPLACEMENT: -assert-config DisableReplacement
 
 // RUN: not %swiftc_driver -import-objc-header fake.h -import-underlying-module -c %s 2>&1 | %FileCheck -check-prefix=FRAMEWORK_BRIDGING_HEADER %s
-// FRAMEWORK_BRIDGING_HEADER: error: using bridging headers with framework targets is unsupported
+// FRAMEWORK_BRIDGING_HEADER: error: using bridging headers with framework targets is unsupported; use the framework umbrella header instead
 
 // RUN: not %swiftc_driver -import-objc-header fake.h -emit-module-interface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s
 // RUN: not %swiftc_driver -import-objc-header fake.h -emit-module-interface-path fake.swiftinterface %s 2>&1 | %FileCheck -check-prefix=BRIDGING_HEADER_SWIFTINTERFACE %s


### PR DESCRIPTION
<!-- What's in this pull request? -->
The error message currently provided is clear enough but doesn't suggest a fix. From my research it looks like we can point the user to the framework umbrella header. I'm not aware of any cases where that's not the right solution, but if there are, we could change the message to "consider using use the framework umbrella header instead".

