### PR TITLE
Use common BottomUpFunctionOrder instance while updating FunctionWorklist

### DIFF
--- a/include/swift/SILOptimizer/Analysis/FunctionOrder.h
+++ b/include/swift/SILOptimizer/Analysis/FunctionOrder.h
@@ -64,8 +64,7 @@ public:
 
   /// Get a flattened view of all functions in all the SCCs in bottom-up order
   ArrayRef<SILFunction *> getBottomUpOrder() {
-    if (!TheFunctions.empty())
-      return TheFunctions;
+    TheFunctions.clear();
     for (auto SCC : getSCCs())
       for (auto *F : SCC)
         TheFunctions.push_back(F);

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -45,6 +45,9 @@ void BottomUpFunctionOrder::DFS(SILFunction *Start) {
 
       auto Callees = FAS ? BCA->getCalleeList(FAS) : BCA->getCalleeList(&I);
       for (auto *CalleeFn : Callees) {
+        if (!CalleeFn->isDefinition()) {
+          continue;
+        }
         // If not yet visited, visit the callee.
         if (DFSNum.find(CalleeFn) == DFSNum.end()) {
           DFS(CalleeFn);

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -528,6 +528,9 @@ runFunctionPasses(unsigned FromTransIdx, unsigned ToTransIdx) {
   if (SILPrintPassName)
     llvm::dbgs() << "Start function passes at stage: " << StageName << "\n";
 
+    // Compute the bottom up order of the new functions and the callees in it
+    BottomUpFunctionOrder SubBottomUpOrder(BCA);
+
   // Run all transforms for all functions, starting at the tail of the worklist.
   while (!FunctionWorklist.empty() && continueTransforming()) {
     unsigned TailIdx = FunctionWorklist.size() - 1;
@@ -561,8 +564,6 @@ runFunctionPasses(unsigned FromTransIdx, unsigned ToTransIdx) {
       continue;
     }
 
-    // Compute the bottom up order of the new functions and the callees in it
-    BottomUpFunctionOrder SubBottomUpOrder(BCA);
     // Initialize BottomUpFunctionOrder with new functions
     for (auto It = FunctionWorklist.begin() + TailIdx + 1;
          It != FunctionWorklist.end(); It++) {

--- a/test/SILOptimizer/bottomuporder_update.swift
+++ b/test/SILOptimizer/bottomuporder_update.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-sil %s -O | %FileCheck %s
+
+extension FloatingPoint {
+  public static var expOverflowThreshold: Self {
+    return Self(Self.greatestFiniteMagnitude.exponent)
+  }
+}
+
+// CHECK-LABEL: sil @$s20bottomuporder_update3fooSfyF :
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function '$s20bottomuporder_update3fooSfyF'
+public func foo() -> Float {
+  return Float.expOverflowThreshold
+}
+
+public func bar() -> Float {
+  return Float(Float.greatestFiniteMagnitude.exponent)
+}
+

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -23,6 +23,7 @@ let globalTestOptions: TestOptions = [.first, .second, .third, .fourth]
 // CHECK-NEXT:   builtin
 // CHECK-NEXT:   integer_literal {{.*}}, 15
 // CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   debug_value
 // CHECK-NEXT:   struct $TestOptions
 // CHECK-NEXT:   return
 public func returnTestOptions() -> TestOptions {
@@ -32,8 +33,9 @@ public func returnTestOptions() -> TestOptions {
 // CHECK-LABEL: sil @{{.*}}returnEmptyTestOptions{{.*}}
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   integer_literal {{.*}}, 0
-// CHECK-NEXT:   builtin "onFastPath"() : $()
 // CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   debug_value
+// CHECK-NEXT:   builtin "onFastPath"() : $()
 // CHECK-NEXT:   struct $TestOptions
 // CHECK-NEXT:   return
 public func returnEmptyTestOptions() -> TestOptions {


### PR DESCRIPTION
Using the same BottomUpFunctionOrder object for subsequent updates to the FunctionWorklist can provide caching of DFS  states and speed up in the case where newly created functions have a lot of common callees to be explored via DFS.
However if the newly created functions have a large number of unique callees, this leads to some unwanted reordering of FunctionWorklist. This fix favors the former case because DFS is more expensive than list reordering. Also based on experiments related to compilation times in some common Swift programs.

Fixes rdar://69073705
