### PR TITLE
[NFC] Minor cleanup related to Clang types in SIL

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -38,7 +38,7 @@ class ModuleDecl;
 enum DeclAttrKind : unsigned;
 class SynthesizedExtensionAnalyzer;
 struct PrintOptions;
-
+class SILPrintContext;
 
 /// Necessary information for archetype transformation during printing.
 struct TypeTransformContext {
@@ -594,22 +594,7 @@ struct PrintOptions {
   static PrintOptions printDocInterface();
 
   /// Retrieve the set of options suitable for printing SIL functions.
-  static PrintOptions printSIL(bool printFullConvention = false) {
-    PrintOptions result;
-    result.PrintLongAttrsOnSeparateLines = true;
-    result.PrintStorageRepresentationAttrs = true;
-    result.AbstractAccessors = false;
-    result.PrintForSIL = true;
-    result.PrintInSILBody = true;
-    result.PreferTypeRepr = false;
-    result.PrintIfConfig = false;
-    result.OpaqueReturnTypePrinting =
-        OpaqueReturnTypePrintingMode::StableReference;
-    if (printFullConvention)
-      result.PrintFunctionRepresentationAttrs =
-          PrintOptions::FunctionRepresentationMode::Full;
-    return result;
-  }
+  static PrintOptions printSIL(const SILPrintContext *silPrintCtx = nullptr);
 
   static PrintOptions printQualifiedSILType() {
     PrintOptions result = PrintOptions::printSIL();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3792,6 +3792,7 @@ namespace {
 
       OS << "\n";
       Indent += 2;
+      // [TODO: Improve-Clang-type-printing]
       if (!T->getClangTypeInfo().empty()) {
         std::string s;
         llvm::raw_string_ostream os(s);
@@ -3842,6 +3843,7 @@ namespace {
       OS << '\n';
       T->getInvocationSubstitutions().dump(OS, SubstitutionMap::DumpStyle::Full,
                                            Indent+2);
+      // [TODO: Improve-Clang-type-printing]
       if (!T->getClangTypeInfo().empty()) {
         std::string s;
         llvm::raw_string_ostream os(s);

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -827,6 +827,7 @@ void AbstractionPattern::print(raw_ostream &out) const {
     }
     getType().dump(out);
     out << ", ";
+    // [TODO: Improve-Clang-type-printing]
     // It would be better to use print, but we need a PrintingPolicy
     // for that, for which we need a clang LangOptions, and... ugh.
     clang::QualType(getClangType(), 0).dump();

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -411,14 +411,7 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
                     : ParameterConvention::Indirect_In_Guaranteed },
   };
 
-  auto extInfo =
-      SILFunctionType::ExtInfoBuilder(SILFunctionTypeRepresentation::Thin,
-                                      /*pseudogeneric*/ false,
-                                      /*non-escaping*/ false,
-                                      /*async*/ false,
-                                      DifferentiabilityKind::NonDifferentiable,
-                                      /*clangFunctionType*/ nullptr)
-          .build();
+  auto extInfo = SILFunctionType::ExtInfo::getThin();
 
   auto functionTy = SILFunctionType::get(sig, extInfo,
                                          SILCoroutineKind::YieldOnce,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -696,12 +696,10 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     };
     auto NSApplicationMainType = SILFunctionType::get(
         nullptr,
-        SILFunctionType::ExtInfoBuilder()
-            // Should be C calling convention, but NSApplicationMain
-            // has an overlay to fix the type of argv.
-            .withRepresentation(SILFunctionType::Representation::Thin)
-            .build(),
-        SILCoroutineKind::None, ParameterConvention::Direct_Unowned, argTypes,
+        // Should be C calling convention, but NSApplicationMain
+        // has an overlay to fix the type of argv.
+        SILFunctionType::ExtInfo::getThin(), SILCoroutineKind::None,
+        ParameterConvention::Direct_Unowned, argTypes,
         /*yields*/ {},
         SILResultInfo(argc->getType().getASTType(), ResultConvention::Unowned),
         /*error result*/ None, SubstitutionMap(), SubstitutionMap(),

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -295,12 +295,7 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
   Results.push_back(SILResultInfo(
                       switchInfo.Br->getArg(0)->getType().getASTType(),
                       ResultConvention::Owned));
-  auto ExtInfo = SILFunctionType::ExtInfoBuilder(
-                     SILFunctionType::Representation::Thin,
-                     /*pseudogeneric*/ false, /*noescape*/ false,
-                     /*async*/ false, DifferentiabilityKind::NonDifferentiable,
-                     /*clangFunctionType*/ nullptr)
-                     .build();
+  auto ExtInfo = SILFunctionType::ExtInfo::getThin();
   auto FunctionType = SILFunctionType::get(
       nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, /*yields*/ {},
@@ -1177,14 +1172,7 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
     ++OrigSigIdx;
   }
 
-  auto ExtInfo =
-      SILFunctionType::ExtInfoBuilder(SILFunctionType::Representation::Thin,
-                                      /*pseudogeneric*/ false,
-                                      /*noescape*/ false,
-                                      /*async*/ false,
-                                      DifferentiabilityKind::NonDifferentiable,
-                                      /*clangFunctionType*/ nullptr)
-          .build();
+  auto ExtInfo = SILFunctionType::ExtInfo::getThin();
 
   SmallVector<SILResultInfo, 4> Results;
   // If we don't have a bridged return we changed from @autoreleased to @owned

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -83,17 +83,10 @@ class BugReducerTester : public SILFunctionTransform {
     ResultInfoArray.push_back(
         SILResultInfo(EmptyTupleCanType, ResultConvention::Unowned));
     auto FuncType = SILFunctionType::get(
-        nullptr,
-        SILFunctionType::ExtInfoBuilder(
-            SILFunctionType::Representation::Thin, false /*isPseudoGeneric*/,
-            false /*noescape*/, false /*async*/,
-            DifferentiabilityKind::NonDifferentiable,
-            nullptr /*clangFunctionType*/)
-            .build(),
-        SILCoroutineKind::None, ParameterConvention::Direct_Unowned,
-        ArrayRef<SILParameterInfo>(), ArrayRef<SILYieldInfo>(), ResultInfoArray,
-        None, SubstitutionMap(), SubstitutionMap(),
-        getFunction()->getModule().getASTContext());
+        nullptr, SILFunctionType::ExtInfo::getThin(), SILCoroutineKind::None,
+        ParameterConvention::Direct_Unowned, ArrayRef<SILParameterInfo>(),
+        ArrayRef<SILYieldInfo>(), ResultInfoArray, None, SubstitutionMap(),
+        SubstitutionMap(), getFunction()->getModule().getASTContext());
 
     SILOptFunctionBuilder FunctionBuilder(*this);
     SILFunction *F = FunctionBuilder.getOrCreateSharedFunction(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1889,27 +1889,21 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionResult),
         TVO_CanBindToNoEscape);
     FunctionType::Param arg(escapeClosure);
-    auto bodyClosure = FunctionType::get(
-        arg, result,
-        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
-                                     /*noescape*/ true,
-                                     /*throws*/ true,
-                                     DifferentiabilityKind::NonDifferentiable,
-                                     /*clangFunctionType*/ nullptr)
-            .build());
+    auto bodyClosure = FunctionType::get(arg, result,
+                                         FunctionType::ExtInfoBuilder()
+                                             .withNoEscape(true)
+                                             .withThrows(true)
+                                             .build());
     FunctionType::Param args[] = {
       FunctionType::Param(noescapeClosure),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
     };
 
-    auto refType = FunctionType::get(
-        args, result,
-        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
-                                     /*noescape*/ false,
-                                     /*throws*/ true,
-                                     DifferentiabilityKind::NonDifferentiable,
-                                     /*clangFunctionType*/ nullptr)
-            .build());
+    auto refType = FunctionType::get(args, result,
+                                     FunctionType::ExtInfoBuilder()
+                                         .withNoEscape(false)
+                                         .withThrows(true)
+                                         .build());
     return {refType, refType};
   }
   case DeclTypeCheckingSemantics::OpenExistential: {
@@ -1928,26 +1922,20 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionResult),
         TVO_CanBindToNoEscape);
     FunctionType::Param bodyArgs[] = {FunctionType::Param(openedTy)};
-    auto bodyClosure = FunctionType::get(
-        bodyArgs, result,
-        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
-                                     /*noescape*/ true,
-                                     /*throws*/ true,
-                                     DifferentiabilityKind::NonDifferentiable,
-                                     /*clangFunctionType*/ nullptr)
-            .build());
+    auto bodyClosure = FunctionType::get(bodyArgs, result,
+                                         FunctionType::ExtInfoBuilder()
+                                             .withNoEscape(true)
+                                             .withThrows(true)
+                                             .build());
     FunctionType::Param args[] = {
       FunctionType::Param(existentialTy),
       FunctionType::Param(bodyClosure, CS.getASTContext().getIdentifier("do")),
     };
-    auto refType = FunctionType::get(
-        args, result,
-        FunctionType::ExtInfoBuilder(FunctionType::Representation::Swift,
-                                     /*noescape*/ false,
-                                     /*throws*/ true,
-                                     DifferentiabilityKind::NonDifferentiable,
-                                     /*clangFunctionType*/ nullptr)
-            .build());
+    auto refType = FunctionType::get(args, result,
+                                     FunctionType::ExtInfoBuilder()
+                                         .withNoEscape(false)
+                                         .withThrows(true)
+                                         .build());
     return {refType, refType};
   }
   }


### PR DESCRIPTION
Addressing review comments from https://github.com/apple/swift/pull/33085.