### PR TITLE
WinSDK: extract Performance submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -251,6 +251,25 @@ module WinSDK [system] {
     link "OleAut32.Lib"
   }
 
+  module Performance {
+    module PerfLib {
+      header "perflib.h"
+      export *
+
+      link "AdvAPI32.Lib"
+    }
+
+    module PDH {
+      header "Pdh.h"
+      export *
+
+      link "Pdh.Lib"
+    }
+
+    header "winperf.h"
+    export *
+  }
+
   module Printing {
     header "winspool.h"
     export *


### PR DESCRIPTION
Currently some of the headers get included into `WinSDK.WinSock2` via windows.h.
This change extracts a separate `Performance` submodule.