### PR TITLE
[5.3][CSGen] Check whether parent has a contextual type before diagnosing `nil` use

### DIFF
--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -449,4 +449,12 @@ func sr_12309() {
   _ = (((nil))) // expected-error {{'nil' requires a contextual type}}
   _ = ((((((nil)))))) // expected-error {{'nil' requires a contextual type}}
   _ = (((((((((nil))))))))) // expected-error {{'nil' requires a contextual type}}
+
+  func test_with_contextual_type_one() -> Int? {
+    return (nil) // Ok
+  }
+
+  func test_with_contextual_type_many() -> Int? {
+    return (((nil))) // Ok
+  }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/34046

---

- Explanation

Before considering `nil` to be used without a context, let's
check whether parent expression (semantic significance of
which is not important) has a contextual type associated with it,
otherwise it's possible to misdiagnose cases like:

```swift
func test() -> Int? {
  return (nil)
}
```

- Scope: Limited to `nil` literals wrapped into parens or other non-semantic expressions e.g. `await`, `try` used `return` statements.

- Resolves:  rdar://problem/69454410

- Risk: Low

- Testing: Added regression tests

- Reviewer: @hborla, @CodaFi 

Resolves: rdar://problem/69454410

(cherry picked from commit 90e6fd47923e60f0ceb45c798c05a4d277adb696)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
