### PR TITLE
Fixup Structure of Mock SDKSettings

### DIFF
--- a/test/Driver/Inputs/MacOSX10.15.4.versioned.sdk/SDKSettings.json
+++ b/test/Driver/Inputs/MacOSX10.15.4.versioned.sdk/SDKSettings.json
@@ -23,5 +23,7 @@
           "13.2" : "10.15.1",
           "13.4" : "10.15.4"
       }
-  }
+  },
+  "DefaultDeploymentTarget" : "11.0",
+  "MaximumDeploymentTarget" : "11.0.99"
 }

--- a/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
+++ b/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
@@ -9,5 +9,7 @@
           "13.1" : "10.15",
           "13.2" : "10.15.1"
       }
-  }
+  },
+  "DefaultDeploymentTarget" : "10.15",
+  "MaximumDeploymentTarget" : "10.15.99"
 }


### PR DESCRIPTION
This better reflects the actual structure of the files as they appear in
the 10.15 and 10.15.4 SDKs respectively.

rdar://69412779