### PR TITLE
[Concurrency] Import "did" delegate methods as @asyncHandler.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5948,6 +5948,10 @@ public:
   /// Returns true if the function is an @asyncHandler.
   bool isAsyncHandler() const;
 
+  /// Returns true if the function if the signature matches the form of an
+  /// @asyncHandler.
+  bool canBeAsyncHandler() const;
+
   /// Returns true if the function body throws.
   bool hasThrows() const { return Bits.AbstractFunctionDecl.Throws; }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4121,6 +4121,9 @@ ERROR(asynchandler_async,none,
 ERROR(asynchandler_inout_parameter,none,
       "'inout' parameter is not allowed in '@asyncHandler' function",
       ())
+ERROR(asynchandler_unsafe_pointer_parameter,none,
+      "'%0' parameter is not allowed in `@asyncHandler` function",
+      ())
 ERROR(asynchandler_mutating,none,
       "'@asyncHandler' function cannot be 'mutating'",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4121,9 +4121,6 @@ ERROR(asynchandler_async,none,
 ERROR(asynchandler_inout_parameter,none,
       "'inout' parameter is not allowed in '@asyncHandler' function",
       ())
-ERROR(asynchandler_unsafe_pointer_parameter,none,
-      "'%0' parameter is not allowed in `@asyncHandler` function",
-      ())
 ERROR(asynchandler_mutating,none,
       "'@asyncHandler' function cannot be 'mutating'",
       ())

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -797,6 +797,25 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Determine whether the given function can be an @asyncHandler, without
+/// producing any diagnostics.
+class CanBeAsyncHandlerRequest :
+    public SimpleRequest<CanBeAsyncHandlerRequest,
+                         bool(FuncDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, FuncDecl *func) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 /// Determine whether the given class is an actor.
 class IsActorRequest :
     public SimpleRequest<IsActorRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -83,6 +83,8 @@ SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest, Type(ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsAsyncHandlerRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CanBeAsyncHandlerRequest, bool(FuncDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(ClassDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ActorIsolationRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6791,6 +6791,17 @@ bool AbstractFunctionDecl::isAsyncHandler() const {
                            false);
 }
 
+bool AbstractFunctionDecl::canBeAsyncHandler() const {
+  auto func = dyn_cast<FuncDecl>(this);
+  if (!func)
+    return false;
+
+  auto mutableFunc = const_cast<FuncDecl *>(func);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           CanBeAsyncHandlerRequest{mutableFunc},
+                           false);
+}
+
 BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
   if ((getBodyKind() == BodyKind::Synthesize ||
        getBodyKind() == BodyKind::Unparsed) &&

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -40,6 +40,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Config.h"
 #include "swift/Parse/Lexer.h"
@@ -7575,6 +7576,46 @@ bool importer::isSpecialUIKitStructZeroProperty(const clang::NamedDecl *decl) {
   return ident->isStr("UIEdgeInsetsZero") || ident->isStr("UIOffsetZero");
 }
 
+/// Determine whether any of the parameters to the given function is of an
+/// unsafe pointer type.
+static bool hasAnyUnsafePointerParameters(FuncDecl *func) {
+  for (auto param : *func->getParameters()) {
+    Type paramType =
+        param->toFunctionParam().getPlainType()->lookThroughAllOptionalTypes();
+    if (paramType->getAnyPointerElementType()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/// Determine whether the given Objective-C method is likely to be an
+/// asynchronous handler based on its name.
+static bool isObjCMethodLikelyAsyncHandler(
+    const clang::ObjCMethodDecl *method) {
+  auto selector = method->getSelector();
+
+  for (unsigned argIdx : range(std::max(selector.getNumArgs(), 1u))) {
+    auto selectorPiece = selector.getNameForSlot(argIdx);
+    // For the first selector piece, look for the word "did" anywhere.
+    if (argIdx == 0) {
+      for (auto word : camel_case::getWords(selectorPiece)) {
+        if (word == "did" || word == "Did")
+          return true;
+      }
+
+      continue;
+    }
+
+    // Otherwise, check whether any subsequent selector piece starts with "did".
+    if (camel_case::getFirstWord(selectorPiece) == "did")
+      return true;
+  }
+
+  return false;
+}
+
 /// Import Clang attributes as Swift attributes.
 void ClangImporter::Implementation::importAttributes(
     const clang::NamedDecl *ClangDecl,
@@ -7812,6 +7853,24 @@ void ClangImporter::Implementation::importAttributes(
   // Map __attribute__((pure)).
   if (ClangDecl->hasAttr<clang::PureAttr>()) {
     MappedDecl->getAttrs().add(new (C) EffectsAttr(EffectsKind::ReadOnly));
+  }
+
+  // Infer @asyncHandler on imported protocol methods that meet the semantic
+  // requirements.
+  if (SwiftContext.LangOpts.EnableExperimentalConcurrency) {
+    if (auto func = dyn_cast<FuncDecl>(MappedDecl)) {
+      if (auto proto = dyn_cast<ProtocolDecl>(func->getDeclContext())) {
+        if (proto->isObjC() && isa<clang::ObjCMethodDecl>(ClangDecl) &&
+            func->isInstanceMember() && !isa<AccessorDecl>(func) &&
+            isObjCMethodLikelyAsyncHandler(
+                cast<clang::ObjCMethodDecl>(ClangDecl)) &&
+            func->canBeAsyncHandler() &&
+            !hasAnyUnsafePointerParameters(func)) {
+          MappedDecl->getAttrs().add(
+              new (C) AsyncHandlerAttr(/*IsImplicit=*/false));
+        }
+      }
+    }
   }
 }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -26,15 +26,6 @@ class Expr;
 class FuncDecl;
 class ValueDecl;
 
-/// Check whether the @asyncHandler attribute can be applied to the given
-/// function declaration.
-///
-/// \param diagnose Whether to emit a diagnostic when a problem is encountered.
-///
-/// \returns \c true if there was a problem with adding the attribute, \c false
-/// otherwise.
-bool checkAsyncHandler(FuncDecl *func, bool diagnose);
-
 /// Add notes suggesting the addition of 'async' or '@asyncHandler', as
 /// appropriate, to a diagnostic for a function that isn't an async context.
 void addAsyncNotes(FuncDecl *func);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2458,7 +2458,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     bool canBeAsyncHandler = false;
     if (auto witnessFunc = dyn_cast<FuncDecl>(match.Witness)) {
       canBeAsyncHandler = !witnessFunc->isAsyncHandler() &&
-          !checkAsyncHandler(witnessFunc, /*diagnose=*/false);
+          witnessFunc->canBeAsyncHandler();
     }
     auto diag = match.Witness->diagnose(
         canBeAsyncHandler ? diag::actor_isolated_witness_could_be_async_handler

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -18,3 +18,11 @@
 // CHECK-DAG:     func findAnswerFailingly() async throws -> String?
 // CHECK-DAG:     func doSomethingFun(_ operation: String) async
 // CHECK: {{^[}]$}}
+
+// CHECK-LABEL: protocol RefrigeratorDelegate
+// CHECK-NEXT: @asyncHandler func someoneDidOpenRefrigerator(_ fridge: Any)
+// CHECK-NEXT: @asyncHandler func refrigerator(_ fridge: Any, didGetFilledWithItems items: [Any])
+// CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, didGetFilledWithIntegers items: UnsafeMutablePointer<Int>, count: Int)
+// CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, willAddItem item: Any)
+// CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, didRemoveItem item: Any) -> Bool
+// CHECK-NEXT: {{^[}]$}}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -13,4 +13,12 @@
 @property(readwrite) void (^completionHandler)(NSInteger);
 @end
 
+@protocol RefrigeratorDelegate<NSObject>
+- (void)someoneDidOpenRefrigerator:(id)fridge;
+- (void)refrigerator:(id)fridge didGetFilledWithItems:(NSArray *)items;
+- (void)refrigerator:(id)fridge didGetFilledWithIntegers:(NSInteger *)items count:(NSInteger)count;
+- (void)refrigerator:(id)fridge willAddItem:(id)item;
+- (BOOL)refrigerator:(id)fridge didRemoveItem:(id)item;
+@end
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Infer `@asyncHandler` on a protocol methods that follow the delegate
convention of reporting that something happened via a "did" method, so
long as they also meet the constraints for an `@asyncHandler` method in
Swift. This enables inference of `@asyncHandler` for witnesses of these
methods.

