### PR TITLE
Emit -enable-experimental-concurrency into module interfaces

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -202,6 +202,10 @@ def disable_objc_attr_requires_foundation_module :
   HelpText<"Disable requiring uses of @objc to require importing the "
            "Foundation module">;
 
+def enable_experimental_concurrency :
+  Flag<["-"], "enable-experimental-concurrency">,
+  HelpText<"Enable experimental concurrency model">;
+
 def enable_resilience : Flag<["-"], "enable-resilience">,
    HelpText<"Deprecated, use -enable-library-evolution instead">;
 
@@ -388,10 +392,6 @@ def enable_large_loadable_types : Flag<["-"], "enable-large-loadable-types">,
 def enable_experimental_static_assert :
   Flag<["-"], "enable-experimental-static-assert">,
   HelpText<"Enable experimental #assert">;
-
-def enable_experimental_concurrency :
-  Flag<["-"], "enable-experimental-concurrency">,
-  HelpText<"Enable experimental concurrency model">;
 
 def enable_subst_sil_function_types_for_function_values :
   Flag<["-"], "enable-subst-sil-function-types-for-function-values">,

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -enable-experimental-concurrency -emit-module-interface-path %t/Library.swiftinterface -DLIBRARY -module-name Library %s
+
+#if LIBRARY
+public func fn() async {
+  fatalError()
+}
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -I %t
+
+#else
+import Library
+
+func callFn() async {
+  await fn()
+}
+#endif
+
+// RUN: %FileCheck %s <%t/Library.swiftinterface
+// CHECK: // swift-module-flags:{{.*}} -enable-experimental-concurrency
+// CHECK: public func fn() async


### PR DESCRIPTION
…when the module is built with that flag. Fixes rdar://69322538.