### PR TITLE
[build] Allow source root relative SWIFT_BUILD_ROOT

### DIFF
--- a/utils/build_swift/build_swift/constants.py
+++ b/utils/build_swift/build_swift/constants.py
@@ -165,7 +165,10 @@ def _get_swift_build_root(source_root, env=None):
     env = env or {}
 
     if "SWIFT_BUILD_ROOT" in env:
-        return env["SWIFT_BUILD_ROOT"]
+        build_root = env["SWIFT_BUILD_ROOT"]
+        if os.path.isabs(build_root):
+            return build_root
+        return os.path.join(source_root, build_root)
 
     return os.path.join(source_root, "build")
 


### PR DESCRIPTION
Allow `SWIFT_BUILD_ROOT` to be a relative path, using the source root as its parent/base.

The motivation for this change is to be able to write `export SWIFT_BUILD_ROOT=build.noindex` in my dotfiles, and have it apply to any swift repo instance. Currently, `SWIFT_BUILD_ROOT` has to be an absolute path, which means it can't easily be used by anyone who has more than one checkout.

I use the `.noindex` suffix to prevent Spotlight from indexing build outputs/artifacts, because indexing competes for system resources during the build.