### PR TITLE
Serialization for Incremental Swift Dependency Information

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -578,7 +578,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1,
     /// If the module was or is being compiled with `-enable-testing`.
     TestingEnabled : 1,
 
@@ -607,7 +607,10 @@ protected:
     IsNonSwiftModule : 1,
 
     /// Whether this module is the main module.
-    IsMainModule : 1
+    IsMainModule : 1,
+
+    /// Whether this module has incremental dependency information available.
+    HasIncrementalInfo : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -59,10 +59,13 @@ namespace swift {
 class DependencyTracker;
 class DiagnosticEngine;
 class FrontendOptions;
+class ModuleDecl;
 class SourceFile;
 
 /// Use a new namespace to help keep the experimental code from clashing.
 namespace fine_grained_dependencies {
+
+class SourceFileDepGraph;
 
 using StringVec = std::vector<std::string>;
 
@@ -343,11 +346,11 @@ private:
 // MARK: Start of fine-grained-dependency-specific code
 //==============================================================================
 
-/// The entry point into this system from the frontend:
-/// Write out the .swiftdeps file for a frontend compilation of a primary file.
-bool emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
-                               const DependencyTracker &depTracker,
-                               StringRef outputPath, bool alsoEmitDotFile);
+bool withReferenceDependencies(
+    llvm::PointerUnion<ModuleDecl *, SourceFile *> MSF,
+    const DependencyTracker &depTracker, StringRef outputPath,
+    bool alsoEmitDotFile, llvm::function_ref<bool(SourceFileDepGraph &&)>);
+
 //==============================================================================
 // MARK: Enums
 //==============================================================================

--- a/include/swift/AST/FineGrainedDependencyFormat.h
+++ b/include/swift/AST/FineGrainedDependencyFormat.h
@@ -124,7 +124,11 @@ bool readFineGrainedDependencyGraph(llvm::StringRef path,
 
 /// Tries to write the dependency graph to the given path name.
 /// Returns true if there was an error.
-bool writeFineGrainedDependencyGraph(DiagnosticEngine &diags, llvm::StringRef path,
+bool writeFineGrainedDependencyGraphToPath(DiagnosticEngine &diags,
+                                           llvm::StringRef path,
+                                           const SourceFileDepGraph &g);
+
+void writeFineGrainedDependencyGraph(llvm::BitstreamWriter &Out,
                                      const SourceFileDepGraph &g);
 
 } // namespace fine_grained_dependencies

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -517,6 +517,12 @@ public:
     Bits.ModuleDecl.RawResilienceStrategy = unsigned(strategy);
   }
 
+  /// Returns true if this module was or is being compiled for testing.
+  bool hasIncrementalInfo() const { return Bits.ModuleDecl.HasIncrementalInfo; }
+  void setHasIncrementalInfo(bool enabled = true) {
+    Bits.ModuleDecl.HasIncrementalInfo = enabled;
+  }
+
   /// \returns true if this module is a system module; note that the StdLib is
   /// considered a system module.
   bool isSystemModule() const {

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -75,6 +75,10 @@ namespace swift {
     class TypeConverter;
   }
 
+  namespace fine_grained_dependencies {
+    class SourceFileDepGraph;
+  }
+
   /// @{
 
   /// \returns true if the declaration should be verified.  This can return
@@ -174,8 +178,10 @@ namespace swift {
   using ModuleOrSourceFile = PointerUnion<ModuleDecl *, SourceFile *>;
 
   /// Serializes a module or single source file to the given output file.
-  void serialize(ModuleOrSourceFile DC, const SerializationOptions &options,
-                 const SILModule *M = nullptr);
+  void
+  serialize(ModuleOrSourceFile DC, const SerializationOptions &options,
+            const SILModule *M = nullptr,
+            const fine_grained_dependencies::SourceFileDepGraph *DG = nullptr);
 
   /// Serializes a module or single source file to the given output file and
   /// returns back the file's contents as a memory buffer.

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -236,30 +236,20 @@ std::string DependencyKey::computeNameForProvidedEntity<
 // MARK: Entry point into frontend graph construction
 //==============================================================================
 
-bool fine_grained_dependencies::emitReferenceDependencies(
-    DiagnosticEngine &diags, SourceFile *const SF,
-    const DependencyTracker &depTracker,
-    StringRef outputPath,
-    const bool alsoEmitDotFile) {
-
-  // Before writing to the dependencies file path, preserve any previous file
-  // that may have been there. No error handling -- this is just a nicety, it
-  // doesn't matter if it fails.
-  llvm::sys::fs::rename(outputPath, outputPath + "~");
-
-  SourceFileDepGraph g = FrontendSourceFileDepGraphFactory(
-                             SF, outputPath, depTracker, alsoEmitDotFile)
-                              .construct();
-
-  bool hadError = writeFineGrainedDependencyGraphToPath(diags, outputPath, g);
-
-  // If path is stdout, cannot read it back, so check for "-"
-  assert(outputPath == "-" || g.verifyReadsWhatIsWritten(outputPath));
-
-  if (alsoEmitDotFile)
-    g.emitDotFile(outputPath, diags);
-
-  return hadError;
+bool fine_grained_dependencies::withReferenceDependencies(
+    llvm::PointerUnion<ModuleDecl *, SourceFile *> MSF,
+    const DependencyTracker &depTracker, StringRef outputPath,
+    bool alsoEmitDotFile,
+    llvm::function_ref<bool(SourceFileDepGraph &&)> cont) {
+  if (MSF.dyn_cast<ModuleDecl *>()) {
+    llvm_unreachable("Cannot construct dependency graph for modules!");
+  } else {
+    auto *SF = MSF.get<SourceFile *>();
+    SourceFileDepGraph g = FrontendSourceFileDepGraphFactory(
+                               SF, outputPath, depTracker, alsoEmitDotFile)
+                               .construct();
+    return cont(std::move(g));
+  }
 }
 
 //==============================================================================

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -251,7 +251,7 @@ bool fine_grained_dependencies::emitReferenceDependencies(
                              SF, outputPath, depTracker, alsoEmitDotFile)
                               .construct();
 
-  bool hadError = writeFineGrainedDependencyGraph(diags, outputPath, g);
+  bool hadError = writeFineGrainedDependencyGraphToPath(diags, outputPath, g);
 
   // If path is stdout, cannot read it back, so check for "-"
   assert(outputPath == "-" || g.verifyReadsWhatIsWritten(outputPath));

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -484,6 +484,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.IsSystemModule = 0;
   Bits.ModuleDecl.IsNonSwiftModule = 0;
   Bits.ModuleDecl.IsMainModule = 0;
+  Bits.ModuleDecl.HasIncrementalInfo = 0;
 }
 
 ArrayRef<ImplicitImport> ModuleDecl::getImplicitImports() const {

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -300,16 +300,15 @@ void DirectLookupRequest::writeDependencySink(
 
 void LookupInModuleRequest::writeDependencySink(
     evaluator::DependencyCollector &reqTracker, QualifiedLookupResult l) const {
-  auto *module = std::get<0>(getStorage());
+  auto *DC = std::get<0>(getStorage());
   auto member = std::get<1>(getStorage());
-  auto *DC = std::get<4>(getStorage());
 
-  // Decline to record lookups outside our module.
-  if (!DC->getParentSourceFile() ||
-      module->getParentModule() != DC->getParentModule()) {
-    return;
+  // Decline to record lookups if the module in question has no incremental
+  // dependency information available.
+  auto *module = DC->getParentModule();
+  if (module->isMainModule() || module->hasIncrementalInfo()) {
+    reqTracker.addTopLevelName(member.getBaseName());
   }
-  reqTracker.addTopLevelName(member.getBaseName());
 }
 
 //----------------------------------------------------------------------------//
@@ -343,16 +342,14 @@ swift::extractNearestSourceLoc(const LookupConformanceDescriptor &desc) {
 
 void ModuleQualifiedLookupRequest::writeDependencySink(
     evaluator::DependencyCollector &reqTracker, QualifiedLookupResult l) const {
-  auto *DC = std::get<0>(getStorage());
   auto *module = std::get<1>(getStorage());
   auto member = std::get<2>(getStorage());
 
-  // Decline to record lookups outside our module.
-  if (!DC->getParentSourceFile() ||
-      module != DC->getModuleScopeContext()->getParentModule()) {
-    return;
+  // Decline to record lookups if the module in question has no incremental
+  // dependency information available.
+  if (module->isMainModule() || module->hasIncrementalInfo()) {
+    reqTracker.addTopLevelName(member.getBaseName());
   }
-  reqTracker.addTopLevelName(member.getBaseName());
 }
 
 //----------------------------------------------------------------------------//
@@ -370,16 +367,13 @@ void LookupConformanceInModuleRequest::writeDependencySink(
   if (!Adoptee)
     return;
 
-  auto source = reqTracker.getRecorder().getActiveDependencySourceOrNull();
-  if (source.isNull())
-    return;
-
-  // Decline to record conformances defined outside of the active module.
+  // Decline to record lookups if the module in question has no incremental
+  // dependency information available.
   auto *conformance = lookupResult.getConcrete();
-  if (source.get()->getParentModule() !=
-      conformance->getDeclContext()->getParentModule())
-    return;
-  reqTracker.addPotentialMember(Adoptee);
+  auto *module = conformance->getDeclContext()->getParentModule();
+  if (module->isMainModule() || module->hasIncrementalInfo()) {
+    reqTracker.addPotentialMember(Adoptee);
+  }
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -8,6 +8,7 @@ add_swift_host_library(swiftSerialization STATIC
   SerializedModuleLoader.cpp
   SerializedSILLoader.cpp
   SerializeDoc.cpp
+  SerializeIncremental.cpp
   SerializeSIL.cpp
 
   LLVM_LINK_COMPONENTS

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -465,6 +465,9 @@ public:
     return Core->Bits.IsImplicitDynamicEnabled;
   }
 
+  /// \c true if this module has incremental dependency information.
+  bool hasIncrementalInfo() const { return Core->hasIncrementalInfo(); }
+
   /// Associates this module file with the AST node representing it.
   ///
   /// Checks that the file is compatible with the AST module it's being loaded

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1427,6 +1427,17 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       break;
     }
 
+    case INCREMENTAL_INFORMATION_BLOCK_ID: {
+      HasIncrementalInfo = true;
+      // Skip incremental info if present. The Frontend currently doesn't do
+      // anything with this.
+      if (cursor.SkipBlock()) {
+        info.status = error(Status::Malformed);
+        return;
+      }
+      break;
+    }
+
     default:
       // Unknown top-level block, possibly for use by a future version of the
       // module format.

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -69,9 +69,12 @@ class ModuleFileSharedCore {
   /// The data blob containing all of the module's identifiers.
   StringRef IdentifierData;
 
-  // Full blob from the misc. version field of the metadata block. This should
-  // include the version string of the compiler that built the module.
+  /// Full blob from the misc. version field of the metadata block. This should
+  /// include the version string of the compiler that built the module.
   StringRef MiscVersion;
+
+  /// \c true if this module has incremental dependency information.
+  bool HasIncrementalInfo = false;
 
 public:
   /// Represents another module that has been imported as a dependency.
@@ -490,6 +493,10 @@ public:
   ArrayRef<Dependency> getDependencies() const {
     return Dependencies;
   }
+
+  /// Returns \c true if this module file contains a section with incremental
+  /// information.
+  bool hasIncrementalInfo() const { return HasIncrementalInfo; }
 };
 
 template <typename T, typename RawData>

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 578; // Remove hasNonPatternBindingInit
+const uint16_t SWIFTMODULE_VERSION_MINOR = 579; // incremental deps info block
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -729,6 +729,11 @@ enum BlockID {
   ///
   /// \sa decl_locs_block
   DECL_LOCS_BLOCK_ID,
+
+  /// The incremental dependency information block.
+  ///
+  /// This is part of a stable format and should not be renumbered.
+  INCREMENTAL_INFORMATION_BLOCK_ID = 196,
 };
 
 /// The record types within the control block.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5212,9 +5212,11 @@ SerializerBase::SerializerBase(ArrayRef<unsigned char> signature,
   this->SF = DC.dyn_cast<SourceFile *>();
 }
 
-void Serializer::writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
-                               const SILModule *SILMod,
-                               const SerializationOptions &options) {
+void Serializer::writeToStream(
+    raw_ostream &os, ModuleOrSourceFile DC,
+    const SILModule *SILMod,
+    const SerializationOptions &options,
+    const fine_grained_dependencies::SourceFileDepGraph *DepGraph) {
   Serializer S{SWIFTMODULE_SIGNATURE, DC};
 
   // FIXME: This is only really needed for debugging. We don't actually use it.
@@ -5226,6 +5228,9 @@ void Serializer::writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
     S.writeInputBlock(options);
     S.writeSIL(SILMod, options.SerializeAllSIL);
     S.writeAST(DC);
+    if (options.ExperimentalCrossModuleIncrementalInfo) {
+      S.writeIncrementalInfo(DepGraph);
+    }
   }
 
   S.writeToStream(os);
@@ -5244,7 +5249,8 @@ void swift::serializeToBuffers(
                                "Serialization, swiftmodule, to buffer");
     llvm::SmallString<1024> buf;
     llvm::raw_svector_ostream stream(buf);
-    Serializer::writeToStream(stream, DC, M, options);
+    Serializer::writeToStream(stream, DC, M, options,
+                              /*dependency info*/ nullptr);
     bool hadError = withOutputFile(getContext(DC).Diags,
                                    options.OutputPath,
                                    [&](raw_ostream &out) {
@@ -5295,12 +5301,13 @@ void swift::serializeToBuffers(
 
 void swift::serialize(ModuleOrSourceFile DC,
                       const SerializationOptions &options,
-                      const SILModule *M) {
+                      const SILModule *M,
+                      const fine_grained_dependencies::SourceFileDepGraph *DG) {
   assert(!StringRef::withNullAsEmpty(options.OutputPath).empty());
 
   if (StringRef(options.OutputPath) == "-") {
     // Special-case writing to stdout.
-    Serializer::writeToStream(llvm::outs(), DC, M, options);
+    Serializer::writeToStream(llvm::outs(), DC, M, options, DG);
     assert(StringRef::withNullAsEmpty(options.DocOutputPath).empty());
     return;
   }
@@ -5310,7 +5317,7 @@ void swift::serialize(ModuleOrSourceFile DC,
                                  [&](raw_ostream &out) {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftmodule");
-    Serializer::writeToStream(out, DC, M, options);
+    Serializer::writeToStream(out, DC, M, options, DG);
     return false;
   });
   if (hadError)

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -34,6 +34,10 @@ namespace clang {
 namespace swift {
   class SILModule;
 
+  namespace fine_grained_dependencies {
+    class SourceFileDepGraph;
+  }
+
 namespace serialization {
 
 using FilenamesTy = ArrayRef<std::string>;
@@ -389,14 +393,21 @@ private:
   /// Top-level entry point for serializing a module.
   void writeAST(ModuleOrSourceFile DC);
 
+  /// Serializes the given dependnecy graph into the incremental information
+  /// section of this swift module.
+  void writeIncrementalInfo(
+      const fine_grained_dependencies::SourceFileDepGraph *DepGraph);
+
   using SerializerBase::SerializerBase;
   using SerializerBase::writeToStream;
 
 public:
   /// Serialize a module to the given stream.
-  static void writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
-                            const SILModule *M,
-                            const SerializationOptions &options);
+  static void
+  writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
+                const SILModule *M,
+                const SerializationOptions &options,
+                const fine_grained_dependencies::SourceFileDepGraph *DepGraph);
 
   /// Records the use of the given Type.
   ///

--- a/lib/Serialization/SerializeIncremental.cpp
+++ b/lib/Serialization/SerializeIncremental.cpp
@@ -1,0 +1,34 @@
+//===--- SerializeIncremental.cpp - Write incremental swiftdeps -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "serialize-incremental"
+#include "Serialization.h"
+#include "swift/AST/FineGrainedDependencyFormat.h"
+
+#include <type_traits>
+
+using namespace swift;
+using namespace swift::serialization;
+using namespace llvm::support;
+using llvm::BCBlockRAII;
+
+void Serializer::writeIncrementalInfo(
+    const fine_grained_dependencies::SourceFileDepGraph *DepGraph) {
+  if (!DepGraph)
+    return;
+
+  {
+    BCBlockRAII restoreBlock(Out, INCREMENTAL_INFORMATION_BLOCK_ID, 5);
+    swift::fine_grained_dependencies::writeFineGrainedDependencyGraph(
+        Out, *DepGraph);
+  }
+}

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -714,6 +714,8 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setPrivateImportsEnabled();
     if (loadedModuleFile->isImplicitDynamicEnabled())
       M.setImplicitDynamicEnabled();
+    if (loadedModuleFile->hasIncrementalInfo())
+      M.setHasIncrementalInfo();
 
     auto diagLocOrInvalid = diagLoc.getValueOr(SourceLoc());
     loadInfo.status =

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -238,7 +238,8 @@ int main(int argc, char *argv[]) {
       return 1;
     }
 
-    if (writeFineGrainedDependencyGraph(diags, options::OutputFilename, fg)) {
+    if (writeFineGrainedDependencyGraphToPath(
+            diags, options::OutputFilename, fg)) {
       llvm::errs() << "Failed to write binary swiftdeps\n";
       return 1;
     }


### PR DESCRIPTION
This doesn't turn anything on yet, it just moves the necessary pieces into place.

* Plumb the incremental info bits through the various (serialized) modules in the AST. 
* Embed binary swiftdeps into a special section of a swiftmodule
* Refactor the frontend to be more amenable to whole-module dependency graph construction - do not actually implement that yet.
