### PR TITLE
Change SIL ref_element_addr getFieldNo() to return a unique index.

### DIFF
--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -406,7 +406,7 @@ template <typename LTy> struct tupleextractoperation_ty {
 
   template <typename ITy> bool match(ITy *V) {
     if (auto *TEI = dyn_cast<TupleExtractInst>(V)) {
-      return TEI->getFieldNo() == index &&
+      return TEI->getFieldIndex() == index &&
              L.match((ValueBase *)TEI->getOperand());
     }
 

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -152,13 +152,13 @@ struct ProjectionIndex {
     }
     case ValueKind::StructElementAddrInst: {
       StructElementAddrInst *SEA = cast<StructElementAddrInst>(V);
-      Index = SEA->getFieldNo();
+      Index = SEA->getFieldIndex();
       Aggregate = SEA->getOperand();
       break;
     }
     case ValueKind::RefElementAddrInst: {
       RefElementAddrInst *REA = cast<RefElementAddrInst>(V);
-      Index = REA->getFieldNo();
+      Index = REA->getFieldIndex();
       Aggregate = REA->getOperand();
       break;
     }
@@ -177,19 +177,19 @@ struct ProjectionIndex {
     }
     case ValueKind::TupleElementAddrInst: {
       TupleElementAddrInst *TEA = cast<TupleElementAddrInst>(V);
-      Index = TEA->getFieldNo();
+      Index = TEA->getFieldIndex();
       Aggregate = TEA->getOperand();
       break;
     }
     case ValueKind::StructExtractInst: {
       StructExtractInst *SEA = cast<StructExtractInst>(V);
-      Index = SEA->getFieldNo();
+      Index = SEA->getFieldIndex();
       Aggregate = SEA->getOperand();
       break;
     }
     case ValueKind::TupleExtractInst: {
       TupleExtractInst *TEA = cast<TupleExtractInst>(V);
-      Index = TEA->getFieldNo();
+      Index = TEA->getFieldIndex();
       Aggregate = TEA->getOperand();
       break;
     }

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -302,10 +302,9 @@ public:
     assert(isValid());
     assert((getKind() == ProjectionKind::Struct ||
             getKind() == ProjectionKind::Class));
-    assert(BaseType.getNominalOrBoundGenericNominal() &&
-           "This should only be called with a nominal type");
-    auto *NDecl = BaseType.getNominalOrBoundGenericNominal();
-    return NDecl->getStoredProperties()[getIndex()];
+    auto *nominalDecl = BaseType.getNominalOrBoundGenericNominal();
+    assert(nominalDecl && "This should only be called with a nominal type");
+    return getIndexedField(nominalDecl, getIndex());
   }
 
   EnumElementDecl *getEnumElementDecl(SILType BaseType) const {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1946,7 +1946,7 @@ SILCloner<ImplClass>::visitTupleExtractInst(TupleExtractInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createTupleExtract(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
-                Inst->getFieldNo(), getOpType(Inst->getType())));
+                Inst->getFieldIndex(), getOpType(Inst->getType())));
 }
 
 template<typename ImplClass>
@@ -1956,7 +1956,7 @@ SILCloner<ImplClass>::visitTupleElementAddrInst(TupleElementAddrInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createTupleElementAddr(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
-                Inst->getFieldNo(), getOpType(Inst->getType())));
+                Inst->getFieldIndex(), getOpType(Inst->getType())));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5715,7 +5715,7 @@ class TupleExtractInst
   }
 
 public:
-  unsigned getFieldNo() const {
+  unsigned getFieldIndex() const {
     return SILInstruction::Bits.TupleExtractInst.FieldNo;
   }
 
@@ -5747,7 +5747,7 @@ class TupleElementAddrInst
   }
 
 public:
-  unsigned getFieldNo() const {
+  unsigned getFieldIndex() const {
     return SILInstruction::Bits.TupleElementAddrInst.FieldNo;
   }
 
@@ -5811,8 +5811,7 @@ public:
 
   VarDecl *getField() const { return field; }
 
-  // FIXME: this should be called getFieldIndex().
-  unsigned getFieldNo() const {
+  unsigned getFieldIndex() const {
     unsigned idx = SILInstruction::Bits.FieldIndexCacheBase.FieldIndex;
     if (idx != InvalidFieldIndex)
       return idx;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5757,6 +5757,26 @@ public:
   }
 };
 
+/// Get a unique index for a struct or class field in layout order.
+///
+/// Precondition: \p decl must be a non-resilient struct or class.
+///
+/// Precondition: \p field must be a stored property declared in \p decl,
+///               not in a superclass.
+///
+/// Postcondition: The returned index is unique across all properties in the
+///                object, including properties declared in a superclass.
+unsigned getFieldIndex(NominalTypeDecl *decl, VarDecl *property);
+
+/// Get the property for a struct or class by its unique index.
+///
+/// Precondition: \p decl must be a non-resilient struct or class.
+///
+/// Precondition: \p index must be the index of a stored property
+///               (as returned by getFieldIndex()) which is declared
+///               in \p decl, not in a superclass.
+VarDecl *getIndexedField(NominalTypeDecl *decl, unsigned index);
+
 /// A common base for instructions that require a cached field index.
 ///
 /// "Field" is a term used here to refer to the ordered, accessible stored

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3787,7 +3787,7 @@ void IRGenSILFunction::visitTupleExtractInst(swift::TupleExtractInst *i) {
   projectTupleElementFromExplosion(*this,
                                    baseType,
                                    fullTuple,
-                                   i->getFieldNo(),
+                                   i->getFieldIndex(),
                                    output);
   (void)fullTuple.claimAll();
   setLoweredExplosion(i, output);
@@ -3799,7 +3799,7 @@ void IRGenSILFunction::visitTupleElementAddrInst(swift::TupleElementAddrInst *i)
   SILType baseType = i->getOperand()->getType();
 
   Address field = projectTupleElementAddress(*this, base, baseType,
-                                             i->getFieldNo());
+                                             i->getFieldIndex());
   setLoweredAddress(i, field);
 }
 

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -85,7 +85,7 @@ BuiltinInst *SILGlobalVariable::getOffsetSubtract(const TupleExtractInst *TE,
   // Match the pattern:
   // tuple_extract(usub_with_overflow(x, integer_literal, integer_literal 0), 0)
 
-  if (TE->getFieldNo() != 0)
+  if (TE->getFieldIndex() != 0)
     return nullptr;
 
   auto *BI = dyn_cast<BuiltinInst>(TE->getOperand());

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -579,7 +579,7 @@ namespace {
       auto *X = cast<TupleExtractInst>(LHS);
       if (X->getTupleType() != RHS->getTupleType())
         return false;
-      if (X->getFieldNo() != RHS->getFieldNo())
+      if (X->getFieldIndex() != RHS->getFieldIndex())
         return false;
       return true;
     }
@@ -590,7 +590,7 @@ namespace {
       auto *X = cast<TupleElementAddrInst>(LHS);
       if (X->getTupleType() != RHS->getTupleType())
         return false;
-      if (X->getFieldNo() != RHS->getFieldNo())
+      if (X->getFieldIndex() != RHS->getFieldIndex())
         return false;
       return true;
     }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1258,7 +1258,7 @@ bool TupleExtractInst::isTrivialEltOfOneRCIDTuple() const {
   // parent tuple has only one non-trivial field.
   bool FoundNonTrivialField = false;
   SILType OpTy = getOperand()->getType();
-  unsigned FieldNo = getFieldNo();
+  unsigned FieldNo = getFieldIndex();
 
   // For each element index of the tuple...
   for (unsigned i = 0, e = getNumTupleElts(); i != e; ++i) {
@@ -1300,7 +1300,7 @@ bool TupleExtractInst::isEltOnlyNonTrivialElt() const {
   // Ok, we know that the elt we are extracting is non-trivial. Make sure that
   // we have no other non-trivial elts.
   SILType OpTy = getOperand()->getType();
-  unsigned FieldNo = getFieldNo();
+  unsigned FieldNo = getFieldIndex();
 
   // For each element index of the tuple...
   for (unsigned i = 0, e = getNumTupleElts(); i != e; ++i) {
@@ -1348,7 +1348,7 @@ VarDecl *swift::getIndexedField(NominalTypeDecl *decl, unsigned index) {
   if (auto *classDecl = dyn_cast<ClassDecl>(decl)) {
     for (auto *superDecl = classDecl->getSuperclassDecl(); superDecl != nullptr;
          superDecl = superDecl->getSuperclassDecl()) {
-      assert(index > superDecl->getStoredProperties().size()
+      assert(index >= superDecl->getStoredProperties().size()
              && "field index cannot refer to a superclass field");
       index -= superDecl->getStoredProperties().size();
     }
@@ -1357,7 +1357,7 @@ VarDecl *swift::getIndexedField(NominalTypeDecl *decl, unsigned index) {
 }
 
 unsigned FieldIndexCacheBase::cacheFieldIndex() {
-  unsigned index = getFieldIndex(getParentDecl(), getField());
+  unsigned index = ::getFieldIndex(getParentDecl(), getField());
   SILInstruction::Bits.FieldIndexCacheBase.FieldIndex = index;
   return index;
 }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1323,18 +1323,43 @@ bool TupleExtractInst::isEltOnlyNonTrivialElt() const {
   return true;
 }
 
-unsigned FieldIndexCacheBase::cacheFieldIndex() {
-  unsigned i = 0;
-  for (VarDecl *property : getParentDecl()->getStoredProperties()) {
-    if (field == property) {
-      SILInstruction::Bits.FieldIndexCacheBase.FieldIndex = i;
-      return i;
+/// Get a unique index for a struct or class field in layout order.
+unsigned swift::getFieldIndex(NominalTypeDecl *decl, VarDecl *field) {
+  unsigned index = 0;
+  if (auto *classDecl = dyn_cast<ClassDecl>(decl)) {
+    for (auto *superDecl = classDecl->getSuperclassDecl(); superDecl != nullptr;
+         superDecl = superDecl->getSuperclassDecl()) {
+      index += superDecl->getStoredProperties().size();
     }
-    ++i;
+  }
+  for (VarDecl *property : decl->getStoredProperties()) {
+    if (field == property) {
+      return index;
+    }
+    ++index;
   }
   llvm_unreachable("The field decl for a struct_extract, struct_element_addr, "
-                   "or ref_element_addr must be an accessible stored property "
-                   "of the operand's type");
+                   "or ref_element_addr must be an accessible stored "
+                   "property of the operand type");
+}
+
+/// Get the property for a struct or class by its unique index.
+VarDecl *swift::getIndexedField(NominalTypeDecl *decl, unsigned index) {
+  if (auto *classDecl = dyn_cast<ClassDecl>(decl)) {
+    for (auto *superDecl = classDecl->getSuperclassDecl(); superDecl != nullptr;
+         superDecl = superDecl->getSuperclassDecl()) {
+      assert(index > superDecl->getStoredProperties().size()
+             && "field index cannot refer to a superclass field");
+      index -= superDecl->getStoredProperties().size();
+    }
+  }
+  return decl->getStoredProperties()[index];
+}
+
+unsigned FieldIndexCacheBase::cacheFieldIndex() {
+  unsigned index = getFieldIndex(getParentDecl(), getField());
+  SILInstruction::Bits.FieldIndexCacheBase.FieldIndex = index;
+  return index;
 }
 
 // FIXME: this should be cached during cacheFieldIndex().

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1774,11 +1774,11 @@ public:
   }
   
   void visitTupleExtractInst(TupleExtractInst *EI) {
-    *this << getIDAndType(EI->getOperand()) << ", " << EI->getFieldNo();
+    *this << getIDAndType(EI->getOperand()) << ", " << EI->getFieldIndex();
   }
 
   void visitTupleElementAddrInst(TupleElementAddrInst *EI) {
-    *this << getIDAndType(EI->getOperand()) << ", " << EI->getFieldNo();
+    *this << getIDAndType(EI->getOperand()) << ", " << EI->getFieldIndex();
   }
   void visitStructExtractInst(StructExtractInst *EI) {
     *this << getIDAndType(EI->getOperand()) << ", #";

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -156,7 +156,7 @@ const ValueDecl *AccessedStorage::getDecl() const {
 
   case Class: {
     auto *decl = getObject()->getType().getNominalOrBoundGenericNominal();
-    return decl->getStoredProperties()[getPropertyIndex()];
+    return getIndexedField(decl, getPropertyIndex());
   }
   case Tail:
     return nullptr;

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -118,7 +118,7 @@ AccessedStorage::AccessedStorage(SILValue base, Kind kind) {
     // conservative given that classes are not "uniquely identified".
     auto *REA = cast<RefElementAddrInst>(base);
     value = stripBorrow(REA->getOperand());
-    setElementIndex(REA->getFieldNo());
+    setElementIndex(REA->getFieldIndex());
     break;
   }
   case Tail: {

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -321,6 +321,10 @@ void Projection::getFirstLevelProjections(
 
   if (auto *C = Ty.getClassOrBoundGenericClass()) {
     unsigned Count = 0;
+    for (auto *superDecl = C->getSuperclassDecl(); superDecl != nullptr;
+         superDecl = superDecl->getSuperclassDecl()) {
+      Count += superDecl->getStoredProperties().size();
+    }
     for (auto *VDecl : C->getStoredProperties()) {
       (void) VDecl;
       Projection P(ProjectionKind::Class, Count++);

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -70,23 +70,23 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     return;
   case SILInstructionKind::StructElementAddrInst: {
     auto *SEAI = cast<StructElementAddrInst>(I);
-    Value = ValueTy(ProjectionKind::Struct, SEAI->getFieldNo());
+    Value = ValueTy(ProjectionKind::Struct, SEAI->getFieldIndex());
     assert(getKind() == ProjectionKind::Struct);
-    assert(getIndex() == SEAI->getFieldNo());
+    assert(getIndex() == SEAI->getFieldIndex());
     break;
   }
   case SILInstructionKind::StructExtractInst: {
     auto *SEI = cast<StructExtractInst>(I);
-    Value = ValueTy(ProjectionKind::Struct, SEI->getFieldNo());
+    Value = ValueTy(ProjectionKind::Struct, SEI->getFieldIndex());
     assert(getKind() == ProjectionKind::Struct);
-    assert(getIndex() == SEI->getFieldNo());
+    assert(getIndex() == SEI->getFieldIndex());
     break;
   }
   case SILInstructionKind::RefElementAddrInst: {
     auto *REAI = cast<RefElementAddrInst>(I);
-    Value = ValueTy(ProjectionKind::Class, REAI->getFieldNo());
+    Value = ValueTy(ProjectionKind::Class, REAI->getFieldIndex());
     assert(getKind() == ProjectionKind::Class);
-    assert(getIndex() == REAI->getFieldNo());
+    assert(getIndex() == REAI->getFieldIndex());
     break;
   }
   case SILInstructionKind::RefTailAddrInst: {
@@ -106,16 +106,16 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
   }
   case SILInstructionKind::TupleExtractInst: {
     auto *TEI = cast<TupleExtractInst>(I);
-    Value = ValueTy(ProjectionKind::Tuple, TEI->getFieldNo());
+    Value = ValueTy(ProjectionKind::Tuple, TEI->getFieldIndex());
     assert(getKind() == ProjectionKind::Tuple);
-    assert(getIndex() == TEI->getFieldNo());
+    assert(getIndex() == TEI->getFieldIndex());
     break;
   }
   case SILInstructionKind::TupleElementAddrInst: {
     auto *TEAI = cast<TupleElementAddrInst>(I);
-    Value = ValueTy(ProjectionKind::Tuple, TEAI->getFieldNo());
+    Value = ValueTy(ProjectionKind::Tuple, TEAI->getFieldIndex());
     assert(getKind() == ProjectionKind::Tuple);
-    assert(getIndex() == TEAI->getFieldNo());
+    assert(getIndex() == TEAI->getFieldIndex());
     break;
   }
   case SILInstructionKind::UncheckedEnumDataInst: {

--- a/lib/SIL/Verifier/MemoryLifetime.cpp
+++ b/lib/SIL/Verifier/MemoryLifetime.cpp
@@ -261,14 +261,14 @@ bool MemoryLocations::analyzeLocationUsesRecursively(SILValue V, unsigned locIdx
     switch (user->getKind()) {
       case SILInstructionKind::StructElementAddrInst: {
         auto SEAI = cast<StructElementAddrInst>(user);
-        if (!analyzeAddrProjection(SEAI, locIdx, SEAI->getFieldNo(),
+        if (!analyzeAddrProjection(SEAI, locIdx, SEAI->getFieldIndex(),
                                 collectedVals, subLocationMap))
           return false;
         break;
       }
       case SILInstructionKind::TupleElementAddrInst: {
         auto *TEAI = cast<TupleElementAddrInst>(user);
-        if (!analyzeAddrProjection(TEAI, locIdx, TEAI->getFieldNo(),
+        if (!analyzeAddrProjection(TEAI, locIdx, TEAI->getFieldIndex(),
                                 collectedVals, subLocationMap))
           return false;
         break;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2747,11 +2747,11 @@ public:
     require(EI->getType().isObject(),
             "result of tuple_extract must be object");
 
-    require(EI->getFieldNo() < operandTy->getNumElements(),
+    require(EI->getFieldIndex() < operandTy->getNumElements(),
             "invalid field index for tuple_extract instruction");
     if (EI->getModule().getStage() != SILStage::Lowered) {
       requireSameType(EI->getType().getASTType(),
-                      operandTy.getElementType(EI->getFieldNo()),
+                      operandTy.getElementType(EI->getFieldIndex()),
                       "type of tuple_extract does not match type of element");
     }
   }
@@ -2793,12 +2793,12 @@ public:
             "must derive tuple_element_addr from tuple");
 
     ArrayRef<TupleTypeElt> fields = operandTy.castTo<TupleType>()->getElements();
-    require(EI->getFieldNo() < fields.size(),
+    require(EI->getFieldIndex() < fields.size(),
             "invalid field index for element_addr instruction");
     if (EI->getModule().getStage() != SILStage::Lowered) {
       requireSameType(
           EI->getType().getASTType(),
-          CanType(fields[EI->getFieldNo()].getType()),
+          CanType(fields[EI->getFieldIndex()].getType()),
           "type of tuple_element_addr does not match type of element");
     }
   }
@@ -2856,7 +2856,7 @@ public:
           loweredFieldTy, EI->getType(),
           "result of ref_element_addr does not match type of field");
     }
-    EI->getFieldNo();  // Make sure we can access the field without crashing.
+    EI->getFieldIndex();  // Make sure we can access the field without crashing.
   }
 
   void checkRefTailAddrInst(RefTailAddrInst *RTAI) {

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -1084,11 +1084,11 @@ swift::getSingleUnsafeGuaranteedValueResult(BuiltinInst *BI) {
     if (!TE || TE->getOperand() != BI)
       return Failed;
 
-    if (TE->getFieldNo() == 0 && !GuaranteedValue) {
+    if (TE->getFieldIndex() == 0 && !GuaranteedValue) {
       GuaranteedValue = TE;
       continue;
     }
-    if (TE->getFieldNo() == 1 && !Token) {
+    if (TE->getFieldIndex() == 1 && !Token) {
       Token = TE;
       continue;
     }

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -506,13 +506,13 @@ getSingleAddressProjectionUser(SingleValueInstruction *I) {
     switch (User->getKind()) {
     case SILInstructionKind::StructElementAddrInst: {
       auto inst = cast<StructElementAddrInst>(User);
-      ProjectionIndex = inst->getFieldNo();
+      ProjectionIndex = inst->getFieldIndex();
       SingleUser = inst;
       break;
     }
     case SILInstructionKind::TupleElementAddrInst: {
       auto inst = cast<TupleElementAddrInst>(User);
-      ProjectionIndex = inst->getFieldNo();
+      ProjectionIndex = inst->getFieldIndex();
       SingleUser = inst;
       break;
     }

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -672,7 +672,7 @@ static SILValue getArrayUninitializedInitResult(ArraySemanticsCall arrayCall,
     auto *tupleElt = dyn_cast<TupleExtractInst>(op->getUser());
     if (!tupleElt)
       return SILValue();
-    if (tupleElt->getFieldNo() != tupleElementIndex)
+    if (tupleElt->getFieldIndex() != tupleElementIndex)
       continue;
     tupleExtractInst = tupleElt;
     break;

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1871,11 +1871,11 @@ EscapeAnalysis::canOptimizeArrayUninitializedCall(ApplyInst *ai) {
   // uses must be mapped to ConnectionGraph nodes by the client of this API.
   for (Operand *use : getNonDebugUses(ai)) {
     if (auto *tei = dyn_cast<TupleExtractInst>(use->getUser())) {
-      if (tei->getFieldNo() == 0 && !call.arrayStruct) {
+      if (tei->getFieldIndex() == 0 && !call.arrayStruct) {
         call.arrayStruct = tei;
         continue;
       }
-      if (tei->getFieldNo() == 1 && !call.arrayElementPtr) {
+      if (tei->getFieldIndex() == 1 && !call.arrayElementPtr) {
         call.arrayElementPtr = tei;
         continue;
       }

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -97,7 +97,7 @@ SILValue InstSimplifier::visitStructInst(StructInst *SI) {
         return SILValue();
 
       // And the order of the field must be identical to the construction order.
-      if (Ex->getFieldNo() != i)
+      if (Ex->getFieldIndex() != i)
         return SILValue();
     }
 
@@ -132,7 +132,7 @@ SILValue InstSimplifier::visitTupleInst(TupleInst *TI) {
         return SILValue();
 
       // And the order of the field must be identical to the construction order.
-      if (Ex->getFieldNo() != i)
+      if (Ex->getFieldIndex() != i)
         return SILValue();
     }
 
@@ -145,11 +145,11 @@ SILValue InstSimplifier::visitTupleInst(TupleInst *TI) {
 SILValue InstSimplifier::visitTupleExtractInst(TupleExtractInst *TEI) {
   // tuple_extract(tuple(x, y), 0) -> x
   if (auto *TheTuple = dyn_cast<TupleInst>(TEI->getOperand()))
-    return TheTuple->getElement(TEI->getFieldNo());
+    return TheTuple->getElement(TEI->getFieldIndex());
 
   // tuple_extract(apply([add|sub|...]overflow(x,y)),  0) -> x
   // tuple_extract(apply(checked_trunc(ext(x))), 0) -> x
-  if (TEI->getFieldNo() == 0)
+  if (TEI->getFieldIndex() == 0)
     if (auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand()))
       return simplifyOverflowBuiltin(BI);
 

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -136,7 +136,7 @@ IsZeroKind swift::isZeroValue(SILValue Value) {
   if (auto *T = dyn_cast<TupleExtractInst>(Value)) {
     // Make sure we are extracting the number value and not
     // the overflow flag.
-    if (T->getFieldNo() != 0)
+    if (T->getFieldIndex() != 0)
       return IsZeroKind::Unknown;
 
     auto *BI = dyn_cast<BuiltinInst>(T->getOperand());

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1113,7 +1113,7 @@ public:
     auto loc = tei->getLoc();
     auto origTupleTy = tei->getOperand()->getType().castTo<TupleType>();
     unsigned tanIndex = 0;
-    for (unsigned i : range(tei->getFieldNo())) {
+    for (unsigned i : range(tei->getFieldIndex())) {
       if (getTangentSpace(
               origTupleTy->getElement(i).getType()->getCanonicalType()))
         ++tanIndex;
@@ -1142,7 +1142,7 @@ public:
     auto &diffBuilder = getDifferentialBuilder();
     auto origTupleTy = teai->getOperand()->getType().castTo<TupleType>();
     unsigned tanIndex = 0;
-    for (unsigned i : range(teai->getFieldNo())) {
+    for (unsigned i : range(teai->getFieldIndex())) {
       if (getTangentSpace(
               origTupleTy->getElement(i).getType()->getCanonicalType()))
         ++tanIndex;

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1350,7 +1350,7 @@ public:
         if (!getTangentSpace(
                 tupleTy->getElement(i).getType()->getCanonicalType()))
           continue;
-        if (tei->getFieldNo() == i)
+        if (tei->getFieldIndex() == i)
           elements.push_back(av);
         else
           elements.push_back(makeZeroAdjointValue(
@@ -2718,7 +2718,7 @@ SILValue PullbackCloner::Implementation::getAdjointProjection(
       return adjSource;
     auto origTupleTy = source->getType().castTo<TupleType>();
     unsigned adjIndex = 0;
-    for (unsigned i : range(teai->getFieldNo())) {
+    for (unsigned i : range(teai->getFieldIndex())) {
       if (getTangentSpace(
               origTupleTy->getElement(i).getType()->getCanonicalType()))
         ++adjIndex;

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -358,7 +358,7 @@ static void replaceLoadsFromGlobal(SILValue addr,
     if (auto *teai = dyn_cast<TupleElementAddrInst>(user)) {
       auto *ti = cast<TupleInst>(initVal);
       auto *member = cast<SingleValueInstruction>(
-                          ti->getElement(teai->getFieldNo()));
+                          ti->getElement(teai->getFieldIndex()));
       replaceLoadsFromGlobal(teai, member, cloner);
       continue;
     }

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -940,7 +940,7 @@ static SILValue projectLoadValue(SILValue addr, SILValue rootAddr,
     SILValue val = projectLoadValue(TEI->getOperand(), rootAddr, rootVal,
                                     beforeInst);
     SILBuilder B(beforeInst);
-    return B.createTupleExtract(beforeInst->getLoc(), val, TEI->getFieldNo(),
+    return B.createTupleExtract(beforeInst->getLoc(), val, TEI->getFieldIndex(),
                                 TEI->getType().getObjectType());
   }
   llvm_unreachable("unknown projection");

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -891,7 +891,7 @@ void ApplyRewriter::convertApplyWithIndirectResults() {
   if (origCallInst->getType().is<TupleType>()) {
     for (Operand *operand : origCallInst->getUses()) {
       if (auto *extract = dyn_cast<TupleExtractInst>(operand->getUser()))
-        origDirectResultValues[extract->getFieldNo()] = extract;
+        origDirectResultValues[extract->getFieldIndex()] = extract;
       else
         nonCanonicalUses.push_back(operand);
     }
@@ -1002,7 +1002,7 @@ void ApplyRewriter::convertApplyWithIndirectResults() {
       assert(pass.valueStorageMap.contains(origCallInst));
       continue;
     }
-    unsigned origResultIdx = extractInst->getFieldNo();
+    unsigned origResultIdx = extractInst->getFieldIndex();
     auto resultInfo = origFnConv.getResults()[origResultIdx];
 
     if (extractInst->getType().isAddressOnly(*pass.F)) {

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -613,7 +613,7 @@ void ElementUseCollector::collectTupleElementUses(TupleElementAddrInst *TEAI,
 
   // tuple_element_addr P, 42 indexes into the current tuple element.
   // Recursively process its uses with the adjusted element number.
-  unsigned FieldNo = TEAI->getFieldNo();
+  unsigned FieldNo = TEAI->getFieldIndex();
   auto T = TEAI->getOperand()->getType();
   if (T.is<TupleType>()) {
     for (unsigned i = 0; i != FieldNo; ++i) {

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -134,7 +134,7 @@ static unsigned computeSubelement(SILValue Pointer,
       SILType TT = TEAI->getOperand()->getType();
       
       // Keep track of what subelement is being referenced.
-      for (unsigned i = 0, e = TEAI->getFieldNo(); i != e; ++i) {
+      for (unsigned i = 0, e = TEAI->getFieldIndex(); i != e; ++i) {
         SubElementNumber +=
             getNumSubElements(TT.getTupleElementType(i), M,
                               TypeExpansionContext(*RootInst->getFunction()));

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -803,7 +803,7 @@ static SingleValueInstruction *getValueFromStaticLet(SILValue v) {
     if (!tupleVal)
       return nullptr;
     return cast<SingleValueInstruction>(
-      cast<TupleInst>(tupleVal)->getElement(teai->getFieldNo()));
+      cast<TupleInst>(tupleVal)->getElement(teai->getFieldIndex()));
   }
   return nullptr;
 }
@@ -1111,9 +1111,9 @@ static SILValue createValueFromAddr(SILValue addr, SILBuilder *builder,
         kind = tuple;
       }
       if (kind == tuple) {
-        if (elems[telem->getFieldNo()])
+        if (elems[telem->getFieldIndex()])
           return SILValue();
-        elems[telem->getFieldNo()] = createValueFromAddr(telem, builder, loc);
+        elems[telem->getFieldIndex()] = createValueFromAddr(telem, builder, loc);
         continue;
       }
     }
@@ -1802,7 +1802,7 @@ SILInstruction *SILCombiner::visitTupleExtractInst(TupleExtractInst *TEI) {
 
   // tuple_extract(apply([add|sub|...]overflow(x, 0)), 1) -> 0
   // if it can be proven that no overflow can happen.
-  if (TEI->getFieldNo() != 1)
+  if (TEI->getFieldIndex() != 1)
     return nullptr;
 
   Builder.setCurrentDebugScope(TEI->getDebugScope());

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -220,12 +220,12 @@ public:
   }
 
   hash_code visitTupleExtractInst(TupleExtractInst *X) {
-    return llvm::hash_combine(X->getKind(), X->getTupleType(), X->getFieldNo(),
+    return llvm::hash_combine(X->getKind(), X->getTupleType(), X->getFieldIndex(),
                               X->getOperand());
   }
 
   hash_code visitTupleElementAddrInst(TupleElementAddrInst *X) {
-    return llvm::hash_combine(X->getKind(), X->getTupleType(), X->getFieldNo(),
+    return llvm::hash_combine(X->getKind(), X->getTupleType(), X->getFieldIndex(),
                               X->getOperand());
   }
 

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -573,9 +573,9 @@ static bool removeAndReleaseArray(SingleValueInstruction *NewArrayValue,
     auto *TupleElt = dyn_cast<TupleExtractInst>(Op->getUser());
     if (!TupleElt)
       return false;
-    if (TupleElt->getFieldNo() == 0 && !ArrayDef) {
+    if (TupleElt->getFieldIndex() == 0 && !ArrayDef) {
       ArrayDef = TupleElt;
-    } else if (TupleElt->getFieldNo() == 1 && !StorageAddress) {
+    } else if (TupleElt->getFieldIndex() == 1 && !StorageAddress) {
       StorageAddress = TupleElt;
     } else {
       return false;

--- a/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
@@ -594,7 +594,7 @@ SILValue DestroyHoisting::createAddress(unsigned locIdx, SILBuilder &builder) {
   } else {
     auto *TEA = dyn_cast<TupleElementAddrInst>(projInst);
     newProj = projBuilder.createTupleElementAddr(TEA->getLoc(), baseAddr,
-                                            TEA->getFieldNo(), TEA->getType());
+                                            TEA->getFieldIndex(), TEA->getType());
   }
   assert(domTree->properlyDominates(newProj, ip) &&
          "new projection does not dominate insert point");

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -210,7 +210,7 @@ bool ObjectOutliner::handleTailAddr(int TailIdx, SILInstruction *TailAddr,
                                     EndCOWMutationInst *toIgnore) {
   if (NumTailTupleElements > 0) {
     if (auto *TEA = dyn_cast<TupleElementAddrInst>(TailAddr)) {
-      unsigned TupleIdx = TEA->getFieldNo();
+      unsigned TupleIdx = TEA->getFieldIndex();
       assert(TupleIdx < NumTailTupleElements);
       for (Operand *Use : TEA->getUses()) {
         if (!handleTailAddr(TailIdx * NumTailTupleElements + TupleIdx, Use->getUser(), 0,

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -87,7 +87,7 @@ SROAMemoryUseAnalyzer::createAgg(SILBuilder &B, SILLocation Loc,
 
 unsigned SROAMemoryUseAnalyzer::getEltNoForProjection(SILInstruction *Inst) {
   if (TT)
-    return cast<TupleElementAddrInst>(Inst)->getFieldNo();
+    return cast<TupleElementAddrInst>(Inst)->getFieldIndex();
 
   assert(SD && "SD should not be null since either it or TT must be set at "
          "this point.");

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3144,7 +3144,7 @@ static SILValue getInsertedValue(SILInstruction *Aggregate,
   }
   auto *Tuple = cast<TupleInst>(Aggregate);
   auto *TEI = cast<TupleExtractInst>(Extract);
-  return Tuple->getElement(TEI->getFieldNo());
+  return Tuple->getElement(TEI->getFieldIndex());
 }
 
 /// Find a parent SwitchEnumInst of the block \p BB. The block \p BB is a

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -380,7 +380,7 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
             dyn_cast<BuiltinInst>(TupleExtract->getOperand()))
       if (UnsafeGuaranteedSelf->getBuiltinKind() ==
               BuiltinValueKind::UnsafeGuaranteed &&
-          TupleExtract->getFieldNo() == 0)
+          TupleExtract->getFieldIndex() == 0)
         return false;
 
   // Strip any upcasts off of our 'self' value, potentially leaving us

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -300,7 +300,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
     auto val = getConstantValue(tei->getOperand());
     if (!val.isConstant())
       return val;
-    return val.getAggregateMembers()[tei->getFieldNo()];
+    return val.getAggregateMembers()[tei->getFieldIndex()];
   }
 
   // If this is a struct extract from a fragile type, then we can return the
@@ -312,7 +312,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
       return val;
     }
     assert(val.getKind() == SymbolicValue::Aggregate);
-    return val.getAggregateMembers()[sei->getFieldNo()];
+    return val.getAggregateMembers()[sei->getFieldIndex()];
   }
 
   // If this is an unchecked_enum_data from a fragile type, then we can return
@@ -379,9 +379,9 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
     // Add our index onto the next of the list.
     unsigned index;
     if (auto sea = dyn_cast<StructElementAddrInst>(inst))
-      index = sea->getFieldNo();
+      index = sea->getFieldIndex();
     else
-      index = cast<TupleElementAddrInst>(inst)->getFieldNo();
+      index = cast<TupleElementAddrInst>(inst)->getFieldIndex();
     accessPath.push_back(index);
     return SymbolicValue::getAddress(memObject, accessPath,
                                      evaluator.getAllocator());

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1395,7 +1395,7 @@ static bool constantFoldInstruction(Operand *Op, Optional<bool> &ResultsInError,
   // Constant fold extraction of a constant element.
   if (auto *TEI = dyn_cast<TupleExtractInst>(User)) {
     if (auto *TheTuple = dyn_cast<TupleInst>(TEI->getOperand())) {
-      Results.push_back(TheTuple->getElement(TEI->getFieldNo()));
+      Results.push_back(TheTuple->getElement(TEI->getFieldIndex()));
       return true;
     }
   }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1644,7 +1644,7 @@ void swift::replaceLoadSequence(SILInstruction *inst, SILValue value) {
   if (auto *teai = dyn_cast<TupleElementAddrInst>(inst)) {
     SILBuilder builder(teai);
     auto *tei =
-        builder.createTupleExtract(teai->getLoc(), value, teai->getFieldNo());
+        builder.createTupleExtract(teai->getLoc(), value, teai->getFieldIndex());
     for (auto teaiUse : teai->getUses()) {
       replaceLoadSequence(teaiUse->getUser(), tei);
     }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1902,11 +1902,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     default: llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::TupleElementAddrInst:
       operand = cast<TupleElementAddrInst>(&SI)->getOperand();
-      FieldNo = cast<TupleElementAddrInst>(&SI)->getFieldNo();
+      FieldNo = cast<TupleElementAddrInst>(&SI)->getFieldIndex();
       break;
     case SILInstructionKind::TupleExtractInst:
       operand = cast<TupleExtractInst>(&SI)->getOperand();
-      FieldNo = cast<TupleExtractInst>(&SI)->getFieldNo();
+      FieldNo = cast<TupleExtractInst>(&SI)->getFieldIndex();
       break;
     }
 


### PR DESCRIPTION
The fix is needed to have a unique AccessStorage object for each property. The AccessPath commits will contain test cases for this functionality.

If you're looking at the diff, only look at the first commit.