### PR TITLE
Differentiate Cross-Module Incremental Dependencies

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -346,6 +346,10 @@ private:
 // MARK: Start of fine-grained-dependency-specific code
 //==============================================================================
 
+/// Uses the provided module or source file to construct a dependency graph,
+/// which is provided back to the caller in the continuation callback.
+///
+/// \Note The returned graph should not be escaped from the callback.
 bool withReferenceDependencies(
     llvm::PointerUnion<ModuleDecl *, SourceFile *> MSF,
     const DependencyTracker &depTracker, StringRef outputPath,

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -75,6 +75,9 @@ enum class IntermoduleDepTrackingMode {
 /// implemented in terms of a wrapped clang::DependencyCollector.
 class DependencyTracker {
   std::shared_ptr<clang::DependencyCollector> clangCollector;
+  SmallVector<std::string, 8> incrementalDeps;
+  llvm::StringSet<> incrementalDepsUniquer;
+
 public:
   explicit DependencyTracker(
       IntermoduleDepTrackingMode Mode,
@@ -87,8 +90,18 @@ public:
   /// No path canonicalization is done.
   void addDependency(StringRef File, bool IsSystem);
 
+  /// Adds a file as an incremental dependency.
+  ///
+  /// No additional canonicalization or adulteration of the file path in
+  /// \p File is performed.
+  void addIncrementalDependency(StringRef File);
+
   /// Fetches the list of dependencies.
   ArrayRef<std::string> getDependencies() const;
+
+  /// Fetches the list of dependencies that are known to have incremental swift
+  /// dependency information embedded inside of them.
+  ArrayRef<std::string> getIncrementalDependencies() const;
 
   /// Return the underlying clang::DependencyCollector that this
   /// class wraps.

--- a/include/swift/Basic/ReferenceDependencyKeys.h
+++ b/include/swift/Basic/ReferenceDependencyKeys.h
@@ -53,6 +53,7 @@ enum class NodeKind {
   dynamicLookup,
   externalDepend,
   sourceFileProvide,
+  incrementalExternalDepend,
   /// For iterating through the NodeKinds.
   kindCount
 };
@@ -60,8 +61,10 @@ enum class NodeKind {
 /// Used for printing out NodeKinds to dot files, and dumping nodes for
 /// debugging.
 const std::string NodeKindNames[]{
-    "topLevel",      "nominal",        "potentialMember",  "member",
-    "dynamicLookup", "externalDepend", "sourceFileProvide"};
+    "topLevel",          "nominal",
+    "potentialMember",   "member",
+    "dynamicLookup",     "externalDepend",
+    "sourceFileProvide", "incrementalExternalDepend"};
 } // end namespace fine_grained_dependencies
 } // end namespace swift
 

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -114,6 +114,7 @@ FRONTEND_STATISTIC(AST, NumASTBytesAllocated)
 /// Number of file-level dependencies of this frontend job, as tracked in the
 /// AST context's dependency collector.
 FRONTEND_STATISTIC(AST, NumDependencies)
+FRONTEND_STATISTIC(AST, NumIncrementalDependencies)
 
 /// Number of top-level, dynamic, and member names referenced in this frontend
 /// job's source file, as tracked by the AST context's referenced-name tracker.

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -168,6 +168,7 @@ class ModuleDepGraph {
 
   // Supports requests from the driver to getExternalDependencies.
   std::unordered_set<std::string> externalDependencies;
+  std::unordered_set<std::string> incrementalExternalDependencies;
 
   /// Keyed by swiftdeps filename, so we can get back to Jobs.
   std::unordered_map<std::string, const driver::Job *> jobsBySwiftDeps;
@@ -512,15 +513,28 @@ public:
   std::vector<const driver::Job *>
   findExternallyDependentUntracedJobs(StringRef externalDependency);
 
+  /// Find jobs that were previously not known to need compilation but that
+  /// depend on \c incrementalExternalDependency.
+  ///
+  /// This code path should only act as a fallback to the status-quo behavior.
+  /// Otherwise it acts to pessimize the behavior of cross-module incremental
+  /// builds.
+  std::vector<const driver::Job *>
+  findIncrementalExternallyDependentUntracedJobs(StringRef externalDependency);
+
   //============================================================================
   // MARK: ModuleDepGraph - External dependencies
   //============================================================================
 
 public:
   std::vector<StringRef> getExternalDependencies() const;
+  std::vector<StringRef> getIncrementalExternalDependencies() const;
 
   void forEachUntracedJobDirectlyDependentOnExternalSwiftDeps(
       StringRef externalDependency, function_ref<void(const driver::Job *)> fn);
+  void forEachUntracedJobDirectlyDependentOnExternalIncrementalSwiftDeps(
+      StringRef externalDependency, function_ref<void(const driver::Job *)> fn);
+
   //============================================================================
   // MARK: ModuleDepGraph - verification
   //============================================================================

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -231,6 +231,7 @@ std::string DependencyKey::humanReadableName() const {
   switch (kind) {
   case NodeKind::member:
     return demangleTypeAsContext(context) + "." + name;
+  case NodeKind::incrementalExternalDepend:
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
     return llvm::sys::path::filename(name).str();
@@ -261,9 +262,12 @@ raw_ostream &fine_grained_dependencies::operator<<(raw_ostream &out,
 bool DependencyKey::verify() const {
   assert((getKind() != NodeKind::externalDepend || isInterface()) &&
          "All external dependencies must be interfaces.");
+  assert((getKind() != NodeKind::incrementalExternalDepend || isInterface()) &&
+         "All incremental external dependencies must be interfaces.");
   switch (getKind()) {
   case NodeKind::topLevel:
   case NodeKind::dynamicLookup:
+  case NodeKind::incrementalExternalDepend:
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
     assert(context.empty() && !name.empty() && "Must only have a name");
@@ -294,6 +298,7 @@ void DependencyKey::verifyNodeKindNames() {
       CHECK_NAME(potentialMember)
       CHECK_NAME(member)
       CHECK_NAME(dynamicLookup)
+      CHECK_NAME(incrementalExternalDepend)
       CHECK_NAME(externalDepend)
       CHECK_NAME(sourceFileProvide)
     case NodeKind::kindCount:

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -594,6 +594,9 @@ private:
   }
 
   void enumerateExternalUses() {
+    for (StringRef s : depTracker.getIncrementalDependencies())
+      enumerateUse<NodeKind::incrementalExternalDepend>("", s);
+
     for (StringRef s : depTracker.getDependencies())
       enumerateUse<NodeKind::externalDepend>("", s);
   }

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -241,8 +241,10 @@ bool fine_grained_dependencies::withReferenceDependencies(
     const DependencyTracker &depTracker, StringRef outputPath,
     bool alsoEmitDotFile,
     llvm::function_ref<bool(SourceFileDepGraph &&)> cont) {
-  if (MSF.dyn_cast<ModuleDecl *>()) {
-    llvm_unreachable("Cannot construct dependency graph for modules!");
+  if (auto *MD = MSF.dyn_cast<ModuleDecl *>()) {
+    SourceFileDepGraph g =
+        ModuleDepGraphFactory(MD, alsoEmitDotFile).construct();
+    return cont(std::move(g));
   } else {
     auto *SF = MSF.get<SourceFile *>();
     SourceFileDepGraph g = FrontendSourceFileDepGraphFactory(
@@ -624,6 +626,78 @@ Optional<std::string> FrontendSourceFileDepGraphFactory::getFingerprintIfAny(
 }
 Optional<std::string>
 FrontendSourceFileDepGraphFactory::getFingerprintIfAny(const Decl *d) {
+  if (const auto *idc = dyn_cast<IterableDeclContext>(d)) {
+    auto result = idc->getBodyFingerprint();
+    assert((!result || !result->empty()) &&
+           "Fingerprint should never be empty");
+    return result;
+  }
+  return None;
+}
+
+//==============================================================================
+// MARK: ModuleDepGraphFactory
+//==============================================================================
+
+ModuleDepGraphFactory::ModuleDepGraphFactory(ModuleDecl *Mod, bool emitDot)
+    : AbstractSourceFileDepGraphFactory(
+          /*include private*/ true, Mod->getASTContext().hadError(),
+          Mod->getNameStr(), "0xBADBEEF", emitDot, Mod->getASTContext().Diags),
+      Mod(Mod) {}
+
+void ModuleDepGraphFactory::addAllDefinedDecls() {
+  // TODO: express the multiple provides and depends streams with variadic
+  // templates
+
+  // Many kinds of Decls become top-level depends.
+
+  SmallVector<Decl *, 32> TopLevelDecls;
+  Mod->getTopLevelDecls(TopLevelDecls);
+  DeclFinder declFinder(TopLevelDecls, includePrivateDeps,
+                        [this](VisibleDeclConsumer &consumer) {
+                          return Mod->lookupClassMembers({}, consumer);
+                        });
+
+  addAllDefinedDeclsOfAGivenType<NodeKind::topLevel>(
+      declFinder.precedenceGroups);
+  addAllDefinedDeclsOfAGivenType<NodeKind::topLevel>(
+      declFinder.memberOperatorDecls);
+  addAllDefinedDeclsOfAGivenType<NodeKind::topLevel>(declFinder.operators);
+  addAllDefinedDeclsOfAGivenType<NodeKind::topLevel>(declFinder.topNominals);
+  addAllDefinedDeclsOfAGivenType<NodeKind::topLevel>(declFinder.topValues);
+  addAllDefinedDeclsOfAGivenType<NodeKind::nominal>(declFinder.allNominals);
+  addAllDefinedDeclsOfAGivenType<NodeKind::potentialMember>(
+      declFinder.potentialMemberHolders);
+  addAllDefinedDeclsOfAGivenType<NodeKind::member>(
+      declFinder.valuesInExtensions);
+  addAllDefinedDeclsOfAGivenType<NodeKind::dynamicLookup>(
+      declFinder.classMembers);
+}
+
+/// Given an array of Decls or pairs of them in \p declsOrPairs
+/// create node pairs for context and name
+template <NodeKind kind, typename ContentsT>
+void ModuleDepGraphFactory::addAllDefinedDeclsOfAGivenType(
+    std::vector<ContentsT> &contentsVec) {
+  for (const auto &declOrPair : contentsVec) {
+    Optional<std::string> fp = getFingerprintIfAny(declOrPair);
+    addADefinedDecl(
+        DependencyKey::createForProvidedEntityInterface<kind>(declOrPair),
+        fp ? StringRef(fp.getValue()) : Optional<StringRef>());
+  }
+}
+
+//==============================================================================
+// MARK: ModuleDepGraphFactory - adding individual defined Decls
+//==============================================================================
+
+/// At present, only \c NominalTypeDecls have (body) fingerprints
+Optional<std::string> ModuleDepGraphFactory::getFingerprintIfAny(
+    std::pair<const NominalTypeDecl *, const ValueDecl *>) {
+  return None;
+}
+Optional<std::string>
+ModuleDepGraphFactory::getFingerprintIfAny(const Decl *d) {
   if (const auto *idc = dyn_cast<IterableDeclContext>(d)) {
     auto result = idc->getBodyFingerprint();
     assert((!result || !result->empty()) &&

--- a/lib/AST/FrontendSourceFileDepGraphFactory.h
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.h
@@ -54,6 +54,30 @@ private:
   static Optional<std::string> getFingerprintIfAny(const Decl *d);
 };
 
+class ModuleDepGraphFactory : public AbstractSourceFileDepGraphFactory {
+  ModuleDecl *const Mod;
+
+public:
+  ModuleDepGraphFactory(ModuleDecl *Mod, bool emitDot);
+
+  ~ModuleDepGraphFactory() override = default;
+
+private:
+  void addAllDefinedDecls() override;
+  void addAllUsedDecls() override {}
+
+  /// Given an array of Decls or pairs of them in \p declsOrPairs
+  /// create node pairs for context and name
+  template <NodeKind kind, typename ContentsT>
+  void addAllDefinedDeclsOfAGivenType(std::vector<ContentsT> &contentsVec);
+
+  /// At present, only nominals, protocols, and extensions have (body)
+  /// fingerprints
+  static Optional<std::string> getFingerprintIfAny(
+      std::pair<const NominalTypeDecl *, const ValueDecl *>);
+  static Optional<std::string> getFingerprintIfAny(const Decl *d);
+};
+
 } // namespace fine_grained_dependencies
 } // namespace swift
 

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -50,9 +50,20 @@ DependencyTracker::addDependency(StringRef File, bool IsSystem) {
                                      /*IsMissing=*/false);
 }
 
+void DependencyTracker::addIncrementalDependency(StringRef File) {
+  if (incrementalDepsUniquer.insert(File).second) {
+    incrementalDeps.emplace_back(File.str());
+  }
+}
+
 ArrayRef<std::string>
 DependencyTracker::getDependencies() const {
   return clangCollector->getDependencies();
+}
+
+ArrayRef<std::string>
+DependencyTracker::getIncrementalDependencies() const {
+  return incrementalDeps;
 }
 
 std::shared_ptr<clang::DependencyCollector>

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -195,6 +195,12 @@ std::vector<StringRef> ModuleDepGraph::getExternalDependencies() const {
                                 externalDependencies.end());
 }
 
+std::vector<StringRef>
+ModuleDepGraph::getIncrementalExternalDependencies() const {
+  return std::vector<StringRef>(incrementalExternalDependencies.begin(),
+                                incrementalExternalDependencies.end());
+}
+
 // Add every (swiftdeps) use of the external dependency to foundJobs.
 // Can return duplicates, but it doesn't break anything, and they will be
 // canonicalized later.
@@ -216,12 +222,45 @@ std::vector<const Job *> ModuleDepGraph::findExternallyDependentUntracedJobs(
   return foundJobs;
 }
 
+std::vector<const Job *>
+ModuleDepGraph::findIncrementalExternallyDependentUntracedJobs(
+    StringRef externalDependency) {
+  FrontendStatsTracer tracer(stats,
+                             "fine-grained-dependencies-"
+                             "findIncrementalExternallyDependentUntracedJobs");
+  std::vector<const Job *> foundJobs;
+  forEachUntracedJobDirectlyDependentOnExternalIncrementalSwiftDeps(
+      externalDependency, [&](const Job *job) {
+        foundJobs.push_back(job);
+        for (const Job *marked : findJobsToRecompileWhenWholeJobChanges(job)) {
+          // findJobsToRecompileWhenWholeJobChanges is reflexive
+          // Don't return job twice.
+          if (marked != job)
+            foundJobs.push_back(marked);
+        }
+      });
+  return foundJobs;
+}
+
 void ModuleDepGraph::forEachUntracedJobDirectlyDependentOnExternalSwiftDeps(
     StringRef externalSwiftDeps, function_ref<void(const Job *)> fn) {
   // TODO move nameForDep into key
   // These nodes will depend on the *interface* of the external Decl.
   DependencyKey key(NodeKind::externalDepend, DeclAspect::interface, "",
                     externalSwiftDeps.str());
+  for (const ModuleDepGraphNode *useNode : usesByDef[key]) {
+    if (!useNode->getHasBeenTraced())
+      fn(getJob(useNode->getSwiftDepsOfProvides()));
+  }
+}
+
+void ModuleDepGraph::
+    forEachUntracedJobDirectlyDependentOnExternalIncrementalSwiftDeps(
+        StringRef externalSwiftDeps, function_ref<void(const Job *)> fn) {
+  // TODO move nameForDep into key
+  // These nodes will depend on the *interface* of the external Decl.
+  DependencyKey key(NodeKind::incrementalExternalDepend, DeclAspect::interface,
+                    "", externalSwiftDeps.str());
   for (const ModuleDepGraphNode *useNode : usesByDef[key]) {
     if (!useNode->getHasBeenTraced())
       fn(getJob(useNode->getSwiftDepsOfProvides()));
@@ -387,9 +426,14 @@ bool ModuleDepGraph::recordWhatUseDependsUpon(
       sourceFileUseNode, [&](const SourceFileDepGraphNode *def) {
         const bool isNewUse =
             usesByDef[def->getKey()].insert(moduleUseNode).second;
-        if (isNewUse && def->getKey().getKind() == NodeKind::externalDepend) {
+        if (isNewUse) {
           StringRef externalSwiftDeps = def->getKey().getName();
-          externalDependencies.insert(externalSwiftDeps.str());
+          if (def->getKey().getKind() == NodeKind::externalDepend) {
+            externalDependencies.insert(externalSwiftDeps.str());
+          } else if (def->getKey().getKind() ==
+                     NodeKind::incrementalExternalDepend) {
+            incrementalExternalDependencies.insert(externalSwiftDeps.str());
+          }
           useHasNewExternalDependency = true;
         }
       });
@@ -641,6 +685,9 @@ void ModuleDepGraph::verifyExternalDependencyUniqueness(
   assert((key.getKind() != NodeKind::externalDepend ||
           externalDependencies.count(key.getName().str()) == 1) &&
          "Ensure each external dependency is tracked exactly once");
+  assert((key.getKind() != NodeKind::incrementalExternalDepend ||
+          incrementalExternalDependencies.count(key.getName().str()) == 1) &&
+         "Ensure each incremental external dependency is tracked exactly once");
 }
 
 void ModuleDepGraph::verifyCanFindEachJob() const {
@@ -724,6 +771,10 @@ void ModuleDepGraph::printOneNodeOfPath(raw_ostream &out,
   case NodeKind::externalDepend:
     out << filename << " depends on " << key.aspectName() << " of module '"
         << key.humanReadableName() << "'";
+    break;
+  case NodeKind::incrementalExternalDepend:
+    out << filename << " depends on " << key.aspectName()
+        << " of incremental module '" << key.humanReadableName() << "'";
     break;
   case NodeKind::sourceFileProvide:
     out << key.aspectName() << " of source file " << key.humanReadableName();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2302,7 +2302,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
       auto *Mod = MSF.get<ModuleDecl *>();
       fine_grained_dependencies::withReferenceDependencies(
           Mod, *Instance.getDependencyTracker(), Mod->getModuleFilename(),
-          alsoEmitDotFile, [](SourceFileDepGraph &&g) {
+          alsoEmitDotFile, [&](SourceFileDepGraph &&g) {
             serialize(MSF, serializationOpts, SM.get(), &g);
             return false;
           });

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -209,6 +209,12 @@ static bool emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
     dependencyString.push_back(' ');
     dependencyString.append(frontend::utils::escapeForMake(path, buffer).str());
   }
+  auto incrementalDependencyPaths =
+      reversePathSortedFilenames(depTracker->getIncrementalDependencies());
+  for (auto const &path : incrementalDependencyPaths) {
+    dependencyString.push_back(' ');
+    dependencyString.append(frontend::utils::escapeForMake(path, buffer).str());
+  }
   
   // FIXME: Xcode can't currently handle multiple targets in a single
   // dependency line.
@@ -1176,6 +1182,7 @@ static void countASTStats(UnifiedStatsReporter &Stats,
 
   if (auto *D = Instance.getDependencyTracker()) {
     C.NumDependencies = D->getDependencies().size();
+    C.NumIncrementalDependencies = D->getIncrementalDependencies().size();
   }
 
   for (auto SF : Instance.getPrimarySourceFiles()) {

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -198,6 +198,10 @@ forEachDependencyUntilTrue(CompilerInstance &CI, unsigned excludeBufferID,
     if (callback(dep))
       return true;
   }
+  for (auto &dep : CI.getDependencyTracker()->getIncrementalDependencies()) {
+    if (callback(dep))
+      return true;
+  }
 
   return false;
 }

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -93,6 +93,8 @@ void ScalarEnumerationTraits<swift::fine_grained_dependencies::NodeKind>::
   io.enumCase(value, "member", NodeKind::member);
   io.enumCase(value, "dynamicLookup", NodeKind::dynamicLookup);
   io.enumCase(value, "externalDepend", NodeKind::externalDepend);
+  io.enumCase(value, "incrementalExternalDepend",
+              NodeKind::incrementalExternalDepend);
   io.enumCase(value, "sourceFileProvide", NodeKind::sourceFileProvide);
 }
 

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
@@ -147,6 +147,7 @@ UnitTestSourceFileDepGraphFactory::singleNameIsContext(const NodeKind kind) {
     return true;
   case NodeKind::topLevel:
   case NodeKind::dynamicLookup:
+  case NodeKind::incrementalExternalDepend:
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
     return false;


### PR DESCRIPTION
This still does not turn anything on. That'll wait until tomorrow.

* Model the idea of a cross-module incremental dependency in the dependency graph. 
* Plumb that through to the serialized format. 
* Teach the `DependencyTracker` what an incremental external dependency is - but don't register any yet
* Add the Driver-level fallback paths to treat incremental external dependencies like plain external dependencies. 