### PR TITLE
Fix TypeBase::hasOpaqueArchetypePropertiesOrCases for recursive types

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -600,9 +600,6 @@ public:
   bool hasOpaqueArchetype() const {
     return getRecursiveProperties().hasOpaqueArchetype();
   }
-  /// Determine whether the type has any stored properties or enum cases that
-  /// involve an opaque type.
-  bool hasOpaqueArchetypePropertiesOrCases();
 
   /// Determine whether the type is an opened existential type.
   ///

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -147,16 +147,23 @@ enum IsResilient_t : bool {
   IsResilient = true
 };
 
+/// Does this type contain an opaque result type that affects type lowering?
+enum IsTypeExpansionSensitive_t : bool {
+  IsNotTypeExpansionSensitive = false,
+  IsTypeExpansionSensitive = true
+};
+
 /// Extended type information used by SIL.
 class TypeLowering {
 public:
   class RecursiveProperties {
     // These are chosen so that bitwise-or merges the flags properly.
     enum : unsigned {
-      NonTrivialFlag     = 1 << 0,
-      NonFixedABIFlag    = 1 << 1,
-      AddressOnlyFlag    = 1 << 2,
-      ResilientFlag      = 1 << 3,
+      NonTrivialFlag             = 1 << 0,
+      NonFixedABIFlag            = 1 << 1,
+      AddressOnlyFlag            = 1 << 2,
+      ResilientFlag              = 1 << 3,
+      TypeExpansionSensitiveFlag = 1 << 4,
     };
 
     uint8_t Flags;
@@ -165,15 +172,17 @@ public:
     /// a trivial, loadable, fixed-layout type.
     constexpr RecursiveProperties() : Flags(0) {}
 
-    constexpr RecursiveProperties(IsTrivial_t isTrivial,
-                                  IsFixedABI_t isFixedABI,
-                                  IsAddressOnly_t isAddressOnly,
-                                  IsResilient_t isResilient)
-      : Flags((isTrivial ? 0U : NonTrivialFlag) | 
-              (isFixedABI ? 0U : NonFixedABIFlag) |
-              (isAddressOnly ? AddressOnlyFlag : 0U) |
-              (isResilient ? ResilientFlag : 0U)) {}
-    
+    constexpr RecursiveProperties(
+        IsTrivial_t isTrivial, IsFixedABI_t isFixedABI,
+        IsAddressOnly_t isAddressOnly, IsResilient_t isResilient,
+        IsTypeExpansionSensitive_t isTypeExpansionSensitive =
+            IsNotTypeExpansionSensitive)
+        : Flags((isTrivial ? 0U : NonTrivialFlag) |
+                (isFixedABI ? 0U : NonFixedABIFlag) |
+                (isAddressOnly ? AddressOnlyFlag : 0U) |
+                (isResilient ? ResilientFlag : 0U) |
+                (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0U)) {}
+
     constexpr bool operator==(RecursiveProperties p) const {
       return Flags == p.Flags;
     }
@@ -183,7 +192,7 @@ public:
     }
 
     static constexpr RecursiveProperties forReference() {
-      return {IsNotTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient };
+      return {IsNotTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient};
     }
 
     static constexpr RecursiveProperties forOpaque() {
@@ -193,6 +202,7 @@ public:
     static constexpr RecursiveProperties forResilient() {
       return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsResilient};
     }
+
 
     void addSubobject(RecursiveProperties other) {
       Flags |= other.Flags;
@@ -210,10 +220,19 @@ public:
     IsResilient_t isResilient() const {
       return IsResilient_t((Flags & ResilientFlag) != 0);
     }
+    IsTypeExpansionSensitive_t isTypeExpansionSensitive() const {
+      return IsTypeExpansionSensitive_t(
+          (Flags & TypeExpansionSensitiveFlag) != 0);
+    }
 
     void setNonTrivial() { Flags |= NonTrivialFlag; }
     void setNonFixedABI() { Flags |= NonFixedABIFlag; }
     void setAddressOnly() { Flags |= AddressOnlyFlag; }
+    void setTypeExpansionSensitive(
+        IsTypeExpansionSensitive_t isTypeExpansionSensitive) {
+      Flags = (Flags & ~TypeExpansionSensitiveFlag) |
+              (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0);
+    }
   };
 
 private:
@@ -303,6 +322,12 @@ public:
 
   bool isResilient() const {
     return Properties.isResilient();
+  }
+
+  /// Does this type contain an opaque result type that could influence how the
+  /// type is lowered if we could look through to the underlying type.
+  bool isTypeExpansionSensitive() const {
+    return Properties.isTypeExpansionSensitive();
   }
 
   ResilienceExpansion getResilienceExpansion() const {
@@ -705,8 +730,6 @@ class TypeConverter {
 
   llvm::DenseMap<SILDeclRef, CaptureInfo> LoweredCaptures;
 
-  llvm::DenseMap<CanType, bool> opaqueArchetypeFields;
-
   /// Cache of loadable SILType to number of (estimated) fields
   ///
   /// Second element is a ResilienceExpansion.
@@ -719,17 +742,15 @@ class TypeConverter {
   Optional<CanType> BridgedType##Ty;
 #include "swift/SIL/BridgedTypes.def"
 
-  const TypeLowering &
-  getTypeLoweringForLoweredType(AbstractionPattern origType,
-                                CanType loweredType,
-                                TypeExpansionContext forExpansion,
-                                bool origHadOpaqueTypeArchetype);
+  const TypeLowering &getTypeLoweringForLoweredType(
+      AbstractionPattern origType, CanType loweredType,
+      TypeExpansionContext forExpansion,
+      IsTypeExpansionSensitive_t isTypeExpansionSensitive);
 
-  const TypeLowering *
-  getTypeLoweringForExpansion(TypeKey key,
-                              TypeExpansionContext forExpansion,
-                              const TypeLowering *lowering,
-                              bool origHadOpaqueTypeArchetype);
+  const TypeLowering *getTypeLoweringForExpansion(
+      TypeKey key, TypeExpansionContext forExpansion,
+      const TypeLowering *minimalExpansionLowering,
+      IsTypeExpansionSensitive_t isOrigTypeExpansionSensitive);
 
 public:
   ModuleDecl &M;
@@ -884,8 +905,6 @@ public:
   AbstractionPattern getAbstractionPattern(EnumElementDecl *element);
 
   CanType getLoweredTypeOfGlobal(VarDecl *var);
-
-  bool hasOpaqueArchetypeOrPropertiesOrCases(CanType ty);
 
   /// Return the SILFunctionType for a native function value of the
   /// given type.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5048,27 +5048,6 @@ Type TypeBase::openAnyExistentialType(OpenedArchetypeType *&opened) {
   return opened;
 }
 
-bool TypeBase::hasOpaqueArchetypePropertiesOrCases() {
-  if (auto *structDecl = getStructOrBoundGenericStruct()) {
-    for (auto *field : structDecl->getStoredProperties()) {
-      auto fieldTy = field->getInterfaceType()->getCanonicalType();
-      if (fieldTy->hasOpaqueArchetype() ||
-          fieldTy->hasOpaqueArchetypePropertiesOrCases())
-        return true;
-    }
-  }
-
-  if (auto *enumDecl = getEnumOrBoundGenericEnum()) {
-    for (auto *elt : enumDecl->getAllElements()) {
-      auto eltType = elt->getInterfaceType();
-      if (eltType->hasOpaqueArchetype() ||
-          eltType->getCanonicalType()->hasOpaqueArchetypePropertiesOrCases())
-        return true;
-    }
-  }
-  return false;
-}
-
 CanType swift::substOpaqueTypesWithUnderlyingTypes(CanType ty,
                                                    TypeExpansionContext context,
                                                    bool allowLoweredTypes) {

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -195,7 +195,19 @@ struct X<T: R, U: R>: R {
 
 var globalOProp: some O = 0
 
-struct OpaqueProps {
+public struct OpaqueProps {
   static var staticOProp: some O = 0
   var instanceOProp: some O = 0
+}
+
+// Make sure we don't recurse indefinitely on recursive enums.
+public enum RecursiveEnum {
+  case a(Int)
+  case b(String)
+  indirect case c(RecursiveEnum)
+}
+
+public enum EnumWithTupleWithOpaqueField {
+  case a(Int)
+  case b((OpaqueProps, String))
 }


### PR DESCRIPTION
Also fix the code handling enums to use getArgumentInterfaceType instead
of getInterfaceType and handle tuples.

rdar://68798822
