### PR TITLE
Teach The Legacy Driver to Unpack Incremental Dependency Information From swiftmodule Files

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -851,6 +851,8 @@ public:
   /// Read a swiftdeps file from \p buffer and return a SourceFileDepGraph if
   /// successful.
   Optional<SourceFileDepGraph> static loadFromBuffer(llvm::MemoryBuffer &);
+  Optional<SourceFileDepGraph> static loadFromSwiftModuleBuffer(
+      llvm::MemoryBuffer &);
 
   void verifySame(const SourceFileDepGraph &other) const;
 

--- a/include/swift/AST/FineGrainedDependencyFormat.h
+++ b/include/swift/AST/FineGrainedDependencyFormat.h
@@ -48,6 +48,7 @@ using NodeKindField = BCFixed<3>;
 using DeclAspectField = BCFixed<1>;
 
 const unsigned RECORD_BLOCK_ID = llvm::bitc::FIRST_APPLICATION_BLOCKID;
+const unsigned INCREMENTAL_INFORMATION_BLOCK_ID = 196;
 
 /// The swiftdeps file format consists of a METADATA record, followed by zero or more
 /// IDENTIFIER_NODE records.
@@ -113,9 +114,15 @@ namespace record_block {
 }
 
 /// Tries to read the dependency graph from the given buffer.
-/// Returns true if there was an error.
+/// Returns \c true if there was an error.
 bool readFineGrainedDependencyGraph(llvm::MemoryBuffer &buffer,
                                     SourceFileDepGraph &g);
+
+/// Tries to read the dependency graph from the given buffer, assuming that it
+/// is in the format of a swiftmodule file.
+/// Returns \c true if there was an error.
+bool readFineGrainedDependencyGraphFromSwiftModule(llvm::MemoryBuffer &buffer,
+                                                   SourceFileDepGraph &g);
 
 /// Tries to read the dependency graph from the given path name.
 /// Returns true if there was an error.

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -336,6 +336,8 @@ public:
                                      const SourceFileDepGraph &,
                                      DiagnosticEngine &);
 
+  Changes loadFromSwiftModuleBuffer(const driver::Job *, llvm::MemoryBuffer &,
+                                    DiagnosticEngine &);
 
 private:
   /// Read a SourceFileDepGraph belonging to \p job from \p buffer

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -58,6 +58,15 @@ SourceFileDepGraph::loadFromBuffer(llvm::MemoryBuffer &buffer) {
   return Optional<SourceFileDepGraph>(std::move(fg));
 }
 
+Optional<SourceFileDepGraph>
+SourceFileDepGraph::loadFromSwiftModuleBuffer(llvm::MemoryBuffer &buffer) {
+  SourceFileDepGraph fg;
+  if (swift::fine_grained_dependencies::
+          readFineGrainedDependencyGraphFromSwiftModule(buffer, fg))
+    return None;
+  return Optional<SourceFileDepGraph>(std::move(fg));
+}
+
 //==============================================================================
 // MARK: SourceFileDepGraph access
 //==============================================================================

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -20,10 +20,11 @@
 #define SWIFT_SERIALIZATION_MODULEFORMAT_H
 
 #include "swift/AST/Decl.h"
+#include "swift/AST/FineGrainedDependencyFormat.h"
 #include "swift/AST/Types.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/Bitcode/RecordLayout.h"
 #include "llvm/Bitstream/BitCodes.h"
-#include "llvm/ADT/PointerEmbeddedInt.h"
 
 namespace swift {
 namespace serialization {
@@ -724,8 +725,10 @@ enum BlockID {
   /// This is part of a stable format and should not be renumbered.
   ///
   /// Though we strive to keep the format stable, breaking the format of
-  /// .swiftsourceinfo doesn't have consequences as serious as breaking the format
-  /// of .swiftdoc because .swiftsourceinfo file is for local development use only.
+  /// .swiftsourceinfo doesn't have consequences as serious as breaking the
+  /// format
+  /// of .swiftdoc because .swiftsourceinfo file is for local development use
+  /// only.
   ///
   /// \sa decl_locs_block
   DECL_LOCS_BLOCK_ID,
@@ -733,7 +736,8 @@ enum BlockID {
   /// The incremental dependency information block.
   ///
   /// This is part of a stable format and should not be renumbered.
-  INCREMENTAL_INFORMATION_BLOCK_ID = 196,
+  INCREMENTAL_INFORMATION_BLOCK_ID =
+      fine_grained_dependencies::INCREMENTAL_INFORMATION_BLOCK_ID,
 };
 
 /// The record types within the control block.


### PR DESCRIPTION
Nothing has been turned on yet.


---

An incremental build involving incremental external dependencies behaves as a hybrid between an external dependency and a normal swiftdeps-laden Swift file.

In the simplest case, we will fall back to the behavior of a plain external dependency today. That is, we will check its timestamp, then schedule all jobs that involve these external dependencies if it is out of date.

Where things get interesting is when cross-module incremental builds are enabled. In such a case, we know that a previous compiler has already emitted serialized swiftdeps information inside of a swiftmodule file. Moreover, we know that that swiftmodule file was loaded by the build of the current swift module. Finally, thanks to the previous stack of commits, we now know exactly how to extract this information from the swiftmodule file. To bring this all home, we unpack incremental dependency information from external dependencies, then integrate them into the current dependency graph - as though they were any other swiftdeps file. This neatly extends the single-module incremental logic to the multi-module case.