### PR TITLE
[Type checker] Eliminate a use-after-free due to C++ temporaries.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5948,7 +5948,7 @@ public:
   /// Returns true if the function is an @asyncHandler.
   bool isAsyncHandler() const;
 
-  /// Returns true if the function if the signature matches the form of an
+  /// Returns true if the function signature matches the form of an
   /// @asyncHandler.
   bool canBeAsyncHandler() const;
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1979,7 +1979,8 @@ void swift::printFunctionBuilderBuildFunction(
     componentTypeString = "<#Component#>";
 
   // Render the code.
-  ExtraIndentStreamPrinter printer(out, stubIndent.getValueOr(std::string()));
+  std::string stubIndentStr = stubIndent.getValueOr(std::string());
+  ExtraIndentStreamPrinter printer(out, stubIndentStr);
 
   // If we're supposed to provide a full stub, add a newline and the introducer
   // keywords.


### PR DESCRIPTION
Found by Brent using ASan, thank you!