### PR TITLE
WinSDK: extract version into a separate submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -127,6 +127,14 @@ module WinSDK [system] {
       header "timezoneapi.h"
       export *
     }
+
+    // api-ms-win-core-version-l1-1-0.dll
+    module version {
+      header "winver.h"
+      export *
+
+      link "Version.Lib"
+    }
   }
 
   module AuthZ {


### PR DESCRIPTION
Currently winver.h gets included into `WinSDK.WinSock2`, however its usages might not be related to sockets, and it requires linking against `Version.Lib`.