### PR TITLE
[Sema] Consider inherited platform unavailability to silence diagnostics

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1566,7 +1566,10 @@ static bool isInsideCompatibleUnavailableDeclaration(
   auto IsUnavailable = [platform](const Decl *D) {
     auto EnclosingUnavailable =
         D->getAttrs().getUnavailable(D->getASTContext());
-    return EnclosingUnavailable && EnclosingUnavailable->Platform == platform;
+    return EnclosingUnavailable &&
+        (EnclosingUnavailable->Platform == platform ||
+         inheritsAvailabilityFromPlatform(platform,
+           EnclosingUnavailable->Platform));
   };
 
   return someEnclosingDeclMatches(ReferenceRange, ReferenceDC, IsUnavailable);

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -140,3 +140,27 @@ protocol P: Builtin.AnyObject {
 }
 
 extension X: P {}
+
+// Test platform inheritance for iOS unavailability.
+// rdar://68597591
+
+@available(iOS, unavailable)
+public struct UnavailableOniOS { } // expected-note 2 {{'UnavailableOniOS' has been explicitly marked unavailable here}}
+
+@available(iOS, unavailable)
+func unavailableOniOS(_ p: UnavailableOniOS) { } // ok
+
+func functionUsingAnUnavailableType(_ p: UnavailableOniOS) { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+
+public extension UnavailableOniOS { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+
+@available(iOS, unavailable)
+public extension UnavailableOniOS { // ok
+  func someMethod(_ p: UnavailableOniOS) { }
+}
+
+@available(iOS, unavailable)
+@available(macCatalyst, introduced: 13.0)
+public struct AvailableOnMacCatalyst { }
+
+public extension AvailableOnMacCatalyst { } // ok


### PR DESCRIPTION
Unavailability inherited by a platform wasn't taken into account when reporting the use of unavailable types imported from Objective-C in unavailable code. This likely forced uses to write an explicit `@available(macCatalyst, unavailable)` even when a `@available(iOS, unavailable)` was present.

rdar://68597591