### PR TITLE
[Diagnostics] Diagnose cases when it's impossible to infer type for `nil` literal

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1239,6 +1239,8 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
       cs.increaseScore(SK_Hole);
 
       ConstraintFix *fix = nullptr;
+      unsigned fixImpact = 1;
+
       if (auto *GP = TypeVar->getImpl().getGenericParameter()) {
         // If it is represetative for a key path root, let's emit a more
         // specific diagnostic.
@@ -1279,9 +1281,12 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
         fix = SpecifyKeyPathRootType::create(cs, dstLocator);
       } else if (dstLocator->directlyAt<NilLiteralExpr>()) {
         fix = SpecifyContextualTypeForNil::create(cs, dstLocator);
+        // This is a dramatic event, it means that there is absolutely
+        // no contextual information to resolve type of `nil`.
+        fixImpact = 10;
       }
 
-      if (fix && cs.recordFix(fix))
+      if (fix && cs.recordFix(fix, fixImpact))
         return true;
     }
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6980,13 +6980,6 @@ bool MissingContextualTypeForNil::diagnoseAsError() {
       emitDiagnostic(diag::unresolved_nil_literal);
       return true;
     }
-    // `_ = nil`
-    if (auto *assignment = dyn_cast<AssignExpr>(parentExpr)) {
-      if (isa<DiscardAssignmentExpr>(assignment->getDest())) {
-        emitDiagnostic(diag::unresolved_nil_literal);
-        return true;
-      }
-    }
   }
 
   emitDiagnostic(diag::unresolved_nil_literal);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6945,3 +6945,50 @@ bool InvalidEmptyKeyPathFailure::diagnoseAsError() {
   emitDiagnostic(diag::expr_swift_keypath_empty);
   return true;
 }
+
+bool MissingContextualTypeForNil::diagnoseAsError() {
+  auto *expr = castToExpr<NilLiteralExpr>(getAnchor());
+
+  // If this is a standalone `nil` literal expression e.g.
+  // `_ = nil`, let's diagnose it here because solver can't
+  // attempt any types for it.
+  auto *parentExpr = findParentExpr(expr);
+
+  while (parentExpr && isa<IdentityExpr>(parentExpr))
+    parentExpr = findParentExpr(parentExpr);
+
+  // In cases like `_ = nil?` AST would have `nil`
+  // wrapped in `BindOptionalExpr`.
+  if (parentExpr && isa<BindOptionalExpr>(parentExpr))
+    parentExpr = findParentExpr(parentExpr);
+
+  if (parentExpr) {
+    // `_ = nil as? ...`
+    if (isa<ConditionalCheckedCastExpr>(parentExpr)) {
+      emitDiagnostic(diag::conditional_cast_from_nil);
+      return true;
+    }
+
+    // `_ = nil!`
+    if (isa<ForceValueExpr>(parentExpr)) {
+      emitDiagnostic(diag::cannot_force_unwrap_nil_literal);
+      return true;
+    }
+
+    // `_ = nil?`
+    if (isa<OptionalEvaluationExpr>(parentExpr)) {
+      emitDiagnostic(diag::unresolved_nil_literal);
+      return true;
+    }
+    // `_ = nil`
+    if (auto *assignment = dyn_cast<AssignExpr>(parentExpr)) {
+      if (isa<DiscardAssignmentExpr>(assignment->getDest())) {
+        emitDiagnostic(diag::unresolved_nil_literal);
+        return true;
+      }
+    }
+  }
+
+  emitDiagnostic(diag::unresolved_nil_literal);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2268,6 +2268,23 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose situations where there is no context to determine a
+/// type of `nil` literal e.g.
+///
+/// \code
+/// let _ = nil
+/// let _ = try nil
+/// let _ = nil!
+/// \endcode
+class MissingContextualTypeForNil final : public FailureDiagnostic {
+public:
+  MissingContextualTypeForNil(const Solution &solution,
+                              ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1606,7 +1606,8 @@ IgnoreInvalidFunctionBuilderBody *IgnoreInvalidFunctionBuilderBody::create(
 
 bool SpecifyContextualTypeForNil::diagnose(const Solution &solution,
                                            bool asNote) const {
-  return false;
+  MissingContextualTypeForNil failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 SpecifyContextualTypeForNil *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1603,3 +1603,14 @@ IgnoreInvalidFunctionBuilderBody *IgnoreInvalidFunctionBuilderBody::create(
   return new (cs.getAllocator())
       IgnoreInvalidFunctionBuilderBody(cs, phase, locator);
 }
+
+bool SpecifyContextualTypeForNil::diagnose(const Solution &solution,
+                                           bool asNote) const {
+  return false;
+}
+
+SpecifyContextualTypeForNil *
+SpecifyContextualTypeForNil::create(ConstraintSystem &cs,
+                                    ConstraintLocator *locator) {
+  return new (cs.getAllocator()) SpecifyContextualTypeForNil(cs, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -279,6 +279,9 @@ enum class FixKind : uint8_t {
 
   /// Ignore function builder body which fails `pre-check` call.
   IgnoreInvalidFunctionBuilderBody,
+
+  /// Resolve type of `nil` by providing a contextual type.
+  SpecifyContextualTypeForNil,
 };
 
 class ConstraintFix {
@@ -2024,6 +2027,26 @@ public:
 private:
   static IgnoreInvalidFunctionBuilderBody *
   create(ConstraintSystem &cs, ErrorInPhase phase, ConstraintLocator *locator);
+};
+
+class SpecifyContextualTypeForNil final : public ConstraintFix {
+  SpecifyContextualTypeForNil(ConstraintSystem &cs,
+                              ConstraintLocator *locator)
+    : ConstraintFix(cs, FixKind::SpecifyContextualTypeForNil, locator) {}
+
+public:
+  std::string getName() const override {
+    return "specify contextual type to resolve `nil` literal";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static SpecifyContextualTypeForNil *create(ConstraintSystem & cs,
+                                             ConstraintLocator * locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1015,80 +1015,13 @@ namespace {
     }
 
     Type visitNilLiteralExpr(NilLiteralExpr *expr) {
-      auto &DE = CS.getASTContext().Diags;
-      // If this is a standalone `nil` literal expression e.g.
-      // `_ = nil`, let's diagnose it here because solver can't
-      // attempt any types for it.
-      auto *parentExpr = CS.getParentExpr(expr);
-      bool hasContextualType = bool(CS.getContextualType(expr));
+      auto literalTy = visitLiteralExpr(expr);
+      // Allow `nil` to be a hole so we can diagnose it via a fix
+      // if it turns out that there is no contextual information.
+      if (auto *typeVar = literalTy->getAs<TypeVariableType>())
+        CS.recordPotentialHole(typeVar);
 
-      while (parentExpr) {
-        if (!isa<IdentityExpr>(parentExpr))
-          break;
-
-        // If there is a parent, use it, otherwise we need
-        // to check whether the last parent node in the chain
-        // had a contextual type associated with it because
-        // in situations like:
-        //
-        // \code
-        // func foo() -> Int? {
-        //   return (nil)
-        // }
-        // \endcode
-        //
-        // parentheses around `nil` are significant.
-        if (auto *nextParent = CS.getParentExpr(parentExpr)) {
-          parentExpr = nextParent;
-        } else {
-          hasContextualType |= bool(CS.getContextualType(parentExpr));
-          // Since current expression is an identity expr
-          // and there are no more parents, let's pretend
-          // that `nil`  don't have a parent since parens
-          // are not semantically significant for further checks.
-          parentExpr = nullptr;
-        }
-      }
-
-      // In cases like `_ = nil?` AST would have `nil`
-      // wrapped in `BindOptionalExpr`.
-      if (parentExpr && isa<BindOptionalExpr>(parentExpr))
-        parentExpr = CS.getParentExpr(parentExpr);
-
-      if (parentExpr) {
-        // `_ = nil as? ...`
-        if (isa<ConditionalCheckedCastExpr>(parentExpr)) {
-          DE.diagnose(expr->getLoc(), diag::conditional_cast_from_nil);
-          return Type();
-        }
-
-        // `_ = nil!`
-        if (isa<ForceValueExpr>(parentExpr)) {
-          DE.diagnose(expr->getLoc(), diag::cannot_force_unwrap_nil_literal);
-          return Type();
-        }
-
-        // `_ = nil?`
-        if (isa<OptionalEvaluationExpr>(parentExpr)) {
-          DE.diagnose(expr->getLoc(), diag::unresolved_nil_literal);
-          return Type();
-        }
-
-        // `_ = nil`
-        if (auto *assignment = dyn_cast<AssignExpr>(parentExpr)) {
-          if (isa<DiscardAssignmentExpr>(assignment->getDest())) {
-            DE.diagnose(expr->getLoc(), diag::unresolved_nil_literal);
-            return Type();
-          }
-        }
-      }
-
-      if (!parentExpr && !hasContextualType) {
-        DE.diagnose(expr->getLoc(), diag::unresolved_nil_literal);
-        return Type();
-      }
-
-      return visitLiteralExpr(expr);
+      return literalTy;
     }
 
     Type visitFloatLiteralExpr(FloatLiteralExpr *expr) {
@@ -3024,11 +2957,19 @@ namespace {
                                             TVO_PrefersSubtypeBinding |
                                             TVO_CanBindToLValue |
                                             TVO_CanBindToNoEscape);
-      
+
+      auto *valueExpr = expr->getSubExpr();
+      // It's invalid to force unwrap `nil` literal e.g. `_ = nil!` or
+      // `_ = (try nil)!` and similar constructs.
+      if (auto *nilLiteral = dyn_cast<NilLiteralExpr>(
+              valueExpr->getSemanticsProvidingExpr())) {
+        CS.recordFix(SpecifyContextualTypeForNil::create(
+            CS, CS.getConstraintLocator(nilLiteral)));
+      }
+
       // The result is the object type of the optional subexpression.
-      CS.addConstraint(ConstraintKind::OptionalObject,
-                       CS.getType(expr->getSubExpr()), objectTy,
-                       locator);
+      CS.addConstraint(ConstraintKind::OptionalObject, CS.getType(valueExpr),
+                       objectTy, locator);
       return objectTy;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5893,6 +5893,12 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
   }
   
 
+  if (optTy->isHole()) {
+    if (auto *typeVar = second->getAs<TypeVariableType>())
+      recordPotentialHole(typeVar);
+    return SolutionKind::Solved;
+  }
+
   Type objectTy = optTy->getOptionalObjectType();
   // If the base type is not optional, let's attempt a fix (if possible)
   // and assume that `!` is just not there.
@@ -10072,7 +10078,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyKeyPathRootType:
   case FixKind::SpecifyLabelToAssociateTrailingClosure:
   case FixKind::AllowKeyPathWithoutComponents:
-  case FixKind::IgnoreInvalidFunctionBuilderBody: {
+  case FixKind::IgnoreInvalidFunctionBuilderBody:
+  case FixKind::SpecifyContextualTypeForNil: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -440,6 +440,7 @@ struct TestConstraintGenerationErrors {
 
   @TupleBuilder var nilWithoutContext: String {
     let a = nil // expected-error {{'nil' requires a contextual type}}
+    ""
   }
 
   func buildTupleClosure() {


### PR DESCRIPTION
Rework diagnostics related to `nil` literal to give a solver a chance
to detect and diagnose situations when it's invalid to use it without 
more context e.g. `_ = nil`, `nil as? Int`, or `_ = nil!`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
