### PR TITLE
Sema: Simplify adjustSelfTypeForMember() a little bit to avoid a cycle 

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1828,30 +1828,30 @@ public:
         Out << "\n";
         abort();
       }
-      
+
+      if (!isa<VarDecl>(E->getMember().getDecl())) {
+        Out << "Member reference to a non-VarDecl\n";
+        E->dump(Out);
+        Out << "\n";
+        abort();
+      }
+
+      auto baseType = E->getBase()->getType();
+      if (baseType->is<InOutType>()) {
+        Out << "Member reference to an inout type\n";
+        E->dump(Out);
+        Out << "\n";
+        abort();
+      }
+
       // The base of a member reference cannot be an existential type.
-      if (E->getBase()->getType()->getWithoutSpecifierType()
-            ->isExistentialType()) {
+      if (baseType->getWithoutSpecifierType()->isExistentialType()) {
         Out << "Member reference into an unopened existential type\n";
         E->dump(Out);
         Out << "\n";
         abort();
       }
 
-      // The only time the base is allowed to be inout is if we are accessing
-      // a computed property or if the base is a protocol or existential.
-      if (auto *baseIOT = E->getBase()->getType()->getAs<InOutType>()) {
-        if (!baseIOT->getObjectType()->is<ArchetypeType>()) {
-          auto *VD = dyn_cast<VarDecl>(E->getMember().getDecl());
-          if (!VD || !VD->requiresOpaqueAccessors()) {
-            Out << "member_ref_expr on value of inout type\n";
-            E->dump(Out);
-            Out << "\n";
-            abort();
-          }
-        }
-      }
-      
       // FIXME: Check container/member types through substitutions.
 
       verifyCheckedBase(E);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1479,31 +1479,31 @@ bool RValueTreatedAsLValueFailure::diagnoseAsNote() {
   return true;
 }
 
-static Decl *findSimpleReferencedDecl(const Expr *E) {
+static VarDecl *findSimpleReferencedVarDecl(const Expr *E) {
   if (auto *LE = dyn_cast<LoadExpr>(E))
     E = LE->getSubExpr();
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(E))
-    return DRE->getDecl();
+    return dyn_cast<VarDecl>(DRE->getDecl());
 
   return nullptr;
 }
 
-static std::pair<Decl *, Decl *> findReferencedDecl(const Expr *E) {
+static std::pair<VarDecl *, VarDecl *> findReferencedVarDecl(const Expr *E) {
   E = E->getValueProvidingExpr();
 
   if (auto *LE = dyn_cast<LoadExpr>(E))
-    return findReferencedDecl(LE->getSubExpr());
+    return findReferencedVarDecl(LE->getSubExpr());
 
   if (auto *AE = dyn_cast<AssignExpr>(E))
-    return findReferencedDecl(AE->getDest());
+    return findReferencedVarDecl(AE->getDest());
 
-  if (auto *D = findSimpleReferencedDecl(E))
+  if (auto *D = findSimpleReferencedVarDecl(E))
     return std::make_pair(nullptr, D);
 
   if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
-    if (auto *BaseDecl = findSimpleReferencedDecl(MRE->getBase()))
-      return std::make_pair(BaseDecl, MRE->getMember().getDecl());
+    if (auto *BaseDecl = findSimpleReferencedVarDecl(MRE->getBase()))
+      return std::make_pair(BaseDecl, cast<VarDecl>(MRE->getMember().getDecl()));
   }
 
   return std::make_pair(nullptr, nullptr);
@@ -1517,10 +1517,12 @@ bool TypeChecker::diagnoseSelfAssignment(const Expr *expr) {
   auto *dstExpr = assignExpr->getDest();
   auto *srcExpr = assignExpr->getSrc();
 
-  auto dstDecl = findReferencedDecl(dstExpr);
-  auto srcDecl = findReferencedDecl(srcExpr);
+  auto dstDecl = findReferencedVarDecl(dstExpr);
+  auto srcDecl = findReferencedVarDecl(srcExpr);
 
-  if (dstDecl.second && dstDecl == srcDecl) {
+  if (dstDecl.second &&
+      dstDecl.second->hasStorage() &&
+      dstDecl == srcDecl) {
     auto &DE = dstDecl.second->getASTContext().Diags;
     DE.diagnose(expr->getLoc(), dstDecl.first ? diag::self_assignment_prop
                                               : diag::self_assignment_var)

--- a/test/Sema/diag_self_assign.swift
+++ b/test/Sema/diag_self_assign.swift
@@ -21,6 +21,24 @@ class SA1 {
   }
 }
 
+struct SA1a {
+  var foo: Int = 0
+  init(fooi: Int) {
+    var foo = fooi
+    foo = foo // expected-error {{assigning a variable to itself}}
+    self.foo = self.foo // expected-error {{assigning a property to itself}}
+    foo = self.foo // no-error
+    self.foo = foo // no-error
+  }
+  mutating func f(fooi: Int) {
+    var foo = fooi
+    foo = foo // expected-error {{assigning a variable to itself}}
+    self.foo = self.foo // expected-error {{assigning a property to itself}}
+    foo = self.foo // no-error
+    self.foo = foo // no-error
+  }
+}
+
 class SA2 {
   var foo: Int {
     get {
@@ -31,14 +49,37 @@ class SA2 {
   init(fooi: Int) {
     var foo = fooi
     foo = foo // expected-error {{assigning a variable to itself}}
-    self.foo = self.foo // expected-error {{assigning a property to itself}}
+    self.foo = self.foo // no-error
     foo = self.foo // no-error
     self.foo = foo // no-error
   }
   func f(fooi: Int) {
     var foo = fooi
     foo = foo // expected-error {{assigning a variable to itself}}
-    self.foo = self.foo // expected-error {{assigning a property to itself}}
+    self.foo = self.foo // no-error
+    foo = self.foo // no-error
+    self.foo = foo // no-error
+  }
+}
+
+struct SA2a {
+  var foo: Int {
+    get {
+      return 0
+    }
+    set {}
+  }
+  init(fooi: Int) {
+    var foo = fooi
+    foo = foo // expected-error {{assigning a variable to itself}}
+    self.foo = self.foo // no-error
+    foo = self.foo // no-error
+    self.foo = foo // no-error
+  }
+  mutating func f(fooi: Int) {
+    var foo = fooi
+    foo = foo // expected-error {{assigning a variable to itself}}
+    self.foo = self.foo // no-error
     foo = self.foo // no-error
     self.foo = foo // no-error
   }
@@ -50,10 +91,24 @@ class SA3 {
       return foo // expected-warning {{attempting to access 'foo' within its own getter}} expected-note{{access 'self' explicitly to silence this warning}} {{14-14=self.}}
     }
     set {
-      foo = foo // expected-error {{assigning a property to itself}} expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}} expected-warning{{setter argument 'newValue' was never used, but the property was accessed}} expected-note{{did you mean to use 'newValue' instead of accessing the property's current value?}}
-      self.foo = self.foo // expected-error {{assigning a property to itself}}
-      foo = self.foo // expected-error {{assigning a property to itself}} expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}}
-      self.foo = foo // expected-error {{assigning a property to itself}}
+      foo = foo // expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}} expected-warning{{setter argument 'newValue' was never used, but the property was accessed}} expected-note{{did you mean to use 'newValue' instead of accessing the property's current value?}}
+      self.foo = self.foo // no-error
+      foo = self.foo // expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}}
+      self.foo = foo
+    }
+  }
+}
+
+struct SA3a {
+  var foo: Int {
+    get {
+      return foo // expected-warning {{attempting to access 'foo' within its own getter}} expected-note{{access 'self' explicitly to silence this warning}} {{14-14=self.}}
+    }
+    set {
+      foo = foo // expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}} expected-warning{{setter argument 'newValue' was never used, but the property was accessed}} expected-note{{did you mean to use 'newValue' instead of accessing the property's current value?}}
+      self.foo = self.foo // no-error
+      foo = self.foo // expected-warning {{attempting to modify 'foo' within its own setter}} expected-note{{access 'self' explicitly to silence this warning}} {{7-7=self.}}
+      self.foo = foo
     }
   }
 }
@@ -69,10 +124,29 @@ class SA4 {
   }
 }
 
+struct SA4a {
+  var foo: Int {
+    get {
+      return foo // expected-warning {{attempting to access 'foo' within its own getter}} expected-note{{access 'self' explicitly to silence this warning}} {{14-14=self.}}
+    }
+    set(value) {
+      value = value // expected-error {{cannot assign to value: 'value' is a 'let' constant}}
+    }
+  }
+}
+
 class SA5 {
   var foo: Int = 0
 }
-func SA5_test(a: SA4, b: SA4) {
+func SA5_test(a: SA5, b: SA5) {
+  a.foo = a.foo // expected-error {{assigning a property to itself}}
+  a.foo = b.foo
+}
+
+struct SA5a {
+  var foo: Int = 0
+}
+func SA5a_test(a: inout SA5, b: inout SA5) {
   a.foo = a.foo // expected-error {{assigning a property to itself}}
   a.foo = b.foo
 }

--- a/test/decl/var/didset_cycle.swift
+++ b/test/decl/var/didset_cycle.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+func doSomething(_: Int) {}
+
+struct S {
+  var x: Int {
+    didSet {
+      doSomething(y)
+      doSomething(self.y)
+    }
+  }
+
+  var y: Int {
+    didSet {
+      doSomething(x)
+      doSomething(self.x)
+    }
+  }
+}


### PR DESCRIPTION
We used to wrap the base expression in an InOutExpr when accessing a
computed property. This was a vestigial remnant of differences in the
SILGen code paths for stored vs computed property access.

These days SILGen doesn't care and is perfectly happy to call getters
and setters with an LValueType base as well.

This allows us to remove the call to getAccessSemantics(), which for
a 'didSet', had to kick off type checking of the body.

Fixes <rdar://problem/69532933>.