### PR TITLE
Implement canImport test for submodule

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -357,8 +357,8 @@ private:
     DelayedPatternContexts;
 
   /// Cache of module names that fail the 'canImport' test in this context.
-  mutable llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
-  
+  mutable llvm::StringSet<> FailedModuleImportNames;
+
   /// Set if a `-module-alias` was passed. Used to store mapping between module aliases and
   /// their corresponding real names, and vice versa for a reverse lookup, which is needed to check
   /// if the module names appearing in source files are aliases or real names.
@@ -980,10 +980,10 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  bool canImportModuleImpl(ImportPath::Element ModulePath,
-                           llvm::VersionTuple version,
-                           bool underlyingVersion,
+  bool canImportModuleImpl(ImportPath::Module ModulePath,
+                           llvm::VersionTuple version, bool underlyingVersion,
                            bool updateFailingList) const;
+
 public:
   namelookup::ImportCache &getImportCache() const;
 
@@ -1012,10 +1012,10 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  bool canImportModule(ImportPath::Element ModulePath,
+  bool canImportModule(ImportPath::Module ModulePath,
                        llvm::VersionTuple version = llvm::VersionTuple(),
                        bool underlyingVersion = false);
-  bool canImportModule(ImportPath::Element ModulePath,
+  bool canImportModule(ImportPath::Module ModulePath,
                        llvm::VersionTuple version = llvm::VersionTuple(),
                        bool underlyingVersion = false) const;
 

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -225,6 +225,22 @@ namespace detail {
       }
     }
 
+    /// Parses \p text into elements separated by \p separator, with identifiers
+    /// from \p ctx starting at \p loc.
+    ///
+    /// \warning This is not very robust; for instance, it doesn't check the
+    /// validity of the identifiers.
+    ImportPathBuilder(ASTContext &ctx, StringRef text, char separator,
+                      SourceLoc loc)
+        : scratch() {
+      while (!text.empty()) {
+        StringRef next;
+        std::tie(next, text) = text.split(separator);
+        push_back({ImportPathBuilder_getIdentifierImpl(ctx, next), loc});
+        loc = loc.getAdvancedLocOrInvalid(next.size() + 1);
+      }
+    }
+
     void push_back(const ImportPathElement &elem) { scratch.push_back(elem); }
     void push_back(Identifier name, SourceLoc loc = SourceLoc()) {
       scratch.push_back({ name, loc });

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -200,7 +200,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named,
+  virtual bool canImportModule(ImportPath::Module named,
                                llvm::VersionTuple version,
                                bool underlyingVersion) = 0;
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -192,7 +192,8 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named, llvm::VersionTuple version,
+  virtual bool canImportModule(ImportPath::Module named,
+                               llvm::VersionTuple version,
                                bool underlyingVersion) override;
 
   /// Import a module with the given module path.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -151,7 +151,7 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
                   bool skipBuildingInterface, bool IsFramework) override;
 
-  bool canImportModule(ImportPath::Element mID, llvm::VersionTuple version,
+  bool canImportModule(ImportPath::Module named, llvm::VersionTuple version,
                        bool underlyingVersion) override;
 
   bool isCached(StringRef DepPath) override { return false; };

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -57,7 +57,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named,
+  virtual bool canImportModule(ImportPath::Module named,
                                llvm::VersionTuple version,
                                bool underlyingVersion) override;
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -168,7 +168,7 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named,
+  virtual bool canImportModule(ImportPath::Module named,
                                llvm::VersionTuple version,
                                bool underlyingVersion) override;
 
@@ -287,7 +287,7 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
 public:
   virtual ~MemoryBufferSerializedModuleLoader();
 
-  bool canImportModule(ImportPath::Element named, llvm::VersionTuple version,
+  bool canImportModule(ImportPath::Module named, llvm::VersionTuple version,
                        bool underlyingVersion) override;
   ModuleDecl *
   loadModule(SourceLoc importLoc,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1808,14 +1808,14 @@ static std::string getScalaNodeText(llvm::yaml::Node *N) {
   return cast<llvm::yaml::ScalarNode>(N)->getValue(Buffer).str();
 }
 
-bool ClangImporter::canImportModule(ImportPath::Element moduleID,
+bool ClangImporter::canImportModule(ImportPath::Module modulePath,
                                     llvm::VersionTuple version,
                                     bool underlyingVersion) {
   // Look up the top-level module to see if it exists.
-  // FIXME: This only works with top-level modules.
   auto &clangHeaderSearch = Impl.getClangPreprocessor().getHeaderSearchInfo();
+  auto topModule = modulePath.front();
   clang::Module *clangModule = clangHeaderSearch.lookupModule(
-      moduleID.Item.str(), /*ImportLoc=*/clang::SourceLocation(),
+      topModule.Item.str(), /*ImportLoc=*/clang::SourceLocation(),
       /*AllowSearch=*/true, /*AllowExtraModuleMapSearch=*/true);
   if (!clangModule) {
     return false;
@@ -1825,10 +1825,34 @@ bool ClangImporter::canImportModule(ImportPath::Element moduleID,
   clang::Module::UnresolvedHeaderDirective mh;
   clang::Module *m;
   auto &ctx = Impl.getClangASTContext();
-  auto available = clangModule->isAvailable(ctx.getLangOpts(), getTargetInfo(),
-                                            r, mh, m);
+  auto &lo = ctx.getLangOpts();
+  auto &ti = getTargetInfo();
+
+  auto available = clangModule->isAvailable(lo, ti, r, mh, m);
   if (!available)
     return false;
+
+  if (modulePath.hasSubmodule()) {
+    for (auto &component : modulePath.getSubmodulePath()) {
+      clangModule = clangModule->findSubmodule(component.Item.str());
+
+      // Special case: a submodule named "Foo.Private" can be moved to a
+      // top-level module named "Foo_Private". Clang has special support for
+      // this.
+      if (!clangModule && component.Item.str() == "Private" &&
+          (&component) == (&modulePath.getRaw()[1])) {
+        clangModule = clangHeaderSearch.lookupModule(
+            (topModule.Item.str() + "_Private").str(),
+            /*ImportLoc=*/clang::SourceLocation(),
+            /*AllowSearch=*/true,
+            /*AllowExtraModuleMapSearch=*/true);
+      }
+      if (!clangModule || !clangModule->isAvailable(lo, ti, r, mh, m)) {
+        return false;
+      }
+    }
+  }
+
   if (version.empty())
     return true;
   assert(available);
@@ -1838,11 +1862,11 @@ bool ClangImporter::canImportModule(ImportPath::Element moduleID,
     .getFilename(clangModule->DefinitionLoc);
   // Look for the .tbd file inside .framework dir to get the project version
   // number.
-  std::string fwName = (llvm::Twine(moduleID.Item.str()) + ".framework").str();
+  std::string fwName = (llvm::Twine(topModule.Item.str()) + ".framework").str();
   auto pos = path.find(fwName);
   while (pos != StringRef::npos) {
     llvm::SmallString<256> buffer(path.substr(0, pos + fwName.size()));
-    llvm::sys::path::append(buffer, llvm::Twine(moduleID.Item.str()) + ".tbd");
+    llvm::sys::path::append(buffer, llvm::Twine(topModule.Item.str()) + ".tbd");
     auto tbdPath = buffer.str();
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> tbdBufOrErr =
       llvm::MemoryBuffer::getFile(tbdPath);
@@ -1877,8 +1901,8 @@ bool ClangImporter::canImportModule(ImportPath::Element moduleID,
   }
   // Diagnose unable to checking the current version.
   if (currentVersion.empty()) {
-    Impl.diagnose(moduleID.Loc, diag::cannot_find_project_version, "Clang",
-                  moduleID.Item.str());
+    Impl.diagnose(topModule.Loc, diag::cannot_find_project_version, "Clang",
+                  topModule.Item.str());
     return true;
   }
   assert(!currentVersion.empty());

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2726,7 +2726,9 @@ ModuleDecl *ClangImporter::Implementation::tryLoadFoundationModule() {
 }
 
 bool ClangImporter::Implementation::canImportFoundationModule() {
-  return SwiftContext.canImportModule({SwiftContext.Id_Foundation, SourceLoc()});
+  ImportPath::Module::Builder builder(SwiftContext.Id_Foundation);
+  auto modulePath = builder.get();
+  return SwiftContext.canImportModule(modulePath);
 }
 
 Type ClangImporter::Implementation::getNamedSwiftType(ModuleDecl *module,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -852,8 +852,10 @@ void CompilerInstance::verifyImplicitConcurrencyImport() {
 }
 
 bool CompilerInstance::canImportSwiftConcurrency() const {
-  return getASTContext().canImportModule(
-      {getASTContext().getIdentifier(SWIFT_CONCURRENCY_NAME), SourceLoc()});
+  ImportPath::Module::Builder builder(
+      getASTContext().getIdentifier(SWIFT_CONCURRENCY_NAME));
+  auto modulePath = builder.get();
+  return getASTContext().canImportModule(modulePath);
 }
 
 void CompilerInstance::verifyImplicitStringProcessingImport() {
@@ -865,9 +867,10 @@ void CompilerInstance::verifyImplicitStringProcessingImport() {
 }
 
 bool CompilerInstance::canImportSwiftStringProcessing() const {
-  return getASTContext().canImportModule(
-      {getASTContext().getIdentifier(SWIFT_STRING_PROCESSING_NAME),
-       SourceLoc()});
+  ImportPath::Module::Builder builder(
+      getASTContext().getIdentifier(SWIFT_STRING_PROCESSING_NAME));
+  auto modulePath = builder.get();
+  return getASTContext().canImportModule(modulePath);
 }
 
 ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1828,8 +1828,11 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
   return std::make_error_code(std::errc::not_supported);
 }
 
-bool ExplicitSwiftModuleLoader::canImportModule(
-    ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
+bool ExplicitSwiftModuleLoader::canImportModule(ImportPath::Module path,
+                                                llvm::VersionTuple version,
+                                                bool underlyingVersion) {
+  // FIXME: Swift submodules?
+  ImportPath::Element mID = path.front();
   // Look up the module with the real name (physical name on disk);
   // in case `-module-alias` is used, the name appearing in source files
   // and the real module name are different. For example, '-module-alias Foo=Bar'

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -69,9 +69,14 @@ void SourceLoader::collectVisibleTopLevelModuleNames(
   // TODO: Implement?
 }
 
-bool SourceLoader::canImportModule(ImportPath::Element ID,
+bool SourceLoader::canImportModule(ImportPath::Module path,
                                    llvm::VersionTuple version,
                                    bool underlyingVersion) {
+  // FIXME: Swift submodules?
+  if (path.size() > 1)
+    return false;
+
+  auto ID = path[0];
   // Search the memory buffers to see if we can find this file on disk.
   FileOrError inputFileOrError = findModule(Ctx, ID.Item,
                                             ID.Loc);

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -179,13 +179,16 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
             {ModuleDependenciesKind::SwiftPlaceholder, currentSearchPathSet}))
     return found;
 
-  auto moduleId = Ctx.getIdentifier(moduleName);
+  ImportPath::Module::Builder builder(Ctx, moduleName, /*separator=*/'.');
+  auto modulePath = builder.get();
+  auto moduleId = modulePath.front().Item;
   // Instantiate dependency scanning "loaders".
   SmallVector<std::unique_ptr<ModuleDependencyScanner>, 2> scanners;
-  // Placeholder dependencies must be resolved first, to prevent the ModuleDependencyScanner
-  // from first discovering artifacts of a previous build. Such artifacts are captured
-  // as compiledModuleCandidates in the dependency graph of the placeholder dependency module
-  // itself.
+  // Placeholder dependencies must be resolved first, to prevent the
+  // ModuleDependencyScanner from first discovering artifacts of a previous
+  // build. Such artifacts are captured as compiledModuleCandidates in the
+  // dependency graph of the placeholder dependency module itself.
+  // FIXME: submodules?
   scanners.push_back(std::make_unique<PlaceholderSwiftModuleScanner>(
       Ctx, LoadMode, moduleId, Ctx.SearchPathOpts.PlaceholderDependencyModuleMap,
       delegate));
@@ -196,8 +199,7 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
   assert(isa<PlaceholderSwiftModuleScanner>(scanners[0].get()) &&
          "Expected PlaceholderSwiftModuleScanner as the first dependency scanner loader.");
   for (auto &scanner : scanners) {
-    if (scanner->canImportModule({moduleId, SourceLoc()},
-                                 llvm::VersionTuple(), false)) {
+    if (scanner->canImportModule(modulePath, llvm::VersionTuple(), false)) {
       // Record the dependencies.
       cache.recordDependencies(moduleName, *(scanner->dependencies));
       return std::move(scanner->dependencies);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1123,8 +1123,9 @@ swift::extractUserModuleVersionFromInterface(StringRef moduleInterfacePath) {
   return result;
 }
 
-bool SerializedModuleLoaderBase::canImportModule(
-    ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
+bool SerializedModuleLoaderBase::canImportModule(ImportPath::Module path,
+                                                 llvm::VersionTuple version,
+                                                 bool underlyingVersion) {
   // If underlying version is specified, this should be handled by Clang importer.
   if (!version.empty() && underlyingVersion)
     return false;
@@ -1145,6 +1146,8 @@ bool SerializedModuleLoaderBase::canImportModule(
     unusedModuleDocBuffer = &moduleDocBuffer;
   }
 
+  // FIXME: Swift submodules?
+  auto mID = path[0];
   auto found = findModule(mID, unusedModuleInterfacePath, unusedModuleBuffer,
                           unusedModuleDocBuffer, unusedModuleSourceInfoBuffer,
                           /* skipBuildingInterface */ true, isFramework,
@@ -1180,10 +1183,13 @@ bool SerializedModuleLoaderBase::canImportModule(
 }
 
 bool MemoryBufferSerializedModuleLoader::canImportModule(
-    ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
+    ImportPath::Module path, llvm::VersionTuple version,
+    bool underlyingVersion) {
   // If underlying version is specified, this should be handled by Clang importer.
   if (!version.empty() && underlyingVersion)
     return false;
+  // FIXME: Swift submodules?
+  auto mID = path[0];
   auto mIt = MemoryBuffers.find(mID.Item.str());
   if (mIt == MemoryBuffers.end())
     return false;

--- a/test/Parse/ConditionalCompilation/Inputs/can-import-submodule-missing-requirement/module.modulemap
+++ b/test/Parse/ConditionalCompilation/Inputs/can-import-submodule-missing-requirement/module.modulemap
@@ -1,0 +1,10 @@
+module A {
+    explicit module B {
+        explicit module CMissingRequirement {
+            requires missing
+        }
+    }
+    explicit module BMissingRequirement {
+        requires missing
+    }
+}

--- a/test/Parse/ConditionalCompilation/Inputs/can-import-submodule-missing-requirement/module.private.modulemap
+++ b/test/Parse/ConditionalCompilation/Inputs/can-import-submodule-missing-requirement/module.private.modulemap
@@ -1,0 +1,10 @@
+module A_Private {
+    explicit module BP {
+        explicit module CPMissingRequirement {
+            requires missing
+        }
+    }
+    explicit module BPMissingRequirement {
+        requires missing
+    }
+}

--- a/test/Parse/ConditionalCompilation/Inputs/can-import-submodule/module.modulemap
+++ b/test/Parse/ConditionalCompilation/Inputs/can-import-submodule/module.modulemap
@@ -1,0 +1,5 @@
+module A {
+    explicit module B {
+        explicit module C { }
+    }
+}

--- a/test/Parse/ConditionalCompilation/Inputs/can-import-submodule/module.private.modulemap
+++ b/test/Parse/ConditionalCompilation/Inputs/can-import-submodule/module.private.modulemap
@@ -1,0 +1,5 @@
+module A_Private {
+    explicit module BP {
+        explicit module CP { }
+    }
+}

--- a/test/Parse/ConditionalCompilation/can_import_submodule.swift
+++ b/test/Parse/ConditionalCompilation/can_import_submodule.swift
@@ -1,0 +1,64 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/can-import-submodule/ 
+
+#if canImport(A)
+import A
+#else
+#error("should can import A")
+#endif
+
+#if canImport(A.B)
+import A.B
+#else
+#error("should can import A.B")
+#endif
+
+#if canImport(A.B.C)
+import A.B.C
+#else
+#error("should can import A.B.C")
+#endif
+
+
+#if canImport(Z)
+#error("should not can import Z")
+#endif
+
+#if canImport(A.Z)
+#error("should not can import A.Z")
+#endif
+
+#if canImport(Z.B)
+#error("should not can import Z.B")
+#endif
+
+#if canImport(Z.B.C)
+#error("should not can import Z.B.C")
+#endif
+
+#if canImport(A.B.Z)
+#error("should not can import A.B.Z")
+#endif
+
+#if canImport(A.Z.C)
+#error("should not can import A.Z.C")
+#endif
+
+#if canImport(A.B.C.Z)
+#error("should not can import A.B.C.Z")
+#endif
+
+
+#if canImport(A(_:).B) // expected-error {{unexpected platform condition argument: expected module name}}
+#endif
+
+#if canImport(A.B(c: "arg")) // expected-error {{unexpected platform condition argument: expected module name}}
+#endif
+
+#if canImport(A(b: 1, c: 2).B.C) // expected-error {{unexpected platform condition argument: expected module name}}
+#endif
+
+#if canImport(A.B("arg")(3).C) // expected-error {{unexpected platform condition argument: expected module name}}
+#endif
+
+#if canImport(A.B.C()) // expected-error {{unexpected platform condition argument: expected module name}}
+#endif

--- a/test/Parse/ConditionalCompilation/can_import_submodule_missing_requirement.swift
+++ b/test/Parse/ConditionalCompilation/can_import_submodule_missing_requirement.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/can-import-submodule-missing-requirement/ 
+
+#if canImport(A.BMissingRequirement)
+#error("should not can import A.BMissingRequirement")
+#endif
+
+#if canImport(A.B.CMissingRequirement)
+#error("should not can import A.B.CMissingRequirement")
+#endif
+
+
+#if canImport(A.Private.BPMissingRequirement)
+#error("should not can import A.Private.BPMissingRequirement")
+#endif
+
+#if canImport(A_Private.BPMissingRequirement)
+#error("should not can import A_Private.BPMissingRequirement")
+#endif
+
+#if canImport(A_Private.BP.CPMissingRequirement)
+#error("should not can import A_Private.BP.CPMissingRequirement")
+#endif

--- a/test/Parse/ConditionalCompilation/can_import_submodule_private.swift
+++ b/test/Parse/ConditionalCompilation/can_import_submodule_private.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/can-import-submodule/ 
+
+#if !canImport(A.Private)
+#error("should can import A.Private")
+#endif
+
+#if canImport(A_Private)
+import A_Private
+#else
+#error("should can import A_Private")
+#endif
+
+#if canImport(A_Private.BP)
+import A_Private.BP
+#else
+#error("should can import A_Private.BP")
+#endif
+
+#if canImport(A_Private.BP.CP)
+import A_Private.BP.CP
+#else
+#error("should can import A_Private.BP.CP")
+#endif
+
+
+#if canImport(A_Private.Z)
+#error("should not can import A_Private.Z")
+#endif
+
+#if canImport(A_Private.BP.Z)
+#error("should not can import A_Private.BP.Z")
+#endif
+
+#if canImport(A_Private.Z.CP)
+#error("should not can import A_Private.Z.CP")
+#endif
+
+#if canImport(A_Private.BP.CP.Z)
+#error("should not can import A_Private.BP.CP.Z")
+#endif

--- a/test/Parse/ConditionalCompilation/canimport_in_inactive.swift
+++ b/test/Parse/ConditionalCompilation/canimport_in_inactive.swift
@@ -21,7 +21,7 @@
 #endif
 
 #if canImport(SomeModule)
-// CHECK: :[[@LINE-1]]:5: error: could not find module 'SomeModule' for target '{{.*}}'; found: i386
+// CHECK: :[[@LINE-1]]:15: error: could not find module 'SomeModule' for target '{{.*}}'; found: i386
 #endif
 
 import SomeModule


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR extends `canImport` to check for submodule availability.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Forums Thread: https://forums.swift.org/t/41196

### Motivation

Currently, `canImport` only supports checking for top-level module availability while many have submodules with different availability. For example, while `CIFilter` was introduced in iOS 5, `CIFilterBuiltins` is only available on iOS 13+. Therefore, one might want to write code like this:

```swift
#if canImport(CoreImage.CIFilterBuiltins)
    ^ Unexpected platform condition argument: expected identifier

import CoreImage.CIFilterBuiltins
...
#endif
```

### Changes needed for *The Swift Programming Language* Reference

This PR would mean:

```diff
+ module-name → import-path
- module-name → identifier
```

For housekeeping, because [`import OpenGL.(GL3, GL3.Ext)`](https://github.com/apple/swift/blob/main/docs/archive/Import.rst) is (likely) never implemented, unless we're planning to have a separate PR extending import to support operators (e.g. `import func SomeModule.+++`) as mentioned in  https://github.com/apple/swift/pull/34094#issuecomment-708709198, we should update:

```diff
+ import-path → identifier | identifier . import-path
- import-path → import-path-identifier | import-path-identifier . import-path
- import-path-identifier → identifier | operator 
```

### Alternatives Considered

While the initial concern could be addressed by introducing `#if available`similiar to how `@available/#available` works but at the top level, clang modules [may specify other requirements](https://clang.llvm.org/docs/Modules.html#requires-declaration), therefore allowing `canImport` to check for submodule availability directly should be a more well-rounded and direct approach.

### Questions/Concerns

- **Is this a bug fix or does it have to go through Swift Evolution?** According to the [original proposal SE-0075](https://github.com/apple/swift-evolution/blob/master/proposals/0075-import-test.md), "`#if canImport(module-name)` tests for module support by name." Are submodule names module names?
- **Current implementation only extends support to clang submodules.** I saw a few `FIXME`s in other module loaders mentioning submodule support is not in place yet. Does this change have to wait for those to be implemented?


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
