### PR TITLE
[android] Disable a test that needs LTO support.

### DIFF
--- a/test/Interpreter/llvm_link_time_opt.swift
+++ b/test/Interpreter/llvm_link_time_opt.swift
@@ -1,6 +1,8 @@
 // UNSUPPORTED: OS=windows-msvc
 // static library is not well supported yet on Windows
 
+// REQUIRES: lld_lto
+
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-library -static -lto=llvm-full -emit-module %S/Inputs/lto/module1.swift -working-directory %t
 // RUN: %target-swiftc_driver -lto=llvm-full %s -I%t -L%t -lmodule1 -module-name main -o %t/main


### PR DESCRIPTION
With Gold from the Android NDK setting up LTO is complicated, and the CI
machines are not setup for it.

Disable this test in platforms that do not use LLD and LTO (which is
basically Android with older NDKs).
