### PR TITLE
Always infer dependencies when not using presets

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1201,6 +1201,10 @@ def main_normal():
 
     args = migration.parse_args(parser, sys.argv[1:])
 
+    # Always infer dependencies when not using presets.
+    # FIXME(drexin): Remove once infer is always used
+    args.infer_dependencies = True
+
     if args.build_script_impl_args:
         # If we received any impl args, check if `build-script-impl` would
         # accept them or not before any further processing.


### PR DESCRIPTION
For now we'll enable it for non-reset builds only to ensure we don't break the builds. Once we are confident that the inference works well, we will switch everything over.