### PR TITLE
[OSLog] Update compiler stubs and tests

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -10,6 +10,9 @@ add_swift_target_library(swiftOSLogTestHelper
   OSLogStringTypes.swift
   OSLogNSObjectType.swift
   OSLogFloatingPointTypes.swift
+  OSLogSwiftProtocols.swift
+  OSLogPrivacy.swift
+  OSLogFloatFormatting.swift
 
   SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC
   SWIFT_MODULE_DEPENDS_OSX Darwin ObjectiveC

--- a/stdlib/private/OSLog/OSLogFloatFormatting.swift
+++ b/stdlib/private/OSLog/OSLogFloatFormatting.swift
@@ -1,0 +1,426 @@
+//===--------------------------- OSLogFloatFormatting.swift ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===------------------------------------------------------------------------------===//
+
+// This file defines types and functions for specifying formatting of
+// floating-point typed interpolations passed to the os log APIs.
+
+@frozen
+public struct OSLogFloatFormatting {
+  /// When set, a `+` will be printed for all non-negative floats.
+  @usableFromInline
+  internal var explicitPositiveSign: Bool
+
+  /// Whether to use uppercase letters to represent numerals greater than 9
+  /// (default is to use lowercase). This applies to hexadecimal digits, NaN, Inf,
+  /// the symbols E and X used to denote exponent and hex format.
+  @usableFromInline
+  internal var uppercase: Bool
+
+  // Note: includePrefix is not supported for FloatFormatting. The format specifier %a
+  // always prints a prefix, %efg don't need one.
+
+  /// Number of digits to display following the radix point. Hex notation does not accept
+  /// a precision. For non-hex notations, precision can be a dynamic value. The default
+  /// precision is 6 for non-hex notations.
+  @usableFromInline
+  internal var precision: (() -> Int)?
+
+  @usableFromInline
+  internal enum Notation {
+    /// Hexadecimal formatting.
+    case hex
+
+    /// fprintf's `%f` formatting.
+    ///
+    /// Prints all digits before the radix point, and `precision` digits following
+    /// the radix point. If `precision` is zero, the radix point is omitted.
+    ///
+    /// Note that very large floating-point values may print quite a lot of digits
+    /// when using this format, even if `precision` is zero--up to hundreds for
+    /// `Double`, and thousands for `Float80`. Note also that this format is
+    /// very likely to print non-zero values as all-zero. If these are a concern, use
+    /// `.exponential` or `.hybrid` instead.
+    ///
+    /// Systems may impose an upper bound on the number of digits that are
+    /// supported following the radix point.
+    case fixed
+
+    /// fprintf's `%e` formatting.
+    ///
+    /// Prints the number in the form [-]d.ddd...dde±dd, with `precision` significant
+    /// digits following the radix point. Systems may impose an upper bound on the number
+    /// of digits that are supported.
+    case exponential
+
+    /// fprintf's `%g` formatting.
+    ///
+    /// Behaves like `.fixed` when the number is scaled close to 1.0, and like
+    /// `.exponential` if it has a very large or small exponent.
+    case hybrid
+  }
+
+  @usableFromInline
+  internal var notation: Notation
+
+  @_transparent
+  @usableFromInline
+  internal init(
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false,
+    precision: (() -> Int)?,
+    notation: Notation
+  ) {
+    self.explicitPositiveSign = explicitPositiveSign
+    self.uppercase = uppercase
+    self.precision = precision
+    self.notation = notation
+  }
+
+  /// Displays an interpolated floating-point value in fprintf's `%f` format with
+  /// default precision.
+  ///
+  /// Prints all digits before the radix point, and 6 digits following the radix point.
+  /// Note also that this format is very likely to print non-zero values as all-zero.
+  ///
+  /// Note that very large floating-point values may print quite a lot of digits
+  /// when using this format --up to hundreds for `Double`. Note also that this
+  /// format is very likely to print non-zero values as all-zero. If these are a concern,
+  /// use `.exponential` or `.hybrid` instead.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var fixed: OSLogFloatFormatting { .fixed() }
+
+  /// Displays an interpolated floating-point value in fprintf's `%f` format with
+  /// specified precision, and optional sign and case.
+  ///
+  /// Prints all digits before the radix point, and `precision` digits following
+  /// the radix point. If `precision` is zero, the radix point is omitted.
+  ///
+  /// Note that very large floating-point values may print quite a lot of digits
+  /// when using this format, even if `precision` is zero--up to hundreds for
+  /// `Double`. Note also that this format is very likely to print non-zero values as
+  /// all-zero. If these are a concern, use `.exponential` or `.hybrid` instead.
+  ///
+  /// Systems may impose an upper bound on the number of digits that are
+  /// supported following the radix point.
+  ///
+  /// All parameters to this function except `precision` must be boolean literals.
+  ///
+  /// - Parameters:
+  ///   - precision: Number of digits to display after the radix point.
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func fixed(
+    precision: @escaping @autoclosure () -> Int,
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: precision,
+      notation: .fixed
+    )
+  }
+
+  /// Displays an interpolated floating-point value in fprintf's `%f` format with
+  /// default precision, and optional sign and case.
+  ///
+  /// Prints all digits before the radix point, and 6 digits following the radix point.
+  /// Note also that this format is very likely to print non-zero values as all-zero.
+  ///
+  /// Note that very large floating-point values may print quite a lot of digits
+  /// when using this format, even if `precision` is zero--up to hundreds for
+  /// `Double`. Note also that this format is very likely to print non-zero values as
+  /// all-zero. If these are a concern, use `.exponential` or `.hybrid` instead.
+  ///
+  /// Systems may impose an upper bound on the number of digits that are
+  /// supported following the radix point.
+  ///
+  /// All parameters to this function must be boolean literals.
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func fixed(
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: nil,
+      notation: .fixed
+    )
+  }
+
+  /// Displays an interpolated floating-point value in hexadecimal format.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var hex: OSLogFloatFormatting { .hex() }
+
+  /// Displays an interpolated floating-point value in hexadecimal format with
+  /// optional sign and case.
+  ///
+  /// All parameters to this function must be boolean literals.
+  ///
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func hex(
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: nil,
+      notation: .hex
+    )
+  }
+
+  /// Displays an interpolated floating-point value in fprintf's `%e` format.
+  ///
+  /// Prints the number in the form [-]d.ddd...dde±dd.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var exponential: OSLogFloatFormatting { .exponential() }
+
+  /// Displays an interpolated floating-point value in fprintf's `%e` format with
+  /// specified precision, and optional sign and case.
+  ///
+  /// Prints the number in the form [-]d.ddd...dde±dd, with `precision` significant
+  /// digits following the radix point. Systems may impose an upper bound on the number
+  /// of digits that are supported.
+  ///
+  /// All parameters except `precision` must be boolean literals.
+  ///
+  /// - Parameters:
+  ///   - precision: Number of digits to display after the radix point.
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func exponential(
+    precision: @escaping @autoclosure () -> Int,
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: precision,
+      notation: .exponential
+    )
+  }
+
+  /// Displays an interpolated floating-point value in fprintf's `%e` format with
+  /// an optional sign and case.
+  ///
+  /// Prints the number in the form [-]d.ddd...dde±dd.
+  ///
+  /// All parameters to this function must be boolean literals.
+  ///
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func exponential(
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: nil,
+      notation: .exponential
+    )
+  }
+
+  /// Displays an interpolated floating-point value in fprintf's `%g` format.
+  ///
+  /// Behaves like `.fixed` when the number is scaled close to 1.0, and like
+  /// `.exponential` if it has a very large or small exponent.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var hybrid: OSLogFloatFormatting { .hybrid() }
+
+  /// Displays an interpolated floating-point value in fprintf's `%g` format with the
+  /// specified precision, and optional sign and case.
+  ///
+  /// Behaves like `.fixed` when the number is scaled close to 1.0, and like
+  /// `.exponential` if it has a very large or small exponent.
+  ///
+  /// All parameters except `precision` must be boolean literals.
+  ///
+  /// - Parameters:
+  ///   - precision: Number of digits to display after the radix point.
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func hybrid(
+    precision: @escaping @autoclosure () -> Int,
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: precision,
+      notation: .hybrid
+    )
+  }
+
+  /// Displays an interpolated floating-point value in fprintf's `%g` format with
+  /// optional sign and case.
+  ///
+  /// Behaves like `.fixed` when the number is scaled close to 1.0, and like
+  /// `.exponential` if it has a very large or small exponent.
+  ///
+  /// All parameters to this function must be boolean literals.
+  ///
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers.
+  ///   - uppercase: Pass `true` to use uppercase letters or `false` to use
+  ///     lowercase letters. The default is `false`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func hybrid(
+    explicitPositiveSign: Bool = false,
+    uppercase: Bool = false
+  ) -> OSLogFloatFormatting {
+    return OSLogFloatFormatting(
+      explicitPositiveSign: explicitPositiveSign,
+      uppercase: uppercase,
+      precision: nil,
+      notation: .hybrid
+    )
+  }
+}
+
+extension OSLogFloatFormatting {
+  /// Returns a fprintf-compatible length modifier for a given argument type
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal static func _formatStringLengthModifier<I: FloatingPoint>(
+    _ type: I.Type
+  ) -> String? {
+    switch type {
+    //   fprintf formatters promote Float to Double
+    case is Float.Type: return ""
+    case is Double.Type: return ""
+#if !os(Windows) && (arch(i386) || arch(x86_64))
+    //   fprintf formatters use L for Float80
+    case is Float80.Type: return "L"
+#endif
+    default: return nil
+    }
+  }
+
+  /// Constructs an os_log format specifier for the given type `type`
+  /// using the specified alignment `align` and privacy qualifier `privacy`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal func formatSpecifier<I: FloatingPoint>(
+    for type: I.Type,
+    align: OSLogStringAlignment,
+    privacy: OSLogPrivacy
+  ) -> String {
+    var specification = "%"
+    // Add privacy qualifier after % sign within curly braces. This is an
+    // os log specific flag.
+    if let privacySpecifier = privacy.privacySpecifier {
+      specification += "{"
+      specification += privacySpecifier
+      specification += "}"
+    }
+
+    // 1. Flags
+    // IEEE: `+` The result of a signed conversion shall always begin with a sign
+    // ( '+' or '-' )
+    if explicitPositiveSign {
+      specification += "+"
+    }
+
+    // IEEE: `-` The result of the conversion shall be left-justified within the field.
+    // The conversion is right-justified if this flag is not specified.
+    if case .start = align.anchor {
+      specification += "-"
+    }
+
+    if let _ = align.minimumColumnWidth {
+      // The alignment could be a dynamic value. Therefore, use a star here and pass it
+      // as an additional argument.
+      specification += "*"
+    }
+
+    if let _ = precision {
+      specification += ".*"
+    }
+
+    guard let lengthModifier =
+      OSLogFloatFormatting._formatStringLengthModifier(type) else {
+      fatalError("Float type has unknown length")
+    }
+    specification += lengthModifier
+
+    // 3. Precision and conversion specifier.
+    switch notation {
+    case .fixed:
+      specification += (uppercase ? "F" : "f")
+    case .exponential:
+      specification += (uppercase ? "E" : "e")
+    case .hybrid:
+      specification += (uppercase ? "G" : "g")
+    case .hex:
+      //guard type.radix == 2 else { return nil }
+      specification += (uppercase ? "A" : "a")
+    default:
+      fatalError("Unknown float notation")
+    }
+    return specification
+  }
+}
+

--- a/stdlib/private/OSLog/OSLogFloatingPointTypes.swift
+++ b/stdlib/private/OSLog/OSLogFloatingPointTypes.swift
@@ -17,46 +17,88 @@
 //
 // The `appendInterpolation` functions defined in this file accept privacy
 // options along with the interpolated expression as shown below:
-// TODO: support floating-point formatting options.
 //
-//    "\(x, privacy: .private\)"
+//    "\(x, format: .fixed(precision: 10), privacy: .private\)"
 
 extension OSLogInterpolation {
 
-  /// Define interpolation for expressions of type Float.
+  /// Defines interpolation for expressions of type Float.
+  ///
+  /// Do not call this function directly. It will be called automatically when interpolating
+  /// a value of type `Float` in the string interpolations passed to the log APIs.
+  ///
   /// - Parameters:
-  ///  - number: the interpolated expression of type Float, which is autoclosured.
-  ///  - privacy: a privacy qualifier which is either private or public.
-  ///    It is auto-inferred by default.
+  ///   - number: The interpolated expression of type Float, which is autoclosured.
+  ///   - format: A formatting option available for float types, defined by the
+  ///     type`OSLogFloatFormatting`. The default is `.fixed`.
+  ///   - align: Left or right alignment with the minimum number of columns as
+  ///     defined by the type `OSLogStringAlignment`.
+  ///   - privacy: A privacy qualifier which is either private or public.
+  ///     It is auto-inferred by default.
   @_semantics("constant_evaluable")
-  @_semantics("oslog.requires_constant_arguments")
   @inlinable
   @_optimize(none)
+  @_semantics("oslog.requires_constant_arguments")
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Float,
+    format: OSLogFloatFormatting = .fixed,
+    align: OSLogStringAlignment = .none,
     privacy: OSLogPrivacy = .auto
   ) {
-    appendInterpolation(Double(number()), privacy: privacy)
+    appendInterpolation(
+      Double(number()),
+      format: format,
+      align: align,
+      privacy: privacy)
   }
 
   /// Define interpolation for expressions of type Double.
+  ///
+  /// Do not call this function directly. It will be called automatically when interpolating
+  /// a value of type `Double` in the string interpolations passed to the log APIs.
+  ///
   /// - Parameters:
-  ///  - number: the interpolated expression of type Double, which is autoclosured.
-  ///  - privacy: a privacy qualifier which is either private or public.
-  ///    It is auto-inferred by default.
+  ///   - number: The interpolated expression of type Double, which is autoclosured.
+  ///   - format: A formatting option available for float types, defined by the
+  ///     type`OSLogFloatFormatting`. The default is `.fixed`.
+  ///   - align: Left or right alignment with the minimum number of columns as
+  ///     defined by the type `OSLogStringAlignment`.
+  ///   - privacy: A privacy qualifier which is either private or public.
+  ///     It is auto-inferred by default.
   @_semantics("constant_evaluable")
-  @_semantics("oslog.requires_constant_arguments")
   @inlinable
   @_optimize(none)
+  @_semantics("oslog.requires_constant_arguments")
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Double,
+    format: OSLogFloatFormatting = .fixed,
+    align: OSLogStringAlignment = .none,
     privacy: OSLogPrivacy = .auto
   ) {
     guard argumentCount < maxOSLogArgumentCount else { return }
+    formatString +=
+      format.formatSpecifier(for: Double.self, align: align, privacy: privacy)
 
-    formatString += getDoubleFormatSpecifier(privacy: privacy)
+    // If minimum column width is specified, append this value first. Note that
+    // the format specifier would use a '*' for width e.g. %*f.
+    if let minColumns = align.minimumColumnWidth {
+      appendAlignmentArgument(minColumns)
+    }
+
+    // If the privacy has a mask, append the mask argument, which is a constant payload.
+    // Note that this should come after the width but before the precision.
+    if privacy.hasMask {
+      appendMaskArgument(privacy)
+    }
+
+    // If minimum number of digits (precision) is specified, append the
+    // precision before the argument. Note that the format specifier would use
+    // a '*' for precision: %.*f.
+    if let precision = format.precision {
+      appendPrecisionArgument(precision)
+    }
+    // Append the double.
     addDoubleHeaders(privacy)
-
     arguments.append(number)
     argumentCount += 1
   }
@@ -82,29 +124,6 @@ extension OSLogInterpolation {
 
     preamble = getUpdatedPreamble(privacy: privacy, isScalar: true)
   }
-
-  /// Construct an os_log format specifier from the given parameters.
-  /// This function must be constant evaluable and all its arguments
-  /// must be known at compile time.
-  @inlinable
-  @_semantics("constant_evaluable")
-  @_effects(readonly)
-  @_optimize(none)
-  internal func getDoubleFormatSpecifier(privacy: OSLogPrivacy) -> String {
-    // TODO: this will become more sophisticated when floating-point formatting
-    // options are supported.
-    var specifier = "%"
-    switch privacy {
-    case .private:
-      specifier += "{private}"
-    case .public:
-      specifier += "{public}"
-    default:
-      break
-    }
-    specifier += "f"
-    return specifier
-  }
 }
 
 extension OSLogArguments {
@@ -115,7 +134,7 @@ extension OSLogArguments {
   @inlinable
   @_optimize(none)
   internal mutating func append(_ value: @escaping () -> Double) {
-    argumentClosures.append({ (position, _) in
+    argumentClosures.append({ (position, _, _) in
       serialize(value(), at: &position)
     })
   }
@@ -125,14 +144,13 @@ extension OSLogArguments {
 /// specified by os_log. Note that this is marked transparent instead of
 /// @inline(__always) as it is used in optimize(none) functions.
 @_transparent
-@usableFromInline
+@_alwaysEmitIntoClient
 internal func doubleSizeInBytes() -> Int {
   return 8
 }
 
 /// Serialize a double at the buffer location that `position` points to and
 /// increment `position` by the byte size of the double.
-@inlinable
 @_alwaysEmitIntoClient
 @inline(__always)
 internal func serialize(
@@ -145,3 +163,4 @@ internal func serialize(
   withUnsafeBytes(of: value) { dest.copyMemory(from: $0) }
   bufferPosition += byteCount
 }
+

--- a/stdlib/private/OSLog/OSLogIntegerFormatting.swift
+++ b/stdlib/private/OSLog/OSLogIntegerFormatting.swift
@@ -17,23 +17,30 @@
 public struct OSLogIntegerFormatting {
   /// The base to use for the string representation. `radix` must be at least 2
   /// and at most 36. The default is 10.
-  public var radix: Int
+  @usableFromInline
+  internal var radix: Int
 
   /// When set, a `+` will be printed for all non-negative integers.
-  public var explicitPositiveSign: Bool
+  @usableFromInline
+  internal var explicitPositiveSign: Bool
 
   /// When set, a prefix: 0b or 0o or 0x will be added when the radix is 2, 8 or
   /// 16 respectively.
-  public var includePrefix: Bool
+  @usableFromInline
+  internal var includePrefix: Bool
 
   /// Whether to use uppercase letters to represent numerals
   /// greater than 9 (default is to use lowercase).
-  public var uppercase: Bool
+  @usableFromInline
+  internal var uppercase: Bool
 
   /// Minimum number of digits to display. Numbers having fewer digits than
   /// minDigits will be displayed with leading zeros.
-  public var minDigits: (() -> Int)?
+  @usableFromInline
+  internal var minDigits: (() -> Int)?
 
+  /// Initializes all stored properties.
+  ///
   /// - Parameters:
   ///   - radix: The base to use for the string representation. `radix` must be
   ///     at least 2 and at most 36. The default is 10.
@@ -46,9 +53,8 @@ public struct OSLogIntegerFormatting {
   ///     `false`.
   ///   - minDigits: minimum number of digits to display. Numbers will be
   ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
-  @_semantics("constant_evaluable")
-  @inlinable
-  @_optimize(none)
+  @_transparent
+  @usableFromInline
   internal init(
     radix: Int = 10,
     explicitPositiveSign: Bool = false,
@@ -56,8 +62,6 @@ public struct OSLogIntegerFormatting {
     uppercase: Bool = false,
     minDigits: (() -> Int)?
   ) {
-    precondition(radix >= 2 && radix <= 36)
-
     self.radix = radix
     self.explicitPositiveSign = explicitPositiveSign
     self.includePrefix = includePrefix
@@ -65,11 +69,17 @@ public struct OSLogIntegerFormatting {
     self.minDigits = minDigits
   }
 
+  /// Displays an interpolated integer as a decimal number with the specified number
+  /// of digits and an optional sign.
+  ///
+  /// The parameter `explicitPositiveSign` must be a boolean literal. The
+  /// parameter `minDigits` can be an arbitrary expression.
+  ///
   /// - Parameters:
   ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
-  ///     numbers. Default is `false`.
+  ///     numbers.
   ///   - minDigits: minimum number of digits to display. Numbers will be
-  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  ///     prefixed with zeros if necessary to meet the minimum.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -83,9 +93,13 @@ public struct OSLogIntegerFormatting {
       minDigits: minDigits)
   }
 
+  /// Displays an interpolated integer as a decimal number with an optional sign.
+  ///
+  /// The parameter `explicitPositiveSign` must be a boolean literal.
+  ///
   /// - Parameters:
   ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
-  ///     numbers. Default is `false`.
+  ///     numbers.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -98,22 +112,28 @@ public struct OSLogIntegerFormatting {
       minDigits: nil)
   }
 
-  /// Default decimal format.
+  /// Displays an interpolated integer as a decimal number. This is the default format for
+  /// integers.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
   public static var decimal: OSLogIntegerFormatting { .decimal() }
 
+  /// Displays an interpolated unsigned integer as a hexadecimal number with the
+  /// specified parameters. This formatting option should be used only with unsigned
+  /// integers.
+  ///
+  /// All parameters except `minDigits` should be boolean literals. `minDigits`
+  /// can be an arbitrary expression.
+  ///
   /// - Parameters:
   ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
-  ///     numbers. Default is `false`.
-  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
-  ///     radices. Default is `false`.
+  ///     numbers.
+  ///   - includePrefix: Pass `true` to add a prefix 0x.
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
-  ///     greater than 9, or `false` to use lowercase letters. The default is
-  ///     `false`.
+  ///     greater than 9, or `false` to use lowercase letters. The default is `false`.
   ///   - minDigits: minimum number of digits to display. Numbers will be
-  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  ///     prefixed with zeros if necessary to meet the minimum.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -131,14 +151,17 @@ public struct OSLogIntegerFormatting {
       minDigits: minDigits)
   }
 
+  /// Displays an interpolated unsigned integer as a hexadecimal number with the specified
+  /// parameters. This formatting option should be used only with unsigned integers.
+  ///
+  /// All parameters  should be boolean literals.
+  ///
   /// - Parameters:
   ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
-  ///     numbers. Default is `false`.
-  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
-  ///     radices. Default is `false`.
+  ///     numbers.
+  ///   - includePrefix: Pass `true` to add a prefix 0x.
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
-  ///     greater than 9, or `false` to use lowercase letters. The default is
-  ///     `false`.
+  ///     greater than 9, or `false` to use lowercase letters. The default is `false`.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -155,22 +178,28 @@ public struct OSLogIntegerFormatting {
       minDigits: nil)
   }
 
-  /// Default hexadecimal format.
+  /// Displays an interpolated unsigned integer as a hexadecimal number.
+  /// This formatting option should be used only with unsigned integers.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
   public static var hex: OSLogIntegerFormatting { .hex() }
 
+  /// Displays an interpolated unsigned integer as an octal number with the specified
+  /// parameters. This formatting option should be used only with unsigned
+  /// integers.
+  ///
+  /// All parameters except `minDigits` should be boolean literals. `minDigits`
+  /// can be an arbitrary expression.
+  ///
   /// - Parameters:
   ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
-  ///     numbers. Default is `false`.
-  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
-  ///     radices. Default is `false`.
+  ///     numbers.
+  ///   - includePrefix: Pass `true` to add a prefix 0o.
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
-  ///     greater than 9, or `false` to use lowercase letters. The default is
-  ///     `false`.
+  ///     greater than 9, or `false` to use lowercase letters. The default is `false`.
   ///   - minDigits: minimum number of digits to display. Numbers will be
-  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  ///     prefixed with zeros if necessary to meet the minimum.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -188,14 +217,17 @@ public struct OSLogIntegerFormatting {
       minDigits: minDigits)
   }
 
+  /// Displays an interpolated unsigned integer as an octal number with the specified parameters.
+  /// This formatting option should be used only with unsigned integers.
+  ///
+  /// All parameters must be boolean literals.
+  ///
   /// - Parameters:
   ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
-  ///     numbers. Default is `false`.
-  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
-  ///     radices. Default is `false`.
+  ///     numbers.
+  ///   - includePrefix: Pass `true` to add a prefix 0o.
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
-  ///     greater than 9, or `false` to use lowercase letters. The default is
-  ///     `false`.
+  ///     greater than 9, or `false` to use lowercase letters.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -212,7 +244,8 @@ public struct OSLogIntegerFormatting {
       minDigits: nil)
   }
 
-  /// Default octal format.
+  /// Displays an interpolated unsigned integer as an octal number.
+  /// This formatting option should be used only with unsigned integers.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -311,13 +344,10 @@ extension OSLogIntegerFormatting {
 
     // Add privacy qualifier after % sign within curly braces. This is an
     // os log specific flag.
-    switch privacy {
-    case .private:
-      specification += "{private}"
-    case .public:
-      specification += "{public}"
-    default:
-      break
+    if let privacySpecifier = privacy.privacySpecifier {
+      specification += "{"
+      specification += privacySpecifier
+      specification += "}"
     }
 
     //

--- a/stdlib/private/OSLog/OSLogNSObjectType.swift
+++ b/stdlib/private/OSLog/OSLogNSObjectType.swift
@@ -24,15 +24,18 @@ import ObjectiveC
 
 extension OSLogInterpolation {
 
-  /// Define interpolation for expressions of type NSObject.
+  /// Defines interpolation for expressions of type NSObject.
+  ///
+  /// Do not call this function directly. It will be called automatically when interpolating
+  /// a value of type `NSObject` in the string interpolations passed to the log APIs.
+  ///
   /// - Parameters:
-  ///  - argumentObject: the interpolated expression of type NSObject, which is autoclosured.
-  ///  - privacy: a privacy qualifier which is either private or public.
-  ///  It is auto-inferred by default.
+  ///   - argumentObject: The interpolated expression of type NSObject, which is autoclosured.
+  ///   - privacy: A privacy qualifier which is either private or public. It is auto-inferred by default.
   @_semantics("constant_evaluable")
-  @_semantics("oslog.requires_constant_arguments")
   @inlinable
   @_optimize(none)
+  @_semantics("oslog.requires_constant_arguments")
   public mutating func appendInterpolation(
     _ argumentObject: @autoclosure @escaping () -> NSObject,
     privacy: OSLogPrivacy = .auto
@@ -40,10 +43,14 @@ extension OSLogInterpolation {
     guard argumentCount < maxOSLogArgumentCount else { return }
 
     formatString += getNSObjectFormatSpecifier(privacy)
+    // If the privacy has a mask, append the mask argument, which is a constant payload.
+    if privacy.hasMask {
+      appendMaskArgument(privacy)
+    }
     addNSObjectHeaders(privacy)
-
     arguments.append(argumentObject)
     argumentCount += 1
+    objectArgumentCount += 1
   }
 
   /// Update preamble and append argument headers based on the parameters of
@@ -76,14 +83,14 @@ extension OSLogInterpolation {
   @_effects(readonly)
   @_optimize(none)
   internal func getNSObjectFormatSpecifier(_ privacy: OSLogPrivacy) -> String {
-    switch privacy {
-    case .private:
-      return "%{private}@"
-    case .public:
-      return "%{public}@"
-    default:
-      return "%@"
+    var specifier = "%"
+    if let privacySpecifier = privacy.privacySpecifier {
+      specifier += "{"
+      specifier += privacySpecifier
+      specifier += "}"
     }
+    specifier += "@"
+    return specifier
   }
 }
 
@@ -95,20 +102,20 @@ extension OSLogArguments {
   @inlinable
   @_optimize(none)
   internal mutating func append(_ value: @escaping () -> NSObject) {
-    argumentClosures.append({ (position, _) in
-      serialize(value(), at: &position)
+    argumentClosures.append({ (position, objectArguments, _) in
+      serialize(value(), at: &position, storingObjectsIn: &objectArguments)
     })
   }
 }
 
 /// Serialize an NSObject pointer at the buffer location pointed by
 /// `bufferPosition`.
-@inlinable
 @_alwaysEmitIntoClient
 @inline(__always)
 internal func serialize(
   _ object: NSObject,
-  at bufferPosition: inout ByteBufferPointer
+  at bufferPosition: inout ByteBufferPointer,
+  storingObjectsIn objectArguments: inout ObjectStorage<NSObject>
 ) {
   let byteCount = pointerSizeInBytes();
   let dest =
@@ -116,9 +123,11 @@ internal func serialize(
   // Get the address of this NSObject as an UnsafeRawPointer.
   let objectAddress = Unmanaged.passUnretained(object).toOpaque()
   // Copy the address into the destination buffer. Note that the input NSObject
-  // is an interpolated expression and is guaranteed to be alive until the
-  // os_log ABI call is completed by the implementation. Therefore, passing
-  // this address to the os_log ABI is safe.
+  // is kept alive until the os_log ABI call completes by storing in the
+  // objectArguments.
   withUnsafeBytes(of: objectAddress) { dest.copyMemory(from: $0) }
   bufferPosition += byteCount
+  // This object could be newly created by the auto-closure. Therefore, make
+  // sure it is alive until the log call completes.
+  initializeAndAdvance(&objectArguments, to: object)
 }

--- a/stdlib/private/OSLog/OSLogPrivacy.swift
+++ b/stdlib/private/OSLog/OSLogPrivacy.swift
@@ -1,0 +1,220 @@
+//===----------------- OSLogPrivacy.swift ---------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines the APIs for specifying privacy in the log messages and also
+// the logic for encoding them in the byte buffer passed to the libtrace library.
+
+/// Privacy options for specifying privacy level of the interpolated expressions
+/// in the string interpolations passed to the log APIs.
+@frozen
+public struct OSLogPrivacy {
+
+  @usableFromInline
+  internal enum PrivacyOption {
+    case `private`
+    case `public`
+    case auto
+  }
+
+  public enum Mask {
+    /// Applies a salted hashing transformation to an interpolated value to redact it in the logs.
+    ///
+    /// Its purpose is to permit the correlation of identical values across multiple log lines
+    /// without revealing the value itself.
+    case hash
+    case none
+  }
+
+  @usableFromInline
+  internal var privacy: PrivacyOption
+
+  @usableFromInline
+  internal var mask: Mask
+
+  @_transparent
+  @usableFromInline
+  internal init(privacy: PrivacyOption, mask: Mask) {
+    self.privacy = privacy
+    self.mask = mask
+  }
+
+  /// Sets the privacy level of an interpolated value to public.
+  ///
+  /// When the privacy level is public, the value will be displayed
+  /// normally without any redaction in the logs.
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  @inlinable
+  public static var `public`: OSLogPrivacy {
+    OSLogPrivacy(privacy: .public, mask: .none)
+  }
+
+  /// Sets the privacy level of an interpolated value to private.
+  ///
+  /// When the privacy level is private, the value will be redacted in the logs,
+  /// subject to the privacy configuration of the logging system.
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  @inlinable
+  public static var `private`: OSLogPrivacy {
+    OSLogPrivacy(privacy: .private, mask: .none)
+  }
+
+  /// Sets the privacy level of an interpolated value to private and
+  /// applies a `mask` to the interpolated value to redacted it.
+  ///
+  /// When the privacy level is private, the value will be redacted in the logs,
+  /// subject to the privacy configuration of the logging system.
+  ///
+  /// If the value need not be redacted in the logs, its full value is captured as normal.
+  /// Otherwise (i.e. if the value would be redacted) the `mask` is applied to
+  /// the argument value and the result of the transformation is recorded instead.
+  ///
+  /// - Parameters:
+  ///   - mask: Mask to use with the privacy option.
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  @inlinable
+  public static func `private`(mask: Mask) -> OSLogPrivacy {
+    OSLogPrivacy(privacy: .private, mask: mask)
+  }
+
+  /// Auto-infers a privacy level for an interpolated value.
+  ///
+  /// The system will automatically decide whether the value should
+  /// be captured fully in the logs or should be redacted.
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  @inlinable
+  public static var auto: OSLogPrivacy {
+    OSLogPrivacy(privacy: .auto, mask: .none)
+  }
+
+  /// Auto-infers a privacy level for an interpolated value and applies a `mask`
+  /// to the interpolated value to redacted it when necessary.
+  ///
+  /// The system will automatically decide whether the value should
+  /// be captured fully in the logs or should be redacted.
+  /// If the value need not be redacted in the logs, its full value is captured as normal.
+  /// Otherwise (i.e. if the value would be redacted) the `mask` is applied to
+  /// the argument value and the result of the transformation is recorded instead.
+  ///
+  /// - Parameters:
+  ///   - mask: Mask to use with the privacy option.
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  @inlinable
+  public static func auto(mask: Mask) -> OSLogPrivacy {
+    OSLogPrivacy(privacy: .auto, mask: mask)
+  }
+
+  /// Return an argument flag for the privacy option., as defined by the
+  /// os_log ABI, which occupies four least significant bits of the first byte of the
+  /// argument header. The first two bits are used to indicate privacy and
+  /// the other two are reserved.
+  @inlinable
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  internal var argumentFlag: UInt8 {
+    switch privacy {
+    case .private:
+      return 0x1
+    case .public:
+      return 0x2
+    default:
+      return 0
+    }
+  }
+
+  @inlinable
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  internal var isAtleastPrivate: Bool {
+    switch privacy {
+    case .public:
+      return false
+    case .auto:
+      return false
+    default:
+      return true
+    }
+  }
+
+  @inlinable
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  internal var needsPrivacySpecifier: Bool {
+    if case .hash = mask {
+      return true
+    }
+    switch privacy {
+    case .auto:
+      return false
+    default:
+      return true
+    }
+  }
+
+  @inlinable
+  @_transparent
+  internal var hasMask: Bool {
+    if case .hash = mask {
+      return true
+    }
+    return false
+  }
+
+  /// A 64-bit value obtained by interpreting the mask name as a little-endian unsigned
+  /// integer.
+  @inlinable
+  @_transparent
+  internal var maskValue: UInt64 {
+    // Return the value of
+    // 'h' | 'a' << 8 | 's' << 16 | 'h' << 24 which equals
+    // 104  |  (97 << 8) | (115 << 16) | (104 << 24)
+    1752392040
+  }
+
+  /// Return an os log format specifier for this `privacy` level. The
+  /// format specifier goes within curly braces e.g. %{private} in the format
+  /// string passed to the os log ABI.
+  @inlinable
+  @_semantics("constant_evaluable")
+  @_optimize(none)
+  internal var privacySpecifier: String? {
+    let hasMask = self.hasMask
+    var isAuto = false
+    if case .auto = privacy {
+      isAuto = true
+    }
+    if isAuto, !hasMask {
+      return nil
+    }
+    var specifier: String
+    switch privacy {
+    case .public:
+      specifier = "public"
+    case .private:
+      specifier = "private"
+    default:
+      specifier = ""
+    }
+    if hasMask {
+      if !isAuto {
+        specifier += ","
+      }
+      specifier += "mask.hash"
+    }
+    return specifier
+  }
+}
+

--- a/stdlib/private/OSLog/OSLogStringAlignment.swift
+++ b/stdlib/private/OSLog/OSLogStringAlignment.swift
@@ -13,8 +13,8 @@
 // This file defines types and functions for specifying alignment of the
 // interpolations passed to the os log APIs.
 
-@frozen
-public enum OSLogCollectionBound {
+@usableFromInline
+internal enum OSLogCollectionBound {
   case start
   case end
 }
@@ -23,20 +23,24 @@ public enum OSLogCollectionBound {
 public struct OSLogStringAlignment {
   /// Minimum number of characters to be displayed. If the value to be printed
   /// is shorter than this number, the result is padded with spaces. The value
-  /// is not truncated even if the result is larger.This value need not be a
+  /// is not truncated even if the result is larger.  This value need not be a
   /// compile-time constant, and is therefore an autoclosure.
-  public var minimumColumnWidth: (() -> Int)?
-  /// This captures right/left alignment.
-  public var anchor: OSLogCollectionBound
+  @usableFromInline
+  internal var minimumColumnWidth: (() -> Int)?
 
+  /// This captures right/left alignment.
+  @usableFromInline
+  internal var anchor: OSLogCollectionBound
+
+  /// Initiailzes stored properties.
+  ///
   /// - Parameters:
   ///   - minimumColumnWidth: Minimum number of characters to be displayed. If the value to be
   ///    printed is shorter than this number, the result is padded with spaces. The value is not truncated
   ///    even if the result is larger.
   ///   - anchor: Use `.end` for right alignment and `.start` for left.
-  @_semantics("constant_evaluable")
-  @inlinable
-  @_optimize(none)
+  @_transparent
+  @usableFromInline
   internal init(
     minimumColumnWidth: (() -> Int)? = nil,
     anchor: OSLogCollectionBound = .end
@@ -45,29 +49,18 @@ public struct OSLogStringAlignment {
     self.anchor = anchor
   }
 
-  /// Right alignment formatter.
+  /// Indicates no alignment.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
-  public static var right: OSLogStringAlignment {
-    OSLogStringAlignment(anchor: .end)
-  }
+  public static var none: OSLogStringAlignment { OSLogStringAlignment(anchor: .end)  }
 
-  /// Left alignment formatter.
-  @_semantics("constant_evaluable")
-  @inlinable
-  @_optimize(none)
-  public static var left: OSLogStringAlignment {
-    OSLogStringAlignment(anchor: .start)
-  }
-
-  /// Use default alignment, which is right alignment.
-  @_semantics("constant_evaluable")
-  @inlinable
-  @_optimize(none)
-  public static var none: OSLogStringAlignment { .right  }
-
-  /// Right align and display at least`columns` characters.
+  /// Right align and display at least `columns` characters.
+  ///
+  /// The interpolated value would be padded with spaces, if necessary, to
+  /// meet the specified `columns` characters.
+  ///
+  /// - Parameter columns: minimum number of characters to display.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
@@ -77,7 +70,12 @@ public struct OSLogStringAlignment {
     OSLogStringAlignment(minimumColumnWidth: columns, anchor: .end)
   }
 
-  /// Left align and display at least`columns` characters.
+  /// Left align and display at least `columns` characters.
+  ///
+  /// The interpolated value would be padded with spaces, if necessary, to
+  /// meet the specified `columns` characters.
+  ///
+  /// - Parameter columns: minimum number of characters to display.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)

--- a/stdlib/private/OSLog/OSLogSwiftProtocols.swift
+++ b/stdlib/private/OSLog/OSLogSwiftProtocols.swift
@@ -1,0 +1,72 @@
+//===----------------- OSLogSwiftProtocols.swift -----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines extensions for interpolating types conforming to common
+// Swift protocols. It defines `appendInterpolation` overloads for these protocols.
+// All overloads defined in this file, delegate to other appendInterpolation
+// functions for types natively supported by os_log.
+
+extension OSLogInterpolation {
+
+  /// Defines interpolation for values conforming to CustomStringConvertible. The values
+  /// are displayed using the description methods on them.
+  ///
+  /// Do not call this function directly. It will be called automatically when interpolating
+  /// a value conforming to CustomStringConvertible in the string interpolations passed
+  /// to the log APIs.
+  ///
+  /// - Parameters:
+  ///   - value: The interpolated expression conforming to CustomStringConvertible.
+  ///   - align: Left or right alignment with the minimum number of columns as
+  ///     defined by the type `OSLogStringAlignment`.
+  ///   - privacy: A privacy qualifier which is either private or public.
+  ///     It is auto-inferred by default.
+  @_optimize(none)
+  @_transparent
+  @_semantics("oslog.requires_constant_arguments")
+  public mutating func appendInterpolation<T : CustomStringConvertible>(
+    _ value: @autoclosure @escaping () -> T,
+    align: OSLogStringAlignment = .none,
+    privacy: OSLogPrivacy = .auto
+  ) {
+    // TODO: Dead code elimination does not remove the call to the default value
+    // of alignment: .none. This function is made @_transparent to work around
+    // that.
+    appendInterpolation(value().description, align: align, privacy: privacy)
+  }
+
+  /// Defines interpolation for meta-types.
+  ///
+  /// Do not call this function directly. It will be called automatically when interpolating
+  /// a value of type `Any.Type` in the string interpolations passed to the log APIs.
+  ///
+  /// - Parameters:
+  ///   - value: An interpolated expression of type Any.Type, which is autoclosured.
+  ///   - align: Left or right alignment with the minimum number of columns as
+  ///     defined by the type `OSLogStringAlignment`.
+  ///   - privacy: A privacy qualifier which is either private or public.
+  ///     It is auto-inferred by default.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  @_semantics("oslog.requires_constant_arguments")
+  public mutating func appendInterpolation(
+    _ value: @autoclosure @escaping () -> Any.Type,
+    align: OSLogStringAlignment = .none,
+    privacy: OSLogPrivacy = .auto
+  ) {
+    appendInterpolation(
+      _typeName(value(), qualified: false),
+      align: align,
+      privacy: privacy)
+  }
+}

--- a/stdlib/private/OSLog/OSLogTestHelper.swift
+++ b/stdlib/private/OSLog/OSLogTestHelper.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ObjectiveC
+
 // This file contains test helpers for testing the compiler diagnostics and optimizations
 // of the new swift APIs for os log that accept string interpolations.
 
@@ -51,41 +53,47 @@ func _osLogTestHelper(
   let preamble = message.interpolation.preamble
   let argumentCount = message.interpolation.argumentCount
   let bufferSize = message.bufferSize
+  let objectCount = message.interpolation.objectArgumentCount
+  let stringCount = message.interpolation.stringArgumentCount
+  let uint32bufferSize = UInt32(bufferSize)
   let argumentClosures = message.interpolation.arguments.argumentClosures
+
   let formatStringPointer = _getGlobalStringTablePointer(formatString)
 
   // Code that will execute at runtime.
   if (!isLoggingEnabled()) {
     return
   }
-
-  // Allocate a byte buffer to store the arguments. The buffer could be stack
-  // allocated as it is local to this function and also its size is a
-  // compile-time constant.
   let bufferMemory = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
-  // Array of references to auxiliary storage created during serialization of
-  // strings. This array can be stack allocated.
-  var stringStorageObjects: [AnyObject] = []
+  // Buffer for storing NSObjects and strings to keep them alive until the
+  // _os_log_impl_test call completes.
+  let objectArguments = createStorage(capacity: objectCount, type: NSObject.self)
+  let stringArgumentOwners = createStorage(capacity: stringCount, type: Any.self)
 
   var currentBufferPosition = bufferMemory
+  var objectArgumentsPosition = objectArguments
+  var stringArgumentOwnersPosition = stringArgumentOwners
   serialize(preamble, at: &currentBufferPosition)
   serialize(argumentCount, at: &currentBufferPosition)
-  argumentClosures.forEach { $0(&currentBufferPosition, &stringStorageObjects) }
+  argumentClosures.forEach {
+    $0(&currentBufferPosition,
+       &objectArgumentsPosition,
+       &stringArgumentOwnersPosition)
+  }
 
   _os_log_impl_test(
     assertion,
     formatString,
     formatStringPointer,
     bufferMemory,
-    UInt32(bufferSize))
+    uint32bufferSize)
 
-  // The following operation extends the lifetime of argumentClosures,
-  // stringStorageObjects, and also of the objects stored in them, till this
-  // point. This is necessary because the assertion is passed internal pointers
-  // to the objects/strings stored in these arrays, as in the actual os log
-  // implementation.
-  _fixLifetime(argumentClosures)
-  _fixLifetime(stringStorageObjects)
+  // The following operation extends the lifetime of objectArguments and
+  // stringArgumentOwners till this point. This is necessary because the
+  // assertion is passed internal pointers to the objects/strings stored
+  // in these arrays, as in the actual os log implementation.
+  destroyStorage(objectArguments, count: objectCount)
+  destroyStorage(stringArgumentOwners, count: stringCount)
   bufferMemory.deallocate()
 }
 

--- a/test/SILOptimizer/Inputs/OSLogConstantEvaluable.swift
+++ b/test/SILOptimizer/Inputs/OSLogConstantEvaluable.swift
@@ -45,3 +45,8 @@ func intValueWithPrecisionTest() -> OSLogMessage {
      \(10, format: .decimal(minDigits: 25), align: .right(columns: 10))
     """
 }
+
+@_semantics("test_driver")
+func intValueWithPrivacyTest() -> OSLogMessage {
+    return "An integer value \(10, privacy: .private(mask: .hash))"
+}

--- a/test/SILOptimizer/OSLogMandatoryOptTest.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.swift
@@ -45,16 +45,16 @@ func testSimpleInterpolation() {
   // the array which is checked by a different test suite.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // We need to wade through some borrows and copy values here.
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 3
 }
@@ -92,15 +92,15 @@ func testInterpolationWithFormatOptions() {
   // the array which is checked by a different test suite.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 3
 }
@@ -140,15 +140,15 @@ func testInterpolationWithFormatOptionsAndPrivacy() {
   // the array which is checked by a different test suite.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 3
 }
@@ -194,15 +194,15 @@ func testInterpolationWithMultipleArguments() {
   // the array which is checked by a different test suite.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 9
 }
@@ -244,13 +244,13 @@ func testLogMessageWithoutData() {
   // Check whether argument array is folded.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[ARGSARRAY:%[0-9]+]]
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 0
 }
@@ -317,15 +317,15 @@ func testMessageWithTooManyArguments() {
   // Check whether argument array is folded.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 144
 }
@@ -402,15 +402,15 @@ func testDynamicStringArguments() {
   // the array which is checked by a different test suite.
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+  // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
   // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
   // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+  // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+  // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
   // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
 }
@@ -455,15 +455,15 @@ func testNSObjectInterpolation() {
     // the array which is checked by a different test suite.
 
     // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-    // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+    // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
     // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
     // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
     // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-    // CHECK-DAG: [[FINARR]] = apply {{.*}}<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+    // CHECK-DAG: [[FINARR]] = apply {{.*}}<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
     // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-    // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+    // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
     // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
     // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
 }
@@ -503,15 +503,15 @@ func testDoubleInterpolation() {
     // not checked here, but is checked by a different test suite.
 
     // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
-    // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+    // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
     // CHECK-DAG: store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR]]
     // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
     // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
-    // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARGSARRAY:%[0-9]+]])
+    // CHECK-DAG: [[FINARR]] = apply [[FINARRFUNC]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARGSARRAY:%[0-9]+]])
     // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
-    // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+    // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>([[ARRAYSIZE:%[0-9]+]])
     // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
     // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 3
 }

--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -27,7 +27,7 @@ func testNonconstantFormatOption(
 
 func testNonconstantPrivacyOption(privacyOpt: OSLogPrivacy) {
   _osLogTestHelper("Integer: \(Int.max, privacy: privacyOpt)")
-    // expected-error@-1 {{argument must be a case of enum 'OSLogPrivacy'}}
+    // expected-error@-1 {{argument must be a static method or property of 'OSLogPrivacy'}}
 }
 
 func testNonconstantAlignmentOption(alignOpt: OSLogStringAlignment) {
@@ -44,7 +44,7 @@ func testMultipleOptions(
     \(2, format: formatOpt, align: .right(columns: 10), privacy: privacyOpt)
     """)
     // expected-error@-2 {{argument must be a static method or property of 'OSLogIntegerFormatting'}}
-    // expected-error@-3 {{argument must be a case of enum 'OSLogPrivacy'}}
+    // expected-error@-3 {{argument must be a static method or property of 'OSLogPrivacy'}}
 }
 
 func testNoninlinedOSLogMessage() {

--- a/test/stdlib/OSLogExecutionTest.swift
+++ b/test/stdlib/OSLogExecutionTest.swift
@@ -77,7 +77,7 @@ internal struct OSLogBufferChecker {
   /// This occupies four most significant bits of the first byte of the
   /// argument header.
   internal enum ArgumentType: UInt8 {
-    case scalar = 0, count, string, pointer, object
+    case scalar = 0, count = 1, string = 2, pointer = 3, object = 4, mask = 7
     // TODO: include wide string and errno here if needed.
   }
 
@@ -142,13 +142,13 @@ internal struct OSLogBufferChecker {
   /// Check whether the bytes starting from `startIndex` contain the encoding for a count.
   internal func checkCount(
     startIndex: Int,
-    flag: ArgumentFlag,
-    expectedCount: Int
+    expectedCount: Int,
+    precision: Bool
   ) {
     checkNumeric(
       startIndex: startIndex,
-      flag: flag,
-      type: .count,
+      flag: .autoFlag,
+      type: precision ? .count : .scalar,
       expectedValue: CInt(expectedCount))
   }
 
@@ -614,8 +614,8 @@ InterpolationTestSuite.test("Integer formatting with precision") {
     bufferChecker.checkArguments(
      { bufferChecker.checkCount(
          startIndex: $0,
-         flag: .autoFlag,
-         expectedCount: 10)
+         expectedCount: 10,
+         precision: true)
      },
      { bufferChecker.checkInt(
          startIndex: $0,
@@ -654,13 +654,13 @@ InterpolationTestSuite.test("Integer formatting with precision and alignment") {
     bufferChecker.checkArguments(
      { bufferChecker.checkCount(
          startIndex: $0,
-         flag: .autoFlag,
-         expectedCount: 7)
+         expectedCount: 7,
+         precision: false)
      },
      { bufferChecker.checkCount(
          startIndex: $0,
-         flag: .autoFlag,
-         expectedCount: 10)
+         expectedCount: 10,
+         precision: true)
      },
      { bufferChecker.checkInt(
          startIndex: $0,


### PR DESCRIPTION
The compiler stubs for testing the OSLog implementation are in need of an update. This change updates the stubs to be consistent with the current OSLog implementation, updates the existing tests, and adds new tests for String and metatype interpolations. 

rdar://69719729