### PR TITLE
Fix @effects of finalizeUninitializedArray when assertions are enabled

### DIFF
--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -64,6 +64,7 @@ func _deallocateUninitializedArray<Element>(
   array._deallocateUninitialized()
 }
 
+#if !INTERNAL_CHECKS_ENABLED
 @_alwaysEmitIntoClient
 @_semantics("array.finalize_intrinsic")
 @_effects(readnone)
@@ -75,6 +76,20 @@ func _finalizeUninitializedArray<Element>(
   mutableArray._endMutation()
   return mutableArray
 }
+#else
+// When asserts are enabled, _endCOWMutation writes to _native.isImmutable
+// So we cannot have @_effects(readnone)
+@_alwaysEmitIntoClient
+@_semantics("array.finalize_intrinsic")
+public // COMPILER_INTRINSIC
+func _finalizeUninitializedArray<Element>(
+  _ array: __owned Array<Element>
+) -> Array<Element> {
+  var mutableArray = array
+  mutableArray._endMutation()
+  return mutableArray
+}
+#endif
 
 extension Collection {  
   // Utility method for collections that wish to implement

--- a/test/SILOptimizer/opt-remark-generator-yaml.swift
+++ b/test/SILOptimizer/opt-remark-generator-yaml.swift
@@ -3,6 +3,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil -save-optimization-record=yaml  -save-optimization-record-path %t/note.yaml %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
 
+// REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
+
 // This file is testing out the basic YAML functionality to make sure that it
 // works without burdening opt-remark-generator-yaml.swift with having to update all
 // of the yaml test cases everytime new code is added.

--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swiftc_driver -O -Rpass-missed=sil-opt-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
-// REQUIRES: optimized_stdlib
+// REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
 
 // XFAIL: OS=linux-androideabi && CPU=armv7
 


### PR DESCRIPTION
When assertions are enabled _endCOWMutation writes to _native.isImmutable.
But finalizeUninitializedArray is marked as @effects(readnone). This
mismatch caused miscompile in the stdlib due to CodeSinking optimization
which relies on SILInstruction::mayReadOrWriteMemory which looks at
@effects.

