### PR TITLE
[Serialization] Gate Clang type (de)serialization behind UseClangFunctionTypes

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5799,6 +5799,9 @@ public:
 
 llvm::Expected<const clang::Type *>
 ModuleFile::getClangType(ClangTypeID TID) {
+  if (!getContext().LangOpts.UseClangFunctionTypes)
+    return nullptr;
+
   if (TID == 0)
     return nullptr;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4140,7 +4140,10 @@ public:
     using namespace decls_block;
 
     auto resultType = S.addTypeRef(fnTy->getResult());
-    auto clangType = S.addClangTypeRef(fnTy->getClangTypeInfo().getType());
+    auto clangType =
+      S.getASTContext().LangOpts.UseClangFunctionTypes
+      ? S.addClangTypeRef(fnTy->getClangTypeInfo().getType())
+      : ClangTypeID(0);
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[FunctionTypeLayout::Code];
     FunctionTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,

--- a/test/Sema/clang_types_in_ast.swift
+++ b/test/Sema/clang_types_in_ast.swift
@@ -3,12 +3,14 @@
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH1 -use-clang-function-types
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH2 -sdk %clang-importer-sdk
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH2 -sdk %clang-importer-sdk -use-clang-function-types
-// RUN: %target-swift-frontend %s -DAUXMODULE -module-name Foo -emit-module -o %t
 
 // rdar://problem/57644243 : We shouldn't crash if -use-clang-function-types is not enabled.
+// RUN: %target-swift-frontend %s -DAUXMODULE -module-name Foo -emit-module -o %t
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH3 -I %t
 
-// RUN: %target-swift-frontend %s -typecheck -DCRASH -I %t -use-clang-function-types
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -DAUXMODULE -module-name Foo -emit-module -o %t -use-clang-function-types
+// RUN: %target-swift-frontend %s -typecheck -DNOCRASH3 -I %t -use-clang-function-types
 
 #if NOCRASH1
 public func my_signal() -> Optional<@convention(c) (Int32) -> Void> {
@@ -31,22 +33,6 @@ public var DUMMY_SIGNAL2 : Optional<@convention(c) (Int32) -> Void> = .none
 #endif
 
 #if NOCRASH3
-import Foo
-public func my_signal1() -> Optional<@convention(c) (Int32) -> ()> {
-  return Foo.DUMMY_SIGNAL1
-}
-public func my_signal2() -> Optional<@convention(c) (Int32) -> Void> {
-  return Foo.DUMMY_SIGNAL1
-}
-public func my_signal3() -> Optional<@convention(c) (Int32) -> ()> {
-  return Foo.DUMMY_SIGNAL2
-}
-public func my_signal4() -> Optional<@convention(c) (Int32) -> Void> {
-  return Foo.DUMMY_SIGNAL2
-}
-#endif
-
-#if CRASH
 import Foo
 public func my_signal1() -> Optional<@convention(c) (Int32) -> ()> {
   return Foo.DUMMY_SIGNAL1


### PR DESCRIPTION
We shouldn't be getting source compat suite failures such as in https://ci.swift.org/job/swift-PR-source-compat-suite-debug/3182/artifact/swift-source-compat-suite/FAIL_siesta-legacy-Siesta.xcodeproj_4.0_BuildXcodeProjectTarget_Siesta-iOS_generic-platform-iOS.log at this stage because the feature is off-by-default.