### PR TITLE
[CSBindings] NFC: Simplify `TypeVariableBinding::attempt` but extract…

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5632,6 +5632,11 @@ public:
 
   bool attempt(ConstraintSystem &cs) const;
 
+  /// Determine what fix (if any) needs to be introduced into a
+  /// constraint system as part of resolving type variable as a hole.
+  Optional<std::pair<ConstraintFix *, unsigned>>
+  fixForHole(ConstraintSystem &cs) const;
+
   void print(llvm::raw_ostream &Out, SourceManager *) const {
     PrintOptions PO;
     PO.PrintTypesForDebugging = true;


### PR DESCRIPTION
…ing fix computation

Add a separate method `fixForHole` on `TypeVariableBinding`
responsible for determining whether fix is required and if so,
what kind of fix to apply when a particular type variable is
resolved to a hole.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
