### PR TITLE
[CSBindings] If hole originates from code completion token avoid "fixing" it

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -769,6 +769,19 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 
     result.InvolvesTypeVariables = true;
 
+    // If current type variable is associated with a code completion token
+    // it's possible that it doesn't have enough contextual information
+    // to be resolved to anything, so let's add a hole type which originates
+    // from type variable associated with code completion expression to
+    // make this relationship explicit and avoid "fixing" problems rooted
+    // in fact that type variable is underconstrained due to code completion.
+    if (auto *locator = bindingTypeVar->getImpl().getLocator()) {
+      if (locator->directlyAt<CodeCompletionExpr>()) {
+        result.PotentiallyIncomplete = true;
+        return PotentialBinding::forHole(bindingTypeVar, locator);
+      }
+    }
+
     if (constraint->getKind() == ConstraintKind::Subtype &&
         kind == AllowedBindingKind::Subtypes) {
       result.SubtypeOf.insert(bindingTypeVar);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1235,6 +1235,21 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
   auto *dstLocator = TypeVar->getImpl().getLocator();
   auto *srcLocator = Binding.getLocator();
 
+  // FIXME: This check could be turned into an assert once
+  // all code completion kinds are ported to use
+  // `TypeChecker::typeCheckForCodeCompletion` API.
+  if (cs.isForCodeCompletion()) {
+    // If the hole is originated from code completion expression
+    // let's not try to fix this, anything connected to a
+    // code completion is allowed to be a hole because presence
+    // of a code completion token makes constraint system
+    // under-constrained due to e.g. lack of expressions on the
+    // right-hand side of the token, which are required for a
+    // regular type-check.
+    if (dstLocator->directlyAt<CodeCompletionExpr>())
+      return None;
+  }
+
   unsigned defaultImpact = 1;
 
   if (auto *GP = TypeVar->getImpl().getGenericParameter()) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5632,6 +5632,11 @@ public:
 
   bool attempt(ConstraintSystem &cs) const;
 
+  /// Determine what fix (if any) needs to be introduced into a
+  /// constraint system as part of resolving type variable as a hole.
+  Optional<std::pair<ConstraintFix *, unsigned>>
+  fixForHole(ConstraintSystem &cs) const;
+
   void print(llvm::raw_ostream &Out, SourceManager *) const {
     PrintOptions PO;
     PO.PrintTypesForDebugging = true;


### PR DESCRIPTION
If the hole is originated from code completion expression
let's not try to add a fix, anything connected to a
code completion is allowed to be a hole because presence
of a code completion token makes constraint system
under-constrained due to e.g. lack of expressions on the
right-hand side of the token, which are required for a
regular type-check.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
