### PR TITLE
[ClangImporter] Update umbrella header diagnostic handling

### DIFF
--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -37,7 +37,7 @@ import Module
 // CHECK-PRIMARY: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
-// CHECK-WARN: <module-includes>:1:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
+// CHECK-WARN: Module.h:20:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
 // FIXME: show [-Wincomplete-umbrella]
 
 // CHECK-NO-WARN-NOT: warning about something


### PR DESCRIPTION
In apple/llvm-project#1860, the diagnostic for a missing import in an umbrella header was improved by moving it to the end of the file and including a fix-it suggesting the import that would be needed. This breaks two things on the Swift side:

* One Swift test assumes the old source location will be used.
* The `ClangSourceBufferImporter` doesn’t work correctly when a diagnostic is emitted at EOF. It tries to create a virtual file covering EOF..<EOF, but it’s not actually valid to start a virtual file at EOF—it would always be empty.

This PR corrects these issues, which should unblock the automerger.

Fixes rdar://69707827.