### PR TITLE
[LookupVisibleDecls] Use correct BaseTy to check the decls are applicable

### DIFF
--- a/test/IDE/complete_sr13574.swift
+++ b/test/IDE/complete_sr13574.swift
@@ -1,0 +1,31 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE | %FileCheck %s --check-prefix=OVERRIDE
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER | %FileCheck %s --check-prefix=MEMBER
+
+class Root {
+    func onRoot() {}
+}
+
+class Base<T: Hashable>: Root {
+    func onBase() -> T {}
+}
+
+class Derived<T: Hashable>: Base<T> {
+    func onDerived() {}
+
+    func #^OVERRIDE^#
+// OVERRIDE: Begin completions, 2 items
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super/Erase[5]: override func onBase() -> T {|};
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super/Erase[5]: override func onRoot() {|};
+// OVERRIDE-DAG: End completions
+
+}
+
+func testMember(val: Derived<Int>) {
+    val.#^MEMBER^#
+// MEMBER: Begin completions, 4 items
+// MEMBER-DAG: Keyword[self]/CurrNominal:          self[#Derived<Int>#]; name=self
+// MEMBER-DAG: Decl[InstanceMethod]/CurrNominal:   onDerived()[#Void#]; name=onDerived()
+// MEMBER-DAG: Decl[InstanceMethod]/Super:         onBase()[#Int#]; name=onBase()
+// MEMBER-DAG: Decl[InstanceMethod]/Super:         onRoot()[#Void#]; name=onRoot()
+// MEMBER: End completions
+}


### PR DESCRIPTION
`lookupTypeMembers()` receives `BaseTy` to check if the found value decls are applicable to the type. When looking into super classes, it used to use the interface type of the super class which was not good. Instead, use the original "base type" consistently.

rdar://problem/69308207
https://bugs.swift.org/browse/SR-13574

