### PR TITLE
[AutoDiff] NFC: Rename AutoDiff-specific method and improve documentation

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3731,18 +3731,23 @@ enum class AbstractFunctionDeclLookupErrorKind {
   CandidateNotFunctionDeclaration
 };
 
-/// Returns the function declaration corresponding to the given base type
-/// (optional), function name, and lookup context.
+/// Returns the original function (in the context of a derivative or transpose
+/// function) declaration corresponding to the given base type (optional),
+/// function name, lookup context, and the expected original function type.
 ///
 /// If the base type of the function is specified, member lookup is performed.
 /// Otherwise, unqualified lookup is performed.
+///
+/// If the expected original function type has a generic signature, any
+/// candidate with a less constrained type signature than the expected original
+/// function type will be treated as a viable candidate.
 ///
 /// If the function declaration cannot be resolved, emits a diagnostic and
 /// returns nullptr.
 ///
 /// Used for resolving the referenced declaration in `@derivative` and
 /// `@transpose` attributes.
-static AbstractFunctionDecl *findAbstractFunctionDecl(
+static AbstractFunctionDecl *findAutoDiffOriginalFunctionDecl(
     DeclAttribute *attr, Type baseType, DeclNameRefWithLoc funcNameWithLoc,
     DeclContext *lookupContext, NameLookupOptions lookupOptions,
     const llvm::function_ref<Optional<AbstractFunctionDeclLookupErrorKind>(
@@ -4671,7 +4676,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   }
 
   // Look up original function.
-  auto *originalAFD = findAbstractFunctionDecl(
+  auto *originalAFD = findAutoDiffOriginalFunctionDecl(
       attr, baseType, originalName, derivativeTypeCtx, lookupOptions,
       isValidOriginalCandidate, originalFnType);
   if (!originalAFD) {
@@ -5230,7 +5235,7 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   auto funcLoc = originalName.Loc.getBaseNameLoc();
   if (attr->getBaseTypeRepr())
     funcLoc = attr->getBaseTypeRepr()->getLoc();
-  auto *originalAFD = findAbstractFunctionDecl(
+  auto *originalAFD = findAutoDiffOriginalFunctionDecl(
       attr, baseType, originalName, transposeTypeCtx, lookupOptions,
       isValidOriginalCandidate, expectedOriginalFnType);
   if (!originalAFD) {


### PR DESCRIPTION
`findAbstractFunctionDecl` in TypeCheckAttr.cpp has a very general name but the functionality is specific to AutoDiff. This patch renames it to `findAutoDiffOriginalFunctionDecl` and introduces minor improvements to the documentation.