### PR TITLE
Replicate changes of doc comments from Array.swift to ArraySlice.swift and ContiguousArray.swift

### DIFF
--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -662,14 +662,14 @@ extension ArraySlice: RangeReplaceableCollection {
   /// `LazyMapCollection<Dictionary<String, Int>, Int>` to a simple
   /// `[String]`.
   ///
-  ///     func cacheImagesWithNames(names: [String]) {
+  ///     func cacheImages(withNames names: [String]) {
   ///         // custom image loading and caching
   ///      }
   ///
   ///     let namedHues: [String: Int] = ["Vermillion": 18, "Magenta": 302,
   ///             "Gold": 50, "Cerise": 320]
   ///     let colorNames = Array(namedHues.keys)
-  ///     cacheImagesWithNames(colorNames)
+  ///     cacheImages(withNames: colorNames)
   ///
   ///     print(colorNames)
   ///     // Prints "["Gold", "Cerise", "Magenta", "Vermillion"]"

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1219,7 +1219,7 @@ extension ArraySlice {
   ///
   /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
   ///   parameter that points to the contiguous storage for the array.
-  ///    If `body` has a return value, that value is also
+  ///    If no such storage exists, it is created. If `body` has a return value, that value is also
   ///   used as the return value for the `withUnsafeMutableBufferPointer(_:)`
   ///   method. The pointer argument is valid only for the duration of the
   ///   method's execution.

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -526,14 +526,14 @@ extension ContiguousArray: RangeReplaceableCollection {
   /// `LazyMapCollection<Dictionary<String, Int>, Int>` to a simple
   /// `[String]`.
   ///
-  ///     func cacheImagesWithNames(names: [String]) {
+  ///     func cacheImages(withNames names: [String]) {
   ///         // custom image loading and caching
   ///      }
   ///
   ///     let namedHues: [String: Int] = ["Vermillion": 18, "Magenta": 302,
   ///             "Gold": 50, "Cerise": 320]
   ///     let colorNames = Array(namedHues.keys)
-  ///     cacheImagesWithNames(colorNames)
+  ///     cacheImages(withNames: colorNames)
   ///
   ///     print(colorNames)
   ///     // Prints "["Gold", "Cerise", "Magenta", "Vermillion"]"

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -684,7 +684,8 @@ extension ContiguousArray: RangeReplaceableCollection {
 
   /// Reserves enough space to store `minimumCapacity` elements.
   /// If a new buffer needs to be allocated and `growForAppend` is true,
-  /// the new capacity is calculated using `_growArrayCapacity`.
+  /// the new capacity is calculated using `_growArrayCapacity`, but at least
+  /// kept at `minimumCapacity`.
   @_alwaysEmitIntoClient
   internal mutating func _reserveCapacityImpl(
     minimumCapacity: Int, growForAppend: Bool
@@ -706,7 +707,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   /// to the new buffer.
   /// The `minimumCapacity` is the lower bound for the new capacity.
   /// If `growForAppend` is true, the new capacity is calculated using
-  /// `_growArrayCapacity`.
+  /// `_growArrayCapacity`, but at least kept at `minimumCapacity`.
   @_alwaysEmitIntoClient
   @inline(never)
   internal mutating func _createNewBuffer(

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1038,6 +1038,7 @@ extension ContiguousArray: CustomStringConvertible, CustomDebugStringConvertible
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
+    // Always show sugared representation for Arrays.
     return _makeCollectionDescription(withTypeName: "ContiguousArray")
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replicate changes of doc comments from Array.swift to ArraySlice.swift and ContiguousArray.swift

Some tome ago I have found that example snippet in Array.swift doesn't compile and fixed it with [PR](https://github.com/apple/swift/pull/33610). Later I have found that files ArraySlice.swift and ContiguousArray.swift also have the same example snippet and therefore should be fixed to match one in Array.swift.

Then I have started to look for all mismatches in comments of corresponding methods in Array.swift, ArraySlice.swift and ContiguousArray.swift. I have found several minor discrepancies. I believe all these discrepancies are result of the same mistake which I did: change was made in Array.swift and ArraySlice.swift and ContiguousArray.swift were just forgotten.

This PR aims to fix mismatch between comments in corresponding methods of Array.swift, ArraySlice.swift and ContiguousArray.swift.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
