### PR TITLE
[code-completion] Fix cache writer for non-decl kind

### DIFF
--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -343,7 +343,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
       if (R->getKind() == CodeCompletionResult::Declaration)
         LE.write(static_cast<uint8_t>(R->getAssociatedDeclKind()));
       else
-        LE.write(~static_cast<uint8_t>(0u));
+        LE.write(static_cast<uint8_t>(~0u));
       if (R->isOperator())
         LE.write(static_cast<uint8_t>(R->getOperatorKind()));
       else


### PR DESCRIPTION
Thanks to Ben Barham for spotting this: `sizeof(~static_cast<uint8_t>(...))` is 4, but we need to write a single byte here. Thankfully this code was probably not being hit in the current caching scheme, which only caches declarations.

Looking at the history, this code was broken by d8fbaa01eb10, which was fixing an MSVC warning in this code. Unfortunately I do not have a way to check if there is still a warning here or for what.  If we see it again, we can figure out the correct fix.