### PR TITLE
[CSBindings] If hole originates from code completion token avoid "fixing" it

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -22,7 +22,7 @@ using namespace swift;
 using namespace constraints;
 
 void ConstraintSystem::PotentialBindings::inferTransitiveBindings(
-    const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes,
+    ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes,
     const llvm::SmallDenseMap<TypeVariableType *,
                               ConstraintSystem::PotentialBindings>
         &inferredBindings) {
@@ -144,7 +144,7 @@ isUnviableDefaultType(Type defaultType,
 }
 
 void ConstraintSystem::PotentialBindings::inferDefaultTypes(
-    const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes) {
+    ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &existingTypes) {
   auto isDirectRequirement = [&](Constraint *constraint) -> bool {
     if (auto *typeVar = constraint->getFirstType()->getAs<TypeVariableType>()) {
       auto *repr = cs.getRepresentative(typeVar);
@@ -300,7 +300,7 @@ void ConstraintSystem::PotentialBindings::inferDefaultTypes(
 }
 
 void ConstraintSystem::PotentialBindings::finalize(
-    const ConstraintSystem &cs,
+    ConstraintSystem &cs,
     const llvm::SmallDenseMap<TypeVariableType *,
                               ConstraintSystem::PotentialBindings>
         &inferredBindings) {
@@ -620,8 +620,7 @@ bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
 }
 
 ConstraintSystem::PotentialBindings
-ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar,
-                                   bool finalize) const {
+ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar, bool finalize) {
   assert(typeVar->getImpl().getRepresentative(nullptr) == typeVar &&
          "not a representative");
   assert(!typeVar->getImpl().getFixedType(nullptr) && "has a fixed type");
@@ -829,7 +828,7 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 /// representative type variable, along with flags indicating whether
 /// those types should be opened.
 bool ConstraintSystem::PotentialBindings::infer(
-    const ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &exactTypes,
+    ConstraintSystem &cs, llvm::SmallPtrSetImpl<CanType> &exactTypes,
     Constraint *constraint) {
   switch (constraint->getKind()) {
   case ConstraintKind::Bind:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4775,7 +4775,7 @@ private:
     /// \param inferredBindings The set of all bindings inferred for type
     /// variables in the workset.
     void inferTransitiveBindings(
-        const ConstraintSystem &cs,
+        ConstraintSystem &cs,
         llvm::SmallPtrSetImpl<CanType> &existingTypes,
         const llvm::SmallDenseMap<TypeVariableType *,
                                   ConstraintSystem::PotentialBindings>
@@ -4783,17 +4783,17 @@ private:
 
     /// Infer bindings based on any protocol conformances that have default
     /// types.
-    void inferDefaultTypes(const ConstraintSystem &cs,
+    void inferDefaultTypes(ConstraintSystem &cs,
                            llvm::SmallPtrSetImpl<CanType> &existingTypes);
 
 public:
-    bool infer(const ConstraintSystem &cs,
+    bool infer(ConstraintSystem &cs,
                llvm::SmallPtrSetImpl<CanType> &exactTypes,
                Constraint *constraint);
 
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
-    void finalize(const ConstraintSystem &cs,
+    void finalize(ConstraintSystem &cs,
                   const llvm::SmallDenseMap<TypeVariableType *,
                                             ConstraintSystem::PotentialBindings>
                       &inferredBindings);
@@ -4862,7 +4862,7 @@ public:
   /// Infer bindings for the given type variable based on current
   /// state of the constraint system.
   PotentialBindings inferBindingsFor(TypeVariableType *typeVar,
-                                     bool finalize = true) const;
+                                     bool finalize = true);
 
 private:
   Optional<ConstraintSystem::PotentialBinding>

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4644,6 +4644,8 @@ private:
     /// `bind param` are present in the system.
     bool PotentiallyIncomplete = false;
 
+    ASTNode AssociatedCodeCompletionToken = ASTNode();
+
     /// Whether this type variable has literal bindings.
     LiteralBindingKind LiteralBinding = LiteralBindingKind::None;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2991,7 +2991,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
         out << " as ";
         Type(fixed).print(out, PO);
       } else {
-        inferBindingsFor(tv).dump(out, 1);
+        const_cast<ConstraintSystem *>(this)->inferBindingsFor(tv).dump(out, 1);
       }
     } else {
       out << " equivalent to ";


### PR DESCRIPTION
If the hole is originated from code completion expression
let's not try to add a fix, anything connected to a
code completion is allowed to be a hole because presence
of a code completion token makes constraint system
under-constrained due to e.g. lack of expressions on the
right-hand side of the token, which are required for a
regular type-check.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
