### PR TITLE
ModuleInterface: refactor ModuleInterfaceChecker out of ModuleInterfaceLoader

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -762,6 +762,12 @@ public:
                        bool isClang = false, bool isDWARF = false,
                        bool IsInterface = false);
 
+  /// Add a module interface checker to use for this AST context.
+  void addModuleInterfaceChecker(std::unique_ptr<ModuleInterfaceChecker> checker);
+
+  /// Retrieve the module interface checker associated with this AST context.
+  ModuleInterfaceChecker *getModuleInterfaceChecker() const;
+
   /// Retrieve the module dependencies for the module with the given name.
   ///
   /// \param isUnderlyingClangModule When true, only look for a Clang module
@@ -839,9 +845,6 @@ public:
   /// If there is no Clang module loader, returns a null pointer.
   /// The loader is owned by the AST context.
   ClangModuleLoader *getDWARFModuleLoader() const;
-
-  /// Retrieve the module interface loader for this ASTContext.
-  ModuleLoader *getModuleInterfaceLoader() const;
 public:
   namelookup::ImportCache &getImportCache() const;
 

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -116,6 +116,23 @@ struct SubCompilerInstanceInfo {
   ArrayRef<StringRef> ExtraPCMArgs;
 };
 
+/// Abstract interface for a checker of module interfaces and prebuilt modules.
+class ModuleInterfaceChecker {
+public:
+  virtual std::vector<std::string>
+  getCompiledModuleCandidatesForInterface(StringRef moduleName,
+                                          StringRef interfacePath) = 0;
+
+  /// Given a list of potential ready-to-use compiled modules for \p interfacePath,
+  /// check if any one of them is up-to-date. If so, emit a forwarding module
+  /// to the candidate binary module to \p outPath.
+  virtual bool tryEmitForwardingModule(StringRef moduleName,
+                               StringRef interfacePath,
+                               ArrayRef<std::string> candidates,
+                               StringRef outPath) = 0;
+  virtual ~ModuleInterfaceChecker() = default;
+};
+
 /// Abstract interface to run an action in a sub ASTContext.
 struct InterfaceSubContextDelegate {
   virtual std::error_code runInSubContext(StringRef moduleName,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -201,18 +201,6 @@ public:
   virtual Optional<ModuleDependencies> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
-
-  virtual std::vector<std::string>
-  getCompiledModuleCandidatesForInterface(StringRef moduleName,
-                                          StringRef interfacePath) {
-    return std::vector<std::string>();
-  }
-  virtual bool tryEmitForwardingModule(StringRef moduleName,
-                                       StringRef interfacePath,
-                                       ArrayRef<std::string> candidates,
-                                       StringRef outPath) {
-    return false;
-  }
 };
 
 /// Imports serialized Swift modules into an ASTContext.

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -170,10 +170,9 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     auto &SubInstance = *info.Instance;
     auto subInvocation = SubInstance.getInvocation();
     // Try building forwarding module first. If succeed, return.
-    if (static_cast<ModuleInterfaceLoader*>(SubInstance.getASTContext()
-        .getModuleInterfaceLoader())->tryEmitForwardingModule(moduleName,
-                                                              interfacePath,
-                                                  CompiledCandidates, OutPath)) {
+    if (SubInstance.getASTContext().getModuleInterfaceChecker()
+          ->tryEmitForwardingModule(moduleName, interfacePath,
+                                    CompiledCandidates, OutPath)) {
       return std::error_code();
     }
     FrontendOptions &FEOpts = subInvocation.getFrontendOptions();

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -98,8 +98,7 @@ std::error_code PlaceholderSwiftModuleScanner::findModuleFilesInDirectory(
 static std::vector<std::string> getCompiledCandidates(ASTContext &ctx,
                                                       StringRef moduleName,
                                                       StringRef interfacePath) {
-  return static_cast<SerializedModuleLoaderBase*>(ctx
-    .getModuleInterfaceLoader())->getCompiledModuleCandidatesForInterface(
+  return ctx.getModuleInterfaceChecker()->getCompiledModuleCandidatesForInterface(
       moduleName.str(), interfacePath);
 }
 

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -103,8 +103,13 @@ protected:
         ASTContext::get(langOpts, typeckOpts, searchPathOpts, clangImpOpts,
                         sourceMgr, diags);
 
+    ctx->addModuleInterfaceChecker(
+      std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,
+        prebuiltCacheDir, ModuleInterfaceLoaderOptions()));
+
     auto loader = ModuleInterfaceLoader::create(
-        *ctx, cacheDir, prebuiltCacheDir,
+        *ctx, *static_cast<ModuleInterfaceCheckerImpl*>(
+          ctx->getModuleInterfaceChecker()),
         /*dependencyTracker*/nullptr,
         ModuleLoadingMode::PreferSerialized);
 


### PR DESCRIPTION
This refactoring allows us to drop ModuleInterfaceLoader when explicit modules are enabled. Before this change, the dependencies scanner needs the loader to be present to access functionalities like collecting prebuilt module candidates.