### PR TITLE
[update_checkout] Improved validation failure diagnostic.

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -17,7 +17,6 @@ import platform
 import re
 import sys
 import traceback
-from functools import reduce
 from multiprocessing import Lock, Pool, cpu_count, freeze_support
 
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
@@ -408,19 +407,16 @@ def validate_config(config):
                                'too.'.format(scheme_name))
 
     # Then make sure the alias names used by our branches are unique.
-    #
-    # We do this by constructing a list consisting of len(names),
-    # set(names). Then we reduce over that list summing the counts and taking
-    # the union of the sets. We have uniqueness if the length of the union
-    # equals the length of the sum of the counts.
-    data = [(len(v['aliases']), set(v['aliases']))
-            for v in config['branch-schemes'].values()]
-    result = reduce(lambda acc, x: (acc[0] + x[0], acc[1] | x[1]), data,
-                    (0, set([])))
-    if result[0] == len(result[1]):
-        return
-    raise RuntimeError('Configuration file has schemes with duplicate '
-                       'aliases?!')
+    seen = dict()
+    for (scheme_name, scheme) in config['branch-schemes'].items():
+        aliases = scheme['aliases']
+        for alias in aliases:
+            if alias in seen:
+                raise RuntimeError('Configuration file defines the alias {0} '
+                                   'in both the {1} scheme and the {2} scheme?!'
+                                   .format(alias, seen[alias], scheme_name))
+            else:
+                seen[alias] = scheme_name
 
 
 def full_target_name(repository, target):


### PR DESCRIPTION
Previously, if an alias were defined for multiple schemes, the produced diagnostic would only say that there was a collision, but did not specify where that collision was.  Here, the diagnostic is improved to read

```
RuntimeError: Configuration file defines the alias ALIAS in both the SCHEME_NAME_1 scheme and the SCHEME_NAME_2 scheme?!
```