### PR TITLE
Implement re-declaration checking for declarations in local context

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -396,31 +396,6 @@ public:
   }
 };
 
-/// A consumer that inserts found decls with a matching name into an
-/// externally-owned SmallVector.
-class NamedDeclConsumer : public VisibleDeclConsumer {
-  virtual void anchor() override;
-public:
-  DeclNameRef name;
-  SmallVectorImpl<LookupResultEntry> &results;
-  bool isTypeLookup;
-
-  NamedDeclConsumer(DeclNameRef name,
-                    SmallVectorImpl<LookupResultEntry> &results,
-                    bool isTypeLookup)
-    : name(name), results(results), isTypeLookup(isTypeLookup) {}
-
-  virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
-                         DynamicLookupInfo dynamicLookupInfo = {}) override {
-    // Give clients an opportunity to filter out non-type declarations early,
-    // to avoid circular validation.
-    if (isTypeLookup && !isa<TypeDecl>(VD))
-      return;
-    if (VD->getName().matchesRef(name.getFullName()))
-      results.push_back(LookupResultEntry(VD));
-  }
-};
-
 /// A consumer that filters out decls that are not accessible from a given
 /// DeclContext.
 class AccessFilteringDeclConsumer final : public VisibleDeclConsumer {

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -383,7 +383,13 @@ bool BraceStmtScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
         localBindings.push_back(vd);
     }
   }
-  return consumer.consume(localBindings, DeclVisibilityKind::LocalVariable);
+  if (consumer.consume(localBindings, DeclVisibilityKind::LocalVariable))
+    return true;
+
+  if (consumer.finishLookupInBraceStmt(stmt))
+    return true;
+
+  return false;
 }
 
 bool PatternEntryInitializerScope::lookupLocalsOrMembers(

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -44,7 +44,6 @@ using namespace swift::namelookup;
 
 void VisibleDeclConsumer::anchor() {}
 void VectorDeclConsumer::anchor() {}
-void NamedDeclConsumer::anchor() {}
 
 ValueDecl *LookupResultEntry::getBaseDecl() const {
   if (BaseDC == nullptr)

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -88,32 +88,6 @@ namespace {
                        SmallVectorImpl<LookupResultEntry> &results) const;
     };
     
-    enum class AddGenericParameters { Yes, No };
-
-#ifndef NDEBUG
-    /// A consumer for debugging that lets the UnqualifiedLookupFactory know when
-    /// finding something.
-    class InstrumentedNamedDeclConsumer : public NamedDeclConsumer {
-      virtual void anchor() override;
-      UnqualifiedLookupFactory *factory;
-      
-    public:
-      InstrumentedNamedDeclConsumer(UnqualifiedLookupFactory *factory,
-                                    DeclNameRef name,
-                                    SmallVectorImpl<LookupResultEntry> &results,
-                                    bool isTypeLookup)
-      : NamedDeclConsumer(name, results, isTypeLookup), factory(factory) {}
-      
-      virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
-                             DynamicLookupInfo dynamicLookupInfo = {}) override {
-        unsigned before = results.size();
-        NamedDeclConsumer::foundDecl(VD, Reason, dynamicLookupInfo);
-        unsigned after = results.size();
-        if (after > before)
-          factory->addedResult(results.back());
-      }
-    };
-#endif
     // Inputs
     const DeclNameRef Name;
     DeclContext *const DC;
@@ -128,12 +102,7 @@ namespace {
     const Options options;
     const bool isOriginallyTypeLookup;
     const NLOptions baseNLOptions;
-    // Transputs
-#ifndef NDEBUG
-    InstrumentedNamedDeclConsumer Consumer;
-#else
-    NamedDeclConsumer Consumer;
-#endif
+
     // Outputs
     SmallVectorImpl<LookupResultEntry> &Results;
     size_t &IndexOfFirstOuterResult;
@@ -279,11 +248,6 @@ UnqualifiedLookupFactory::UnqualifiedLookupFactory(
   options(options),
   isOriginallyTypeLookup(options.contains(Flags::TypeLookup)),
   baseNLOptions(computeBaseNLOptions(options, isOriginallyTypeLookup)),
-  #ifdef NDEBUG
-  Consumer(Name, Results, isOriginallyTypeLookup),
-  #else
-  Consumer(this, Name, Results, isOriginallyTypeLookup),
-  #endif
   Results(Results),
   IndexOfFirstOuterResult(IndexOfFirstOuterResult)
 {}
@@ -675,9 +639,6 @@ UnqualifiedLookupRequest::evaluate(Evaluator &evaluator,
 }
 
 #pragma mark debugging
-#ifndef NDEBUG
-void UnqualifiedLookupFactory::InstrumentedNamedDeclConsumer::anchor() {}
-#endif
 
 void UnqualifiedLookupFactory::ResultFinderForTypeContext::dump() const {
   (void)factory;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3206,12 +3206,6 @@ void AttributeChecker::visitNonEphemeralAttr(NonEphemeralAttr *attr) {
   attr->setInvalid();
 }
 
-void TypeChecker::checkParameterAttributes(ParameterList *params) {
-  for (auto param: *params) {
-    checkDeclAttributes(param);
-  }
-}
-
 void AttributeChecker::checkOriginalDefinedInAttrs(Decl *D,
     ArrayRef<OriginallyDefinedInAttr*> Attrs) {
   if (Attrs.empty())

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -573,18 +573,6 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
                                        &wouldBeSwift5Redeclaration);
     // If there is another conflict, complain.
     if (isRedeclaration || wouldBeSwift5Redeclaration) {
-      // If the two declarations occur in the same source file, make sure
-      // we get the diagnostic ordering to be sensible.
-      if (auto otherFile = other->getDeclContext()->getParentSourceFile()) {
-        if (currentFile == otherFile &&
-            current->getLoc().isValid() &&
-            other->getLoc().isValid() &&
-            ctx.SourceMgr.isBeforeInBuffer(current->getLoc(),
-                                           other->getLoc())) {
-          std::swap(current, other);
-        }
-      }
-
       // If we're currently looking at a .sil and the conflicting declaration
       // comes from a .sib, don't error since we won't be considering the sil
       // from the .sib. So it's fine for the .sil to shadow it, since that's the
@@ -798,11 +786,6 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
         }
       }
 
-      // Make sure we don't do this checking again for the same decl. We also
-      // set this at the beginning of the function, but we might have swapped
-      // the decls for diagnostics; so ensure we also set this for the actual
-      // decl we diagnosed on.
-      current->setCheckedRedeclaration();
       break;
     }
   }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -504,6 +504,8 @@ static bool typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
     }
     elt.setPattern(pattern);
 
+    TypeChecker::diagnoseDuplicateBoundVars(pattern);
+
     // Check the pattern, it allows unspecified types because the pattern can
     // provide type information.
     auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
@@ -956,6 +958,8 @@ public:
     if (TypeChecker::typeCheckForEachBinding(DC, S))
       return nullptr;
 
+    TypeChecker::diagnoseDuplicateBoundVars(S->getPattern());
+
     // Type-check the body of the loop.
     auto sourceFile = DC->getParentSourceFile();
     checkLabeledStmtShadowing(getASTContext(), sourceFile, S);
@@ -1031,6 +1035,8 @@ public:
       });
     }
     labelItem.setPattern(pattern, /*resolved=*/true);
+
+    TypeChecker::diagnoseDuplicateBoundVars(pattern);
 
     // Otherwise for each variable in the pattern, make sure its type is
     // identical to the initial case decl and stash the previous case decl as
@@ -2039,7 +2045,7 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 }
 
 bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
-  checkParameterAttributes(closure->getParameters());
+  TypeChecker::checkParameterList(closure->getParameters());
 
   BraceStmt *body = closure->getBody();
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -497,7 +497,9 @@ void typeCheckDecl(Decl *D);
 
 void addImplicitDynamicAttribute(Decl *D);
 void checkDeclAttributes(Decl *D);
-void checkParameterAttributes(ParameterList *params);
+void checkParameterList(ParameterList *params);
+
+void diagnoseDuplicateBoundVars(Pattern *pattern);
 
 Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
                                  ReferenceOwnershipAttr *attr);

--- a/test/Sema/redeclaration-checking.swift
+++ b/test/Sema/redeclaration-checking.swift
@@ -1,0 +1,96 @@
+// RUN: %target-typecheck-verify-swift -disable-parser-lookup
+
+// Test redeclaration checking in local context.
+
+func test1() {
+  let x = 123 // expected-note{{'x' previously declared here}}
+  func f() {} // expected-note{{'f()' previously declared here}}
+  struct S {} // expected-note{{'S' previously declared here}}
+  let x = 321 // expected-error{{invalid redeclaration of 'x'}}
+  func f() {} // expected-error{{invalid redeclaration of 'f()'}}
+  struct S {} // expected-error{{invalid redeclaration of 'S'}}
+}
+
+func test2() {
+  let x = 123 // expected-warning {{never used}}
+  func f() {}
+  struct S {}
+  do {
+    let x = 321 // expected-warning {{never used}}
+    func f() {}
+    struct S {}
+  }
+}
+
+func test3<T, T>(_: T, _: T) {}
+// expected-note@-1 {{'T' previously declared here}}
+// expected-error@-2 {{invalid redeclaration of 'T'}}
+// expected-error@-3 {{generic parameter 'T' is not used in function signature}}
+
+func test4(x: Int, x: Int) {}
+// expected-note@-1 {{'x' previously declared here}}
+// expected-error@-2 {{invalid redeclaration of 'x'}}
+
+struct Test4<T, T> {}
+// expected-note@-1 {{'T' previously declared here}}
+// expected-error@-2 {{invalid redeclaration of 'T'}}
+
+typealias Test5<T, T> = ()
+// expected-note@-1 {{'T' previously declared here}}
+// expected-error@-2 {{invalid redeclaration of 'T'}}
+
+enum E {
+  case test6(x: Int, x: Int)
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+
+  subscript(x: Int, x: Int) -> Int { return 0 }
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+}
+
+_ = { (x: Int, x: Int) in }
+// expected-note@-1 {{'x' previously declared here}}
+// expected-error@-2 {{invalid redeclaration of 'x'}}
+
+enum MyError : Error {
+  case error(Int, Int)
+}
+
+func stmtTest() {
+  let n: (Int, Int)? = nil
+
+  if case (let x, let x)? = n {}
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+  // expected-warning@-3 2{{never used}}
+
+  for case (let x, let x) in [(Int, Int)]() {}
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+  // expected-warning@-3 2{{never used}}
+
+  switch n {
+  case (let x, let x)?: _ = ()
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+  // expected-warning@-3 2{{never used}}
+  case nil: _ = ()
+  }
+
+  while case (let x, let x)? = n {}
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+  // expected-warning@-3 2{{never used}}
+
+  guard case (let x, let x)? = n else {}
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+  // expected-warning@-3 2{{never used}}
+
+  do {} catch MyError.error(let x, let x) {}
+  // expected-note@-1 {{'x' previously declared here}}
+  // expected-error@-2 {{invalid redeclaration of 'x'}}
+  // expected-warning@-3 2{{never used}}
+  // expected-warning@-4 {{unreachable}}
+}


### PR DESCRIPTION
Currently parse-time lookup diagnoses these, so we need to implement it in Sema to prepare for disabling parse-time lookup.

There are two cases:
- Local declarations inside a BraceStmt are now handled via the same CheckRedeclarationRequest used for type and global members, because we visit them as part of typeCheckDecl(). For this, I added a new `finishLookupInBraceStmt` flag to `ASTScope::lookupLocalDecls()`; when set, this stops the lookup at the innermost BraceStmt, because for purposes of re-declaration checking we only want to consider other declarations with the same name contained in the same BraceStmt. This is because shadowing of local declarations from outer scopes is, in fact, permitted.
- Generic parameters, function parameters and pattern bindings in statements get their own bespoke check. This one is simpler, since we have all the declarations in a sequence; we just iterate over sequence looking for duplicate names.

While we're here, delete a couple of bits of dead code as well.