### PR TITLE
AST: Fix assertions crash with try expressions (main branch cherry-pick)

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1943,7 +1943,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
     body = body->getSemanticsProvidingExpr();
 
     if (auto *openExistential = dyn_cast<OpenExistentialExpr>(body)) {
-      body = openExistential->getSubExpr();
+      body = openExistential->getSubExpr()->getSemanticsProvidingExpr();
     }
 
     if (auto *outerCall = dyn_cast<ApplyExpr>(body)) {
@@ -1963,7 +1963,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
       innerBody = innerBody->getSemanticsProvidingExpr();
 
       if (auto *openExistential = dyn_cast<OpenExistentialExpr>(innerBody)) {
-        innerBody = openExistential->getSubExpr();
+        innerBody = openExistential->getSubExpr()->getSemanticsProvidingExpr();
         if (auto *ICE = dyn_cast<ImplicitConversionExpr>(innerBody))
           innerBody = ICE->getSyntacticSubExpr();
       }

--- a/validation-test/compiler_crashers_2_fixed/sr12994.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12994.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s -verify
+
+protocol MyProto {
+  func compile() throws
+}
+
+func compile(x: MyProto) throws {
+  try x.compile 
+  // expected-error@-1 {{expression resolves to an unused function}}
+  // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
+}


### PR DESCRIPTION
Look through try expressions inside open existential expression's sub expression in `getUnwrappedCurryThunkExpr()`. 

This cherry-picks #32458 to the 5.3 branch.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12994.
