### PR TITLE
Implement backward-compatible closure capture behavior with parser lookup disabled

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -444,7 +444,6 @@ protected:
   // It is not an instance variable or inherited type.
 
   static bool lookupLocalBindingsInPattern(const Pattern *p,
-                                           DeclVisibilityKind vis,
                                            DeclConsumer consumer);
 
   /// When lookup must stop before the outermost scope, return the scope to stop

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1658,10 +1658,22 @@ protected:
 };
 
 class BraceStmtScope final : public AbstractStmtScope {
+  BraceStmt *const stmt;
+
+  /// Declarations which are in scope from the beginning of the statement.
+  SmallVector<ValueDecl *, 2> localFuncsAndTypes;
+
+  /// Declarations that are normally in scope only after their
+  /// definition.
+  SmallVector<VarDecl *, 2> localVars;
 
 public:
-  BraceStmt *const stmt;
-  BraceStmtScope(BraceStmt *e) : stmt(e) {}
+  BraceStmtScope(BraceStmt *e,
+                 SmallVector<ValueDecl *, 2> localFuncsAndTypes,
+                 SmallVector<VarDecl *, 2> localVars)
+      : stmt(e),
+        localFuncsAndTypes(localFuncsAndTypes),
+        localVars(localVars) {}
   virtual ~BraceStmtScope() {}
 
 protected:

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -29,7 +29,7 @@
 #define SWIFT_AST_AST_SCOPE_H
 
 #include "swift/AST/ASTNode.h"
-#include "swift/AST/NameLookup.h" // for DeclVisibilityKind
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Debug.h"
@@ -1023,10 +1023,10 @@ class AbstractPatternEntryScope : public ASTScopeImpl {
 public:
   PatternBindingDecl *const decl;
   const unsigned patternEntryIndex;
-  const DeclVisibilityKind vis;
+  const bool isLocalBinding;
 
   AbstractPatternEntryScope(PatternBindingDecl *, unsigned entryIndex,
-                            DeclVisibilityKind);
+                            bool);
   virtual ~AbstractPatternEntryScope() {}
 
   const PatternBindingEntry &getPatternEntry() const;
@@ -1043,8 +1043,8 @@ public:
 class PatternEntryDeclScope final : public AbstractPatternEntryScope {
 public:
   PatternEntryDeclScope(PatternBindingDecl *pbDecl, unsigned entryIndex,
-                        DeclVisibilityKind vis)
-      : AbstractPatternEntryScope(pbDecl, entryIndex, vis) {}
+                        bool isLocalBinding)
+      : AbstractPatternEntryScope(pbDecl, entryIndex, isLocalBinding) {}
   virtual ~PatternEntryDeclScope() {}
 
 protected:
@@ -1071,8 +1071,8 @@ class PatternEntryInitializerScope final : public AbstractPatternEntryScope {
 
 public:
   PatternEntryInitializerScope(PatternBindingDecl *pbDecl, unsigned entryIndex,
-                               DeclVisibilityKind vis)
-      : AbstractPatternEntryScope(pbDecl, entryIndex, vis),
+                               bool isLocalBinding)
+      : AbstractPatternEntryScope(pbDecl, entryIndex, isLocalBinding),
         initAsWrittenWhenCreated(pbDecl->getOriginalInit(entryIndex)) {}
   virtual ~PatternEntryInitializerScope() {}
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -613,6 +613,14 @@ public:
   lookInMembers(DeclContext *const scopeDC,
                 NominalTypeDecl *const nominal) = 0;
 
+  /// Called for local VarDecls that might not yet be in scope.
+  ///
+  /// Note that the set of VarDecls visited here are going to be a
+  /// superset of those visited in consume().
+  virtual bool consumePossiblyNotInScope(ArrayRef<VarDecl *> values) {
+    return false;
+  }
+
   /// Called right before looking at the parent scope of a BraceStmt.
   ///
   /// \return true if the lookup should be stopped at this point.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -603,7 +603,7 @@ public:
   /// of type -vs- instance lookup results.
   ///
   /// \return true if the lookup should be stopped at this point.
-  virtual bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
+  virtual bool consume(ArrayRef<ValueDecl *> values,
                        NullablePtr<DeclContext> baseDC = nullptr) = 0;
 
   /// Look for members of a nominal type or extension scope.
@@ -644,7 +644,7 @@ class ASTScopeDeclGatherer : public AbstractASTScopeDeclConsumer {
 public:
   virtual ~ASTScopeDeclGatherer() = default;
 
-  bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
+  bool consume(ArrayRef<ValueDecl *> values,
                NullablePtr<DeclContext> baseDC = nullptr) override;
 
   /// Eventually this functionality should move into ASTScopeLookup

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -701,23 +701,23 @@ public:
     if (auto *var = patternBinding->getSingleVar())
       scopeCreator.addChildrenForKnownAttributes(var, parentScope);
 
-    const bool isLocalBinding = patternBinding->getDeclContext()->isLocalContext();
-
-    const DeclVisibilityKind vis =
-        isLocalBinding ? DeclVisibilityKind::LocalVariable
-                       : DeclVisibilityKind::MemberOfCurrentNominal;
     auto *insertionPoint = parentScope;
     for (auto i : range(patternBinding->getNumPatternEntries())) {
+      bool isLocalBinding = false;
+      if (auto *varDecl = patternBinding->getAnchoringVarDecl(i)) {
+        isLocalBinding = varDecl->getDeclContext()->isLocalContext();
+      }
+
       insertionPoint =
           scopeCreator
               .ifUniqueConstructExpandAndInsert<PatternEntryDeclScope>(
-                  insertionPoint, patternBinding, i, vis)
+                  insertionPoint, patternBinding, i, isLocalBinding)
               .getPtrOr(insertionPoint);
-    }
 
-    ASTScopeAssert(isLocalBinding || insertionPoint == parentScope,
-                   "Bindings at the top-level or members of types should "
-                   "not change the insertion point");
+      ASTScopeAssert(isLocalBinding || insertionPoint == parentScope,
+                     "Bindings at the top-level or members of types should "
+                     "not change the insertion point");
+    }
 
     return insertionPoint;
   }
@@ -991,7 +991,7 @@ PatternEntryDeclScope::expandAScopeThatCreatesANewInsertionPoint(
         "Original inits are always after the '='");
     scopeCreator
         .constructExpandAndInsertUncheckable<PatternEntryInitializerScope>(
-            this, decl, patternEntryIndex, vis);
+            this, decl, patternEntryIndex, isLocalBinding);
   }
 
   // Add accessors for the variables in this pattern.
@@ -1002,7 +1002,7 @@ PatternEntryDeclScope::expandAScopeThatCreatesANewInsertionPoint(
   // In local context, the PatternEntryDeclScope becomes the insertion point, so
   // that all any bindings introduecd by the pattern are in scope for subsequent
   // lookups.
-  if (vis == DeclVisibilityKind::LocalVariable)
+  if (isLocalBinding)
     return {this, "All code that follows is inside this scope"};
 
   return {getParent().get(), "Global and type members do not introduce scopes"};
@@ -1378,8 +1378,9 @@ ASTScopeImpl *LabeledConditionalStmtScope::createNestedConditionalClauseScopes(
 
 AbstractPatternEntryScope::AbstractPatternEntryScope(
     PatternBindingDecl *declBeingScoped, unsigned entryIndex,
-    DeclVisibilityKind vis)
-    : decl(declBeingScoped), patternEntryIndex(entryIndex), vis(vis) {
+    bool isLocalBinding)
+    : decl(declBeingScoped), patternEntryIndex(entryIndex),
+      isLocalBinding(isLocalBinding) {
   ASTScopeAssert(entryIndex < declBeingScoped->getPatternList().size(),
                  "out of bounds");
 }

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -371,20 +371,10 @@ bool DifferentiableAttributeScope::lookupLocalsOrMembers(
 }
 
 bool BraceStmtScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
-  // All types and functions are visible anywhere within a brace statement
-  // scope. When ordering matters (i.e. var decl) we will have split the brace
-  // statement into nested scopes.
-  //
-  // Don't stop at the first one, there may be local funcs with same base name
-  // and want them all.
-  SmallVector<ValueDecl *, 32> localBindings;
-  for (auto braceElement : stmt->getElements()) {
-    if (auto localBinding = braceElement.dyn_cast<Decl *>()) {
-      if (auto *vd = dyn_cast<ValueDecl>(localBinding))
-        localBindings.push_back(vd);
-    }
-  }
-  if (consumer.consume(localBindings, DeclVisibilityKind::LocalVariable))
+  if (consumer.consume(localFuncsAndTypes, DeclVisibilityKind::LocalVariable))
+    return true;
+
+  if (consumer.consumePossiblyNotInScope(localVars))
     return true;
 
   if (consumer.finishLookupInBraceStmt(stmt))

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -293,8 +293,8 @@ bool GenericParamScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
 }
 
 bool PatternEntryDeclScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
-  if (vis != DeclVisibilityKind::LocalVariable)
-    return false; // look in self type will find this later
+  if (!isLocalBinding)
+    return false;
   return lookupLocalBindingsInPattern(getPattern(), consumer);
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1447,7 +1447,8 @@ void PatternBindingEntry::setInit(Expr *E) {
 VarDecl *PatternBindingEntry::getAnchoringVarDecl() const {
   SmallVector<VarDecl *, 8> variables;
   getPattern()->collectVariables(variables);
-  assert(!variables.empty());
+  if (variables.empty())
+    return nullptr;
   return variables[0];
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -211,7 +211,7 @@ public:
 
   void maybeUpdateSelfDC(VarDecl *var);
 
-  bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
+  bool consume(ArrayRef<ValueDecl *> values,
                NullablePtr<DeclContext> baseDC = nullptr) override;
 
   bool consumePossiblyNotInScope(ArrayRef<VarDecl *> vars) override;
@@ -561,8 +561,7 @@ void ASTScopeDeclConsumerForUnqualifiedLookup::maybeUpdateSelfDC(
 }
 
 bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
-    ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
-    NullablePtr<DeclContext> baseDC) {
+    ArrayRef<ValueDecl *> values, NullablePtr<DeclContext> baseDC) {
   for (auto *value: values) {
     if (factory.isOriginallyTypeLookup && !isa<TypeDecl>(value))
       continue;
@@ -609,7 +608,6 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::consumePossiblyNotInScope(
 }
 
 bool ASTScopeDeclGatherer::consume(ArrayRef<ValueDecl *> valuesArg,
-                                   DeclVisibilityKind,
                                    NullablePtr<DeclContext>) {
   for (auto *v: valuesArg)
     values.push_back(v);
@@ -768,7 +766,7 @@ public:
     : name(name), stopAfterInnermostBraceStmt(stopAfterInnermostBraceStmt),
       results(results) {}
 
-  bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
+  bool consume(ArrayRef<ValueDecl *> values,
                NullablePtr<DeclContext> baseDC) override {
     for (auto *value: values) {
       if (!value->getName().matchesRef(name))

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -584,17 +584,6 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
     if (!value->getName().matchesRef(factory.Name.getFullName()))
       continue;
 
-    // In order to preserve the behavior of the existing context-based lookup,
-    // which finds all results for non-local variables at the top level instead
-    // of stopping at the first one, ignore results at the top level that are
-    // not local variables. The caller \c lookInASTScopes will
-    // then do the appropriate work when the scope lookup fails. In
-    // FindLocalVal::visitBraceStmt, it sees PatternBindingDecls, not VarDecls,
-    // so a VarDecl at top level would not be found by the context-based lookup.
-    if (isa<SourceFile>(value->getDeclContext()) &&
-        (vis != DeclVisibilityKind::LocalVariable || isa<VarDecl>(value)))
-      return false;
-
     factory.Results.push_back(LookupResultEntry(value));
 #ifndef NDEBUG
     factory.stopForDebuggingIfAddingTargetLookupResult(factory.Results.back());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -572,6 +572,11 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
     if (currentDC->isTypeContext() != other->getDeclContext()->isTypeContext())
       continue;
 
+    // In local context, only consider exact name matches.
+    if (currentDC->isLocalContext() &&
+        current->getName() != other->getName())
+      continue;
+
     // Check whether the overload signatures conflict (ignoring the type for
     // now).
     auto otherSig = other->getOverloadSignature();

--- a/test/NameLookup/edge-cases.swift
+++ b/test/NameLookup/edge-cases.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -disable-parser-lookup
+
+struct A {}
+struct B {}
+
+func other() -> A {}
+
+func takesB(_: B) {}
+
+func multipleLocalResults1() {
+  func other() -> B {}
+  let result = other()
+  takesB(result)
+}
+
+func multipleLocalResults2() {
+  func other() -> B {}
+  let result = other()
+  takesB(result)
+  let other: Int = 123 // expected-warning {{never used}}
+}

--- a/test/NameLookup/scope_map_top_level.swift
+++ b/test/NameLookup/scope_map_top_level.swift
@@ -31,8 +31,8 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [4:11 - 4:13]
 // CHECK-EXPANDED-NEXT: `-TopLevelCodeScope {{.*}}, [6:1 - 21:28]
 // CHECK-EXPANDED-NEXT:   `-BraceStmtScope {{.*}}, [6:1 - 21:28]
-// CHECK-EXPANDED-NEXT:     `-PatternEntryDeclScope {{.*}}, [6:5 - 21:28] entry 0 'a'
-// CHECK-EXPANDED-NEXT:       |-PatternEntryInitializerScope {{.*}}, [6:15 - 6:15] entry 0 'a'
+// CHECK-EXPANDED-NEXT:     |-PatternEntryDeclScope {{.*}}, [6:5 - 6:15] entry 0 'a'
+// CHECK-EXPANDED-NEXT:       `-PatternEntryInitializerScope {{.*}}, [6:15 - 6:15] entry 0 'a'
 // CHECK-EXPANDED-NEXT:     `-TopLevelCodeScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 21:28]
@@ -46,9 +46,9 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:                 `-BraceStmtScope {{.*}}, [11:18 - 11:19]
 // CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 21:28]
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 21:28]
-// CHECK-EXPANDED-NEXT:                 `-PatternEntryDeclScope {{.*}}, [13:5 - 21:28] entry 0 'c'
-// CHECK-EXPANDED-NEXT:                   |-PatternEntryInitializerScope {{.*}}, [13:9 - 13:9] entry 0 'c'
-// CHECK-EXPANDED-NEXT:                   |-TypeAliasDeclScope {{.*}}, [15:1 - 15:15]
+// CHECK-EXPANDED-NEXT:                 |-PatternEntryDeclScope {{.*}}, [13:5 - 13:9] entry 0 'c'
+// CHECK-EXPANDED-NEXT:                   `-PatternEntryInitializerScope {{.*}}, [13:9 - 13:9] entry 0 'c'
+// CHECK-EXPANDED-NEXT:                 |-TypeAliasDeclScope {{.*}}, [15:1 - 15:15]
 // CHECK-EXPANDED-NEXT:                 |-ExtensionDeclScope {{.*}}, [17:14 - 19:1]
 // CHECK-EXPANDED-NEXT:                   `-ExtensionBodyScope {{.*}}, [17:15 - 19:1]
 // CHECK-EXPANDED-NEXT:                     `-AbstractFunctionDeclScope {{.*}}, [18:3 - 18:43] 'my_identity()'

--- a/test/Sema/redeclaration-checking.swift
+++ b/test/Sema/redeclaration-checking.swift
@@ -94,3 +94,8 @@ func stmtTest() {
   // expected-warning@-3 2{{never used}}
   // expected-warning@-4 {{unreachable}}
 }
+
+func fullNameTest() {
+  let x = 123 // expected-warning {{never used}}
+  func x() {}
+}


### PR DESCRIPTION
I wrote about the existing Swift scoping rules for local functions here: https://forums.swift.org/t/clarify-scoping-behavior-with-local-functions/40558

The quick summary is that today, parser lookup runs first, and only finds names that precede the use location in the source file. The old context-based lookup done from `preCheckExpression()` finds all local declarations, even those not in scope. A set of heuristics are used to find the relevant local declaration.

Since ASTScope has to replace parse-time lookup, it has to model both behaviors. This PR wires it all up.

In the future, we can consider simplifying pre-check's name lookup rules by banning forward references to captured bindings, as I wrote in my forum post. But that's not in the critical path for removing parser lookup anymore.

Builds upon https://github.com/apple/swift/pull/34125.