### PR TITLE
Do not install the diagnostics .gitkeep file

### DIFF
--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -19,4 +19,6 @@ add_dependencies(diagnostic-database swift-def-to-yaml-converter)
 swift_install_in_component(
   DIRECTORY ${CMAKE_BINARY_DIR}/share/swift/diagnostics/
   DESTINATION "share/swift/diagnostics"
-  COMPONENT compiler)
+  COMPONENT compiler
+  PATTERN ".gitkeep" EXCLUDE
+)


### PR DESCRIPTION
We don't want to install random empty files with the compiler.

This could also be handled in `swift_install_in_component` which would prevent the issue in the future, but I wasn't sure if we wanted to make that change.