### PR TITLE
[Localization] Install only *.db and *.yaml files

### DIFF
--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -19,4 +19,7 @@ add_dependencies(diagnostic-database swift-def-to-yaml-converter)
 swift_install_in_component(
   DIRECTORY ${CMAKE_BINARY_DIR}/share/swift/diagnostics/
   DESTINATION "share/swift/diagnostics"
-  COMPONENT compiler)
+  COMPONENT compiler
+  PATTERN "*.db"
+  PATTERN "*.yaml"
+)


### PR DESCRIPTION
This prevents us from picking up the `.gitkeep` file and any other stray files that might end up in there.

Fixes rdar://68580755