### PR TITLE
[Concurrency] Async CC, part 1.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -694,6 +694,9 @@ public:
   /// generic metadata.
   AvailabilityContext getIntermodulePrespecializedGenericMetadataAvailability();
 
+  /// Get the runtime availability of support for concurrency.
+  AvailabilityContext getConcurrencyAvailability();
+
   /// Get the runtime availability of features introduced in the Swift 5.2
   /// compiler for the target platform.
   AvailabilityContext getSwift52Availability();

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1461,6 +1461,22 @@ FUNCTION(GetTypeByMangledNameInContextInMetadataState,
               Int8PtrPtrTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
+// void *swift_taskAlloc(SwiftTask *task, size_t size);
+FUNCTION(TaskAlloc,
+         swift_taskAlloc, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(Int8PtrTy),
+         ARGS(SwiftTaskPtrTy, SizeTy),
+         ATTRS(NoUnwind, ArgMemOnly))
+
+// void swift_taskDealloc(SwiftTask *task, void *ptr);
+FUNCTION(TaskDealloc,
+         swift_taskDealloc, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(SwiftTaskPtrTy, Int8PtrTy),
+         ATTRS(NoUnwind, ArgMemOnly))
+
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -323,6 +323,10 @@ ASTContext::getIntermodulePrespecializedGenericMetadataAvailability() {
   return getSwift54Availability();
 }
 
+AvailabilityContext ASTContext::getConcurrencyAvailability() {
+  return getSwiftFutureAvailability();
+}
+
 AvailabilityContext ASTContext::getSwift52Availability() {
   auto target = LangOpts.Target;
 

--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -1,0 +1,46 @@
+//===-- EntryPointArgumentEmission.h - Emit function entries. -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace llvm {
+class Value;
+}
+
+namespace swift {
+namespace irgen {
+
+class Explosion;
+
+class EntryPointArgumentEmission {
+
+public:
+  virtual ~EntryPointArgumentEmission() {}
+  virtual bool requiresIndirectResult(SILType retType) = 0;
+  virtual llvm::Value *getIndirectResultForFormallyDirectResult() = 0;
+  virtual llvm::Value *getIndirectResult(unsigned index) = 0;
+};
+
+class NativeCCEntryPointArgumentEmission
+    : public virtual EntryPointArgumentEmission {
+
+public:
+  virtual llvm::Value *getCallerErrorResultArgument() = 0;
+  virtual llvm::Value *getContext() = 0;
+  virtual Explosion getArgumentExplosion(unsigned index, unsigned size) = 0;
+  virtual llvm::Value *getSelfWitnessTable() = 0;
+  virtual llvm::Value *getSelfMetadata() = 0;
+  virtual llvm::Value *getCoroutineBuffer() = 0;
+};
+
+} // end namespace irgen
+} // end namespace swift

--- a/lib/IRGen/Explosion.h
+++ b/lib/IRGen/Explosion.h
@@ -152,6 +152,11 @@ public:
     return Values[NextValue-1];
   }
 
+  llvm::Value *peek(unsigned n) {
+    assert(n < Values.size());
+    return Values[n];
+  }
+
   /// Claim and remove the last item in the array.
   /// Unlike the normal 'claim' methods, the item is gone forever.
   llvm::Value *takeLast() {

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -408,10 +408,10 @@ if (Builtin.ID == BuiltinValueKind::id) { \
   
     auto *fn = cast<llvm::Function>(IGF.IGM.getWillThrowFn());
     auto error = args.claimNext();
-    auto errorBuffer = IGF.getErrorResultSlot(
-               SILType::getPrimitiveObjectType(IGF.IGM.Context.getErrorDecl()
-                                                  ->getDeclaredInterfaceType()
-                                                  ->getCanonicalType()));
+    auto errorBuffer = IGF.getCalleeErrorResultSlot(
+        SILType::getPrimitiveObjectType(IGF.IGM.Context.getErrorDecl()
+                                            ->getDeclaredInterfaceType()
+                                            ->getCanonicalType()));
     IGF.Builder.CreateStore(error, errorBuffer);
     
     auto context = llvm::UndefValue::get(IGF.IGM.Int8PtrTy);

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -16,23 +16,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "GenCall.h"
-#include "Signature.h"
-
+#include "swift/ABI/MetadataValues.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/Runtime/Config.h"
+#include "swift/SIL/SILType.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
 #include "clang/CodeGen/ModuleBuilder.h"
-#include "swift/AST/GenericEnvironment.h"
-#include "swift/SIL/SILType.h"
-#include "swift/ABI/MetadataValues.h"
-#include "swift/Runtime/Config.h"
 #include "llvm/IR/GlobalPtrAuthInfo.h"
 #include "llvm/Support/Compiler.h"
 
 #include "CallEmission.h"
+#include "EntryPointArgumentEmission.h"
 #include "Explosion.h"
+#include "GenCall.h"
+#include "GenFunc.h"
+#include "GenHeap.h"
 #include "GenObjC.h"
 #include "GenPointerAuth.h"
 #include "GenPoly.h"
@@ -42,6 +44,8 @@
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
 #include "NativeConventionSchema.h"
+#include "Signature.h"
+#include "StructLayout.h"
 
 using namespace swift;
 using namespace irgen;
@@ -71,6 +75,174 @@ static Size getCoroutineContextSize(IRGenModule &IGM,
     return getYieldManyCoroutineBufferSize(IGM);
   }
   llvm_unreachable("bad kind");
+}
+
+AsyncContextLayout irgen::getAsyncContextLayout(IRGenFunction &IGF,
+                                                SILFunction *function) {
+  SubstitutionMap forwardingSubstitutionMap =
+      function->getForwardingSubstitutionMap();
+  CanSILFunctionType originalType = function->getLoweredFunctionType();
+  CanSILFunctionType substitutedType = originalType->substGenericArgs(
+      IGF.IGM.getSILModule(), forwardingSubstitutionMap,
+      IGF.IGM.getMaximalTypeExpansionContext());
+  auto layout = getAsyncContextLayout(IGF, originalType, substitutedType,
+                                      forwardingSubstitutionMap);
+  return layout;
+}
+
+AsyncContextLayout irgen::getAsyncContextLayout(
+    IRGenFunction &IGF, CanSILFunctionType originalType,
+    CanSILFunctionType substitutedType, SubstitutionMap substitutionMap) {
+  SmallVector<const TypeInfo *, 4> typeInfos;
+  SmallVector<SILType, 4> valTypes;
+  SmallVector<AsyncContextLayout::ArgumentInfo, 4> paramInfos;
+  SmallVector<SILResultInfo, 4> indirectReturnInfos;
+  SmallVector<SILResultInfo, 4> directReturnInfos;
+
+  auto parameters = substitutedType->getParameters();
+  SILFunctionConventions fnConv(substitutedType, IGF.getSILModule());
+
+  //   SwiftError *errorResult;
+  auto errorCanType = IGF.IGM.Context.getExceptionType();
+  auto errorType = SILType::getPrimitiveObjectType(errorCanType);
+  auto &errorTypeInfo = IGF.getTypeInfoForLowered(errorCanType);
+  typeInfos.push_back(&errorTypeInfo);
+  valTypes.push_back(errorType);
+
+  //   IndirectResultTypes *indirectResults...;
+  auto indirectResults = fnConv.getIndirectSILResults();
+  for (auto indirectResult : indirectResults) {
+    auto ty = fnConv.getSILType(indirectResult,
+                                IGF.IGM.getMaximalTypeExpansionContext());
+    auto retLoweringTy = CanInOutType::get(ty.getASTType());
+    auto &ti = IGF.getTypeInfoForLowered(retLoweringTy);
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+    indirectReturnInfos.push_back(indirectResult);
+  }
+
+  //   SelfType self?;
+  bool hasLocalContextParameter = hasSelfContextParameter(substitutedType);
+  bool canHaveValidError = substitutedType->hasErrorResult();
+  bool hasLocalContext = (hasLocalContextParameter || canHaveValidError ||
+                          substitutedType->getRepresentation() ==
+                              SILFunctionTypeRepresentation::Thick);
+  SILParameterInfo localContextParameter =
+      hasLocalContextParameter ? parameters.back() : SILParameterInfo();
+  if (hasLocalContextParameter) {
+    parameters = parameters.drop_back();
+  }
+  Optional<AsyncContextLayout::ArgumentInfo> localContextInfo = llvm::None;
+  if (hasLocalContext) {
+    if (hasLocalContextParameter) {
+      SILType ty =
+          IGF.IGM.silConv.getSILType(localContextParameter, substitutedType,
+                                     IGF.IGM.getMaximalTypeExpansionContext());
+      auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      localContextInfo = {ty, localContextParameter.getConvention()};
+    } else {
+      // TODO: DETERMINE: Is there a field in this case to match the sync ABI?
+      auto &ti = IGF.IGM.getNativeObjectTypeInfo();
+      SILType ty = SILType::getNativeObjectType(IGF.IGM.Context);
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      localContextInfo = {ty, substitutedType->getCalleeConvention()};
+    }
+  }
+
+  //   ArgTypes formalArguments...;
+  auto bindings = NecessaryBindings::forAsyncFunctionInvocations(
+      IGF.IGM, originalType, substitutionMap);
+  if (!bindings.empty()) {
+    auto bindingsSize = bindings.getBufferSize(IGF.IGM);
+    auto &bindingsTI = IGF.IGM.getOpaqueStorageTypeInfo(
+        bindingsSize, IGF.IGM.getPointerAlignment());
+    valTypes.push_back(SILType());
+    typeInfos.push_back(&bindingsTI);
+  }
+  for (auto parameter : parameters) {
+    SILType ty = IGF.IGM.silConv.getSILType(
+        parameter, substitutedType, IGF.IGM.getMaximalTypeExpansionContext());
+
+    auto argumentLoweringType =
+        getArgumentLoweringType(ty.getASTType(), parameter,
+                                /*isNoEscape*/ true);
+
+    auto &ti = IGF.getTypeInfoForLowered(argumentLoweringType);
+
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+    paramInfos.push_back({ty, parameter.getConvention()});
+  }
+
+  //     ResultTypes directResults...;
+  auto directResults = fnConv.getDirectSILResults();
+  for (auto result : directResults) {
+    auto ty =
+        fnConv.getSILType(result, IGF.IGM.getMaximalTypeExpansionContext());
+    auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+    directReturnInfos.push_back(result);
+  }
+
+  return AsyncContextLayout(IGF.IGM, LayoutStrategy::Optimal, valTypes,
+                            typeInfos, IGF, originalType, substitutedType,
+                            substitutionMap, std::move(bindings), errorType,
+                            canHaveValidError, paramInfos, indirectReturnInfos,
+                            directReturnInfos, localContextInfo);
+}
+
+AsyncContextLayout::AsyncContextLayout(
+    IRGenModule &IGM, LayoutStrategy strategy, ArrayRef<SILType> fieldTypes,
+    ArrayRef<const TypeInfo *> fieldTypeInfos, IRGenFunction &IGF,
+    CanSILFunctionType originalType, CanSILFunctionType substitutedType,
+    SubstitutionMap substitutionMap, NecessaryBindings &&bindings,
+    SILType errorType, bool canHaveValidError,
+    ArrayRef<ArgumentInfo> argumentInfos,
+    ArrayRef<SILResultInfo> indirectReturnInfos,
+    ArrayRef<SILResultInfo> directReturnInfos,
+    Optional<AsyncContextLayout::ArgumentInfo> localContextInfo)
+    : StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject, strategy,
+                   fieldTypeInfos, /*typeToFill*/ nullptr),
+      IGF(IGF), originalType(originalType), substitutedType(substitutedType),
+      substitutionMap(substitutionMap), errorType(errorType),
+      canHaveValidError(canHaveValidError),
+      directReturnInfos(directReturnInfos.begin(), directReturnInfos.end()),
+      indirectReturnInfos(indirectReturnInfos.begin(),
+                          indirectReturnInfos.end()),
+      localContextInfo(localContextInfo), bindings(std::move(bindings)),
+      argumentInfos(argumentInfos.begin(), argumentInfos.end()) {
+#ifndef NDEBUG
+  assert(fieldTypeInfos.size() == fieldTypes.size() &&
+         "type infos don't match types");
+  if (!bindings.empty()) {
+    assert(fieldTypeInfos.size() >= 2 && "no field for bindings");
+    auto fixedBindingsField =
+        dyn_cast<FixedTypeInfo>(fieldTypeInfos[getBindingsIndex()]);
+    assert(fixedBindingsField && "bindings field is not fixed size");
+    assert(fixedBindingsField->getFixedSize() == bindings.getBufferSize(IGM) &&
+           fixedBindingsField->getFixedAlignment() ==
+               IGM.getPointerAlignment() &&
+           "bindings field doesn't fit bindings");
+  }
+  assert(this->isFixedLayout());
+#endif
+}
+
+static Size getAsyncContextSize(AsyncContextLayout layout) {
+  return layout.getSize();
+}
+
+static Alignment getAsyncContextAlignment(IRGenModule &IGM) {
+  return IGM.getPointerAlignment();
+}
+
+static llvm::Value *getAsyncTask(IRGenFunction &IGF) {
+  // TODO: Return the appropriate task.
+  return llvm::Constant::getNullValue(IGF.IGM.SwiftTaskPtrTy);
 }
 
 llvm::Type *ExplosionSchema::getScalarResultType(IRGenModule &IGM) const {
@@ -288,6 +460,7 @@ namespace {
     }
 
     void addCoroutineContextParameter();
+    void addAsyncParameters();
 
     void expandResult();
     llvm::Type *expandDirectResult();
@@ -312,6 +485,12 @@ llvm::Type *SignatureExpansion::addIndirectResult() {
 
 /// Expand all of the direct and indirect result types.
 void SignatureExpansion::expandResult() {
+  if (FnType->isAsync()) {
+    // The result will be stored within the SwiftContext that is passed to async
+    // functions.
+    ResultIRType = IGM.VoidTy;
+    return;
+  }
   if (FnType->isCoroutine()) {
     // This should be easy enough to support if we need to: use the
     // same algorithm but add the direct results to the results as if
@@ -480,6 +659,12 @@ void SignatureExpansion::expandCoroutineContinuationParameters() {
 
   // Whether this is an unwind resumption.
   ParamIRTypes.push_back(IGM.Int1Ty);
+}
+
+void SignatureExpansion::addAsyncParameters() {
+  ParamIRTypes.push_back(IGM.SwiftContextPtrTy);
+  // TODO: Add actor.
+  // TODO: Add task.
 }
 
 void SignatureExpansion::addCoroutineContextParameter() {
@@ -1343,6 +1528,13 @@ void SignatureExpansion::expandParameters() {
   assert(FnType->getRepresentation() != SILFunctionTypeRepresentation::Block
          && "block with non-C calling conv?!");
 
+  if (FnType->isAsync()) {
+    addAsyncParameters();
+    // All other parameters will be passed inside the context added by the
+    // addAsyncParameters call.
+    return;
+  }
+
   // First, if this is a coroutine, add the coroutine-context parameter.
   switch (FnType->getCoroutineKind()) {
   case SILCoroutineKind::None:
@@ -1515,69 +1707,373 @@ void irgen::extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
     out.add(returned);
 }
 
+static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
+                                 Explosion &in, Explosion &out,
+                                 TemporarySet &temporaries, bool isOutlined);
+
+namespace {
+
+class SyncCallEmission final : public CallEmission {
+  using super = CallEmission;
+
+public:
+  SyncCallEmission(IRGenFunction &IGF, llvm::Value *selfValue, Callee &&callee)
+      : CallEmission(IGF, selfValue, std::move(callee)) {
+    setFromCallee();
+  }
+
+  SILType getParameterType(unsigned index) override {
+    SILFunctionConventions origConv(getCallee().getOrigFunctionType(),
+                                    IGF.getSILModule());
+    return origConv.getSILArgumentType(
+        index, IGF.IGM.getMaximalTypeExpansionContext());
+  }
+  void begin() override { super::begin(); }
+  void end() override { super::end(); }
+  void setFromCallee() override {
+    super::setFromCallee();
+
+    auto fnType = CurCallee.getOrigFunctionType();
+
+    if (fnType->getRepresentation() ==
+        SILFunctionTypeRepresentation::WitnessMethod) {
+      unsigned n = getTrailingWitnessSignatureLength(IGF.IGM, fnType);
+      while (n--) {
+        Args[--LastArgWritten] = nullptr;
+      }
+    }
+
+    llvm::Value *contextPtr = CurCallee.getSwiftContext();
+
+    // Add the error result if we have one.
+    if (fnType->hasErrorResult()) {
+      // The invariant is that this is always zero-initialized, so we
+      // don't need to do anything extra here.
+      SILFunctionConventions fnConv(fnType, IGF.getSILModule());
+      Address errorResultSlot = IGF.getCalleeErrorResultSlot(
+          fnConv.getSILErrorType(IGF.IGM.getMaximalTypeExpansionContext()));
+
+      assert(LastArgWritten > 0);
+      Args[--LastArgWritten] = errorResultSlot.getAddress();
+      addAttribute(LastArgWritten + llvm::AttributeList::FirstArgIndex,
+                   llvm::Attribute::NoCapture);
+      IGF.IGM.addSwiftErrorAttributes(CurCallee.getMutableAttributes(),
+                                      LastArgWritten);
+
+      // Fill in the context pointer if necessary.
+      if (!contextPtr) {
+        assert(!CurCallee.getOrigFunctionType()->getExtInfo().hasContext() &&
+               "Missing context?");
+        contextPtr = llvm::UndefValue::get(IGF.IGM.RefCountedPtrTy);
+      }
+    }
+
+    // Add the data pointer if we have one.
+    // (Note that we're emitting backwards, so this correctly goes
+    // *before* the error pointer.)
+    if (contextPtr) {
+      assert(LastArgWritten > 0);
+      Args[--LastArgWritten] = contextPtr;
+      IGF.IGM.addSwiftSelfAttributes(CurCallee.getMutableAttributes(),
+                                     LastArgWritten);
+    }
+  }
+  void setArgs(Explosion &original, bool isOutlined,
+               WitnessMetadata *witnessMetadata) override {
+    // Convert arguments to a representation appropriate to the calling
+    // convention.
+    Explosion adjusted;
+
+    auto origCalleeType = CurCallee.getOrigFunctionType();
+    SILFunctionConventions fnConv(origCalleeType, IGF.getSILModule());
+
+    // Pass along the indirect result pointers.
+    original.transferInto(adjusted, fnConv.getNumIndirectSILResults());
+
+    // Pass along the coroutine buffer.
+    switch (origCalleeType->getCoroutineKind()) {
+    case SILCoroutineKind::YieldMany:
+    case SILCoroutineKind::YieldOnce:
+      original.transferInto(adjusted, 1);
+      break;
+
+    case SILCoroutineKind::None:
+      break;
+    }
+
+    // Translate the formal arguments and handle any special arguments.
+    switch (getCallee().getRepresentation()) {
+    case SILFunctionTypeRepresentation::ObjCMethod:
+      adjusted.add(getCallee().getObjCMethodReceiver());
+      adjusted.add(getCallee().getObjCMethodSelector());
+      externalizeArguments(IGF, getCallee(), original, adjusted, Temporaries,
+                           isOutlined);
+      break;
+
+    case SILFunctionTypeRepresentation::Block:
+      adjusted.add(getCallee().getBlockObject());
+      LLVM_FALLTHROUGH;
+
+    case SILFunctionTypeRepresentation::CFunctionPointer:
+      externalizeArguments(IGF, getCallee(), original, adjusted, Temporaries,
+                           isOutlined);
+      break;
+
+    case SILFunctionTypeRepresentation::WitnessMethod:
+      assert(witnessMetadata);
+      assert(witnessMetadata->SelfMetadata->getType() ==
+             IGF.IGM.TypeMetadataPtrTy);
+      assert(witnessMetadata->SelfWitnessTable->getType() ==
+             IGF.IGM.WitnessTablePtrTy);
+      Args.rbegin()[1] = witnessMetadata->SelfMetadata;
+      Args.rbegin()[0] = witnessMetadata->SelfWitnessTable;
+      LLVM_FALLTHROUGH;
+
+    case SILFunctionTypeRepresentation::Closure:
+    case SILFunctionTypeRepresentation::Method:
+    case SILFunctionTypeRepresentation::Thin:
+    case SILFunctionTypeRepresentation::Thick: {
+      // Check for value arguments that need to be passed indirectly.
+      // But don't expect to see 'self' if it's been moved to the context
+      // position.
+      auto params = origCalleeType->getParameters();
+      if (hasSelfContextParameter(origCalleeType)) {
+        params = params.drop_back();
+      }
+      for (auto param : params) {
+        addNativeArgument(IGF, original, origCalleeType, param, adjusted,
+                          isOutlined);
+      }
+
+      // Anything else, just pass along.  This will include things like
+      // generic arguments.
+      adjusted.add(original.claimAll());
+
+      break;
+    }
+    }
+    super::setArgs(adjusted, isOutlined, witnessMetadata);
+  }
+  void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {
+    // Bail out immediately on a void result.
+    llvm::Value *result = call;
+    if (result->getType()->isVoidTy())
+      return;
+
+    SILFunctionConventions fnConv(getCallee().getOrigFunctionType(),
+                                  IGF.getSILModule());
+
+    // If the result was returned autoreleased, implicitly insert the reclaim.
+    // This is only allowed on a single direct result.
+    if (fnConv.getNumDirectSILResults() == 1
+        && (fnConv.getDirectSILResults().begin()->getConvention()
+            == ResultConvention::Autoreleased)) {
+      result = emitObjCRetainAutoreleasedReturnValue(IGF, result);
+    }
+
+    auto origFnType = getCallee().getOrigFunctionType();
+
+    // Specially handle noreturn c function which would return a 'Never' SIL result
+    // type.
+    if (origFnType->getLanguage() == SILFunctionLanguage::C &&
+        origFnType->isNoReturnFunction(
+            IGF.getSILModule(), IGF.IGM.getMaximalTypeExpansionContext())) {
+      auto clangResultTy = result->getType();
+      extractScalarResults(IGF, clangResultTy, result, out);
+      return;
+    }
+
+    // Get the natural IR type in the body of the function that makes
+    // the call. This may be different than the IR type returned by the
+    // call itself due to ABI type coercion.
+    auto resultType =
+        fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext());
+    auto &nativeSchema = IGF.IGM.getTypeInfo(resultType).nativeReturnValueSchema(IGF.IGM);
+
+    // For ABI reasons the result type of the call might not actually match the
+    // expected result type.
+    //
+    // This can happen when calling C functions, or class method dispatch thunks
+    // for methods that have covariant ABI-compatible overrides.
+    auto expectedNativeResultType = nativeSchema.getExpandedType(IGF.IGM);
+    if (result->getType() != expectedNativeResultType) {
+      result =
+          IGF.coerceValue(result, expectedNativeResultType, IGF.IGM.DataLayout);
+    }
+
+    // Gather the values.
+    Explosion nativeExplosion;
+    extractScalarResults(IGF, result->getType(), result, nativeExplosion);
+
+    out = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeExplosion, resultType);
+  }
+  Address getCalleeErrorSlot(SILType errorType) override {
+    return IGF.getCalleeErrorResultSlot(errorType);
+  };
+};
+
+class AsyncCallEmission final : public CallEmission {
+  using super = CallEmission;
+
+  Address contextBuffer;
+  Size contextSize;
+  Address context;
+
+  AsyncContextLayout getAsyncContextLayout() {
+    return ::getAsyncContextLayout(IGF, getCallee().getOrigFunctionType(),
+                                   getCallee().getSubstFunctionType(),
+                                   getCallee().getSubstitutions());
+  }
+
+public:
+  AsyncCallEmission(IRGenFunction &IGF, llvm::Value *selfValue, Callee &&callee)
+      : CallEmission(IGF, selfValue, std::move(callee)) {
+    setFromCallee();
+  }
+
+  void begin() override {
+    super::begin();
+    assert(!contextBuffer.isValid());
+    assert(!context.isValid());
+    // Allocate space for the async arguments.
+    auto layout = getAsyncContextLayout();
+    std::tie(contextBuffer, contextSize) = emitAllocAsyncContext(IGF, layout);
+    context = layout.emitCastTo(IGF, contextBuffer.getAddress());
+    if (layout.canHaveError()) {
+      auto fieldLayout = layout.getErrorLayout();
+      auto addr = fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
+      auto &ti = fieldLayout.getType();
+      auto nullError = llvm::Constant::getNullValue(ti.getStorageType());
+      IGF.Builder.CreateStore(nullError, addr);
+    }
+  }
+  void end() override {
+    assert(contextBuffer.isValid());
+    assert(context.isValid());
+    emitDeallocAsyncContext(IGF, contextBuffer, contextSize);
+    super::end();
+  }
+  void setFromCallee() override { super::setFromCallee(); }
+  SILType getParameterType(unsigned index) override {
+    return getAsyncContextLayout().getParameterType(index);
+  }
+  void setArgs(Explosion &llArgs, bool isOutlined,
+               WitnessMetadata *witnessMetadata) override {
+    Explosion asyncExplosion;
+    asyncExplosion.add(contextBuffer.getAddress());
+    super::setArgs(asyncExplosion, false, witnessMetadata);
+    SILFunctionConventions fnConv(getCallee().getSubstFunctionType(),
+                                  IGF.getSILModule());
+
+    // Move all the arguments into the context.
+    if (selfValue) {
+      llArgs.add(selfValue);
+    }
+    auto layout = getAsyncContextLayout();
+    auto params = fnConv.getParameters();
+    for (auto index : indices(params)) {
+      Optional<ElementLayout> fieldLayout;
+      if (selfValue && index == params.size() - 1) {
+        fieldLayout = layout.getLocalContextLayout();
+      } else {
+        fieldLayout = layout.getArgumentLayout(index);
+      }
+      Address fieldAddr =
+          fieldLayout->project(IGF, context, /*offsets*/ llvm::None);
+      auto &ti = cast<LoadableTypeInfo>(fieldLayout->getType());
+      ti.initialize(IGF, llArgs, fieldAddr, isOutlined);
+    }
+    unsigned index = 0;
+    for (auto indirectResult : fnConv.getIndirectSILResultTypes(
+             IGF.IGM.getMaximalTypeExpansionContext())) {
+      (void)indirectResult;
+      auto fieldLayout = layout.getIndirectReturnLayout(index);
+      Address fieldAddr =
+          fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
+      cast<LoadableTypeInfo>(fieldLayout.getType())
+          .initialize(IGF, llArgs, fieldAddr, isOutlined);
+      ++index;
+    }
+    if (layout.hasBindings()) {
+      auto bindingLayout = layout.getBindingsLayout();
+      auto bindingsAddr = bindingLayout.project(IGF, context, /*offsets*/ None);
+      layout.getBindings().save(IGF, bindingsAddr);
+    }
+    // At this point, llArgs contains the arguments that are being passed along
+    // via the async context.  We can safely drop them on the floor.
+    (void)llArgs.claimAll();
+    // TODO: Validation: we should be able to check that the contents of llArgs
+    //       matches what is expected by the layout.
+  }
+  void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {
+    SILFunctionConventions fnConv(getCallee().getSubstFunctionType(),
+                                  IGF.getSILModule());
+    auto resultType =
+        fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext());
+    auto &nativeSchema =
+        IGF.IGM.getTypeInfo(resultType).nativeReturnValueSchema(IGF.IGM);
+    auto expectedNativeResultType = nativeSchema.getExpandedType(IGF.IGM);
+    if (expectedNativeResultType->isVoidTy()) {
+      // If the async return is void, there is no return to move out of the
+      // argument buffer.
+      return;
+    }
+    assert(call->arg_size() == 1);
+    auto context = call->arg_begin()->get();
+    // Gather the values.
+    Explosion nativeExplosion;
+    auto layout = getAsyncContextLayout();
+    auto dataAddr = layout.emitCastTo(IGF, context);
+    int index = layout.getFirstDirectReturnIndex();
+    for (auto result : fnConv.getDirectSILResults()) {
+      auto &fieldLayout = layout.getElement(index);
+      Address fieldAddr =
+          fieldLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+      auto &fieldTI = fieldLayout.getType();
+      cast<LoadableTypeInfo>(fieldTI).loadAsTake(IGF, fieldAddr,
+                                                 nativeExplosion);
+      ++index;
+    }
+
+    out = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeExplosion, resultType);
+  }
+  Address getCalleeErrorSlot(SILType errorType) override {
+    auto layout = getAsyncContextLayout();
+    auto errorLayout = layout.getErrorLayout();
+    auto address = errorLayout.project(IGF, context, /*offsets*/ llvm::None);
+    return address;
+  };
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<CallEmission> irgen::getCallEmission(IRGenFunction &IGF,
+                                                     llvm::Value *selfValue,
+                                                     Callee &&callee) {
+  if (callee.getOrigFunctionType()->isAsync()) {
+    return std::make_unique<AsyncCallEmission>(IGF, selfValue,
+                                               std::move(callee));
+  } else {
+    return std::make_unique<SyncCallEmission>(IGF, selfValue,
+                                              std::move(callee));
+  }
+}
+
 /// Emit the unsubstituted result of this call into the given explosion.
 /// The unsubstituted result must be naturally returned directly.
 void CallEmission::emitToUnmappedExplosion(Explosion &out) {
+  assert(state == State::Emitting);
   assert(LastArgWritten == 0 && "emitting unnaturally to explosion");
 
   auto call = emitCallSite();
 
-  // Bail out immediately on a void result.
-  llvm::Value *result = call;
-  if (result->getType()->isVoidTy())
-    return;
-
-  SILFunctionConventions fnConv(getCallee().getOrigFunctionType(),
-                                IGF.getSILModule());
-
-  // If the result was returned autoreleased, implicitly insert the reclaim.
-  // This is only allowed on a single direct result.
-  if (fnConv.getNumDirectSILResults() == 1
-      && (fnConv.getDirectSILResults().begin()->getConvention()
-          == ResultConvention::Autoreleased)) {
-    result = emitObjCRetainAutoreleasedReturnValue(IGF, result);
-  }
-
-  auto origFnType = getCallee().getOrigFunctionType();
-
-  // Specially handle noreturn c function which would return a 'Never' SIL result
-  // type.
-  if (origFnType->getLanguage() == SILFunctionLanguage::C &&
-      origFnType->isNoReturnFunction(
-          IGF.getSILModule(), IGF.IGM.getMaximalTypeExpansionContext())) {
-    auto clangResultTy = result->getType();
-    extractScalarResults(IGF, clangResultTy, result, out);
-    return;
-  }
-
-  // Get the natural IR type in the body of the function that makes
-  // the call. This may be different than the IR type returned by the
-  // call itself due to ABI type coercion.
-  auto resultType =
-      fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext());
-  auto &nativeSchema = IGF.IGM.getTypeInfo(resultType).nativeReturnValueSchema(IGF.IGM);
-
-  // For ABI reasons the result type of the call might not actually match the
-  // expected result type.
-  //
-  // This can happen when calling C functions, or class method dispatch thunks
-  // for methods that have covariant ABI-compatible overrides.
-  auto expectedNativeResultType = nativeSchema.getExpandedType(IGF.IGM);
-  if (result->getType() != expectedNativeResultType) {
-    result =
-        IGF.coerceValue(result, expectedNativeResultType, IGF.IGM.DataLayout);
-  }
-
-  // Gather the values.
-  Explosion nativeExplosion;
-  extractScalarResults(IGF, result->getType(), result, nativeExplosion);
-
-  out = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeExplosion, resultType);
+  emitCallToUnmappedExplosion(call, out);
 }
 
 /// Emit the unsubstituted result of this call to the given address.
 /// The unsubstituted result must be naturally returned indirectly.
 void CallEmission::emitToUnmappedMemory(Address result) {
+  assert(state == State::Emitting);
   assert(LastArgWritten == 1 && "emitting unnaturally to indirect result");
 
   Args[0] = result.getAddress();
@@ -1594,6 +2090,7 @@ void CallEmission::emitToUnmappedMemory(Address result) {
 
 /// The private routine to ultimately emit a call or invoke instruction.
 llvm::CallInst *CallEmission::emitCallSite() {
+  assert(state == State::Emitting);
   assert(LastArgWritten == 0);
   assert(!EmittedCall);
   EmittedCall = true;
@@ -1681,6 +2178,7 @@ llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
 void CallEmission::emitToMemory(Address addr,
                                 const LoadableTypeInfo &indirectedResultTI,
                                 bool isOutlined) {
+  assert(state == State::Emitting);
   assert(LastArgWritten <= 1);
 
   // If the call is naturally to an explosion, emit it that way and
@@ -1742,6 +2240,7 @@ static void emitCastToSubstSchema(IRGenFunction &IGF, Explosion &in,
 }
 
 void CallEmission::emitYieldsToExplosion(Explosion &out) {
+  assert(state == State::Emitting);
   // Emit the call site.
   auto call = emitCallSite();
 
@@ -1820,6 +2319,7 @@ void CallEmission::emitYieldsToExplosion(Explosion &out) {
 
 /// Emit the result of this call to an explosion.
 void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
+  assert(state == State::Emitting);
   assert(LastArgWritten <= 1);
 
   // For coroutine calls, we need to collect the yields, not the results;
@@ -1892,12 +2392,21 @@ CallEmission::CallEmission(CallEmission &&other)
   // Prevent other's destructor from asserting.
   LastArgWritten = 0;
   EmittedCall = true;
+  state = State::Finished;
 }
 
 CallEmission::~CallEmission() {
   assert(LastArgWritten == 0);
   assert(EmittedCall);
   assert(Temporaries.hasBeenCleared());
+  assert(state == State::Finished);
+}
+
+void CallEmission::begin() {}
+
+void CallEmission::end() {
+  assert(state == State::Emitting);
+  state = State::Finished;
 }
 
 Callee::Callee(CalleeInfo &&info, const FunctionPointer &fn,
@@ -1982,6 +2491,7 @@ llvm::Value *Callee::getObjCMethodSelector() const {
 
 /// Set up this emitter afresh from the current callee specs.
 void CallEmission::setFromCallee() {
+  assert(state == State::Emitting);
   IsCoroutine = CurCallee.getSubstFunctionType()->isCoroutine();
   EmittedCall = false;
 
@@ -1992,51 +2502,6 @@ void CallEmission::setFromCallee() {
   Args.reserve(numArgs);
   Args.set_size(numArgs);
   LastArgWritten = numArgs;
-
-  auto fnType = CurCallee.getOrigFunctionType();
-
-  if (fnType->getRepresentation()
-        == SILFunctionTypeRepresentation::WitnessMethod) {
-    unsigned n = getTrailingWitnessSignatureLength(IGF.IGM, fnType);
-    while (n--) {
-      Args[--LastArgWritten] = nullptr;
-    }
-  }
-
-  llvm::Value *contextPtr = CurCallee.getSwiftContext();
-
-  // Add the error result if we have one.
-  if (fnType->hasErrorResult()) {
-    // The invariant is that this is always zero-initialized, so we
-    // don't need to do anything extra here.
-    SILFunctionConventions fnConv(fnType, IGF.getSILModule());
-    Address errorResultSlot = IGF.getErrorResultSlot(
-        fnConv.getSILErrorType(IGF.IGM.getMaximalTypeExpansionContext()));
-
-    assert(LastArgWritten > 0);
-    Args[--LastArgWritten] = errorResultSlot.getAddress();
-    addAttribute(LastArgWritten + llvm::AttributeList::FirstArgIndex,
-                 llvm::Attribute::NoCapture);
-    IGF.IGM.addSwiftErrorAttributes(CurCallee.getMutableAttributes(),
-                                    LastArgWritten);
-
-    // Fill in the context pointer if necessary.
-    if (!contextPtr) {
-      assert(!CurCallee.getOrigFunctionType()->getExtInfo().hasContext() &&
-             "Missing context?");
-      contextPtr = llvm::UndefValue::get(IGF.IGM.RefCountedPtrTy);
-    }
-  }
-
-  // Add the data pointer if we have one.
-  // (Note that we're emitting backwards, so this correctly goes
-  // *before* the error pointer.)
-  if (contextPtr) {
-    assert(LastArgWritten > 0);
-    Args[--LastArgWritten] = contextPtr;
-    IGF.IGM.addSwiftSelfAttributes(CurCallee.getMutableAttributes(),
-                                   LastArgWritten);
-  }
 }
 
 bool irgen::canCoerceToSchema(IRGenModule &IGM,
@@ -2610,12 +3075,11 @@ irgen::getCoroutineResumeFunctionPointerAuth(IRGenModule &IGM,
   llvm_unreachable("bad coroutine kind");
 }
 
-static void emitRetconCoroutineEntry(IRGenFunction &IGF,
-                                     CanSILFunctionType fnType,
-                                     Explosion &allParamValues,
-                                     llvm::Intrinsic::ID idIntrinsic,
-                                     Size bufferSize,
-                                     Alignment bufferAlignment) {
+static void
+emitRetconCoroutineEntry(IRGenFunction &IGF, CanSILFunctionType fnType,
+                         NativeCCEntryPointArgumentEmission &emission,
+                         llvm::Intrinsic::ID idIntrinsic, Size bufferSize,
+                         Alignment bufferAlignment) {
   auto prototype =
     IGF.IGM.getOpaquePtr(IGF.IGM.getAddrOfContinuationPrototype(fnType));
 
@@ -2624,7 +3088,7 @@ static void emitRetconCoroutineEntry(IRGenFunction &IGF,
   auto deallocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getFreeFn());
 
   // Call the right 'llvm.coro.id.retcon' variant.
-  llvm::Value *buffer = allParamValues.claimNext();
+  llvm::Value *buffer = emission.getCoroutineBuffer();
   llvm::Value *id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, {
     llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferSize.getValue()),
     llvm::ConstantInt::get(IGF.IGM.Int32Ty, bufferAlignment.getValue()),
@@ -2645,19 +3109,19 @@ static void emitRetconCoroutineEntry(IRGenFunction &IGF,
   IGF.setCoroutineHandle(hdl);
 }
 
-void irgen::emitYieldOnceCoroutineEntry(IRGenFunction &IGF,
-                                        CanSILFunctionType fnType,
-                                        Explosion &allParamValues) {
-  emitRetconCoroutineEntry(IGF, fnType, allParamValues,
+void irgen::emitYieldOnceCoroutineEntry(
+    IRGenFunction &IGF, CanSILFunctionType fnType,
+    NativeCCEntryPointArgumentEmission &emission) {
+  emitRetconCoroutineEntry(IGF, fnType, emission,
                            llvm::Intrinsic::coro_id_retcon_once,
                            getYieldOnceCoroutineBufferSize(IGF.IGM),
                            getYieldOnceCoroutineBufferAlignment(IGF.IGM));
 }
 
-void irgen::emitYieldManyCoroutineEntry(IRGenFunction &IGF,
-                                        CanSILFunctionType fnType,
-                                        Explosion &allParamValues) {
-  emitRetconCoroutineEntry(IGF, fnType, allParamValues,
+void irgen::emitYieldManyCoroutineEntry(
+    IRGenFunction &IGF, CanSILFunctionType fnType,
+    NativeCCEntryPointArgumentEmission &emission) {
+  emitRetconCoroutineEntry(IGF, fnType, emission,
                            llvm::Intrinsic::coro_id_retcon,
                            getYieldManyCoroutineBufferSize(IGF.IGM),
                            getYieldManyCoroutineBufferAlignment(IGF.IGM));
@@ -2694,9 +3158,49 @@ void irgen::emitDeallocYieldManyCoroutineBuffer(IRGenFunction &IGF,
   IGF.Builder.CreateLifetimeEnd(buffer, bufferSize);
 }
 
+Address irgen::emitTaskAlloc(IRGenFunction &IGF, llvm::Value *size,
+                             Alignment alignment) {
+  auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskAllocFn(),
+                                      {getAsyncTask(IGF), size});
+  call->setDoesNotThrow();
+  call->setCallingConv(IGF.IGM.SwiftCC);
+  call->addAttribute(llvm::AttributeList::FunctionIndex,
+                     llvm::Attribute::ReadNone);
+  auto address = Address(call, alignment);
+  return address;
+}
+
+void irgen::emitTaskDealloc(IRGenFunction &IGF, Address address,
+                            llvm::Value *size) {
+  auto *call = IGF.Builder.CreateCall(
+      IGF.IGM.getTaskDeallocFn(), {getAsyncTask(IGF), address.getAddress()});
+  call->setDoesNotThrow();
+  call->setCallingConv(IGF.IGM.SwiftCC);
+  call->addAttribute(llvm::AttributeList::FunctionIndex,
+                     llvm::Attribute::ReadNone);
+}
+
+std::pair<Address, Size>
+irgen::emitAllocAsyncContext(IRGenFunction &IGF, AsyncContextLayout layout) {
+  auto size = getAsyncContextSize(layout);
+  auto *sizeValue = llvm::ConstantInt::get(IGF.IGM.SizeTy, size.getValue());
+  auto alignment = getAsyncContextAlignment(IGF.IGM);
+  auto address = emitTaskAlloc(IGF, sizeValue, alignment);
+  IGF.Builder.CreateLifetimeStart(address, size);
+  return {address, size};
+}
+
+void irgen::emitDeallocAsyncContext(IRGenFunction &IGF, Address context,
+                                    Size size) {
+  auto *sizeValue = llvm::ConstantInt::get(IGF.IGM.SizeTy, size.getValue());
+  emitTaskDealloc(IGF, context, sizeValue);
+  IGF.Builder.CreateLifetimeEnd(context, size);
+}
+
 llvm::Value *irgen::emitYield(IRGenFunction &IGF,
                               CanSILFunctionType coroutineType,
                               Explosion &substValues) {
+  // TODO: Handle async!
   auto coroSignature = IGF.IGM.getSignature(coroutineType);
   auto coroInfo = coroSignature.getCoroutineInfo();
 
@@ -2772,88 +3276,16 @@ llvm::Value *irgen::emitYield(IRGenFunction &IGF,
 }
 
 /// Add a new set of arguments to the function.
-void CallEmission::setArgs(Explosion &original, bool isOutlined,
+void CallEmission::setArgs(Explosion &adjusted, bool isOutlined,
                            WitnessMetadata *witnessMetadata) {
-  // Convert arguments to a representation appropriate to the calling
-  // convention.
-  Explosion adjusted;
-
-  auto origCalleeType = CurCallee.getOrigFunctionType();
-  SILFunctionConventions fnConv(origCalleeType, IGF.getSILModule());
-
-  // Pass along the indirect result pointers.
-  original.transferInto(adjusted, fnConv.getNumIndirectSILResults());
-
-  // Pass along the coroutine buffer.
-  switch (origCalleeType->getCoroutineKind()) {
-  case SILCoroutineKind::YieldMany:
-  case SILCoroutineKind::YieldOnce:
-    original.transferInto(adjusted, 1);
-    break;
-
-  case SILCoroutineKind::None:
-    break;
-  }
-
-  // Translate the formal arguments and handle any special arguments.
-  switch (getCallee().getRepresentation()) {
-  case SILFunctionTypeRepresentation::ObjCMethod:
-    adjusted.add(getCallee().getObjCMethodReceiver());
-    adjusted.add(getCallee().getObjCMethodSelector());
-    externalizeArguments(IGF, getCallee(), original, adjusted,
-                         Temporaries, isOutlined);
-    break;
-
-  case SILFunctionTypeRepresentation::Block:
-    adjusted.add(getCallee().getBlockObject());
-    LLVM_FALLTHROUGH;
-
-  case SILFunctionTypeRepresentation::CFunctionPointer:
-    externalizeArguments(IGF, getCallee(), original, adjusted,
-                         Temporaries, isOutlined);
-    break;
-
-  case SILFunctionTypeRepresentation::WitnessMethod:
-    assert(witnessMetadata);
-    assert(witnessMetadata->SelfMetadata->getType() ==
-           IGF.IGM.TypeMetadataPtrTy);
-    assert(witnessMetadata->SelfWitnessTable->getType() ==
-           IGF.IGM.WitnessTablePtrTy);
-    Args.rbegin()[1] = witnessMetadata->SelfMetadata;
-    Args.rbegin()[0] = witnessMetadata->SelfWitnessTable;
-    LLVM_FALLTHROUGH;
-
-  case SILFunctionTypeRepresentation::Closure:
-  case SILFunctionTypeRepresentation::Method:
-  case SILFunctionTypeRepresentation::Thin:
-  case SILFunctionTypeRepresentation::Thick: {
-    // Check for value arguments that need to be passed indirectly.
-    // But don't expect to see 'self' if it's been moved to the context
-    // position.
-    auto params = origCalleeType->getParameters();
-    if (hasSelfContextParameter(origCalleeType)) {
-      params = params.drop_back();
-    }
-    for (auto param : params) {
-      addNativeArgument(IGF, original,
-                        origCalleeType, param, adjusted, isOutlined);
-    }
-
-    // Anything else, just pass along.  This will include things like
-    // generic arguments.
-    adjusted.add(original.claimAll());
-
-    break;
-  }
-  }
-
+  assert(state == State::Emitting);
   // Add the given number of arguments.
   assert(LastArgWritten >= adjusted.size());
 
   size_t targetIndex = LastArgWritten - adjusted.size();
   assert(targetIndex <= 1);
   LastArgWritten = targetIndex;
-  
+
   auto argIterator = Args.begin() + targetIndex;
   for (auto value : adjusted.claimAll()) {
     *argIterator++ = value;
@@ -2862,6 +3294,7 @@ void CallEmission::setArgs(Explosion &original, bool isOutlined,
 
 void CallEmission::addAttribute(unsigned index,
                                 llvm::Attribute::AttrKind attr) {
+  assert(state == State::Emitting);
   auto &attrs = CurCallee.getMutableAttributes();
   attrs = attrs.addAttribute(IGF.IGM.getLLVMContext(), index, attr);
 }
@@ -2877,8 +3310,8 @@ Explosion IRGenFunction::collectParameters() {
 }
 
 /// Fetch the error result slot.
-Address IRGenFunction::getErrorResultSlot(SILType errorType) {
-  if (!ErrorResultSlot) {
+Address IRGenFunction::getCalleeErrorResultSlot(SILType errorType) {
+  if (!CalleeErrorResultSlot) {
     auto &errorTI = cast<FixedTypeInfo>(getTypeInfo(errorType));
 
     IRBuilder builder(IGM.getLLVMContext(), IGM.DebugInfo != nullptr);
@@ -2902,23 +3335,28 @@ Address IRGenFunction::getErrorResultSlot(SILType errorType) {
                             cast<llvm::PointerType>(errorTI.getStorageType()));
     builder.CreateStore(nullError, addr);
 
-    ErrorResultSlot = addr.getAddress();
+    CalleeErrorResultSlot = addr.getAddress();
   }
-  return Address(ErrorResultSlot, IGM.getPointerAlignment());
+  return Address(CalleeErrorResultSlot, IGM.getPointerAlignment());
 }
 
 /// Fetch the error result slot received from the caller.
 Address IRGenFunction::getCallerErrorResultSlot() {
-  assert(ErrorResultSlot && "no error result slot!");
-  assert(isa<llvm::Argument>(ErrorResultSlot) && "error result slot is local!");
-  return Address(ErrorResultSlot, IGM.getPointerAlignment());
+  assert(CallerErrorResultSlot && "no error result slot!");
+  assert(isa<llvm::Argument>(CallerErrorResultSlot) && !isAsync() ||
+         isa<llvm::GetElementPtrInst>(CallerErrorResultSlot) && isAsync() &&
+             "error result slot is local!");
+  return Address(CallerErrorResultSlot, IGM.getPointerAlignment());
 }
 
 // Set the error result slot.  This should only be done in the prologue.
-void IRGenFunction::setErrorResultSlot(llvm::Value *address) {
-  assert(!ErrorResultSlot && "already have error result slot!");
+void IRGenFunction::setCallerErrorResultSlot(llvm::Value *address) {
+  assert(!CallerErrorResultSlot && "already have a caller error result slot!");
   assert(isa<llvm::PointerType>(address->getType()));
-  ErrorResultSlot = address;
+  CallerErrorResultSlot = address;
+  if (!isAsync()) {
+    CalleeErrorResultSlot = address;
+  }
 }
 
 /// Emit the basic block that 'return' should branch to and insert it into

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -20,9 +20,13 @@
 
 #include <stdint.h>
 
-#include "swift/Basic/LLVM.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/ApplySite.h"
 #include "llvm/IR/CallingConv.h"
+
+#include "GenHeap.h"
+#include "IRGenModule.h"
 
 namespace llvm {
   class AttributeList;
@@ -49,6 +53,7 @@ namespace irgen {
   class IRGenFunction;
   class IRGenModule;
   class LoadableTypeInfo;
+  class NativeCCEntryPointArgumentEmission;
   class Size;
   class TypeInfo;
 
@@ -59,6 +64,147 @@ namespace irgen {
   inline TranslationDirection reverse(TranslationDirection direction) {
     return TranslationDirection(!bool(direction));
   }
+
+  // struct SwiftContext {
+  //   SwiftContext * __ptrauth(...) callerContext;
+  //   SwiftPartialFunction * __ptrauth(...) returnToCaller;
+  //   SwiftActor * __ptrauth(...) callerActor;
+  //   SwiftPartialFunction * __ptrauth(...) yieldToCaller?;
+  //   SwiftError *errorResult;
+  //   IndirectResultTypes *indirectResults...;
+  //   SelfType self?;
+  //   ArgTypes formalArguments...;
+  //   union {
+  //     struct {
+  //       SwiftPartialFunction * __ptrauth(...) resumeFromYield?;
+  //       SwiftPartialFunction * __ptrauth(...) abortFromYield?;
+  //       SwiftActor * __ptrauth(...) calleeActorDuringYield?;
+  //       YieldTypes yieldValues...;
+  //     };
+  //     ResultTypes directResults...;
+  //   };
+  // };
+  struct AsyncContextLayout : StructLayout {
+    struct ArgumentInfo {
+      SILType type;
+      ParameterConvention convention;
+    };
+
+  private:
+    enum class FixedIndex : unsigned {
+      Error = 0,
+    };
+    enum class FixedCount : unsigned {
+      Error = 1,
+    };
+    IRGenFunction &IGF;
+    CanSILFunctionType originalType;
+    CanSILFunctionType substitutedType;
+    SubstitutionMap substitutionMap;
+    SILType errorType;
+    bool canHaveValidError;
+    SmallVector<SILResultInfo, 4> directReturnInfos;
+    SmallVector<SILResultInfo, 4> indirectReturnInfos;
+    Optional<ArgumentInfo> localContextInfo;
+    NecessaryBindings bindings;
+    SmallVector<ArgumentInfo, 4> argumentInfos;
+
+  public:
+    bool canHaveError() { return canHaveValidError; }
+    unsigned getErrorIndex() { return (unsigned)FixedIndex::Error; }
+    ElementLayout getErrorLayout() { return getElement(getErrorIndex()); }
+    unsigned getErrorCount() { return (unsigned)FixedCount::Error; }
+    SILType getErrorType() { return errorType; }
+
+    unsigned getFirstIndirectReturnIndex() {
+      return getErrorIndex() + getErrorCount();
+    }
+    ElementLayout getIndirectReturnLayout(unsigned index) {
+      return getElement(getFirstIndirectReturnIndex() + index);
+    }
+    unsigned getIndirectReturnCount() { return indirectReturnInfos.size(); }
+
+    bool hasLocalContext() { return (bool)localContextInfo; }
+    unsigned getLocalContextIndex() {
+      assert(hasLocalContext());
+      return getFirstIndirectReturnIndex() + getIndirectReturnCount();
+    }
+    ElementLayout getLocalContextLayout() {
+      assert(hasLocalContext());
+      return getElement(getLocalContextIndex());
+    }
+    ParameterConvention getLocalContextConvention() {
+      assert(hasLocalContext());
+      return localContextInfo->convention;
+    }
+    SILType getLocalContextType() {
+      assert(hasLocalContext());
+      return localContextInfo->type;
+    }
+    unsigned getIndexAfterLocalContext() {
+      return getFirstIndirectReturnIndex() + getIndirectReturnCount() +
+             (hasLocalContext() ? 1 : 0);
+    }
+
+    bool hasBindings() const { return !bindings.empty(); }
+    unsigned getBindingsIndex() {
+      assert(hasBindings());
+      return getIndexAfterLocalContext();
+    }
+    ElementLayout getBindingsLayout() {
+      assert(hasBindings());
+      return getElement(getBindingsIndex());
+    }
+    ParameterConvention getBindingsConvention() {
+      return ParameterConvention::Direct_Unowned;
+    }
+    const NecessaryBindings &getBindings() const { return bindings; }
+
+    unsigned getFirstArgumentIndex() {
+      return getIndexAfterLocalContext() + (hasBindings() ? 1 : 0);
+    }
+    ElementLayout getArgumentLayout(unsigned index) {
+      return getElement(getFirstArgumentIndex() + index);
+    }
+    ParameterConvention getArgumentConvention(unsigned index) {
+      return argumentInfos[index].convention;
+    }
+    SILType getArgumentType(unsigned index) {
+      return argumentInfos[index].type;
+    }
+    SILType getParameterType(unsigned index) {
+      SILFunctionConventions origConv(substitutedType, IGF.getSILModule());
+      return origConv.getSILArgumentType(
+          index, IGF.IGM.getMaximalTypeExpansionContext());
+    }
+    unsigned getArgumentCount() { return argumentInfos.size(); }
+    unsigned getIndexAfterArguments() {
+      return getFirstArgumentIndex() + getArgumentCount();
+    }
+
+    unsigned getFirstDirectReturnIndex() { return getIndexAfterArguments(); }
+
+    AsyncContextLayout(IRGenModule &IGM, LayoutStrategy strategy,
+                       ArrayRef<SILType> fieldTypes,
+                       ArrayRef<const TypeInfo *> fieldTypeInfos,
+                       IRGenFunction &IGF, CanSILFunctionType originalType,
+                       CanSILFunctionType substitutedType,
+                       SubstitutionMap substitutionMap,
+                       NecessaryBindings &&bindings, SILType errorType,
+                       bool canHaveValidError,
+                       ArrayRef<ArgumentInfo> argumentInfos,
+                       ArrayRef<SILResultInfo> directReturnInfos,
+                       ArrayRef<SILResultInfo> indirectReturnInfos,
+                       Optional<ArgumentInfo> localContextInfo);
+  };
+
+  AsyncContextLayout getAsyncContextLayout(IRGenFunction &IGF,
+                                           SILFunction *function);
+
+  AsyncContextLayout getAsyncContextLayout(IRGenFunction &IGF,
+                                           CanSILFunctionType originalType,
+                                           CanSILFunctionType substitutedType,
+                                           SubstitutionMap substitutionMap);
 
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention);
@@ -127,15 +273,24 @@ namespace irgen {
 
   Address emitAllocYieldOnceCoroutineBuffer(IRGenFunction &IGF);
   void emitDeallocYieldOnceCoroutineBuffer(IRGenFunction &IGF, Address buffer);
-  void emitYieldOnceCoroutineEntry(IRGenFunction &IGF,
-                                   CanSILFunctionType coroutineType,
-                                   Explosion &allParams);
+  void
+  emitYieldOnceCoroutineEntry(IRGenFunction &IGF,
+                              CanSILFunctionType coroutineType,
+                              NativeCCEntryPointArgumentEmission &emission);
 
   Address emitAllocYieldManyCoroutineBuffer(IRGenFunction &IGF);
   void emitDeallocYieldManyCoroutineBuffer(IRGenFunction &IGF, Address buffer);
-  void emitYieldManyCoroutineEntry(IRGenFunction &IGF,
-                                   CanSILFunctionType coroutineType,
-                                   Explosion &allParams);
+  void
+  emitYieldManyCoroutineEntry(IRGenFunction &IGF,
+                              CanSILFunctionType coroutineType,
+                              NativeCCEntryPointArgumentEmission &emission);
+
+  Address emitTaskAlloc(IRGenFunction &IGF, llvm::Value *size,
+                        Alignment alignment);
+  void emitTaskDealloc(IRGenFunction &IGF, Address address, llvm::Value *size);
+  std::pair<Address, Size> emitAllocAsyncContext(IRGenFunction &IGF,
+                                                 AsyncContextLayout layout);
+  void emitDeallocAsyncContext(IRGenFunction &IGF, Address context, Size size);
 
   /// Yield the given values from the current continuation.
   ///

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -189,6 +189,7 @@ namespace {
   class FuncTypeInfo :
       public ScalarPairTypeInfo<FuncTypeInfo, ReferenceTypeInfo>,
       public FuncSignatureInfo {
+  protected:
     FuncTypeInfo(CanSILFunctionType formalType, llvm::StructType *storageType,
                  Size size, Alignment align, SpareBitVector &&spareBits,
                  IsPOD_t pod)
@@ -655,7 +656,7 @@ static void emitApplyArgument(IRGenFunction &IGF,
                         out);
 }
 
-static CanType getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
+CanType irgen::getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
                                        bool isNoEscape) {
   switch (paramInfo.getConvention()) {
   // Capture value parameters by value, consuming them.

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -53,6 +53,8 @@ namespace irgen {
       ArrayRef<SILParameterInfo> argTypes, SubstitutionMap subs,
       CanSILFunctionType origType, CanSILFunctionType substType,
       CanSILFunctionType outType, Explosion &out, bool isOutlined);
+  CanType getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
+                                  bool isNoEscape);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -46,6 +46,7 @@ namespace irgen {
   class IRGenModule;
   class MetadataPath;
   class MetadataResponse;
+  class NativeCCEntryPointArgumentEmission;
   class ProtocolInfo;
   class TypeInfo;
 
@@ -120,9 +121,10 @@ namespace irgen {
 
   /// Collect any required metadata for a witness method from the end
   /// of the given parameter list.
-  void collectTrailingWitnessMetadata(IRGenFunction &IGF, SILFunction &fn,
-                                      Explosion &params,
-                                      WitnessMetadata &metadata);
+  void
+  collectTrailingWitnessMetadata(IRGenFunction &IGF, SILFunction &fn,
+                                 NativeCCEntryPointArgumentEmission &params,
+                                 WitnessMetadata &metadata);
 
   using GetParameterFn = llvm::function_ref<llvm::Value*(unsigned)>;
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -587,6 +587,11 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   DynamicReplacementKeyTy = createStructType(*this, "swift.dyn_repl_key",
                                              {RelativeAddressTy, Int32Ty});
 
+  SwiftContextTy = createStructType(*this, "swift.context", {});
+  SwiftTaskTy = createStructType(*this, "swift.task", {});
+  SwiftContextPtrTy = SwiftContextTy->getPointerTo(DefaultAS);
+  SwiftTaskPtrTy = SwiftTaskTy->getPointerTo(DefaultAS);
+
   DifferentiabilityWitnessTy = createStructType(
       *this, "swift.differentiability_witness", {Int8PtrTy, Int8PtrTy});
 }
@@ -676,6 +681,14 @@ namespace RuntimeConstants {
   GetCanonicalSpecializedMetadataAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getIntermodulePrespecializedGenericMetadataAvailability();
+    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+      return RuntimeAvailability::ConditionallyAvailable;
+    }
+    return RuntimeAvailability::AlwaysAvailable;
+  }
+
+  RuntimeAvailability ConcurrencyAvailability(ASTContext &context) {
+    auto featureAvailability = context.getConcurrencyAvailability();
     if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -723,6 +723,11 @@ public:
       *DynamicReplacementLinkEntryPtrTy; // %link_entry*
   llvm::StructType *DynamicReplacementKeyTy; // { i32, i32}
 
+  llvm::StructType *SwiftContextTy;
+  llvm::StructType *SwiftTaskTy;
+  llvm::PointerType *SwiftContextPtrTy;
+  llvm::PointerType *SwiftTaskPtrTy;
+
   llvm::StructType *DifferentiabilityWitnessTy; // { i8*, i8* }
 
   llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -406,6 +406,9 @@ public:
   llvm::SmallVector<llvm::BasicBlock *, 8> FailBBs;
 
   SILFunction *CurSILFn;
+  // If valid, the address by means of which a return--which is direct in
+  // SIL--is passed indirectly in IR.  Such indirection is necessary when the
+  // value which would be returned directly cannot fit into registers.
   Address IndirectReturn;
 
   /// The unique block that calls @llvm.coro.end.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -55,6 +55,7 @@
 #include "llvm/Transforms/Utils/Local.h"
 
 #include "CallEmission.h"
+#include "EntryPointArgumentEmission.h"
 #include "Explosion.h"
 #include "GenArchetype.h"
 #include "GenBuiltin.h"
@@ -70,8 +71,8 @@
 #include "GenIntegerLiteral.h"
 #include "GenObjC.h"
 #include "GenOpaque.h"
-#include "GenPoly.h"
 #include "GenPointerAuth.h"
+#include "GenPoly.h"
 #include "GenProto.h"
 #include "GenStruct.h"
 #include "GenTuple.h"
@@ -1119,6 +1120,188 @@ public:
 
 } // end anonymous namespace
 
+static AsyncContextLayout getAsyncContextLayout(IRGenSILFunction &IGF) {
+  return getAsyncContextLayout(IGF, IGF.CurSILFn);
+}
+
+namespace {
+class SyncEntryPointArgumentEmission
+    : public virtual EntryPointArgumentEmission {
+protected:
+  IRGenSILFunction &IGF;
+  SILBasicBlock &entry;
+  Explosion &allParamValues;
+  SyncEntryPointArgumentEmission(IRGenSILFunction &IGF, SILBasicBlock &entry,
+                                 Explosion &allParamValues)
+      : IGF(IGF), entry(entry), allParamValues(allParamValues){};
+
+public:
+  bool requiresIndirectResult(SILType retType) override {
+    auto &schema =
+        IGF.IGM.getTypeInfo(retType).nativeReturnValueSchema(IGF.IGM);
+    return schema.requiresIndirect();
+  }
+  llvm::Value *getIndirectResultForFormallyDirectResult() override {
+    return allParamValues.claimNext();
+  }
+  llvm::Value *getIndirectResult(unsigned index) override {
+    return allParamValues.claimNext();
+  };
+};
+class AsyncEntryPointArgumentEmission
+    : public virtual EntryPointArgumentEmission {
+protected:
+  IRGenSILFunction &IGF;
+  SILBasicBlock &entry;
+  Explosion &allParamValues;
+  AsyncEntryPointArgumentEmission(IRGenSILFunction &IGF, SILBasicBlock &entry,
+                                  Explosion &allParamValues)
+      : IGF(IGF), entry(entry), allParamValues(allParamValues){};
+};
+
+class COrObjCEntryPointArgumentEmission
+    : public virtual EntryPointArgumentEmission {};
+
+class SyncCOrObjCEntryPointArgumentEmission
+    : public SyncEntryPointArgumentEmission,
+      public COrObjCEntryPointArgumentEmission {
+public:
+  SyncCOrObjCEntryPointArgumentEmission(IRGenSILFunction &_IGF,
+                                        SILBasicBlock &_entry,
+                                        Explosion &_allParamValues)
+      : SyncEntryPointArgumentEmission(_IGF, _entry, _allParamValues){};
+};
+
+class SyncNativeCCEntryPointArgumentEmission final
+    : public NativeCCEntryPointArgumentEmission,
+      public SyncEntryPointArgumentEmission {
+public:
+  SyncNativeCCEntryPointArgumentEmission(IRGenSILFunction &_IGF,
+                                         SILBasicBlock &_entry,
+                                         Explosion &_allParamValues)
+      : SyncEntryPointArgumentEmission(_IGF, _entry, _allParamValues){};
+
+  llvm::Value *getCallerErrorResultArgument() override {
+    return allParamValues.takeLast();
+  }
+  llvm::Value *getContext() override { return allParamValues.takeLast(); }
+  Explosion getArgumentExplosion(unsigned index, unsigned size) override {
+    assert(size > 0);
+    Explosion result;
+    allParamValues.transferInto(result, size);
+    return result;
+  }
+  llvm::Value *getSelfWitnessTable() override {
+    return allParamValues.takeLast();
+  }
+  llvm::Value *getSelfMetadata() override { return allParamValues.takeLast(); }
+  llvm::Value *getCoroutineBuffer() override {
+    return allParamValues.claimNext();
+  }
+};
+
+class AsyncNativeCCEntryPointArgumentEmission final
+    : public NativeCCEntryPointArgumentEmission,
+      public AsyncEntryPointArgumentEmission {
+  llvm::Value *context;
+  /*const*/ AsyncContextLayout layout;
+  const Address dataAddr;
+
+public:
+  AsyncNativeCCEntryPointArgumentEmission(IRGenSILFunction &IGF,
+                                          SILBasicBlock &entry,
+                                          Explosion &allParamValues)
+      : AsyncEntryPointArgumentEmission(IGF, entry, allParamValues),
+        context(allParamValues.claimNext()), layout(getAsyncContextLayout(IGF)),
+        dataAddr(layout.emitCastTo(IGF, context)){};
+
+  llvm::Value *getCallerErrorResultArgument() override {
+    auto errorLayout = layout.getErrorLayout();
+    Address addr = errorLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+    return addr.getAddress();
+  }
+  llvm::Value *getErrorResultAddrForCall() {
+    auto errorLayout = layout.getErrorLayout();
+    auto &ti = cast<LoadableTypeInfo>(errorLayout.getType());
+    auto allocaAddr = ti.allocateStack(IGF, layout.getErrorType(), "arg");
+    auto addrInContext =
+        layout.getErrorLayout().project(IGF, dataAddr, /*offsets*/ llvm::None);
+    Explosion explosion;
+    ti.loadAsTake(IGF, addrInContext, explosion);
+    ti.initialize(IGF, explosion, allocaAddr.getAddress(),
+                  /*isOutlined*/ false);
+    return allocaAddr.getAddress().getAddress();
+  }
+  llvm::Value *getContext() override {
+    auto contextLayout = layout.getLocalContextLayout();
+    Address addr = contextLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+    auto &ti = cast<LoadableTypeInfo>(contextLayout.getType());
+    Explosion explosion;
+    ti.loadAsTake(IGF, addr, explosion);
+    return explosion.claimNext();
+  }
+  Explosion getArgumentExplosion(unsigned index, unsigned size) override {
+    assert(size > 0);
+    Explosion result;
+    for (unsigned i = index, end = index + size; i < end; ++i) {
+      auto argumentLayout = layout.getArgumentLayout(i);
+      auto addr = argumentLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+      auto &ti = cast<LoadableTypeInfo>(argumentLayout.getType());
+      Explosion explosion;
+      ti.loadAsTake(IGF, addr, explosion);
+      result.add(explosion.claimAll());
+    }
+    return result;
+  }
+  bool requiresIndirectResult(SILType retType) override { return false; }
+  llvm::Value *getIndirectResultForFormallyDirectResult() override {
+    llvm_unreachable("async function do not need to lower direct SIL results "
+                     "into indirect IR results because all results are already "
+                     "indirected through the context");
+  }
+  llvm::Value *getIndirectResult(unsigned index) override {
+    Address dataAddr = layout.emitCastTo(IGF, context);
+    unsigned baseIndirectReturnIndex = layout.getFirstIndirectReturnIndex();
+    unsigned elementIndex = baseIndirectReturnIndex + index;
+    auto &fieldLayout = layout.getElement(elementIndex);
+    Address fieldAddr =
+        fieldLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+    return IGF.Builder.CreateLoad(fieldAddr);
+  };
+  llvm::Value *getSelfWitnessTable() override {
+    llvm_unreachable("unimplemented");
+  }
+  llvm::Value *getSelfMetadata() override { llvm_unreachable("unimplemented"); }
+  llvm::Value *getCoroutineBuffer() override {
+    llvm_unreachable("unimplemented");
+  }
+};
+
+std::unique_ptr<NativeCCEntryPointArgumentEmission>
+getNativeCCEntryPointArgumentEmission(IRGenSILFunction &IGF,
+                                      SILBasicBlock &entry,
+                                      Explosion &allParamValues) {
+  if (IGF.CurSILFn->isAsync()) {
+    return std::make_unique<AsyncNativeCCEntryPointArgumentEmission>(
+        IGF, entry, allParamValues);
+  } else {
+    return std::make_unique<SyncNativeCCEntryPointArgumentEmission>(
+        IGF, entry, allParamValues);
+  }
+}
+std::unique_ptr<COrObjCEntryPointArgumentEmission>
+getCOrObjCEntryPointArgumentEmission(IRGenSILFunction &IGF,
+                                     SILBasicBlock &entry,
+                                     Explosion &allParamValues) {
+  if (IGF.CurSILFn->isAsync()) {
+    llvm_unreachable("unsupported");
+  } else {
+    return std::make_unique<SyncCOrObjCEntryPointArgumentEmission>(
+        IGF, entry, allParamValues);
+  }
+}
+} // end anonymous namespace
+
 void LoweredValue::getExplosion(IRGenFunction &IGF, SILType type,
                                 Explosion &ex) const {
   switch (kind) {
@@ -1221,6 +1404,8 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
   if (f->isDynamicallyReplaceable()) {
     IGM.createReplaceableProlog(*this, f);
   }
+
+  setAsync(f->getLoweredFunctionType()->isAsync());
 }
 
 IRGenSILFunction::~IRGenSILFunction() {
@@ -1303,22 +1488,24 @@ static void addIncomingExplosionToPHINodes(IRGenSILFunction &IGF,
                                            Explosion &argValue);
 
 // TODO: Handle this during SIL AddressLowering.
-static ArrayRef<SILArgument*> emitEntryPointIndirectReturn(
-                                 IRGenSILFunction &IGF,
-                                 SILBasicBlock *entry,
-                                 Explosion &params,
-                                 CanSILFunctionType funcTy,
-                    llvm::function_ref<bool(SILType)> requiresIndirectResult) {
+static ArrayRef<SILArgument *> emitEntryPointIndirectReturn(
+    EntryPointArgumentEmission &emission, IRGenSILFunction &IGF,
+    SILBasicBlock *entry, CanSILFunctionType funcTy,
+    llvm::function_ref<bool(SILType)> requiresIndirectResult) {
   // Map an indirect return for a type SIL considers loadable but still
   // requires an indirect return at the IR level.
   SILFunctionConventions fnConv(funcTy, IGF.getSILModule());
   SILType directResultType = IGF.CurSILFn->mapTypeIntoContext(
       fnConv.getSILResultType(IGF.IGM.getMaximalTypeExpansionContext()));
   if (requiresIndirectResult(directResultType)) {
+    assert(!IGF.CurSILFn->isAsync() &&
+           "async function do not need to lower direct SIL results into "
+           "indirect IR results because all results are already indirected "
+           "through the context");
     auto &paramTI = IGF.IGM.getTypeInfo(directResultType);
     auto &retTI =
         IGF.IGM.getTypeInfo(IGF.getLoweredTypeInContext(directResultType));
-    auto ptr = params.claimNext();
+    auto ptr = emission.getIndirectResultForFormallyDirectResult();
     if (paramTI.getStorageType() != retTI.getStorageType()) {
       assert(directResultType.getASTType()->hasOpaqueArchetype());
       ptr = IGF.Builder.CreateBitCast(ptr,
@@ -1338,10 +1525,11 @@ static ArrayRef<SILArgument*> emitEntryPointIndirectReturn(
     auto inContextResultType =
         IGF.CurSILFn->mapTypeIntoContext(indirectResultType);
     auto &retTI = IGF.IGM.getTypeInfo(ret->getType());
+    auto &paramTI = IGF.IGM.getTypeInfo(inContextResultType);
+
     // The parameter's type might be different due to looking through opaque
     // archetypes.
-    auto ptr = params.claimNext();
-    auto &paramTI = IGF.IGM.getTypeInfo(inContextResultType);
+    llvm::Value *ptr = emission.getIndirectResult(idx);
     if (paramTI.getStorageType() != retTI.getStorageType()) {
       assert(inContextResultType.getASTType()->hasOpaqueArchetype());
       ptr = IGF.Builder.CreateBitCast(ptr,
@@ -1356,10 +1544,10 @@ static ArrayRef<SILArgument*> emitEntryPointIndirectReturn(
   return bbargs.slice(numIndirectResults);
 }
 
-static void bindParameter(IRGenSILFunction &IGF,
-                          SILArgument *param,
-                          SILType paramTy,
-                          Explosion &allParamValues) {
+template <typename ExplosionForArgument>
+static void bindParameter(IRGenSILFunction &IGF, unsigned index,
+                          SILArgument *param, SILType paramTy,
+                          ExplosionForArgument explosionForArgument) {
   // Pull out the parameter value and its formal type.
   auto &paramTI = IGF.getTypeInfo(IGF.CurSILFn->mapTypeIntoContext(paramTy));
   auto &argTI = IGF.getTypeInfo(param->getType());
@@ -1374,8 +1562,9 @@ static void bindParameter(IRGenSILFunction &IGF,
     // indirect address.
     auto &nativeSchema = argTI.nativeParameterValueSchema(IGF.IGM);
     if (nativeSchema.requiresIndirect()) {
+      Explosion paramExplosion = explosionForArgument(index, 1);
       Address paramAddr =
-          loadableParamTI.getAddressForPointer(allParamValues.claimNext());
+          loadableParamTI.getAddressForPointer(paramExplosion.claimNext());
       if (paramTI.getStorageType() != argTI.getStorageType())
         paramAddr =
             loadableArgTI.getAddressForPointer(IGF.Builder.CreateBitCast(
@@ -1387,7 +1576,9 @@ static void bindParameter(IRGenSILFunction &IGF,
         // Otherwise, we map from the native convention to the type's explosion
         // schema.
         Explosion nativeParam;
-        allParamValues.transferInto(nativeParam, nativeSchema.size());
+        unsigned size = nativeSchema.size();
+        Explosion paramExplosion = explosionForArgument(index, size);
+        paramExplosion.transferInto(nativeParam, size);
         paramValues = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeParam,
                                                  param->getType());
       } else {
@@ -1403,7 +1594,8 @@ static void bindParameter(IRGenSILFunction &IGF,
   // FIXME: that doesn't mean we should physically pass it
   // indirectly at this resilience expansion. An @in or @in_guaranteed parameter
   // could be passed by value in the right resilience domain.
-  auto ptr = allParamValues.claimNext();
+  Explosion paramExplosion = explosionForArgument(index, 1);
+  auto ptr = paramExplosion.claimNext();
   if (paramTI.getStorageType() != argTI.getStorageType()) {
     ptr =
         IGF.Builder.CreateBitCast(ptr, argTI.getStorageType()->getPointerTo());
@@ -1417,36 +1609,36 @@ static void bindParameter(IRGenSILFunction &IGF,
 static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
                                             SILBasicBlock *entry,
                                             Explosion &allParamValues) {
+  auto emission =
+      getNativeCCEntryPointArgumentEmission(IGF, *entry, allParamValues);
   auto funcTy = IGF.CurSILFn->getLoweredFunctionType();
-  
+
   // Map the indirect return if present.
   ArrayRef<SILArgument *> params = emitEntryPointIndirectReturn(
-      IGF, entry, allParamValues, funcTy, [&](SILType retType) -> bool {
-        auto &schema =
-            IGF.IGM.getTypeInfo(retType).nativeReturnValueSchema(IGF.IGM);
-        return schema.requiresIndirect();
+      *emission, IGF, entry, funcTy, [&](SILType retType) -> bool {
+        return emission->requiresIndirectResult(retType);
       });
 
   // The witness method CC passes Self as a final argument.
   WitnessMetadata witnessMetadata;
   if (funcTy->getRepresentation() == SILFunctionTypeRepresentation::WitnessMethod) {
-    collectTrailingWitnessMetadata(IGF, *IGF.CurSILFn, allParamValues,
+    collectTrailingWitnessMetadata(IGF, *IGF.CurSILFn, *emission,
                                    witnessMetadata);
   }
 
   // Bind the error result by popping it off the parameter list.
   if (funcTy->hasErrorResult()) {
-    IGF.setErrorResultSlot(allParamValues.takeLast());
+    IGF.setCallerErrorResultSlot(emission->getCallerErrorResultArgument());
   }
   // The coroutine context should be the first parameter.
   switch (funcTy->getCoroutineKind()) {
   case SILCoroutineKind::None:
     break;
   case SILCoroutineKind::YieldOnce:
-    emitYieldOnceCoroutineEntry(IGF, funcTy, allParamValues);
+    emitYieldOnceCoroutineEntry(IGF, funcTy, *emission);
     break;
   case SILCoroutineKind::YieldMany:
-    emitYieldManyCoroutineEntry(IGF, funcTy, allParamValues);
+    emitYieldManyCoroutineEntry(IGF, funcTy, *emission);
     break;
   }
 
@@ -1458,20 +1650,24 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
     SILArgument *selfParam = params.back();
     params = params.drop_back();
 
-    Explosion selfTemp;
-    selfTemp.add(allParamValues.takeLast());
     bindParameter(
-        IGF, selfParam,
+        IGF, 0, selfParam,
         conv.getSILArgumentType(conv.getNumSILArguments() - 1,
                                 IGF.IGM.getMaximalTypeExpansionContext()),
-        selfTemp);
+        [&](unsigned startIndex, unsigned size) {
+          assert(size == 1);
+          Explosion selfTemp;
+          selfTemp.add(emission->getContext());
+          return selfTemp;
+        });
 
     // Even if we don't have a 'self', if we have an error result, we
     // should have a placeholder argument here.
   } else if (funcTy->hasErrorResult() ||
            funcTy->getRepresentation() == SILFunctionTypeRepresentation::Thick)
   {
-    llvm::Value *contextPtr = allParamValues.takeLast(); (void) contextPtr;
+    llvm::Value *contextPtr = emission->getContext();
+    (void)contextPtr;
     assert(contextPtr->getType() == IGF.IGM.RefCountedPtrTy);
   }
 
@@ -1479,10 +1675,12 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
   unsigned i = 0;
   for (SILArgument *param : params) {
     auto argIdx = conv.getSILArgIndexOfFirstParam() + i;
-    bindParameter(IGF, param,
+    bindParameter(IGF, i, param,
                   conv.getSILArgumentType(
                       argIdx, IGF.IGM.getMaximalTypeExpansionContext()),
-                  allParamValues);
+                  [&](unsigned index, unsigned size) {
+                    return emission->getArgumentExplosion(index, size);
+                  });
     ++i;
   }
 
@@ -1507,6 +1705,7 @@ static void emitEntryPointArgumentsCOrObjC(IRGenSILFunction &IGF,
                                            SILBasicBlock *entry,
                                            Explosion &params,
                                            CanSILFunctionType funcTy) {
+  auto emission = getCOrObjCEntryPointArgumentEmission(IGF, *entry, params);
   // First, lower the method type.
   ForeignFunctionInfo foreignInfo = IGF.IGM.getForeignFunctionInfo(funcTy);
   assert(foreignInfo.ClangInfo);
@@ -1515,9 +1714,8 @@ static void emitEntryPointArgumentsCOrObjC(IRGenSILFunction &IGF,
   // Okay, start processing the parameters explosion.
 
   // First, claim all the indirect results.
-  ArrayRef<SILArgument*> args
-    = emitEntryPointIndirectReturn(IGF, entry, params, funcTy,
-      [&](SILType directResultType) -> bool {
+  ArrayRef<SILArgument *> args = emitEntryPointIndirectReturn(
+      *emission, IGF, entry, funcTy, [&](SILType directResultType) -> bool {
         return FI.getReturnInfo().isIndirect();
       });
 
@@ -2342,14 +2540,11 @@ Callee LoweredValue::getCallee(IRGenFunction &IGF,
   llvm_unreachable("bad kind");
 }
 
-static CallEmission getCallEmissionForLoweredValue(IRGenSILFunction &IGF,
-                                         CanSILFunctionType origCalleeType,
-                                         CanSILFunctionType substCalleeType,
-                                         const LoweredValue &lv,
-                                         llvm::Value *selfValue,
-                                         SubstitutionMap substitutions,
-                                         WitnessMetadata *witnessMetadata,
-                                         Explosion &args) {
+static std::unique_ptr<CallEmission> getCallEmissionForLoweredValue(
+    IRGenSILFunction &IGF, CanSILFunctionType origCalleeType,
+    CanSILFunctionType substCalleeType, const LoweredValue &lv,
+    llvm::Value *selfValue, SubstitutionMap substitutions,
+    WitnessMetadata *witnessMetadata) {
   Callee callee = lv.getCallee(IGF, selfValue,
                                CalleeInfo(origCalleeType, substCalleeType,
                                           substitutions));
@@ -2371,10 +2566,10 @@ static CallEmission getCallEmissionForLoweredValue(IRGenSILFunction &IGF,
     break;
   }
 
-  CallEmission callEmission(IGF, std::move(callee));
+  auto callEmission = getCallEmission(IGF, selfValue, std::move(callee));
   if (IGF.CurSILFn->isThunk())
-    callEmission.addAttribute(llvm::AttributeList::FunctionIndex,
-                              llvm::Attribute::NoInline);
+    callEmission->addAttribute(llvm::AttributeList::FunctionIndex,
+                               llvm::Attribute::NoInline);
 
   return callEmission;
 }
@@ -2455,11 +2650,11 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
 
   Explosion llArgs;    
   WitnessMetadata witnessMetadata;
-  CallEmission emission =
-    getCallEmissionForLoweredValue(*this, origCalleeType, substCalleeType,
-                                   calleeLV, selfValue,
-                                   site.getSubstitutionMap(),
-                                   &witnessMetadata, llArgs);
+  auto emission = getCallEmissionForLoweredValue(
+      *this, origCalleeType, substCalleeType, calleeLV, selfValue,
+      site.getSubstitutionMap(), &witnessMetadata);
+
+  emission->begin();
 
   // Lower the arguments and return value in the callee's generic context.
   GenericContextScope scope(IGM, origCalleeType->getInvocationGenericSignature());
@@ -2486,9 +2681,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   
   // Turn the formal SIL parameters into IR-gen things.
   for (auto index : indices(args)) {
-    emitApplyArgument(*this, args[index],
-                      origConv.getSILArgumentType(
-                          index, IGM.getMaximalTypeExpansionContext()),
+    emitApplyArgument(*this, args[index], emission->getParameterType(index),
                       llArgs);
   }
 
@@ -2500,29 +2693,30 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   }
 
   // Add all those arguments.
-  emission.setArgs(llArgs, false, &witnessMetadata);
+  emission->setArgs(llArgs, false, &witnessMetadata);
 
   SILInstruction *i = site.getInstruction();
   
   Explosion result;
-  emission.emitToExplosion(result, false);
+  emission->emitToExplosion(result, false);
 
   // For a simple apply, just bind the apply result to the result of the call.
   if (auto apply = dyn_cast<ApplyInst>(i)) {
     setLoweredExplosion(apply, result);
+    emission->end();
 
   // For begin_apply, we have to destructure the call.
   } else if (auto beginApply = dyn_cast<BeginApplyInst>(i)) {
     // Grab the continuation pointer.  This will still be an i8*.
     auto continuation = result.claimNext();
 
-    setLoweredCoroutine(beginApply->getTokenResult(),
-                        { *coroutineBuffer,
-                          continuation,
-                          emission.claimTemporaries() });
+    setLoweredCoroutine(
+        beginApply->getTokenResult(),
+        {*coroutineBuffer, continuation, emission->claimTemporaries()});
 
     setCorrespondingLoweredValues(beginApply->getYieldedValues(), result);
 
+    emission->end();
   } else {
     auto tryApplyInst = cast<TryApplyInst>(i);
 
@@ -2530,8 +2724,9 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     SILFunctionConventions substConv(substCalleeType, getSILModule());
     SILType errorType =
         substConv.getSILErrorType(IGM.getMaximalTypeExpansionContext());
-    Address errorSlot = getErrorResultSlot(errorType);
-    auto errorValue = Builder.CreateLoad(errorSlot);
+    Address calleeErrorSlot = emission->getCalleeErrorSlot(errorType);
+    auto errorValue = Builder.CreateLoad(calleeErrorSlot);
+    emission->end();
 
     auto &normalDest = getLoweredBB(tryApplyInst->getNormalBB());
     auto &errorDest = getLoweredBB(tryApplyInst->getErrorBB());
@@ -2542,7 +2737,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     if (!tryApplyInst->getErrorBB()->getSinglePredecessorBlock()) {
       // Only do that here if we can't move the store to the error block.
       // See below.
-      Builder.CreateStore(nullError, errorSlot);
+      Builder.CreateStore(nullError, calleeErrorSlot);
     }
 
     // If the error value is non-null, branch to the error destination.
@@ -2563,7 +2758,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
       // that it will become a dead store.
       auto origBB = Builder.GetInsertBlock();
       Builder.SetInsertPoint(errorDest.bb);
-      Builder.CreateStore(nullError, errorSlot);
+      Builder.CreateStore(nullError, calleeErrorSlot);
       Builder.SetInsertPoint(origBB);
     }
   }
@@ -2705,6 +2900,7 @@ static bool isSimplePartialApply(IRGenFunction &IGF, PartialApplyInst *i) {
 }
 
 void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
+  // TODO: Handle async!
   SILValue v(i);
 
   if (isSimplePartialApply(*this, i)) {
@@ -2891,8 +3087,31 @@ static void emitReturnInst(IRGenSILFunction &IGF,
   // Even if SIL has a direct return, the IR-level calling convention may
   // require an indirect return.
   if (IGF.IndirectReturn.isValid()) {
+    assert(!IGF.isAsync());
     auto &retTI = cast<LoadableTypeInfo>(IGF.getTypeInfo(resultTy));
     retTI.initialize(IGF, result, IGF.IndirectReturn, false);
+    IGF.Builder.CreateRetVoid();
+  } else if (IGF.isAsync()) {
+    // If we're generating an async function, store the result into the buffer.
+    assert(!IGF.IndirectReturn.isValid() &&
+           "Formally direct results should stay direct results for async "
+           "functions");
+    Explosion parameters = IGF.collectParameters();
+    llvm::Value *context = parameters.claimNext();
+    auto layout = getAsyncContextLayout(IGF);
+
+    Address dataAddr = layout.emitCastTo(IGF, context);
+    unsigned index = layout.getFirstDirectReturnIndex();
+    for (auto r :
+         IGF.CurSILFn->getLoweredFunctionType()->getDirectFormalResults()) {
+      (void)r;
+      auto &fieldLayout = layout.getElement(index);
+      Address fieldAddr =
+          fieldLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+      cast<LoadableTypeInfo>(fieldLayout.getType())
+          .initialize(IGF, result, fieldAddr, /*isOutlined*/ false);
+      ++index;
+    }
     IGF.Builder.CreateRetVoid();
   } else {
     auto funcLang = IGF.CurSILFn->getLoweredFunctionType()->getLanguage();
@@ -3918,7 +4137,7 @@ void IRGenSILFunction::emitErrorResultVar(CanSILFunctionType FnTy,
   // swifterror in a register.
   if (IGM.IsSwiftErrorInRegister)
     return;
-  auto ErrorResultSlot = getErrorResultSlot(IGM.silConv.getSILType(
+  auto ErrorResultSlot = getCalleeErrorResultSlot(IGM.silConv.getSILType(
       ErrorInfo, FnTy, IGM.getMaximalTypeExpansionContext()));
   auto Var = DbgValue->getVarInfo();
   assert(Var && "error result without debug info");
@@ -4357,8 +4576,9 @@ void IRGenSILFunction::visitAllocStackInst(swift::AllocStackInst *i) {
   dbgname = getVarName(i, IsAnonymous);
 # endif
 
-  auto addr = type.allocateStack(*this, i->getElementType(), dbgname);
-  setLoweredStackAddress(i, addr);
+  auto stackAddr = type.allocateStack(*this, i->getElementType(), dbgname);
+  setLoweredStackAddress(i, stackAddr);
+  Address addr = stackAddr.getAddress();
 
   // Generate Debug Info.
   if (!Decl)
@@ -4369,8 +4589,8 @@ void IRGenSILFunction::visitAllocStackInst(swift::AllocStackInst *i) {
   Type Desugared = Decl->getType()->getDesugaredType();
   if (Desugared->getClassOrBoundGenericClass() ||
       Desugared->getStructOrBoundGenericStruct())
-    zeroInit(dyn_cast<llvm::AllocaInst>(addr.getAddress().getAddress()));
-  emitDebugInfoForAllocStack(i, type, addr.getAddress().getAddress());
+    zeroInit(dyn_cast<llvm::AllocaInst>(addr.getAddress()));
+  emitDebugInfoForAllocStack(i, type, addr.getAddress());
 }
 
 static void

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -41,7 +41,7 @@ namespace irgen {
 /// order to perform some set of operations on a type.
 class NecessaryBindings {
   llvm::SetVector<GenericRequirement> Requirements;
-
+  llvm::DenseMap<GenericRequirement, ProtocolConformanceRef> Conformances;
 
   /// Are the bindings to be computed for a partial apply forwarder.
   /// In the case this is true we need to store/restore the conformance of a
@@ -54,9 +54,9 @@ public:
   
   /// Collect the necessary bindings to invoke a function with the given
   /// signature.
-  static NecessaryBindings forFunctionInvocations(IRGenModule &IGM,
-                                                  CanSILFunctionType origType,
-                                                  SubstitutionMap subs);
+  static NecessaryBindings
+  forAsyncFunctionInvocations(IRGenModule &IGM, CanSILFunctionType origType,
+                              SubstitutionMap subs);
   static NecessaryBindings forPartialApplyForwarder(IRGenModule &IGM,
                                                     CanSILFunctionType origType,
                                                     SubstitutionMap subs,
@@ -69,6 +69,11 @@ public:
   /// Get the requirement from the bindings at index i.
   const GenericRequirement &operator[](size_t i) const {
     return Requirements[i];
+  }
+
+  ProtocolConformanceRef
+  getConformance(const GenericRequirement &requirement) const {
+    return Conformances.lookup(requirement);
   }
 
   size_t size() const {
@@ -95,6 +100,9 @@ public:
   const llvm::SetVector<GenericRequirement> &getRequirements() const {
     return Requirements;
   }
+
+  bool forAsyncFunction() { return !forPartialApply; }
+
 private:
   static NecessaryBindings computeBindings(IRGenModule &IGM,
                                            CanSILFunctionType origType,

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4198,6 +4198,8 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   // Build the uncurried function type.
   if (innerExtInfo.isThrowing())
     extInfo = extInfo.withThrows(true);
+  if (innerExtInfo.isAsync())
+    extInfo = extInfo.withAsync(true);
 
   bridgedParams.push_back(selfParam);
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -31,6 +31,7 @@ set(swift_runtime_sources
     BackDeployment.cpp
     Casting.cpp
     CompatibilityOverride.cpp
+    Concurrency.cpp
     CygwinPort.cpp
     Demangle.cpp
     DynamicCast.cpp

--- a/stdlib/public/runtime/Concurrency.cpp
+++ b/stdlib/public/runtime/Concurrency.cpp
@@ -1,0 +1,37 @@
+//===------------ Concurrency.cpp - Swift Concurrency Support ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementations of the concurrency runtime functions.
+//
+// void *swift_taskAlloc(SwiftTask *task, size_t size);
+// void swift_taskDealloc(SwiftTask *task, void *ptr);
+//
+//===----------------------------------------------------------------------===//
+
+#include "../SwiftShims/Visibility.h"
+#include "swift/Runtime/Config.h"
+#include <cstddef>
+#include <stdlib.h>
+
+struct SwiftTask;
+
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void *swift_taskAlloc(SwiftTask *task, size_t size) {
+  return malloc(size);
+}
+
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void swift_taskDealloc(SwiftTask *task, void *ptr) {
+  free(ptr);
+}

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -1,0 +1,105 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+
+
+
+
+
+class S {
+  func classinstanceSInt64ToVoid(_ int: Int64) async
+  deinit
+  init()
+}
+
+// CHECK-LL: define hidden swiftcc void @classinstanceSInt64ToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @classinstanceSInt64ToVoid : $@async @convention(method) (Int64, @guaranteed S) -> () {
+bb0(%int : $Int64, %instance : $S):
+  %take_s = function_ref @take_S : $@convention(thin) (@guaranteed S) -> ()
+  %result = apply %take_s(%instance) : $@convention(thin) (@guaranteed S) -> ()
+  return %result : $()
+}
+
+sil hidden @take_S : $@convention(thin) (@guaranteed S) -> () {
+bb0(%instance : $S):
+  %any = alloc_stack $Any
+  strong_retain %instance : $S
+  %any_addr = init_existential_addr %any : $*Any, $S
+  store %instance to %any_addr : $*S
+  %print_any = function_ref @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+  %result = apply %print_any(%any) : $@convention(thin) (@in_guaranteed Any) -> ()
+  destroy_addr %any_addr : $*S
+  dealloc_stack %any : $*Any
+  return %result : $()
+}
+
+sil hidden [exact_self_class] @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S {
+bb0(%0 : $@thick S.Type):
+  %1 = alloc_ref $S
+  %2 = function_ref @$S_init : $@convention(method) (@owned S) -> @owned S
+  %3 = apply %2(%1) : $@convention(method) (@owned S) -> @owned S
+  return %3 : $S
+}
+
+sil hidden @$S_init : $@convention(method) (@owned S) -> @owned S {
+bb0(%0 : $S):
+  return %0 : $S
+}
+
+sil hidden @$S_deinit : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject {
+bb0(%0 : $S):
+  %2 = unchecked_ref_cast %0 : $S to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}
+
+sil hidden @S_deallocating_deinit : $@convention(method) (@owned S) -> () {
+bb0(%0 : $S):
+  %2 = function_ref @$S_deinit : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject
+  %3 = apply %2(%0) : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject
+  %4 = unchecked_ref_cast %3 : $Builtin.NativeObject to $S
+  dealloc_ref %4 : $S
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil_vtable S {
+  #S.classinstanceSInt64ToVoid: (S) -> (Int64) async -> () : @classinstanceSInt64ToVoid
+  #S.init!allocator: (S.Type) -> () -> S : @S_allocating_init
+  #S.deinit!deallocator: @S_deallocating_deinit
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %s_type = metatype $@thick S.Type
+  %allocating_init = function_ref @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S
+  %instance = apply %allocating_init(%s_type) : $@convention(method) (@thick S.Type) -> @owned S
+  %classinstanceSInt64ToVoid = class_method %instance : $S, #S.classinstanceSInt64ToVoid : (S) -> (Int64) async -> (), $@convention(method) @async (Int64, @guaranteed S) -> ()
+  strong_retain %instance : $S
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %result = apply %classinstanceSInt64ToVoid(%int, %instance) : $@convention(method) @async (Int64, @guaranteed S) -> () // CHECK: main.S
+  strong_release %instance : $S
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+
+
+

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -1,0 +1,102 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+
+
+
+
+
+class S {
+  func classinstanceSVoidToVoid() async
+  deinit
+  init()
+}
+
+// CHECK-LL: define hidden swiftcc void @classinstanceSVoidToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @classinstanceSVoidToVoid : $@async @convention(method) (@guaranteed S) -> () {
+bb0(%instance : $S):
+  %take_s = function_ref @take_S : $@convention(thin) (@guaranteed S) -> ()
+  %result = apply %take_s(%instance) : $@convention(thin) (@guaranteed S) -> ()
+  return %result : $()
+}
+
+sil hidden @take_S : $@convention(thin) (@guaranteed S) -> () {
+bb0(%instance : $S):
+  %any = alloc_stack $Any
+  strong_retain %instance : $S
+  %any_addr = init_existential_addr %any : $*Any, $S
+  store %instance to %any_addr : $*S
+  %print_any = function_ref @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+  %result = apply %print_any(%any) : $@convention(thin) (@in_guaranteed Any) -> ()
+  destroy_addr %any_addr : $*S
+  dealloc_stack %any : $*Any
+  return %result : $()
+}
+
+sil hidden [exact_self_class] @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S {
+bb0(%0 : $@thick S.Type):
+  %1 = alloc_ref $S
+  %2 = function_ref @$S_init : $@convention(method) (@owned S) -> @owned S
+  %3 = apply %2(%1) : $@convention(method) (@owned S) -> @owned S
+  return %3 : $S
+}
+
+sil hidden @$S_init : $@convention(method) (@owned S) -> @owned S {
+bb0(%0 : $S):
+  return %0 : $S
+}
+
+sil hidden @$S_deinit : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject {
+bb0(%0 : $S):
+  %2 = unchecked_ref_cast %0 : $S to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}
+
+sil hidden @S_deallocating_deinit : $@convention(method) (@owned S) -> () {
+bb0(%0 : $S):
+  %2 = function_ref @$S_deinit : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject
+  %3 = apply %2(%0) : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject
+  %4 = unchecked_ref_cast %3 : $Builtin.NativeObject to $S
+  dealloc_ref %4 : $S
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil_vtable S {
+  #S.classinstanceSVoidToVoid: (S) -> () async -> () : @classinstanceSVoidToVoid
+  #S.init!allocator: (S.Type) -> () -> S : @S_allocating_init
+  #S.deinit!deallocator: @S_deallocating_deinit
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %s_type = metatype $@thick S.Type
+  %allocating_init = function_ref @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S
+  %instance = apply %allocating_init(%s_type) : $@convention(method) (@thick S.Type) -> @owned S
+  %classinstanceSVoidToVoid = class_method %instance : $S, #S.classinstanceSVoidToVoid : (S) -> () async -> (), $@convention(method) @async (@guaranteed S) -> ()
+  strong_retain %instance : $S
+  %result = apply %classinstanceSVoidToVoid(%instance) : $@convention(method) @async (@guaranteed S) -> () // CHECK: main.S
+  strong_release %instance : $S
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+
+

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -1,0 +1,78 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+
+public protocol P {
+}
+
+public struct S : P {
+  @_hasStorage let int: Int64 { get }
+  init(int: Int64)
+}
+
+
+sil_witness_table [serialized] S: P module main {
+}
+
+sil hidden @S_init : $@convention(method) (Int64, @thin S.Type) -> S {
+bb0(%int : $Int64, %S_type : $@thin S.Type):
+  %instance = struct $S (%int : $Int64)
+  return %instance : $S
+}
+
+// CHECK-LL: define hidden swiftcc void @existentialToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @existentialToVoid : $@async @convention(thin) (@in_guaranteed P) -> () {
+bb0(%existential : $*P):
+  %existential_addr = open_existential_addr immutable_access %existential : $*P to $*@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77") P
+  %any = alloc_stack $Any
+  %any_addr = init_existential_addr %any : $*Any, $@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77") P
+  copy_addr %existential_addr to [initialization] %any_addr : $*@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77") P
+  %printAny = function_ref @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+  %result = apply %printAny(%any) : $@convention(thin) (@in_guaranteed Any) -> ()
+  destroy_addr %any : $*Any
+  dealloc_stack %any : $*Any
+  return %result : $()
+}
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %S_type = metatype $@thin S.Type
+  %int_literal = integer_literal $Builtin.Int64, 7384783
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %S_init = function_ref @S_init : $@convention(method) (Int64, @thin S.Type) -> S
+  %instance = apply %S_init(%int, %S_type) : $@convention(method) (Int64, @thin S.Type) -> S
+  %existential = alloc_stack $P, let, name "existential"
+  %existential_addr = init_existential_addr %existential : $*P, $S
+  store %instance to %existential_addr : $*S
+  %existentialToVoid = function_ref @existentialToVoid : $@async @convention(thin) (@in_guaranteed P) -> ()
+  %result = apply %existentialToVoid(%existential) : $@async @convention(thin) (@in_guaranteed P) -> ()
+  destroy_addr %existential : $*P
+  dealloc_stack %existential : $*P
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 7384783
+  %result = apply %call() : $@convention(thin) () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+// CHECK-LL: define hidden swiftcc void @genericToGeneric(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @genericToGeneric : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T {
+bb0(%out : $*T, %in : $*T):
+  copy_addr %in to [initialization] %out : $*T
+  %result = tuple ()
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %int_addr = alloc_stack $Int64
+  store %int to %int_addr : $*Int64
+  %out_addr = alloc_stack $Int64
+
+  %genericToGeneric = function_ref @genericToGeneric : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T
+  %result1 = apply %genericToGeneric<Int64>(%int_addr, %out_addr) : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T
+
+  %print_int = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %out = load %out_addr : $*Int64
+  %result2 = apply %print_int(%out) : $@convention(thin) (Int64) -> () // CHECK: 42
+
+  dealloc_stack %out_addr : $*Int64
+  dealloc_stack %int_addr : $*Int64
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+
+
+
+

--- a/test/IRGen/async/run-call-generic-to-void.sil
+++ b/test/IRGen/async/run-call-generic-to-void.sil
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+// CHECK-LL: define hidden swiftcc void @genericToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @genericToVoid : $@async @convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%instance : $*T):
+  %print_generic = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %print_generic<T>(%instance) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 922337203685477580
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %int_literal = integer_literal $Builtin.Int64, 922337203685477580
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %int_addr = alloc_stack $Int64
+  store %int to %int_addr : $*Int64
+  %genericToVoid = function_ref @genericToVoid : $@async @convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %genericToVoid<Int64>(%int_addr) : $@async @convention(thin) <T> (@in_guaranteed T) -> ()
+  dealloc_stack %int_addr : $*Int64
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+
+
+

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printBool : $@convention(thin) (Bool) -> ()
+
+// CHECK-LL: define hidden swiftcc void @genericEquatableAndGenericEquatableToBool(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @genericEquatableAndGenericEquatableToBool : $@async @convention(thin) <T where T : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool {
+bb0(%0 : $*T, %1 : $*T):
+  %4 = metatype $@thick T.Type
+  %5 = witness_method $T, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %6 = apply %5<T>(%0, %1, %4) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  return %6 : $Bool
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %int1_literal = integer_literal $Builtin.Int64, 42
+  %int1 = struct $Int64 (%int1_literal : $Builtin.Int64)
+  %int1_addr = alloc_stack $Int64
+  store %int1 to %int1_addr : $*Int64
+
+  %int2_literal = integer_literal $Builtin.Int64, 99
+  %int2 = struct $Int64 (%int2_literal : $Builtin.Int64)
+  %int2_addr = alloc_stack $Int64
+  store %int2 to %int2_addr : $*Int64
+
+  %genericEquatableAndGenericEquatableToBool = function_ref @genericEquatableAndGenericEquatableToBool : $@async @convention(thin) <T where T : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool
+  %false = apply %genericEquatableAndGenericEquatableToBool<Int64>(%int1_addr, %int2_addr) : $@async @convention(thin) <T where T : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool
+
+  %print_bool = function_ref @printBool : $@convention(thin) (Bool) -> ()
+  %print_false = apply %print_bool(%false) : $@convention(thin) (Bool) -> () // CHECK: false
+
+  %true = apply %genericEquatableAndGenericEquatableToBool<Int64>(%int1_addr, %int1_addr) : $@async @convention(thin) <T where T : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool
+
+  %print_true = apply %print_bool(%true) : $@convention(thin) (Bool) -> () // CHECK: true
+
+  dealloc_stack %int2_addr : $*Int64
+  dealloc_stack %int1_addr : $*Int64
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @int64AndInt64ToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil @int64AndInt64ToVoid : $@async @convention(thin) (Int64, Int64) -> () {
+entry(%int1: $Int64, %int2: $Int64):
+  %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result1 = apply %print(%int1) : $@convention(thin) (Int64) -> ()  // CHECK: 42
+  %result2 = apply %print(%int2) : $@convention(thin) (Int64) -> ()  // CHECK: 13
+  return %result2 : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %int_literal1 = integer_literal $Builtin.Int64, 42
+  %int1 = struct $Int64 (%int_literal1 : $Builtin.Int64)
+  %int_literal2 = integer_literal $Builtin.Int64, 13
+  %int2 = struct $Int64 (%int_literal2 : $Builtin.Int64)
+
+  %int64AndInt64ToVoid = function_ref @int64AndInt64ToVoid : $@async @convention(thin) (Int64, Int64) -> ()
+  %result = apply %int64AndInt64ToVoid(%int1, %int2) : $@async @convention(thin) (Int64, Int64) -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @int64ToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil @int64ToVoid : $@async @convention(thin) (Int64) -> () {
+entry(%int: $Int64):
+  %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %print(%int) : $@convention(thin) (Int64) -> ()  // CHECK: 42
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %int64ToVoid = function_ref @int64ToVoid : $@async @convention(thin) (Int64) -> ()
+  %result = apply %int64ToVoid(%int) : $@async @convention(thin) (Int64) -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+struct S {
+  @_hasStorage var storage: Int64 { get set }
+  func structinstanceSInt64ToVoid(_ int: Int64)
+  init(storage: Int64)
+}
+
+// CHECK-LL: define hidden swiftcc void @structinstanceSInt64ToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @structinstanceSInt64ToVoid : $@async @convention(method) (Int64, S) -> () {
+bb0(%int : $Int64, %self : $S):
+  %takeSAndInt64 = function_ref @takeSAndInt64 : $@convention(thin) (S, Int64) -> ()
+  %takeSAndInt64_result = apply %takeSAndInt64(%self, %int) : $@convention(thin) (S, Int64) -> ()
+  %out = tuple ()
+  return %out : $()
+}
+
+sil hidden @takeSAndInt64 : $@convention(thin) (S, Int64) -> () {
+bb0(%self : $S, %int : $Int64):
+  %s_addr = alloc_stack $S
+  store %self to %s_addr : $*S
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %printGeneric_result = apply %printGeneric<S>(%s_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // CHECK: S(storage: 987654321)
+  dealloc_stack %s_addr : $*S
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%int) : $@convention(thin) (Int64) -> () // CHECK: 123456789
+  %out = tuple ()
+  return %out : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %s_type = metatype $@thin S.Type
+  %storage_literal = integer_literal $Builtin.Int64, 987654321
+  %storage = struct $Int64 (%storage_literal : $Builtin.Int64)
+  %s = struct $S (%storage : $Int64)
+  %int_literal = integer_literal $Builtin.Int64, 123456789
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %structinstanceSInt64ToVoid = function_ref @structinstanceSInt64ToVoid : $@async @convention(method) (Int64, S) -> ()
+  %result = apply %structinstanceSInt64ToVoid(%int, %s) : $@async @convention(method) (Int64, S) -> ()
+
+  %exitcode_literal = integer_literal $Builtin.Int32, 0
+  %exitcode = struct $Int32 (%exitcode_literal : $Builtin.Int32)
+  return %exitcode : $Int32
+}
+
+
+

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -1,0 +1,126 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+sil @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+sil @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+sil @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+
+struct E : Error {
+  @_hasStorage let code: Int64 { get }
+  init(code: Int64)
+}
+
+sil hidden @E_init : $@convention(method) (Int64, @thin E.Type) -> E {
+bb0(%int : $Int64, %E_type : $@thin E.Type):
+  %instance = struct $E (%int : $Int64)
+  return %instance : $E
+}
+
+sil private [transparent] [thunk] @S_domain_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned String {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  return %2 : $String
+}
+
+
+sil private [transparent] [thunk] @S_code_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> Int {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  return %2 : $Int
+}
+
+sil private [transparent] [thunk] @S_userinfo_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned Optional<AnyObject> {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  return %2 : $Optional<AnyObject>
+}
+
+sil_witness_table hidden E: Error module main {
+  method #Error._domain!getter: <Self where Self : Error> (Self) -> () -> String : @S_domain_getter
+  method #Error._code!getter: <Self where Self : Error> (Self) -> () -> Int : @S_code_getter
+  method #Error._userInfo!getter: <Self where Self : Error> (Self) -> () -> AnyObject? : @S_userinfo_getter
+}
+
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
+  try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb3
+
+bb1(%result_int : $Int):
+  br bb2
+
+bb2:
+  %out = tuple ()
+  return %out : $()
+
+bb3(%result_error : $Error):
+  %error = alloc_stack $Error
+  strong_retain %result_error : $Error
+  store %result_error to %error : $*Error
+  %instance = alloc_stack $E
+  checked_cast_addr_br copy_on_success Error in %error : $*Error to E in %instance : $*E, bb4, bb5
+
+bb4:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  %int_addr = struct_element_addr %instance : $*E, #E.code
+  %int = load %int_addr : $*Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %printInt64(%int) : $@convention(thin) (Int64) -> ()
+  br bb2
+
+bb5:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  br bb2
+}
+
+// CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
+bb0:
+  %e_type = metatype $@thin E.Type
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %E_init = function_ref @E_init : $@convention(method) (Int64, @thin E.Type) -> E
+  %instance = apply %E_init(%int, %e_type) : $@convention(method) (Int64, @thin E.Type) -> E
+  %error = alloc_existential_box $Error, $E
+  %instance_addr = project_existential_box $E in %error : $Error
+  store %instance to %instance_addr : $*E
+  %result = builtin "willThrow"(%error : $Error) : $()
+  throw %error : $Error
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@convention(thin) () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+
+

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -1,0 +1,152 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+sil @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+sil @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+sil @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+
+struct E : Error {
+  @_hasStorage let code: Int64 { get }
+  init(code: Int64)
+}
+
+sil hidden @E_init : $@convention(method) (Int64, @thin E.Type) -> E {
+bb0(%int : $Int64, %E_type : $@thin E.Type):
+  %instance = struct $E (%int : $Int64)
+  return %instance : $E
+}
+
+sil private [transparent] [thunk] @S_domain_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned String {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  return %2 : $String
+}
+
+
+sil private [transparent] [thunk] @S_code_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> Int {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  return %2 : $Int
+}
+
+sil private [transparent] [thunk] @S_userinfo_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned Optional<AnyObject> {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  return %2 : $Optional<AnyObject>
+}
+
+sil_witness_table hidden E: Error module main {
+  method #Error._domain!getter: <Self where Self : Error> (Self) -> () -> String : @S_domain_getter
+  method #Error._code!getter: <Self where Self : Error> (Self) -> () -> Int : @S_code_getter
+  method #Error._userInfo!getter: <Self where Self : Error> (Self) -> () -> AnyObject? : @S_userinfo_getter
+}
+
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
+  try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal bb1, error bb3
+
+bb1(%result_int : $Int64):
+  br bb2
+
+bb2:
+  %out = tuple ()
+  return %out : $()
+
+bb3(%result_error : $Error):
+  %error = alloc_stack $Error
+  strong_retain %result_error : $Error
+  store %result_error to %error : $*Error
+  %instance = alloc_stack $E
+  checked_cast_addr_br copy_on_success Error in %error : $*Error to E in %instance : $*E, bb4, bb5
+
+bb4:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  %int_addr = struct_element_addr %instance : $*E, #E.code
+  %Int64 = load %int_addr : $*Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %printInt64(%Int64) : $@convention(thin) (Int64) -> ()
+  br bb2
+
+bb5:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  br bb2
+}
+
+// CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
+entry:
+  %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
+  try_apply %asyncVoidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal success1, error error1
+success1(%out1 : $Int64):
+  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error)
+  try_apply %syncVoidThrowsToInt() : $@convention(thin) () -> (Int64, @error Error), normal success2, error error2
+success2(%out : $Int64):
+  return %out : $Int64
+error1(%error1 : $Error):
+  br error(%error1 : $Error)
+error2(%error2 : $Error):
+  br error(%error2 : $Error)
+error(%error : $Error):
+  throw %error : $Error
+}
+
+sil hidden @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error) {
+bb0:
+  %e_type = metatype $@thin E.Type
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %Int64 = struct $Int64 (%int_literal : $Builtin.Int64)
+  %E_init = function_ref @E_init : $@convention(method) (Int64, @thin E.Type) -> E
+  %instance = apply %E_init(%Int64, %e_type) : $@convention(method) (Int64, @thin E.Type) -> E
+  %error = alloc_existential_box $Error, $E
+  %instance_addr = project_existential_box $E in %error : $Error
+  store %instance to %instance_addr : $*E
+  %result = builtin "willThrow"(%error : $Error) : $()
+  throw %error : $Error
+}
+
+sil hidden @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
+bb0:
+  %int_literal = integer_literal $Builtin.Int64, 1          // user: %2
+  %Int64 = struct $Int64 (%int_literal : $Builtin.Int64)          // user: %3
+  return %Int64 : $Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@convention(thin) () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+
+
+
+
+

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -1,0 +1,138 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+sil @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+sil @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+sil @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+
+struct E : Error {
+  @_hasStorage let code: Int64 { get }
+  init(code: Int64)
+}
+
+sil hidden @E_init : $@convention(method) (Int64, @thin E.Type) -> E {
+bb0(%int : $Int64, %E_type : $@thin E.Type):
+  %instance = struct $E (%int : $Int64)
+  return %instance : $E
+}
+
+sil private [transparent] [thunk] @S_domain_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned String {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  return %2 : $String
+}
+
+
+sil private [transparent] [thunk] @S_code_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> Int {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  return %2 : $Int
+}
+
+sil private [transparent] [thunk] @S_userinfo_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned Optional<AnyObject> {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  return %2 : $Optional<AnyObject>
+}
+
+sil_witness_table hidden E: Error module main {
+  method #Error._domain!getter: <Self where Self : Error> (Self) -> () -> String : @S_domain_getter
+  method #Error._code!getter: <Self where Self : Error> (Self) -> () -> Int : @S_code_getter
+  method #Error._userInfo!getter: <Self where Self : Error> (Self) -> () -> AnyObject? : @S_userinfo_getter
+}
+
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
+  try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb3
+
+bb1(%result_int : $Int):
+  br bb2
+
+bb2:
+  %out = tuple ()
+  return %out : $()
+
+bb3(%result_error : $Error):
+  %error = alloc_stack $Error
+  strong_retain %result_error : $Error
+  store %result_error to %error : $*Error
+  %instance = alloc_stack $E
+  checked_cast_addr_br copy_on_success Error in %error : $*Error to E in %instance : $*E, bb4, bb5
+
+bb4:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  %int_addr = struct_element_addr %instance : $*E, #E.code
+  %int = load %int_addr : $*Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %printInt64(%int) : $@convention(thin) (Int64) -> ()
+  br bb2
+
+bb5:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  br bb2
+}
+
+// CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
+bb0:
+  %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
+  try_apply %asyncVoidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb2
+bb1(%out : $Int):
+  return %out : $Int
+bb2(%error : $Error):
+  throw %error : $Error
+}
+
+sil hidden @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
+bb0:
+  %e_type = metatype $@thin E.Type
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %E_init = function_ref @E_init : $@convention(method) (Int64, @thin E.Type) -> E
+  %instance = apply %E_init(%int, %e_type) : $@convention(method) (Int64, @thin E.Type) -> E
+  %error = alloc_existential_box $Error, $E
+  %instance_addr = project_existential_box $E in %error : $Error
+  store %instance to %instance_addr : $*E
+  %result = builtin "willThrow"(%error : $Error) : $()
+  throw %error : $Error
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@convention(thin) () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+
+
+
+

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -1,0 +1,153 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+sil @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+sil @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+sil @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+
+struct E : Error {
+  @_hasStorage let code: Int64 { get }
+  init(code: Int64)
+}
+
+sil hidden @E_init : $@convention(method) (Int64, @thin E.Type) -> E {
+bb0(%int : $Int64, %E_type : $@thin E.Type):
+  %instance = struct $E (%int : $Int64)
+  return %instance : $E
+}
+
+sil private [transparent] [thunk] @S_domain_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned String {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  return %2 : $String
+}
+
+
+sil private [transparent] [thunk] @S_code_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> Int {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  return %2 : $Int
+}
+
+sil private [transparent] [thunk] @S_userinfo_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned Optional<AnyObject> {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  return %2 : $Optional<AnyObject>
+}
+
+sil_witness_table hidden E: Error module main {
+  method #Error._domain!getter: <Self where Self : Error> (Self) -> () -> String : @S_domain_getter
+  method #Error._code!getter: <Self where Self : Error> (Self) -> () -> Int : @S_code_getter
+  method #Error._userInfo!getter: <Self where Self : Error> (Self) -> () -> AnyObject? : @S_userinfo_getter
+}
+
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
+  try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal bb1, error bb3
+
+bb1(%result_int : $Int64):
+  br bb2
+
+bb2:
+  %out = tuple ()
+  return %out : $()
+
+bb3(%result_error : $Error):
+  %error = alloc_stack $Error
+  strong_retain %result_error : $Error
+  store %result_error to %error : $*Error
+  %instance = alloc_stack $E
+  checked_cast_addr_br copy_on_success Error in %error : $*Error to E in %instance : $*E, bb4, bb5
+
+bb4:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  %int_addr = struct_element_addr %instance : $*E, #E.code
+  %Int64 = load %int_addr : $*Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %printInt64(%Int64) : $@convention(thin) (Int64) -> ()
+  br bb2
+
+bb5:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  br bb2
+}
+
+// CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
+entry:
+  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error)
+  try_apply %syncVoidThrowsToInt() : $@convention(thin) () -> (Int64, @error Error), normal success1, error error1
+success1(%out1 : $Int64):
+  %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
+  try_apply %asyncVoidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal success2, error error2
+success2(%out : $Int64):
+  return %out : $Int64
+error1(%error1 : $Error):
+  br error(%error1 : $Error)
+error2(%error2 : $Error):
+  br error(%error2 : $Error)
+error(%error : $Error):
+  throw %error : $Error
+}
+
+sil hidden @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error) {
+bb0:
+  %int_literal = integer_literal $Builtin.Int64, 1          // user: %2
+  %Int64 = struct $Int64 (%int_literal : $Builtin.Int64)          // user: %3
+  return %Int64 : $Int64
+}
+
+sil hidden @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
+bb0:
+  %e_type = metatype $@thin E.Type
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %Int64 = struct $Int64 (%int_literal : $Builtin.Int64)
+  %E_init = function_ref @E_init : $@convention(method) (Int64, @thin E.Type) -> E
+  %instance = apply %E_init(%Int64, %e_type) : $@convention(method) (Int64, @thin E.Type) -> E
+  %error = alloc_existential_box $Error, $E
+  %instance_addr = project_existential_box $E in %error : $Error
+  store %instance to %instance_addr : $*E
+  %result = builtin "willThrow"(%error : $Error) : $()
+  throw %error : $Error
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@convention(thin) () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+
+
+
+
+

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -1,0 +1,137 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+sil @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+sil @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+sil @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+
+struct E : Error {
+  @_hasStorage let code: Int64 { get }
+  init(code: Int64)
+}
+
+sil hidden @E_init : $@convention(method) (Int64, @thin E.Type) -> E {
+bb0(%int : $Int64, %E_type : $@thin E.Type):
+  %instance = struct $E (%int : $Int64)
+  return %instance : $E
+}
+
+sil private [transparent] [thunk] @S_domain_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned String {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE7_domainSSvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned String
+  return %2 : $String
+}
+
+
+sil private [transparent] [thunk] @S_code_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> Int {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE5_codeSivg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int
+  return %2 : $Int
+}
+
+sil private [transparent] [thunk] @S_userinfo_getter : $@convention(witness_method: Error) (@in_guaranteed E) -> @owned Optional<AnyObject> {
+bb0(%0 : $*E):
+  %1 = function_ref @$ss5ErrorPsE9_userInfoyXlSgvg : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  %2 = apply %1<E>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> @owned Optional<AnyObject>
+  return %2 : $Optional<AnyObject>
+}
+
+sil_witness_table hidden E: Error module main {
+  method #Error._domain!getter: <Self where Self : Error> (Self) -> () -> String : @S_domain_getter
+  method #Error._code!getter: <Self where Self : Error> (Self) -> () -> Int : @S_code_getter
+  method #Error._userInfo!getter: <Self where Self : Error> (Self) -> () -> AnyObject? : @S_userinfo_getter
+}
+
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
+  try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb3
+
+bb1(%result_int : $Int):
+  br bb2
+
+bb2:
+  %out = tuple ()
+  return %out : $()
+
+bb3(%result_error : $Error):
+  %error = alloc_stack $Error
+  strong_retain %result_error : $Error
+  store %result_error to %error : $*Error
+  %instance = alloc_stack $E
+  checked_cast_addr_br copy_on_success Error in %error : $*Error to E in %instance : $*E, bb4, bb5
+
+bb4:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  %int_addr = struct_element_addr %instance : $*E, #E.code
+  %int = load %int_addr : $*Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %printInt64(%int) : $@convention(thin) (Int64) -> ()
+  br bb2
+
+bb5:
+  dealloc_stack %instance : $*E
+  destroy_addr %error : $*Error
+  dealloc_stack %error : $*Error
+  br bb2
+}
+
+// CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
+bb0:
+  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@convention(thin) () -> (Int, @error Error)
+  try_apply %syncVoidThrowsToInt() : $@convention(thin) () -> (Int, @error Error), normal bb1, error bb2
+bb1(%out : $Int):
+  return %out : $Int
+bb2(%error : $Error):
+  throw %error : $Error
+}
+
+sil hidden @syncVoidThrowsToInt : $@convention(thin) () -> (Int, @error Error) {
+bb0:
+  %e_type = metatype $@thin E.Type
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %E_init = function_ref @E_init : $@convention(method) (Int64, @thin E.Type) -> E
+  %instance = apply %E_init(%int, %e_type) : $@convention(method) (Int64, @thin E.Type) -> E
+  %error = alloc_existential_box $Error, $E
+  %instance_addr = project_existential_box $E in %error : $Error
+  store %instance to %instance_addr : $*E
+  %result = builtin "willThrow"(%error : $Error) : $()
+  throw %error : $Error
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@convention(thin) () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+
+
+

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+
+public protocol P {
+}
+
+public struct S : P {
+  @_hasStorage let int: Int64 { get }
+  init(int: Int64)
+}
+
+sil_witness_table [serialized] S: P module main {
+}
+
+sil hidden @S_init : $@convention(method) (Int64, @thin S.Type) -> S {
+bb0(%int : $Int64, %S_type : $@thin S.Type):
+  %instance = struct $S (%int : $Int64)
+  return %instance : $S
+}
+
+// CHECK-LL: define hidden swiftcc void @voidToExistential(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @voidToExistential : $@async @convention(thin) () -> @out P {
+bb0(%out : $*P):
+  %S_type = metatype $@thin S.Type
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %S_init = function_ref @S_init : $@convention(method) (Int64, @thin S.Type) -> S
+  %instance = apply %S_init(%int, %S_type) : $@convention(method) (Int64, @thin S.Type) -> S
+  %existential = alloc_stack $P
+  %existential_addr = init_existential_addr %existential : $*P, $S
+  store %instance to %existential_addr : $*S
+  copy_addr %existential to [initialization] %out : $*P
+  destroy_addr %existential : $*P
+  dealloc_stack %existential : $*P
+  %result = tuple ()
+  return %result : $()
+}
+
+sil hidden @call : $@convention(thin) () -> () {
+bb0:
+  %existential = alloc_stack $P
+  %voidToExistential = function_ref @voidToExistential : $@async @convention(thin) () -> @out P
+  %voidToExistential_result = apply %voidToExistential(%existential) : $@async @convention(thin) () -> @out P
+  %existential_addr = open_existential_addr immutable_access %existential : $*P to $*@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77") P
+  %any = alloc_stack $Any
+  %any_addr = init_existential_addr %any : $*Any, $@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77") P
+  copy_addr %existential_addr to [initialization] %any_addr : $*@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77") P
+  %printAny = function_ref @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
+  %result = apply %printAny(%any) : $@convention(thin) (@in_guaranteed Any) -> ()
+  destroy_addr %any : $*Any
+  dealloc_stack %any : $*Any
+  destroy_addr %existential : $*P
+  dealloc_stack %existential : $*P
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %call = function_ref @call : $@convention(thin) () -> ()
+  %result = apply %call() : $@convention(thin) () -> () // CHECK: S(int: 42)
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+
+

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @voidToInt64AndInt64(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil @voidToInt64AndInt64 : $@async @convention(thin) () -> (Int64, Int64) {
+  %int_literal1 = integer_literal $Builtin.Int64, 42
+  %int1 = struct $Int64 (%int_literal1 : $Builtin.Int64)
+  %int_literal2 = integer_literal $Builtin.Int64, 13
+  %int2 = struct $Int64 (%int_literal2 : $Builtin.Int64)
+  %tuple = tuple (%int1 : $Int64, %int2 : $Int64)
+  return %tuple : $(Int64, Int64)
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %voidToInt64AndInt64 = function_ref @voidToInt64AndInt64 : $@async @convention(thin) () -> (Int64, Int64)
+  %tuple = apply %voidToInt64AndInt64() : $@async @convention(thin) () -> (Int64, Int64)
+  %int1 = tuple_extract %tuple : $(Int64, Int64), 0
+  %int2 = tuple_extract %tuple : $(Int64, Int64), 1
+
+  %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result1 = apply %print(%int1) : $@convention(thin) (Int64) -> ()  // CHECK: 42
+  %result2 = apply %print(%int2) : $@convention(thin) (Int64) -> ()  // CHECK: 13
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+
+

--- a/test/IRGen/async/run-call-void-to-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64.sil
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @voidToInt64(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil @voidToInt64 : $@async @convention(thin) () -> (Int64) {
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  return %int : $Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %voidToInt64 = function_ref @voidToInt64 : $@async @convention(thin) () -> Int64
+  %int = apply %voidToInt64() : $@async @convention(thin) () -> Int64
+
+  %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %print(%int) : $@convention(thin) (Int64) -> ()  // CHECK: 42
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}
+

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -1,0 +1,132 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+struct Big {
+  @_hasStorage let i1: Int64 { get }
+  @_hasStorage let i2: Int64 { get }
+  @_hasStorage let i3: Int64 { get }
+  @_hasStorage let i4: Int64 { get }
+  @_hasStorage let i5: Int64 { get }
+  @_hasStorage let i6: Int64 { get }
+  @_hasStorage let i7: Int64 { get }
+  @_hasStorage let i8: Int64 { get }
+  @_hasStorage let i9: Int64 { get }
+  @_hasStorage let i0: Int64 { get }
+  init()
+}
+
+sil hidden @Big_init : $@convention(method) (@thin Big.Type) -> Big {
+// %0 "$metatype"
+bb0(%0 : $@thin Big.Type):
+  %1 = alloc_stack $Big, var, name "self"
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  %4 = begin_access [modify] [static] %1 : $*Big
+  %5 = struct_element_addr %4 : $*Big, #Big.i1
+  store %3 to %5 : $*Int64
+  end_access %4 : $*Big
+  %8 = integer_literal $Builtin.Int64, 2
+  %9 = struct $Int64 (%8 : $Builtin.Int64)
+  %10 = begin_access [modify] [static] %1 : $*Big
+  %11 = struct_element_addr %10 : $*Big, #Big.i2
+  store %9 to %11 : $*Int64
+  end_access %10 : $*Big
+  %14 = integer_literal $Builtin.Int64, 3
+  %15 = struct $Int64 (%14 : $Builtin.Int64)
+  %16 = begin_access [modify] [static] %1 : $*Big
+  %17 = struct_element_addr %16 : $*Big, #Big.i3
+  store %15 to %17 : $*Int64
+  end_access %16 : $*Big
+  %20 = integer_literal $Builtin.Int64, 4
+  %21 = struct $Int64 (%20 : $Builtin.Int64)
+  %22 = begin_access [modify] [static] %1 : $*Big
+  %23 = struct_element_addr %22 : $*Big, #Big.i4
+  store %21 to %23 : $*Int64
+  end_access %22 : $*Big
+  %26 = integer_literal $Builtin.Int64, 5
+  %27 = struct $Int64 (%26 : $Builtin.Int64)
+  %28 = begin_access [modify] [static] %1 : $*Big
+  %29 = struct_element_addr %28 : $*Big, #Big.i5
+  store %27 to %29 : $*Int64
+  end_access %28 : $*Big
+  %32 = integer_literal $Builtin.Int64, 6
+  %33 = struct $Int64 (%32 : $Builtin.Int64)
+  %34 = begin_access [modify] [static] %1 : $*Big
+  %35 = struct_element_addr %34 : $*Big, #Big.i6
+  store %33 to %35 : $*Int64
+  end_access %34 : $*Big
+  %38 = integer_literal $Builtin.Int64, 7
+  %39 = struct $Int64 (%38 : $Builtin.Int64)
+  %40 = begin_access [modify] [static] %1 : $*Big
+  %41 = struct_element_addr %40 : $*Big, #Big.i7
+  store %39 to %41 : $*Int64
+  end_access %40 : $*Big
+  %44 = integer_literal $Builtin.Int64, 8
+  %45 = struct $Int64 (%44 : $Builtin.Int64)
+  %46 = begin_access [modify] [static] %1 : $*Big
+  %47 = struct_element_addr %46 : $*Big, #Big.i8
+  store %45 to %47 : $*Int64
+  end_access %46 : $*Big
+  %50 = integer_literal $Builtin.Int64, 9
+  %51 = struct $Int64 (%50 : $Builtin.Int64)
+  %52 = begin_access [modify] [static] %1 : $*Big
+  %53 = struct_element_addr %52 : $*Big, #Big.i9
+  store %51 to %53 : $*Int64
+  end_access %52 : $*Big
+  %56 = integer_literal $Builtin.Int64, 0
+  %57 = struct $Int64 (%56 : $Builtin.Int64)
+  %58 = begin_access [modify] [static] %1 : $*Big
+  %59 = struct_element_addr %58 : $*Big, #Big.i0
+  store %57 to %59 : $*Int64
+  end_access %58 : $*Big
+  %62 = struct $Big (%3 : $Int64, %9 : $Int64, %15 : $Int64, %21 : $Int64, %27 : $Int64, %33 : $Int64, %39 : $Int64, %45 : $Int64, %51 : $Int64, %57 : $Int64)
+  dealloc_stack %1 : $*Big
+  return %62 : $Big
+}
+
+// CHECK-LL: define hidden swiftcc void @getBig(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @getBig : $@async @convention(thin) () -> Big {
+bb0:
+  %0 = metatype $@thin Big.Type
+  // function_ref Big.init()
+  %1 = function_ref @Big_init : $@convention(method) (@thin Big.Type) -> Big
+  %2 = apply %1(%0) : $@convention(method) (@thin Big.Type) -> Big
+  return %2 : $Big
+}
+
+sil hidden @printBig : $@convention(thin) () -> () {
+    %getBig = function_ref @getBig : $@async @convention(thin) () -> Big
+    %big = apply %getBig() : $@async @convention(thin) () -> Big
+    %big_addr = alloc_stack $Big
+    store %big to %big_addr : $*Big
+    %print = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+    %result = apply %print<Big>(%big_addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+    dealloc_stack %big_addr : $*Big
+    %out = tuple ()
+    return %out : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %printBig = function_ref @printBig : $@convention(thin) () -> ()
+  %result = apply %printBig() : $@convention(thin) () -> () // CHECK: Big(i1: 1, i2: 2, i3: 3, i4: 4, i5: 5, i6: 6, i7: 7, i8: 8, i9: 9, i0: 0)
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32                              // id: %4
+}

--- a/test/Inputs/print-shims.swift
+++ b/test/Inputs/print-shims.swift
@@ -1,0 +1,19 @@
+@_silgen_name("printInt64")
+public func printInt64(_ int: Int64) {
+  print(int)
+}
+
+@_silgen_name("printGeneric")
+public func printGeneric<T>(_ t: T) {
+  print(t)
+}
+
+@_silgen_name("printBool")
+public func printBool(_ bool: Bool) {
+  print(bool)
+}
+
+@_silgen_name("printAny")
+public func printAny(_ any: Any) {
+  print(any)
+}


### PR DESCRIPTION
Here, the following is implemented:
- Construction of SwiftContext struct with the fields needed for calling functions.
- Allocating and deallocating these swift context via runtime calls before calling async functions and after returning from them.
- Storing arguments (including bindings and the self parameter but not including protocol fields for witness methods) and returns (both direct (however the convention is currently ignorend) and indirect).
- Wrangling errors.

Additional things that still need to be done:
- interaction between async function contexts and coroutine contexts
- yields from async functions
- partial applies of async functions

To support, a couple of structural changes were helpful:
- addition of a small EntryPointCallingConvention class hierarchy
- addition of a couple of subclasses of CallEmission