### PR TITLE
[windows] XFAIL crash-in-user-code test in MSVC 2017

### DIFF
--- a/test/Frontend/crash-in-user-code.swift
+++ b/test/Frontend/crash-in-user-code.swift
@@ -8,6 +8,8 @@
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
 
+// XFAIL: MSVC_VER=15.0
+
 // CHECK: Stack dump:
 // CHECK-NEXT: Program arguments:
 // CHECK-NEXT: Swift version

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2018,8 +2018,6 @@ if copy_env is not None:
   for key in copy_env.split(':'):
     config.environment[key] = os.environ[key]
 
-lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))
-
 # On macOS reflection information is read through the dyld APIs
 # On other platorms, this information is exported through extra
 # entry points in the Swift runtime that are only available in debug builds.
@@ -2040,3 +2038,9 @@ if kIsWindows:
   config.substitutions.append( ('%diff', 'diff --strip-trailing-cr') )
 else:
   config.substitutions.append( ('%diff', 'diff') )
+
+visual_studio_version = os.environ.get('VisualStudioVersion')
+if kIsWindows and visual_studio_version:
+  config.available_features.add('MSVC_VER=%s' % visual_studio_version)
+
+lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))


### PR DESCRIPTION
See also #33383 where this problem is better explained.

MSVC doesn't seem to trigger the exception code when no frame pointers are generated. The only thing missing would be for interpreted code to have a more informative crash message.

Add a new LLVM Lit feature with the value of the VisualStudioVersion environment variable (it seems to not change even for minor versions, so it is an easy way to figure out the 2017/2019 difference, even if updates are applied).

Use the new feature in a XFAIL check in the test.
