### PR TITLE
Fix use-after-free in SILCombine

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -357,6 +357,11 @@ void getConsumedPartialApplyArgs(PartialApplyInst *pai,
                                  SmallVectorImpl<Operand *> &argOperands,
                                  bool includeTrivialAddrArgs);
 
+/// Emit destroy operation for \p operand, and call appropriate functions from
+/// \p callbacks for newly created instructions and deleted instructions.
+void emitDestroyOperation(SILBuilder &builder, SILLocation loc,
+                          SILValue operand, InstModCallbacks callbacks);
+
 /// Collect all (transitive) users of \p inst which just copy or destroy \p
 /// inst.
 ///
@@ -366,6 +371,7 @@ void getConsumedPartialApplyArgs(PartialApplyInst *pai,
 /// destroys, i.e. if \p inst can be considered as "dead".
 bool collectDestroys(SingleValueInstruction *inst,
                      SmallVectorImpl<SILInstruction *> &destroys);
+
 /// If Closure is a partial_apply or thin_to_thick_function with only local
 /// ref count users and a set of post-dominating releases:
 ///


### PR DESCRIPTION
SILCombine maintains a worklist of instructions and deleting of instructions is valid only via callbacks that remove them from the worklist as well. It calls swift::tryDeleteDeadClosure which in turn calls SILBuilder apis like emitStrongRelease/emitReleaseValue/emitDestroyValue which can delete instructions via SILInstruction::eraseFromParent leaving behind a stale entry in SILCombine's worklist causing a crash.

This PR adds swift::emitDestroyOperation which correctly calls the appropriate InstModCallbacks on added/removed instructions. This comes from swift::releasePartialApplyCapturedArg which was handling creation of destroys with callbacks correctly.
