### PR TITLE
WinSDK: extract System submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -164,13 +164,6 @@ module WinSDK [system] {
     link "NetAPI32.Lib"
   }
 
-  module DbgHelp {
-    header "DbgHelp.h"
-    export *
-
-    link "DbgHelp.Lib"
-  }
-
   module DWM {
     header "dwmapi.h"
     export *
@@ -242,6 +235,20 @@ module WinSDK [system] {
     export *
 
     link "shcore.lib"
+  }
+
+  module System {
+    module DbgHelp {
+      header "DbgHelp.h"
+      export *
+
+      link "DbgHelp.Lib"
+    }
+
+    module IOCTL {
+      header "winioctl.h"
+      export *
+    }
   }
 
   module OLE32 {


### PR DESCRIPTION
Currently `winioctl.h` header gets included into `WinSDK.WinSock2` via `windows.h` & `winscard.h`.
MSDN lists this header in https://docs.microsoft.com/en-us/windows/win32/api/_base/ along with `DbgHelp.h`, so this change also moves `WinSDK.DbgHelp` to the System submodule.