### PR TITLE
[build] Run dsymutil on multiple files at a time

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3049,7 +3049,7 @@ for host in "${ALL_HOSTS[@]}"; do
                grep -v '.py$' | \
                grep -v '.a$' | \
                grep -v 'swift-api-digester' | \
-               xargs -n 1 -P 1 ${dsymutil_path})
+               xargs -P 1 ${dsymutil_path})
 
             # Strip executables, shared libraries and static libraries in
             # `host_install_destdir`.


### PR DESCRIPTION
The change in #33654 had the effect of not leveraging dsymutil
parallelism -- pass instead multiple file at once.

Addresses rdar://69550787