### PR TITLE
Driver: forwarding driver invocations to the new driver when SWIFT_USE_NEW_DRIVER is defined

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -190,5 +190,7 @@ WARNING(warn_drv_darwin_sdk_invalid_settings, none,
     "SDK settings were ignored because 'SDKSettings.json' could not be parsed",
     ())
 
+REMARK(remark_forwarding_to_new_driver, none, "new Swift driver will be used", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"


### PR DESCRIPTION
This allows us to experiment with the new swift-driver without changing build systems.
