### PR TITLE
AccessPath: Look past class casts when finding the reference root.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1201,6 +1201,10 @@ SILBasicBlock::iterator removeBeginAccess(BeginAccessInst *beginAccess);
 
 namespace swift {
 
+/// Return true if \p value is a cast that preserves the identity of the
+/// reference at operand zero.
+bool isRCIdentityPreservingCast(SingleValueInstruction *svi);
+
 /// If \p svi is an access projection, return an address-type operand for the
 /// incoming address.
 ///

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1201,8 +1201,8 @@ SILBasicBlock::iterator removeBeginAccess(BeginAccessInst *beginAccess);
 
 namespace swift {
 
-/// Return true if \p value is a cast that preserves the identity of the
-/// reference at operand zero.
+/// Return true if \p svi is a cast that preserves the identity and
+/// reference-counting equivalence of the reference at operand zero.
 bool isRCIdentityPreservingCast(SingleValueInstruction *svi);
 
 /// If \p svi is an access projection, return an address-type operand for the

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -129,6 +129,9 @@ bool SILType::isPointerSizeAndAligned() {
 //
 // TODO: handle casting to a loadable existential by generating
 // init_existential_ref. Until then, only promote to a heap object dest.
+//
+// This cannot allow trivial-to-reference casts, as required by
+// isRCIdentityPreservingCast.
 bool SILType::canRefCast(SILType operTy, SILType resultTy, SILModule &M) {
   auto fromTy = operTy.unwrapOptionalType();
   auto toTy = resultTy.unwrapOptionalType();

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -365,15 +365,27 @@ bool swift::isLetAddress(SILValue address) {
 //                          MARK: FindReferenceRoot
 //===----------------------------------------------------------------------===//
 
+bool swift::isRCIdentityPreservingCast(SingleValueInstruction *svi) {
+  switch (svi->getKind()) {
+  default:
+    return false;
+  // Ignore ownership casts
+  case SILInstructionKind::CopyValueInst:
+  case SILInstructionKind::BeginBorrowInst:
+  // Ignore class type casts
+  case SILInstructionKind::UpcastInst:
+  case SILInstructionKind::UncheckedRefCastInst:
+  case SILInstructionKind::UnconditionalCheckedCastInst:
+  case SILInstructionKind::UnconditionalCheckedCastValueInst:
+  case SILInstructionKind::RefToBridgeObjectInst:
+  case SILInstructionKind::BridgeObjectToRefInst:
+    return true;
+  }
+}
+
 namespace {
 
 // Essentially RC identity where the starting point is already a reference.
-//
-// FIXME: We cannot currently see through type casts for true RC identity,
-// because property indices are not unique within a class hierarchy. Either fix
-// RefElementAddr::getFieldNo so it returns a unique index, or figure out a
-// different way to encode the property's VarDecl. (Note that the lack of a
-// unique property index could be the source of bugs elsewhere).
 class FindReferenceRoot {
   SmallPtrSet<SILPhiArgument *, 4> visitedPhis;
 
@@ -386,18 +398,13 @@ public:
 
 protected:
   // Return an invalid value for a phi with no resolved inputs.
-  //
-  // FIXME: We should be able to see through RC identity like this:
-  //   nextRoot = stripRCIdentityCasts(nextRoot);
   SILValue recursiveFindRoot(SILValue ref) {
-    while (true) {
-      SILValue nextRoot = ref;
-      nextRoot = stripOwnershipInsts(nextRoot);
-      if (nextRoot == ref)
+    while (auto *svi = dyn_cast<SingleValueInstruction>(ref)) {
+      if (!isRCIdentityPreservingCast(svi)) {
         break;
-      ref = nextRoot;
-    }
-
+      }
+      ref = svi->getOperand(0);
+    };
     auto *phi = dyn_cast<SILPhiArgument>(ref);
     if (!phi || !phi->isPhiArgument()) {
       return ref;
@@ -558,8 +565,16 @@ const ValueDecl *AccessedStorage::getDecl(SILValue base) const {
     return global->getDecl();
 
   case Class: {
-    auto *decl = getObject()->getType().getNominalOrBoundGenericNominal();
-    return decl ? getIndexedField(decl, getPropertyIndex()) : nullptr;
+    // The property index is relative to the VarDecl in ref_element_addr, and
+    // can only be reliably determined when the base is avaiable. Otherwise, we
+    // can only make a best effort to extract it from the object type, which
+    // might not even be a class in the case of bridge objects.
+    if (ClassDecl *classDecl =
+            base ? cast<RefElementAddrInst>(base)->getClassDecl()
+                 : getObject()->getType().getClassOrBoundGenericClass()) {
+      return getIndexedField(classDecl, getPropertyIndex());
+    }
+    return nullptr;
   }
   case Tail:
     return nullptr;
@@ -1297,7 +1312,14 @@ void AccessPathDefUseTraversal::followProjection(SingleValueInstruction *svi,
 AccessPathDefUseTraversal::UseKind
 AccessPathDefUseTraversal::visitSingleValueUser(SingleValueInstruction *svi,
                                                 DFSEntry dfs) {
-  if (isAccessedStorageCast(svi)) {
+  if (dfs.isRef()) {
+    if (isRCIdentityPreservingCast(svi)) {
+      pushUsers(svi, dfs);
+      return IgnoredUse;
+    }
+    // 'svi' will be processed below as either RefElementAddrInst,
+    // RefTailAddrInst, or some unknown LeafUse.
+  } else if (isAccessedStorageCast(svi)) {
     pushUsers(svi, dfs);
     return IgnoredUse;
   }

--- a/test/SILOptimizer/accessed_storage.sil
+++ b/test/SILOptimizer/accessed_storage.sil
@@ -131,14 +131,14 @@ struct MyArray<T> {
 
 // CHECK-LABEL: @arrayValue
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
-// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Tail     %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Base:    %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $Int64
-// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Storage: Tail %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Path:    (@3,#0)
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int64
-// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Tail    %{{.*}} = struct_extract %5 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Base:    %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $Int64
-// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Storage: Tail   %{{.*}} = struct_extract %5 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Path:    (@4,#0)
 sil [ossa] @arrayValue : $@convention(thin) (@guaranteed MyArray<Int64>) -> Int64 {
 bb0(%0 : @guaranteed $MyArray<Int64>):
@@ -191,7 +191,7 @@ bb0(%0 : $Builtin.RawPointer):
 
 // CHECK-LABEL: @staticIndexAddrSubobject
 // CHECK: ###For MemOp:   %5 = load [trivial] %4 : $*Int64
-// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer        // user: %1
+// CHECK: Argument %0 = argument of bb0 : $Builtin.RawPointer
 // CHECK: INVALID
 sil [ossa] @staticIndexAddrSubobject : $@convention(thin) (Builtin.RawPointer) -> () {
 bb0(%0 : $Builtin.RawPointer):
@@ -271,10 +271,10 @@ class B : A {
 // CHECK:   Field: var prop1: Int64 Index: 1
 // CHECK: Path: ()
 // CHECK:   store %0 to %{{.*}} : $*Int64
-// CHECK: Class   %{{.*}} = upcast %{{.*}} : $B to $A
+// CHECK: Class   %{{.*}} = alloc_ref $B
 // CHECK:   Field: var prop0: Int64 Index: 0
 // CHECK: Base:   %{{.*}} = ref_element_addr %{{.*}} : $A, #A.prop0
-// CHECK: Storage: Class   %{{.*}} = upcast %{{.*}} : $B to $A
+// CHECK: Storage: Class   %{{.*}} = alloc_ref $B
 // CHECK:   Field: var prop0: Int64 Index: 0
 // CHECK: Path: ()
 sil @testNonUniquePropertyIndex : $@convention(thin) (Int64) -> () {
@@ -291,21 +291,21 @@ bb0(%0 : $Int64):
 
 // CHECK-LABEL: @testRefTailAndStruct0
 // CHECK: %{{.*}} = load %{{.*}} : $*Builtin.Int64
-// CHECK: Class   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
-// CHECK:   Field: @usableFromInline final var countAndCapacity: _ArrayBody Index: 0
+// CHECK: Class   %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
+// CHECK:  Index: 0
 // CHECK: Base:   %{{.*}} = ref_element_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
-// CHECK: Storage: Class   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
-// CHECK:   Field: @usableFromInline final var countAndCapacity: _ArrayBody Index: 0
+// CHECK: Storage: Class   %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
+// CHECK:  Index: 0
 // CHECK: Path: (#0,#0,#0)
 // CHECK:   %{{.*}} = load %{{.*}} : $*_StringGuts
-// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Tail   %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Base:   %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $String
-// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Storage: Tail   %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Path: (#0)
 // CHECK: %{{.*}} = load %{{.*}} : $*String
-// CHECK: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Tail   %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Base:   %{{.*}} = ref_tail_addr [immutable] %{{.*}} : $__ContiguousArrayStorageBase, $String
-// CHECK: Storage: Tail   %{{.*}} = unchecked_ref_cast %{{.*}} : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+// CHECK: Storage: Tail   %{{.*}} = struct_extract %{{.*}} : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
 // CHECK: Path: ()
 sil hidden [noinline] @testRefTailAndStruct0 : $@convention(thin) (@owned MyArray<String>) -> () {
 bb0(%0 : $MyArray<String>):

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -638,7 +638,7 @@ class BaseClass {
 class SubClass : BaseClass {}
 
 // CHECK-LABEL: @testElementAddressPhiAccess
-// CHECK: [read] [no_nested_conflict] Class %{{.*}} = upcast %0 : $SubClass to $BaseClass
+// CHECK: [read] [no_nested_conflict] Class %{{.*}} = argument of bb0 : $SubClass
 // CHECK: Field: @_hasInitialValue var f: Float
 sil @testElementAddressPhiAccess : $@convention(thin) (@guaranteed SubClass) -> () {
 bb0(%0 : $SubClass):

--- a/test/SILOptimizer/accesspath_uses.sil
+++ b/test/SILOptimizer/accesspath_uses.sil
@@ -706,3 +706,163 @@ bb0(%0 : $*T, %1 : $*T):
   %10 = tuple ()
   return %10 : $()
 }
+
+// Test reference root casts.
+class A {
+  var prop0: Int64
+}
+class B : A {
+  var alsoProp0: Int64
+}
+
+// CHECK-LABEL: @testReferenceRootCast
+// CHECK: ###For MemOp:   store %0 to [[ADR0:%.*]] : $*Int64
+// CHECK: Class  %{{.*}} = alloc_ref $B
+// CHECK: Field: var prop0: Int64 Index: 0
+// CHECK: Base:  [[ADR0]] = ref_element_addr %{{.*}} : $A, #A.prop0
+// CHECK: Storage: Class   %1 = alloc_ref $B
+// CHECK: Field: var prop0: Int64 Index: 0
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  store %0 to [[ADR0]] : $*Int64
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  store %0 to [[ADR0]] : $*Int64
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   store %0 to [[ADR1:%.*]] : $*Int64
+// CHECK-NEXT: Class   %{{.*}} = alloc_ref $B
+// CHECK-NEXT:  Field: var alsoProp0: Int64 Index: 1
+// CHECK-NEXT: Base:   [[ADR1]] = ref_element_addr %10 : $B, #B.alsoProp0
+// CHECK-NEXT: Storage: Class   %{{.*}} = alloc_ref $B
+// CHECK-NEXT:  Field: var alsoProp0: Int64 Index: 1
+// CHECK-NEXT: Path: ()
+// CHECK-NEXT: Exact Uses {
+// CHECK-NEXT:  store %0 to [[ADR1]] : $*Int64
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: Overlapping Uses {
+// CHECK-NEXT:  store %0 to [[ADR1]] : $*Int64
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+sil @testReferenceRootCast : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_ref $B
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = upcast %1 : $B to $A
+  br bb3(%3 : $A)
+
+bb2:
+  %5 = upcast %1 : $B to $A
+  br bb3(%5 : $A)
+
+bb3(%7 : $A):
+  %8 = ref_element_addr %7 : $A, #A.prop0
+  store %0 to %8 : $*Int64
+  %10 = unchecked_ref_cast %7 : $A to $B
+  %11 = ref_element_addr %10 : $B, #B.alsoProp0
+  store %0 to %11 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Test a phi cycle where the phi itself is the root (there is no common phi reference).
+// CHECK-LABEL: @testRootPhiCycle
+// CHECK: ###For MemOp: %{{.*}} = load %{{.*}} : $*Double
+// CHECK: Storage: Tail %{{.*}} = argument of bb3 : $Builtin.BridgeObject
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK: Storage: Tail %{{.*}} = argument of bb3 : $Builtin.BridgeObject
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT: }
+sil @testRootPhiCycle : $@convention(thin) (Builtin.BridgeObject, Builtin.BridgeObject) -> () {
+bb0(%0 : $Builtin.BridgeObject, %1 : $Builtin.BridgeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Builtin.BridgeObject)
+
+bb2:
+  br bb3(%1 : $Builtin.BridgeObject)
+
+bb3(%820 : $Builtin.BridgeObject):
+  %834 = unchecked_ref_cast %820 : $Builtin.BridgeObject to $C
+  %844 = ref_tail_addr [immutable] %834 : $C, $Double
+  %853 = load %844 : $*Double
+  %943 = load %844 : $*Double
+  cond_br undef, bb4, bb5
+
+bb4:
+  br bb3(%820 : $Builtin.BridgeObject)
+
+bb5:
+  %999 = tuple ()
+  return %999 : $()
+}
+
+class C {}
+
+// Test a CoW mutation followed by a phi cycle.
+//
+// Note: FindReferenceRoot currently does not see past CoW mutation,
+// but probably should.
+// CHECK: @testCowMutationPhi
+// CHECK: ###For MemOp:   (%{{.*}}, %{{.*}}) = begin_cow_mutation [native] %0 : $Builtin.BridgeObject
+// CHECK-NEXT: ###For MemOp:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK: Storage: Tail %{{.*}} = argument of bb3 : $Builtin.BridgeObject
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK: Storage: Tail %{{.*}} = argument of bb3 : $Builtin.BridgeObject
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT:   %{{.*}} = load %{{.*}} : $*Double
+// CHECK-NEXT:   Path: ()
+// CHECK-NEXT: }
+sil @testCowMutationPhi : $@convention(thin) (Builtin.BridgeObject) -> () {
+bb0(%0 : $Builtin.BridgeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Builtin.BridgeObject)
+
+bb2:
+  (%3, %4) = begin_cow_mutation [native] %0 : $Builtin.BridgeObject
+  %5 = end_cow_mutation [keep_unique] %4 : $Builtin.BridgeObject
+  br bb3(%5 : $Builtin.BridgeObject)
+
+bb3(%820 : $Builtin.BridgeObject):
+  %834 = unchecked_ref_cast %820 : $Builtin.BridgeObject to $C
+  %844 = ref_tail_addr [immutable] %834 : $C, $Double
+  %853 = load %844 : $*Double
+  %943 = load %844 : $*Double
+  cond_br undef, bb4, bb5
+
+bb4:
+  br bb3(%820 : $Builtin.BridgeObject)
+
+bb5:
+  %999 = tuple ()
+  return %999 : $()
+}


### PR DESCRIPTION
For class storage AccessedStorage is now close to what some passes use
for RC identity, but it still does not look past wrapping references
in an Optional.