### PR TITLE
[android] Add support for building the toolchain for ARMv7

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -291,6 +291,16 @@ function(_add_host_variant_c_compile_flags target)
       target_compile_options(${target} PRIVATE -march=core2)
     endif()
   endif()
+
+  # The LLVM backend is built with these defines on most 32-bit platforms,
+  # llvm/llvm-project@66395c9, which can cause incompatibilities with the Swift
+  # frontend if not built the same way.
+  if("${SWIFT_HOST_VARIANT_ARCH}" MATCHES "armv6|armv7|i686" AND
+     NOT (SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID AND SWIFT_ANDROID_API_LEVEL LESS 24))
+    target_compile_definitions(${target} PRIVATE
+      _LARGEFILE_SOURCE
+      _FILE_OFFSET_BITS=64)
+  endif()
 endfunction()
 
 function(_add_host_variant_link_flags target)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -556,7 +556,7 @@ namespace {
       if (size > 4096)
         return Type();
       
-      SmallVector<TupleTypeElt, 8> elts{size, elementType};
+      SmallVector<TupleTypeElt, 8> elts{static_cast<size_t>(size), elementType};
       return TupleType::get(elts, elementType->getASTContext());
     }
 

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -29,7 +29,7 @@
 
 // Android NDK <r21 do not provide `__aeabi_d2h` in the compiler runtime,
 // provide shims in that case.
-#if (defined(ANDROID) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
+#if (defined(__ANDROID__) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
   ((defined(__i686__) || defined(__x86_64__)) && !defined(__APPLE__))
 
 #include "../SwiftShims/Visibility.h"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -454,6 +454,10 @@ function set_build_options_for_host() {
             SWIFT_HOST_TRIPLE="aarch64-unknown-linux-android"
             llvm_target_arch="AArch64"
             ;;
+        android-armv7)
+            SWIFT_HOST_TRIPLE="armv7-unknown-linux-androideabi"
+            llvm_target_arch="ARM"
+            ;;
         linux-armv6)
             SWIFT_HOST_TRIPLE="armv6-unknown-linux-gnueabihf"
             llvm_target_arch="ARM"


### PR DESCRIPTION
I just shipped a Swift toolchain for Android ARMv7, termux/termux-packages#5843, and these are the changes I had to make. @uraimo and I may be the only people building the Swift compiler for a 32-bit platform anymore, as the ClangImporter static_cast will be needed for all 32-bit platforms.