### PR TITLE
tests: correct availability checks in Interpreter/runtime_name_local_class_opaque_type.swift

### DIFF
--- a/test/Interpreter/runtime_name_local_class_opaque_type.swift
+++ b/test/Interpreter/runtime_name_local_class_opaque_type.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s -o %t/a.out
+// RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
@@ -7,18 +7,27 @@
 
 protocol MyProtocol {}
 
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 func returnsClass1() -> some MyProtocol {
   class MyClass1: MyProtocol {}
   return MyClass1()
 }
 
-var returnsClass2: some MyProtocol {
-  class MyClass2: MyProtocol {}
-  return MyClass2()
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+struct Outer {
+  static var returnsClass2: some MyProtocol {
+    class MyClass2: MyProtocol {}
+    return MyClass2()
+  }
 }
 
-print(returnsClass1())
 // CHECK: a.(unknown context at ${{[0-9a-z]+}}).(unknown context at ${{[0-9a-z]+}}).MyClass1
-
-print(returnsClass2)
-// CHECK: a.(unknown context at ${{[0-9a-z]+}}).(unknown context at ${{[0-9a-z]+}}).MyClass2
+// CHECK: a.Outer.(unknown context at ${{[0-9a-z]+}}).(unknown context at ${{[0-9a-z]+}}).MyClass2
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+  print(returnsClass1())
+  print(Outer.returnsClass2)
+} else {
+  // Make FileCheck happy if this test runs on an older OS.
+  print("a.(unknown context at $0).(unknown context at $0).MyClass1")
+  print("a.Outer.(unknown context at $0).(unknown context at $0).MyClass2")
+}


### PR DESCRIPTION
The test checks a fix, which also affects the runtime.
Therefore, the test requires a minimum OS version to run without a crash.
