### PR TITLE
AST: Find local property wrappers in ASTScope::lookupLocalDecls()

### DIFF
--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -357,17 +357,16 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
   SmallVector<ValueDecl*, 4> ResultValues;
 
   auto &Context = DC->getASTContext();
-  if (Context.LangOpts.DisableParserLookup) {
-    // First, look for a local binding in scope.
-    if (Loc.isValid() && !Name.isOperator()) {
-      SmallVector<ValueDecl *, 2> localDecls;
-      ASTScope::lookupLocalDecls(DC->getParentSourceFile(),
-                                 Name.getFullName(), Loc,
-                                 /*stopAfterInnermostBraceStmt=*/false,
-                                 ResultValues);
-      for (auto *localDecl : ResultValues) {
-        Lookup.add(LookupResultEntry(localDecl), /*isOuter=*/false);
-      }
+
+  // First, look for a local binding in scope.
+  if (Loc.isValid() && !Name.isOperator()) {
+    SmallVector<ValueDecl *, 2> localDecls;
+    ASTScope::lookupLocalDecls(DC->getParentSourceFile(),
+                               Name.getFullName(), Loc,
+                               /*stopAfterInnermostBraceStmt=*/false,
+                               ResultValues);
+    for (auto *localDecl : ResultValues) {
+      Lookup.add(LookupResultEntry(localDecl), /*isOuter=*/false);
     }
   }
 


### PR DESCRIPTION
I broke the build with https://github.com/apple/swift/pull/34135, because @hborla merged a PR and I didn't re-run the tests after that. The problem is there's now another AbstractASTScopeDeclConsumer subclass that needs to handle local property wrappers.

There's a bit of code duplication now; I'm going to clean it up later once CI is unblocked.