### PR TITLE
[build] Remove forced tracing of lldb dotest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2012,7 +2012,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
 
                 # Construct dotest arguments. We use semicolons so CMake interprets this as a list.
-                DOTEST_ARGS="--build-dir;${lldb_build_dir}/lldb-test-build.noindex;${LLDB_TEST_CATEGORIES};-t"
+                DOTEST_ARGS="--build-dir;${lldb_build_dir}/lldb-test-build.noindex;${LLDB_TEST_CATEGORIES}"
 
                 # Only set the extra arguments if they're not empty.
                 if [[ -n "${DOTEST_EXTRA}" ]]; then


### PR DESCRIPTION
Remove `-t` from `DOTEST_ARGS`. This causes verbose output of lldb tests that can't be overridden when calling dotest directly. It appears the initial use of `-t` was introduced for a legacy xcodebuild path in https://github.com/apple/swift/pull/20090, and then the flag got propagated in other dotest related changes.