### PR TITLE
Fix another use-after-free in SILCombine

### DIFF
--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -17,8 +17,9 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_CFG_H
 #define SWIFT_SILOPTIMIZER_UTILS_CFG_H
 
-#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
 
 namespace swift {
 
@@ -159,7 +160,8 @@ private:
 /// destroy_value at each instruction of the \p frontier.
 void endLifetimeAtFrontier(SILValue valueOrStackLoc,
                            const ValueLifetimeAnalysis::Frontier &frontier,
-                           SILBuilderContext &builderCtxt);
+                           SILBuilderContext &builderCtxt,
+                           InstModCallbacks callbacks);
 
 } // end namespace swift
 

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -115,7 +115,7 @@ bool PartialApplyCombiner::copyArgsToTemporaries(
 
     // Destroy the argument value (either as SSA value or in the stack-
     // allocated temporary) at the end of the partial_apply's lifetime.
-    endLifetimeAtFrontier(tmp, partialApplyFrontier, builderCtxt);
+    endLifetimeAtFrontier(tmp, partialApplyFrontier, builderCtxt, callbacks);
   }
   return true;
 }

--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -327,15 +327,12 @@ void ValueLifetimeAnalysis::dump() const {
 
 void swift::endLifetimeAtFrontier(
     SILValue valueOrStackLoc, const ValueLifetimeAnalysis::Frontier &frontier,
-    SILBuilderContext &builderCtxt) {
+    SILBuilderContext &builderCtxt, InstModCallbacks callbacks) {
   for (SILInstruction *endPoint : frontier) {
     SILBuilderWithScope builder(endPoint, builderCtxt);
     SILLocation loc = RegularLocation(endPoint->getLoc().getSourceLoc());
-    if (valueOrStackLoc->getType().isObject()) {
-      builder.emitDestroyValueOperation(loc, valueOrStackLoc);
-    } else {
-      assert(isa<AllocStackInst>(valueOrStackLoc));
-      builder.createDestroyAddr(loc, valueOrStackLoc);
+    emitDestroyOperation(builder, loc, valueOrStackLoc, callbacks);
+    if (isa<AllocStackInst>(valueOrStackLoc)) {
       builder.createDeallocStack(loc, valueOrStackLoc);
     }
   }

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -991,3 +991,29 @@ sil @test_partial_apply_method : $@convention(thin) () -> @owned @callee_owned (
 // CHECK: [[FN:%.*]] = function_ref @method
 // CHECK-NEXT: partial_apply [[FN]]()
 // CHECK-NEXT: return
+
+sil [noinline] @$foo : $@convention(thin) (@owned { var Int64 }) -> () 
+
+// CHECK-LABEL: sil private [noinline] @$testdeadpartialapply :
+// CHECK-NOT: partial_apply
+// CHECK-LABEL: } // end sil function '$testdeadpartialapply'
+sil private [noinline] @$testdeadpartialapply : $@convention(thin) (@owned { var Int64 }) -> () {
+bb0(%0 : ${ var Int64 }):
+  %3 = function_ref @$foo : $@convention(thin) (@owned { var Int64 }) -> ()
+  %5 = partial_apply [callee_guaranteed] %3(%0) : $@convention(thin) (@owned { var Int64 }) -> ()
+  cond_br undef, bb1, bb2
+bb1:
+  strong_retain %0 : ${ var Int64 }
+  strong_retain %5 : $@callee_guaranteed () -> ()
+  unreachable
+bb2:
+  strong_retain %0 : ${ var Int64 }
+  strong_retain %5 : $@callee_guaranteed () -> ()
+  br bb3
+bb3:
+  strong_release %5 : $@callee_guaranteed () -> ()
+  strong_release %5 : $@callee_guaranteed () -> ()
+  strong_release %0 : ${ var Int64 }
+  %rv = tuple()
+  return %rv : $()
+}


### PR DESCRIPTION
swift::endLifetimeAtFrontier also needs to use swift::emitDestroyOperation and delete instructions via callbacks that
can correctly remove it from the worklist that SILCombine maintains.
