### PR TITLE
[NFC] Split ProtocolDispatchStrategy out of MetadataValues.h

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -20,6 +20,7 @@
 #define SWIFT_ABI_METADATAVALUES_H
 
 #include "swift/ABI/KeyPath.h"
+#include "swift/ABI/ProtocolDispatchStrategy.h"
 #include "swift/AST/Ownership.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/FlagSet.h"
@@ -410,20 +411,6 @@ enum class SpecialProtocol: uint8_t {
   Error = 1,
 };
 
-/// Identifiers for protocol method dispatch strategies.
-enum class ProtocolDispatchStrategy: uint8_t {
-  /// Uses ObjC method dispatch.
-  ///
-  /// This must be 0 for ABI compatibility with Objective-C protocol_t records.
-  ObjC = 0,
-  
-  /// Uses Swift protocol witness table dispatch.
-  ///
-  /// To invoke methods of this protocol, a pointer to a protocol witness table
-  /// corresponding to the protocol conformance must be available.
-  Swift = 1,
-};
-
 /// Flags for protocol descriptors.
 class ProtocolDescriptorFlags {
   typedef uint32_t int_type;
@@ -486,18 +473,7 @@ public:
   
   /// Does the protocol require a witness table for method dispatch?
   bool needsWitnessTable() const {
-    return needsWitnessTable(getDispatchStrategy());
-  }
-  
-  static bool needsWitnessTable(ProtocolDispatchStrategy strategy) {
-    switch (strategy) {
-    case ProtocolDispatchStrategy::ObjC:
-      return false;
-    case ProtocolDispatchStrategy::Swift:
-      return true;
-    }
-
-    swift_runtime_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
+    return swift::needsWitnessTable(getDispatchStrategy());
   }
   
   /// Return the identifier if this is a special runtime-known protocol.

--- a/include/swift/ABI/ProtocolDispatchStrategy.h
+++ b/include/swift/ABI/ProtocolDispatchStrategy.h
@@ -1,0 +1,54 @@
+//===--- ProtocolDispatchStrategy.h - ---------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This header declares the ProtocolDispatchStrategy enum and some
+// related operations.  It's split out because we would otherwise need
+// to include MetadataValues.h in some relatively central headers.s
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_PROTOCOLDISPATCHSTRATEGY_H
+#define SWIFT_ABI_PROTOCOLDISPATCHSTRATEGY_H
+
+#include "swift/Runtime/Unreachable.h"
+
+namespace swift {
+
+/// Identifiers for protocol method dispatch strategies.
+enum class ProtocolDispatchStrategy: uint8_t {
+  /// Uses ObjC method dispatch.
+  ///
+  /// This must be 0 for ABI compatibility with Objective-C protocol_t records.
+  ObjC = 0,
+  
+  /// Uses Swift protocol witness table dispatch.
+  ///
+  /// To invoke methods of this protocol, a pointer to a protocol witness table
+  /// corresponding to the protocol conformance must be available.
+  Swift = 1,
+};
+
+/// Does the given strategy require a witness table?
+inline bool needsWitnessTable(ProtocolDispatchStrategy strategy) {
+  switch (strategy) {
+  case ProtocolDispatchStrategy::ObjC:
+    return false;
+  case ProtocolDispatchStrategy::Swift:
+    return true;
+  }
+
+  swift_runtime_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
+}
+
+}
+
+#endif

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -13,7 +13,7 @@
 #ifndef SWIFT_SIL_TYPELOWERING_H
 #define SWIFT_SIL_TYPELOWERING_H
 
-#include "swift/ABI/MetadataValues.h"
+#include "swift/ABI/ProtocolDispatchStrategy.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/Module.h"
 #include "swift/SIL/AbstractionPattern.h"


### PR DESCRIPTION
Including MetadataValues.h from TypeLowering.h makes changing that header exceptional painful on build times.