### PR TITLE
[Concurrency] Improve source compatibility with 'async' imports

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4172,10 +4172,10 @@ NOTE(actor_mutable_state,none,
 WARNING(shared_mutable_state_access,none,
         "reference to %0 %1 is not concurrency-safe because it involves "
         "shared mutable state", (DescriptiveDeclKind, DeclName))
-NOTE(actor_isolated_witness,none,
+ERROR(actor_isolated_witness,none,
      "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement",
      (DescriptiveDeclKind, DeclName))
-NOTE(actor_isolated_witness_could_be_async_handler,none,
+ERROR(actor_isolated_witness_could_be_async_handler,none,
      "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement; "
      "did you mean to make it an asychronous handler?",
      (DescriptiveDeclKind, DeclName))

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3701,48 +3701,46 @@ void ClangImporter::Implementation::lookupValue(
 
     // If we have a declaration and nothing matched so far, try the names used
     // in other versions of Swift.
-    if (!anyMatching) {
-      if (auto clangDecl = entry.dyn_cast<clang::NamedDecl *>()) {
-        const clang::NamedDecl *recentClangDecl =
-            clangDecl->getMostRecentDecl();
+    if (auto clangDecl = entry.dyn_cast<clang::NamedDecl *>()) {
+      const clang::NamedDecl *recentClangDecl =
+          clangDecl->getMostRecentDecl();
 
-        CurrentVersion.forEachOtherImportNameVersion(
-            SwiftContext.LangOpts.EnableExperimentalConcurrency,
-            [&](ImportNameVersion nameVersion) {
-          if (anyMatching)
-            return;
+      CurrentVersion.forEachOtherImportNameVersion(
+          SwiftContext.LangOpts.EnableExperimentalConcurrency,
+          [&](ImportNameVersion nameVersion) {
+        if (anyMatching)
+          return;
 
-          // Check to see if the name and context match what we expect.
-          ImportedName newName = importFullName(recentClangDecl, nameVersion);
-          if (!newName.getDeclName().matchesRef(name))
-            return;
+        // Check to see if the name and context match what we expect.
+        ImportedName newName = importFullName(recentClangDecl, nameVersion);
+        if (!newName.getDeclName().matchesRef(name))
+          return;
 
-          // If we asked for an async import and didn't find one, skip this.
-          // This filters out duplicates.
-          if (nameVersion.supportsConcurrency() &&
-              !newName.getAsyncInfo())
-            return;
+        // If we asked for an async import and didn't find one, skip this.
+        // This filters out duplicates.
+        if (nameVersion.supportsConcurrency() &&
+            !newName.getAsyncInfo())
+          return;
 
-          const clang::DeclContext *clangDC =
-              newName.getEffectiveContext().getAsDeclContext();
-          if (!clangDC || !clangDC->isFileContext())
-            return;
+        const clang::DeclContext *clangDC =
+            newName.getEffectiveContext().getAsDeclContext();
+        if (!clangDC || !clangDC->isFileContext())
+          return;
 
-          // Then try to import the decl under the alternate name.
-          auto alternateNamedDecl =
-              cast_or_null<ValueDecl>(importDeclReal(recentClangDecl,
-                                                     nameVersion));
-          if (!alternateNamedDecl || alternateNamedDecl == decl)
-            return;
-          assert(alternateNamedDecl->getName().matchesRef(name) &&
-                 "importFullName behaved differently from importDecl");
-          if (alternateNamedDecl->getDeclContext()->isModuleScopeContext()) {
-            consumer.foundDecl(alternateNamedDecl,
-                               DeclVisibilityKind::VisibleAtTopLevel);
-            anyMatching = true;
-          }
-        });
-      }
+        // Then try to import the decl under the alternate name.
+        auto alternateNamedDecl =
+            cast_or_null<ValueDecl>(importDeclReal(recentClangDecl,
+                                                   nameVersion));
+        if (!alternateNamedDecl || alternateNamedDecl == decl)
+          return;
+        assert(alternateNamedDecl->getName().matchesRef(name) &&
+               "importFullName behaved differently from importDecl");
+        if (alternateNamedDecl->getDeclContext()->isModuleScopeContext()) {
+          consumer.foundDecl(alternateNamedDecl,
+                             DeclVisibilityKind::VisibleAtTopLevel);
+          anyMatching = true;
+        }
+      });
     }
   }
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -110,12 +110,14 @@ bool IsAsyncHandlerRequest::evaluate(
 
   // Are we in a context where inference is possible?
   auto dc = func->getDeclContext();
-  if (!dc->isTypeContext() || !dc->getParentSourceFile() ||
-      isa<ProtocolDecl>(dc) || !func->hasBody())
+  if (!dc->getSelfClassDecl() || !dc->getParentSourceFile() || !func->hasBody())
     return false;
 
   // Is it possible to infer @asyncHandler for this function at all?
   if (!func->canBeAsyncHandler())
+    return false;
+
+  if (!dc->getSelfClassDecl()->isActor())
     return false;
 
   // Add an implicit @asyncHandler attribute and return true. We're done.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -789,7 +789,10 @@ class ConformanceChecker : public WitnessChecker {
 
 public:
   /// Call this to diagnose currently known missing witnesses.
-  void diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind);
+  ///
+  /// \returns true if any witnesses were diagnosed.
+  bool diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind);
+
   /// Emit any diagnostics that have been delayed.
   void emitDelayedDiags();
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -268,9 +268,6 @@ enum class MatchKind : uint8_t {
   /// The witness is explicitly @nonobjc but the requirement is @objc.
   NonObjC,
 
-  /// The witness is part of actor-isolated state.
-  ActorIsolatedWitness,
-
   /// The witness is missing a `@differentiable` attribute from the requirement.
   MissingDifferentiableAttr,
   
@@ -503,7 +500,6 @@ struct RequirementMatch {
     case MatchKind::AsyncConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
-    case MatchKind::ActorIsolatedWitness:
     case MatchKind::MissingDifferentiableAttr:
     case MatchKind::EnumCaseWithAssociatedValues:
       return false;
@@ -536,7 +532,6 @@ struct RequirementMatch {
     case MatchKind::AsyncConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
-    case MatchKind::ActorIsolatedWitness:
     case MatchKind::MissingDifferentiableAttr:
     case MatchKind::EnumCaseWithAssociatedValues:
       return false;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -678,6 +678,12 @@ public:
 /// This helper class handles most of the details of checking whether a
 /// given type (\c Adoptee) conforms to a protocol (\c Proto).
 class ConformanceChecker : public WitnessChecker {
+public:
+  /// Key that can be used to uniquely identify a particular Objective-C
+  /// method.
+  using ObjCMethodKey = std::pair<ObjCSelector, char>;
+
+private:
   friend class MultiConformanceChecker;
   friend class AssociatedTypeInference;
 
@@ -711,6 +717,14 @@ class ConformanceChecker : public WitnessChecker {
 
   /// Whether we checked the requirement signature already.
   bool CheckedRequirementSignature = false;
+
+  /// Mapping from Objective-C methods to the set of requirements within this
+  /// protocol that have the same selector and instance/class designation.
+  llvm::SmallDenseMap<ObjCMethodKey, TinyPtrVector<AbstractFunctionDecl *>, 4>
+    objcMethodRequirements;
+
+  /// Whether objcMethodRequirements has been computed.
+  bool computedObjCMethodRequirements = false;
 
   /// Retrieve the associated types that are referenced by the given
   /// requirement with a base of 'Self'.
@@ -827,6 +841,13 @@ public:
   /// Check the entire protocol conformance, ensuring that all
   /// witnesses are resolved and emitting any diagnostics.
   void checkConformance(MissingWitnessDiagnosisKind Kind);
+
+  /// Retrieve the Objective-C method key from the given function.
+  ObjCMethodKey getObjCMethodKey(AbstractFunctionDecl *func);
+
+  /// Retrieve the Objective-C requirements in this protocol that have the
+  /// given Objective-C method key.
+  ArrayRef<AbstractFunctionDecl *> getObjCRequirements(ObjCMethodKey key);
 };
 
 /// Captures the state needed to infer associated types.

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -11,6 +11,18 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: String = await try slowServer.findAnswerFailingly() ?? "nope"
   let _: Void = await slowServer.doSomethingFun("jump")
   let _: (Int) -> Void = slowServer.completionHandler
+
+  // async version
+  let _: Int = await slowServer.doSomethingConflicted("thinking")
+
+  // still async version...
+  let _: Int = slowServer.doSomethingConflicted("thinking")
+  // expected-error@-1{{call is 'async' but is not marked with 'await'}}
+}
+
+func testSlowServerSynchronous(slowServer: SlowServer) {
+  // synchronous version
+  let _: Int = slowServer.doSomethingConflicted("thinking")
 }
 
 func testSlowServerOldSchool(slowServer: SlowServer) {

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -11,6 +11,9 @@
 -(BOOL)findAnswerFailinglyWithError:(NSError * _Nullable * _Nullable)error completion:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswerFailingly(completionHandler:)")));
 -(void)doSomethingFun:(NSString *)operation then:(void (^)(void))completionHandler;
 @property(readwrite) void (^completionHandler)(NSInteger);
+
+-(void)doSomethingConflicted:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
+-(NSInteger)doSomethingConflicted:(NSString *)operation;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>
@@ -19,6 +22,13 @@
 - (void)refrigerator:(id)fridge didGetFilledWithIntegers:(NSInteger *)items count:(NSInteger)count;
 - (void)refrigerator:(id)fridge willAddItem:(id)item;
 - (BOOL)refrigerator:(id)fridge didRemoveItem:(id)item;
+@end
+
+@protocol ConcurrentProtocol
+-(void)askUserToSolvePuzzle:(NSString *)puzzle completionHandler:(void (^ _Nullable)(NSString * _Nullable, NSError * _Nullable))completionHandler;
+
+@optional
+-(void)askUserToJumpThroughHoop:(NSString *)hoop completionHandler:(void (^ _Nullable)(NSString *))completionHandler;
 @end
 
 #pragma clang assume_nonnull end

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
 // RUN: %FileCheck -input-file %t/*.csv %s
 
-// CHECK-DAG: {{[0-9]+,[0-9]+,"exit","check-conformance","Sema.NumConstraintScopes",[0-9]+,[0-9]+,"Bar: Proto module main",".*stats_dir_tracer.swift.*"}}
+// CHECK-DAG: {{[0-9]+,[0-9]+,"exit","check-conformance","Frontend.NumInstructionsExecuted",[0-9]+,[0-9]+,"Bar: Proto module main",".*stats_dir_tracer.swift.*"}}
 // CHECK-DAG: {{[0-9]+,[0-9]+,"exit","SuperclassDeclRequest","Sema.SuperclassDeclRequest",[0-9]+,[0-9]+,"Bar","\[.*stats_dir_tracer.swift.*\]"}}
 
 public func foo() {

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
 // RUN: %FileCheck -input-file %t/*.csv %s
 
-// CHECK-DAG: {{[0-9]+,[0-9]+,"exit","check-conformance","Frontend.NumInstructionsExecuted",[0-9]+,[0-9]+,"Bar: Proto module main",".*stats_dir_tracer.swift.*"}}
+// CHECK-DAG: {{[0-9]+,[0-9]+,"exit","SelfBoundsFromWhereClauseRequest","Sema.SelfBoundsFromWhereClauseRequest",[0-9]+,[0-9]+,"Proto",".*stats_dir_tracer.swift.*"}}
 // CHECK-DAG: {{[0-9]+,[0-9]+,"exit","SuperclassDeclRequest","Sema.SuperclassDeclRequest",[0-9]+,[0-9]+,"Bar","\[.*stats_dir_tracer.swift.*\]"}}
 
 public func foo() {

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -27,17 +27,12 @@ func asyncHandlerBad3() throws { }
 func asyncHandlerBad4(result: inout Int) { }
 // expected-error@-1{{'inout' parameter is not allowed in '@asyncHandler' function}}
 
-struct X {
+actor class X {
   @asyncHandler func asyncHandlerMethod() { }
-
-  @asyncHandler
-  mutating func asyncHandlerMethodBad1() { }
-  // expected-error@-1{{'@asyncHandler' function cannot be 'mutating'}}{{3-12=}}
 
   @asyncHandler init() { }
   // expected-error@-1{{@asyncHandler may only be used on 'func' declarations}}
 }
-
 
 // Inference of @asyncHandler
 protocol P {
@@ -49,4 +44,22 @@ extension X: P {
     // okay, it's an async context
     let _ = await globalAsyncFunction()
  }
+}
+
+class Y: P {
+  // @asyncHandler is not inferred for classes
+
+  func callback() {
+    // expected-note@-1{{add 'async' to function 'callback()' to make it asynchronous}}
+    // expected-note@-2{{add '@asyncHandler' to function 'callback()' to create an implicit asynchronous context}}
+
+    // okay, it's an async context
+    let _ = await globalAsyncFunction() // expected-error{{'async' in a function that does not support concurrency}}
+ }
+}
+
+struct Z {
+  @asyncHandler
+  mutating func asyncHandlerMethodBad1() { }
+  // expected-error@-1{{'@asyncHandler' function cannot be 'mutating'}}{{3-12=}}
 }

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -12,37 +12,32 @@ extension MyActor: AsyncProtocol {
   func asyncMethod() async -> Int { return 0 }
 }
 
-// FIXME: "Do you want to add a stub?" diagnostics should be suppressed here.
 protocol SyncProtocol {
   var propertyA: Int { get }
-  // expected-note@-1{{do you want to add a stub}}
   var propertyB: Int { get set }
-  // expected-note@-1{{do you want to add a stub}}
 
   func syncMethodA()
-  // expected-note@-1{{do you want to add a stub}}
 
   func syncMethodB()
 
   func syncMethodC() -> Int
 
   subscript (index: Int) -> String { get }
-  // expected-note@-1{{do you want to add a stub}}
 
   static func staticMethod()
   static var staticProperty: Int { get }
 }
 
 
-actor class OtherActor: SyncProtocol { // expected-error{{type 'OtherActor' does not conform to protocol 'SyncProtocol'}}
+actor class OtherActor: SyncProtocol {
   var propertyB: Int = 17
-  // expected-note@-1{{actor-isolated property 'propertyB' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy a protocol requirement}}
 
   var propertyA: Int { 17 }
-  // expected-note@-1{{actor-isolated property 'propertyA' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated property 'propertyA' cannot be used to satisfy a protocol requirement}}
 
   func syncMethodA() { }
-  // expected-note@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}{{3-3=@asyncHandler }}
+  // expected-error@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}{{3-3=@asyncHandler }}
 
   // Async handlers are okay.
   @asyncHandler
@@ -53,7 +48,7 @@ actor class OtherActor: SyncProtocol { // expected-error{{type 'OtherActor' does
   @actorIndependent func syncMethodC() -> Int { 5 }
 
   subscript (index: Int) -> String { "\(index)" }
-  // expected-note@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy a protocol requirement}}
 
   // Static methods and properties are okay.
   static func staticMethod() { }

--- a/test/decl/protocol/conforms/objc_async.swift
+++ b/test/decl/protocol/conforms/objc_async.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify -verify-ignore-unknown
+
+// REQUIRES: objc_interop
+import Foundation
+import ObjCConcurrency
+
+// Conform via async method
+class C1: ConcurrentProtocol {
+  func askUser(toSolvePuzzle puzzle: String) async throws -> String? { nil }
+
+  func askUser(toJumpThroughHoop hoop: String) async -> String { "hello" }
+}
+
+// Conform via completion-handler method
+class C2: ConcurrentProtocol {
+  func askUser(toSolvePuzzle puzzle: String, completionHandler: ((String?, Error?) -> Void)?) {
+    completionHandler?("hello", nil)
+  }
+
+  func askUser(toJumpThroughHoop hoop: String, completionHandler: ((String) -> Void)?) {
+    completionHandler?("hello")
+  }
+}
+
+// Conform via both; this is an error
+class C3: ConcurrentProtocol {
+  // expected-note@+1{{method 'askUser(toSolvePuzzle:)' declared here}}
+  func askUser(toSolvePuzzle puzzle: String) async throws -> String? { nil }
+
+  // expected-error@+1{{'askUser(toSolvePuzzle:completionHandler:)' with Objective-C selector 'askUserToSolvePuzzle:completionHandler:' conflicts with method 'askUser(toSolvePuzzle:)' with the same Objective-C selector}}
+  func askUser(toSolvePuzzle puzzle: String, completionHandler: ((String?, Error?) -> Void)?) {
+    completionHandler?("hello", nil)
+  }
+}
+
+// Conform but forget to supply either. Also an error.
+// FIXME: Suppress one of the notes?
+class C4: ConcurrentProtocol { // expected-error{{type 'C4' does not conform to protocol 'ConcurrentProtocol'}}
+}
+
+class C5 {
+}
+
+extension C5: ConcurrentProtocol {
+  func askUser(toSolvePuzzle puzzle: String, completionHandler: ((String?, Error?) -> Void)?) {
+    completionHandler?("hello", nil)
+  }
+
+  func askUser(toJumpThroughHoop hoop: String, completionHandler: ((String) -> Void)?) {
+    completionHandler?("hello")
+  }
+}

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -42,7 +42,7 @@ class C1: Actor {
 
 // Method that is not usable as a witness.
 actor class BA1 {
-  func enqueue(partialTask: PartialAsyncTask) { } // expected-note{{actor-isolated instance method 'enqueue(partialTask:)' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}
+  func enqueue(partialTask: PartialAsyncTask) { } // expected-error{{actor-isolated instance method 'enqueue(partialTask:)' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}
 }
 
 // Method that isn't part of the main class definition cannot be used to

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -42,7 +42,7 @@ class C1: Actor {
 
 // Method that is not usable as a witness.
 actor class BA1 {
-  func enqueue(partialTask: PartialAsyncTask) { } // expected-error{{invalid redeclaration of synthesized implementation for protocol requirement 'enqueue(partialTask:)'}}
+  func enqueue(partialTask: PartialAsyncTask) { } // expected-note{{actor-isolated instance method 'enqueue(partialTask:)' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}
 }
 
 // Method that isn't part of the main class definition cannot be used to


### PR DESCRIPTION
Address a few source-compatibility issues introduced by importing completion-handler Objective-C methods
as '`async' alongside their completion handlers. This is a combination of outright bug fixes in the existing implementation, language rules for coping with the result of this transformation, and backing off slightly on concurrency-related inference rules:

* Fixes a bug in the Clang importer where we would fail to import both an `async` function (from a completion handler) and a non-`async` function that has the same signature, because we would filter one out as a "duplicate".
* Copes with conformance to protocols where the same Objective-C method has been imported with two different Swift requirements (a completion-handler one and an `async` one). Ensure that we don't treat one requirement as a "missing witness" if indeed the other requirement was satisfied.
* Dial back `@asyncHandler` inference for witnesses in classes, because it causes source compatibility issues when combined with other aspects of the concurrency model.