### PR TITLE
[NFC] A trio of patches to improve incremental build times and compiler abstraction

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -630,3 +630,9 @@ macro(add_swift_tool_symlink name dest component)
   add_llvm_tool_symlink(${name} ${dest} ALWAYS_GENERATE)
   llvm_install_symlink(${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
 endmacro()
+
+# Declare that files in this library are built with LLVM's support
+# libraries available.
+macro(set_swift_llvm_is_available)
+  add_compile_options(-DSWIFT_LLVM_SUPPORT_IS_AVAILABLE)
+endmacro()

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -38,7 +38,7 @@
 #include "swift/Basic/RelativePointer.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/ManglingMacros.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 #include "../../../stdlib/public/SwiftShims/HeapObject.h"
 #if SWIFT_OBJC_INTEROP
 #include <objc/runtime.h>
@@ -4664,7 +4664,7 @@ int32_t TargetTypeContextDescriptor<Runtime>::getGenericArgumentOffset() const {
     return llvm::cast<TargetStructDescriptor<Runtime>>(this)
         ->getGenericArgumentOffset();
   default:
-    swift_runtime_unreachable("Not a type context descriptor.");
+    swift_unreachable("Not a type context descriptor.");
   }
 }
 
@@ -4682,7 +4682,7 @@ TargetTypeContextDescriptor<Runtime>::getFullGenericContextHeader() const {
     return llvm::cast<TargetStructDescriptor<Runtime>>(this)
         ->getFullGenericContextHeader();
   default:
-    swift_runtime_unreachable("Not a type context descriptor.");
+    swift_unreachable("Not a type context descriptor.");
   }
 }
 
@@ -4699,7 +4699,7 @@ TargetTypeContextDescriptor<Runtime>::getGenericParams() const {
   case ContextDescriptorKind::OpaqueType:
     return llvm::cast<TargetOpaqueTypeDescriptor<Runtime>>(this)->getGenericParams();
   default:
-    swift_runtime_unreachable("Not a type context descriptor.");
+    swift_unreachable("Not a type context descriptor.");
   }
 }
 
@@ -4717,7 +4717,7 @@ TargetTypeContextDescriptor<Runtime>::getForeignMetadataInitialization() const {
     return llvm::cast<TargetStructDescriptor<Runtime>>(this)
         ->getForeignMetadataInitialization();
   default:
-    swift_runtime_unreachable("Not a type context descriptor.");
+    swift_unreachable("Not a type context descriptor.");
   }
 }
 
@@ -4735,7 +4735,7 @@ TargetTypeContextDescriptor<Runtime>::getSingletonMetadataInitialization() const
     return llvm::cast<TargetClassDescriptor<Runtime>>(this)
         ->getSingletonMetadataInitialization();
   default:
-    swift_runtime_unreachable("Not a enum, struct or class type descriptor.");
+    swift_unreachable("Not a enum, struct or class type descriptor.");
   }
 }
 
@@ -4753,7 +4753,7 @@ TargetTypeContextDescriptor<Runtime>::getCanonicicalMetadataPrespecializations()
     return llvm::cast<TargetClassDescriptor<Runtime>>(this)
         ->getCanonicicalMetadataPrespecializations();
   default:
-    swift_runtime_unreachable("Not a type context descriptor.");
+    swift_unreachable("Not a type context descriptor.");
   }
 }
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -20,10 +20,10 @@
 #define SWIFT_ABI_METADATAVALUES_H
 
 #include "swift/ABI/KeyPath.h"
+#include "swift/ABI/ProtocolDispatchStrategy.h"
 #include "swift/AST/Ownership.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/FlagSet.h"
-#include "swift/Runtime/Unreachable.h"
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -410,20 +410,6 @@ enum class SpecialProtocol: uint8_t {
   Error = 1,
 };
 
-/// Identifiers for protocol method dispatch strategies.
-enum class ProtocolDispatchStrategy: uint8_t {
-  /// Uses ObjC method dispatch.
-  ///
-  /// This must be 0 for ABI compatibility with Objective-C protocol_t records.
-  ObjC = 0,
-  
-  /// Uses Swift protocol witness table dispatch.
-  ///
-  /// To invoke methods of this protocol, a pointer to a protocol witness table
-  /// corresponding to the protocol conformance must be available.
-  Swift = 1,
-};
-
 /// Flags for protocol descriptors.
 class ProtocolDescriptorFlags {
   typedef uint32_t int_type;
@@ -486,18 +472,7 @@ public:
   
   /// Does the protocol require a witness table for method dispatch?
   bool needsWitnessTable() const {
-    return needsWitnessTable(getDispatchStrategy());
-  }
-  
-  static bool needsWitnessTable(ProtocolDispatchStrategy strategy) {
-    switch (strategy) {
-    case ProtocolDispatchStrategy::ObjC:
-      return false;
-    case ProtocolDispatchStrategy::Swift:
-      return true;
-    }
-
-    swift_runtime_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
+    return swift::protocolRequiresWitnessTable(getDispatchStrategy());
   }
   
   /// Return the identifier if this is a special runtime-known protocol.

--- a/include/swift/ABI/ProtocolDispatchStrategy.h
+++ b/include/swift/ABI/ProtocolDispatchStrategy.h
@@ -1,0 +1,54 @@
+//===--- ProtocolDispatchStrategy.h - ---------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This header declares the ProtocolDispatchStrategy enum and some
+// related operations.  It's split out because we would otherwise need
+// to include MetadataValues.h in some relatively central headers.s
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_PROTOCOLDISPATCHSTRATEGY_H
+#define SWIFT_ABI_PROTOCOLDISPATCHSTRATEGY_H
+
+#include "swift/Runtime/Unreachable.h"
+
+namespace swift {
+
+/// Identifiers for protocol method dispatch strategies.
+enum class ProtocolDispatchStrategy: uint8_t {
+  /// Uses ObjC method dispatch.
+  ///
+  /// This must be 0 for ABI compatibility with Objective-C protocol_t records.
+  ObjC = 0,
+  
+  /// Uses Swift protocol witness table dispatch.
+  ///
+  /// To invoke methods of this protocol, a pointer to a protocol witness table
+  /// corresponding to the protocol conformance must be available.
+  Swift = 1,
+};
+
+/// Does a protocol using the given strategy require a witness table?
+inline bool protocolRequiresWitnessTable(ProtocolDispatchStrategy strategy) {
+  switch (strategy) {
+  case ProtocolDispatchStrategy::ObjC:
+    return false;
+  case ProtocolDispatchStrategy::Swift:
+    return true;
+  }
+
+  swift_runtime_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
+}
+
+}
+
+#endif

--- a/include/swift/ABI/ProtocolDispatchStrategy.h
+++ b/include/swift/ABI/ProtocolDispatchStrategy.h
@@ -19,7 +19,7 @@
 #ifndef SWIFT_ABI_PROTOCOLDISPATCHSTRATEGY_H
 #define SWIFT_ABI_PROTOCOLDISPATCHSTRATEGY_H
 
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 
 namespace swift {
 
@@ -46,7 +46,7 @@ inline bool protocolRequiresWitnessTable(ProtocolDispatchStrategy strategy) {
     return true;
   }
 
-  swift_runtime_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
+  swift_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
 }
 
 }

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -34,10 +34,59 @@
 #define SWIFT_ASSUME(x)
 #endif
 
+/// Attributes.
+
 #if __has_attribute(constructor)
 #define SWIFT_CONSTRUCTOR __attribute__((constructor))
 #else
 #define SWIFT_CONSTRUCTOR
+#endif
+
+/// \macro SWIFT_GNUC_PREREQ
+/// Extend the default __GNUC_PREREQ even if glibc's features.h isn't
+/// available.
+#ifndef SWIFT_GNUC_PREREQ
+# if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#  define SWIFT_GNUC_PREREQ(maj, min, patch) \
+    ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >= \
+     ((maj) << 20) + ((min) << 10) + (patch))
+# elif defined(__GNUC__) && defined(__GNUC_MINOR__)
+#  define SWIFT_GNUC_PREREQ(maj, min, patch) \
+    ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
+# else
+#  define SWIFT_GNUC_PREREQ(maj, min, patch) 0
+# endif
+#endif
+
+
+/// SWIFT_ATTRIBUTE_NOINLINE - On compilers where we have a directive to do so,
+/// mark a method "not for inlining".
+#if __has_attribute(noinline) || SWIFT_GNUC_PREREQ(3, 4, 0)
+#define SWIFT_ATTRIBUTE_NOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define SWIFT_ATTRIBUTE_NOINLINE __declspec(noinline)
+#else
+#define SWIFT_ATTRIBUTE_NOINLINE
+#endif
+
+/// SWIFT_ATTRIBUTE_ALWAYS_INLINE - On compilers where we have a directive to do
+/// so, mark a method "always inline" because it is performance sensitive. GCC
+/// 3.4 supported this but is buggy in various cases and produces unimplemented
+/// errors, just use it in GCC 4.0 and later.
+#if __has_attribute(always_inline) || SWIFT_GNUC_PREREQ(4, 0, 0)
+#define SWIFT_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define SWIFT_ATTRIBUTE_ALWAYS_INLINE __forceinline
+#else
+#define SWIFT_ATTRIBUTE_ALWAYS_INLINE
+#endif
+
+#ifdef __GNUC__
+#define SWIFT_ATTRIBUTE_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define SWIFT_ATTRIBUTE_NORETURN __declspec(noreturn)
+#else
+#define SWIFT_ATTRIBUTE_NORETURN
 #endif
 
 #endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/Basic/Unreachable.h
+++ b/include/swift/Basic/Unreachable.h
@@ -1,4 +1,4 @@
-//===--- Unreachable.h - Implements swift_runtime_unreachable ---*- C++ -*-===//
+//===--- Unreachable.h - Implements swift_unreachable ---*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,13 +10,25 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  This file defines swift_runtime_unreachable, an LLVM-independent
-//  implementation of llvm_unreachable.
+//  This file defines swift_unreachable, which provides the
+//  functionality of llvm_unreachable without necessarily depending on
+//  the LLVM support libraries.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_RUNTIME_UNREACHABLE_H
-#define SWIFT_RUNTIME_UNREACHABLE_H
+#ifndef SWIFT_BASIC_UNREACHABLE_H
+#define SWIFT_BASIC_UNREACHABLE_H
+
+#ifdef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
+
+// The implementation when LLVM is available.
+
+#include "llvm/Support/ErrorHandling.h"
+#define swift_unreachable llvm_unreachable
+
+#else
+
+// The implementation when LLVM is not available.
 
 #include <assert.h>
 #include <stdlib.h>
@@ -24,10 +36,12 @@
 #include "swift/Runtime/Config.h"
 
 SWIFT_RUNTIME_ATTRIBUTE_NORETURN
-inline static void swift_runtime_unreachable(const char *msg) {
+inline static void swift_unreachable(const char *msg) {
   assert(false && msg);
   (void)msg;
   abort();
 }
 
-#endif // SWIFT_RUNTIME_UNREACHABLE_H
+#endif
+
+#endif

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -24,7 +24,7 @@
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Runtime/Portability.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <vector>

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -33,7 +33,7 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 
 #include <set>
 #include <unordered_map>
@@ -1302,7 +1302,7 @@ private:
       return true;
     }
 
-    swift_runtime_unreachable("Unhandled MetadataSourceKind in switch.");
+    swift_unreachable("Unhandled MetadataSourceKind in switch.");
   }
 
   /// Read metadata for a captured generic type from a closure context.

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -22,7 +22,7 @@
 #include "llvm/Support/Casting.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Remote/MetadataReader.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 
 namespace swift {
 namespace reflection {
@@ -856,7 +856,7 @@ public:
 #include "swift/Reflection/TypeRefs.def"
     }
 
-    swift_runtime_unreachable("Unhandled TypeRefKind in switch.");
+    swift_unreachable("Unhandled TypeRefKind in switch.");
   }
 };
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -28,7 +28,7 @@
 #include "swift/ABI/TypeIdentity.h"
 #include "swift/Runtime/ExistentialContainer.h"
 #include "swift/Runtime/HeapObject.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 
 #include <vector>
 #include <unordered_map>
@@ -923,7 +923,7 @@ public:
     }
     }
 
-    swift_runtime_unreachable("Unhandled MetadataKind in switch");
+    swift_unreachable("Unhandled MetadataKind in switch");
   }
 
   TypeLookupErrorOr<typename BuilderType::BuiltType>
@@ -1295,7 +1295,7 @@ public:
     }
     }
 
-    swift_runtime_unreachable("Unhandled IsaEncodingKind in switch.");
+    swift_unreachable("Unhandled IsaEncodingKind in switch.");
   }
 
   /// Read the offset of the generic parameters of a class from the nominal

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -17,23 +17,8 @@
 #ifndef SWIFT_RUNTIME_CONFIG_H
 #define SWIFT_RUNTIME_CONFIG_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/Runtime/CMakeConfig.h"
-
-/// \macro SWIFT_RUNTIME_GNUC_PREREQ
-/// Extend the default __GNUC_PREREQ even if glibc's features.h isn't
-/// available.
-#ifndef SWIFT_RUNTIME_GNUC_PREREQ
-# if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#  define SWIFT_RUNTIME_GNUC_PREREQ(maj, min, patch) \
-    ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >= \
-     ((maj) << 20) + ((min) << 10) + (patch))
-# elif defined(__GNUC__) && defined(__GNUC_MINOR__)
-#  define SWIFT_RUNTIME_GNUC_PREREQ(maj, min, patch) \
-    ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
-# else
-#  define SWIFT_RUNTIME_GNUC_PREREQ(maj, min, patch) 0
-# endif
-#endif
 
 /// SWIFT_RUNTIME_LIBRARY_VISIBILITY - If a class marked with this attribute is
 /// linked into a shared library, then the class should be private to the
@@ -41,47 +26,20 @@
 /// variables and functions, making them private to any shared library they are
 /// linked into.
 /// On PE/COFF targets, library visibility is the default, so this isn't needed.
-#if (__has_attribute(visibility) || SWIFT_RUNTIME_GNUC_PREREQ(4, 0, 0)) &&    \
+#if (__has_attribute(visibility) || SWIFT_GNUC_PREREQ(4, 0, 0)) &&    \
     !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_WIN32)
 #define SWIFT_RUNTIME_LIBRARY_VISIBILITY __attribute__ ((visibility("hidden")))
 #else
 #define SWIFT_RUNTIME_LIBRARY_VISIBILITY
 #endif
 
-/// Attributes.
-/// SWIFT_RUNTIME_ATTRIBUTE_NOINLINE - On compilers where we have a directive to do so,
-/// mark a method "not for inlining".
-#if __has_attribute(noinline) || SWIFT_RUNTIME_GNUC_PREREQ(3, 4, 0)
-#define SWIFT_RUNTIME_ATTRIBUTE_NOINLINE __attribute__((noinline))
-#elif defined(_MSC_VER)
-#define SWIFT_RUNTIME_ATTRIBUTE_NOINLINE __declspec(noinline)
-#else
-#define SWIFT_RUNTIME_ATTRIBUTE_NOINLINE
-#endif
-
-/// SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE - On compilers where we have a directive to do
-/// so, mark a method "always inline" because it is performance sensitive. GCC
-/// 3.4 supported this but is buggy in various cases and produces unimplemented
-/// errors, just use it in GCC 4.0 and later.
-#if __has_attribute(always_inline) || SWIFT_RUNTIME_GNUC_PREREQ(4, 0, 0)
-#define SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
-#elif defined(_MSC_VER)
-#define SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE __forceinline
-#else
-#define SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE
-#endif
-
-#ifdef __GNUC__
-#define SWIFT_RUNTIME_ATTRIBUTE_NORETURN __attribute__((noreturn))
-#elif defined(_MSC_VER)
-#define SWIFT_RUNTIME_ATTRIBUTE_NORETURN __declspec(noreturn)
-#else
-#define SWIFT_RUNTIME_ATTRIBUTE_NORETURN
-#endif
+#define SWIFT_RUNTIME_ATTRIBUTE_NOINLINE SWIFT_ATTRIBUTE_NOINLINE
+#define SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE SWIFT_ATTRIBUTE_ALWAYS_INLINE
+#define SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_ATTRIBUTE_NORETURN
 
 /// SWIFT_RUNTIME_BUILTIN_TRAP - On compilers which support it, expands to an expression
 /// which causes the program to exit abnormally.
-#if __has_builtin(__builtin_trap) || SWIFT_RUNTIME_GNUC_PREREQ(4, 3, 0)
+#if __has_builtin(__builtin_trap) || SWIFT_GNUC_PREREQ(4, 3, 0)
 # define SWIFT_RUNTIME_BUILTIN_TRAP __builtin_trap()
 #elif defined(_MSC_VER)
 // The __debugbreak intrinsic is supported by MSVC, does not require forward

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -18,7 +18,7 @@
 #define SWIFT_RUNTIME_DEBUG_HELPERS_H
 
 #include "swift/Runtime/Config.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 #include <atomic>
 #include <cstdarg>
 #include <functional>
@@ -79,7 +79,7 @@ static inline void crash(const char *message) {
   CRSetCrashLogMessage(message);
 
   SWIFT_RUNTIME_BUILTIN_TRAP;
-  swift_runtime_unreachable("Expected compiler to crash.");
+  swift_unreachable("Expected compiler to crash.");
 }
 
 // swift::fatalError() halts with a crash log message, 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -13,7 +13,7 @@
 #ifndef SWIFT_SIL_TYPELOWERING_H
 #define SWIFT_SIL_TYPELOWERING_H
 
-#include "swift/ABI/MetadataValues.h"
+#include "swift/ABI/ProtocolDispatchStrategy.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/Module.h"
 #include "swift/SIL/AbstractionPattern.h"
@@ -792,8 +792,7 @@ public:
 
   /// True if a protocol uses witness tables for dynamic dispatch.
   static bool protocolRequiresWitnessTable(ProtocolDecl *P) {
-    return ProtocolDescriptorFlags::needsWitnessTable
-             (getProtocolDispatchStrategy(P));
+    return swift::protocolRequiresWitnessTable(getProtocolDispatchStrategy(P));
   }
   
   /// True if a type is passed indirectly at +0 when used as the "self"

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -9,6 +9,8 @@ else()
   )
 endif()
 
+set_swift_llvm_is_available()
+
 add_swift_host_library(swiftAST STATIC
   AbstractSourceFileDepGraphFactory.cpp
   AccessRequests.cpp

--- a/lib/ASTSectionImporter/CMakeLists.txt
+++ b/lib/ASTSectionImporter/CMakeLists.txt
@@ -1,3 +1,5 @@
+set_swift_llvm_is_available()
+
 add_swift_host_library(swiftASTSectionImporter STATIC
   ASTSectionImporter.cpp
   LLVM_LINK_COMPONENTS core)

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -4,6 +4,8 @@ set(SWIFT_GYB_FLAGS
 add_gyb_target(generated_sorted_cf_database
     SortedCFDatabase.def.gyb)
 
+set_swift_llvm_is_available()
+
 add_swift_host_library(swiftClangImporter STATIC
   CFTypeInfo.cpp
   ClangAdapter.cpp

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -1,3 +1,5 @@
+set_swift_llvm_is_available()
+
 set(swiftDriver_sources
   Action.cpp
   Compilation.cpp

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftFrontend STATIC
   ArgsToFrontendInputsConverter.cpp
   ArgsToFrontendOptionsConverter.cpp

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftFrontendTool STATIC
   FrontendTool.cpp
   ImportedModules.cpp

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftIDE STATIC
   CodeCompletion.cpp
   CodeCompletionCache.cpp

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftIRGen STATIC
   AllocStackHoisting.cpp
   ClassLayout.cpp

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -16,6 +16,7 @@
 
 #define DEBUG_TYPE "irgen"
 #include "IRGenModule.h"
+#include "swift/ABI/MetadataValues.h"
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/IRGenRequests.h"

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftLLVMPasses STATIC
   LLVMSwiftAA.cpp
   LLVMSwiftRCIdentity.cpp

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -47,6 +47,8 @@ swift_install_in_component(FILES ${datafiles}
                            DESTINATION "lib/swift/migrator"
                            COMPONENT compiler)
 
+set_swift_llvm_is_available()
+
 add_swift_host_library(swiftMigrator STATIC
   APIDiffMigratorPass.cpp
   EditorAdapter.cpp

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -1,3 +1,5 @@
+set_swift_llvm_is_available()
+
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
   set(SWIFT_GYB_FLAGS --line-directive "^\"#line %(line)d \\\"%(file)s\\\"^\"")
 else()

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftPrintAsObjC STATIC
   DeclAndTypePrinter.cpp
   ModuleContentsWriter.cpp

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftSIL STATIC
   SIL.cpp)
 target_link_libraries(swiftSIL PUBLIC

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftSILGen STATIC
   ArgumentSource.cpp
   Cleanup.cpp

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftSILOptimizer STATIC
   SILOptimizer.cpp)
 target_link_libraries(swiftSILOptimizer PRIVATE

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftSema STATIC
   BuilderTransform.cpp
   CSApply.cpp

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftSerialization STATIC
   Deserialization.cpp
   DeserializeSIL.cpp

--- a/lib/SyntaxParse/CMakeLists.txt
+++ b/lib/SyntaxParse/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftSyntaxParse STATIC
   RawSyntaxTokenCache.cpp
   SyntaxTreeCreator.cpp)

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_swift_llvm_is_available()
 add_swift_host_library(swiftTBDGen STATIC
   TBDGen.cpp
   TBDGenRequests.cpp

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -23,7 +23,7 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 
 #ifdef DEBUG_TYPE_LOWERING
   #define DEBUG_LOG(expr) expr;
@@ -212,7 +212,7 @@ public:
     }
     }
 
-    swift_runtime_unreachable("Bad TypeInfo kind");
+    swift_unreachable("Bad TypeInfo kind");
   }
 };
 
@@ -2007,7 +2007,7 @@ public:
       return nullptr;
     }
 
-    swift_runtime_unreachable("Unhandled FieldDescriptorKind in switch.");
+    swift_unreachable("Unhandled FieldDescriptorKind in switch.");
   }
 
   const TypeInfo *visitNominalTypeRef(const NominalTypeRef *N) {
@@ -2039,7 +2039,7 @@ public:
       return TC.getTypeInfo(TC.getThinFunctionTypeRef(), ExternalTypeInfo);
     }
 
-    swift_runtime_unreachable("Unhandled FunctionMetadataConvention in switch.");
+    swift_unreachable("Unhandled FunctionMetadataConvention in switch.");
   }
 
   const TypeInfo *
@@ -2060,7 +2060,7 @@ public:
       return TC.getTypeInfo(TC.getAnyMetatypeTypeRef(), ExternalTypeInfo);
     }
 
-    swift_runtime_unreachable("Unhandled MetatypeRepresentation in switch.");
+    swift_unreachable("Unhandled MetatypeRepresentation in switch.");
   }
 
   const TypeInfo *
@@ -2256,7 +2256,7 @@ const TypeInfo *TypeConverter::getClassInstanceTypeInfo(
     return nullptr;
   }
 
-  swift_runtime_unreachable("Unhandled FieldDescriptorKind in switch.");
+  swift_unreachable("Unhandled FieldDescriptorKind in switch.");
 }
 
 } // namespace reflection

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -23,7 +23,7 @@ unsigned long long swift_reflection_classIsSwiftMask = 2;
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Remote/CMemoryReader.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TargetConditionals.h>
@@ -406,7 +406,7 @@ swift_layout_kind_t getTypeInfoKind(const TypeInfo &TI) {
   }
   }
 
-  swift_runtime_unreachable("Unhandled TypeInfoKind in switch");
+  swift_unreachable("Unhandled TypeInfoKind in switch");
 }
 
 static swift_typeinfo_t convertTypeInfo(const TypeInfo *TI) {

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -35,7 +35,7 @@
 # define SWIFT_CASTING_SUPPORTS_MUTEX 1
 # include "swift/Runtime/Mutex.h"
 #endif
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
 #if SWIFT_OBJC_INTEROP
@@ -1016,7 +1016,7 @@ static bool _dynamicCastToExistential(OpaqueValue *dest,
   }
   }
 
-  swift_runtime_unreachable("Unhandled ExistentialTypeRepresentation in switch.");
+  swift_unreachable("Unhandled ExistentialTypeRepresentation in switch.");
 }
 
 /******************************************************************************/
@@ -1214,7 +1214,7 @@ swift_dynamicCastMetatypeImpl(const Metadata *sourceType,
     return nullptr;
   }
 
-  swift_runtime_unreachable("Unhandled MetadataKind in switch.");
+  swift_unreachable("Unhandled MetadataKind in switch.");
 }
 
 static const Metadata *
@@ -1424,7 +1424,7 @@ static bool _dynamicCastToUnknownClassFromExistential(OpaqueValue *dest,
   }
   }
 
-  swift_runtime_unreachable(
+  swift_unreachable(
       "Unhandled ExistentialTypeRepresentation in switch.");
 }
 

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -1806,7 +1806,7 @@ static tryCastFunctionType *selectCasterForDest(const Metadata *destType) {
     case ExistentialTypeRepresentation::Error: // => Error existential
       return tryCastToErrorExistential;
     }
-    swift_runtime_unreachable(
+    swift_unreachable(
       "Unknown existential type representation in dynamic cast dispatch");
   }
   case MetadataKind::Metatype:
@@ -1821,14 +1821,14 @@ static tryCastFunctionType *selectCasterForDest(const Metadata *destType) {
     // These are internal details of runtime-only structures,
     // so will never appear in compiler-generated types.
     // As such, they don't need support here.
-    swift_runtime_unreachable(
+    swift_unreachable(
       "Unexpected MetadataKind in dynamic cast dispatch");
     return nullptr;
   default:
     // If you see this message, then there is a new MetadataKind that I didn't
     // know about when I wrote this code.  Please figure out what it is, how to
     // handle it, and add a case for it.
-    swift_runtime_unreachable(
+    swift_unreachable(
       "Unknown MetadataKind in dynamic cast dispatch");
   }
 }

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -219,7 +219,7 @@ public:
       }
     }
 
-    swift_runtime_unreachable("access not found in set");
+    swift_unreachable("access not found in set");
   }
 
 #ifndef NDEBUG

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -194,7 +194,7 @@ computeMetadataBoundsForSuperclass(const void *ref,
 #endif
   }
   }
-  swift_runtime_unreachable("unsupported superclass reference kind");
+  swift_unreachable("unsupported superclass reference kind");
 }
 
 static ClassMetadataBounds computeMetadataBoundsFromSuperclass(
@@ -3716,7 +3716,7 @@ getExistentialValueWitnesses(ProtocolClassConstraint classConstraint,
     return getOpaqueExistentialValueWitnesses(numWitnessTables);
   }
 
-  swift_runtime_unreachable("Unhandled ProtocolClassConstraint in switch.");
+  swift_unreachable("Unhandled ProtocolClassConstraint in switch.");
 }
 
 template<> ExistentialTypeRepresentation
@@ -3761,7 +3761,7 @@ ExistentialTypeMetadata::mayTakeValue(const OpaqueValue *container) const {
   }
   }
 
-  swift_runtime_unreachable(
+  swift_unreachable(
       "Unhandled ExistentialTypeRepresentation in switch.");
 }
 
@@ -3810,7 +3810,7 @@ ExistentialTypeMetadata::projectValue(const OpaqueValue *container) const {
   }
   }
 
-  swift_runtime_unreachable(
+  swift_unreachable(
       "Unhandled ExistentialTypeRepresentation in switch.");
 }
 
@@ -3835,7 +3835,7 @@ ExistentialTypeMetadata::getDynamicType(const OpaqueValue *container) const {
   }
   }
 
-  swift_runtime_unreachable(
+  swift_unreachable(
       "Unhandled ExistentialTypeRepresentation in switch.");
 }
 
@@ -4030,7 +4030,7 @@ class ForeignMetadataCacheEntry
     return Value;
   }
   void setValue(ValueType value) {
-    swift_runtime_unreachable("should never be called");
+    swift_unreachable("should never be called");
   }
 
 public:
@@ -4094,7 +4094,7 @@ public:
   }
 
   AllocationResult allocate(Metadata *candidate) {
-    swift_runtime_unreachable(
+    swift_unreachable(
                         "always flags allocation complete during construction");
   }
 
@@ -4555,7 +4555,7 @@ static void initProtocolWitness(void **slot, void *witness,
                                       reqt);
     return;
   }
-  swift_runtime_unreachable("bad witness kind");
+  swift_unreachable("bad witness kind");
 #else
   *slot = witness;
 #endif
@@ -4588,7 +4588,7 @@ static void copyProtocolWitness(void **dest, void * const *src,
     swift_ptrauth_copy(dest, src, reqt.Flags.getExtraDiscriminator());
     return;
   }
-  swift_runtime_unreachable("bad witness kind");
+  swift_unreachable("bad witness kind");
 #else
   *dest = *src;
 #endif
@@ -5141,7 +5141,7 @@ static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
     return assocWitnessTable;
   }
 
-  swift_runtime_unreachable("Invalid mangled associate conformance");
+  swift_unreachable("Invalid mangled associate conformance");
 }
 
 const WitnessTable *swift::swift_getAssociatedConformanceWitness(
@@ -5234,7 +5234,7 @@ static Result performOnMetadataCache(const Metadata *metadata,
     case TypeContextDescriptorFlags::SingletonMetadataInitialization:
       return std::move(callbacks).forSingletonMetadata(description);
     }
-    swift_runtime_unreachable("bad metadata initialization kind");
+    swift_unreachable("bad metadata initialization kind");
   }
 
   auto &generics = description->getFullGenericContextHeader();
@@ -5280,7 +5280,7 @@ bool swift::addToMetadataQueue(MetadataCompletionQueueEntry *queueEntry,
     }
 
     bool forOtherMetadata(const Metadata *metadata) && {
-      swift_runtime_unreachable("metadata should always be complete");
+      swift_unreachable("metadata should always be complete");
     }
   } callbacks = { queueEntry, dependency };
 
@@ -5312,7 +5312,7 @@ void swift::resumeMetadataCompletion(MetadataCompletionQueueEntry *queueEntry) {
     }
 
     void forOtherMetadata(const Metadata *metadata) && {
-      swift_runtime_unreachable("metadata should always be complete");
+      swift_unreachable("metadata should always be complete");
     }
   } callbacks = { queueEntry };
 

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -366,7 +366,7 @@ public:
   template <class... ArgTys>
   Status beginInitialization(ConcurrencyControl &concurrency,
                              ArgTys &&...args) {
-    swift_runtime_unreachable("beginAllocation always short-circuits");
+    swift_unreachable("beginAllocation always short-circuits");
   }
 };
 
@@ -592,7 +592,7 @@ inline bool satisfies(PrivateMetadataState state, MetadataState requirement) {
   case MetadataState::Complete:
     return state >= PrivateMetadataState::Complete;
   }
-  swift_runtime_unreachable("unsupported requirement kind");
+  swift_unreachable("unsupported requirement kind");
 }
 
 class PrivateMetadataTrackingInfo {
@@ -642,7 +642,7 @@ public:
   MetadataState getAccomplishedRequestState() const {
     switch (getState()) {
     case PrivateMetadataState::Allocating:
-      swift_runtime_unreachable("cannot call on allocating state");
+      swift_unreachable("cannot call on allocating state");
     case PrivateMetadataState::Abstract:
       return MetadataState::Abstract;
     case PrivateMetadataState::LayoutComplete:
@@ -652,7 +652,7 @@ public:
     case PrivateMetadataState::Complete:
       return MetadataState::Complete;
     }
-    swift_runtime_unreachable("bad state");
+    swift_unreachable("bad state");
   }
 
   bool satisfies(MetadataState requirement) {
@@ -678,7 +678,7 @@ public:
       // Otherwise, if it's a non-blocking request, we do not need to block.
       return (request.isBlocking() && !satisfies(request.getState()));
     }
-    swift_runtime_unreachable("bad state");
+    swift_unreachable("bad state");
   }
 
   constexpr RawType getRawValue() const { return Data; }
@@ -1124,9 +1124,9 @@ private:
       return;
 
     case LSK::Complete:
-      swift_runtime_unreachable("preparing to enqueue when already complete?");
+      swift_unreachable("preparing to enqueue when already complete?");
     }
-    swift_runtime_unreachable("bad kind");
+    swift_unreachable("bad kind");
   }
 
   /// Claim all the satisfied completion queue entries, given that
@@ -1288,7 +1288,7 @@ public:
 
       switch (LockedStorageKind) {
       case LSK::Complete:
-        swift_runtime_unreachable("enqueuing on complete cache entry?");
+        swift_unreachable("enqueuing on complete cache entry?");
 
       case LSK::AllocatingThread:
         LockedStorageKind = LSK::CompletionQueue;
@@ -1340,7 +1340,7 @@ public:
       // Check for an existing dependency.
       switch (LockedStorageKind) {
       case LSK::Complete:
-        swift_runtime_unreachable("dependency on complete cache entry?");
+        swift_unreachable("dependency on complete cache entry?");
 
       case LSK::AllocatingThread:
       case LSK::CompletionQueue:

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -88,10 +88,10 @@ static uintptr_t resolveSymbolicReferenceOffset(SymbolicReferenceKind kind,
       return (uintptr_t)contextPtr;
     }
     case SymbolicReferenceKind::AccessorFunctionReference: {
-      swift_runtime_unreachable("should not be indirectly referenced");
+      swift_unreachable("should not be indirectly referenced");
     }
     }
-    swift_runtime_unreachable("unknown symbolic reference kind");
+    swift_unreachable("unknown symbolic reference kind");
   } else {
     return ptr;
   }
@@ -176,7 +176,7 @@ _buildDemanglingForSymbolicReference(SymbolicReferenceKind kind,
                           (uintptr_t)resolvedReference);
   }
   
-  swift_runtime_unreachable("invalid symbolic reference kind");
+  swift_unreachable("invalid symbolic reference kind");
 }
   
 NodePointer
@@ -1168,7 +1168,7 @@ findAssociatedTypeByName(const ProtocolDescriptor *protocol, StringRef name) {
     ++currentAssocTypeIdx;
   }
 
-  swift_runtime_unreachable("associated type names don't line up");
+  swift_unreachable("associated type names don't line up");
 }
 
 namespace {

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -20,7 +20,7 @@
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 #include "CompatibilityOverride.h"
 #include "ImageInspection.h"
 #include "Private.h"
@@ -116,7 +116,7 @@ const ClassMetadata *TypeReference::getObjCClass(TypeReferenceKind kind) const {
     return nullptr;
   }
 
-  swift_runtime_unreachable("Unhandled TypeReferenceKind in switch.");
+  swift_unreachable("Unhandled TypeReferenceKind in switch.");
 }
 #endif
 
@@ -155,7 +155,7 @@ ProtocolConformanceDescriptor::getCanonicalTypeMetadata() const {
   }
   }
 
-  swift_runtime_unreachable("Unhandled TypeReferenceKind in switch.");
+  swift_unreachable("Unhandled TypeReferenceKind in switch.");
 }
 
 template<>

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -17,7 +17,7 @@
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Enum.h"
-#include "swift/Runtime/Unreachable.h"
+#include "swift/Basic/Unreachable.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Portability.h"

--- a/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
+++ b/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
@@ -231,7 +231,7 @@ override_getCanonicalTypeMetadata(const ProtocolConformanceDescriptor *conf) {
   }
   }
 
-  swift_runtime_unreachable("Unhandled TypeReferenceKind in switch.");
+  swift_unreachable("Unhandled TypeReferenceKind in switch.");
 }
 
   class ConformanceCandidate {


### PR DESCRIPTION
Incremental improvements to the runtime — at least the ones I make :) — often add new things to Runtime/Config.h and ABI/MetadataValues.h.  Currently, MetadataValues.h is included by TypeLowering.h, which is ubiquitously included by SILGen and everything afterward, so editing it requires rebuilding all that.

1. Split the one pertinent declaration out into its own file and make TypeLowering just include that.
2. That file includes a helper function that uses `swift_runtime_unreachable`, which is a layering violation.  Fix it by moving Unreachable.h into Basic, renaming the function to `swift_unreachable`, and making it forward to `llvm_unreachable` (which is generally superior) whenever we're building with LLVM support, which we indicate with a new `-D` flag within the appropriate `lib/` directories.
3. Move some of the attribute macros from Runtime/Config.h to Basic/Compiler.h so that we don't have to include Config.h just to get compiler abstraction.