### PR TITLE
CI: add concurrency to the Windows CI set

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -201,6 +201,7 @@ cmake^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES^
     -S "%source_root%\llvm-project\llvm" %exitOnError%
 
 cmake --build "%build_root%\llvm" %exitOnError%


### PR DESCRIPTION
Enable the concurrency support for Windows CI to mirror the other
platforms.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
