### PR TITLE
Fixed docs link to Rust's demand-driven compilation guide

### DIFF
--- a/docs/RequestEvaluator.md
+++ b/docs/RequestEvaluator.md
@@ -71,4 +71,4 @@ The request-evaluator is relatively new to the Swift compiler, having been intro
 * Port higher-level queries (e.g., those that come from SourceKit) over to the request-evaluator, so we can see the dependencies of a given SourceKit request for testing and performance tuning.
 
 ## Prior art
-Rust's compiler went through a similar transformation to support [demand-driven compilation](https://rust-lang-nursery.github.io/rustc-guide/query.html). We should learn from their experience!
+Rust's compiler went through a similar transformation to support [demand-driven compilation](https://rustc-dev-guide.rust-lang.org/query.html). We should learn from their experience!


### PR DESCRIPTION
This PR fixes the link to Rust's guide on demand-driven compilation, which has changed location.