### PR TITLE
Make Unicode.Scalar.Properties added after ICU 55 available on Linux

### DIFF
--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -590,12 +590,6 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_NFKC_CASEFOLDED)
   }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-  // FIXME: These properties were introduced in ICU 57, but Ubuntu 16.04 comes
-  // with ICU 55 so the values won't be correct there. Exclude them on
-  // non-Darwin platforms for now; bundling ICU with the toolchain would resolve
-  // this and other inconsistencies (https://bugs.swift.org/browse/SR-6076).
-
   /// A Boolean value indicating whether the scalar has an emoji
   /// presentation, whether or not it is the default.
   ///
@@ -670,7 +664,6 @@ extension Unicode.Scalar.Properties {
   public var isEmojiModifierBase: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI_MODIFIER_BASE)
   }
-#endif
 }
 
 /// Case mapping properties.

--- a/test/stdlib/UnicodeScalarPropertiesTests.swift
+++ b/test/stdlib/UnicodeScalarPropertiesTests.swift
@@ -82,7 +82,6 @@ UnicodeScalarPropertiesTests.test("properties.booleanProperties") {
   expectBooleanProperty(\.changesWhenCaseMapped, trueFor: "A", falseFor: "!")
   expectBooleanProperty(\.changesWhenNFKCCaseFolded, trueFor: "A", falseFor: "!")
 
-#if canImport(Darwin)
   if #available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *) {
     // U+2708 AIRPLANE
     expectBooleanProperty(\.isEmoji, trueFor: "\u{2708}", falseFor: "A")
@@ -96,7 +95,6 @@ UnicodeScalarPropertiesTests.test("properties.booleanProperties") {
     expectBooleanProperty(
       \.isEmojiModifierBase, trueFor: "\u{270B}", falseFor: "A")
   }
-#endif
 }
 
 UnicodeScalarPropertiesTests.test("properties.lowercaseMapping") {


### PR DESCRIPTION
[SE-0211](https://github.com/apple/swift-evolution/blob/master/proposals/0211-unicode-scalar-properties.md) added new properties to `Unicode.Scalar.Properties`. Some of the properties added were never made available on Linux because they were not yet available in ICU 55 (the default on Ubuntu 16.04).

Since then, Swift on Linux has  been changed to ship with ICU 61, so this is no longer a problem. This PR makes the remaining properties from [SE-0211](https://github.com/apple/swift-evolution/blob/master/proposals/0211-unicode-scalar-properties.md) available on Linux.

See https://github.com/apple/swift/pull/19860 for when ICU was added & always built with Swift on Linux.