### PR TITLE
NFC: fix typo in build_swift/versions.py docstring

### DIFF
--- a/utils/build_swift/build_swift/versions.py
+++ b/utils/build_swift/build_swift/versions.py
@@ -168,7 +168,7 @@ class InvalidVersionError(Exception):
 
 @functools.total_ordering
 class Version(object):
-    """Similar to the standard distutils.versons.LooseVersion, but with a
+    """Similar to the standard distutils.version.LooseVersion, but with a
     little more wiggle-room for alpha characters.
     """
 


### PR DESCRIPTION
`distutils.versons.LooseVersion` -> `distutils.version.LooseVersion`. The actual module name is singular, hence the removed `s`.

