### PR TITLE
[build] Support installing swift-driver without swiftpm

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -821,7 +821,7 @@ class BuildScriptInvocation(object):
         product_classes = []
         if self.args.build_swiftpm:
             product_classes.append(products.SwiftPM)
-        if self.args.build_swift_driver:
+        if self.args.build_swift_driver or self.args.install_swift_driver:
             product_classes.append(products.SwiftDriver)
         if self.args.build_swiftsyntax:
             product_classes.append(products.SwiftSyntax)


### PR DESCRIPTION
The swift-driver Install phase knows how to build swift-driver using CMake. Allowing `--install-swift-driver` without also requiring `--swift-driver` allows installing it without requiring SwiftPM. This is a workaround for now, and we should unify the builds later.