### PR TITLE
[AST] Fix linker errors with the parser-only build

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -119,6 +119,10 @@ const clang::Module *ClangNode::getClangModule() const {
 }
 
 void ClangNode::dump() const {
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  return; // not needed for the parser library.
+#endif
+
   if (auto D = getAsDecl())
     D->dump();
   else if (auto M = getAsMacro())

--- a/lib/AST/ExtInfo.cpp
+++ b/lib/AST/ExtInfo.cpp
@@ -92,6 +92,10 @@ Optional<UnexpectedClangTypeError> UnexpectedClangTypeError::checkClangType(
 }
 
 void UnexpectedClangTypeError::dump() {
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  return; // not needed for the parser library.
+#endif
+
   auto &e = llvm::errs();
   using Kind = UnexpectedClangTypeError::Kind;
   switch (errorKind) {


### PR DESCRIPTION
Parser-only build avoids linking clangAST library.