### PR TITLE
Revert "[PassManager] Update PassManager's function worklist for newly added SILFunctions"

### DIFF
--- a/include/swift/SILOptimizer/Analysis/FunctionOrder.h
+++ b/include/swift/SILOptimizer/Analysis/FunctionOrder.h
@@ -31,6 +31,7 @@ public:
   typedef TinyPtrVector<SILFunction *> SCC;
 
 private:
+  SILModule &M;
   llvm::SmallVector<SCC, 32> TheSCCs;
   llvm::SmallVector<SILFunction *, 32> TheFunctions;
 
@@ -43,29 +44,24 @@ private:
   llvm::SmallSetVector<SILFunction *, 4> DFSStack;
 
 public:
-  BottomUpFunctionOrder(BasicCalleeAnalysis *BCA)
-      : BCA(BCA), NextDFSNum(0) {}
-
-  /// DFS on 'F' to compute bottom up order
-  void computeBottomUpOrder(SILFunction *F) {
-     DFS(F);
-  }
-
-  /// DFS on all functions in the module to compute bottom up order
-  void computeBottomUpOrder(SILModule *M) {
-    for (auto &F : *M)
-      DFS(&F);
-  }
+  BottomUpFunctionOrder(SILModule &M, BasicCalleeAnalysis *BCA)
+      : M(M), BCA(BCA), NextDFSNum(0) {}
 
   /// Get the SCCs in bottom-up order.
   ArrayRef<SCC> getSCCs() {
+    if (!TheSCCs.empty())
+      return TheSCCs;
+
+    FindSCCs(M);
     return TheSCCs;
   }
 
-  /// Get a flattened view of all functions in all the SCCs in bottom-up order
-  ArrayRef<SILFunction *> getBottomUpOrder() {
+  /// Get a flattened view of all functions in all the SCCs in
+  /// bottom-up order
+  ArrayRef<SILFunction *> getFunctions() {
     if (!TheFunctions.empty())
       return TheFunctions;
+
     for (auto SCC : getSCCs())
       for (auto *F : SCC)
         TheFunctions.push_back(F);
@@ -75,6 +71,7 @@ public:
 
 private:
   void DFS(SILFunction *F);
+  void FindSCCs(SILModule &M);
 };
 
 } // end namespace swift

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -74,3 +74,7 @@ void BottomUpFunctionOrder::DFS(SILFunction *Start) {
   }
 }
 
+void BottomUpFunctionOrder::FindSCCs(SILModule &M) {
+  for (auto &F : M)
+    DFS(&F);
+}

--- a/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
@@ -35,8 +35,8 @@ class FunctionOrderPrinterPass : public SILModuleTransform {
   /// The entry point to the transformation.
   void run() override {
     BCA = getAnalysis<BasicCalleeAnalysis>();
-    BottomUpFunctionOrder Orderer(BCA);
-    Orderer.computeBottomUpOrder(getModule());
+    auto &M = *getModule();
+    BottomUpFunctionOrder Orderer(M, BCA);
 
     llvm::outs() << "Bottom up function order:\n";
     auto SCCs = Orderer.getSCCs();

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -91,9 +91,9 @@ public class C<R> {
 // IR-LABEL: ret void
 
 // IR: ![[BOOL:[0-9]+]] = !DICompositeType({{.*}}name: "Bool"
+// IR: ![[LET_BOOL:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[BOOL]])
 // IR: ![[INT:[0-9]+]] = !DICompositeType({{.*}}name: "Int"
 // IR: ![[LET_INT:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[INT]])
-// IR: ![[LET_BOOL:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[BOOL]])
 // IR: ![[TAU_0_0:[0-9]+]] = {{.*}}DW_TAG_structure_type, name: "$sxD",
 // IR: ![[LET_TAU_0_0:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TAU_0_0]])
 // IR: ![[TAU_1_0:[0-9]+]] = {{.*}}DW_TAG_structure_type, name: "$sqd__D",


### PR DESCRIPTION
Reverts apple/swift#30710

For some programs which create large number of specialized functions each with deep call chains. This can cause redundant DFS leading to large compile times. Reverting this until we implement a better incremental DFS for updating the bottom up order of newly added functions.