### PR TITLE
Frontend: add a frontend flag to disable building module from textual interface

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -272,6 +272,10 @@ public:
   /// built and given to the compiler invocation.
   bool DisableImplicitModules = false;
 
+  /// Disable building Swift modules from textual interfaces. This should be
+  /// for testing purposes only.
+  bool DisableBuildingInterface = false;
+
   /// When performing a dependency scanning action, only identify and output all imports
   /// of the main Swift module's source files.
   bool ImportPrescan = false;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -290,11 +290,13 @@ struct ModuleInterfaceLoaderOptions {
   bool remarkOnRebuildFromInterface = false;
   bool disableInterfaceLock = false;
   bool disableImplicitSwiftModule = false;
+  bool disableBuildingInterface = false;
   std::string mainExecutablePath;
   ModuleInterfaceLoaderOptions(const FrontendOptions &Opts):
     remarkOnRebuildFromInterface(Opts.RemarkOnRebuildFromModuleInterface),
     disableInterfaceLock(Opts.DisableInterfaceFileLock),
     disableImplicitSwiftModule(Opts.DisableImplicitModules),
+    disableBuildingInterface(Opts.DisableBuildingInterface),
     mainExecutablePath(Opts.MainExecutablePath)
   {
     switch (Opts.RequestedAction) {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -758,4 +758,8 @@ def candidate_module_file
 def use_static_resource_dir
   : Flag<["-"], "use-static-resource-dir">,
     HelpText<"Use resources in the static resource directory">;
+
+def disable_building_interface
+  : Flag<["-"], "disable-building-interface">,
+    HelpText<"Disallow building binary module from textual interface">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -212,6 +212,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.ImportUnderlyingModule |= Args.hasArg(OPT_import_underlying_module);
   Opts.EnableIncrementalDependencyVerifier |= Args.hasArg(OPT_verify_incremental_dependencies);
   Opts.UseSharedResourceFolder = !Args.hasArg(OPT_use_static_resource_dir);
+  Opts.DisableBuildingInterface = Args.hasArg(OPT_disable_building_interface);
 
   computeImportObjCHeaderOptions();
   computeImplicitImportModuleNames();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -859,13 +859,6 @@ class ModuleInterfaceLoaderImpl {
                                                 prebuiltCacheDir,
                                                 /*serializeDependencyHashes*/false,
                                                 trackSystemDependencies);
-    // Set up a builder if we need to build the module. It'll also set up
-    // the genericSubInvocation we'll need to use to compute the cache paths.
-    ModuleInterfaceBuilder builder(
-      ctx.SourceMgr, ctx.Diags, astDelegate, interfacePath, moduleName, cacheDir,
-      prebuiltCacheDir,
-      Opts.disableInterfaceLock, diagnosticLoc,
-      dependencyTracker);
 
     // Compute the output path if we're loading or emitting a cached module.
     llvm::SmallString<256> cachedOutputPath;
@@ -908,6 +901,18 @@ class ModuleInterfaceLoaderImpl {
 
       return std::move(module.moduleBuffer);
     }
+    // If building from interface is disabled, return error.
+    if (Opts.disableBuildingInterface) {
+      return std::make_error_code(std::errc::not_supported);
+    }
+
+    // Set up a builder if we need to build the module. It'll also set up
+    // the genericSubInvocation we'll need to use to compute the cache paths.
+    ModuleInterfaceBuilder builder(
+      ctx.SourceMgr, ctx.Diags, astDelegate, interfacePath, moduleName, cacheDir,
+      prebuiltCacheDir,
+      Opts.disableInterfaceLock, diagnosticLoc,
+      dependencyTracker);
 
     std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
 

--- a/test/ModuleInterface/disable-building-interface.swift
+++ b/test/ModuleInterface/disable-building-interface.swift
@@ -1,0 +1,21 @@
+// 1. Create folders
+// RUN: %empty-directory(%t/PrebuiltModule.swiftmodule)
+// RUN: %empty-directory(%t/ModuleCache)
+
+// 2. Define some public API
+// RUN: echo 'public struct InPrebuiltModule {}' > %t/PrebuiltModule.swift
+
+// 3. Compile textual interface only into a directory
+// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -module-name PrebuiltModule -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name
+
+// 4. Import this module with -disable-building-interface should fail
+// RUN: not %target-swift-frontend -typecheck -I %t %s -module-cache-path %t/ModuleCache -sdk %t -disable-building-interface
+
+// 5. Import this module without -disable-building-interface should succeed
+// RUN: %target-swift-frontend -typecheck -I %t %s -module-cache-path %t/ModuleCache -sdk %t
+
+import PrebuiltModule
+
+func x<T>(_ x: T) {}
+
+x(InPrebuiltModule.self)


### PR DESCRIPTION
This is for testing purposes to ensure prebuilt modules are up to date.

rdar://68770805