### PR TITLE
[build] Add FILES_MATCHING to CMakeLists.txt

### DIFF
--- a/localization/CMakeLists.txt
+++ b/localization/CMakeLists.txt
@@ -20,6 +20,7 @@ swift_install_in_component(
   DIRECTORY ${CMAKE_BINARY_DIR}/share/swift/diagnostics/
   DESTINATION "share/swift/diagnostics"
   COMPONENT compiler
+  FILES_MATCHING
   PATTERN "*.db"
   PATTERN "*.yaml"
 )

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -197,13 +197,13 @@ endif()
 swift_install_in_component(DIRECTORY "${clang_headers_location}/"
                            DESTINATION "lib/swift/clang"
                            COMPONENT clang-builtin-headers
-                           PATTERN "*.h")
+                           FILES_MATCHING PATTERN "*.h")
 
 if(SWIFT_BUILD_STATIC_STDLIB)
   swift_install_in_component(DIRECTORY "${clang_headers_location}/"
                              DESTINATION "lib/swift_static/clang"
                              COMPONENT clang-builtin-headers
-                             PATTERN "*.h")
+                             FILES_MATCHING PATTERN "*.h")
 endif()
 
 
@@ -227,4 +227,4 @@ file(TO_CMAKE_PATH "${LLVM_LIBRARY_OUTPUT_INTDIR}"
 swift_install_in_component(DIRECTORY "${_SWIFT_SHIMS_PATH_TO_CLANG_BUILD}/lib/clang"
                            DESTINATION "lib"
                            COMPONENT clang-builtin-headers-in-clang-resource-dir
-                           PATTERN "*.h")
+                           FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
The bare `PATTERN` argument by default does nothing, you need either `EXCLUDE` or `FILES_MATCHING` to make it do something. This likely wasn't previously a problem because clang is only installing headers, but it should be fixed for robustness.