### PR TITLE
Copy sources from Differentiation before building 

### DIFF
--- a/stdlib/public/Differentiation_NoTgMath/CMakeLists.txt
+++ b/stdlib/public/Differentiation_NoTgMath/CMakeLists.txt
@@ -1,3 +1,15 @@
+#===--- CMakeLists.txt - Differentiable programming support library ------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
 set(SOURCES_FOLDER ../Differentiation)
 
 add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB

--- a/stdlib/public/Differentiation_NoTgMath/CMakeLists.txt
+++ b/stdlib/public/Differentiation_NoTgMath/CMakeLists.txt
@@ -10,19 +10,34 @@
 #
 #===----------------------------------------------------------------------===#
 
-set(SOURCES_FOLDER ../Differentiation)
+set(DIFF_SOURCE_FILES
+    Differentiable.swift
+    DifferentialOperators.swift
+    DifferentiationUtilities.swift
+    AnyDifferentiable.swift
+    ArrayDifferentiation.swift
+    OptionalDifferentiation.swift)
+
+set(GYB_SOURCE_FILES
+    FloatingPointDifferentiation.swift.gyb
+    SIMDDifferentiation.swift.gyb)
+
+# The logic handling gyb files gets confused if we want to pull the sources
+# directly from ../Differentiation -- for now prefer copying those files
+# in the current source directory
+# A better solution would be to use symlinks, however
+# those could not readily available under Windows
+# (see https://github.com/git-for-windows/git/wiki/Symbolic-Links)
+foreach(CURRENT_FILE IN LISTS DIFF_SOURCE_FILES GYB_SOURCE_FILES)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCES_FOLDER}/${CURRENT_FILE}
+    ${CMAKE_CURRENT_SOURCE_DIR} COPYONLY)
+endforeach()
 
 add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
-  ${SOURCES_FOLDER}/Differentiable.swift
-  ${SOURCES_FOLDER}/DifferentialOperators.swift
-  ${SOURCES_FOLDER}/DifferentiationUtilities.swift
-  ${SOURCES_FOLDER}/AnyDifferentiable.swift
-  ${SOURCES_FOLDER}/ArrayDifferentiation.swift
-  ${SOURCES_FOLDER}/OptionalDifferentiation.swift
+  ${DIFF_SOURCE_FILES}
 
   GYB_SOURCES
-    ${SOURCES_FOLDER}/FloatingPointDifferentiation.swift.gyb
-    ${SOURCES_FOLDER}/SIMDDifferentiation.swift.gyb
+    ${GYB_SOURCE_FILES}
 
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}

--- a/stdlib/public/Differentiation_NoTgMath/CMakeLists.txt
+++ b/stdlib/public/Differentiation_NoTgMath/CMakeLists.txt
@@ -10,6 +10,8 @@
 #
 #===----------------------------------------------------------------------===#
 
+set(SOURCES_FOLDER ../Differentiation)
+
 set(DIFF_SOURCE_FILES
     Differentiable.swift
     DifferentialOperators.swift


### PR DESCRIPTION
This is needed since the generation of files from gyb templates gets
confused when trying to use files in parent directories.
Symlinks are likely not an option since they could not be available
under a Windows build environment

Take this chance to add the proper header to the file

Addresses rdar://69953208