### PR TITLE
Enable --build-sil-debugging-stdlib for all of swift/stdlib/public

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -15,7 +15,11 @@ if(SWIFT_RUNTIME_USE_SANITIZERS)
   endif()
 endif()
 
-list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-verify-syntax-tree")
+list(APPEND  SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-verify-syntax-tree")
+
+if(SWIFT_STDLIB_SIL_DEBUGGING)
+  list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-gsil")
+endif()
 
 # Build the runtime with -Wall to catch, e.g., uninitialized variables
 # warnings.

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -284,10 +284,6 @@ option(SWIFT_CHECK_ESSENTIAL_STDLIB
     "Check core standard library layering by linking its essential subset"
     FALSE)
 
-if(SWIFT_STDLIB_SIL_DEBUGGING)
-  list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-gsil")
-endif()
-
 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
   list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
   list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")


### PR DESCRIPTION
Previously it was enable only for swift/stdlib/public/core

