### PR TITLE
Implement a simple library for task cancellation and status management

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -40,8 +40,13 @@ function(add_swift_unittest test_dirname)
   endif()
 
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    # Add an @rpath to the swift library directory.
     set_target_properties(${test_dirname} PROPERTIES
       BUILD_RPATH ${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx)
+    # Force all the swift libraries to be found via rpath.
+    add_custom_command(TARGET "${test_dirname}" POST_BUILD
+      COMMAND "${SWIFT_SOURCE_DIR}/utils/swift-rpathize.py"
+              "$<TARGET_FILE:${test_dirname}>")
   elseif("${SWIFT_HOST_VARIANT}" STREQUAL "android")
     swift_android_lib_for_arch(${SWIFT_HOST_VARIANT_ARCH} android_system_libs)
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_DIRECTORIES

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -1,0 +1,275 @@
+//===--- Task.h - ABI structures for asynchronous tasks ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift ABI describing tasks.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_TASK_H
+#define SWIFT_ABI_TASK_H
+
+#include "swift/ABI/HeapObject.h"
+#include "swift/ABI/MetadataValues.h"
+#include "swift/Runtime/Config.h"
+#include "swift/Basic/STLExtras.h"
+
+namespace swift {
+
+class AsyncTask;
+class AsyncContext;
+class Executor;
+class Job;
+class TaskStatusRecord;
+
+/// An ExecutorRef isn't necessarily just a pointer to an executor
+/// object; it may have other bits set.
+using ExecutorRef = Executor *;
+
+using JobInvokeFunction =
+  SWIFT_CC(swift)
+  void (Job *, ExecutorRef);
+
+using TaskContinuationFunction =
+  SWIFT_CC(swift)
+  void (AsyncTask *, ExecutorRef, AsyncContext *);
+
+/// A schedulable job.
+class alignas(2 * alignof(void*)) Job {
+public:
+  // Reserved for the use of the scheduler.
+  void *SchedulerPrivate[2];
+
+  JobFlags Flags;
+
+  // We use this union to avoid having to do a second indirect branch
+  // when resuming an asynchronous task, which we expect will be the
+  // common case.
+  union {
+    // A function to run a job that isn't an AsyncTask.
+    JobInvokeFunction * __ptrauth_swift_job_invoke_function RunJob;
+
+    // A function to resume an AsyncTask.
+    TaskContinuationFunction * __ptrauth_swift_task_resume_function ResumeTask;
+  };
+
+  Job(JobFlags flags, JobInvokeFunction *invoke)
+      : Flags(flags), RunJob(invoke) {
+    assert(!isAsyncTask() && "wrong constructor for a task");
+  }
+
+  Job(JobFlags flags, TaskContinuationFunction *invoke)
+      : Flags(flags), ResumeTask(invoke) {
+    assert(isAsyncTask() && "wrong constructor for a non-task job");
+  }
+
+  bool isAsyncTask() const {
+    return Flags.isAsyncTask();
+  }
+
+  /// Run this job.
+  void run(Executor *currentExecutor);
+};
+
+// The compiler will eventually assume these.
+static_assert(sizeof(Job) == 4 * sizeof(void*),
+              "Job size is wrong");
+static_assert(alignof(Job) == 2 * alignof(void*),
+              "Job alignment is wrong");
+
+/// The current state of a task's status records.
+class ActiveTaskStatus {
+  enum : uintptr_t {
+    IsCancelled = 0x1,
+    IsLocked = 0x2,
+    RecordMask = ~uintptr_t(IsCancelled | IsLocked)
+  };
+
+  uintptr_t Value;
+
+public:
+  constexpr ActiveTaskStatus() : Value(0) {}
+  ActiveTaskStatus(TaskStatusRecord *innermostRecord,
+                   bool cancelled, bool locked)
+    : Value(reinterpret_cast<uintptr_t>(innermostRecord)
+                + (locked ? IsLocked : 0)
+                + (cancelled ? IsCancelled : 0)) {}
+
+  /// Is the task currently cancelled?
+  bool isCancelled() const { return Value & IsCancelled; }
+
+  /// Is there an active lock on the cancellation information?
+  bool isLocked() const { return Value & IsLocked; }
+
+  /// Return the innermost cancellation record.  Code running
+  /// asynchronously with this task should not access this record
+  /// without having first locked it; see swift_taskCancel.
+  TaskStatusRecord *getInnermostRecord() const {
+    return reinterpret_cast<TaskStatusRecord*>(Value & RecordMask);
+  }
+
+  static TaskStatusRecord *getStatusRecordParent(TaskStatusRecord *ptr);
+
+  using record_iterator =
+    LinkedListIterator<TaskStatusRecord, getStatusRecordParent>;
+  llvm::iterator_range<record_iterator> records() const {
+    return record_iterator::rangeBeginning(getInnermostRecord());
+  }
+};
+
+/// An asynchronous task.  Tasks are the analogue of threads for
+/// asynchronous functions: that is, they are a persistent identity
+/// for the overall async computation.
+class AsyncTask : public Job {
+public:
+  /// The context for resuming the job.  When a task is scheduled
+  /// as a job, the next continuation should be installed as the
+  /// ResumeTask pointer in the job header, with this serving as
+  /// the context pointer.
+  ///
+  /// We can't protect the data in the context from being overwritten
+  /// by attackers, but we can at least sign the context pointer to
+  /// prevent it from being corrupted in flight.
+  AsyncContext * __ptrauth_swift_task_resume_context ResumeContext;
+
+  /// The currntly-active information about cancellation.
+  std::atomic<ActiveTaskStatus> Status;
+
+  /// Reserved for the use of the task-local stack allocator.
+  void *AllocatorPrivate[4];
+
+  AsyncTask(JobFlags flags, TaskContinuationFunction *run,
+            AsyncContext *initialContext)
+    : Job(flags, run),
+      ResumeContext(initialContext),
+      Status(ActiveTaskStatus()) {
+    assert(flags.isAsyncTask());
+  }
+
+  void run(ExecutorRef currentExecutor) {
+    ResumeTask(this, currentExecutor, ResumeContext);
+  }
+
+  /// Check whether this task has been cancelled.  Checking this is,
+  /// of course, inherently race-prone on its own.
+  bool isCancelled() const {
+    return Status.load(std::memory_order_relaxed).isCancelled();
+  }
+
+  bool isHeapObject() const { return Flags.task_isHeapObject(); }
+  HeapObject *heapObjectHeader() {
+    assert(isHeapObject());
+    return reinterpret_cast<HeapObject*>(this) - 1;
+  }
+
+  /// A fragment of an async task structure that happens to be a child task.
+  class ChildFragment {
+    /// The parent task of this task.
+    AsyncTask *Parent;
+
+    /// The next task in the singly-linked list of child tasks.
+    /// The list must start in a `ChildTaskStatusRecord` registered
+    /// with the parent task.
+    /// Note that the parent task may have multiple such records.
+    AsyncTask *NextChild = nullptr;
+
+  public:
+    AsyncTask *getParent() const {
+      return Parent;
+    }
+
+    AsyncTask *getNextChild() const {
+      return NextChild;
+    }
+  };
+
+  bool hasChildFragment() const { return Flags.task_isChildTask(); }
+  ChildFragment *childFragment() {
+    assert(hasChildFragment());
+    return reinterpret_cast<ChildFragment*>(this + 1);
+  }
+
+  // TODO: Future fragment
+
+  static bool classof(const Job *job) {
+    return job->isAsyncTask();
+  }
+};
+
+// The compiler will eventually assume these.
+static_assert(sizeof(AsyncTask) == 10 * sizeof(void*),
+              "AsyncTask size is wrong");
+static_assert(alignof(AsyncTask) == 2 * alignof(void*),
+              "AsyncTask alignment is wrong");
+
+inline void Job::run(ExecutorRef currentExecutor) {
+  if (auto task = dyn_cast<AsyncTask>(this))
+    task->run(currentExecutor);
+  else
+    RunJob(this, currentExecutor);
+}
+
+/// An asynchronous context within a task.  Generally contexts are
+/// allocated using the task-local stack alloc/dealloc operations, but
+/// there's no guarantee of that, and the ABI is designed to permit
+/// contexts to be allocated within their caller's frame.
+class alignas(MaximumAlignment) AsyncContext {
+public:
+  /// The parent context.
+  AsyncContext * __ptrauth_swift_async_context_parent Parent;
+
+  /// The function to call to resume running in the parent context.
+  /// Generally this means a semantic return, but for some temporary
+  /// translation contexts it might mean initiating a call.
+  ///
+  /// Eventually, the actual type here will depend on the types
+  /// which need to be passed to the parent.  For now, arguments
+  /// are always written into the context, and so the type is
+  /// always the same.
+  TaskContinuationFunction * __ptrauth_swift_async_context_resume
+    ResumeParent;
+
+  /// Flags describing this context.
+  ///
+  /// Note that this field is only 32 bits; any alignment padding
+  /// following this on 64-bit platforms can be freely used by the
+  /// function.  If the function is a yielding function, that padding
+  /// is of course interrupted by the YieldToParent field.
+  AsyncContextFlags Flags;
+
+  // Fields following this point may not be valid in all instances
+  // of AsyncContext.
+
+  /// The function to call to temporarily resume running in the
+  /// parent context temporarily.  Generally this means a semantic
+  /// yield.  Requires Flags.hasYieldFunction().
+  TaskContinuationFunction * __ptrauth_swift_async_context_yield
+    YieldToParent;
+
+  AsyncContext(AsyncContextFlags flags,
+               TaskContinuationFunction *resumeParent,
+               AsyncContext *parent)
+    : Parent(parent), ResumeParent(resumeParent), Flags(flags) {}
+
+  AsyncContext(AsyncContextFlags flags,
+               TaskContinuationFunction *resumeParent,
+               TaskContinuationFunction *yieldToParent,
+               AsyncContext *parent)
+    : Parent(parent), ResumeParent(resumeParent), Flags(flags),
+      YieldToParent(yieldToParent) {}
+
+  AsyncContext(const AsyncContext &) = delete;
+  AsyncContext &operator=(const AsyncContext &) = delete;
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -1,0 +1,220 @@
+//===--- TaskStatusRecord.h - Structures to track task status --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift ABI describing "status records", the mechanism by which
+// tasks track dynamic information about their child tasks, custom
+// cancellation hooks, and other information which may need to be exposed
+// asynchronously outside of the task.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_TASKSTATUS_H
+#define SWIFT_ABI_TASKSTATUS_H
+
+#include "swift/ABI/MetadataValues.h"
+#include "swift/ABI/Task.h"
+
+namespace swift {
+
+/// The abstract base class for all sttatus records.
+///
+/// TaskStatusRecords are typically allocated on the stack (possibly
+/// in the task context), partially initialized, and then atomically
+/// added to the task with `swift_task_addTaskStatusRecord`.  While
+/// registered with the task, a status record should only be 
+/// modified in ways that respect the possibility of asynchronous
+/// access by a cancelling thread.  In particular, the chain of
+/// status records must not be disturbed.  When the task leaves
+/// the scope that requires the status record, the record can
+/// be unregistered from the task with `swift_task_removeTaskStatusRecord`,
+/// at which point the memory can be returned to the system.
+class TaskStatusRecord {
+public:
+  TaskStatusRecordFlags Flags;
+  TaskStatusRecord *Parent;
+
+  TaskStatusRecord(TaskStatusRecordKind kind,
+                   TaskStatusRecord *parent = nullptr)
+      : Flags(kind) {
+    resetParent(parent);
+  }
+
+  TaskStatusRecord(const TaskStatusRecord &) = delete;
+  TaskStatusRecord &operator=(const TaskStatusRecord &) = delete;
+
+  TaskStatusRecordKind getKind() const {
+    return Flags.getKind();
+  }
+
+  TaskStatusRecord *getParent() const {
+    return Parent;
+  }
+
+  /// Change the parent of this unregistered status record to the
+  /// given record.
+  ///
+  /// This should be used when the record has been previously initialized
+  /// without knowing what the true parent is.  If we decide to cache
+  /// important information (e.g. the earliest timeout) in the innermost
+  /// status record, this is the method that should fill that in
+  /// from the parent.
+  void resetParent(TaskStatusRecord *newParent) {
+    Parent = newParent;
+    // TODO: cache
+  }
+
+  /// Splice a record out of the status-record chain.
+  ///
+  /// Unlike resetParent, this assumes that it's just removing one or
+  /// more records from the chain and that there's no need to do any
+  /// extra cache manipulation.
+  void spliceParent(TaskStatusRecord *newParent) {
+    Parent = newParent;
+  }
+};
+
+TaskStatusRecord *
+ActiveTaskStatus::getStatusRecordParent(TaskStatusRecord *ptr) {
+  return ptr->getParent();
+}
+
+/// A deadline for the task.  If this is reached, the task will be
+/// automatically cancelled.  The deadline can also be queried and used
+/// in other ways.
+struct TaskDeadline {
+  // FIXME: I don't really know what this should look like right now.
+  // It's probably target-specific.
+  uint64_t Value;
+
+  bool operator==(const TaskDeadline &other) const {
+    return Value == other.Value;
+  }
+  bool operator<(const TaskDeadline &other) const {
+    return Value < other.Value;
+  }
+};
+
+/// A status record which states that there's an active deadline
+/// within the task.
+class DeadlineStatusRecord : public TaskStatusRecord {
+  TaskDeadline Deadline;
+public:
+  DeadlineStatusRecord(TaskDeadline deadline)
+    : TaskStatusRecord(TaskStatusRecordKind::Deadline),
+      Deadline(deadline) {}
+
+  TaskDeadline getDeadline() const {
+    return Deadline;
+  }
+
+  static bool classof(const TaskStatusRecord *record) {
+    return record->getKind() == TaskStatusRecordKind::Deadline;
+  }
+};
+
+/// A status record which states that a task has one or
+/// more active child tasks.
+class ChildTaskStatusRecord : public TaskStatusRecord {
+  /// FIXME: should this be an array?  How are things like task
+  /// nurseries supposed to actually manage this?  Should it be
+  /// atomically moodifiable?
+  AsyncTask *FirstChild;
+
+public:
+  ChildTaskStatusRecord(AsyncTask *child)
+    : TaskStatusRecord(TaskStatusRecordKind::ChildTask),
+      FirstChild(child) {}
+
+  /// Return the first child linked by this record.  This may be null;
+  /// if not, it (and all of its successors) are guaranteed to satisfy
+  /// `isChildTask()`.
+  AsyncTask *getFirstChild() const {
+    return FirstChild;
+  }
+
+  static AsyncTask *getNextChildTask(AsyncTask *task) {
+    return task->childFragment()->getNextChild();
+  }
+
+  using child_iterator = LinkedListIterator<AsyncTask, getNextChildTask>;
+  llvm::iterator_range<child_iterator> children() const {
+    return child_iterator::rangeBeginning(getFirstChild());
+  }
+
+  static bool classof(const TaskStatusRecord *record) {
+    return record->getKind() == TaskStatusRecordKind::ChildTask;
+  }
+};
+
+/// A cancellation record which states that a task has an arbitrary
+/// function that needs to be called if the task is cancelled.
+///
+/// The end of any call to the function will be ordered before the
+/// end of a call to unregister this record from the task.  That is,
+/// code may call `swift_task_removeTaskStatusRecord` and freely
+/// assume after it returns that this function will not be
+/// subsequently used.
+class CancellationNotificationStatusRecord : public TaskStatusRecord {
+public:
+  using FunctionType = void (void *);
+
+private:
+  FunctionType * __ptrauth_swift_cancellation_notification_function Function;
+  void *Argument;
+
+public:
+  CancellationNotificationStatusRecord(FunctionType *fn, void *arg)
+    : TaskStatusRecord(TaskStatusRecordKind::CancellationNotification),
+      Function(fn), Argument(arg) {}
+
+  void run() {
+    Function(Argument);
+  }
+
+  static bool classof(const TaskStatusRecord *record) {
+    return record->getKind() == TaskStatusRecordKind::CancellationNotification;
+  }
+};
+
+/// A status record which says that a task has an arbitrary
+/// function that needs to be called if the task's priority is escalated.
+///
+/// The end of any call to the function will be ordered before the
+/// end of a call to unregister this record from the task.  That is,
+/// code may call `swift_task_removeTaskStatusRecord` and freely
+/// assume after it returns that this function will not be
+/// subsequently used.
+class EscalationNotificationStatusRecord : public TaskStatusRecord {
+public:
+  using FunctionType = void (void *, JobPriority);
+
+private:
+  FunctionType * __ptrauth_swift_escalation_notification_function Function;
+  void *Argument;
+
+public:
+  EscalationNotificationStatusRecord(FunctionType *fn, void *arg)
+    : TaskStatusRecord(TaskStatusRecordKind::EscalationNotification),
+      Function(fn), Argument(arg) {}
+
+  void run(JobPriority newPriority) {
+    Function(Argument, newPriority);
+  }
+
+  static bool classof(const TaskStatusRecord *record) {
+    return record->getKind() == TaskStatusRecordKind::EscalationNotification;
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -1,0 +1,106 @@
+//===--- Concurrency.h - Runtime interface for concurrency ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The runtime interface for concurrency.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_CONCURRENCY_H
+#define SWIFT_RUNTIME_CONCURRENCY_H
+
+#include "swift/ABI/TaskStatus.h"
+
+namespace swift {
+
+/// Cancel a task and all of its child tasks.
+///
+/// This can be called from any thread.
+///
+/// This has no effect if the task is already cancelled.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_cancel(AsyncTask *task);
+
+/// Escalate the priority of a task and all of its child tasks.
+///
+/// This can be called from any thread.
+///
+/// This has no effect if the task already has at least the given priority.
+/// Returns the priority of the task.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+JobPriority
+swift_task_escalate(AsyncTask *task, JobPriority newPriority);
+
+/// Add a status record to a task.  The record should not be
+/// modified while it is registered with a task.
+///
+/// This must be called synchronously with the task.
+///
+/// If the task is already cancelled, returns `false` but still adds
+/// the status record.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_addStatusRecord(AsyncTask *task,
+                                TaskStatusRecord *record);
+
+/// Add a status record to a task if the task has not already
+/// been cancelled.   The record should not be modified while it is
+/// registered with a task.
+///
+/// This must be called synchronously with the task.
+///
+/// If the task is already cancelled, returns `false` and does not
+/// add the status record.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_tryAddStatusRecord(AsyncTask *task,
+                                   TaskStatusRecord *record);
+
+/// Remove a status record from a task.  After this call returns,
+/// the record's memory can be freely modified or deallocated.
+///
+/// This must be called synchronously with the task.  The record must
+/// be registered with the task or else this may crash.
+///
+/// The given record need not be the last record added to
+/// the task, but the operation may be less efficient if not.
+///s
+/// Returns false if the task has been cancelled.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_removeStatusRecord(AsyncTask *task,
+                                   TaskStatusRecord *record);
+
+/// This should have the same representation as an enum like this:
+///    enum NearestTaskDeadline {
+///      case none
+///      case alreadyCancelled
+///      case active(TaskDeadline)
+///    }
+/// TODO: decide what this interface should really be.
+struct NearestTaskDeadline {
+  enum Kind : uint8_t {
+    None,
+    AlreadyCancelled,
+    Active
+  };
+
+  TaskDeadline Value;
+  Kind ValueKind;
+};
+
+/// Returns the nearest deadline that's been registered with this task.
+///
+/// This must be called synchronously with the task.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+NearestTaskDeadline
+swift_task_getNearestDeadline(AsyncTask *task);
+
+}
+
+#endif

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -209,6 +209,30 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_dynamic_replacement_key                                \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             SpecialPointerAuthDiscriminators::DynamicReplacementKey)
+#define __ptrauth_swift_job_invoke_function                                    \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::JobInvokeFunction)
+#define __ptrauth_swift_task_resume_function                                   \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::TaskResumeFunction)
+#define __ptrauth_swift_task_resume_context                                    \
+  __ptrauth(ptrauth_key_process_independent_data, 1,                           \
+            SpecialPointerAuthDiscriminators::TaskResumeContext)
+#define __ptrauth_swift_async_context_parent                                   \
+  __ptrauth(ptrauth_key_process_independent_data, 1,                           \
+            SpecialPointerAuthDiscriminators::AsyncContextParent)
+#define __ptrauth_swift_async_context_resume                                   \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::AsyncContextResume)
+#define __ptrauth_swift_async_context_yield                                    \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::AsyncContextYield)
+#define __ptrauth_swift_cancellation_notification_function                     \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::CancellationNotificationFunction)
+#define __ptrauth_swift_escalation_notification_function                       \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::EscalationNotificationFunction)
 #define swift_ptrauth_sign_opaque_read_resume_function(__fn, __buffer)         \
   ptrauth_auth_and_resign(__fn, ptrauth_key_function_pointer, 0,               \
                           ptrauth_key_process_independent_code,                \
@@ -226,6 +250,14 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_protocol_witness_function_pointer(__declkey)
 #define __ptrauth_swift_value_witness_function_pointer(__key)
 #define __ptrauth_swift_type_metadata_instantiation_function
+#define __ptrauth_swift_job_invoke_function
+#define __ptrauth_swift_task_resume_function
+#define __ptrauth_swift_task_resume_context
+#define __ptrauth_swift_async_context_parent
+#define __ptrauth_swift_async_context_resume
+#define __ptrauth_swift_async_context_yield
+#define __ptrauth_swift_cancellation_notification_function
+#define __ptrauth_swift_escalation_notification_function
 #define __ptrauth_swift_runtime_function_entry
 #define __ptrauth_swift_runtime_function_entry_with_key(__key)
 #define __ptrauth_swift_runtime_function_entry_strip(__fn) (__fn)

--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -76,6 +76,7 @@ public:
 /// multi-threaded producers and consumers to signal each other in a safe way.
 class ConditionVariable {
   friend class Mutex;
+  friend class StaticMutex;
 
   ConditionVariable(const ConditionVariable &) = delete;
   ConditionVariable &operator=(const ConditionVariable &) = delete;
@@ -613,6 +614,9 @@ public:
 
   /// See Mutex::wait
   void wait(StaticConditionVariable &condition) {
+    ConditionPlatformHelper::wait(condition.Handle, Handle);
+  }
+  void wait(ConditionVariable &condition) {
     ConditionPlatformHelper::wait(condition.Handle, Handle);
   }
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -13,6 +13,8 @@
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Actor.swift
   PartialAsyncTask.swift
+  TaskStatus.cpp
+  Mutex.cpp
 
   SWIFT_MODULE_DEPENDS_OSX Darwin
   SWIFT_MODULE_DEPENDS_IOS Darwin
@@ -25,6 +27,10 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   SWIFT_MODULE_DEPENDS_HAIKU Glibc
   SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
 
+  LINK_LIBRARIES swiftCore
+
+  C_COMPILE_FLAGS
+    -Dswift_Concurrency_EXPORTS
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib

--- a/stdlib/public/Concurrency/Mutex.cpp
+++ b/stdlib/public/Concurrency/Mutex.cpp
@@ -1,0 +1,21 @@
+//===--- Mutex.cpp - Mutex support code -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Include the runtime's mutex support code.
+// FIXME: figure out some reasonable way to share this stuff
+
+#include "../runtime/MutexPThread.cpp"
+#include "../runtime/MutexWin32.cpp"
+
+SWIFT_NORETURN void swift::fatalError(uint32_t flags, const char *format, ...) {
+  abort();
+}

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -1,0 +1,588 @@
+//===--- Metadata.cpp - Swift Language ABI Metadata Support ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Routines for cancelling tasks.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/Mutex.h"
+#include "swift/ABI/TaskStatus.h"
+#include <atomic>
+
+using namespace swift;
+
+/**************************************************************************/
+/************************* RECORD LOCK MANAGEMENT *************************/
+/**************************************************************************/
+
+/// A lock used to protect management of task-specific status
+/// record locks.
+static StaticMutex StatusRecordLockLock;
+
+namespace {
+
+/// A lock record which can be used to protect a task's active
+/// status records.
+///
+/// For the most part, the active task status records of a task are
+/// only accessed by the task itself.  If that were always true,
+/// no synchronization would be required to change them.  However,
+/// cancellation and escalation can occur asynchronously, and they
+/// must be able to inspect the status records without worrying about
+/// their concurrent modification or destruction of the records.
+/// Therefore, these operations freeze the active status records
+/// for their duration.  They do this by (1) setting a bit in the
+/// task's `Status` field state which says that the records are
+/// locked and (2) creating a lock record as the new innermost
+/// status record.  When the operation is complete, it removes this
+/// record and clears the lock bit, then notifies the lock record that
+/// the locking operation is complete.
+///
+/// When a task wants to change its active status record, but
+/// it sees that the locked bit is set in the `Status` field, it
+/// must acquire the global status-record lock, find this record
+/// (which should be the innermost record), and wait for an unlock.
+class StatusRecordLockRecord : public TaskStatusRecord {
+  /// A lock held by the locking thread for the duration of some
+  /// operation.  The real lock for the status record state is the
+  /// isLocked() bit in the active state; this lock is just a
+  /// mechanism to allow threads to wait for that lock.  This is
+  /// rather unfortunately heavyweight, but we're willing make
+  /// locking expensive if it makes a task's normal record
+  /// manipulations as cheap as possible.
+  Mutex LockingThreadLock;
+
+  /// A condition variable that the locking thread waits for if
+  /// there are active unlock waiters when it tries to unlock.
+  ConditionVariable LockerQueue;
+
+  // These fields are protected by StatusRecordLockLock,
+  // not LockingThreadLock.
+
+  /// The number of threads waiting for Locked to become false.
+  size_t NumUnlockWaiters : CHAR_BIT * sizeof(size_t) - 1;
+
+  /// True if the lock has been cleared.
+  size_t Locked : 1;
+
+public:
+  StatusRecordLockRecord(TaskStatusRecord *parent)
+    : TaskStatusRecord(TaskStatusRecordKind::Private_RecordLock, parent),
+      NumUnlockWaiters(0), Locked(true) {
+    // This is always initialized on the locking thread, and
+    // the private lock starts off locked.
+    LockingThreadLock.lock();
+  }
+
+  ~StatusRecordLockRecord() {
+    // Unlock the lock before destroying it.
+    if (Locked) LockingThreadLock.unlock();
+  }
+
+  /// Wait on the queue until there's an unlock.
+  void waitForUnlock(StaticScopedLock &globalLock) {
+    assert(Locked);
+
+    // Flag that we're waiting, then drop the global lock.
+    NumUnlockWaiters++;
+    {
+      StaticScopedLock globalUnlock(StatusRecordLockLock);
+
+      // Attempt to acquire the locking-thread lock, thereby
+      // waiting until the locking thread unlocks the record.
+      {
+        ScopedLock acquirePrivateLock(LockingThreadLock);
+      }
+
+      // Now reacquire the global lock.
+    }
+
+    // The record should always be unlocked now.
+    assert(!Locked);
+
+    // Remove ourselves from the count, and if the count is zero,
+    // wake the locking thread.
+    NumUnlockWaiters--;
+    if (NumUnlockWaiters == 0)
+      LockerQueue.notifyAll();
+  }
+
+  /// Wake up any threads that were waiting for unlock.  Must be
+  /// called by the locking thread.
+  void unlock() {
+    StaticScopedLock globalLock(StatusRecordLockLock);
+    assert(Locked);
+    Locked = false;
+
+    // Unlock the locking-thread lock, balancing out the lock()
+    // call in the constructor.  This allows any unlock waiters
+    // to wake up.
+    LockingThreadLock.unlock();
+
+    // As soon as we don't have any unlock waiters, we're done.
+    while (NumUnlockWaiters) {
+      // In the meantime, wait on the locker queue, temporarily
+      // releasing the global lock.
+      // FIXME: this is a priority inversion; we really want to
+      // escalate the priority of the waiting threads.
+      StatusRecordLockLock.wait(LockerQueue);
+    }
+  }
+
+  static bool classof(const TaskStatusRecord *record) {
+    return record->getKind() == TaskStatusRecordKind::Private_RecordLock;
+  }
+};
+
+}
+
+/// Wait for a task's status record lock to be unlocked.
+///
+/// When this function returns, `oldStatus` will have been updated
+/// to the last value read and `isLocked()` will be false.
+/// Of course, another thread may still be concurrently trying
+/// to acquire the record lock.
+static void waitForStatusRecordUnlock(AsyncTask *task,
+                                      ActiveTaskStatus &oldStatus) {
+  assert(oldStatus.isLocked());
+
+  // Acquire the lock.
+  StaticScopedLock globalLock(StatusRecordLockLock);
+
+  while (true) {
+    // Check that oldStatus is still correct.
+    oldStatus = task->Status.load(std::memory_order_acquire);
+    if (!oldStatus.isLocked())
+      return;
+
+    // The innermost entry should be a record lock record; wait
+    // for it to be unlocked.
+    auto record = oldStatus.getInnermostRecord();
+    auto recordLockRecord = cast<StatusRecordLockRecord>(record);
+    recordLockRecord->waitForUnlock(globalLock);
+  }
+}
+
+/// Acquire a task's status record lock and return the
+/// previous value of its status record state.
+///
+/// If `forCancellation` is true, the cancelled bit will be set in the
+/// state, and the lock will not be acquired if the task is already
+/// cancelled or can be cancelled without the lock.  If this occurs,
+/// `isCancelled()` will be true for the return value.
+static ActiveTaskStatus
+acquireStatusRecordLock(AsyncTask *task,
+                        Optional<StatusRecordLockRecord> &recordLockRecord,
+                        bool forCancellation) {
+  auto loadOrdering = forCancellation
+                        ? std::memory_order_acquire
+                        : std::memory_order_relaxed;
+
+  // Load the current state.  We can use relaxed loads if this isn't
+  // for cancellation because (1) this operation should be synchronous
+  // with the task, so the only thing that can modify it asynchronously
+  // is a cancelling thread, and (2) we'll reload with acquire ordering
+  // if a cancelling thread forces us to wait for an unlock.
+  auto oldStatus = task->Status.load(loadOrdering);
+
+  while (true) {
+    // Cancellation should be idempotent: if the task has already
+    // been cancelled (or is being cancelled concurrently), there
+    // shouldn't be any need to do this work again.
+    if (oldStatus.isCancelled() && forCancellation)
+      return oldStatus;
+
+    // If the old info says we're locked, wait for the lock to clear.
+    if (oldStatus.isLocked()) {
+      waitForStatusRecordUnlock(task, oldStatus);
+      continue;
+    }
+
+    // If we're cancelling and the task has no active status records,
+    // try to just set the cancelled bit and return.
+    auto oldRecord = oldStatus.getInnermostRecord();
+    if (!oldRecord && forCancellation) {
+      ActiveTaskStatus newStatus(nullptr,
+                                 /*cancelled*/ true,
+                                 /*locked*/ false);
+      if (task->Status.compare_exchange_weak(oldStatus, newStatus,
+            /*success*/ std::memory_order_relaxed,
+            /*failure*/ loadOrdering))
+        return newStatus;
+
+      // If that failed, just restart.
+      continue;
+    }
+
+    // Make (or reconfigure) a lock record.
+    if (!recordLockRecord) {
+      recordLockRecord.emplace(oldRecord);
+    } else {
+      recordLockRecord->resetParent(oldRecord);
+    }
+
+    // Install the lock record as the active cancellation info, or
+    // restart if that fails.
+    bool newIsCancelled = forCancellation || oldStatus.isCancelled();
+    ActiveTaskStatus newStatus(&*recordLockRecord,
+                               /*cancelled*/ newIsCancelled,
+                               /*locked*/ true);
+    if (task->Status.compare_exchange_weak(oldStatus, newStatus,
+           /*success*/ std::memory_order_release,
+           /*failure*/ loadOrdering))
+      return oldStatus;
+  }
+}
+
+/// Release a task's status record lock that was previously
+/// acquired on this thread.
+static void releaseStatusRecordLock(AsyncTask *task,
+                                    ActiveTaskStatus newStatus,
+                     Optional<StatusRecordLockRecord> &recordLockRecord) {
+  assert(!newStatus.isLocked());
+
+  // We can just unconditionally store because nobody can be modifying
+  // the state while we've locked it.  The task shouldn't depend
+  // on memory-ordering with anything we've done, so we can use a
+  // relaxed store.
+  task->Status.store(newStatus, std::memory_order_relaxed);
+
+  // Unlock the record lock.
+  recordLockRecord->unlock();
+}
+
+/**************************************************************************/
+/*************************** RECORD MANAGEMENT ****************************/
+/**************************************************************************/
+
+bool swift::swift_task_addStatusRecord(AsyncTask *task,
+                                       TaskStatusRecord *newRecord) {
+  // Load the current state.  We can use a relaxed load because we're
+  // synchronous with the task.
+  auto oldStatus = task->Status.load(std::memory_order_relaxed);
+
+  while (true) {
+    // Wait for any active lock to be released.
+    if (oldStatus.isLocked())
+      waitForStatusRecordUnlock(task, oldStatus);
+
+    // Reset the parent of the new record.
+    newRecord->resetParent(oldStatus.getInnermostRecord());
+
+    // Set the record as the new innermost record.
+    // We have to use a release on success to make the initialization of
+    // the new record visible to the cancelling thread.
+    ActiveTaskStatus newStatus(newRecord,
+                               oldStatus.isCancelled(),
+                               /*locked*/ false);
+    if (task->Status.compare_exchange_weak(oldStatus, newStatus,
+           /*success*/ std::memory_order_release,
+           /*failure*/ std::memory_order_relaxed))
+      return !oldStatus.isCancelled();
+  }
+}
+
+bool swift::swift_task_tryAddStatusRecord(AsyncTask *task,
+                                          TaskStatusRecord *newRecord) {
+  // Load the current state.  We can use a relaxed load because we're
+  // synchronous with the task.
+  auto oldStatus = task->Status.load(std::memory_order_relaxed);
+
+  while (true) {
+    // If the old info is already cancelled, do nothing.
+    if (oldStatus.isCancelled())
+      return false;
+
+    // Wait for any active lock to be released.
+    if (oldStatus.isLocked()) {
+      waitForStatusRecordUnlock(task, oldStatus);
+
+      if (oldStatus.isCancelled())
+        return false;
+    }
+
+    // Reset the parent of the new record.
+    newRecord->resetParent(oldStatus.getInnermostRecord());
+
+    // Set the record as the new innermost record.
+    // We have to use a release on success to make the initialization of
+    // the new record visible to the cancelling thread.
+    ActiveTaskStatus newStatus(newRecord,
+                               /*cancelled*/ false,
+                               /*locked*/ false);
+    if (task->Status.compare_exchange_weak(oldStatus, newStatus,
+           /*success*/ std::memory_order_release,
+           /*failure*/ std::memory_order_relaxed))
+      return true;
+  }
+}
+
+bool swift::swift_task_removeStatusRecord(AsyncTask *task,
+                                          TaskStatusRecord *record) {
+  // Load the current state.
+  auto oldStatus = task->Status.load(std::memory_order_relaxed);
+
+  while (true) {
+    // Wait for any active lock to be released.
+    if (oldStatus.isLocked())
+      waitForStatusRecordUnlock(task, oldStatus);
+
+    // If the record is the innermost record, try to just pop it off.
+    if (oldStatus.getInnermostRecord() == record) {
+      ActiveTaskStatus newStatus(record->getParent(),
+                                 oldStatus.isCancelled(),
+                                 /*locked*/ false);
+      if (task->Status.compare_exchange_weak(oldStatus, newStatus,
+             /*success*/ std::memory_order_release,
+             /*failure*/ std::memory_order_relaxed))
+        return !oldStatus.isCancelled();
+
+      // Otherwise, restart.
+      continue;
+    }
+
+    // If the record is not the innermost record, we need to acquire the
+    // record lock; there's no way to splice the record list safely with
+    // a thread that's attempting to acquire the lock.
+    break;
+  }
+
+  // Acquire the status record lock.
+  Optional<StatusRecordLockRecord> recordLockRecord;
+  oldStatus = acquireStatusRecordLock(task, recordLockRecord,
+                                      /*forCancellation*/ false);
+  assert(!oldStatus.isLocked());
+
+  // We can't observe the record to be the innermost record here because
+  // that would require some other thread to be concurrently structurally
+  // changing the set of status records, but we're running
+  // synchronously with the task.
+  auto cur = oldStatus.getInnermostRecord();
+  assert(cur != record);
+
+  // Splice the record out.
+  while (true) {
+    auto next = cur->getParent();
+    if (next == record) {
+      cur->spliceParent(record->getParent());
+      break;
+    }
+  }
+
+  // Release the lock.  Since the record can't be the root, we don't
+  // have to worry about replacing the root, and oldStatus is always
+  // exactly what we want to restore.
+  releaseStatusRecordLock(task, oldStatus, recordLockRecord);
+
+  return !oldStatus.isCancelled();
+}
+
+/**************************************************************************/
+/****************************** CANCELLATION ******************************/
+/**************************************************************************/
+
+/// Perform any cancellation actions required by the given record.
+static void performCancellationAction(TaskStatusRecord *record) {
+  switch (record->getKind()) {
+  // Deadlines don't require any special support.
+  case TaskStatusRecordKind::Deadline:
+    return;
+
+  // Child tasks need to be recursively cancelled.
+  case TaskStatusRecordKind::ChildTask: {
+    auto childRecord = cast<ChildTaskStatusRecord>(record);
+    for (AsyncTask *child: childRecord->children())
+      swift_task_cancel(child);
+    return;
+  }
+
+  // Cancellation notifications need to be called.
+  case TaskStatusRecordKind::CancellationNotification: {
+    auto notification =
+      cast<CancellationNotificationStatusRecord>(record);
+    notification->run();
+    return;
+  }
+
+  // Escalation notifications can be ignored.
+  case TaskStatusRecordKind::EscalationNotification:
+    return;
+
+  // Record locks shouldn't be found this way, but they don't have
+  // anything to do anyway.
+  case TaskStatusRecordKind::Private_RecordLock:
+    return;
+  }
+
+  // Other cases can fall through here and be ignored.
+  // FIXME: allow dynamic extension/correction?
+}
+
+void swift::swift_task_cancel(AsyncTask *task) {
+  Optional<StatusRecordLockRecord> recordLockRecord;
+
+  // Acquire the status record lock.
+  auto oldStatus = acquireStatusRecordLock(task, recordLockRecord,
+                                           /*forCancellation*/ true);
+  assert(!oldStatus.isLocked());
+
+  // If we were already cancelled or were able to cancel without acquiring
+  // the lock, there's nothing else to do.
+  if (oldStatus.isCancelled())
+    return;
+
+  // Otherwise, we've installed the lock record and are now the
+  // locking thread.
+
+  // Carry out the cancellation operations associated with all
+  // the active records.
+  for (auto cur: oldStatus.records()) {
+    performCancellationAction(cur);
+  }
+
+  // Release the status record lock, being sure to flag that
+  // the task is now cancelled.
+  ActiveTaskStatus cancelledStatus(oldStatus.getInnermostRecord(),
+                                   /*cancelled*/ true,
+                                   /*locked*/ false);
+  releaseStatusRecordLock(task, cancelledStatus, recordLockRecord);
+}
+
+/**************************************************************************/
+/******************************* ESCALATION *******************************/
+/**************************************************************************/
+
+/// Perform any escalation actions required by the given record.
+static void performEscalationAction(TaskStatusRecord *record,
+                                    JobPriority newPriority) {
+  switch (record->getKind()) {
+  // Deadlines don't require any special support.
+  case TaskStatusRecordKind::Deadline:
+    return;
+
+  // Child tasks need to be recursively escalated.
+  case TaskStatusRecordKind::ChildTask: {
+    auto childRecord = cast<ChildTaskStatusRecord>(record);
+    for (AsyncTask *child: childRecord->children())
+      swift_task_escalate(child, newPriority);
+    return;
+  }
+
+  // Cancellation notifications can be ignore.
+  case TaskStatusRecordKind::CancellationNotification:
+    return;
+
+  // Escalation notifications need to be called.
+  case TaskStatusRecordKind::EscalationNotification:  {
+    auto notification =
+      cast<EscalationNotificationStatusRecord>(record);
+    notification->run(newPriority);
+    return;
+  }
+
+  // Record locks shouldn't be found this way, but they don't have
+  // anything to do anyway.
+  case TaskStatusRecordKind::Private_RecordLock:
+    return;
+  }
+
+  // Other cases can fall through here and be ignored.
+  // FIXME: allow dynamic extension/correction?
+}
+
+JobPriority
+swift::swift_task_escalate(AsyncTask *task, JobPriority newPriority) {
+  Optional<StatusRecordLockRecord> recordLockRecord;
+
+  // Fast path: check that the task's priority is not already at laest
+  // as high as the target.  The task's priority can only be modified
+  // under the status record lock; it's possible that the priority could
+  // be getting simultaneously escalated, but it's okay for us to return
+  // before that's complete.
+  if (task->Flags.getPriority() >= newPriority)
+    return task->Flags.getPriority();
+
+  // Acquire the status record lock.
+  auto oldStatus = acquireStatusRecordLock(task, recordLockRecord,
+                                           /*forCancellation*/ false);
+  assert(!oldStatus.isLocked());
+
+  // Now that we have the task's status lock, check again that the
+  // priority is still too low.
+  auto priorityToReturn = task->Flags.getPriority();
+  if (priorityToReturn < newPriority) {
+    // Change the priority.
+    task->Flags.setPriority(newPriority);
+    priorityToReturn = newPriority;
+
+    // TODO: attempt to escalate the thread running the task, if it's
+    // currently running.  This probably requires the task to be enqueued
+    // on a standard executor.
+
+    // Perform escalation operations for all the status records.
+    for (auto cur: oldStatus.records()) {
+      performEscalationAction(cur, newPriority);
+    }
+  }
+
+  // Release the status record lock, restoring the old status.
+  releaseStatusRecordLock(task, oldStatus, recordLockRecord);
+
+  return priorityToReturn;
+}
+
+/**************************************************************************/
+/******************************** DEADLINE ********************************/
+/**************************************************************************/
+
+NearestTaskDeadline swift::swift_task_getNearestDeadline(AsyncTask *task) {
+  // We don't have to worry about the deadline records being
+  // concurrently modified, so we can just walk the record chain,
+  // ignoring the possibility of a concurrent cancelling task.
+
+  // Load the current state.
+  auto oldStatus = task->Status.load(std::memory_order_relaxed);
+
+  NearestTaskDeadline result;
+
+  // If it's already cancelled, we're done.
+  if (oldStatus.isCancelled()) {
+    result.ValueKind = NearestTaskDeadline::AlreadyCancelled;
+    return result;
+  }
+
+  // If it's locked, wait for the lock; we can't safely step through
+  // the RecordLockStatusRecord on a different thread.
+  if (oldStatus.isLocked()) {
+    waitForStatusRecordUnlock(task, oldStatus);
+    assert(!oldStatus.isLocked());
+  }
+
+  // Walk all the records looking for deadlines.
+  result.ValueKind = NearestTaskDeadline::None;
+  for (const auto *record: oldStatus.records()) {
+    auto deadlineRecord = dyn_cast<DeadlineStatusRecord>(record);
+    if (!deadlineRecord) continue;
+    auto recordDeadline = deadlineRecord->getDeadline();
+
+    // If we already have a deadline, pick the earlier.
+    if (result.ValueKind == NearestTaskDeadline::Active) {
+      if (recordDeadline < result.Value)
+        result.Value = recordDeadline;
+    } else {
+      result.Value = recordDeadline;
+      result.ValueKind = NearestTaskDeadline::Active;
+    }
+  }
+  return result;
+}

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -173,6 +173,11 @@
 #else
 #define SWIFT_IMAGE_EXPORTS_swiftCore 0
 #endif
+#if defined(swift_Concurrency_EXPORTS)
+#define SWIFT_IMAGE_EXPORTS_swift_Concurrency 1
+#else
+#define SWIFT_IMAGE_EXPORTS_swift_Concurrency 0
+#endif
 
 #define SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)                          \
   SWIFT_MACRO_IF(SWIFT_IMAGE_EXPORTS_##LIBRARY,                       \

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -53,6 +53,21 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES DbgHelp)
   endif()
 
+  if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+    list(APPEND PLATFORM_SOURCES
+      TaskStatus.cpp
+      )
+    list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
+      swift_Concurrency${SWIFT_PRIMARY_VARIANT_SUFFIX}
+      )
+  endif()
+
+  # Don't complain about these files not being in the sources list.
+  set(LLVM_OPTIONAL_SOURCES
+    weak.mm
+    Refcounting.mm
+    TaskStatus.cpp)
+
   add_swift_unittest(SwiftRuntimeTests
     Array.cpp
     CompatibilityOverride.cpp

--- a/unittests/runtime/TaskStatus.cpp
+++ b/unittests/runtime/TaskStatus.cpp
@@ -1,0 +1,269 @@
+//===--- TaskStatus.cpp - Unit tests for the task-status API --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Basic/STLExtras.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+template <class T> struct ValueContext;
+
+template <class T>
+using InvokeFunctionRef =
+  llvm::function_ref<void(AsyncTask *task,
+                          ExecutorRef executor,
+                          ValueContext<T> *context)>;
+using BodyFunctionRef =
+  llvm::function_ref<void(AsyncTask *task)>;
+
+template <class Storage> struct ValueContext : AsyncContext, Storage {
+  InvokeFunctionRef<Storage> StoredInvokeFn;
+  ValueContext(JobFlags flags, InvokeFunctionRef<Storage> invokeFn,
+               Storage &&value)
+    : AsyncContext(AsyncContextKind::Ordinary, nullptr, nullptr),
+      Storage(std::forward<Storage>(value)),
+      StoredInvokeFn(invokeFn) {}
+};
+
+// Disable template argument deduction.
+template <class T>
+using undeduced =
+  typename std::enable_if<std::is_same<T, T>::value, T>::type;
+
+template <class T>
+SWIFT_CC(swift)
+static void simpleTaskInvokeFunction(AsyncTask *task, ExecutorRef executor,
+                                     AsyncContext *context) {
+  auto valueContext = static_cast<ValueContext<T>*>(context);
+  valueContext->StoredInvokeFn(task, executor, valueContext);
+}
+
+template <class T>
+static void withSimpleTask(JobFlags flags, T &&value,
+                           undeduced<InvokeFunctionRef<T>> invokeFn,
+                           BodyFunctionRef body) {
+  TaskContinuationFunction *invokeFP = &simpleTaskInvokeFunction<T>;
+  ValueContext<T> initialContext(flags, invokeFn, std::forward<T>(value));
+  AsyncTask task(flags, invokeFP, &initialContext);
+  body(&task);
+}
+
+template <class T>
+static void withSimpleTask(T &&value,
+                           undeduced<InvokeFunctionRef<T>> invokeFn,
+                           BodyFunctionRef bodyFn) {
+  withSimpleTask(JobKind::Task, std::forward<T>(value), invokeFn, bodyFn);
+}
+
+static ExecutorRef createFakeExecutor(uintptr_t value) {
+  return reinterpret_cast<ExecutorRef>(value);
+}
+
+} // end anonymous namespace
+
+TEST(TaskStatusTest, basicTasks) {
+  AsyncTask *createdTask = nullptr;
+  auto createdExecutor = createFakeExecutor(1234);
+  bool hasRun = false;
+
+  struct Storage { int value; };
+  withSimpleTask(Storage{47},
+    [&](AsyncTask *task, ExecutorRef executor,
+        ValueContext<Storage> *context) {
+    // The task passed in should be the task we created.
+    EXPECT_EQ(createdTask, task);
+    EXPECT_EQ(createdExecutor, executor);
+
+    if (hasRun) {
+      EXPECT_EQ(94, context->value);
+    } else {
+      EXPECT_EQ(47, context->value);
+      context->value *= 2;
+    }
+
+    hasRun = true;
+
+  }, [&](AsyncTask *task) {
+    createdTask = task;
+
+    EXPECT_FALSE(hasRun);
+    createdTask->run(createdExecutor);
+    EXPECT_TRUE(hasRun);
+    createdTask->run(createdExecutor);
+    EXPECT_TRUE(hasRun);
+  });
+
+  EXPECT_TRUE(hasRun);
+}
+
+TEST(TaskStatusTest, cancellation_simple) {
+  struct Storage { int value; };
+  withSimpleTask(Storage{47},
+    [&](AsyncTask *task, ExecutorRef executor,
+        ValueContext<Storage> *context) {
+    EXPECT_FALSE(task->isCancelled());
+    swift_task_cancel(task);
+    EXPECT_TRUE(task->isCancelled());
+    swift_task_cancel(task);
+    EXPECT_TRUE(task->isCancelled());
+  }, [&](AsyncTask *task) {
+    task->run(createFakeExecutor(1234));
+  });
+}
+
+// Test basic deadline mechanics (other than actually setting up
+// something to cancel the task).  Also tests adding and removing
+// records quite a bit.
+TEST(TaskStatusTest, deadline) {
+  struct Storage { int value; };
+  withSimpleTask(Storage{47},
+    [&](AsyncTask *task, ExecutorRef executor,
+        ValueContext<Storage> *context) {
+    EXPECT_FALSE(task->isCancelled());
+
+    TaskDeadline deadlineOne = { 1234 };
+    TaskDeadline deadlineTwo = { 2345 };
+    DeadlineStatusRecord recordOne(deadlineOne);
+    DeadlineStatusRecord recordTwo(deadlineTwo);
+    bool result;
+
+    NearestTaskDeadline nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::None, nearest.ValueKind);
+
+    // Add deadline 1.  Check that we haven't been cancelled yet.
+    result = swift_task_addStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+
+    // There should now be an active deadline.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineOne, nearest.Value);
+
+    // Remove deadline 1.  Check that we haven't been cancelled yet.
+    result = swift_task_removeStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+
+    // There shouldn't be an active deadline anymore.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::None, nearest.ValueKind);
+
+    // Add deadline 1, then 2.
+    result = swift_task_addStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+    result = swift_task_addStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+
+    // The nearest deadline should be deadline 1.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineOne, nearest.Value);
+
+    // Remove the deadlines.
+    result = swift_task_removeStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+    result = swift_task_removeStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+
+    // Add deadline 2, then 1s.
+    result = swift_task_addStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+
+    // In the middle, the nearest deadline should be deadline 2.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineTwo, nearest.Value);
+
+    result = swift_task_addStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+
+    // The nearest deadline should be deadline 1.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineOne, nearest.Value);
+
+    // Remove the deadlines.
+    result = swift_task_removeStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+    result = swift_task_removeStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+
+    // Do the same thing with tryAddStatus.
+    result = swift_task_tryAddStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+    result = swift_task_tryAddStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+    // The nearest deadline should be deadline 1.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineOne, nearest.Value);
+    result = swift_task_removeStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+    result = swift_task_removeStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+
+    // Remove out of order.
+    result = swift_task_addStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+    result = swift_task_addStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+    // The nearest deadline should be deadline 1.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineOne, nearest.Value);
+    result = swift_task_removeStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+    result = swift_task_removeStatusRecord(task, &recordOne);
+    EXPECT_TRUE(result);
+
+    // Add deadline 2, then cancel.
+    result = swift_task_addStatusRecord(task, &recordTwo);
+    EXPECT_TRUE(result);
+
+    // The nearest deadline should be deadline 2.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
+    EXPECT_EQ(deadlineTwo, nearest.Value);
+
+    // Cancel.
+    swift_task_cancel(task);
+    EXPECT_TRUE(task->isCancelled());
+
+    // We should report already cancelled now.
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::AlreadyCancelled, nearest.ValueKind);
+
+    // Add deadline 1.
+    result = swift_task_addStatusRecord(task, &recordOne);
+    EXPECT_FALSE(result);
+
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::AlreadyCancelled, nearest.ValueKind);
+
+    result = swift_task_removeStatusRecord(task, &recordOne);
+    EXPECT_FALSE(result);
+
+    result = swift_task_tryAddStatusRecord(task, &recordOne);
+    EXPECT_FALSE(result);
+
+    result = swift_task_removeStatusRecord(task, &recordTwo);
+    EXPECT_FALSE(result);
+
+    nearest = swift_task_getNearestDeadline(task);
+    EXPECT_EQ(NearestTaskDeadline::AlreadyCancelled, nearest.ValueKind);
+
+    EXPECT_TRUE(task->isCancelled());
+  }, [&](AsyncTask *task) {
+    task->run(createFakeExecutor(1234));
+  });
+}

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# On Darwin, dynamic libraries have an install name.  At link time, the
+# linker can work with a dylib anywhere in the filesystem, but it will
+# write the dylib's install name into the resulting image, and at load
+# time that dylib will normally be expected to be found at exactly that
+# path.  However, if the install name in an image begins with `@rpath`,
+# it will instead be searched for in the image's runtime search path
+# list.  That list may contain absolute paths, but it may also contain
+# paths beginning with `@executable_path` or `@loader_path`, meaning the
+# path containing the running executable or the image being loaded,
+# respectively.
+#
+# Many of Swift's dylibs are meant to be installed on the system, which
+# means they have install names like this:
+#   /usr/lib/swift/libswiftFoo.dylib
+# To support back-deployment, they also provide magic override symbols
+# ($ld$install_name) for all the OS versions preceding the addition of
+# of the library.  When the linker finds a dylib with a matching override
+# for the OS deployment target, it ignores the normal install name and
+# uses the override path in the linked image's load command.  Swift's
+# libraries use override paths that begin with `@rpath`, and Swift
+# builds images with a runtime search path list that starts with
+# /usr/lib/swift but then falls back on a path relative to the image;
+# thus, apps will use the system libraries if available but will
+# otherwise use fallback libraries.
+#
+# When we're working on Swift, we usually want to test the libraries
+# we just built rather than the system libraries.  There are two ways
+# to achieve that.  The first is to override dyld's runtime search path
+# with DYLD_LIBRARY_PATH; this will take precedence over even an
+# absolute install name.  The second is to make sure the dylibs are
+# loaded via an @rpath install name and then link the program with an
+# rpath that will use the just-built libraries.  Unfortunately, the
+# toolchain will ordinarily use an absolute install name instead of
+# an @rpath if the deployment target is old enough, subverting testing.
+#
+# This script looks for dependent dylibs with an absolute path in
+# /usr/lib/swift and changes them to use @rpath.
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+def main(arguments):
+    parser = argparse.ArgumentParser(
+        description='Change absolute install names to use @rpath')
+    parser.add_argument('bin', help='the binary')
+
+    args = parser.parse_args(arguments)
+    rpathize(args.bin)
+
+
+def rpathize(filename):
+    dylibsOutput = subprocess.check_output(
+        ['xcrun', 'dyldinfo', '-dylibs', filename])
+
+    # The output from dyldinfo -dylibs is a line of header followed by one
+    # install name per line, indented with spaces.
+    dylib_regex = re.compile(
+        r"^\s*(?P<path>/usr/lib/swift/(?P<filename>.*\.dylib))\s*$")
+
+    # Build a command to invoke install_name_tool.
+    command = ['install_name_tool']
+    for line in dylibsOutput.splitlines():
+        match = dylib_regex.match(line)
+        if match:
+            command.append('-change')
+            command.append(match.group('path'))
+            command.append('@rpath/' + match.group('filename'))
+            continue
+
+    # Don't run the command if we didn't find any dylibs to change:
+    # it's invalid to invoke install_name_tool without any operations.
+    if len(command) == 1:
+        return
+
+    # The last argument is the filename to operate on.
+    command.append(filename)
+
+    subprocess.check_call(command)
+
+
+sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
There are things about this that I'm far from sold on.  In particular, I'm concerned that in order to implement escalation correctly, we're going to have to add a status record for the fact that the task is being executed, which means we're going
to have to potentially wait to acquire the status lock; overall, that means making an extra runtime function call and doing some
atomics whenever we resume or suspend a task, which is an uncomfortable amount of overhead.

The testing here is pretty grossly inadequate, but I wanted to lay down the groundwork.