### PR TITLE
[lldb-toolbox] Add the ability to disassemble-to-file a specific function from a target without running the target.

### DIFF
--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -73,12 +73,26 @@ def disassemble_to_file(debugger, command, exec_ctx, result, internal_dict):
     by the user.
     """
     parser = argparse.ArgumentParser(prog='disassemble-to-file', description="""
-    Dump the disassembly of the current frame to the specified file.
+    Dump the disassembly of the current frame or specified function to the
+    specified file.
     """)
     parser.add_argument('file', type=argparse.FileType('w'),
                         default=sys.stdout)
+    parser.add_argument('-n', dest='func_name', help="""
+    Function name to disassembly. Frame used if unset.""")
     args = parser.parse_args(shlex.split(command))
-    args.file.write(exec_ctx.frame.disassembly)
+    if args.func_name is None:
+        args.file.write(exec_ctx.frame.disassembly)
+    else:
+        name = args.func_name
+        result = exec_ctx.target.FindFunctions(name)
+        if result is None:
+            raise RuntimeError('No function with name: {}'.format(name))
+        if len(result) > 1:
+            errorStr = 'Matched multiple functions to name: {}'
+            raise RuntimeError(errorStr.format(name))
+        f = result[0].GetFunction()
+        args.file.write(str(f.GetInstructions(exec_ctx.target)) + "\n")
 
 
 def sequence(debugger, command, exec_ctx, result, internal_dict):


### PR DESCRIPTION
The routine already supports dumping the assembly to file if we are at a
breakpoint using the current frame. This adds a -n option so one can without
running just dump the assembly to a file of a specific function in a binary.
