### PR TITLE
ASTScope: Pre-compute the right source ranges instead of relying on widening

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1189,8 +1189,10 @@ protected:
 class TopLevelCodeScope final : public ASTScopeImpl {
 public:
   TopLevelCodeDecl *const decl;
+  SourceLoc endLoc;
 
-  TopLevelCodeScope(TopLevelCodeDecl *e) : decl(e) {}
+  TopLevelCodeScope(TopLevelCodeDecl *e, SourceLoc endLoc)
+      : decl(e), endLoc(endLoc) {}
   virtual ~TopLevelCodeScope() {}
 
 protected:
@@ -1643,13 +1645,21 @@ class BraceStmtScope final : public AbstractStmtScope {
   /// definition.
   SmallVector<VarDecl *, 2> localVars;
 
+  /// The end location for bindings introduced in this scope. This can
+  /// extend past the actual end of the BraceStmt in top-level code,
+  /// where every TopLevelCodeDecl introduces a new scope through the
+  /// end of the buffer.
+  SourceLoc endLoc;
+
 public:
   BraceStmtScope(BraceStmt *e,
                  SmallVector<ValueDecl *, 2> localFuncsAndTypes,
-                 SmallVector<VarDecl *, 2> localVars)
+                 SmallVector<VarDecl *, 2> localVars,
+                 SourceLoc endLoc)
       : stmt(e),
         localFuncsAndTypes(localFuncsAndTypes),
-        localVars(localVars) {}
+        localVars(localVars),
+        endLoc(endLoc) {}
   virtual ~BraceStmtScope() {}
 
 protected:

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -966,19 +966,8 @@ public:
   CustomAttr *attr;
   VarDecl *decl;
 
-  /// Because we have to avoid request cycles, we approximate the test for an
-  /// AttachedPropertyWrapper with one based on source location. We might get
-  /// false positives, that that doesn't hurt anything. However, the result of
-  /// the conservative source range computation doesn't seem to be stable. So
-  /// keep the original here, and use it for source range queries.
-  const SourceRange sourceRangeWhenCreated;
-
   AttachedPropertyWrapperScope(CustomAttr *attr, VarDecl *decl)
-      : attr(attr), decl(decl),
-        sourceRangeWhenCreated(attr->getTypeRepr()->getSourceRange()) {
-    ASTScopeAssert(sourceRangeWhenCreated.isValid(),
-                   "VarDecls must have ranges to be looked-up");
-  }
+      : attr(attr), decl(decl) {}
   virtual ~AttachedPropertyWrapperScope() {}
 
 protected:

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -137,8 +137,8 @@ DEFINE_GET_CLASS_NAME(DefaultArgumentInitializerScope)
 DEFINE_GET_CLASS_NAME(AttachedPropertyWrapperScope)
 DEFINE_GET_CLASS_NAME(PatternEntryDeclScope)
 DEFINE_GET_CLASS_NAME(PatternEntryInitializerScope)
-DEFINE_GET_CLASS_NAME(ConditionalClauseScope)
 DEFINE_GET_CLASS_NAME(ConditionalClausePatternUseScope)
+DEFINE_GET_CLASS_NAME(ConditionalClauseInitializerScope)
 DEFINE_GET_CLASS_NAME(CaptureListScope)
 DEFINE_GET_CLASS_NAME(ClosureParametersScope)
 DEFINE_GET_CLASS_NAME(TopLevelCodeScope)
@@ -149,7 +149,7 @@ DEFINE_GET_CLASS_NAME(EnumElementScope)
 DEFINE_GET_CLASS_NAME(IfStmtScope)
 DEFINE_GET_CLASS_NAME(WhileStmtScope)
 DEFINE_GET_CLASS_NAME(GuardStmtScope)
-DEFINE_GET_CLASS_NAME(LookupParentDiversionScope)
+DEFINE_GET_CLASS_NAME(GuardStmtBodyScope)
 DEFINE_GET_CLASS_NAME(RepeatWhileScope)
 DEFINE_GET_CLASS_NAME(DoStmtScope)
 DEFINE_GET_CLASS_NAME(DoCatchStmtScope)
@@ -197,15 +197,6 @@ void ASTScopeImpl::postOrderDo(function_ref<void(ASTScopeImpl *)> fn) {
   for (auto *child : getChildren())
     child->postOrderDo(fn);
   fn(this);
-}
-
-ArrayRef<StmtConditionElement> ConditionalClauseScope::getCond() const {
-  return stmt->getCond();
-}
-
-const StmtConditionElement &
-ConditionalClauseScope::getStmtConditionElement() const {
-  return getCond()[index];
 }
 
 unsigned ASTScopeImpl::countDescendants() const {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -994,10 +994,8 @@ ASTSourceFileScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   ASTScopeAssert(SF, "Must already have a SourceFile.");
   ArrayRef<Decl *> decls = SF->getTopLevelDecls();
-  // Assume that decls are only added at the end, in source order
-  Optional<SourceLoc> endLoc = None;
-  if (!decls.empty())
-    endLoc = decls.back()->getEndLoc();
+
+  SourceLoc endLoc = getSourceRangeOfThisASTNode().End;
 
   std::vector<ASTNode> newNodes(decls.begin(), decls.end());
   insertionPoint =

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -176,18 +176,13 @@ void AbstractPatternEntryScope::printSpecifics(llvm::raw_ostream &out) const {
   });
 }
 
-void ConditionalClauseScope::printSpecifics(llvm::raw_ostream &out) const {
-  ASTScopeImpl::printSpecifics(out);
-  out << "index " << index;
-}
-
 void SubscriptDeclScope::printSpecifics(llvm::raw_ostream &out) const {
   decl->dumpRef(out);
 }
 
 void ConditionalClausePatternUseScope::printSpecifics(
     llvm::raw_ostream &out) const {
-  pattern->print(out);
+  sec.getPattern()->print(out);
 }
 
 bool GenericTypeOrExtensionScope::doesDeclHaveABody() const { return false; }

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -226,7 +226,7 @@ SourceRange TopLevelCodeScope::getSourceRangeOfThisASTNode(
 
 SourceRange SubscriptDeclScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  return decl->getSourceRange();
+  return decl->getSourceRangeIncludingAttrs();
 }
 
 SourceRange

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -448,7 +448,7 @@ SourceRange ClosureParametersScope::getSourceRangeOfThisASTNode(
 
 SourceRange AttachedPropertyWrapperScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  return sourceRangeWhenCreated;
+  return attr->getRange();
 }
 
 SourceRange GuardStmtScope::getSourceRangeOfThisASTNode(

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -221,7 +221,7 @@ SourceRange FunctionBodyScope::getSourceRangeOfThisASTNode(
 
 SourceRange TopLevelCodeScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  return decl->getSourceRange();
+  return SourceRange(decl->getStartLoc(), endLoc);
 }
 
 SourceRange SubscriptDeclScope::getSourceRangeOfThisASTNode(
@@ -401,9 +401,9 @@ BraceStmtScope::getSourceRangeOfThisASTNode(const bool omitAssertions) const {
   // 'in' keyword, when present.
   if (auto closure = parentClosureIfAny()) {
     if (closure.get()->getInLoc().isValid())
-      return SourceRange(closure.get()->getInLoc(), stmt->getEndLoc());
+      return SourceRange(closure.get()->getInLoc(), endLoc);
   }
-  return stmt->getSourceRange();
+  return SourceRange(stmt->getStartLoc(), endLoc);
 }
 
 SourceRange ConditionalClauseInitializerScope::getSourceRangeOfThisASTNode(

--- a/test/NameLookup/scope_map-astscopelookup.swift
+++ b/test/NameLookup/scope_map-astscopelookup.swift
@@ -308,7 +308,7 @@ func HasLabeledDo() {
 // CHECK-EXPANDED-NEXT:           |-BraceStmtScope {{.*}}, [69:53 - 72:3]
 // CHECK-EXPANDED-NEXT:             `-PatternEntryDeclScope {{.*}}, [70:9 - 70:13] entry 0 'c'
 // CHECK-EXPANDED-NEXT:               `-PatternEntryInitializerScope {{.*}}, [70:13 - 70:13] entry 0 'c'
-// CHECK-EXPANDED-NEXT:           `-LookupParentDiversionScope, [72:3 - 100:38]
+// CHECK-EXPANDED-NEXT:           `-GuardStmtBodyScope, [72:3 - 100:38]
 // CHECK-EXPANDED-NEXT:             |-WhileStmtScope {{.*}}, [74:3 - 76:3]
 // CHECK-EXPANDED-NEXT:               `-ConditionalClauseScope, [74:9 - 76:3] index 0
 // CHECK-EXPANDED-NEXT:                 `-ConditionalClausePatternUseScope, [74:21 - 76:3] let b3

--- a/test/NameLookup/scope_map_top_level.swift
+++ b/test/NameLookup/scope_map_top_level.swift
@@ -29,20 +29,20 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT: ASTSourceFileScope {{.*}}, (uncached) [1:1 - 61:1] 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}NameLookup{{[/\\]}}scope_map_top_level.swift'
 // CHECK-EXPANDED-NEXT: |-NominalTypeDeclScope {{.*}}, [4:1 - 4:13]
 // CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [4:11 - 4:13]
-// CHECK-EXPANDED-NEXT: `-TopLevelCodeScope {{.*}}, [6:1 - 21:28]
-// CHECK-EXPANDED-NEXT:   `-BraceStmtScope {{.*}}, [6:1 - 21:28]
+// CHECK-EXPANDED-NEXT: `-TopLevelCodeScope {{.*}}, [6:1 - 61:1]
+// CHECK-EXPANDED-NEXT:   `-BraceStmtScope {{.*}}, [6:1 - 61:1]
 // CHECK-EXPANDED-NEXT:     |-PatternEntryDeclScope {{.*}}, [6:5 - 6:15] entry 0 'a'
 // CHECK-EXPANDED-NEXT:       `-PatternEntryInitializerScope {{.*}}, [6:15 - 6:15] entry 0 'a'
-// CHECK-EXPANDED-NEXT:     `-TopLevelCodeScope {{.*}}, [8:1 - 21:28]
-// CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 21:28]
-// CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 21:28]
-// CHECK-EXPANDED-NEXT:           `-ConditionalClausePatternUseScope, [8:15 - 21:28] let b{{\??}}
+// CHECK-EXPANDED-NEXT:     `-TopLevelCodeScope {{.*}}, [8:1 - 61:1]
+// CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 61:1]
+// CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 61:1]
+// CHECK-EXPANDED-NEXT:           `-ConditionalClausePatternUseScope, [8:15 - 61:1] let b{{\??}}
 // CHECK-EXPANDED-NEXT:             |-ConditionalClauseInitializerScope, [8:15 - 8:15]
 // CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [11:1 - 11:19] 'foo(x:)'
 // CHECK-EXPANDED-NEXT:               |-ParameterListScope {{.*}}, [11:9 - 11:16]
 // CHECK-EXPANDED-NEXT:               `-FunctionBodyScope {{.*}}, [11:18 - 11:19]
-// CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 21:28]
-// CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 21:28]
+// CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 61:1]
+// CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 61:1]
 // CHECK-EXPANDED-NEXT:                 |-PatternEntryDeclScope {{.*}}, [13:5 - 13:9] entry 0 'c'
 // CHECK-EXPANDED-NEXT:                   `-PatternEntryInitializerScope {{.*}}, [13:9 - 13:9] entry 0 'c'
 // CHECK-EXPANDED-NEXT:                 |-TypeAliasDeclScope {{.*}}, [15:1 - 15:15]
@@ -51,8 +51,8 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:                     `-AbstractFunctionDeclScope {{.*}}, [18:3 - 18:43] 'my_identity()'
 // CHECK-EXPANDED-NEXT:                       `-FunctionBodyScope {{.*}}, [18:29 - 18:43]
 // CHECK-EXPANDED-NEXT:                         `-BraceStmtScope {{.*}}, [18:29 - 18:43]
-// CHECK-EXPANDED-NEXT:                 `-TopLevelCodeScope {{.*}}, [21:1 - 21:28]
-// CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [21:1 - 21:28]
+// CHECK-EXPANDED-NEXT:                 `-TopLevelCodeScope {{.*}}, [21:1 - 61:1]
+// CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [21:1 - 61:1]
 // CHECK-EXPANDED-NEXT:                     `-PatternEntryDeclScope {{.*}}, [21:5 - 21:28] entry 0 'i'
 // CHECK-EXPANDED-NEXT:                       `-PatternEntryInitializerScope {{.*}}, [21:14 - 21:28] entry 0 'i'
 

--- a/test/NameLookup/scope_map_top_level.swift
+++ b/test/NameLookup/scope_map_top_level.swift
@@ -26,7 +26,7 @@ var i: Int = b.my_identity()
 
 
 // CHECK-EXPANDED:      ***Complete scope map***
-// CHECK-EXPANDED-NEXT: ASTSourceFileScope {{.*}}, (uncached) [1:1 - 6{{.*}}:1] 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}NameLookup{{[/\\]}}scope_map_top_level.swift'
+// CHECK-EXPANDED-NEXT: ASTSourceFileScope {{.*}}, (uncached) [1:1 - 61:1] 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}NameLookup{{[/\\]}}scope_map_top_level.swift'
 // CHECK-EXPANDED-NEXT: |-NominalTypeDeclScope {{.*}}, [4:1 - 4:13]
 // CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [4:11 - 4:13]
 // CHECK-EXPANDED-NEXT: `-TopLevelCodeScope {{.*}}, [6:1 - 21:28]
@@ -36,14 +36,11 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:     `-TopLevelCodeScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 21:28]
-// CHECK-EXPANDED-NEXT:           |-ConditionalClauseScope, [8:7 - 8:22] index 0
-// CHECK-EXPANDED-NEXT:             `-ConditionalClausePatternUseScope, [8:22 - 8:22] let b{{\??}}
-// CHECK-EXPANDED-NEXT:           |-BraceStmtScope {{.*}}, [8:22 - 9:1]
-// CHECK-EXPANDED-NEXT:           `-LookupParentDiversionScope, [9:1 - 21:28]
+// CHECK-EXPANDED-NEXT:           `-ConditionalClausePatternUseScope, [8:15 - 21:28] let b{{\??}}
+// CHECK-EXPANDED-NEXT:             |-ConditionalClauseInitializerScope, [8:15 - 8:15]
 // CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [11:1 - 11:19] 'foo(x:)'
 // CHECK-EXPANDED-NEXT:               |-ParameterListScope {{.*}}, [11:9 - 11:16]
 // CHECK-EXPANDED-NEXT:               `-FunctionBodyScope {{.*}}, [11:18 - 11:19]
-// CHECK-EXPANDED-NEXT:                 `-BraceStmtScope {{.*}}, [11:18 - 11:19]
 // CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 21:28]
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                 |-PatternEntryDeclScope {{.*}}, [13:5 - 13:9] entry 0 'c'
@@ -60,5 +57,4 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:                       `-PatternEntryInitializerScope {{.*}}, [21:14 - 21:28] entry 0 'i'
 
 
-// REQUIRES: asserts
-// absence of assertions can change the "uncached" bit and cause failures
+


### PR DESCRIPTION
Today, if the source range of a child scope extends beyond the bounds of the parent, we automatically extend the source range of the parent. This PR fixes the handful of scope implementations which relied on this behavior to compute their complete source range up-front.

Also, in a few places in the parser, we recover from a missing BraceStmt by creating a new, empty BraceStmt whose source location is where the brace was expected to be seen. This can overlap with a scope created for the following statement, though. To avoid violating invariants, we now skip creating a BraceStmtScope entirely if the corresponding BraceStmt is empty. Not only is this a small optimization, it also avoids creating the scope in the invalid case.