### PR TITLE
[Sema] Decouple ConstraintSystem and TypeChecker headers

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4296,7 +4296,7 @@ namespace {
                                                 { Identifier() });
 
       auto resultTy = TypeChecker::typeCheckExpression(
-          callExpr, cs.DC, valueType, CTP_CannotFail);
+          callExpr, cs.DC, /*contextualInfo=*/{valueType, CTP_CannotFail});
       assert(resultTy && "Conversion cannot fail!");
       (void)resultTy;
 
@@ -8026,8 +8026,8 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
     Expr *convertElementExpr = elementExpr;
     if (TypeChecker::typeCheckExpression(
             convertElementExpr, dc,
-            optPatternType,
-            CTP_CoerceOperand).isNull()) {
+            /*contextualInfo=*/{optPatternType, CTP_CoerceOperand})
+            .isNull()) {
       return None;
     }
     elementExpr->setIsPlaceholder(false);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 #include "ConstraintGraph.h"
 #include "ConstraintSystem.h"
+#include "TypeChecker.h"
 #include "llvm/ADT/SetVector.h"
 #include <tuple>
 

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -17,6 +17,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
+#include "TypeChecker.h"
+
 using namespace swift;
 using namespace swift::constraints;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -19,6 +19,7 @@
 #include "Constraint.h"
 #include "ConstraintSystem.h"
 #include "OverloadChoice.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/Decl.h"

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -16,6 +16,7 @@
 #include "ConstraintGraph.h"
 #include "ConstraintSystem.h"
 #include "TypeCheckType.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Expr.h"

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ConstraintSystem.h"
+#include "TypeChecker.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -18,6 +18,7 @@
 #include "ConstraintSystem.h"
 #include "SolutionResult.h"
 #include "TypeCheckType.h"
+#include "TypeChecker.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeWalker.h"
 #include "llvm/ADT/STLExtras.h"

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -20,6 +20,7 @@
 #include "CSDiagnostics.h"
 #include "CSFix.h"
 #include "SolutionResult.h"
+#include "TypeChecker.h"
 #include "TypeCheckType.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -5214,4 +5215,40 @@ Type ConstraintSystem::getVarType(const VarDecl *var) {
       return type;
     return HoleType::get(Context, const_cast<VarDecl *>(var));
   });
+}
+
+bool ConstraintSystem::isReadOnlyKeyPathComponent(
+    const AbstractStorageDecl *storage, SourceLoc referenceLoc) {
+  // See whether key paths can store to this component. (Key paths don't
+  // get any special power from being formed in certain contexts, such
+  // as the ability to assign to `let`s in initialization contexts, so
+  // we pass null for the DC to `isSettable` here.)
+  if (!getASTContext().isSwiftVersionAtLeast(5)) {
+    // As a source-compatibility measure, continue to allow
+    // WritableKeyPaths to be formed in the same conditions we did
+    // in previous releases even if we should not be able to set
+    // the value in this context.
+    if (!storage->isSettable(DC)) {
+      // A non-settable component makes the key path read-only, unless
+      // a reference-writable component shows up later.
+      return true;
+    }
+  } else if (!storage->isSettable(nullptr) ||
+             !storage->isSetterAccessibleFrom(DC)) {
+    // A non-settable component makes the key path read-only, unless
+    // a reference-writable component shows up later.
+    return true;
+  }
+
+  // If the setter is unavailable, then the keypath ought to be read-only
+  // in this context.
+  if (auto setter = storage->getOpaqueAccessor(AccessorKind::Set)) {
+    auto maybeUnavail =
+        TypeChecker::checkDeclarationAvailability(setter, referenceLoc, DC);
+    if (maybeUnavail.hasValue()) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -66,6 +66,46 @@ void *operator new(size_t bytes, swift::constraints::ConstraintSystem& cs,
 
 namespace swift {
 
+/// This specifies the purpose of the contextual type, when specified to
+/// typeCheckExpression.  This is used for diagnostic generation to produce more
+/// specified error messages when the conversion fails.
+///
+enum ContextualTypePurpose {
+  CTP_Unused,           ///< No contextual type is specified.
+  CTP_Initialization,   ///< Pattern binding initialization.
+  CTP_ReturnStmt,       ///< Value specified to a 'return' statement.
+  CTP_ReturnSingleExpr, ///< Value implicitly returned from a function.
+  CTP_YieldByValue,     ///< By-value yield operand.
+  CTP_YieldByReference, ///< By-reference yield operand.
+  CTP_ThrowStmt,        ///< Value specified to a 'throw' statement.
+  CTP_EnumCaseRawValue, ///< Raw value specified for "case X = 42" in enum.
+  CTP_DefaultParameter, ///< Default value in parameter 'foo(a : Int = 42)'.
+
+  /// Default value in @autoclosure parameter
+  /// 'foo(a : @autoclosure () -> Int = 42)'.
+  CTP_AutoclosureDefaultParameter,
+
+  CTP_CalleeResult,     ///< Constraint is placed on the result of a callee.
+  CTP_CallArgument,     ///< Call to function or operator requires type.
+  CTP_ClosureResult,    ///< Closure result expects a specific type.
+  CTP_ArrayElement,     ///< ArrayExpr wants elements to have a specific type.
+  CTP_DictionaryKey,    ///< DictionaryExpr keys should have a specific type.
+  CTP_DictionaryValue,  ///< DictionaryExpr values should have a specific type.
+  CTP_CoerceOperand,    ///< CoerceExpr operand coerced to specific type.
+  CTP_AssignSource,     ///< AssignExpr source operand coerced to result type.
+  CTP_SubscriptAssignSource, ///< AssignExpr source operand coerced to subscript
+                             ///< result type.
+  CTP_Condition,        ///< Condition expression of various statements e.g.
+                        ///< `if`, `for`, `while` etc.
+  CTP_ForEachStmt,      ///< "expression/sequence" associated with 'for-in' loop
+                        ///< is expected to conform to 'Sequence' protocol.
+  CTP_WrappedProperty,  ///< Property type expected to match 'wrappedValue' type
+  CTP_ComposedPropertyWrapper, ///< Composed wrapper type expected to match
+                               ///< former 'wrappedValue' type
+
+  CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
+};
+
 namespace constraints {
 
 /// Describes the algorithm to use for trailing closure matching.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4971,41 +4971,7 @@ private:
                                   llvm::function_ref<bool(Constraint *)> pred);
 
   bool isReadOnlyKeyPathComponent(const AbstractStorageDecl *storage,
-                                  SourceLoc referenceLoc) {
-    // See whether key paths can store to this component. (Key paths don't
-    // get any special power from being formed in certain contexts, such
-    // as the ability to assign to `let`s in initialization contexts, so
-    // we pass null for the DC to `isSettable` here.)
-    if (!getASTContext().isSwiftVersionAtLeast(5)) {
-      // As a source-compatibility measure, continue to allow
-      // WritableKeyPaths to be formed in the same conditions we did
-      // in previous releases even if we should not be able to set
-      // the value in this context.
-      if (!storage->isSettable(DC)) {
-        // A non-settable component makes the key path read-only, unless
-        // a reference-writable component shows up later.
-        return true;
-      }
-    } else if (!storage->isSettable(nullptr) ||
-               !storage->isSetterAccessibleFrom(DC)) {
-      // A non-settable component makes the key path read-only, unless
-      // a reference-writable component shows up later.
-      return true;
-    }
-    
-    // If the setter is unavailable, then the keypath ought to be read-only
-    // in this context.
-    if (auto setter = storage->getOpaqueAccessor(AccessorKind::Set)) {
-      auto maybeUnavail = TypeChecker::checkDeclarationAvailability(setter,
-                                                                    referenceLoc,
-                                                                    DC);
-      if (maybeUnavail.hasValue()) {
-        return true;
-      }
-    }
-
-    return false;
-  }
+                                  SourceLoc referenceLoc);
 
 public:
   // Given a type variable, attempt to find the disjunction of

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -106,6 +106,17 @@ enum ContextualTypePurpose {
   CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
 };
 
+/// Specify how we handle the binding of underconstrained (free) type variables
+/// within a solution to a constraint system.
+enum class FreeTypeVariableBinding {
+  /// Disallow any binding of such free type variables.
+  Disallow,
+  /// Allow the free type variables to persist in the solution.
+  Allow,
+  /// Bind the type variables to UnresolvedType to represent the ambiguity.
+  UnresolvedType
+};
+
 namespace constraints {
 
 /// Describes the algorithm to use for trailing closure matching.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -908,6 +908,14 @@ struct ContextualTypeInfo {
   TypeLoc typeLoc;
   ContextualTypePurpose purpose;
 
+  ContextualTypeInfo() : typeLoc(TypeLoc()), purpose(CTP_Unused) {}
+
+  ContextualTypeInfo(Type contextualTy, ContextualTypePurpose purpose)
+      : typeLoc(TypeLoc::withoutLoc(contextualTy)), purpose(purpose) {}
+
+  ContextualTypeInfo(TypeLoc typeLoc, ContextualTypePurpose purpose)
+      : typeLoc(typeLoc), purpose(purpose) {}
+
   Type getType() const { return typeLoc.getType(); }
 };
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -24,16 +24,20 @@
 #include "ConstraintGraphScope.h"
 #include "ConstraintLocator.h"
 #include "OverloadChoice.h"
-#include "TypeChecker.h"
+#include "SolutionResult.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
@@ -49,14 +53,31 @@
 namespace swift {
 
 class Expr;
+class FuncDecl;
+class BraseStmt;
+enum class TypeCheckExprFlags;
 
 namespace constraints {
 
 class ConstraintGraph;
 class ConstraintGraphNode;
 class ConstraintSystem;
+class SolutionApplicationTarget;
 
 } // end namespace constraints
+
+// Forward declare some TypeChecker related functions
+// so they could be made friends of ConstraintSystem.
+namespace TypeChecker {
+
+Optional<BraceStmt *> applyFunctionBuilderBodyTransform(FuncDecl *func,
+                                                        Type builderType);
+
+Optional<constraints::SolutionApplicationTarget>
+typeCheckExpression(constraints::SolutionApplicationTarget &target,
+                    OptionSet<TypeCheckExprFlags> options);
+
+} // end namespace TypeChecker
 
 } // end namespace swift
 
@@ -2730,9 +2751,10 @@ private:
   friend Optional<BraceStmt *>
   swift::TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *func,
                                                         Type builderType);
+
   friend Optional<SolutionApplicationTarget>
-  swift::TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
-                                          TypeCheckExprOptions options);
+  swift::TypeChecker::typeCheckExpression(
+      SolutionApplicationTarget &target, OptionSet<TypeCheckExprFlags> options);
 
   /// Emit the fixes computed as part of the solution, returning true if we were
   /// able to emit an error message, or false if none of the fixits worked out.

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -29,7 +29,6 @@
 #include "swift/Subsystems.h"
 
 #include "TypeChecker.h"
-#include "ConstraintSystem.h"
 
 using namespace swift;
 

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -29,6 +29,7 @@
 #include "swift/Subsystems.h"
 
 #include "TypeChecker.h"
+#include "ConstraintSystem.h"
 
 using namespace swift;
 
@@ -244,7 +245,8 @@ private:
     // TODO: typeCheckExpression() seems to assign types to everything here,
     // but may not be sufficient in some cases.
     Expr *FinalExpr = ClosureCall;
-    if (!TypeChecker::typeCheckExpression(FinalExpr, getCurrentDeclContext()))
+    if (!TypeChecker::typeCheckExpression(FinalExpr, getCurrentDeclContext(),
+                                          /*contextualInfo=*/{}))
       llvm::report_fatal_error("Could not type-check instrumentation");
 
     // Captures have to be computed after the closure is type-checked. This

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -119,7 +119,7 @@ bool InstrumenterBase::doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC,
   DiagnosticSuppression suppression(Ctx.Diags);
   ErrorGatherer errorGatherer(Ctx.Diags);
 
-  TypeChecker::typeCheckExpression(parsedExpr, DC);
+  TypeChecker::typeCheckExpression(parsedExpr, DC, /*contextualInfo=*/{});
 
   if (parsedExpr) {
     ErrorFinder errorFinder;

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -16,7 +16,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
-#include "ConstraintSystem.h"
 #include "swift/AST/ASTWalker.h"
 
 namespace swift {

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
-
+#include "ConstraintSystem.h"
 #include "swift/AST/ASTWalker.h"
 
 namespace swift {

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -962,8 +962,8 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   parsedExpr = parsedExpr->walk(SanitizeExpr(ctx, /*shouldReusePrecheckedType=*/false));
 
   DiagnosticSuppression suppression(ctx.Diags);
-  auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC, Type(),
-                                                   CTP_Unused);
+  auto resultTy =
+      TypeChecker::typeCheckExpression(parsedExpr, DC, /*contextualInfo=*/{});
   return !resultTy;
 }
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -962,8 +962,7 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   parsedExpr = parsedExpr->walk(SanitizeExpr(ctx, /*shouldReusePrecheckedType=*/false));
 
   DiagnosticSuppression suppression(ctx.Diags);
-  auto resultTy =
-      TypeChecker::typeCheckExpression(parsedExpr, DC, /*contextualInfo=*/{});
+  auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC);
   return !resultTy;
 }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -594,7 +594,7 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
   // re-typecheck it.
   if (expr->getType() && expr->getType()->isBool()) {
     auto resultTy =
-        TypeChecker::typeCheckExpression(expr, dc, /*contextualInfo=*/{});
+        TypeChecker::typeCheckExpression(expr, dc);
     return !resultTy;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -300,11 +300,10 @@ void constraints::performSyntacticDiagnosticsForTarget(
 
 #pragma mark High-level entry points
 Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
-                                      Type convertType,
-                                      ContextualTypePurpose convertTypePurpose,
+                                      ContextualTypeInfo contextualInfo,
                                       TypeCheckExprOptions options) {
   SolutionApplicationTarget target(
-      expr, dc, convertTypePurpose, convertType,
+      expr, dc, contextualInfo.purpose, contextualInfo.getType(),
       options.contains(TypeCheckExprFlags::IsDiscarded));
   auto resultTarget = typeCheckExpression(target, options);
   if (!resultTarget) {
@@ -422,9 +421,10 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
                                             DeclContext *DC, Type paramType,
                                             bool isAutoClosure) {
   assert(paramType && !paramType->hasError());
-  return typeCheckExpression(
-      defaultValue, DC, paramType,
-      isAutoClosure ? CTP_AutoclosureDefaultParameter : CTP_DefaultParameter);
+  return typeCheckExpression(defaultValue, DC, /*contextualInfo=*/
+                             {paramType, isAutoClosure
+                                             ? CTP_AutoclosureDefaultParameter
+                                             : CTP_DefaultParameter});
 }
 
 bool TypeChecker::typeCheckBinding(
@@ -593,7 +593,8 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
   // If this expression is already typechecked and has type Bool, then just
   // re-typecheck it.
   if (expr->getType() && expr->getType()->isBool()) {
-    auto resultTy = TypeChecker::typeCheckExpression(expr, dc);
+    auto resultTy =
+        TypeChecker::typeCheckExpression(expr, dc, /*contextualInfo=*/{});
     return !resultTy;
   }
 
@@ -602,8 +603,8 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
     return true;
 
   auto resultTy = TypeChecker::typeCheckExpression(
-      expr, dc, boolDecl->getDeclaredInterfaceType(),
-      CTP_Condition);
+      expr, dc,
+      /*contextualInfo=*/{boolDecl->getDeclaredInterfaceType(), CTP_Condition});
   return !resultTy;
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
-#include "ConstraintSystem.h"
 #include "DerivedConformances.h"
 #include "TypeChecker.h"
 #include "TypeCheckAccess.h"

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1199,9 +1199,9 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
     
     {
       Expr *exprToCheck = prevValue;
-      if (TypeChecker::typeCheckExpression(exprToCheck, ED,
-                                           rawTy,
-                                           CTP_EnumCaseRawValue)) {
+      if (TypeChecker::typeCheckExpression(
+              exprToCheck, ED,
+              /*contextualInfo=*/{rawTy, CTP_EnumCaseRawValue})) {
         TypeChecker::checkEnumElementEffects(elt, exprToCheck);
       }
     }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -18,7 +18,6 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckType.h"
 #include "MiscDiagnostics.h"
-#include "ConstraintSystem.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
@@ -882,7 +881,7 @@ public:
     TypeChecker::typeCheckDecl(DS->getTempDecl());
 
     Expr *theCall = DS->getCallExpr();
-    TypeChecker::typeCheckExpression(theCall, DC, /*contextualInfo=*/{});
+    TypeChecker::typeCheckExpression(theCall, DC);
     DS->setCallExpr(theCall);
 
     return DS;
@@ -1156,8 +1155,7 @@ public:
   Stmt *visitSwitchStmt(SwitchStmt *switchStmt) {
     // Type-check the subject expression.
     Expr *subjectExpr = switchStmt->getSubjectExpr();
-    auto resultTy = TypeChecker::typeCheckExpression(subjectExpr, DC,
-                                                     /*contextualInfo=*/{});
+    auto resultTy = TypeChecker::typeCheckExpression(subjectExpr, DC);
     auto limitExhaustivityChecks = !resultTy;
     if (Expr *newSubjectExpr =
             TypeChecker::coerceToRValue(getASTContext(), subjectExpr))

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -17,7 +17,6 @@
 
 #include "CodeSynthesis.h"
 #include "TypeChecker.h"
-#include "ConstraintSystem.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeCheckType.h"
@@ -917,8 +916,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     // FIXME: Since we're not resolving overloads or anything, we should be
     // building fully type-checked AST above; we already have all the
     // information that we need.
-    if (!TypeChecker::typeCheckExpression(lookupExpr, accessor,
-                                          /*contextualInfo=*/{}))
+    if (!TypeChecker::typeCheckExpression(lookupExpr, accessor))
       return nullptr;
 
     // Make sure we produce an lvalue only when desired.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -17,6 +17,7 @@
 
 #include "CodeSynthesis.h"
 #include "TypeChecker.h"
+#include "ConstraintSystem.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeCheckType.h"
@@ -916,7 +917,8 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     // FIXME: Since we're not resolving overloads or anything, we should be
     // building fully type-checked AST above; we already have all the
     // information that we need.
-    if (!TypeChecker::typeCheckExpression(lookupExpr, accessor))
+    if (!TypeChecker::typeCheckExpression(lookupExpr, accessor,
+                                          /*contextualInfo=*/{}))
       return nullptr;
 
     // Make sure we produce an lvalue only when desired.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -51,6 +51,7 @@ namespace constraints {
   class Solution;
   class SolutionApplicationTarget;
   class SolutionResult;
+  struct ContextualTypeInfo;
 }
 
 /// Special-case type checking semantics for certain declarations.
@@ -549,21 +550,18 @@ Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
 /// \param expr The expression to type-check, which will be modified in
 /// place.
 ///
-/// \param convertTypePurpose When convertType is specified, this indicates
+/// \param contextualInfo The type that the expression is being converted to,
+/// or null if the expression is standalone. When convertType is specified, this indicates
 /// what the conversion is doing.  This allows diagnostics generation to
 /// produce more specific and helpful error messages when the conversion fails
 /// to be possible.
-///
-/// \param convertType The type that the expression is being converted to,
-/// or null if the expression is standalone.
 ///
 /// \param options Options that control how type checking is performed.
 ///
 /// \returns The type of the top-level expression, or Type() if an
 ///          error occurred.
 Type typeCheckExpression(Expr *&expr, DeclContext *dc,
-                         Type convertType = Type(),
-                         ContextualTypePurpose convertTypePurpose = CTP_Unused,
+                         constraints::ContextualTypeInfo contextualInfo,
                          TypeCheckExprOptions options = TypeCheckExprOptions());
 
 Optional<constraints::SolutionApplicationTarget>

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -181,17 +181,6 @@ enum class Comparison {
   Worse
 };
 
-/// Specify how we handle the binding of underconstrained (free) type variables
-/// within a solution to a constraint system.
-enum class FreeTypeVariableBinding {
-  /// Disallow any binding of such free type variables.
-  Disallow,
-  /// Allow the free type variables to persist in the solution.
-  Allow,
-  /// Bind the type variables to UnresolvedType to represent the ambiguity.
-  UnresolvedType
-};
-
 /// A conditional conformance that implied some other requirements. That is, \c
 /// ConformingType conforming to \c Protocol may have required additional
 /// requirements to be satisfied.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -112,48 +112,6 @@ public:
   }
 };
 
-/// This specifies the purpose of the contextual type, when specified to
-/// typeCheckExpression.  This is used for diagnostic generation to produce more
-/// specified error messages when the conversion fails.
-///
-enum ContextualTypePurpose {
-  CTP_Unused,           ///< No contextual type is specified.
-  CTP_Initialization,   ///< Pattern binding initialization.
-  CTP_ReturnStmt,       ///< Value specified to a 'return' statement.
-  CTP_ReturnSingleExpr, ///< Value implicitly returned from a function.
-  CTP_YieldByValue,     ///< By-value yield operand.
-  CTP_YieldByReference, ///< By-reference yield operand.
-  CTP_ThrowStmt,        ///< Value specified to a 'throw' statement.
-  CTP_EnumCaseRawValue, ///< Raw value specified for "case X = 42" in enum.
-  CTP_DefaultParameter, ///< Default value in parameter 'foo(a : Int = 42)'.
-
-  /// Default value in @autoclosure parameter
-  /// 'foo(a : @autoclosure () -> Int = 42)'.
-  CTP_AutoclosureDefaultParameter,
-
-  CTP_CalleeResult,     ///< Constraint is placed on the result of a callee.
-  CTP_CallArgument,     ///< Call to function or operator requires type.
-  CTP_ClosureResult,    ///< Closure result expects a specific type.
-  CTP_ArrayElement,     ///< ArrayExpr wants elements to have a specific type.
-  CTP_DictionaryKey,    ///< DictionaryExpr keys should have a specific type.
-  CTP_DictionaryValue,  ///< DictionaryExpr values should have a specific type.
-  CTP_CoerceOperand,    ///< CoerceExpr operand coerced to specific type.
-  CTP_AssignSource,     ///< AssignExpr source operand coerced to result type.
-  CTP_SubscriptAssignSource, ///< AssignExpr source operand coerced to subscript
-                             ///< result type.
-  CTP_Condition,        ///< Condition expression of various statements e.g.
-                        ///< `if`, `for`, `while` etc.
-  CTP_ForEachStmt,      ///< "expression/sequence" associated with 'for-in' loop
-                        ///< is expected to conform to 'Sequence' protocol.
-  CTP_WrappedProperty,  ///< Property type expected to match 'wrappedValue' type
-  CTP_ComposedPropertyWrapper, ///< Composed wrapper type expected to match
-                               ///< former 'wrappedValue' type
-
-  CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
-};
-
-
-
 /// Flags that can be used to control type checking.
 enum class TypeCheckExprFlags {
   /// Whether we know that the result of the expression is discarded.  This

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -17,6 +17,7 @@
 #ifndef TYPECHECKING_H
 #define TYPECHECKING_H
 
+#include "ConstraintSystem.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/AnyFunctionRef.h"
@@ -51,7 +52,6 @@ namespace constraints {
   class Solution;
   class SolutionApplicationTarget;
   class SolutionResult;
-  struct ContextualTypeInfo;
 }
 
 /// Special-case type checking semantics for certain declarations.
@@ -561,7 +561,7 @@ Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
 /// \returns The type of the top-level expression, or Type() if an
 ///          error occurred.
 Type typeCheckExpression(Expr *&expr, DeclContext *dc,
-                         constraints::ContextualTypeInfo contextualInfo,
+                         constraints::ContextualTypeInfo contextualInfo = {},
                          TypeCheckExprOptions options = TypeCheckExprOptions());
 
 Optional<constraints::SolutionApplicationTarget>


### PR DESCRIPTION
* NFC: Move implementation of `isReadOnlyKeyPathComponent` to .cpp
* Switch `typeCheckExpression` to use `ContextualTypeInfo`
* Move `FreeTypeVariableBinding` to constraint system header
* NFC: Move `ContextualTypePurpose` to constraint system header

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
