### PR TITLE
[OSSignpost] Update apinotes to allow usage of os_signpost ABI entrypoint

### DIFF
--- a/apinotes/os.apinotes
+++ b/apinotes/os.apinotes
@@ -63,5 +63,5 @@ Functions:
   SwiftPrivate: true
   NullabilityOfRet: O
 - Name: _os_signpost_emit_with_name_impl
-  Availability: nonswift
-  AvailabilityMsg: 'Use os_signpost'
+  SwiftPrivate: true
+  NullabilityOfRet: O


### PR DESCRIPTION
Currently, the `_os_signpost_emit_with_name_impl` function is not available to be called from Swift. This is the main ABI entrypoint for making os_signpost calls. In order to facilitate more efficient calls to os_signpost in future iterations of the Swift os_signpost API, we should allow calling this function from Swift. 

rdar://70015938