### PR TITLE
SR-13098 Diagnostic improvement: encountering an unexpected statement at type scope (second PR)

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3912,7 +3912,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
       const bool IsProbablyFuncDecl =
           Tok.isIdentifierOrUnderscore() || Tok.isAnyOperator();
 
-      if (IsProbablyFuncDecl) {
+      if (IsProbablyFuncDecl && (!peekToken().is(tok::period))) {
 
         DescriptiveDeclKind DescriptiveKind;
 

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -2,6 +2,25 @@
 
 // https://bugs.swift.org/browse/SR-10477
 
+// RUN: %target-typecheck-verify-swift
+
+struct SR13098 { // expected-note {{in declaration of 'SR13098'}}
+  var srValue = 0xABABABAB // expected-note {{'srValue' previously declared here}}
+  var a: Int 
+
+  srValue = 0xCDCDCDCD // expected-error {{invalid redeclaration of 'srValue'}}
+                       // expected-error @-1 {{expected 'var' keyword in property declaration}}
+                        
+  
+  // ensure that the id.id pattern is not interpreted as a function
+  a.foo = 345 // expected-error {{expected declaration}}
+
+  // note that the expected declaration blocks further diagnostics up to 
+  // the closing right brace.
+  srValue.bar = 345
+}
+ 
+
 protocol Brew { // expected-note {{in declaration of 'Brew'}}
   tripel() -> Int // expected-error {{expected 'func' keyword in instance method declaration}} {{3-3=func }}
 


### PR DESCRIPTION
This is a new branch to address this. 

(Commit message below) 

Added a simple check for a period token after the identifier to inhibit the IsProbablyFuncDecl logic. 

When the parser finds an identifier at type scope it tries to determine
if it is a function declaration without the `func` keyword. This
generates a cascate of diagnostics if the identifier is actually an
assignment to part of a value using the period (like a.b = 3). In this
case the parser should not try to treat is as a function and instead
just generate a simple expected declaration diagnostic.

<!-- What's in this pull request? -->
The approach this time is to limit the change to only the case 

```swift
struct X {
  ...
  x.y = 1
  ...
}
```

That's the case in the examples in the bug and is straightforward to identify and handle. Earlier versions of the first pull request https://github.com/apple/swift/pull/32984 tried this method. The main reason we did not pursue it was because it's a limited class of errors and probing with parser functions is more general. But at the same time, probing with parser functions causes problems with performance and with maintaining the parser state correctly in some situations as @rintaro discovered. 

The diagnostic cascade that is the original problem occurs when the parser is trying to emit a fix-it for a missing `func` or `var` token. If a bare identifier is in the parse stream the parser tries to generate a diagnostic for a missing `func`. Something like `func a.b ...` or `var a.b ...` would not be valid and we should just inhibit the check. If we inhibit the check when there's a period we go directly to the `expected declaration` diagnostic and don't get the cascade. 

In the original PR, one of the problems was that once we reach the `expected declaration` diagnostic the parser skips to the next right-brace, so will not emit any diagnostics for anything after the problem syntax. This is a little unfortunate but I'm not sure there's a good way to fix it. In the test there is no `expected-error` after the expected declaration. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13098.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
