### PR TITLE
[Async CC] Support for protocol witness methods.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1974,14 +1974,6 @@ public:
       llArgs.add(selfValue);
     }
     auto layout = getAsyncContextLayout();
-    for (unsigned index = 0, count = layout.getArgumentCount(); index < count;
-         ++index) {
-      auto fieldLayout = layout.getArgumentLayout(index);
-      Address fieldAddr =
-          fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
-      auto &ti = cast<LoadableTypeInfo>(fieldLayout.getType());
-      ti.initialize(IGF, llArgs, fieldAddr, isOutlined);
-    }
     for (unsigned index = 0, count = layout.getIndirectReturnCount();
          index < count; ++index) {
       auto fieldLayout = layout.getIndirectReturnLayout(index);
@@ -1989,6 +1981,14 @@ public:
           fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
       cast<LoadableTypeInfo>(fieldLayout.getType())
           .initialize(IGF, llArgs, fieldAddr, isOutlined);
+    }
+    for (unsigned index = 0, count = layout.getArgumentCount(); index < count;
+         ++index) {
+      auto fieldLayout = layout.getArgumentLayout(index);
+      Address fieldAddr =
+          fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
+      auto &ti = cast<LoadableTypeInfo>(fieldLayout.getType());
+      ti.initialize(IGF, llArgs, fieldAddr, isOutlined);
     }
     if (layout.hasBindings()) {
       auto bindingLayout = layout.getBindingsLayout();

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -153,7 +153,7 @@ AsyncContextLayout irgen::getAsyncContextLayout(
   }
 
   //   ArgTypes formalArguments...;
-  auto bindings = NecessaryBindings::forAsyncFunctionInvocations(
+  auto bindings = NecessaryBindings::forAsyncFunctionInvocation(
       IGF.IGM, originalType, substitutionMap);
   if (!bindings.empty()) {
     auto bindingsSize = bindings.getBufferSize(IGF.IGM);

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -138,7 +138,11 @@ AsyncContextLayout irgen::getAsyncContextLayout(
       SILType ty =
           IGF.IGM.silConv.getSILType(localContextParameter, substitutedType,
                                      IGF.IGM.getMaximalTypeExpansionContext());
-      auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
+      auto argumentLoweringType =
+          getArgumentLoweringType(ty.getASTType(), localContextParameter,
+                                  /*isNoEscape*/ true);
+
+      auto &ti = IGF.getTypeInfoForLowered(argumentLoweringType);
       valTypes.push_back(ty);
       typeInfos.push_back(&ti);
       localContextInfo = {ty, localContextParameter.getConvention()};
@@ -1998,7 +2002,6 @@ public:
       auto &ti = cast<LoadableTypeInfo>(fieldLayout.getType());
       ti.initialize(IGF, llArgs, fieldAddr, isOutlined);
     }
-  }
   }
   void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {
     SILFunctionConventions fnConv(getCallee().getSubstFunctionType(),

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -183,6 +183,10 @@ namespace irgen {
     }
 
     unsigned getFirstDirectReturnIndex() { return getIndexAfterArguments(); }
+    unsigned getDirectReturnCount() { return directReturnInfos.size(); }
+    ElementLayout getDirectReturnLayout(unsigned index) {
+      return getElement(getFirstDirectReturnIndex() + index);
+    }
 
     AsyncContextLayout(IRGenModule &IGM, LayoutStrategy strategy,
                        ArrayRef<SILType> fieldTypes,

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -109,26 +109,42 @@ namespace irgen {
     NecessaryBindings bindings;
     SmallVector<ArgumentInfo, 4> argumentInfos;
 
+    unsigned getErrorIndex() { return (unsigned)FixedIndex::Error; }
+    unsigned getFirstIndirectReturnIndex() {
+      return getErrorIndex() + getErrorCount();
+    }
+    unsigned getLocalContextIndex() {
+      assert(hasLocalContext());
+      return getFirstIndirectReturnIndex() + getIndirectReturnCount();
+    }
+    unsigned getIndexAfterLocalContext() {
+      return getFirstIndirectReturnIndex() + getIndirectReturnCount() +
+             (hasLocalContext() ? 1 : 0);
+    }
+    unsigned getBindingsIndex() {
+      assert(hasBindings());
+      return getIndexAfterLocalContext();
+    }
+    unsigned getFirstArgumentIndex() {
+      return getIndexAfterLocalContext() + (hasBindings() ? 1 : 0);
+    }
+    unsigned getIndexAfterArguments() {
+      return getFirstArgumentIndex() + getArgumentCount();
+    }
+    unsigned getFirstDirectReturnIndex() { return getIndexAfterArguments(); }
+
   public:
     bool canHaveError() { return canHaveValidError; }
-    unsigned getErrorIndex() { return (unsigned)FixedIndex::Error; }
     ElementLayout getErrorLayout() { return getElement(getErrorIndex()); }
     unsigned getErrorCount() { return (unsigned)FixedCount::Error; }
     SILType getErrorType() { return errorType; }
 
-    unsigned getFirstIndirectReturnIndex() {
-      return getErrorIndex() + getErrorCount();
-    }
     ElementLayout getIndirectReturnLayout(unsigned index) {
       return getElement(getFirstIndirectReturnIndex() + index);
     }
     unsigned getIndirectReturnCount() { return indirectReturnInfos.size(); }
 
     bool hasLocalContext() { return (bool)localContextInfo; }
-    unsigned getLocalContextIndex() {
-      assert(hasLocalContext());
-      return getFirstIndirectReturnIndex() + getIndirectReturnCount();
-    }
     ElementLayout getLocalContextLayout() {
       assert(hasLocalContext());
       return getElement(getLocalContextIndex());
@@ -141,48 +157,30 @@ namespace irgen {
       assert(hasLocalContext());
       return localContextInfo->type;
     }
-    unsigned getIndexAfterLocalContext() {
-      return getFirstIndirectReturnIndex() + getIndirectReturnCount() +
-             (hasLocalContext() ? 1 : 0);
-    }
 
     bool hasBindings() const { return !bindings.empty(); }
-    unsigned getBindingsIndex() {
-      assert(hasBindings());
-      return getIndexAfterLocalContext();
-    }
     ElementLayout getBindingsLayout() {
       assert(hasBindings());
       return getElement(getBindingsIndex());
     }
-    ParameterConvention getBindingsConvention() {
-      return ParameterConvention::Direct_Unowned;
-    }
     const NecessaryBindings &getBindings() const { return bindings; }
 
-    unsigned getFirstArgumentIndex() {
-      return getIndexAfterLocalContext() + (hasBindings() ? 1 : 0);
-    }
     ElementLayout getArgumentLayout(unsigned index) {
       return getElement(getFirstArgumentIndex() + index);
-    }
-    ParameterConvention getArgumentConvention(unsigned index) {
-      return argumentInfos[index].convention;
     }
     SILType getArgumentType(unsigned index) {
       return argumentInfos[index].type;
     }
+    // Returns the type of a parameter of the substituted function using the
+    // indexing of the function parameters, *not* the indexing of
+    // AsyncContextLayout.
     SILType getParameterType(unsigned index) {
       SILFunctionConventions origConv(substitutedType, IGF.getSILModule());
       return origConv.getSILArgumentType(
           index, IGF.IGM.getMaximalTypeExpansionContext());
     }
     unsigned getArgumentCount() { return argumentInfos.size(); }
-    unsigned getIndexAfterArguments() {
-      return getFirstArgumentIndex() + getArgumentCount();
-    }
 
-    unsigned getFirstDirectReturnIndex() { return getIndexAfterArguments(); }
     unsigned getDirectReturnCount() { return directReturnInfos.size(); }
     ElementLayout getDirectReturnLayout(unsigned index) {
       return getElement(getFirstDirectReturnIndex() + index);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2728,24 +2728,45 @@ void NecessaryBindings::restore(IRGenFunction &IGF, Address buffer,
                                     [&](CanType type) { return type;});
 }
 
+template <typename Transform>
+static void save(const NecessaryBindings &bindings, IRGenFunction &IGF,
+                 Address buffer, Transform transform) {
+  emitInitOfGenericRequirementsBuffer(
+      IGF, bindings.getRequirements().getArrayRef(), buffer,
+      [&](GenericRequirement requirement) -> llvm::Value * {
+        CanType type = requirement.TypeParameter;
+        if (auto protocol = requirement.Protocol) {
+          if (auto archetype = dyn_cast<ArchetypeType>(type)) {
+            auto wtable =
+                emitArchetypeWitnessTableRef(IGF, archetype, protocol);
+            return transform(requirement, wtable);
+          } else {
+            auto conformance = bindings.getConformance(requirement);
+            auto wtable = emitWitnessTableRef(IGF, type, conformance);
+            return transform(requirement, wtable);
+          }
+        } else {
+          auto metadata = IGF.emitTypeMetadataRef(type);
+          return transform(requirement, metadata);
+        }
+      });
+};
+
+void NecessaryBindings::save(IRGenFunction &IGF, Address buffer,
+                             Explosion &source) const {
+  ::save(*this, IGF, buffer,
+         [&](GenericRequirement requirement,
+             llvm::Value *expected) -> llvm::Value * {
+           auto *value = source.claimNext();
+           assert(value == expected);
+           return value;
+         });
+}
+
 void NecessaryBindings::save(IRGenFunction &IGF, Address buffer) const {
-  emitInitOfGenericRequirementsBuffer(IGF, Requirements.getArrayRef(), buffer,
-        [&](GenericRequirement requirement) -> llvm::Value* {
-    CanType type = requirement.TypeParameter;
-    if (auto protocol = requirement.Protocol) {
-      if (auto archetype = dyn_cast<ArchetypeType>(type)) {
-        auto wtable = emitArchetypeWitnessTableRef(IGF, archetype, protocol);
-        return wtable;
-      } else {
-        auto conformance = getConformance(requirement);
-        auto wtable = emitWitnessTableRef(IGF, type, conformance);
-        return wtable;
-      }
-    } else {
-      auto metadata = IGF.emitTypeMetadataRef(type);
-      return metadata;
-    }
-  });
+  ::save(*this, IGF, buffer,
+         [](GenericRequirement requirement,
+            llvm::Value *value) -> llvm::Value * { return value; });
 }
 
 void NecessaryBindings::addTypeMetadata(CanType type) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3098,7 +3098,11 @@ NecessaryBindings NecessaryBindings::computeBindings(
       continue;
 
     case MetadataSource::Kind::SelfMetadata:
-      bindings.addTypeMetadata(getSubstSelfType(IGM, origType, subs));
+      // Async functions pass the SelfMetadata and SelfWitnessTable parameters
+      // along explicitly.
+      if (forPartialApplyForwarder) {
+        bindings.addTypeMetadata(getSubstSelfType(IGM, origType, subs));
+      }
       continue;
 
     case MetadataSource::Kind::SelfWitnessTable:

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3042,7 +3042,7 @@ void EmitPolymorphicArguments::emit(SubstitutionMap subs,
   }
 }
 
-NecessaryBindings NecessaryBindings::forAsyncFunctionInvocations(
+NecessaryBindings NecessaryBindings::forAsyncFunctionInvocation(
     IRGenModule &IGM, CanSILFunctionType origType, SubstitutionMap subs) {
   return computeBindings(IGM, origType, subs,
                          false /*forPartialApplyForwarder*/);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1220,18 +1220,6 @@ public:
     Address addr = errorLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
     return addr.getAddress();
   }
-  llvm::Value *getErrorResultAddrForCall() {
-    auto errorLayout = layout.getErrorLayout();
-    auto &ti = cast<LoadableTypeInfo>(errorLayout.getType());
-    auto allocaAddr = ti.allocateStack(IGF, layout.getErrorType(), "arg");
-    auto addrInContext =
-        layout.getErrorLayout().project(IGF, dataAddr, /*offsets*/ llvm::None);
-    Explosion explosion;
-    ti.loadAsTake(IGF, addrInContext, explosion);
-    ti.initialize(IGF, explosion, allocaAddr.getAddress(),
-                  /*isOutlined*/ false);
-    return allocaAddr.getAddress().getAddress();
-  }
   llvm::Value *getContext() override {
     auto contextLayout = layout.getLocalContextLayout();
     Address addr = contextLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1257,9 +1257,23 @@ public:
     return explosion.claimNext();
   };
   llvm::Value *getSelfWitnessTable() override {
-    llvm_unreachable("unimplemented");
+    auto fieldLayout = layout.getSelfWitnessTableLayout();
+    Address fieldAddr =
+        fieldLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+    auto &ti = cast<LoadableTypeInfo>(fieldLayout.getType());
+    Explosion explosion;
+    ti.loadAsTake(IGF, fieldAddr, explosion);
+    return explosion.claimNext();
   }
-  llvm::Value *getSelfMetadata() override { llvm_unreachable("unimplemented"); }
+  llvm::Value *getSelfMetadata() override {
+    auto fieldLayout = layout.getSelfMetadataLayout();
+    Address fieldAddr =
+        fieldLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
+    auto &ti = cast<LoadableTypeInfo>(fieldLayout.getType());
+    Explosion explosion;
+    ti.loadAsTake(IGF, fieldAddr, explosion);
+    return explosion.claimNext();
+  }
   llvm::Value *getCoroutineBuffer() override {
     llvm_unreachable("unimplemented");
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1260,11 +1260,13 @@ public:
                      "indirected through the context");
   }
   llvm::Value *getIndirectResult(unsigned index) override {
-    Address dataAddr = layout.emitCastTo(IGF, context);
     auto fieldLayout = layout.getIndirectReturnLayout(index);
     Address fieldAddr =
         fieldLayout.project(IGF, dataAddr, /*offsets*/ llvm::None);
-    return IGF.Builder.CreateLoad(fieldAddr);
+    auto &ti = cast<LoadableTypeInfo>(fieldLayout.getType());
+    Explosion explosion;
+    ti.loadAsTake(IGF, fieldAddr, explosion);
+    return explosion.claimNext();
   };
   llvm::Value *getSelfWitnessTable() override {
     llvm_unreachable("unimplemented");

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -57,8 +57,8 @@ public:
   /// Collect the necessary bindings to invoke a function with the given
   /// signature.
   static NecessaryBindings
-  forAsyncFunctionInvocations(IRGenModule &IGM, CanSILFunctionType origType,
-                              SubstitutionMap subs);
+  forAsyncFunctionInvocation(IRGenModule &IGM, CanSILFunctionType origType,
+                             SubstitutionMap subs);
   static NecessaryBindings forPartialApplyForwarder(IRGenModule &IGM,
                                                     CanSILFunctionType origType,
                                                     SubstitutionMap subs,

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -25,6 +25,8 @@
 #include "llvm/ADT/SetVector.h"
 #include "swift/AST/Types.h"
 
+#include "Explosion.h"
+
 namespace swift {
   class CanType;
   enum class MetadataState : size_t;
@@ -93,6 +95,8 @@ public:
 
   /// Save the necessary bindings to the given buffer.
   void save(IRGenFunction &IGF, Address buffer) const;
+
+  void save(IRGenFunction &IGF, Address buffer, Explosion &source) const;
 
   /// Restore the necessary bindings from the given buffer.
   void restore(IRGenFunction &IGF, Address buffer, MetadataState state) const;

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -35,7 +35,7 @@ bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>
   %out_addr = alloc_stack $Int64
 
   %genericToGeneric = function_ref @genericToGeneric : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T
-  %result1 = apply %genericToGeneric<Int64>(%int_addr, %out_addr) : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T
+  %result1 = apply %genericToGeneric<Int64>(%out_addr, %int_addr) : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T
 
   %print_int = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
   %out = load %out_addr : $*Int64

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -1,0 +1,82 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+protocol P {
+  func printMe() -> Int64
+}
+
+extension P {
+  func callPrintMe() async -> Int64
+}
+
+struct I : P {
+  @_hasStorage let int: Int64 { get }
+  func printMe() -> Int64
+  init(int: Int64)
+}
+
+// CHECK-LL: define hidden swiftcc void @callPrintMe(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @callPrintMe : $@async @convention(method) <Self where Self : P> (@in_guaranteed Self) -> Int64 {
+bb0(%self : $*Self):
+  %P_printMe = witness_method $Self, #P.printMe : <Self where Self : P> (Self) -> () -> Int64 : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %result = apply %P_printMe<Self>(%self) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  return %result : $Int64
+}
+
+sil hidden @I_printMe : $@convention(method) (I) -> Int64 {
+bb0(%self : $I):
+  %self_addr = alloc_stack $I
+  store %self to %self_addr : $*I
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %printGeneric_result = apply %printGeneric<I>(%self_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %self_addr : $*I
+  %result = struct_extract %self : $I, #I.int
+  return %result : $Int64
+}
+
+sil private [transparent] [thunk] @I_P_printMe : $@convention(witness_method: P) (@in_guaranteed I) -> Int64 {
+bb0(%self_addr : $*I):
+  %self = load %self_addr : $*I
+  %I_printMe = function_ref @I_printMe : $@convention(method) (I) -> Int64
+  %result = apply %I_printMe(%self) : $@convention(method) (I) -> Int64
+  return %result : $Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %i_type = metatype $@thin I.Type
+  %i_int_literal = integer_literal $Builtin.Int64, 99
+  %i_int = struct $Int64 (%i_int_literal : $Builtin.Int64)
+  %i = struct $I (%i_int : $Int64)
+  %i_addr = alloc_stack $I
+  store %i to %i_addr : $*I
+  %callPrintMe = function_ref @callPrintMe : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %result = apply %callPrintMe<I>(%i_addr) : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // CHECK: I(int: 99)
+  dealloc_stack %i_addr : $*I
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 99
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}
+
+sil_witness_table hidden I: P module main {
+  method #P.printMe: <Self where Self : P> (Self) -> () -> Int64 : @I_P_printMe
+}

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -1,0 +1,73 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+protocol P {
+  func printMe() async -> Int64
+}
+
+struct I : P {
+  @_hasStorage let int: Int64 { get }
+  func printMe() async -> Int64
+  init(int: Int64)
+}
+
+// CHECK-LL-LABEL: define hidden swiftcc void @I_printMe(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @I_printMe : $@async @convention(method) (I) -> Int64 {
+bb0(%self : $I):
+  %self_addr = alloc_stack $I
+  store %self to %self_addr : $*I
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %printGeneric_result = apply %printGeneric<I>(%self_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %self_addr : $*I
+  %result = struct_extract %self : $I, #I.int
+  return %result : $Int64
+}
+
+// CHECK-LL-LABEL: define internal swiftcc void @I_P_printMe(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil private [transparent] [thunk] @I_P_printMe : $@async @convention(witness_method: P) (@in_guaranteed I) -> Int64 {
+bb0(%self_addr : $*I):
+  %self = load %self_addr : $*I
+  %I_printMe = function_ref @I_printMe : $@async @convention(method) (I) -> Int64
+  %result = apply %I_printMe(%self) : $@async @convention(method) (I) -> Int64
+  return %result : $Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %i_type = metatype $@thin I.Type
+  %i_int_literal = integer_literal $Builtin.Int64, 99
+  %i_int = struct $Int64 (%i_int_literal : $Builtin.Int64)
+  %i = struct $I (%i_int : $Int64)
+  %i_addr = alloc_stack $I
+  store %i to %i_addr : $*I
+  %P_printMe = witness_method $I, #P.printMe : <Self where Self : P> (Self) -> () async -> Int64 : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %result = apply %P_printMe<I>(%i_addr) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // CHECK: I(int: 99)
+  dealloc_stack %i_addr : $*I
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 99
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}
+
+sil_witness_table hidden I: P module main {
+  method #P.printMe: <Self where Self : P> (Self) -> () async -> Int64 : @I_P_printMe
+}
+

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -1,0 +1,97 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+protocol P {
+  func printMe<T>(_ t: T) async -> (Int64, T)
+}
+
+extension P {
+  func callPrintMe<T>(_ t: T) async -> (Int64, T)
+}
+
+struct I : P {
+  @_hasStorage let int: Int64 { get }
+  func printMe<T>(_ t: T) async -> (Int64, T)
+  init(int: Int64)
+}
+
+sil hidden @I_printMe : $@convention(method) @async <T> (@in_guaranteed T, I) -> (Int64, @out T) {
+bb0(%out_addr : $*T, %in_addr : $*T, %self : $I):
+  %self_addr = alloc_stack $I
+  store %self to %self_addr : $*I
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %printGeneric_result = apply %printGeneric<I>(%self_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %self_addr : $*I
+  %value = struct_extract %self : $I, #I.int
+  copy_addr %in_addr to [initialization] %out_addr : $*T
+  return %value : $Int64
+}
+
+// CHECK-LL: define internal swiftcc void @I_P_printMe(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil private [transparent] [thunk] @I_P_printMe : $@convention(witness_method: P) @async <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed I) -> (Int64, @out τ_0_0) {
+bb0(%out_addr : $*τ_0_0, %in_addr : $*τ_0_0, %self_addr : $*I):
+  %self = load %self_addr : $*I
+  %I_printMe = function_ref @I_printMe : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, I) -> (Int64, @out τ_0_0)
+  %result = apply %I_printMe<τ_0_0>(%out_addr, %in_addr, %self) : $@convention(method) @async <τ_0_0> (@in_guaranteed τ_0_0, I) -> (Int64, @out τ_0_0)
+  return %result : $Int64
+}
+
+sil hidden @callPrintMe : $@convention(thin) <T, U where T : P> (@in_guaranteed T, @in_guaranteed U) -> (Int64, @out U) {
+bb0(%out_addr : $*U, %self_addr : $*T, %in_addr : $*U):
+  %I_P_printMe = witness_method $T, #P.printMe : <Self where Self : P><T> (Self) -> (T) async -> (Int64, T) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P><τ_1_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_0_0) -> (Int64, @out τ_1_0)
+  %result = apply %I_P_printMe<T, U>(%out_addr, %in_addr, %self_addr) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P><τ_1_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_0_0) -> (Int64, @out τ_1_0)
+  return %result : $Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %I_type = metatype $@thin I.Type
+  %int_literal = integer_literal $Builtin.Int64, 99
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %i = struct $I (%int : $Int64)
+  %out_addr = alloc_stack $I
+  %in_addr = alloc_stack $I
+  store %i to %in_addr : $*I
+  %i_addr = alloc_stack $I
+  store %i to %i_addr : $*I
+  %callPrintMe = function_ref @callPrintMe : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Int64, @out τ_0_1)
+  %result = apply %callPrintMe<I, I>(%out_addr, %in_addr, %i_addr) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Int64, @out τ_0_1)
+  dealloc_stack %i_addr : $*I
+  dealloc_stack %in_addr : $*I
+  %out = load %out_addr : $*I
+  dealloc_stack %out_addr : $*I
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 99
+  %out_addr_2 = alloc_stack $I
+  store %out to %out_addr_2 : $*I
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %printGeneric_result = apply %printGeneric<I>(%out_addr_2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // CHECK: I(int: 99)
+  dealloc_stack %out_addr_2 : $*I
+
+
+
+  %returnCode_literal = integer_literal $Builtin.Int32, 0
+  %returnCode = struct $Int32 (%returnCode_literal : $Builtin.Int32)
+  return %returnCode : $Int32
+}
+
+
+sil_witness_table hidden I: P module main {
+  method #P.printMe: <Self where Self : P><T> (Self) -> (T) async -> (Int64, T) : @I_P_printMe
+}

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+protocol P {
+  func printMe() async -> Int64
+}
+
+struct I : P {
+  @_hasStorage let int: Int64 { get }
+  func printMe() async -> Int64
+  init(int: Int64)
+}
+
+// CHECK-LL-LABEL: define hidden swiftcc void @I_printMe(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @I_printMe : $@async @convention(method) (I) -> Int64 {
+bb0(%self : $I):
+  %self_addr = alloc_stack $I
+  store %self to %self_addr : $*I
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %printGeneric_result = apply %printGeneric<I>(%self_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %self_addr : $*I
+  %result = struct_extract %self : $I, #I.int
+  return %result : $Int64
+}
+
+// CHECK-LL-LABEL: define internal swiftcc void @I_P_printMe(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil private [transparent] [thunk] @I_P_printMe : $@async @convention(witness_method: P) (@in_guaranteed I) -> Int64 {
+bb0(%self_addr : $*I):
+  %self = load %self_addr : $*I
+  %I_printMe = function_ref @I_printMe : $@async @convention(method) (I) -> Int64
+  %result = apply %I_printMe(%self) : $@async @convention(method) (I) -> Int64
+  return %result : $Int64
+}
+
+sil hidden @callPrintMe : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64 {
+bb0(%t : $*T):
+  %I_P_printMe = witness_method $T, #P.printMe : <Self where Self : P> (Self) -> () async -> Int64 : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %result = apply %I_P_printMe<T>(%t) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  return %result : $Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %i_type = metatype $@thin I.Type
+  %i_int_literal = integer_literal $Builtin.Int64, 99
+  %i_int = struct $Int64 (%i_int_literal : $Builtin.Int64)
+  %i = struct $I (%i_int : $Int64)
+  %i_addr = alloc_stack $I
+  store %i to %i_addr : $*I
+  %callPrintMe = function_ref @callPrintMe : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %result = apply %callPrintMe<I>(%i_addr) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // users: %13, %11 // CHECK: I(int: 99)
+  dealloc_stack %i_addr : $*I
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 99
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}
+
+sil_witness_table hidden I: P module main {
+  method #P.printMe: <Self where Self : P> (Self) -> () async -> Int64 : @I_P_printMe
+}
+


### PR DESCRIPTION
Based on https://github.com/apple/swift/pull/34200 .

Previously, the AsyncContextLayout did not make space for the trailing witness fields (self metadata and self witness table) and the AsyncNativeCCEntryPointArgumentEmission could consequently not vend these fields.  Here, the fields are added to the layout.

Additionally, corrected ordering of indirect results.  Previously, the indirect results were claimed from the explosion after the arguments were claimed.  That failed to match the order in which arguments actually appear in the explosion.  Here the order is reversed.