### PR TITLE
[build] Remove unused lldb cmake

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2030,7 +2030,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_ENABLE_PYTHON=ON
                     -DLLDB_ENABLE_LZMA=OFF
                     -DLLDB_ENABLE_LUA=OFF
-                    -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
                     -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
                     -DLLDB_TEST_USER_ARGS="${DOTEST_ARGS}"
                 )

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1960,17 +1960,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${lldb_cmake_options[@]}"
                     )
 
-                # Figure out if we think this is a buildbot build.
-                # This will influence the lldb version line.
-                if [ ! -z "${JENKINS_HOME}" -a ! -z "${JOB_NAME}" -a ! -z "${BUILD_NUMBER}" ]; then
-                    LLDB_IS_BUILDBOT_BUILD=1
-                else
-                    LLDB_IS_BUILDBOT_BUILD=0
-                fi
-
-                # Get the build date.
-                LLDB_BUILD_DATE=$(date +%Y-%m-%d)
-
                 # Pick the right cache.
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                   cmake_cache="Apple-lldb-macOS.cmake"
@@ -2042,8 +2031,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_ENABLE_LZMA=OFF
                     -DLLDB_ENABLE_LUA=OFF
                     -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
-                    -DLLDB_IS_BUILDBOT_BUILD:BOOL="${LLDB_IS_BUILDBOT_BUILD}"
-                    -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
                     -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
                     -DLLDB_TEST_USER_ARGS="${DOTEST_ARGS}"
                 )


### PR DESCRIPTION
This removes the CMake definitions for:

* `LLDB_IS_BUILDBOT_BUILD`
* `LLDB_BUILD_DATE`
* `LLDB_PATH_TO_SWIFT_SOURCE`

Despite being defined here, their values have not been passed through to the compiler. See also https://github.com/apple/llvm-project/pull/1912