### PR TITLE
WinSDK: extract Security submodule with winscard.h

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -137,13 +137,6 @@ module WinSDK [system] {
     }
   }
 
-  module AuthZ {
-    header "AuthZ.h"
-    export *
-
-    link "AuthZ.Lib"
-  }
-
   module Controls {
     module CommCtrl {
       header "CommCtrl.h"
@@ -222,6 +215,29 @@ module WinSDK [system] {
     export *
 
     link "WinMM.Lib"
+  }
+
+  module Security {
+    module AuthZ {
+      header "AuthZ.h"
+      export *
+
+      link "AuthZ.Lib"
+    }
+
+    module SmartCard {
+      header "winscard.h"
+      export *
+
+      link "winscard.lib"
+    }
+
+    module WinCrypt {
+      header "wincrypt.h"
+      export *
+
+      link "Crypt32.Lib"
+    }
   }
 
   module Shell {
@@ -305,13 +321,6 @@ module WinSDK [system] {
   module WinBase {
     header "winbase.h"
     export *
-  }
-
-  module WinCrypt {
-    header "wincrypt.h"
-    export *
-
-    link "Crypt32.Lib"
   }
 
   module WinDNS {


### PR DESCRIPTION
Currently `winscard.h` gets included into `WinSDK.WinSock2` via `windows.h`.
This change extracts it into a separate submodule.
MSDN lists this header in https://docs.microsoft.com/en-us/windows/win32/api/_security/ along with `authz.h` & `wincrypt.h`, so this change also moves these submodules into `Security`.