### PR TITLE
[build] Adjust install name for Differentiation and Concurrency

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -13,7 +13,6 @@
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Actor.swift
   PartialAsyncTask.swift
-  "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_MODULE_DEPENDS_OSX Darwin
   SWIFT_MODULE_DEPENDS_IOS Darwin

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -13,6 +13,7 @@
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Actor.swift
   PartialAsyncTask.swift
+  "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   SWIFT_MODULE_DEPENDS_OSX Darwin
   SWIFT_MODULE_DEPENDS_IOS Darwin
@@ -29,5 +30,4 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  DARWIN_INSTALL_NAME_DIR "@rpath"
   INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -17,7 +17,6 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
   AnyDifferentiable.swift
   ArrayDifferentiation.swift
   OptionalDifferentiation.swift
-  "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   GYB_SOURCES
     FloatingPointDifferentiation.swift.gyb

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -17,6 +17,7 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
   AnyDifferentiable.swift
   ArrayDifferentiation.swift
   OptionalDifferentiation.swift
+  "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
   GYB_SOURCES
     FloatingPointDifferentiation.swift.gyb
@@ -38,5 +39,4 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  DARWIN_INSTALL_NAME_DIR "@rpath"
   INSTALL_IN_COMPONENT stdlib)


### PR DESCRIPTION
This effectively reverts #31183 -- we need to match the install name convention of the other stdlib libraries.

From the review feedback:

> The right way to load the stdlib & runtime libraries from a custom toolchain is to set `DYLD_LIBRARY_PATH` when executing the generated binary. This is how we run tests against the just-built libraries and this is how downloadable toolchain snapshots are currently configured in Xcode -- see #33178