### PR TITLE
Patch Out Use-Of-Stack-After-Free In Cross Module Dependencies

### DIFF
--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -752,6 +752,11 @@ StringRef ModuleDepGraph::getProvidingFilename(
     const Optional<std::string> swiftDeps) const {
   if (!swiftDeps)
     return "<unknown";
+  auto ext = llvm::sys::path::extension(*swiftDeps);
+  if (file_types::lookupTypeForExtension(ext) ==
+      file_types::TY_SwiftModuleFile) {
+    return *swiftDeps;
+  }
   const StringRef inputName =
       llvm::sys::path::filename(getJob(swiftDeps)->getFirstSwiftPrimaryInput());
   // FineGrainedDependencyGraphTests work with simulated jobs with empty


### PR DESCRIPTION
The fake job is entered into the map to satisfy the tracing machinery.
When that same machinery kicks into gear to print out paths, lookups
into the dictionary will access data has gone out of scope.

For now, cut off the read. There will be another refactoring patch that
keeps these temporaries out of the Driver's data structures entirely.

rdar://70053563