### PR TITLE
Keep a Cache of Externally-Dependent Jobs

### DIFF
--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -466,7 +466,7 @@ public:
   void printPath(raw_ostream &out, const driver::Job *node) const;
 
   /// Get a printable filename, given a node's swiftDeps.
-  StringRef getProvidingFilename(Optional<std::string> swiftDeps) const;
+  StringRef getProvidingFilename(const Optional<std::string> &swiftDeps) const;
 
   /// Print one node on the dependency path.
   static void printOneNodeOfPath(raw_ostream &out, const DependencyKey &key,

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -749,7 +749,7 @@ void ModuleDepGraph::printPath(raw_ostream &out,
 }
 
 StringRef ModuleDepGraph::getProvidingFilename(
-    const Optional<std::string> swiftDeps) const {
+    const Optional<std::string> &swiftDeps) const {
   if (!swiftDeps)
     return "<unknown";
   auto ext = llvm::sys::path::extension(*swiftDeps);


### PR DESCRIPTION
A more durable form of #34218. Keep a side cache of externally-dependent
jobs for now. This ensures our pseudo-Jobs don't get prematurely
deallocated before the tracing machinery has had a chance to report the
structure of the Job graph.

rdar://70053563