### PR TITLE
ModuleInterface: rephrase remark message when acquiring lock file failed

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -393,7 +393,7 @@ ERROR(error_creating_remark_serializer,none,
       "error while creating remark serializer: '%0'", (StringRef))
 
 REMARK(interface_file_lock_failure,none,
-      "could not acquire lock file for module interface '%0'", (StringRef))
+      "building module interface without lock file", ())
 
 REMARK(interface_file_lock_timed_out,none,
       "timed out waiting to acquire lock file for module interface '%0'", (StringRef))

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -297,7 +297,7 @@ bool ModuleInterfaceBuilder::buildSwiftModule(StringRef OutPath,
     // necessary for performance. Fallback to building the module in case of any lock
     // related errors.
     if (RemarkRebuild) {
-      diagnose(diag::interface_file_lock_failure, interfacePath);
+      diagnose(diag::interface_file_lock_failure);
     }
     // Clear out any potential leftover.
     Locked.unsafeRemoveLockFile();


### PR DESCRIPTION
The original remark message “could not acquire lock file for module interface” sounds too severe.
It may confuse users that this is a serious issue. We should rephrase it to a less obtrusive one.

rdar://70055223
