### PR TITLE
[NFC] Add IncrementalJobAction

### DIFF
--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -43,6 +43,8 @@ void InputAction::anchor() {}
 
 void JobAction::anchor() {}
 
+void IncrementalJobAction::anchor() {}
+
 void CompileJobAction::anchor() {}
 
 void InterpretJobAction::anchor() {}


### PR DESCRIPTION
Add a common base class for `Action`s that have incremental behavior - for now, that means they can be skipped. This forms the foundation of the work to extend incremental behavior to merge-modules and the precompile step.

rdar://65893400, rdar://64765215 