### PR TITLE
[Runtime] Change SimpleGlobalCache to use ConcurrentReadableHashMap instead of ConcurrentMap.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -229,8 +229,10 @@ public:
     return reinterpret_cast<intptr_t>(Data.BoxedType);
   }
 
-  int compareWithKey(const Metadata *type) const {
-    return comparePointers(type, Data.BoxedType);
+  bool matchesKey(const Metadata *type) const { return type == Data.BoxedType; }
+
+  friend llvm::hash_code hash_value(const BoxCacheEntry &value) {
+    return llvm::hash_value(value.Data.BoxedType);
   }
 
   static size_t getExtraAllocationSize(const Metadata *key) {

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -51,16 +51,17 @@ public:
   }
 };
 
-template<uint16_t StaticTag>
-class TaggedMetadataAllocator: public MetadataAllocator {
+template <uint16_t StaticTag>
+class TaggedMetadataAllocator : public MetadataAllocator {
 public:
   constexpr TaggedMetadataAllocator() : MetadataAllocator(StaticTag) {}
 };
 
-/// A typedef for simple global caches.
+/// A typedef for simple global caches with stable addresses for the entries.
 template <class EntryTy, uint16_t Tag>
 using SimpleGlobalCache =
-  ConcurrentMap<EntryTy, /*destructor*/ false, TaggedMetadataAllocator<Tag>>;
+    StableAddressConcurrentReadableHashMap<EntryTy,
+                                           TaggedMetadataAllocator<Tag>>;
 
 template <class T, bool ProvideDestructor = true>
 class StaticOwningPointer {

--- a/unittests/runtime/Concurrent.cpp
+++ b/unittests/runtime/Concurrent.cpp
@@ -229,6 +229,9 @@ TEST(ConcurrentReadableHashMapTest, SingleThreaded) {
   check(1000000);
   map.clear();
   check(0);
+
+  ASSERT_FALSE(map.hasActiveReaders());
+  map.clear();
 }
 
 struct MultiThreadedKey {
@@ -328,6 +331,9 @@ TEST(ConcurrentReadableHashMapTest, MultiThreaded) {
     else
       reader();
   });
+
+  ASSERT_FALSE(map.hasActiveReaders());
+  map.clear();
 }
 
 // Test readers and writers while also constantly clearing the map.
@@ -389,6 +395,9 @@ TEST(ConcurrentReadableHashMapTest, MultiThreaded2) {
     else
       clear();
   });
+
+  ASSERT_FALSE(map.hasActiveReaders());
+  map.clear();
 }
 
 // Test readers and writers, with readers taking lots of snapshots.
@@ -443,6 +452,9 @@ TEST(ConcurrentReadableHashMapTest, MultiThreaded3) {
     else
       reader();
   });
+
+  ASSERT_FALSE(map.hasActiveReaders());
+  map.clear();
 }
 
 // Test readers and writers, with readers taking lots of snapshots, and
@@ -498,4 +510,6 @@ TEST(ConcurrentReadableHashMapTest, MultiThreaded4) {
     else
       clear();
   });
+  ASSERT_FALSE(map.hasActiveReaders());
+  map.clear();
 }


### PR DESCRIPTION
This gives us faster lookups and a small advantage in memory usage. Most of these maps need stable addresses for their entries, so we add a level of indirection to ConcurrentReadableHashMap for these cases to accommodate that. This costs some extra memory, but it's still a net win.

A new StableAddressConcurrentReadableHashMap type handles this indirection and adds a convenience getOrInsert to take advantage of it.

ConcurrentReadableHashMap is tweaked to avoid any global constructors or destructors when using it as a global variable.

ForeignWitnessTables does not need stable addresses and it now uses ConcurrentReadableHashMap directly.

rdar://problem/70056398