### PR TITLE
Add check for Xcode version compatibility

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -62,6 +62,7 @@ _SUPPORTED_XCODE_BUILDS = [
 # -----------------------------------------------------------------------------
 # Helpers
 
+
 def print_note(message, stream=sys.stdout):
     """Writes a diagnostic message to the given stream. By default this
     function outputs to stdout.
@@ -152,6 +153,7 @@ def print_xcodebuild_versions(file=sys.stdout):
     print(fmt.format(version=version, sdks=sdks), file=file)
     file.flush()
 
+
 def validate_xcode_compatibility():
     if sys.platform != 'darwin':
         return
@@ -168,10 +170,13 @@ def validate_xcode_compatibility():
         valid_versions_string = "\n".join(
             "{} ({})".format(*x) for x in _SUPPORTED_XCODE_BUILDS)
         raise SystemExit(
-            "error: using unsupported Xcode version:\n\n{}\n\nInstall one of:\n{}\n\nOr set 'SKIP_XCODE_VERSION_CHECK=1' in the environment".format(
+            "error: using unsupported Xcode version:\n\n{}\n\n"
+            "Install one of:\n{}\n\n"
+            "Or set 'SKIP_XCODE_VERSION_CHECK=1' in the environment".format(
                 version, valid_versions_string
             )
         )
+
 
 def tar(source, destination):
     """

--- a/utils/build-script
+++ b/utils/build-script
@@ -56,13 +56,7 @@ HOME = os.environ.get("HOME", "/")
 # These versions are community sourced. At any given time only the Xcode
 # version used by Swift CI is officially supported. See ci.swift.org
 _SUPPORTED_XCODE_BUILDS = [
-    ("12.0 beta 3", "12A8169g"),
-    ("12.0 beta 4", "12A8179i"),
-    ("12.0 beta 5", "12A8189h"),
-    ("12.0 beta 6", "12A8189n"),
-    ("12.0 GM 1", "12A7208"),
-    ("12.0 GM 2", "12A7209"),
-    ("12.0.1", "12A7300"),
+    ("12.2 beta 3", "12B5035g"),
 ]
 
 # -----------------------------------------------------------------------------

--- a/utils/build-script
+++ b/utils/build-script
@@ -53,6 +53,15 @@ from swift_build_support.swift_build_support.toolchain import host_toolchain
 # TODO: Remove this constant, it's really not helpful.
 HOME = os.environ.get("HOME", "/")
 
+_SUPPORTED_XCODE_BUILDS = (
+    "12A8169g", # 12.0b3
+    "12A8179i", # 12.0b4
+    "12A8189h", # 12.0b5
+    "12A8189n", # 12.0b6
+    "12A7208", # 12.0GM1
+    "12A7209", # 12.0GM2
+    "12A7300", # 12.0.1
+)
 
 # -----------------------------------------------------------------------------
 # Helpers
@@ -147,6 +156,22 @@ def print_xcodebuild_versions(file=sys.stdout):
     print(fmt.format(version=version, sdks=sdks), file=file)
     file.flush()
 
+def validate_xcode_compatibility():
+    if sys.platform != 'darwin':
+        return
+
+    if os.getenv("SKIP_XCODE_VERSION_CHECK"):
+        print("note: skipping Xcode version check")
+        return
+
+    version = shell.capture(
+        ['xcodebuild', '-version'], dry_run=False, echo=False).strip()
+    if not version.endswith(_SUPPORTED_XCODE_BUILDS):
+        raise SystemExit(
+            "error: using unsupported Xcode version:\n\n{}\n\nInstall one of: {}".format(
+                version, ", ".join(_SUPPORTED_XCODE_BUILDS)
+            )
+        )
 
 def tar(source, destination):
     """
@@ -1334,6 +1359,8 @@ def main():
             "source root directory \'" + SWIFT_SOURCE_ROOT +
             "\' does not exist " +
             "(forgot to set $SWIFT_SOURCE_ROOT environment variable?)")
+
+    validate_xcode_compatibility()
 
     # Determine if we are invoked in the preset mode and dispatch accordingly.
     if any([(opt.startswith("--preset") or opt == "--show-presets")

--- a/utils/build-script
+++ b/utils/build-script
@@ -53,15 +53,15 @@ from swift_build_support.swift_build_support.toolchain import host_toolchain
 # TODO: Remove this constant, it's really not helpful.
 HOME = os.environ.get("HOME", "/")
 
-_SUPPORTED_XCODE_BUILDS = (
-    "12A8169g", # 12.0b3
-    "12A8179i", # 12.0b4
-    "12A8189h", # 12.0b5
-    "12A8189n", # 12.0b6
-    "12A7208", # 12.0GM1
-    "12A7209", # 12.0GM2
-    "12A7300", # 12.0.1
-)
+_SUPPORTED_XCODE_BUILDS = [
+    ("12.0 beta 3", "12A8169g"),
+    ("12.0 beta 4", "12A8179i"),
+    ("12.0 beta 5", "12A8189h"),
+    ("12.0 beta 6", "12A8189n"),
+    ("12.0 GM 1", "12A7208"),
+    ("12.0 GM 2", "12A7209"),
+    ("12.0.1", "12A7300"),
+]
 
 # -----------------------------------------------------------------------------
 # Helpers
@@ -166,10 +166,14 @@ def validate_xcode_compatibility():
 
     version = shell.capture(
         ['xcodebuild', '-version'], dry_run=False, echo=False).strip()
-    if not version.endswith(_SUPPORTED_XCODE_BUILDS):
+
+    valid_build_numbers = tuple(x[1] for x in _SUPPORTED_XCODE_BUILDS)
+    if not version.endswith(valid_build_numbers):
+        valid_versions_string = "\n".join(
+            "{} ({})".format(*x) for x in _SUPPORTED_XCODE_BUILDS)
         raise SystemExit(
-            "error: using unsupported Xcode version:\n\n{}\n\nInstall one of: {}".format(
-                version, ", ".join(_SUPPORTED_XCODE_BUILDS)
+            "error: using unsupported Xcode version:\n\n{}\n\nInstall one of:\n{}\n\nOr set 'SKIP_XCODE_VERSION_CHECK=1' in the environment".format(
+                version, valid_versions_string
             )
         )
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -53,6 +53,8 @@ from swift_build_support.swift_build_support.toolchain import host_toolchain
 # TODO: Remove this constant, it's really not helpful.
 HOME = os.environ.get("HOME", "/")
 
+# These versions are community sourced. At any given time only the Xcode
+# version used by Swift CI is officially supported. See ci.swift.org
 _SUPPORTED_XCODE_BUILDS = [
     ("12.0 beta 3", "12A8169g"),
     ("12.0 beta 4", "12A8179i"),


### PR DESCRIPTION
This adds a check validating the current Xcode version is supported for
building the current sha. This makes us fail fast in the case that
you've selected too new or too old of an Xcode version that might
otherwise fail very late in the build process. You can also set
SKIP_XCODE_VERSION_CHECK to anything to skip this.

Fixes https://bugs.swift.org/browse/SR-13497