### PR TITLE
[Sema] Correct lvalue computation in `buildStorageRef` for synthesizing local accessors.

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2362,6 +2362,7 @@ public:
     } else if (FD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.
       (void)FD->getTypecheckedBody();
+      TypeChecker::computeCaptures(FD);
     } else if (shouldSkipBodyTypechecking(FD)) {
       FD->setBodySkipped(FD->getBodySourceRange());
     } else {


### PR DESCRIPTION
This is a follow-up to the local property wrapper implementation to address https://github.com/apple/swift/pull/34109#discussion_r496998875

The fix turned out to be pretty simple - the lvalue adjustment for the storage reference base simply needed to be moved earlier and slightly adjusted to account for cases where the base is not `self`.