### PR TITLE
Skip Merge-Modules When We Can

### DIFF
--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -132,8 +132,8 @@ public:
   struct InputInfo {
     enum Status {
       UpToDate,
-      NeedsCascadingBuild,
       NeedsNonCascadingBuild,
+      NeedsCascadingBuild,
       NewlyAdded
     };
 

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -130,15 +130,28 @@ public:
 class IncrementalJobAction : public JobAction {
 public:
   struct InputInfo {
-    enum Status {
+    /// The status of an input known to the driver. These are used to affect
+    /// the scheduling decisions made during an incremental build.
+    ///
+    /// \Note The order of cases matters. They are ordered from least to
+    /// greatest impact on the incremental build schedule.
+    enum class Status {
+      /// The input to this job is up to date.
       UpToDate,
+      /// The input to this job has changed in a way that requires this job to
+      /// be rerun, but not in such a way that it requires a cascading rebuild.
       NeedsNonCascadingBuild,
+      /// The input to this job has changed in a way that requires this job to
+      /// be rerun, and in such a way that all jobs dependent upon this one
+      /// must be scheduled as well.
       NeedsCascadingBuild,
+      /// The input to this job was not known to the driver when it was last
+      /// run.
       NewlyAdded
     };
 
   public:
-    Status status = UpToDate;
+    Status status = Status::UpToDate;
     llvm::sys::TimePoint<> previousModTime;
 
     InputInfo() = default;

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -146,7 +146,11 @@ public:
         : status(stat), previousModTime(time) {}
 
     static InputInfo makeNewlyAdded() {
-      return InputInfo(Status::NewlyAdded, llvm::sys::TimePoint<>::max());
+      return {Status::NewlyAdded, llvm::sys::TimePoint<>::max()};
+    }
+
+    static InputInfo makeNeedsCascadingRebuild() {
+      return {Status::NeedsCascadingBuild, llvm::sys::TimePoint<>::min()};
     }
   };
 

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -183,7 +183,8 @@ public:
 
 public:
   static bool classof(const Action *A) {
-    return A->getKind() == Action::Kind::CompileJob;
+    return A->getKind() == Action::Kind::CompileJob ||
+           A->getKind() == Action::Kind::MergeModuleJob;
   }
 };
 
@@ -280,12 +281,12 @@ public:
   }
 };
 
-class MergeModuleJobAction : public JobAction {
+class MergeModuleJobAction : public IncrementalJobAction {
   virtual void anchor() override;
 public:
-  MergeModuleJobAction(ArrayRef<const Action *> Inputs)
-      : JobAction(Action::Kind::MergeModuleJob, Inputs,
-                  file_types::TY_SwiftModuleFile) {}
+  MergeModuleJobAction(ArrayRef<const Action *> Inputs, InputInfo input)
+      : IncrementalJobAction(Action::Kind::MergeModuleJob, Inputs,
+                             file_types::TY_SwiftModuleFile, input) {}
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::MergeModuleJob;

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1608,8 +1608,8 @@ namespace driver {
           CompileJobAction::InputInfo info;
           info.previousModTime = entry.first->getInputModTime();
           info.status = entry.second ?
-            CompileJobAction::InputInfo::NeedsCascadingBuild :
-            CompileJobAction::InputInfo::NeedsNonCascadingBuild;
+            CompileJobAction::InputInfo::Status::NeedsCascadingBuild :
+            CompileJobAction::InputInfo::Status::NeedsNonCascadingBuild;
           inputs[&inputFile->getInputArg()] = info;
         }
       }
@@ -1626,7 +1626,7 @@ namespace driver {
 
           CompileJobAction::InputInfo info;
           info.previousModTime = entry->getInputModTime();
-          info.status = CompileJobAction::InputInfo::UpToDate;
+          info.status = CompileJobAction::InputInfo::Status::UpToDate;
           inputs[&inputFile->getInputArg()] = info;
         }
       }

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1163,7 +1163,12 @@ namespace driver {
           continue;
         }
 
-        // Can we run a cross-module incremental build at all? If not, fallback.
+        // Is this module out of date? If not, just keep searching.
+        if (Comp.getLastBuildTime() >= depStatus.getLastModificationTime())
+          continue;
+
+        // Can we run a cross-module incremental build at all?
+        // If not, fall back.
         if (!Comp.getEnableCrossModuleIncrementalBuild()) {
           fallbackToExternalBehavior(external);
           continue;

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -446,7 +446,7 @@ namespace driver {
 
     std::vector<const Job*>
     reloadAndRemarkDeps(const Job *FinishedCmd, int ReturnCode,
-                             const bool forRanges) {
+                        const bool forRanges) {
       const CommandOutput &Output = FinishedCmd->getOutput();
       StringRef DependenciesFile =
           Output.getAdditionalOutputForType(file_types::TY_SwiftDeps);
@@ -458,7 +458,8 @@ namespace driver {
         // coarse dependencies that always affect downstream nodes), but we're
         // not using either of those right now, and this logic should probably
         // be revisited when we are.
-        assert(FinishedCmd->getCondition() == Job::Condition::Always);
+        assert(isa<MergeModuleJobAction>(FinishedCmd->getSource()) ||
+               FinishedCmd->getCondition() == Job::Condition::Always);
         return {};
       }
       const bool compileExitedNormally =
@@ -907,12 +908,18 @@ namespace driver {
         return everyIncrementalJob;
       };
 
+      const Job *mergeModulesJob = nullptr;
       CommandSet jobsToSchedule;
       CommandSet initialCascadingCommands;
       for (const Job *cmd : Comp.getJobs()) {
         // Skip jobs that have no associated incremental info.
         if (!isa<IncrementalJobAction>(cmd->getSource())) {
           continue;
+        }
+
+        if (isa<MergeModuleJobAction>(cmd->getSource())) {
+          assert(!mergeModulesJob && "multiple scheduled merge-modules jobs?");
+          mergeModulesJob = cmd;
         }
 
         const Optional<std::pair<bool, bool>> shouldSchedAndIsCascading =
@@ -936,6 +943,15 @@ namespace driver {
            collectIncrementalExternallyDependentJobsFromDependencyGraph(
                forRanges))
         jobsToSchedule.insert(cmd);
+
+      // The merge-modules job is special: it *must* be scheduled if any other
+      // job has been scheduled because any other job can influence the
+      // structure of the resulting module. Additionally, the initial scheduling
+      // predicate above is only aware of intra-module changes. External
+      // dependencies changing *must* cause merge-modules to be scheduled.
+      if (!jobsToSchedule.empty() && mergeModulesJob) {
+        jobsToSchedule.insert(mergeModulesJob);
+      }
       return jobsToSchedule;
     }
 
@@ -1031,6 +1047,13 @@ namespace driver {
     /// But returns None if there was a dependency read error.
     Optional<std::pair<Job::Condition, bool>>
     loadDependenciesAndComputeCondition(const Job *const Cmd, bool forRanges) {
+      // merge-modules Jobs do not have .swiftdeps files associated with them,
+      // however, their compilation condition is computed as a function of their
+      // inputs, so their condition can be used as normal.
+      if (isa<MergeModuleJobAction>(Cmd->getSource())) {
+        return std::make_pair(Cmd->getCondition(), true);
+      }
+
       // Try to load the dependencies file for this job. If there isn't one, we
       // always have to run the job, but it doesn't affect any other jobs. If
       // there should be one but it's not present or can't be loaded, we have to

--- a/lib/Driver/CompilationRecord.h
+++ b/lib/Driver/CompilationRecord.h
@@ -59,12 +59,12 @@ inline static StringRef getName(TopLevelKey Key) {
 inline static StringRef
 getIdentifierForInputInfoStatus(CompileJobAction::InputInfo::Status Status) {
   switch (Status) {
-  case CompileJobAction::InputInfo::UpToDate:
+  case CompileJobAction::InputInfo::Status::UpToDate:
     return "";
-  case CompileJobAction::InputInfo::NewlyAdded:
-  case CompileJobAction::InputInfo::NeedsCascadingBuild:
+  case CompileJobAction::InputInfo::Status::NewlyAdded:
+  case CompileJobAction::InputInfo::Status::NeedsCascadingBuild:
     return "!dirty";
-  case CompileJobAction::InputInfo::NeedsNonCascadingBuild:
+  case CompileJobAction::InputInfo::Status::NeedsNonCascadingBuild:
     return "!private";
   }
 
@@ -76,11 +76,11 @@ getIdentifierForInputInfoStatus(CompileJobAction::InputInfo::Status Status) {
 /// compilation record file (.swiftdeps file).
 inline static Optional<CompileJobAction::InputInfo::Status>
 getInfoStatusForIdentifier(StringRef Identifier) {
-  return llvm::StringSwitch<Optional<
-      CompileJobAction::InputInfo::Status>>(Identifier)
-    .Case("", CompileJobAction::InputInfo::UpToDate)
-    .Case("!dirty", CompileJobAction::InputInfo::NeedsCascadingBuild)
-    .Case("!private", CompileJobAction::InputInfo::NeedsNonCascadingBuild)
+  using InputStatus = CompileJobAction::InputInfo::Status;
+  return llvm::StringSwitch<Optional<InputStatus>>(Identifier)
+    .Case("", InputStatus::UpToDate)
+    .Case("!dirty", InputStatus::NeedsCascadingBuild)
+    .Case("!private", InputStatus::NeedsNonCascadingBuild)
     .Default(None);
 }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2755,6 +2755,7 @@ static void
 handleCompileJobCondition(Job *J, CompileJobAction::InputInfo inputInfo,
                           StringRef input, bool alwaysRebuildDependents) {
   if (inputInfo.status == CompileJobAction::InputInfo::NewlyAdded) {
+  using InputStatus = CompileJobAction::InputInfo::Status;
     J->setCondition(Job::Condition::NewlyAdded);
     return;
   }
@@ -2769,24 +2770,24 @@ handleCompileJobCondition(Job *J, CompileJobAction::InputInfo inputInfo,
   Job::Condition condition;
   if (hasValidModTime && J->getInputModTime() == inputInfo.previousModTime) {
     switch (inputInfo.status) {
-    case CompileJobAction::InputInfo::UpToDate:
-      if (llvm::sys::fs::exists(J->getOutput().getPrimaryOutputFilename()))
+    case InputStatus::UpToDate:
+      if (llvm::sys::fs::exists(output))
         condition = Job::Condition::CheckDependencies;
       else
         condition = Job::Condition::RunWithoutCascading;
       break;
-    case CompileJobAction::InputInfo::NeedsCascadingBuild:
+    case InputStatus::NeedsCascadingBuild:
       condition = Job::Condition::Always;
       break;
-    case CompileJobAction::InputInfo::NeedsNonCascadingBuild:
+    case InputStatus::NeedsNonCascadingBuild:
       condition = Job::Condition::RunWithoutCascading;
       break;
-    case CompileJobAction::InputInfo::NewlyAdded:
+    case InputStatus::NewlyAdded:
       llvm_unreachable("handled above");
     }
   } else {
     if (alwaysRebuildDependents ||
-        inputInfo.status == CompileJobAction::InputInfo::NeedsCascadingBuild) {
+        inputInfo.status == InputStatus::NeedsCascadingBuild) {
       condition = Job::Condition::Always;
     } else {
       condition = Job::Condition::RunWithoutCascading;

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -15,4 +15,4 @@
 
 // CHECK-SECOND-NOT: warning
 // CHECK-SECOND-NOT: Handled
-// CHECK-SECOND: Produced master.swiftmodule
+// CHECK-SECOND-NOT: Produced master.swiftmodule

--- a/test/Incremental/CrossModule/linear.swift
+++ b/test/Incremental/CrossModule/linear.swift
@@ -38,4 +38,21 @@
 // MODULE-B: Job finished: {merge-module: B.swiftmodule <= B.o}
 
 // MODULE-A: Job skipped: {compile: A.o <= A.swift}
-// MODULE-A: Job finished: {merge-module: A.swiftmodule <= A.o}
+// MODULE-A: Job skipped: {merge-module: A.swiftmodule <= A.o}
+
+//
+// And ensure that the null build really is null.
+//
+
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle -DNEW %t/C.swift 2>&1 | %FileCheck -check-prefix MODULE-C-NULL %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/B.swift 2>&1 | %FileCheck -check-prefix MODULE-B-NULL %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/A.swift 2>&1 | %FileCheck -check-prefix MODULE-A-NULL %s
+
+// MODULE-C-NULL: Job skipped: {compile: C.o <= C.swift}
+// MODULE-C-NULL: Job skipped: {merge-module: C.swiftmodule <= C.o}
+
+// MODULE-B-NULL: Job skipped: {compile: B.o <= B.swift}
+// MODULE-B-NULL: Job skipped: {merge-module: B.swiftmodule <= B.o}
+
+// MODULE-A-NULL: Job skipped: {compile: A.o <= A.swift}
+// MODULE-A-NULL: Job skipped: {merge-module: A.swiftmodule <= A.o}

--- a/test/Incremental/CrossModule/transitive.swift
+++ b/test/Incremental/CrossModule/transitive.swift
@@ -42,3 +42,20 @@
 // MODULE-A: Queuing because of incremental external dependencies: {compile: A.o <= A.swift}
 // MODULE-A: Job finished: {compile: A.o <= A.swift}
 // MODULE-A: Job finished: {merge-module: A.swiftmodule <= A.o}
+
+//
+// And ensure that the null build really is null.
+//
+
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle -DUSEC -DNEW %t/C.swift 2>&1 | %FileCheck -check-prefix MODULE-C-NULL %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle -DUSEC %t/B.swift 2>&1 | %FileCheck -check-prefix MODULE-B-NULL %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle -DUSEC %t/A.swift 2>&1 | %FileCheck -check-prefix MODULE-A-NULL %s
+
+// MODULE-C-NULL: Job skipped: {compile: C.o <= C.swift}
+// MODULE-C-NULL: Job skipped: {merge-module: C.swiftmodule <= C.o}
+
+// MODULE-B-NULL: Job skipped: {compile: B.o <= B.swift}
+// MODULE-B-NULL: Job skipped: {merge-module: B.swiftmodule <= B.o}
+
+// MODULE-A-NULL: Job skipped: {compile: A.o <= A.swift}
+// MODULE-A-NULL: Job skipped: {merge-module: A.swiftmodule <= A.o}


### PR DESCRIPTION
Plumb the logic necessary to schedule merge-modules incrementally. This means that if any input jobs to merge-modules run, merge-modules is run. But, if they are all skipped, merge-modules will be skipped as well.

This requires some light special-casing of the legacy driver's incremental job handling because it assumes in a few places it can always extract a swiftdeps file. This invariant will be further broken when the precompile step for bridging headers is skipped as well.

rdar://65893400