### PR TITLE
[5.3][build] properly install compiler-rt from Xcode toolchain

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1380,6 +1380,61 @@ function cmake_config_opt() {
     fi
 }
 
+function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
+    local clang_dest_dir="$1"
+
+    HOST_CXX_DIR=$(dirname "${HOST_CXX}")
+    HOST_LIB_CLANG_DIR="${HOST_CXX_DIR}/../lib/clang"
+    DEST_LIB_CLANG_DIR="${clang_dest_dir}/lib/clang"
+
+    [ -d "${HOST_LIB_CLANG_DIR}" -a -d "${DEST_LIB_CLANG_DIR}" ] || return 0
+
+    DEST_CXX_BUILTINS_VERSION=$(ls -1 "${DEST_LIB_CLANG_DIR}")
+    DEST_BUILTINS_DIR="${clang_dest_dir}/lib/clang/${DEST_CXX_BUILTINS_VERSION}/lib/darwin"
+
+    if [[ -d "${DEST_BUILTINS_DIR}" ]]; then
+        for HOST_CXX_BUILTINS_PATH in "${HOST_LIB_CLANG_DIR}"/*; do
+            HOST_CXX_BUILTINS_DIR="${HOST_CXX_BUILTINS_PATH}/lib/darwin"
+            echo "copying compiler-rt embedded builtins from ${HOST_CXX_BUILTINS_DIR} into the local clang build directory ${DEST_BUILTINS_DIR}."
+
+            for OS in ios watchos tvos; do
+                # Copy over the device .a when necessary
+                LIB_NAME="libclang_rt.$OS.a"
+                HOST_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$LIB_NAME"
+                DEST_LIB_PATH="${DEST_BUILTINS_DIR}/${LIB_NAME}"
+                if [[ ! -f "${DEST_LIB_PATH}" ]]; then
+                    if [[ -f "${HOST_LIB_PATH}" ]]; then
+                        call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                    elif [[ "${VERBOSE_BUILD}" ]]; then
+                        echo "no file exists at ${HOST_LIB_PATH}"
+                    fi
+                fi
+
+                # Copy over the simulator .a when necessary
+                SIM_LIB_NAME="libclang_rt.${OS}sim.a"
+                HOST_SIM_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$SIM_LIB_NAME"
+                DEST_SIM_LIB_PATH="${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
+                if [[ ! -f "${DEST_SIM_LIB_PATH}" ]]; then
+                    if [[ -f "${HOST_SIM_LIB_PATH}" ]]; then
+                        call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                    elif [[ -f "${HOST_LIB_PATH}" ]]; then
+                        # The simulator .a might not exist if the host
+                        # Xcode is old. In that case, copy over the
+                        # device library to the simulator location to allow
+                        # clang to find it. The device library has the simulator
+                        # slices in Xcode that doesn't have the simulator .a, so
+                        # the link is still valid.
+                        echo "copying over faux-sim library ${HOST_LIB_PATH} to ${SIM_LIB_NAME}"
+                        call cp "${HOST_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                    elif [[ "${VERBOSE_BUILD}" ]]; then
+                        echo "no file exists at ${HOST_SIM_LIB_PATH}"
+                    fi
+                fi
+            done
+        done
+    fi
+}
+
 #
 # Configure and build each product
 #
@@ -2349,49 +2404,7 @@ for host in "${ALL_HOSTS[@]}"; do
         # builtins for iOS/tvOS/watchOS to ensure that Swift's
         # stdlib can use compiler-rt builtins when targetting iOS/tvOS/watchOS.
         if [[ "${product}" = "llvm" ]] && [[ "${BUILD_LLVM}" = "1" ]] && [[ "$(uname -s)" = "Darwin" ]]; then
-            HOST_CXX_DIR=$(dirname "${HOST_CXX}")
-            HOST_LIB_CLANG_DIR="${HOST_CXX_DIR}/../lib/clang"
-            DEST_LIB_CLANG_DIR="$(build_directory_bin ${host} llvm)/../lib/clang"
-
-            if [[ -d "${HOST_LIB_CLANG_DIR}" ]] && [[ -d "${DEST_LIB_CLANG_DIR}" ]]; then
-                DEST_CXX_BUILTINS_VERSION=$(ls "${DEST_LIB_CLANG_DIR}" | awk '{print $0}')
-                DEST_BUILTINS_DIR="$(build_directory_bin ${host} llvm)/../lib/clang/$DEST_CXX_BUILTINS_VERSION/lib/darwin"
-
-                if [[ -d "${DEST_BUILTINS_DIR}" ]]; then
-                    for HOST_CXX_BUILTINS_PATH in "${HOST_LIB_CLANG_DIR}"/*; do
-                        HOST_CXX_BUILTINS_DIR="${HOST_CXX_BUILTINS_PATH}/lib/darwin"
-                        echo "copying compiler-rt embedded builtins from ${HOST_CXX_BUILTINS_DIR} into the local clang build directory ${DEST_BUILTINS_DIR}."
-
-                        for OS in ios watchos tvos; do
-                            # Copy over the device .a
-                            LIB_NAME="libclang_rt.$OS.a"
-                            HOST_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$LIB_NAME"
-                            if [[ -f "${HOST_LIB_PATH}" ]]; then
-                                call cp "${HOST_LIB_PATH}" "${DEST_BUILTINS_DIR}/${LIB_NAME}"
-                            elif [[ "${VERBOSE_BUILD}" ]]; then
-                                echo "no file exists at ${HOST_LIB_PATH}"
-                            fi
-                            # Copy over the simulator .a
-                            SIM_LIB_NAME="libclang_rt.${OS}sim.a"
-                            HOST_SIM_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$SIM_LIB_NAME"
-                            if [[ -f "${HOST_SIM_LIB_PATH}" ]]; then
-                                call cp "${HOST_SIM_LIB_PATH}" "${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
-                            elif [[ -f "${HOST_LIB_PATH}" ]]; then
-                                # The simulator .a might not exist if the host
-                                # Xcode is old. In that case, copy over the
-                                # device library to the simulator location to allow
-                                # clang to find it. The device library has the simulator
-                                # slices in Xcode that doesn't have the simulator .a, so
-                                # the link is still valid.
-                                echo "copying over faux-sim library ${HOST_LIB_PATH} to ${SIM_LIB_NAME}"
-                                call cp "${HOST_LIB_PATH}" "${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
-                            elif [[ "${VERBOSE_BUILD}" ]]; then
-                                echo "no file exists at ${HOST_SIM_LIB_PATH}"
-                            fi
-                        done
-                    done
-                fi
-            fi
+            copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain "$(build_directory_bin ${host} llvm)/.."
         fi
     done
 done
@@ -2908,6 +2921,13 @@ for host in "${ALL_HOSTS[@]}"; do
         build_dir=$(build_directory ${host} ${product})
 
         call env DESTDIR="${host_install_destdir}" "${CMAKE_BUILD[@]}" "${build_dir}" -- ${INSTALL_TARGETS}
+
+        # When we are installing LLVM copy over the compiler-rt
+        # builtins for iOS/tvOS/watchOS to ensure that we don't
+        # have linker errors  when building apps for such platforms.
+        if [[ "${product}" = "llvm" ]] && [[ ! -z "${LLVM_INSTALL_COMPONENTS}" ]] && [[ "$(uname -s)" = "Darwin" ]]; then
+            copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain "${host_install_destdir}${host_install_prefix}"
+        fi
     done
 done
 


### PR DESCRIPTION
Similarly to what was done for #25547, copy the compiler-rt built-ins
for embedded platforms from the Xcode toolchain into the new generated
one, so to avoid link time errors.

Addresses SR-12001, rdar://57837918

Cherry-pick of #31247 -- this also brings in the improvements from #34049