### PR TITLE
[Runtime] NFC: Fix `swift_runtime_unreachable` to `swift_unreachable`

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -668,7 +668,7 @@ private:
       case sizeof(uint32_t):
         return (&IndexZero32)[i].load(order);
       default:
-        swift_runtime_unreachable("unknown index size");
+        swift_unreachable("unknown index size");
       }
     }
 
@@ -683,7 +683,7 @@ private:
       case sizeof(uint32_t):
         return (&IndexZero32)[i].store(value, order);
       default:
-        swift_runtime_unreachable("unknown index size");
+        swift_unreachable("unknown index size");
       }
     }
   };


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
