### PR TITLE
[CodeCompletion][CSGen] Treat ErrorExprs as holes when generating constraints for code completion

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -87,6 +87,7 @@ class ModuleType;
 class ProtocolConformance;
 enum PointerTypeKind : unsigned;
 struct ValueOwnershipKind;
+class ErrorExpr;
 
 typedef CanTypeWrapper<SILFunctionType> CanSILFunctionType;
 
@@ -5738,7 +5739,8 @@ DEFINE_EMPTY_CAN_TYPE_WRAPPER(TypeVariableType, Type)
 /// constraint solver and transformed into UnresolvedType to be used in AST.
 class HoleType : public TypeBase {
   using Originator = llvm::PointerUnion<TypeVariableType *,
-                                        DependentMemberType *, VarDecl *>;
+                                        DependentMemberType *, VarDecl *,
+                                        ErrorExpr *>;
 
   Originator O;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3523,6 +3523,8 @@ namespace {
         printRec("type_variable", typeVar);
       } else if (auto *VD = originator.dyn_cast<VarDecl *>()) {
         VD->dumpRef(PrintWithColorRAII(OS, DeclColor).getOS());
+      } else if (auto *EE = originator.dyn_cast<ErrorExpr *>()) {
+        printFlag("error_expr");
       } else {
         printRec("dependent_member_type",
                  originator.get<DependentMemberType *>());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3828,6 +3828,8 @@ public:
       } else if (auto *VD = originator.dyn_cast<VarDecl *>()) {
         Printer << "decl = ";
         Printer << VD->getName();
+      } else if (auto *EE = originator.dyn_cast<ErrorExpr *>()) {
+        Printer << "error_expr";
       } else {
         visit(originator.get<DependentMemberType *>());
       }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -786,6 +786,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
     ConstraintSystemOptions options;
     options |= ConstraintSystemFlags::AllowFixes;
     options |= ConstraintSystemFlags::SuppressDiagnostics;
+    options |= ConstraintSystemFlags::ForCodeCompletion;
 
     ConstraintSystem cs(DC, options);
 

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -4,6 +4,7 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=RELATED | %FileCheck %s --check-prefix=RELATED
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=RELATED_EXTRAARG | %FileCheck %s --check-prefix=RELATED
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=RELATED_INERROREXPR | %FileCheck %s --check-prefix=RELATED
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=ERROR_IN_BASE | %FileCheck %s --check-prefix=SIMPLE
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=GENERIC | %FileCheck %s --check-prefix=GENERIC
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=GENERIC_MISSINGARG | %FileCheck %s --check-prefix=NORESULTS
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=CLOSURE_MISSINGARG | %FileCheck %s --check-prefix=POINT_MEMBER
@@ -33,6 +34,11 @@ struct HasMembers {
 }
 
 HasMembers().overloadedReturn().#^SIMPLE_MEMBERS^#
+
+func givenErrorExpr(_ a: String) -> A {}
+func givenErrorExpr(_ b: Int) -> B {}
+
+givenErrorExpr(undefined).#^ERROR_IN_BASE^#
 
 // SIMPLE: Begin completions, 4 items
 // SIMPLE-DAG: Keyword[self]/CurrNominal:          self[#A#]{{; name=.+$}}

--- a/test/IDE/complete_assignment.swift
+++ b/test/IDE/complete_assignment.swift
@@ -202,7 +202,7 @@ func f2() {
 // ASSIGN_11-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
 // ASSIGN_11-DAG: Decl[InstanceMethod]/CurrNominal:   D1Gen()[#D1#]
 // ASSIGN_11-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
-// ASSIGN_11-DAG: Decl[InstanceMethod]/CurrNominal:   VoidGen()[#Void#]
+// ASSIGN_11-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:   VoidGen()[#Void#]
 // ASSIGN_11-DAG: Decl[InstanceVar]/CurrNominal:      InternalC2[#C2#]
 
   func f12() {

--- a/test/IDE/complete_func_body_typechecking.swift
+++ b/test/IDE/complete_func_body_typechecking.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_4 | %FileCheck %s -check-prefix=FOO_STRUCT_COMMON
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_5 | %FileCheck %s -check-prefix=FOO_STRUCT_COMMON
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_6 | %FileCheck %s -check-prefix=FOO_STRUCT_COMMON
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_7 | %FileCheck %s -check-prefix=ERROR_COMMON
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_7 | %FileCheck %s -check-prefix=FOO_STRUCT_COMMON
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_IN_CONSTRUCTOR_1 | %FileCheck %s -check-prefix=FOO_STRUCT_COMMON
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TC_VAR_IN_CONSTRUCTOR_2 | %FileCheck %s -check-prefix=FOO_STRUCT_COMMON
@@ -91,10 +91,6 @@ func testTypecheckVar6() {
 }
 
 func testTypecheckVar7() {
-  // FIXME: We don't display any useful completions here, although we could --
-  // it is obvious that the expression could only have type 'FooStruct'.
-  //
-  // In any case, ensure that we don't crash.
   var localInt = 42
   FooStruct(localInt).builderFunc2(unknown_var).#^TC_VAR_7^#
 }


### PR DESCRIPTION
This lets us still provide member completions when the base expression contains parse errors or unresolved decls
e.g. `returnsAString(undefined).<complete here>`