### PR TITLE
[build] Remove FILES_MATCHING from SwiftShims/CMakeLists.txt

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -197,13 +197,13 @@ endif()
 swift_install_in_component(DIRECTORY "${clang_headers_location}/"
                            DESTINATION "lib/swift/clang"
                            COMPONENT clang-builtin-headers
-                           FILES_MATCHING PATTERN "*.h")
+                           PATTERN "*.h")
 
 if(SWIFT_BUILD_STATIC_STDLIB)
   swift_install_in_component(DIRECTORY "${clang_headers_location}/"
                              DESTINATION "lib/swift_static/clang"
                              COMPONENT clang-builtin-headers
-                             FILES_MATCHING PATTERN "*.h")
+                             PATTERN "*.h")
 endif()
 
 
@@ -227,4 +227,4 @@ file(TO_CMAKE_PATH "${LLVM_LIBRARY_OUTPUT_INTDIR}"
 swift_install_in_component(DIRECTORY "${_SWIFT_SHIMS_PATH_TO_CLANG_BUILD}/lib/clang"
                            DESTINATION "lib"
                            COMPONENT clang-builtin-headers-in-clang-resource-dir
-                           FILES_MATCHING PATTERN "*.h")
+                           PATTERN "*.h")


### PR DESCRIPTION
This is not an ideal solution, as we are likely installing more that we
should with those instructions -- but it would unblock quickly the
Source Compatibility suite.

Addresses rdar://70040046