### PR TITLE
Fix-it for missing let/var in pattern when identifier is unbound

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3947,7 +3947,7 @@ ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
       (DescriptiveDeclKind, DeclName, bool, unsigned, bool))
 
 NOTE(letvar_required_for_binding,none,
-      "add 'let' or 'var' keyword to introduce %0 in a pattern", (DeclNameRef))
+      "add 'let' or 'var' keyword to bind %0 in a pattern", (DeclNameRef))
 ERROR(enum_element_pattern_assoc_values_mismatch,none,
       "pattern with associated values does not match enum case %0",
       (DeclNameRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3946,6 +3946,8 @@ ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
       "%select{|; remove extra parentheses to change tuple into separate arguments}4",
       (DescriptiveDeclKind, DeclName, bool, unsigned, bool))
 
+NOTE(letvar_required_for_binding,none,
+      "add 'let' or 'var' keyword to introduce %0 in a pattern", (DeclNameRef))
 ERROR(enum_element_pattern_assoc_values_mismatch,none,
       "pattern with associated values does not match enum case %0",
       (DeclNameRef))

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -525,7 +525,7 @@ public:
     auto result = TypeChecker::resolveDeclRefExpr(
                                 ude, DC, /*replaceInvalidRefsWithErrors=*/true);
 
-    // if name lookup in the pattern failed, suggest binding it with let / var
+    // if name lookup failed, suggest binding it with let / var
     if (isa<ErrorExpr>(result)) {
       Context.Diags.diagnose(ude->getStartLoc(), 
                              diag::letvar_required_for_binding, ude->getName())

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -638,7 +638,7 @@ struct MyView {
 
   @TupleBuilder var invalidCaseWithoutDot: some P {
     switch Optional.some(1) {
-    case none: 42 // expected-error {{cannot find 'none' in scope}}
+    case none: 42 // expected-error {{cannot find 'none' in scope}} expected-note {{add 'let' or 'var' keyword to bind 'none' in a pattern}}
     case .some(let x):
       0
     }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -21,7 +21,7 @@ default:
 }
 
 switch (1, 2) {
-case (var a, a): // expected-error {{cannot find 'a' in scope}}
+case (var a, a): // expected-error {{cannot find 'a' in scope}} expected-note {{add 'let' or 'var' keyword to bind 'a' in a pattern}}
   ()
 }
 

--- a/test/Constraints/patterns_unbound.swift
+++ b/test/Constraints/patterns_unbound.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Color {
+  case grayscale(Int)
+  case rgb(r : Int, g : Int, b : Int)
+  indirect case inverted(Color)
+  case transparent
+}
+
+func colorToInt (_ c : Color) -> Int {
+  return 0
+}
+
+///////// begin tests for SR-13706
+
+// errors that are expected to be accompanied by the let/var note
+
+switch Color.transparent {
+  case grayscale: () // expected-error {{cannot find 'grayscale' in scope}} expected-note {{add 'let' or 'var' keyword to bind 'grayscale' in a pattern}}
+  default: ()
+}
+
+switch Color.transparent {
+  case .inverted(.inverted(.inverted(.rgb(🐈, _, _)))): () // expected-error {{cannot find '🐈' in scope}} expected-note {{add 'let' or 'var' keyword to bind '🐈' in a pattern}}
+  default: ()
+}
+
+switch Color.transparent {
+  case .rgb(_, g, // expected-error {{cannot find 'g' in scope}} expected-note {{add 'let' or 'var' keyword to bind 'g' in a pattern}}
+               b): () // expected-error {{cannot find 'b' in scope}} expected-note {{add 'let' or 'var' keyword to bind 'b' in a pattern}}
+  default: ()
+}
+
+// errors that should not have a note
+
+switch Color.transparent {
+  case .rgb(5 / 2, y / 3, _): () // expected-error {{cannot find 'y' in scope}}
+  default: ()
+}
+
+switch Color.transparent {
+  case inverted(koala): () // expected-error {{cannot find 'inverted' in scope}} expected-error {{cannot find 'koala' in scope}}
+  case inverted(let koala): () // expected-error {{cannot find 'inverted' in scope}}
+  case let inverted(koala): () // expected-error {{cannot find 'inverted' in scope}}
+  case .inverted(let koala): ()
+  case let .inverted(koala): ()
+}
+
+switch Color.transparent {
+  case .grayscale(colorToInt(y)): () // expected-error {{cannot find 'y' in scope}}
+  case .grayscale(mountian(43)): () // expected-error {{cannot find 'mountian' in scope}}
+  case .grayscale(hop(y)): () // expected-error {{cannot find 'hop' in scope}} expected-error {{cannot find 'y' in scope}}
+  default: ()
+}

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -246,7 +246,7 @@ case (1, _):
 func patternVarUsedInAnotherPattern(x: Int) {
   switch x {
   case let a, // expected-error {{'a' must be bound in every pattern}}
-       a: // expected-error {{cannot find 'a' in scope}}
+       a: // expected-error {{cannot find 'a' in scope}} expected-note {{add 'let' or 'var' keyword to bind 'a' in a pattern}}
     break
   }
 }


### PR DESCRIPTION
Resolves SR-13706 / rdar://problem/70075206

This PR adds functionality to the compiler that emits a hint and fix-it after an UnresolvedDeclRefExpr inside of a pattern fails to be resolved. For example, assuming `y` is unbound:

```swift
switch x {
  case y: ...
}
```

The fix-it suggests adding `let` or `var` (preferring `let`) before `y` so that the pattern introduces a binding instead. The fix-it will also trigger for associated-value patterns:

```swift
func test(x : Int?) -> Int {
  switch x {
    case .some(y): return y  
    default: return 0
  }
}
```

The diagnostics for the above example is:

```
test.swift:3:16: error: cannot find 'y' in scope
    case .some(y): return y  
               ^
test.swift:3:16: note: add 'let' or 'var' keyword to bind 'y' in a pattern
    case .some(y): return y  
               ^
               let 
test.swift:3:27: error: cannot find 'y' in scope
    case .some(y): return y  
                          ^
```

This PR added the `note` in those diagnostics.

~~**NOTE:** I have not yet fully tested this patch (and regression tests are TODO), but~~ so far the fix-it is correctly **not** suggested for non-trivial expression patterns that contain an unbound identifier, such as `y(1)` or `y * 2`.

---

A smarter, extended version of this would provide a different fix-it for the following situation:

```swift
switch nil {
    case none: ()
    default: ()
  }
```

Here, it's more likely that the programmer forgot to add a dot. We can detect this by inspecting the expected type of the unbound identifier: if it is an enum and the identifier's name matches one of the names of the enum variants, then the note should suggest a dot instead. This functionality is *not* in this PR.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
