### PR TITLE
ASTScope: Allocate list of local bindings for BraceStmt in the ASTContext

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1534,11 +1534,11 @@ class BraceStmtScope final : public AbstractStmtScope {
   BraceStmt *const stmt;
 
   /// Declarations which are in scope from the beginning of the statement.
-  SmallVector<ValueDecl *, 2> localFuncsAndTypes;
+  ArrayRef<ValueDecl *> localFuncsAndTypes;
 
   /// Declarations that are normally in scope only after their
   /// definition.
-  SmallVector<VarDecl *, 2> localVars;
+  ArrayRef<VarDecl *> localVars;
 
   /// The end location for bindings introduced in this scope. This can
   /// extend past the actual end of the BraceStmt in top-level code,
@@ -1548,8 +1548,8 @@ class BraceStmtScope final : public AbstractStmtScope {
 
 public:
   BraceStmtScope(BraceStmt *e,
-                 SmallVector<ValueDecl *, 2> localFuncsAndTypes,
-                 SmallVector<VarDecl *, 2> localVars,
+                 ArrayRef<ValueDecl *> localFuncsAndTypes,
+                 ArrayRef<VarDecl *> localVars,
                  SourceLoc endLoc)
       : stmt(e),
         localFuncsAndTypes(localFuncsAndTypes),

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -588,12 +588,15 @@ public:
     if (endLoc.hasValue())
       endLocForBraceStmt = *endLoc;
 
-    if (auto *s = scopeCreator.getASTContext().Stats)
+    ASTContext &ctx = scopeCreator.getASTContext();
+    if (auto *s = ctx.Stats)
       ++s->getFrontendCounters().NumBraceStmtASTScopes;
 
     return
         scopeCreator.constructExpandAndInsert<BraceStmtScope>(
-            p, bs, std::move(localFuncsAndTypes), std::move(localVars),
+            p, bs,
+            ctx.AllocateCopy(localFuncsAndTypes),
+            ctx.AllocateCopy(localVars),
             endLocForBraceStmt);
   }
 


### PR DESCRIPTION
Scopes need to register cleanups for non-trivial ivars in the ASTContext.
Instead of doing that here, let's just change the SmallVectors into
ArrayRefs.

Fixes <rdar://problem/69908937>.