### PR TITLE
[Dependency Scanner] Refactor ModuleDependencies to represent binary-only Swift modules explicitly

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -34,7 +34,8 @@ class Identifier;
 
 /// Which kind of module dependencies we are looking for.
 enum class ModuleDependenciesKind : int8_t {
-  Swift,
+  SwiftTextual,
+  SwiftBinary,
   // Placeholder dependencies are a kind of dependencies used only by the
   // dependency scanner. They are swift modules that the scanner will not be
   // able to locate in its search paths and which are the responsibility of the
@@ -68,17 +69,12 @@ class ModuleDependenciesStorageBase {
 public:
   const ModuleDependenciesKind dependencyKind;
 
-  ModuleDependenciesStorageBase(ModuleDependenciesKind dependencyKind,
-                                const std::string &compiledModulePath)
-      : dependencyKind(dependencyKind),
-        compiledModulePath(compiledModulePath) { }
+  ModuleDependenciesStorageBase(ModuleDependenciesKind dependencyKind)
+      : dependencyKind(dependencyKind) { }
 
   virtual ModuleDependenciesStorageBase *clone() const = 0;
 
   virtual ~ModuleDependenciesStorageBase();
-
-  /// The path to the compiled module file.
-  const std::string compiledModulePath;
 
   /// The set of modules on which this module depends.
   std::vector<std::string> moduleDependencies;
@@ -87,7 +83,8 @@ public:
 /// Describes the dependencies of a Swift module.
 ///
 /// This class is mostly an implementation detail for \c ModuleDependencies.
-class SwiftModuleDependenciesStorage : public ModuleDependenciesStorageBase {
+class SwiftTextualModuleDependenciesStorage :
+  public ModuleDependenciesStorageBase {
 public:
   /// The Swift interface file, if it can be used to generate the module file.
   const Optional<std::string> swiftInterfaceFile;
@@ -122,16 +119,14 @@ public:
   /// (Clang) modules on which the bridging header depends.
   std::vector<std::string> bridgingModuleDependencies;
 
-  SwiftModuleDependenciesStorage(
-      const std::string &compiledModulePath,
+  SwiftTextualModuleDependenciesStorage(
       const Optional<std::string> &swiftInterfaceFile,
       ArrayRef<std::string> compiledModuleCandidates,
       ArrayRef<StringRef> buildCommandLine,
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash,
       bool isFramework
-  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Swift,
-                                    compiledModulePath),
+  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftTextual),
       swiftInterfaceFile(swiftInterfaceFile),
       compiledModuleCandidates(compiledModuleCandidates.begin(),
                                compiledModuleCandidates.end()),
@@ -140,11 +135,47 @@ public:
       contextHash(contextHash), isFramework(isFramework) { }
 
   ModuleDependenciesStorageBase *clone() const override {
-    return new SwiftModuleDependenciesStorage(*this);
+    return new SwiftTextualModuleDependenciesStorage(*this);
   }
 
   static bool classof(const ModuleDependenciesStorageBase *base) {
-    return base->dependencyKind == ModuleDependenciesKind::Swift;
+    return base->dependencyKind == ModuleDependenciesKind::SwiftTextual;
+  }
+};
+
+/// Describes the dependencies of a pre-built Swift module (with no .swiftinterface).
+///
+/// This class is mostly an implementation detail for \c ModuleDependencies.
+class SwiftBinaryModuleDependencyStorage : public ModuleDependenciesStorageBase {
+public:
+  SwiftBinaryModuleDependencyStorage(const std::string &compiledModulePath,
+                                     const std::string &moduleDocPath,
+                                     const std::string &sourceInfoPath,
+                                     const bool isFramework)
+      : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftBinary),
+        compiledModulePath(compiledModulePath),
+        moduleDocPath(moduleDocPath),
+        sourceInfoPath(sourceInfoPath),
+        isFramework(isFramework) {}
+
+  ModuleDependenciesStorageBase *clone() const override {
+    return new SwiftBinaryModuleDependencyStorage(*this);
+  }
+
+  /// The path to the .swiftmodule file.
+  const std::string compiledModulePath;
+
+  /// The path to the .swiftModuleDoc file.
+  const std::string moduleDocPath;
+
+  /// The path to the .swiftSourceInfo file.
+  const std::string sourceInfoPath;
+
+  /// A flag that indicates this dependency is a framework
+  const bool isFramework;
+
+  static bool classof(const ModuleDependenciesStorageBase *base) {
+    return base->dependencyKind == ModuleDependenciesKind::SwiftBinary;
   }
 };
 
@@ -166,13 +197,11 @@ public:
   const std::vector<std::string> fileDependencies;
 
   ClangModuleDependenciesStorage(
-      const std::string &compiledModulePath,
       const std::string &moduleMapFile,
       const std::string &contextHash,
       const std::vector<std::string> &nonPathCommandLine,
       const std::vector<std::string> &fileDependencies
-  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Clang,
-                                    compiledModulePath),
+  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Clang),
       moduleMapFile(moduleMapFile),
       contextHash(contextHash),
       nonPathCommandLine(nonPathCommandLine),
@@ -190,19 +219,23 @@ public:
 /// Describes an placeholder Swift module dependency module stub.
 ///
 /// This class is mostly an implementation detail for \c ModuleDependencies.
-class PlaceholderSwiftModuleDependencyStorage : public ModuleDependenciesStorageBase {
+
+class SwiftPlaceholderModuleDependencyStorage : public ModuleDependenciesStorageBase {
 public:
-  PlaceholderSwiftModuleDependencyStorage(const std::string &compiledModulePath,
-                                       const std::string &moduleDocPath,
-                                       const std::string &sourceInfoPath)
-      : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftPlaceholder,
-                                      compiledModulePath),
+  SwiftPlaceholderModuleDependencyStorage(const std::string &compiledModulePath,
+                                          const std::string &moduleDocPath,
+                                          const std::string &sourceInfoPath)
+      : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftPlaceholder),
+        compiledModulePath(compiledModulePath),
         moduleDocPath(moduleDocPath),
         sourceInfoPath(sourceInfoPath) {}
 
   ModuleDependenciesStorageBase *clone() const override {
-    return new PlaceholderSwiftModuleDependencyStorage(*this);
+    return new SwiftPlaceholderModuleDependencyStorage(*this);
   }
+
+  /// The path to the .swiftmodule file.
+  const std::string compiledModulePath;
 
   /// The path to the .swiftModuleDoc file.
   const std::string moduleDocPath;
@@ -248,43 +281,41 @@ public:
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash,
       bool isFramework) {
-    std::string compiledModulePath;
     return ModuleDependencies(
-        std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, swiftInterfaceFile, compiledCandidates, buildCommands,
+        std::make_unique<SwiftTextualModuleDependenciesStorage>(
+          swiftInterfaceFile, compiledCandidates, buildCommands,
           extraPCMArgs, contextHash, isFramework));
   }
 
   /// Describe the module dependencies for a serialized or parsed Swift module.
-  static ModuleDependencies forSwiftModule(
-      const std::string &compiledModulePath, bool isFramework) {
+  static ModuleDependencies forSwiftBinaryModule(
+      const std::string &compiledModulePath,
+      const std::string &moduleDocPath,
+      const std::string &sourceInfoPath,
+      bool isFramework) {
     return ModuleDependencies(
-        std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, None, ArrayRef<std::string>(), ArrayRef<StringRef>(),
-          ArrayRef<StringRef>(), StringRef(), isFramework));
+        std::make_unique<SwiftBinaryModuleDependencyStorage>(
+          compiledModulePath, moduleDocPath, sourceInfoPath, isFramework));
   }
 
   /// Describe the main Swift module.
   static ModuleDependencies forMainSwiftModule(ArrayRef<StringRef> extraPCMArgs) {
-    std::string compiledModulePath;
     return ModuleDependencies(
-        std::make_unique<SwiftModuleDependenciesStorage>(
-          compiledModulePath, None, ArrayRef<std::string>(),
-          ArrayRef<StringRef>(), extraPCMArgs, StringRef(), false));
+        std::make_unique<SwiftTextualModuleDependenciesStorage>(
+          None, ArrayRef<std::string>(), ArrayRef<StringRef>(),
+          extraPCMArgs, StringRef(), false));
   }
 
   /// Describe the module dependencies for a Clang module that can be
   /// built from a module map and headers.
   static ModuleDependencies forClangModule(
-      const std::string &compiledModulePath,
       const std::string &moduleMapFile,
       const std::string &contextHash,
       const std::vector<std::string> &nonPathCommandLine,
       const std::vector<std::string> &fileDependencies) {
     return ModuleDependencies(
         std::make_unique<ClangModuleDependenciesStorage>(
-          compiledModulePath, moduleMapFile, contextHash, nonPathCommandLine,
-          fileDependencies));
+          moduleMapFile, contextHash, nonPathCommandLine, fileDependencies));
   }
 
   /// Describe a placeholder dependency swift module.
@@ -293,13 +324,8 @@ public:
       const std::string &moduleDocPath,
       const std::string &sourceInfoPath) {
     return ModuleDependencies(
-        std::make_unique<PlaceholderSwiftModuleDependencyStorage>(
+        std::make_unique<SwiftPlaceholderModuleDependencyStorage>(
           compiledModulePath, moduleDocPath, sourceInfoPath));
-  }
-
-  /// Retrieve the path to the compiled module.
-  const std::string getCompiledModulePath() const {
-    return storage->compiledModulePath;
   }
 
   /// Retrieve the module-level dependencies.
@@ -307,24 +333,36 @@ public:
     return storage->moduleDependencies;
   }
 
-  /// Whether the dependencies are for a Swift module.
+  /// Whether the dependencies are for a Swift module: either Textual, Binary, or Placeholder.
   bool isSwiftModule() const;
 
+  /// Whether the dependencies are for a textual Swift module.
+  bool isSwiftTextualModule() const;
+
+  /// Whether the dependencies are for a binary Swift module.
+  bool isSwiftBinaryModule() const;
+
   /// Whether this represents a placeholder module stub
-  bool isPlaceholderSwiftModule() const;
+  bool isSwiftPlaceholderModule() const;
+
+  /// Whether the dependencies are for a Clang module.
+  bool isClangModule() const;
 
   ModuleDependenciesKind getKind() const {
     return storage->dependencyKind;
   }
   /// Retrieve the dependencies for a Swift module.
-  const SwiftModuleDependenciesStorage *getAsSwiftModule() const;
+  const SwiftTextualModuleDependenciesStorage *getAsSwiftTextualModule() const;
+
+  /// Retrieve the dependencies for a binary Swift module.
+  const SwiftBinaryModuleDependencyStorage *getAsSwiftBinaryModule() const;
 
   /// Retrieve the dependencies for a Clang module.
   const ClangModuleDependenciesStorage *getAsClangModule() const;
 
   /// Retrieve the dependencies for a placeholder dependency module stub.
-  const PlaceholderSwiftModuleDependencyStorage *
-  getAsPlaceholderDependencyModule() const;
+  const SwiftPlaceholderModuleDependencyStorage *
+    getAsPlaceholderDependencyModule() const;
 
   /// Add a dependency on the given module, if it was not already in the set.
   void addModuleDependency(StringRef module,
@@ -363,11 +401,14 @@ class ModuleDependenciesCache {
   /// encountered.
   std::vector<ModuleDependencyID> AllModules;
 
-  /// Dependencies for Swift modules that have already been computed.
-  llvm::StringMap<ModuleDependencies> SwiftModuleDependencies;
+  /// Dependencies for Textual Swift modules that have already been computed.
+  llvm::StringMap<ModuleDependencies> SwiftTextualModuleDependencies;
 
-  /// Dependencies for Swift placeholder dependency modules.
-  llvm::StringMap<ModuleDependencies> PlaceholderSwiftModuleDependencies;
+  /// Dependencies for Binary Swift modules that have already been computed.
+  llvm::StringMap<ModuleDependencies> SwiftBinaryModuleDependencies;
+
+  /// Dependencies for Swift placeholder dependency modules that have already been computed.
+  llvm::StringMap<ModuleDependencies> SwiftPlaceholderModuleDependencies;
 
   /// Dependencies for Clang modules that have already been computed.
   llvm::StringMap<ModuleDependencies> ClangModuleDependencies;
@@ -429,8 +470,7 @@ public:
 
   /// Record dependencies for the given module.
   void recordDependencies(StringRef moduleName,
-                          ModuleDependencies dependencies,
-                          ModuleDependenciesKind kind);
+                          ModuleDependencies dependencies);
 
   /// Update stored dependencies for the given module.
   void updateDependencies(ModuleDependencyID moduleID,

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -40,18 +40,13 @@ namespace swift {
     public:
       Optional<ModuleDependencies> dependencies;
 
-      /// Describes the kind of dependencies this scanner is able to identify
-      ModuleDependenciesKind dependencyKind;
-
       ModuleDependencyScanner(
           ASTContext &ctx, ModuleLoadingMode LoadMode, Identifier moduleName,
           InterfaceSubContextDelegate &astDelegate,
-          ModuleDependenciesKind dependencyKind = ModuleDependenciesKind::Swift,
           ScannerKind kind = MDS_plain)
           : SerializedModuleLoaderBase(ctx, nullptr, LoadMode,
                                        /*IgnoreSwiftSourceInfoFile=*/true),
-            kind(kind), moduleName(moduleName), astDelegate(astDelegate),
-            dependencyKind(dependencyKind) {}
+            kind(kind), moduleName(moduleName), astDelegate(astDelegate) {}
 
       std::error_code findModuleFilesInDirectory(
           ImportPath::Element ModuleID,
@@ -60,7 +55,7 @@ namespace swift {
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-                                                 bool IsFramework) override;
+          bool IsFramework) override;
 
       virtual void collectVisibleTopLevelModuleNames(
           SmallVectorImpl<Identifier> &names) const override {
@@ -106,7 +101,6 @@ namespace swift {
                                     StringRef PlaceholderDependencyModuleMap,
                                     InterfaceSubContextDelegate &astDelegate)
           : ModuleDependencyScanner(ctx, LoadMode, moduleName, astDelegate,
-                                    ModuleDependenciesKind::SwiftPlaceholder,
                                     MDS_placeholder) {
 
         // FIXME: Find a better place for this map to live, to avoid

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -21,17 +21,37 @@ using namespace swift;
 ModuleDependenciesStorageBase::~ModuleDependenciesStorageBase() { }
 
 bool ModuleDependencies::isSwiftModule() const {
-  return isa<SwiftModuleDependenciesStorage>(storage.get());
+  return isSwiftTextualModule() ||
+         isSwiftBinaryModule() ||
+         isSwiftPlaceholderModule();
 }
 
-bool ModuleDependencies::isPlaceholderSwiftModule() const {
-  return isa<PlaceholderSwiftModuleDependencyStorage>(storage.get());
+bool ModuleDependencies::isSwiftTextualModule() const {
+  return isa<SwiftTextualModuleDependenciesStorage>(storage.get());
+}
+
+bool ModuleDependencies::isSwiftBinaryModule() const {
+  return isa<SwiftBinaryModuleDependencyStorage>(storage.get());
+}
+
+bool ModuleDependencies::isSwiftPlaceholderModule() const {
+  return isa<SwiftPlaceholderModuleDependencyStorage>(storage.get());
+}
+
+bool ModuleDependencies::isClangModule() const {
+  return isa<ClangModuleDependenciesStorage>(storage.get());
 }
 
 /// Retrieve the dependencies for a Swift module.
-const SwiftModuleDependenciesStorage *
-ModuleDependencies::getAsSwiftModule() const {
-  return dyn_cast<SwiftModuleDependenciesStorage>(storage.get());
+const SwiftTextualModuleDependenciesStorage *
+ModuleDependencies::getAsSwiftTextualModule() const {
+  return dyn_cast<SwiftTextualModuleDependenciesStorage>(storage.get());
+}
+
+/// Retrieve the dependencies for a binary Swift dependency module.
+const SwiftBinaryModuleDependencyStorage *
+ModuleDependencies::getAsSwiftBinaryModule() const {
+  return dyn_cast<SwiftBinaryModuleDependencyStorage>(storage.get());
 }
 
 /// Retrieve the dependencies for a Clang module.
@@ -41,9 +61,9 @@ ModuleDependencies::getAsClangModule() const {
 }
 
 /// Retrieve the dependencies for a placeholder dependency module stub.
-const PlaceholderSwiftModuleDependencyStorage *
+const SwiftPlaceholderModuleDependencyStorage *
 ModuleDependencies::getAsPlaceholderDependencyModule() const {
-  return dyn_cast<PlaceholderSwiftModuleDependencyStorage>(storage.get());
+  return dyn_cast<SwiftPlaceholderModuleDependencyStorage>(storage.get());
 }
 
 void ModuleDependencies::addModuleDependency(
@@ -72,7 +92,7 @@ void ModuleDependencies::addModuleDependencies(
 
   // If the storage is for an interface file, the only source file we
   // should see is that interface file.
-  auto swiftStorage = cast<SwiftModuleDependenciesStorage>(storage.get());
+  auto swiftStorage = cast<SwiftTextualModuleDependenciesStorage>(storage.get());
   if (swiftStorage->swiftInterfaceFile) {
     assert(fileName == *swiftStorage->swiftInterfaceFile);
     return;
@@ -83,26 +103,26 @@ void ModuleDependencies::addModuleDependencies(
 }
 
 Optional<std::string> ModuleDependencies::getBridgingHeader() const {
-  auto swiftStorage = cast<SwiftModuleDependenciesStorage>(storage.get());
+  auto swiftStorage = cast<SwiftTextualModuleDependenciesStorage>(storage.get());
   return swiftStorage->bridgingHeaderFile;
 }
 
 void ModuleDependencies::addBridgingHeader(StringRef bridgingHeader) {
-  auto swiftStorage = cast<SwiftModuleDependenciesStorage>(storage.get());
+  auto swiftStorage = cast<SwiftTextualModuleDependenciesStorage>(storage.get());
   assert(!swiftStorage->bridgingHeaderFile);
   swiftStorage->bridgingHeaderFile = bridgingHeader.str();
 }
 
 /// Add source files that the bridging header depends on.
 void ModuleDependencies::addBridgingSourceFile(StringRef bridgingSourceFile) {
-  auto swiftStorage = cast<SwiftModuleDependenciesStorage>(storage.get());
+  auto swiftStorage = cast<SwiftTextualModuleDependenciesStorage>(storage.get());
   swiftStorage->bridgingSourceFiles.push_back(bridgingSourceFile.str());
 }
 
 /// Add (Clang) module on which the bridging header depends.
 void ModuleDependencies::addBridgingModuleDependency(
     StringRef module, llvm::StringSet<> &alreadyAddedModules) {
-  auto swiftStorage = cast<SwiftModuleDependenciesStorage>(storage.get());
+  auto swiftStorage = cast<SwiftTextualModuleDependenciesStorage>(storage.get());
   if (alreadyAddedModules.insert(module).second)
     swiftStorage->bridgingModuleDependencies.push_back(module.str());
 }
@@ -110,10 +130,12 @@ void ModuleDependencies::addBridgingModuleDependency(
 llvm::StringMap<ModuleDependencies> &
 ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) {
   switch (kind) {
-  case ModuleDependenciesKind::Swift:
-    return SwiftModuleDependencies;
+  case ModuleDependenciesKind::SwiftTextual:
+    return SwiftTextualModuleDependencies;
+  case ModuleDependenciesKind::SwiftBinary:
+    return SwiftBinaryModuleDependencies;
   case ModuleDependenciesKind::SwiftPlaceholder:
-    return PlaceholderSwiftModuleDependencies;
+    return SwiftPlaceholderModuleDependencies;
   case ModuleDependenciesKind::Clang:
     return ClangModuleDependencies;
   }
@@ -123,10 +145,12 @@ ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) {
 const llvm::StringMap<ModuleDependencies> &
 ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) const {
   switch (kind) {
-  case ModuleDependenciesKind::Swift:
-    return SwiftModuleDependencies;
+  case ModuleDependenciesKind::SwiftTextual:
+    return SwiftTextualModuleDependencies;
+  case ModuleDependenciesKind::SwiftBinary:
+    return SwiftBinaryModuleDependencies;
   case ModuleDependenciesKind::SwiftPlaceholder:
-    return PlaceholderSwiftModuleDependencies;
+    return SwiftPlaceholderModuleDependencies;
   case ModuleDependenciesKind::Clang:
     return ClangModuleDependencies;
   }
@@ -137,7 +161,8 @@ bool ModuleDependenciesCache::hasDependencies(
     StringRef moduleName,
     Optional<ModuleDependenciesKind> kind) const {
   if (!kind) {
-    return hasDependencies(moduleName, ModuleDependenciesKind::Swift) ||
+    return hasDependencies(moduleName, ModuleDependenciesKind::SwiftTextual) ||
+        hasDependencies(moduleName, ModuleDependenciesKind::SwiftBinary) ||
         hasDependencies(moduleName, ModuleDependenciesKind::SwiftPlaceholder) ||
         hasDependencies(moduleName, ModuleDependenciesKind::Clang);
   }
@@ -150,9 +175,12 @@ Optional<ModuleDependencies> ModuleDependenciesCache::findDependencies(
     StringRef moduleName,
     Optional<ModuleDependenciesKind> kind) const {
   if (!kind) {
-    if (auto swiftDep = findDependencies(
-            moduleName, ModuleDependenciesKind::Swift))
-      return swiftDep;
+    if (auto swiftTextualDep = findDependencies(
+            moduleName, ModuleDependenciesKind::SwiftTextual))
+      return swiftTextualDep;
+    else if (auto swiftBinaryDep = findDependencies(
+            moduleName, ModuleDependenciesKind::SwiftBinary))
+      return swiftBinaryDep;
     else if (auto swiftPlaceholderDep = findDependencies(
             moduleName, ModuleDependenciesKind::SwiftPlaceholder))
       return swiftPlaceholderDep;
@@ -170,8 +198,8 @@ Optional<ModuleDependencies> ModuleDependenciesCache::findDependencies(
 
 void ModuleDependenciesCache::recordDependencies(
     StringRef moduleName,
-    ModuleDependencies dependencies,
-    ModuleDependenciesKind kind) {
+    ModuleDependencies dependencies) {
+  auto kind = dependencies.getKind();
   auto &map = getDependenciesMap(kind);
   assert(map.count(moduleName) == 0 && "Already added to map");
   map.insert({moduleName, std::move(dependencies)});

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -267,7 +267,6 @@ void ClangImporter::recordModuleDependencies(
     // Module-level dependencies.
     llvm::StringSet<> alreadyAddedModules;
     auto dependencies = ModuleDependencies::forClangModule(
-        clangModuleDep.ImplicitModulePCMPath,
         clangModuleDep.ClangModuleMapFile,
         clangModuleDep.ContextHash,
         swiftArgs,
@@ -277,8 +276,7 @@ void ClangImporter::recordModuleDependencies(
     }
 
     cache.recordDependencies(clangModuleDep.ModuleName,
-                             std::move(dependencies),
-                             ModuleDependenciesKind::Clang);
+                             std::move(dependencies));
   }
 }
 
@@ -327,10 +325,10 @@ bool ClangImporter::addBridgingHeaderDependencies(
     StringRef moduleName,
     ModuleDependenciesCache &cache) {
   auto targetModule = *cache.findDependencies(
-      moduleName, ModuleDependenciesKind::Swift);
+      moduleName, ModuleDependenciesKind::SwiftTextual);
 
   // If we've already recorded bridging header dependencies, we're done.
-  auto swiftDeps = targetModule.getAsSwiftModule();
+  auto swiftDeps = targetModule.getAsSwiftTextualModule();
   if (!swiftDeps->bridgingSourceFiles.empty() ||
       !swiftDeps->bridgingModuleDependencies.empty())
     return false;
@@ -376,7 +374,7 @@ bool ClangImporter::addBridgingHeaderDependencies(
 
   // Update the cache with the new information for the module.
   cache.updateDependencies(
-     {moduleName.str(), ModuleDependenciesKind::Swift},
+     {moduleName.str(), ModuleDependenciesKind::SwiftTextual},
      std::move(targetModule));
 
   return false;

--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -158,7 +158,7 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
     InterfaceSubContextDelegate &ASTDelegate) {
   auto &ctx = instance.getASTContext();
   auto knownDependencies = *cache.findDependencies(module.first, module.second);
-  auto isSwift = knownDependencies.isSwiftModule();
+  auto isSwift = knownDependencies.isSwiftTextualModule();
 
   // Find the dependencies of every module this module directly depends on.
   std::vector<ModuleDependencyID> result;
@@ -189,7 +189,7 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
 
         // Add the Clang modules referenced from the bridging header to the
         // set of Clang modules we know about.
-        auto swiftDeps = knownDependencies.getAsSwiftModule();
+        auto swiftDeps = knownDependencies.getAsSwiftTextualModule();
         for (const auto &clangDep : swiftDeps->bridgingModuleDependencies) {
           findAllImportedClangModules(ctx, clangDep, cache, allClangModules,
                                       knownModules);
@@ -214,7 +214,9 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
         // ASTContext::getModuleDependencies returns dependencies for a module with a given name.
         // This Clang module may have the same name as the Swift module we are resolving, so we
         // need to make sure we don't add a dependency from a Swift module to itself.
-        if (found->getKind() == ModuleDependenciesKind::Swift && clangDep != module.first)
+        if ((found->getKind() == ModuleDependenciesKind::SwiftTextual ||
+             found->getKind() == ModuleDependenciesKind::SwiftBinary) &&
+            clangDep != module.first)
           result.push_back({clangDep, found->getKind()});
       }
     }
@@ -258,17 +260,18 @@ static void discoverCrosssImportOverlayDependencies(
   auto dummyMainDependencies = ModuleDependencies::forMainSwiftModule({});
 
   // Update main module's dependencies to include these new overlays.
-  auto mainDep = *cache.findDependencies(mainModuleName, ModuleDependenciesKind::Swift);
+  auto mainDep = *cache.findDependencies(mainModuleName,
+                                         ModuleDependenciesKind::SwiftTextual);
   std::for_each(newOverlays.begin(), newOverlays.end(), [&](Identifier modName) {
     dummyMainDependencies.addModuleDependency(modName.str());
     mainDep.addModuleDependency(modName.str());
   });
-  cache.updateDependencies({mainModuleName.str(), ModuleDependenciesKind::Swift}, mainDep);
+  cache.updateDependencies({mainModuleName.str(),
+                            ModuleDependenciesKind::SwiftTextual}, mainDep);
 
   // Record the dummy main module's direct dependencies. The dummy main module
   // only directly depend on these newly discovered overlay modules.
-  cache.recordDependencies(dummyMainName, dummyMainDependencies,
-                           ModuleDependenciesKind::Swift);
+  cache.recordDependencies(dummyMainName, dummyMainDependencies);
   llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
                   std::set<ModuleDependencyID>> allModules;
 
@@ -321,8 +324,11 @@ namespace {
                       unsigned indentLevel) {
     out << "{\n";
     std::string moduleKind;
-    if (module.second == ModuleDependenciesKind::Swift)
+    if (module.second == ModuleDependenciesKind::SwiftTextual)
       moduleKind = "swift";
+    else if (module.second == ModuleDependenciesKind::SwiftBinary)
+      // FIXME: rename to be consistent in the clients (swift-driver)
+      moduleKind = "swiftPrebuiltExternal";
     else if (module.second == ModuleDependenciesKind::SwiftPlaceholder)
       moduleKind = "swiftPlaceholder";
     else
@@ -434,23 +440,31 @@ static void writeJSON(llvm::raw_ostream &out,
     out.indent(2 * 2);
     out << "{\n";
 
-    auto externalSwiftDep = moduleDeps.getAsPlaceholderDependencyModule();
-    auto swiftDeps = moduleDeps.getAsSwiftModule();
+    auto swiftPlaceholderDeps = moduleDeps.getAsPlaceholderDependencyModule();
+    auto swiftTextualDeps = moduleDeps.getAsSwiftTextualModule();
+    auto swiftBinaryDeps = moduleDeps.getAsSwiftBinaryModule();
     auto clangDeps = moduleDeps.getAsClangModule();
 
     // Module path.
     const char *modulePathSuffix =
         moduleDeps.isSwiftModule() ? ".swiftmodule" : ".pcm";
 
-    std::string modulePath = externalSwiftDep
-                                 ? externalSwiftDep->compiledModulePath
-                                 : module.first + modulePathSuffix;
+    std::string modulePath;
+    if (swiftPlaceholderDeps)
+      modulePath = swiftPlaceholderDeps->compiledModulePath;
+    else if (swiftBinaryDeps)
+      modulePath = swiftBinaryDeps->compiledModulePath;
+    else
+      modulePath = module.first + modulePathSuffix;
+
     writeJSONSingleField(out, "modulePath", modulePath, /*indentLevel=*/3,
                          /*trailingComma=*/true);
 
+    // Artem Refactoring
+    {
     // Source files.
-    if (swiftDeps) {
-      writeJSONSingleField(out, "sourceFiles", swiftDeps->sourceFiles, 3,
+    if (swiftTextualDeps) {
+      writeJSONSingleField(out, "sourceFiles", swiftTextualDeps->sourceFiles, 3,
                            /*trailingComma=*/true);
     } else if (clangDeps) {
       writeJSONSingleField(out, "sourceFiles", clangDeps->fileDependencies, 3,
@@ -458,7 +472,7 @@ static void writeJSON(llvm::raw_ostream &out,
     }
 
     // Direct dependencies.
-    if (swiftDeps || clangDeps)
+    if (swiftTextualDeps || swiftBinaryDeps || clangDeps)
       writeJSONSingleField(out, "directDependencies", directDependencies, 3,
                            /*trailingComma=*/true);
 
@@ -466,25 +480,25 @@ static void writeJSON(llvm::raw_ostream &out,
     out.indent(3 * 2);
     out << "\"details\": {\n";
     out.indent(4 * 2);
-    if (swiftDeps) {
+    if (swiftTextualDeps) {
       out << "\"swift\": {\n";
 
-      /// Swift interface file, if any.
-      if (swiftDeps->swiftInterfaceFile) {
-        writeJSONSingleField(
-            out, "moduleInterfacePath",
-            *swiftDeps->swiftInterfaceFile, 5,
-            /*trailingComma=*/true);
+      /// Swift interface file, if there is one. The main module, for example, will not have
+      /// an interface file.
+      if (swiftTextualDeps->swiftInterfaceFile) {
+        writeJSONSingleField(out, "moduleInterfacePath",
+                             *swiftTextualDeps->swiftInterfaceFile, 5,
+                             /*trailingComma=*/true);
         writeJSONSingleField(out, "contextHash",
-                             swiftDeps->contextHash, 5,
+                             swiftTextualDeps->contextHash, 5,
                              /*trailingComma=*/true);
         out.indent(5 * 2);
         out << "\"commandLine\": [\n";
-        for (auto &arg :swiftDeps->buildCommandLine) {
+        for (auto &arg :swiftTextualDeps->buildCommandLine) {
 
           out.indent(6 * 2);
           out << "\"" << arg << "\"";
-          if (&arg != &swiftDeps->buildCommandLine.back())
+          if (&arg != &swiftTextualDeps->buildCommandLine.back())
             out << ",";
           out << "\n";
         }
@@ -492,70 +506,86 @@ static void writeJSON(llvm::raw_ostream &out,
         out << "],\n";
         out.indent(5 * 2);
         out << "\"compiledModuleCandidates\": [\n";
-        for (auto &candidate: swiftDeps->compiledModuleCandidates) {
+        for (auto &candidate: swiftTextualDeps->compiledModuleCandidates) {
           out.indent(6 * 2);
           out << "\"" << candidate << "\"";
-          if (&candidate != &swiftDeps->compiledModuleCandidates.back())
+          if (&candidate != &swiftTextualDeps->compiledModuleCandidates.back())
             out << ",";
           out << "\n";
         }
         out.indent(5 * 2);
         out << "],\n";
-      } else if (!swiftDeps->compiledModulePath.empty()) {
-        writeJSONSingleField(
-            out, "compiledModulePath",
-            swiftDeps->compiledModulePath, 5,
-            /*trailingComma=*/false);
       }
       writeJSONSingleField(
           out, "isFramework",
-          swiftDeps->isFramework, 5,
-          /*trailingComma=*/!swiftDeps->extraPCMArgs.empty() ||
-                           swiftDeps->bridgingHeaderFile.hasValue());
-      if (!swiftDeps->extraPCMArgs.empty()) {
+          swiftTextualDeps->isFramework, 5,
+          /*trailingComma=*/!swiftTextualDeps->extraPCMArgs.empty() ||
+                           swiftTextualDeps->bridgingHeaderFile.hasValue());
+      if (!swiftTextualDeps->extraPCMArgs.empty()) {
         out.indent(5 * 2);
         out << "\"extraPcmArgs\": [\n";
-        for (auto &arg : swiftDeps->extraPCMArgs) {
+        for (auto &arg : swiftTextualDeps->extraPCMArgs) {
           out.indent(6 * 2);
           out << "\"" << arg << "\"";
-          if (&arg != &swiftDeps->extraPCMArgs.back())
+          if (&arg != &swiftTextualDeps->extraPCMArgs.back())
             out << ",";
           out << "\n";
         }
         out.indent(5 * 2);
-        out << (swiftDeps->bridgingHeaderFile.hasValue() ? "],\n" : "]\n");
+        out << (swiftTextualDeps->bridgingHeaderFile.hasValue() ? "],\n" : "]\n");
       }
       /// Bridging header and its source file dependencies, if any.
-      if (swiftDeps->bridgingHeaderFile) {
+      if (swiftTextualDeps->bridgingHeaderFile) {
         out.indent(5 * 2);
         out << "\"bridgingHeader\": {\n";
-        writeJSONSingleField(out, "path", *swiftDeps->bridgingHeaderFile, 6,
+        writeJSONSingleField(out, "path", *swiftTextualDeps->bridgingHeaderFile, 6,
                              /*trailingComma=*/true);
-        writeJSONSingleField(out, "sourceFiles", swiftDeps->bridgingSourceFiles,
+        writeJSONSingleField(out, "sourceFiles", swiftTextualDeps->bridgingSourceFiles,
                              6,
                              /*trailingComma=*/true);
         writeJSONSingleField(out, "moduleDependencies",
-                             swiftDeps->bridgingModuleDependencies, 6,
+                             swiftTextualDeps->bridgingModuleDependencies, 6,
                              /*trailingComma=*/false);
         out.indent(5 * 2);
         out << "}\n";
       }
-    } else if (externalSwiftDep) {
+    } else if (swiftPlaceholderDeps) {
       out << "\"swiftPlaceholder\": {\n";
 
       // Module doc file
-      if (externalSwiftDep->moduleDocPath != "")
+      if (swiftPlaceholderDeps->moduleDocPath != "")
         writeJSONSingleField(out, "moduleDocPath",
-                             externalSwiftDep->moduleDocPath,
+                             swiftPlaceholderDeps->moduleDocPath,
                              /*indentLevel=*/5,
                              /*trailingComma=*/true);
 
       // Module Source Info file
-      if (externalSwiftDep->moduleDocPath != "")
+      if (swiftPlaceholderDeps->moduleDocPath != "")
         writeJSONSingleField(out, "moduleSourceInfoPath",
-                             externalSwiftDep->sourceInfoPath,
+                             swiftPlaceholderDeps->sourceInfoPath,
+                             /*indentLevel=*/5,
+                             /*trailingComma=*/false);
+    } else if (swiftBinaryDeps) {
+      out << "\"swiftPrebuiltExternal\": {\n";
+      assert(swiftBinaryDeps->compiledModulePath != "" &&
+             "Expected .swiftmodule for a Binary Swift Module Dependency.");
+      writeJSONSingleField(out, "compiledModulePath",
+                           swiftBinaryDeps->compiledModulePath,
+                           /*indentLevel=*/5,
+                           /*trailingComma=*/true);
+      // Module doc file
+      if (swiftBinaryDeps->moduleDocPath != "")
+        writeJSONSingleField(out, "moduleDocPath",
+                             swiftBinaryDeps->moduleDocPath,
                              /*indentLevel=*/5,
                              /*trailingComma=*/true);
+
+      // Module Source Info file
+      if (swiftBinaryDeps->moduleDocPath != "")
+        writeJSONSingleField(out, "moduleSourceInfoPath",
+                             swiftBinaryDeps->sourceInfoPath,
+                             /*indentLevel=*/5,
+                             /*trailingComma=*/false);
     } else {
       out << "\"clang\": {\n";
 
@@ -582,6 +612,7 @@ static void writeJSON(llvm::raw_ostream &out,
     if (&module != &allModules.back())
       out << ",";
     out << "\n";
+  }
   }
 }
 
@@ -611,12 +642,14 @@ static bool diagnoseCycle(CompilerInstance &instance,
         llvm::SmallString<64> buffer;
         for (auto it = startIt; it != openSet.end(); ++ it) {
           buffer.append(it->first);
-          buffer.append(it->second == ModuleDependenciesKind::Swift?
+          buffer.append((it->second == ModuleDependenciesKind::SwiftTextual ||
+                         it->second == ModuleDependenciesKind::SwiftBinary)?
                         ".swiftmodule": ".pcm");
           buffer.append(" -> ");
         }
         buffer.append(startIt->first);
-        buffer.append(startIt->second == ModuleDependenciesKind::Swift?
+        buffer.append((startIt->second == ModuleDependenciesKind::SwiftTextual ||
+                       startIt->second == ModuleDependenciesKind::SwiftBinary)?
                       ".swiftmodule": ".pcm");
         instance.getASTContext().Diags.diagnose(SourceLoc(),
                                                 diag::scanner_find_cycle,
@@ -677,7 +710,7 @@ static bool scanModuleDependencies(CompilerInstance &instance,
   }
   // Add the main module.
   allModules.insert({moduleName.str(), isClang ? ModuleDependenciesKind::Clang:
-    ModuleDependenciesKind::Swift});
+                                        ModuleDependenciesKind::SwiftTextual});
 
   // Output module prescan.
   if (FEOpts.ImportPrescan) {
@@ -859,8 +892,7 @@ bool swift::scanDependencies(CompilerInstance &instance) {
 
   // Create the module dependency cache.
   ModuleDependenciesCache cache;
-  cache.recordDependencies(mainModuleName, std::move(mainDependencies),
-                           ModuleDependenciesKind::Swift);
+  cache.recordDependencies(mainModuleName, std::move(mainDependencies));
 
   auto &ctx = instance.getASTContext();
   auto ModuleCachePath = getModuleCachePathFromClang(ctx
@@ -908,7 +940,7 @@ bool swift::scanDependencies(CompilerInstance &instance) {
       if (!deps)
         continue;
 
-      if (auto swiftDeps = deps->getAsSwiftModule()) {
+      if (auto swiftDeps = deps->getAsSwiftTextualModule()) {
         if (auto swiftInterfaceFile = swiftDeps->swiftInterfaceFile)
           depTracker->addDependency(*swiftInterfaceFile, /*IsSystem=*/false);
         for (const auto &sourceFile : swiftDeps->sourceFiles)

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -166,10 +166,13 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
     InterfaceSubContextDelegate &delegate) {
   // Check whether we've cached this result.
   if (auto found = cache.findDependencies(
-          moduleName, ModuleDependenciesKind::Swift))
+          moduleName, ModuleDependenciesKind::SwiftTextual))
     return found;
-  if (auto found =
-          cache.findDependencies(moduleName, ModuleDependenciesKind::SwiftPlaceholder))
+  if (auto found = cache.findDependencies(
+          moduleName, ModuleDependenciesKind::SwiftBinary))
+    return found;
+  if (auto found = cache.findDependencies(
+          moduleName, ModuleDependenciesKind::SwiftPlaceholder))
     return found;
 
   auto moduleId = Ctx.getIdentifier(moduleName);
@@ -191,8 +194,7 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
   for (auto &scanner : scanners) {
     if (scanner->canImportModule({moduleId, SourceLoc()})) {
       // Record the dependencies.
-      cache.recordDependencies(moduleName, *(scanner->dependencies),
-                               scanner->dependencyKind);
+      cache.recordDependencies(moduleName, *(scanner->dependencies));
       return std::move(scanner->dependencies);
     }
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -394,8 +394,13 @@ llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
                        nullptr,
                        isFramework, loadedModuleFile);
 
+  const std::string moduleDocPath;
+  const std::string sourceInfoPath;
   // Map the set of dependencies over to the "module dependencies".
-  auto dependencies = ModuleDependencies::forSwiftModule(modulePath.str(), isFramework);
+  auto dependencies = ModuleDependencies::forSwiftBinaryModule(modulePath.str(),
+                                                               moduleDocPath,
+                                                               sourceInfoPath,
+                                                               isFramework);
   llvm::StringSet<> addedModuleNames;
   for (const auto &dependency : loadedModuleFile->getDependencies()) {
     // FIXME: Record header dependency?

--- a/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
+++ b/test/ScanDependencies/Inputs/ModuleDependencyGraph.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -14,12 +14,14 @@ import Foundation
 enum ModuleDependencyId: Hashable {
   case swift(String)
   case swiftPlaceholder(String)
+  case swiftPrebuiltExternal(String)
   case clang(String)
 
   var moduleName: String {
     switch self {
     case .swift(let name): return name
     case .swiftPlaceholder(let name): return name
+    case .swiftPrebuiltExternal(let name): return name
     case .clang(let name): return name
     }
   }
@@ -29,6 +31,7 @@ extension ModuleDependencyId: Codable {
   enum CodingKeys: CodingKey {
     case swift
     case swiftPlaceholder
+    case swiftPrebuiltExternal
     case clang
   }
 
@@ -42,8 +45,13 @@ extension ModuleDependencyId: Codable {
         let moduleName =  try container.decode(String.self, forKey: .swiftPlaceholder)
         self = .swiftPlaceholder(moduleName)
       } catch {
-        let moduleName =  try container.decode(String.self, forKey: .clang)
-        self = .clang(moduleName)
+        do {
+          let moduleName =  try container.decode(String.self, forKey: .swiftPrebuiltExternal)
+          self = .swiftPrebuiltExternal(moduleName)
+        } catch {
+          let moduleName =  try container.decode(String.self, forKey: .clang)
+          self = .clang(moduleName)
+        }
       }
     }
   }
@@ -54,7 +62,9 @@ extension ModuleDependencyId: Codable {
       case .swift(let moduleName):
         try container.encode(moduleName, forKey: .swift)
       case .swiftPlaceholder(let moduleName):
-        try container.encode(moduleName, forKey: .swift)
+        try container.encode(moduleName, forKey: .swiftPlaceholder)
+      case .swiftPrebuiltExternal(let moduleName):
+        try container.encode(moduleName, forKey: .swiftPrebuiltExternal)
       case .clang(let moduleName):
         try container.encode(moduleName, forKey: .clang)
     }
@@ -76,27 +86,39 @@ struct SwiftModuleDetails: Codable {
   /// The paths of potentially ready-to-use compiled modules for the interface.
   var compiledModuleCandidates: [String]?
 
-  /// The compiled Swift module to use.
-  var compiledModulePath: String?
-
   /// The bridging header, if any.
-  var bridgingHeader: BridgingHeader?
+  var bridgingHeaderPath: String?
 
-  /// The Swift command line arguments that need to be passed through
-  /// to the -compile-module-from-interface action to build this module.
-  var commandLine: [String]?
+  /// The source files referenced by the bridging header.
+  var bridgingSourceFiles: [String]? = []
+
+  /// Options to the compile command
+  var commandLine: [String]? = []
 
   /// To build a PCM to be used by this Swift module, we need to append these
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
-  var extraPcmArgs: [String]?
+  var extraPcmArgs: [String]
 
   /// A flag to indicate whether or not this module is a framework.
   var isFramework: Bool
 }
 
-/// Details specific to Swift external modules.
-struct swiftPlaceholderModuleDetails: Codable {
+/// Details specific to Swift placeholder dependencies.
+struct SwiftPlaceholderModuleDetails: Codable {
+  /// The path to the .swiftModuleDoc file.
+  var moduleDocPath: String?
+
+  /// The path to the .swiftSourceInfo file.
+  var moduleSourceInfoPath: String?
+}
+
+/// Details specific to Swift externally-pre-built modules.
+struct SwiftPrebuiltExternalModuleDetails: Codable {
+  /// The path to the already-compiled module that must be used instead of
+  /// generating a job to build this module.
+  var compiledModulePath: String
+
   /// The path to the .swiftModuleDoc file.
   var moduleDocPath: String?
 
@@ -107,25 +129,28 @@ struct swiftPlaceholderModuleDetails: Codable {
 /// Details specific to Clang modules.
 struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
-  var moduleMapPath: String
+  public var moduleMapPath: String
 
-  /// The context hash used to discriminate this module file.
+  /// Set of PCM Arguments of depending modules which
+  /// are covered by the directDependencies info of this module
+  public var dependenciesCapturedPCMArgs: Set<[String]>?
+
+  /// clang-generated context hash
   var contextHash: String
 
-  /// The Clang command line arguments that need to be passed through
-  /// to the -emit-pcm action to build this module.
+  /// Options to the compile command
   var commandLine: [String] = []
 }
 
-struct ModuleDependencies: Codable {
+struct ModuleInfo: Codable {
   /// The path for the module.
   var modulePath: String
 
   /// The source files used to build this module.
-  var sourceFiles: [String]? = []
+  var sourceFiles: [String]?
 
   /// The set of direct module dependencies of this module.
-  var directDependencies: [ModuleDependencyId]? = []
+  var directDependencies: [ModuleDependencyId]?
 
   /// Specific details of a particular kind of module.
   var details: Details
@@ -136,19 +161,23 @@ struct ModuleDependencies: Codable {
     /// a bridging header.
     case swift(SwiftModuleDetails)
 
-    /// Swift external modules carry additional details that specify their
+    /// Swift placeholder modules carry additional details that specify their
     /// module doc path and source info paths.
-    case swiftPlaceholder(swiftPlaceholderModuleDetails)
+    case swiftPlaceholder(SwiftPlaceholderModuleDetails)
+
+    /// Swift externally-prebuilt modules must communicate the path to pre-built binary artifacts
+    case swiftPrebuiltExternal(SwiftPrebuiltExternalModuleDetails)
 
     /// Clang modules are built from a module map file.
     case clang(ClangModuleDetails)
   }
 }
 
-extension ModuleDependencies.Details: Codable {
+extension ModuleInfo.Details: Codable {
   enum CodingKeys: CodingKey {
     case swift
     case swiftPlaceholder
+    case swiftPrebuiltExternal
     case clang
   }
 
@@ -159,11 +188,18 @@ extension ModuleDependencies.Details: Codable {
       self = .swift(details)
     } catch {
       do {
-        let details = try container.decode(swiftPlaceholderModuleDetails.self, forKey: .swiftPlaceholder)
+        let details = try container.decode(SwiftPlaceholderModuleDetails.self,
+                                           forKey: .swiftPlaceholder)
         self = .swiftPlaceholder(details)
       } catch {
-        let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
-        self = .clang(details)
+        do {
+          let details = try container.decode(SwiftPrebuiltExternalModuleDetails.self,
+                                             forKey: .swiftPrebuiltExternal)
+          self = .swiftPrebuiltExternal(details)
+        } catch {
+          let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
+          self = .clang(details)
+        }
       }
     }
   }
@@ -175,6 +211,8 @@ extension ModuleDependencies.Details: Codable {
         try container.encode(details, forKey: .swift)
       case .swiftPlaceholder(let details):
         try container.encode(details, forKey: .swiftPlaceholder)
+      case .swiftPrebuiltExternal(let details):
+        try container.encode(details, forKey: .swiftPrebuiltExternal)
       case .clang(let details):
         try container.encode(details, forKey: .clang)
     }
@@ -188,8 +226,8 @@ struct ModuleDependencyGraph: Codable {
   var mainModuleName: String
 
   /// The complete set of modules discovered
-  var modules: [ModuleDependencyId: ModuleDependencies] = [:]
+  var modules: [ModuleDependencyId: ModuleInfo] = [:]
 
   /// Information about the main module.
-  var mainModule: ModuleDependencies { modules[.swift(mainModuleName)]! }
+  var mainModule: ModuleInfo { modules[.swift(mainModuleName)]! }
 }

--- a/test/ScanDependencies/binary_module_only.swift
+++ b/test/ScanDependencies/binary_module_only.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: %empty-directory(%t/Foo.swiftmodule)
+// RUN: %empty-directory(%t/binaryModuleOnly)
+// RUN: echo "public func foo() {}" > %t/Foo.swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foo
+
+// BINARY_MODULE_ONLY: "swiftPrebuiltExternal": "Foo"
+// BINARY_MODULE_ONLY:  "swiftPrebuiltExternal": {
+// BINARY_MODULE_ONLY-NEXT:  "compiledModulePath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/binary_module_only.swift.tmp/binaryModuleOnly/Foo.swiftmodule",
+
+// HAS_NO_COMPILED-NOT: "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
+
+// Step 1: build swift interface and swift module side by side
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// Step 2: build module from interface and put it in a location separate from the interface file
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/binaryModuleOnly/Foo.swiftmodule -module-name Foo -disable-interface-lock %t/Foo.swiftmodule/%target-swiftinterface-name
+
+// Step 3: scan dependencies, pointed only at the binary module file should detect it as a swiftBinaryModule kind of dependency
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t/binaryModuleOnly -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
+// RUN: %FileCheck %s -check-prefix=BINARY_MODULE_ONLY < %t/deps.json

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -76,7 +76,7 @@ import SomeExternalModule
 // CHECK-NEXT: "details": {
 // CHECK-NEXT: "swiftPlaceholder": {
 // CHECK-NEXT: "moduleDocPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftdoc",
-// CHECK-NEXT: "moduleSourceInfoPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftsourceinfo",
+// CHECK-NEXT: "moduleSourceInfoPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftsourceinfo"
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "Swift.swiftmodule",


### PR DESCRIPTION
This matches the expectation of the client (`swift-driver`) and reduces ambiguity in how the nodes in the graph are to be treated. Swift dependencies with a textual interface, for example, must be built into a binary module by clients. Swift dependencies without a textual interface, with only a binary module, are to be used directly, without any up-to-date checks.

Note, this is distinct from Swift dependencies that have a textual interface, for which we also detect potential pre-built binary module candidates. Those are still reported in the `details` field of textual Swift dependencies as `prebuiltModuleCandidates`.

swift-driver's matching refactoring: https://github.com/apple/swift-driver/pull/287 

As a side-effect of this refactoring, this PR also resolves rdar://70103935