### PR TITLE
Generalize SWIFT_RUNTIME_EXPORT to work for other runtime libraries

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -26,6 +26,14 @@
 // without a definition of NoneType.
 #include "llvm/ADT/None.h"
 
+// Don't pre-declare certain LLVM types in the runtime, which must
+// not put things in namespace llvm for ODR reasons.
+#if !defined(swiftCore_EXPORTS)
+#define SWIFT_LLVM_ODR_SAFE 1
+#else
+#define SWIFT_LLVM_ODR_SAFE 0
+#endif
+
 // Forward declarations.
 namespace llvm {
   // Containers.
@@ -34,18 +42,18 @@ namespace llvm {
   class Twine;
   template <typename T> class SmallPtrSetImpl;
   template <typename T, unsigned N> class SmallPtrSet;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   template <typename T> class SmallVectorImpl;
   template <typename T, unsigned N> class SmallVector;
 #endif
   template <unsigned N> class SmallString;
   template <typename T, unsigned N> class SmallSetVector;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   template<typename T> class ArrayRef;
   template<typename T> class MutableArrayRef;
 #endif
   template<typename T> class TinyPtrVector;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   template<typename T> class Optional;
 #endif
   template <typename ...PTs> class PointerUnion;
@@ -56,7 +64,7 @@ namespace llvm {
   class raw_ostream;
   class APInt;
   class APFloat;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   template <typename Fn> class function_ref;
 #endif
 } // end namespace llvm
@@ -71,13 +79,13 @@ namespace swift {
   using llvm::cast_or_null;
 
   // Containers.
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   using llvm::ArrayRef;
   using llvm::MutableArrayRef;
 #endif
   using llvm::iterator_range;
   using llvm::None;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   using llvm::Optional;
 #endif
   using llvm::PointerUnion;
@@ -86,7 +94,7 @@ namespace swift {
   using llvm::SmallPtrSetImpl;
   using llvm::SmallSetVector;
   using llvm::SmallString;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   using llvm::SmallVector;
   using llvm::SmallVectorImpl;
 #endif
@@ -98,7 +106,7 @@ namespace swift {
   // Other common classes.
   using llvm::APFloat;
   using llvm::APInt;
-#if !defined(swiftCore_EXPORTS)
+#if SWIFT_LLVM_ODR_SAFE
   using llvm::function_ref;
 #endif
   using llvm::NoneType;

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -878,7 +878,10 @@ const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type
 SWIFT_RUNTIME_EXPORT
 const HeapObject *swift_getKeyPath(const void *pattern, const void *arguments);
 
+// For some reason, MSVC doesn't accept these declarations outside of
+// swiftCore.  TODO: figure out a reasonable way to declare them.
 #if defined(swiftCore_EXPORTS)
+
 /// Given a pointer to a borrowed value of type `Root` and a
 /// `KeyPath<Root, Value>`, project a pointer to a borrowed value of type
 /// `Value`.
@@ -900,7 +903,8 @@ swift_modifyAtWritableKeyPath;
 SWIFT_RUNTIME_EXPORT
 YieldOnceCoroutine<OpaqueValue* (const OpaqueValue *root, void *keyPath)>::type
 swift_modifyAtReferenceWritableKeyPath;
-#endif
+
+#endif // swiftCore_EXPORTS
 
 SWIFT_RUNTIME_EXPORT
 void swift_enableDynamicReplacementScope(const DynamicReplacementScope *scope);

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -52,6 +52,12 @@
 # define SWIFT_END_NULLABILITY_ANNOTATIONS
 #endif
 
+#define SWIFT_MACRO_CONCAT(A, B) A ## B
+#define SWIFT_MACRO_IF_0(IF_TRUE, IF_FALSE) IF_FALSE
+#define SWIFT_MACRO_IF_1(IF_TRUE, IF_FALSE) IF_TRUE
+#define SWIFT_MACRO_IF(COND, IF_TRUE, IF_FALSE) \
+  SWIFT_MACRO_CONCAT(SWIFT_MACRO_IF_, COND)(IF_TRUE, IF_FALSE)
+
 #if __has_attribute(pure)
 #define SWIFT_READONLY __attribute__((__pure__))
 #else
@@ -94,48 +100,97 @@
 #define SWIFT_ATTRIBUTE_UNAVAILABLE
 #endif
 
-// TODO: support using shims headers in overlays by parameterizing
-// SWIFT_RUNTIME_EXPORT on the library it's exported from.
-
-/// Attribute used to export symbols from the runtime.
+// Define the appropriate attributes for sharing symbols across
+// image (executable / shared-library) boundaries.
+//
+// SWIFT_ATTRIBUTE_FOR_EXPORTS will be placed on declarations that
+// are known to be exported from the current image.  Typically, they
+// are placed on header declarations and then inherited by the actual
+// definitions.
+//
+// SWIFT_ATTRIBUTE_FOR_IMPORTS will be placed on declarations that
+// are known to be exported from a different image.  This never
+// includes a definition.
+//
+// Getting the right attribute on a declaratioon can be pretty awkward,
+// but it's necessary under the C translation model.  All of this
+// ceremony is familiar to Windows programmers; C/C++ programmers
+// everywhere else usually don't bother, but since we have to get it
+// right for Windows, we have everything set up to get it right on
+// other targets as well, and doing so lets the compiler use more
+// efficient symbol access patterns.
 #if defined(__MACH__) || defined(__wasi__)
 
-# define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
+// On Mach-O and WebAssembly, we use non-hidden visibility.  We just use
+// default visibility on both imports and exports, both because these
+// targets don't support protected visibility but because they don't
+// need it: symbols are not interposable outside the current image
+// by default.
+# define SWIFT_ATTRIBUTE_FOR_EXPORTS __attribute__((__visibility__("default")))
+# define SWIFT_ATTRIBUTE_FOR_IMPORTS __attribute__((__visibility__("default")))
 
 #elif defined(__ELF__)
 
-// We make assumptions that the runtime and standard library can refer to each
-// other's symbols as DSO-local, which means we can't allow the dynamic linker
-// to relocate these symbols. We must give them protected visibility while
-// building the standard library and runtime.
-# if defined(swiftCore_EXPORTS)
-#  define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("protected")))
-# else
-#  define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
-# endif
+// On ELF, we use non-hidden visibility.  For exports, we must use
+// protected visibility to tell the compiler and linker that the symbols
+// can't be interposed outside the current image.  For imports, we must
+// use default visibility because protected visibility guarantees that
+// the symbol is defined in the current library, which isn't true for
+// an import.
+//
+// The compiler does assume that the runtime and standard library can
+// refer to each other's symbols as DSO-local, so it's important that
+// we get this right or we can get linker errors.
+# define SWIFT_ATTRIBUTE_FOR_EXPORTS __attribute__((__visibility__("protected")))
+# define SWIFT_ATTRIBUTE_FOR_IMPORTS __attribute__((__visibility__("default")))
+
+#elif defined(__CYGWIN__)
+
+// For now, we ignore all this on Cygwin.
+# define SWIFT_ATTRIBUTE_FOR_EXPORTS
+# define SWIFT_ATTRIBUTE_FOR_IMPORTS
 
 // FIXME: this #else should be some sort of #elif Windows
 #else // !__MACH__ && !__ELF__
 
-# if defined(__CYGWIN__)
-#  define SWIFT_EXPORT_ATTRIBUTE
-# else
-
-#  if defined(swiftCore_EXPORTS)
-#   define SWIFT_EXPORT_ATTRIBUTE __declspec(dllexport)
-#  else
-#   define SWIFT_EXPORT_ATTRIBUTE __declspec(dllimport)
-#  endif
-
-# endif
+// On PE/COFF, we use dllimport and dllexport.
+# define SWIFT_ATTRIBUTE_FOR_EXPORTS __declspec(dllexport)
+# define SWIFT_ATTRIBUTE_FOR_IMPORTS __declspec(dllimport)
 
 #endif
 
-#if defined(__cplusplus)
-#define SWIFT_RUNTIME_EXPORT extern "C" SWIFT_EXPORT_ATTRIBUTE
+// CMake conventionally passes -DlibraryName_EXPORTS when building
+// code that goes into libraryName.  This isn't the best macro name,
+// but it's conventional.  We do have to pass it explicitly in a few
+// places in the build system for a variety of reasons.
+//
+// Unfortunately, defined(D) is a special function you can use in
+// preprocessor conditions, not a macro you can use anywhere, so we
+// need to manually check for all the libraries we know about so that
+// we can use them in our condition below.s
+#if defined(swiftCore_EXPORTS)
+#define SWIFT_IMAGE_EXPORTS_swiftCore 1
 #else
-#define SWIFT_RUNTIME_EXPORT SWIFT_EXPORT_ATTRIBUTE
+#define SWIFT_IMAGE_EXPORTS_swiftCore 0
 #endif
+
+#define SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)                          \
+  SWIFT_MACRO_IF(SWIFT_IMAGE_EXPORTS_##LIBRARY,                       \
+                 SWIFT_ATTRIBUTE_FOR_EXPORTS,                         \
+                 SWIFT_ATTRIBUTE_FOR_IMPORTS)
+
+// SWIFT_EXPORT_FROM(LIBRARY) declares something to be a C-linkage
+// entity exported by the given library.
+//
+// SWIFT_RUNTIME_EXPORT is just SWIFT_EXPORT_FROM(swiftCore).
+//
+// TODO: use this in shims headers in overlays.
+#if defined(__cplusplus)
+#define SWIFT_EXPORT_FROM(LIBRARY) extern "C" SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)
+#else
+#define SWIFT_EXPORT_FROM(LIBRARY) SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)
+#endif
+#define SWIFT_RUNTIME_EXPORT SWIFT_EXPORT_FROM(swiftCore)
 
 #if __cplusplus > 201402l && __has_cpp_attribute(fallthrough)
 #define SWIFT_FALLTHROUGH [[fallthrough]]


### PR DESCRIPTION
The goal is to also use this in e.g. `swift_Concurrency`.