### PR TITLE
Add test case and changelog entry for local function overloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ CHANGELOG
 Swift Next
 ----------
 
+* [SR-10069][]:
+
+  Function overloading now works in local contexts, making the following valid:
+
+  ```swift
+  func outer(x: Int, y: String) {
+    func doIt(_: Int) {}
+    func doIt(_: String) {}
+
+    doIt(x) // calls the first 'doIt(_:)' with an Int value
+    doIt(y) // calls the second 'doIt(_:)' with a String value
+  }
+  ```
+
 * [SE-0284][]:
 
   Functions, subscripts, and initializers may now have more than one variadic parameter, as long as all parameters which follow variadic parameters are labeled. This makes declarations like the following valid:
@@ -8196,6 +8210,7 @@ Swift 1.0
 [SR-8974]: <https://bugs.swift.org/browse/SR-8974>
 [SR-9043]: <https://bugs.swift.org/browse/SR-9043>
 [SR-9827]: <https://bugs.swift.org/browse/SR-9827>
+[SR-10069]: <https://bugs.swift.org/browse/SR-10069>
 [SR-11298]: <https://bugs.swift.org/browse/SR-11298>
 [SR-11429]: <https://bugs.swift.org/browse/SR-11429>
 [SR-11700]: <https://bugs.swift.org/browse/SR-11700>

--- a/test/decl/func/local-function-overload.swift
+++ b/test/decl/func/local-function-overload.swift
@@ -1,0 +1,63 @@
+// RUN: %target-typecheck-verify-swift -disable-parser-lookup
+
+func valid1() {
+  func inner(_: Int) {}
+  func inner(_: String) {}
+
+  func inner(label: Int) {}
+  func inner(label: String) {}
+
+  inner(123)
+  inner("hello")
+
+  inner(label: 123)
+  inner(label: "hello")
+}
+
+func valid2() {
+  func inner(_: Int = 0) {}
+  func inner() -> Bool {}
+  func inner(first: Int, second: Int = 0) {}
+
+  let _: Bool = inner()
+  let _ = inner()
+
+  inner(first: 123)
+}
+
+func invalid1() {
+  func inner(_: Int) {}
+  // expected-note@-1 {{'inner' previously declared here}}
+  func inner(_: Int) {}
+  // expected-error@-1 {{invalid redeclaration of 'inner'}}
+}
+
+func invalid2() {
+  func inner(_: Int) {}
+  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
+  // expected-note@-2 {{found this candidate}}
+  // expected-note@-3 {{did you mean 'inner'?}}
+  func inner(_: String) {}
+  // expected-note@-1 {{candidate expects value of type 'String' for parameter #1}}
+  // expected-note@-2 {{found this candidate}}
+  // expected-note@-3 {{did you mean 'inner'?}}
+
+  func inner(label: Int) {}
+  // expected-note@-1 {{found this candidate}}
+  // expected-note@-2 {{did you mean 'inner'?}}
+
+  inner([])
+  // expected-error@-1 {{no exact matches in call to local function 'inner'}}
+
+  inner(label: "hi")
+  // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'Int'}}
+
+  _ = inner
+  // expected-error@-1 {{ambiguous use of 'inner'}}
+
+  _ = inner(label:) // no-error
+
+  // FIXME: This isn't as good as in the non-local function case?
+  _ = inner(invalidLabel:)
+  // expected-error@-1 {{cannot find 'inner(invalidLabel:)' in scope}}
+}


### PR DESCRIPTION
rdar://problem/17503169 / https://bugs.swift.org/browse/SR-10069

This now works thanks to ASTScope lookup replacing parse-time lookup:

```swift
func outer(x: Int, y: String) {
  func doIt(_: Int) {}
  func doIt(_: String) {}
  doIt(x) // calls the first 'doIt(_:)' with an Int value
  doIt(y) // calls the second 'doIt(_:)' with a String value
}
```