### PR TITLE
Ensure Changes to External Dependencies Cascade

### DIFF
--- a/test/Incremental/CrossModule/Inputs/external-cascade/A.json
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/A.json
@@ -1,0 +1,11 @@
+{
+  "A.swift": {
+    "object": "./A.o",
+    "swift-dependencies": "./A.swiftdeps",
+    "swiftmodule": "./A~partial.swiftmodule",
+    "swiftdoc": "./A.swiftdoc",
+  },
+  "": {
+    "swift-dependencies": "./A~buildrecord.swiftdeps"
+  }
+}

--- a/test/Incremental/CrossModule/Inputs/external-cascade/A.swift
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/A.swift
@@ -1,0 +1,3 @@
+import B
+
+public let fromA = fromB

--- a/test/Incremental/CrossModule/Inputs/external-cascade/B.json
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/B.json
@@ -1,0 +1,11 @@
+{
+  "B.swift": {
+    "object": "./B.o",
+    "swift-dependencies": "./B.swiftdeps",
+    "swiftmodule": "./B~partial.swiftmodule",
+    "swiftdoc": "./B.swiftdoc",
+  },
+  "": {
+    "swift-dependencies": "./B~buildrecord.swiftdeps"
+  }
+}

--- a/test/Incremental/CrossModule/Inputs/external-cascade/B.swift
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/B.swift
@@ -1,0 +1,3 @@
+import C
+
+public let fromB = fromC

--- a/test/Incremental/CrossModule/Inputs/external-cascade/C.json
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/C.json
@@ -1,0 +1,11 @@
+{
+  "C.swift": {
+    "object": "./C.o",
+    "swift-dependencies": "./C.swiftdeps",
+    "swiftmodule": "./C~partial.swiftmodule",
+    "swiftdoc": "./C.swiftdoc",
+  },
+  "": {
+    "swift-dependencies": "./C~buildrecord.swiftdeps"
+  }
+}

--- a/test/Incremental/CrossModule/Inputs/external-cascade/C.swift
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/C.swift
@@ -1,0 +1,1 @@
+public let fromC = ASymbolFromAHeader + ASymbolFromAnotherHeader

--- a/test/Incremental/CrossModule/Inputs/external-cascade/another-header.h
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/another-header.h
@@ -1,0 +1,1 @@
+int ASymbolFromAnotherHeader = 43;

--- a/test/Incremental/CrossModule/Inputs/external-cascade/bridging-header.h
+++ b/test/Incremental/CrossModule/Inputs/external-cascade/bridging-header.h
@@ -1,0 +1,2 @@
+#include "another-header.h"
+int ASymbolFromAHeader = 42;

--- a/test/Incremental/CrossModule/external-cascade.swift
+++ b/test/Incremental/CrossModule/external-cascade.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/external-cascade/* %t
+
+// rdar://problem/70012853
+// XFAIL: OS=windows-msvc
+
+//
+// This test establishes a chain of modules that all depend on a set of
+// bridging headers. This test ensures that changes to external dependencies -
+// especially those that aren't directly imported - cause incremental rebuilds.
+//
+// |bridging-header.h| - Module C    Module B    Module A
+//         ^             -------- -> -------- -> --------
+//         |                |                        ^
+//         |                |                        |
+// |another-header.h|        ------------------------
+
+//
+// Set up a clean incremental build of all three modules
+//
+
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -import-objc-header %t/bridging-header.h -Xfrontend -validate-tbd-against-ir=none -driver-show-incremental -driver-show-job-lifecycle %t/C.swift
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/B.swift
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/A.swift
+
+//
+// Now change a header and ensure that the rebuild cascades outwards
+//
+
+// RUN: rm %t/another-header.h
+// RUN: cp %S/Inputs/external-cascade/another-header.h %t/another-header.h
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -import-objc-header %t/bridging-header.h -Xfrontend -validate-tbd-against-ir=none -driver-show-incremental -driver-show-job-lifecycle %t/C.swift 2>&1 | %FileCheck -check-prefix MODULE-C %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/B.swift 2>&1 | %FileCheck -check-prefix MODULE-B %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/A.swift 2>&1 | %FileCheck -check-prefix MODULE-A %s
+
+// MODULE-C: Job finished: {generate-pch: bridging-header-[[BRIDGING_HEADER:.*]].pch <= bridging-header.h}
+// MODULE-C: Job finished: {compile: C.o <= C.swift bridging-header-[[BRIDGING_HEADER]].pch}
+// MODULE-C: Job finished: {merge-module: C.swiftmodule <= C.o}
+
+// MODULE-B: Queuing because of external dependencies: {compile: B.o <= B.swift}
+// MODULE-B: Job finished: {compile: B.o <= B.swift}
+// MODULE-B: Job finished: {merge-module: B.swiftmodule <= B.o}
+
+
+// MODULE-A: Queuing because of external dependencies: {compile: A.o <= A.swift}
+// MODULE-A: Job finished: {compile: A.o <= A.swift}
+// MODULE-A: Job finished: {merge-module: A.swiftmodule <= A.o}
+
+//
+// And ensure that the null build really is null.
+//
+
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -import-objc-header %t/bridging-header.h -Xfrontend -validate-tbd-against-ir=none -driver-show-incremental -driver-show-job-lifecycle %t/C.swift 2>&1 | %FileCheck -check-prefix MODULE-C-NULL %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/B.swift 2>&1 | %FileCheck -check-prefix MODULE-B-NULL %s
+// RUN: cd %t && %swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle %t/A.swift 2>&1 | %FileCheck -check-prefix MODULE-A-NULL %s
+
+// MODULE-C-NULL: Job finished: {generate-pch: bridging-header-[[BRIDGING_HEADER:.*]].pch <= bridging-header.h}
+// MODULE-C-NULL: Job skipped: {compile: C.o <= C.swift bridging-header-[[BRIDGING_HEADER]].pch}
+// MODULE-C-NULL: Job skipped: {merge-module: C.swiftmodule <= C.o}
+
+// MODULE-B-NULL: Job skipped: {compile: B.o <= B.swift}
+// MODULE-B-NULL: Job skipped: {merge-module: B.swiftmodule <= B.o}
+
+// MODULE-A-NULL: Job skipped: {compile: A.o <= A.swift}
+// MODULE-A-NULL: Job skipped: {merge-module: A.swiftmodule <= A.o}


### PR DESCRIPTION
We cannot know a-priori how a change to an external dependency will
affect the resulting structure of every file in the module that depends
upon it. Therefore, we must be conservative and ensure that these
dependent files always rebuild. Commit a test to this effect.