### PR TITLE
SILOptimizer: fix a miscompile in TempRValueOpt and improve MemBehavior

### DIFF
--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -389,6 +389,13 @@ public:
   /// instructions are considered as side effects.
   MemoryBehavior getMemBehavior(RetainObserveKind ScanKind) const;
 
+  /// Gets the memory behavior for an argument.
+  ///
+  /// This is derived from the combined argument and the global effects.
+  /// Also the argument type and convention are considered.
+  MemoryBehavior getArgumentBehavior(FullApplySite applySite,
+                                                unsigned argIdx);
+
   /// Get the global effects for the function. These are effects which cannot
   /// be associated to a specific parameter, e.g. writes to global variables
   /// or writes to unknown pointers.

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -219,6 +219,34 @@ FunctionSideEffects::getMemBehavior(RetainObserveKind ScanKind) const {
   return Behavior;
 }
 
+MemoryBehavior
+FunctionSideEffects::getArgumentBehavior(FullApplySite applySite,
+                                         unsigned argIdx) {
+  // Rule out trivial non-address argument types.
+  SILType argType = applySite.getArgument(argIdx)->getType();
+  if (!argType.isAddress() && argType.isTrivial(*applySite.getFunction()))
+    return MemoryBehavior::None;
+
+  // The overall argument effect is the combination of the argument and the
+  // global effects.
+  MemoryBehavior behavior =
+    GlobalEffects.getMemBehavior(RetainObserveKind::IgnoreRetains);
+  MemoryBehavior argBehavior =
+    ParamEffects[argIdx].getMemBehavior(RetainObserveKind::IgnoreRetains);
+
+  behavior = combineMemoryBehavior(behavior, argBehavior);
+
+  if (behavior > MemoryBehavior::MayRead &&
+      applySite.getArgumentConvention(applySite.getArgumentRef(argIdx)) ==
+        SILArgumentConvention::Indirect_In_Guaranteed) {
+    // Even if side-effect analysis doesn't know anything about the called
+    // called function, the in_guaranteed convention guarantees that the
+    // argument is never written to.
+    return MemoryBehavior::MayRead;
+  }
+  return behavior;
+}
+
 bool FunctionSideEffects::mergeFrom(const FunctionSideEffects &RHS) {
   bool Changed = mergeFlags(RHS);
   Changed |= GlobalEffects.mergeFrom(RHS.GlobalEffects);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -393,6 +393,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   P.addEarlyCodeMotion();
   P.addReleaseHoisting();
   P.addARCSequenceOpts();
+  P.addTempRValueOpt();
 
   P.addSimplifyCFG();
   if (OpLevel == OptimizationLevelKind::LowLevel) {

--- a/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
@@ -88,11 +88,9 @@ class MemBehaviorDumper : public SILModuleTransform {
 
               bool Read = AA->mayReadFromMemory(&I, V);
               bool Write = AA->mayWriteToMemory(&I, V);
-              bool SideEffects = AA->mayHaveSideEffects(&I, V);
               llvm::outs() << "PAIR #" << PairCount++ << ".\n"
                            << "  " << I << "  " << V
-                           << "  r=" << Read << ",w=" << Write
-                           << ",se=" << SideEffects << "\n";
+                           << "  r=" << Read << ",w=" << Write << "\n";
             }
           }
         }

--- a/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
@@ -59,7 +59,10 @@ class MemBehaviorDumper : public SILModuleTransform {
   // selected types of instructions.
   static bool shouldTestInstruction(SILInstruction *I) {
     // Only consider function calls.
-    if ((EnableDumpAll && I->mayReadOrWriteMemory()) || FullApplySite::isa(I))
+    if ((EnableDumpAll && I->mayReadOrWriteMemory()) ||
+        FullApplySite::isa(I) ||
+        isa<EndApplyInst>(I) ||
+        isa<AbortApplyInst>(I))
       return true;
 
     return false;

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -904,8 +904,12 @@ var anyHashable: AnyHashable = 0
 
 // CHECK-LABEL: $s21bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF
 // CHECK: [[GLOBAL:%[0-9]+]] = global_addr @$s21bridged_casts_folding11anyHashables03AnyE0Vv
+// CHECK: [[TMP:%[0-9]+]] = alloc_stack $AnyHashable
+// CHECK: [[ACCESS:%[0-9]+]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]]
+// CHECK: copy_addr [[ACCESS]] to [initialization] [[TMP]]
 // CHECK: [[FUNC:%.*]] = function_ref @$ss11AnyHashableV10FoundationE19_bridgeToObjectiveCSo8NSObjectCyF
-// CHECK-NEXT: apply [[FUNC]]([[GLOBAL]])
+// CHECK-NEXT: apply [[FUNC]]([[TMP]])
+// CHECK-NEXT: destroy_addr [[TMP]]
 // CHECK-NEXT: unconditional_checked_cast {{%.*}} : $NSObject to NSObjectSubclass
 // CHECK: } // end sil function '$s21bridged_casts_folding29testUncondCastSwiftToSubclassAA08NSObjectI0CyF'
 @inline(never)

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -22,17 +22,17 @@ class Parent {
 // CHECK: PAIR #25.
 // CHECK-NEXT:    %6 = begin_access [modify] [static] %1 : $*Builtin.Int32
 // CHECK-NEXT:    %10 = ref_element_addr %9 : $C, #C.prop
-// CHECK-NEXT:  r=0,w=0,se=0
+// CHECK-NEXT:  r=0,w=0
 //
 // Any unknown instructions with side effects does affect the let-load.
 // CHECK: PAIR #83.
 // CHECK-NEXT:     end_borrow %{{.*}} : $C
 // CHECK-NEXT:     ref_element_addr %{{.*}} : $C, #C.prop
-// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK-NEXT:   r=1,w=1
 // CHECK: PAIR #103.
 // CHECK-NEXT:     destroy_value %0 : $Parent
 // CHECK-NEXT:     ref_element_addr %{{.*}} : $C, #C.prop
-// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK-NEXT:   r=1,w=1
 sil [ossa] @testLetSideEffects : $@convention(thin) (@owned Parent, @inout Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : @owned $Parent, %1 : $*Builtin.Int32):
   %borrow1 = begin_borrow %0 : $Parent
@@ -60,47 +60,47 @@ bb0(%0 : @owned $Parent, %1 : $*Builtin.Int32):
 // CHECK: PAIR #0.
 // CHECK-NEXT:     %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
 // CHECK-NEXT:     %0 = argument of bb0 : $*Builtin.Int32
-// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK-NEXT:   r=1,w=0
 // CHECK: PAIR #1.
 // CHECK-NEXT:     %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
 // CHECK-NEXT:     load [trivial] %{{.*}} : $*Builtin.Int32
-// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK-NEXT:   r=1,w=0
 // CHECK: PAIR #3.
 // CHECK-NEXT:     %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
 // CHECK-NEXT:     %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
-// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK-NEXT:   r=1,w=0
 // CHECK: PAIR #8.
 // CHECK-NEXT:     end_access %{{.*}} : $*Builtin.Int32
 // CHECK-NEXT:   %0 = argument of bb0 : $*Builtin.Int32
-// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK-NEXT:   r=1,w=0
 // CHECK: PAIR #9.
 // CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
 // CHECK-NEXT:    %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
-// CHECK-NEXT:  r=1,w=0,se=0
+// CHECK-NEXT:  r=1,w=0
 // CHECK: PAIR #12.
 // CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
 // CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
-// CHECK-NEXT:  r=1,w=0,se=0
+// CHECK-NEXT:  r=1,w=0
 // CHECK: PAIR #13.
 // CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
 // CHECK-NEXT:    %0 = argument of bb0 : $*Builtin.Int32
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 // CHECK: PAIR #14.
 // CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
 // CHECK-NEXT:    %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 // CHECK: PAIR #22.
 // CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
 // CHECK-NEXT:    %0 = argument of bb0 : $*Builtin.Int32
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 // CHECK: PAIR #23.
 // CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
 // CHECK-NEXT:    %{{.*}} = begin_access [read] [static] %0 : $*Builtin.Int32
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 // CHECK: PAIR #26.
 // CHECK-NEXT:    end_access %{{.*}} : $*Builtin.Int32
 // CHECK-NEXT:    %{{.*}} = begin_access [modify] [static] %0 : $*Builtin.Int32
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 sil [ossa] @testReadWriteAccess : $@convention(thin) (@inout Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $*Builtin.Int32):
   %read = begin_access [read] [static] %0 : $*Builtin.Int32
@@ -117,11 +117,11 @@ bb0(%0 : $*Builtin.Int32):
 // CHECK:      PAIR #0.
 // CHECK-NEXT:   %2 = load [take] %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
-// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK-NEXT:   r=1,w=1
 // CHECK:      PAIR #1.
 // CHECK-NEXT:   %2 = load [take] %0 : $*C
 // CHECK-NEXT:   %1 = argument of bb0 : $*C
-// CHECK-NEXT:   r=0,w=0,se=0
+// CHECK-NEXT:   r=0,w=0
 sil [ossa] @testLoadTake : $@convention(thin) (@in C, @in_guaranteed C) -> @owned C {
 bb0(%0 : $*C, %1 : $*C):
   %2 = load [take] %0 : $*C
@@ -139,11 +139,11 @@ sil_global hidden [let] @globalC : $C
 // CHECK:      PAIR #5.
 // CHECK-NEXT:     load %{{.*}} : $*C
 // CHECK-NEXT:     begin_access [deinit] [static] %{{.*}} : $*Builtin.Int32
-// CHECK-NEXT:   r=1,w=0,se=0
+// CHECK-NEXT:   r=1,w=0
 // CHECK:      PAIR #16.
 // CHECK-NEXT:    %6 = begin_access [deinit] [static] %5 : $*Builtin.Int32 // user: %7
 // CHECK-NEXT:    %2 = load %1 : $*C                              // user: %3
-// CHECK-NEXT:  r=1,w=0,se=0
+// CHECK-NEXT:  r=1,w=0
 sil hidden @testDeinitInstVsNonAddressValue : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : $C):
   %1 = global_addr @globalC : $*C
@@ -169,7 +169,7 @@ struct Int64Wrapper {
 // CHECK: PAIR #2.
 // CHECK:     %1 = begin_access [modify] [static] %0 : $*Int64Wrapper // users: %7, %2
 // CHECK:     %3 = begin_access [read] [static] %2 : $*Int64  // users: %6, %4
-// CHECK:   r=0,w=1,se=1
+// CHECK:   r=0,w=1
 // CHECK: PAIR #3.
 sil @testNestedAccessWithInterposedProjection : $@convention(thin) (@inout Int64Wrapper) -> () {
 bb0(%0 : $*Int64Wrapper):
@@ -188,15 +188,15 @@ bb0(%0 : $*Int64Wrapper):
 // CHECK:      PAIR #0.
 // CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
-// CHECK-NEXT:   r=0,w=1,se=1
+// CHECK-NEXT:   r=0,w=1
 // CHECK:      PAIR #1.
 // CHECK-NEXT:    copy_addr %1 to [initialization] %0 : $*C
 // CHECK-NEXT:    %1 = argument of bb0 : $*C
-// CHECK-NEXT:    r=1,w=0,se=0
+// CHECK-NEXT:    r=1,w=0
 // CHECK:      PAIR #2.
 // CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*C
 // CHECK-NEXT:   %2 = argument of bb0 : $*C
-// CHECK-NEXT:   r=0,w=0,se=0
+// CHECK-NEXT:   r=0,w=0
 sil @test_copy_addr_initialize : $@convention(thin) (@inout C, @inout C) -> @out C {
 bb0(%0 : $*C, %1 : $*C, %2: $*C):
   copy_addr %1 to [initialization] %0 : $*C
@@ -208,15 +208,15 @@ bb0(%0 : $*C, %1 : $*C, %2: $*C):
 // CHECK:      PAIR #0.
 // CHECK-NEXT:   copy_addr %1 to %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
-// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK-NEXT:   r=1,w=1
 // CHECK:      PAIR #1.
 // CHECK-NEXT:    copy_addr %1 to %0 : $*C
 // CHECK-NEXT:    %1 = argument of bb0 : $*C
-// CHECK-NEXT:    r=1,w=1,se=1
+// CHECK-NEXT:    r=1,w=1
 // CHECK:      PAIR #2.
 // CHECK-NEXT:   copy_addr %1 to %0 : $*C
 // CHECK-NEXT:   %2 = argument of bb0 : $*C
-// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK-NEXT:   r=1,w=1
 sil @test_copy_addr_assign : $@convention(thin) (@inout C, @inout C, @inout C) -> () {
 bb0(%0 : $*C, %1 : $*C, %2: $*C):
   copy_addr %1 to %0 : $*C
@@ -228,15 +228,15 @@ bb0(%0 : $*C, %1 : $*C, %2: $*C):
 // CHECK:      PAIR #0.
 // CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
-// CHECK-NEXT:   r=0,w=1,se=1
+// CHECK-NEXT:   r=0,w=1
 // CHECK:      PAIR #1.
 // CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
 // CHECK-NEXT:   %1 = argument of bb0 : $*C
-// CHECK-NEXT:   r=1,w=1,se=1
+// CHECK-NEXT:   r=1,w=1
 // CHECK:      PAIR #2.
 // CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
 // CHECK-NEXT:   %2 = argument of bb0 : $*C
-// CHECK-NEXT:   r=0,w=0,se=0
+// CHECK-NEXT:   r=0,w=0
 sil @test_copy_addr_take : $@convention(thin) (@in C, @inout C) -> @out C {
 bb0(%0 : $*C, %1 : $*C, %2: $*C):
   copy_addr [take] %1 to [initialization] %0 : $*C

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -13,7 +13,11 @@ class X {
 }
 
 sil @unknown_func : $@convention(thin) (Int32, @in Int32) -> ()
-
+sil @single_indirect_arg : $@convention(thin) (@in Int32) -> Int32
+sil @single_indirect_arg_and_error : $@convention(thin) (@in Int32) -> (Int32, @error Error)
+sil @single_indirect_arg_coroutine : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
+sil @indirect_arg_and_ptr : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
+sil @single_reference : $@convention(thin) (@guaranteed X) -> Int32
 sil @nouser_func : $@convention(thin) () -> ()
 
 sil @store_to_int : $@convention(thin) (Int32, @inout Int32) -> () {
@@ -160,6 +164,144 @@ bb0(%0 : $X):
   return %6 : $()
 }
 
+// CHECK-LABEL:  @allocstack_and_copyaddr
+// CHECK:        PAIR #0.
+// CHECK-NEXT:     %4 = apply %3(%0) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #1.
+// CHECK-NEXT:     %4 = apply %3(%0) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:     %1 = alloc_stack $Int32
+// CHECK-NEXT:     r=0,w=0
+sil @allocstack_and_copyaddr : $@convention(thin) (@in Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %1 = alloc_stack $Int32
+  copy_addr %0 to %1 : $*Int32
+  %3 = function_ref @single_indirect_arg : $@convention(thin) (@in Int32) -> Int32
+  %4 = apply %3(%0) : $@convention(thin) (@in Int32) -> Int32
+  dealloc_stack %1 : $*Int32
+  return %4 : $Int32
+}
+
+// CHECK-LABEL:  @inout_and_copyaddr
+// CHECK:        PAIR #0.
+// CHECK-NEXT:       %4 = apply %3(%0) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #1.
+// CHECK-NEXT:       %4 = apply %3(%0) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:     %1 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=0,w=0
+sil @inout_and_copyaddr : $@convention(thin) (@in Int32, @inout Int32) -> Int32 {
+bb0(%0 : $*Int32, %1 : $*Int32):
+  copy_addr %0 to %1 : $*Int32
+  %3 = function_ref @single_indirect_arg : $@convention(thin) (@in Int32) -> Int32
+  %4 = apply %3(%0) : $@convention(thin) (@in Int32) -> Int32
+  return %4 : $Int32
+}
+
+// CHECK-LABEL:  @esacping_allocstack_and_copyaddr
+// CHECK:        PAIR #0.
+// CHECK-NEXT:       %5 = apply %4(%0, %3) : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #1.
+// CHECK-NEXT:       %5 = apply %4(%0, %3) : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
+// CHECK-NEXT:       %1 = alloc_stack $Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #2.
+// CHECK-NEXT:       %5 = apply %4(%0, %3) : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
+// CHECK-NEXT:       %3 = address_to_pointer %1 : $*Int32 to $Builtin.RawPointer
+// CHECK-NEXT:     r=1,w=1
+sil @esacping_allocstack_and_copyaddr : $@convention(thin) (@in Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %1 = alloc_stack $Int32
+  copy_addr %0 to %1 : $*Int32
+  %3 = address_to_pointer %1 : $*Int32 to $Builtin.RawPointer
+  %4 = function_ref @indirect_arg_and_ptr : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
+  %5 = apply %4(%0, %3) : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
+  dealloc_stack %1 : $*Int32
+  return %5 : $Int32
+}
+
+
+// CHECK-LABEL:  @tryapply_allocstack_and_copyaddr
+// CHECK:        PAIR #0.
+// CHECK-NEXT:       try_apply %3(%0) : $@convention(thin) (@in Int32) -> (Int32, @error Error), normal bb1, error bb2
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #1.
+// CHECK-NEXT:       try_apply %3(%0) : $@convention(thin) (@in Int32) -> (Int32, @error Error), normal bb1, error bb2
+// CHECK-NEXT:       %1 = alloc_stack $Int32
+// CHECK-NEXT:     r=0,w=0
+sil @tryapply_allocstack_and_copyaddr : $@convention(thin) (@in Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %1 = alloc_stack $Int32
+  copy_addr %0 to %1 : $*Int32
+  %3 = function_ref @single_indirect_arg_and_error : $@convention(thin) (@in Int32) -> (Int32, @error Error)
+  try_apply %3(%0) : $@convention(thin) (@in Int32) -> (Int32, @error Error), normal bb1, error bb2
+bb1(%5 : $Int32):
+  dealloc_stack %1 : $*Int32
+  return %5 : $Int32
+bb2(%8 : $Error):
+  unreachable
+}
+
+
+// CHECK-LABEL:  @beginapply_allocstack_and_copyaddr
+// CHECK:        PAIR #0.
+// CHECK-NEXT:       (%4, %5) = begin_apply %3(%0) : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #1.
+// CHECK-NEXT:       (%4, %5) = begin_apply %3(%0) : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
+// CHECK-NEXT:       %1 = alloc_stack $Int32
+// CHECK-NEXT:     r=0,w=0
+// CHECK:        PAIR #3.
+// CHECK-NEXT:       end_apply %5
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #4.
+// CHECK-NEXT:       end_apply %5
+// CHECK-NEXT:       %1 = alloc_stack $Int32
+// CHECK-NEXT:     r=0,w=0
+// CHECK:        PAIR #8.
+// CHECK-NEXT:       abort_apply %5
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #9.
+// CHECK-NEXT:       abort_apply %5
+// CHECK-NEXT:       %1 = alloc_stack $Int32
+// CHECK-NEXT:     r=0,w=0
+sil @beginapply_allocstack_and_copyaddr : $@convention(thin) (@in Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %1 = alloc_stack $Int32
+  copy_addr %0 to %1 : $*Int32
+  %3 = function_ref @single_indirect_arg_coroutine : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
+  (%4, %5) = begin_apply %3(%0) : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
+  cond_br undef, bb1, bb2
+bb1:
+  end_apply %5
+  dealloc_stack %1 : $*Int32
+  return %4 : $Int32
+bb2:
+  abort_apply %5
+  unreachable
+}
+
+// CHECK-LABEL: @refelementaddr_and_reference
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %3 = apply %2(%0) : $@convention(thin) (@guaranteed X) -> Int32
+// CHECK-NEXT:      %1 = ref_element_addr %0 : $X, #X.a
+// CHECK-NEXT:    r=1,w=1
+sil @refelementaddr_and_reference : $@convention(thin) (@guaranteed X) -> Int32 {
+bb0(%0 : $X):
+  %1 = ref_element_addr %0 : $X, #X.a
+  %2 = function_ref @single_reference : $@convention(thin) (@guaranteed X) -> Int32
+  %3 = apply %2(%0) : $@convention(thin) (@guaranteed X) -> Int32
+  return %3 : $Int32
+}
+
 sil @load_from_in : $@convention(thin) (@in X) -> () {
 bb0(%0 : $*X):
   %1 = load %0 : $*X
@@ -187,6 +329,28 @@ bb0:
   dealloc_stack %0 : $*TwoInts
   %r = tuple()
   return %r : $()
+}
+
+// CHECK-LABEL:  @non_overlapping_struct_fields
+// CHECK:        PAIR #0.
+// CHECK-NEXT:       %4 = apply %3(%1) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:     %0 = argument of bb0 : $*TwoInts
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #1.
+// CHECK-NEXT:       %4 = apply %3(%1) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:       %1 = struct_element_addr %0 : $*TwoInts, #TwoInts.i1
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #2.
+// CHECK-NEXT:       %4 = apply %3(%1) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:       %2 = struct_element_addr %0 : $*TwoInts, #TwoInts.i2
+// CHECK-NEXT:     r=0,w=0
+sil @non_overlapping_struct_fields : $@convention(thin) (@in TwoInts) -> Int32 {
+bb0(%0 : $*TwoInts):
+  %1 = struct_element_addr %0 : $*TwoInts, #TwoInts.i1
+  %2 = struct_element_addr %0 : $*TwoInts, #TwoInts.i2
+  %3 = function_ref @single_indirect_arg : $@convention(thin) (@in Int32) -> Int32
+  %4 = apply %3(%1) : $@convention(thin) (@in Int32) -> Int32
+  return %4 : $Int32
 }
 
 sil @copy_ints : $@convention(thin) (@inout Int32, @inout Int32) -> () {

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -35,11 +35,11 @@ bb0(%0 : $X):
 // CHECK:     PAIR #1.
 // CHECK-NEXT:   %4 = apply %3(%0, %1) : $@convention(thin) (Int32, @in Int32) -> ()
 // CHECK-NEXT:   %1 = argument of bb0 : $*Int32{{.*}}                  // user: %4
-// CHECK-NEXT:  r=1,w=1,se=1
+// CHECK-NEXT:  r=1,w=1
 // CHECK:     PAIR #2.
 // CHECK-NEXT:   %4 = apply %3(%0, %1) : $@convention(thin) (Int32, @in Int32) -> ()
 // CHECK-NEXT:   %2 = argument of bb0 : $*Int32
-// CHECK-NEXT:  r=0,w=0,se=0
+// CHECK-NEXT:  r=0,w=0
 sil @call_unknown_func : $@convention(thin) (Int32, @in Int32, @in Int32) -> () {
 bb0(%0 : $Int32, %1 : $*Int32, %2 : $*Int32):
   %3 = function_ref @unknown_func : $@convention(thin) (Int32, @in Int32) -> ()
@@ -53,11 +53,11 @@ bb0(%0 : $Int32, %1 : $*Int32, %2 : $*Int32):
 // CHECK:     PAIR #1.
 // CHECK-NEXT:   %4 = apply %3(%0, %1) : $@convention(thin) (Int32, @inout Int32) -> ()
 // CHECK-NEXT:   %1 = argument of bb0 : $*Int32{{.*}}                  // user: %4
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 // CHECK:     PAIR #2.
 // CHECK-NEXT:   %4 = apply %3(%0, %1) : $@convention(thin) (Int32, @inout Int32) -> ()
 // CHECK-NEXT:   %2 = argument of bb0 : $*Int32
-// CHECK-NEXT:  r=0,w=0,se=0
+// CHECK-NEXT:  r=0,w=0
 sil @call_store_to_int_not_aliased : $@convention(thin) (Int32, @inout Int32, @in Int32) -> () {
 bb0(%0 : $Int32, %1 : $*Int32, %2 : $*Int32):
   %3 = function_ref @store_to_int : $@convention(thin) (Int32, @inout Int32) -> ()
@@ -71,11 +71,11 @@ bb0(%0 : $Int32, %1 : $*Int32, %2 : $*Int32):
 // CHECK:     PAIR #3.
 // CHECK-NEXT:   %6 = apply %5(%0, %3) : $@convention(thin) (Int32, @inout Int32) -> ()
 // CHECK-NEXT:   %3 = ref_element_addr %1 : $X, #X.a{{.*}}             // user: %6
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 // CHECK:     PAIR #4.
 // CHECK-NEXT:   %6 = apply %5(%0, %3) : $@convention(thin) (Int32, @inout Int32) -> ()
 // CHECK-NEXT:   %4 = ref_element_addr %2 : $X, #X.a
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 sil @call_store_to_int_aliased : $@convention(thin) (Int32, @guaranteed X, @guaranteed X) -> () {
 bb0(%0 : $Int32, %1 : $X, %2 : $X):
   %3 = ref_element_addr %1 : $X, #X.a
@@ -100,7 +100,7 @@ bb0(%0 : $X, %1 : $X):
 // CHECK:     PAIR #1
 // CHECK-NEXT:   %3 = apply %2() : $@convention(thin) () -> ()
 // CHECK-NEXT:   %1 = alloc_stack $Int32{{.*}}                         // user: %5
-// CHECK-NEXT:  r=0,w=0,se=0
+// CHECK-NEXT:  r=0,w=0
 sil @allocstack_apply_no_side_effect : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
   %1 = alloc_stack $Int32                         // user: %5
@@ -115,7 +115,7 @@ bb0(%0 : $Int32):
 // CHECK: PAIR #1.
 // CHECK-NEXT:   %3 = apply %2(%0, %1) : $@convention(thin) (Int32, @inout Int32) -> ()
 // CHECK-NEXT:   %1 = alloc_stack $Int32
-// CHECK-NEXT:  r=0,w=1,se=1
+// CHECK-NEXT:  r=0,w=1
 sil @allocstack_apply_side_effect : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
   %1 = alloc_stack $Int32                         // users: %3, %5
@@ -131,7 +131,7 @@ bb0(%0 : $Int32):
 // CHECK: PAIR #1.
 // CHECK-NEXT:   %3 = apply %2() : $@convention(thin) () -> ()
 // CHECK-NEXT:   %1 = alloc_stack $Int32{{.*}}                    // users: %7, %5
-// CHECK-NEXT:  r=0,w=0,se=0
+// CHECK-NEXT:  r=0,w=0
 sil @allocstack_apply_no_escaping : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
   %1 = alloc_stack $Int32                         // users: %3, %5
@@ -148,7 +148,7 @@ bb0(%0 : $Int32):
 // CHECK:     PAIR #1.
 // CHECK-NEXT:   %4 = apply %3(%1) : $@convention(thin) (@in X) -> ()
 // CHECK-NEXT:   %1 = alloc_stack $X{{.*}}                      // users: %5, %4, %2
-// CHECK-NEXT: r=1,w=0,se=0
+// CHECK-NEXT: r=1,w=0
 sil @allocstack_apply_read_only : $@convention(thin) (X) -> () {
 bb0(%0 : $X):
   %1 = alloc_stack $X
@@ -176,7 +176,7 @@ struct TwoInts {
 // CHECK:     PAIR #0.
 // CHECK-NEXT:   %4 = apply %3(%1, %2) : $@convention(thin) (@inout Int32, @inout Int32) -> ()
 // CHECK-NEXT:   %0 = alloc_stack $TwoInts{{.*}}                // users: %5, %2, %1
-// CHECK-NEXT: r=1,w=1,se=1
+// CHECK-NEXT: r=1,w=1
 sil @combination_of_read_and_write_effects : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $TwoInts
@@ -201,7 +201,7 @@ bb0(%0 : $*Int32, %1 : $*Int32):
 // CHECK:      PAIR #0.
 // CHECK-NEXT:    %2 = apply %1(%0) : $@convention(thin) (@in_guaranteed Int) -> ()
 // CHECK-NEXT:    %0 = argument of bb0 : $*Int
-// CHECK-NEXT:  r=1,w=0,se=0
+// CHECK-NEXT:  r=1,w=0
 sil @test_in_guaranteed_only_fun_is_ro_sink : $@convention(thin) (Int) -> ()
 sil @test_in_guaranteed_only_fun_is_ro_callee : $@convention(thin) (@in_guaranteed Int) -> ()
 

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -210,12 +210,10 @@ sil hidden_external @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
 // It should contain alloc_ref and alloc_stack instructions using opened archetypes.
 // CHECK-LABEL: sil @bar
 // CHECK: open_existential{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
-// CHECK: alloc_stack{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
 // CHECK: alloc_ref{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
 // CHECK-NOT: function_ref @use
 // CHECK: function_ref @use 
 // CHECK-NOT: function_ref
-// CHECK: dealloc_stack{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
 // CHECK: strong_release{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
 // CHECK: dealloc_ref{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
 // CHECK: end sil function 'bar' 

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -245,8 +245,10 @@ internal class OtherClass {
 // CHECK: load [[S11]] 
 // CHECK: [[R2:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg2
 // CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[R2]] : $*GenericPropProtocol to $*@opened("{{.*}}") GenericPropProtocol
+// CHECK: [[T1:%.*]] = alloc_stack $@opened
+// CHECK: copy_addr [[O2]] to [initialization] [[T1]]
 // CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}") GenericPropProtocol, #GenericPropProtocol.val!getter : <Self where Self : GenericPropProtocol> (Self) -> () -> Int, [[O2]] : $*@opened("{{.*}}") GenericPropProtocol : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
-// CHECK: apply [[W2]]<@opened("{{.*}}") GenericPropProtocol>([[O2]]) : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W2]]<@opened("{{.*}}") GenericPropProtocol>([[T1]]) : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: integer_literal
 // CHECK: builtin
@@ -265,8 +267,10 @@ internal class OtherClass {
 // CHECK: cond_fail
 // CHECK: [[R5:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg4
 // CHECK: [[O5:%.*]] = open_existential_addr immutable_access [[R5]] : $*GenericNestedPropProtocol to $*@opened("{{.*}}") GenericNestedPropProtocol
+// CHECK: [[T2:%.*]] = alloc_stack $@opened
+// CHECK: copy_addr [[O5]] to [initialization] [[T2]]
 // CHECK: [[W5:%.*]] = witness_method $@opened("{{.*}}") GenericNestedPropProtocol, #GenericNestedPropProtocol.val!getter : <Self where Self : GenericNestedPropProtocol> (Self) -> () -> Int, [[O5:%.*]] : $*@opened("{{.*}}") GenericNestedPropProtocol : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int 
-// CHECK: apply [[W5]]<@opened("{{.*}}") GenericNestedPropProtocol>([[O5]]) : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W5]]<@opened("{{.*}}") GenericNestedPropProtocol>([[T2]]) : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: builtin
 // CHECK: tuple_extract
@@ -333,8 +337,10 @@ internal class OtherKlass {
 // CHECK: integer_literal
 // CHECK: [[R1:%.*]] = ref_element_addr [[ARG]] : $OtherKlass, #OtherKlass.arg2
 // CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[R1]] : $*AGenericProtocol to $*@opened("{{.*}}") AGenericProtocol
+// CHECK: [[T1:%.*]] = alloc_stack $@opened
+// CHECK: copy_addr [[O1]] to [initialization] [[T1]]
 // CHECK: [[W1:%.*]] = witness_method $@opened("{{.*}}") AGenericProtocol, #AGenericProtocol.val!getter : <Self where Self : AGenericProtocol> (Self) -> () -> Int, [[O1]] : $*@opened("{{.*}}") AGenericProtocol : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
-// CHECK: apply [[W1]]<@opened("{{.*}}") AGenericProtocol>([[O1]]) : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W1]]<@opened("{{.*}}") AGenericProtocol>([[T1]]) : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: integer_literal
 // CHECK: builtin

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -229,7 +229,6 @@ func nonResilient() -> some ExternalP2 {
 
 // CHECK-LABEL: sil @$s1A019usePairResilientNonC0yyF : $@convention(thin) () -> ()
 // CHECK: alloc_stack $Pair<MyInt64, @_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0)
-// CHECK: cond_fail
 // CHECK: [[USEP:%.*]] = function_ref @$s1A4usePyyxAA1PRzlFs5Int64V_Tg5
 // CHECK: [[FIRST_MYVALUE3:%.*]] = struct $Int64
 // CHECK: apply [[USEP]]([[FIRST_MYVALUE3]])

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -14,7 +14,9 @@ struct GS<Base> {
   var _value: Builtin.Int64
 }
 
-class Klass {}
+class Klass {
+  @_hasStorage var a: String
+}
 
 struct Str {
   var kl: Klass
@@ -22,6 +24,7 @@ struct Str {
 }
 
 sil @unknown : $@convention(thin) () -> ()
+sil @load_string : $@convention(thin) (@in_guaranteed String) -> String
 
 sil @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
 bb0(%0 : $*Klass):
@@ -331,6 +334,23 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   dealloc_stack %4 : $*GS<B>
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @consider_implicit_aliases_in_callee
+// CHECK:         alloc_stack
+// CHECK-NEXT:    copy_addr
+// CHECK:       } // end sil function 'consider_implicit_aliases_in_callee'
+
+sil [ossa] @consider_implicit_aliases_in_callee : $@convention(thin) (@guaranteed Klass) -> String {
+bb0(%0 : @guaranteed $Klass):
+  %1 = ref_element_addr %0 : $Klass, #Klass.a
+  %2 = alloc_stack $String
+  copy_addr %1 to [initialization] %2 : $*String
+  %f = function_ref @load_string : $@convention(thin) (@in_guaranteed String) -> String
+  %a = apply %f(%2) : $@convention(thin) (@in_guaranteed String) -> String
+  destroy_addr %2 : $*String
+  dealloc_stack %2 : $*String
+  return %a : $String
 }
 
 // Test temp RValue elimination on switches.

--- a/test/SILOptimizer/temp_rvalue_opt.swift
+++ b/test/SILOptimizer/temp_rvalue_opt.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+var global: Any = 1
+func withValue(action: (Any) -> Void) {
+  action(global)
+}
+
+@inline(never)
+public func test_global_side_effect() {
+  withValue { value in
+      print(value)
+      global = 24
+      print(value)
+  }
+}
+
+// CHECK:      1
+// CHECK-NEXT: 1
+test_global_side_effect()


### PR DESCRIPTION
Why include an optimization improvement and a correctness fix in one PR?
Unfortunately the correctness fix makes TempRValueElimination more conservative and this can cause some performance regressions. To compensate for this, I improved the handling of apply instructions in MemBehavior.

This change fixes a miscompile in case the source of the optimized copy_addr is modified in a called function via an invisible alias. This can happen with class properties or global variables.

This fix removes the special handling of function parameters, which was just wrong.
Instead it simply uses the alias analysis API to check for modifications of the source object.

The changes to improve MemBehavior for apply instructions include:
1. Do a better alias analysis for "function-local" objects, like alloc_stack and inout parameters
2. Fully support try_apply and begin/end/abort_apply

For details, see the commit messages.

rdar://problem/69605657