### PR TITLE
[build] Add lldb-smoketest mixin to buildbot_incremental,tools=RA,stdlib=RA

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -342,6 +342,7 @@ watchos
 mixin-preset=
     buildbot_incremental_base_all_platforms
     mixin_buildbot_install_components_with_clang
+    lldb-smoketest,tools=RA
 
 build-subdir=buildbot_incremental
 


### PR DESCRIPTION
Adds `lldb-smoketest` mixin to `buildbot_incremental,tools=RA,stdlib=RA`. The definition of `lldb-smoketest` is:

```
lldb
lldb-no-debugserver
lldb-use-system-debugserver
lldb-build-type=Release
lldb-test-swift-only
lldb-assertions
```

For both apple/swift PRs and apple/llvm-project PRs to swift branches, this reduces the chance of silent breaks to lldb's build, or its swift specific tests.

It's expected a follow up change will create a new expanded preset for apple/llvm-project PRs, to test lldb more completely.