### PR TITLE
SILGen: Fix crash when a stored property with an initial value has a reabstractable type

### DIFF
--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -307,6 +307,39 @@ public:
   void finishUninitialized(SILGenFunction &SGF) override;
 };
 
+/// A "null" initialization that indicates that any value being initialized
+/// into this initialization should be discarded. This represents AnyPatterns
+/// (that is, 'var (_)') that bind to values without storing them.
+class BlackHoleInitialization : public Initialization {
+public:
+  BlackHoleInitialization() {}
+
+  bool canSplitIntoTupleElements() const override {
+    return true;
+  }
+  
+  MutableArrayRef<InitializationPtr>
+  splitIntoTupleElements(SILGenFunction &SGF, SILLocation loc,
+                         CanType type,
+                         SmallVectorImpl<InitializationPtr> &buf) override {
+    // "Destructure" an ignored binding into multiple ignored bindings.
+    for (auto fieldType : cast<TupleType>(type)->getElementTypes()) {
+      (void) fieldType;
+      buf.push_back(InitializationPtr(new BlackHoleInitialization()));
+    }
+    return buf;
+  }
+
+  void copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
+                           ManagedValue value, bool isInit) override {
+    /// This just ignores the provided value.
+  }
+
+  void finishUninitialized(SILGenFunction &SGF) override {
+    // do nothing
+  }
+};
+
 } // end namespace Lowering
 } // end namespace swift
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -901,68 +901,66 @@ static ManagedValue emitSelfForMemberInit(SILGenFunction &SGF, SILLocation loc,
                                          SGFAccessKind::Write);
 }
 
-static LValue emitLValueForMemberInit(SILGenFunction &SGF, SILLocation loc,
-                                      VarDecl *selfDecl,
-                                      VarDecl *property) {
-  CanType selfFormalType = selfDecl->getType()->getCanonicalType();
-  auto self = emitSelfForMemberInit(SGF, loc, selfDecl);
-  return SGF.emitPropertyLValue(loc, self, selfFormalType, property,
-                                LValueOptions(), SGFAccessKind::Write,
-                                AccessSemantics::DirectToStorage);
-}
-
-/// Emit a member initialization for the members described in the
-/// given pattern from the given source value.
-static void emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl,
-                           Pattern *pattern, RValue &&src) {
+// FIXME: Can emitMemberInit() share code with InitializationForPattern in
+// SILGenDecl.cpp? Note that this version operates on stored properties of
+// types, whereas the former only knows how to handle local bindings, but
+// we could generalize it.
+static InitializationPtr
+emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl, Pattern *pattern) {
   switch (pattern->getKind()) {
   case PatternKind::Paren:
     return emitMemberInit(SGF, selfDecl,
-                          cast<ParenPattern>(pattern)->getSubPattern(),
-                          std::move(src));
+                          cast<ParenPattern>(pattern)->getSubPattern());
 
   case PatternKind::Tuple: {
+    TupleInitialization *init = new TupleInitialization();
     auto tuple = cast<TuplePattern>(pattern);
-    auto fields = tuple->getElements();
-
-    SmallVector<RValue, 4> elements;
-    std::move(src).extractElements(elements);
-    for (unsigned i = 0, n = fields.size(); i != n; ++i) {
-      emitMemberInit(SGF, selfDecl, fields[i].getPattern(),
-                     std::move(elements[i]));
+    for (auto &elt : tuple->getElements()) {
+      init->SubInitializations.push_back(
+        emitMemberInit(SGF, selfDecl, elt.getPattern()));
     }
-    break;
+    return InitializationPtr(init);
   }
 
   case PatternKind::Named: {
     auto named = cast<NamedPattern>(pattern);
-    // Form the lvalue referencing this member.
-    FormalEvaluationScope scope(SGF);
-    LValue memberRef = emitLValueForMemberInit(SGF, pattern, selfDecl,
-                                               named->getDecl());
 
-    // Assign to it.
-    SGF.emitAssignToLValue(pattern, std::move(src), std::move(memberRef));
-    return;
+    auto self = emitSelfForMemberInit(SGF, pattern, selfDecl);
+
+    auto *field = named->getDecl();
+
+    auto selfTy = self.getType();
+    auto fieldTy =
+      selfTy.getFieldType(field, SGF.SGM.M, SGF.getTypeExpansionContext());
+    SILValue slot;
+
+    if (auto *structDecl = dyn_cast<StructDecl>(field->getDeclContext())) {
+      slot = SGF.B.createStructElementAddr(pattern, self.forward(SGF), field,
+                                           fieldTy.getAddressType());
+    } else {
+      assert(isa<ClassDecl>(field->getDeclContext()));
+      slot = SGF.B.createRefElementAddr(pattern, self.forward(SGF), field,
+                                        fieldTy.getAddressType());
+    }
+
+    return InitializationPtr(new KnownAddressInitialization(slot));
   }
 
   case PatternKind::Any:
-    return;
+    return InitializationPtr(new BlackHoleInitialization());;
 
   case PatternKind::Typed:
     return emitMemberInit(SGF, selfDecl,
-                          cast<TypedPattern>(pattern)->getSubPattern(),
-                          std::move(src));
+                          cast<TypedPattern>(pattern)->getSubPattern());
 
   case PatternKind::Binding:
     return emitMemberInit(SGF, selfDecl,
-                          cast<BindingPattern>(pattern)->getSubPattern(),
-                          std::move(src));
+                          cast<BindingPattern>(pattern)->getSubPattern());
 
 #define PATTERN(Name, Parent)
 #define REFUTABLE_PATTERN(Name, Parent) case PatternKind::Name:
 #include "swift/AST/PatternNodes.def"
-    llvm_unreachable("Refutable pattern in pattern binding");
+    llvm_unreachable("Refutable pattern in stored property pattern binding");
   }
 }
 
@@ -991,6 +989,46 @@ getInitializationTypeInContext(
   return std::make_pair(origType, substType);
 }
 
+static void
+emitAndStoreInitialValueInto(SILGenFunction &SGF,
+                             SILLocation loc,
+                             PatternBindingDecl *pbd, unsigned i,
+                             SubstitutionMap subs,
+                             AbstractionPattern origType,
+                             CanType substType,
+                             Initialization *init) {
+  bool injectIntoWrapper = false;
+  if (auto singleVar = pbd->getSingleVar()) {
+    auto originalVar = singleVar->getOriginalWrappedProperty();
+    if (originalVar &&
+        originalVar->isPropertyMemberwiseInitializedWithWrappedType()) {
+      injectIntoWrapper = true;
+    }
+  }
+
+  SGFContext C = (injectIntoWrapper ? SGFContext() : SGFContext(init));
+
+  RValue result = SGF.emitApplyOfStoredPropertyInitializer(
+                            pbd->getExecutableInit(i),
+                            pbd->getAnchoringVarDecl(i),
+                            subs, substType, origType, C);
+
+  // need to store result into the init if its in context
+
+  // If we have the backing storage for a property with an attached
+  // property wrapper initialized with `=`, inject the value into an
+  // instance of the wrapper.
+  if (injectIntoWrapper) {
+    auto *singleVar = pbd->getSingleVar();
+    result = maybeEmitPropertyWrapperInitFromValue(
+        SGF, pbd->getExecutableInit(i),
+        singleVar, subs, std::move(result));
+  }
+
+  if (!result.isInContext())
+    std::move(result).forwardInto(SGF, loc, init);
+}
+
 void SILGenFunction::emitMemberInitializers(DeclContext *dc,
                                             VarDecl *selfDecl,
                                             NominalTypeDecl *nominal) {
@@ -1006,6 +1044,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         if (!init) continue;
 
         auto *varPattern = pbd->getPattern(i);
+
         // Cleanup after this initialization.
         FullExpr scope(Cleanups, varPattern);
 
@@ -1016,26 +1055,11 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         AbstractionPattern origType = resultType.first;
         CanType substType = resultType.second;
 
-        // FIXME: Can emitMemberInit() share code with
-        // InitializationForPattern in SILGenDecl.cpp?
-        RValue result = emitApplyOfStoredPropertyInitializer(
-                                  init, pbd->getAnchoringVarDecl(i), subs,
-                                  substType, origType,
-                                  SGFContext());
+        // Figure out what we're initializing.
+        auto memberInit = emitMemberInit(*this, selfDecl, varPattern);
 
-        // If we have the backing storage for a property with an attached
-        // property wrapper initialized with `=`, inject the value into an
-        // instance of the wrapper.
-        if (auto singleVar = pbd->getSingleVar()) {
-          auto originalVar = singleVar->getOriginalWrappedProperty();
-          if (originalVar &&
-              originalVar->isPropertyMemberwiseInitializedWithWrappedType()) {
-            result = maybeEmitPropertyWrapperInitFromValue(
-                *this, init, singleVar, subs, std::move(result));
-          }
-        }
-
-        emitMemberInit(*this, selfDecl, varPattern, std::move(result));
+        emitAndStoreInitialValueInto(*this, varPattern, pbd, i, subs,
+                                     origType, substType, memberInit.get());
       }
     }
   }

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1354,7 +1354,25 @@ Lowering::canPeepholeConversions(SILGenFunction &SGF,
   switch (outerConversion.getKind()) {
   case Conversion::OrigToSubst:
   case Conversion::SubstToOrig:
-    // TODO: peephole these when the abstraction patterns are the same!
+    switch (innerConversion.getKind()) {
+    case Conversion::OrigToSubst:
+    case Conversion::SubstToOrig:
+      if (innerConversion.getKind() == outerConversion.getKind())
+        break;
+
+      if (innerConversion.getReabstractionOrigType().getCachingKey() !=
+          outerConversion.getReabstractionOrigType().getCachingKey() ||
+          innerConversion.getReabstractionSubstType() !=
+          outerConversion.getReabstractionSubstType()) {
+        break;
+      }
+
+      return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
+
+    default:
+      break;
+    }
+
     return None;
 
   case Conversion::AnyErasure:

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1255,7 +1255,7 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
     switch (elt.getKind()) {
     case StmtConditionElement::CK_PatternBinding: {
       InitializationPtr initialization =
-      InitializationForPattern(*this, FalseDest).visit(elt.getPattern());
+        emitPatternBindingInitialization(elt.getPattern(), FalseDest);
 
       // Emit the initial value into the initialization.
       FullExpr Scope(Cleanups, CleanupLocation(elt.getInitializer()));

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -39,41 +39,6 @@ using namespace Lowering;
 void Initialization::_anchor() {}
 void SILDebuggerClient::anchor() {}
 
-namespace {
-  /// A "null" initialization that indicates that any value being initialized
-  /// into this initialization should be discarded. This represents AnyPatterns
-  /// (that is, 'var (_)') that bind to values without storing them.
-  class BlackHoleInitialization : public Initialization {
-  public:
-    BlackHoleInitialization() {}
-
-    bool canSplitIntoTupleElements() const override {
-      return true;
-    }
-    
-    MutableArrayRef<InitializationPtr>
-    splitIntoTupleElements(SILGenFunction &SGF, SILLocation loc,
-                           CanType type,
-                           SmallVectorImpl<InitializationPtr> &buf) override {
-      // "Destructure" an ignored binding into multiple ignored bindings.
-      for (auto fieldType : cast<TupleType>(type)->getElementTypes()) {
-        (void) fieldType;
-        buf.push_back(InitializationPtr(new BlackHoleInitialization()));
-      }
-      return buf;
-    }
-
-    void copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
-                             ManagedValue value, bool isInit) override {
-      /// This just ignores the provided value.
-    }
-
-    void finishUninitialized(SILGenFunction &SGF) override {
-      // do nothing
-    }
-  };
-} // end anonymous namespace
-
 static void copyOrInitValueIntoHelper(
     SILGenFunction &SGF, SILLocation loc, ManagedValue value, bool isInit,
     ArrayRef<InitializationPtr> subInitializations,

--- a/test/IRGen/generic_structs.swift
+++ b/test/IRGen/generic_structs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-type-layout -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize -DINT_32=i32
+// RUN: %target-swift-frontend -disable-type-layout -primary-file %s -emit-ir
 
 struct A<T1, T2>
 {
@@ -37,13 +37,3 @@ public struct GenericStruct<T : Proto> {
 
   public init() {}
 }
-
-// CHECK-LABEL: define{{.*}} swiftcc void @"$s15generic_structs13GenericStructVACyxGycfC"
-// CHECK:  [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s15generic_structs13GenericStructVMa"([[INT]] 0, %swift.type* %T, i8** %T.Proto)
-// CHECK:  [[TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to [[INT_32]]*
-// CHECK:  [[FIELDOFFSET:%.*]] = getelementptr inbounds [[INT_32]], [[INT_32]]* [[PTR]], [[INT]] [[IDX:6|10]]
-// CHECK:  [[OFFSET:%.*]] = load [[INT_32]], [[INT_32]]* [[FIELDOFFSET]]
-// CHECK:  [[ADDROFOPT:%.*]] = getelementptr inbounds i8, i8* {{.*}}, [[INT_32]] [[OFFSET]]
-// CHECK:  [[OPTPTR:%.*]] = bitcast i8* [[ADDROFOPT]] to %TSq*
-// CHECK:  call %TSq* @"$sxSg15generic_structs5ProtoRzlWOb"(%TSq* {{.*}}, %TSq* [[OPTPTR]]

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -177,8 +177,8 @@ struct AnythingGoes<T> {
 extension AnythingGoes where T : VeryConstrained {
   // CHECK-LABEL: sil hidden [ossa] @$s22constrained_extensions12AnythingGoesVA2A15VeryConstrainedRzlE13fromExtensionACyxGyt_tcfC : $@convention(method) <T where T : VeryConstrained> (@thin AnythingGoes<T>.Type) -> @out AnythingGoes<T> {
 
+  // CHECK: [[RESULT:%.*]] = struct_element_addr {{%.*}} : $*AnythingGoes<T>, #AnythingGoes.meaningOfLife
   // CHECK: [[INIT:%.*]] = function_ref @$s22constrained_extensions12AnythingGoesV13meaningOfLifexSgvpfi : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
-  // CHECK: [[RESULT:%.*]] = alloc_stack $Optional<T>
   // CHECK: apply [[INIT]]<T>([[RESULT]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
   // CHECK: return
   init(fromExtension: ()) {}

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -31,13 +31,13 @@ struct D {
 // CHECK: [[THISBOX:%[0-9]+]] = alloc_box ${ var D }
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
 // CHECK: [[PB_THIS:%.*]] = project_box [[THIS]]
+// CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.i
+// CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.j
 // CHECK: [[INIT:%[0-9]+]] = function_ref @$s19default_constructor1DV1iSivpfi
 // CHECK: [[RESULT:%[0-9]+]] = apply [[INIT]]()
 // CHECK: ([[INTVAL:%[0-9]+]], [[FLOATVAL:%[0-9]+]]) = destructure_tuple [[RESULT]]
-// CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.i
-// CHECK: assign [[INTVAL]] to [[IADDR]]
-// CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.j
-// CHECK: assign [[FLOATVAL]] to [[JADDR]]
+// CHECK: store [[INTVAL]] to [trivial] [[IADDR]]
+// CHECK: store [[FLOATVAL]] to [trivial] [[JADDR]]
 
 class E {
   var i = Int64()
@@ -55,13 +55,11 @@ class E {
 // CHECK-LABEL: sil hidden [ossa] @$s19default_constructor1EC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned E) -> @owned E
 // CHECK: bb0([[SELFIN:%[0-9]+]] : @owned $E)
 // CHECK: [[SELF:%[0-9]+]] = mark_uninitialized
-// CHECK: [[INIT:%[0-9]+]] = function_ref @$s19default_constructor1EC1is5Int64Vvpfi : $@convention(thin) () -> Int64
-// CHECK-NEXT: [[VALUE:%[0-9]+]] = apply [[INIT]]() : $@convention(thin) () -> Int64
 // CHECK-NEXT: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK-NEXT: [[IREF:%[0-9]+]] = ref_element_addr [[BORROWED_SELF]] : $E, #E.i
-// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[IREF]] : $*Int64
-// CHECK-NEXT: assign [[VALUE]] to [[WRITE]] : $*Int64
-// CHECK-NEXT: end_access [[WRITE]] : $*Int64
+// CHECK: [[INIT:%[0-9]+]] = function_ref @$s19default_constructor1EC1is5Int64Vvpfi : $@convention(thin) () -> Int64
+// CHECK-NEXT: [[VALUE:%[0-9]+]] = apply [[INIT]]() : $@convention(thin) () -> Int64
+// CHECK-NEXT: store [[VALUE]] to [trivial] [[IREF]] : $*Int64
 // CHECK-NEXT: end_borrow [[BORROWED_SELF]]
 // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]]
 // CHECK-NEXT: destroy_value [[SELF]]
@@ -103,8 +101,8 @@ struct H<T> {
   var opt: T?
 
   // CHECK-LABEL: sil hidden [ossa] @$s19default_constructor1HVyACyxGqd__clufC : $@convention(method) <T><U> (@in U, @thin H<T>.Type) -> @out H<T> {
+  // CHECK: [[OPT_T:%[0-9]+]] = struct_element_addr {{%.*}} : $*H<T>, #H.opt
   // CHECK: [[INIT_FN:%[0-9]+]] = function_ref @$s19default_constructor1HV3optxSgvpfi : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
-  // CHECK-NEXT: [[OPT_T:%[0-9]+]] = alloc_stack $Optional<T>
   // CHECK-NEXT: apply [[INIT_FN]]<T>([[OPT_T]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
   init<U>(_: U) { }
 }
@@ -115,10 +113,10 @@ struct I {
   var x: Int = 0
 
   // CHECK-LABEL: sil hidden [ossa] @$s19default_constructor1IVyACxclufC : $@convention(method) <T> (@in T, @thin I.Type) -> I {
+  // CHECK: [[X_ADDR:%[0-9]+]] = struct_element_addr {{.*}} : $*I, #I.x
   // CHECK: [[INIT_FN:%[0-9]+]] = function_ref @$s19default_constructor1IV1xSivpfi : $@convention(thin) () -> Int
   // CHECK: [[RESULT:%[0-9]+]] = apply [[INIT_FN]]() : $@convention(thin) () -> Int
-  // CHECK: [[X_ADDR:%[0-9]+]] = struct_element_addr {{.*}} : $*I, #I.x
-  // CHECK: assign [[RESULT]] to [[X_ADDR]] : $*Int
+  // CHECK: store [[RESULT]] to [trivial] [[X_ADDR]] : $*Int
   init<T>(_: T) {}
 }
 

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -53,15 +53,12 @@ struct Box<T> {
 // CHECK:      [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK-NEXT: [[UNINIT_SELF_BOX:%.*]] = mark_uninitialized [rootself] [[SELF_BOX]]
 // CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[UNINIT_SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
+// CHECK:      [[RESULT:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
 // CHECK:      [[INIT:%.*]] = function_ref @$s10extensions3BoxV1txSgvpfi : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
-// CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<T>
 // CHECK-NEXT: apply [[INIT]]<T>([[RESULT]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
-// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
-// CHECK-NEXT: copy_addr [take] [[RESULT]] to [[T_ADDR]] : $*Optional<T>
-// CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
 // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<T>
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = init_enum_data_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt
-// CHECK-NEXT: copy_addr %1 to [initialization] %14 : $*T
+// CHECK-NEXT: copy_addr %1 to [initialization] [[RESULT_ADDR]] : $*T
 // CHECK-NEXT: inject_enum_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*Box<T>
 // CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[WRITE]] : $*Box<T>, #Box.t

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -580,13 +580,11 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK:   store {{%.*}} to [init] [[PROJ]]
   //
   // Then initialize the canary with nil. We are able to borrow the initialized self to avoid retain/release overhead.
-  // CHECK:   [[CANARY_FUNC:%.*]] = function_ref @$s21failable_initializers17ThrowDerivedClassC6canaryAA6CanaryCSgvpfi :
-  // CHECK:   [[OPT_CANARY:%.*]] = apply [[CANARY_FUNC]]()
   // CHECK:   [[SELF:%.*]] = load_borrow [[PROJ]]
   // CHECK:   [[CANARY_ADDR:%.*]] = ref_element_addr [[SELF]]
-  // CHECK:   [[CANARY_ACCESS:%.*]] = begin_access [modify] [dynamic] [[CANARY_ADDR]]
-  // CHECK:   assign [[OPT_CANARY]] to [[CANARY_ACCESS]]
-  // CHECK:   end_access [[CANARY_ACCESS]]
+  // CHECK:   [[CANARY_FUNC:%.*]] = function_ref @$s21failable_initializers17ThrowDerivedClassC6canaryAA6CanaryCSgvpfi :
+  // CHECK:   [[OPT_CANARY:%.*]] = apply [[CANARY_FUNC]]()
+  // CHECK:   store [[OPT_CANARY]] to [init] [[CANARY_ADDR]]
   // CHECK:   end_borrow [[SELF]]
   //
   // Now we perform the unwrap.
@@ -624,13 +622,11 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK:   store {{%.*}} to [init] [[PROJ]]
   //
   // Then initialize the canary with nil. We are able to borrow the initialized self to avoid retain/release overhead.
-  // CHECK:   [[CANARY_FUNC:%.*]] = function_ref @$s21failable_initializers17ThrowDerivedClassC6canaryAA6CanaryCSgvpfi :
-  // CHECK:   [[OPT_CANARY:%.*]] = apply [[CANARY_FUNC]]()
   // CHECK:   [[SELF:%.*]] = load_borrow [[PROJ]]
   // CHECK:   [[CANARY_ADDR:%.*]] = ref_element_addr [[SELF]]
-  // CHECK:   [[CANARY_ACCESS:%.*]] = begin_access [modify] [dynamic] [[CANARY_ADDR]]
-  // CHECK:   assign [[OPT_CANARY]] to [[CANARY_ACCESS]]
-  // CHECK:   end_access [[CANARY_ACCESS]]
+  // CHECK:   [[CANARY_FUNC:%.*]] = function_ref @$s21failable_initializers17ThrowDerivedClassC6canaryAA6CanaryCSgvpfi :
+  // CHECK:   [[OPT_CANARY:%.*]] = apply [[CANARY_FUNC]]()
+  // CHECK:   store [[OPT_CANARY]] to [init] [[CANARY_ADDR]]
   // CHECK:   end_borrow [[SELF]]
   //
   // Now we begin argument emission where we perform the unwrap.

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -398,26 +398,23 @@ class Foo<T> {
     // CHECK: [[THIS:%[0-9]+]] = mark_uninitialized
 
     // -- initialization for y
-    // CHECK: [[Y_INIT:%[0-9]+]] = function_ref @$s8lifetime3FooC1ySi_AA3RefCtvpfi : $@convention(thin) <τ_0_0> () -> (Int, @owned Ref)
-    // CHECK: [[Y_VALUE:%[0-9]+]] = apply [[Y_INIT]]<T>()
-    // CHECK: ([[Y_EXTRACTED_0:%.*]], [[Y_EXTRACTED_1:%.*]]) = destructure_tuple
     // CHECK: [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
     // CHECK: [[THIS_Y:%.*]] = ref_element_addr [[BORROWED_THIS]] : {{.*}}, #Foo.y
-    // CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_Y]] : $*(Int, Ref)
-    // CHECK: [[THIS_Y_0:%.*]] = tuple_element_addr [[WRITE]] : $*(Int, Ref), 0
-    // CHECK: assign [[Y_EXTRACTED_0]] to [[THIS_Y_0]]
-    // CHECK: [[THIS_Y_1:%.*]] = tuple_element_addr [[WRITE]] : $*(Int, Ref), 1
-    // CHECK: assign [[Y_EXTRACTED_1]] to [[THIS_Y_1]]
-    // CHECK: end_access [[WRITE]] : $*(Int, Ref)
+    // CHECK: [[Y_INIT:%[0-9]+]] = function_ref @$s8lifetime3FooC1ySi_AA3RefCtvpfi : $@convention(thin) <τ_0_0> () -> (Int, @owned Ref)
+    // CHECK: [[THIS_Y_0:%.*]] = tuple_element_addr [[THIS_Y]] : $*(Int, Ref), 0
+    // CHECK: [[THIS_Y_1:%.*]] = tuple_element_addr [[THIS_Y]] : $*(Int, Ref), 1
+    // CHECK: [[Y_VALUE:%[0-9]+]] = apply [[Y_INIT]]<T>()
+    // CHECK: ([[Y_EXTRACTED_0:%.*]], [[Y_EXTRACTED_1:%.*]]) = destructure_tuple
+    // CHECK: store [[Y_EXTRACTED_0]] to [trivial] [[THIS_Y_0]]
+    // CHECK: store [[Y_EXTRACTED_1]] to [init] [[THIS_Y_1]]
     // CHECK: end_borrow [[BORROWED_THIS]]
 
     // -- Initialization for w
-    // CHECK: [[Z_FUNC:%.*]] = function_ref @$s{{.*}}8lifetime3FooC1wAA3RefCvpfi : $@convention(thin) <τ_0_0> () -> @owned Ref
-    // CHECK: [[Z_RESULT:%.*]] = apply [[Z_FUNC]]<T>()
     // CHECK: [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
     // CHECK: [[THIS_Z:%.*]] = ref_element_addr [[BORROWED_THIS]]
-    // CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_Z]] : $*Ref
-    // CHECK: assign [[Z_RESULT]] to [[WRITE]]
+    // CHECK: [[Z_FUNC:%.*]] = function_ref @$s{{.*}}8lifetime3FooC1wAA3RefCvpfi : $@convention(thin) <τ_0_0> () -> @owned Ref
+    // CHECK: [[Z_RESULT:%.*]] = apply [[Z_FUNC]]<T>()
+    // CHECK: store [[Z_RESULT]] to [init] [[THIS_Z]]
     // CHECK: end_borrow [[BORROWED_THIS]]
 
     // -- Initialization for x
@@ -462,11 +459,10 @@ class Foo<T> {
     // -- First we initialize #Foo.y.
     // CHECK:   [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
     // CHECK:   [[THIS_Y:%.*]] = ref_element_addr [[BORROWED_THIS]] : $Foo<T>, #Foo.y
-    // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_Y]] : $*(Int, Ref)
-    // CHECK:   [[THIS_Y_1:%.*]] = tuple_element_addr [[WRITE]] : $*(Int, Ref), 0
-    // CHECK:   assign {{.*}} to [[THIS_Y_1]] : $*Int
-    // CHECK:   [[THIS_Y_2:%.*]] = tuple_element_addr [[WRITE]] : $*(Int, Ref), 1
-    // CHECK:   assign {{.*}} to [[THIS_Y_2]] : $*Ref
+    // CHECK:   [[THIS_Y_1:%.*]] = tuple_element_addr [[THIS_Y]] : $*(Int, Ref), 0
+    // CHECK:   [[THIS_Y_2:%.*]] = tuple_element_addr [[THIS_Y]] : $*(Int, Ref), 1
+    // CHECK:   store {{.*}} to [trivial] [[THIS_Y_1]] : $*Int
+    // CHECK:   store {{.*}} to [init] [[THIS_Y_2]] : $*Ref
     // CHECK:   end_borrow [[BORROWED_THIS]]
 
     // -- Then we create a box that we will use to perform a copy_addr into #Foo.x a bit later.

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -66,13 +66,11 @@ class SwiftGizmo : Gizmo {
   // CHECK: bb0([[SELF_PARAM:%[0-9]+]] : @owned $SwiftGizmo):
   // CHECK-NEXT:   debug_value [[SELF_PARAM]] : $SwiftGizmo, let, name "self"
   // CHECK-NEXT:   [[SELF:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_PARAM]] : $SwiftGizmo
+  // CHECK:        [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK-NEXT:   [[X:%[0-9]+]] = ref_element_addr [[BORROWED_SELF]] : $SwiftGizmo, #SwiftGizmo.x
   // CHECK:        [[XINIT:%[0-9]+]] = function_ref @$s12objc_dealloc10SwiftGizmoC1xAA1XCvpfi
   // CHECK-NEXT:   [[XOBJ:%[0-9]+]] = apply [[XINIT]]() : $@convention(thin) () -> @owned X
-  // CHECK-NEXT:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
-  // CHECK-NEXT:   [[X:%[0-9]+]] = ref_element_addr [[BORROWED_SELF]] : $SwiftGizmo, #SwiftGizmo.x
-  // CHECK-NEXT:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[X]] : $*X
-  // CHECK-NEXT:   assign [[XOBJ]] to [[WRITE]] : $*X
-  // CHECK-NEXT:   end_access [[WRITE]] : $*X
+  // CHECK-NEXT:   store [[XOBJ]] to [init] [[X]] : $*X
   // CHECK-NEXT:   end_borrow [[BORROWED_SELF]]
   // CHECK-NEXT:   return [[SELF]] : $SwiftGizmo
 

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -670,7 +670,9 @@ class r19254812Derived: r19254812Base{
 // Initialization of the pi field: no copy_values/releases.
 // CHECK:  [[SELF:%[0-9]+]] = load_borrow [[PB_BOX]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
-// CHECK-NEXT:  assign {{.*}} to [[PIPTR]] : $*Double
+// CHECK:  [[FN:%[0-9]+]] = function_ref @$s10properties16r19254812DerivedC2piSdvpfi : $@convention(thin) () -> Double
+// CHECK-NEXT:  [[RESULT:%[0-9]+]] = apply [[FN]]() : $@convention(thin) () -> Double
+// CHECK-NEXT:  store [[RESULT]] to [trivial] [[PIPTR]] : $*Double
 
 // CHECK-NOT: destroy_value
 // CHECK-NOT: copy_value

--- a/test/SILGen/stored_property_init_reabstraction.swift
+++ b/test/SILGen/stored_property_init_reabstraction.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// rdar://problem/67419937
+
+class Class<T> {
+  var fn: ((T) -> ())? = nil
+
+  init(_: T) where T == Int {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34stored_property_init_reabstraction5ClassCyACySiGSicSiRszlufc : $@convention(method) (Int, @owned Class<Int>) -> @owned Class<Int> {
+// CHECK: [[SELF:%.*]] = mark_uninitialized [rootself] %1 : $Class<Int>
+// CHECK: [[BORROW:%.*]] = begin_borrow [[SELF]] : $Class<Int>
+// CHECK: [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $Class<Int>, #Class.fn
+// CHECK: [[INIT:%.*]] = function_ref @$s34stored_property_init_reabstraction5ClassC2fnyxcSgvpfi : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>
+// CHECK: [[VALUE:%.*]] = apply [[INIT]]<Int>() : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>
+// CHECK: store [[VALUE]] to [init] [[ADDR]] : $*Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <Int>>
+// CHECK: end_borrow [[BORROW]] : $Class<Int>
+
+struct Struct<T> {
+  var fn: ((T) -> ())? = nil
+
+  init(_: T) where T == Int {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34stored_property_init_reabstraction6StructVyACySiGSicSiRszlufC : $@convention(method) (Int, @thin Struct<Int>.Type) -> @owned Struct<Int> {
+// CHECK: [[SELF_BOX:%.*]] = mark_uninitialized [rootself] {{%.*}} : ${ var Struct<Int> }
+// CHECK: [[SELF:%.*]] = project_box [[SELF_BOX]] : ${ var Struct<Int> }, 0
+// CHECK: [[ADDR:%.*]] = struct_element_addr [[SELF]] : $*Struct<Int>, #Struct.fn
+// CHECK: [[INIT:%.*]] = function_ref @$s34stored_property_init_reabstraction6StructV2fnyxcSgvpfi : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>
+// CHECK: [[VALUE:%.*]] = apply [[INIT]]<Int>() : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>
+// CHECK: store [[VALUE]] to [init] [[ADDR]] : $*Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <Int>>
+
+struct ComplexExample<T, U> {
+  var (fn, value): (((T) -> ())?, U?) = (nil, nil)
+  var anotherValue: (((T) -> ())?, U?) = (nil, nil)
+
+  init(_: T) where T == String {}
+}

--- a/test/SILOptimizer/stored_property_initial_value.swift
+++ b/test/SILOptimizer/stored_property_initial_value.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+// This is an integration test to ensure that SILGen, DI and the ownership
+// verifier support the SIL we generate for stored properties with initial
+// values.
+
+enum E {
+  case foo(Any)
+}
+
+struct S<T, U : BinaryInteger> {
+  var x1: T? = nil
+  var x2 = 0 as! T
+  var x3 = E.foo(0)
+  var x4: (Int, Int, Int, Int) = (0, 0, 0, 0)
+  var x5: (U, U, U, U) = (0, 0, 0, 0)
+
+  init() {}
+}
+
+class C<T, U : BinaryInteger> {
+  var x1: T? = nil
+  var x2 = 0 as! T
+  var x3 = E.foo(0)
+  var x4: (Int, Int, Int, Int) = (0, 0, 0, 0)
+  var x5: (U, U, U, U) = (0, 0, 0, 0)
+
+  init() {}
+}


### PR DESCRIPTION
A constructor can constrain generic parameters more than the
type itself, either because there is a 'where' clause on the
constructor, or because the constructor is defined inside an
extension with a 'where' clause.

In this case, when the constructor calls a stored property
initializer to implicitly initialize a stored property with
an initial value, we must apply substitutions to get the
correct result type for the call.

If the original type of the stored property lowers differently
based on the abstraction pattern, for example if it is a
function type, then emitApply() would by default re-abstract
the result to the most specific abstraction pattern possible.

However, this was wrong because we store the result value into
the stored property, and a stored property's type should
always be lowered with the most generic abstraction pattern.

In practice, this meant if you have a stored property of type
`(T) -> ()`, and an initializer with `where T == String` for
example, we would call the initializer, to produce a value with
lowered type `(@in_guaranteed String) -> ()`, then thunk it to a
`(@guaranteed String) -> ()`, and try to store the thunk into
the stored property -- which has type `(@in_guaranteed String) -> ()`.

This would either miscompile or trigger an assertion.

To get around this, we want to bypass the orig-to-subst
conversion performed in emitApply(). My chosen solution is
to have emitApply() emit the result into a
ConvertingInitialization set up to perform a subst-to-orig
conversion.

Now that ConvertingInitialization is smart enough to
peephole away matched pairs of orig-to-subst and subst-to-orig
conversions, this always reduces to a no-op, and the
emitApply() call produces and stores a value with the
correct abstraction pattern.

Fixes <rdar://problem/67419937>.