### PR TITLE
[windows] Use extended length paths for os.walk invocation.

### DIFF
--- a/test/CrossImport/Inputs/rewrite-module-triples.py
+++ b/test/CrossImport/Inputs/rewrite-module-triples.py
@@ -17,6 +17,9 @@ if len(sys.argv) < 3:
     sys.exit(1)
 
 root_dir = sys.argv[1]
+if platform.system() == 'Windows':
+    root_dir = "\\\\?\\" + os.path.abspath(root_dir)
+
 triples = sys.argv[2:]
 
 
@@ -37,16 +40,9 @@ def rewrite(parent, names, copy_fn, rm_fn):
 
         for new_name in new_names:
             new_path = os.path.join(parent, new_name)
-            if platform.system() == 'Windows':
-                copy_fn(u'\\'.join([u'\\\\?', os.path.normpath(path)]),
-                        u'\\'.join([u'\\\\?', os.path.normpath(new_path)]))
-            else:
-                copy_fn(path, new_path)
+            copy_fn(path, new_path)
 
-        if platform.system() == 'Windows':
-            rm_fn(u'\\'.join([u'\\\\?', os.path.normpath(path)]))
-        else:
-            rm_fn(path)
+        rm_fn(path)
 
 
 for parent, dirs, files in os.walk(root_dir, topdown=False):


### PR DESCRIPTION
In the Windows VS 2017 CI machines, the path for certain tests end up
being very long. rewrite-module-triples.py was aware and was using
extended length paths for the copy and remove operations in Windows
but it was not using it for the os.walk invocation, so when a folder
that was longer than MAX_PATH was encountered, the walk stopped
drilling into it, missing some module-triple-here substitutions and
making some test fail.

The changes remove the special treatment of the copy and remove
operations and move it into os.walk, which carries the prefix to
every path.

This should fix the problems seen in the SourceKit test in the
Windows VS 2017 machine:

- SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
- SourceKit/DocSupport/doc_cross_import_common.swift
- SourceKit/CursorInfo/cursor_info_cross_import_common_case.swift

PD: Misc/stats_dir_profiler.swift is something else. It seems as if
an glob was not being expanded by lit for some reason.
