### PR TITLE
[cxx-interop] Cast "data" to the correct type in _swift_dispatch_data_apply. 

### DIFF
--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -215,8 +215,8 @@ static inline unsigned int
 _swift_dispatch_data_apply(
     __swift_shims_dispatch_data_t data,
     __swift_shims_dispatch_data_applier SWIFT_DISPATCH_NOESCAPE applier) {
-  return dispatch_data_apply(data, ^bool(dispatch_data_t data, size_t off, const void *loc, size_t size){
-    return applier(data, off, loc, size);
+  return dispatch_data_apply((dispatch_data_t)data, ^bool(dispatch_data_t data, size_t off, const void *loc, size_t size){
+    return applier((__swift_shims_dispatch_data_t)data, off, loc, size);
   });
 }
 


### PR DESCRIPTION
The implicit conversions are OK in C but C++ will error. To make this header valid in both C and C++ we should just always cast.

This and https://github.com/apple/swift-corelibs-foundation/pull/2895 fix the Linux builds for #32721. 