### PR TITLE
WinSDK: extract Networking submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -217,6 +217,13 @@ module WinSDK [system] {
     link "WinMM.Lib"
   }
 
+  module Networking {
+    header "winnetwk.h"
+    export *
+
+    link "Mpr.Lib"
+  }
+
   module Security {
     module AuthZ {
       header "AuthZ.h"


### PR DESCRIPTION
Currently `winnetwk.h` gets included via `windows.h`.
This change extracts it into a separate submodule.

Related discussion: https://github.com/apple/swift/pull/33929
