### PR TITLE
[Diagnostics] Localization support for educational notes

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -115,11 +115,17 @@ To add a new educational note:
     - An entry in a `Diagnostics*.def` file describing the diagnostic. If there are any closely related diagnostics the note should also be attached to, they can usually be found nearby.
     - Each point in the compiler source where the diagnostic is emitted. This can be helpful in determining the exact circumstances which cause it to be emitted.
 4. Add a new Markdown file in the `userdocs/diagnostics/` directory in the swift repository containing the contents of the note. When writing a note, keep the writing guidelines from the section above in mind. The existing notes in the directory are another useful guide.
-5. Associate the note with the appropriate diagnostics in `EducationalNotes.def`. An entry like `EDUCATIONAL_NOTES(property_wrapper_failable_init, "property-wrapper-requirements.md")` will associate the note with filename `property-wrapper-requirements.md` with the diagnostic having an internal identifier of `property_wrapper_failable_init`.
+5. Associate the note with the appropriate diagnostics in `EducationalNotes.def`. An entry like `EDUCATIONAL_NOTES(property_wrapper_failable_init, "property-wrapper-requirements.md", "en")` will associate the note with filename `property-wrapper-requirements.md` with the diagnostic having an internal identifier of `property_wrapper_failable_init`.
 6. If possible, rebuild the compiler and try recompiling your test program with `-print-educational-notes`. Your new note should appear after the diagnostic in the terminal.
 7. That's it! The new note is now ready to be submitted as a pull request on GitHub.
 
 If you run into any issues or have questions while following the steps above, feel free to post a question on the Swift forums or open a work-in-progress pull request on GitHub.
+
+### Localizing Educational Notes ###
+
+To add a localization of an educational note:
+1. Add a file to the `userdocs/diagnostics/<language code>/` directory with the contents of the localized note, where <language code> is an [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language code. The localized note should have the same filename as the english version.
+2. In `EducationalNotes.def`, add the language code to the end of the list corresponding to the relevant diagnostics. 
 
 ### Format Specifiers ###
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -687,6 +687,9 @@ namespace swift {
     /// Path to diagnostic documentation directory.
     std::string diagnosticDocumentationPath = "";
 
+    /// The current locale, if set.
+    std::string locale = "";
+
     friend class InFlightDiagnostic;
     friend class DiagnosticTransaction;
     friend class CompoundDiagnosticTransaction;
@@ -745,6 +748,7 @@ namespace swift {
     void setLocalization(std::string locale, std::string path) {
       assert(!locale.empty());
       assert(!path.empty());
+      this->locale = locale;
       llvm::SmallString<128> filePath(path);
       llvm::sys::path::append(filePath, locale);
       llvm::sys::path::replace_extension(filePath, ".db");

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -19,77 +19,109 @@
 #  error Must define EDUCATIONAL_NOTES
 #endif
 
-// EDUCATIONAL_NOTES(DIAG_ID, EDUCATIONAL_NOTE_FILENAMES...)
+// EDUCATIONAL_NOTES(DIAG_ID, EDUCATIONAL_NOTE_FILENAME, LANGUAGE_CODES...)
 
 EDUCATIONAL_NOTES(unsupported_existential_type,
-                  "associated-type-requirements.md")
+                  "associated-type-requirements.md",
+                  "en")
 
-EDUCATIONAL_NOTES(cannot_pass_type_to_non_ephemeral, "temporary-pointers.md")
+EDUCATIONAL_NOTES(cannot_pass_type_to_non_ephemeral, "temporary-pointers.md",
+                  "en")
 EDUCATIONAL_NOTES(cannot_pass_type_to_non_ephemeral_warning,
-                  "temporary-pointers.md")
+                  "temporary-pointers.md",
+                  "en")
 EDUCATIONAL_NOTES(cannot_use_inout_non_ephemeral,
-                  "temporary-pointers.md")
+                  "temporary-pointers.md",
+                  "en")
 EDUCATIONAL_NOTES(cannot_use_inout_non_ephemeral_warning,
-                  "temporary-pointers.md")
-EDUCATIONAL_NOTES(cannot_construct_dangling_pointer, "temporary-pointers.md")
+                  "temporary-pointers.md",
+                  "en")
+EDUCATIONAL_NOTES(cannot_construct_dangling_pointer, "temporary-pointers.md",
+                  "en")
 EDUCATIONAL_NOTES(cannot_construct_dangling_pointer_warning,
-                  "temporary-pointers.md")
+                  "temporary-pointers.md",
+                  "en")
 
 
 
-EDUCATIONAL_NOTES(non_nominal_no_initializers, "nominal-types.md")
-EDUCATIONAL_NOTES(non_nominal_extension, "nominal-types.md")
+EDUCATIONAL_NOTES(non_nominal_no_initializers, "nominal-types.md",
+                  "en")
+EDUCATIONAL_NOTES(non_nominal_extension, "nominal-types.md",
+                  "en")
 EDUCATIONAL_NOTES(associated_type_witness_conform_impossible,
-                  "nominal-types.md")
+                  "nominal-types.md",
+                  "en")
 
 EDUCATIONAL_NOTES(cannot_infer_closure_result_type,
-                  "complex-closure-inference.md")
+                  "complex-closure-inference.md",
+                  "en")
 
 EDUCATIONAL_NOTES(invalid_dynamic_callable_type,
-                  "dynamic-callable-requirements.md")
+                  "dynamic-callable-requirements.md",
+                  "en")
 EDUCATIONAL_NOTES(missing_dynamic_callable_kwargs_method,
-                  "dynamic-callable-requirements.md")
+                  "dynamic-callable-requirements.md",
+                  "en")
 
 EDUCATIONAL_NOTES(property_wrapper_no_value_property,
-                  "property-wrapper-requirements.md")
+                  "property-wrapper-requirements.md",
+                  "en")
 EDUCATIONAL_NOTES(property_wrapper_wrong_initial_value_init,
-                  "property-wrapper-requirements.md")
+                  "property-wrapper-requirements.md",
+                  "en")
 EDUCATIONAL_NOTES(property_wrapper_failable_init,
-                  "property-wrapper-requirements.md")
+                  "property-wrapper-requirements.md",
+                  "en")
 EDUCATIONAL_NOTES(property_wrapper_type_requirement_not_accessible,
-                  "property-wrapper-requirements.md")
+                  "property-wrapper-requirements.md",
+                  "en")
 
-EDUCATIONAL_NOTES(opaque_type_var_no_init, "opaque-type-inference.md")
+EDUCATIONAL_NOTES(opaque_type_var_no_init, "opaque-type-inference.md",
+                  "en")
 EDUCATIONAL_NOTES(opaque_type_no_underlying_type_candidates,
-                  "opaque-type-inference.md")
+                  "opaque-type-inference.md",
+                  "en")
 EDUCATIONAL_NOTES(opaque_type_mismatched_underlying_type_candidates,
-                  "opaque-type-inference.md")
+                  "opaque-type-inference.md",
+                  "en")
 EDUCATIONAL_NOTES(opaque_type_self_referential_underlying_type,
-                  "opaque-type-inference.md")
+                  "opaque-type-inference.md",
+                  "en")
 EDUCATIONAL_NOTES(opaque_type_var_no_underlying_type,
-                  "opaque-type-inference.md")
+                  "opaque-type-inference.md",
+                  "en")
 
 
 EDUCATIONAL_NOTES(missing_append_interpolation,
-                  "string-interpolation-conformance.md")
+                  "string-interpolation-conformance.md",
+                  "en")
 EDUCATIONAL_NOTES(append_interpolation_static,
-                  "string-interpolation-conformance.md")
+                  "string-interpolation-conformance.md",
+                  "en")
 EDUCATIONAL_NOTES(append_interpolation_void_or_discardable,
-                  "string-interpolation-conformance.md")
-EDUCATIONAL_NOTES(type_cannot_conform, "protocol-type-non-conformance.md")
+                  "string-interpolation-conformance.md",
+                  "en")
+EDUCATIONAL_NOTES(type_cannot_conform, "protocol-type-non-conformance.md",
+                  "en")
 
 EDUCATIONAL_NOTES(unlabeled_trailing_closure_deprecated,
-                  "trailing-closure-matching.md")
+                  "trailing-closure-matching.md",
+                  "en")
 
 EDUCATIONAL_NOTES(function_builder_static_buildblock,
-                  "function-builder-methods.md")
+                  "function-builder-methods.md",
+                  "en")
 EDUCATIONAL_NOTES(function_builder_missing_limited_availability,
-                  "function-builder-methods.md")
+                  "function-builder-methods.md",
+                  "en")
 EDUCATIONAL_NOTES(function_builder_missing_build_optional,
-                  "function-builder-methods.md")
+                  "function-builder-methods.md",
+                  "en")
 EDUCATIONAL_NOTES(function_builder_missing_build_either,
-                  "function-builder-methods.md")
+                  "function-builder-methods.md",
+                  "en")
 EDUCATIONAL_NOTES(function_builder_missing_build_array,
-                  "function-builder-methods.md")
+                  "function-builder-methods.md",
+                  "en")
 
 #undef EDUCATIONAL_NOTES

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -58,7 +58,7 @@ EDUCATIONAL_NOTES(cannot_infer_closure_result_type,
 
 EDUCATIONAL_NOTES(invalid_dynamic_callable_type,
                   "dynamic-callable-requirements.md",
-                  "en")
+                  "en", "test")
 EDUCATIONAL_NOTES(missing_dynamic_callable_kwargs_method,
                   "dynamic-callable-requirements.md",
                   "en")

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -958,7 +958,9 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   if (Arg *A = Args.getLastArg(OPT_locale)) {
     std::string localeCode = A->getValue();
 
-    // Check if the locale code is available.
+    // Check if the locale code is available, or "test" was specified.
+    // -locale test is a specially recognized code used as a temporary hack
+    // to support testing before real translations are available.
     if (llvm::none_of(localeCodes, [&](const char *locale) {
           return localeCode == locale;
         }) && localeCode != "test") {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -961,7 +961,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
     // Check if the locale code is available.
     if (llvm::none_of(localeCodes, [&](const char *locale) {
           return localeCode == locale;
-        })) {
+        }) && localeCode != "test") {
       std::string availableLocaleCodes = "";
       llvm::interleave(
           std::begin(localeCodes), std::end(localeCodes),

--- a/test/diagnostics/Localization/Inputs/test-docs/dynamic-callable-requirements.md
+++ b/test/diagnostics/Localization/Inputs/test-docs/dynamic-callable-requirements.md
@@ -1,0 +1,1 @@
+@dynamicCallable note contents - en

--- a/test/diagnostics/Localization/Inputs/test-docs/property-wrapper-requirements.md
+++ b/test/diagnostics/Localization/Inputs/test-docs/property-wrapper-requirements.md
@@ -1,0 +1,1 @@
+@propertyWrapper note contents - en

--- a/test/diagnostics/Localization/Inputs/test-docs/test/dynamic-callable-requirements.md
+++ b/test/diagnostics/Localization/Inputs/test-docs/test/dynamic-callable-requirements.md
@@ -1,0 +1,1 @@
+@dynamicCallable note contents - test

--- a/test/diagnostics/Localization/educational-notes-localization.swift
+++ b/test/diagnostics/Localization/educational-notes-localization.swift
@@ -1,0 +1,18 @@
+// RUN: not %target-swift-frontend -no-color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/Inputs/test-docs/ -locale en -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK-EN
+// RUN: not %target-swift-frontend -no-color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/Inputs/test-docs/ -locale test -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK-TEST
+
+// Test a note with an available translation.
+@dynamicCallable struct Foo {}
+// CHECK-EN: error: @dynamicCallable attribute requires 'Foo' to have either a valid 'dynamicallyCall(withArguments:)' method or 'dynamicallyCall(withKeywordArguments:)' method
+// CHECK-EN: @dynamicCallable note contents - en
+
+// CHECK-TEST: error: @dynamicCallable attribute requires 'Foo' to have either a valid 'dynamicallyCall(withArguments:)' method or 'dynamicallyCall(withKeywordArguments:)' method
+// CHECK-TEST: @dynamicCallable note contents - test
+
+// Test a note without an available translation.
+@propertyWrapper struct Bar {}
+// CHECK-EN: error: property wrapper type 'Bar' does not contain a non-static property named 'wrappedValue'
+// CHECK-EN: @propertyWrapper note contents - en
+
+// CHECK-TEST: error: property wrapper type 'Bar' does not contain a non-static property named 'wrappedValue'
+// CHECK-TEST: @propertyWrapper note contents - en


### PR DESCRIPTION
With this change, the existing `-locale` flag can now be used to present localized educational notes, if available. Localized notes will be installed at `usr/share/doc/swift/diagnostics/<language code>/<note name>` and registered in `EducationalNotes.def`. This does mean that adding a new translation requires rebuilding the compiler, but it avoids needing to check the filesystem for the existence of a translation every time we emit a diagnostic. In the future, we could probably load the educational note definitions at runtime instead of including them in the compiler binary.