### PR TITLE
[windows] Provide %long-tmp in Windows for extended length temp paths.

### DIFF
--- a/test/Misc/stats_dir_profiler.swift
+++ b/test/Misc/stats_dir_profiler.swift
@@ -3,8 +3,11 @@
 // RUN: %empty-directory(%t/stats-entities)
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-events %s -profile-stats-events
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-entities %s -profile-stats-entities
-// RUN: %FileCheck -check-prefix=EVENTS -input-file %t/stats-events/*.dir/Time.User.events %s
-// RUN: %FileCheck -check-prefix=ENTITIES -input-file %t/stats-entities/*.dir/Time.User.entities %s
+
+// Need to use %long-tmp because in Windows the * may expand to a path longer
+// than 260 characters.
+// RUN: %FileCheck -check-prefix=EVENTS -input-file %long-tmp/stats-events/*.dir/Time.User.events %s
+// RUN: %FileCheck -check-prefix=ENTITIES -input-file %long-tmp/stats-entities/*.dir/Time.User.entities %s
 
 // EVENTS: {{perform-sema;.*;typecheck-decl.* [0-9]+}}
 // ENTITIES: {{perform-sema;.*;TypeCheckFunctionBodyRequest bar\(\);typecheck-stmt.* [0-9]+}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2074,8 +2074,12 @@ config.substitutions.append(('%add_num_extra_inhabitants', add_num_extra_inhabit
 
 if kIsWindows:
   config.substitutions.append( ('%diff', 'diff --strip-trailing-cr') )
+  # Use instead of %t when the possible temporal path (and suffix) might end
+  # up being longer than 260 characters in Windows machines.
+  config.substitutions.append( ('%long-tmp', '\\\\?\\%t') )
 else:
   config.substitutions.append( ('%diff', 'diff') )
+  config.substitutions.append( ('%long-tmp', '%t') )
 
 visual_studio_version = os.environ.get('VisualStudioVersion')
 if kIsWindows and visual_studio_version:


### PR DESCRIPTION
In Windows %t might end up very close to the maximum path length of 260
characters. It is possible to use extended lenght paths with a \\?\
prefix. The changes introduce %long-tmp for cases that the test suite
is going over those limits and need a hint in Windows that the path
might be long. It expands to the same as %t in other platforms.

This should fix the test/Misc/stats_dir_profiler.swift in the Windows
VS 2017 CI machines and hopefully not affect anything else.
