### PR TITLE
[Async CC] Pull polymorphic parameters from entry point emission.

### DIFF
--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -20,6 +20,7 @@ namespace swift {
 namespace irgen {
 
 class Explosion;
+struct GenericRequirement;
 
 class EntryPointArgumentEmission {
 
@@ -28,6 +29,9 @@ public:
   virtual bool requiresIndirectResult(SILType retType) = 0;
   virtual llvm::Value *getIndirectResultForFormallyDirectResult() = 0;
   virtual llvm::Value *getIndirectResult(unsigned index) = 0;
+  virtual llvm::Value *getNextPolymorphicParameterAsMetadata() = 0;
+  virtual llvm::Value *
+  getNextPolymorphicParameter(GenericRequirement &requirement) = 0;
 };
 
 class NativeCCEntryPointArgumentEmission

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -40,6 +40,7 @@ namespace swift {
 namespace irgen {
   class Address;
   class DynamicMetadataRequest;
+  class EntryPointArgumentEmission;
   class Explosion;
   class FunctionPointer;
   class IRGenFunction;
@@ -133,12 +134,11 @@ namespace irgen {
   ///
   /// \param witnessMetadata - can be omitted if the function is
   ///   definitely not a witness method
-  void emitPolymorphicParameters(IRGenFunction &IGF,
-                                 SILFunction &Fn,
-                                 Explosion &args,
+  void emitPolymorphicParameters(IRGenFunction &IGF, SILFunction &Fn,
+                                 EntryPointArgumentEmission &emission,
                                  WitnessMetadata *witnessMetadata,
                                  const GetParameterFn &getParameter);
- 
+
   void emitPolymorphicParametersFromArray(IRGenFunction &IGF,
                                           NominalTypeDecl *typeDecl,
                                           Address array,

--- a/validation-test/compiler_crashers_2_fixed/rdar70144083.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar70144083.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-concurrency
+
+public protocol AsyncIteratorProtocol {
+    associatedtype Element
+    associatedtype Failure: Error
+
+    mutating func nextResult() async -> Result<Element, Failure>?
+    mutating func cancel()
+}
+
+public protocol AsyncSequence {
+    associatedtype Element
+    associatedtype Failure: Error
+    associatedtype AsyncIterator: AsyncIteratorProtocol where AsyncIterator.Element == Element, AsyncIterator.Failure == Failure
+    
+    func makeAsyncIterator() -> AsyncIterator
+}
+
+struct Just<Element>: AsyncSequence {
+    typealias Failure = Never
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        var value: Element?
+        mutating func nextResult() async -> Result<Element, Never>? {
+            defer { value = nil }
+            return value.map { .success($0) }
+        }
+
+        mutating func cancel() {
+            value = nil
+        }
+    }
+    var value: Element
+    func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(value: value)
+    }
+}


### PR DESCRIPTION
Previously, `EmitPolymorphicParameters` dealt directly with an `Explosion` from which it pulled values.  In one place, there was a conditional check for async which handled some cases.  There was however another place where the polymorphic parameter was pulled directly from the explosion.  That missed case resulted in attempting to pull a polymorphic parameter directly from an `Explosion` which contains only a `%swift.context*` per the async calling convention.

Here, those parameters are now pulled from an `EntryPointArgumentEmission` subclasses of which are able to provide the relevant definition of what pulling a parameter means.

rdar://problem/70144083