### PR TITLE
[CSBindings] Implement transtive protocol requirement inference

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4708,6 +4708,10 @@ private:
     /// The set of protocol requirements placed on this type variable.
     llvm::SmallVector<Constraint *, 4> Protocols;
 
+    /// The set of transitive protocol requirements inferred through
+    /// subtype/conversion/equivalence relations with other type variables.
+    Optional<llvm::SmallPtrSet<Constraint *, 4>> TransitiveProtocols;
+
     /// The set of constraints which would be used to infer default types.
     llvm::TinyPtrVector<Constraint *> Defaults;
 
@@ -4873,6 +4877,15 @@ private:
                                   ConstraintSystem::PotentialBindings>
             &inferredBindings);
 
+    /// Detect subtype, conversion or equivalence relationship
+    /// between two type variables and attempt to propagate protocol
+    /// requirements down the subtype or equivalence chain.
+    void inferTransitiveProtocolRequirements(
+        const ConstraintSystem &cs,
+        llvm::SmallDenseMap<TypeVariableType *,
+                            ConstraintSystem::PotentialBindings>
+            &inferredBindings);
+
     /// Infer bindings based on any protocol conformances that have default
     /// types.
     void inferDefaultTypes(ConstraintSystem &cs,
@@ -4886,8 +4899,8 @@ public:
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
     void finalize(ConstraintSystem &cs,
-                  const llvm::SmallDenseMap<TypeVariableType *,
-                                            ConstraintSystem::PotentialBindings>
+                  llvm::SmallDenseMap<TypeVariableType *,
+                                      ConstraintSystem::PotentialBindings>
                       &inferredBindings);
 
     void dump(llvm::raw_ostream &out,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4741,15 +4741,13 @@ private:
     /// Tracks the position of the last known supertype in the group.
     Optional<unsigned> lastSupertypeIndex;
 
-    /// A set of all constraints which contribute to pontential bindings.
-    llvm::SmallPtrSet<Constraint *, 8> Sources;
-
     /// A set of all not-yet-resolved type variables this type variable
-    /// is a subtype of. This is used to determine ordering inside a
-    /// chain of subtypes because binding inference algorithm can't,
-    /// at the moment, determine bindings transitively through supertype
-    /// type variables.
-    llvm::SmallDenseMap<TypeVariableType *, Constraint *, 4> SubtypeOf;
+    /// is a subtype of, supertype of or is equivalent to. This is used
+    /// to determine ordering inside of a chain of subtypes to help infer
+    /// transitive bindings  and protocol requirements.
+    llvm::SmallMapVector<TypeVariableType *, Constraint *, 4> SubtypeOf;
+    llvm::SmallMapVector<TypeVariableType *, Constraint *, 4> SupertypeOf;
+    llvm::SmallMapVector<TypeVariableType *, Constraint *, 4> EquivalentTo;
 
     PotentialBindings(TypeVariableType *typeVar)
         : TypeVar(typeVar), PotentiallyIncomplete(isGenericParameter()) {}

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4706,7 +4706,7 @@ private:
     SmallVector<PotentialBinding, 4> Bindings;
 
     /// The set of protocol requirements placed on this type variable.
-    llvm::TinyPtrVector<Constraint *> Protocols;
+    llvm::SmallVector<Constraint *, 4> Protocols;
 
     /// The set of constraints which would be used to infer default types.
     llvm::TinyPtrVector<Constraint *> Defaults;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -66,6 +66,12 @@ class SolutionApplicationTarget;
 
 } // end namespace constraints
 
+namespace unittest {
+
+class SemaTest;
+
+} // end namespace unittest
+
 // Forward declare some TypeChecker related functions
 // so they could be made friends of ConstraintSystem.
 namespace TypeChecker {
@@ -2017,6 +2023,8 @@ enum class SolutionApplicationToFunctionResult {
 /// Constraint systems are typically generated given an (untyped) expression.
 class ConstraintSystem {
   ASTContext &Context;
+
+  friend class swift::unittest::SemaTest;
 
 public:
   DeclContext *DC;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -790,9 +790,28 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
       }
     }
 
-    if (constraint->getKind() == ConstraintKind::Subtype &&
-        kind == AllowedBindingKind::Subtypes) {
-      result.SubtypeOf.insert(bindingTypeVar);
+    switch (constraint->getKind()) {
+    case ConstraintKind::Subtype:
+    case ConstraintKind::Conversion:
+    case ConstraintKind::ArgumentConversion:
+    case ConstraintKind::OperatorArgumentConversion: {
+      if (kind == AllowedBindingKind::Subtypes) {
+        result.SubtypeOf.insert({bindingTypeVar, constraint});
+      } else {
+        // TODO: record this type variable as a `supertypeOf`
+      }
+      break;
+    }
+
+    case ConstraintKind::Bind:
+    case ConstraintKind::BindParam:
+    case ConstraintKind::Equal: {
+      // TODO: record this type variable as being equal to other type variable.
+      break;
+    }
+
+    default:
+      break;
     }
 
     return None;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -986,8 +986,13 @@ bool ConstraintSystem::PotentialBindings::infer(
     break;
 
   case ConstraintKind::ConformsTo:
-  case ConstraintKind::SelfObjectOfProtocol:
-    return false;
+  case ConstraintKind::SelfObjectOfProtocol: {
+    auto protocolTy = constraint->getSecondType();
+    if (!protocolTy->is<ProtocolType>())
+      return false;
+
+    LLVM_FALLTHROUGH;
+  }
 
   case ConstraintKind::LiteralConformsTo: {
     // Record constraint where protocol requirement originated

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -46,23 +46,41 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
   ASSERT_TRUE(binding.hasDefaultedLiteralProtocol());
 }
 
+// Given a set of inferred protocol requirements, make sure that
+// all of the expected types are present.
+static void verifyProtocolInferenceResults(
+    const llvm::SmallPtrSetImpl<Constraint *> &protocols,
+    ArrayRef<Type> expectedTypes) {
+  ASSERT_TRUE(protocols.size() >= expectedTypes.size());
+
+  llvm::SmallPtrSet<Type, 2> inferredProtocolTypes;
+  for (auto *protocol : protocols)
+    inferredProtocolTypes.insert(protocol->getSecondType());
+
+  for (auto expectedTy : expectedTypes) {
+    ASSERT_TRUE(inferredProtocolTypes.count(expectedTy));
+  }
+}
+
 TEST_F(SemaTest, TestTransitiveProtocolInference) {
   ConstraintSystemOptions options;
   ConstraintSystem cs(DC, options);
 
-  auto *PD1 =
-      new (Context) ProtocolDecl(DC, SourceLoc(), SourceLoc(),
-                                 Context.getIdentifier("P1"), /*Inherited=*/{},
-                                 /*trailingWhere=*/nullptr);
-  PD1->setImplicit();
+  auto *protocolTy1 = createProtocol("P1");
+  auto *protocolTy2 = createProtocol("P2");
 
-  auto *protocolTy1 = ProtocolType::get(PD1, Type(), Context);
-
-  auto *GPT = cs.createTypeVariable(cs.getConstraintLocator({}),
-                                    /*options=*/TVO_CanBindToNoEscape);
+  auto *GPT1 = cs.createTypeVariable(cs.getConstraintLocator({}),
+                                     /*options=*/TVO_CanBindToNoEscape);
+  auto *GPT2 = cs.createTypeVariable(cs.getConstraintLocator({}),
+                                     /*options=*/TVO_CanBindToNoEscape);
 
   cs.addConstraint(
-      ConstraintKind::ConformsTo, GPT, protocolTy1,
+      ConstraintKind::ConformsTo, GPT1, protocolTy1,
+      cs.getConstraintLocator({}, LocatorPathElt::TypeParameterRequirement(
+                                      0, RequirementKind::Conformance)));
+
+  cs.addConstraint(
+      ConstraintKind::ConformsTo, GPT2, protocolTy2,
       cs.getConstraintLocator({}, LocatorPathElt::TypeParameterRequirement(
                                       0, RequirementKind::Conformance)));
 
@@ -73,16 +91,114 @@ TEST_F(SemaTest, TestTransitiveProtocolInference) {
                                           /*options=*/0);
 
     cs.addConstraint(
-        ConstraintKind::Conversion, typeVar, GPT,
+        ConstraintKind::Conversion, typeVar, GPT1,
         cs.getConstraintLocator({}, LocatorPathElt::ContextualType()));
 
     auto bindings = inferBindings(cs, typeVar);
     ASSERT_TRUE(bindings.Protocols.empty());
-
-    const auto &inferredProtocols = bindings.TransitiveProtocols;
-    ASSERT_TRUE(bool(inferredProtocols));
-    ASSERT_EQ(inferredProtocols->size(), (unsigned)1);
-    ASSERT_TRUE(
-        (*inferredProtocols->begin())->getSecondType()->isEqual(protocolTy1));
+    ASSERT_TRUE(bool(bindings.TransitiveProtocols));
+    verifyProtocolInferenceResults(*bindings.TransitiveProtocols,
+                                   {protocolTy1});
   }
+
+  // Now, let's make sure that protocol requirements could be propagated
+  // down conversion/equality chains through multiple hops.
+  {
+    // GPT1 is a subtype of GPT2 and GPT2 is convertible to a target type
+    // variable, target should get both protocols inferred - P1 & P2.
+
+    auto *typeVar = cs.createTypeVariable(cs.getConstraintLocator({}),
+                                          /*options=*/0);
+
+    cs.addConstraint(ConstraintKind::Subtype, GPT1, GPT2,
+                     cs.getConstraintLocator({}));
+
+    cs.addConstraint(ConstraintKind::Conversion, typeVar, GPT1,
+                     cs.getConstraintLocator({}));
+
+    auto bindings = inferBindings(cs, typeVar);
+    ASSERT_TRUE(bindings.Protocols.empty());
+    ASSERT_TRUE(bool(bindings.TransitiveProtocols));
+    verifyProtocolInferenceResults(*bindings.TransitiveProtocols,
+                                   {protocolTy1, protocolTy2});
+  }
+}
+
+/// Let's try a more complicated situation where there protocols
+/// are inferred from multiple sources on different levels of
+/// convertion chain.
+///
+///  (P1) T0   T4 (T3)         T6 (P4)
+///        \   /              /
+///          T3 = T1 (P2) = T5
+///           \   /
+///             T2
+
+TEST_F(SemaTest, TestComplexTransitiveProtocolInference) {
+  ConstraintSystemOptions options;
+  ConstraintSystem cs(DC, options);
+
+  auto *protocolTy1 = createProtocol("P1");
+  auto *protocolTy2 = createProtocol("P2");
+  auto *protocolTy3 = createProtocol("P3");
+  auto *protocolTy4 = createProtocol("P4");
+
+  auto *nilLocator = cs.getConstraintLocator({});
+
+  auto typeVar0 = cs.createTypeVariable(nilLocator, /*options=*/0);
+  auto typeVar1 = cs.createTypeVariable(nilLocator, /*options=*/0);
+  auto typeVar2 = cs.createTypeVariable(nilLocator, /*options=*/0);
+  // Allow this type variable to be bound to l-value type to prevent
+  // it from being merged with the rest of the type variables.
+  auto typeVar3 =
+      cs.createTypeVariable(nilLocator, /*options=*/TVO_CanBindToLValue);
+  auto typeVar4 = cs.createTypeVariable(nilLocator, /*options=*/0);
+  auto typeVar5 =
+      cs.createTypeVariable(nilLocator, /*options=*/TVO_CanBindToLValue);
+  auto typeVar6 = cs.createTypeVariable(nilLocator, /*options=*/0);
+
+  cs.addConstraint(ConstraintKind::ConformsTo, typeVar0, protocolTy1,
+                   nilLocator);
+  cs.addConstraint(ConstraintKind::ConformsTo, typeVar1, protocolTy2,
+                   nilLocator);
+  cs.addConstraint(ConstraintKind::ConformsTo, typeVar4, protocolTy3,
+                   nilLocator);
+  cs.addConstraint(ConstraintKind::ConformsTo, typeVar6, protocolTy4,
+                   nilLocator);
+
+  // T3 <: T0, T3 <: T4
+  cs.addConstraint(ConstraintKind::Conversion, typeVar3, typeVar0, nilLocator);
+  cs.addConstraint(ConstraintKind::Conversion, typeVar3, typeVar4, nilLocator);
+
+  // T2 <: T3, T2 <: T1, T3 == T1
+  cs.addConstraint(ConstraintKind::Subtype, typeVar2, typeVar3, nilLocator);
+  cs.addConstraint(ConstraintKind::Conversion, typeVar2, typeVar1, nilLocator);
+  cs.addConstraint(ConstraintKind::Equal, typeVar3, typeVar1, nilLocator);
+  // T1 == T5, T <: T6
+  cs.addConstraint(ConstraintKind::Equal, typeVar1, typeVar5, nilLocator);
+  cs.addConstraint(ConstraintKind::Conversion, typeVar5, typeVar6, nilLocator);
+
+  auto bindingsForT1 = inferBindings(cs, typeVar1);
+  auto bindingsForT2 = inferBindings(cs, typeVar2);
+  auto bindingsForT3 = inferBindings(cs, typeVar3);
+  auto bindingsForT5 = inferBindings(cs, typeVar5);
+
+  ASSERT_TRUE(bool(bindingsForT1.TransitiveProtocols));
+  verifyProtocolInferenceResults(*bindingsForT1.TransitiveProtocols,
+                                 {protocolTy1, protocolTy3, protocolTy4});
+
+  ASSERT_TRUE(bool(bindingsForT2.TransitiveProtocols));
+  verifyProtocolInferenceResults(
+      *bindingsForT2.TransitiveProtocols,
+      {protocolTy1, protocolTy2, protocolTy3, protocolTy4});
+
+  ASSERT_TRUE(bool(bindingsForT3.TransitiveProtocols));
+  verifyProtocolInferenceResults(
+      *bindingsForT3.TransitiveProtocols,
+      {protocolTy1, protocolTy2, protocolTy3, protocolTy4});
+
+  ASSERT_TRUE(bool(bindingsForT5.TransitiveProtocols));
+  verifyProtocolInferenceResults(
+      *bindingsForT5.TransitiveProtocols,
+      {protocolTy1, protocolTy2, protocolTy3, protocolTy4});
 }

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -13,6 +13,7 @@
 #include "SemaFixture.h"
 #include "swift/AST/Expr.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 using namespace swift;
 using namespace swift::unittest;
@@ -43,4 +44,45 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
 
   ASSERT_TRUE(binding.BindingType->isEqual(getStdlibType("Int")));
   ASSERT_TRUE(binding.hasDefaultedLiteralProtocol());
+}
+
+TEST_F(SemaTest, TestTransitiveProtocolInference) {
+  ConstraintSystemOptions options;
+  ConstraintSystem cs(DC, options);
+
+  auto *PD1 =
+      new (Context) ProtocolDecl(DC, SourceLoc(), SourceLoc(),
+                                 Context.getIdentifier("P1"), /*Inherited=*/{},
+                                 /*trailingWhere=*/nullptr);
+  PD1->setImplicit();
+
+  auto *protocolTy1 = ProtocolType::get(PD1, Type(), Context);
+
+  auto *GPT = cs.createTypeVariable(cs.getConstraintLocator({}),
+                                    /*options=*/TVO_CanBindToNoEscape);
+
+  cs.addConstraint(
+      ConstraintKind::ConformsTo, GPT, protocolTy1,
+      cs.getConstraintLocator({}, LocatorPathElt::TypeParameterRequirement(
+                                      0, RequirementKind::Conformance)));
+
+  // First, let's try inferring through a single conversion
+  // relationship.
+  {
+    auto *typeVar = cs.createTypeVariable(cs.getConstraintLocator({}),
+                                          /*options=*/0);
+
+    cs.addConstraint(
+        ConstraintKind::Conversion, typeVar, GPT,
+        cs.getConstraintLocator({}, LocatorPathElt::ContextualType()));
+
+    auto bindings = inferBindings(cs, typeVar);
+    ASSERT_TRUE(bindings.Protocols.empty());
+
+    const auto &inferredProtocols = bindings.TransitiveProtocols;
+    ASSERT_TRUE(bool(inferredProtocols));
+    ASSERT_EQ(inferredProtocols->size(), (unsigned)1);
+    ASSERT_TRUE(
+        (*inferredProtocols->begin())->getSecondType()->isEqual(protocolTy1));
+  }
 }

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -22,6 +22,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Subsystems.h"
+#include "llvm/ADT/DenseMap.h"
 
 using namespace swift;
 using namespace swift::unittest;
@@ -73,4 +74,28 @@ Type SemaTest::getStdlibType(StringRef name) const {
   }
 
   return Type();
+}
+
+ConstraintSystem::PotentialBindings
+SemaTest::inferBindings(ConstraintSystem &cs, TypeVariableType *typeVar) {
+  llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>
+      cache;
+
+  for (auto *typeVar : cs.getTypeVariables()) {
+    if (!typeVar->getImpl().hasRepresentativeOrFixed())
+      cache.insert({typeVar, cs.inferBindingsFor(typeVar, /*finalize=*/false)});
+  }
+
+  for (auto *typeVar : cs.getTypeVariables()) {
+    auto cachedBindings = cache.find(typeVar);
+    if (cachedBindings == cache.end())
+      continue;
+
+    auto &bindings = cachedBindings->getSecond();
+    bindings.finalize(cs, cache);
+  }
+
+  auto result = cache.find(typeVar);
+  assert(result != cache.end());
+  return result->second;
 }

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -76,6 +76,17 @@ Type SemaTest::getStdlibType(StringRef name) const {
   return Type();
 }
 
+ProtocolType *SemaTest::createProtocol(llvm::StringRef protocolName,
+                                       Type parent) {
+  auto *PD = new (Context)
+      ProtocolDecl(DC, SourceLoc(), SourceLoc(),
+                   Context.getIdentifier(protocolName), /*Inherited=*/{},
+                   /*trailingWhere=*/nullptr);
+  PD->setImplicit();
+
+  return ProtocolType::get(PD, parent, Context);
+}
+
 ConstraintSystem::PotentialBindings
 SemaTest::inferBindings(ConstraintSystem &cs, TypeVariableType *typeVar) {
   llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -18,12 +18,15 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
-#include "llvm/ADT/StringRef.h"
+#include "swift/Sema/ConstraintSystem.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/Path.h"
 #include "gtest/gtest.h"
 #include <string>
+
+using namespace swift::constraints;
 
 namespace swift {
 namespace unittest {
@@ -62,6 +65,9 @@ public:
 
 protected:
   Type getStdlibType(StringRef name) const;
+
+  static ConstraintSystem::PotentialBindings
+  inferBindings(ConstraintSystem &cs, TypeVariableType *typeVar);
 };
 
 } // end namespace unittest

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -15,6 +15,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
@@ -65,6 +66,9 @@ public:
 
 protected:
   Type getStdlibType(StringRef name) const;
+
+  ProtocolType *createProtocol(llvm::StringRef protocolName,
+                               Type parent = Type());
 
   static ConstraintSystem::PotentialBindings
   inferBindings(ConstraintSystem &cs, TypeVariableType *typeVar);


### PR DESCRIPTION
Implements iterative protocol requirement inference through
subtype, conversion and equivalence relationships.

This algorithm doesn't depend on a type variable finalization
order (which is currently the order of type variable introduction).

If a given type variable doesn't yet have its transitive protocol
requirements inferred, algorithm would use iterative depth-first
walk through its supertypes and equivalences and incrementally
infer transitive protocols for each type variable involved,
transferring new information down the chain e.g.

      T1   T3
       \   /
        T4    T5
         \    /
           T2

Here `T1`, `T3` are supertypes of `T4`, `T4` and `T5`
are supertypes of `T2`.

Let's assume that algorithm starts at `T2` and none of the involved
type variables have their protocol requirements inferred yet.

First, it would consider supertypes of `T2` which are `T4` and `T5`,
since `T5` is the last in the chain algorithm would transfer its
direct protocol requirements to `T2`. `T4` has supertypes `T1` and
`T3` - they transfer their direct protocol requirements to `T4`
and `T4` transfers its direct and transitive (from `T1` and `T3`)
protocol requirements to `T2`. At this point all the type variables
in subtype chain have their transitive protocol requirements resolved
and cached so they don't have to be re-inferred later.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
