### PR TITLE
Add a -emit-dead-strippable-symbols flag that emits functions/variable/metadata in a dead_strip-friendly way.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -250,6 +250,10 @@ public:
   /// Emit names of struct stored properties and enum cases.
   unsigned EnableReflectionNames : 1;
 
+  /// Emit metadata, variables and functions in a way that a linker can remove
+  /// them if they're unused, even across modules (when linking statically).
+  unsigned EmitDeadStrippableSymbols : 1;
+
   /// Emit mangled names of anonymous context descriptors.
   unsigned EnableAnonymousContextMangledNames : 1;
 
@@ -348,7 +352,8 @@ public:
         PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
         LLVMLTOKind(IRGenLLVMLTOKind::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),
-        EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
+        EnableReflectionNames(true), EmitDeadStrippableSymbols(false),
+        EnableAnonymousContextMangledNames(false),
         ForcePublicLinkage(false), LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),
         PrespecializeGenericMetadata(false), UseIncrementalLLVMCodeGen(true),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -604,6 +604,11 @@ def emit_sorted_sil : Flag<["-"], "emit-sorted-sil">,
   HelpText<"When printing SIL, print out all sil entities sorted by name to "
            "ease diffing">;
 
+def emit_dead_strippable_symbols : Flag<["-"], "emit-dead-strippable-symbols">,
+  HelpText<"Emit metadata, variables and functions in a way that a linker can "
+           "remove them if they're unused, even across modules (when linking "
+           "statically).">;
+
 def emit_syntax : Flag<["-"], "emit-syntax">,
   HelpText<"Parse input file(s) and emit the Syntax tree(s) as JSON">, ModeOpt;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1546,6 +1546,12 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableReflectionNames = false;
   }
 
+  if (Args.hasArg(OPT_emit_dead_strippable_symbols)) {
+    if (!Opts.UseJIT) {
+      Opts.EmitDeadStrippableSymbols = true;
+    }
+  }
+
   if (Args.hasArg(OPT_force_public_linkage)) {
     Opts.ForcePublicLinkage = true;
   }

--- a/test/IRGen/dead_strip.swift
+++ b/test/IRGen/dead_strip.swift
@@ -1,0 +1,71 @@
+// Checks that applying -dead_strip linker flag actually removes unused classes and functions from static libraries.
+
+// REQUIRES: OS=macosx
+
+// RUN: echo "-target x86_64-apple-macos11.0 -swift-version 5 -parse-as-library -working-directory %t" >> %t-commonflags
+// RUN: echo "-Xfrontend -disable-objc-interop" >> %t-commonflags
+// RUN: echo "-Xfrontend -disable-reflection-metadata -Xfrontend -disable-reflection-names" >> %t-commonflags
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver @%t-commonflags -emit-library -static -DMODULE -emit-module %s -module-name MyModule
+// RUN: %target-swiftc_driver @%t-commonflags %s -I%t -L%t -lMyModule -Xlinker -dead_strip -module-name main -o %t/main
+// RUN: %llvm-nm --defined-only %t/main | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver @%t-commonflags -emit-library -static -DMODULE -emit-module %s -module-name MyModule -Xfrontend -emit-dead-strippable-symbols
+// RUN: %target-swiftc_driver @%t-commonflags %s -I%t -L%t -lMyModule -Xlinker -dead_strip -module-name main -o %t/main
+// RUN: %llvm-nm --defined-only %t/main | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
+
+#if MODULE
+
+public protocol MyProtocol {
+}
+public class MyClass: MyProtocol {
+}
+
+public func fooFromModule() { print("fooFromModule") }
+public func barFromModule() { print("barFromModule") }
+
+#else
+
+import MyModule
+
+@_cdecl("main")
+func main() {
+	print("Hello!")
+	fooFromModule()
+}
+
+#endif
+
+// CHECK: _$s8MyModule07barFromB0yyF
+// CHECK: _$s8MyModule07fooFromB0yyF
+// CHECK: _$s8MyModule0A5ClassCAA0A8ProtocolAAMc
+// CHECK: _$s8MyModule0A5ClassCAA0A8ProtocolAAWP
+// CHECK: _$s8MyModule0A5ClassCACycfC
+// CHECK: _$s8MyModule0A5ClassCACycfCTq
+// CHECK: _$s8MyModule0A5ClassCACycfc
+// CHECK: _$s8MyModule0A5ClassCMa
+// CHECK: _$s8MyModule0A5ClassCMf
+// CHECK: _$s8MyModule0A5ClassCMn
+// CHECK: _$s8MyModule0A5ClassCN
+// CHECK: _$s8MyModule0A5ClassCfD
+// CHECK: _$s8MyModule0A5ClassCfd
+// CHECK: _$s8MyModule0A8ProtocolMp
+// CHECK: _$s8MyModuleMXM
+
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule07barFromB0yyF
+// CHECK-DEADSTRIPPABLE:     _$s8MyModule07fooFromB0yyF
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCAA0A8ProtocolAAMc
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCAA0A8ProtocolAAWP
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCACycfC
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCACycfCTq
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCACycfc
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCMa
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCMf
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCMn
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCN
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCfD
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A5ClassCfd
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModule0A8ProtocolMp
+// CHECK-DEADSTRIPPABLE-NOT: _$s8MyModuleMXM

--- a/test/IRGen/dead_strip_class.swift
+++ b/test/IRGen/dead_strip_class.swift
@@ -1,0 +1,36 @@
+// RUN: echo "-target x86_64-apple-macos11.0 -swift-version 5" >> %t-commonflags
+
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
+
+public class MyClass {
+}
+
+// CHECK:      @"\01l_type_metadata_table" = private constant [1 x
+// CHECK-SAME:   @"$s8MyModule0A5ClassCMn"
+// CHECK-SAME: ], section "__TEXT, __swift5_types, regular, no_dead_strip", align 4
+
+// CHECK:      @llvm.used = appending global [
+// CHECK-SAME:   %swift.refcounted* (%T8MyModule0A5ClassC*)* @"$s8MyModule0A5ClassCfd"
+// CHECK-SAME:   void (%T8MyModule0A5ClassC*)* @"$s8MyModule0A5ClassCfD"
+// CHECK-SAME:   @"$s8MyModule0A5ClassCMn"
+// CHECK-SAME:   @"$s8MyModule0A5ClassCMa"
+// CHECK-SAME:   @"$s8MyModule0A5ClassCN"
+// CHECK-SAME:   @"\01l_type_metadata_table"
+// CHECK-SAME:   @__swift_reflection_version
+// CHECK-SAME: ], section "llvm.metadata", align 8
+
+// CHECK-DEADSTRIPPABLE:      @"\01l_type_metadata_$s8MyModule0A5ClassCMn" = private constant %swift.type_metadata_record
+// CHECK-DEADSTRIPPABLE-SAME: @"$s8MyModule0A5ClassCMn"
+// CHECK-DEADSTRIPPABLE-SAME: section "__TEXT, __swift5_types, regular, live_support", align 4
+
+// CHECK-DEADSTRIPPABLE:      @llvm.used = appending global [
+// CHECK-DEADSTRIPPABLE-NOT:    @"\01l_type_metadata_table"
+// CHECK-DEADSTRIPPABLE-NOT:    @"\01l_type_metadata_$s8MyModule0A5ClassCMn"
+// CHECK-DEADSTRIPPABLE-NOT:    %swift.refcounted* (%T8MyModule0A5ClassC*)* @"$s8MyModule0A5ClassCfd"
+// CHECK-DEADSTRIPPABLE-NOT:    void (%T8MyModule0A5ClassC*)* @"$s8MyModule0A5ClassCfD"
+// CHECK-DEADSTRIPPABLE-NOT:    @"$s8MyModule0A5ClassCMn"
+// CHECK-DEADSTRIPPABLE-NOT:    @"$s8MyModule0A5ClassCMa"
+// CHECK-DEADSTRIPPABLE-NOT:    @"$s8MyModule0A5ClassCN"
+// CHECK-DEADSTRIPPABLE-SAME:   @__swift_reflection_version
+// CHECK-DEADSTRIPPABLE-SAME: ], section "llvm.metadata", align 8

--- a/test/IRGen/dead_strip_class.swift
+++ b/test/IRGen/dead_strip_class.swift
@@ -3,6 +3,8 @@
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
 
+// REQUIRES: OS=macosx
+
 public class MyClass {
 }
 

--- a/test/IRGen/dead_strip_func.swift
+++ b/test/IRGen/dead_strip_func.swift
@@ -1,0 +1,17 @@
+// RUN: echo "-target x86_64-apple-macos11.0 -swift-version 5" >> %t-commonflags
+
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
+
+public func myfunc() {
+}
+
+// CHECK:      @llvm.used = appending global [
+// CHECK-SAME:   @"$s8MyModule6myfuncyyF"
+// CHECK-SAME:   @__swift_reflection_version
+// CHECK-SAME: ], section "llvm.metadata", align 8
+
+// CHECK-DEADSTRIPPABLE:      @llvm.used = appending global [
+// CHECK-DEADSTRIPPABLE-NOT:    @"$s8MyModule6myfuncyyF"
+// CHECK-DEADSTRIPPABLE-SAME:   @__swift_reflection_version
+// CHECK-DEADSTRIPPABLE-SAME: ], section "llvm.metadata", align 8

--- a/test/IRGen/dead_strip_func.swift
+++ b/test/IRGen/dead_strip_func.swift
@@ -3,6 +3,8 @@
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
 
+// REQUIRES: OS=macosx
+
 public func myfunc() {
 }
 

--- a/test/IRGen/dead_strip_protocol.swift
+++ b/test/IRGen/dead_strip_protocol.swift
@@ -1,0 +1,27 @@
+// RUN: echo "-target x86_64-apple-macos11.0 -swift-version 5 -disable-reflection-metadata" >> %t-commonflags
+
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
+
+public protocol MyProtocol {
+}
+
+// CHECK:      @"\01l_protocols" = private constant [1 x
+// CHECK-SAME:   @"$s8MyModule0A8ProtocolMp"
+// CHECK-SAME: ], section "__TEXT, __swift5_protos, regular, no_dead_strip", align 4
+
+// CHECK:      @llvm.used = appending global [
+// CHECK-SAME:   @"$s8MyModule0A8ProtocolMp"
+// CHECK-SAME:   @"\01l_protocols"
+// CHECK-SAME:   @__swift_reflection_version
+// CHECK-SAME: ], section "llvm.metadata", align 8
+
+// CHECK-DEADSTRIPPABLE:      @"\01l_protocol_$s8MyModule0A8ProtocolMp" = private constant %swift.protocolref
+// CHECK-DEADSTRIPPABLE-SAME: @"$s8MyModule0A8ProtocolMp"
+// CHECK-DEADSTRIPPABLE-SAME: section "__TEXT, __swift5_protos, regular, live_support", align 4
+
+// CHECK-DEADSTRIPPABLE:      @llvm.used = appending global [
+// CHECK-DEADSTRIPPABLE-NOT:    @"$s8MyModule0A8ProtocolMp"
+// CHECK-DEADSTRIPPABLE-NOT:    @"\01l_protocols"
+// CHECK-DEADSTRIPPABLE-SAME:   @__swift_reflection_version
+// CHECK-DEADSTRIPPABLE-SAME: ], section "llvm.metadata", align 8

--- a/test/IRGen/dead_strip_protocol.swift
+++ b/test/IRGen/dead_strip_protocol.swift
@@ -3,6 +3,8 @@
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
 
+// REQUIRES: OS=macosx
+
 public protocol MyProtocol {
 }
 

--- a/test/IRGen/dead_strip_protocol_conformance.swift
+++ b/test/IRGen/dead_strip_protocol_conformance.swift
@@ -1,0 +1,29 @@
+// RUN: echo "-target x86_64-apple-macos11.0 -swift-version 5 -disable-reflection-metadata" >> %t-commonflags
+
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
+// RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
+
+public protocol MyProtocol {
+}
+public class MyClass: MyProtocol {
+}
+
+// CHECK:      @"\01l_protocol_conformances" = private constant [1 x
+// CHECK-SAME:   @"$s8MyModule0A5ClassCAA0A8ProtocolAAMc"
+// CHECK-SAME: ], section "__TEXT, __swift5_proto, regular, no_dead_strip", align 4
+
+// CHECK:      @llvm.used = appending global [
+// CHECK-SAME:   @"$s8MyModule0A5ClassCAA0A8ProtocolAAMc"
+// CHECK-SAME:   @"\01l_protocol_conformances"
+// CHECK-SAME:   @__swift_reflection_version
+// CHECK-SAME: ], section "llvm.metadata", align 8
+
+// CHECK-DEADSTRIPPABLE:      @"\01l_protocol_conformance_$s8MyModule0A5ClassCAA0A8ProtocolAAMc" = private constant i32
+// CHECK-DEADSTRIPPABLE-SAME: @"$s8MyModule0A5ClassCAA0A8ProtocolAAMc"
+// CHECK-DEADSTRIPPABLE-SAME: section "__TEXT, __swift5_proto, regular, live_support", align 4
+
+// CHECK-DEADSTRIPPABLE:      @llvm.used = appending global [
+// CHECK-DEADSTRIPPABLE-NOT:    @"$s8MyModule0A5ClassCAA0A8ProtocolAAMc"
+// CHECK-DEADSTRIPPABLE-NOT:    @"\01l_protocol_conformances"
+// CHECK-DEADSTRIPPABLE-SAME:   @__swift_reflection_version
+// CHECK-DEADSTRIPPABLE-SAME: ], section "llvm.metadata", align 8

--- a/test/IRGen/dead_strip_protocol_conformance.swift
+++ b/test/IRGen/dead_strip_protocol_conformance.swift
@@ -3,6 +3,8 @@
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - | %FileCheck %s
 // RUN: %swift @%t-commonflags -module-name MyModule -emit-ir %s -o - -emit-dead-strippable-symbols | %FileCheck %s -check-prefix CHECK-DEADSTRIPPABLE
 
+// REQUIRES: OS=macosx
+
 public protocol MyProtocol {
 }
 public class MyClass: MyProtocol {


### PR DESCRIPTION
Add a -emit-dead-strippable-symbols flag that emits functions/variable/metadata in a dead_strip-friendly way. This enables static linking to remove unused functions and classes even across modules. For now, I'm adding the flag as an opt-in experimental mode, but the goal is to eventually be able to emit symbols this way for everything. This way we could see nice code size savings when e.g. including a lot of package dependencies where not everything is actually used.