### PR TITLE
[Parse] Parse opaque result types in closure signature position

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -841,7 +841,7 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
   // This is only semantically allowed in certain contexts, but we parse it
   // generally for diagnostics and recovery.
   SourceLoc opaqueLoc;
-  if (Tok.is(tok::identifier) && Tok.getRawText() == "some") {
+  if (Tok.isContextualKeyword("some")) {
     // Treat some as a keyword.
     TokReceiver->registerTokenKindChange(Tok.getLoc(), tok::contextual_keyword);
     opaqueLoc = consumeToken();
@@ -905,7 +905,7 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
     }
     
     // Diagnose invalid `some` after an ampersand.
-    if (Tok.is(tok::identifier) && Tok.getRawText() == "some") {
+    if (Tok.isContextualKeyword("some")) {
       auto badLoc = consumeToken();
 
       diagnose(badLoc, diag::opaque_mid_composition)
@@ -1094,7 +1094,7 @@ ParserResult<TypeRepr> Parser::parseTypeTupleBody() {
     // If the label is "some", this could end up being an opaque type
     // description if there's `some <identifier>` without a following colon,
     // so we may need to backtrack as well.
-    if (Tok.getText().equals("some")) {
+    if (Tok.isContextualKeyword("some")) {
       Backtracking.emplace(*this);
     }
 
@@ -1530,6 +1530,9 @@ bool Parser::canParseGenericArguments() {
 bool Parser::canParseType() {
   // Accept 'inout' at for better recovery.
   consumeIf(tok::kw_inout);
+
+  if (Tok.isContextualKeyword("some"))
+    consumeToken();
 
   switch (Tok.getKind()) {
   case tok::kw_Self:

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -73,7 +73,7 @@ struct Test {
   let inferredOpaqueStructural2 = (bar(), bas()) // expected-error{{inferred type}}
 }
 
-//let zingle = {() -> some P in 1 } // FIXME ex/pected-error{{'some' types are only implemented}}
+let zingle = {() -> some P in 1 } // expected-error{{'some' types are only implemented}}
 
 // Invalid positions
 


### PR DESCRIPTION
e.g.
```swift
let _ = { () -> some Collection in
  ...
}
```

`canParseType()` didn't use to handle `some`.

Also, use `isContexttualKeyword("some")` for checking `some` keyword.

https://bugs.swift.org/browse/SR-10769
