### PR TITLE
[Concurrency] Implement global actor isolation checking for conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4194,6 +4194,18 @@ ERROR(actor_isolated_witness_could_be_async_handler,none,
      "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement; "
      "did you mean to make it an asychronous handler?",
      (DescriptiveDeclKind, DeclName))
+ERROR(global_actor_isolated_requirement,none,
+      "%0 %1 must be isolated to the global actor %2 to satisfy corresponding "
+      "requirement from protocol %3",
+      (DescriptiveDeclKind, DeclName, Type, Identifier))
+ERROR(global_actor_isolated_witness,none,
+      "%0 %1 isolated to global actor %2 can not satisfy corresponding "
+      "requirement from protocol %3",
+      (DescriptiveDeclKind, DeclName, Type, Identifier))
+ERROR(global_actor_isolated_requirement_witness_conflict,none,
+      "%0 %1 isolated to global actor %2 can not satisfy corresponding "
+      "requirement from protocol %3 isolated to global actor %4",
+      (DescriptiveDeclKind, DeclName, Type, Identifier, Type))
 
 ERROR(actorisolated_let,none,
       "'@actorIsolated' is meaningless on 'let' declarations because "

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -739,6 +739,11 @@ private:
                                    Type type,
                                    TypeDecl *typeDecl);
 
+  /// Check that the witness and requirement have compatible actor contexts.
+  ///
+  /// \returns true if an error occurred, false otherwise.
+  bool checkActorIsolation(ValueDecl *requirement, ValueDecl *witness);
+
   /// Record a type witness.
   ///
   /// \param assocType The associated type whose witness is being recorded.

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -1,0 +1,59 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+import _Concurrency
+
+actor class SomeActor { }
+
+@globalActor
+struct GlobalActor {
+  static var shared: SomeActor { SomeActor() }
+}
+
+@globalActor
+struct GenericGlobalActor<T> {
+  static var shared: SomeActor { SomeActor() }
+}
+
+protocol P1 {
+  associatedtype Assoc
+
+  @GlobalActor func method1() // expected-note{{declared here}}
+  @GenericGlobalActor<Int> func method2()  // expected-note{{declared here}}
+  @GenericGlobalActor<Assoc> func method3()
+  func method4() // expected-note{{declared here}}
+}
+
+protocol P2 {
+  @GlobalActor func asyncMethod1() async
+  @GenericGlobalActor<Int> func asyncMethod2() async
+  func asyncMethod3() async
+}
+
+class C1 : P1, P2 {
+  typealias Assoc = String
+
+  // FIXME: This will be inferred
+  func method1() { } // expected-error{{instance method 'method1()' must be isolated to the global actor 'GlobalActor' to satisfy corresponding requirement from protocol 'P1'}}{{3-3=@GlobalActor}}
+
+  @GenericGlobalActor<String> func method2() { } // expected-error{{instance method 'method2()' isolated to global actor 'GenericGlobalActor<String>' can not satisfy corresponding requirement from protocol 'P1' isolated to global actor 'GenericGlobalActor<Int>'}}
+  @GenericGlobalActor<String >func method3() { }
+  @GlobalActor func method4() { } // expected-error{{instance method 'method4()' isolated to global actor 'GlobalActor' can not satisfy corresponding requirement from protocol 'P1'}}
+
+  // Okay: we can ignore the mismatch in global actor types for 'async' methods.
+  func asyncMethod1() async { }
+  @GenericGlobalActor<String> func asyncMethod2() async { }
+  @GlobalActor func asyncMethod3() async { }
+}
+
+
+class C2: P1 {
+  typealias Assoc = Int
+
+  // Okay: we can ignore the mismatch in global actor types for 'asyncHandler'
+  // methods.
+  @asyncHandler func method1() { }
+  @asyncHandler func method2() { }
+  @asyncHandler func method3() { }
+  @asyncHandler func method4() { }
+}


### PR DESCRIPTION
Witnesses and requirements need to agree on their global actor
annotations. However, this is not true for 'async' or '@asyncHandler'
witnesses, for which it does not matter what the actor annotation is
because part of the contract is that the function will execute on the
appropriate actor.
