### PR TITLE
[CodeCompletion] Reuse CompletionContextFinder for fallback completion when no typeCheckExpression call is made

### DIFF
--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -593,6 +593,167 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
   }
 }
 
+namespace {
+
+class CompletionContextFinder : public ASTWalker {
+  enum class ContextKind {
+    FallbackExpression,
+    StringInterpolation,
+    SingleStmtClosure,
+    MultiStmtClosure,
+    ErrorExpression
+  };
+
+  struct Context {
+    ContextKind Kind;
+    Expr * E;
+  };
+
+  /// Stack of all "interesting" contexts up to code completion expression.
+  llvm::SmallVector<Context, 4> Contexts;
+  CodeCompletionExpr *CompletionExpr = nullptr;
+  Expr *InitialExpr = nullptr;
+  DeclContext *InitialDC;
+
+public:
+  /// Finder for completion contexts within the provided initial expression.
+  CompletionContextFinder(Expr *initialExpr, DeclContext *DC)
+      : InitialExpr(initialExpr), InitialDC(DC) {
+    assert(DC);
+    initialExpr->walk(*this);
+  };
+
+  /// Finder for completion contexts within the outermost non-closure context of
+  /// the code completion expression's direct context.
+  CompletionContextFinder(DeclContext *completionDC): InitialDC(completionDC) {
+    while (auto *ACE = dyn_cast<AbstractClosureExpr>(InitialDC))
+      InitialDC = ACE->getParent();
+    InitialDC->walkContext(*this);
+  }
+
+  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    if (auto *closure = dyn_cast<ClosureExpr>(E)) {
+      Contexts.push_back({closure->hasSingleExpressionBody()
+                            ? ContextKind::SingleStmtClosure
+                            : ContextKind::MultiStmtClosure,
+                          closure});
+    }
+
+    if (isa<InterpolatedStringLiteralExpr>(E)) {
+      Contexts.push_back({ContextKind::StringInterpolation, E});
+    }
+
+    if (isa<ApplyExpr>(E) || isa<SequenceExpr>(E)) {
+      Contexts.push_back({ContextKind::FallbackExpression, E});
+    }
+
+    if (auto *Error = dyn_cast<ErrorExpr>(E)) {
+      Contexts.push_back({ContextKind::ErrorExpression, E});
+      if (auto *OrigExpr = Error->getOriginalExpr()) {
+        OrigExpr->walk(*this);
+        if (hasCompletionExpr())
+          return std::make_pair(false, nullptr);
+      }
+    }
+
+    if (auto *CCE = dyn_cast<CodeCompletionExpr>(E)) {
+      CompletionExpr = CCE;
+      return std::make_pair(false, nullptr);
+    }
+
+    return std::make_pair(true, E);
+  }
+
+  Expr *walkToExprPost(Expr *E) override {
+    if (isa<ClosureExpr>(E) || isa<InterpolatedStringLiteralExpr>(E) ||
+        isa<ApplyExpr>(E) || isa<SequenceExpr>(E) || isa<ErrorExpr>(E)) {
+      assert(Contexts.back().E == E);
+      Contexts.pop_back();
+    }
+    return E;
+  }
+
+  /// Check whether code completion expression is located inside of a
+  /// multi-statement closure.
+  bool locatedInMultiStmtClosure() const {
+    return hasContext(ContextKind::MultiStmtClosure);
+  }
+
+  bool locatedInStringIterpolation() const {
+    return hasContext(ContextKind::StringInterpolation);
+  }
+
+  bool hasCompletionExpr() const {
+    return CompletionExpr;
+  }
+
+  CodeCompletionExpr *getCompletionExpr() const {
+    assert(CompletionExpr);
+    return CompletionExpr;
+  }
+
+  struct Fallback {
+    Expr *E; ///< The fallback expression.
+    DeclContext *DC; ///< The fallback expression's decl context.
+    bool SeparatePrecheck; ///< True if the fallback may require prechecking.
+  };
+
+  /// As a fallback sometimes its useful to not only type-check
+  /// code completion expression directly but instead add some
+  /// of the enclosing context e.g. when completion is an argument
+  /// to a call.
+  Optional<Fallback> getFallbackCompletionExpr() const {
+    assert(CompletionExpr);
+
+    Optional<Fallback> fallback;
+    bool separatePrecheck = false;
+    DeclContext *fallbackDC = InitialDC;
+
+    // Find the outermost fallback expression within the innermost error
+    // expression or multi-statement closure, keeping track of its decl context.
+    for (auto context: Contexts) {
+      switch (context.Kind) {
+      case ContextKind::StringInterpolation:
+        LLVM_FALLTHROUGH;
+      case ContextKind::FallbackExpression:
+        if (!fallback && context.E != InitialExpr)
+          fallback = Fallback{context.E, fallbackDC, separatePrecheck};
+        continue;
+
+      case ContextKind::SingleStmtClosure:
+        if (!fallback && context.E != InitialExpr)
+          fallback = Fallback{context.E, fallbackDC, separatePrecheck};
+        fallbackDC = cast<AbstractClosureExpr>(context.E);
+        continue;
+
+      case ContextKind::MultiStmtClosure:
+        fallbackDC = cast<AbstractClosureExpr>(context.E);
+        LLVM_FALLTHROUGH;
+      case ContextKind::ErrorExpression:;
+        fallback = None;
+        separatePrecheck = true;
+        continue;
+      }
+    }
+
+    if (fallback)
+      return fallback;
+
+    if (CompletionExpr->getBase() && CompletionExpr != InitialExpr)
+      return Fallback{CompletionExpr, fallbackDC, separatePrecheck};
+    return None;
+  }
+
+private:
+  bool hasContext(ContextKind kind) const {
+    return llvm::find_if(Contexts, [&kind](const Context &currContext) {
+             return currContext.Kind == kind;
+           }) != Contexts.end();
+  }
+};
+
+} // end namespace
+
 bool TypeChecker::typeCheckForCodeCompletion(
     SolutionApplicationTarget &target,
     llvm::function_ref<void(const Solution &)> callback) {
@@ -618,144 +779,14 @@ bool TypeChecker::typeCheckForCodeCompletion(
 
   expr = expr->walk(SanitizeExpr(Context,
                                  /*shouldReusePrecheckedType=*/false));
+  target.setExpr(expr);
 
-  enum class ContextKind {
-    Expression,
-    Application,
-    StringInterpolation,
-    SingleStmtClosure,
-    MultiStmtClosure,
-    ErrorExpression
-  };
-
-  class ContextFinder : public ASTWalker {
-    using Context = std::pair<ContextKind, Expr *>;
-
-    // Stack of all "interesting" contexts up to code completion expression.
-    llvm::SmallVector<Context, 4> Contexts;
-
-    Expr *CompletionExpr = nullptr;
-
-  public:
-    ContextFinder(Expr *E) {
-      Contexts.push_back(std::make_pair(ContextKind::Expression, E));
-    }
-
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      if (auto *closure = dyn_cast<ClosureExpr>(E)) {
-        Contexts.push_back(std::make_pair(closure->hasSingleExpressionBody()
-                                              ? ContextKind::SingleStmtClosure
-                                              : ContextKind::MultiStmtClosure,
-                                          closure));
-      }
-
-      if (isa<InterpolatedStringLiteralExpr>(E)) {
-        Contexts.push_back(std::make_pair(ContextKind::StringInterpolation, E));
-      }
-
-      if (isa<ApplyExpr>(E)) {
-        Contexts.push_back(std::make_pair(ContextKind::Application, E));
-      }
-
-      if (isa<CodeCompletionExpr>(E)) {
-        CompletionExpr = E;
-        return std::make_pair(false, nullptr);
-      }
-
-      if (auto *Error = dyn_cast<ErrorExpr>(E)) {
-        Contexts.push_back(std::make_pair(ContextKind::ErrorExpression, E));
-        if (auto *OrigExpr = Error->getOriginalExpr()) {
-          OrigExpr->walk(*this);
-          return std::make_pair(false, hasCompletionExpr() ? nullptr : E);
-        }
-      }
-
-      return std::make_pair(true, E);
-    }
-
-    Expr *walkToExprPost(Expr *E) override {
-      if (isa<ClosureExpr>(E) || isa<InterpolatedStringLiteralExpr>(E) ||
-          isa<ApplyExpr>(E) || isa<ErrorExpr>(E))
-        Contexts.pop_back();
-      return E;
-    }
-
-    /// Check whether code completion expression is located inside of a
-    /// multi-statement closure.
-    bool locatedInMultiStmtClosure() const {
-      return hasContext(ContextKind::MultiStmtClosure);
-    }
-
-    bool locatedInStringIterpolation() const {
-      return hasContext(ContextKind::StringInterpolation);
-    }
-
-    bool hasCompletionExpr() const {
-      return CompletionExpr;
-    }
-
-    Expr *getCompletionExpr() const {
-      assert(CompletionExpr);
-      return CompletionExpr;
-    }
-
-    ErrorExpr *getInnermostErrorExpr() const {
-      for (const Context &curr : llvm::reverse(Contexts)) {
-        if (curr.first == ContextKind::ErrorExpression)
-          return cast<ErrorExpr>(curr.second);
-      }
-      return nullptr;
-    }
-
-    ClosureExpr *getOutermostMultiStmtClosure() const {
-      for (const Context &curr : Contexts) {
-        if (curr.first == ContextKind::MultiStmtClosure)
-          return cast<ClosureExpr>(curr.second);
-      }
-      return nullptr;
-    }
-
-    /// As a fallback sometimes its useful to not only type-check
-    /// code completion expression directly but instead add some
-    /// of the enclosing context e.g. when completion is an argument
-    /// to a call.
-    Expr *getCompletionExprInContext() const {
-      assert(CompletionExpr);
-
-      auto &innerContext = Contexts.back();
-      return innerContext.first == ContextKind::Application
-                 ? innerContext.second
-                 : CompletionExpr;
-    }
-
-  private:
-    bool hasContext(ContextKind kind) const {
-      return llvm::find_if(Contexts, [&kind](const Context &currContext) {
-               return currContext.first == kind;
-             }) != Contexts.end();
-    }
-  };
-
-  ContextFinder contextAnalyzer(expr);
-  expr->walk(contextAnalyzer);
+  CompletionContextFinder contextAnalyzer(expr, DC);
 
   // If there was no completion expr (e.g. if the code completion location was
   // among tokens that were skipped over during parser error recovery) bail.
   if (!contextAnalyzer.hasCompletionExpr())
     return false;
-
-  // If the completion expression is in a valid subexpression of an ErrorExpr,
-  // fallback to trying the valid subexpression without any context. This can
-  // happen for cases like `expectsBoolArg(foo.<complete>).` which becomes an
-  // ErrorExpr due to the missing member name after the final dot.
-  if (auto *errorExpr = contextAnalyzer.getInnermostErrorExpr()) {
-    if (auto *origExpr = errorExpr->getOriginalExpr()) {
-      SolutionApplicationTarget completionTarget(origExpr, DC, CTP_Unused,
-                                                 /*contextualType=*/Type(),
-                                                 /*isDiscarded=*/true);
-      return typeCheckForCodeCompletion(completionTarget, callback);
-    }
-  }
 
   // Interpolation components are type-checked separately.
   if (contextAnalyzer.locatedInStringIterpolation())
@@ -793,41 +824,36 @@ bool TypeChecker::typeCheckForCodeCompletion(
     llvm::SmallVector<Solution, 4> solutions;
 
     // If solve failed to generate constraints or with some other
-    // issue, we need to fallback to type-checking code completion
-    // expression directly.
+    // issue, we need to fallback to type-checking a sub-expression.
     if (!cs.solveForCodeCompletion(target, solutions))
       return CompletionResult::Fallback;
 
-    // If case type-check didn't produce any solutions, let's
-    // attempt to type-check code completion expression without
-    // enclosing context.
+    // Similarly, if the type-check didn't produce any solutions, fall back
+    // to type-checking a sub-expression in isolation.
     if (solutions.empty())
       return CompletionResult::Fallback;
 
     // If code completion expression resides inside of multi-statement
-    // closure body it code either be type-checker together with context
-    // or not, it's impossible to say without trying. If solution
-    // doesn't have a type for a code completion expression it means that
-    // we have to wait until body of the closure is type-checked.
+    // closure body it could either be type-checked together with the context
+    // or not, it's impossible to say without checking.
     if (contextAnalyzer.locatedInMultiStmtClosure()) {
       auto &solution = solutions.front();
 
-      // Let's check whether closure participated in the type-check.
       if (solution.hasType(contextAnalyzer.getCompletionExpr())) {
         llvm::for_each(solutions, callback);
         return CompletionResult::Ok;
       }
 
-      if (solutions.size() > 1)
-        return CompletionResult::Fallback;
+      // At this point we know the code completion expression wasn't checked
+      // with the closure's surrounding context. If a single valid solution
+      // was formed we can wait until body of the closure is type-checked and
+      // gather completions then.
+      if (solutions.size() == 1 && solution.Fixes.empty())
+        return CompletionResult::NotApplicable;
 
-      auto *closure = contextAnalyzer.getOutermostMultiStmtClosure();
-      auto closureType = solution.getResolvedType(closure);
-
-      if (closureType->hasUnresolvedType())
-        return CompletionResult::Fallback;
-
-      return CompletionResult::NotApplicable;
+      // Otherwise, it's unlikely the body will ever be type-checked, so fall
+      // back to manually checking a sub-expression within the closure body.
+      return CompletionResult::Fallback;
     }
 
     llvm::for_each(solutions, callback);
@@ -845,33 +871,25 @@ bool TypeChecker::typeCheckForCodeCompletion(
     break;
   }
 
-  {
-    auto *completionExpr = contextAnalyzer.getCompletionExpr();
-
-    if (contextAnalyzer.locatedInMultiStmtClosure()) {
-      auto completionInContext = contextAnalyzer.getCompletionExprInContext();
-      // If pre-check fails, let's switch to code completion
-      // expression without any enclosing context.
-      if (ConstraintSystem::preCheckExpression(
-              completionInContext, DC, /*replaceInvalidRefsWithErrors=*/true)) {
-        completionExpr = contextAnalyzer.getCompletionExpr();
-      } else {
-        completionExpr = completionInContext;
-      }
-    }
-
-    // If initial solve failed, let's fallback to checking only code completion
-    // expresion without any context.
-    SolutionApplicationTarget completionTarget(completionExpr, DC, CTP_Unused,
+  // Determine the best subexpression to use based on the collected context
+  // of the code completion expression.
+  if (auto fallback = contextAnalyzer.getFallbackCompletionExpr()) {
+    assert(fallback->E != expr);
+    SolutionApplicationTarget completionTarget(fallback->E,
+                                               fallback->DC, CTP_Unused,
                                                /*contextualType=*/Type(),
                                                /*isDiscarded=*/true);
+    if (fallback->SeparatePrecheck) {
+      typeCheckForCodeCompletion(completionTarget, callback);
+      return true;
+    }
 
     switch (solveForCodeCompletion(completionTarget)) {
     case CompletionResult::Ok:
     case CompletionResult::Fallback:
       break;
     case CompletionResult::NotApplicable:
-      llvm_unreachable("solve on CodeCompletionExpr produced not applicable?");
+      llvm_unreachable("fallback expr not applicable?");
     }
   }
   return true;
@@ -974,8 +992,23 @@ swift::lookupSemanticMember(DeclContext *DC, Type ty, DeclName name) {
 
 void DotExprTypeCheckCompletionCallback::fallbackTypeCheck() {
   assert(!gotCallback());
-  SolutionApplicationTarget completionTarget(CompletionExpr, DC, CTP_Unused,
-                                             Type(), /*isDiscared=*/true);
+
+  // Default to checking the completion expression in isolation.
+  Expr *fallbackExpr = CompletionExpr;
+  DeclContext *fallbackDC = DC;
+
+  CompletionContextFinder finder(DC);
+  if (finder.hasCompletionExpr()) {
+    if (auto fallback = finder.getFallbackCompletionExpr()) {
+      fallbackExpr = fallback->E;
+      fallbackDC = fallback->DC;
+    }
+  }
+
+  SolutionApplicationTarget completionTarget(fallbackExpr, fallbackDC,
+                                             CTP_Unused, Type(),
+                                             /*isDiscared=*/true);
+
   TypeChecker::typeCheckForCodeCompletion(
       completionTarget, [&](const Solution &S) { sawSolution(S); });
 }

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -4,6 +4,8 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=RELATED | %FileCheck %s --check-prefix=RELATED
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=RELATED_EXTRAARG | %FileCheck %s --check-prefix=RELATED
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=RELATED_INERROREXPR | %FileCheck %s --check-prefix=RELATED
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=NOCALLBACK_FALLBACK | %FileCheck %s --check-prefix=RELATED
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FALLBACK | %FileCheck %s --check-prefix=MULTICLOSURE_FALLBACK
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=ERROR_IN_BASE | %FileCheck %s --check-prefix=SIMPLE
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=GENERIC | %FileCheck %s --check-prefix=GENERIC
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=GENERIC_MISSINGARG | %FileCheck %s --check-prefix=NORESULTS
@@ -61,6 +63,27 @@ func takesA(_ callback: () -> A) -> B {}
 func takesB(_ item: B) {}
 
 takesB((takesA { return overloadedReturn().#^RELATED_INERROREXPR^# }).)
+
+switch undefined {
+  case takesA { return overloadedReturn().#^NOCALLBACK_FALLBACK^# }:
+    break
+}
+
+
+func takesClosureA(_ arg: (A) -> ()) {}
+func takesClosureB(_ arg: (B) -> ()) {}
+
+takesClosureA { arg in
+  takesClosureB { arg in
+    arg.#^MULTICLOSURE_FALLBACK^#
+  }
+  print() + 10
+} + 10
+
+// MULTICLOSURE_FALLBACK: Begin completions, 2 items
+// MULTICLOSURE_FALLBACK-DAG: Keyword[self]/CurrNominal:        self[#B#]{{; name=.+$}}
+// MULTICLOSURE_FALLBACK-DAG: Decl[InstanceMethod]/CurrNominal: doBThings()[#Void#]{{; name=.+$}}
+// MULTICLOSURE_FALLBACK: End completions
 
 protocol C {
   associatedtype Element


### PR DESCRIPTION
Also adjust the fallback context it choses now that `ErrorExpr`s no longer cause constraint generation to fail, and provide the correct DeclContext of the fallback as well, rather than using the DeclContext of the original expression.

This PR also fixes some issues with the fallback logic in `typeCheckForCodeCompletion`:

1) For completion expressions in multi-statement closures, we were assuming a separate `typeCheckExpression` call would be made when the outer expression produced a single solution that had a resolved type for the closure. If the solution contained other fixes unrelated to the closure however, it wasn't applied and a separate call for the body was never made.

2) `typeCheckForCodeCompletion` sometimes falls through to normal expression type checking but didn't update the passed-in target's expression after sanitizing and prechecking it, which may have modified it and/or its sub-expressions. This triggered assertion failures in certain cases due to a stale top-level expression pointer being used with updated subexpressions.