### PR TITLE
[Dependency Scanner] Always add NonPathCommandLine arguments from Clang scan-deps result

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -245,6 +245,15 @@ void ClangImporter::recordModuleDependencies(
       }
     }
 
+    // Add all args the non-path arguments required to be passed in, according
+    // to the Clang scanner
+    for (const auto &clangArg : clangModuleDep.NonPathCommandLine) {
+      swiftArgs.push_back("-Xcc");
+      swiftArgs.push_back("-Xclang");
+      swiftArgs.push_back("-Xcc");
+      swiftArgs.push_back(clangArg);
+    }
+
     // Swift frontend action: -emit-pcm
     swiftArgs.push_back("-emit-pcm");
     swiftArgs.push_back("-module-name");

--- a/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/module.modulemap
@@ -8,7 +8,7 @@ module B {
   export *
 }
 
-module C {
+module C [system] {
   header "C.h"
   export *
 }

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -105,6 +105,10 @@ import SubE
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
 // CHECK-NEXT: "clang"
+// CHECK:      "-fsystem-module",
+// CHECK-NEXT: "-emit-pcm",
+// CHECK-NEXT: "-module-name",
+// CHECK-NEXT: "C"
 
 /// --------Swift module E
 // CHECK: "swift": "E"


### PR DESCRIPTION
When building a set of command-line options required to build a Clang module, also add `NonPathCommandLine` from Clang's `ModuleDeps`. These flags are mandatory in order to build modules discovered by the scanner. For example, they will include `-fsystem-module` for system modules, which will then alter ClangImporter's behaviour for such modules. 

This is a part of the solution for: rdar://70212660
