### PR TITLE
Use The Location of the Pattern Binding in Codable Fixit

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -799,8 +799,10 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
               diag::decodable_property_init_or_codingkeys_explicit,
               varDecl->getName());
         }
-        varDecl->diagnose(diag::decodable_make_property_mutable)
-            .fixItReplace(varDecl->getAttributeInsertionLoc(true), "var");
+        if (auto *PBD = varDecl->getParentPatternBinding()) {
+          varDecl->diagnose(diag::decodable_make_property_mutable)
+              .fixItReplace(PBD->getLoc(), "var");
+        }
 
         continue;
       }

--- a/test/decl/protocol/special/coding/immutable_property.swift
+++ b/test/decl/protocol/special/coding/immutable_property.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct Foo : Codable {
+  let x1: String = ""
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'x1' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{3-6=var}}
+
+  public let x2: String = ""
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'x2' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{10-13=var}}
+
+  internal let x3: String = ""
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'x3' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{12-15=var}}
+
+  fileprivate let x4: String = ""
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'x4' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{15-18=var}}
+
+  private let x5: String = ""
+  // expected-warning@-1 {{immutable property will not be decoded because it is declared with an initial value which cannot be overwritten}}
+  // expected-note@-2 {{set the initial value via the initializer or explicitly define a CodingKeys enum including a 'x5' case to silence this warning}}
+  // expected-note@-3 {{make the property mutable instead}}{{11-14=var}}
+}


### PR DESCRIPTION
The code here used to use the location of the nearest place to insert
attributes, which makes no sense. Use the pattern binding's location
instead to ensure that we actually replace the 'let' part of the
pattern every time.

rdar://69971194