### PR TITLE
[Sema] Don't require explicit availability for implicit decls

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2900,9 +2900,10 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
       return false;
   }
 
-  // Skip functions emitted into clients or SPI.
+  // Skip functions emitted into clients, SPI or implicit.
   if (decl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>() ||
-      decl->isSPI())
+      decl->isSPI() ||
+      decl->isImplicit())
     return false;
 
   // Warn on decls without an introduction version.

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -164,3 +164,11 @@ extension SomeClass { // expected-warning {{public declarations should have an a
     set(newValue) { }
   }
 }
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
+public struct StructWithImplicitMembers { }
+
+extension StructWithImplicitMembers: Hashable { }
+// expected-note @-1 {{add @available attribute to enclosing extension}}
+// expected-warning @-2 {{public declarations should have an availability attribute when building with -require-explicit-availability}}
+// expected-error @-3 {{'StructWithImplicitMembers' is only available in macOS 10.15 or newer}}


### PR DESCRIPTION
Suppress warnings from `-require-explicit-availability` in synthesized code. The parent decls should already show a warning.

This affects warnings with the following form for the newly added test:
```
require_explicit_availability.StructWithImplicitMembers:2:16: warning:
public declarations should have an availability attribute when building
with -require-explicit-availability
    public var hashValue: Int { get }
               ^
```