### PR TITLE
[Clang Importer] Set IsSystem module flag for Clang input files when precompiling a clang module

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1624,11 +1624,12 @@ bool ClangImporter::emitPrecompiledModule(StringRef moduleMapPath,
   LangOpts->CurrentModule = LangOpts->ModuleName;
 
   auto language = getLanguageFromOptions(LangOpts);
-  auto inputFile = clang::FrontendInputFile(
-      moduleMapPath, clang::InputKind(
-          language, clang::InputKind::ModuleMap, false));
 
   auto &FrontendOpts = invocation.getFrontendOpts();
+  auto inputFile = clang::FrontendInputFile(
+      moduleMapPath, clang::InputKind(
+          language, clang::InputKind::ModuleMap, false),
+      FrontendOpts.IsSystemModule);
   FrontendOpts.Inputs = {inputFile};
   FrontendOpts.OriginalModuleMap = moduleMapPath.str();
   FrontendOpts.OutputFile = outputPath.str();

--- a/test/ClangImporter/pcm-emit-system-module.swift
+++ b/test/ClangImporter/pcm-emit-system-module.swift
@@ -1,0 +1,8 @@
+// Emit the explicit system module.
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-pcm -module-name script -Xcc -Xclang -Xcc -emit-module -Xcc -Xclang -Xcc -fsystem-module -o %t/script.pcm %S/Inputs/custom-modules/module.map
+
+// Verify that the input modulemap if marked [System] in the output of the -dump-pcm action.
+// RUN: %swift-dump-pcm %t/script.pcm | %FileCheck %s --check-prefix=CHECK-SYSTEM-INPUT
+// CHECK-SYSTEM-INPUT: Input file: {{.*[/\\]}}ClangImporter{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}module.map [System]
+import script


### PR DESCRIPTION
This flag is important when we are pre-building system modules to be loaded later in Explicit Module Builds.
Resolves rdar://70212660