### PR TITLE
[NFC] Tweak formatting of _Concurrency module CMakeLists.txt

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -29,4 +29,5 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  INSTALL_IN_COMPONENT stdlib)
+  INSTALL_IN_COMPONENT stdlib
+)


### PR DESCRIPTION
Helps fix rdar://66414410.

(We don't usually commit pure formatting changes; I'm making an exception here because this should help avoid merge conflicts with Mac Catalyst build configuration settings that can't be upstreamed yet.)