### PR TITLE
[build] Remove dash-dash from build-presets.ini (NFC)

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -14,8 +14,6 @@
 # Buildbots for Darwin OSes
 #===------------------------------------------------------------------------===#
 [preset: mixin_buildbot_install_components]
-dash-dash
-
 swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;toolchain-tools;testsuite-tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;
 
 [preset: mixin_buildbot_install_components_with_clang]
@@ -31,8 +29,6 @@ test
 validation-test
 lit-args=-v
 compiler-vendor=apple
-
-dash-dash
 
 verbose-build
 build-ninja
@@ -59,8 +55,6 @@ mixin-preset=
 # Build Release without debug info, because it is faster to build.
 release
 assertions
-
-dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=false
@@ -91,8 +85,6 @@ assertions
 test-optimized
 test-optimize-for-size
 
-dash-dash
-
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
 
@@ -109,8 +101,6 @@ release-debuginfo
 assertions
 # Also run tests in optimized modes.
 test-optimized
-
-dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
@@ -130,8 +120,6 @@ assertions
 test-optimized
 test-optimize-for-size
 
-dash-dash
-
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=false
 
@@ -143,8 +131,6 @@ mixin-preset=
 # Build Release without debug info, because it is faster to build.
 release
 no-assertions
-
-dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=false
@@ -158,8 +144,6 @@ mixin-preset=
 release
 assertions
 
-dash-dash
-
 swift-stdlib-build-type=Debug
 swift-stdlib-enable-assertions=true
 
@@ -167,8 +151,6 @@ swift-stdlib-enable-assertions=true
 [preset: buildbot,tools=RA,stdlib=DA]
 mixin-preset=
     mixin_buildbot_tools_RA_stdlib_DA
-
-dash-dash
 
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
@@ -192,8 +174,6 @@ skip-test-watchos-simulator
 mixin-preset=
     mixin_buildbot_tools_RA_stdlib_RD
 
-dash-dash
-
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
 skip-test-ios-host
@@ -215,8 +195,6 @@ skip-test-watchos-simulator
 [preset: buildbot,tools=R,stdlib=RD]
 mixin-preset=
     mixin_buildbot_tools_R_stdlib_RD
-
-dash-dash
 
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
@@ -240,8 +218,6 @@ skip-test-watchos-simulator
 [preset: buildbot,tools=RA,stdlib=RDA]
 mixin-preset=
     mixin_buildbot_tools_RA_stdlib_RDA
-
-dash-dash
 
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
@@ -300,8 +276,6 @@ skip-test-watchos-host
 # Build LLDB
 lldb
 
-dash-dash
-
 # Use the system debugserver to run the lldb swift tests
 lldb-no-debugserver
 lldb-use-system-debugserver
@@ -319,8 +293,6 @@ validation-test
 lit-args=-v --time-tests
 
 compiler-vendor=apple
-
-dash-dash
 
 # On buildbots, always force a reconfiguration to make sure we pick up changes
 # in the build-script and build-presets.ini.
@@ -369,8 +341,6 @@ swiftevolve
 # Build Playground support
 playgroundsupport
 
-dash-dash
-
 # Only run OS X tests to make the build cycle faster.
 # We still build the iOS standard library though -- it is free given the
 # parallelism.
@@ -390,7 +360,6 @@ mixin-preset=buildbot_incremental,tools=RA,stdlib=RA
 build-subdir=buildbot_incremental_xcode
 
 xcode
-dash-dash
 # We do not support building cross compiled stdlibs on OS X with Xcode. So only
 # build the OS X SDK.
 skip-build-ios
@@ -421,8 +390,6 @@ xctest
 
 build-swift-stdlib-unittest-extra
 
-dash-dash
-
 # This preset is meant to test XCTest, not Swift or Foundation. We don't
 # want stochastic failures in those test suites to prevent XCTest tests from
 # being run.
@@ -440,8 +407,6 @@ assertions
 xctest
 test
 
-dash-dash
-
 skip-test-cmark
 skip-test-swift
 skip-test-foundation
@@ -457,8 +422,6 @@ release-debuginfo
 assertions
 
 build-swift-stdlib-unittest-extra
-
-dash-dash
 
 # FIXME: Swift/ASan does not support iOS yet.
 skip-build-ios
@@ -486,8 +449,6 @@ enable-tsan
 
 build-swift-stdlib-unittest-extra
 
-dash-dash
-
 skip-build-ios
 skip-test-ios
 skip-build-tvos
@@ -505,8 +466,6 @@ release-debuginfo
 assertions
 
 build-swift-stdlib-unittest-extra
-
-dash-dash
 
 # FIXME: Swift/UBSan does not support mac os x yet.
 skip-build-osx
@@ -536,8 +495,6 @@ build-subdir=buildbot_incremental_asan_debug
 assertions
 
 build-swift-stdlib-unittest-extra
-
-dash-dash
 
 # FIXME: Swift/ASan does not support iOS yet.
 skip-build-ios
@@ -575,8 +532,6 @@ llvm-targets-to-build=X86;ARM;AArch64;PowerPC
 
 # Set the vendor to apple
 compiler-vendor=apple
-
-dash-dash
 
 # Always reconfigure cmake
 reconfigure
@@ -627,8 +582,6 @@ build-subdir=buildbot_incremental
 
 lto
 
-dash-dash
-
 [preset: buildbot_incremental,tools=RA,llvm-only]
 build-subdir=buildbot_incremental_llvmonly
 
@@ -639,8 +592,6 @@ test=0
 lit-args=-v
 
 compiler-vendor=apple
-
-dash-dash
 
 llvm-include-tests
 reconfigure
@@ -668,8 +619,6 @@ extra-swift-args=%(extra_swift_args)s
 release
 assertions
 compiler-vendor=apple
-
-dash-dash
 
 # On buildbots, always force a reconfiguration to make sure we pick up changes
 # in the build-script and build-presets.ini.
@@ -704,8 +653,6 @@ mixin-preset=buildbot_incremental_asan,tools=RDA,stdlib=RDA
 
 [preset: buildbot_incremental_leaks]
 compiler-vendor=apple
-dash-dash
-
 # Disable ios. These builders are x86 only.
 skip-ios
 skip-tvos
@@ -728,8 +675,6 @@ build-subdir=buildbot_incremental_leaks_RA_R
 # Build release+asserts
 release
 assertions
-
-dash-dash
 
 # We want our stdlib to not have assertions.
 swift-stdlib-enable-assertions=false
@@ -755,8 +700,6 @@ assertions
 # no-assertions
 # swift-assertions
 # ... but our tests are expecting assertions to be either on or off everywhere.
-
-dash-dash
 
 # AST verifier slows down the compiler significantly.
 swift-enable-ast-verifier=0
@@ -785,8 +728,6 @@ swift-driver
 xctest
 libicu
 libcxx
-
-dash-dash
 
 build-ninja
 install-llvm
@@ -834,8 +775,6 @@ indexstore-db
 sourcekit-lsp
 lit-args=-v --time-tests
 
-dash-dash
-
 # rdar://problem/31454823
 lldb-test-swift-only
 
@@ -844,8 +783,6 @@ install-libdispatch
 reconfigure
 
 [preset: mixin_buildbot_linux,no_test]
-dash-dash
-
 skip-test-cmark
 skip-test-lldb
 skip-test-swift
@@ -884,8 +821,6 @@ build-ninja
 libicu
 libcxx
 
-dash-dash
-
 android
 android-ndk=%(ndk_path)s
 android-api-level=21
@@ -922,8 +857,6 @@ reconfigure
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,aarch64]
 mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
-
-dash-dash
 
 android-arch=aarch64
 
@@ -984,8 +917,6 @@ indexstore-db
 sourcekit-lsp
 lit-args=-v
 
-dash-dash
-
 install-foundation
 install-libdispatch
 reconfigure
@@ -1017,8 +948,6 @@ swift-driver
 xctest
 
 build-subdir=buildbot_linux
-
-dash-dash
 
 install-llvm
 install-swift
@@ -1059,8 +988,6 @@ test
 validation-test
 lit-args=-v
 
-dash-dash
-
 build-ninja
 reconfigure
 
@@ -1081,8 +1008,6 @@ libdispatch
 swiftsyntax
 indexstore-db
 sourcekit-lsp
-dash-dash
-
 install-llvm
 install-swift
 install-llbuild
@@ -1112,8 +1037,6 @@ validation-test=0
 long-test=0
 stress-test=0
 test-optimized=0
-
-dash-dash
 
 skip-build-swift
 skip-build-cmark
@@ -1151,8 +1074,6 @@ release-debuginfo
 assertions
 enable-lsan
 
-dash-dash
-
 build-ninja
 reconfigure
 
@@ -1164,8 +1085,6 @@ assertions
 enable-lsan
 debug-swift-stdlib
 debug-libdispatch
-
-dash-dash
 
 build-ninja
 reconfigure
@@ -1209,8 +1128,6 @@ swiftsyntax-verify-generated-files
 # production builds.
 release-debuginfo
 compiler-vendor=apple
-
-dash-dash
 
 # Cross compile for Apple Silicon
 cross-compile-hosts=macosx-arm64
@@ -1293,8 +1210,6 @@ validation-test
 long-test
 stress-test
 
-dash-dash
-
 lldb-test-swift-only
 
 # Path to the .tar.gz package we would create.
@@ -1322,8 +1237,6 @@ mixin-preset=
     mixin_osx_package_base
     mixin_osx_package_test
 
-dash-dash
-
 no-assertions
 
 [preset: buildbot_osx_package,no_assertions,use_os_runtime]
@@ -1344,8 +1257,6 @@ mixin-preset=
 [preset: buildbot_osx_package,no_assertions,no_test]
 mixin-preset=
     buildbot_osx_package,no_assertions
-
-dash-dash
 
 skip-test-swift
 skip-test-swiftpm
@@ -1418,7 +1329,6 @@ mixin-preset=
 #===------------------------------------------------------------------------===#
 
 [preset: LLDB_Nested]
-dash-dash
 skip-build-benchmarks
 install-destdir=%(swift_install_destdir)s
 llvm-targets-to-build=X86;ARM;AArch64;PowerPC;SystemZ;Mips
@@ -1498,8 +1408,6 @@ install-libcxx
 # Build Playground support
 playgroundsupport
 
-dash-dash
-
 # Run the SIL verifier after each transform when building swift files
 sil-verify-all
 
@@ -1555,8 +1463,6 @@ swiftevolve
 # Build Playground support
 playgroundsupport
 
-dash-dash
-
 # Skip build and test for tvOS
 skip-build-tvos
 skip-test-tvos
@@ -1589,8 +1495,6 @@ build-swift-stdlib-unittest-extra
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
-
-dash-dash
 
 # Only run watchOS tests
 skip-test-ios
@@ -1911,8 +1815,6 @@ swift-assertions
 clang-user-visible-version=9.1.0
 
 compiler-vendor=apple
-dash-dash
-
 build-ninja
 release-debuginfo
 reconfigure
@@ -1938,8 +1840,6 @@ llvm-include-tests=0
 
 [preset: remote_mirror_ios_customization]
 
-dash-dash
-
 darwin-xcrun-toolchain=ios
 darwin-deployment-version-ios=11.0
 skip-build-osx
@@ -1960,8 +1860,6 @@ mixin-preset=
 
 [preset: remote_mirror_watchos_customization]
 
-dash-dash
-
 darwin-xcrun-toolchain=watchos
 darwin-deployment-version-watchos=4.0
 skip-build-osx
@@ -1981,8 +1879,6 @@ mixin-preset=
     remote_mirror_watchos_customization
 
 [preset: remote_mirror_tvos_customization]
-
-dash-dash
 
 darwin-xcrun-toolchain=tvos
 darwin-deployment-version-tvos=11.0
@@ -2016,8 +1912,6 @@ ios
 tvos
 watchos
 
-dash-dash
-
 # On buildbots, always force a reconfiguration to make sure we pick up changes
 # in the build-script and build-presets.ini.
 reconfigure
@@ -2033,8 +1927,6 @@ test
 validation-test
 lit-args=-v
 
-dash-dash
-
 skip-test-ios
 skip-test-tvos
 skip-test-watchos
@@ -2046,8 +1938,6 @@ test
 validation-test
 lit-args=-v
 
-dash-dash
-
 skip-test-osx
 skip-test-tvos
 skip-test-watchos
@@ -2057,8 +1947,6 @@ skip-reconfigure
 test
 validation-test
 lit-args=-v
-
-dash-dash
 
 skip-test-osx
 skip-test-watchos
@@ -2070,8 +1958,6 @@ skip-reconfigure
 test
 validation-test
 lit-args=-v
-
-dash-dash
 
 skip-test-osx
 skip-test-tvos
@@ -2089,8 +1975,6 @@ mixin-preset=mixin_buildbot_incremental,build
 # Build Release without debug info, because it is faster to build.
 release
 assertions
-
-dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=false
@@ -2126,8 +2010,6 @@ mixin-preset=mixin_buildbot_incremental,build
 # Build Release without debug info, because it is faster to build.
 release
 assertions
-
-dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
@@ -2175,8 +2057,6 @@ mixin-preset=mixin_buildbot_incremental,build
 release
 assertions
 
-dash-dash
-
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=false
 
@@ -2220,8 +2100,6 @@ mixin-preset=mixin_buildbot_incremental,build
 release
 assertions
 
-dash-dash
-
 [preset: buildbot_incremental,tools=RA,stdlib=RA,test=macOS,type=device]
 mixin-preset=
     buildbot_incremental,tools=RA,stdlib=RA,build
@@ -2264,8 +2142,6 @@ assertions
 debug-llvm
 debug-swift
 
-dash-dash
-
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: DebInfo and Assertions
@@ -2279,8 +2155,6 @@ release-debuginfo
 assertions
 debug-llvm
 debug-swift
-
-dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
@@ -2312,8 +2186,6 @@ build-ninja
 
 build-subdir=LLVMClangSwift_iphoneos
 release
-
-dash-dash
 
 cross-compile-hosts=iphoneos-arm64
 compiler-vendor=apple


### PR DESCRIPTION
Remove the many `dash-dash` lines in build-presets.ini, their handling is a no-op:

https://github.com/apple/swift/blob/2c3a6e06f4edc2ed64a638e30379bbcc83479768/utils/build_swift/build_swift/presets.py#L256-L258