### PR TITLE
[linux] remove absolute rpath of /usr/lib/swift/linux added to many shared libraries

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -618,7 +618,7 @@ function(_add_swift_host_library_single target)
   elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
     set_target_properties("${target}"
       PROPERTIES
-      INSTALL_RPATH "$ORIGIN:/usr/lib/swift/linux")
+      INSTALL_RPATH "$ORIGIN")
   elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "CYGWIN")
     set_target_properties("${target}"
       PROPERTIES

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -949,7 +949,7 @@ function(_add_swift_target_library_single target name)
   elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "LINUX")
     set_target_properties("${target}"
       PROPERTIES
-      INSTALL_RPATH "$ORIGIN:/usr/lib/swift/linux")
+      INSTALL_RPATH "$ORIGIN")
   elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "CYGWIN")
     set_target_properties("${target}"
       PROPERTIES

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -168,7 +168,7 @@ macro(add_sourcekit_library name)
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     if(SOURCEKITLIB_SHARED)
       set_target_properties(${name} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
-      set_target_properties(${name} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/swift/linux:/usr/lib/swift/linux")
+      set_target_properties(${name} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/swift/linux")
     endif()
   endif()
 


### PR DESCRIPTION
- Explanation

This RPATH was presumably added as a backup, in case the libraries in a toolchain couldn't be found, but will not work well, so take it out.

This pull is a cherry-pick of #34023 to the 5.3 branch.

- Scope

Since the stdlib and these other Swift shared libraries all have `$ORIGIN` set, the toolchain should be self-contained and never have to go to `/usr/lib`. In the rare occasion of a broken toolchain, eg `libswiftCore.so` is missing, the other libraries might find one in the system that works. That is such a rare scenario, that is as likely to break if a different Swift version is installed in the system, that it's better not to have this.

- SR issue

At least partially resolves SR-5755, fully if he's not saying we should add `CMAKE_INSTALL_PREFIX` to the RPATH instead, which I don't think should be added by default either.

- Risk

Low

- Testing

I'm currently building SPM with the official Oct. 22 trunk snapshot build that had this pull merged and everything works fine.

- Reviewer

I discussed these rpath issues in detail across the entire toolchain with @gottesmm and @compnerd.

@drexin, will a merge window for the 5.3.1 release be announced on the forums? I'd like to get this and apple/swift-corelibs-xctest#308 in before the next patch release.