### PR TITLE
[Concurrency] Proper serialization/interface printing for actor-isolation attributes

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2696,6 +2696,10 @@ enum class CustomAttrTypeKind {
   /// Property delegates have some funky rules, like allowing
   /// unbound generic types.
   PropertyDelegate,
+
+  /// Global actors are represented as custom type attributes. They don't
+  /// have any particularly interesting semantics.
+  GlobalActor,
 };
 
 void simple_display(llvm::raw_ostream &out, CustomAttrTypeKind value);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2693,9 +2693,9 @@ enum class CustomAttrTypeKind {
   /// any contextual type parameters.
   NonGeneric,
 
-  /// Property delegates have some funky rules, like allowing
+  /// Property wrappers have some funky rules, like allowing
   /// unbound generic types.
-  PropertyDelegate,
+  PropertyWrapper,
 
   /// Global actors are represented as custom type attributes. They don't
   /// have any particularly interesting semantics.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1427,8 +1427,8 @@ void swift::simple_display(llvm::raw_ostream &out, CustomAttrTypeKind value) {
     out << "non-generic";
     return;
 
-  case CustomAttrTypeKind::PropertyDelegate:
-    out << "property-delegate";
+  case CustomAttrTypeKind::PropertyWrapper:
+    out << "property-wrapper";
     return;
 
   case CustomAttrTypeKind::GlobalActor:

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1430,6 +1430,10 @@ void swift::simple_display(llvm::raw_ostream &out, CustomAttrTypeKind value) {
   case CustomAttrTypeKind::PropertyDelegate:
     out << "property-delegate";
     return;
+
+  case CustomAttrTypeKind::GlobalActor:
+    out << "global-actor";
+    return;
   }
   llvm_unreachable("bad kind");
 }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -513,7 +513,7 @@ Type AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   auto ty = evaluateOrDefault(
       evaluator,
       CustomAttrTypeRequest{customAttr, var->getDeclContext(),
-                            CustomAttrTypeKind::PropertyDelegate},
+                            CustomAttrTypeKind::PropertyWrapper},
       Type());
   if (!ty || ty->hasError()) {
     return ErrorType::get(var->getASTContext());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3974,7 +3974,7 @@ Type CustomAttrTypeRequest::evaluate(Evaluator &eval, CustomAttr *attr,
 
   OpenUnboundGenericTypeFn unboundTyOpener = nullptr;
   // Property delegates allow their type to be an unbound generic.
-  if (typeKind == CustomAttrTypeKind::PropertyDelegate) {
+  if (typeKind == CustomAttrTypeKind::PropertyWrapper) {
     unboundTyOpener = [](auto unboundTy) {
       // FIXME: Don't let unbound generic types
       // escape type resolution. For now, just

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency %s
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency
+// RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
+
+// REQUIRES: concurrency
+import _Concurrency
+
+// CHECK: actor public class SomeActor
+public actor class SomeActor {
+  @actorIndependent func maine() { }
+}
+
+// CHECK: @globalActor public struct SomeGlobalActor
+@globalActor
+public struct SomeGlobalActor {
+  public static let shared = SomeActor()
+}
+
+// CHECK: @{{(Test.)?}}SomeGlobalActor public protocol P1
+// CHECK-NEXT: @{{(Test.)?}}SomeGlobalActor func method()
+@SomeGlobalActor
+public protocol P1 {
+  func method()
+}
+
+// CHECK: class C1
+// CHECK-NEXT: @{{(Test.)?}}SomeGlobalActor public func method()
+public class C1: P1 {
+  public func method() { }
+}
+
+@SomeGlobalActor
+public class C2 { }
+
+// CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
+public class C3: C2 { }
+
+// CHECK: actor public class SomeSubActor
+// CHECK-NEXT: @actorIndependent public func maine()
+public actor class SomeSubActor: SomeActor {
+  override public func maine() { }
+}


### PR DESCRIPTION
When we infer an actor-isolation attribute on a declaration, add an
implicit attribute that will show up in the printed interface and get
serialized.

... and clean up the type resolution logic for global actor attributes
to make it use `CustomAttrTypeRequest`, so the result gets appropriately
cached in `CustomAttr` for serialization.