### PR TITLE
[Runtime] Switch MetadataCache to ConcurrentReadableHashMap.

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -1091,6 +1091,13 @@ struct StableAddressConcurrentReadableHashMap
     return {ptr, outerCreated};
   }
 
+  template <class KeyTy> ElemTy *find(const KeyTy &key) {
+    auto result = this->snapshot().find(key);
+    if (!result)
+      return nullptr;
+    return result->Ptr;
+  }
+
 private:
   // Clearing would require deallocating elements, which we don't support.
   void clear() = delete;

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -106,16 +106,13 @@ struct ConcurrencyControl {
   ConcurrencyControl() = default;
 };
 
-template <class EntryType, uint16_t Tag, bool ProvideDestructor = true>
+template <class EntryType, uint16_t Tag>
 class LockingConcurrentMapStorage {
-  ConcurrentMap<EntryType, ProvideDestructor,
-                TaggedMetadataAllocator<Tag>> Map;
-  StaticOwningPointer<ConcurrencyControl, ProvideDestructor> Concurrency;
+  StableAddressConcurrentReadableHashMap<EntryType, TaggedMetadataAllocator<Tag>> Map;
+  StaticOwningPointer<ConcurrencyControl, false> Concurrency;
 
 public:
   LockingConcurrentMapStorage() : Concurrency(new ConcurrencyControl()) {}
-
-  MetadataAllocator &getAllocator() { return Map.getAllocator(); }
 
   ConcurrencyControl &getConcurrency() { return *Concurrency; }
 
@@ -185,8 +182,6 @@ class LockingConcurrentMap {
 
 public:
   LockingConcurrentMap() = default;
-
-  MetadataAllocator &getAllocator() { return Storage.getAllocator(); }
 
   template <class KeyType, class... ArgTys>
   std::pair<EntryType*, Status>
@@ -492,6 +487,10 @@ public:
 
   uint32_t hash() const {
     return Hash;
+  }
+
+  friend llvm::hash_code hash_value(const MetadataCacheKey &key) {
+    return key.Hash;
   }
 
   const void * const *begin() const { return Data; }
@@ -1424,15 +1423,19 @@ public:
     return Hash;
   }
 
-  int compareWithKey(const MetadataCacheKey &key) const {
-    return key.compare(getKey());
+  friend llvm::hash_code hash_value(const VariadicMetadataCacheEntryBase<Impl, Objects...> &value) {
+    return hash_value(value.getKey());
+  }
+
+  bool matchesKey(const MetadataCacheKey &key) const {
+    return key == getKey();
   }
 };
 
-template <class EntryType, uint16_t Tag, bool ProvideDestructor = true>
+template <class EntryType, uint16_t Tag>
 class MetadataCache :
     public LockingConcurrentMap<EntryType,
-             LockingConcurrentMapStorage<EntryType, Tag, ProvideDestructor>> {
+             LockingConcurrentMapStorage<EntryType, Tag>> {
 };
 
 } // namespace swift

--- a/unittests/runtime/Mutex.cpp
+++ b/unittests/runtime/Mutex.cpp
@@ -56,6 +56,11 @@ TEST(StaticUnsafeMutexTest, BasicLockableThreaded) {
   basicLockableThreaded(mutex);
 }
 
+TEST(SmallMutex, BasicLockableThreaded) {
+  SmallMutex mutex;
+  basicLockableThreaded(mutex);
+}
+
 template <typename M> void lockableThreaded(M &mutex) {
   mutex.lock();
   threadedExecute(5, [&](int) { ASSERT_FALSE(mutex.try_lock()); });
@@ -94,6 +99,11 @@ TEST(StaticMutexTest, LockableThreaded) {
   lockableThreaded(Mutex);
 }
 
+TEST(SmallMutexTest, LockableThreaded) {
+  SmallMutex Mutex;
+  lockableThreaded(Mutex);
+}
+
 template <typename SL, typename M> void scopedLockThreaded(M &mutex) {
   int count1 = 0;
   int count2 = 0;
@@ -119,6 +129,11 @@ TEST(MutexTest, ScopedLockThreaded) {
 TEST(StaticMutexTest, ScopedLockThreaded) {
   static StaticMutex Mutex;
   scopedLockThreaded<StaticScopedLock>(Mutex);
+}
+
+TEST(SmallMutexTest, ScopedLockThreaded) {
+  SmallMutex mutex(/* checked = */ true);
+  scopedLockThreaded<ScopedLockT<SmallMutex, false>>(mutex);
 }
 
 template <typename SL, typename SU, typename M>
@@ -153,6 +168,12 @@ TEST(StaticMutexTest, ScopedUnlockUnderScopedLockThreaded) {
   static StaticMutex Mutex;
   scopedUnlockUnderScopedLockThreaded<StaticScopedLock, StaticScopedUnlock>(
       Mutex);
+}
+
+TEST(SmallMutexTest, ScopedUnlockUnderScopedLockThreaded) {
+  SmallMutex mutex(/* checked = */ true);
+  scopedUnlockUnderScopedLockThreaded<ScopedLockT<SmallMutex, false>,
+                                      ScopedLockT<SmallMutex, true>>(mutex);
 }
 
 template <typename M> void criticalSectionThreaded(M &mutex) {


### PR DESCRIPTION
Use `StableAddressConcurrentReadableHashMap` for now. `MetadataCacheEntry`'s methods for awaiting a particular state assume a stable address, where it will repeatedly examine `this` in a loop while waiting on a condition variable, so we give it a stable address to accommodate that. This code can be changed to perform the necessary table lookup each time through the loop instead, and thus allow us to use a plain `ConcurrentReadableHashMap` and avoid the extra indirection, and I'll take care of that in a followup.

rdar://problem/70220660