### PR TITLE
Fix several correctness issues in TempRValueOpt

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2499,6 +2499,20 @@ public:
     assert(DS && "Instruction without debug scope associated!");
     setCurrentDebugScope(DS);
   }
+
+  /// If \p inst is a terminator apply site, then pass a builder to insert at
+  /// the first instruction of each successor to \p func. Otherwise, pass a
+  /// builder to insert at std::next(inst).
+  ///
+  /// The intention is that this abstraction will enable the compiler writer to
+  /// ignore whether or not \p inst is a terminator when inserting instructions
+  /// after \p inst.
+  ///
+  /// Precondition: It's the responsibility of the caller to ensure that if
+  /// \p inst is a terminator, all successor blocks have only a single
+  /// predecessor block: the parent of \p inst.
+  static void insertAfter(SILInstruction *inst,
+                          function_ref<void(SILBuilder &)> func);
 };
 
 class SavedInsertionPointRAII {

--- a/lib/SIL/IR/ApplySite.cpp
+++ b/lib/SIL/IR/ApplySite.cpp
@@ -1,0 +1,46 @@
+//===--- ApplySite.cpp - Wrapper around apply instructions ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/SILBuilder.h"
+
+
+using namespace swift;
+
+void FullApplySite::insertAfterInvocation(function_ref<void(SILBuilder &)> func) const {
+  SILBuilderWithScope::insertAfter(getInstruction(), func);
+}
+
+void FullApplySite::insertAfterFullEvaluation(
+    function_ref<void(SILBuilder &)> func) const {
+  switch (getKind()) {
+  case FullApplySiteKind::ApplyInst:
+  case FullApplySiteKind::TryApplyInst:
+    return insertAfterInvocation(func);
+  case FullApplySiteKind::BeginApplyInst:
+    SmallVector<EndApplyInst *, 2> endApplies;
+    SmallVector<AbortApplyInst *, 2> abortApplies;
+    auto *bai = cast<BeginApplyInst>(getInstruction());
+    bai->getCoroutineEndPoints(endApplies, abortApplies);
+    for (auto *eai : endApplies) {
+      SILBuilderWithScope builder(std::next(eai->getIterator()));
+      func(builder);
+    }
+    for (auto *aai : abortApplies) {
+      SILBuilderWithScope builder(std::next(aai->getIterator()));
+      func(builder);
+    }
+    return;
+  }
+  llvm_unreachable("covered switch isn't covered");
+}
+

--- a/lib/SIL/IR/CMakeLists.txt
+++ b/lib/SIL/IR/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(swiftSIL PRIVATE
   AbstractionPattern.cpp
+  ApplySite.cpp
   Bridging.cpp
   Linker.cpp
   Notifications.cpp

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -661,3 +661,19 @@ CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
       destLoweredTy, destFormalTy, successBB, failureBB,
       getFunction(), C.OpenedArchetypes, target1Count, target2Count));
 }
+
+void SILBuilderWithScope::insertAfter(SILInstruction *inst,
+                                      function_ref<void(SILBuilder &)> func) {
+  if (isa<TermInst>(inst)) {
+    for (const SILSuccessor &succ : inst->getParent()->getSuccessors()) {
+      SILBasicBlock *succBlock = succ;
+      assert(succBlock->getSinglePredecessorBlock() == inst->getParent() &&
+             "the terminator instruction must not have critical successors");
+      SILBuilderWithScope builder(succBlock->begin());
+      func(builder);
+    }
+  } else {
+    SILBuilderWithScope builder(std::next(inst->getIterator()));
+    func(builder);
+  }
+}

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -364,6 +364,7 @@ static bool hasEscapingUses(SILValue address, int &numChecks) {
       case SILInstructionKind::CopyAddrInst:
       case SILInstructionKind::DestroyAddrInst:
       case SILInstructionKind::DeallocStackInst:
+      case SILInstructionKind::EndAccessInst:
         // Those instructions have no result and cannot escape the address.
         break;
       case SILInstructionKind::ApplyInst:
@@ -373,6 +374,7 @@ static bool hasEscapingUses(SILValue address, int &numChecks) {
         // possible that an address, passed as an indirect parameter, escapes
         // the function in any way (which is not unsafe and undefined behavior).
         break;
+      case SILInstructionKind::BeginAccessInst:
       case SILInstructionKind::OpenExistentialAddrInst:
       case SILInstructionKind::UncheckedTakeEnumDataAddrInst:
       case SILInstructionKind::StructElementAddrInst:

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -123,9 +123,9 @@ static  bool fixupReferenceCounts(
           });
 
       if (!consumedInLoop) {
-        applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
-          SILBuilderWithScope(iter).createDestroyAddr(loc, stackLoc);
-          SILBuilderWithScope(iter).createDeallocStack(loc, stackLoc);
+        applySite.insertAfterInvocation([&](SILBuilder &builder) {
+          builder.createDestroyAddr(loc, stackLoc);
+          builder.createDeallocStack(loc, stackLoc);
         });
       }
       v = stackLoc;
@@ -176,11 +176,11 @@ static  bool fixupReferenceCounts(
       // uses in the top of a diamond and need to insert a destroy after the
       // apply since the leak will just cover the other path.
       if (!consumedInLoop) {
-        applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
+        applySite.insertAfterInvocation([&](SILBuilder &builder) {
           if (hasOwnership) {
-            SILBuilderWithScope(iter).createEndBorrow(loc, argument);
+            builder.createEndBorrow(loc, argument);
           }
-          SILBuilderWithScope(iter).emitDestroyValueOperation(loc, copy);
+          builder.emitDestroyValueOperation(loc, copy);
         });
       }
       v = argument;
@@ -217,8 +217,8 @@ static  bool fixupReferenceCounts(
 
       // Then insert destroys after the apply site since our value is not being
       // consumed as part of the actual apply.
-      applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
-        SILBuilderWithScope(iter).emitDestroyValueOperation(loc, v);
+      applySite.insertAfterInvocation([&](SILBuilder &builder) {
+        builder.emitDestroyValueOperation(loc, v);
       });
       break;
     }
@@ -263,8 +263,8 @@ static  bool fixupReferenceCounts(
   // Destroy the callee as the apply would have done if our function is not
   // callee guaranteed.
   if (!isCalleeGuaranteed) {
-    applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
-      SILBuilderWithScope(iter).emitDestroyValueOperation(loc, calleeValue);
+    applySite.insertAfterInvocation([&](SILBuilder &builder) {
+      builder.emitDestroyValueOperation(loc, calleeValue);
     });
   }
   return invalidatedStackNesting;

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -282,6 +282,10 @@ collectLoads(Operand *addressUse, CopyAddrInst *originalCopy,
       LLVM_DEBUG(llvm::dbgs() << "  Temp written or taken" << *user);
       return false;
     }
+    // As with load [take], only accept copy_addr [take] if it takes the whole
+    // temporary object.
+    if (copyFromTmp->isTakeOfSrc() && address != originalCopy->getDest())
+      return false;
     loadInsts.insert(copyFromTmp);
     return true;
   }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2027,8 +2027,7 @@ static ApplySite replaceWithSpecializedCallee(ApplySite applySite,
     assert(resultBlock->getSinglePredecessorBlock() == tai->getParent());
     // First insert the cleanups for our arguments int he appropriate spot.
     FullApplySite(tai).insertAfterFullEvaluation(
-        [&](SILBasicBlock::iterator insertPt) {
-          SILBuilderWithScope argBuilder(insertPt);
+        [&](SILBuilder &argBuilder) {
           cleanupCallArguments(argBuilder, loc, arguments,
                                argsNeedingEndBorrow);
         });
@@ -2052,8 +2051,7 @@ static ApplySite replaceWithSpecializedCallee(ApplySite applySite,
   case ApplySiteKind::ApplyInst: {
     auto *ai = cast<ApplyInst>(applySite);
     FullApplySite(ai).insertAfterFullEvaluation(
-        [&](SILBasicBlock::iterator insertPt) {
-          SILBuilderWithScope argBuilder(insertPt);
+        [&](SILBuilder &argBuilder) {
           cleanupCallArguments(argBuilder, loc, arguments,
                                argsNeedingEndBorrow);
         });
@@ -2082,8 +2080,7 @@ static ApplySite replaceWithSpecializedCallee(ApplySite applySite,
     auto *bai = cast<BeginApplyInst>(applySite);
     assert(!resultOut);
     FullApplySite(bai).insertAfterFullEvaluation(
-        [&](SILBasicBlock::iterator insertPt) {
-          SILBuilderWithScope argBuilder(insertPt);
+        [&](SILBuilder &argBuilder) {
           cleanupCallArguments(argBuilder, loc, arguments,
                                argsNeedingEndBorrow);
         });
@@ -2227,8 +2224,7 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
 
   // Now that we have finished constructing our CFG (note the return above),
   // insert any compensating end borrows that we need.
-  ApplySite.insertAfterFullEvaluation([&](SILBasicBlock::iterator insertPt) {
-    SILBuilderWithScope argBuilder(insertPt);
+  ApplySite.insertAfterFullEvaluation([&](SILBuilder &argBuilder) {
     cleanupCallArguments(argBuilder, Loc, Arguments, ArgsThatNeedEndBorrow);
   });
 

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -153,8 +153,7 @@ void PartialApplyCombiner::processSingleApply(FullApplySite paiAI) {
         auto *ASI = builder.createAllocStack(pai->getLoc(), arg->getType());
         builder.createCopyAddr(pai->getLoc(), arg, ASI, IsTake_t::IsNotTake,
                                IsInitialization_t::IsInitialization);
-        paiAI.insertAfterFullEvaluation([&](SILBasicBlock::iterator insertPt) {
-          SILBuilderWithScope builder(insertPt);
+        paiAI.insertAfterFullEvaluation([&](SILBuilder &builder) {
           builder.createDeallocStack(destroyloc, ASI);
         });
         arg = ASI;
@@ -184,8 +183,7 @@ void PartialApplyCombiner::processSingleApply(FullApplySite paiAI) {
   // We also need to destroy the partial_apply instruction itself because it is
   // consumed by the apply_instruction.
   if (!pai->hasCalleeGuaranteedContext()) {
-    paiAI.insertAfterFullEvaluation([&](SILBasicBlock::iterator insertPt) {
-      SILBuilderWithScope builder(insertPt);
+    paiAI.insertAfterFullEvaluation([&](SILBuilder &builder) {
       builder.emitDestroyValueOperation(destroyloc, pai);
     });
   }

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -269,7 +269,6 @@ bb2(%8 : $Error):
   unreachable
 }
 
-
 // CHECK-LABEL:  @beginapply_allocstack_and_copyaddr
 // CHECK:        PAIR #0.
 // CHECK-NEXT:       (%4, %5) = begin_apply %3(%0) : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
@@ -322,6 +321,23 @@ bb0(%0 : $X):
   %2 = function_ref @single_reference : $@convention(thin) (@guaranteed X) -> Int32
   %3 = apply %2(%0) : $@convention(thin) (@guaranteed X) -> Int32
   return %3 : $Int32
+}
+
+// CHECK-LABEL: @apply_and_begin_access
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %6 = apply %5(%1) : $@convention(thin) (@in Int32) -> Int32
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:    r=0,w=0
+sil @apply_and_begin_access : $@convention(thin) (@in Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %1 = alloc_stack $Int32
+  %2 = begin_access [read] [static] %0 : $*Int32
+  copy_addr %2 to %1 : $*Int32
+  end_access %2 : $*Int32
+  %5 = function_ref @single_indirect_arg : $@convention(thin) (@in Int32) -> Int32
+  %6 = apply %5(%1) : $@convention(thin) (@in Int32) -> Int32
+  dealloc_stack %1 : $*Int32
+  return %6 : $Int32
 }
 
 sil @load_from_in : $@convention(thin) (@in X) -> () {

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -25,6 +25,7 @@ struct Str {
 
 sil @unknown : $@convention(thin) () -> ()
 sil @load_string : $@convention(thin) (@in_guaranteed String) -> String
+sil @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
 
 sil @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
 bb0(%0 : $*Klass):
@@ -456,6 +457,25 @@ bb3:
   return %9 : $()
 }
 
+// CHECK-LABEL: sil @lifetime_beyond_last_use :
+// CHECK-NOT: copy_addr
+// CHECK:   [[V:%[0-9]+]] = load %0
+// CHECK:   apply {{%[0-9]+}}([[V]])
+// CHECK:   destroy_addr %0
+// CHECK: } // end sil function 'lifetime_beyond_last_use'
+sil @lifetime_beyond_last_use : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %2 = alloc_stack $Klass
+  copy_addr [take] %0 to [initialization] %2 : $*Klass
+  %4 = load %2 : $*Klass
+  %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %9 = tuple ()
+  return %9 : $()
+}
+
 // Make sure that we can eliminate temporaries passed via a temporary rvalue to
 // an @in_guaranteed function.
 //
@@ -683,12 +703,13 @@ bb0(%0 : $*Builtin.NativeObject):
   return %v : $()
 }
 
-// Remove a copy that is released via a load as long as it was a copy [take].
 // CHECK-LABEL: sil @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK:   [[V:%.*]] = load %0 : $*Builtin.NativeObject
-// CHECK:   apply %{{.*}}([[V]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-// CHECK:   release_value [[V]] : $Builtin.NativeObject
+// CHECK:   [[STK:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK:   copy_addr [take] %0 to [initialization] [[STK]] : $*Builtin.NativeObject
+// CHECK:   [[VAL:%.*]] = load [[STK]] : $*Builtin.NativeObject
+// CHECK:   apply %{{.*}}([[VAL]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+// CHECK:   release_value [[VAL]] : $Builtin.NativeObject
 // CHECK-LABEL: } // end sil function 'takeWithLoadRelease'
 sil @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -144,6 +144,70 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   dealloc_stack %stk : $*Builtin.NativeObject
   return %obj : $Builtin.NativeObject
 }
+
+// CHECK-LABEL: sil [ossa] @copy_with_take_and_copy_from_src
+// CHECK:       bb0({{.*}}):
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    copy_addr [take] %1 to [initialization] %0
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'copy_with_take_and_copy_from_src'
+sil [ossa] @copy_with_take_and_copy_from_src : $@convention(thin) (@inout Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
+  %stk = alloc_stack $Builtin.NativeObject
+  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr [take] %1 to [initialization] %0 : $*Builtin.NativeObject
+  destroy_addr %stk : $*Builtin.NativeObject
+  dealloc_stack %stk : $*Builtin.NativeObject
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_take_and_try_apply
+// CHECK-NOT: copy_addr
+// CHECK:   try_apply {{%[0-9]+}}(%0)
+// CHECK: bb1({{.*}}):
+// CHECK:   destroy_addr %0
+// CHECK: bb2({{.*}}):
+// CHECK:   destroy_addr %0
+// CHECK: bb3:
+// CHECK:   store %1 to [init] %0
+// CHECK: } // end sil function 'copy_take_and_try_apply'
+sil [ossa] @copy_take_and_try_apply : $@convention(thin) (@inout Klass, @owned Klass) -> () {
+bb0(%0 : $*Klass, %1 : @owned $Klass):
+  %2 = alloc_stack $Klass
+  copy_addr [take] %0 to [initialization] %2 : $*Klass
+  %5 = function_ref @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
+  try_apply %5(%2) : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error), normal bb1, error bb2
+bb1(%r : $()):
+  br bb3
+bb2(%e : $Error):
+  br bb3
+bb3:
+  store %1 to [init] %0 : $*Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// Currently we cannot optimize this. But in theory it's possible to eliminate
+// both copies.
+//
+// CHECK-LABEL: sil [ossa] @copy_and_copy_back
+// CHECK:   [[STK:%[0-9]+]] = alloc_stack
+// CHECK:   copy_addr [take] %0 to [initialization] [[STK]]
+// CHECK:   copy_addr [take] [[STK]] to [initialization] %0
+// CHECK: } // end sil function 'copy_and_copy_back'
+sil [ossa] @copy_and_copy_back : $@convention(thin) (@inout Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %stk = alloc_stack $Builtin.NativeObject
+  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr [take] %stk to [initialization] %0 : $*Builtin.NativeObject
+  dealloc_stack %stk : $*Builtin.NativeObject
+  %v = tuple ()
+  return %v : $()
+}
 // CHECK-LABEL: sil [ossa] @load_in_wrong_block
 // CHECK:      bb0(%0 : $*GS<B>):
 // CHECK-NEXT:   alloc_stack
@@ -654,7 +718,8 @@ bb0(%0 : $*Builtin.NativeObject):
 //
 // CHECK-LABEL: sil [ossa] @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK:   [[V:%.*]] = load [take] %0 : $*Builtin.NativeObject
+// CHECK:   [[V:%.*]] = load [copy] %0 : $*Builtin.NativeObject
+// CHECK:   destroy_addr %0 : $*Builtin.NativeObject
 // CHECK:   apply %{{.*}}([[V]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK:   destroy_value [[V]] : $Builtin.NativeObject
 // CHECK-LABEL: } // end sil function 'takeWithLoadRelease'

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -16,6 +16,11 @@ struct GS<Base> {
 
 class Klass {}
 
+struct Two {
+  var a: Klass
+  var b: Klass
+}
+
 sil @unknown : $@convention(thin) () -> ()
 
 sil [ossa] @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
@@ -208,6 +213,26 @@ bb0(%0 : $*Builtin.NativeObject):
   %v = tuple ()
   return %v : $()
 }
+
+// CHECK-LABEL: sil [ossa] @dont_allow_copy_take_from_projection
+// CHECK:   [[STK:%[0-9]+]] = alloc_stack
+// CHECK:   copy_addr [take] %1 to [initialization] [[STK]]
+// CHECK: } // end sil function 'dont_allow_copy_take_from_projection'
+sil [ossa] @dont_allow_copy_take_from_projection : $@convention(thin) (@in Two) -> @out Two {
+bb0(%0 : $*Two, %1 : $*Two):
+  %a0 = struct_element_addr %0 : $*Two, #Two.a
+  %b0 = struct_element_addr %0 : $*Two, #Two.b
+  %s = alloc_stack $Two
+  copy_addr [take] %1 to [initialization] %s : $*Two
+  %as = struct_element_addr %s : $*Two, #Two.a
+  %bs = struct_element_addr %s : $*Two, #Two.b
+  copy_addr [take] %as to [initialization] %a0 : $*Klass
+  copy_addr [take] %bs to [initialization] %b0 : $*Klass
+  dealloc_stack %s : $*Two
+  %r = tuple ()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil [ossa] @load_in_wrong_block
 // CHECK:      bb0(%0 : $*GS<B>):
 // CHECK-NEXT:   alloc_stack

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -759,6 +759,27 @@ bb0(%0 : $*Klass):
   return %9999 : $()
 }
 
+
+// CHECK-LABEL: sil [ossa] @dont_optimize_with_modify_inside_access
+// CHECK:   [[STK:%[0-9]+]] = alloc_stack $Klass
+// CHECK:   copy_addr %0 to [initialization] [[STK]]
+// CHECK:   begin_access [read] [static] [[STK]]
+// CHECK-LABEL: } // end sil function 'dont_optimize_with_modify_inside_access'
+sil [ossa] @dont_optimize_with_modify_inside_access : $@convention(thin) (@inout Klass, @owned Klass) -> () {
+bb0(%0 : $*Klass, %1 : @owned $Klass):
+  %stack = alloc_stack $Klass
+  copy_addr %0 to [initialization] %stack : $*Klass
+  %f = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
+  %access = begin_access [read] [static] %stack : $*Klass
+  store %1 to [assign] %0 : $*Klass // This store prevents the optimization
+  %call = apply %f(%access) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  end_access %access : $*Klass
+  destroy_addr %stack : $*Klass
+  dealloc_stack %stack : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 /////////////////
 // Store Tests //
 /////////////////

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -128,6 +128,22 @@ bb0(%0 : $*B, %1 : $*GS<B>):
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @store_before_load_take
+// CHECK:   [[STK:%[0-9]+]] = alloc_stack
+// CHECK:   copy_addr [take] %0 to [initialization] [[STK]]
+// CHECK:   store
+// CHECK:   load [take] [[STK]]
+// CHECK:   return
+// CHECK: } // end sil function 'store_before_load_take'
+sil [ossa] @store_before_load_take : $@convention(thin) (@inout Builtin.NativeObject, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %stk = alloc_stack $Builtin.NativeObject
+  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
+  store %1 to [init] %0 : $*Builtin.NativeObject
+  %obj = load [take] %stk : $*Builtin.NativeObject
+  dealloc_stack %stk : $*Builtin.NativeObject
+  return %obj : $Builtin.NativeObject
+}
 // CHECK-LABEL: sil [ossa] @load_in_wrong_block
 // CHECK:      bb0(%0 : $*GS<B>):
 // CHECK-NEXT:   alloc_stack
@@ -693,31 +709,20 @@ bb0(%0 : @owned $GS<Builtin.NativeObject>):
   return %obj : $GS<Builtin.NativeObject>
 }
 
-// CHECK-LABEL: sil [ossa] @hoist_load_copy_to_src_copy_addr_site_two_takes : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
-// CHECK: bb0([[ARG:%.*]] :
-// CHECK:   [[COPY_1:%.*]] = load [copy] [[ARG]]
-// CHECK:   [[COPY_2:%.*]] = load [copy] [[ARG]]
-// CHECK:   destroy_addr [[ARG]]
-// CHECK:   cond_br undef, bb1, bb2
-//
+// CHECK-LABEL: sil [ossa] @dont_optimize_with_load_in_different_block
+// CHECK:   [[STK:%[0-9]+]] = alloc_stack
+// CHECK:   copy_addr %0 to [initialization] [[STK]]
 // CHECK: bb1:
-// CHECK:   destroy_value [[COPY_1]]
-// CHECK:   br bb3([[COPY_2]] :
-//
+// CHECK:   load [take] [[STK]]
 // CHECK: bb2:
-// CHECK:   destroy_value [[COPY_2]]
-// CHECK:   br bb3([[COPY_1]] :
-//
-// CHECK: bb3([[RESULT:%.*]] : @owned
-// CHECK:   apply {{%.*}}([[RESULT]])
-// CHECK:   return [[RESULT]]
-// CHECK: } // end sil function 'hoist_load_copy_to_src_copy_addr_site_two_takes'
-sil [ossa] @hoist_load_copy_to_src_copy_addr_site_two_takes : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
-bb0(%0 : $*GS<Builtin.NativeObject>):
+// CHECK:   copy_addr %1 to %0
+// CHECK:   load [take] [[STK]]
+// CHECK: } // end sil function 'dont_optimize_with_load_in_different_block'
+sil [ossa] @dont_optimize_with_load_in_different_block : $@convention(thin) (@inout GS<Builtin.NativeObject>, @in_guaranteed GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
+bb0(%0 : $*GS<Builtin.NativeObject>, %1 : $*GS<Builtin.NativeObject>):
   %f = function_ref @use_gsbase_builtinnativeobject : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
   %stk = alloc_stack $GS<Builtin.NativeObject>
   copy_addr %0 to [initialization] %stk : $*GS<Builtin.NativeObject>
-  destroy_addr %0 : $*GS<Builtin.NativeObject>
   cond_br undef, bb1, bb2
 
 bb1:
@@ -725,6 +730,7 @@ bb1:
   br bb3(%obj : $GS<Builtin.NativeObject>)
 
 bb2:
+  copy_addr %1 to %0 : $*GS<Builtin.NativeObject>
   %obj2 = load [take] %stk : $*GS<Builtin.NativeObject>
   br bb3(%obj2 : $GS<Builtin.NativeObject>)
 


### PR DESCRIPTION
* fix the handling of begin_access
* fix the handling of load [take]
* don't allow copy_addr [take] from a projection of the temporary.
* fix the placement of destroy_addr in case of a copy_addr [take]

plus some refactoring.
For details see the commit messages.

rdar://problem/69757314