### PR TITLE
Sema: Pull availability checking out of resolveType()

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4607,7 +4607,9 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   checkActorIsolation(E, DC);
 }
 
-void swift::performStmtDiagnostics(ASTContext &ctx, const Stmt *S) {
+void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {
+  auto &ctx = DC->getASTContext();
+
   TypeChecker::checkUnsupportedProtocolType(ctx, const_cast<Stmt *>(S));
     
   if (auto switchStmt = dyn_cast<SwitchStmt>(S))
@@ -4619,6 +4621,9 @@ void swift::performStmtDiagnostics(ASTContext &ctx, const Stmt *S) {
   if (auto *lcs = dyn_cast<LabeledConditionalStmt>(S))
     for (const auto &elt : lcs->getCond())
       checkImplicitPromotionsInCondition(elt, ctx);
+
+  if (!ctx.LangOpts.DisableAvailabilityChecking)
+    diagAvailability(S, const_cast<DeclContext*>(DC));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -38,7 +38,7 @@ void performSyntacticExprDiagnostics(const Expr *E, const DeclContext *DC,
                                      bool isExprStmt);
 
 /// Emit diagnostics for a given statement.
-void performStmtDiagnostics(ASTContext &ctx, const Stmt *S);
+void performStmtDiagnostics(const Stmt *S, DeclContext *DC);
 
 void performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD);
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1326,11 +1326,8 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
   // Fold 'T.U' into a nested type.
   if (auto *ITR = dyn_cast<IdentTypeRepr>(InnerTypeRepr)) {
     // Resolve the TypeRepr to get the base type for the lookup.
-    // Disable availability diagnostics here, because the final
-    // TypeRepr will be resolved again when generating constraints.
     const auto options =
-        TypeResolutionOptions(TypeResolverContext::InExpression) |
-        TypeResolutionFlags::AllowUnavailable;
+        TypeResolutionOptions(TypeResolverContext::InExpression);
     const auto resolution =
         TypeResolution::forContextual(DC, options, [](auto unboundTy) {
           // FIXME: Don't let unbound generic types escape type resolution.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2071,8 +2071,7 @@ class DeclAvailabilityChecker : public DeclVisitor<DeclAvailabilityChecker> {
 
     // Check the type for references to unavailable conformances.
     if (type)
-      if (!context->getDeclContext()->isLocalContext())
-        diagnoseTypeAvailability(type, context->getLoc(), DC);
+      diagnoseTypeAvailability(type, context->getLoc(), DC);
   }
 
   void checkGenericParams(const GenericContext *ownerCtx,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2394,11 +2394,6 @@ public:
     FragileKind = DC->getFragileFunctionKind();
   }
 
-  // FIXME: Remove this
-  bool shouldWalkAccessorsTheOldWay() override {
-    return true;
-  }
-
   bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
     return false;
   }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeDeclFinder.h"
 #include "swift/AST/TypeRefinementContext.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
@@ -2468,6 +2469,11 @@ public:
     return E;
   }
 
+  bool walkToTypeReprPre(TypeRepr *T) override {
+    diagnoseTypeReprAvailability(T, DC);
+    return false;
+  }
+
   bool diagAvailability(ConcreteDeclRef declRef, SourceRange R,
                         const ApplyExpr *call = nullptr,
                         DeclAvailabilityFlags flags = None) const;
@@ -2869,6 +2875,170 @@ AvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
 void swift::diagAvailability(const Expr *E, DeclContext *DC) {
   AvailabilityWalker walker(DC);
   const_cast<Expr*>(E)->walk(walker);
+}
+
+namespace {
+
+class StmtAvailabilityWalker : public ASTWalker {
+  DeclContext *DC;
+
+public:
+  explicit StmtAvailabilityWalker(DeclContext *DC) : DC(DC) {}
+
+  /// We'll visit the expression from performSyntacticExprDiagnostics().
+  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    return std::make_pair(false, E);
+  }
+
+  bool walkToTypeReprPre(TypeRepr *T) override {
+    diagnoseTypeReprAvailability(T, DC);
+    return false;
+  }
+};
+
+}
+
+void swift::diagAvailability(const Stmt *S, DeclContext *DC) {
+  // We'll visit the individual statements when we check them.
+  if (isa<BraceStmt>(S))
+    return;
+
+  StmtAvailabilityWalker walker(DC);
+  const_cast<Stmt*>(S)->walk(walker);
+}
+
+namespace {
+
+class TypeReprAvailabilityWalker : public ASTWalker {
+  DeclContext *DC;
+  DeclAvailabilityFlags flags;
+
+  bool checkComponentIdentTypeRepr(ComponentIdentTypeRepr *ITR) {
+    if (auto *typeDecl = ITR->getBoundDecl()) {
+      auto range = ITR->getNameLoc().getSourceRange();
+      if (diagnoseDeclAvailability(typeDecl, DC, range, flags))
+        return true;
+    }
+
+    bool foundAnyIssues = false;
+
+    if (auto *GTR = dyn_cast<GenericIdentTypeRepr>(ITR)) {
+      auto genericFlags = flags;
+      genericFlags -= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
+
+      for (auto *genericArg : GTR->getGenericArgs()) {
+        if (diagnoseTypeReprAvailability(genericArg, DC, genericFlags))
+          foundAnyIssues = true;
+      }
+    }
+
+    return foundAnyIssues;
+  }
+
+public:
+  bool foundAnyIssues = false;
+
+  TypeReprAvailabilityWalker(DeclContext *DC,
+                             DeclAvailabilityFlags flags)
+      : DC(DC), flags(flags) {}
+
+  bool walkToTypeReprPre(TypeRepr *T) override {
+    if (auto *ITR = dyn_cast<IdentTypeRepr>(T)) {
+      if (auto *CTR = dyn_cast<CompoundIdentTypeRepr>(ITR)) {
+        for (auto *comp : CTR->getComponents()) {
+          // If a parent type is unavailable, don't go on to diagnose
+          // the member since that will just produce a redundant
+          // diagnostic.
+          if (checkComponentIdentTypeRepr(comp)) {
+            foundAnyIssues = true;
+            break;
+          }
+        }
+      } else if (auto *GTR = dyn_cast<GenericIdentTypeRepr>(T)) {
+        if (checkComponentIdentTypeRepr(GTR))
+          foundAnyIssues = true;
+      } else if (auto *STR = dyn_cast<SimpleIdentTypeRepr>(T)) {
+        if (checkComponentIdentTypeRepr(STR))
+          foundAnyIssues = true;
+      }
+
+      // We've already visited all the children above, so we don't
+      // need to recurse.
+      return false;
+    }
+
+    return true;
+  }
+};
+
+}
+
+bool swift::diagnoseTypeReprAvailability(const TypeRepr *T, DeclContext *DC,
+                                         DeclAvailabilityFlags flags) {
+  TypeReprAvailabilityWalker walker(DC, flags);
+  const_cast<TypeRepr*>(T)->walk(walker);
+  return walker.foundAnyIssues;
+}
+
+namespace {
+
+class ProblematicTypeFinder : public TypeDeclFinder {
+  DeclContext *DC;
+  FragileFunctionKind FragileKind;
+  SourceLoc Loc;
+
+public:
+  ProblematicTypeFinder(DeclContext *DC, SourceLoc Loc)
+      : DC(DC), Loc(Loc) {
+    FragileKind = DC->getFragileFunctionKind();
+  }
+
+  Action visitNominalType(NominalType *ty) override {
+    if (FragileKind.kind != FragileFunctionKind::None)
+      TypeChecker::diagnoseGenericTypeExportability(Loc, ty, DC);
+    return Action::Continue;
+  }
+
+  Action visitBoundGenericType(BoundGenericType *ty) override {
+    if (FragileKind.kind != FragileFunctionKind::None)
+      TypeChecker::diagnoseGenericTypeExportability(Loc, ty, DC);
+    return Action::Continue;
+  }
+
+  Action visitTypeAliasType(TypeAliasType *ty) override {
+    if (FragileKind.kind != FragileFunctionKind::None)
+      TypeChecker::diagnoseGenericTypeExportability(Loc, ty, DC);
+    return Action::Continue;
+  }
+
+  // We diagnose unserializable Clang function types in the
+  // post-visitor so that we diagnose any unexportable component
+  // types first.
+  Action walkToTypePost(Type T) override {
+    if (FragileKind.kind != FragileFunctionKind::None) {
+      if (auto fnType = T->getAs<AnyFunctionType>()) {
+        if (auto clangType = fnType->getClangTypeInfo().getType()) {
+          auto &ctx = DC->getASTContext();
+          auto loader = ctx.getClangModuleLoader();
+          // Serialization will serialize the sugared type if it can,
+          // but we need the canonical type to be serializable or else
+          // canonicalization (e.g. in SIL) might break things.
+          if (!loader->isSerializable(clangType, /*check canonical*/ true)) {
+            ctx.Diags.diagnose(Loc, diag::unexportable_clang_function_type,
+                               fnType);
+          }
+        }
+      }
+    }
+
+    return TypeDeclFinder::walkToTypePost(T);
+  }
+};
+
+}
+
+void swift::diagnoseTypeAvailability(Type T, SourceLoc loc, DeclContext *DC) {
+  T.walk(ProblematicTypeFinder(DC, loc));
 }
 
 /// Run the Availability-diagnostics algorithm otherwise used in an expr

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -28,10 +28,10 @@ namespace swift {
   class Expr;
   class InFlightDiagnostic;
   class Decl;
+  class Stmt;
+  class Type;
+  class TypeRepr;
   class ValueDecl;
-
-/// Diagnose uses of unavailable declarations.
-void diagAvailability(const Expr *E, DeclContext *DC);
 
 enum class DeclAvailabilityFlag : uint8_t {
   /// Do not diagnose uses of protocols in versions before they were introduced.
@@ -56,6 +56,20 @@ enum class DeclAvailabilityFlag : uint8_t {
   ForObjCKeyPath = 1 << 4
 };
 using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;
+
+/// Diagnose uses of unavailable declarations in expressions.
+void diagAvailability(const Expr *E, DeclContext *DC);
+
+/// Diagnose uses of unavailable declarations in statements (via patterns, etc),
+/// without walking into expressions.
+void diagAvailability(const Stmt *S, DeclContext *DC);
+
+/// Diagnose uses of unavailable declarations in types.
+bool diagnoseTypeReprAvailability(const TypeRepr *T, DeclContext *DC,
+                                  DeclAvailabilityFlags flags = None);
+
+/// Diagnose uses of unavailable conformances in types.
+void diagnoseTypeAvailability(Type T, SourceLoc loc, DeclContext *DC);
 
 /// Run the Availability-diagnostics algorithm otherwise used in an expr
 /// context, but for non-expr contexts such as TypeDecls referenced from

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -254,7 +254,7 @@ public:
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
-    performStmtDiagnostics(dcStack.back()->getASTContext(), stmt);
+    performStmtDiagnostics(stmt, dcStack.back());
     return {true, stmt};
   }
 

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -30,31 +30,27 @@ Type InheritedTypeRequest::evaluate(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
     unsigned index, TypeResolutionStage stage) const {
   // Figure out how to resolve types.
-  TypeResolutionOptions options = None;
   DeclContext *dc;
   if (auto typeDecl = decl.dyn_cast<const TypeDecl *>()) {
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
       dc = (DeclContext *)nominal;
-
-      options |= TypeResolutionFlags::AllowUnavailableProtocol;
     } else {
       dc = typeDecl->getDeclContext();
     }
   } else {
     dc = (DeclContext *)decl.get<const ExtensionDecl *>();
-    options |= TypeResolutionFlags::AllowUnavailableProtocol;
   }
 
   Optional<TypeResolution> resolution;
   switch (stage) {
   case TypeResolutionStage::Structural:
     resolution =
-        TypeResolution::forStructural(dc, options, /*unboundTyOpener*/ nullptr);
+        TypeResolution::forStructural(dc, None, /*unboundTyOpener*/ nullptr);
     break;
 
   case TypeResolutionStage::Interface:
     resolution =
-        TypeResolution::forInterface(dc, options, /*unboundTyOpener*/ nullptr);
+        TypeResolution::forInterface(dc, None, /*unboundTyOpener*/ nullptr);
     break;
 
   case TypeResolutionStage::Contextual: {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -677,7 +677,7 @@ public:
     if (S2 == nullptr)
       return true;
     S = S2;
-    performStmtDiagnostics(getASTContext(), S);
+    performStmtDiagnostics(S, DC);
     return false;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -813,13 +813,6 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
   const auto result = TypeChecker::applyUnboundGenericArguments(
       decl, unboundType->getParent(), loc, resolution, args);
 
-  const auto genericOptions = genericResolution.getOptions();
-  if (!genericOptions.contains(TypeResolutionFlags::AllowUnavailable)) {
-    if (genericOptions.isAnyExpr() || dc->getParent()->isLocalContext())
-      if (dc->getResilienceExpansion() == ResilienceExpansion::Minimal)
-        TypeChecker::diagnoseGenericTypeExportability(loc, result, dc);
-  }
-
   // Migration hack.
   bool isMutablePointer;
   if (isPointerToVoid(dc->getASTContext(), result, isMutablePointer)) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -575,7 +575,6 @@ static TypeResolutionOptions
 adjustOptionsForGenericArgs(TypeResolutionOptions options) {
   options.setContext(None);
   options -= TypeResolutionFlags::SILType;
-  options -= TypeResolutionFlags::AllowUnavailableProtocol;
 
   return options;
 }
@@ -1877,9 +1876,6 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
       !isa<ImplicitlyUnwrappedOptionalTypeRepr>(repr)) {
     options.setContext(None);
   }
-
-  if (getASTContext().LangOpts.DisableAvailabilityChecking)
-    options |= TypeResolutionFlags::AllowUnavailable;
 
   bool isDirect = false;
   if ((options & TypeResolutionFlags::Direct) && !isa<SpecifierTypeRepr>(repr)){

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -36,37 +36,31 @@ enum class TypeResolutionFlags : uint16_t {
   /// Whether to allow unspecified types within a pattern.
   AllowUnspecifiedTypes = 1 << 0,
 
-  /// Whether an unavailable protocol can be referenced.
-  AllowUnavailableProtocol = 1 << 1,
-
-  /// Whether we should allow references to unavailable types.
-  AllowUnavailable = 1 << 2,
-
   /// Whether the given type can override the type of a typed pattern.
-  OverrideType = 1 << 3,
+  OverrideType = 1 << 1,
 
   /// Whether we are validating the type for SIL.
   // FIXME: Move this flag to TypeResolverContext.
-  SILType = 1 << 4,
+  SILType = 1 << 2,
 
   /// Whether we are parsing a SIL file.  Not the same as SILType,
   /// because the latter is not set if we're parsing an AST type.
-  SILMode = 1 << 5,
+  SILMode = 1 << 3,
 
   /// Whether this is a resolution based on a non-inferred type pattern.
-  FromNonInferredPattern = 1 << 6,
+  FromNonInferredPattern = 1 << 4,
 
   /// Whether we are at the direct base of a type expression.
-  Direct = 1 << 7,
+  Direct = 1 << 5,
 
   /// Whether we should not produce diagnostics if the type is invalid.
-  SilenceErrors = 1 << 8,
+  SilenceErrors = 1 << 6,
 
   /// Whether to allow module declaration types.
-  AllowModule = 1 << 9,
+  AllowModule = 1 << 7,
 
   /// Make internal @usableFromInline and @inlinable decls visible.
-  AllowInlinable = 1 << 10,
+  AllowInlinable = 1 << 8,
 };
 
 /// Type resolution contexts that require special handling.

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -20,6 +20,7 @@ __attribute__((objc_root_class))
 
 __attribute__((objc_root_class))
 @interface Base
+-(nonnull instancetype)init;
 @end
 
 @interface B : A

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -107,6 +107,7 @@ func testRenamedTopLevelDiags() {
   // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE-1]]:
   _ = s.value
   // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE-1]]:
+  _ = t
 }
 
 func testAKA(structValue: ImportantCStruct, aliasValue: ImportantCAlias) {

--- a/test/ClangImporter/SceneKit_test.swift
+++ b/test/ClangImporter/SceneKit_test.swift
@@ -10,91 +10,91 @@ import Foundation
 // wrapper types with nestest values.
 @available(macOS 10.11, *)
 func testNestingRenames() {
-  let _ = SCNGeometrySourceSemantic
+  let _ = SCNGeometrySourceSemantic.self
     // expected-error@-1{{'SCNGeometrySourceSemantic' has been renamed to 'SCNGeometrySource.Semantic'}}
-  let _ = SCNLightType
+  let _ = SCNLightType.self
     // expected-error@-1{{'SCNLightType' has been renamed to 'SCNLight.LightType'}}
-  let _ = SCNLightingModel
+  let _ = SCNLightingModel.self
     // expected-error@-1{{'SCNLightingModel' has been renamed to 'SCNMaterial.LightingModel'}}
-  let _ = SCNParticleProperty
+  let _ = SCNParticleProperty.self
     // expected-error@-1{{'SCNParticleProperty' has been renamed to 'SCNParticleSystem.ParticleProperty'}}
-  let _ = SCNPhysicsShapeOption
+  let _ = SCNPhysicsShapeOption.self
     // expected-error@-1{{'SCNPhysicsShapeOption' has been renamed to 'SCNPhysicsShape.Option'}}
-  let _ = SCNPhysicsShapeType
+  let _ = SCNPhysicsShapeType.self
     // expected-error@-1{{'SCNPhysicsShapeType' has been renamed to 'SCNPhysicsShape.ShapeType'}}
-  let _ = SCNPhysicsTestOption
+  let _ = SCNPhysicsTestOption.self
     // expected-error@-1{{'SCNPhysicsTestOption' has been renamed to 'SCNPhysicsWorld.TestOption'}}
-  let _ = SCNPhysicsTestSearchMode
+  let _ = SCNPhysicsTestSearchMode.self
     // expected-error@-1{{'SCNPhysicsTestSearchMode' has been renamed to 'SCNPhysicsWorld.TestSearchMode'}}
-  let _ = SCNSceneAttribute
+  let _ = SCNSceneAttribute.self
     // expected-error@-1{{'SCNSceneAttribute' has been renamed to 'SCNScene.Attribute'}}
-  let _ = SCNSceneSourceAnimationImportPolicy
+  let _ = SCNSceneSourceAnimationImportPolicy.self
     // expected-error@-1{{'SCNSceneSourceAnimationImportPolicy' has been renamed to 'SCNSceneSource.AnimationImportPolicy'}}
-  let _ = SCNSceneSourceLoadingOption
+  let _ = SCNSceneSourceLoadingOption.self
     // expected-error@-1{{'SCNSceneSourceLoadingOption' has been renamed to 'SCNSceneSource.LoadingOption'}}
-  let _ = SCNViewOption
+  let _ = SCNViewOption.self
     // expected-error@-1{{'SCNViewOption' has been renamed to 'SCNView.Option'}}
-  let _ = SCNHitTestFirstFoundOnlyKey
+  let _ = SCNHitTestFirstFoundOnlyKey.self
     // expected-error@-1{{'SCNHitTestFirstFoundOnlyKey' has been renamed to 'SCNHitTestOption.firstFoundOnly'}}
-  let _ = SCNHitTestSortResultsKey
+  let _ = SCNHitTestSortResultsKey.self
     // expected-error@-1{{'SCNHitTestSortResultsKey' has been renamed to 'SCNHitTestOption.sortResults'}}
-  let _ = SCNHitTestClipToZRangeKey
+  let _ = SCNHitTestClipToZRangeKey.self
     // expected-error@-1{{'SCNHitTestClipToZRangeKey' has been renamed to 'SCNHitTestOption.clipToZRange'}}
-  let _ = SCNHitTestBackFaceCullingKey
+  let _ = SCNHitTestBackFaceCullingKey.self
     // expected-error@-1{{'SCNHitTestBackFaceCullingKey' has been renamed to 'SCNHitTestOption.backFaceCulling'}}
-  let _ = SCNHitTestBoundingBoxOnlyKey
+  let _ = SCNHitTestBoundingBoxOnlyKey.self
     // expected-error@-1{{'SCNHitTestBoundingBoxOnlyKey' has been renamed to 'SCNHitTestOption.boundingBoxOnly'}}
-  let _ = SCNHitTestIgnoreChildNodesKey
+  let _ = SCNHitTestIgnoreChildNodesKey.self
     // expected-error@-1{{'SCNHitTestIgnoreChildNodesKey' has been renamed to 'SCNHitTestOption.ignoreChildNodes'}}
-  let _ = SCNHitTestRootNodeKey
+  let _ = SCNHitTestRootNodeKey.self
     // expected-error@-1{{'SCNHitTestRootNodeKey' has been renamed to 'SCNHitTestOption.rootNode'}}
-  let _ = SCNHitTestIgnoreHiddenNodesKey
+  let _ = SCNHitTestIgnoreHiddenNodesKey.self
     // expected-error@-1{{'SCNHitTestIgnoreHiddenNodesKey' has been renamed to 'SCNHitTestOption.ignoreHiddenNodes'}}
-  let _ = SCNPhysicsShapeTypeKey
+  let _ = SCNPhysicsShapeTypeKey.self
     // expected-error@-1{{'SCNPhysicsShapeTypeKey' has been renamed to 'SCNPhysicsShape.Option.type'}}
-  let _ = SCNPhysicsShapeKeepAsCompoundKey
+  let _ = SCNPhysicsShapeKeepAsCompoundKey.self
     // expected-error@-1{{'SCNPhysicsShapeKeepAsCompoundKey' has been renamed to 'SCNPhysicsShape.Option.keepAsCompound'}}
-  let _ = SCNPhysicsShapeScaleKey
+  let _ = SCNPhysicsShapeScaleKey.self
     // expected-error@-1{{'SCNPhysicsShapeScaleKey' has been renamed to 'SCNPhysicsShape.Option.scale'}}
-  let _ = SCNPhysicsTestCollisionBitMaskKey
+  let _ = SCNPhysicsTestCollisionBitMaskKey.self
     // expected-error@-1{{'SCNPhysicsTestCollisionBitMaskKey' has been renamed to 'SCNPhysicsWorld.TestOption.collisionBitMask'}}
-  let _ = SCNPhysicsTestSearchModeKey
+  let _ = SCNPhysicsTestSearchModeKey.self
     // expected-error@-1{{'SCNPhysicsTestSearchModeKey' has been renamed to 'SCNPhysicsWorld.TestOption.searchMode'}}
-  let _ = SCNPhysicsTestBackfaceCullingKey
+  let _ = SCNPhysicsTestBackfaceCullingKey.self
     // expected-error@-1{{'SCNPhysicsTestBackfaceCullingKey' has been renamed to 'SCNPhysicsWorld.TestOption.backfaceCulling'}}
-  let _ = SCNSceneStartTimeAttributeKey
+  let _ = SCNSceneStartTimeAttributeKey.self
     // expected-error@-1{{'SCNSceneStartTimeAttributeKey' has been renamed to 'SCNScene.Attribute.startTime'}}
-  let _ = SCNSceneEndTimeAttributeKey
+  let _ = SCNSceneEndTimeAttributeKey.self
     // expected-error@-1{{'SCNSceneEndTimeAttributeKey' has been renamed to 'SCNScene.Attribute.endTime'}}
-  let _ = SCNSceneFrameRateAttributeKey
+  let _ = SCNSceneFrameRateAttributeKey.self
     // expected-error@-1{{'SCNSceneFrameRateAttributeKey' has been renamed to 'SCNScene.Attribute.frameRate'}}
-  let _ = SCNSceneUpAxisAttributeKey
+  let _ = SCNSceneUpAxisAttributeKey.self
     // expected-error@-1{{'SCNSceneUpAxisAttributeKey' has been renamed to 'SCNScene.Attribute.upAxis'}}
-  let _ = SCNSceneSourceCreateNormalsIfAbsentKey
+  let _ = SCNSceneSourceCreateNormalsIfAbsentKey.self
     // expected-error@-1{{'SCNSceneSourceCreateNormalsIfAbsentKey' has been renamed to 'SCNSceneSource.LoadingOption.createNormalsIfAbsent'}}
-  let _ = SCNSceneSourceCheckConsistencyKey
+  let _ = SCNSceneSourceCheckConsistencyKey.self
     // expected-error@-1{{'SCNSceneSourceCheckConsistencyKey' has been renamed to 'SCNSceneSource.LoadingOption.checkConsistency'}}
-  let _ = SCNSceneSourceFlattenSceneKey
+  let _ = SCNSceneSourceFlattenSceneKey.self
     // expected-error@-1{{'SCNSceneSourceFlattenSceneKey' has been renamed to 'SCNSceneSource.LoadingOption.flattenScene'}}
-  let _ = SCNSceneSourceUseSafeModeKey
+  let _ = SCNSceneSourceUseSafeModeKey.self
     // expected-error@-1{{'SCNSceneSourceUseSafeModeKey' has been renamed to 'SCNSceneSource.LoadingOption.useSafeMode'}}
-  let _ = SCNSceneSourceAssetDirectoryURLsKey
+  let _ = SCNSceneSourceAssetDirectoryURLsKey.self
     // expected-error@-1{{'SCNSceneSourceAssetDirectoryURLsKey' has been renamed to 'SCNSceneSource.LoadingOption.assetDirectoryURLs'}}
-  let _ = SCNSceneSourceOverrideAssetURLsKey
+  let _ = SCNSceneSourceOverrideAssetURLsKey.self
     // expected-error@-1{{'SCNSceneSourceOverrideAssetURLsKey' has been renamed to 'SCNSceneSource.LoadingOption.overrideAssetURLs'}}
-  let _ = SCNSceneSourceStrictConformanceKey
+  let _ = SCNSceneSourceStrictConformanceKey.self
     // expected-error@-1{{'SCNSceneSourceStrictConformanceKey' has been renamed to 'SCNSceneSource.LoadingOption.strictConformance'}}
-  let _ = SCNSceneSourceConvertUnitsToMetersKey
+  let _ = SCNSceneSourceConvertUnitsToMetersKey.self
     // expected-error@-1{{'SCNSceneSourceConvertUnitsToMetersKey' has been renamed to 'SCNSceneSource.LoadingOption.convertUnitsToMeters'}}
-  let _ = SCNSceneSourceConvertToYUpKey
+  let _ = SCNSceneSourceConvertToYUpKey.self
     // expected-error@-1{{'SCNSceneSourceConvertToYUpKey' has been renamed to 'SCNSceneSource.LoadingOption.convertToYUp'}}
-  let _ = SCNSceneSourceAnimationImportPolicyKey
+  let _ = SCNSceneSourceAnimationImportPolicyKey.self
     // expected-error@-1{{'SCNSceneSourceAnimationImportPolicyKey' has been renamed to 'SCNSceneSource.LoadingOption.animationImportPolicy'}}
-  let _ = SCNPreferredRenderingAPIKey
+  let _ = SCNPreferredRenderingAPIKey.self
     // expected-error@-1{{'SCNPreferredRenderingAPIKey' has been renamed to 'SCNView.Option.preferredRenderingAPI'}}
-  let _ = SCNPreferredDeviceKey
+  let _ = SCNPreferredDeviceKey.self
     // expected-error@-1{{'SCNPreferredDeviceKey' has been renamed to 'SCNView.Option.preferredDevice'}}
-  let _ = SCNPreferLowPowerDeviceKey
+  let _ = SCNPreferLowPowerDeviceKey.self
     // expected-error@-1{{'SCNPreferLowPowerDeviceKey' has been renamed to 'SCNView.Option.preferLowPowerDevice'}}
 }
 

--- a/test/ClangImporter/attr-swift_name_renaming.swift
+++ b/test/ClangImporter/attr-swift_name_renaming.swift
@@ -9,7 +9,7 @@ func test() {
 
   // Enum name remapping.
   var color: ColorKind = CT_red
-  var color2: ColorType = CT_Red // expected-error{{'ColorType' has been renamed to 'ColorKind'}}{{15-24=ColorKind}}
+  var color2: ColorType = CT_red // expected-error{{'ColorType' has been renamed to 'ColorKind'}}{{15-24=ColorKind}}
 
   // Enumerator remapping.
   var excuse: HomeworkExcuse = .dogAteIt

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -103,8 +103,8 @@ func makeSureAnyObject(_: AnyObject) {}
 
 #if !IRGEN
 func testUnavailableRefs() {
-  var x: __PrivCFTypeRef // expected-error {{'__PrivCFTypeRef' has been renamed to '__PrivCFType'}}
-  var y: __PrivCFSubRef // expected-error {{'__PrivCFSubRef' has been renamed to '__PrivCFSub'}}
+  var _: __PrivCFTypeRef // expected-error {{'__PrivCFTypeRef' has been renamed to '__PrivCFType'}}
+  var _: __PrivCFSubRef // expected-error {{'__PrivCFSubRef' has been renamed to '__PrivCFSub'}}
 }
 #endif
 

--- a/test/ClangImporter/availability.swift
+++ b/test/ClangImporter/availability.swift
@@ -137,6 +137,7 @@ func test_swift_unavailable() {
   NSSwiftNewUnavailableFunctionPremium() // expected-error {{'NSSwiftNewUnavailableFunctionPremium()' is unavailable in Swift: You didn't want to use it anyway.}}
 
   let x: NSSwiftUnavailableStruct? = nil // expected-error {{'NSSwiftUnavailableStruct' is unavailable in Swift}}
+  _ = x
 }
 
 func test_CFReleaseRetainAutorelease(_ x: CFTypeRef, color: CGColor) {
@@ -152,9 +153,9 @@ func testRedeclarations() {
   unavail2() // expected-error {{is unavailable: middle}}
   unavail3() // expected-error {{is unavailable: last}}
 
-  UnavailClass1.self // expected-error {{is unavailable: first}}
-  UnavailClass2.self // expected-error {{is unavailable: middle}}
-  UnavailClass3.self // expected-error {{is unavailable: last}}
+  _ = UnavailClass1.self // expected-error {{is unavailable: first}}
+  _ = UnavailClass2.self // expected-error {{is unavailable: middle}}
+  _ = UnavailClass3.self // expected-error {{is unavailable: last}}
 
   let _: UnavailStruct1 // expected-error {{is unavailable: first}}
   let _: UnavailStruct2 // expected-error {{is unavailable: first}}
@@ -186,7 +187,9 @@ func test_DistributedObjects(_ o: NSObject,
                              i: NSPortCoder) {          // expected-error {{'NSPortCoder' is unavailable in Swift: Use NSXPCConnection instead}}
 
   let ca = NSConnectionDidDieNotification // expected-error {{'NSConnectionDidDieNotification' is unavailable in Swift: Use NSXPCConnection instead}}
+  _ = ca
   let cc = NSConnectionReplyMode // expected-error {{'NSConnectionReplyMode' is unavailable in Swift: Use NSXPCConnection instead}}
+  _ = cc
   _ = o.classForPortCoder // expected-error {{'classForPortCoder' is unavailable in Swift: Use NSXPCConnection instead}}
 }
 

--- a/test/ClangImporter/swift2_warnings.swift
+++ b/test/ClangImporter/swift2_warnings.swift
@@ -8,8 +8,7 @@ import ImportAsMember.A
 import AppKit
 
 func testOldTypeNames() {
-  var ps: NSPostingStyle? // expected-error{{'NSPostingStyle' has been renamed to 'NotificationQueue.PostingStyle'}}{{11-25=NotificationQueue.PostingStyle}}
-
+  let _: NSPostingStyle? // expected-error{{'NSPostingStyle' has been renamed to 'NotificationQueue.PostingStyle'}}{{10-24=NotificationQueue.PostingStyle}}
 
   _ = NSPostingStyle(rawValue: 1) // expected-error{{'NSPostingStyle' has been renamed to 'NotificationQueue.PostingStyle'}}{{7-21=NotificationQueue.PostingStyle}}
 

--- a/test/SPI/implementation_only_spi_import_exposability.swift
+++ b/test/SPI/implementation_only_spi_import_exposability.swift
@@ -38,8 +38,10 @@ public struct PublicStruct : IOIProtocol, SPIProtocol { // expected-error {{cann
   public func publicInlinable() {
     spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
     ioiFunc() // expected-error {{global function 'ioiFunc()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
-    let s = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from an '@inlinable' function}}
-    let i = IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    let _ = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+    // expected-error@-1 {{initializer 'init()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+    let _ = IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
   }
 }
 

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -17,6 +17,8 @@
   // expected-note @-1 3 {{class 'SPIClass' is not '@usableFromInline' or public}}
   // expected-note @-2 {{class 'SPIClass' is not public}}
   public init() {}
+  // expected-note@-1 2 {{initializer 'init()' is not '@usableFromInline' or public}}
+  // expected-note@-2 {{initializer 'init()' is not public}}
 }
 class InternalClass {} // expected-note 2 {{type declared here}}
 private class PrivateClass {} // expected-note 2 {{type declared here}}
@@ -32,17 +34,25 @@ public func useOfSPITypeInvalid() -> SPIClass { fatalError() } // expected-error
 func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   _ = SPIClass() // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+  // expected-error@-1 {{initializer 'init()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
 }
 
 @_spi(S) public struct SPIStruct { // expected-note 2 {{struct 'SPIStruct' is not '@usableFromInline' or public}}
+  // FIXME: Misleading diagnostic here
   public init() {}
+  // expected-note@-1 2 {{initializer 'init()' is not '@usableFromInline' or public}}
 }
 
 @frozen public struct FrozenStruct {
   @_spi(S) public var spiInFrozen = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
-  // expected-error @-1 {{stored property 'spiInFrozen' cannot be declared '@_spi' in a '@frozen' struct}}
+  // expected-error@-1 {{stored property 'spiInFrozen' cannot be declared '@_spi' in a '@frozen' struct}}
+  // expected-error@-2 {{cannot use struct 'SPIStruct' here; it is SPI}}
+  // expected-error@-3 {{initializer 'init()' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
 
   var spiTypeInFrozen = SPIStruct() // expected-error {{struct 'SPIStruct' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
+  // expected-error@-1 {{cannot use struct 'SPIStruct' here; it is SPI}}
+  // expected-error@-2 {{initializer 'init()' is '@_spi' and cannot be referenced from a property initializer in a '@frozen' type}}
+
   private var spiTypeInFrozen1: SPIClass // expected-error {{cannot use class 'SPIClass' here; it is SPI}}
 }
 
@@ -98,7 +108,8 @@ public struct NestedParent {
 }
 
 public func publicFuncWithDefaultValue(_ p: SPIClass = SPIClass()) {} // expected-error {{cannot use class 'SPIClass' here; it is SPI}}
-// expected-error @-1 {{class 'SPIClass' is '@_spi' and cannot be referenced from a default argument value}}
+// expected-error@-1 {{class 'SPIClass' is '@_spi' and cannot be referenced from a default argument value}}
+// expected-error@-2 {{initializer 'init()' is '@_spi' and cannot be referenced from a default argument value}}
 
 @_spi(S)
 public func spiFuncWithDefaultValue(_ p: SPIClass = SPIClass()) {}
@@ -107,6 +118,7 @@ public func spiFuncWithDefaultValue(_ p: SPIClass = SPIClass()) {}
 public func inlinablePublic() {
   spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   let _ = SPIClass() // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+  // expected-error@-1 {{initializer 'init()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
 }
 
 @_spi(S)

--- a/test/SPI/spi_client.swift
+++ b/test/SPI/spi_client.swift
@@ -53,15 +53,16 @@ public func publicUseOfSPI(param: SPIClass) -> SPIClass {} // expected-error 2{{
 public func publicUseOfSPI2() -> [SPIClass] {} // expected-error {{cannot use class 'SPIClass' here; it is an SPI imported from 'SPIHelper'}}
 
 @inlinable
-public func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+public func inlinable1() -> SPIClass { // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   spiFunc() // expected-error {{global function 'spiFunc()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   _ = SPIClass() // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
+  // expected-error@-1 {{initializer 'init()' is '@_spi' and cannot be referenced from an '@inlinable' function}}
   _ = [SPIClass]() // expected-error {{class 'SPIClass' is '@_spi' and cannot be referenced from an '@inlinable' function}}
 }
 
 @_spi(S)
 @inlinable
-public func inlinable() -> SPIClass {
+public func inlinable2() -> SPIClass {
   spiFunc()
   _ = SPIClass()
   _ = [SPIClass]()

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -1,6 +1,10 @@
-// This file is used by Sema/availability_versions_multi.swift to
+// This file was used by Sema/availability_versions_multi.swift to
 // test that we build enough of the type refinement context as needed to
 // validate declarations when resolving declaration signatures.
+//
+// These days, we don't validate availability in secondary files at all,
+// so the test here is just to make sure we don't crash.
+//
 // This file relies on the minimum deployment target for OS X being 10.9.
 
 @available(OSX, introduced: 99.52)
@@ -18,11 +22,9 @@ class OtherIntroduced99_51 {
     _ = PrivateIntroduced99_52()
   }
 
-  // This method uses a 99_52 only type in its signature, so validating
-  // the declaration should produce an availability error
-  func returns99_52() -> OtherIntroduced99_52 { // expected-error {{'OtherIntroduced99_52' is only available in macOS 99.52 or newer}}
-      // expected-note@-1 {{add @available attribute to enclosing instance method}}
-
+  // This method uses a 99_52 only type in its signature, but we don't
+  // validate it since it comes from a secondary file.
+  func returns99_52() -> OtherIntroduced99_52 {
     // Body is not type checked (by design) so no error is expected for unavailable type used in return.
     return OtherIntroduced99_52()
   }
@@ -86,5 +88,4 @@ extension OtherIntroduced99_51 {
 class OtherIntroduced99_53 {
 }
 
-var globalFromOtherOn99_52 : OtherIntroduced99_52? = nil // expected-error {{'OtherIntroduced99_52' is only available in macOS 99.52 or newer}}
-    // expected-note@-1 {{add @available attribute to enclosing var}}
+var globalFromOtherOn99_52 : OtherIntroduced99_52? = nil

--- a/test/Sema/Inputs/implementation-only-imports/directs.swift
+++ b/test/Sema/Inputs/implementation-only-imports/directs.swift
@@ -1,6 +1,7 @@
 @_exported import indirects
 
 public struct StructFromDirect {
+  public init() {}
   public func method() {}
   public var property: Int {
     get { return 0 }

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -19,12 +19,16 @@ struct Outer {
 
 func foo(x : NSUInteger) { // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
      let y : NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
+     // expected-error@-1 {{cannot convert value of type 'Int' to specified type 'NSUInteger'}}
 
   let z : MyModule.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
+  // expected-error@-1 {{cannot convert value of type 'Int' to specified type 'NSUInteger'}}
 
-  let z2 : Outer.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'UInt' instead}}  
+  let z2 : Outer.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'UInt' instead}}
+  // expected-error@-1 {{cannot convert value of type 'Int' to specified type 'Outer.NSUInteger'}}
 
-  let z3 : MyModule.Outer.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'UInt' instead}}  
+  let z3 : MyModule.Outer.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'UInt' instead}}
+  // expected-error@-1 {{cannot convert value of type 'Int' to specified type 'Outer.NSUInteger'}}
 }
 
 // Test preventing overrides (but allowing shadowing) of unavailable methods.

--- a/test/Sema/availability_compound.swift
+++ b/test/Sema/availability_compound.swift
@@ -12,7 +12,16 @@ public struct PublicStruct {
 public typealias ObsoleteAlias = PublicStruct // expected-note * {{marked unavailable here}}
 
 public let a: ObsoleteAlias.Inner? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+
 public let b: ObsoleteAlias.Obsolete? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+// expected-error@-1 {{constant cannot be declared public because its type uses an internal type}}
+
 public let c: Pair<ObsoleteAlias.Inner, PublicStruct.Obsolete>? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+// expected-error@-1 {{'Obsolete' is unavailable}}
+// expected-error@-2 {{constant cannot be declared public because its type uses an internal type}}
+
 public let c2: Pair<PublicStruct.Obsolete, ObsoleteAlias.Inner>? // expected-error {{'Obsolete' is unavailable}}
+// expected-error@-1 {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+// expected-error@-2 {{constant cannot be declared public because its type uses an internal type}}
+
 public let d: ObsoleteAlias? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -70,11 +70,11 @@ func genericFunctionSigilArray<T>(
 }
 
 protocol P {
-  associatedtype T // expected-note {{protocol requires nested type 'T'; do you want to add it?}}
-  associatedtype U // expected-note {{protocol requires nested type 'U'; do you want to add it?}}
+  associatedtype T
+  associatedtype U
 }
 
-struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}}
+struct S : P {
   typealias T = ImplicitlyUnwrappedOptional<Int> // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{17-44=Optional}}
   typealias U = Optional<ImplicitlyUnwrappedOptional<Int>> // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{26-53=Optional}}
 

--- a/test/Sema/implementation-only-import-inlinable-conformances.swift
+++ b/test/Sema/implementation-only-import-inlinable-conformances.swift
@@ -33,7 +33,7 @@ public struct NormalProtoAssocHolder<T: NormalProto> {
   _ = x
   // FIXME: We get this error twice: once for the TypeExpr and once for the implicit init.
   _ = NormalProtoAssocHolder<NormalStruct>() // expected-error 2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
-  _ = NormalProtoAssocHolder(nil as NormalStruct?) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
+  _ = NormalProtoAssocHolder(nil as NormalStruct?) // expected-error 2{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; 'BADLibrary' has been imported as implementation-only}}
 }
 
 func internalConformanceInBoundGeneric() {

--- a/test/Sema/implementation-only-import-inlinable-indirect.swift
+++ b/test/Sema/implementation-only-import-inlinable-indirect.swift
@@ -11,16 +11,18 @@
 @inlinable
 public func testStructFromIndirect() {
   _ = StructFromIndirect() // expected-error {{struct 'StructFromIndirect' cannot be used in an '@inlinable' function because 'indirects' was imported implementation-only}}
+  // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'indirects' was imported implementation-only}}
 }
 
 @inlinable
 public func testAliasFromIndirect() {
   _ = AliasFromIndirect() // expected-error {{type alias 'AliasFromIndirect' cannot be used in an '@inlinable' function because 'indirects' was imported implementation-only}}
+  // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'indirects' was imported implementation-only}}
 }
 
 @inlinable
 public func testGenericAliasFromIndirect() {
-  _ = GenericAliasFromIndirect<Int>() // expected-error {{type alias 'GenericAliasFromIndirect' cannot be used in an '@inlinable' function because 'indirects' was imported implementation-only}}
+  _ = GenericAliasFromIndirect<Int>.self // expected-error {{type alias 'GenericAliasFromIndirect' cannot be used in an '@inlinable' function because 'indirects' was imported implementation-only}}
 }
 
 // Functions

--- a/test/Sema/implementation-only-import-inlinable-multifile.swift
+++ b/test/Sema/implementation-only-import-inlinable-multifile.swift
@@ -12,6 +12,7 @@
 @inlinable
 public func testStructFromDirect() {
   _ = StructFromDirect() // expected-error {{struct 'StructFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
 }
 
 @inlinable
@@ -22,6 +23,7 @@ public func testStructFromIndirect() {
 @inlinable
 public func testAliasFromDirect() {
   _ = AliasFromDirect() // expected-error {{type alias 'AliasFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
 }
 
 @inlinable
@@ -31,7 +33,7 @@ public func testAliasFromIndirect() {
 
 @inlinable
 public func testGenericAliasFromDirect() {
-  _ = GenericAliasFromDirect<Int>() // expected-error {{type alias 'GenericAliasFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  _ = GenericAliasFromDirect<Int>.self // expected-error {{type alias 'GenericAliasFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
 }
 
 @inlinable

--- a/test/Sema/implementation-only-import-inlinable.swift
+++ b/test/Sema/implementation-only-import-inlinable.swift
@@ -12,6 +12,7 @@ import indirects
 @inlinable
 public func testStructFromDirect() {
   _ = StructFromDirect() // expected-error {{struct 'StructFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
 }
 
 @inlinable
@@ -22,6 +23,7 @@ public func testStructFromIndirect() {
 @inlinable
 public func testAliasFromDirect() {
   _ = AliasFromDirect() // expected-error {{type alias 'AliasFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
 }
 
 @inlinable
@@ -31,7 +33,7 @@ public func testAliasFromIndirect() {
 
 @inlinable
 public func testGenericAliasFromDirect() {
-  _ = GenericAliasFromDirect<Int>() // expected-error {{type alias 'GenericAliasFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
+  _ = GenericAliasFromDirect<Int>.self // expected-error {{type alias 'GenericAliasFromDirect' cannot be used in an '@inlinable' function because 'directs' was imported implementation-only}}
 }
 
 @inlinable

--- a/test/Sema/spi-inlinable-conformances.swift
+++ b/test/Sema/spi-inlinable-conformances.swift
@@ -67,7 +67,7 @@ public struct NormalProtoAssocHolder<T: NormalProto> {
   _ = x
   // FIXME: We get this error twice: once for the TypeExpr and once for the implicit init.
   _ = NormalProtoAssocHolder<NormalStruct>() // expected-error 2 {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
-  _ = NormalProtoAssocHolder(nil as NormalStruct?) // expected-error {{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
+  _ = NormalProtoAssocHolder(nil as NormalStruct?) // expected-error 2{{cannot use conformance of 'NormalStruct' to 'NormalProto' here; the conformance is declared as SPI}}
 }
 
 @_spi(AcceptInSPI)

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -54,8 +54,8 @@ typealias YourCollection<Element> = MyCollection<Element> // expected-note {{'Yo
 
 var x : YourCollection<Int> // expected-error {{'YourCollection' has been renamed to 'MyCollection'}}{{9-23=MyCollection}}
 
-var x : int // expected-error {{'int' is unavailable: oh no you don't}}
-var y : float // expected-error {{'float' has been renamed to 'Float'}}{{9-14=Float}}
+var y : int // expected-error {{'int' is unavailable: oh no you don't}}
+var z : float // expected-error {{'float' has been renamed to 'Float'}}{{9-14=Float}}
 
 // Encoded message
 @available(*, unavailable, message: "This message has a double quote \"")

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -19,8 +19,10 @@ public func publicFunction() {}
 
 private struct PrivateStruct {}
 // expected-note@-1 3{{struct 'PrivateStruct' is not '@usableFromInline' or public}}
+// expected-note@-2 {{initializer 'init()' is not '@usableFromInline' or public}}
 struct InternalStruct {}
 // expected-note@-1 3{{struct 'InternalStruct' is not '@usableFromInline' or public}}
+// expected-note@-2 {{initializer 'init()' is not '@usableFromInline' or public}}
 @usableFromInline struct VersionedStruct {
   @usableFromInline init() {}
 }
@@ -75,8 +77,10 @@ public struct Struct {
     let _ = VersionedStruct()
     let _ = InternalStruct()
     // expected-error@-1 {{struct 'InternalStruct' is internal and cannot be referenced from an '@inlinable' function}}
+    // expected-error@-2 {{initializer 'init()' is internal and cannot be referenced from an '@inlinable' function}}
     let _ = PrivateStruct()
     // expected-error@-1 {{struct 'PrivateStruct' is private and cannot be referenced from an '@inlinable' function}}
+    // expected-error@-2 {{initializer 'init()' is private and cannot be referenced from an '@inlinable' function}}
   }
 
   private func privateMethod() {}
@@ -107,7 +111,7 @@ public struct Struct {
   private func privateInlinableMethod() {
   // expected-error@-2 {{'@inlinable' attribute can only be applied to public declarations, but 'privateInlinableMethod' is private}}
     struct Nested {}
-    // OK
+    // expected-error@-1 {{type 'Nested' cannot be nested inside an '@inlinable' function}}
   }
 
   @inline(__always)
@@ -143,14 +147,18 @@ enum InternalEnum {
   // expected-note@-1 2{{enum 'InternalEnum' is not '@usableFromInline' or public}}
   // expected-note@-2 {{type declared here}}
   case apple
+  // expected-note@-1 {{enum case 'apple' is not '@usableFromInline' or public}}
   case orange
+  // expected-note@-1 {{enum case 'orange' is not '@usableFromInline' or public}}
 }
 
 @inlinable public func usesInternalEnum() {
   _ = InternalEnum.apple
   // expected-error@-1 {{enum 'InternalEnum' is internal and cannot be referenced from an '@inlinable' function}}
+  // expected-error@-2 {{enum case 'apple' is internal and cannot be referenced from an '@inlinable' function}}
   let _: InternalEnum = .orange
   // expected-error@-1 {{enum 'InternalEnum' is internal and cannot be referenced from an '@inlinable' function}}
+  // expected-error@-2 {{enum case 'orange' is internal and cannot be referenced from an '@inlinable' function}}
 }
 
 @usableFromInline enum VersionedEnum {

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -276,7 +276,7 @@ extension P10 where A == X<U> { }
 
 extension P10 where A == X<Self.U> { }
 
-extension P10 where V == Int { } // expected-warning 2{{'V' is deprecated: just use Int, silly}}
+extension P10 where V == Int { } // expected-warning {{'V' is deprecated: just use Int, silly}}
 // expected-warning@-1{{neither type in same-type constraint ('Self.V' (aka 'Int') or 'Int') refers to a generic parameter or associated type}}
 
 // rdar://problem/36003312

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-frontend -typecheck -swift-version 5 %s -verify
 
 func testPopFirst() {
-  var str = "abc"
-  var charView: String.CharacterView // expected-error{{'CharacterView' is unavailable: Please use String directly}}
+  let str = "abc"
+  let charView: String.CharacterView // expected-error{{'CharacterView' is unavailable: Please use String directly}}
   _ = str.characters // expected-error{{'characters' is unavailable: Please use String directly}}
   dump(charView)
 
@@ -11,7 +11,7 @@ func testPopFirst() {
   _ = substr.characters.popFirst() // expected-error{{'characters' is unavailable: Please use Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
 
-  var charSubView: Substring.CharacterView // expected-error{{'CharacterView' is unavailable: Please use Substring directly}}
+  let charSubView: Substring.CharacterView // expected-error{{'CharacterView' is unavailable: Please use Substring directly}}
   _ = substr.characters // expected-error{{'characters' is unavailable: Please use Substring directly}}
   dump(charSubView)
 }


### PR DESCRIPTION
We used to diagnose references to unavailable declarations in
two places:

- inside Exprs, right after type checking the expression
- inside TypeReprs, from resolveType()

In broad terms, resolveType() is called with TypeReprs
stored inside both Stmts and Decls.

To handle the first case, I added a new overload of
diagAvailability() that takes a Stmt, to be called from
typeCheckStmt(). This doesn't actually walk into any Exprs
stored inside the statement; this means it only walks
Patterns and such.

For the second case, a new DeclAvailabilityChecker is
now defined in TypeCheckAccess.cpp. It's structure is
analogous to the other three walkers there:

- AccessControlChecker
- UsableFromInlineChecker
- ExportabilityChecker

The new implementation of availability checking for types
introduces a lot more code than the old online logic
it replaces. However, I hope to consolidate some of the
code duplication among the four checkers that are defined
in TypeCheckAccess.cpp, and do some other cleanups that
will make the benefit of the new approach apparent.