### PR TITLE
Silence a Raft of Warnings from the Windows Build

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3762,6 +3762,7 @@ public:
     case Contravariant:
       return Covariant;
     }
+    llvm_unreachable("unhandled self reference position!");
   }
 
   explicit operator bool() const { return kind > None; }

--- a/include/swift/AST/ForeignErrorConvention.h
+++ b/include/swift/AST/ForeignErrorConvention.h
@@ -198,6 +198,7 @@ public:
     case NonNilError:
       return false;
     }
+    llvm_unreachable("unhandled foreign error kind!");
   }
 
   bool operator==(ForeignErrorConvention other) const {

--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -150,6 +150,7 @@ public:
         delete castContext;
         return nullptr;
       }
+      llvm_unreachable("unhandled command!");
     };
   }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1907,6 +1907,7 @@ public:
     case Kind::patternBinding:
       return patternBinding;
     }
+    llvm_unreachable("invalid case label type");
   }
 
   VarDecl *getAsUninitializedWrappedVar() const {
@@ -1921,6 +1922,7 @@ public:
     case Kind::uninitializedWrappedVar:
       return uninitializedWrappedVar;
     }
+    llvm_unreachable("invalid case label type");
   }
 
   BraceStmt *getFunctionBody() const {

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -462,6 +462,7 @@ bool swift::operator==(const TangentPropertyInfo::Error &lhs,
   case TangentPropertyInfo::Error::Kind::TangentPropertyWrongType:
     return lhs.getType()->isEqual(rhs.getType());
   }
+  llvm_unreachable("unhandled tangent property!");
 }
 
 void swift::simple_display(llvm::raw_ostream &os, TangentPropertyInfo info) {

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -207,6 +207,7 @@ const clang::Type *ClangTypeConverter::getFunctionType(
   case SILFunctionType::Representation::Closure:
     llvm_unreachable("Expected a C-compatible representation.");
   }
+  llvm_unreachable("unhandled representation!");
 }
 
 clang::QualType ClangTypeConverter::convertMemberType(NominalTypeDecl *DC,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1497,6 +1497,7 @@ bool ActorIsolation::requiresSubstitution() const {
   case GlobalActor:
     return getGlobalActor()->hasTypeParameter();
   }
+  llvm_unreachable("unhandled actor isolation kind!");
 }
 
 ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
@@ -1509,6 +1510,7 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   case GlobalActor:
     return forGlobalActor(getGlobalActor().subst(subs));
   }
+  llvm_unreachable("unhandled actor isolation kind!");
 }
 
 void swift::simple_display(

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -364,6 +364,7 @@ bool jobMatchesFilter(LinkKind jobKind, BackDeployLibFilter filter) {
   case BackDeployLibFilter::all:
     return true;
   }
+  llvm_unreachable("unhandled back deploy lib filter!");
 }
 
 }

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -56,6 +56,7 @@ StringRef swift::ide::api::getDeclKindStr(const DeclKind Value, bool lower) {
     }
 #include "swift/AST/DeclNodes.def"
     }
+    llvm_unreachable("Unhandled DeclKind in switch.");
   } else {
     return getDeclKindStrRaw(Value);
   }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1015,7 +1015,7 @@ namespace {
     llvm::Type *convertVectorType(clang::CanQual<clang::VectorType> type) {
       auto eltTy =
         convertBuiltinType(type->getElementType().castAs<clang::BuiltinType>());
-      return llvm::VectorType::get(eltTy, type->getNumElements());
+      return llvm::FixedVectorType::get(eltTy, type->getNumElements());
     }
 
     llvm::Type *convertBuiltinType(clang::CanQual<clang::BuiltinType> type) {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1216,7 +1216,7 @@ TypeConverter::createPrimitiveForAlignedPointer(llvm::PointerType *type,
                                                 Alignment align,
                                                 Alignment pointerAlignment) {
   SpareBitVector spareBits = IGM.TargetInfo.PointerSpareBits;
-  for (unsigned bit = 0; Alignment(1 << bit) != pointerAlignment; ++bit) {
+  for (unsigned bit = 0; Alignment(1ull << bit) != pointerAlignment; ++bit) {
     spareBits.setBit(bit);
   }
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1872,7 +1872,7 @@ convertPrimitiveBuiltin(IRGenModule &IGM, CanType canTy) {
       = convertPrimitiveBuiltin(IGM,
                                 vecTy->getElementType()->getCanonicalType());
 
-    auto llvmVecTy = llvm::VectorType::get(elementTy, vecTy->getNumElements());
+    auto llvmVecTy = llvm::FixedVectorType::get(elementTy, vecTy->getNumElements());
     unsigned bitSize = size.getValue() * vecTy->getNumElements() * 8;
     if (!llvm::isPowerOf2_32(bitSize))
       bitSize = llvm::NextPowerOf2(bitSize);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1219,6 +1219,13 @@ public:
   llvm::Value *getCoroutineBuffer() override {
     return allParamValues.claimNext();
   }
+
+public:
+  using SyncEntryPointArgumentEmission::requiresIndirectResult;
+  using SyncEntryPointArgumentEmission::getIndirectResultForFormallyDirectResult;
+  using SyncEntryPointArgumentEmission::getIndirectResult;
+  using SyncEntryPointArgumentEmission::getNextPolymorphicParameterAsMetadata;
+  using SyncEntryPointArgumentEmission::getNextPolymorphicParameter;
 };
 
 class AsyncNativeCCEntryPointArgumentEmission final

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -414,6 +414,7 @@ ClassMetadataLayout::getMethodInfo(IRGenFunction &IGF, SILDeclRef method) const{
   case MethodInfo::Kind::DirectImpl:
     return MethodInfo(stored.TheImpl);
   }
+  llvm_unreachable("unhandled method info kind!");
 }
 
 Offset ClassMetadataLayout::getFieldOffset(IRGenFunction &IGF,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -616,6 +616,7 @@ static MetadataResponse emitNominalPrespecializedGenericMetadataRef(
     return MetadataResponse::handle(IGF, request, call);
   }
   }
+  llvm_unreachable("unhandled metadata canonicality");
 }
 
 static llvm::Value *

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -336,6 +336,7 @@ private:
     case AdjointValueKind::Concrete:
       return val.getConcreteValue();
     }
+    llvm_unreachable("unhandled adjoint value kind!");
   }
 
   /// Materializes an adjoint value indirectly to a SIL buffer.

--- a/lib/SILOptimizer/SemanticARC/OwnershipPhiOperand.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipPhiOperand.h
@@ -88,6 +88,7 @@ public:
     case Kind::Struct:
       return false;
     }
+    llvm_unreachable("unhandled operand kind!");
   }
 
   bool operator<(const OwnershipPhiOperand &other) const {
@@ -113,6 +114,7 @@ public:
           });
     }
     }
+    llvm_unreachable("unhandled operand kind!");
   }
 };
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -984,6 +984,7 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
         GenericSpecializationInformation::create(ApplyInst, Builder));
   }
   }
+  llvm_unreachable("unhandled apply inst kind!");
 }
 
 static void rewriteApplySites(AllocBoxToStackState &pass) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -825,6 +825,7 @@ void swift::checkActorIsolation(const Expr *expr, const DeclContext *dc) {
         // Okay.
         return false;
       }
+      llvm_unreachable("unhandled actor isolation kind!");
     }
 
     /// Check a reference to a local or global.
@@ -868,6 +869,7 @@ void swift::checkActorIsolation(const Expr *expr, const DeclContext *dc) {
       case ActorIsolationRestriction::Unsafe:
         return diagnoseReferenceToUnsafe(value, loc);
       }
+      llvm_unreachable("unhandled actor isolation kind!");
     }
 
     /// Check a reference with the given base expression to the given member.
@@ -964,6 +966,7 @@ void swift::checkActorIsolation(const Expr *expr, const DeclContext *dc) {
       case ActorIsolationRestriction::Unsafe:
         return diagnoseReferenceToUnsafe(member, memberLoc);
       }
+      llvm_unreachable("unhandled actor isolation kind!");
     }
   };
 

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -262,6 +262,7 @@ static Type inferFunctionBuilderType(ValueDecl *decl)  {
       case DynamicReplacement:
         return dynamicReplacement->getName();
       }
+      llvm_unreachable("unhandled decl name kind!");
     }
   };
 


### PR DESCRIPTION
* Silence unhandled control flow in switches
* Use an explicit 64-bit shift where a 32-bit shift-then-convert was being applied
* Cut over to `FixedVectorType`. I don't believe these were meant to be scalable vectors.