### PR TITLE
Platform: link against Pathcch.lib when using pathcch.h

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -102,6 +102,8 @@ module WinSDK [system] {
     module path {
       header "PathCch.h"
       export *
+
+      link "pathcch.lib"
     }
 
     // api-ms-win-core-processthreads-l1-1-2.dll


### PR DESCRIPTION
The MSDN documentation indicates that you should link against the
`Pathcch.lib` import library when using functions from `pathcch.h` which
can also be verified by use functions failing to link due to unresolved
symbols.  Add the missing linking to enable autolinking for `WinSDK`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
