### PR TITLE
sil-opt: Disable parser lookup

### DIFF
--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -278,8 +278,8 @@ bb0(%0 : $*T):
   %2 = apply %1<T>(%0) : $@convention(witness_method: Runcible) <Self : Runcible> (@in Self) -> Int
   %3 = metatype $@thick T.Type
   // CHECK: witness_method $T, #Runcible.static_method
-  %4 = witness_method $T, #Runcible.static_method : $@convention(witness_method: Runcible) <Self : Runcible> (@thick T.Type) -> ()
-  %5 = apply %4<T>(%3) : $@convention(witness_method: Runcible) <Self : Runcible> (@thick T.Type) -> ()
+  %4 = witness_method $T, #Runcible.static_method : $@convention(witness_method: Runcible) <Self : Runcible> (@thick Self.Type) -> ()
+  %5 = apply %4<T>(%3) : $@convention(witness_method: Runcible) <Self : Runcible> (@thick Self.Type) -> ()
   %6 = tuple ()
   destroy_addr %0 : $*T
   return %6 : $()

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -337,6 +337,7 @@ int main(int argc, char **argv) {
   // cache.
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
   Invocation.setParseStdlib();
+  Invocation.getLangOptions().DisableParserLookup = true;
   Invocation.getLangOptions().DisableAvailabilityChecking = true;
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;


### PR DESCRIPTION
This caught some invalid SIL in a SIL parser test.