### PR TITLE
SimplifyCFG: fix a crash caused by unreachable CFG cycles with block arguments.

### DIFF
--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -44,6 +44,11 @@ bool ReachableBlocks::visit(SILFunction *f,
 /// Remove all instructions in the body of \p bb in safe manner by using
 /// undef.
 void swift::clearBlockBody(SILBasicBlock *bb) {
+
+  for (SILArgument *arg : bb->getArguments()) {
+    arg->replaceAllUsesWithUndef();
+  }
+
   // Instructions in the dead block may be used by other dead blocks.  Replace
   // any uses of them with undef values.
   while (!bb->empty()) {

--- a/test/SILOptimizer/simplify-cfg-crash.swift
+++ b/test/SILOptimizer/simplify-cfg-crash.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+
+// Check that the optimizer does not crash.
+
+
+public class Base {
+  @inline(never)
+  final func next() -> Base? {
+    return self
+  }
+}
+
+public class Derived : Base {}
+
+// CHECK: sil {{.*}}testit
+public func testit(_ x: Base?) -> Derived? {
+    var i: Base? = x
+    while (i is Derived) == false && i != nil {
+        i = i?.next()
+    }
+    return i as? Derived
+}
+


### PR DESCRIPTION
When SimplifyCFG (temporarily) produces an unreachable CFG cycle, some other transformations in SimplifyCFG didn't deal with this situation correctly.

Unfortunately I couldn't create a SIL test case for this bug, so I just added a swift test case.

https://bugs.swift.org/browse/SR-13650
rdar://problem/69942431
