### PR TITLE
[5.3][Sema] Consider inherited platform unavailability to silence diagnostics

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1565,7 +1565,10 @@ static bool isInsideCompatibleUnavailableDeclaration(
   auto IsUnavailable = [platform](const Decl *D) {
     auto EnclosingUnavailable =
         D->getAttrs().getUnavailable(D->getASTContext());
-    return EnclosingUnavailable && EnclosingUnavailable->Platform == platform;
+    return EnclosingUnavailable &&
+        (EnclosingUnavailable->Platform == platform ||
+         inheritsAvailabilityFromPlatform(platform,
+           EnclosingUnavailable->Platform));
   };
 
   return someEnclosingDeclMatches(ReferenceRange, ReferenceDC, IsUnavailable);

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -140,3 +140,27 @@ protocol P: Builtin.AnyObject {
 }
 
 extension X: P {}
+
+// Test platform inheritance for iOS unavailability.
+// rdar://68597591
+
+@available(iOS, unavailable)
+public struct UnavailableOniOS { } // expected-note 2 {{'UnavailableOniOS' has been explicitly marked unavailable here}}
+
+@available(iOS, unavailable)
+func unavailableOniOS(_ p: UnavailableOniOS) { } // ok
+
+func functionUsingAnUnavailableType(_ p: UnavailableOniOS) { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+
+public extension UnavailableOniOS { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+
+@available(iOS, unavailable)
+public extension UnavailableOniOS { // ok
+  func someMethod(_ p: UnavailableOniOS) { }
+}
+
+@available(iOS, unavailable)
+@available(macCatalyst, introduced: 13.0)
+public struct AvailableOnMacCatalyst { }
+
+public extension AvailableOnMacCatalyst { } // ok


### PR DESCRIPTION
The compiler reported a superfluous error on some uses of an unavailable type in unavailable declaration, which should be accepted. This affected only platforms like Mac Catalyst when the user declaration was marked unavailable on iOS and the unavailable type was defined in Objective-C. The fix makes the diagnostic consider the inherited platform unavailability on the user declaration to suppress the error.

- Scope: This is affecting the Swift overlay for OSLog.

- Risk: Low, this change can only show less errors.

- Origination: Likely from the introduction of the diagnostic.

- Resolves: rdar://68597591

- Testing: Added tests to compare the difference in behavior between Swift and Objective-C declared types.

- Cherry-pick of #34087