### PR TITLE
LoadableByAddress: Make sure that indirect return arguments are at the right type expansion

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1407,7 +1407,8 @@ void LoadableStorageAllocation::insertIndirectReturnArgs() {
     canType = genEnv->mapTypeIntoContext(canType)->getCanonicalType();
   }
   resultStorageType = SILType::getPrimitiveObjectType(canType);
-  auto newResultStorageType = pass.getNewSILType(loweredTy, resultStorageType);
+  auto newResultStorageType =
+      pass.F->getLoweredType(pass.getNewSILType(loweredTy, resultStorageType));
 
   auto &ctx = pass.F->getModule().getASTContext();
   auto var = new (ctx) ParamDecl(

--- a/test/IRGen/big_types_generic.swift
+++ b/test/IRGen/big_types_generic.swift
@@ -67,3 +67,29 @@ func useStuff() {
   print(generic2(1).0)
   print(generic2(1).1)
 }
+
+
+public struct BigThing<T> {
+  var x: (Int64, Int64, Int64, Int64) = (0, 0, 0, 0)
+  var y: (Int64, Int64, Int64, Int64) = (0, 0, 0, 0)
+  var z: (Int64, Int64, Int64, Int64) = (0, 0, 0, 0)
+}
+
+public protocol P {}
+
+public protocol Assoc {
+ associatedtype A
+ func foo() -> A
+}
+
+extension Int : P {}
+
+public struct DefineSome : Assoc {
+   public func foo() -> some P {
+     return 5
+   }
+}
+
+public func abiIndirect() -> BigThing<DefineSome.A> {
+  return BigThing<DefineSome.A>()
+}


### PR DESCRIPTION

rdar://70220886
