### PR TITLE
SR-13742: Remove diagnostic preventing case [Int] which actually works

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3987,10 +3987,6 @@ NOTE(unowned_assignment_requires_strong,none,
      "a strong reference is required to prevent the instance from being "
      "deallocated", ())
 
-ERROR(isa_collection_downcast_pattern_value_unimplemented,none,
-      "collection downcast in cast pattern is not implemented; use an explicit "
-      "downcast to %0 instead", (Type))
-
 //------------------------------------------------------------------------------
 // MARK: Error-handling diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1322,10 +1322,6 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
     case CheckedCastKind::ArrayDowncast:
     case CheckedCastKind::DictionaryDowncast:
     case CheckedCastKind::SetDowncast: {
-      diags.diagnose(IP->getLoc(),
-                     diag::isa_collection_downcast_pattern_value_unimplemented,
-                     IP->getCastType());
-      IP->setType(ErrorType::get(Context));
       if (Pattern *sub = IP->getSubPattern())
         sub->forEachVariable([](VarDecl *VD) { VD->setInvalid(); });
       return P;

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -296,9 +296,9 @@ class Derived : Base { }
 
 
 switch [Derived(), Derived(), Base()] {
-case let ds as [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
+case let ds as [Derived]:
   ()
-case is [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
+case is [Derived]:
   ()
 
 default:

--- a/test/Parse/matching_patterns_parser_lookup.swift
+++ b/test/Parse/matching_patterns_parser_lookup.swift
@@ -296,9 +296,9 @@ class Derived : Base { }
 
 
 switch [Derived(), Derived(), Base()] {
-case let ds as [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
+case let ds as [Derived]:
   ()
-case is [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
+case is [Derived]:
   ()
 
 default:

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -637,79 +637,18 @@ func test_isa_class_2(x: B) -> AnyObject {
 
 // CHECK-LABEL: sil hidden [ossa] @$s6switch10test_isa_array_11pyAA1P_p_tF
 func test_isa_array(ps: Array<P>) {
-  // CHECK: [[PTMPBUF:%[0-9]+]] = alloc_stack $P
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[PTMPBUF]] : $*P
   switch ps {
-      // CHECK: [[TMPBUF:%[0-9]+]] = alloc_stack $X
-      // CHECK:   checked_cast_addr_br copy_on_success P in [[P:%.*]] : $*P to X in [[TMPBUF]] : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
-
   case is [X]:
-    // CHECK: [[IS_X]]:
-    // CHECK-NEXT: load [trivial] [[TMPBUF]]
-    // CHECK-NEXT: // function_ref
-    // CHECK-NEXT: [[FUNC:%.*]] = function_ref @$s6switch1ayyF
-    // CHECK-NEXT: apply [[FUNC]]()
-    // CHECK-NEXT: dealloc_stack [[TMPBUF]]
-    // CHECK-NEXT: destroy_addr [[PTMPBUF]]
-    // CHECK-NEXT: dealloc_stack [[PTMPBUF]]
     a()
-      // CHECK:   br [[CONT:bb[0-9]+]]
-
-      // CHECK: [[IS_NOT_X]]:
-      // CHECK:   checked_cast_addr_br copy_on_success P in [[P]] : $*P to Y in {{%.*}} : $*Y, [[IS_Y:bb[0-9]+]], [[IS_NOT_Y:bb[0-9]+]]
-
   // CHECK: [[IS_Y]]:
   case is [Y]:
-    // CHECK:   function_ref @$s6switch1byyF
-    // CHECK:   br [[Y_CONT:bb[0-9]+]]
     b()
 
-      // CHECK: [[IS_NOT_Y]]:
-      // CHECK:   checked_cast_addr_br copy_on_success P in [[P]] : $*P to Z in {{%.*}} : $*Z, [[IS_Z:bb[0-9]+]], [[IS_NOT_Z:bb[0-9]+]]
-      // CHECK: [[IS_NOT_Z]]:
   case _:
-    // CHECK:   function_ref @$s6switch1dyyF
-    // CHECK:   br [[CONT]]
     d()
   }
-  // CHECK: [[CONT]]:
-  // CHECK:   function_ref @$s6switch1eyyF
   e()
 }
-
-// CHECK-LABEL: sil hidden [ossa] @$s6switch10test_isa_array_11pyAA1P_p_tF
-//func test_let_as_array(ps: Array<P>) -> AnyObject {
-//  // CHECK: [[PTMPBUF:%[0-9]+]] = alloc_stack $P
-//  // CHECK-NEXT: copy_addr %0 to [initialization] [[PTMPBUF]] : $*P
-//  switch ps {
-//      // CHECK: [[TMPBUF:%[0-9]+]] = alloc_stack $X
-//      // CHECK:   checked_cast_addr_br copy_on_success P in [[P:%.*]] : $*P to X in [[TMPBUF]] : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
-//
-//  case let xs as [X]:
-//    // CHECK: [[CASE2]]([[CAST_D2:%.*]] : @guaranteed $D2):
-//    // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
-//    // CHECK:   function_ref @$s6switch1byyF
-//    // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [[CAST_D2_COPY]]
-//    // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D2_COPY]]
-//    // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2_COPY_COPY]]
-//    // CHECK:   end_borrow [[BORROWED_CAST_D2_COPY]]
-//    // CHECK:   destroy_value [[CAST_D2_COPY]]
-//    // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
-//    return xs
-//      // CHECK:   br [[CONT:bb[0-9]+]]
-//
-//      // CHECK: [[IS_NOT_X]]:
-//      // CHECK:   checked_cast_addr_br copy_on_success P in [[P]] : $*P to Y in {{%.*}} : $*Y, [[IS_Y:bb[0-9]+]], [[IS_NOT_Y:bb[0-9]+]]
-//
-//  case _:
-//    // CHECK:   function_ref @$s6switch1dyyF
-//    // CHECK:   br [[CONT]]
-//    d()
-//  }
-//  // CHECK: [[CONT]]:
-//  // CHECK:   function_ref @$s6switch1eyyF
-//  e()
-//}
 
 enum MaybePair {
   case Neither

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -635,6 +635,82 @@ func test_isa_class_2(x: B) -> AnyObject {
 }
 // CHECK: } // end sil function '$s6switch16test_isa_class_21xyXlAA1BC_tF'
 
+// CHECK-LABEL: sil hidden [ossa] @$s6switch10test_isa_array_11pyAA1P_p_tF
+func test_isa_array(ps: Array<P>) {
+  // CHECK: [[PTMPBUF:%[0-9]+]] = alloc_stack $P
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[PTMPBUF]] : $*P
+  switch ps {
+      // CHECK: [[TMPBUF:%[0-9]+]] = alloc_stack $X
+      // CHECK:   checked_cast_addr_br copy_on_success P in [[P:%.*]] : $*P to X in [[TMPBUF]] : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
+
+  case is [X]:
+    // CHECK: [[IS_X]]:
+    // CHECK-NEXT: load [trivial] [[TMPBUF]]
+    // CHECK-NEXT: // function_ref
+    // CHECK-NEXT: [[FUNC:%.*]] = function_ref @$s6switch1ayyF
+    // CHECK-NEXT: apply [[FUNC]]()
+    // CHECK-NEXT: dealloc_stack [[TMPBUF]]
+    // CHECK-NEXT: destroy_addr [[PTMPBUF]]
+    // CHECK-NEXT: dealloc_stack [[PTMPBUF]]
+    a()
+      // CHECK:   br [[CONT:bb[0-9]+]]
+
+      // CHECK: [[IS_NOT_X]]:
+      // CHECK:   checked_cast_addr_br copy_on_success P in [[P]] : $*P to Y in {{%.*}} : $*Y, [[IS_Y:bb[0-9]+]], [[IS_NOT_Y:bb[0-9]+]]
+
+  // CHECK: [[IS_Y]]:
+  case is [Y]:
+    // CHECK:   function_ref @$s6switch1byyF
+    // CHECK:   br [[Y_CONT:bb[0-9]+]]
+    b()
+
+      // CHECK: [[IS_NOT_Y]]:
+      // CHECK:   checked_cast_addr_br copy_on_success P in [[P]] : $*P to Z in {{%.*}} : $*Z, [[IS_Z:bb[0-9]+]], [[IS_NOT_Z:bb[0-9]+]]
+      // CHECK: [[IS_NOT_Z]]:
+  case _:
+    // CHECK:   function_ref @$s6switch1dyyF
+    // CHECK:   br [[CONT]]
+    d()
+  }
+  // CHECK: [[CONT]]:
+  // CHECK:   function_ref @$s6switch1eyyF
+  e()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s6switch10test_isa_array_11pyAA1P_p_tF
+//func test_let_as_array(ps: Array<P>) -> AnyObject {
+//  // CHECK: [[PTMPBUF:%[0-9]+]] = alloc_stack $P
+//  // CHECK-NEXT: copy_addr %0 to [initialization] [[PTMPBUF]] : $*P
+//  switch ps {
+//      // CHECK: [[TMPBUF:%[0-9]+]] = alloc_stack $X
+//      // CHECK:   checked_cast_addr_br copy_on_success P in [[P:%.*]] : $*P to X in [[TMPBUF]] : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
+//
+//  case let xs as [X]:
+//    // CHECK: [[CASE2]]([[CAST_D2:%.*]] : @guaranteed $D2):
+//    // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
+//    // CHECK:   function_ref @$s6switch1byyF
+//    // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [[CAST_D2_COPY]]
+//    // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D2_COPY]]
+//    // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2_COPY_COPY]]
+//    // CHECK:   end_borrow [[BORROWED_CAST_D2_COPY]]
+//    // CHECK:   destroy_value [[CAST_D2_COPY]]
+//    // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
+//    return xs
+//      // CHECK:   br [[CONT:bb[0-9]+]]
+//
+//      // CHECK: [[IS_NOT_X]]:
+//      // CHECK:   checked_cast_addr_br copy_on_success P in [[P]] : $*P to Y in {{%.*}} : $*Y, [[IS_Y:bb[0-9]+]], [[IS_NOT_Y:bb[0-9]+]]
+//
+//  case _:
+//    // CHECK:   function_ref @$s6switch1dyyF
+//    // CHECK:   br [[CONT]]
+//    d()
+//  }
+//  // CHECK: [[CONT]]:
+//  // CHECK:   function_ref @$s6switch1eyyF
+//  e()
+//}
+
 enum MaybePair {
   case Neither
   case Left(Int)


### PR DESCRIPTION
Resolves https://bugs.swift.org/browse/SR-13742

The diagnostic is not necessary because this type of pattern match just works nowadays already.