### PR TITLE
[SR-13732] [Sema] Fix crash on simplifyFix constraint for tuple mismatch

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3158,8 +3158,7 @@ public:
   /// subsequent solution would be worse than the best known solution.
   bool recordFix(ConstraintFix *fix, unsigned impact = 1);
 
-  void recordPotentialHole(TypeVariableType *typeVar);
-  void recordPotentialHole(FunctionType *fnType);
+  void recordPotentialHole(Type type);
 
   void recordTrailingClosureMatch(
       ConstraintLocator *locator,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9913,16 +9913,11 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   return false;
 }
 
-void ConstraintSystem::recordPotentialHole(TypeVariableType *typeVar) {
-  assert(typeVar);
-  typeVar->getImpl().enableCanBindToHole(getSavedBindings());
-}
-
-void ConstraintSystem::recordPotentialHole(FunctionType *fnType) {
-  assert(fnType);
-  Type(fnType).visit([&](Type type) {
+void ConstraintSystem::recordPotentialHole(Type type) {
+  assert(type->hasTypeVariable());
+  type.visit([&](Type type) {
     if (auto *typeVar = type->getAs<TypeVariableType>())
-      recordPotentialHole(typeVar);
+      typeVar->getImpl().enableCanBindToHole(getSavedBindings());
   });
 }
 
@@ -10024,7 +10019,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
           newTupleTypes.push_back(smallerElt);
       } else {
         if (largerElt.getType()->isTypeVariableOrMember())
-          recordPotentialHole(largerElt.getType()->getAs<TypeVariableType>());
+          recordPotentialHole(largerElt.getType());
       }
     }
     auto matchingType =

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -241,3 +241,28 @@ func wump<T>(to: T, _ body: (G<T>) -> ()) {}
 
 wump(to: 0, { $0[] = 0 })
 // expected-error@-1 {{missing argument for parameter #1 in call}}
+
+// SR-13732
+extension MutableCollection {
+  public mutating func writePrefix<I: IteratorProtocol>(from source: inout I)
+    -> (writtenCount: Int, afterLastWritten: Index)
+    where I.Element == Element
+  {
+    fatalError()
+  }
+  
+  public mutating func writePrefix<Source: Collection>(from source: Source)
+    -> (writtenCount: Int, afterLastWritten: Index, afterLastRead: Source.Index)
+    where Source.Element == Element
+  {
+    fatalError()
+  }
+
+}
+
+func testWritePrefixIterator() {
+  var a = Array(0..<10)
+  
+  var underflow = (1..<10).makeIterator()
+  var (writtenCount, afterLastWritten) = a.writePrefix(from: underflow) // expected-error {{passing value of type 'IndexingIterator<(Range<Int>)>' to an inout parameter requires explicit '&'}} {{62-62=&}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just make sure we handle the extract the base type variable from base type when tuple elt is a dependent member.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves: SR-13732
Resolves: rdar://problem/70338668

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
