### PR TITLE
Update swift-rpathize.py to work with Python 3.8 and Python 2.7

### DIFF
--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -64,9 +64,9 @@ def rpathize(filename):
 
     # Build a command to invoke install_name_tool.
     command = ['install_name_tool']
-    for line in dylibsOutput.splitlines():
-        l = line.decode("utf-8", "strict")
-        match = dylib_regex.match(l)
+    for binaryline in dylibsOutput.splitlines():
+        line = binaryline.decode("utf-8", "strict")
+        match = dylib_regex.match(line)
         if match:
             command.append('-change')
             command.append(match.group('path'))

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -65,7 +65,8 @@ def rpathize(filename):
     # Build a command to invoke install_name_tool.
     command = ['install_name_tool']
     for line in dylibsOutput.splitlines():
-        match = dylib_regex.match(line)
+        l = line.decode("utf-8", "strict")
+        match = dylib_regex.match(l)
         if match:
             command.append('-change')
             command.append(match.group('path'))


### PR DESCRIPTION
Just need to explicitly convert the bytes blob into a real string before trying to pattern-match.

(In Python 2, str() and bytes are basically the same, so it's a lot more forgiving of such mixups.)
