### PR TITLE
[Index] Don't report extensions with nothing to index

### DIFF
--- a/test/Index/Store/record-sourcefile.swift
+++ b/test/Index/Store/record-sourcefile.swift
@@ -30,7 +30,7 @@
 // CHECK: type-alias/Swift | TA | s:{{.*}} | <no-cgname> | Def,RelChild -
 // CHECK: class/Swift | C1 | s:{{.*}} | <no-cgname> | Def,Ref,RelBase,RelCont -
 // CHECK: instance-method/Swift | method() | s:{{.*}} | <no-cgname> | Def,Ref,Call,Dyn,RelChild,RelRec,RelCall,RelCont -
-// CHECK: class/Swift | C2 | s:{{.*}} | <no-cgname> | Def -
+// CHECK: class/Swift | C2 | s:{{.*}} | <no-cgname> | Def,Ref - RelChild,RelBase
 // CHECK: instance-method/Swift | method() | s:{{.*}} | <no-cgname> | Def,Dyn,RelChild,RelOver -
 // CHECK: function/Swift | takeC1(x:) | s:{{.*}} | <no-cgname> | Def -
 // CHECK: instance-method(test)/Swift | testFoo() | s:{{.*}} | <no-cgname> | Def,Dyn,RelChild -
@@ -151,3 +151,6 @@ class MyTestCase: XCTestCase {
 // CHECK-NEXT: RelChild | s:4file10MyTestCaseC
   func testFoo() { test1() }
 }
+
+// CHECK: [[@LINE+1]]:11 | class/Swift | s:4file2C2C | Ref | rel: 0
+extension C2 {}

--- a/test/Index/Store/record-systemmodule.swift
+++ b/test/Index/Store/record-systemmodule.swift
@@ -1,0 +1,71 @@
+// --- Prepare SDK (.swiftmodule).
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/SDK)
+// RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name SomeModule \
+// RUN:     -o %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     -D SOME_MODULE \
+// RUN:     %s
+
+#if SOME_MODULE
+
+public func someFunc() {}
+
+public class C2 {}
+
+extension C2 {
+  public func publicFunc() {}
+}
+
+// Don't record extensions with nothing to index.
+extension C2 {}
+
+extension C2 {
+  internal func SECRET() {}
+  private func SECRET1() {}
+  fileprivate func SECRET2() {}
+}
+
+internal protocol SECRETProto {}
+extension C2: SECRETProto {}
+
+// -----------------------------------------------------------------------------
+// Test-1 - '.swiftmodule' - Normal index-while-building.
+//
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+//
+// --- Built with indexing
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     -D CLIENT \
+// RUN:     %s
+
+#elseif CLIENT
+
+import SomeModule
+print(someFunc())
+
+#endif
+
+// -----------------------------------------------------------------------------
+// --- Check the records.
+// RUN: c-index-test core -print-record %t/idx | %FileCheck %s
+
+// CHECK: 0:0 | function/Swift | s:10SomeModule8someFuncyyF | Def | rel: 0
+// CHECK-NEXT: 0:0 | class/Swift | [[class_USR:s:10SomeModule2C2C]] | Def | rel: 0
+// CHECK-NEXT: 0:0 | class/Swift | [[class_USR]] | Ref,RelExt | rel: 1
+// CHECK-NEXT: 	RelExt | s:e:[[publicFunc_USR:s:10SomeModule2C2C10publicFuncyyF]]
+// CHECK-NEXT: 0:0 | instance-method/Swift | [[publicFunc_USR]] | Def,Dyn,RelChild | rel: 1
+// CHECK-NEXT: 	RelChild | s:e:[[publicFunc_USR]]
+// CHECK-NEXT: 0:0 | extension/ext-class/Swift | s:e:[[publicFunc_USR]] | Def | rel: 0
+// CHECK-NOT: SECRET

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -172,7 +172,16 @@
     {
       key.kind: source.lang.swift.decl.extension.class,
       key.name: "C2",
-      key.usr: "s:e:s:11test_module2C2C6SECRETyyF"
+      key.usr: "s:e:s:11test_module2C2C10publicFuncyyF",
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "publicFunc()",
+          key.usr: "s:11test_module2C2C10publicFuncyyF",
+          key.is_dynamic: 1,
+          key.effective_access: source.decl.effective_access.public
+        }
+      ]
     }
   ]
 }

--- a/test/SourceKit/Indexing/Inputs/test_module.swift
+++ b/test/SourceKit/Indexing/Inputs/test_module.swift
@@ -12,7 +12,7 @@ public class TwoInts {
 public class ComputedProperty {
   public var value : Int {
     get {
-      var result = 0
+      let result = 0
       return result
     }
     set(newVal) {
@@ -34,5 +34,15 @@ public func globalFunc() {}
 private func SECRET() {}
 
 extension C2 {
-  internal func SECRET() {}
+  public func publicFunc() {}
 }
+
+// Don't record extensions with nothing to index.
+extension C2 {
+  internal func SECRET() {}
+  private func SECRET1() {}
+  fileprivate func SECRET2() {}
+}
+
+internal protocol InternalProto {}
+extension C2: InternalProto {}


### PR DESCRIPTION
The indexer was looking into “empty” extensions to public types,
triggering the computation of the extension USR which could fail at
deserializing implementation-only imported types. As a solution,
don’t index extensions with no content to index.

rdar://70225906