### PR TITLE
When parsing floating-point from String, underflow to 0, overflow to ∞

### DIFF
--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -31,22 +31,19 @@ SWIFT_RUNTIME_STDLIB_API
 void *_swift_objCMirrorSummary(const void * nsObject);
 
 /// Call strtold_l with the C locale, swapping argument and return
-/// types so we can operate on Float80.  Return NULL on overflow.
+/// types so we can operate on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtold_clocale(const char *nptr, void *outResult);
 /// Call strtod_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.  Return NULL on
-/// overflow.
+/// types so we can operate consistently on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtod_clocale(const char *nptr, double *outResult);
 /// Call strtof_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.  Return NULL on
-/// overflow.
+/// types so we can operate consistently on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtof_clocale(const char *nptr, float *outResult);
 /// Call strtof_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.  Return NULL on
-/// overflow.
+/// types so we can operate consistently on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtof16_clocale(const char *nptr, __fp16 *outResult);
 

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -452,10 +452,6 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   _swift_set_errno(0);
   const auto result = posixImpl(nptr, &EndPtr, getCLocale());
   *outResult = result;
-  if (result == huge || result == -huge || result == 0.0 || result == -0.0) {
-      if (errno == ERANGE)
-          EndPtr = nullptr;
-  }
   return EndPtr;
 }
     

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -181,17 +181,11 @@ tests.test("${Self}/Basics") {
   expectNil(${Self}("0 "))  // Trailing whitespace
   expectNil(${Self}("\u{1D7FF}"))  // MATHEMATICAL MONOSPACE DIGIT NINE
 
-  // Overflow and underflow.  Interleave with other checks to make
-  // sure we're not abusing errno
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("2e99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("2e-99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("-2e99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("-2e-99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
+  // Overflow to infinity, underflow to zero.
+  expectEqual(.infinity, ${Self}("2e99999999999999"))
+  expectEqual(0.0, ${Self}("2e-99999999999999"))
+  expectEqual(-.infinity, ${Self}("-2e99999999999999"))
+  expectEqual(0.0, ${Self}("-2e-99999999999999"))
 }
 
 % if Self == 'Float80':


### PR DESCRIPTION
Previously, overflow and underflow both caused this to return `nil`, which causes several problems:
* It does not distinguish between a large but valid input and a malformed input.  `Float("3.402824e+38")` is perfectly well-formed but returns nil
* It differs from how the compiler handles literals.  As a result, `Float(3.402824e+38)` is very different from `Float("3.402824e+38")`
* It's inconsistent with Foundation Scanner()
* It's inconsistent with other programming languages

Note: This is exactly the same as #25313 by @stephentyrone

Fixes rdar://problem/36990878