### PR TITLE
Sema: Fix failure to diagnose throwing expressions inside string interpolations

### DIFF
--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -133,3 +133,12 @@ func testStringInterpolation() async throws {
   _ = "Eventually produces \(await getInt())"
   _ = await "Eventually produces \(getInt())"
 }
+
+// Make sure try await works too
+func invalidAsyncFunction() async {
+  _ = try await throwingAndAsync() // expected-error {{errors thrown from here are not handled}}
+}
+
+func validAsyncFunction() async throws {
+  _ = try await throwingAndAsync()
+}

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -251,3 +251,16 @@ func sr_11402_func2(_ x: SR_11402_P) {
     print(y)
   }
 }
+
+// https://bugs.swift.org/browse/SR-13654
+
+func sr_13654_func() throws -> String {}
+
+func sr_13654_invalid_interpolation() {
+  _ = try "\(sr_13654_func())" // expected-error {{errors thrown from here are not handled}}
+  _ = "\(try sr_13654_func())" // expected-error {{errors thrown from here are not handled}}
+}
+func sr_13654_valid_interpolation() throws {
+  _ = try "\(sr_13654_func())"
+  _ = "\(try sr_13654_func())"
+}


### PR DESCRIPTION
We need to preserve the DiagnoseErrorOnTry bit stored in the Context when
exiting a ContextScope. Otherwise, we fail to produce a diagnostic if the
'try' expression pushes an intertwining Context, such as a string interpolation
or 'await'.

Fixes <https://bugs.swift.org/browse/SR-13654>, <rdar://problem/69958774>.
