### PR TITLE
[build] OpenBSD can install XCTest.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2889,7 +2889,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
 
                 case ${host} in
-                  linux-*|freebsd-*|cygwin-*|haiku-*|android-*) ;;
+                  linux-*|freebsd-*|openbsd-*|cygwin-*|haiku-*|android-*) ;;
                   *)
                     echo "error: --install-xctest is not supported on this platform"
                     exit 1


### PR DESCRIPTION
Just looks like an oversight in the initial port setup.
