### PR TITLE
AST: Add a no-type-parameters early return to findProtocolSelfReferences

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4704,6 +4704,10 @@ bool ProtocolDecl::existentialConformsToSelf() const {
 static SelfReferenceInfo
 findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
                            SelfReferencePosition position) {
+  // If there are no type parameters, we're done.
+  if (!type->hasTypeParameter())
+    return SelfReferenceInfo();
+
   // Tuples preserve variance.
   if (auto tuple = type->getAs<TupleType>()) {
     auto info = SelfReferenceInfo();


### PR DESCRIPTION
I was going to add this to ProtocolDecl::findProtocolSelfReferences as well, but apparently, GenericFunctionType is purposely ignorant of its type parameters