### PR TITLE
WinSDK: extract System.MCX submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -280,6 +280,11 @@ module WinSDK [system] {
       header "winioctl.h"
       export *
     }
+
+    module MCX {
+      header "mcx.h"
+      export *
+    }
   }
 
   module OLE32 {


### PR DESCRIPTION
Currently this header gets included into `WinSDK.WinSock2` via `windows.h`.
This change extracts it into a separate submodule.