### PR TITLE
[docs] Fix a typo in CppInteroperabilityManifesto.md

### DIFF
--- a/docs/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperabilityManifesto.md
@@ -3197,7 +3197,7 @@ UTF-8 data.
 class Employee {
 public:
   std::string DebugDescription() const;
-  [[swift::import_as_std_string]] std::string SeriaziledAsProtobuf() const;
+  [[swift::import_as_std_string]] std::string SerializedAsProtobuf() const;
 };
 ```
 


### PR DESCRIPTION
The "bridging-std-string" section contained a typo in the C++ header example, compared to the imported Swift header.