### PR TITLE
Disregard Overridden Candidates in Infinite Recursion Check

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -52,14 +52,15 @@ static bool hasRecursiveCallInPath(SILBasicBlock &Block,
 
     if (FullApplySite FAI = FullApplySite::isa(&I)) {
       // Don't touch dynamic dispatch.
-      if (isa<SuperMethodInst>(FAI.getCallee()) ||
-          isa<ObjCSuperMethodInst>(FAI.getCallee()) ||
-          isa<ObjCMethodInst>(FAI.getCallee())) {
+      const auto callee = FAI.getCallee();
+      if (isa<SuperMethodInst>(callee) ||
+          isa<ObjCSuperMethodInst>(callee) ||
+          isa<ObjCMethodInst>(callee)) {
         continue;
       }
 
       auto &M = FAI.getModule();
-      if (auto *CMI = dyn_cast<ClassMethodInst>(FAI.getCallee())) {
+      if (auto *CMI = dyn_cast<ClassMethodInst>(callee)) {
         auto ClassType = CMI->getOperand()->getType().getASTType();
 
         // FIXME: If we're not inside the module context of the method,
@@ -93,7 +94,7 @@ static bool hasRecursiveCallInPath(SILBasicBlock &Block,
         continue;
       }
 
-      if (auto *WMI = dyn_cast<WitnessMethodInst>(FAI.getCallee())) {
+      if (auto *WMI = dyn_cast<WitnessMethodInst>(callee)) {
         SILFunction *F;
         SILWitnessTable *WT;
 

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 
 func a() {  // expected-warning {{all paths through this function will call itself}}
   a()
@@ -123,7 +123,7 @@ class S {
     return a()
   }
 
-  func b() { // expected-warning {{all paths through this function will call itself}}
+  func b() { // No warning - has a known override.
     var i = 0
     repeat {
       i += 1
@@ -170,4 +170,15 @@ func factorial(_ n : UInt) -> UInt { // expected-warning {{all paths through thi
 
 func tr(_ key: String) -> String { // expected-warning {{all paths through this function will call itself}}
   return tr(key) ?? key // expected-warning {{left side of nil coalescing operator '??' has non-optional type}}
+}
+
+class Node {
+  var parent: Node?
+  var rootNode: RootNode {
+    return parent!.rootNode // No warning - has an override.
+  }
+}
+
+class RootNode: Node {
+  override var rootNode: RootNode { return self }
 }


### PR DESCRIPTION
Disregard candidates that have known override points because those
points are possible targets for dynamic dispatch. This removes a class
of false positives involving classes with known override points in
the module, as is this case in many node-based data structures.

rdar://70410948