### PR TITLE
[stdlib] Change misleading comment

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3010,7 +3010,10 @@ extension FixedWidthInteger {
     let minBitWidth = source.significandWidth
     let isExact = (minBitWidth <= exponent)
     let bitPattern = source.significandBitPattern
-    // Determine the number of meaningful bits in the significand bit pattern.
+    // Determine the actual number of fractional significand bits.
+    // `Source.significandBitCount` would not reflect the actual number of
+    // fractional significand bits if `Source` is not a fixed-width floating-point
+    // type; we can compute this value as follows if `source` is finite:
     let bitWidth = minBitWidth &+ bitPattern.trailingZeroBitCount
     let shift = exponent - Source.Exponent(bitWidth)
     // Use `Self.Magnitude` to prevent sign extension if `shift < 0`.

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3010,9 +3010,7 @@ extension FixedWidthInteger {
     let minBitWidth = source.significandWidth
     let isExact = (minBitWidth <= exponent)
     let bitPattern = source.significandBitPattern
-    // `RawSignificand.bitWidth` is not available if `RawSignificand` does not
-    // conform to `FixedWidthInteger`; we can compute this value as follows if
-    // `source` is finite:
+    // Determine the number of meaningful bits in the significand bit pattern.
     let bitWidth = minBitWidth &+ bitPattern.trailingZeroBitCount
     let shift = exponent - Source.Exponent(bitWidth)
     // Use `Self.Magnitude` to prevent sign extension if `shift < 0`.


### PR DESCRIPTION
<!-- What's in this pull request? -->
The original comment suggests that `RawSignificand.bitWidth` would be the thing we'd want to use if it were available, however using this would be incorrect as this would include leading zero bits in the bit pattern. For example, for a `Double` this would always be 64 even though only the least significant 52 bits of this are used. Instead, 52 is the number we are after in our example.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
