### PR TITLE
[Docs] Clarifies `ObjectIdentifier` guarantees 

### DIFF
--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -19,9 +19,6 @@
 /// lifetime of an object. When the instance gets deallocated, its object 
 /// identifier may be reused for a different object. (Internally, objects are
 /// identified by their memory location.)
-///
-/// If you need an object identifier over the lifetime of an object, it may
-/// be appropriate to provide a custom implementation of `Identifiable`.
 @frozen // trivial-implementation
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -17,9 +17,11 @@
 @frozen // trivial-implementation
 /// 
 /// `ObjectIdentifier` is only guaranteed to remain unique for the
-/// lifetime of an object. If an object has a stronger notion of identity, it
-/// may be appropriate to provide a custom implementation.
-
+/// lifetime of an object. When the instance gets deallocated, its object 
+/// identifier may be reused for a different object. (Internally, objects are
+/// identified by their memory location.)
+/// If you need an object identifier over the lifetime of an objec, it may
+/// be appropriate to provide a custom implementation of `Identifiable`.
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -15,6 +15,11 @@
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
 @frozen // trivial-implementation
+/// 
+/// `ObjectIdentifier` is only guaranteed to remain unique for the
+/// lifetime of an object. If an object has a stronger notion of identity, it
+/// may be appropriate to provide a custom implementation.
+
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -14,14 +14,14 @@
 ///
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
-@frozen // trivial-implementation
-/// 
 /// `ObjectIdentifier` is only guaranteed to remain unique for the
 /// lifetime of an object. When the instance gets deallocated, its object 
 /// identifier may be reused for a different object. (Internally, objects are
 /// identified by their memory location.)
-/// If you need an object identifier over the lifetime of an objec, it may
+/// If you need an object identifier over the lifetime of an object, it may
 /// be appropriate to provide a custom implementation of `Identifiable`.
+@frozen // trivial-implementation
+/// 
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -14,14 +14,15 @@
 ///
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
+///
 /// `ObjectIdentifier` is only guaranteed to remain unique for the
 /// lifetime of an object. When the instance gets deallocated, its object 
 /// identifier may be reused for a different object. (Internally, objects are
 /// identified by their memory location.)
+///
 /// If you need an object identifier over the lifetime of an object, it may
 /// be appropriate to provide a custom implementation of `Identifiable`.
 @frozen // trivial-implementation
-/// 
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -17,7 +17,6 @@
 ///
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
-///
 @frozen // trivial-implementation
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -16,9 +16,7 @@
 /// is no notion of identity for structs, enums, functions, or tuples.
 ///
 /// `ObjectIdentifier` is only guaranteed to remain unique for the
-/// lifetime of an object. When the instance gets deallocated, its object 
-/// identifier may be reused for a different object. (Internally, objects are
-/// identified by their memory location.)
+/// lifetime of an object. 
 @frozen // trivial-implementation
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -12,7 +12,7 @@
 
 /// A unique identifier for a class instance or metatype.
 ///
-/// And the unique identifier is only valid for comparisons during the lifetime
+/// This unique identifier is only valid for comparisons during the lifetime
 /// of the instance.
 ///
 /// In Swift, only class instances and metatypes have unique identities. There

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -12,11 +12,12 @@
 
 /// A unique identifier for a class instance or metatype.
 ///
+/// And the unique identifier is only valid for comparisons during the lifetime
+/// of the instance.
+///
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
 ///
-/// `ObjectIdentifier` is only guaranteed to remain unique for the
-/// lifetime of an object. 
 @frozen // trivial-implementation
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation


### PR DESCRIPTION
[SR-13564](https://bugs.swift.org/browse/SR-13564)
rdar://69169351
