### PR TITLE
[Test] Remove `as AnyObject` cast from OS_objects.swift.

### DIFF
--- a/test/Interpreter/SDK/OS_objects.swift
+++ b/test/Interpreter/SDK/OS_objects.swift
@@ -16,9 +16,8 @@ import DispatchObjects
 
 // CHECK: Get current queue
 print("Get current queue")
-// TODO: Properly implement generalized dynamic casts from Any to
-// runtime-visible classes. `as AnyObject` should be unnecessary here.
-let obj = dispatch_get_current_queue() as AnyObject
+
+let obj = dispatch_get_current_queue()
 
 // CHECK-NEXT: Object is a dispatch queue
 if let q = obj as? OS_dispatch_queue {


### PR DESCRIPTION
This workaround is no longer needed.

rdar://problem/27526994