### PR TITLE
Sema: Allow duplicate internal parameter names on protocol requirements

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2061,7 +2061,7 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 }
 
 bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
-  TypeChecker::checkParameterList(closure->getParameters());
+  TypeChecker::checkParameterList(closure->getParameters(), closure);
 
   BraceStmt *body = closure->getBody();
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -448,7 +448,7 @@ void typeCheckDecl(Decl *D);
 
 void addImplicitDynamicAttribute(Decl *D);
 void checkDeclAttributes(Decl *D);
-void checkParameterList(ParameterList *params);
+void checkParameterList(ParameterList *params, DeclContext *owner);
 
 void diagnoseDuplicateBoundVars(Pattern *pattern);
 

--- a/test/Sema/redeclaration-checking.swift
+++ b/test/Sema/redeclaration-checking.swift
@@ -99,3 +99,16 @@ func fullNameTest() {
   let x = 123 // expected-warning {{never used}}
   func x() {}
 }
+
+// For source compatibility, allow duplicate parameter labels on
+// protocol requirements.
+protocol SillyProtocol {
+  init(x: Int, x: Int)
+  init(a x: Int, b x: Int)
+
+  func foo(x: Int, x: Int)
+  func foo(a x: Int, b x: Int)
+
+  subscript(x: Int, x: Int) -> Int { get }
+  subscript(a x: Int, b x: Int) -> Int { get }
+}


### PR DESCRIPTION
This fixes a recent source compatibility regression.

Fixes <rdar://problem/70445751>.