### PR TITLE
[Runtime] Restore objc_addLoadImageFunc in ImageInspectionMacho.cpp.

### DIFF
--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -122,7 +122,11 @@ void addImageCallback2Sections(const mach_header *mh, intptr_t vmaddr_slide) {
 
 #if OBJC_ADDLOADIMAGEFUNC_DEFINED && SWIFT_OBJC_INTEROP
 #define REGISTER_FUNC(...)                                               \
-    _dyld_register_func_for_add_image(__VA_ARGS__);
+  if (__builtin_available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)) { \
+    objc_addLoadImageFunc(__VA_ARGS__);                                  \
+  } else {                                                               \
+    _dyld_register_func_for_add_image(__VA_ARGS__);                      \
+  }
 #else
 #define REGISTER_FUNC(...) _dyld_register_func_for_add_image(__VA_ARGS__)
 #endif


### PR DESCRIPTION
The conditional use of objc_addLoadImageFunc was accidentally removed in b5759c9fd93ea9d09613c018c48217e7e03f30bd. Put it back.

rdar://problem/70452221