### PR TITLE
[build-script-impl] Add an option to skip stripping executables.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -116,6 +116,7 @@ KNOWN_SETTINGS=(
     darwin-toolchain-version                      ""                "Version for xctoolchain info plist and installer pkg"
     darwin-toolchain-require-use-os-runtime       "0"               "When setting up a plist for a toolchain, require the users of the toolchain to link against the OS instead of the packaged toolchain runtime. 0 for false, 1 for true"
     darwin-xcrun-toolchain                        "default"         "the name of the toolchain to use on Darwin"
+    darwin-no-strip                               ""                "If set, do not strip executables"
 
     ## Build Types for Components
     swift-stdlib-build-type                       "Debug"           "the CMake build variant for Swift"
@@ -3055,11 +3056,13 @@ for host in "${ALL_HOSTS[@]}"; do
                grep -v 'swift-api-digester' | \
                xargs -P 1 ${dsymutil_path})
 
-            # Strip executables, shared libraries and static libraries in
-            # `host_install_destdir`.
-            find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-              '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
-              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+            if [[ -z "${DARWIN_NO_STRIP}" ]]; then
+              # Strip executables, shared libraries and static libraries in
+              # `host_install_destdir`.
+              find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
+                '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
+                xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+            fi
 
             # Codesign dylibs after strip tool
             # rdar://45388785


### PR DESCRIPTION
This is to work around a bug in strip we are seeing on the bots.
