### PR TITLE
[Dependency Scanner] Do not escape strings in the scanner output

### DIFF
--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -307,7 +307,7 @@ namespace {
                       StringRef value,
                       unsigned indentLevel) {
     out << "\"";
-    out.write_escaped(value);
+    out << value;
     out << "\"";
   }
 
@@ -460,8 +460,6 @@ static void writeJSON(llvm::raw_ostream &out,
     writeJSONSingleField(out, "modulePath", modulePath, /*indentLevel=*/3,
                          /*trailingComma=*/true);
 
-    // Artem Refactoring
-    {
     // Source files.
     if (swiftTextualDeps) {
       writeJSONSingleField(out, "sourceFiles", swiftTextualDeps->sourceFiles, 3,
@@ -612,7 +610,6 @@ static void writeJSON(llvm::raw_ostream &out,
     if (&module != &allModules.back())
       out << ",";
     out << "\n";
-  }
   }
 }
 

--- a/test/ScanDependencies/Inputs/unicode_filёnamё.swift
+++ b/test/ScanDependencies/Inputs/unicode_filёnamё.swift
@@ -1,0 +1,3 @@
+func foo() {
+    print(1)
+}

--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies %s %S/Inputs/unicode_filёnamё.swift -o %t/deps.json
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s < %t/deps.json
+
+print(foo())
+
+// CHECK:      "swift": "deps"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "modulePath": "deps.swiftmodule",
+// CHECK-NEXT:      "sourceFiles": [
+// CHECK-NEXT:        "{{.*}}ScanDependencies{{/|\\}}unicode_filename.swift",
+// CHECK-NEXT:        "{{.*}}ScanDependencies{{/|\\}}Inputs{{/|\\}}unicode_filёnamё.swift"
+// CHECK-NEXT:      ],


### PR DESCRIPTION
When outputting strings for things like filenames, using `write_escaped` will result in Unicode characters being outputted with a full 3-character-octal or hex escape. Clients which expect a UTF-8 JSON output will not be able to parse such escape sequences.

