### PR TITLE
[Build System] Remove tvOS i386 slice from compiler-rt lib

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1406,7 +1406,12 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                         # slices in Xcode that doesn't have the simulator .a, so
                         # the link is still valid.
                         echo "copying over faux-sim library ${HOST_LIB_PATH} to ${SIM_LIB_NAME}"
-                        call cp "${HOST_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        if [[ "$OS" == "tvos" ]]; then
+                            echo "Remove i386 from tvOS ${DEST_SIM_LIB_PATH}"
+                            call lipo -remove i386 "${HOST_LIB_PATH}" -output "${DEST_SIM_LIB_PATH}"
+                        else
+                            call cp "${HOST_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        fi
                     elif [[ "${VERBOSE_BUILD}" ]]; then
                         echo "no file exists at ${HOST_SIM_LIB_PATH}"
                     fi

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1385,7 +1385,11 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                 DEST_LIB_PATH="${DEST_BUILTINS_DIR}/${LIB_NAME}"
                 if [[ ! -f "${DEST_LIB_PATH}" ]]; then
                     if [[ -f "${HOST_LIB_PATH}" ]]; then
-                        call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                        if [[ "$OS" == "tvos" ]]; then
+                           call lipo -remove i386 "${HOST_LIB_PATH}" -output "${DEST_LIB_PATH}"
+                        else
+                           call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                        fi
                     elif [[ "${VERBOSE_BUILD}" ]]; then
                         echo "no file exists at ${HOST_LIB_PATH}"
                     fi
@@ -1397,7 +1401,11 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                 DEST_SIM_LIB_PATH="${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
                 if [[ ! -f "${DEST_SIM_LIB_PATH}" ]]; then
                     if [[ -f "${HOST_SIM_LIB_PATH}" ]]; then
-                        call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        if [[ "$OS" == "tvos" ]]; then
+                           call lipo -remove i386 "${HOST_SIM_LIB_PATH}" -output "${DEST_SIM_LIB_PATH}"
+                        else
+                           call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        fi
                     elif [[ -f "${HOST_LIB_PATH}" ]]; then
                         # The simulator .a might not exist if the host
                         # Xcode is old. In that case, copy over the


### PR DESCRIPTION
To fix this issue:
ld: building for tvOS, but linking in object file built for tvOS Simulator, file '/tmp/strip.rgKCdx' for architecture i386
fatal error: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: internal link edit command failed

rdar://70443440
