### PR TITLE
Avoid introducing critical edges in SimplifyCFG

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1530,7 +1530,7 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
   // If the destination block is a simple trampoline (jump to another block)
   // then jump directly.
   SILBasicBlock *TrueTrampolineDest = getTrampolineDest(TrueSide);
-  if (TrueTrampolineDest && TrueTrampolineDest != FalseSide) {
+  if (TrueTrampolineDest && TrueTrampolineDest->getSinglePredecessorBlock()) {
     LLVM_DEBUG(llvm::dbgs() << "true-trampoline from bb" << ThisBB->getDebugID()
                             << " to bb" << TrueTrampolineDest->getDebugID()
                             << '\n');
@@ -1547,7 +1547,7 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
   }
 
   SILBasicBlock *FalseTrampolineDest = getTrampolineDest(FalseSide);
-  if (FalseTrampolineDest && FalseTrampolineDest != TrueSide) {
+  if (FalseTrampolineDest && FalseTrampolineDest->getSinglePredecessorBlock()) {
     LLVM_DEBUG(llvm::dbgs() << "false-trampoline from bb"
                             << ThisBB->getDebugID() << " to bb"
                             << FalseTrampolineDest->getDebugID() << '\n');

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -789,6 +789,10 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::GetAsyncContinuationInst:
     return InlineCost::Free;
 
+  // Unconditional branch is free.
+  case SILInstructionKind::BranchInst:
+    return InlineCost::Free;
+
   case SILInstructionKind::AbortApplyInst:
   case SILInstructionKind::ApplyInst:
   case SILInstructionKind::TryApplyInst:
@@ -804,7 +808,6 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::WitnessMethodInst:
   case SILInstructionKind::AssignInst:
   case SILInstructionKind::AssignByWrapperInst:
-  case SILInstructionKind::BranchInst:
   case SILInstructionKind::CheckedCastBranchInst:
   case SILInstructionKind::CheckedCastValueBranchInst:
   case SILInstructionKind::CheckedCastAddrBranchInst:

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1148,19 +1148,21 @@ sil [_semantics "array.check_subscript"] @checkbounds3 : $@convention(method) (I
 
 // CHECK-LABEL: sil @rangeCheck
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb2, bb1
+// CHECK:   cond_br {{.*}}, bb1, bb2
 // CHECK: bb1
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK:   br bb3
 // CHECK: bb2
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:   br bb4
+// CHECK: bb3
 // CHECK:   return
-// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
+// CHECK: bb4([[IV:%.*]] : $Builtin.Int64):
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb2, bb4
-// CHECK: bb4:
-// CHECK:   br bb3
+// CHECK:   cond_br {{.*}}, bb6, bb5
+// CHECK: bb5:
+// CHECK:   br bb4
 // CHECK: }
 sil @rangeCheck : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
@@ -1197,21 +1199,23 @@ bb3(%15 : $Builtin.Int64):
 
 // CHECK-LABEL: sil @rangeCheck2
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb2, bb1
+// CHECK:   cond_br {{.*}}, bb1, bb2
 // CHECK: bb1
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK:   br bb3
 // CHECK: bb2
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:   br bb4
+// CHECK: bb3
 // CHECK:   return
-// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
+// CHECK: bb4([[IV:%.*]] : $Builtin.Int64):
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "or_Int1"([[FALSE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb2, bb4
-// CHECK: bb4:
-// CHECK:   br bb3
+// CHECK:   cond_br {{.*}}, bb6, bb5
+// CHECK: bb5:
+// CHECK:   br bb4
 // CHECK: }
 sil @rangeCheck2 : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -453,18 +453,16 @@ bb5(%6 : $Int64):
   return %6 : $Int64
 }
 
-// Make sure that a conditional branch to a trampoline without parameters
-// gets eliminated by branching to a target of this trampoline.
+// Eliminate the trampoline from from a cond_br at bb5->bb3->bb4/
+// This becomes a cond_br at bb8->bb5
 // CHECK-LABEL: @elim_trampoline5
 // CHECK: cond_br
-// CHECK: bb3:
-// CHECK: cond_br
-// CHECK: bb4{{.*}}:
-// Last cond_br should branch directly to the target of a trampoline
-// instead of the original bb3
-// CHECK: cond_br {{.*}}, bb3, bb5
 // CHECK: bb5:
-// CHECK-NEXT: br bb4
+// CHECK: cond_br
+// CHECK: bb8{{.*}}:
+// CHECK: cond_br {{.*}}, bb5, bb9
+// CHECK: bb9:
+// CHECK-NEXT: br bb8
 // CHECK: }
 sil @elim_trampoline5 : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
@@ -1837,7 +1835,7 @@ bb2:
 
 // CHECK-LABEL: sil @dont_remove_cond_fail_wrong_const
 // CHECK:      bb0(%0 : $Builtin.Int1):
-// CHECK-NEXT:   cond_br %0, bb1, bb2
+// CHECK-NEXT:   cond_br %0, bb2, bb1
 sil @dont_remove_cond_fail_wrong_const : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   cond_br %0, bb1, bb2
@@ -1930,7 +1928,7 @@ bb3:
 // CHECK-LABEL: sil @dont_remove_cond_fail_same_cond_in_false
 // CHECK: bb0([[COND:%[0-9]*]]
 // CHECK-NEXT: cond_br
-// CHECK: bb1:
+// CHECK: bb2:
 // CHECK-NEXT: cond_fail [[COND]]
 // CHECK: return
 sil @dont_remove_cond_fail_same_cond_in_false : $@convention(thin)(Builtin.Int1, Builtin.Int1) -> () {
@@ -2051,13 +2049,13 @@ bb3(%a3 : $Builtin.Int1):
 // CHECK:      bb1:
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   integer_literal
-// CHECK-NEXT:   br bb4
+// CHECK-NEXT:   br bb5
 // CHECK:      bb2:
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   cond_br
 // CHECK:      bb3:
-// CHECK:        br bb4
-// CHECK:      bb4({{.*}}):
+// CHECK:        br bb6
+// CHECK:      bb5({{.*}}):
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   cond_fail
 sil @dont_move_cond_fail_no_postdom : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
@@ -2202,19 +2200,19 @@ bb3 (%10: $Builtin.Int32):
 
 // CHECK-LABEL: sil @thread_objc_method_call_succ_block
 // CHECK: bb0
-// CHECK:  cond_br {{.*}}, bb1, bb2
+// CHECK:  cond_br {{.*}}, bb1, bb3
 // CHECK: bb1
 // CHECK:  objc_method
 // CHECK:  apply
 // CHECK:  strong_release
-// CHECK:  cond_br {{.*}}, bb3, bb4
-// CHECK: bb2
-// CHECK:  strong_release
-// CHECK:  cond_br {{.*}}, bb3, bb4
+// CHECK:  cond_br {{.*}}, bb2, bb6
 // CHECK: bb3
+// CHECK:  strong_release
+// CHECK:  cond_br {{.*}}, bb5, bb4
+// CHECK: bb7
 // CHECK:  cond_fail
-// CHECK:  br bb4
-// CHECK: bb4:
+// CHECK:  br bb8
+// CHECK: bb8:
 // CHECK:  strong_release
 // CHECK:  return
 
@@ -2248,20 +2246,20 @@ sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK: bb1:
 // CHECK:  [[INVADD:%.*]] = builtin "sadd
 // CHECK:  [[EXT:%.*]] = tuple_extract [[INVADD]]
-// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb2
+// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb3
 
-// CHECK: bb2{{.*}}
-// CHECK:  br bb4({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
+// CHECK: bb3{{.*}}
+// CHECK:  br bb5({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
 
-// CHECK: bb4({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
+// CHECK: bb5({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
 // CHECK:  [[F:%.*]] = function_ref @f
 // CHECK:  apply [[F]]([[CUR]])
-// CHECK:  cond_br {{.*}}, bb5, bb6
+// CHECK:  cond_br {{.*}}, bb7, bb6
 
-// CHECK: bb5:
+// CHECK: bb7:
 // CHECK:   [[VARADD:%.*]] = builtin "sadd_with_overflow_Int32"([[NEXT]] : $Builtin.Int32
 // CHECK:   [[NEXT2:%.*]] = tuple_extract [[VARADD]]
-// CHECK:   br bb4({{.*}} : $Builtin.Int32, [[NEXT]] : $Builtin.Int32, [[NEXT2]]
+// CHECK:   br bb5({{.*}} : $Builtin.Int32, [[NEXT]] : $Builtin.Int32, [[NEXT2]]
 
 
 sil @switch_enum_jumpthreading_bug : $@convention(thin) (Optional<Builtin.Int32>, Builtin.Int1, Builtin.Int32, Builtin.Int1) -> Builtin.Int32 {
@@ -3047,7 +3045,7 @@ bb3(%11 : $String):
 // CHECK-LABEL: sil @dont_hang
 // CHECK:      bb6:
 // CHECK:        integer_literal $Builtin.Int64, 1
-// CHECK-NEXT:   br bb5
+// CHECK-NEXT:   br bb6
 // CHECK-NEXT: }
 sil @dont_hang : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/simplify_cfg_address_phi.sil
+++ b/test/SILOptimizer/simplify_cfg_address_phi.sil
@@ -148,7 +148,7 @@ sil @useAny : $@convention(thin) <V> (@in_guaranteed V) -> ()
 // CHECK: apply %{{.*}}<S>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK: [[FIELD:%.*]] = ref_element_addr %1 : $CC<R>, #CC.r
 // CHECK: debug_value_addr [[FIELD]] : $*R, let, name "u"
-// CHECK: apply %10<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply %{{.*}}<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK-LABEL: } // end sil function 'testDebugValue'
 sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
 bb0(%0 : $*S, %1 : $CC<R>, %2 : $Bool):

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -61,7 +61,7 @@ bb3(%35 : $()):                                   // Preds: bb2
 
 //CHECK-LABEL: remove_dead_args
 //CHECK-NOT: br bb2([[VAR_21:%[0-9]+]] : $Bool)
-//CHECK: bb2:
+//CHECK: bb3:
 //CHECK-NEXT: tuple ()
 //CHECK-NEXT: return
 sil @remove_dead_args: $@convention(thin) (Int32) -> () {

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -7,7 +7,7 @@ import Swift
 import SwiftShims
 
 // CHECK-LABEL: sil @test_jump_threading
-// CHECK: bb4(%{{[0-9]+}} : $Builtin.Int64):
+// CHECK: bb5(%{{[0-9]+}} : $Builtin.Int64):
 // CHECK-NEXT: br bb1
 sil @test_jump_threading : $@convention(thin)  (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):

--- a/test/SILOptimizer/simplify_cfg_unique_values.sil
+++ b/test/SILOptimizer/simplify_cfg_unique_values.sil
@@ -13,9 +13,7 @@ enum DupCaseEnum {
 // CHECK-LABEL: sil @performSwitch : $@convention(thin) (Int64, @thin DupCaseEnum.Type) -> DupCaseEnum {
 // CHECK: bb0(%0 : $Int64, %1 : $@thin DupCaseEnum.Type):
 // CHECK:   select_value
-// CHECK:   br bb1
-// CHECK: bb1:
-// CHECK:   return
+// CHECK-NEXT:   return
 sil @performSwitch : $@convention(thin) (Int64, @thin DupCaseEnum.Type) -> DupCaseEnum {
 // %0                                             // users: %9, %5, %3, %2
 bb0(%0 : $Int64, %1 : $@thin DupCaseEnum.Type):


### PR DESCRIPTION
Passes will end up resplitting them, forcing SimplifyCFG to
continually rerun.

Also, we want to allow SIL utilities to assume no critical edges, and
avoid the need for several passes to internally split edges and modify
the CFG for no reason.

Preparation for adding invariants that simplify working with OSSA form and opaque values.