### PR TITLE
tests: fix APINotes/blocks.swift

### DIFF
--- a/test/APINotes/blocks.swift
+++ b/test/APINotes/blocks.swift
@@ -1,5 +1,4 @@
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk %s -emit-ir
-// REQUIRES: executable_test
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
The requirement executable_test is not needed here. It was there for historical reasons.

rdar://problem/70400635
