### PR TITLE
[cxx-interop] Support bool-based enums.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8558,11 +8558,19 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
     // Create the expression node.
     StringRef printedValueCopy(context.AllocateCopy(printedValue));
     if (value.getKind() == clang::APValue::Int) {
-      if (type->getCanonicalType()->isBool()) {
-        auto *boolExpr =
-            new (context) BooleanLiteralExpr(value.getInt().getBoolValue(),
-                                             SourceLoc(),
-                                             /**Implicit=*/true);
+      bool isBool = type->getCanonicalType()->isBool();
+      // Check if "type" is a C++ enum with an underlying type of "bool".
+      if (!isBool && type->getStructOrBoundGenericStruct() &&
+          type->getStructOrBoundGenericStruct()->getClangDecl()) {
+        if (auto enumDecl = dyn_cast<clang::EnumDecl>(
+                type->getStructOrBoundGenericStruct()->getClangDecl())) {
+          isBool = enumDecl->getIntegerType()->isBooleanType();
+        }
+      }
+      if (isBool) {
+        auto *boolExpr = new (context)
+            BooleanLiteralExpr(value.getInt().getBoolValue(), SourceLoc(),
+                               /*Implicit=*/true);
 
         boolExpr->setBuiltinInitializer(
           context.getBoolBuiltinInitDecl());

--- a/test/Interop/Cxx/enum/Inputs/bool-enums.h
+++ b/test/Interop/Cxx/enum/Inputs/bool-enums.h
@@ -1,0 +1,6 @@
+enum Maybe : bool { No, Yes };
+enum BinaryNumbers : bool { One = 1, Zero = 0 };
+enum class EnumClass : bool { Foo, Bar };
+struct WrapperStruct {
+  enum InnerBoolEnum : bool { A, B };
+};

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module BoolEnums {
+  header "bool-enums.h"
+}

--- a/test/Interop/Cxx/enum/bool-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/bool-enums-module-interface.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=BoolEnums -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// TODO: these should be enums eventually (especially the enum class).
+
+// CHECK:       struct Maybe : Equatable, RawRepresentable {
+// CHECK-NEXT:    init(_ rawValue: Bool)
+// CHECK-NEXT:    init(rawValue: Bool)
+// CHECK-NEXT:    var rawValue: Bool
+// CHECK-NEXT:	  typealias RawValue = Bool
+// CHECK-NEXT:  }
+
+// CHECK:       var No: Maybe { get }
+// CHECK:       var Yes: Maybe { get }
+
+// CHECK:       struct BinaryNumbers : Equatable, RawRepresentable {
+// CHECK-NEXT:    init(_ rawValue: Bool)
+// CHECK-NEXT:    init(rawValue: Bool)
+// CHECK-NEXT:	  var rawValue: Bool
+// CHECK-NEXT:    typealias RawValue = Bool
+// CHECK-NEXT:  }
+
+// CHECK:       var One: BinaryNumbers { get }
+// CHECK:       var Zero: BinaryNumbers { get }
+// CHECK:       struct EnumClass : Equatable, RawRepresentable {
+// CHECK-NEXT:    init(_ rawValue: Bool)
+// CHECK-NEXT:    init(rawValue: Bool)
+// CHECK-NEXT:    var rawValue: Bool
+// CHECK-NEXT:    typealias RawValue = Bool
+// CHECK-NEXT:  }
+
+// CHECK:       struct WrapperStruct {
+// TODO: where is "A" and "B"? They should be member variables.
+// CHECK-NEXT:    struct InnerBoolEnum : Equatable, RawRepresentable {
+// CHECK-NEXT:      init(_ rawValue: Bool)
+// CHECK-NEXT:      init(rawValue: Bool)
+// CHECK-NEXT:      var rawValue: Bool
+// CHECK-NEXT:      typealias RawValue = Bool
+// CHECK-NEXT:    }
+// CHECK-NEXT:    init()
+// CHECK-NEXT:  }


### PR DESCRIPTION
This is a small fix to prevent a crash. This change simply adds another condition for the `bool` branch that checks if the APInt has a bit-width of `1`.

There are some big changes we should make in the future around enums. But, this patch is only to prevent a crash.