### PR TITLE
[Async CC] Support for partial application.

### DIFF
--- a/lib/IRGen/Explosion.h
+++ b/lib/IRGen/Explosion.h
@@ -152,11 +152,6 @@ public:
     return Values[NextValue-1];
   }
 
-  llvm::Value *peek(unsigned n) {
-    assert(n < Values.size());
-    return Values[n];
-  }
-
   /// Claim and remove the last item in the array.
   /// Unlike the normal 'claim' methods, the item is gone forever.
   llvm::Value *takeLast() {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1959,8 +1959,8 @@ class AsyncCallEmission final : public CallEmission {
   }
   void loadValue(ElementLayout layout, Explosion &explosion) {
     Address addr = layout.project(IGF, context, /*offsets*/ llvm::None);
-    auto &ti = layout.getType();
-    cast<LoadableTypeInfo>(ti).loadAsTake(IGF, addr, explosion);
+    auto &ti = cast<LoadableTypeInfo>(layout.getType());
+    ti.loadAsTake(IGF, addr, explosion);
   }
 
 public:

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -168,15 +168,6 @@ AsyncContextLayout irgen::getAsyncContextLayout(
   }
 
   //   ArgTypes formalArguments...;
-  auto bindings = NecessaryBindings::forAsyncFunctionInvocation(
-      IGF.IGM, originalType, substitutionMap);
-  if (!bindings.empty()) {
-    auto bindingsSize = bindings.getBufferSize(IGF.IGM);
-    auto &bindingsTI = IGF.IGM.getOpaqueStorageTypeInfo(
-        bindingsSize, IGF.IGM.getPointerAlignment());
-    valTypes.push_back(SILType());
-    typeInfos.push_back(&bindingsTI);
-  }
   for (auto parameter : parameters) {
     SILType ty = IGF.IGM.silConv.getSILType(
         parameter, substitutedType, IGF.IGM.getMaximalTypeExpansionContext());
@@ -190,6 +181,15 @@ AsyncContextLayout irgen::getAsyncContextLayout(
     valTypes.push_back(ty);
     typeInfos.push_back(&ti);
     paramInfos.push_back({ty, parameter.getConvention()});
+  }
+  auto bindings = NecessaryBindings::forAsyncFunctionInvocation(
+      IGF.IGM, originalType, substitutionMap);
+  if (!bindings.empty()) {
+    auto bindingsSize = bindings.getBufferSize(IGF.IGM);
+    auto &bindingsTI = IGF.IGM.getOpaqueStorageTypeInfo(
+        bindingsSize, IGF.IGM.getPointerAlignment());
+    valTypes.push_back(SILType());
+    typeInfos.push_back(&bindingsTI);
   }
 
   Optional<AsyncContextLayout::TrailingWitnessInfo> trailingWitnessInfo;

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -121,6 +121,17 @@ AsyncContextLayout irgen::getAsyncContextLayout(
     indirectReturnInfos.push_back(indirectResult);
   }
 
+  //     ResultTypes directResults...;
+  auto directResults = fnConv.getDirectSILResults();
+  for (auto result : directResults) {
+    auto ty =
+        fnConv.getSILType(result, IGF.IGM.getMaximalTypeExpansionContext());
+    auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+    directReturnInfos.push_back(result);
+  }
+
   //   SelfType self?;
   bool hasLocalContextParameter = hasSelfContextParameter(substitutedType);
   bool canHaveValidError = substitutedType->hasErrorResult();
@@ -201,17 +212,6 @@ AsyncContextLayout irgen::getAsyncContextLayout(
       typeInfos.push_back(&ti);
     }
     trailingWitnessInfo = AsyncContextLayout::TrailingWitnessInfo();
-  }
-
-  //     ResultTypes directResults...;
-  auto directResults = fnConv.getDirectSILResults();
-  for (auto result : directResults) {
-    auto ty =
-        fnConv.getSILType(result, IGF.IGM.getMaximalTypeExpansionContext());
-    auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
-    valTypes.push_back(ty);
-    typeInfos.push_back(&ti);
-    directReturnInfos.push_back(result);
   }
 
   return AsyncContextLayout(

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2004,9 +2004,6 @@ public:
                                   IGF.getSILModule());
 
     // Move all the arguments into the context.
-    if (selfValue) {
-      llArgs.add(selfValue);
-    }
     auto layout = getAsyncContextLayout();
     for (unsigned index = 0, count = layout.getIndirectReturnCount();
          index < count; ++index) {
@@ -2024,8 +2021,10 @@ public:
       layout.getBindings().save(IGF, bindingsAddr, llArgs);
     }
     if (selfValue) {
+      Explosion selfExplosion;
+      selfExplosion.add(selfValue);
       auto fieldLayout = layout.getLocalContextLayout();
-      saveValue(fieldLayout, llArgs, isOutlined);
+      saveValue(fieldLayout, selfExplosion, isOutlined);
     }
   }
   void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -115,13 +115,21 @@ namespace irgen {
     unsigned getFirstIndirectReturnIndex() {
       return getErrorIndex() + getErrorCount();
     }
-    unsigned getLocalContextIndex() {
-      assert(hasLocalContext());
+    unsigned getIndexAfterIndirectReturns() {
       return getFirstIndirectReturnIndex() + getIndirectReturnCount();
     }
+    unsigned getFirstDirectReturnIndex() {
+      return getIndexAfterIndirectReturns();
+    }
+    unsigned getIndexAfterDirectReturns() {
+      return getFirstDirectReturnIndex() + getDirectReturnCount();
+    }
+    unsigned getLocalContextIndex() {
+      assert(hasLocalContext());
+      return getIndexAfterDirectReturns();
+    }
     unsigned getIndexAfterLocalContext() {
-      return getFirstIndirectReturnIndex() + getIndirectReturnCount() +
-             (hasLocalContext() ? 1 : 0);
+      return getIndexAfterDirectReturns() + (hasLocalContext() ? 1 : 0);
     }
     unsigned getBindingsIndex() {
       assert(hasBindings());
@@ -144,9 +152,6 @@ namespace irgen {
     }
     unsigned getIndexAfterTrailingWitnesses() {
       return getIndexAfterArguments() + (hasTrailingWitnesses() ? 2 : 0);
-    }
-    unsigned getFirstDirectReturnIndex() {
-      return getIndexAfterTrailingWitnesses();
     }
 
   public:

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -131,27 +131,27 @@ namespace irgen {
     unsigned getIndexAfterLocalContext() {
       return getIndexAfterDirectReturns() + (hasLocalContext() ? 1 : 0);
     }
-    unsigned getBindingsIndex() {
-      assert(hasBindings());
-      return getIndexAfterLocalContext();
-    }
-    unsigned getIndexAfterBindings() {
-      return getIndexAfterLocalContext() + (hasBindings() ? 1 : 0);
-    }
-    unsigned getFirstArgumentIndex() { return getIndexAfterBindings(); }
+    unsigned getFirstArgumentIndex() { return getIndexAfterLocalContext(); }
     unsigned getIndexAfterArguments() {
       return getFirstArgumentIndex() + getArgumentCount();
     }
+    unsigned getBindingsIndex() {
+      assert(hasBindings());
+      return getIndexAfterArguments();
+    }
+    unsigned getIndexAfterBindings() {
+      return getIndexAfterArguments() + (hasBindings() ? 1 : 0);
+    }
     unsigned getSelfMetadataIndex() {
       assert(hasTrailingWitnesses());
-      return getIndexAfterArguments();
+      return getIndexAfterBindings();
     }
     unsigned getSelfWitnessTableIndex() {
       assert(hasTrailingWitnesses());
-      return getIndexAfterArguments() + 1;
+      return getIndexAfterBindings() + 1;
     }
     unsigned getIndexAfterTrailingWitnesses() {
-      return getIndexAfterArguments() + (hasTrailingWitnesses() ? 2 : 0);
+      return getIndexAfterBindings() + (hasTrailingWitnesses() ? 2 : 0);
     }
 
   public:

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -83,6 +83,8 @@ namespace irgen {
   //     };
   //     ResultTypes directResults...;
   //   };
+  //   ArgTypes formalArguments...;
+  //   SelfType self?;
   // };
   struct AsyncContextLayout : StructLayout {
     struct ArgumentInfo {
@@ -124,14 +126,7 @@ namespace irgen {
     unsigned getIndexAfterDirectReturns() {
       return getFirstDirectReturnIndex() + getDirectReturnCount();
     }
-    unsigned getLocalContextIndex() {
-      assert(hasLocalContext());
-      return getIndexAfterDirectReturns();
-    }
-    unsigned getIndexAfterLocalContext() {
-      return getIndexAfterDirectReturns() + (hasLocalContext() ? 1 : 0);
-    }
-    unsigned getFirstArgumentIndex() { return getIndexAfterLocalContext(); }
+    unsigned getFirstArgumentIndex() { return getIndexAfterDirectReturns(); }
     unsigned getIndexAfterArguments() {
       return getFirstArgumentIndex() + getArgumentCount();
     }
@@ -142,16 +137,24 @@ namespace irgen {
     unsigned getIndexAfterBindings() {
       return getIndexAfterArguments() + (hasBindings() ? 1 : 0);
     }
+    unsigned getLocalContextIndex() {
+      assert(hasLocalContext());
+      return getIndexAfterBindings();
+    }
+    unsigned getIndexAfterLocalContext() {
+      return getIndexAfterBindings() +
+             (hasLocalContext() ? 1 : 0);
+    }
     unsigned getSelfMetadataIndex() {
       assert(hasTrailingWitnesses());
-      return getIndexAfterBindings();
+      return getIndexAfterLocalContext();
     }
     unsigned getSelfWitnessTableIndex() {
       assert(hasTrailingWitnesses());
-      return getIndexAfterBindings() + 1;
+      return getIndexAfterLocalContext() + 1;
     }
     unsigned getIndexAfterTrailingWitnesses() {
-      return getIndexAfterBindings() + (hasTrailingWitnesses() ? 2 : 0);
+      return getIndexAfterLocalContext() + (hasTrailingWitnesses() ? 2 : 0);
     }
 
   public:

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -720,57 +720,93 @@ static unsigned findSinglePartiallyAppliedParameterIndexIgnoringEmptyTypes(
   return firstNonEmpty;
 }
 
-/// Emit the forwarding stub function for a partial application.
-///
-/// If 'layout' is null, there is a single captured value of
-/// Swift-refcountable type that is being used directly as the
-/// context object.
-static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
-                                   const Optional<FunctionPointer> &staticFnPtr,
-                                   bool calleeHasContext,
-                                   const Signature &origSig,
-                                   CanSILFunctionType origType,
-                                   CanSILFunctionType substType,
-                                   CanSILFunctionType outType,
-                                   SubstitutionMap subs,
-                                   HeapLayout const *layout,
-                                   ArrayRef<ParameterConvention> conventions) {
-  auto outSig = IGM.getSignature(outType);
-  llvm::AttributeList outAttrs = outSig.getAttributes();
-  llvm::FunctionType *fwdTy = outSig.getType();
-  SILFunctionConventions outConv(outType, IGM.getSILModule());
+namespace {
+class PartialApplicationForwarderEmission {
+protected:
+  IRGenModule &IGM;
+  IRGenFunction &subIGF;
+  llvm::Function *fwd;
+  const Optional<FunctionPointer> &staticFnPtr;
+  bool calleeHasContext;
+  const Signature &origSig;
+  CanSILFunctionType origType;
+  CanSILFunctionType substType;
+  CanSILFunctionType outType;
+  SubstitutionMap subs;
+  HeapLayout const *layout;
+  const ArrayRef<ParameterConvention> conventions;
+  SILFunctionConventions origConv;
+  SILFunctionConventions outConv;
+  Explosion origParams;
 
-  StringRef FnName;
-  if (staticFnPtr)
-    FnName = staticFnPtr->getPointer()->getName();
+  PartialApplicationForwarderEmission(
+      IRGenModule &IGM, IRGenFunction &subIGF, llvm::Function *fwd,
+      const Optional<FunctionPointer> &staticFnPtr, bool calleeHasContext,
+      const Signature &origSig, CanSILFunctionType origType,
+      CanSILFunctionType substType, CanSILFunctionType outType,
+      SubstitutionMap subs, HeapLayout const *layout,
+      ArrayRef<ParameterConvention> conventions)
+      : IGM(IGM), subIGF(subIGF), fwd(fwd), staticFnPtr(staticFnPtr),
+        calleeHasContext(calleeHasContext), origSig(origSig),
+        origType(origType), substType(substType), outType(outType), subs(subs),
+        conventions(conventions), origConv(origType, IGM.getSILModule()),
+        outConv(outType, IGM.getSILModule()),
+        origParams(subIGF.collectParameters()) {}
 
-  IRGenMangler Mangler;
-  std::string thunkName = Mangler.manglePartialApplyForwarder(FnName);
-
-  // FIXME: Maybe cache the thunk by function and closure types?.
-  llvm::Function *fwd =
-    llvm::Function::Create(fwdTy, llvm::Function::InternalLinkage,
-                           llvm::StringRef(thunkName), &IGM.Module);
-  fwd->setCallingConv(outSig.getCallingConv());
-
-  fwd->setAttributes(outAttrs);
-  // Merge initial attributes with outAttrs.
-  llvm::AttrBuilder b;
-  IGM.constructInitialFnAttributes(b);
-  fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
-
-  IRGenFunction subIGF(IGM, fwd);
-  if (IGM.DebugInfo)
-    IGM.DebugInfo->emitArtificialFunction(subIGF, fwd);
-  
-  Explosion origParams = subIGF.collectParameters();
-
+public:
+  enum class DynamicFunctionKind {
+    Witness,
+    PartialApply,
+  };
+  virtual void begin(){};
+  virtual void gatherArgumentsFromApply() = 0;
+  virtual unsigned getCurrentArgumentIndex() = 0;
+  virtual bool transformArgumentToNative(SILParameterInfo origParamInfo,
+                                         Explosion &in, Explosion &out) = 0;
+  virtual void addArgument(Explosion &explosion) = 0;
+  virtual void addArgument(llvm::Value *argValue) = 0;
+  virtual void addArgument(Explosion &explosion, unsigned index) = 0;
+  virtual void addArgument(llvm::Value *argValue, unsigned index) = 0;
+  virtual SILParameterInfo getParameterInfo(unsigned index) = 0;
+  virtual llvm::Value *getContext() = 0;
+  virtual llvm::Value *getDynamicFunctionPointer() = 0;
+  virtual llvm::Value *getDynamicFunctionContext() = 0;
+  virtual void addDynamicFunctionContext(Explosion &explosion,
+                                         DynamicFunctionKind kind) = 0;
+  virtual void addDynamicFunctionPointer(Explosion &explosion,
+                                         DynamicFunctionKind kind) = 0;
+  virtual void addSelf(Explosion &explosion) = 0;
+  virtual void addWitnessSelfMetadata(llvm::Value *value) = 0;
+  virtual void addWitnessSelfWitnessTable(llvm::Value *value) = 0;
+  virtual void forwardErrorResult() = 0;
+  virtual bool originalParametersConsumed() = 0;
+  virtual void addPolymorphicArguments(Explosion polyArgs) = 0;
+  virtual llvm::CallInst *createCall(FunctionPointer &fnPtr) = 0;
+  virtual void createReturn(llvm::CallInst *call) = 0;
+  virtual void end(){};
+  virtual ~PartialApplicationForwarderEmission() {}
+};
+class SyncPartialApplicationForwarderEmission
+    : public PartialApplicationForwarderEmission {
+  using super = PartialApplicationForwarderEmission;
   // Create a new explosion for potentially reabstracted parameters.
   Explosion args;
-
   Address resultValueAddr;
 
-  {
+public:
+  SyncPartialApplicationForwarderEmission(
+      IRGenModule &IGM, IRGenFunction &subIGF, llvm::Function *fwd,
+      const Optional<FunctionPointer> &staticFnPtr, bool calleeHasContext,
+      const Signature &origSig, CanSILFunctionType origType,
+      CanSILFunctionType substType, CanSILFunctionType outType,
+      SubstitutionMap subs, HeapLayout const *layout,
+      ArrayRef<ParameterConvention> conventions)
+      : PartialApplicationForwarderEmission(
+            IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
+            substType, outType, subs, layout, conventions) {}
+
+  void begin() override { super::begin(); }
+  void gatherArgumentsFromApply() override {
     // Lower the forwarded arguments in the original function's generic context.
     GenericContextScope scope(IGM, origType->getInvocationGenericSignature());
 
@@ -876,6 +912,403 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       nativeApplyArg.transferInto(args, nativeApplyArg.size());
     }
   }
+  unsigned getCurrentArgumentIndex() override { return args.size(); }
+  bool transformArgumentToNative(SILParameterInfo origParamInfo, Explosion &in,
+                                 Explosion &out) override {
+    return addNativeArgument(subIGF, in, origType, origParamInfo, out, false);
+  }
+  void addArgument(Explosion &explosion) override {
+    args.add(explosion.claimAll());
+  }
+  void addArgument(llvm::Value *argValue) override { args.add(argValue); }
+  void addArgument(Explosion &explosion, unsigned index) override {
+    addArgument(explosion);
+  }
+  void addArgument(llvm::Value *argValue, unsigned index) override {
+    addArgument(argValue);
+  }
+  SILParameterInfo getParameterInfo(unsigned index) override {
+    return substType->getParameters()[index];
+  }
+  llvm::Value *getContext() override { return origParams.claimNext(); }
+  llvm::Value *getDynamicFunctionPointer() override { return args.takeLast(); }
+  llvm::Value *getDynamicFunctionContext() override { return args.takeLast(); }
+  void addDynamicFunctionContext(Explosion &explosion,
+                                 DynamicFunctionKind kind) override {
+    addArgument(explosion);
+  }
+  void addDynamicFunctionPointer(Explosion &explosion,
+                                 DynamicFunctionKind kind) override {
+    addArgument(explosion);
+  }
+  void addSelf(Explosion &explosion) override { addArgument(explosion); }
+  void addWitnessSelfMetadata(llvm::Value *value) override {
+    addArgument(value);
+  }
+  void addWitnessSelfWitnessTable(llvm::Value *value) override {
+    addArgument(value);
+  }
+  void forwardErrorResult() override {
+    llvm::Value *errorResultPtr = origParams.claimNext();
+    args.add(errorResultPtr);
+  }
+  bool originalParametersConsumed() override { return origParams.empty(); }
+  void addPolymorphicArguments(Explosion polyArgs) override {
+    polyArgs.transferInto(args, polyArgs.size());
+  }
+  llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
+    return subIGF.Builder.CreateCall(fnPtr, args.claimAll());
+  }
+  void createReturn(llvm::CallInst *call) override {
+    // Reabstract the result value as substituted.
+    SILFunctionConventions origConv(origType, IGM.getSILModule());
+    auto &outResultTI = IGM.getTypeInfo(
+        outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
+    auto &nativeResultSchema = outResultTI.nativeReturnValueSchema(IGM);
+    if (call->getType()->isVoidTy()) {
+      if (!resultValueAddr.isValid())
+        subIGF.Builder.CreateRetVoid();
+      else {
+        // Okay, we have called a function that expects an indirect return type
+        // but the partially applied return type is direct.
+        assert(!nativeResultSchema.requiresIndirect());
+        Explosion loadedResult;
+        cast<LoadableTypeInfo>(outResultTI)
+            .loadAsTake(subIGF, resultValueAddr, loadedResult);
+        Explosion nativeResult = nativeResultSchema.mapIntoNative(
+            IGM, subIGF, loadedResult,
+            outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()),
+            false);
+        outResultTI.deallocateStack(
+            subIGF, resultValueAddr,
+            outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
+        if (nativeResult.size() == 1)
+          subIGF.Builder.CreateRet(nativeResult.claimNext());
+        else {
+          llvm::Value *nativeAgg =
+              llvm::UndefValue::get(nativeResultSchema.getExpandedType(IGM));
+          for (unsigned i = 0, e = nativeResult.size(); i != e; ++i) {
+            auto *elt = nativeResult.claimNext();
+            nativeAgg = subIGF.Builder.CreateInsertValue(nativeAgg, elt, i);
+          }
+          subIGF.Builder.CreateRet(nativeAgg);
+        }
+      }
+    } else {
+      llvm::Value *callResult = call;
+      // If the result type is dependent on a type parameter we might have to
+      // cast to the result type - it could be substituted.
+      if (origConv.getSILResultType(IGM.getMaximalTypeExpansionContext())
+              .hasTypeParameter()) {
+        auto ResType = fwd->getReturnType();
+        if (ResType != callResult->getType())
+          callResult =
+              subIGF.coerceValue(callResult, ResType, subIGF.IGM.DataLayout);
+      }
+      subIGF.Builder.CreateRet(callResult);
+    }
+  }
+  void end() override { super::end(); }
+};
+class AsyncPartialApplicationForwarderEmission
+    : public PartialApplicationForwarderEmission {
+  using super = PartialApplicationForwarderEmission;
+  AsyncContextLayout layout;
+  llvm::Value *contextBuffer;
+  Size contextSize;
+  Address context;
+  llvm::Value *heapContextBuffer;
+  unsigned currentArgumentIndex;
+  struct DynamicFunction {
+    using Kind = DynamicFunctionKind;
+    Kind kind;
+    llvm::Value *pointer;
+    llvm::Value *context;
+  };
+  Optional<DynamicFunction> dynamicFunction = llvm::None;
+  struct Self {
+    enum class Kind {
+      Method,
+      WitnessMethod,
+    };
+    Kind kind;
+    llvm::Value *value;
+  };
+  Optional<Self> self = llvm::None;
+
+  llvm::Value *loadValue(ElementLayout layout) {
+    Address addr = layout.project(subIGF, context, /*offsets*/ llvm::None);
+    auto &ti = cast<LoadableTypeInfo>(layout.getType());
+    Explosion explosion;
+    ti.loadAsTake(subIGF, addr, explosion);
+    return explosion.claimNext();
+  }
+  void saveValue(ElementLayout layout, Explosion &explosion) {
+    Address addr = layout.project(subIGF, context, /*offsets*/ llvm::None);
+    auto &ti = cast<LoadableTypeInfo>(layout.getType());
+    ti.initialize(subIGF, explosion, addr, /*isOutlined*/ false);
+  }
+  void loadValue(ElementLayout layout, Explosion &explosion) {
+    Address addr = layout.project(subIGF, context, /*offsets*/ llvm::None);
+    auto &ti = cast<LoadableTypeInfo>(layout.getType());
+    ti.loadAsTake(subIGF, addr, explosion);
+  }
+
+public:
+  AsyncPartialApplicationForwarderEmission(
+      IRGenModule &IGM, IRGenFunction &subIGF, llvm::Function *fwd,
+      const Optional<FunctionPointer> &staticFnPtr, bool calleeHasContext,
+      const Signature &origSig, CanSILFunctionType origType,
+      CanSILFunctionType substType, CanSILFunctionType outType,
+      SubstitutionMap subs, HeapLayout const *layout,
+      ArrayRef<ParameterConvention> conventions)
+      : PartialApplicationForwarderEmission(
+            IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
+            substType, outType, subs, layout, conventions),
+        layout(getAsyncContextLayout(subIGF, origType, substType, subs)),
+        currentArgumentIndex(outType->getNumParameters()) {
+    contextBuffer = origParams.claimNext();
+    heapContextBuffer = origParams.claimNext();
+  }
+
+  void begin() override {
+    super::begin();
+    assert(contextBuffer);
+    assert(heapContextBuffer);
+    context = layout.emitCastTo(subIGF, contextBuffer);
+  }
+  bool transformArgumentToNative(SILParameterInfo origParamInfo, Explosion &in,
+                                 Explosion &out) override {
+    out.add(in.claimAll());
+    return false;
+  }
+  unsigned getCurrentArgumentIndex() override { return currentArgumentIndex; }
+  void gatherArgumentsFromApply() override {
+    // The provided %swift.context* already contains all the values from the
+    // apply site.  All that remains to do is bind polymorphic parameters.
+    for (unsigned index = 0; index < outType->getParameters().size(); ++index) {
+      auto fieldLayout = layout.getArgumentLayout(index);
+      Explosion explosion;
+      loadValue(fieldLayout, explosion);
+      bindPolymorphicParameter(subIGF, origType, substType, explosion, index);
+      (void)explosion.claimAll();
+      // TODO: Rather than just discard this explosion, avoid loading the
+      //       parameters if no polymorphic binding is necessary.
+    }
+  }
+  void addArgument(llvm::Value *argValue) override {
+    addArgument(argValue, currentArgumentIndex);
+  }
+  void addArgument(Explosion &explosion) override {
+    addArgument(explosion, currentArgumentIndex);
+  }
+  void addArgument(llvm::Value *argValue, unsigned index) override {
+    Explosion explosion;
+    explosion.add(argValue);
+    addArgument(explosion, index);
+  }
+  void addArgument(Explosion &explosion, unsigned index) override {
+    currentArgumentIndex = index + 1;
+    auto isLocalContext = (hasSelfContextParameter(origType) &&
+                           index == origType->getParameters().size() - 1);
+    if (isLocalContext) {
+      addSelf(explosion);
+      return;
+    }
+    auto fieldLayout = layout.getArgumentLayout(index);
+    saveValue(fieldLayout, explosion);
+  }
+  SILParameterInfo getParameterInfo(unsigned index) override {
+    return origType->getParameters()[index];
+  }
+  llvm::Value *getContext() override { return heapContextBuffer; }
+  llvm::Value *getDynamicFunctionPointer() override {
+    assert(dynamicFunction && dynamicFunction->pointer);
+    return dynamicFunction->pointer;
+  }
+  llvm::Value *getDynamicFunctionContext() override {
+    assert((dynamicFunction && dynamicFunction->context) ||
+           (self && self->value));
+    return dynamicFunction ? dynamicFunction->context : self->value;
+  }
+  void addDynamicFunctionContext(Explosion &explosion,
+                                 DynamicFunction::Kind kind) override {
+    auto *value = explosion.claimNext();
+    assert(explosion.empty());
+    if (dynamicFunction) {
+      assert(dynamicFunction->kind == kind);
+      if (dynamicFunction->context) {
+        assert(dynamicFunction->context == value);
+      } else {
+        dynamicFunction->context = value;
+      }
+      return;
+    }
+    dynamicFunction = {kind, /*pointer*/ nullptr, /*context*/ value};
+  }
+  void addDynamicFunctionPointer(Explosion &explosion,
+                                 DynamicFunction::Kind kind) override {
+    auto *value = explosion.claimNext();
+    assert(explosion.empty());
+    if (dynamicFunction) {
+      assert(dynamicFunction->kind == kind);
+      if (dynamicFunction->pointer) {
+        assert(dynamicFunction->pointer == value);
+      } else {
+        dynamicFunction->pointer = value;
+      }
+      return;
+    }
+    dynamicFunction = {kind, /*pointer*/ value, /*context*/ nullptr};
+  }
+  void addSelf(Explosion &explosion) override {
+    auto *value = explosion.claimNext();
+    assert(explosion.empty());
+    Self::Kind kind = [&](SILFunctionTypeRepresentation representation) {
+      switch (representation) {
+      case SILFunctionTypeRepresentation::Method:
+        return Self::Kind::Method;
+      case SILFunctionTypeRepresentation::WitnessMethod:
+        return Self::Kind::WitnessMethod;
+      default:
+        llvm_unreachable("representation does not have a self");
+      }
+    }(origType->getRepresentation());
+    if (self) {
+      assert(self->kind == kind);
+      if (self->value) {
+        assert(self->value == value);
+      } else {
+        self->value = value;
+      }
+      return;
+    }
+    self = {kind, value};
+
+    Explosion toSave;
+    toSave.add(value);
+    auto fieldLayout = layout.getLocalContextLayout();
+    saveValue(fieldLayout, toSave);
+  }
+  void addWitnessSelfMetadata(llvm::Value *value) override {
+    auto fieldLayout = layout.getSelfMetadataLayout();
+    Explosion explosion;
+    explosion.add(value);
+    saveValue(fieldLayout, explosion);
+  }
+  void addWitnessSelfWitnessTable(llvm::Value *value) override {
+    auto fieldLayout = layout.getSelfWitnessTableLayout();
+    Explosion explosion;
+    explosion.add(value);
+    saveValue(fieldLayout, explosion);
+  }
+  void forwardErrorResult() override {
+    // Nothing to do here.  The error result pointer is already in the
+    // appropriate position.
+  }
+  bool originalParametersConsumed() override {
+    // The original parameters remain in the initially allocated
+    // %swift.context*, so they have always already been consumed.
+    return true;
+  }
+  void addPolymorphicArguments(Explosion polyArgs) override {
+    if (polyArgs.size() == 0) {
+      return;
+    }
+    assert(layout.hasBindings());
+    auto bindingsLayout = layout.getBindingsLayout();
+    auto bindingsAddr =
+        bindingsLayout.project(subIGF, context, /*offsets*/ None);
+    layout.getBindings().save(subIGF, bindingsAddr, polyArgs);
+  }
+  llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
+    Explosion asyncExplosion;
+    asyncExplosion.add(contextBuffer);
+    if (dynamicFunction &&
+        dynamicFunction->kind == DynamicFunction::Kind::PartialApply) {
+      assert(dynamicFunction->context);
+      asyncExplosion.add(dynamicFunction->context);
+    }
+
+    return subIGF.Builder.CreateCall(fnPtr, asyncExplosion.claimAll());
+  }
+  void createReturn(llvm::CallInst *call) override {
+    subIGF.Builder.CreateRetVoid();
+  }
+  void end() override {
+    assert(context.isValid());
+    super::end();
+  }
+};
+std::unique_ptr<PartialApplicationForwarderEmission>
+getPartialApplicationForwarderEmission(
+    IRGenModule &IGM, IRGenFunction &subIGF, llvm::Function *fwd,
+    const Optional<FunctionPointer> &staticFnPtr, bool calleeHasContext,
+    const Signature &origSig, CanSILFunctionType origType,
+    CanSILFunctionType substType, CanSILFunctionType outType,
+    SubstitutionMap subs, HeapLayout const *layout,
+    ArrayRef<ParameterConvention> conventions) {
+  if (origType->isAsync()) {
+    return std::make_unique<AsyncPartialApplicationForwarderEmission>(
+        IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
+        substType, outType, subs, layout, conventions);
+  } else {
+    return std::make_unique<SyncPartialApplicationForwarderEmission>(
+        IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
+        substType, outType, subs, layout, conventions);
+  }
+}
+
+} // end anonymous namespace
+
+/// Emit the forwarding stub function for a partial application.
+///
+/// If 'layout' is null, there is a single captured value of
+/// Swift-refcountable type that is being used directly as the
+/// context object.
+static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
+                                   const Optional<FunctionPointer> &staticFnPtr,
+                                   bool calleeHasContext,
+                                   const Signature &origSig,
+                                   CanSILFunctionType origType,
+                                   CanSILFunctionType substType,
+                                   CanSILFunctionType outType,
+                                   SubstitutionMap subs,
+                                   HeapLayout const *layout,
+                                   ArrayRef<ParameterConvention> conventions) {
+  auto outSig = IGM.getSignature(outType);
+  llvm::AttributeList outAttrs = outSig.getAttributes();
+  llvm::FunctionType *fwdTy = outSig.getType();
+  SILFunctionConventions outConv(outType, IGM.getSILModule());
+
+  StringRef FnName;
+  if (staticFnPtr)
+    FnName = staticFnPtr->getPointer()->getName();
+
+  IRGenMangler Mangler;
+  std::string thunkName = Mangler.manglePartialApplyForwarder(FnName);
+
+  // FIXME: Maybe cache the thunk by function and closure types?.
+  llvm::Function *fwd =
+      llvm::Function::Create(fwdTy, llvm::Function::InternalLinkage,
+                             llvm::StringRef(thunkName), &IGM.Module);
+  fwd->setCallingConv(outSig.getCallingConv());
+
+  fwd->setAttributes(outAttrs);
+  // Merge initial attributes with outAttrs.
+  llvm::AttrBuilder b;
+  IGM.constructInitialFnAttributes(b);
+  fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
+
+  IRGenFunction subIGF(IGM, fwd);
+  if (IGM.DebugInfo)
+    IGM.DebugInfo->emitArtificialFunction(subIGF, fwd);
+
+  auto emission = getPartialApplicationForwarderEmission(
+      IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
+      substType, outType, subs, layout, conventions);
+  emission->begin();
+  emission->gatherArgumentsFromApply();
 
   struct AddressToDeallocate {
     SILType Type;
@@ -912,10 +1345,15 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   Address data;
   unsigned nextCapturedField = 0;
   if (!layout) {
-    rawData = origParams.claimNext();
+    rawData = emission->getContext();
   } else if (!layout->isKnownEmpty()) {
-    rawData = origParams.claimNext();
+    rawData = emission->getContext();
     data = layout->emitCastTo(subIGF, rawData);
+    if (origType->isAsync()) {
+      // Async layouts contain the size of the needed async context as their
+      // first element.  It is not a parameter and needs to be skipped.
+      ++nextCapturedField;
+    }
 
     // Restore type metadata bindings, if we have them.
     if (layout->hasBindings()) {
@@ -931,7 +1369,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   // or there's an error result.
   } else if (outType->getRepresentation()==SILFunctionTypeRepresentation::Thick
              || outType->hasErrorResult()) {
-    llvm::Value *contextPtr = origParams.claimNext(); (void)contextPtr;
+    llvm::Value *contextPtr = emission->getContext(); (void)contextPtr;
     assert(contextPtr->getType() == IGM.RefCountedPtrTy);
   }
 
@@ -989,6 +1427,8 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   // arguments come before this.
   bool isWitnessMethodCallee = origType->getRepresentation() ==
       SILFunctionTypeRepresentation::WitnessMethod;
+  bool isMethodCallee =
+      origType->getRepresentation() == SILFunctionTypeRepresentation::Method;
   Explosion witnessMethodSelfValue;
 
   llvm::Value *lastCapturedFieldPtr = nullptr;
@@ -1038,7 +1478,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
     // If there is a context argument, it comes after the polymorphic
     // arguments.
-    auto argIndex = args.size();
+    auto argIndex = emission->getCurrentArgumentIndex();
     if (haveContextArgument)
       argIndex += polyArgs.size();
 
@@ -1064,12 +1504,13 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     } else {
       argValue = subIGF.Builder.CreateBitCast(rawData, expectedArgTy);
     }
-    args.add(argValue);
+    emission->addArgument(argValue);
 
   // If there's a data pointer required, grab it and load out the
   // extra, previously-curried parameters.
   } else {
     unsigned origParamI = outType->getParameters().size();
+    unsigned extraFieldIndex = 0;
     assert(layout->getElements().size() == conventions.size()
            && "conventions don't match context layout");
 
@@ -1175,18 +1616,41 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
         if (hasPolymorphicParams)
           bindPolymorphicParameter(subIGF, origType, substType, param,
                                    origParamI);
-        emitApplyArgument(subIGF,
-                          origType, origParamInfo,
-                          substType, substType->getParameters()[origParamI],
-                          param, origParam);
+        emitApplyArgument(subIGF, origType, origParamInfo, substType,
+                          emission->getParameterInfo(origParamI), param,
+                          origParam);
         bool isWitnessMethodCalleeSelf = (isWitnessMethodCallee &&
             origParamI + 1 == origType->getParameters().size());
-        needsAllocas |= addNativeArgument(
-            subIGF, origParam, origType, origParamInfo,
-            isWitnessMethodCalleeSelf ? witnessMethodSelfValue : args, false);
+        Explosion arg;
+        needsAllocas |= emission->transformArgumentToNative(
+            origParamInfo, origParam,
+            isWitnessMethodCalleeSelf ? witnessMethodSelfValue : arg);
+        if (!isWitnessMethodCalleeSelf) {
+          emission->addArgument(arg, origParamI);
+        }
         ++origParamI;
       } else {
-        args.add(param.claimAll());
+        switch (extraFieldIndex) {
+        case 0:
+          emission->addDynamicFunctionContext(
+              param, isWitnessMethodCallee
+                         ? PartialApplicationForwarderEmission::
+                               DynamicFunctionKind::Witness
+                         : PartialApplicationForwarderEmission::
+                               DynamicFunctionKind::PartialApply);
+          break;
+        case 1:
+          emission->addDynamicFunctionPointer(
+              param, isWitnessMethodCallee
+                         ? PartialApplicationForwarderEmission::
+                               DynamicFunctionKind::Witness
+                         : PartialApplicationForwarderEmission::
+                               DynamicFunctionKind::PartialApply);
+          break;
+        default:
+          llvm_unreachable("unexpected extra field in thick context");
+        }
+        ++extraFieldIndex;
       }
       
     }
@@ -1224,7 +1688,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
     // The dynamic function pointer is packed "last" into the context,
     // and we pulled it out as an argument.  Just pop it off.
-    auto fnPtr = args.takeLast();
+    auto fnPtr = emission->getDynamicFunctionPointer();
 
     // It comes out of the context as an i8*. Cast to the function type.
     fnPtr = subIGF.Builder.CreateBitCast(fnPtr, fnTy);
@@ -1246,9 +1710,9 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   // In either case, it's the last thing in 'args'.
   llvm::Value *fnContext = nullptr;
   if (haveContextArgument)
-    fnContext = args.takeLast();
+    fnContext = emission->getDynamicFunctionContext();
 
-  polyArgs.transferInto(args, polyArgs.size());
+  emission->addPolymorphicArguments(std::move(polyArgs));
 
   // If we have a witness method call, the inner context is the
   // witness table. Metadata for Self is derived inside the partial
@@ -1263,35 +1727,45 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
   // Okay, this is where the callee context goes.
   } else if (fnContext) {
-    args.add(fnContext);
+    Explosion explosion;
+    explosion.add(fnContext);
+    if (isMethodCallee) {
+      emission->addSelf(explosion);
+    } else {
+      emission->addDynamicFunctionContext(
+          explosion, isWitnessMethodCallee
+                         ? PartialApplicationForwarderEmission::
+                               DynamicFunctionKind::Witness
+                         : PartialApplicationForwarderEmission::
+                               DynamicFunctionKind::PartialApply);
+    }
 
   // Pass a placeholder for thin function calls.
   } else if (origType->hasErrorResult()) {
-    args.add(llvm::UndefValue::get(IGM.RefCountedPtrTy));
+    emission->addArgument(llvm::UndefValue::get(IGM.RefCountedPtrTy));
   }
 
   // Add the witness methods self argument before the error parameter after the
   // polymorphic arguments.
   if (isWitnessMethodCallee)
-    witnessMethodSelfValue.transferInto(args, witnessMethodSelfValue.size());
+    emission->addSelf(witnessMethodSelfValue);
 
   // Pass down the error result.
   if (origType->hasErrorResult()) {
-    llvm::Value *errorResultPtr = origParams.claimNext();
-    args.add(errorResultPtr);
+    emission->forwardErrorResult();
   }
 
-  assert(origParams.empty());
+  assert(emission->originalParametersConsumed());
 
   if (isWitnessMethodCallee) {
     assert(witnessMetadata.SelfMetadata->getType() == IGM.TypeMetadataPtrTy);
-    args.add(witnessMetadata.SelfMetadata);
+    emission->addWitnessSelfMetadata(witnessMetadata.SelfMetadata);
     assert(witnessMetadata.SelfWitnessTable->getType() == IGM.WitnessTablePtrTy);
-    args.add(witnessMetadata.SelfWitnessTable);
+    emission->addWitnessSelfWitnessTable(witnessMetadata.SelfWitnessTable);
   }
 
-  llvm::CallInst *call = subIGF.Builder.CreateCall(fnPtr, args.claimAll());
-  
+  llvm::CallInst *call = emission->createCall(fnPtr);
+
   if (addressesToDeallocate.empty() && !needsAllocas &&
       (!consumesContext || !dependsOnContextLifetime))
     call->setTailCall();
@@ -1308,52 +1782,8 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     subIGF.emitNativeStrongRelease(rawData, subIGF.getDefaultAtomicity());
   }
 
-  // Reabstract the result value as substituted.
-  SILFunctionConventions origConv(origType, IGM.getSILModule());
-  auto &outResultTI = IGM.getTypeInfo(
-      outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
-  auto &nativeResultSchema = outResultTI.nativeReturnValueSchema(IGM);
-  if (call->getType()->isVoidTy()) {
-    if (!resultValueAddr.isValid())
-      subIGF.Builder.CreateRetVoid();
-    else {
-      // Okay, we have called a function that expects an indirect return type
-      // but the partially applied return type is direct.
-      assert(!nativeResultSchema.requiresIndirect());
-      Explosion loadedResult;
-      cast<LoadableTypeInfo>(outResultTI)
-          .loadAsTake(subIGF, resultValueAddr, loadedResult);
-      Explosion nativeResult = nativeResultSchema.mapIntoNative(
-          IGM, subIGF, loadedResult,
-          outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()),
-          false);
-      outResultTI.deallocateStack(
-          subIGF, resultValueAddr,
-          outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
-      if (nativeResult.size() == 1)
-        subIGF.Builder.CreateRet(nativeResult.claimNext());
-      else {
-        llvm::Value *nativeAgg =
-            llvm::UndefValue::get(nativeResultSchema.getExpandedType(IGM));
-        for (unsigned i = 0, e = nativeResult.size(); i != e; ++i) {
-          auto *elt = nativeResult.claimNext();
-          nativeAgg = subIGF.Builder.CreateInsertValue(nativeAgg, elt, i);
-        }
-        subIGF.Builder.CreateRet(nativeAgg);
-      }
-    }
-  } else {
-    llvm::Value *callResult = call;
-    // If the result type is dependent on a type parameter we might have to
-    // cast to the result type - it could be substituted.
-    if (origConv.getSILResultType(IGM.getMaximalTypeExpansionContext())
-            .hasTypeParameter()) {
-      auto ResType = fwd->getReturnType();
-      if (ResType != callResult->getType())
-        callResult = subIGF.coerceValue(callResult, ResType, subIGF.IGM.DataLayout);
-    }
-    subIGF.Builder.CreateRet(callResult);
-  }
+  emission->createReturn(call);
+  emission->end();
 
   return fwd;
 }
@@ -1375,6 +1805,19 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
   SmallVector<const TypeInfo *, 4> argTypeInfos;
   SmallVector<SILType, 4> argValTypes;
   SmallVector<ParameterConvention, 4> argConventions;
+
+  if (origType->isAsync()) {
+    // Store the size of the partially applied async function's context here so
+    // that it can be recovered by at the apply site.
+    auto int32ASTType =
+        BuiltinIntegerType::get(32, IGF.IGM.IRGen.SIL.getASTContext())
+            ->getCanonicalType();
+    auto int32SILType = SILType::getPrimitiveObjectType(int32ASTType);
+    const TypeInfo &int32TI = IGF.IGM.getTypeInfo(int32SILType);
+    argValTypes.push_back(int32SILType);
+    argTypeInfos.push_back(&int32TI);
+    argConventions.push_back(ParameterConvention::Direct_Unowned);
+  }
 
   // A context's HeapLayout stores all of the partially applied args.
   // A HeapLayout is "fixed" if all of its fields have a fixed layout.
@@ -1404,6 +1847,23 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
   // Reserve space for polymorphic bindings.
   auto bindings = NecessaryBindings::forPartialApplyForwarder(
       IGF.IGM, origType, subs, considerParameterSources);
+
+  if (origType->isAsync()) {
+    // The size of the async context needs to be available at the apply site.
+    //
+    // TODO: In the "single refcounted context" case the async "function
+    //       pointer" (actually a pointer to a
+    //         constant {
+    //           /*context size*/ i32,
+    //           /*relative address of function*/ i32
+    //         }
+    //       rather than a pointer directly to the function) would be able to
+    //       provide the async context size required.  At the apply site, it is
+    //       possible to determine whether we're in the "single refcounted
+    //       context" by looking at the metadata of a nonnull context pointer
+    //       and checking whether it is TargetHeapMetadata.
+    hasSingleSwiftRefcountedContext = No;
+  }
 
   if (!bindings.empty()) {
     hasSingleSwiftRefcountedContext = No;
@@ -1590,8 +2050,8 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
          && argTypeInfos.size() == argConventions.size()
          && "argument info lists out of sync");
   HeapLayout layout(IGF.IGM, LayoutStrategy::Optimal, argValTypes, argTypeInfos,
-                    /*typeToFill*/ nullptr,
-                    std::move(bindings));
+                    /*typeToFill*/ nullptr, std::move(bindings),
+                    /*bindingsIndex*/ origType->isAsync() ? 1 : 0);
 
   llvm::Value *data;
 
@@ -1622,7 +2082,16 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
     Address dataAddr = layout.emitCastTo(IGF, data);
     
     unsigned i = 0;
-    
+
+    if (origType->isAsync()) {
+      auto &fieldLayout = layout.getElement(i);
+      auto &fieldTI = fieldLayout.getType();
+      Address fieldAddr = fieldLayout.project(IGF, dataAddr, offsets);
+      cast<LoadableTypeInfo>(fieldTI).initialize(IGF, args, fieldAddr,
+                                                 isOutlined);
+      ++i;
+    }
+
     // Store necessary bindings, if we have them.
     if (layout.hasBindings()) {
       auto &bindingsLayout = layout.getElement(i);

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -37,6 +37,7 @@ namespace irgen {
 class HeapLayout : public StructLayout {
   SmallVector<SILType, 8> ElementTypes;
   NecessaryBindings Bindings;
+  unsigned BindingsIndex;
   mutable llvm::Constant *privateMetadata = nullptr;
   
 public:
@@ -44,8 +45,8 @@ public:
              ArrayRef<SILType> elementTypes,
              ArrayRef<const TypeInfo *> elementTypeInfos,
              llvm::StructType *typeToFill = 0,
-             NecessaryBindings &&bindings = {});
-  
+             NecessaryBindings &&bindings = {}, unsigned bindingsIndex = 0);
+
   /// True if the heap object carries type bindings.
   ///
   /// If true, the first element of the heap layout will be the type metadata
@@ -56,6 +57,12 @@ public:
   
   const NecessaryBindings &getBindings() const {
     return Bindings;
+  }
+
+  unsigned getBindingsIndex() const { return BindingsIndex; }
+
+  unsigned getIndexAfterBindings() const {
+    return BindingsIndex + (hasBindings() ? 1 : 0);
   }
 
   /// Get the types of the elements.

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1025,8 +1025,8 @@ public:
         return true;
     }
 
-    auto ElementTypes = Layout.getElementTypes().slice(
-        Layout.hasBindings() ? 1 : 0);
+    auto ElementTypes =
+        Layout.getElementTypes().slice(Layout.getIndexAfterBindings());
     for (auto ElementType : ElementTypes) {
       auto SwiftType = ElementType.getASTType();
       if (SwiftType->hasOpenedExistential())
@@ -1040,7 +1040,7 @@ public:
   /// We'll keep track of how many things are in the bindings struct with its
   /// own count in the capture descriptor.
   ArrayRef<SILType> getElementTypes() {
-    return Layout.getElementTypes().slice(Layout.hasBindings() ? 1 : 0);
+    return Layout.getElementTypes().slice(Layout.getIndexAfterBindings());
   }
 
   /// Build a map from generic parameter -> source of its metadata at runtime.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1215,11 +1215,15 @@ class AsyncNativeCCEntryPointArgumentEmission final
   const Address dataAddr;
   unsigned polymorphicParameterIndex = 0;
 
-  llvm::Value *loadValue(ElementLayout layout) {
+  Explosion loadExplosion(ElementLayout layout) {
     Address addr = layout.project(IGF, dataAddr, /*offsets*/ llvm::None);
     auto &ti = cast<LoadableTypeInfo>(layout.getType());
     Explosion explosion;
     ti.loadAsTake(IGF, addr, explosion);
+    return explosion;
+  }
+  llvm::Value *loadValue(ElementLayout layout) {
+    auto explosion = loadExplosion(layout);
     return explosion.claimNext();
   }
 
@@ -1242,12 +1246,9 @@ public:
   }
   Explosion getArgumentExplosion(unsigned index, unsigned size) override {
     assert(size > 0);
-    Explosion result;
-    for (unsigned i = index, end = index + size; i < end; ++i) {
-      auto argumentLayout = layout.getArgumentLayout(i);
-      auto *value = loadValue(argumentLayout);
-      result.add(value);
-    }
+    auto argumentLayout = layout.getArgumentLayout(index);
+    auto result = loadExplosion(argumentLayout);
+    assert(result.size() == size);
     return result;
   }
   bool requiresIndirectResult(SILType retType) override { return false; }
@@ -1309,7 +1310,8 @@ public:
     return loadValue(fieldLayout);
   }
   llvm::Value *getCoroutineBuffer() override {
-    llvm_unreachable("unimplemented");
+    llvm_unreachable(
+        "async functions do not use a fixed size coroutine buffer");
   }
 };
 
@@ -2936,7 +2938,6 @@ static bool isSimplePartialApply(IRGenFunction &IGF, PartialApplyInst *i) {
 }
 
 void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
-  // TODO: Handle async!
   SILValue v(i);
 
   if (isSimplePartialApply(*this, i)) {
@@ -2984,6 +2985,19 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   params = params.slice(params.size() - args.size(), args.size());
   
   Explosion llArgs;
+
+  if (i->getOrigCalleeType()->isAsync()) {
+    auto result = getPartialApplicationFunction(*this, i->getCallee(),
+                                                i->getSubstitutionMap(),
+                                                i->getSubstCalleeType());
+    llvm::Value *innerContext = std::get<1>(result);
+    auto layout =
+        getAsyncContextLayout(*this, i->getOrigCalleeType(),
+                              i->getSubstCalleeType(), i->getSubstitutionMap());
+    auto size = getDynamicAsyncContextSize(
+        *this, layout, i->getOrigCalleeType(), innerContext);
+    llArgs.add(size);
+  }
 
   // Lower the parameters in the callee's generic context.
   {

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -1,0 +1,527 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -I %t -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: CPU=x86_64
+// REQUIRES: concurrency
+
+import Builtin
+import Swift
+import resilient_struct
+
+class SwiftClass {}
+sil_vtable SwiftClass {}
+sil @$s13partial_apply10SwiftClassCfD : $@async @convention(method) (SwiftClass) -> ()
+
+sil @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
+sil @partially_applyable_to_two_classes : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> ()
+
+sil @use_closure : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_class(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil @partial_apply_class : $@async @convention(thin) (SwiftClass) -> @async @callee_owned () -> () {
+entry(%c : $SwiftClass):
+  %f = function_ref @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
+  %g = partial_apply %f(%c) : $@async @convention(thin) (@owned SwiftClass) -> ()
+  return %g : $@async @callee_owned () -> ()
+}
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_class_on_stack(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil @partial_apply_class_on_stack : $@async @convention(thin) (@owned SwiftClass) -> () {
+entry(%a : $SwiftClass):
+  %f = function_ref @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
+  %c = partial_apply [callee_guaranteed] [on_stack] %f(%a) : $@async @convention(thin) (@owned SwiftClass) -> ()
+  %use = function_ref @use_closure : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
+  apply %use(%c) : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %c : $@noescape @async @callee_guaranteed () ->()
+  strong_release %a : $SwiftClass
+  %t = tuple()
+  return %t : $()
+}
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_two_classes_on_stack(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_two_classes_on_stack : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> () {
+entry(%a : $SwiftClass, %b: $SwiftClass):
+  %f = function_ref @partially_applyable_to_two_classes : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> ()
+  %c = partial_apply [callee_guaranteed] [on_stack] %f(%a, %b) : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> ()
+  %use = function_ref @use_closure : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
+  apply %use(%c) : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %c : $@noescape @async @callee_guaranteed () ->()
+  strong_release %a : $SwiftClass
+  strong_release %b : $SwiftClass
+  %t = tuple()
+  return %t : $()
+}
+// CHECK-LABEL: define internal swiftcc void @"$s22generic_captured_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+sil public_external @generic_captured_param : $@async @convention(thin) <T> (Int, @inout T) -> Int
+
+sil @partial_apply_generic_capture : $@async @convention(thin) (Int) -> @async @callee_owned (Int) -> Int {
+entry(%x : $Int):
+  %a = alloc_stack $Int
+  store %x to %a : $*Int
+  %f = function_ref @generic_captured_param : $@async @convention(thin) <T> (Int, @inout T) -> Int
+  %p = partial_apply %f<Int>(%a) : $@async @convention(thin) <T> (Int, @inout T) -> Int
+  dealloc_stack %a : $*Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+sil public_external @generic_captured_and_open_param : $@async @convention(thin) <T> (@in T, @inout T) -> @out T
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_open_generic_capture(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil @partial_apply_open_generic_capture : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
+entry(%a : $*T):
+  %f = function_ref @generic_captured_and_open_param : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
+  %p = partial_apply %f<T>(%a) : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
+  return %p : $@async @callee_owned (@in T) -> @out T
+}
+
+/*****************************************************************************/
+/* Swift-refcounted class captures.  Optimizable by using the reference      */
+/* as the partial apply context.                                             */
+/*****************************************************************************/
+
+sil public_external @guaranteed_captured_class_param : $@async @convention(thin) (Int, @guaranteed SwiftClass) -> Int
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_guaranteed_class_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_guaranteed_class_param : $@async @convention(thin) (@owned SwiftClass) -> @async @callee_owned (Int) -> Int {
+bb0(%x : $SwiftClass):
+  %f = function_ref @guaranteed_captured_class_param : $@async @convention(thin) (Int, @guaranteed SwiftClass) -> Int
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int, @guaranteed SwiftClass) -> Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+sil public_external @indirect_guaranteed_captured_class_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_indirect_guaranteed_class_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s40indirect_guaranteed_captured_class_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_indirect_guaranteed_class_param : $@async @convention(thin) (@in SwiftClass) -> @async @callee_owned (Int) -> Int {
+bb0(%x : $*SwiftClass):
+  %f = function_ref @indirect_guaranteed_captured_class_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+sil public_external @indirect_consumed_captured_class_param : $@async @convention(thin) (Int, @in SwiftClass) -> Int
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_indirect_consumed_class_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s38indirect_consumed_captured_class_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_indirect_consumed_class_param : $@async @convention(thin) (@in SwiftClass) -> @async @callee_owned (Int) -> Int {
+bb0(%x : $*SwiftClass):
+  %f = function_ref @indirect_consumed_captured_class_param : $@async @convention(thin) (Int, @in SwiftClass) -> Int
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int, @in SwiftClass) -> Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+/*****************************************************************************/
+/* A non-trivial capture.  Indirect applications can directly reference the  */
+/* field from the partial apply context.                                     */
+/*****************************************************************************/
+
+struct SwiftClassPair { var x: SwiftClass, y: SwiftClass }
+
+sil public_external @guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_guaranteed_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s36guaranteed_captured_class_pair_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_guaranteed_class_pair_param : $@async @convention(thin) (@owned SwiftClassPair) -> @async @callee_owned (Int) -> Int {
+bb0(%x : $SwiftClassPair):
+  %f = function_ref @guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+sil public_external @indirect_guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_indirect_guaranteed_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s45indirect_guaranteed_captured_class_pair_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @async @callee_owned (Int) -> Int {
+bb0(%x : $*SwiftClassPair):
+  %f = function_ref @indirect_guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+sil public_external @indirect_consumed_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_indirect_consumed_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s43indirect_consumed_captured_class_pair_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_indirect_consumed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @async @callee_owned (Int) -> Int {
+bb0(%x : $*SwiftClassPair):
+  %f = function_ref @indirect_consumed_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+  return %p : $@async @callee_owned (Int) -> Int
+}
+
+sil public_external @captured_fixed_and_dependent_params : $@async @convention(thin) <A> (@owned SwiftClass, @in A, Int) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_indirect_non_fixed_layout(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s35captured_fixed_and_dependent_paramsTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+sil @partial_apply_indirect_non_fixed_layout : $@async @convention(thin) <T> (@owned SwiftClass, @in T, Int) -> @async @callee_owned () -> () {
+bb0(%a : $SwiftClass, %b : $*T, %c : $Int):
+  %f = function_ref @captured_fixed_and_dependent_params : $@async @convention(thin) <B> (@owned SwiftClass, @in B, Int) -> ()
+  %p = partial_apply %f<T>(%a, %b, %c) : $@async @convention(thin) <C> (@owned SwiftClass, @in C, Int) -> ()
+  return %p : $@async @callee_owned () -> ()
+}
+
+sil public_external @captured_dependent_out_param : $@async @convention(thin) <A> (@in A) -> @out A
+
+sil @partial_apply_with_out_param : $@async @convention(thin) <T> (@in T) -> @async @callee_owned () -> @out T {
+bb0(%x : $*T):
+  %f = function_ref @captured_dependent_out_param : $@async @convention(thin) <B> (@in B) -> @out B
+  %p = partial_apply %f<T>(%x) : $@async @convention(thin) <C> (@in C) -> @out C
+  return %p : $@async @callee_owned () -> @out T
+}
+
+// CHECK-LABEL: define internal swiftcc void @"$s28captured_dependent_out_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_dynamic_with_out_param : $@async @convention(thin) <T> (Int32, @owned @async @callee_owned (Int32) -> @out T) -> @async @callee_owned () -> @out T {
+bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
+  %p = partial_apply %f(%x) : $@async @callee_owned (Int32) -> @out T
+  return %p : $@async @callee_owned () -> @out T
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_dynamic_with_out_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+class Base {
+}
+sil_vtable Base {}
+
+class Sub : Base {
+}
+
+sil_vtable Sub {}
+
+sil @parametric_casting_closure : $@async @convention(thin) <C where C : Base> (@owned Base) -> @owned C {
+bb0(%0 : $Base):
+  %1 = unconditional_checked_cast %0 : $Base to C
+  return %1 : $C
+}
+
+sil public_external @receive_closure : $@async @convention(thin) <C where C : Base> (@owned @async @callee_owned () -> (@owned C)) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_partial_apply(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+// CHECK-LABEL: define internal swiftcc void @"$s26parametric_casting_closureTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @test_partial_apply : $@async @convention(thin) (@owned Base) -> () {
+bb0(%0 : $Base):
+ %1 = function_ref @parametric_casting_closure : $@async @convention(thin) <C where C : Base> (@owned Base) -> @owned C
+ %6 = partial_apply %1<Sub>() : $@async @convention(thin) <C where C : Base> (@owned Base) -> @owned C
+ %2 = partial_apply %1<Sub>(%0) : $@async @convention(thin) <C where C : Base> (@owned Base) -> @owned C
+ %3 = function_ref @receive_closure : $@async @convention(thin) <C where C : Base> (@owned @async @callee_owned () -> (@owned C)) -> ()
+ %4 = apply %3<Sub>(%2) : $@async @convention(thin) <C where C : Base> (@owned @async @callee_owned () -> (@owned C)) -> ()
+ %5 = tuple ()
+ return %5 : $()
+}
+
+sil public_external @partial_empty_box : $@async @convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @empty_box(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil @empty_box : $@async @convention(thin) () -> () {
+entry:
+  // CHECK: [[BOX:%.*]] = call {{.*}}swift_allocEmptyBox
+  // CHECK: store %swift.refcounted* [[BOX]]
+  // CHECK: store %swift.opaque* undef
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <()>
+  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <()>, 0
+  %f = function_ref @partial_empty_box : $@async @convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
+  %g = partial_apply %f(%b, %ba) : $@async @convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
+  return undef : $()
+}
+
+protocol P0 {}
+protocol P1 { associatedtype X : P0 }
+protocol P2 { associatedtype Y : P1 }
+
+sil hidden_external @complex_generic_function : $@async @convention(thin) <T where T : P2, T.Y : P2> (Int) -> ()
+
+sil @partial_apply_complex_generic_function : $@async @convention(thin) <T where T : P2, T.Y : P2> (Int) -> () {
+bb0(%0 : $Int):
+  %fn = function_ref @complex_generic_function : $@async @convention(thin) <T where T : P2, T.Y : P2> (Int) -> ()
+  %pa = partial_apply %fn <T>(%0) : $@async @convention(thin) <T where T : P2, T.Y : P1, T.Y : P2> (Int) -> ()
+  %result = tuple ()
+  return %result : $()
+}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_complex_generic_function(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s24complex_generic_functionTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+struct ComplexBoundedType<T: P2> {}
+
+// SR-901: Ensure that a partial_apply which captures bound generic type
+// metadata doesn't crash when restoring the generic context.
+
+sil hidden_external @generic_function : $@async @convention(thin) <T> () -> ()
+sil @partial_apply_with_generic_type : $@async @convention(thin) <U: P2> () -> () {
+bb0:
+  %fn = function_ref @generic_function : $@async @convention(thin) <T> () -> ()
+  %pa = partial_apply %fn <ComplexBoundedType<U>>() : $@async @convention(thin) <T> () -> ()
+  %result = tuple ()
+  return %result : $()
+}
+
+// Crash on partial apply of witness_method without generic signature
+
+extension Int: P0 {}
+
+sil hidden_external @concrete_witness_method : $@async @convention(witness_method: P0) (Int, Int) -> ()
+
+sil hidden @partial_apply_witness_method : $@async @convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %fn = function_ref @concrete_witness_method : $@async @convention(witness_method: P0) (Int, Int) -> ()
+  %pa = partial_apply %fn (%0) : $@async @convention(witness_method: P0) (Int, Int) -> ()
+  %result = tuple ()
+  return %result : $()
+}
+
+
+// Crash on partial apply of a generic enum.
+enum GenericEnum<T> {
+  case X(String)
+  case Y(T, T, T, T, T)
+}
+sil public_external @generic_indirect_return : $@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_generic_indirect_return(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s23generic_indirect_returnTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+sil @partial_apply_generic_indirect_return : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum<Int> {
+  bb0(%0 : $Int):
+  %fn = function_ref @generic_indirect_return :$@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
+  %pa = partial_apply %fn<Int> (%0) : $@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
+  return %pa : $@async @callee_owned () -> @owned GenericEnum<Int>
+
+}
+
+// Crash on partial apply of a generic enum.
+enum GenericEnum2<T> {
+  case X(String)
+  case Y(T)
+}
+sil public_external @generic_indirect_return2 : $@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_generic_indirect_return2(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s24generic_indirect_return2TA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+sil @partial_apply_generic_indirect_return2 : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum2<Int> {
+  bb0(%0 : $Int):
+  %fn = function_ref @generic_indirect_return2 :$@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+  %pa = partial_apply %fn<Int> (%0) : $@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+  return %pa : $@async @callee_owned () -> @owned GenericEnum2<Int>
+}
+
+struct SwiftStruct {}
+
+sil @fun : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_thin_type(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_thin_type : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> @async @callee_owned () -> () {
+entry(%0: $@thin SwiftStruct.Type, %1: $SwiftClass):
+  %fun = function_ref @fun : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> ()
+  %closure = partial_apply %fun (%0, %1) : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> ()
+  return %closure : $@async @callee_owned () -> ()
+}
+
+sil @afun : $@async @convention(thin) (Int) -> @error Error
+
+// Check that we don't assert on a thin noescape function.
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @convert_thin_test(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil @convert_thin_test : $@async @convention(thin) (Int) -> () {
+bb(%0 : $Int):
+  %f = function_ref @afun : $@async @convention(thin) (Int) -> @error Error
+  %c = convert_function %f : $@async @convention(thin) (Int) -> @error Error to $@async @convention(thin) @noescape (Int) -> @error Error
+  try_apply %c(%0) : $@async @convention(thin) @noescape (Int) -> @error Error, normal bb2, error bb1
+
+bb1(%err: $Error):
+  %t = tuple ()
+  br bb3(%t: $())
+
+bb2(%r : $()):
+  br bb3(%r : $())
+
+bb3(%v : $()):
+  return %v : $()
+}
+
+struct A1 {
+    let b: () -> ()
+}
+
+struct A2<T>  {
+    let a: T
+}
+
+class  A3 {}
+
+sil @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+
+sil @repo : $@async @convention(thin) (@in_guaranteed A2<A3>) -> @owned @async @callee_guaranteed () -> (@owned A1, @error Error) {
+bb0(%0 : $*A2<A3>):
+  %1 = load %0 : $*A2<A3>
+  %2 = alloc_stack $A2<A3>
+  store %1 to %2 : $*A2<A3>
+  %4 = function_ref @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+  %5 = partial_apply [callee_guaranteed] %4(%2) : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+  dealloc_stack %2 : $*A2<A3>
+  return %5 : $@async @callee_guaranteed () -> (@owned A1, @error Error)
+}
+
+sil @capture_class : $@async @convention(thin) (@guaranteed A3) -> ()
+
+// CHECK-LABEL: define{{.*}} swiftcc i8* @partial_apply_stack_in_coroutine(i8* {{.*}} %0, %T13partial_apply2A3C* %1)
+sil @partial_apply_stack_in_coroutine : $@yield_once (@owned A3) -> () {
+entry(%0: $A3):
+  %f = function_ref @capture_class : $@async @convention(thin) (@guaranteed A3) -> ()
+  %p = partial_apply [callee_guaranteed] [on_stack] %f(%0) : $@async @convention(thin) (@guaranteed A3) -> ()
+  apply %p() : $@noescape @async @callee_guaranteed () -> ()
+  dealloc_stack %p : $@noescape @async @callee_guaranteed () -> ()
+  %1000 = integer_literal $Builtin.Int32, 1000
+  yield (), resume resume, unwind unwind
+
+resume:
+  %ret = tuple ()
+  return %ret : $()
+
+unwind:
+  unwind
+}
+sil_vtable A3 {}
+
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @owned @async @callee_guaranteed (Int) -> Int {
+bb0(%x : $*SwiftClassPair):
+  %f = function_ref @indirect_guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+  %p = partial_apply [callee_guaranteed] %f(%x) : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+  return %p : $@async @callee_guaranteed(Int) -> (Int)
+}
+
+sil public_external @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.67"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in_guaranteed SwiftClassPair) -> () {
+bb0(%x : $*SwiftClassPair):
+  %f = function_ref @indirect_guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+  %p = partial_apply [callee_guaranteed] [on_stack] %f(%x) : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+  %u = function_ref @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+  %r = apply %u(%p) : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+  dealloc_stack %p : $@noescape @async @callee_guaranteed (Int) ->(Int)
+  %t = tuple()
+  return %t : $()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil public_external @indirect_in_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+
+sil @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> () {
+bb0(%x : $*SwiftClassPair):
+  %f = function_ref @indirect_in_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+  %p = partial_apply [callee_guaranteed] [on_stack] %f(%x) : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+  %u = function_ref @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+  %r = apply %u(%p) : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+  dealloc_stack %p : $@noescape @async @callee_guaranteed (Int) ->(Int)
+  destroy_addr %x: $*SwiftClassPair
+  %t = tuple()
+  return %t : $()
+}
+
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil public_external @indirect_in_constant_captured_class_pair_param : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int
+
+sil @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> () {
+bb0(%x : $*SwiftClassPair):
+  %f = function_ref @indirect_in_constant_captured_class_pair_param : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int
+  %p = partial_apply [callee_guaranteed] [on_stack] %f(%x) : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int
+  %u = function_ref @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+  %r = apply %u(%p) : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
+  dealloc_stack %p : $@noescape @async @callee_guaranteed (Int) ->(Int)
+  destroy_addr %x: $*SwiftClassPair
+  %t = tuple()
+  return %t : $()
+}
+
+sil public_external @closure : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> ()
+
+// Make sure that we use the heap header size (16) for the initial offset.
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_initial_offset(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @test_initial_offset : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> () {
+bb0(%x : $*ResilientInt, %y : $SwiftClass):
+  %f = function_ref @closure : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> ()
+  %p = partial_apply [callee_guaranteed] %f(%x, %y) : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> ()
+  release_value %p : $@async @callee_guaranteed () ->()
+  %t = tuple()
+  return %t : $()
+}
+
+protocol Proto1 {}
+protocol Proto2 {}
+struct EmptyType : Proto1 { }
+
+struct SomeType : Proto2 {
+  var d : ResilientInt // some resilient type
+  var x : Int
+}
+
+sil @foo : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
+
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @empty_followed_by_non_fixed(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @empty_followed_by_non_fixed : $@async @convention(thin)  (EmptyType, @in_guaranteed SomeType) -> () {
+entry(%0 : $EmptyType, %1: $*SomeType):
+  %5 = alloc_stack $EmptyType
+  store %0 to %5 : $*EmptyType
+  %31 = function_ref @foo : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
+  %32 = alloc_stack $EmptyType
+  copy_addr %5 to [initialization] %32 : $*EmptyType
+  %34 = alloc_stack $SomeType
+  copy_addr %1 to [initialization] %34 : $*SomeType // id: %35
+  %36 = partial_apply [callee_guaranteed] %31<EmptyType, SomeType>(%32, %34) : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
+  release_value %36: $@async @callee_guaranteed () ->()
+  dealloc_stack %34 : $*SomeType
+  dealloc_stack %32 : $*EmptyType
+  dealloc_stack %5 : $*EmptyType
+  %40 = tuple()
+  return %40 : $()
+}
+
+struct FixedType {
+  var f: Int32
+}
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @fixed_followed_by_empty_followed_by_non_fixed(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+sil @fixed_followed_by_empty_followed_by_non_fixed : $@async @convention(thin)  (EmptyType, @in_guaranteed SomeType, FixedType) -> () {
+entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
+  %5 = alloc_stack $EmptyType
+  store %0 to %5 : $*EmptyType
+  %7 = alloc_stack $FixedType
+  store %3 to %7 : $*FixedType
+  %31 = function_ref @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+  %32 = alloc_stack $EmptyType
+  copy_addr %5 to [initialization] %32 : $*EmptyType
+  %34 = alloc_stack $SomeType
+  copy_addr %1 to [initialization] %34 : $*SomeType // id: %35
+  %36 = partial_apply [callee_guaranteed] %31<FixedType, EmptyType, SomeType>(%7, %32, %34) : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+  release_value %36: $@async @callee_guaranteed () ->()
+  dealloc_stack %34 : $*SomeType
+  dealloc_stack %32 : $*EmptyType
+  dealloc_stack %7 : $*FixedType
+  dealloc_stack %5 : $*EmptyType
+  %40 = tuple()
+  return %40 : $()
+}

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -1,0 +1,231 @@
+// RUN: %target-swift-frontend -enable-experimental-concurrency -enable-objc-interop  -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-objc-interop -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-native
+
+// REQUIRES: concurrency
+
+sil_stage canonical
+
+import Builtin
+
+public protocol P {}
+public class C : P {}
+public class D<T : P> {}
+class E {}
+
+public protocol Observable {
+  associatedtype Result
+  func subscribe<T: Observer>(o: T) async -> ()
+}
+
+public protocol Observer {
+  associatedtype Result
+}
+
+sil hidden @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> () {
+bb0(%0 : $*S):
+  %1 = witness_method $S, #Observable.subscribe : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %2 = partial_apply %1<S, O>(%0) : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  return %2 : $@async @callee_owned (@in O) -> ()
+}
+
+// CHECK-LABEL: define internal swiftcc void @"$s23unspecialized_uncurriedTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil hidden @specialized_curried : $@async @convention(thin) (@owned E) -> @owned @async @callee_owned () -> @owned D<C> {
+bb0(%0 : $E):
+  %1 = function_ref @unspecialized_uncurried : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0>
+  %2 = partial_apply %1<C>(%0) : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0>
+  return %2 : $@async @callee_owned () -> @owned D<C>
+}
+
+sil hidden_external @unspecialized_uncurried : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0>
+
+
+// CHECK-LABEL: define internal swiftcc void @"$s7takingPTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+sil hidden_external @takingP : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+
+sil hidden @reabstract_context : $@async @convention(thin) (@owned C) -> () {
+bb0(%0 : $C):
+  %6 = alloc_stack $C
+  store %0 to %6 : $*C
+  %8 = function_ref @takingP : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %9 = partial_apply %8<C>(%6) : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*C
+  strong_release %9 : $@async @callee_owned() -> ()
+  %10 = tuple ()
+  return %10 : $()
+}
+
+public protocol Q {
+  associatedtype Update
+}
+
+public struct BaseProducer<T> : Q {
+  public typealias Update = T
+}
+
+public class WeakBox<T> {}
+
+public struct EmptyType {}
+
+sil hidden_external @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+sil hidden_external @takingQAndEmpty : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> ()
+sil hidden_external @takingEmptyAndQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_context(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s7takingQTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil public @bind_polymorphic_param_from_context : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> () {
+bb0(%0 : $*τ_0_1):
+  %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>(%1) : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  return %9 : $@async @callee_owned () -> ()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_context_2(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil public @bind_polymorphic_param_from_context_2 : $@async @convention(thin) <τ_0_1>(@in τ_0_1, EmptyType) -> @owned @async @callee_owned () -> () {
+bb0(%0 : $*τ_0_1, %2: $EmptyType):
+  %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingQAndEmpty : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>(%1, %2) : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> ()
+  return %9 : $@async @callee_owned () -> ()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_context_3(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+sil public @bind_polymorphic_param_from_context_3 : $@async @convention(thin) <τ_0_1>(@in τ_0_1, EmptyType) -> @owned @async @callee_owned () -> () {
+bb0(%0 : $*τ_0_1, %2: $EmptyType):
+  %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingEmptyAndQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>(%2, %1) : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> ()
+  return %9 : $@async @callee_owned () -> ()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_forwarder_parameter(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s7takingQTA.19"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+
+sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> () {
+bb0(%0 : $*τ_0_1):
+  %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>() : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  %10 = tuple ()
+  return %10 : $()
+}
+
+struct S {
+  var x : Builtin.Int64
+}
+
+sil hidden_external @takingQAndS : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> ()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_context_with_layout(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s11takingQAndSTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+sil public @bind_polymorphic_param_from_context_with_layout : $@async @convention(thin) <τ_0_1>(@in τ_0_1, S) -> @owned @async @callee_owned () -> () {
+bb0(%0 : $*τ_0_1, %1: $S):
+  %2 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingQAndS : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>(%1, %2) : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> ()
+  return %9 : $@async @callee_owned () -> ()
+}
+
+public class Empty<T> {}
+
+sil private @inner_closure : $@async @convention(thin) <T> (Empty<T>) -> @owned Empty<T> {
+bb0(%0 : $Empty<T>):
+  return %0 : $Empty<T>
+}
+
+sil hidden @returns_closure : $@async @convention(thin) <T> (Empty<T>) -> (@owned Empty<T>, @async @callee_guaranteed @owned (Empty<T>) -> @owned Empty<T>) {
+bb0(%0 : $Empty<T>):
+  %1 = function_ref @inner_closure : $@async @convention(thin) <τ_0_0> (Empty<τ_0_0>) -> @owned Empty<τ_0_0>
+  %2 = partial_apply [callee_guaranteed] %1<T>() : $@async @convention(thin) <τ_0_0> (Empty<τ_0_0>) -> @owned Empty<τ_0_0>
+  %5 = tuple (%0 : $Empty<T>, %2 : $@async @callee_guaranteed (Empty<T>) -> @owned Empty<T>)
+  return %5 : $(Empty<T>, @async @callee_guaranteed (Empty<T>) -> @owned Empty<T>)
+}
+
+sil hidden @specializes_closure_returning_closure : $@async @convention(thin) () -> @async @callee_guaranteed (Empty<S>) -> (@owned Empty<S>, @owned @async @callee_guaranteed (Empty<S>) -> @owned Empty<S>) {
+bb0:
+  %0 = function_ref @returns_closure : $@async @convention(thin) <τ_0_0> (Empty<τ_0_0>) -> (@owned Empty<τ_0_0>, @owned @async @callee_guaranteed (Empty<τ_0_0>) -> @owned Empty<τ_0_0>)
+  %1 = partial_apply [callee_guaranteed] %0<S>() : $@async @convention(thin) <τ_0_0> (Empty<τ_0_0>) -> (@owned Empty<τ_0_0>, @owned @async @callee_guaranteed (Empty<τ_0_0>) -> @owned Empty<τ_0_0>)
+  return %1 : $@async @callee_guaranteed (Empty<S>) -> (@owned Empty<S>, @owned @async @callee_guaranteed (Empty<S>) -> @owned Empty<S>)
+}
+
+// CHECK-LABEL: define hidden swiftcc void @specializes_closure_returning_closure(%swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s15returns_closureTA"(%swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]+}}) {{#[0-9]+}} {
+protocol MyEquatable {
+  static func isEqual (lhs: Self, rhs: Self) -> Builtin.Int1
+}
+
+protocol MyExtended : MyEquatable {
+  func extended()
+}
+public struct Inner<Element> {
+  public init()
+  public init(_ e: Element)
+}
+
+extension Inner : MyEquatable where Element : MyEquatable {
+  public static func isEqual (lhs: Inner<Element>, rhs: Inner<Element>) -> Builtin.Int1
+}
+
+public struct Outer<Value> {
+  init()
+}
+
+extension Outer : MyEquatable where Value : MyEquatable {
+  public static func isEqual (lhs: Outer<Value>, rhs: Outer<Value>) -> Builtin.Int1
+}
+
+public struct Outermost<Value> {
+}
+
+sil @$closure : $@async @convention(method) <Value where Value : MyEquatable> (Outer<Value>, Outer<Value>, @thin Outer<Value>.Type) -> Builtin.Int1
+sil @$closure2 : $@async @convention(method) <Value where Value : MyEquatable> (Outermost<Value>, Outermost<Value>, @thin Outermost<Value>.Type) -> Builtin.Int1
+
+sil @$dont_crash_test_capture_specialized_conditional_conformance : $@async @convention(thin) <Element where Element : MyExtended> (Outer<Inner<Element>>) -> () {
+bb0(%0 : $Outer<Inner<Element>>):
+  %2 = alloc_stack $Outer<Inner<Element>>
+  store %0 to %2 : $*Outer<Inner<Element>>
+  %4 = metatype $@thin Outer<Inner<Element>>.Type
+  %5 = function_ref @$closure : $@async @convention(method) <τ_0_0 where τ_0_0 : MyEquatable> (Outer<τ_0_0>, Outer<τ_0_0>, @thin Outer<τ_0_0>.Type) -> Builtin.Int1
+  %6 = partial_apply [callee_guaranteed] %5<Inner<Element>>(%4) : $@async @convention(method) <τ_0_0 where τ_0_0 : MyEquatable> (Outer<τ_0_0>, Outer<τ_0_0>, @thin Outer<τ_0_0>.Type) -> Builtin.Int1
+  strong_release %6 : $@async @callee_guaranteed (Outer<Inner<Element>>, Outer<Inner<Element>>) -> Builtin.Int1
+  dealloc_stack %2 : $*Outer<Inner<Element>>
+  %15 = tuple ()
+  return %15 : $()
+}
+
+protocol AssocType {
+  associatedtype A : MyExtended
+}
+
+sil @$dont_crash_test_capture_specialized_conditional_conformance_associated_type : $@async @convention(thin) <Element where Element : AssocType> (Outer<Inner<Element.A>>) -> () {
+bb0(%0 : $Outer<Inner<Element.A>>):
+  %2 = alloc_stack $Outer<Inner<Element.A>>
+  store %0 to %2 : $*Outer<Inner<Element.A>>
+  %4 = metatype $@thin Outer<Inner<Element.A>>.Type
+  %5 = function_ref @$closure : $@async @convention(method) <τ_0_0 where τ_0_0 : MyEquatable> (Outer<τ_0_0>, Outer<τ_0_0>, @thin Outer<τ_0_0>.Type) -> Builtin.Int1
+  %6 = partial_apply [callee_guaranteed] %5<Inner<Element.A>>(%4) : $@async @convention(method) <τ_0_0 where τ_0_0 : MyEquatable> (Outer<τ_0_0>, Outer<τ_0_0>, @thin Outer<τ_0_0>.Type) -> Builtin.Int1
+  strong_release %6 : $@async @callee_guaranteed (Outer<Inner<Element.A>>, Outer<Inner<Element.A>>) -> Builtin.Int1
+  dealloc_stack %2 : $*Outer<Inner<Element.A>>
+  %15 = tuple ()
+  return %15 : $()
+}
+
+sil @$dont_crash_test_capture_specialized_conditional_conformance_nested : $@async @convention(thin) <A, B, Element where Element : MyEquatable> (Outer<Inner<Element>>) -> () {
+bb0(%0 : $Outer<Inner<Element>>):
+  %4 = metatype $@thin Outermost<Outer<Inner<Element>>>.Type
+  %5 = function_ref @$closure2 : $@async @convention(method) <Value where Value : MyEquatable> (Outermost<Value>, Outermost<Value>, @thin Outermost<Value>.Type) -> Builtin.Int1
+  %6 = partial_apply [callee_guaranteed] %5<Outer<Inner<Element>>>(%4) : $@async @convention(method) <Value where Value : MyEquatable> (Outermost<Value>, Outermost<Value>, @thin Outermost<Value>.Type) -> Builtin.Int1
+  strong_release %6 : $@async @callee_guaranteed (Outermost<Outer<Inner<Element>>>, Outermost<Outer<Inner<Element>>>) -> Builtin.Int1
+  %15 = tuple ()
+  return %15 : $()
+}
+
+
+sil_vtable WeakBox {}
+sil_vtable C {}
+sil_vtable D {}
+sil_vtable E {}
+sil_vtable Empty {}
+sil_witness_table C: P module main {}

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+class S {
+  deinit
+  init()
+}
+
+sil hidden [exact_self_class] @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S {
+bb0(%0 : $@thick S.Type):
+  %1 = alloc_ref $S
+  %2 = function_ref @$S_init : $@convention(method) (@owned S) -> @owned S
+  %3 = apply %2(%1) : $@convention(method) (@owned S) -> @owned S
+  return %3 : $S
+}
+
+sil hidden @$S_init : $@convention(method) (@owned S) -> @owned S {
+bb0(%0 : $S):
+  return %0 : $S
+}
+
+sil hidden @$S_deinit : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject {
+bb0(%0 : $S):
+  %2 = unchecked_ref_cast %0 : $S to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}
+
+sil hidden @S_deallocating_deinit : $@convention(method) (@owned S) -> () {
+bb0(%0 : $S):
+  %2 = function_ref @$S_deinit : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject
+  %3 = apply %2(%0) : $@convention(method) (@guaranteed S) -> @owned Builtin.NativeObject
+  %4 = unchecked_ref_cast %3 : $Builtin.NativeObject to $S
+  dealloc_ref %4 : $S
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil_vtable S {
+  #S.init!allocator: (S.Type) -> () -> S : @S_allocating_init
+  #S.deinit!deallocator: @S_deallocating_deinit
+}
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @classinstanceSToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil @classinstanceSToVoid : $@async @convention(thin) (@owned S) -> () {
+entry(%c : $S):
+  %class_addr = alloc_stack $S
+  store %c to %class_addr : $*S
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %printGeneric<S>(%class_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: main.S
+  dealloc_stack %class_addr : $*S
+  return %result : $()
+}
+
+sil @partial_apply_class : $@async @convention(thin) (S) -> @async @callee_owned () -> () {
+entry(%instance : $S):
+  %classinstanceSToVoid = function_ref @classinstanceSToVoid : $@async @convention(thin) (@owned S) -> ()
+  %partiallyApplied = partial_apply %classinstanceSToVoid(%instance) : $@async @convention(thin) (@owned S) -> ()
+  return %partiallyApplied : $@async @callee_owned () -> ()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %s_type = metatype $@thick S.Type
+  %allocating_init = function_ref @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S
+  %instance = apply %allocating_init(%s_type) : $@convention(method) (@thick S.Type) -> @owned S
+  strong_retain %instance : $S
+
+  %partial_apply_class = function_ref @partial_apply_class : $@async @convention(thin) (S) -> @async @callee_owned () -> ()
+  %partiallyApplied = apply %partial_apply_class(%instance) : $@async @convention(thin) (S) -> @async @callee_owned () -> ()
+  %result = apply %partiallyApplied() : $@async @callee_owned () -> ()
+
+  strong_release %instance : $S
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -1,0 +1,87 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+public protocol Observable {
+  associatedtype Result
+  func subscribe<T: Observer>(o: T) async -> ()
+}
+class ObservableImpl : Observable {
+  typealias Result = Void
+  func subscribe<T: Observer>(o: T) async -> ()
+}
+sil_vtable ObservableImpl {
+}
+// CHECK-LL: define hidden swiftcc void @subscribe_ObservableImpl_Observable(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @subscribe_ObservableImpl_Observable : $@convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observer> (@in_guaranteed τ_0_0, @in_guaranteed ObservableImpl) -> () {
+bb0(%observer : $*τ_0_0, %self : $*ObservableImpl):
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printGeneric_result1 = apply %printGeneric<τ_0_0>(%observer) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: main.ObserverImpl
+  %printGeneric_result2 = apply %printGeneric<ObservableImpl>(%self) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: main.ObservableImpl
+  %result = tuple ()
+  return %result : $()
+}
+sil_witness_table ObservableImpl : Observable module main {
+  associated_type Result : ()
+  method #Observable.subscribe: <Self where Self : Observable><T where T : Observer> (Self) -> (T) async -> () : @subscribe_ObservableImpl_Observable
+}
+
+public protocol Observer {
+  associatedtype Result
+}
+
+class ObserverImpl : Observer {
+  typealias Result = Void
+}
+sil_vtable ObserverImpl {}
+sil_witness_table ObserverImpl : Observer module main {
+    associated_type Result : ()
+}
+
+// CHECK-LL: define internal swiftcc void @"$sTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @witness_method : $@convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> () {
+bb0(%0 : $*S):
+  %1 = witness_method $S, #Observable.subscribe : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %2 = partial_apply %1<S, O>(%0) : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  return %2 : $@async @callee_owned (@in O) -> ()
+}
+
+
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %observableImpl = alloc_ref $ObservableImpl
+  strong_retain %observableImpl : $ObservableImpl
+  %observableImpl_addr = alloc_stack $ObservableImpl
+  store %observableImpl to %observableImpl_addr : $*ObservableImpl
+  %witness_method = function_ref @witness_method : $@convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> ()
+  %partiallyApplied = apply %witness_method<ObservableImpl, ObserverImpl>(%observableImpl_addr) : $@convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> ()
+  %observerImpl = alloc_ref $ObserverImpl
+  %observerImpl_addr = alloc_stack $ObserverImpl
+  store %observerImpl to %observerImpl_addr : $*ObserverImpl
+
+  %result = apply %partiallyApplied(%observerImpl_addr) : $@async @callee_owned (@in ObserverImpl) -> ()
+
+  dealloc_stack %observerImpl_addr : $*ObserverImpl
+  dealloc_stack %observableImpl_addr : $*ObservableImpl
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @inGenericAndInoutGenericToGeneric(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+// CHECK-LL: define internal swiftcc void @"$s017inGenericAndInoutb2ToB0TA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil @inGenericAndInoutGenericToGeneric : $@async @convention(thin) <T> (@in T, @inout T) -> @out T {
+entry(%out : $*T, %in : $*T, %inout : $*T):
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printGeneric_result1 = apply %printGeneric<T>(%in) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 876
+  %printGeneric_result2 = apply %printGeneric<T>(%inout) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 678
+  copy_addr %inout to [initialization] %out : $*T
+  %result = tuple ()
+  return %result : $()
+}
+
+sil @partial_apply_open_generic_capture : $@convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
+entry(%a : $*T):
+  %f = function_ref @inGenericAndInoutGenericToGeneric : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
+  %p = partial_apply %f<T>(%a) : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
+  return %p : $@async @callee_owned (@in T) -> @out T
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %in_literal = integer_literal $Builtin.Int64, 876
+  %in = struct $Int64 (%in_literal : $Builtin.Int64)
+  %inout_literal = integer_literal $Builtin.Int64, 678
+  %inout = struct $Int64 (%inout_literal : $Builtin.Int64)
+
+  %in_addr = alloc_stack $Int64
+  store %in to %in_addr : $*Int64
+  %inout_addr = alloc_stack $Int64
+  store %inout to %inout_addr : $*Int64
+  %result_addr = alloc_stack $Int64
+
+  %partial_apply_open_generic_capture = function_ref @partial_apply_open_generic_capture : $@convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T
+  %partiallyApplied = apply %partial_apply_open_generic_capture<Int64>(%inout_addr) : $@convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T
+  %void = apply %partiallyApplied(%result_addr, %in_addr) : $@async @callee_owned (@in Int64) -> @out Int64
+
+  %result = load %result_addr : $*Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 678
+
+  dealloc_stack %result_addr : $*Int64
+  dealloc_stack %inout_addr : $*Int64
+  dealloc_stack %in_addr : $*Int64
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+sil hidden @createAndInvokeClosure : $@convention(thin) () -> () {
+bb0:
+  %captured_literal = integer_literal $Builtin.Int64, 783247897
+  %captured = struct $Int64 (%captured_literal : $Builtin.Int64)
+  %createPartialApply = function_ref @createPartialApply : $@convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64
+  %partialApply = apply %createPartialApply(%captured) : $@convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64
+  strong_retain %partialApply : $@async @callee_guaranteed (Int64) -> Int64
+  %applied_literal = integer_literal $Builtin.Int64, 7823478
+  %applied = struct $Int64 (%applied_literal : $Builtin.Int64)
+  %sum = apply %partialApply(%applied) : $@async @callee_guaranteed (Int64) -> Int64
+  strong_release %partialApply : $@async @callee_guaranteed (Int64) -> Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %result = apply %printInt64(%sum) : $@convention(thin) (Int64) -> () // CHECK: 791071375
+  strong_release %partialApply : $@async @callee_guaranteed (Int64) -> Int64
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %createAndInvokeClosure = function_ref @createAndInvokeClosure : $@convention(thin) () -> ()
+  %createAndInvokeClosure_result = apply %createAndInvokeClosure() : $@convention(thin) () -> ()
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}
+
+// CHECK-LL: define internal swiftcc void @closure(%swift.context* {{%[0-9]*}}) {{#[0-9]*}}
+// CHECK-LL: define internal swiftcc void @"$s7closureTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}}
+sil hidden @createPartialApply : $@convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64 {
+bb0(%captured : $Int64):
+  %closure = function_ref @closure : $@async @convention(thin) (Int64, Int64) -> Int64
+  %partialApply = partial_apply [callee_guaranteed] %closure(%captured) : $@async @convention(thin) (Int64, Int64) -> Int64
+  return %partialApply : $@async @callee_guaranteed (Int64) -> Int64
+}
+
+sil private @closure : $@async @convention(thin) (Int64, Int64) -> Int64 {
+bb0(%one : $Int64, %two : $Int64):
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_1 = apply %printInt64(%one) : $@convention(thin) (Int64) -> ()
+  %printInt64_2 = apply %printInt64(%two) : $@convention(thin) (Int64) -> ()
+  %one_builtin = struct_extract %one : $Int64, #Int64._value
+  %two_builtin = struct_extract %two : $Int64, #Int64._value
+  %flag = integer_literal $Builtin.Int1, -1
+  %sumAndOverflowed = builtin "sadd_with_overflow_Int64"(%one_builtin : $Builtin.Int64, %two_builtin : $Builtin.Int64, %flag : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %sum_builtin = tuple_extract %sumAndOverflowed : $(Builtin.Int64, Builtin.Int1), 0
+  %overflowed = tuple_extract %sumAndOverflowed : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %overflowed : $Builtin.Int1, "arithmetic overflow"
+  %sum = struct $Int64 (%sum_builtin : $Builtin.Int64)
+  return %sum : $Int64
+}
+

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt32 : $@convention(thin) (Int32) -> ()
+
+sil @partial_apply_dynamic_with_out_param : $@convention(thin) <T> (Int32, @owned @async @callee_owned (Int32) -> @out T) -> @async @callee_owned () -> @out T {
+bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
+  %p = partial_apply %f(%x) : $@async @callee_owned (Int32) -> @out T
+  return %p : $@async @callee_owned () -> @out T
+}
+
+// CHECK-LL: define internal swiftcc void @"$sTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+// CHECK-LL: define internal swiftcc void @"$s6calleeTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil @callee : $@async @convention(thin) <T> (Int32, @in_guaranteed T) -> @out T {
+entry(%out_t : $*T, %x : $Int32, %in_t : $*T):
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printInt32 = function_ref @printInt32 : $@convention(thin) (Int32) -> ()
+  %result = apply %printGeneric<T>(%in_t) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 1
+  %printInt32_result = apply %printInt32(%x) : $@convention(thin) (Int32) -> () // CHECK: 6789
+  copy_addr %in_t to [initialization] %out_t : $*T
+  return %result : $()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %callee = function_ref @callee : $@async @convention(thin) <T> (Int32, @in_guaranteed T) -> @out T
+  %first_literal = integer_literal $Builtin.Int32, 1
+  %first = struct $Int32 (%first_literal : $Builtin.Int32)
+  %first_addr = alloc_stack $Int32
+  store %first to %first_addr : $*Int32
+  %callee1 = partial_apply %callee<Int32>(%first_addr) : $@async @convention(thin) <T> (Int32, @in_guaranteed T) -> @out T
+  %partialApplier = function_ref @partial_apply_dynamic_with_out_param : $@convention(thin) <T> (Int32, @owned @async @callee_owned (Int32) -> @out T) -> @async @callee_owned () -> @out T
+  %second_literal = integer_literal $Builtin.Int32, 6789
+  %second = struct $Int32 (%second_literal : $Builtin.Int32)
+  %callee2 = apply %partialApplier<Int32>(%second, %callee1) : $@convention(thin) <T> (Int32, @owned @async @callee_owned (Int32) -> @out T) -> @async @callee_owned () -> @out T
+  
+  %result_addr = alloc_stack $Int32
+  %result = apply %callee2(%result_addr) : $@async @callee_owned () -> @out Int32
+
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printGeneric_result = apply %printGeneric<Int32>(%result_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 1
+
+  dealloc_stack %result_addr : $*Int32
+  dealloc_stack %first_addr : $*Int32
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -1,0 +1,105 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+class C {
+  deinit
+  init()
+}
+
+sil hidden [exact_self_class] @S_allocating_init : $@convention(method) (@thick C.Type) -> @owned C {
+bb0(%0 : $@thick C.Type):
+  %1 = alloc_ref $C
+  %2 = function_ref @$S_init : $@convention(method) (@owned C) -> @owned C
+  %3 = apply %2(%1) : $@convention(method) (@owned C) -> @owned C
+  return %3 : $C
+}
+
+sil hidden @$S_init : $@convention(method) (@owned C) -> @owned C {
+bb0(%0 : $C):
+  return %0 : $C
+}
+
+sil hidden @$S_deinit : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject {
+bb0(%0 : $C):
+  %2 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}
+
+sil hidden @S_deallocating_deinit : $@convention(method) (@owned C) -> () {
+bb0(%0 : $C):
+  %2 = function_ref @$S_deinit : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
+  %3 = apply %2(%0) : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
+  %4 = unchecked_ref_cast %3 : $Builtin.NativeObject to $C
+  dealloc_ref %4 : $C
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil_vtable C {
+  #C.init!allocator: (C.Type) -> () -> C : @S_allocating_init
+  #C.deinit!deallocator: @S_deallocating_deinit
+}
+
+
+struct S { var x: C, y: C }
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @structClassInstanceClassInstanceAndInt64ToInt64(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+// CHECK-LL: define internal swiftcc void @"$s019structClassInstancebc10AndInt64ToE0TA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil @structClassInstanceClassInstanceAndInt64ToInt64 : $@async @convention(thin) (Int64, @guaranteed S) -> Int64 {
+entry(%in : $Int64, %s : $S):
+  %s_addr = alloc_stack $S
+  store %s to %s_addr : $*S
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printGeneric_result = apply %printGeneric<S>(%s_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () //CHECK: S(x: main.C, y: main.C)
+  dealloc_stack %s_addr : $*S
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%in) : $@convention(thin) (Int64) -> () // CHECK: 9999
+  return %in : $Int64
+}
+
+sil @partial_apply_guaranteed_class_pair_param : $@convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64 {
+bb0(%x : $S):
+  %f = function_ref @structClassInstanceClassInstanceAndInt64ToInt64 : $@async @convention(thin) (Int64, @guaranteed S) -> Int64
+  %p = partial_apply %f(%x) : $@async @convention(thin) (Int64, @guaranteed S) -> Int64
+  return %p : $@async @callee_owned (Int64) -> Int64
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %s_type = metatype $@thick C.Type
+  %allocating_init = function_ref @S_allocating_init : $@convention(method) (@thick C.Type) -> @owned C
+  %instance1 = apply %allocating_init(%s_type) : $@convention(method) (@thick C.Type) -> @owned C
+  %instance2 = apply %allocating_init(%s_type) : $@convention(method) (@thick C.Type) -> @owned C
+  strong_retain %instance1 : $C
+  strong_retain %instance2 : $C
+  %instance = struct $S (%instance1 : $C, %instance2 : $C)
+
+  %partial_apply_guaranteed_class_pair_param = function_ref @partial_apply_guaranteed_class_pair_param : $@convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64
+  %partiallyApplied = apply %partial_apply_guaranteed_class_pair_param(%instance) : $@convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64
+  %int_literal = integer_literal $Builtin.Int64, 9999
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %result = apply %partiallyApplied(%int) : $@async @callee_owned (Int64) -> Int64
+  %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
+  %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 9999
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -1,0 +1,97 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+struct A1 {
+    let b: () -> ()
+}
+
+struct A2<T>  {
+    let a: T
+}
+
+class A3 {}
+sil_vtable A3 {}
+
+sil @printA2AtA3 : $@convention(thin) (A2<A3>) -> () {
+entry(%value : $A2<A3>):
+  %addr = alloc_stack $A2<A3>
+  store %value to %addr : $*A2<A3>
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %printGeneric<A2<A3>>(%addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  dealloc_stack %addr : $*A2<A3>
+  return %result : $()
+}
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @amethod(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error) {
+entry(%a2_at_a3_addr : $*A2<A3>):
+  %a2_at_a3 = load %a2_at_a3_addr : $*A2<A3>
+  %printA2AtA3 = function_ref @printA2AtA3 : $@convention(thin) (A2<A3>) -> () 
+  %partiallyApplied = partial_apply [callee_guaranteed] %printA2AtA3(%a2_at_a3) : $@convention(thin) (A2<A3>) -> () 
+  %result = struct $A1 ( %partiallyApplied : $@callee_guaranteed () -> () )
+  return %result : $A1
+}
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @repo(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+// CHECK-LL: define internal swiftcc void @"$s7amethodTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil @repo : $@async @convention(thin) (@in_guaranteed A2<A3>) -> @owned @async @callee_guaranteed () -> (@owned A1, @error Error) {
+bb0(%0 : $*A2<A3>):
+  %1 = load %0 : $*A2<A3>
+  %2 = alloc_stack $A2<A3>
+  store %1 to %2 : $*A2<A3>
+  %4 = function_ref @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+  %5 = partial_apply [callee_guaranteed] %4(%2) : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+  dealloc_stack %2 : $*A2<A3>
+  return %5 : $@async @callee_guaranteed () -> (@owned A1, @error Error)
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %a3 = alloc_ref $A3
+  %a2 = struct $A2<A3> (%a3 : $A3)
+
+  %a2_addr = alloc_stack $A2<A3>
+  store %a2 to %a2_addr : $*A2<A3>
+
+  %callee = function_ref @repo : $@async @convention(thin) (@in_guaranteed A2<A3>) -> @owned @async @callee_guaranteed () -> (@owned A1, @error Error)
+  %partiallyApplied = apply %callee(%a2_addr) : $@async @convention(thin) (@in_guaranteed A2<A3>) -> @owned @async @callee_guaranteed () -> (@owned A1, @error Error)
+  try_apply %partiallyApplied() : $@async @callee_guaranteed () -> (@owned A1, @error Error), normal bb_success, error bb_error
+
+bb_success(%value : $A1):
+  %value_addr = alloc_stack $A1
+  store %value to %value_addr : $*A1
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %printGeneric<A1>(%value_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: A1(b: (Function))
+  %closure = struct_extract %value : $A1, #A1.b
+  %closure_result = apply %closure() : $@callee_guaranteed () -> () // CHECK: A2<A3>(a: main.A3)
+  dealloc_stack %value_addr : $*A1
+  
+  br bb_finish
+
+bb_error(%error : $Error):
+  br bb_finish
+
+bb_finish:
+
+  dealloc_stack %a2_addr : $*A2<A3>
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+public protocol Q {
+  associatedtype Update
+}
+
+public struct BaseProducer<T> : Q {
+  public typealias Update = T
+}
+sil_witness_table <T> BaseProducer<T> : Q module main {
+  associated_type Update : T
+}
+
+public class WeakBox<T> {}
+sil_vtable WeakBox {}
+
+// CHECK-LL: define internal swiftcc void @"$s7takingQTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> () {
+entry(%box : $WeakBox<τ_0_0>):
+  %box_addr = alloc_stack $WeakBox<τ_0_0>
+  store %box to %box_addr : $*WeakBox<τ_0_0>
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %printGeneric<WeakBox<τ_0_0>>(%box_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: main.WeakBox<main.BaseProducer<Swift.Int64>>
+  dealloc_stack %box_addr : $*WeakBox<τ_0_0>
+  return %result : $()
+}
+
+sil public @bind_polymorphic_param_from_context : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> () {
+bb0(%0 : $*τ_0_1):
+  %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>(%1) : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  return %9 : $@async @callee_owned () -> ()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %bind_polymorphic_param_from_context = function_ref @bind_polymorphic_param_from_context : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
+  %int_literal = integer_literal $Builtin.Int64, 9999
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %int_addr = alloc_stack $Int64
+  store %int to %int_addr : $*Int64
+  %partiallyApplied = apply %bind_polymorphic_param_from_context<Int64>(%int_addr) :  $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
+  dealloc_stack %int_addr : $*Int64
+
+  %result = apply %partiallyApplied() : $@async @callee_owned () -> ()
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+public protocol Q {
+  associatedtype Update
+}
+
+public struct BaseProducer<T> : Q {
+  public typealias Update = T
+}
+sil_witness_table <T> BaseProducer<T> : Q module main {
+  associated_type Update : T
+}
+
+public class WeakBox<T> {}
+sil_vtable WeakBox {}
+
+// CHECK-LL: define hidden swiftcc void @takingQ(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+sil hidden @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> () {
+entry(%box : $WeakBox<τ_0_0>):
+  %box_addr = alloc_stack $WeakBox<τ_0_0>
+  store %box to %box_addr : $*WeakBox<τ_0_0>
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %result = apply %printGeneric<WeakBox<τ_0_0>>(%box_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: main.WeakBox<main.BaseProducer<Swift.Int64>>
+  dealloc_stack %box_addr : $*WeakBox<τ_0_0>
+  return %result : $()
+}
+
+
+// CHECK-LL: define internal swiftcc void @"$s7takingQTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil public @bind_polymorphic_param_from_forwarder_parameter : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> () {
+bb0(%0 : $*τ_0_1):
+  %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
+  %8 = function_ref @takingQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  %9 = partial_apply %8<BaseProducer<τ_0_1>>() : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
+  return %9 : $@callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %bind_polymorphic_param_from_forwarder_parameter = function_ref @bind_polymorphic_param_from_forwarder_parameter : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
+  %int_literal = integer_literal $Builtin.Int64, 9999
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %int_addr = alloc_stack $Int64
+  store %int to %int_addr : $*Int64
+  %partiallyApplied = apply %bind_polymorphic_param_from_forwarder_parameter<Int64>(%int_addr) : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
+  dealloc_stack %int_addr : $*Int64
+
+  %box = alloc_ref $WeakBox<BaseProducer<Int64>>
+  %result = apply %partiallyApplied(%box) : $@callee_owned @async (@owned WeakBox<BaseProducer<Int64>>) -> ()
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
@@ -1,0 +1,102 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_oC_stdlib
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
+
+class C {
+  deinit
+  init()
+}
+
+sil hidden [exact_self_class] @C_allocating_init : $@convention(method) (@thick C.Type) -> @owned C {
+bb0(%0 : $@thick C.Type):
+  %1 = alloc_ref $C
+  %2 = function_ref @$C_init : $@convention(method) (@owned C) -> @owned C
+  %3 = apply %2(%1) : $@convention(method) (@owned C) -> @owned C
+  return %3 : $C
+}
+
+sil hidden @$C_init : $@convention(method) (@owned C) -> @owned C {
+bb0(%0 : $C):
+  return %0 : $C
+}
+
+sil hidden @$C_deinit : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject {
+bb0(%0 : $C):
+  %2 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}
+
+sil hidden @C_deallocating_deinit : $@convention(method) (@owned C) -> () {
+bb0(%0 : $C):
+  %2 = function_ref @$C_deinit : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
+  %3 = apply %2(%0) : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
+  %4 = unchecked_ref_cast %3 : $Builtin.NativeObject to $C
+  dealloc_ref %4 : $C
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil_vtable C {
+  #C.init!allocator: (C.Type) -> () -> C : @C_allocating_init
+  #C.deinit!deallocator: @C_deallocating_deinit
+}
+
+struct S {}
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @structtypeSAndClassinstanceCToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
+// CHECK-LL: define internal swiftcc void @"$s34structtypeSAndClassinstanceCToVoidTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
+sil @structtypeSAndClassinstanceCToVoid : $@async @convention(thin) (@thin S.Type, @owned C) -> () {
+entry(%S_type: $@thin S.Type, %C_instance: $C):
+  %S_type_addr = alloc_stack $@thick S.Type
+  %S_type_thick = metatype $@thick S.Type
+  store %S_type_thick to %S_type_addr : $*@thick S.Type
+  %C_instance_addr = alloc_stack $C
+  store %C_instance to %C_instance_addr : $*C
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printGeneric_result1 = apply %printGeneric<S.Type>(%S_type_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () //CHECK: S
+  %printGeneric_result2 = apply %printGeneric<C>(%C_instance_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () //CHECK: main.C
+  dealloc_stack %C_instance_addr : $*C
+  dealloc_stack %S_type_addr : $*@thick S.Type
+  return %printGeneric_result2 : $()
+}
+
+sil @partial_apply_thin_type : $@async @convention(thin) (@thin S.Type, @owned C) -> @async @callee_owned () -> () {
+entry(%S_type: $@thin S.Type, %C_instance: $C):
+  %structtypeSAndClassinstanceCToVoid = function_ref @structtypeSAndClassinstanceCToVoid : $@async @convention(thin) (@thin S.Type, @owned C) -> ()
+  %closure = partial_apply %structtypeSAndClassinstanceCToVoid (%S_type, %C_instance) : $@async @convention(thin) (@thin S.Type, @owned C) -> ()
+  return %closure : $@async @callee_owned () -> ()
+}
+
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %c_type = metatype $@thick C.Type
+  %allocating_init = function_ref @C_allocating_init : $@convention(method) (@thick C.Type) -> @owned C
+  %instance = apply %allocating_init(%c_type) : $@convention(method) (@thick C.Type) -> @owned C
+  strong_retain %instance : $C
+
+
+  %partial_apply_thin_type = function_ref @partial_apply_thin_type : $@async @convention(thin) (@thin S.Type, @owned C) -> @async @callee_owned () -> ()
+  %S_type = metatype $@thin S.Type
+  %partiallyApplied = apply %partial_apply_thin_type(%S_type, %instance) : $@async @convention(thin) (@thin S.Type, @owned C) -> @async @callee_owned () -> ()
+  %result = apply %partiallyApplied() : $@async @callee_owned () -> ()
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}

--- a/test/Inputs/print-shims.swift
+++ b/test/Inputs/print-shims.swift
@@ -3,6 +3,11 @@ public func printInt64(_ int: Int64) {
   print(int)
 }
 
+@_silgen_name("printInt32")
+public func printInt32(_ int: Int32) {
+  print(int)
+}
+
 @_silgen_name("printGeneric")
 public func printGeneric<T>(_ t: T) {
   print(t)


### PR DESCRIPTION
The majority of support comes in the form of emitting partial application forwarders for partial applications of async functions. Such a partial application forwarder must take an async context which has been partially populated at the apply site.  It is responsible for populating it "the rest of the way".  To do so, like sync partial application forwarders, it takes a second argument, its context, from which it pulls the additional arguments which were capture at partial_apply time.

The size of the async context that is passed to the forwarder, however, can't be known at the apply site by simply looking at the signature of the function to be applied (not even by looking at the size associated with the function in the special async function pointer constant which will soon be emitted).  The reason is that there are an unknown (at the apply site) number of additional arguments which will be filled by the partial apply forwarder (and in the case of repeated partial applications, further filled in incrementally at each level).  To enable this, there will always be a heap object for thick async functions. These heap objects will always store the size of the async context to be allocated as their first element.  (Note that it may be possible to apply the same optimization that was applied for thick sync functions where a single refcounted object could be used as the context; doing so, however, must be made to interact properly with the async context size stored in the heap object.)

To continue to allow promoting thin async functions to thick async functions without incurring a thunk, at the apply site, a null-check will be performed on the context pointer.  If it is null, then the async context size will be determined based on the signature.  (When async function pointers become pointers to a constant with a size i32 and a relative address to the underlying function, the size will be read from that constant.)  When it is not-null, the size will be pulled from the first field of the context (which will in that case be cast to <{%swift.refcounted, i32}>).

To facilitate sharing code and preserving the original structure of emitPartialApplicationForwarder, a new small class hierarchy, descending from PartialApplicationForwarderEmission has been added, with subclasses for the sync and async case.  The shuffling of arguments into and out of the final explosion that was being performed in the synchronous case has been preserved there, though the arguments are added and removed through a number of methods on the superclass with more descriptive names.  That was necessary to enable the async class to handle these different flavors of parameters correctly.

To get some initial test coverage, the preexisting IRGen/partial_apply.sil and IRGen/partial_apply_forwarder.sil tests have been duplicated into the async folder.  Those tests cases within these files which happened to have been crashing have each been extracted into its own runnable test that both verifies that the compiler does not crash and also that the partial application forwarder behaves correctly. The FileChecks in these tests are extremely minimal, providing only enough information to be sure that arguments are in fact squeezed into an async context.