### PR TITLE
[CMake] Make sure that library evolution is set when compiling overlays.

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -58,9 +58,17 @@ set(SWIFT_NATIVE_CLANG_TOOLS_PATH "${TOOLCHAIN_DIR}/usr/bin" CACHE STRING
 set(SWIFT_NATIVE_SWIFT_TOOLS_PATH "${TOOLCHAIN_DIR}/usr/bin" CACHE STRING
   "Path to Swift tools that are executable on the build machine.")
 
+# NOTE: The initialization in stdlib/CMakeLists.txt will be bypassed if we
+# directly invoke CMake for this directory, so we initialize the variables
+# related to library evolution here as well.
+
+option(SWIFT_STDLIB_STABLE_ABI
+  "Should stdlib be built with stable ABI (library evolution, resilience)."
+  TRUE)
+
 option(SWIFT_ENABLE_MODULE_INTERFACES
   "Generate .swiftinterface files alongside .swiftmodule files."
-  TRUE)
+  "${SWIFT_STDLIB_STABLE_ABI}")
 
 set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
   "Build type for the Swift standard library and SDK overlays.")

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -42,9 +42,16 @@ endif()
 # User-configurable options for the standard library.
 #
 
+# NOTE: Some of these variables are also initialized in StandaloneOverlay.cmake
+# so that interfaces are emitted when overlays are separately built.
+
 option(SWIFT_STDLIB_STABLE_ABI
   "Should stdlib be built with stable ABI (library evolution, resilience)."
   "${SWIFT_STDLIB_STABLE_ABI_default}")
+
+option(SWIFT_ENABLE_MODULE_INTERFACES
+  "Generate .swiftinterface files alongside .swiftmodule files"
+  "${SWIFT_STDLIB_STABLE_ABI}")
 
 option(SWIFT_ENABLE_COMPATIBILITY_OVERRIDES
   "Support back-deploying compatibility fixes for newer apps running on older runtimes."
@@ -61,10 +68,6 @@ option(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
 option(SWIFT_STDLIB_OS_VERSIONING
     "Build stdlib with availability based on OS versions (Darwin only)."
     TRUE)
-
-option(SWIFT_ENABLE_MODULE_INTERFACES
-       "Generate .swiftinterface files alongside .swiftmodule files"
-       "${SWIFT_STDLIB_STABLE_ABI}")
 
 option(SWIFT_COMPILE_DIFFERENTIATION_WITHOUT_TGMATH
        "Build Differentation without tgmath (and dependency on platform runtime libraries)"

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -9,7 +9,7 @@ project(swift-stdlib LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "OSX")
+if("${SWIFT_HOST_VARIANT_SDK}" MATCHES "(OSX|IOS*|TVOS*|WATCHOS*)")
   # All Darwin platforms have ABI stability.
   set(SWIFT_STDLIB_STABLE_ABI_default TRUE)
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")


### PR DESCRIPTION
If library evolution is not set, the generated swiftinterface will be incorrect, leading to further errors downstream.

In direct CMake calls to `stdlib/public/Platform/CMakeLists.txt`, the variable `SWIFT_STDLIB_STABLE_ABI` is not initialized. ~For now, we duplicate the logic in `stdlib/CMakeLists.txt` to make sure that it is initialized properly. We can potentially de-duplicate it later.~ So we add some initialization in `StandaloneOverlay.cmake` which is consumed by `stdlib/public/Platform/CMakeLists.txt`, mimicking the "duplicate" initialization we already have for `SWIFT_ENABLE_MODULE_INTERFACES`.

Fixes rdar://70156840.