### PR TITLE
SILCombine: fix metatype simplification

### DIFF
--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -488,7 +488,8 @@ SILValue InstSimplifier::visitMetatypeInst(MetatypeInst *MI) {
       || instanceType.getStructOrBoundGenericStruct()
       || instanceType.getEnumOrBoundGenericEnum()) {
     for (SILArgument *argument : MI->getFunction()->getArguments()) {
-      if (argument->getType().getASTType() == metaType)
+      if (argument->getType().getASTType() == metaType &&
+          argument->getType().isObject())
         return argument;
     }
   }

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -371,3 +371,16 @@ bb0(%0 : $@thick SpecialEnum.Type):
   %5 = struct $Bool (%4 : $Builtin.Int1)
   return %5 : $Bool
 }
+
+// CHECK-LABEL: sil @dontSimplifyIndirectMetatype : $@convention(thin) () -> @out @thick Int.Type {
+// CHECK:   [[MT:%[0-9]+]] = metatype $@thick Int.Type
+// CHECK:   store [[MT]] to %0
+// CHECK-LABEL: }  // end sil function 'dontSimplifyIndirectMetatype'
+sil @dontSimplifyIndirectMetatype : $@convention(thin) () -> @out @thick Int.Type {
+bb0(%0 : $*@thick Int.Type):
+  %1 = metatype $@thick Int.Type
+  store %1 to %0 : $*@thick Int.Type
+  %3 = tuple ()
+  return %3 : $()
+}
+


### PR DESCRIPTION
Don't reuse argument metadata if it's an indirect argument.
Fixes a verifier crash.

https://bugs.swift.org/browse/SR-13731
rdar://problem/70338666
