### PR TITLE
update and unify the "please file a bug report" message

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -156,7 +156,7 @@ ERROR(error_unable_to_load_supplementary_output_file_map, none,
 
 ERROR(error_missing_entry_in_supplementary_output_file_map, none,
       "supplementary output file map '%0' is missing an entry for '%1' "
-      "(this likely indicates a compiler issue; please file a bug report)",
+      "(this likely indicates a compiler issue; " SWIFT_BUG_REPORT_MESSAGE ")",
       (StringRef, StringRef))
 
 ERROR(error_repl_requires_no_input_files,none,
@@ -307,8 +307,8 @@ ERROR(symbol_in_ir_not_in_tbd,none,
       (StringRef, StringRef))
 
 ERROR(tbd_validation_failure,none,
-      "please file a radar or open a bug on bugs.swift.org with this code, and "
-      "add -Xfrontend -validate-tbd-against-ir=none to squash the errors", ())
+      SWIFT_BUG_REPORT_MESSAGE ", and add "
+      "'-Xfrontend -validate-tbd-against-ir=none' to squash the errors", ())
 
 ERROR(redundant_prefix_compilation_flag,none,
       "invalid argument '-D%0'; did you provide a redundant '-D' in your "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -766,7 +766,7 @@ ERROR(serialization_target_too_new_repl,none,
 
 ERROR(serialization_fatal,Fatal,
       "fatal error encountered while reading from module '%0'; "
-      "please file a bug report with your project and the crash log",
+      SWIFT_BUG_REPORT_MESSAGE,
       (StringRef))
 NOTE(serialization_misc_version,none,
      "module '%0' full misc version is '%1'",
@@ -3441,7 +3441,7 @@ ERROR(type_of_expression_is_ambiguous,none,
 
 ERROR(failed_to_produce_diagnostic,Fatal,
       "failed to produce diagnostic for expression; "
-      "please file a bug report", ())
+      SWIFT_BUG_REPORT_MESSAGE, ())
 
 
 ERROR(missing_protocol,none,

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -89,4 +89,18 @@
 #define SWIFT_ATTRIBUTE_NORETURN
 #endif
 
+#ifndef SWIFT_BUG_REPORT_URL
+#define SWIFT_BUG_REPORT_URL "https://swift.org/contributing/#reporting-bugs"
+#endif
+
+#define SWIFT_BUG_REPORT_MESSAGE_BASE \
+  "submit a bug report (" SWIFT_BUG_REPORT_URL \
+  ") and include the project"
+
+#define SWIFT_BUG_REPORT_MESSAGE \
+  "please " SWIFT_BUG_REPORT_MESSAGE_BASE
+
+#define SWIFT_CRASH_BUG_REPORT_MESSAGE \
+  "Please " SWIFT_BUG_REPORT_MESSAGE_BASE " and the crash backtrace."
+
 #endif // SWIFT_BASIC_COMPILER_H

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2671,6 +2671,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
                            const char *Argv0, void *MainAddr,
                            FrontendObserver *observer) {
   INITIALIZE_LLVM();
+  llvm::setBugReportMsg(SWIFT_CRASH_BUG_REPORT_MESSAGE "\n");
   llvm::EnablePrettyStackTraceOnSigInfoForThisThread();
 
   PrintingDiagnosticConsumer PDC;
@@ -2694,8 +2695,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
     DiagnosticInfo errorInfo(
         DiagID(0), SourceLoc(), DiagnosticKind::Error,
-        "fatal error encountered during compilation; please file a bug report "
-        "with your project and the crash log",
+        "fatal error encountered during compilation; " SWIFT_BUG_REPORT_MESSAGE,
         {}, SourceLoc(), {}, {}, {}, false);
     DiagnosticInfo noteInfo(DiagID(0), SourceLoc(), DiagnosticKind::Note,
                             reason, {}, SourceLoc(), {}, {}, {}, false);

--- a/test/Frontend/batch_mode_output_file_map_missing_primary.swift
+++ b/test/Frontend/batch_mode_output_file_map_missing_primary.swift
@@ -5,4 +5,4 @@
 // RUN: not %target-swift-frontend -parse -primary-file main.swift -primary-file file-01.swift -supplementary-output-file-map %S/Inputs/supplementary_output_filemap_missing_a_primary.yaml >%t/errs.txt 2>&1
 // RUN: %FileCheck %s <%t/errs.txt
 
-// CHECK: error: supplementary output file map '{{.*}}supplementary_output_filemap_missing_a_primary.yaml' is missing an entry for 'file-01.swift' (this likely indicates a compiler issue; please file a bug report)
+// CHECK: error: supplementary output file map '{{.*}}supplementary_output_filemap_missing_a_primary.yaml' is missing an entry for 'file-01.swift' (this likely indicates a compiler issue; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project)

--- a/test/Sema/rdar38885760.swift
+++ b/test/Sema/rdar38885760.swift
@@ -3,7 +3,7 @@
 // RUN: not %target-swift-frontend -typecheck %s -parse-stdlib 2>%t/fallback_diagnostic.txt
 // RUN: %FileCheck %s --check-prefix FALLBACK-DIAGNOSTIC <%t/fallback_diagnostic.txt
 //
-// FALLBACK-DIAGNOSTIC: error: failed to produce diagnostic for expression; please file a bug report
+// FALLBACK-DIAGNOSTIC: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project
 
 import Swift
 

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -12,7 +12,7 @@ public class Sub: Base {
   public override func disappearingMethod() {}
 }
 
-// CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please file a bug report with your project and the crash log
+// CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project
 // CHECK-CRASH: note: module 'Lib' full misc version is
 // CHECK-CRASH-4-NOT: note: compiling as
 // CHECK-CRASH-4_2: note: compiling as Swift 4.2, with 'Lib' built as Swift 4.1.50

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -299,6 +299,7 @@ void anchorForGetMainExecutable() {}
 int main(int argc, char **argv) {
   PROGRAM_START(argc, argv);
   INITIALIZE_LLVM();
+  llvm::setBugReportMsg(SWIFT_CRASH_BUG_REPORT_MESSAGE  "\n");
   llvm::EnablePrettyStackTraceOnSigInfoForThisThread();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift SIL optimizer\n");

--- a/tools/swift-def-to-yaml-converter/swift-def-to-yaml-converter.cpp
+++ b/tools/swift-def-to-yaml-converter/swift-def-to-yaml-converter.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Localization/LocalizationFormat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"

--- a/unittests/Localization/LocalizationTest.h
+++ b/unittests/Localization/LocalizationTest.h
@@ -14,6 +14,7 @@
 #define LOCALIZATION_TEST_H
 
 #include "swift/Localization/LocalizationFormat.h"
+#include "swift/Basic/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"


### PR DESCRIPTION
The new message is:
"Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace."

1. In crash logs we used to print a message which points to the llvm bug tracking page. Now it points to the swift.org bug tracking guidelines.
2. Use the same message in all compiler diagnostics which ask the user to file a bug report.

rdar://problem/70488534
