### PR TITLE
Platform: extract `WLANAPI` module on Windows

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -377,5 +377,15 @@ module WinSDK [system] {
 
     link "AdvAPI32.Lib"
   }
+
+  // TODO(compnerd) does it make sense to implicitly export this API surface?
+  // It seems to be meant for device drivers.
+  module WLANAPI {
+    header "wlanapi.h"
+    header "wlanihv.h"
+    header "wlclient.h"
+
+    link "wlanapi.lib"
+  }
 }
 


### PR DESCRIPTION
The WLAN APIs are used for the native WiFi implementation and is not as
generally useful.  Extract it into a submodule.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
