### PR TITLE
[Concurrency] Asynchronous Objective-C method importer naming adjustments

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -442,6 +442,8 @@ public:
 ///
 /// \param allPropertyNames The set of property names in the enclosing context.
 ///
+/// \param isAsync Whether this is a function imported as 'async'.
+///
 /// \param scratch Scratch space that will be used for modifications beyond
 /// just chopping names.
 ///
@@ -455,6 +457,7 @@ bool omitNeedlessWords(StringRef &baseName,
                        bool returnsSelf,
                        bool isProperty,
                        const InheritedNameSet *allPropertyNames,
+                       bool isAsync,
                        StringScratchSpace &scratch);
 
 } // end namespace swift

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -1301,6 +1301,15 @@ bool swift::omitNeedlessWords(StringRef &baseName,
       splitBaseName(baseName, argNames[0], paramTypes[0], firstParamName))
     anyChanges = true;
 
+  // For a method imported as "async", drop the "Asynchronously" suffix from
+  // the base name. It is redundant with 'async'.
+  const StringRef asynchronously = "Asynchronously";
+  if (isAsync && camel_case::getLastWord(baseName) == asynchronously &&
+      baseName.size() > asynchronously.size()) {
+    baseName = baseName.drop_back(asynchronously.size());
+    anyChanges = true;
+  }
+
   // Omit needless words based on parameter types.
   for (unsigned i = 0, n = argNames.size(); i != n; ++i) {
     // If there is no corresponding parameter, there is nothing to

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -1220,6 +1220,7 @@ bool swift::omitNeedlessWords(StringRef &baseName,
                               bool returnsSelf,
                               bool isProperty,
                               const InheritedNameSet *allPropertyNames,
+                              bool isAsync,
                               StringScratchSpace &scratch) {
   bool anyChanges = false;
   OmissionTypeName resultType = returnsSelf ? contextType : givenResultType;
@@ -1285,6 +1286,14 @@ bool swift::omitNeedlessWords(StringRef &baseName,
       baseName = newBaseName;
       anyChanges = true;
     }
+  }
+
+  // If the base name of a method imported as "async" starts with the word
+  // "get", drop the "get".
+  if (isAsync && camel_case::getFirstWord(baseName) == "get" &&
+      baseName.size() > 3) {
+    baseName = baseName.substr(3);
+    anyChanges = true;
   }
 
   // If needed, split the base name.

--- a/lib/ClangImporter/IAMInference.cpp
+++ b/lib/ClangImporter/IAMInference.cpp
@@ -448,7 +448,7 @@ private:
     baseName = humbleBaseName.userFacingName();
     bool didOmit =
         omitNeedlessWords(baseName, argStrs, "", "", "", paramTypeNames, false,
-                          false, nullptr, scratch);
+                          false, nullptr, false, scratch);
     SmallVector<Identifier, 8> argLabels;
     for (auto str : argStrs)
       argLabels.push_back(getIdentifier(str));

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -456,6 +456,7 @@ private:
   Optional<ForeignAsyncConvention::Info>
   considerAsyncImport(const clang::ObjCMethodDecl *clangDecl,
                       StringRef &baseName,
+                      SmallVectorImpl<char> &baseNameScratch,
                       SmallVectorImpl<StringRef> &paramNames,
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName,

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -456,7 +456,6 @@ private:
   Optional<ForeignAsyncConvention::Info>
   considerAsyncImport(const clang::ObjCMethodDecl *clangDecl,
                       StringRef &baseName,
-                      SmallVectorImpl<char> &baseNameScratch,
                       SmallVectorImpl<StringRef> &paramNames,
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4867,7 +4867,8 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
                                 getTypeNameForOmission(resultType),
                                 getTypeNameForOmission(contextType),
                                 paramTypes, returnsSelf, false,
-                                /*allPropertyNames=*/nullptr, scratch))
+                                /*allPropertyNames=*/nullptr,
+                                afd->hasAsync(), scratch))
     return None;
 
   /// Retrieve a replacement identifier.
@@ -4922,7 +4923,8 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   OmissionTypeName contextTypeName = getTypeNameForOmission(contextType);
   if (::omitNeedlessWords(name, { }, "", typeName, contextTypeName, { },
                           /*returnsSelf=*/false, true,
-                          /*allPropertyNames=*/nullptr, scratch)) {
+                          /*allPropertyNames=*/nullptr, /*isAsync=*/false,
+                          scratch)) {
     return Context.getIdentifier(name);
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -18,6 +18,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   // still async version...
   let _: Int = slowServer.doSomethingConflicted("thinking")
   // expected-error@-1{{call is 'async' but is not marked with 'await'}}
+
+  let _: String? = await try slowServer.fortune()
 }
 
 func testSlowServerSynchronous(slowServer: SlowServer) {

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -20,6 +20,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
   // expected-error@-1{{call is 'async' but is not marked with 'await'}}
 
   let _: String? = await try slowServer.fortune()
+  let _: Int = await try slowServer.magicNumber(withSeed: 42)
 }
 
 func testSlowServerSynchronous(slowServer: SlowServer) {

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -10,6 +10,7 @@
 -(void)findAnswerAsynchronously:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswer(completionHandler:)")));
 -(BOOL)findAnswerFailinglyWithError:(NSError * _Nullable * _Nullable)error completion:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswerFailingly(completionHandler:)")));
 -(void)doSomethingFun:(NSString *)operation then:(void (^)(void))completionHandler;
+-(void)getFortuneWithCompletionHandler:(void (^)(NSString *_Nullable, NSError * _Nullable))handler;
 @property(readwrite) void (^completionHandler)(NSInteger);
 
 -(void)doSomethingConflicted:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -10,7 +10,8 @@
 -(void)findAnswerAsynchronously:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswer(completionHandler:)")));
 -(BOOL)findAnswerFailinglyWithError:(NSError * _Nullable * _Nullable)error completion:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswerFailingly(completionHandler:)")));
 -(void)doSomethingFun:(NSString *)operation then:(void (^)(void))completionHandler;
--(void)getFortuneWithCompletionHandler:(void (^)(NSString *_Nullable, NSError * _Nullable))handler;
+-(void)getFortuneAsynchronouslyWithCompletionHandler:(void (^)(NSString *_Nullable, NSError * _Nullable))handler;
+-(void)getMagicNumberAsynchronouslyWithSeed:(NSInteger)seed completionHandler:(void (^)(NSInteger, NSError * _Nullable))handler;
 @property(readwrite) void (^completionHandler)(NSInteger);
 
 -(void)doSomethingConflicted:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;


### PR DESCRIPTION
Make some adjustments to the names of Objective-C methods imported as `async`:

* Drop a leading `get` from the base name; the `async` function returns the result directly
* Drop an `Asynchronously` suffix from the base name; it's redundant with `async`

Implements rdar://70506634.
