### PR TITLE
RCIdentity: fix another case of not-RC-identity-preserving casts.

### DIFF
--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -433,6 +433,9 @@ public:
     return TargetIsBridgeable != SourceIsBridgeable;
   }
 
+  /// Returns true if this dynamic cast can release its source operand.
+  bool isRCIdentityPreserving() const;
+
   /// If getSourceType() is a Swift type that can bridge to an ObjC type, return
   /// the ObjC type it bridges to. If the source type is an objc type, an empty
   /// CanType() is returned.

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -15,6 +15,7 @@
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
+#include "swift/SIL/DynamicCasts.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
@@ -388,9 +389,7 @@ bool swift::isRCIdentityPreservingCast(SingleValueInstruction *svi) {
     return true;
   case SILInstructionKind::UnconditionalCheckedCastInst:
   case SILInstructionKind::UnconditionalCheckedCastValueInst:
-    // If the source is nontrivial, then this checked cast may actually create a
-    // new object, so its source is not ref-count equivalent.
-    return !svi->getOperand(0)->getType().isTrivial(*svi->getFunction());
+    return SILDynamicCastInst(svi).isRCIdentityPreserving();
   }
 }
 

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -31,6 +31,8 @@ struct A {
 
 class fuzz { }
 
+protocol P : class { }
+
 enum Boo {
   case one
   case two
@@ -816,4 +818,70 @@ bb0(%0 : $_ContiguousArrayBuffer<AnyObject>, %1 : $Builtin.Word, %2 : $Builtin.W
   %copy = builtin "copyArray"<AnyObject>(%eltty : $@thick AnyObject.Protocol, %newptr : $Builtin.RawPointer, %rawptr : $Builtin.RawPointer, %1 : $Builtin.Word) : $()
   release_value %0 : $_ContiguousArrayBuffer<AnyObject>
   return %newptr : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil @dontMoveOverExistentialToClassCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<fuzz>
+// CHECK:    strong_retain %0
+// CHECK:    checked_cast_br %0
+// CHECK:  } // end sil function 'dontMoveOverExistentialToClassCast'
+sil @dontMoveOverExistentialToClassCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<fuzz> {
+bb0(%0 : $AnyObject):
+  strong_retain %0 : $AnyObject
+  checked_cast_br %0 : $AnyObject to fuzz, bb1, bb2
+
+bb1(%18 : $fuzz):
+  %19 = enum $Optional<fuzz>, #Optional.some!enumelt, %18 : $fuzz
+  br bb3(%19 : $Optional<fuzz>)
+
+bb2:
+  strong_release %0 : $AnyObject
+  %22 = enum $Optional<fuzz>, #Optional.none!enumelt
+  br bb3(%22 : $Optional<fuzz>)
+
+bb3(%24 : $Optional<fuzz>):
+  return %24 : $Optional<fuzz>
+}
+
+// CHECK-LABEL: sil @dontMoveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P>
+// CHECK:    strong_retain %0
+// CHECK:    checked_cast_br %0
+// CHECK:  } // end sil function 'dontMoveOverClassToExistentialCast'
+sil @dontMoveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P> {
+bb0(%0 : $fuzz):
+  strong_retain %0 : $fuzz
+  checked_cast_br %0 : $fuzz to P, bb1, bb2
+
+bb1(%18 : $P):
+  %19 = enum $Optional<P>, #Optional.some!enumelt, %18 : $P
+  br bb3(%19 : $Optional<P>)
+
+bb2:
+  strong_release %0 : $fuzz
+  %22 = enum $Optional<P>, #Optional.none!enumelt
+  br bb3(%22 : $Optional<P>)
+
+bb3(%24 : $Optional<P>):
+  return %24 : $Optional<P>
+}
+
+// CHECK-LABEL: sil @dontMoveOverExistentialToExistentialCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<P>
+// CHECK:    strong_retain %0
+// CHECK:    checked_cast_br %0
+// CHECK:  } // end sil function 'dontMoveOverExistentialToExistentialCast'
+sil @dontMoveOverExistentialToExistentialCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<P> {
+bb0(%0 : $AnyObject):
+  strong_retain %0 : $AnyObject
+  checked_cast_br %0 : $AnyObject to P, bb1, bb2
+
+bb1(%18 : $P):
+  %19 = enum $Optional<P>, #Optional.some!enumelt, %18 : $P
+  br bb3(%19 : $Optional<P>)
+
+bb2:
+  strong_release %0 : $AnyObject
+  %22 = enum $Optional<P>, #Optional.none!enumelt
+  br bb3(%22 : $Optional<P>)
+
+bb3(%24 : $Optional<P>):
+  return %24 : $Optional<P>
 }


### PR DESCRIPTION
When casting from existentials to class - and vice versa - it can happen that a cast is not RC identity preserving (because of potential bridging).
This also affects mayRelease() of such cast instructions.
For details see the comments in SILDynamicCastInst::isRCIdentityPreserving().

This change also includes some refactoring: I centralized the logic in SILDynamicCastInst::isRCIdentityPreserving().

rdar://problem/70454804
