### PR TITLE
[utils/swift_build_sdk_interfaces.py] Remove passing '-track-system-dependencies' when prebuilding modules from the interfaces

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
@@ -17,12 +17,12 @@
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Swifty-*.swiftmodule
 
-// Actually change a file in the SDK, to check that we're tracking dependencies
+// Actually change a file in the SDK, to check that we're not tracking system dependencies
 // at all.
 // RUN: rm -rf %t/MCP
 // RUN: echo "void unrelated();" >> %t/sdk/usr/include/Platform.h
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
-// RUN: not %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Swifty-*.swiftmodule
+// RUN: %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Swifty-*.swiftmodule
 
 // Without the prebuilt cache everything should still work; it'll just take time
 // because we have to build the interfaces.

--- a/utils/swift_build_sdk_interfaces.py
+++ b/utils/swift_build_sdk_interfaces.py
@@ -253,7 +253,6 @@ def process_module(module_file):
             '-build-module-from-parseable-interface',
             '-sdk', args.sdk,
             '-prebuilt-module-cache-path', args.output_dir,
-            '-track-system-dependencies'
         ]
         module_cache_path = ""
         if args.module_cache_path:


### PR DESCRIPTION
Including all the system header dependencies and `stat`ing them all the time introduces significant performance overhead for normal compilation, and other features like code-completion, without being worth it in practice.
