### PR TITLE
Rewrite LoadBorrowImmutabilityChecker

### DIFF
--- a/lib/SIL/Verifier/CMakeLists.txt
+++ b/lib/SIL/Verifier/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(swiftSIL PRIVATE
-  LoadBorrowInvalidationChecker.cpp
+  LoadBorrowImmutabilityChecker.cpp
   LinearLifetimeChecker.cpp
   MemoryLifetime.cpp
   SILOwnershipVerifier.cpp

--- a/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
+++ b/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
@@ -313,11 +313,6 @@ bool LoadBorrowImmutabilityAnalysis::isImmutableInScope(
 //===----------------------------------------------------------------------===//
 
 bool LoadBorrowImmutabilityAnalysis::isImmutable(LoadBorrowInst *lbi) {
-  // Find either the enclosing access scope or a single base address.
-
-  // FIXME: To be reenabled separately in a follow-on commit.
-  return true;
-
   AccessPath accessPath = AccessPath::computeInScope(lbi->getOperand());
   // Bail on an invalid AccessPath. AccessPath completeness is verified
   // independently--it may be invalid in extraordinary situations. When

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1881,7 +1881,7 @@ public:
     requireSameType(LBI->getOperand()->getType().getObjectType(),
                     LBI->getType(),
                     "Load operand type and result type mismatch");
-    require(loadBorrowNeverInvalidatedAnalysis.isNeverInvalidated(LBI),
+    require(!loadBorrowNeverInvalidatedAnalysis.isInvalidated(LBI),
             "Found load borrow that is invalidated by a local write?!");
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -664,7 +664,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   llvm::DenseMap<const SILInstruction *, unsigned> InstNumbers;
   
   DeadEndBlocks DEBlocks;
-  LoadBorrowImmutabilityAnalysis loadBorrowNeverInvalidatedAnalysis;
+  LoadBorrowImmutabilityAnalysis loadBorrowImmutabilityAnalysis;
   bool SingleFunction = true;
 
   SILVerifier(const SILVerifier&) = delete;
@@ -863,7 +863,7 @@ public:
         fnConv(F.getConventionsInContext()), TC(F.getModule().Types),
         OpenedArchetypes(&F), Dominance(nullptr),
         InstNumbers(numInstsInFunction(F)), DEBlocks(&F),
-        loadBorrowNeverInvalidatedAnalysis(DEBlocks),
+        loadBorrowImmutabilityAnalysis(DEBlocks, &F),
         SingleFunction(SingleFunction) {
     if (F.isExternalDeclaration())
       return;
@@ -1881,7 +1881,7 @@ public:
     requireSameType(LBI->getOperand()->getType().getObjectType(),
                     LBI->getType(),
                     "Load operand type and result type mismatch");
-    require(!loadBorrowNeverInvalidatedAnalysis.isInvalidated(LBI),
+    require(loadBorrowImmutabilityAnalysis.isImmutable(LBI),
             "Found load borrow that is invalidated by a local write?!");
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -664,7 +664,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   llvm::DenseMap<const SILInstruction *, unsigned> InstNumbers;
   
   DeadEndBlocks DEBlocks;
-  LoadBorrowNeverInvalidatedAnalysis loadBorrowNeverInvalidatedAnalysis;
+  LoadBorrowImmutabilityAnalysis loadBorrowNeverInvalidatedAnalysis;
   bool SingleFunction = true;
 
   SILVerifier(const SILVerifier&) = delete;

--- a/lib/SIL/Verifier/VerifierPrivate.h
+++ b/lib/SIL/Verifier/VerifierPrivate.h
@@ -25,12 +25,12 @@ class Operand;
 
 namespace silverifier {
 
-class LoadBorrowNeverInvalidatedAnalysis {
+class LoadBorrowImmutabilityAnalysis {
   SmallMultiMapCache<SILValue, Operand *> cache;
   DeadEndBlocks &deadEndBlocks;
 
 public:
-  LoadBorrowNeverInvalidatedAnalysis(DeadEndBlocks &deadEndBlocks);
+  LoadBorrowImmutabilityAnalysis(DeadEndBlocks &deadEndBlocks);
 
   /// Returns true if exhaustively lbi is guaranteed to never be invalidated by
   /// local writes.

--- a/lib/SIL/Verifier/VerifierPrivate.h
+++ b/lib/SIL/Verifier/VerifierPrivate.h
@@ -34,7 +34,7 @@ public:
 
   /// Returns true if exhaustively lbi is guaranteed to never be invalidated by
   /// local writes.
-  bool isNeverInvalidated(LoadBorrowInst *lbi);
+  bool isInvalidated(LoadBorrowInst *lbi);
 
 private:
   bool doesAddressHaveWriteThatInvalidatesLoadBorrow(

--- a/lib/SIL/Verifier/VerifierPrivate.h
+++ b/lib/SIL/Verifier/VerifierPrivate.h
@@ -14,6 +14,7 @@
 #define SWIFT_SIL_VERIFIER_VERIFIERPRIVATE_H
 
 #include "swift/Basic/MultiMapCache.h"
+#include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/SILValue.h"
 
 namespace swift {
@@ -26,21 +27,21 @@ class Operand;
 namespace silverifier {
 
 class LoadBorrowImmutabilityAnalysis {
-  SmallMultiMapCache<SILValue, Operand *> cache;
+  SmallMultiMapCache<AccessPath, Operand *> cache;
   DeadEndBlocks &deadEndBlocks;
 
 public:
-  LoadBorrowImmutabilityAnalysis(DeadEndBlocks &deadEndBlocks);
+  LoadBorrowImmutabilityAnalysis(DeadEndBlocks &deadEndBlocks,
+                                 const SILFunction *f);
 
   /// Returns true if exhaustively lbi is guaranteed to never be invalidated by
   /// local writes.
-  bool isInvalidated(LoadBorrowInst *lbi);
+  bool isImmutable(LoadBorrowInst *lbi);
 
 private:
-  bool doesAddressHaveWriteThatInvalidatesLoadBorrow(
-      LoadBorrowInst *lbi, ArrayRef<Operand *> endBorrowUses, SILValue address);
-  bool doesBoxHaveWritesThatInvalidateLoadBorrow(
-      LoadBorrowInst *lbi, ArrayRef<Operand *> endBorrowUses, SILValue box);
+  bool isImmutableInScope(LoadBorrowInst *lbi,
+                          ArrayRef<Operand *> endBorrowUses,
+                          AccessPath accessPath);
 };
 
 } // namespace silverifier

--- a/test/SILOptimizer/load_borrow_verify.sil
+++ b/test/SILOptimizer/load_borrow_verify.sil
@@ -1,0 +1,60 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s | %FileCheck %s
+
+// Test that the LoadBorrowImmutabilityChecker accepts these cases.
+// The verification should not bail-out on these, but there's no way
+// to check that.
+
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+private var testGlobal: Int64
+
+sil_global private @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_token0 : $Builtin.Word
+
+sil_global private @$s4test10testGlobalSivp : $Int64
+
+sil private @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_func0 : $@convention(c) () -> () {
+bb0:
+  alloc_global @$s4test10testGlobalSivp
+  %1 = global_addr @$s4test10testGlobalSivp : $*Int64
+  %2 = integer_literal $Builtin.Int64, 27
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil hidden [global_init] @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_token0 : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_func0 : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$s4test10testGlobalSivp : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil @dont_propagate_global_with_multiple_writes
+// CHECK:   [[V:%[0-9]+]] = load
+// CHECK:   return [[V]]
+// CHECK: } // end sil function 'dont_propagate_global_with_multiple_writes'
+sil @dont_propagate_global_with_multiple_writes : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Int64
+  %5 = integer_literal $Builtin.Int64, 42
+  %6 = struct $Int64 (%5 : $Builtin.Int64)
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int64
+  store %6 to %7 : $*Int64
+  end_access %7 : $*Int64
+  %33 = begin_access [read] [dynamic] [no_nested_conflict] %4 : $*Int64
+  %35 = load %33 : $*Int64
+  end_access %33 : $*Int64
+  return %35 : $Int64
+}


### PR DESCRIPTION
AccessPath allows us to discard a lot of the original implementation.

The verification will now be as complete as it can be within the
capability of our SIL utilities. It is much more aggressive with
respect to boxes, references, and pointers. It's more efficient in
that it only considers "overlapping" uses.

It is also now wholly consistent with the utilities that it uses, so
can be reenabled.

We could probably go even further and remove the switch statement
entirely, relying on AccessPath to recognize any operations that
propagate addresses, boxes, or pointers. But I didn't want to
potentially weaken enforcement without more careful consideration.