### PR TITLE
Add Compilation "Wave" Assertion in +Asserts Builds

### DIFF
--- a/include/swift/AST/AbstractSourceFileDepGraphFactory.h
+++ b/include/swift/AST/AbstractSourceFileDepGraphFactory.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_SOURCE_FILE_DEP_GRAPH_CONSTRUCTOR_H
 #define SWIFT_AST_SOURCE_FILE_DEP_GRAPH_CONSTRUCTOR_H
 
+#include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/FineGrainedDependencies.h"
 
@@ -72,6 +73,21 @@ protected:
                        Optional<StringRef> fingerprint);
 
   void addAUsedDecl(const DependencyKey &def, const DependencyKey &use);
+
+  static Optional<std::string> getFingerprintIfAny(
+      std::pair<const NominalTypeDecl *, const ValueDecl *>) {
+    return None;
+  }
+
+  static Optional<std::string> getFingerprintIfAny(const Decl *d) {
+    if (const auto *idc = dyn_cast<IterableDeclContext>(d)) {
+      auto result = idc->getBodyFingerprint();
+      assert((!result || !result->empty()) &&
+             "Fingerprint should never be empty");
+      return result;
+    }
+    return None;
+  }
 };
 
 } // namespace fine_grained_dependencies

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -950,9 +950,6 @@ public:
   /// If this returns true, the decl can be safely casted to ValueDecl.
   bool isPotentiallyOverridable() const;
 
-  /// Returns true if this Decl cannot be seen by any other source file
-  bool isPrivateToEnclosingFile() const;
-
   /// Retrieve the global actor attribute that applies to this declaration,
   /// if any.
   ///

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -308,6 +308,23 @@ private:
   /// The modification time of the main input file, if any.
   llvm::sys::TimePoint<> InputModTime = llvm::sys::TimePoint<>::max();
 
+#ifndef NDEBUG
+  /// The "wave" of incremental jobs that this \c Job was scheduled into.
+  ///
+  /// The first "wave" of jobs is computed by the driver from the set of inputs
+  /// and external files that have been mutated by the user. From there, as
+  /// jobs from the first wave finish executing, we reload their \c swiftdeps
+  /// files and re-integrate them into the dependency graph to discover
+  /// the jobs for the second "wave".
+  ///
+  /// In +asserts builds, we ensure that no more than two "waves" occur for
+  /// any given incremental compilation session. This is a consequence of
+  /// 1) transitivity in dependency arcs
+  /// 2) dependency tracing from uses that affect a def's interfaces to that
+  ///    def's uses.
+  mutable unsigned Wave = 1;
+#endif
+
 public:
   Job(const JobAction &Source, SmallVectorImpl<const Job *> &&Inputs,
       std::unique_ptr<CommandOutput> Output, const char *Executable,
@@ -399,6 +416,11 @@ public:
   /// Assumes that, if a compile job, has one primary swift input
   /// May return empty if none.
   StringRef getFirstSwiftPrimaryInput() const;
+
+#ifndef NDEBUG
+  unsigned getWave() const { return Wave; }
+  void setWave(unsigned WaveNum) const { Wave = WaveNum; }
+#endif
 };
 
 /// A BatchJob comprises a _set_ of jobs, each of which is sufficiently similar

--- a/lib/AST/FrontendSourceFileDepGraphFactory.h
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.h
@@ -44,12 +44,6 @@ private:
   /// create node pairs for context and name
   template <NodeKind kind, typename ContentsT>
   void addAllDefinedDeclsOfAGivenType(std::vector<ContentsT> &contentsVec);
-
-  /// At present, only nominals, protocols, and extensions have (body)
-  /// fingerprints
-  static Optional<std::string>
-  getFingerprintIfAny(std::pair<const NominalTypeDecl *, const ValueDecl *>);
-  static Optional<std::string> getFingerprintIfAny(const Decl *d);
 };
 
 class ModuleDepGraphFactory : public AbstractSourceFileDepGraphFactory {
@@ -68,12 +62,6 @@ private:
   /// create node pairs for context and name
   template <NodeKind kind, typename ContentsT>
   void addAllDefinedDeclsOfAGivenType(std::vector<ContentsT> &contentsVec);
-
-  /// At present, only nominals, protocols, and extensions have (body)
-  /// fingerprints
-  static Optional<std::string> getFingerprintIfAny(
-      std::pair<const NominalTypeDecl *, const ValueDecl *>);
-  static Optional<std::string> getFingerprintIfAny(const Decl *d);
 };
 
 } // namespace fine_grained_dependencies


### PR DESCRIPTION
- Clean up some artifacts left over from cross-module incremental builds
- Crash the driver when we have a +asserts build and we schedule a job into a wave larger than two.

The "wave" of a compilation job describes the number of indirections through other compile jobs the driver required to reach the decision to schedule a job. In incremental mode, it should always be the case that it takes no more than two complete waves to arrive at a fixpoint in the build. This is a natural consequence of the structure of the dependencies emitted by the Swift frontend - namely we rely on transitivity in dependency arcs.

A quick proof sketch: Suppose an arbitrary perturbation of the inputs to an incremental compilation session are made. In the first wave, dependency edges from the prior build's state (the "zeroeth wave") are loaded and invalidations of dependency arcs schedule in the first wave. Supposing the second wave is not the null set - the trivial case - there are additional arcs that were invalidated. Now suppose that there were a third wave. Take an arbitrary arc invalidated by this third wave. It must be the case that the file containing the use is not new - else it would be scheduled. Further it must be the case that its def was not invalidated by the zeroeth or first waves of compilation otherwise we would have scheduled it into the first or second waves. Finally, it must have a use that was discovered in the second wave. But in order for that use to have been included in the second wave, there must have been an invalidated arc created by the first wave. By transitivity of dependency arcs, there must therefore be a dependency arc from a definition invalidated in the first wave to our third wave job, which implies that the file would be scheduled into the second wave!

[Insert contradiction pig image here]