### PR TITLE
[nfc] Make getMangledName a virtual member of ClangModuleLoader.

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/ModuleLoader.h"
 #include "swift/Basic/TaggedUnion.h"
+#include "clang/AST/Decl.h"
 
 namespace clang {
 class ASTContext;
@@ -219,6 +220,10 @@ public:
   /// based on subtleties like the target module interface format.
   virtual bool isSerializable(const clang::Type *type,
                               bool checkCanonical) const = 0;
+
+  /// Writes the mangled name of \p clangDecl to \p os.
+  virtual void getMangledName(raw_ostream &os,
+                              const clang::NamedDecl *clangDecl) const = 0;
 };
 
 } // namespace swift

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -429,7 +429,8 @@ public:
   Identifier getEnumConstantName(const clang::EnumConstantDecl *enumConstant);
 
   /// Writes the mangled name of \p clangDecl to \p os.
-  void getMangledName(raw_ostream &os, const clang::NamedDecl *clangDecl) const;
+  void getMangledName(raw_ostream &os,
+                      const clang::NamedDecl *clangDecl) const override;
 
   // Print statistics from the Clang AST reader.
   void printStatistics() const override;


### PR DESCRIPTION
This will allow it to be used anywhere in the code base through an `ASTContext`. We should prefer using `getMangledName` over manually creating a mangler and mangling decls to catch special cases (such as `CXXConstructorDecl`). 