### PR TITLE
[Concurrency] Don't lose name information from completion-handler arguments

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -442,7 +442,8 @@ public:
 ///
 /// \param allPropertyNames The set of property names in the enclosing context.
 ///
-/// \param isAsync Whether this is a function imported as 'async'.
+/// \param completionHandlerIndex For an 'async' function, the index of the
+/// completion handler in argNames.
 ///
 /// \param scratch Scratch space that will be used for modifications beyond
 /// just chopping names.
@@ -457,8 +458,12 @@ bool omitNeedlessWords(StringRef &baseName,
                        bool returnsSelf,
                        bool isProperty,
                        const InheritedNameSet *allPropertyNames,
-                       bool isAsync,
+                       Optional<unsigned> completionHandlerIndex,
+                       Optional<StringRef> completionHandlerName,
                        StringScratchSpace &scratch);
+
+/// If the name has a completion-handler suffix, strip off that suffix.
+Optional<StringRef> stripWithCompletionHandlerSuffix(StringRef name);
 
 } // end namespace swift
 

--- a/lib/ClangImporter/IAMInference.cpp
+++ b/lib/ClangImporter/IAMInference.cpp
@@ -448,7 +448,7 @@ private:
     baseName = humbleBaseName.userFacingName();
     bool didOmit =
         omitNeedlessWords(baseName, argStrs, "", "", "", paramTypeNames, false,
-                          false, nullptr, false, scratch);
+                          false, nullptr, None, None, scratch);
     SmallVector<Identifier, 8> argLabels;
     for (auto str : argStrs)
       argLabels.push_back(getIdentifier(str));

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -804,7 +804,8 @@ static bool omitNeedlessWordsInFunctionName(
     ArrayRef<const clang::ParmVarDecl *> params, clang::QualType resultType,
     const clang::DeclContext *dc, const SmallBitVector &nonNullArgs,
     Optional<unsigned> errorParamIndex, bool returnsSelf, bool isInstanceMethod,
-    Optional<unsigned> completionHandlerIndex, NameImporter &nameImporter) {
+    Optional<unsigned> completionHandlerIndex,
+    Optional<StringRef> completionHandlerName, NameImporter &nameImporter) {
   clang::ASTContext &clangCtx = nameImporter.getClangContext();
 
   // Collect the parameter type names.
@@ -854,8 +855,8 @@ static bool omitNeedlessWordsInFunctionName(
                            getClangTypeNameForOmission(clangCtx, resultType),
                            getClangTypeNameForOmission(clangCtx, contextType),
                            paramTypes, returnsSelf, /*isProperty=*/false,
-                           allPropertyNames, completionHandlerIndex.hasValue(),
-                           nameImporter.getScratch());
+                           allPropertyNames, completionHandlerIndex,
+                           completionHandlerName, nameImporter.getScratch());
 }
 
 /// Prepare global name for importing onto a swift_newtype.
@@ -1135,25 +1136,8 @@ Optional<ForeignErrorConvention::Info> NameImporter::considerErrorImport(
 /// Whether the given parameter name identifies a completion handler.
 static bool isCompletionHandlerParamName(StringRef paramName) {
   return paramName == "completionHandler" || paramName == "completion" ||
-      paramName == "withCompletionHandler";
+      paramName == "withCompletionHandler" || paramName == "withCompletion";
 }
-
-/// Whether the give base name implies that the first parameter is a completion
-/// handler.
-///
-/// \returns a trimmed base name when it does, \c None others
-static Optional<StringRef> isCompletionHandlerInBaseName(StringRef basename) {
-  if (basename.endswith("WithCompletionHandler")) {
-    return basename.drop_back(strlen("WithCompletionHandler"));
-  }
-
-  if (basename.endswith("WithCompletion")) {
-    return basename.drop_back(strlen("WithCompletion"));
-  }
-
-  return None;
-}
-
 
 // Determine whether the given type is a nullable NSError type.
 static bool isNullableNSErrorType(
@@ -1185,7 +1169,7 @@ static bool isNullableNSErrorType(
 Optional<ForeignAsyncConvention::Info>
 NameImporter::considerAsyncImport(
     const clang::ObjCMethodDecl *clangDecl,
-    StringRef &baseName,
+    StringRef baseName,
     SmallVectorImpl<StringRef> &paramNames,
     ArrayRef<const clang::ParmVarDecl *> params,
     bool isInitializer, bool hasCustomName,
@@ -1207,12 +1191,14 @@ NameImporter::considerAsyncImport(
 
   // Determine whether the naming indicates that this is a completion
   // handler.
-  Optional<StringRef> newBaseName;
   if (isCompletionHandlerParamName(
-          paramNames[completionHandlerParamNameIndex])) {
+          paramNames[completionHandlerParamNameIndex]) ||
+      (completionHandlerParamNameIndex > 0 &&
+       stripWithCompletionHandlerSuffix(
+           paramNames[completionHandlerParamNameIndex]))) {
     // The argument label itself has an appropriate name.
   } else if (!hasCustomName && completionHandlerParamIndex == 0 &&
-             (newBaseName = isCompletionHandlerInBaseName(baseName))) {
+             stripWithCompletionHandlerSuffix(baseName)) {
     // The base name implies that the first parameter is a completion handler.
   } else if (isCompletionHandlerParamName(
                  params[completionHandlerParamIndex]->getName())) {
@@ -1300,10 +1286,6 @@ NameImporter::considerAsyncImport(
 
   // Drop the completion handler parameter name.
   paramNames.erase(paramNames.begin() + completionHandlerParamNameIndex);
-
-  // Update the base name, if needed.
-  if (newBaseName && !hasCustomName)
-    baseName = *newBaseName;
 
   return ForeignAsyncConvention::Info(
       completionHandlerParamIndex, completionHandlerErrorParamIndex);
@@ -1954,7 +1936,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         (void)omitNeedlessWords(baseName, {}, "", propertyTypeName,
                                 contextTypeName, {}, /*returnsSelf=*/false,
                                 /*isProperty=*/true, allPropertyNames,
-                                /*isAsync=*/false, scratch);
+                                None, None, scratch);
       }
     }
 
@@ -1970,6 +1952,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
           result.getAsyncInfo().map(
             [](const ForeignAsyncConvention::Info &info) {
               return info.CompletionHandlerParamIndex;
+            }),
+          result.getAsyncInfo().map(
+            [&](const ForeignAsyncConvention::Info &info) {
+              return method->getDeclName().getObjCSelector().getNameForSlot(
+                  info.CompletionHandlerParamIndex);
             }),
           *this);
     }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -455,7 +455,7 @@ private:
 
   Optional<ForeignAsyncConvention::Info>
   considerAsyncImport(const clang::ObjCMethodDecl *clangDecl,
-                      StringRef &baseName,
+                      StringRef baseName,
                       SmallVectorImpl<StringRef> &paramNames,
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4868,7 +4868,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
                                 getTypeNameForOmission(contextType),
                                 paramTypes, returnsSelf, false,
                                 /*allPropertyNames=*/nullptr,
-                                afd->hasAsync(), scratch))
+                                None, None, scratch))
     return None;
 
   /// Retrieve a replacement identifier.
@@ -4923,8 +4923,7 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   OmissionTypeName contextTypeName = getTypeNameForOmission(contextType);
   if (::omitNeedlessWords(name, { }, "", typeName, contextTypeName, { },
                           /*returnsSelf=*/false, true,
-                          /*allPropertyNames=*/nullptr, /*isAsync=*/false,
-                          scratch)) {
+                          /*allPropertyNames=*/nullptr, None, None, scratch)) {
     return Context.getIdentifier(name);
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -21,6 +21,9 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   let _: String? = await try slowServer.fortune()
   let _: Int = await try slowServer.magicNumber(withSeed: 42)
+
+  await slowServer.serverRestart("localhost")
+  await slowServer.server("localhost", atPriorityRestart: 0.8)
 }
 
 func testSlowServerSynchronous(slowServer: SlowServer) {

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -16,6 +16,8 @@
 
 -(void)doSomethingConflicted:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
 -(NSInteger)doSomethingConflicted:(NSString *)operation;
+-(void)server:(NSString *)name restartWithCompletionHandler:(void (^)(void))block;
+-(void)server:(NSString *)name atPriority:(double)priority restartWithCompletionHandler:(void (^)(void))block;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>


### PR DESCRIPTION
When a completion handler parameter has a selector piece that ends with
"WithCompletion(Handler)", prepend the text before that suffix to the
base name or previous argument label, as appropriate. This ensures that
we don't lose information from the name, particularly with delegate names.
