### PR TITLE
ClangImporter: support the MS anonymous structure extension

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1390,7 +1390,8 @@ createValueConstructor(ClangImporter::Implementation &Impl,
         continue;
 
       if (auto clangField = dyn_cast<clang::FieldDecl>(var->getClangDecl()))
-        if (clangField->isAnonymousStructOrUnion())
+        if (clangField->isAnonymousStructOrUnion() ||
+            clangField->getDeclName().isEmpty())
           generateParamName = false;
     }
 
@@ -2397,6 +2398,8 @@ namespace {
             if (field->isAnonymousStructOrUnion()) {
               IdStream << "__Anonymous_field" << field->getFieldIndex();
             } else {
+              assert(!field->getDeclName().isEmpty() &&
+                     "Microsoft anonymous struct extension?");
               IdStream << field->getName();
             }
             ImportedName Result;
@@ -4011,7 +4014,7 @@ namespace {
       Optional<ImportedName> correctSwiftName;
       ImportedName importedName;
 
-      if (!decl->isAnonymousStructOrUnion()) {
+      if (!decl->isAnonymousStructOrUnion() && !decl->getDeclName().isEmpty()) {
         importedName = importFullName(decl, correctSwiftName);
         if (!importedName) {
           return nullptr;

--- a/test/ClangImporter/Inputs/ctypes_msvc.h
+++ b/test/ClangImporter/Inputs/ctypes_msvc.h
@@ -1,0 +1,8 @@
+
+typedef struct S {
+  unsigned char uc;
+} S;
+
+typedef struct T {
+  S;
+} T;

--- a/test/ClangImporter/ctypes_parse_msvc.swift
+++ b/test/ClangImporter/ctypes_parse_msvc.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -Xcc -fms-extensions -import-objc-header %S/Inputs/ctypes_msvc.h -typecheck -verify %s
+
+_ = T().uc
+_ = T(S(uc: 0))


### PR DESCRIPTION
The Microsoft extension permits the creation of structures without a
name which effectively create an anonymous inline structure.  Accommodate
that in the ClangImporter.

For more details about the extension, see:
https://docs.microsoft.com/en-us/previous-versions/a3bbz53t(v=vs.140)#anonymous-structs

Thanks to @brentdax for the suggestion of the additional check!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
