### PR TITLE
Add an end-to-end test for ThinLTO (-lto=llvm-thin flag), fix compiler crashes

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5166,7 +5166,9 @@ llvm::Constant *IRGenModule::getAddrOfGlobalString(StringRef data,
     return entry.second;
   }
 
-  entry = createStringConstant(data, willBeRelativelyAddressed);
+  entry = createStringConstant(data, willBeRelativelyAddressed,
+                               /*sectionName*/ "",
+                               ".str" /* match how Clang creates strings */);
   return entry.second;
 }
 
@@ -5195,9 +5197,9 @@ llvm::Constant *IRGenModule::getAddrOfGlobalUTF16String(StringRef utf8) {
   ArrayRef<llvm::UTF16> utf16(&buffer[0], utf16Length + 1);
 
   auto init = llvm::ConstantDataArray::get(getLLVMContext(), utf16);
-  auto global = new llvm::GlobalVariable(Module, init->getType(), true,
-                                         llvm::GlobalValue::PrivateLinkage,
-                                         init);
+  auto global = new llvm::GlobalVariable(
+      Module, init->getType(), true, llvm::GlobalValue::PrivateLinkage, init,
+      ".str" /* match how Clang creates strings */);
   global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
 
   // Drill down to make an i16*.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -995,13 +995,13 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
 #include "swift/Runtime/RuntimeFunctions.def"
 
 std::pair<llvm::GlobalVariable *, llvm::Constant *>
-IRGenModule::createStringConstant(StringRef Str,
-  bool willBeRelativelyAddressed, StringRef sectionName) {
+IRGenModule::createStringConstant(StringRef Str, bool willBeRelativelyAddressed,
+                                  StringRef sectionName, StringRef name) {
   // If not, create it.  This implicitly adds a trailing null.
   auto init = llvm::ConstantDataArray::getString(getLLVMContext(), Str);
   auto global = new llvm::GlobalVariable(Module, init->getType(), true,
                                          llvm::GlobalValue::PrivateLinkage,
-                                         init);
+                                         init, name);
   // FIXME: ld64 crashes resolving relative references to coalesceable symbols.
   // rdar://problem/22674524
   // If we intend to relatively address this string, don't mark it with

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1007,9 +1007,9 @@ private:
   
 //--- Globals ---------------------------------------------------------------
 public:
-  std::pair<llvm::GlobalVariable *, llvm::Constant *>
-  createStringConstant(StringRef Str, bool willBeRelativelyAddressed = false,
-                       StringRef sectionName = "");
+  std::pair<llvm::GlobalVariable *, llvm::Constant *> createStringConstant(
+      StringRef Str, bool willBeRelativelyAddressed = false,
+      StringRef sectionName = "", StringRef name = "");
   llvm::Constant *getAddrOfGlobalString(StringRef utf8,
                                         bool willBeRelativelyAddressed = false);
   llvm::Constant *getAddrOfGlobalUTF16String(StringRef utf8);

--- a/test/IRGen/UseObjCMethod.swift
+++ b/test/IRGen/UseObjCMethod.swift
@@ -23,5 +23,5 @@ testDemo()
 
 // Make sure the clang importer puts the selectors and co into the llvm.compiler used variable.
 
-// CHECK: @llvm.compiler.used = appending global [{{.*}} x i8*] [{{.*}} @"OBJC_CLASSLIST_REFERENCES_$_"{{.*}}@OBJC_METH_VAR_NAME_{{.*}}@OBJC_SELECTOR_REFERENCES_{{.*}}@OBJC_METH_VAR_NAME_.1{{.*}}@OBJC_SELECTOR_REFERENCES_.2{{.*}}]
+// CHECK: @llvm.compiler.used = appending global [{{.*}} x i8*] [{{.*}} @"OBJC_CLASSLIST_REFERENCES_$_"{{.*}}@OBJC_METH_VAR_NAME_{{.*}}@OBJC_SELECTOR_REFERENCES_{{.*}}@OBJC_METH_VAR_NAME_.1{{.*}}@OBJC_SELECTOR_REFERENCES_.{{.*}}]
 

--- a/test/IRGen/anonymous_context_descriptors.sil
+++ b/test/IRGen/anonymous_context_descriptors.sil
@@ -12,7 +12,7 @@ class Blah<T: P> {
 
 // Mangled name of the anonymous descriptor
 // CHECK-NOT: private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
-// CHECK-MANGLED: [[INNER_MANGLED:@[0-9]+]] = private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
+// CHECK-MANGLED: [[INNER_MANGLED:@.str.[0-9]+]] = private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
 
 // Anonymous descriptor
 // CHECK: @"$s29anonymous_context_descriptors4BlahC5Inner33{{.*}}MXX" =

--- a/test/IRGen/builtins_objc.swift
+++ b/test/IRGen/builtins_objc.swift
@@ -7,8 +7,8 @@ import Swift
 import Foundation
 import CoreGraphics
 
-// CHECK: [[INT32:@[0-9]+]] = {{.*}} c"i\00"
-// CHECK: [[OBJECT:@[0-9]+]] = {{.*}} c"@\00"
+// CHECK: [[INT32:@.str.[0-9]+]] = {{.*}} c"i\00"
+// CHECK: [[OBJECT:@.str.[0-9]+]] = {{.*}} c"@\00"
 
 @objc enum ObjCEnum: Int32 { case X }
 @objc class ObjCClass: NSObject {}
@@ -22,9 +22,9 @@ func getObjCTypeEncoding<T>(_: T) {
   use(Builtin.getObjCTypeEncoding(Int32.self))
   // CHECK: call swiftcc void @use({{.* i8]\*}} [[INT32]]
   use(Builtin.getObjCTypeEncoding(ObjCEnum.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[CGRECT:@[0-9]+]],
+  // CHECK: call swiftcc void @use({{.* i8]\*}} [[CGRECT:@.str.[0-9]+]],
   use(Builtin.getObjCTypeEncoding(CGRect.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[NSRANGE:@[0-9]+]],
+  // CHECK: call swiftcc void @use({{.* i8]\*}} [[NSRANGE:@.str.[0-9]+]],
   use(Builtin.getObjCTypeEncoding(NSRange.self))
   // CHECK: call swiftcc void @use({{.* i8]\*}} [[OBJECT]]
   use(Builtin.getObjCTypeEncoding(AnyObject.self))

--- a/test/IRGen/class_update_callback_with_stub.swift
+++ b/test/IRGen/class_update_callback_with_stub.swift
@@ -23,7 +23,7 @@ import resilient_objc_class
 // -- parent
 // CHECK-SAME: @"$s31class_update_callback_with_stubMXM"
 // -- name
-// CHECK-SAME: @1
+// CHECK-SAME: @.str.1
 // -- access function
 // CHECK-SAME: @"$s31class_update_callback_with_stub17ResilientSubclassCMa"
 // -- field descriptor

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -4,8 +4,8 @@
 
 // REQUIRES: PTRSIZE=64
 
-// CHECK-DAG: [[FILENAME:@[0-9]+]] = {{.*}} c"{{.*}}closure.swift\00"
-// OPT: [[FILENAME:@[0-9]+]] = {{.*}} [1 x i8] zeroinitializer
+// CHECK-DAG: [[FILENAME:@.str]] = {{.*}} c"{{.*}}closure.swift\00"
+// OPT: [[FILENAME:@.str]] = {{.*}} [1 x i8] zeroinitializer
 
 // -- partial_apply context metadata
 

--- a/test/IRGen/expressions.swift
+++ b/test/IRGen/expressions.swift
@@ -8,14 +8,14 @@ import Swift
 // CHECK: private unnamed_addr constant [22 x i8] c"this is just a\0A\0A test\00"
 
 // CHECK: define hidden [[stringLayout:[^@]*]] @"$s11expressions17TestStringLiteralSSyF"() {{.*}} {
-// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @0, i64 0, i64 0), i64 21, i1 true)
+// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str, i64 0, i64 0), i64 21, i1 true)
 
 func TestStringLiteral() -> String {
   return "this is just a\n\u{0a} test"
 }
 
 // CHECK: define hidden [[stringLayout]] @"$s11expressions18TestStringLiteral2SSyF"() {{.*}} {
-// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @1, i64 0, i64 0), i64 19, i1 false)
+// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @.str.1, i64 0, i64 0), i64 19, i1 false)
 func TestStringLiteral2() -> String {
   return "non-ASCII string \u{00B5}"
 }

--- a/test/IRGen/objc_attr_NSManaged.sil
+++ b/test/IRGen/objc_attr_NSManaged.sil
@@ -19,7 +19,7 @@ sil_vtable X {}
 // The getter/setter should not show up in the Objective-C metadata.
 // CHECK: @_INSTANCE_METHODS__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] } { i32 24, i32 2, {{.*}} @"\01L_selector_data(initWithBellsOn:)", {{.*}} @"\01L_selector_data(init)",
 
-// CHECK: [[X:@[0-9]+]] = private unnamed_addr constant [2 x i8] c"x\00"
+// CHECK: [[X:@.str.[0-9]+]] = private unnamed_addr constant [2 x i8] c"x\00"
 
 // The property 'x' should show up in the Objective-C metadata.
 // CHECK: @_PROPERTIES__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { {{.*}}i32, i32, [1 x { i8*, i8* }] } { i32 16, i32 1, [1 x { i8*, i8* }] [{ i8*, i8* } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* [[X]], i64 0, i64 0),

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -101,7 +101,7 @@ import Foundation
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"\01L_selector_data(acceptSet:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @{{[0-9]+}}, i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @.str.{{[0-9]+}}, i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void (%3*, i8*, %4*)* @"$s11objc_bridge3BasC9acceptSetyyShyACGFTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC9acceptSetyyShyACGFTo.ptrauth" to i8*)
 // CHECK:     }

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -2,9 +2,9 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @[[THINGY_NAME:[0-9]]]
+// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @.str
 
-// CHECK: @[[THINGY_NAME]] = private constant [7 x i8] c"Thingy\00"
+// CHECK: @.str = private constant [7 x i8] c"Thingy\00"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -28,7 +28,7 @@ class Foo : NSRuncing, NSFunging, Ansible {
 // CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Foo = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC:@[0-9]+]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC:@.str.[0-9]+]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC3fooyyFTo{{(\.ptrauth)?}}" to i8*)
 // CHECK:   }]

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -10,8 +10,8 @@ extension A : YourProtocol {}
 
 // CHECK-LABEL: @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACMc"
 // CHECK-SAME:    @"$s32objc_runtime_visible_conformance10MyProtocolMp"
-// CHECK-SAME:    [[STRING_A:@[0-9]+]]
+// CHECK-SAME:    @.str
 // CHECK-SAME:    @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACWP"
 //   DirectObjCClassName
 // CHECK-SAME:    i32 16
-// CHECK:       [[STRING_A]] = private constant [22 x i8] c"MyRuntimeVisibleClass\00"
+// CHECK:       @.str = private constant [22 x i8] c"MyRuntimeVisibleClass\00"

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -95,19 +95,19 @@
 // CHECK-32:     i8* bitcast {{.*}}* @"$s13objc_subclass10SwiftGizmoCfDTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(isEnabled)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* {{@[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(setIsEnabled:)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* @"\01L_selector_data(.cxx_construct)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfeTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }]
 // CHECK-32: }, section "__DATA, {{.*}}", align 4
@@ -145,19 +145,19 @@
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfDTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(isEnabled)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* {{@[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(setIsEnabled:)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* @"\01L_selector_data(.cxx_construct)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfeTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }]
 // CHECK-64: }, section "__DATA, {{.*}}", align 8
@@ -239,11 +239,11 @@
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CACycfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }, {
 // CHECK-32:       i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i32 0, i32 0),
-// CHECK-32:       i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@[0-9]+}}, i32 0, i32 0),
+// CHECK-32:       i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }, {
 // CHECK-32:       i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(.cxx_destruct)", i32 0, i32 0),
-// CHECK-32:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@[0-9]+}}, i32 0, i32 0),
+// CHECK-32:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CfETo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }
 // CHECK-32:   ]
@@ -267,11 +267,11 @@
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CACycfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }, {
 // CHECK-64:       i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i64 0, i64 0),
-// CHECK-64:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@[0-9]+}}, i64 0, i64 0),
+// CHECK-64:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }, {
 // CHECK-64:       i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(.cxx_destruct)", i64 0, i64 0),
-// CHECK-64:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@[0-9]+}}, i64 0, i64 0)
+// CHECK-64:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i64 0, i64 0)
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CfETo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }
 // CHECK-64: ] }

--- a/test/IRGen/objc_subscripts.swift
+++ b/test/IRGen/objc_subscripts.swift
@@ -42,7 +42,7 @@
 // CHECK:       { i8*, i8*, i8* } 
 // CHECK:         {
 // CHECK:           i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i64 0, i64 0),
-// CHECK:           i8* getelementptr inbounds ([8 x i8], [8 x i8]* @{{[0-9]+}}, i64 0, i64 0),
+// CHECK:           i8* getelementptr inbounds ([8 x i8], [8 x i8]* @.str.{{[0-9]+}}, i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE8:%.*]]* ([[OPAQUE9:%.*]]*, i8*)* @"$s15objc_subscripts10SomeObjectCACycfcTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s15objc_subscripts10SomeObjectCACycfcTo.ptrauth" to i8*)
 // CHECK:         }

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -30,7 +30,7 @@ extension NSRect: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class name reference
-// CHECK-SAME:           @[[GIZMO_NAME:[0-9]+]]
+// CHECK-SAME:           @.str
 // -- witness table
 // CHECK-SAME:           @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags
@@ -40,7 +40,7 @@ extension Gizmo: Runcible {
   public func runce() {}
 }
 
-// CHECK: @[[GIZMO_NAME]] = private constant [6 x i8] c"Gizmo\00"
+// CHECK: @.str = private constant [6 x i8] c"Gizmo\00"
 
 // CHECK-LABEL: @"$sSo6NSRectV33protocol_conformance_records_objc8RuncibleACHc" = private constant
 // CHECK-LABEL: @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACHc" = private constant

--- a/test/IRGen/related_entity.sil
+++ b/test/IRGen/related_entity.sil
@@ -13,37 +13,37 @@ sil @use_metatypes : $@convention(thin) () -> () {
 bb0:
   %take = function_ref @take_metatype : $@convention(thin) <T> (@thick T.Type) -> ()
 
-// CHECK:         [[NestedTypedefErrorCode_NAME:@[0-9]+]] = private constant [29 x i8] c"Code\00NNestedTypedefError\00St\00\00"
+// CHECK:         [[NestedTypedefErrorCode_NAME:@.str.[0-9]+]] = private constant [29 x i8] c"Code\00NNestedTypedefError\00St\00\00"
 // CHECK:         @"$sSo18NestedTypedefErroraMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
 // CHECK-SAME:    [29 x i8]* [[NestedTypedefErrorCode_NAME]]
 
-// CHECK:         [[NestedTagError_NAME:@[0-9]+]] = private constant [29 x i8] c"TagError\00NNestedTagError\00Re\00\00"
+// CHECK:         [[NestedTagError_NAME:@.str.[0-9]+]] = private constant [29 x i8] c"TagError\00NNestedTagError\00Re\00\00"
 // CHECK:         @"$sSC14NestedTagErrorLeVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"
 // CHECK-SAME:    [29 x i8]* [[NestedTagError_NAME]]
 
-// CHECK:         [[TypedefError2Code_NAME:@[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
+// CHECK:         [[TypedefError2Code_NAME:@.str.[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
 // CHECK:         @"$sSo13TypedefError2aMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
 // CHECK-SAME:    [24 x i8]* [[TypedefError2Code_NAME]]
 
-// CHECK:         [[TypedefError1_NAME:@[0-9]+]] = private constant [18 x i8] c"TypedefError1\00RE\00\00"
+// CHECK:         [[TypedefError1_NAME:@.str.[0-9]+]] = private constant [18 x i8] c"TypedefError1\00RE\00\00"
 // CHECK:         @"$sSC13TypedefError1LEVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"
 // CHECK-SAME:    [18 x i8]* [[TypedefError1_NAME]]
 
-// CHECK:         [[TagError2_NAME:@[0-9]+]] = private constant [17 x i8] c"Code\00NTagError2\00\00"
+// CHECK:         [[TagError2_NAME:@.str.[0-9]+]] = private constant [17 x i8] c"Code\00NTagError2\00\00"
 // CHECK:         @"$sSo9TagError2VMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
 // CHECK-SAME:    [17 x i8]* [[TagError2_NAME]]
 
-// CHECK:         [[TagError1_NAME:@[0-9]+]] = private constant [14 x i8] c"TagError1\00Re\00\00"
+// CHECK:         [[TagError1_NAME:@.str.[0-9]+]] = private constant [14 x i8] c"TagError1\00Re\00\00"
 // CHECK:         @"$sSC9TagError1LeVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -123,7 +123,7 @@ sil_global [let] @string_with_offset : $MyString = {
   %9 = value_to_bridge_object %8 : $Builtin.Int64
   %initval = struct $MyString (%9 : $Builtin.BridgeObject)
 }
-// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @0 to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
+// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @.str to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:

--- a/test/IRGen/thinlto.swift
+++ b/test/IRGen/thinlto.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -working-directory %t -lto=llvm-thin -DMODULE -static -emit-library -emit-module %s -module-name MyModule
+// RUN: %target-build-swift -parse-as-library -working-directory %t -lto=llvm-thin %s -I%t -L%t -lMyModule -module-name main -o %t/main %lto_flags
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+#if MODULE
+
+public protocol MyProtocol {
+}
+public class MyClass: MyProtocol {
+}
+
+public func fooFromModule() { print("fooFromModule") }
+public func barFromModule() { print("barFromModule") }
+
+#else
+
+import MyModule
+
+@_cdecl("main")
+func main() -> Int {
+	print("Hello!")
+	fooFromModule()
+	return 0
+}
+
+#endif
+
+// CHECK: Hello!
+// CHECK: fooFromModule

--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -43,7 +43,7 @@ public func singleNonAsciiChar() -> Character {
 //
 // CHECK-LABEL: define {{.*}}singleNonSmolChar
 // CHECK-NEXT: entry:
-// CHECK:   ret { i64, %swift.bridge* } { i64 1152921504606847001, %swift.bridge* {{.*}}@0{{.*}}i64 -9223372036854775808
+// CHECK:   ret { i64, %swift.bridge* } { i64 1152921504606847001, %swift.bridge* {{.*}}@.str{{.*}}i64 -9223372036854775808
 public func singleNonSmolChar() -> Character {
   return "👩‍👩‍👦‍👦"
 }


### PR DESCRIPTION
- Add lit.cfg support to add the right path to the just-built LTO library on Darwin
- Add an end-to-end ThinLTO test
- Fix discovered compiler crash 1: ThinLTO probihits unnamed global variables, let's name them all. This part of the PR is authored by @gottesmm, thx!!!
- Fix discovered compiler crash 2: Stop marking llvm.used as disableAddressSanitizer, which causes ThinLTO's global variable merging logic to fail, and it's not really needed to let's stop doing that. (At first I considered this a bug in the merging logic, but on a second thought, it's highly unusual to reference llvm.used from any other variables/metadata that I actually think it's a mistake on the swiftc side to do that.)