### PR TITLE
[Async CC] Test: Mark functions that call async functions async.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1747,6 +1747,8 @@ llvm::Value *irgen::getDynamicAsyncContextSize(IRGenFunction &IGF,
                                                AsyncContextLayout layout,
                                                CanSILFunctionType functionType,
                                                llvm::Value *thickContext) {
+  // TODO: This calculation should be extracted out into a standalone function
+  //       emitted on-demand per-module to improve codesize.
   switch (functionType->getRepresentation()) {
   case SILFunctionTypeRepresentation::Thick: {
     // If the called function is thick, the size of the called function's

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2061,11 +2061,15 @@ class AsyncCallEmission final : public CallEmission {
   Size contextSize;
   Address context;
   llvm::Value *thickContext = nullptr;
+  Optional<AsyncContextLayout> asyncContextLayout;
 
   AsyncContextLayout getAsyncContextLayout() {
-    return ::getAsyncContextLayout(IGF, getCallee().getOrigFunctionType(),
-                                   getCallee().getSubstFunctionType(),
-                                   getCallee().getSubstitutions());
+    if (!asyncContextLayout) {
+      asyncContextLayout.emplace(::getAsyncContextLayout(
+          IGF, getCallee().getOrigFunctionType(),
+          getCallee().getSubstFunctionType(), getCallee().getSubstitutions()));
+    }
+    return *asyncContextLayout;
   }
 
   void saveValue(ElementLayout layout, Explosion &explosion, bool isOutlined) {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2686,7 +2686,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     }
   }
 
-  Explosion llArgs;    
+  Explosion llArgs;
   WitnessMetadata witnessMetadata;
   auto emission = getCallEmissionForLoweredValue(
       *this, origCalleeType, substCalleeType, calleeLV, selfValue,

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -25,8 +25,6 @@
 #include "llvm/ADT/SetVector.h"
 #include "swift/AST/Types.h"
 
-#include "Explosion.h"
-
 namespace swift {
   class CanType;
   enum class MetadataState : size_t;
@@ -36,6 +34,7 @@ namespace swift {
 
   namespace irgen {
   class Address;
+  class Explosion;
   class IRGenFunction;
   class IRGenModule;
   class Size;

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -32,8 +32,9 @@ namespace swift {
   enum class MetadataState : size_t;
   class ProtocolDecl;
   class ProtocolConformanceRef;
+  class SpecializedProtocolConformance;
 
-namespace irgen {
+  namespace irgen {
   class Address;
   class IRGenFunction;
   class IRGenModule;
@@ -42,14 +43,32 @@ namespace irgen {
 /// NecessaryBindings - The set of metadata that must be saved in
 /// order to perform some set of operations on a type.
 class NecessaryBindings {
-  llvm::SetVector<GenericRequirement> Requirements;
+  enum class Kind {
+    /// Are the bindings to be computed for a partial apply forwarder.
+    /// In the case this is true we need to store/restore the conformance of a
+    /// specialized type with conditional conformance because the conditional
+    /// requirements are not available in the partial apply forwarder.
+    PartialApply,
+    AsyncFunction,
+  };
+  Kind kind;
+  llvm::SetVector<GenericRequirement> RequirementsSet;
+  llvm::SmallVector<GenericRequirement, 2> RequirementsVector;
   llvm::DenseMap<GenericRequirement, ProtocolConformanceRef> Conformances;
 
-  /// Are the bindings to be computed for a partial apply forwarder.
-  /// In the case this is true we need to store/restore the conformance of a
-  /// specialized type with conditional conformance because the conditional
-  /// requirements are not available in the partial apply forwarder.
-  bool forPartialApply = false;
+  void addRequirement(GenericRequirement requirement) {
+    switch (kind) {
+    case Kind::PartialApply:
+      RequirementsSet.insert(requirement);
+      break;
+    case Kind::AsyncFunction:
+      RequirementsVector.push_back(requirement);
+      break;
+    }
+  }
+
+  void addAbstractConditionalRequirements(
+      SpecializedProtocolConformance *specializedConformance);
 
 public:
   NecessaryBindings() = default;
@@ -70,7 +89,12 @@ public:
 
   /// Get the requirement from the bindings at index i.
   const GenericRequirement &operator[](size_t i) const {
-    return Requirements[i];
+    switch (kind) {
+    case Kind::PartialApply:
+      return RequirementsSet[i];
+    case Kind::AsyncFunction:
+      return RequirementsVector[i];
+    }
   }
 
   ProtocolConformanceRef
@@ -78,16 +102,14 @@ public:
     return Conformances.lookup(requirement);
   }
 
-  size_t size() const {
-    return Requirements.size();
-  }
+  size_t size() const { return getRequirements().size(); }
 
   /// Add whatever information is necessary to reconstruct a witness table
   /// reference for the given type.
   void addProtocolConformance(CanType type, ProtocolConformanceRef conf);
 
   /// Is the work to do trivial?
-  bool empty() const { return Requirements.empty(); }
+  bool empty() const { return getRequirements().empty(); }
 
   /// Returns the required size of the bindings.
   /// Pointer alignment is sufficient.
@@ -101,11 +123,17 @@ public:
   /// Restore the necessary bindings from the given buffer.
   void restore(IRGenFunction &IGF, Address buffer, MetadataState state) const;
 
-  const llvm::SetVector<GenericRequirement> &getRequirements() const {
-    return Requirements;
+  const llvm::ArrayRef<GenericRequirement> getRequirements() const {
+    switch (kind) {
+    case Kind::PartialApply:
+      return RequirementsSet.getArrayRef();
+    case Kind::AsyncFunction:
+      return RequirementsVector;
+    }
   }
 
-  bool forAsyncFunction() { return !forPartialApply; }
+  bool forPartialApply() { return kind == Kind::PartialApply; }
+  bool forAsyncFunction() { return kind == Kind::AsyncFunction; }
 
 private:
   static NecessaryBindings computeBindings(IRGenModule &IGM,

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -372,25 +372,25 @@ bb0(%0 : $*A2<A3>):
   return %5 : $@async @callee_guaranteed () -> (@owned A1, @error Error)
 }
 
-sil @capture_class : $@async @convention(thin) (@guaranteed A3) -> ()
-
-// CHECK-LABEL: define{{.*}} swiftcc i8* @partial_apply_stack_in_coroutine(i8* {{.*}} %0, %T13partial_apply2A3C* %1)
-sil @partial_apply_stack_in_coroutine : $@yield_once (@owned A3) -> () {
-entry(%0: $A3):
-  %f = function_ref @capture_class : $@async @convention(thin) (@guaranteed A3) -> ()
-  %p = partial_apply [callee_guaranteed] [on_stack] %f(%0) : $@async @convention(thin) (@guaranteed A3) -> ()
-  apply %p() : $@noescape @async @callee_guaranteed () -> ()
-  dealloc_stack %p : $@noescape @async @callee_guaranteed () -> ()
-  %1000 = integer_literal $Builtin.Int32, 1000
-  yield (), resume resume, unwind unwind
-
-resume:
-  %ret = tuple ()
-  return %ret : $()
-
-unwind:
-  unwind
-}
+//sil @capture_class : $@async @convention(thin) (@guaranteed A3) -> ()
+//
+//// CHECK LABEL: define{{.*}} swiftcc i8* @partial_apply_stack_in_coroutine(i8* {{.*}} %0, %T13partial_apply2A3C* %1)
+//sil @partial_apply_stack_in_coroutine : $@async @yield_once (@owned A3) -> () {
+//entry(%0: $A3):
+//  %f = function_ref @capture_class : $@async @convention(thin) (@guaranteed A3) -> ()
+//  %p = partial_apply [callee_guaranteed] [on_stack] %f(%0) : $@async @convention(thin) (@guaranteed A3) -> ()
+//  apply %p() : $@noescape @async @callee_guaranteed () -> ()
+//  dealloc_stack %p : $@noescape @async @callee_guaranteed () -> ()
+//  %1000 = integer_literal $Builtin.Int32, 1000
+//  yield (), resume resume, unwind unwind
+//
+//resume:
+//  %ret = tuple ()
+//  return %ret : $()
+//
+//unwind:
+//  unwind
+//}
 sil_vtable A3 {}
 
 

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -83,7 +83,7 @@ sil_vtable S {
   #S.deinit!deallocator: @S_deallocating_deinit
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %s_type = metatype $@thick S.Type

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -30,12 +30,12 @@ class S {
 // CHECK-LL: define hidden swiftcc void @classinstanceSInt64ToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
 sil hidden @classinstanceSInt64ToVoid : $@async @convention(method) (Int64, @guaranteed S) -> () {
 bb0(%int : $Int64, %instance : $S):
-  %take_s = function_ref @take_S : $@convention(thin) (@guaranteed S) -> ()
-  %result = apply %take_s(%instance) : $@convention(thin) (@guaranteed S) -> ()
+  %take_s = function_ref @take_S : $@async @convention(thin) (@guaranteed S) -> ()
+  %result = apply %take_s(%instance) : $@async @convention(thin) (@guaranteed S) -> ()
   return %result : $()
 }
 
-sil hidden @take_S : $@convention(thin) (@guaranteed S) -> () {
+sil hidden @take_S : $@async @convention(thin) (@guaranteed S) -> () {
 bb0(%instance : $S):
   %any = alloc_stack $Any
   strong_retain %instance : $S

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -83,7 +83,7 @@ sil_vtable S {
   #S.deinit!deallocator: @S_deallocating_deinit
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %s_type = metatype $@thick S.Type

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -30,12 +30,12 @@ class S {
 // CHECK-LL: define hidden swiftcc void @classinstanceSVoidToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
 sil hidden @classinstanceSVoidToVoid : $@async @convention(method) (@guaranteed S) -> () {
 bb0(%instance : $S):
-  %take_s = function_ref @take_S : $@convention(thin) (@guaranteed S) -> ()
-  %result = apply %take_s(%instance) : $@convention(thin) (@guaranteed S) -> ()
+  %take_s = function_ref @take_S : $@async @convention(thin) (@guaranteed S) -> ()
+  %result = apply %take_s(%instance) : $@async @convention(thin) (@guaranteed S) -> ()
   return %result : $()
 }
 
-sil hidden @take_S : $@convention(thin) (@guaranteed S) -> () {
+sil hidden @take_S : $@async @convention(thin) (@guaranteed S) -> () {
 bb0(%instance : $S):
   %any = alloc_stack $Any
   strong_retain %instance : $S

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -49,7 +49,7 @@ bb0(%existential : $*P):
   return %result : $()
 }
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %S_type = metatype $@thin S.Type
   %int_literal = integer_literal $Builtin.Int64, 7384783
@@ -68,8 +68,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 7384783
-  %result = apply %call() : $@convention(thin) () -> ()
+  %call = function_ref @call : $@async @convention(thin) () -> () // CHECK: 7384783
+  %result = apply %call() : $@async @convention(thin) () -> ()
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -66,7 +66,7 @@ bb0:
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> () // CHECK: 7384783
   %result = apply %call() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -25,7 +25,7 @@ bb0(%out : $*T, %in : $*T):
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %int_literal = integer_literal $Builtin.Int64, 42

--- a/test/IRGen/async/run-call-generic-to-void.sil
+++ b/test/IRGen/async/run-call-generic-to-void.sil
@@ -25,7 +25,7 @@ bb0(%instance : $*T):
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %int_literal = integer_literal $Builtin.Int64, 922337203685477580

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -26,7 +26,7 @@ bb0(%0 : $*T, %1 : $*T):
   return %6 : $Bool
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %int1_literal = integer_literal $Builtin.Int64, 42

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -26,7 +26,7 @@ entry(%int1: $Int64, %int2: $Int64):
   return %result2 : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %int_literal1 = integer_literal $Builtin.Int64, 42

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -25,7 +25,7 @@ entry(%int: $Int64):
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %int_literal = integer_literal $Builtin.Int64, 42

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -58,7 +58,7 @@ bb0(%self_addr : $*I):
   return %result : $Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %i_type = metatype $@thin I.Type
   %i_int_literal = integer_literal $Builtin.Int64, 99

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -48,7 +48,7 @@ bb0(%self_addr : $*I):
   return %result : $Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %i_type = metatype $@thin I.Type
   %i_int_literal = integer_literal $Builtin.Int64, 99

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -45,7 +45,7 @@ bb0(%self : $S, %int : $Int64):
   return %out : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %s_type = metatype $@thin S.Type
   %storage_literal = integer_literal $Builtin.Int64, 987654321

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -26,13 +26,13 @@ struct S {
 // CHECK-LL: define hidden swiftcc void @structinstanceSInt64ToVoid(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
 sil hidden @structinstanceSInt64ToVoid : $@async @convention(method) (Int64, S) -> () {
 bb0(%int : $Int64, %self : $S):
-  %takeSAndInt64 = function_ref @takeSAndInt64 : $@convention(thin) (S, Int64) -> ()
-  %takeSAndInt64_result = apply %takeSAndInt64(%self, %int) : $@convention(thin) (S, Int64) -> ()
+  %takeSAndInt64 = function_ref @takeSAndInt64 : $@async @convention(thin) (S, Int64) -> ()
+  %takeSAndInt64_result = apply %takeSAndInt64(%self, %int) : $@async @convention(thin) (S, Int64) -> ()
   %out = tuple ()
   return %out : $()
 }
 
-sil hidden @takeSAndInt64 : $@convention(thin) (S, Int64) -> () {
+sil hidden @takeSAndInt64 : $@async @convention(thin) (S, Int64) -> () {
 bb0(%self : $S, %int : $Int64):
   %s_addr = alloc_stack $S
   store %self to %s_addr : $*S

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -61,7 +61,7 @@ sil_witness_table hidden E: Error module main {
 }
 
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
   try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb3
@@ -114,8 +114,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
-  %result = apply %call() : $@convention(thin) () -> ()
+  %call = function_ref @call : $@async @convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@async @convention(thin) () -> ()
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -112,7 +112,7 @@ bb0:
   throw %error : $Error
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
   %result = apply %call() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -135,7 +135,7 @@ bb0:
   return %Int64 : $Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
   %result = apply %call() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -60,7 +60,7 @@ sil_witness_table hidden E: Error module main {
 }
 
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
   try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal bb1, error bb3
@@ -102,8 +102,8 @@ entry:
   %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
   try_apply %asyncVoidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal success1, error error1
 success1(%out1 : $Int64):
-  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error)
-  try_apply %syncVoidThrowsToInt() : $@convention(thin) () -> (Int64, @error Error), normal success2, error error2
+  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
+  try_apply %syncVoidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal success2, error error2
 success2(%out : $Int64):
   return %out : $Int64
 error1(%error1 : $Error):
@@ -114,7 +114,7 @@ error(%error : $Error):
   throw %error : $Error
 }
 
-sil hidden @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error) {
+sil hidden @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 bb0:
   %e_type = metatype $@thin E.Type
   %int_literal = integer_literal $Builtin.Int64, 42
@@ -137,8 +137,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
-  %result = apply %call() : $@convention(thin) () -> ()
+  %call = function_ref @call : $@async @convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@async @convention(thin) () -> ()
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -122,7 +122,7 @@ bb0:
   throw %error : $Error
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
   %result = apply %call() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -61,7 +61,7 @@ sil_witness_table hidden E: Error module main {
 }
 
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
   try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb3
@@ -124,8 +124,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
-  %result = apply %call() : $@convention(thin) () -> ()
+  %call = function_ref @call : $@async @convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@async @convention(thin) () -> ()
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -61,7 +61,7 @@ sil_witness_table hidden E: Error module main {
 }
 
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
   try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal bb1, error bb3
@@ -100,8 +100,8 @@ bb5:
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 entry:
-  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error)
-  try_apply %syncVoidThrowsToInt() : $@convention(thin) () -> (Int64, @error Error), normal success1, error error1
+  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
+  try_apply %syncVoidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal success1, error error1
 success1(%out1 : $Int64):
   %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)
   try_apply %asyncVoidThrowsToInt() : $@async @convention(thin) () -> (Int64, @error Error), normal success2, error error2
@@ -115,7 +115,7 @@ error(%error : $Error):
   throw %error : $Error
 }
 
-sil hidden @syncVoidThrowsToInt : $@convention(thin) () -> (Int64, @error Error) {
+sil hidden @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 bb0:
   %int_literal = integer_literal $Builtin.Int64, 1          // user: %2
   %Int64 = struct $Int64 (%int_literal : $Builtin.Int64)          // user: %3
@@ -138,8 +138,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
-  %result = apply %call() : $@convention(thin) () -> ()
+  %call = function_ref @call : $@async @convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@async @convention(thin) () -> ()
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -136,7 +136,7 @@ bb0:
   throw %error : $Error
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
   %result = apply %call() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -61,7 +61,7 @@ sil_witness_table hidden E: Error module main {
 }
 
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %voidThrowsToInt = function_ref @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
   try_apply %voidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb3
@@ -100,15 +100,15 @@ bb5:
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.context* {{%[0-9]*}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:
-  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@convention(thin) () -> (Int, @error Error)
-  try_apply %syncVoidThrowsToInt() : $@convention(thin) () -> (Int, @error Error), normal bb1, error bb2
+  %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)
+  try_apply %syncVoidThrowsToInt() : $@async @convention(thin) () -> (Int, @error Error), normal bb1, error bb2
 bb1(%out : $Int):
   return %out : $Int
 bb2(%error : $Error):
   throw %error : $Error
 }
 
-sil hidden @syncVoidThrowsToInt : $@convention(thin) () -> (Int, @error Error) {
+sil hidden @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:
   %e_type = metatype $@thin E.Type
   %int_literal = integer_literal $Builtin.Int64, 42
@@ -124,8 +124,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
-  %result = apply %call() : $@convention(thin) () -> ()
+  %call = function_ref @call : $@async @convention(thin) () -> () // CHECK: 42
+  %result = apply %call() : $@async @convention(thin) () -> ()
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -122,7 +122,7 @@ bb0:
   throw %error : $Error
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> () // CHECK: 42
   %result = apply %call() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -70,7 +70,7 @@ bb0:
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %call = function_ref @call : $@convention(thin) () -> ()
   %result = apply %call() : $@convention(thin) () -> () // CHECK: S(int: 42)

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -52,7 +52,7 @@ bb0(%out : $*P):
   return %result : $()
 }
 
-sil hidden @call : $@convention(thin) () -> () {
+sil hidden @call : $@async @convention(thin) () -> () {
 bb0:
   %existential = alloc_stack $P
   %voidToExistential = function_ref @voidToExistential : $@async @convention(thin) () -> @out P
@@ -72,8 +72,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %call = function_ref @call : $@convention(thin) () -> ()
-  %result = apply %call() : $@convention(thin) () -> () // CHECK: S(int: 42)
+  %call = function_ref @call : $@async @convention(thin) () -> ()
+  %result = apply %call() : $@async @convention(thin) () -> () // CHECK: S(int: 42)
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -27,7 +27,7 @@ sil @voidToInt64AndInt64 : $@async @convention(thin) () -> (Int64, Int64) {
   return %tuple : $(Int64, Int64)
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %voidToInt64AndInt64 = function_ref @voidToInt64AndInt64 : $@async @convention(thin) () -> (Int64, Int64)

--- a/test/IRGen/async/run-call-void-to-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64.sil
@@ -24,7 +24,7 @@ sil @voidToInt64 : $@async @convention(thin) () -> (Int64) {
   return %int : $Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
   %voidToInt64 = function_ref @voidToInt64 : $@async @convention(thin) () -> Int64

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -109,7 +109,7 @@ bb0:
   return %2 : $Big
 }
 
-sil hidden @printBig : $@convention(thin) () -> () {
+sil hidden @printBig : $@async @convention(thin) () -> () {
     %getBig = function_ref @getBig : $@async @convention(thin) () -> Big
     %big = apply %getBig() : $@async @convention(thin) () -> Big
     %big_addr = alloc_stack $Big
@@ -123,8 +123,8 @@ sil hidden @printBig : $@convention(thin) () -> () {
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %printBig = function_ref @printBig : $@convention(thin) () -> ()
-  %result = apply %printBig() : $@convention(thin) () -> () // CHECK: Big(i1: 1, i2: 2, i3: 3, i4: 4, i5: 5, i6: 6, i7: 7, i8: 8, i9: 9, i0: 0)
+  %printBig = function_ref @printBig : $@async @convention(thin) () -> ()
+  %result = apply %printBig() : $@async @convention(thin) () -> () // CHECK: Big(i1: 1, i2: 2, i3: 3, i4: 4, i5: 5, i6: 6, i7: 7, i8: 8, i9: 9, i0: 0)
 
   %2 = integer_literal $Builtin.Int32, 0
   %3 = struct $Int32 (%2 : $Builtin.Int32)

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -121,7 +121,7 @@ sil hidden @printBig : $@convention(thin) () -> () {
     return %out : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %printBig = function_ref @printBig : $@convention(thin) () -> ()
   %result = apply %printBig() : $@convention(thin) () -> () // CHECK: Big(i1: 1, i2: 2, i3: 3, i4: 4, i5: 5, i6: 6, i7: 7, i8: 8, i9: 9, i0: 0)

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -59,7 +59,7 @@ bb0(%out_addr : $*U, %self_addr : $*T, %in_addr : $*U):
   return %result : $Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %I_type = metatype $@thin I.Type
   %int_literal = integer_literal $Builtin.Int64, 99

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -52,7 +52,7 @@ bb0(%out_addr : $*τ_0_0, %in_addr : $*τ_0_0, %self_addr : $*I):
   return %result : $Int64
 }
 
-sil hidden @callPrintMe : $@convention(thin) <T, U where T : P> (@in_guaranteed T, @in_guaranteed U) -> (Int64, @out U) {
+sil hidden @callPrintMe : $@async @convention(thin) <T, U where T : P> (@in_guaranteed T, @in_guaranteed U) -> (Int64, @out U) {
 bb0(%out_addr : $*U, %self_addr : $*T, %in_addr : $*U):
   %I_P_printMe = witness_method $T, #P.printMe : <Self where Self : P><T> (Self) -> (T) async -> (Int64, T) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P><τ_1_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_0_0) -> (Int64, @out τ_1_0)
   %result = apply %I_P_printMe<T, U>(%out_addr, %in_addr, %self_addr) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P><τ_1_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_0_0) -> (Int64, @out τ_1_0)
@@ -70,8 +70,8 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   store %i to %in_addr : $*I
   %i_addr = alloc_stack $I
   store %i to %i_addr : $*I
-  %callPrintMe = function_ref @callPrintMe : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Int64, @out τ_0_1)
-  %result = apply %callPrintMe<I, I>(%out_addr, %in_addr, %i_addr) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Int64, @out τ_0_1)
+  %callPrintMe = function_ref @callPrintMe : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Int64, @out τ_0_1)
+  %result = apply %callPrintMe<I, I>(%out_addr, %in_addr, %i_addr) : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Int64, @out τ_0_1)
   dealloc_stack %i_addr : $*I
   dealloc_stack %in_addr : $*I
   %out = load %out_addr : $*I

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -55,7 +55,7 @@ bb0(%t : $*T):
   return %result : $Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %i_type = metatype $@thin I.Type
   %i_int_literal = integer_literal $Builtin.Int64, 99

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -48,7 +48,7 @@ bb0(%self_addr : $*I):
   return %result : $Int64
 }
 
-sil hidden @callPrintMe : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64 {
+sil hidden @callPrintMe : $@async @convention(thin) <T where T : P> (@in_guaranteed T) -> Int64 {
 bb0(%t : $*T):
   %I_P_printMe = witness_method $T, #P.printMe : <Self where Self : P> (Self) -> () async -> Int64 : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
   %result = apply %I_P_printMe<T>(%t) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
@@ -63,8 +63,8 @@ bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>
   %i = struct $I (%i_int : $Int64)
   %i_addr = alloc_stack $I
   store %i to %i_addr : $*I
-  %callPrintMe = function_ref @callPrintMe : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
-  %result = apply %callPrintMe<I>(%i_addr) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // users: %13, %11 // CHECK: I(int: 99)
+  %callPrintMe = function_ref @callPrintMe : $@async @convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %result = apply %callPrintMe<I>(%i_addr) : $@async @convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // users: %13, %11 // CHECK: I(int: 99)
   dealloc_stack %i_addr : $*I
   %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
   %printInt64_result = apply %printInt64(%result) : $@convention(thin) (Int64) -> () // CHECK: 99

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -74,7 +74,7 @@ entry(%instance : $S):
   return %partiallyApplied : $@async @callee_owned () -> ()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %s_type = metatype $@thick S.Type
   %allocating_init = function_ref @S_allocating_init : $@convention(method) (@thick S.Type) -> @owned S

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -64,7 +64,7 @@ bb0(%0 : $*S):
 
 
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %observableImpl = alloc_ref $ObservableImpl
   strong_retain %observableImpl : $ObservableImpl

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -37,7 +37,7 @@ entry(%a : $*T):
   return %p : $@async @callee_owned (@in T) -> @out T
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %in_literal = integer_literal $Builtin.Int64, 876
   %in = struct $Int64 (%in_literal : $Builtin.Int64)

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -30,7 +30,7 @@ entry(%out : $*T, %in : $*T, %inout : $*T):
   return %result : $()
 }
 
-sil @partial_apply_open_generic_capture : $@convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
+sil @partial_apply_open_generic_capture : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
 entry(%a : $*T):
   %f = function_ref @inGenericAndInoutGenericToGeneric : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
   %p = partial_apply %f<T>(%a) : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
@@ -50,8 +50,8 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   store %inout to %inout_addr : $*Int64
   %result_addr = alloc_stack $Int64
 
-  %partial_apply_open_generic_capture = function_ref @partial_apply_open_generic_capture : $@convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T
-  %partiallyApplied = apply %partial_apply_open_generic_capture<Int64>(%inout_addr) : $@convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T
+  %partial_apply_open_generic_capture = function_ref @partial_apply_open_generic_capture : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T
+  %partiallyApplied = apply %partial_apply_open_generic_capture<Int64>(%inout_addr) : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T
   %void = apply %partiallyApplied(%result_addr, %in_addr) : $@async @callee_owned (@in Int64) -> @out Int64
 
   %result = load %result_addr : $*Int64

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -18,12 +18,12 @@ import PrintShims
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
-sil hidden @createAndInvokeClosure : $@convention(thin) () -> () {
+sil hidden @createAndInvokeClosure : $@async @convention(thin) () -> () {
 bb0:
   %captured_literal = integer_literal $Builtin.Int64, 783247897
   %captured = struct $Int64 (%captured_literal : $Builtin.Int64)
-  %createPartialApply = function_ref @createPartialApply : $@convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64
-  %partialApply = apply %createPartialApply(%captured) : $@convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64
+  %createPartialApply = function_ref @createPartialApply : $@async @convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64
+  %partialApply = apply %createPartialApply(%captured) : $@async @convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64
   strong_retain %partialApply : $@async @callee_guaranteed (Int64) -> Int64
   %applied_literal = integer_literal $Builtin.Int64, 7823478
   %applied = struct $Int64 (%applied_literal : $Builtin.Int64)
@@ -37,8 +37,8 @@ bb0:
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %createAndInvokeClosure = function_ref @createAndInvokeClosure : $@convention(thin) () -> ()
-  %createAndInvokeClosure_result = apply %createAndInvokeClosure() : $@convention(thin) () -> ()
+  %createAndInvokeClosure = function_ref @createAndInvokeClosure : $@async @convention(thin) () -> ()
+  %createAndInvokeClosure_result = apply %createAndInvokeClosure() : $@async @convention(thin) () -> ()
   %out_literal = integer_literal $Builtin.Int32, 0
   %out = struct $Int32 (%out_literal : $Builtin.Int32)
   return %out : $Int32
@@ -46,7 +46,7 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
 
 // CHECK-LL: define internal swiftcc void @closure(%swift.context* {{%[0-9]*}}) {{#[0-9]*}}
 // CHECK-LL: define internal swiftcc void @"$s7closureTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}}
-sil hidden @createPartialApply : $@convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64 {
+sil hidden @createPartialApply : $@async @convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64 {
 bb0(%captured : $Int64):
   %closure = function_ref @closure : $@async @convention(thin) (Int64, Int64) -> Int64
   %partialApply = partial_apply [callee_guaranteed] %closure(%captured) : $@async @convention(thin) (Int64, Int64) -> Int64

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -35,7 +35,7 @@ bb0:
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %createAndInvokeClosure = function_ref @createAndInvokeClosure : $@convention(thin) () -> ()
   %createAndInvokeClosure_result = apply %createAndInvokeClosure() : $@convention(thin) () -> ()

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -36,7 +36,7 @@ entry(%out_t : $*T, %x : $Int32, %in_t : $*T):
   return %result : $()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %callee = function_ref @callee : $@async @convention(thin) <T> (Int32, @in_guaranteed T) -> @out T
   %first_literal = integer_literal $Builtin.Int32, 1

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -81,7 +81,7 @@ bb0(%x : $S):
   return %p : $@async @callee_owned (Int64) -> Int64
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %s_type = metatype $@thick C.Type
   %allocating_init = function_ref @S_allocating_init : $@convention(method) (@thick C.Type) -> @owned C

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -74,7 +74,7 @@ entry(%in : $Int64, %s : $S):
   return %in : $Int64
 }
 
-sil @partial_apply_guaranteed_class_pair_param : $@convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64 {
+sil @partial_apply_guaranteed_class_pair_param : $@async @convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64 {
 bb0(%x : $S):
   %f = function_ref @structClassInstanceClassInstanceAndInt64ToInt64 : $@async @convention(thin) (Int64, @guaranteed S) -> Int64
   %p = partial_apply %f(%x) : $@async @convention(thin) (Int64, @guaranteed S) -> Int64
@@ -91,8 +91,8 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   strong_retain %instance2 : $C
   %instance = struct $S (%instance1 : $C, %instance2 : $C)
 
-  %partial_apply_guaranteed_class_pair_param = function_ref @partial_apply_guaranteed_class_pair_param : $@convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64
-  %partiallyApplied = apply %partial_apply_guaranteed_class_pair_param(%instance) : $@convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64
+  %partial_apply_guaranteed_class_pair_param = function_ref @partial_apply_guaranteed_class_pair_param : $@async @convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64
+  %partiallyApplied = apply %partial_apply_guaranteed_class_pair_param(%instance) : $@async @convention(thin) (@owned S) -> @async @callee_owned (Int64) -> Int64
   %int_literal = integer_literal $Builtin.Int64, 9999
   %int = struct $Int64 (%int_literal : $Builtin.Int64)
   %result = apply %partiallyApplied(%int) : $@async @callee_owned (Int64) -> Int64

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -61,7 +61,7 @@ bb0(%0 : $*A2<A3>):
   return %5 : $@async @callee_guaranteed () -> (@owned A1, @error Error)
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %a3 = alloc_ref $A3
   %a2 = struct $A2<A3> (%a3 : $A3)

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -42,7 +42,7 @@ entry(%box : $WeakBox<τ_0_0>):
   return %result : $()
 }
 
-sil public @bind_polymorphic_param_from_context : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> () {
+sil public @bind_polymorphic_param_from_context : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1):
   %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
   %8 = function_ref @takingQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
@@ -52,12 +52,12 @@ bb0(%0 : $*τ_0_1):
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %bind_polymorphic_param_from_context = function_ref @bind_polymorphic_param_from_context : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
+  %bind_polymorphic_param_from_context = function_ref @bind_polymorphic_param_from_context : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
   %int_literal = integer_literal $Builtin.Int64, 9999
   %int = struct $Int64 (%int_literal : $Builtin.Int64)
   %int_addr = alloc_stack $Int64
   store %int to %int_addr : $*Int64
-  %partiallyApplied = apply %bind_polymorphic_param_from_context<Int64>(%int_addr) :  $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
+  %partiallyApplied = apply %bind_polymorphic_param_from_context<Int64>(%int_addr) :  $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
   dealloc_stack %int_addr : $*Int64
 
   %result = apply %partiallyApplied() : $@async @callee_owned () -> ()

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -50,7 +50,7 @@ bb0(%0 : $*τ_0_1):
   return %9 : $@async @callee_owned () -> ()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %bind_polymorphic_param_from_context = function_ref @bind_polymorphic_param_from_context : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> ()
   %int_literal = integer_literal $Builtin.Int64, 9999

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -44,7 +44,7 @@ entry(%box : $WeakBox<τ_0_0>):
 
 
 // CHECK-LL: define internal swiftcc void @"$s7takingQTA"(%swift.context* {{%[0-9]*}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
-sil public @bind_polymorphic_param_from_forwarder_parameter : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> () {
+sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> () {
 bb0(%0 : $*τ_0_1):
   %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
   %8 = function_ref @takingQ : $@async @convention(thin) <τ_0_0 where τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
@@ -54,12 +54,12 @@ bb0(%0 : $*τ_0_1):
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %bind_polymorphic_param_from_forwarder_parameter = function_ref @bind_polymorphic_param_from_forwarder_parameter : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
+  %bind_polymorphic_param_from_forwarder_parameter = function_ref @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
   %int_literal = integer_literal $Builtin.Int64, 9999
   %int = struct $Int64 (%int_literal : $Builtin.Int64)
   %int_addr = alloc_stack $Int64
   store %int to %int_addr : $*Int64
-  %partiallyApplied = apply %bind_polymorphic_param_from_forwarder_parameter<Int64>(%int_addr) : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
+  %partiallyApplied = apply %bind_polymorphic_param_from_forwarder_parameter<Int64>(%int_addr) : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
   dealloc_stack %int_addr : $*Int64
 
   %box = alloc_ref $WeakBox<BaseProducer<Int64>>

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -52,7 +52,7 @@ bb0(%0 : $*τ_0_1):
   return %9 : $@callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %bind_polymorphic_param_from_forwarder_parameter = function_ref @bind_polymorphic_param_from_forwarder_parameter : $@convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> ()
   %int_literal = integer_literal $Builtin.Int64, 9999

--- a/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
@@ -83,7 +83,7 @@ entry(%S_type: $@thin S.Type, %C_instance: $C):
   return %closure : $@async @callee_owned () -> ()
 }
 
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
   %c_type = metatype $@thick C.Type
   %allocating_init = function_ref @C_allocating_init : $@convention(method) (@thick C.Type) -> @owned C


### PR DESCRIPTION
To unblock the SIL verification that async functions are called only from async functions, update the tests to meet this invariant.  To enable this, in particular, `@main` had to be marked `@async` until `Task.runDetached` is available.  To allow that, a couple of small workaround were commited in their own commit.  Reverting that commit when possible is tracked by rdar://problem/70597390.

This process revealed an issue with AsyncContextLayout's usage of NecessaryBindings.  Specifically, if an async function happens to use the same generic parameter twice, space was only made in the layout for one usage.  That can't work for async callees which actually have two distinct generic parameters since they will need to bind the two distinct generic parameters separately since in general they will not be the same type even though at a particular call site they happened to be the same.  To address this, make NecessaryBindings use a vector rather than a set to collection generic requirements.