### PR TITLE
Support -print-target-info in fake frontends used by incremental dependency tests

### DIFF
--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -19,9 +19,15 @@
 from __future__ import print_function
 
 import os
+import subprocess
 import sys
 
 assert sys.argv[1] == '-frontend'
+
+# Forward -print-target-info to the real frontend by way of the driver.
+if '-print-target-info' in sys.argv:
+    process = subprocess.Popen(["swift-frontend"] + sys.argv[1:])
+    exit(process.wait())
 
 primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
 outputFile = sys.argv[sys.argv.index('-o') + 1]

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -18,9 +18,16 @@
 from __future__ import print_function
 
 import os
+import subprocess
 import sys
 
 assert sys.argv[1] == '-frontend'
+
+# Forward -print-target-info to the real frontend by way of the driver.
+if '-print-target-info' in sys.argv:
+    process = subprocess.Popen(["swift-frontend"] + sys.argv[1:])
+    exit(process.wait())
+
 assert '-primary-file' not in sys.argv
 
 outputFile = sys.argv[sys.argv.index('-o') + 1]

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -19,9 +19,15 @@
 from __future__ import print_function
 
 import os
+import subprocess
 import sys
 
 assert sys.argv[1] == '-frontend'
+
+# Forward -print-target-info to the real frontend by way of the driver.
+if '-print-target-info' in sys.argv:
+    process = subprocess.Popen(["swift-frontend"] + sys.argv[1:])
+    exit(process.wait())
 
 if '-primary-file' in sys.argv:
     primaryFileIndex = sys.argv.index('-primary-file') + 1

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -27,6 +27,11 @@ import sys
 
 assert sys.argv[2] == '-frontend'
 
+# Forward -print-target-info to the real frontend by way of the driver.
+if '-print-target-info' in sys.argv:
+    process = subprocess.Popen(["swift-frontend"] + sys.argv[2:])
+    exit(process.wait())
+
 primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
 
 if (os.path.basename(primaryFile) == 'bad.swift' or

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -36,6 +36,11 @@ import sys
 
 assert sys.argv[2] == '-frontend'
 
+# Forward -print-target-info to the real frontend by way of the driver.
+if '-print-target-info' in sys.argv:
+    process = subprocess.Popen(["swift-frontend"] + sys.argv[2:])
+    exit(process.wait())
+
 # NB: The bitcode options automatically specify a -primary-file, even in cases
 #     where we do not wish to use a dependencies file in the test.
 if '-primary-file' in sys.argv \

--- a/test/Driver/Dependencies/fake-frontend-target-info.swift
+++ b/test/Driver/Dependencies/fake-frontend-target-info.swift
@@ -1,0 +1,12 @@
+
+// Verify the fake frontends used by dependencies tests support -print-target-info
+
+// RUN: %{python} %S/Inputs/update-dependencies.py %swift-dependency-tool -frontend -print-target-info | %FileCheck %s
+// RUN: %{python} %S/Inputs/update-dependencies-bad.py %swift-dependency-tool -frontend -print-target-info | %FileCheck %s
+
+// RUN: %{python} %S/Inputs/fake-build-for-bitcode.py -frontend -print-target-info | %FileCheck %s
+// RUN: %{python} %S/Inputs/fake-build-whole-module.py -frontend -print-target-info | %FileCheck %s
+// RUN: %{python} %S/Inputs/modify-non-primary-files.py -frontend -print-target-info | %FileCheck %s
+
+// CHECK: {{"}}target{{": \{}}
+


### PR DESCRIPTION
Forward these invocations to the real driver instead, so that we can run these tests with the new driver (otherwise nearly all the tests fail immediately because the driver can't decode the target info).

