### PR TITLE
Make it possible to configure Swift test options with CMake

### DIFF
--- a/test/Frontend/embed-bitcode-tvos.ll
+++ b/test/Frontend/embed-bitcode-tvos.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: CODEGENERATOR=AArch64
 ; RUN: llvm-as %s -o %t.bc
-; RUN: %swift -target arm64-apple-tvos9 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
+; RUN: %swiftc_driver_plain -frontend -target arm64-apple-tvos9 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
 ; RUN: llvm-objdump --macho --private-headers %t2.o | %FileCheck %s
 ; RUN: %FileCheck -check-prefix CHECK-IMPORTER %s < %t.diags.txt
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -392,9 +392,9 @@ if test_options:
     config.swift_test_options += ' '
     config.swift_test_options += test_options
 
-config.swift_frontend_test_options = os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
+config.swift_frontend_test_options += os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
 config.swift_frontend_test_options += ' -ignore-module-source-info'
-config.swift_driver_test_options = os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
+config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
 config.swift_driver_test_options += ' -Xfrontend'
 config.swift_driver_test_options += ' -ignore-module-source-info'
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
@@ -1062,8 +1062,8 @@ if run_vendor == 'apple':
         target_options_for_mock_sdk_after
     config.target_swiftc_driver = (
         ("%s %s -toolchain-stdlib-rpath %s " +
-         "-Xlinker -rpath -Xlinker /usr/lib/swift ")%
-        (xcrun_prefix, config.swiftc, target_options))
+         "-Xlinker -rpath -Xlinker /usr/lib/swift %s ")%
+        (xcrun_prefix, config.swiftc, target_options, config.swift_driver_test_options))
     config.target_clang = (
         "%s clang++ %s" %
         (xcrun_prefix, config.target_cc_options))
@@ -1146,8 +1146,9 @@ elif run_os in ['windows-msvc']:
     subst_target_swift_ide_test_mock_sdk_after = ''
 
     config.target_swiftc_driver =                                                \
-            ('%r -target %s %s %s' % (config.swiftc, config.variant_triple,      \
-                                      resource_dir_opt, mcp_opt))
+            ('%r -target %s %s %s %s' % (config.swiftc, config.variant_triple,   \
+                                      resource_dir_opt, mcp_opt,                 \
+                                      config.swift_driver_test_options))
     config.target_swift_modulewrap =                                             \
             ('%r -modulewrap -target %s' % (config.swiftc, config.variant_triple))
     config.target_swift_emit_pcm =                                               \
@@ -1254,8 +1255,8 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
-        "%s -target %s -toolchain-stdlib-rpath %s %s" %
-        (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt))
+        "%s -target %s -toolchain-stdlib-rpath %s %s %s" %
+        (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt, config.swift_driver_test_options))
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -1384,7 +1385,8 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-Xclang-linker', '--sysroot={}'.format(config.variant_sdk),
         '-tools-directory', tools_directory,
         android_link_paths_opt, resource_dir_opt, mcp_opt,
-        '-use-ld=%s' % config.android_linker_name])
+        '-use-ld=%s' % config.android_linker_name,
+        config.swift_driver_test_options])
     config.target_swift_modulewrap = ' '.join([
         config.swiftc, '-modulewrap',
         '-target', config.variant_triple])

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -34,6 +34,8 @@ config.swift_test_results_dir = \
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
 config.lldb_build_root = "@LLDB_BUILD_DIR@"
 config.libdispatch_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_BUILD@"
+config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
+config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
 
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -29,6 +29,9 @@ config.variant_sdk = "@VARIANT_SDK@"
 config.swift_test_results_dir = \
     lit_config.params.get("swift_test_results_dir", "@SWIFT_TEST_RESULTS_DIR@")
 
+config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
+config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
+
 # --- Darwin Configuration ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently it is only possible to specify Swift driver and frontend test options via environment variables. This makes it unwieldy to run the tests when cross compiling or compiling for different sysroots. This PR makes it possible to add Swift driver and frontend flags as part of CMake configuration using the existing names provided in the environment.
