### PR TITLE
Dont replace witness_method instruction if the conforming type is a c…

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1230,7 +1230,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
   // When we specialize (because now we know the underlying method) we run into
   // invalid SIL: load %self_arg : $*NonClassProtocol.
   if (SelfCEI.ConcreteType && SelfCEI.ConcreteType.isAnyClassReferenceType() &&
-      WMI->getLookupType() && WMI->getLookupType().isAnyClassReferenceType()) {
+      WMI->getLookupType() && !WMI->getLookupType().isAnyClassReferenceType()) {
     return nullptr;
   }
   // Propagate the concrete type into a callee-operand, which is a


### PR DESCRIPTION
…lass type but the original lookup type was not class constraint

This will trip the generic specializer/inliner.

The problem is that witness method implementations can add 'isReferenceTypeness' by specifying that the self type is of the implementation's class type. The caller's apply substitution list contains plain protocol constraints while the implementation can use loadable types for self. This creates problems when specializing or inlining. Something is obviously broken how we represent witness method's in SIL. But fixing this is something for another day...

rdar://70582785
