### PR TITLE
Point to new yams fix

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -41,7 +41,7 @@
             "platforms": [ "Linux" ]
         },
         "yams": {
-            "remote": { "id": "asuhan/Yams" }
+            "remote": { "id": "compnerd/Yams" }
         },
         "cmake": {
             "remote": { "id": "KitWare/CMake" },
@@ -338,7 +338,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2020-09-11-a",
                 "ninja": "release",
                 "icu": "release-65-1",
-                "yams": "3.0.1-patched",
+                "yams": "3.0.1-tensorflow",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2020-09-11-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2020-09-11-a",
                 "PythonKit": "master",


### PR DESCRIPTION
<!-- What's in this pull request? -->
The macOS toolchain no longer builds with the temporary fix in `asuhan/yams`:

```
/Users/swiftninjas/s4tf/yams/Sources/Yams/Representer.swift:143:28: error: type 'Double' has no member 'pow'
        let radix = Double.pow(10.0, Double(precision))
                    ~~~~~~ ^~~
```

This change points to a fix suitable for submission upstream, which would make a fork no longer necessary.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
