### PR TITLE
[ownership] Add another run of SemanticARCOpts right before eliminating ARC on the stdlib functions.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -300,7 +300,8 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   P.addMem2Reg();
 
   // We earlier eliminated ownership if we are not compiling the stdlib. Now
-  // handle the stdlib functions.
+  // handle the stdlib functions, re-simplifying, eliminating ARC as we do.
+  P.addSemanticARCOpts();
   P.addNonTransparentFunctionOwnershipModelEliminator();
 
   // Run the existential specializer Pass.

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
@@ -100,8 +100,10 @@ struct SemanticARCOpts : SILFunctionTransform {
   void run() override {
     SILFunction &f = *getFunction();
 
-    // Return early if we are not performing OSSA optimizations.
-    if (!f.getModule().getOptions().EnableOSSAOptimizations)
+    // Return early if we are not performing OSSA optimizations or we are not in
+    // ownership.
+    if (!f.getModule().getOptions().EnableOSSAOptimizations ||
+        !f.hasOwnership())
       return;
 
     // Make sure we are running with ownership verification enabled.


### PR DESCRIPTION
This just canonicalizes the ARC before we lower OME in the face of ARC twiddles
by other passes.
