### PR TITLE
SILGen: Fix crash in emitEnumConstructor() if type lowering depends on resilience

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -531,6 +531,11 @@ IsSerialized_t SILDeclRef::isSerialized() const {
   if (d->getEffectiveAccess() < AccessLevel::Public)
     return IsNotSerialized;
 
+  // Enum element constructors are serializable if the enum is
+  // @usableFromInline or public.
+  if (isEnumElement())
+    return IsSerializable;
+
   // 'read' and 'modify' accessors synthesized on-demand are serialized if
   // visible outside the module.
   if (auto fn = dyn_cast<FuncDecl>(d))

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -544,8 +544,11 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
   // Return the enum.
   auto ReturnLoc = ImplicitReturnLocation::getImplicitReturnLoc(Loc);
 
-  if (mv.isInContext()) {
-    assert(enumTI.isAddressOnly());
+  if (dest) {
+    if (!mv.isInContext()) {
+      dest->copyOrInitValueInto(*this, Loc, mv, /*isInit*/ true);
+      dest->finishInitialization(*this);
+    }
     scope.pop();
     B.createReturn(ReturnLoc, emitEmptyTuple(Loc));
   } else {

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -1,22 +1,23 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -enable-library-evolution
 
-protocol Foo {
+public protocol Foo {
   static var button: Self { get }
 }
 
-enum Bar: Foo {
+public enum Bar: Foo {
   case button
 }
 
-protocol AnotherFoo {
+public protocol AnotherFoo {
   static func bar(arg: Int) -> Self
 }
 
-enum AnotherBar: AnotherFoo {
+public enum AnotherBar: AnotherFoo {
   case bar(arg: Int)
 }
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW : $@convention(witness_method: Foo) (@thick Bar.Type) -> @out Bar {
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW : $@convention(witness_method: Foo) (@thick Bar.Type) -> @out Bar {
 // CHECK: bb0([[BAR:%.*]] : $*Bar, [[BAR_TYPE:%.*]] : $@thick Bar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin Bar.Type
 // CHECK: [[REF:%.*]] = function_ref @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar
@@ -26,13 +27,13 @@ enum AnotherBar: AnotherFoo {
 // CHECK-NEXT: return [[TUPLE]] : $()
 // CHECK-END: }
 
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
+// CHECK-LABEL: sil shared [transparent] [serializable] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
 // CHECK: bb0({{%.*}} : $@thin Bar.Type):
 // CHECK-NEXT: [[CASE:%.*]] = enum $Bar, #Bar.button!enumelt
 // CHECK-NEXT: return [[CASE]] : $Bar
 // CHECK-END: }
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness10AnotherBarOAA0D3FooA2aDP3bar3argxSi_tFZTW : $@convention(witness_method: AnotherFoo) (Int, @thick AnotherBar.Type) -> @out AnotherBar {
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$s21protocol_enum_witness10AnotherBarOAA0D3FooA2aDP3bar3argxSi_tFZTW : $@convention(witness_method: AnotherFoo) (Int, @thick AnotherBar.Type) -> @out AnotherBar {
 // CHECK: bb0([[ANOTHER_BAR:%.*]] : $*AnotherBar, [[INT_ARG:%.*]] : $Int, [[ANOTHER_BAR_TYPE:%.*]] : $@thick AnotherBar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin AnotherBar.Type
 // CHECK: [[REF:%.*]] = function_ref @$s21protocol_enum_witness10AnotherBarO3baryACSi_tcACmF : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
@@ -42,8 +43,8 @@ enum AnotherBar: AnotherFoo {
 // CHECK-NEXT: return [[TUPLE]] : $()
 // CHECK-END: }
 
-// CHECK-LABEL: sil_witness_table hidden Bar: Foo module protocol_enum_witness {
+// CHECK-LABEL: sil_witness_table [serialized] Bar: Foo module protocol_enum_witness {
 // CHECK: method #Foo.button!getter: <Self where Self : Foo> (Self.Type) -> () -> Self : @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW
 
-// CHECK-LABEL: sil_witness_table hidden AnotherBar: AnotherFoo module protocol_enum_witness {
+// CHECK-LABEL: sil_witness_table [serialized] AnotherBar: AnotherFoo module protocol_enum_witness {
 // CHECK: method #AnotherFoo.bar: <Self where Self : AnotherFoo> (Self.Type) -> (Int) -> Self : @$s21protocol_enum_witness10AnotherBarOAA0D3FooA2aDP3bar3argxSi_tFZTW

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -17,6 +17,13 @@ public enum AnotherBar: AnotherFoo {
   case bar(arg: Int)
 }
 
+public struct PublicStruct {}
+
+enum InternalEnumWithPublicStruct : Foo {
+  case button
+  case other(PublicStruct)
+}
+
 // CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW : $@convention(witness_method: Foo) (@thick Bar.Type) -> @out Bar {
 // CHECK: bb0([[BAR:%.*]] : $*Bar, [[BAR_TYPE:%.*]] : $@thick Bar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin Bar.Type


### PR DESCRIPTION
It's possible that the result value here is passed indirectly,
but the enum value is loadable inside the constructor's body.
Let's make sure we handle this correctly.

Fixes https://bugs.swift.org/browse/SR-12966 / rdar://problem/70395861.