### PR TITLE
WinSDK: prevent windows.h from hijacking imm.h

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -187,6 +187,7 @@ module WinSDK [system] {
 
     module IMM {
       header "immdev.h"
+      header "imm.h"
       export *
 
       link "Imm32.lib"


### PR DESCRIPTION
Both `immdev.h` & `windows.h` include `imm.h`, and sometimes `imm.h` gets assigned to the module containing `windows.h` (currently `WinSDK.WinSock2`) instead of the Internationalization submodule.