### PR TITLE
[cmake] Semi-parametrize manpage location.

### DIFF
--- a/cmake/modules/SwiftManpage.cmake
+++ b/cmake/modules/SwiftManpage.cmake
@@ -39,8 +39,12 @@ function(manpage)
       ALL)
 
   add_dependencies(${MP_INSTALL_IN_COMPONENT} ${manpage_target})
+  set(MANPAGE_DEST "share/")
+  if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "OPENBSD")
+    set(MANPAGE_DEST "")
+  endif()
   swift_install_in_component(FILES "${output_file_name}"
-                             DESTINATION "share/man/man${MP_MAN_SECTION}"
+                             DESTINATION "${MANPAGE_DEST}man/man${MP_MAN_SECTION}"
                              COMPONENT "${MP_INSTALL_IN_COMPONENT}")
 endfunction()
 


### PR DESCRIPTION
On OpenBSD, man pages go in $CMAKE_INSTALL_PATH/man. This requires
changing the default to something with a parameter when installing
on this platform.