### PR TITLE
[stdlib] Fix Array.append(contentsOf:) for arguments of type NSArray

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1229,7 +1229,7 @@ extension Array: RangeReplaceableCollection {
       // elements. It reduces code size, because the following code
       // can be removed by the optimizer by constant folding this check in a
       // generic specialization.
-      if newElements is [Element] {
+      if S.self == [Element].self {
         _internalInvariant(remainder.next() == nil)
         return
       }

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -1110,6 +1110,15 @@ ArrayTestSuite.test("BridgedToObjC.Nonverbatim.RoundtripThroughSwiftArray") {
   }
 }
 
+ArrayTestSuite.test("append(contentsOf: NSArray)") {
+  // A stray runtime `is` test caused this particular operation to fail in 5.3.
+  // rdar://70448247
+  let nsarray: NSArray = [2, 3, 4]
+  var array: [Any] = [1]
+  array.append(contentsOf: nsarray)
+  expectEqual(array as? [Int], [1, 2, 3, 4])
+}
+
 ArrayTestSuite.setUp {
   resetLeaksOfDictionaryKeysValues()
   resetLeaksOfObjCDictionaryKeysValues()


### PR DESCRIPTION
Due to a couple of unfortunate circumstances, appending an NSArray instance to an Array instance does not actually append any elements.

The cause is https://github.com/apple/swift/pull/29220, which accidentally optimized away the actual loop that appends the elements in this particular case. (And only this particular case, which is why this wasn’t detected by the test suite.)

When the argument to `Array.append(contentsOf:)` is of type NSArray, the `newElements is [Element]` expression is compiled into a runtime check that returns true, eliminating the subsequent loop over the remaining items of the iterator. Sadly, `NSArray.underestimatedCount` currently returns 0, so the earlier `_copyContents` call is a noop, so no elements get added to `self` at all.

Turning the `is` test into a direct equality check between the metatype instances resolves the issue.

Resolves rdar://70448247