### PR TITLE
[cxx-interop] Disable importing fully specialized class templates.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3544,6 +3544,14 @@ namespace {
       auto def = dyn_cast<clang::ClassTemplateSpecializationDecl>(
           decl->getDefinition());
       assert(def && "Class template instantiation didn't have definition");
+
+      // If this type is fully specialized (i.e. "Foo<>" or "Foo<int, int>"),
+      // bail to prevent a crash.
+      // TODO: we should be able to support fully specialized class templates.
+      // See SR-13775 for more info.
+      if (def->getTypeAsWritten())
+        return nullptr;
+
       // FIXME: This will instantiate all members of the specialization (and detect
       // instantiation failures in them), which can be more than is necessary
       // and is more than what Clang does. As a result we reject some C++

--- a/test/Interop/Cxx/templates/Inputs/explicit-class-specialization.h
+++ b/test/Interop/Cxx/templates/Inputs/explicit-class-specialization.h
@@ -26,4 +26,39 @@ struct MagicWrapper<SpecializedIntWrapper> {
 typedef MagicWrapper<SpecializedIntWrapper> WrapperWithSpecialization;
 typedef MagicWrapper<NonSpecializedIntWrapper> WrapperWithoutSpecialization;
 
+// Make sure these declarations don't cause a crash even though we can't import
+// them.
+
+template <class...> class HasSpecializations;
+
+template <> class HasSpecializations<> {
+  int value;
+  struct Child {};
+  enum Maybe : int { No, Yes };
+};
+
+template <> class HasSpecializations<int> {
+  int value;
+  struct Child {};
+  enum Maybe : int { No, Yes };
+};
+
+template <> class HasSpecializations<int, int> {
+  int value;
+  struct Child {};
+  enum Maybe : int { No, Yes };
+};
+
+template <class T> class HasSpecializations<T, int> {
+  int value;
+  struct Child {};
+  enum Maybe : int { No, Yes };
+};
+
+template <class T, class... Ts> class HasSpecializations<int, T, Ts...> {
+  int value;
+  struct Child {};
+  enum Maybe : int { No, Yes };
+};
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_EXPLICIT_SPECIALIZATION_H

--- a/test/Interop/Cxx/templates/explicit-class-specialization.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization.swift
@@ -8,9 +8,10 @@ import StdlibUnittest
 var TemplatesTestSuite = TestSuite("TemplatesTestSuite")
 
 TemplatesTestSuite.test("explicit-specialization") {
-  let specializedInt = SpecializedIntWrapper(value: 7)
-  var specializedMagicInt = WrapperWithSpecialization(t: specializedInt)
-  expectEqual(specializedMagicInt.doubleIfSpecializedElseTriple(), 14)
+  // TODO: re-enable this test once SR-13775 is resolved.
+  // let specializedInt = SpecializedIntWrapper(value: 7)
+  // var specializedMagicInt = WrapperWithSpecialization(t: specializedInt)
+  // expectEqual(specializedMagicInt.doubleIfSpecializedElseTriple(), 14)
 
   let nonSpecializedInt = NonSpecializedIntWrapper(value: 7)
   var nonSpecializedMagicInt = WrapperWithoutSpecialization(t: nonSpecializedInt)


### PR DESCRIPTION
Before this patch, we would crash when importing a fully specialized class template containing a child declaration. This patch simply bails on fully-specialized class templates instead of potentially crashing.

References (but does not fix) [SR-13775](https://bugs.swift.org/browse/SR-13775).