### PR TITLE
[cxx-interop] Bail instead of crashing If we cannot find a constructor decl in importNameImpl.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1616,7 +1616,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     auto ctor = dyn_cast<clang::CXXConstructorDecl>(D);
     if (auto templateCtor = dyn_cast<clang::FunctionTemplateDecl>(D))
       ctor = cast<clang::CXXConstructorDecl>(templateCtor->getAsFunction());
-    assert(ctor && "Unkown decl with CXXConstructorName.");
+    // If we couldn't find a constructor decl, bail.
+    if (!ctor)
+      return ImportedName();
     addEmptyArgNamesForClangFunction(ctor, argumentNames);
     break;
   }

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -43,3 +43,9 @@ struct EmptyStruct {};
 struct IntWrapper {
   int x;
 };
+
+// TODO: we should be able to import this constructor correctly. Until we can,
+// make sure not to crash.
+struct UsingBaseConstructor : ConstructorWithParam {
+  using ConstructorWithParam::ConstructorWithParam;
+};


### PR DESCRIPTION
It's possible to have a "UnresolvedUsingValueDecl" with a "CXXConstructorName". If that's the case (or if there's any other unknown decl) bail instead of crashing.