### PR TITLE
Add NestedSemanticFunctionCheck warning diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -643,5 +643,7 @@ ERROR(box_to_stack_cannot_promote_box_to_stack_due_to_escape_alloc, none,
 NOTE(box_to_stack_cannot_promote_box_to_stack_due_to_escape_location, none,
      "value escapes here", ())
 
+WARNING(semantic_function_improper_nesting, none, "'@_semantics' function calls non-'@_semantics' function with nested '@_semantics' calls", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -42,6 +42,7 @@ enum class ArrayCallKind {
   // a function, and it has a self parameter, make sure that it is defined
   // before this comment.
   kArrayInit,
+  kArrayInitEmpty,
   kArrayUninitialized,
   kArrayUninitializedIntrinsic,
   kArrayFinalizeIntrinsic
@@ -187,7 +188,7 @@ public:
 
   /// Could this array be backed by an NSArray.
   bool mayHaveBridgedObjectElementType() const;
-  
+
   /// Can this function be inlined by the early inliner.
   bool canInlineEarly() const;
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -251,6 +251,8 @@ PASS(Outliner, "outliner",
      "Function Outlining Optimization")
 PASS(OwnershipModelEliminator, "ownership-model-eliminator",
      "Eliminate Ownership Annotation of SIL")
+PASS(NestedSemanticFunctionCheck, "nested-semantic-function-check",
+     "Diagnose improperly nested '@_semantics' functions")
 PASS(NonTransparentFunctionOwnershipModelEliminator,
      "non-transparent-func-ownership-model-eliminator",
      "Eliminate Ownership Annotations from non-transparent SIL Functions")

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -30,7 +30,8 @@ ArrayCallKind swift::getArraySemanticsKind(SILFunction *f) {
         llvm::StringSwitch<ArrayCallKind>(Attrs)
             .Case("array.props.isNativeTypeChecked",
                   ArrayCallKind::kArrayPropsIsNativeTypeChecked)
-            .StartsWith("array.init", ArrayCallKind::kArrayInit)
+            .Case("array.init", ArrayCallKind::kArrayInit)
+            .Case("array.init.empty", ArrayCallKind::kArrayInitEmpty)
             .Case("array.uninitialized", ArrayCallKind::kArrayUninitialized)
             .Case("array.uninitialized_intrinsic", ArrayCallKind::kArrayUninitializedIntrinsic)
             .Case("array.finalize_intrinsic", ArrayCallKind::kArrayFinalizeIntrinsic)
@@ -682,8 +683,10 @@ static SILValue getArrayUninitializedInitResult(ArraySemanticsCall arrayCall,
 
 SILValue swift::ArraySemanticsCall::getArrayValue() const {
   ArrayCallKind arrayCallKind = getKind();
-  if (arrayCallKind == ArrayCallKind::kArrayInit)
+  if (arrayCallKind == ArrayCallKind::kArrayInit
+      || arrayCallKind == ArrayCallKind::kArrayInitEmpty) {
     return SILValue(SemanticsCall);
+  }
   return getArrayUninitializedInitResult(*this, 0);
 }
 

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1943,6 +1943,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       !isa<BeginApplyInst>(I)) {
     ArraySemanticsCall ASC(FAS.getInstruction());
     switch (ASC.getKind()) {
+      // TODO: Model ReserveCapacityForAppend, AppendContentsOf, AppendElement.
       case ArrayCallKind::kArrayPropsIsNativeTypeChecked:
       case ArrayCallKind::kCheckSubscript:
       case ArrayCallKind::kCheckIndex:

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -2024,36 +2024,6 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         break;
       }
 
-    if (FAS.getReferencedFunctionOrNull() &&
-        FAS.getReferencedFunctionOrNull()->hasSemanticsAttr(
-            "self_no_escaping_closure") &&
-        ((FAS.hasIndirectSILResults() && FAS.getNumArguments() == 3) ||
-         (!FAS.hasIndirectSILResults() && FAS.getNumArguments() == 2)) &&
-        FAS.hasSelfArgument()) {
-      // The programmer has guaranteed that the closure will not capture the
-      // self pointer passed to it or anything that is transitively reachable
-      // from the pointer.
-      auto Args = FAS.getArgumentsWithoutIndirectResults();
-      // The first not indirect result argument is the closure.
-      ConGraph->setEscapesGlobal(Args[0]);
-      return;
-    }
-
-    if (FAS.getReferencedFunctionOrNull() &&
-        FAS.getReferencedFunctionOrNull()->hasSemanticsAttr(
-            "pair_no_escaping_closure") &&
-        ((FAS.hasIndirectSILResults() && FAS.getNumArguments() == 4) ||
-         (!FAS.hasIndirectSILResults() && FAS.getNumArguments() == 3)) &&
-        FAS.hasSelfArgument()) {
-      // The programmer has guaranteed that the closure will not capture the
-      // self pointer passed to it or anything that is transitively reachable
-      // from the pointer.
-      auto Args = FAS.getArgumentsWithoutIndirectResults();
-      // The second not indirect result argument is the closure.
-      ConGraph->setEscapesGlobal(Args[1]);
-      return;
-    }
-
     if (RecursionDepth < MaxRecursionDepth) {
       CalleeList Callees = BCA->getCalleeList(FAS);
       if (buildConnectionGraphForCallees(FAS.getInstruction(), Callees, FInfo,

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -269,6 +269,7 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
     ArraySemanticsCall semCall(AI);
     switch (semCall.getKind()) {
       case ArrayCallKind::kArrayInit:
+      case ArrayCallKind::kArrayInitEmpty:
       case ArrayCallKind::kArrayUninitialized:
       case ArrayCallKind::kMutateUnknown:
       case ArrayCallKind::kMakeMutable:

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -295,6 +295,7 @@ static bool isNonMutatingArraySemanticCall(SILInstruction *Inst) {
   case ArrayCallKind::kReserveCapacityForAppend:
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
+  case ArrayCallKind::kArrayInitEmpty:
   case ArrayCallKind::kArrayUninitialized:
   case ArrayCallKind::kArrayUninitializedIntrinsic:
   case ArrayCallKind::kArrayFinalizeIntrinsic:
@@ -658,6 +659,7 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
         auto Kind = Sem.getKind();
         // Safe because they create new arrays.
         if (Kind == ArrayCallKind::kArrayInit ||
+            Kind == ArrayCallKind::kArrayInitEmpty ||
             Kind == ArrayCallKind::kArrayUninitialized ||
             Kind == ArrayCallKind::kArrayUninitializedIntrinsic)
           continue;

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -194,7 +194,7 @@ static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount) {
         auto Callee = AI.getCalleeFunction();
         if (Callee && getEligibleFunction(AI, InlineSelection::Everything)) {
           // If callee is rather big and potentialy inlinable, it may be better
-          // not to unroll, so that the body of the calle can be inlined later.
+          // not to unroll, so that the body of the callee can be inlined later.
           Cost += Callee->size() * InsnsPerBB;
         }
       }

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(swiftSILOptimizer PRIVATE
   Differentiation.cpp
   IRGenPrepare.cpp
   MandatoryInlining.cpp
+  NestedSemanticFunctionCheck.cpp
   PredictableMemOpt.cpp
   PMOMemoryUseCollector.cpp
   RawSILInstLowering.cpp

--- a/lib/SILOptimizer/Mandatory/NestedSemanticFunctionCheck.cpp
+++ b/lib/SILOptimizer/Mandatory/NestedSemanticFunctionCheck.cpp
@@ -1,0 +1,142 @@
+//===--- NestedSemanticFunctionCheck.cpp - Disallow nested @_semantic -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This pass raises a diagnostic error if any semantic functions in the current
+/// module are improperly nested. A semantic function has an @_semantic
+/// attribute. Semantic functions may call other semantic functions, but
+/// semantic and non-semantic call frames may not be interleaved.
+///
+/// @_semantics(...)
+/// func funcA() {
+///   funcB()
+/// }
+/// // Error: funcB is called by a semantic function and calls
+/// // a semantic function.
+/// func funcB() {
+///   funcC()
+/// }
+/// @_semantics(...)
+/// func funcC() {}
+///
+/// For the pass pipeline to function well, @_semantic calls need to be
+/// processed top-down, while inlining proceeds bottom-up. With proper nesting,
+/// this is easily accomplished, but with improper nesting, semantic function
+/// can be prematurely "hidden".
+///
+/// For simplicity, don't bother checking whether semantic functions in one
+/// module call non-semantic functions in a different module. Really,
+/// "optimizable" @_semantics should only exist in the standard library.
+///
+/// TODO: The @_semantics tag should only ever be used to convey function
+/// semantics that are important to optimizations and which cannot be determined
+/// from the function body. Make sure this tag is never used for compiler hints
+/// or informational attributes, which do not require special pass pipeline and
+/// module serialization behavior.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
+
+using namespace swift;
+
+namespace {
+
+class NestedSemanticFunctionCheck : public SILFunctionTransform {
+  // Mark all functions that may indirectly call a semantic function, ignoring
+  // simple wrappers, but are not themselves an optimizable semantic function.
+  //
+  // This could be a very large set. It is built gradually during bottom-up
+  // function transforms, then deleted once all functions are processed before
+  // excuting the next pass pipeline.
+  llvm::SmallPtrSet<SILFunction *, 8> mayCallSemanticFunctions;
+
+  // Mark semantic functions and wrappers around semantic calls.
+  llvm::SmallPtrSet<SILFunction *, 8> semanticFunctions;
+
+public:
+  void run() override;
+
+protected:
+  void checkSemanticFunction(SILFunction *f);
+};
+
+} // end anonymous namespace
+
+/// This is a semantic function. Diagnose any calls to mayCallSemanticFunctions.
+void NestedSemanticFunctionCheck::checkSemanticFunction(SILFunction *f) {
+  for (auto &bb : *f) {
+    for (auto &i : bb) {
+      auto apply = FullApplySite::isa(&i);
+      if (!apply) {
+        continue;
+      }
+      auto callee = apply.getReferencedFunctionOrNull();
+      if (!callee) {
+        continue;
+      }
+      // Semantic function calling non-semantic function with improperly
+      // nested semantic calls underneath.
+      if (mayCallSemanticFunctions.count(callee)) {
+        ASTContext &astContext = f->getASTContext();
+        astContext.Diags.diagnose(apply.getLoc().getSourceLoc(),
+                                  diag::semantic_function_improper_nesting);
+      }
+    }
+  }
+}
+
+// If this is a semantic function, diagnose it immediately. Otherwise propagate
+// the mayCallSemanticFunctions and semanticCallWrappers sets upward in the call
+// tree.
+void NestedSemanticFunctionCheck::run() {
+  auto *f = getFunction();
+  if (!semanticFunctions.count(f) && isOptimizableSemanticFunction(f)) {
+    semanticFunctions.insert(f);
+    checkSemanticFunction(f);
+    return;
+  }
+  // Add this function to mayCallSemanticFunctions if needed.
+  if (mayCallSemanticFunctions.count(f)) {
+    return;
+  }
+  for (auto &bb : *f) {
+    for (auto &i : bb) {
+      auto apply = FullApplySite::isa(&i);
+      if (!apply) {
+        continue;
+      }
+      // If this is a trivial wrapper around a semantic call, don't add it
+      // immediately to the mayCallSemanticFunctions set, but add it to
+      // semanticCallWrappers so that its caller will be added to
+      // mayCallSemanticFunctions.
+      if (isNestedSemanticCall(apply)) {
+        semanticFunctions.insert(f);
+        continue;
+      }
+      auto callee = apply.getReferencedFunctionOrNull();
+      if (!callee) {
+        continue;
+      }
+      // Propagate mayCallSemanticFunctions.
+      if (mayCallSemanticFunctions.count(callee)
+          || semanticFunctions.count(callee)) {
+        mayCallSemanticFunctions.insert(f);
+      }
+    }
+  }
+}
+
+SILTransform *swift::createNestedSemanticFunctionCheck() {
+  return new NestedSemanticFunctionCheck();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -90,6 +90,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addSILGenCleanup();
   P.addDiagnoseInvalidEscapingCaptures();
   P.addDiagnoseStaticExclusivity();
+  P.addNestedSemanticFunctionCheck();
   P.addCapturePromotion();
 
   // Select access kind after capture promotion and before stack promotion.

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -566,33 +566,116 @@ static bool calleeIsSelfRecursive(SILFunction *Callee) {
   return false;
 }
 
-// Returns true if a given apply site should be skipped during the
-// early inlining pass.
-//
-// NOTE: Add here the checks for any specific @_semantics/@_effects
-// attributes causing a given callee to be excluded from the inlining
-// during the early inlining pass.
-static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
-  // Add here the checks for any specific @_semantics attributes that need
-  // to be skipped during the early inlining pass.
-  ArraySemanticsCall ASC(AI.getInstruction());
-  if (ASC && !ASC.canInlineEarly())
-    return true;
+SemanticFunctionLevel swift::getSemanticFunctionLevel(SILFunction *function) {
+  // Currently, we only consider "array" semantic calls to be "optimizable
+  // semantic functions" (non-transient) because we only have semantic passes
+  // that recognize array operations, for example, hoisting them out of loops.
+  //
+  // Compiler "hints" and informational annotations (like remarks) should
+  // ideally use a separate annotation rather than @_semantics.
+  switch (getArraySemanticsKind(function)) {
+  case ArrayCallKind::kNone:
+    return SemanticFunctionLevel::Transient;
 
-  SILFunction *Callee = AI.getReferencedFunctionOrNull();
-  if (!Callee)
+  case ArrayCallKind::kArrayInitEmpty:
+  case ArrayCallKind::kArrayPropsIsNativeTypeChecked:
+  case ArrayCallKind::kCheckSubscript:
+  case ArrayCallKind::kCheckIndex:
+  case ArrayCallKind::kGetCount:
+  case ArrayCallKind::kGetCapacity:
+  case ArrayCallKind::kGetElement:
+  case ArrayCallKind::kGetElementAddress:
+  case ArrayCallKind::kMakeMutable:
+  case ArrayCallKind::kEndMutation:
+  case ArrayCallKind::kMutateUnknown:
+    return SemanticFunctionLevel::Fundamental;
+
+  // These have nested semantic calls, but they also expose the underlying
+  // buffer so must be treated as fundamental, and should not be inlined until
+  // after array semantic passes have run.
+  //
+  // TODO: Once Nested semantics calls are preserved during early inlining,
+  // change these to Nested.
+  case ArrayCallKind::kArrayInit:
+  case ArrayCallKind::kArrayUninitialized:
+  case ArrayCallKind::kWithUnsafeMutableBufferPointer:
+    return SemanticFunctionLevel::Fundamental;
+
+  case ArrayCallKind::kReserveCapacityForAppend:
+  case ArrayCallKind::kAppendContentsOf:
+  case ArrayCallKind::kAppendElement:
+    return SemanticFunctionLevel::Nested;
+
+  // Compiler intrinsics hide "normal" semantic methods, such as
+  // "array.uninitialized" or "array.end_mutation"--they are intentionally
+  // transient and should be inlined away immediately.
+  case ArrayCallKind::kArrayUninitializedIntrinsic:
+  case ArrayCallKind::kArrayFinalizeIntrinsic:
+    return SemanticFunctionLevel::Transient;
+
+  } // end switch
+}
+
+/// Return true if \p apply calls into an optimizable semantic function from
+/// within another semantic function, or from a "trivial" wrapper.
+///
+/// Checking for wrappers, in addition to directly annotated nested semantic
+/// functions, allows semantic function calls to be wrapped inside trivial
+/// getters and closures without needing to explicitly annotate those wrappers.
+///
+/// For example:
+///
+///   public var count: Int { getCount() }
+///   @_semantic("count") internal func getCount() { ... }
+///
+/// Wrappers may be closures, so this semantic "nesting" is allowed:
+///
+///   @_semantics("append")
+///   public func append(...) {
+///     defer { endMutation() }
+///     ...
+///   }
+///   @_semantics("endMutation") func endMutation() { ... }
+///
+/// TODO: if simply checking the call arguments results in too many functions
+/// being considered "wrappers", thus preventing useful inlining, consider
+/// either using a cost metric to check for low-cost wrappers or directly
+/// checking for getters or closures.
+///
+/// TODO: Move this into PerformanceInlinerUtils and apply it to
+/// getEligibleFunction. The mid-level pipeline should not inline semantic
+/// functions into their wrappers. If such wrappers have still not been fully
+/// inlined by the time late inlining runs, then the semantic call can be
+/// inlined into the wrapper at that time.
+bool swift::isNestedSemanticCall(FullApplySite apply) {
+  auto callee = apply.getReferencedFunctionOrNull();
+  if (!callee) {
+     return false;
+  }
+  if (!isOptimizableSemanticFunction(callee)) {
     return false;
-
-  if (Callee->hasSemanticsAttr("self_no_escaping_closure") ||
-      Callee->hasSemanticsAttr("pair_no_escaping_closure"))
+  }
+  if (isOptimizableSemanticFunction(apply.getFunction())) {
     return true;
-
-  // Add here the checks for any specific @_effects attributes that need
-  // to be skipped during the early inlining pass.
-  if (Callee->hasEffectsKind())
-    return true;
-
-  return false;
+  }
+  // In a trivial wrapper, all call arguments are simply forwarded from the
+  // wrapper's arguments.
+  auto isForwardedArg = [](SILValue arg) {
+    while (true) {
+      if (isa<SILFunctionArgument>(arg) || isa<LiteralInst>(arg)) {
+        return true;
+      }
+      auto *argInst = arg->getDefiningInstruction();
+      if (!argInst) {
+        return false;
+      }
+      if (!getSingleValueCopyOrCast(argInst)) {
+        return false;
+      }
+      arg = argInst->getOperand(0);
+    }
+  };
+  return llvm::all_of(apply.getArguments(), isForwardedArg);
 }
 
 /// Checks if a generic callee and caller have compatible layout constraints.
@@ -668,8 +751,12 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   // attribute if the inliner is asked not to inline them.
   if (Callee->hasSemanticsAttrs() || Callee->hasEffectsKind()) {
     if (WhatToInline >= InlineSelection::NoSemanticsAndGlobalInit) {
-      if (shouldSkipApplyDuringEarlyInlining(AI))
+      // TODO: for stable optimization of semantics, prevent inlining whenever
+      // isOptimizableSemanticFunction(Callee) is true.
+      if (getSemanticFunctionLevel(Callee) == SemanticFunctionLevel::Fundamental
+          || Callee->hasEffectsKind()) {
         return nullptr;
+      }
       if (Callee->hasSemanticsAttr("inline_late"))
         return nullptr;
     }
@@ -698,7 +785,7 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
     return nullptr;
   }
 
-  // Explicitly disabled inlining.
+  // Explicitly disabled inlining or optimization.
   if (Callee->getInlineStrategy() == NoInline) {
     return nullptr;
   }
@@ -756,6 +843,8 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   // Inlining self-recursive functions into other functions can result
   // in excessive code duplication since we run the inliner multiple
   // times in our pipeline
+  //
+  // FIXME: This should be cached!
   if (calleeIsSelfRecursive(Callee)) {
     return nullptr;
   }

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -636,7 +636,7 @@ extension ArraySlice: RangeReplaceableCollection {
   ///     print(emptyArray.isEmpty)
   ///     // Prints "true"
   @inlinable
-  @_semantics("array.init")
+  @_semantics("array.init.empty")
   public init() {
     _buffer = _Buffer()
   }
@@ -726,6 +726,7 @@ extension ArraySlice: RangeReplaceableCollection {
 
   /// Construct a ArraySlice of `count` uninitialized elements.
   @inlinable
+  @_semantics("array.init")
   internal init(_uninitializedCount count: Int) {
     _precondition(count >= 0, "Can't construct ArraySlice with count < 0")
     // Note: Sinking this constructor into an else branch below causes an extra

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -500,7 +500,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   ///     print(emptyArray.isEmpty)
   ///     // Prints "true"
   @inlinable
-  @_semantics("array.init")
+  @_semantics("array.init.empty")
   public init() {
     _buffer = _Buffer()
   }

--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir -swift-version 5 -O -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 //
 // REQUIRES: VENDOR=apple
+// REQUIRES: swift_stdlib_no_asserts
 
 // This tests the optimality of the IR generated for the new os log APIs. This
 // is not testing the output of a specific optimization pass (which has separate
@@ -8,6 +9,13 @@
 // fails, it implies that some expected optimizations fail to get triggered on
 // os log APIs. TODO: eventually these optimization should also happen in Onone
 // mode.
+
+// With stdlib asserts, this test exhibits the same problem as
+// dead_array_elim.swift. The problem can be overcome by handling
+// non-trivial stores in OSSA, as described here:
+//   [OSSA] Improve DeadObjectElimination to handle array copies
+//   https://bugs.swift.org/browse/SR-13782
+// Once that bug is fixed, remove the requirement: swift_stdlib_no_asserts.
 
 import OSLogTestHelper
 import Foundation

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -1,11 +1,24 @@
 // RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
 
+// REQUIRES: swift_stdlib_no_asserts
+
 // These tests check whether DeadObjectElimination pass runs as a part of the
 // optimization pipeline and eliminates dead array literals in Swift code.
 // Note that DeadObjectElimination pass relies on @_semantics annotations on
 // the array initializer that is used by the compiler to create array literals.
 // This test would fail if in case the initializer used by the compiler to
 // initialize array literals doesn't match the one expected by the pass.
+
+// testDeadArrayElimination requires swift_stdlib_no_asserts because,
+// with runtime verification enabled, "array.finalize" becomes a
+// mutating operation, preventing SILCombine from deleting it when it
+// removes dead pure instructions. After inlining,
+// DeadObjectElimination is still unable to remove the array because a
+// second array is initialized by copying the first. This problem can be
+// overcome by handling non-trivial stores in OSSA, as described here:
+//   [OSSA] Improve DeadObjectElimination to handle array copies
+//   https://bugs.swift.org/browse/SR-13782
+// Once that bug is fixed, remove the requirement: swift_stdlib_no_asserts.
 
 // CHECK-LABEL: sil hidden @$s15dead_array_elim24testDeadArrayEliminationyyF
 func testDeadArrayElimination() {

--- a/test/SILOptimizer/diagnose_nested_semantic.swift
+++ b/test/SILOptimizer/diagnose_nested_semantic.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+
+@_semantics("array.append_contentsOf")
+public func funcA() {
+  funcB() // expected-warning {{'@_semantics' function calls non-'@_semantics' function with nested '@_semantics' calls}}
+}
+
+func getInt() -> Int {
+  return 3
+}
+
+// Make sure funcB is not itself a trivial wrapper by calling getInt
+// for funcC's argument.
+func funcB() {
+  funcC(i: getInt())
+}
+
+@_semantics("array.mutate_unknown")
+func funcC(i: Int) {}

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1363,55 +1363,10 @@ sil [_semantics "array.get_element_address"] @get_element_address : $@convention
 sil [_semantics "array.get_count"] @get_count : $@convention(method) (@guaranteed Array<X>) -> Int32
 sil [_semantics "array.get_capacity"] @get_capacity : $@convention(method) (@guaranteed Array<X>) -> Int32
 
-sil [_semantics "pair_no_escaping_closure"] @unsafeWithNotEscapedSelfPointerPair : $@convention(method) (@owned X, @owned @callee_owned (X, X) -> (@out X, @error Error), @guaranteed X) -> (@out X, @error Error)
-sil [_semantics "self_no_escaping_closure"] @unsafeWithNotEscapedSelfPointer: $@convention(method) (@owned @callee_owned (X, X) -> (@out X, @error Error), @guaranteed X) -> (@out X, @error Error)
 sil [_semantics "array.uninitialized"] @createUninitialized : $@convention(method) (@owned AnyObject) -> (@owned Array<X>, UnsafeMutablePointer<X>)
 
 // A simplified version of swift_bufferAllocate
 sil @swift_bufferAllocate : $@convention(thin) () -> @owned AnyObject
-
-// CHECK-LABEL: CG of semantics_pair_no_escaping_closure
-// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:
-// CHECK-NEXT:   Con [int] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:   Con [ref] %0.2 Esc: A, Succ: 
-// CHECK-NEXT:   Arg [ref] %1 Esc: A, Succ:
-// CHECK-NEXT:   Con [int] %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:   Con [ref] %1.2 Esc: A, Succ: 
-// CHECK-NEXT:   Arg [ref] %2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:   Con [int] %2.1 Esc: G, Succ: (%2.2)
-// CHECK-NEXT:   Con %2.2 Esc: G, Succ: 
-// CHECK-NEXT:   Val %4 Esc: , Succ: (%4.1)
-// CHECK-NEXT:   Con [ref] %4.1 Esc: %5, Succ: 
-// CHECK-NEXT: End
-sil @semantics_pair_no_escaping_closure : $@convention(thin) (@owned X, @guaranteed X, @owned @callee_owned (X, X) -> (@out X, @error Error)) -> () {
-bb(%0 : $X, %1 : $X, %2: $@callee_owned (X, X) -> (@out X, @error Error)):
-  %3 = function_ref @unsafeWithNotEscapedSelfPointerPair : $@convention(method) (@owned X, @owned @callee_owned (X, X) -> (@out X, @error Error), @guaranteed X) -> (@out X, @error Error)
-  %4 = alloc_stack $X
-  %6 = apply [nothrow] %3(%4, %0, %2, %1) : $@convention(method) (@owned X, @owned @callee_owned (X, X) -> (@out X, @error Error), @guaranteed X) -> (@out X, @error Error)
-  dealloc_stack %4 : $*X
-  %7 = tuple()
-	return %7 : $()
-}
-
-// CHECK-LABEL: CG of semantics_self_no_escaping_closure
-// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:
-// CHECK-NEXT:   Con [int] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:   Con [ref] %0.2 Esc: A, Succ: 
-// CHECK-NEXT:   Arg [ref] %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:   Con [int] %1.1 Esc: G, Succ: (%1.2)
-// CHECK-NEXT:   Con %1.2 Esc: G, Succ: 
-// CHECK-NEXT:   Val %3 Esc: , Succ:
-// CHECK-NEXT:   Con [ref] %3.1 Esc: %4, Succ: 
-// CHECK-NEXT: End
-sil @semantics_self_no_escaping_closure : $@convention(thin) (@guaranteed X, @owned @callee_owned (X, X) -> (@out X, @error Error)) -> () {
-bb(%0 : $X, %1: $@callee_owned (X, X) -> (@out X, @error Error)):
-  %2 = function_ref @unsafeWithNotEscapedSelfPointer : $@convention(method) (@owned @callee_owned (X, X) -> (@out X, @error Error), @guaranteed X) -> (@out X, @error Error)
-  %3 = alloc_stack $X
-  %6 = apply [nothrow] %2(%3, %1, %0) : $@convention(method) (@owned @callee_owned (X, X) -> (@out X, @error Error), @guaranteed X) -> (@out X, @error Error)
-  dealloc_stack %3 : $*X
-  %7 = tuple()
-	return %7 : $()
-}
 
 // CHECK-LABEL: CG of check_dealloc_ref
 // CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:

--- a/test/SILOptimizer/inline_semantics.sil
+++ b/test/SILOptimizer/inline_semantics.sil
@@ -12,9 +12,6 @@ bb0:
   return %1 : $Int32
 }
 
-//Not every @_semantics should be skipped during the early inlining pass, but
-//only those ones which are explicitly listed in shouldSkipApplyDuringEarlyInlining.
-
 //CHECK-LABEL: caller_func
 //CHECK-NOT: function_ref
 //CHECK-NOT: apply
@@ -33,9 +30,6 @@ bb0(%self : $*Int32):
   return %1 : $Int32
 }
 
-//Not every @_semantics should be skipped during the early inlining pass, but
-//only those ones which are explicitly listed in shouldSkipApplyDuringEarlyInlining.
-
 //CHECK-LABEL: caller_func2
 //CHECK: function_ref
 //CHECK: apply
@@ -44,46 +38,6 @@ sil @caller_func2 : $@convention(thin) () -> Int32 {
 bb0:
   %self = alloc_stack $Int32
   %0 = function_ref @callee_func_with_to_be_skipped_during_inlining_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
-  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32
-  dealloc_stack %self : $*Int32
-  return %1 : $Int32
-}
-
-sil [_semantics "pair_no_escaping_closure"] @callee_func_with_pair_no_escaping_closure_semantics : $@convention(method) (@inout Int32) -> Int32 {
-bb0(%self : $*Int32):
-  %0 = integer_literal $Builtin.Int32, 3
-  %1 = struct $Int32 (%0 : $Builtin.Int32)
-  return %1 : $Int32
-}
-
-//CHECK-LABEL: caller_func3
-//CHECK: function_ref
-//CHECK: apply
-//CHECK: end sil function 'caller_func3'
-sil @caller_func3 : $@convention(thin) () -> Int32 {
-bb0:
-  %self = alloc_stack $Int32
-  %0 = function_ref @callee_func_with_pair_no_escaping_closure_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
-  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32
-  dealloc_stack %self : $*Int32
-  return %1 : $Int32
-}
-
-sil [_semantics "self_no_escaping_closure"] @callee_func_with_self_no_escaping_closure_semantics : $@convention(method) (@inout Int32) -> Int32 {
-bb0(%self : $*Int32):
-  %0 = integer_literal $Builtin.Int32, 3
-  %1 = struct $Int32 (%0 : $Builtin.Int32)
-  return %1 : $Int32
-}
-
-//CHECK-LABEL: caller_func4
-//CHECK: function_ref
-//CHECK: apply
-//CHECK: end sil function 'caller_func4'
-sil @caller_func4 : $@convention(thin) () -> Int32 {
-bb0:
-  %self = alloc_stack $Int32
-  %0 = function_ref @callee_func_with_self_no_escaping_closure_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
   %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32
   dealloc_stack %self : $*Int32
   return %1 : $Int32


### PR DESCRIPTION
to check for improperly nested '@_semantic' functions.

Add a missing @_semantics("array.init") in ArraySlice found by the
diagnostic.

Distinguish between array.init and array.init.empty.

Categorize the types of semantic functions by how they affect the
inliner and pass pipeline, and centralize this logic in
PerformanceInlinerUtils. The ultimate goal is to prevent inlining of
"Fundamental" @_semantics calls and @_effects calls until the late
pipeline where we can safely discard semantics. However, that requires
significant pipeline changes.

In the meantime, this change prevents the situation from getting worse
and makes the intention clear. However, it has no significant effect
on the pass pipeline and inliner.