### PR TITLE
[ConstraintSystem] Remove `RValueAdjustment` locator element

### DIFF
--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -147,8 +147,8 @@ ABSTRACT_LOCATOR_PATH_ELT(AnyRequirement)
   /// A single requirement placed on the type parameters.
   CUSTOM_LOCATOR_PATH_ELT(TypeParameterRequirement)
 
-/// RValue adjustment.
-SIMPLE_LOCATOR_PATH_ELT(RValueAdjustment)
+/// Access to `.dynamicType` element
+SIMPLE_LOCATOR_PATH_ELT(DynamicType)
 
 /// The element type of a sequence in a for ... in ... loop.
 SIMPLE_LOCATOR_PATH_ELT(SequenceElementType)

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -810,10 +810,10 @@ protected:
     VarDecl *arrayVar = buildVar(loc);
     Type arrayElementType = cs->createTypeVariable(
         cs->getConstraintLocator(forEachStmt), 0);
-    cs->addConstraint(
-        ConstraintKind::Equal, cs->getType(bodyVar), arrayElementType,
-        cs->getConstraintLocator(
-          forEachStmt, ConstraintLocator::RValueAdjustment));
+    cs->addConstraint(ConstraintKind::Equal, cs->getType(bodyVar),
+                      arrayElementType,
+                      cs->getConstraintLocator(
+                          forEachStmt, ConstraintLocator::SequenceElementType));
     Type arrayType = ArraySliceType::get(arrayElementType);
     cs->setType(arrayVar, arrayType);
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2463,9 +2463,6 @@ void ContextualFailure::tryFixIts(InFlightDiagnostic &diagnostic) const {
 }
 
 bool ContextualFailure::diagnoseMissingFunctionCall() const {
-  if (getLocator()->isLastElement<LocatorPathElt::RValueAdjustment>())
-    return false;
-
   if (getLocator()
       ->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>())
     return false;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1446,9 +1446,6 @@ namespace {
 
       // The result of the last element of the chain must be convertible to the
       // whole chain, and the type of the whole chain must be equal to the base.
-      CS.addConstraint(
-          ConstraintKind::Conversion, memberTy, chainBaseTy,
-          CS.getConstraintLocator(tail, ConstraintLocator::RValueAdjustment));
       CS.addConstraint(ConstraintKind::Conversion, memberTy, chainResultTy,
                        locator);
       CS.addConstraint(ConstraintKind::Equal, chainBaseTy, chainResultTy,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2591,9 +2591,9 @@ namespace {
     Type visitDynamicTypeExpr(DynamicTypeExpr *expr) {
       auto tv = CS.createTypeVariable(CS.getConstraintLocator(expr),
                                       TVO_CanBindToNoEscape);
-      CS.addConstraint(ConstraintKind::DynamicTypeOf, tv,
-                       CS.getType(expr->getBase()),
-           CS.getConstraintLocator(expr, ConstraintLocator::RValueAdjustment));
+      CS.addConstraint(
+          ConstraintKind::DynamicTypeOf, tv, CS.getType(expr->getBase()),
+          CS.getConstraintLocator(expr, ConstraintLocator::DynamicType));
       return tv;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4371,9 +4371,6 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
-  case ConstraintLocator::RValueAdjustment:
-    return true;
-
   case ConstraintLocator::UnresolvedMemberChainResult: {
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -54,7 +54,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ParentType:
   case ConstraintLocator::ExistentialSuperclassType:
   case ConstraintLocator::LValueConversion:
-  case ConstraintLocator::RValueAdjustment:
+  case ConstraintLocator::DynamicType:
   case ConstraintLocator::SubscriptMember:
   case ConstraintLocator::OpenedGeneric:
   case ConstraintLocator::GenericParameter:
@@ -350,8 +350,8 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       out << "@lvalue-to-inout conversion";
       break;
 
-    case RValueAdjustment:
-      out << "rvalue adjustment";
+    case DynamicType:
+      out << "`.dynamicType` reference";
       break;
 
     case SubscriptMember:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1868,8 +1868,9 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     FunctionType::Param inputArg(input,
                                  CS.getASTContext().getIdentifier("of"));
 
-    CS.addConstraint(ConstraintKind::DynamicTypeOf, output, input,
-        CS.getConstraintLocator(locator, ConstraintLocator::RValueAdjustment));
+    CS.addConstraint(
+        ConstraintKind::DynamicTypeOf, output, input,
+        CS.getConstraintLocator(locator, ConstraintLocator::DynamicType));
     auto refType = FunctionType::get({inputArg}, output);
     return {refType, refType};
   }
@@ -1883,9 +1884,8 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto escapeClosure = CS.createTypeVariable(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionArgument),
         TVO_CanBindToNoEscape);
-    CS.addConstraint(ConstraintKind::EscapableFunctionOf,
-         escapeClosure, noescapeClosure,
-         CS.getConstraintLocator(locator, ConstraintLocator::RValueAdjustment));
+    CS.addConstraint(ConstraintKind::EscapableFunctionOf, escapeClosure,
+                     noescapeClosure, CS.getConstraintLocator(locator));
     auto result = CS.createTypeVariable(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionResult),
         TVO_CanBindToNoEscape);
@@ -1916,9 +1916,8 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto existentialTy = CS.createTypeVariable(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionArgument),
         TVO_CanBindToNoEscape);
-    CS.addConstraint(ConstraintKind::OpenedExistentialOf,
-         openedTy, existentialTy,
-         CS.getConstraintLocator(locator, ConstraintLocator::RValueAdjustment));
+    CS.addConstraint(ConstraintKind::OpenedExistentialOf, openedTy,
+                     existentialTy, CS.getConstraintLocator(locator));
     auto result = CS.createTypeVariable(
         CS.getConstraintLocator(locator, ConstraintLocator::FunctionResult),
         TVO_CanBindToNoEscape);
@@ -3914,7 +3913,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
 
     case ConstraintLocator::AutoclosureResult:
     case ConstraintLocator::LValueConversion:
-    case ConstraintLocator::RValueAdjustment:
+    case ConstraintLocator::DynamicType:
     case ConstraintLocator::UnresolvedMember:
     case ConstraintLocator::ImplicitCallAsFunction:
       // Arguments in autoclosure positions, lvalue and rvalue adjustments,


### PR DESCRIPTION
It was used for unresolved member and `.dynamicType` references
as well as a couple of other places, but now unresolved member
references no longer need that due to new implicit "chain result"
AST node and other places could use more precise locators
e.g. new `.dynamicType` locator or `sequence element` for `for ... in`
loops.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
