### PR TITLE
Rename swift-latest symlink as swift-latest.xctoolchain

### DIFF
--- a/utils/darwin-installer-scripts/postinstall
+++ b/utils/darwin-installer-scripts/postinstall
@@ -13,4 +13,4 @@
 
 INSTALLED_TOOLCHAIN=$2
 
-ln -fs "${INSTALLED_TOOLCHAIN}" "${INSTALLED_TOOLCHAIN%/*}/swift-latest"
+ln -fs "${INSTALLED_TOOLCHAIN}" "${INSTALLED_TOOLCHAIN%/*}/swift-latest.xctoolchain"


### PR DESCRIPTION
Toolchain installers distributed on https://swift.org/download creates a
symbolic link of the toolchain as `swift-latest.xctoolchain`, but postinstall
script in this repo creates as `swift-latest`.

The suffix was removed by https://github.com/apple/swift/commit/1cc28c769e92fd0095639d11a5e76e55496afa1d but I'm not well sure why it was dropped.

This patch syncs the difference of symlink name.
