### PR TITLE
Verify that nil can cast to AnyHashable

### DIFF
--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -761,4 +761,12 @@ CastsTests.test("Async function types") {
   expectFalse(asyncFnType is (() -> Void).Type)
 }
 
+// `Optional<Int>` is Hashable, so it must cast to AnyHashable,
+// even if it contains a nil.  (This was broken in 5.3 and earlier,
+// but was fixed by the new dynamic cast runtime.)
+CastsTests.test("Optional nil -> AnyHashable") {
+  let a : Int? = nil
+  expectNotNil(a as? AnyHashable)
+}
+
 runAllTests()


### PR DESCRIPTION
This is another case that was broken in Swift 5.3 and earlier but was
fixed by the new dynamic cast runtime.

Add a test to help ensure it stays fixed.