### PR TITLE
Add benchmarks for UTF16 decoding

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -198,6 +198,7 @@ set(SWIFT_BENCH_MODULES
     single-source/TwoSum
     single-source/TypeFlood
     single-source/UTF8Decode
+    single-source/UTF16Decode
     single-source/Walsh
     single-source/WordCount
     single-source/XorLoop

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -110,7 +110,7 @@ public func run_UTF16Decode_InitFromData(_ N: Int) {
 @inline(never)
 public func run_UTF16Decode_InitDecoding(_ N: Int) {
     let input: [CodeUnit] = allStringsCodeUnits
-  for _ in 0..<200*N {
+  for _ in 0..<2*N {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
@@ -118,7 +118,7 @@ public func run_UTF16Decode_InitDecoding(_ N: Int) {
 @inline(never)
 public func run_UTF16Decode_InitFromData_ascii(_ N: Int) {
   let input = asciiData
-  for _ in 0..<1_000*N {
+  for _ in 0..<100*N {
     blackHole(String(data: input, encoding: .utf16))
   }
 }
@@ -126,7 +126,7 @@ public func run_UTF16Decode_InitFromData_ascii(_ N: Int) {
 @inline(never)
 public func run_UTF16Decode_InitDecoding_ascii(_ N: Int) {
   let input = asciiCodeUnits
-  for _ in 0..<1_000*N {
+  for _ in 0..<N {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
@@ -183,7 +183,7 @@ let asciiCustomNoncontiguous = CustomNoncontiguousCollection(Array(ascii.utf16))
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_contiguous(_ N: Int) {
   let input = allStringsCustomContiguous
-  for _ in 0..<200*N {
+  for _ in 0..<20*N {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
@@ -191,7 +191,7 @@ public func run_UTF16Decode_InitFromCustom_contiguous(_ N: Int) {
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_contiguous_ascii(_ N: Int) {
   let input = asciiCustomContiguous
-  for _ in 0..<1_000*N {
+  for _ in 0..<10*N {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
@@ -199,7 +199,7 @@ public func run_UTF16Decode_InitFromCustom_contiguous_ascii(_ N: Int) {
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_noncontiguous(_ N: Int) {
   let input = allStringsCustomNoncontiguous
-  for _ in 0..<200*N {
+  for _ in 0..<20*N {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
@@ -207,7 +207,7 @@ public func run_UTF16Decode_InitFromCustom_noncontiguous(_ N: Int) {
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_noncontiguous_ascii(_ N: Int) {
   let input = asciiCustomNoncontiguous
-  for _ in 0..<1_000*N {
+  for _ in 0..<10*N {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -19,39 +19,39 @@ public let benchmarks = [
       runFunction: run_UTF16Decode,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromCustom_contiguous",
+      name: "UTF16Decode.initFromCustom.cont",
       runFunction: run_UTF16Decode_InitFromCustom_contiguous,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromCustom_contiguous_ascii",
+      name: "UTF16Decode.initFromCustom.cont.ascii",
       runFunction: run_UTF16Decode_InitFromCustom_contiguous_ascii,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromCustom_noncontiguous",
+      name: "UTF16Decode.initFromCustom.noncont",
       runFunction: run_UTF16Decode_InitFromCustom_noncontiguous,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromCustom_noncontiguous_ascii",
+      name: "UTF16Decode.initFromCustom.noncont.ascii",
       runFunction: run_UTF16Decode_InitFromCustom_noncontiguous_ascii,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromData",
+      name: "UTF16Decode.initFromData",
       runFunction: run_UTF16Decode_InitFromData,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitDecoding",
+      name: "UTF16Decode.initDecoding",
       runFunction: run_UTF16Decode_InitDecoding,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromData_ascii",
+      name: "UTF16Decode.initFromData.ascii",
       runFunction: run_UTF16Decode_InitFromData_ascii,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitDecoding_ascii",
+      name: "UTF16Decode.initDecoding.ascii",
       runFunction: run_UTF16Decode_InitDecoding_ascii,
       tags: [.validation, .api, .String]),
     BenchmarkInfo(
-      name: "UTF16Decode_InitFromData_ascii_as_ascii",
+      name: "UTF16Decode.initFromData.asciiAsAscii",
       runFunction: run_UTF16Decode_InitFromData_ascii_as_ascii,
       tags: [.validation, .api, .String]),
 ]

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -1,0 +1,210 @@
+//===--- UTF16Decode.swift -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+import Foundation
+
+public let UTF16Decode = [
+    BenchmarkInfo(
+      name: "UTF16Decode",
+      runFunction: run_UTF16Decode,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromCustom_contiguous",
+      runFunction: run_UTF16Decode_InitFromCustom_contiguous,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromCustom_contiguous_ascii",
+      runFunction: run_UTF16Decode_InitFromCustom_contiguous_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromCustom_noncontiguous",
+      runFunction: run_UTF16Decode_InitFromCustom_noncontiguous,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromCustom_noncontiguous_ascii",
+      runFunction: run_UTF16Decode_InitFromCustom_noncontiguous_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromData",
+      runFunction: run_UTF16Decode_InitFromData,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitDecoding",
+      runFunction: run_UTF16Decode_InitDecoding,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromData_ascii",
+      runFunction: run_UTF16Decode_InitFromData_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitDecoding_ascii",
+      runFunction: run_UTF16Decode_InitDecoding_ascii,
+      tags: [.validation, .api, .String]),
+    BenchmarkInfo(
+      name: "UTF16Decode_InitFromData_ascii_as_ascii",
+      runFunction: run_UTF16Decode_InitFromData_ascii_as_ascii,
+      tags: [.validation, .api, .String]),
+]
+
+typealias CodeUnit = UInt16
+
+// 1-byte sequences
+// This test case is the longest as it's the most performance sensitive.
+let ascii = "Swift is a multi-paradigm, compiled programming language created for iOS, OS X, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
+let asciiCodeUnits: [CodeUnit] = Array(ascii.utf16)
+let asciiData: Data = asciiCodeUnits.withUnsafeBytes { Data($0) }
+
+// 2-byte sequences
+let russian = "Ру́сский язы́к один из восточнославянских языков, национальный язык русского народа."
+// 3-byte sequences
+let japanese = "日本語（にほんご、にっぽんご）は、主に日本国内や日本人同士の間で使われている言語である。"
+// 4-byte sequences
+// Most commonly emoji, which are usually mixed with other text.
+let emoji = "Panda 🐼, Dog 🐶, Cat 🐱, Mouse 🐭."
+
+let allStrings: [[CodeUnit]] = [ascii, russian, japanese, emoji].map { Array($0.utf16) }
+let allStringsCodeUnits: [CodeUnit] = Array(allStrings.joined())
+let allStringsData: Data = allStringsCodeUnits.withUnsafeBytes { Data($0) }
+
+
+@inline(never)
+public func run_UTF16Decode(_ N: Int) {
+  let strings = allStrings
+
+  func isEmpty(_ result: UnicodeDecodingResult) -> Bool {
+    switch result {
+    case .emptyInput:
+      return true
+    default:
+      return false
+    }
+  }
+
+  for _ in 1...200*N {
+    for string in strings {
+      var it = string.makeIterator()
+      var utf16 = UTF16()
+      while !isEmpty(utf16.decode(&it)) { }
+    }
+  }
+}
+
+@inline(never)
+public func run_UTF16Decode_InitFromData(_ N: Int) {
+  let input = allStringsData
+  for _ in 0..<200*N {
+    blackHole(String(data: input, encoding: .utf16))
+  }
+}
+@inline(never)
+public func run_UTF16Decode_InitDecoding(_ N: Int) {
+    let input: [CodeUnit] = allStringsCodeUnits
+  for _ in 0..<200*N {
+    blackHole(String(decoding: input, as: UTF16.self))
+  }
+}
+
+@inline(never)
+public func run_UTF16Decode_InitFromData_ascii(_ N: Int) {
+  let input = asciiData
+  for _ in 0..<1_000*N {
+    blackHole(String(data: input, encoding: .utf16))
+  }
+}
+@inline(never)
+public func run_UTF16Decode_InitDecoding_ascii(_ N: Int) {
+  let input = asciiCodeUnits
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: UTF16.self))
+  }
+}
+
+@inline(never)
+public func run_UTF16Decode_InitFromData_ascii_as_ascii(_ N: Int) {
+  let input = asciiData
+  for _ in 0..<1_000*N {
+    blackHole(String(data: input, encoding: .ascii))
+  }
+}
+
+struct CustomContiguousCollection: Collection {
+  let storage: [CodeUnit]
+  typealias Index = Int
+  typealias Element = CodeUnit
+
+  init(_ codeUnits: [CodeUnit]) { self.storage = codeUnits }
+  subscript(position: Int) -> Element { self.storage[position] }
+  var startIndex: Index { 0 }
+  var endIndex: Index { storage.count }
+  func index(after i: Index) -> Index { i+1 }
+
+  @inline(never)
+  func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<CodeUnit>) throws -> R
+  ) rethrows -> R? {
+    try storage.withContiguousStorageIfAvailable(body)
+  }
+}
+struct CustomNoncontiguousCollection: Collection {
+  let storage: [CodeUnit]
+  typealias Index = Int
+  typealias Element = CodeUnit
+
+  init(_ codeUnits: [CodeUnit]) { self.storage = codeUnits }
+  subscript(position: Int) -> Element { self.storage[position] }
+  var startIndex: Index { 0 }
+  var endIndex: Index { storage.count }
+  func index(after i: Index) -> Index { i+1 }
+
+  @inline(never)
+  func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> R
+  ) rethrows -> R? {
+    nil
+  }
+}
+let allStringsCustomContiguous = CustomContiguousCollection(allStringsCodeUnits)
+let asciiCustomContiguous = CustomContiguousCollection(Array(ascii.utf16))
+let allStringsCustomNoncontiguous = CustomNoncontiguousCollection(allStringsCodeUnits)
+let asciiCustomNoncontiguous = CustomNoncontiguousCollection(Array(ascii.utf16))
+
+@inline(never)
+public func run_UTF16Decode_InitFromCustom_contiguous(_ N: Int) {
+  let input = allStringsCustomContiguous
+  for _ in 0..<200*N {
+    blackHole(String(decoding: input, as: UTF16.self))
+  }
+}
+@inline(never)
+public func run_UTF16Decode_InitFromCustom_contiguous_ascii(_ N: Int) {
+  let input = asciiCustomContiguous
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: UTF16.self))
+  }
+}
+
+@inline(never)
+public func run_UTF16Decode_InitFromCustom_noncontiguous(_ N: Int) {
+  let input = allStringsCustomNoncontiguous
+  for _ in 0..<200*N {
+    blackHole(String(decoding: input, as: UTF16.self))
+  }
+}
+@inline(never)
+public func run_UTF16Decode_InitFromCustom_noncontiguous_ascii(_ N: Int) {
+  let input = asciiCustomNoncontiguous
+  for _ in 0..<1_000*N {
+    blackHole(String(decoding: input, as: UTF16.self))
+  }
+}
+

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -17,43 +17,53 @@ public let benchmarks = [
     BenchmarkInfo(
       name: "UTF16Decode",
       runFunction: run_UTF16Decode,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.cont",
       runFunction: run_UTF16Decode_InitFromCustom_contiguous,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.cont.ascii",
       runFunction: run_UTF16Decode_InitFromCustom_contiguous_ascii,
-      tags: [.validation, .api, .String, .skip]),
+      tags: [.validation, .api, .String, .skip],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.noncont",
       runFunction: run_UTF16Decode_InitFromCustom_noncontiguous,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.noncont.ascii",
       runFunction: run_UTF16Decode_InitFromCustom_noncontiguous_ascii,
-      tags: [.validation, .api, .String, .skip]),
+      tags: [.validation, .api, .String, .skip],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromData",
       runFunction: run_UTF16Decode_InitFromData,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initDecoding",
       runFunction: run_UTF16Decode_InitDecoding,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromData.ascii",
       runFunction: run_UTF16Decode_InitFromData_ascii,
-      tags: [.validation, .api, .String, .skip]),
+      tags: [.validation, .api, .String, .skip],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initDecoding.ascii",
       runFunction: run_UTF16Decode_InitDecoding_ascii,
-      tags: [.validation, .api, .String, .skip]),
+      tags: [.validation, .api, .String, .skip],
+      setUpFunction: setUp),
     BenchmarkInfo(
       name: "UTF16Decode.initFromData.asciiAsAscii",
       runFunction: run_UTF16Decode_InitFromData_ascii_as_ascii,
-      tags: [.validation, .api, .String, .skip]),
+      tags: [.validation, .api, .String, .skip],
+      setUpFunction: setUp),
 ]
 
 typealias CodeUnit = UInt16
@@ -76,6 +86,17 @@ let allStrings: [[CodeUnit]] = [ascii, russian, japanese, emoji].map { Array($0.
 let allStringsCodeUnits: [CodeUnit] = Array(allStrings.joined())
 let allStringsData: Data = allStringsCodeUnits.withUnsafeBytes { Data($0) }
 
+func setUp() {
+    blackHole(asciiCodeUnits)
+    blackHole(asciiData)
+    blackHole(allStrings)
+    blackHole(allStringsCodeUnits)
+    blackHole(allStringsData)
+    blackHole(allStringsCustomContiguous)
+    blackHole(asciiCustomContiguous)
+    blackHole(allStringsCustomNoncontiguous)
+    blackHole(asciiCustomNoncontiguous)
+}
 
 @inline(never)
 public func run_UTF16Decode(_ N: Int) {

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -79,8 +79,6 @@ let allStringsData: Data = allStringsCodeUnits.withUnsafeBytes { Data($0) }
 
 @inline(never)
 public func run_UTF16Decode(_ N: Int) {
-  let strings = allStrings
-
   func isEmpty(_ result: UnicodeDecodingResult) -> Bool {
     switch result {
     case .emptyInput:
@@ -91,7 +89,7 @@ public func run_UTF16Decode(_ N: Int) {
   }
 
   for _ in 1...200*N {
-    for string in strings {
+    for string in allStrings {
       var it = string.makeIterator()
       var utf16 = UTF16()
       while !isEmpty(utf16.decode(&it)) { }
@@ -101,41 +99,36 @@ public func run_UTF16Decode(_ N: Int) {
 
 @inline(never)
 public func run_UTF16Decode_InitFromData(_ N: Int) {
-  let input = allStringsData
   for _ in 0..<200*N {
-    blackHole(String(data: input, encoding: .utf16))
+    blackHole(String(data: allStringsData, encoding: .utf16))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitDecoding(_ N: Int) {
-    let input: [CodeUnit] = allStringsCodeUnits
   for _ in 0..<2*N {
-    blackHole(String(decoding: input, as: UTF16.self))
+    blackHole(String(decoding: allStringsCodeUnits, as: UTF16.self))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitFromData_ascii(_ N: Int) {
-  let input = asciiData
   for _ in 0..<100*N {
-    blackHole(String(data: input, encoding: .utf16))
+    blackHole(String(data: asciiData, encoding: .utf16))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitDecoding_ascii(_ N: Int) {
-  let input = asciiCodeUnits
   for _ in 0..<N {
-    blackHole(String(decoding: input, as: UTF16.self))
+    blackHole(String(decoding: asciiCodeUnits, as: UTF16.self))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitFromData_ascii_as_ascii(_ N: Int) {
-  let input = asciiData
   for _ in 0..<1_000*N {
-    blackHole(String(data: input, encoding: .ascii))
+    blackHole(String(data: asciiData, encoding: .ascii))
   }
 }
 
@@ -182,32 +175,28 @@ let asciiCustomNoncontiguous = CustomNoncontiguousCollection(Array(ascii.utf16))
 
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_contiguous(_ N: Int) {
-  let input = allStringsCustomContiguous
   for _ in 0..<20*N {
-    blackHole(String(decoding: input, as: UTF16.self))
+    blackHole(String(decoding: allStringsCustomContiguous, as: UTF16.self))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_contiguous_ascii(_ N: Int) {
-  let input = asciiCustomContiguous
   for _ in 0..<10*N {
-    blackHole(String(decoding: input, as: UTF16.self))
+    blackHole(String(decoding: asciiCustomContiguous, as: UTF16.self))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_noncontiguous(_ N: Int) {
-  let input = allStringsCustomNoncontiguous
   for _ in 0..<20*N {
-    blackHole(String(decoding: input, as: UTF16.self))
+    blackHole(String(decoding: allStringsCustomNoncontiguous, as: UTF16.self))
   }
 }
 
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_noncontiguous_ascii(_ N: Int) {
-  let input = asciiCustomNoncontiguous
   for _ in 0..<10*N {
-    blackHole(String(decoding: input, as: UTF16.self))
+    blackHole(String(decoding: asciiCustomNoncontiguous, as: UTF16.self))
   }
 }

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -25,7 +25,7 @@ public let benchmarks = [
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.cont.ascii",
       runFunction: run_UTF16Decode_InitFromCustom_contiguous_ascii,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String, .skip]),
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.noncont",
       runFunction: run_UTF16Decode_InitFromCustom_noncontiguous,
@@ -33,7 +33,7 @@ public let benchmarks = [
     BenchmarkInfo(
       name: "UTF16Decode.initFromCustom.noncont.ascii",
       runFunction: run_UTF16Decode_InitFromCustom_noncontiguous_ascii,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String, .skip]),
     BenchmarkInfo(
       name: "UTF16Decode.initFromData",
       runFunction: run_UTF16Decode_InitFromData,
@@ -45,15 +45,15 @@ public let benchmarks = [
     BenchmarkInfo(
       name: "UTF16Decode.initFromData.ascii",
       runFunction: run_UTF16Decode_InitFromData_ascii,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String, .skip]),
     BenchmarkInfo(
       name: "UTF16Decode.initDecoding.ascii",
       runFunction: run_UTF16Decode_InitDecoding_ascii,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String, .skip]),
     BenchmarkInfo(
       name: "UTF16Decode.initFromData.asciiAsAscii",
       runFunction: run_UTF16Decode_InitFromData_ascii_as_ascii,
-      tags: [.validation, .api, .String]),
+      tags: [.validation, .api, .String, .skip]),
 ]
 
 typealias CodeUnit = UInt16

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -106,6 +106,7 @@ public func run_UTF16Decode_InitFromData(_ N: Int) {
     blackHole(String(data: input, encoding: .utf16))
   }
 }
+
 @inline(never)
 public func run_UTF16Decode_InitDecoding(_ N: Int) {
     let input: [CodeUnit] = allStringsCodeUnits
@@ -121,6 +122,7 @@ public func run_UTF16Decode_InitFromData_ascii(_ N: Int) {
     blackHole(String(data: input, encoding: .utf16))
   }
 }
+
 @inline(never)
 public func run_UTF16Decode_InitDecoding_ascii(_ N: Int) {
   let input = asciiCodeUnits
@@ -185,6 +187,7 @@ public func run_UTF16Decode_InitFromCustom_contiguous(_ N: Int) {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
+
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_contiguous_ascii(_ N: Int) {
   let input = asciiCustomContiguous
@@ -200,6 +203,7 @@ public func run_UTF16Decode_InitFromCustom_noncontiguous(_ N: Int) {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
+
 @inline(never)
 public func run_UTF16Decode_InitFromCustom_noncontiguous_ascii(_ N: Int) {
   let input = asciiCustomNoncontiguous
@@ -207,4 +211,3 @@ public func run_UTF16Decode_InitFromCustom_noncontiguous_ascii(_ N: Int) {
     blackHole(String(decoding: input, as: UTF16.self))
   }
 }
-

--- a/benchmark/single-source/UTF16Decode.swift
+++ b/benchmark/single-source/UTF16Decode.swift
@@ -13,7 +13,7 @@
 import TestsUtils
 import Foundation
 
-public let UTF16Decode = [
+public let benchmarks = [
     BenchmarkInfo(
       name: "UTF16Decode",
       runFunction: run_UTF16Decode,

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -199,6 +199,7 @@ import SuperChars
 import TwoSum
 import TypeFlood
 import UTF8Decode
+import UTF16Decode
 import Walsh
 import WordCount
 import XorLoop
@@ -393,6 +394,7 @@ register(SuperChars.benchmarks)
 register(TwoSum.benchmarks)
 register(TypeFlood.benchmarks)
 register(UTF8Decode.benchmarks)
+register(UTF16Decode.benchmarks)
 register(Walsh.benchmarks)
 register(WordCount.benchmarks)
 register(XorLoop.benchmarks)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds benchmarks for UTF16 decoding

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Partially resolves [SR-8905](https://bugs.swift.org/browse/SR-8905)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
