### PR TITLE
[ownership] Add a new ReborrowVerifier

### DIFF
--- a/include/swift/SIL/LinearLifetimeChecker.h
+++ b/include/swift/SIL/LinearLifetimeChecker.h
@@ -50,6 +50,7 @@ public:
   class ErrorBuilder;
 
 private:
+  friend class ReborrowVerifier;
   friend class SILOwnershipVerifier;
   friend class SILValueOwnershipChecker;
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -66,6 +66,9 @@ bool isOwnedForwardingInstruction(SILInstruction *inst);
 /// previous terminator.
 bool isOwnedForwardingValue(SILValue value);
 
+/// Returns true if the instruction is a 'reborrow'.
+bool isReborrowInstruction(const SILInstruction *inst);
+
 class BorrowingOperandKind {
 public:
   enum Kind : uint8_t {
@@ -134,7 +137,7 @@ struct BorrowingOperand {
     return BorrowingOperand(*kind, op);
   }
 
-  void visitEndScopeInstructions(function_ref<void(Operand *)> func) const;
+  void visitLocalEndScopeInstructions(function_ref<void(Operand *)> func) const;
 
   /// Returns true if this borrow scope operand consumes guaranteed
   /// values and produces a new scope afterwards.
@@ -204,7 +207,7 @@ struct BorrowingOperand {
   /// \p errorFunction a callback that if non-null is passed an operand that
   /// triggers a mal-formed SIL error. This is just needed for the ownership
   /// verifier to emit good output.
-  bool getImplicitUses(
+  void getImplicitUses(
       SmallVectorImpl<Operand *> &foundUses,
       std::function<void(Operand *)> *errorFunction = nullptr) const;
 

--- a/lib/SIL/Verifier/CMakeLists.txt
+++ b/lib/SIL/Verifier/CMakeLists.txt
@@ -2,5 +2,6 @@ target_sources(swiftSIL PRIVATE
   LoadBorrowImmutabilityChecker.cpp
   LinearLifetimeChecker.cpp
   MemoryLifetime.cpp
+  ReborrowVerifier.cpp
   SILOwnershipVerifier.cpp
   SILVerifier.cpp)

--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -305,10 +305,14 @@ void State::checkForSameBlockUseAfterFree(Operand *consumingUse,
   // must be instructions in the given block. Make sure that the non consuming
   // user is strictly before the consuming user.
   for (auto *nonConsumingUse : nonConsumingUsesInBlock) {
-    if (std::find_if(consumingUse->getUser()->getIterator(), userBlock->end(),
-                     [&nonConsumingUse](const SILInstruction &i) -> bool {
-                       return nonConsumingUse->getUser() == &i;
-                     }) == userBlock->end()) {
+    if (nonConsumingUse->getUser() != consumingUse->getUser()) {
+      if (std::find_if(consumingUse->getUser()->getIterator(), userBlock->end(),
+                       [&nonConsumingUse](const SILInstruction &i) -> bool {
+                         return nonConsumingUse->getUser() == &i;
+                       }) == userBlock->end()) {
+        continue;
+      }
+    } else if (isReborrowInstruction(consumingUse->getUser())) {
       continue;
     }
 

--- a/lib/SIL/Verifier/ReborrowVerifier.cpp
+++ b/lib/SIL/Verifier/ReborrowVerifier.cpp
@@ -1,0 +1,96 @@
+//===--- ReborrowVerifier.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-reborrow-checker"
+
+#include "ReborrowVerifierPrivate.h"
+
+using namespace swift;
+
+bool ReborrowVerifier::verifyReborrowLifetime(SILPhiArgument *phiArg,
+                                              SILValue baseVal) {
+  SmallPtrSet<SILBasicBlock *, 4> visitedBlocks;
+  bool result = false;
+  SmallVector<Operand *, 4> phiArgUses(phiArg->getUses());
+
+  // Verify whether the guaranteed phi arg lies within the lifetime of the base
+  // value.
+  LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+  // newErrorBuilder is consumed at the end of the checkValue function.
+  // Copy initial state from errorBuilder everytime
+  LinearLifetimeChecker::ErrorBuilder newErrorBuilder = errorBuilder;
+  SmallVector<Operand *, 4> baseValConsumingUses(baseVal->getConsumingUses());
+  // If the baseValue has no consuming uses, there is nothing more to verify
+  if (baseValConsumingUses.empty())
+    return false;
+  auto linearLifetimeResult = checker.checkValue(baseVal, baseValConsumingUses,
+                                                 phiArgUses, newErrorBuilder);
+  result |= linearLifetimeResult.getFoundError();
+  return result;
+}
+
+void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
+                                       SILValue value) {
+  SmallVector<std::tuple<Operand *, SILValue>, 4> worklist;
+  // Initialize the worklist with borrow lifetime ending uses
+  initialScopedOperand.visitLocalEndScopeInstructions([&](Operand *op) {
+    worklist.emplace_back(op, value);
+  });
+
+  while (!worklist.empty()) {
+    Operand *borrowLifetimeEndOp;
+    SILValue baseVal;
+    std::tie(borrowLifetimeEndOp, baseVal) = worklist.pop_back_val();
+    auto *borrowLifetimeEndUser = borrowLifetimeEndOp->getUser();
+
+    // TODO: Add a ReborrowOperand ADT if we need to treat more instructions as
+    // a reborrow
+    if (!isReborrowInstruction(borrowLifetimeEndUser)) {
+      continue;
+    }
+
+    if (isVisitedOp(borrowLifetimeEndOp, baseVal))
+      continue;
+
+    // Process reborrow
+    auto *branchInst = cast<BranchInst>(borrowLifetimeEndUser);
+    for (auto *succBlock : branchInst->getSuccessorBlocks()) {
+      auto *phiArg = cast<SILPhiArgument>(
+          succBlock->getArgument(borrowLifetimeEndOp->getOperandNumber()));
+      assert(phiArg->getOwnershipKind() == ValueOwnershipKind::Guaranteed);
+
+      SILValue newBaseVal = baseVal;
+      // If the previous base value was also passed as a phi arg, that will be
+      // the new base value.
+      for (auto *arg : succBlock->getArguments()) {
+        if (arg->getIncomingPhiValue(branchInst->getParent()) == baseVal) {
+          newBaseVal = arg;
+          break;
+        }
+      }
+
+      if (isVisitedPhiArg(phiArg, newBaseVal))
+        continue;
+      addVisitedPhiArg(phiArg, newBaseVal);
+      verifyReborrowLifetime(phiArg, newBaseVal);
+
+      // Find the scope ending uses of the guaranteed phi arg and add it to the
+      // worklist.
+      auto scopedValue = BorrowedValue::get(phiArg);
+      assert(scopedValue.hasValue());
+      scopedValue->visitLocalScopeEndingUses([&](Operand *op) {
+        addVisitedOp(op, newBaseVal);
+        worklist.emplace_back(op, newBaseVal);
+      });
+    }
+  }
+}

--- a/lib/SIL/Verifier/ReborrowVerifierPrivate.h
+++ b/lib/SIL/Verifier/ReborrowVerifierPrivate.h
@@ -1,0 +1,77 @@
+//===--- ReborrowVerifierPrivate.h ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_REBORROWVERIFIER_H
+#define SWIFT_SIL_REBORROWVERIFIER_H
+
+#include "LinearLifetimeCheckerPrivate.h"
+
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+
+namespace swift {
+
+class DeadEndBlocks;
+
+/// A guaranteed phi arg ends the borrow scope of its incoming value and begins
+/// a new borrow scope. ReborrowVerifier validates the lifetime of the reborrow
+/// lies within the lifetime of its base value. It uses LinearLifetimeChecker
+/// for this.
+class ReborrowVerifier {
+  /// A cache of dead-end basic blocks that we use to determine if we can
+  /// ignore "leaks".
+  DeadEndBlocks &deadEndBlocks;
+  /// A cache map of borrow lifetime ending operands and their base value
+  llvm::SmallDenseMap<Operand *, SILValue> visitedOps;
+  /// A cache map of guaranteed phi args and their base value
+  llvm::SmallDenseMap<SILPhiArgument *, SILValue> visitedPhiArgs;
+  /// The builder that the checker uses to emit error messages, crash if asked
+  /// for, or supply back interesting info to the caller.
+  LinearLifetimeChecker::ErrorBuilder errorBuilder;
+
+public:
+  ReborrowVerifier(const SILFunction *func, DeadEndBlocks &deadEndBlocks,
+                   LinearLifetimeChecker::ErrorBuilder errorBuilder)
+      : deadEndBlocks(deadEndBlocks), errorBuilder(errorBuilder) {}
+
+  void verifyReborrows(BorrowingOperand initialScopedOperand, SILValue value);
+
+private:
+  /// Verifies whether the reborrow's lifetime lies within its base value
+  bool verifyReborrowLifetime(SILPhiArgument *phiArg, SILValue baseVal);
+
+  /// Check if the operand is visited
+  bool isVisitedOp(Operand *op, SILValue baseVal) {
+    return visitedOps.find(op) != visitedOps.end();
+  }
+
+  /// Check if the phi arg and base value are visited
+  bool isVisitedPhiArg(SILPhiArgument *phiArg, SILValue baseVal) {
+    auto itPhiArg = visitedPhiArgs.find(phiArg);
+    return itPhiArg != visitedPhiArgs.end() && (*itPhiArg).second == baseVal;
+  }
+
+  /// Mark operand as visited
+  void addVisitedOp(Operand *op, SILValue baseVal) {
+    visitedOps.insert({op, baseVal});
+  }
+
+  /// Mark guaranteed phi arg as visited
+  void addVisitedPhiArg(SILPhiArgument *phiArg, SILValue baseVal) {
+    visitedPhiArgs.insert({phiArg, baseVal});
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "sil-ownership-verifier"
 
 #include "LinearLifetimeCheckerPrivate.h"
+#include "ReborrowVerifierPrivate.h"
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AnyFunctionRef.h"
@@ -78,7 +79,6 @@ static llvm::cl::opt<bool>
 //===----------------------------------------------------------------------===//
 
 namespace swift {
-
 // TODO: This class uses a bunch of global state like variables. It should be
 // refactored into a large state object that is used by functions.
 class SILValueOwnershipChecker {
@@ -107,13 +107,17 @@ class SILValueOwnershipChecker {
   /// The set of blocks that we have visited.
   SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks;
 
+  ReborrowVerifier &reborrowVerifier;
+
 public:
   SILValueOwnershipChecker(
       DeadEndBlocks &deadEndBlocks, SILValue value,
       LinearLifetimeChecker::ErrorBuilder &errorBuilder,
-      llvm::SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks)
+      llvm::SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
+      ReborrowVerifier &reborrowVerifier)
       : result(), deadEndBlocks(deadEndBlocks), value(value),
-        errorBuilder(errorBuilder), visitedBlocks(visitedBlocks) {
+        errorBuilder(errorBuilder), visitedBlocks(visitedBlocks),
+        reborrowVerifier(reborrowVerifier) {
     assert(value && "Can not initialize a checker with an empty SILValue");
   }
 
@@ -157,8 +161,9 @@ bool SILValueOwnershipChecker::check() {
 
   LLVM_DEBUG(llvm::dbgs() << "Verifying ownership of: " << *value);
   result = checkUses();
-  if (!result.getValue())
+  if (!result.getValue()) {
     return false;
+  }
 
   SmallVector<Operand *, 32> allLifetimeEndingUsers;
   llvm::copy(lifetimeEndingUsers, std::back_inserter(allLifetimeEndingUsers));
@@ -281,8 +286,8 @@ bool SILValueOwnershipChecker::gatherNonGuaranteedUsers(
                      << "Initial: " << *initialScopedOperand << "\n";
       });
     };
-    foundError |=
-        initialScopedOperand->getImplicitUses(nonLifetimeEndingUsers, &error);
+    initialScopedOperand->getImplicitUses(nonLifetimeEndingUsers, &error);
+    reborrowVerifier.verifyReborrows(initialScopedOperand.getValue(), value);
   }
 
   return foundError;
@@ -301,7 +306,7 @@ bool SILValueOwnershipChecker::gatherUsers(
                                      nonLifetimeEndingUsers);
   }
 
-  // Ok, we have a value with guarantee ownership. Before we continue, check if
+  // Ok, we have a value with guaranteed ownership. Before we continue, check if
   // this value forwards guaranteed ownership. In such a case, we are going to
   // validate it as part of the borrow introducer from which the forwarding
   // value originates. So we can just return true and continue.
@@ -310,8 +315,8 @@ bool SILValueOwnershipChecker::gatherUsers(
 
   // Ok, we have some sort of borrow introducer. We need to recursively validate
   // that all of its uses (including sub-scopes) are before any end_borrows that
-  // end the lifetime of the borrow introducer. With that in mind, gather up our
-  // initial list of users.
+  // may end the lifetime of the borrow introducer. With that in mind, gather up
+  // our initial list of users.
   SmallVector<Operand *, 8> users;
   llvm::copy(value->getUses(), std::back_inserter(users));
 
@@ -378,8 +383,9 @@ bool SILValueOwnershipChecker::gatherUsers(
                          << "Initial: " << *scopedOperand << "\n";
           });
         };
-        foundError |=
-            scopedOperand->getImplicitUses(nonLifetimeEndingUsers, &onError);
+
+        scopedOperand->getImplicitUses(nonLifetimeEndingUsers, &onError);
+        reborrowVerifier.verifyReborrows(scopedOperand.getValue(), value);
       }
 
       // Next see if our use is an interior pointer operand. If we have an
@@ -429,16 +435,13 @@ bool SILValueOwnershipChecker::gatherUsers(
                "Should have guaranteed ownership as well.");
         llvm::copy(result->getUses(), std::back_inserter(users));
       }
-
       continue;
     }
-
     assert(user->getResults().empty());
     auto *ti = dyn_cast<TermInst>(user);
     if (!ti) {
       continue;
     }
-
     // At this point, the only type of thing we could have is a transformation
     // terminator since all forwarding terminators are transformation
     // terminators.
@@ -774,7 +777,8 @@ void SILInstruction::verifyOperandOwnership() const {
 static void
 verifySILValueHelper(const SILFunction *f, SILValue value,
                      LinearLifetimeChecker::ErrorBuilder &errorBuilder,
-                     DeadEndBlocks *deadEndBlocks) {
+                     DeadEndBlocks *deadEndBlocks,
+                     ReborrowVerifier &reborrowVerifier) {
   assert(!isa<SILUndef>(value) &&
          "We assume we are always passed arguments or instruction results");
 
@@ -785,11 +789,13 @@ verifySILValueHelper(const SILFunction *f, SILValue value,
 
   SmallPtrSet<SILBasicBlock *, 32> liveBlocks;
   if (deadEndBlocks) {
-    SILValueOwnershipChecker(*deadEndBlocks, value, errorBuilder, liveBlocks)
+    SILValueOwnershipChecker(*deadEndBlocks, value, errorBuilder, liveBlocks,
+                             reborrowVerifier)
         .check();
   } else {
     DeadEndBlocks deadEndBlocks(f);
-    SILValueOwnershipChecker(deadEndBlocks, value, errorBuilder, liveBlocks)
+    SILValueOwnershipChecker(deadEndBlocks, value, errorBuilder, liveBlocks,
+                             reborrowVerifier)
         .check();
   }
 }
@@ -838,7 +844,8 @@ void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   using BehaviorKind = LinearLifetimeChecker::ErrorBehaviorKind;
   LinearLifetimeChecker::ErrorBuilder errorBuilder(
       *f, BehaviorKind::PrintMessageAndAssert);
-  verifySILValueHelper(f, *this, errorBuilder, deadEndBlocks);
+  ReborrowVerifier reborrowVerifier(f, *deadEndBlocks, errorBuilder);
+  verifySILValueHelper(f, *this, errorBuilder, deadEndBlocks, reborrowVerifier);
 }
 
 void SILFunction::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
@@ -873,16 +880,19 @@ void SILFunction::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
     errorBuilder.emplace(*this, BehaviorKind::PrintMessageAndAssert);
   }
 
+  ReborrowVerifier reborrowVerifier(this, *deadEndBlocks, *errorBuilder);
   for (auto &block : *this) {
     for (auto *arg : block.getArguments()) {
       LinearLifetimeChecker::ErrorBuilder newBuilder = *errorBuilder;
-      verifySILValueHelper(this, arg, newBuilder, deadEndBlocks);
+      verifySILValueHelper(this, arg, newBuilder, deadEndBlocks,
+                           reborrowVerifier);
     }
 
     for (auto &inst : block) {
       for (auto result : inst.getResults()) {
         LinearLifetimeChecker::ErrorBuilder newBuilder = *errorBuilder;
-        verifySILValueHelper(this, result, newBuilder, deadEndBlocks);
+        verifySILValueHelper(this, result, newBuilder, deadEndBlocks,
+                             reborrowVerifier);
       }
     }
   }

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -21,23 +21,37 @@ struct NativeObjectPair {
 // Tests //
 ///////////
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'no_end_borrow_error'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'no_end_borrow_error1'
 // CHECK: Guaranteed function parameter with life ending uses!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Lifetime Ending User:   br bb1(%0 : $Builtin.NativeObject)
-// CHECK: Error#: 0. End Error in Function: 'no_end_borrow_error'
-//
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'no_end_borrow_error'
+// CHECK: Error#: 0. End Error in Function: 'no_end_borrow_error1'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'no_end_borrow_error1'
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
-// CHECK: Error#: 1. End Error in Function: 'no_end_borrow_error'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'no_end_borrow_error'
-sil [ossa] @no_end_borrow_error : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-LABEL: Error#: 1. End Error in Function: 'no_end_borrow_error1'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'no_end_borrow_error1'
+sil [ossa] @no_end_borrow_error1 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
 
 bb1(%1 : @guaranteed $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'no_end_borrow_error2'
+// CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
+// CHECK: Value: %3 = argument of bb1 : $Builtin.NativeObject
+// CHECK-LABEL: Error#: 0. End Error in Function: 'no_end_borrow_error2'
+//
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'no_end_borrow_error2'
+sil [ossa] @no_end_borrow_error2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
@@ -274,21 +288,21 @@ bb5:
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found outside of lifetime use?!
-// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %7
 // CHECK: Block: bb2
-// CHECK: Error#: 0. End Error in Function: 'bad_order_add_a_level'
-//
+// CHECK-LABEL: Error#: 0. End Error in Function: 'bad_order_add_a_level'
+
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found over consume?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
 // CHECK: User:   end_borrow %1 : $Builtin.NativeObject           // id: %14
 // CHECK: Block: bb2
 // CHECK: Consuming Users:
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %14
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %19
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %14
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
 // CHECK: Error#: 1. End Error in Function: 'bad_order_add_a_level'
 //
 // This block is reported as leaking block since given our partial-cfg:
@@ -305,42 +319,61 @@ bb5:
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
-// CHECK: Error#: 2. End Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 2. End Error in Function: 'bad_order_add_a_level'
 //
 // CHECK-LABEL: Error#: 3. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found outside of lifetime use!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %19, %14, %6, %3
+// CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 3. End Error in Function: 'bad_order_add_a_level'
+//
+// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found over consume?!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
 // CHECK: Block: bb2
 // CHECK: Consuming Users:
-// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %7
 // CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %13
-// CHECK: Error#: 3. End Error in Function: 'bad_order_add_a_level'
+// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %7
+// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 4. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 7. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
-// CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 7. End Error in Function: 'bad_order_add_a_level'
+
+// CHECK: Error#: 9. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
+// CHECK: Post Dominating Failure Blocks:
+// CHECK: bb3
+// CHECK-LABEL: Error#: 9. End Error in Function: 'bad_order_add_a_level'
+//
+// CHECK-LABEL: Error#: 10. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK: Found outside of lifetime use!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
+// CHECK: User:  br bb4(%9 : $Builtin.NativeObject)              // id: %10
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 10. End Error in Function: 'bad_order_add_a_level'
 //
 // We found a use that we didn't visit. For our purposes, we consider this to be
 // an outside lifetime use rather than use after freer to unite it with errors
 // from uses that are not reachable from the definition of the value.
 //
-// CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 11. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Found outside of lifetime use!
 // CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %13, %9, %7
 // CHECK: User:  %9 = begin_borrow %5 : $Builtin.NativeObject    // user: %10
 // CHECK: Block: bb3
-// CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 11. End Error in Function: 'bad_order_add_a_level'
 //
-// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level'
+// CHECK-LABEL: Error#: 12. Begin Error in Function: 'bad_order_add_a_level'
 // CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
 // CHECK: Value: %11 = argument of bb4 : $Builtin.NativeObject
-// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'bad_order_add_a_level'
+// CHECK: Error#: 12. End Error in Function: 'bad_order_add_a_level'
 sil [ossa] @bad_order_add_a_level : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -383,14 +416,13 @@ bb7:
 // properly visit terminators so that we do not erroneously flag them as
 // improper uses.
 //
-//
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
-// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %6
-// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %7
-// CHECK: Block: bb2
-// CHECK: Error#: 0. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %17
+// CHECK: Block: bb5
+// CHECK-LABEL: Error#: 0. End Error in Function: 'bad_order_add_a_level_2'
 //
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found outside of lifetime use?!
@@ -398,15 +430,15 @@ bb7:
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %12
 // CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
 // CHECK: Block: bb4
-// CHECK: Error#: 1. End Error in Function: 'bad_order_add_a_level_2'
-//
+// CHECK-LABEL:Error#: 1. End Error in Function: 'bad_order_add_a_level_2'
+
 // CHECK-LABEL: Error#: 2. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
-// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
-// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %17
-// CHECK: Block: bb5
-// CHECK: Error#: 2. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %7
+// CHECK: Block: bb2
+// CHECK-LABEL: Error#: 2. End Error in Function: 'bad_order_add_a_level_2'
 //
 // CHECK-LABEL: Error#: 3. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found over consume?!
@@ -414,39 +446,29 @@ bb7:
 // CHECK: User:   end_borrow %1 : $Builtin.NativeObject           // id: %16
 // CHECK: Block: bb2
 // CHECK: Consuming Users:
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
 // CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
-// CHECK: Error#: 3. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
+// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
+// CHECK-LABEL: Error#: 3. End Error in Function: 'bad_order_add_a_level_2'
 //
-// This comes from the dataflow, but we already actually identified this error.
-//
-// CHECK-LABEL: Error#: 4. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 7. Begin Error in Function: 'bad_order_add_a_level_2'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %17, %13, %9, %7
+// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %13
+// CHECK: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject          // id: %14
+// CHECK: Block: bb4
+// CHECK-LABEL: Error#: 7. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK-LABEL: Error#: 8. Begin Error in Function: 'bad_order_add_a_level_2'
 // CHECK: Found over consume?!
-// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %22, %16, %12, %6, %3
+// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %17, %13, %9, %7
+// CHECK: User:   end_borrow %5 : $Builtin.NativeObject           // id: %17
 // CHECK: Block: bb2
 // CHECK: Consuming Users:
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %6
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %12
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %16
-// CHECK:   end_borrow %1 : $Builtin.NativeObject           // id: %22
-// CHECK: Error#: 4. End Error in Function: 'bad_order_add_a_level_2'
-//
-// CHECK-LABEL: Error#: 5. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found outside of lifetime use?!
-// CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
-// CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Non Consuming User:   end_borrow %11 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb4
-// CHECK: Error#: 5. End Error in Function: 'bad_order_add_a_level_2'
-//
-// CHECK-LABEL: Error#: 6. Begin Error in Function: 'bad_order_add_a_level_2'
-// CHECK-NEXT: Found over consume?!
-// CHECK-NEXT: Value: %5 = argument of bb2 : $Builtin.NativeObject
-// CHECK-NEXT: User:   end_borrow %5 : $Builtin.NativeObject
-// CHECK-NEXT: Block: bb2
-// CHECK: Error#: 6. End Error in Function: 'bad_order_add_a_level_2'
+// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %17
+// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %13
+// CHECK:   end_borrow %5 : $Builtin.NativeObject           // id: %7
+// CHECK-LABEL: Error#: 8. End Error in Function: 'bad_order_add_a_level_2'
 //
 // NOTE: There are 2-3 errors here we are not pattern matching. We should add
 // patterns for them so we track if they are changed.
@@ -541,11 +563,10 @@ bb1(%1 : @owned $Builtin.NativeObject):
 // be on the original borrowed value.
 //
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
-// CHECK-NEXT: Invalid End Borrow!
-// CHECK-NEXT: Original Value:   %5 = begin_borrow %1 : $NativeObjectPair        // user: %6
-// CHECK-NEXT: End Borrow:   br bb3(%6 : $Builtin.NativeObject)              // id: %7
-// CHECK: Error#: 0. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
-//
+// CHECK: Invalid End Borrow!
+// CHECK: Original Value:   %5 = begin_borrow %1 : $NativeObjectPair        // user: %6
+// CHECK: End Borrow:   br bb3(%6 : $Builtin.NativeObject)              // id: %7
+// CHECK-LABEL: Error#: 0. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_non_postdominating_diamond_with_forwarding_uses'
 sil [ossa] @simple_non_postdominating_diamond_with_forwarding_uses : $@convention(thin) (@in_guaranteed Builtin.NativeObject, @guaranteed NativeObjectPair) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $NativeObjectPair):
@@ -567,22 +588,6 @@ bb3(%7 : @guaranteed $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// We error due to the cycle in the def-use graph that describes %1's borrow
-// scope.
-//
-// TODO: If we ever add simple support for this, we should make sure that we
-// error on %0.
-//
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrow_owned_arg'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %7, %1
-// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
-// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_borrow_owned_arg'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_borrow_owned_arg'
 sil [ossa] @simple_loop_carry_borrow_owned_arg : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -605,20 +610,6 @@ bb3:
   return %9999 : $()
 }
 
-// This test makes sure that due to the lifetime of %3 ending in bb2a, we get an
-// error since %3a is live over the loop-carry.
-//
-// TODO: Could we ever figure out a way to support this? Maybe via a special
-// terminator? This works for load_borrow, but not for copy_value +
-// begin_borrow.
-//
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
-// CHECK: Found non consuming use outside of the lifetime being verified.
-// CHECK: Value:   %8 = copy_value %4 : $Builtin.NativeObject      // users: %12, %9
-// CHECK: User:   end_borrow %4 : $Builtin.NativeObject           // id: %13
-// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_implicitregularusers_do_not_loop_carry'
 sil [ossa] @simple_loop_carry_implicitregularusers_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1a = begin_borrow %0 : $Builtin.NativeObject
@@ -657,31 +648,13 @@ bb3:
 // CHECK-NEXT:   br bb2(%1 : $Builtin.NativeObject, %1 : $Builtin.NativeObject) // id: %3
 // CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_over_consume'
 //
-// This error is a little non-sensical since we have malformed SIL here. The
-// end_borrow is considered to be a read only use of itself since we borrow %5
-// and then pass %8 (the result of the borrow) around the loop. This then
-// becomes %5 and then our end_borrow is treated as the end of the lfietime of
-// the end_borrow and thus a liveness requiring use of the thing that %8 was
-// borrowed from, %5.
-//
 // CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_over_consume'
 // CHECK: Found outside of lifetime use?!
-// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
-// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK: Block: bb5
-// CHECK: Error#: 1. End Error in Function: 'simple_loop_carry_over_consume'
-//
-// %5 is passed around the loop as an incoming value to %4. So we get a certain
-// amount of circularity here. The important thing is we flag it.
-//
-// CHECK-LABEL: Error#: 2. Begin Error in Function: 'simple_loop_carry_over_consume'
-// CHECK: Found outside of lifetime use?!
-// CHECK: Value: %5 = argument of bb2 : $Builtin.NativeObject      // users: %11, %10, %8
-// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
-// CHECK: Block: bb5
-// CHECK: Error#: 2. End Error in Function: 'simple_loop_carry_over_consume'
+// CHECK: Value: %4 = argument of bb2 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   br bb2(%5 : $Builtin.NativeObject, %8 : $Builtin.NativeObject)
+// CHECK: Block: bb4
+// CHECK-LABEL: Error#: 1. End Error in Function: 'simple_loop_carry_over_consume'
 //
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_over_consume'
 sil [ossa] @simple_loop_carry_over_consume : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
@@ -710,16 +683,7 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_cycle'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%3 : $Builtin.NativeObject)              // id: %6
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // user: %1
-// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %2
-// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_cycle'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_cycle'
+// CHECK-NOT: Function: 'simple_loop_carry_cycle'
 sil [ossa] @simple_loop_carry_cycle : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -740,29 +704,13 @@ bb3:
   return %9999 : $()
 }
 
-// This is slightly non-sensical since we are feeding the verifier broken SIL.
-//
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
-// CHECK-NEXT: Found outside of lifetime use?!
-// CHECK-NEXT: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
-// CHECK-NEXT: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK-NEXT: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK-NEXT: Block: bb4
-// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
-//
-// This test fails since the %2a is considered dead at bb2a's terminator. So the
-// end_borrow of %2a in bb3 is considered a liveness use of %2 due to it
-// consuming %3 via the loop carry.
-//
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 // CHECK: Found outside of lifetime use?!
-// CHECK: Value: %5 = argument of bb1 : $Builtin.NativeObject      // users: %11, %10, %8
-// CHECK: Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %11
-// CHECK: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %12
-// CHECK: Block: bb4
-// CHECK: Error#: 1. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
+// CHECK: Value: %4 = argument of bb1 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   br bb1(%5 : $Builtin.NativeObject, %8 : $Builtin.NativeObject)
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry'
 sil [ossa] @simple_loop_carry_borrows_do_not_loop_carry : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -787,28 +735,38 @@ bb3:
   return %9999 : $()
 }
 
-// We could potentially support this in the future if we wanted to have some
-// sort of support for phi node loops.
-//
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
-// CHECK-NEXT: User:   %2 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
-// CHECK: Error#: 0. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
-//
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%6 : $Builtin.NativeObject, %5 : $Builtin.NativeObject) // id: %9
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %12, %3, %2
-// CHECK-NEXT: User:   %3 = begin_borrow %1 : $Builtin.NativeObject    // user: %4
-// CHECK: Error#: 1. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_validate_enclosing_borrow_around_loop'
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry2'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %4 = argument of bb1 : $Builtin.NativeObject      // users: %11, %9
+// CHECK: Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %11
+// CHECK: Non Consuming User:   end_borrow %5 : $Builtin.NativeObject           // id: %12
+// CHECK: Block: bb4
+// CHECK: Error#: 0. End Error in Function: 'simple_loop_carry_borrows_do_not_loop_carry2'
+sil [ossa] @simple_loop_carry_borrows_do_not_loop_carry2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %1a = begin_borrow %0 : $Builtin.NativeObject
+  br bb1(%1 : $Builtin.NativeObject, %1a : $Builtin.NativeObject)
+
+bb1(%2 : @guaranteed $Builtin.NativeObject, %2a : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb2a
+
+bb2a:
+  %3 = begin_borrow %2a : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  br bb1(%2a : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %2 : $Builtin.NativeObject
+  end_borrow %2a : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-NOT: Function: 'simple_validate_enclosing_borrow_around_loop'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
@@ -833,27 +791,7 @@ bb3:
   return %9999 : $()
 }
 
-// Make sure we detect this phi cycle.
-//
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
-// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 0. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
-//
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %2, %1
-// CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 1. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_2'
+// CHECK-NOT: Function: 'simple_validate_enclosing_borrow_around_loop_2'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject
@@ -876,27 +814,7 @@ bb3:
   return %9999 : $()
 }
 
-// Same as before, but this time with an owned value as a base.
-//
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
-// CHECK-NEXT: User:   %2 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 0. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
-//
-// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
-// CHECK-NEXT: Implicit Regular User Guaranteed Phi Cycle!
-// CHECK-NEXT: User:   br bb1(%5 : $Builtin.NativeObject, %4 : $Builtin.NativeObject) // id: %8
-// CHECK-NEXT: Initial: BorrowScopeOperand:
-// CHECK-NEXT: Kind: BeginBorrow
-// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject      // users: %11, %2, %1
-// CHECK-NEXT: User:   %1 = begin_borrow %0 : $Builtin.NativeObject    // user: %3
-// CHECK: Error#: 1. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_validate_enclosing_borrow_around_loop_3'
+// CHECK-NOT: Function: 'simple_validate_enclosing_borrow_around_loop_3'
 sil [ossa] @simple_validate_enclosing_borrow_around_loop_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject

--- a/test/SIL/ownership-verifier/borrow_cast_validate.sil
+++ b/test/SIL/ownership-verifier/borrow_cast_validate.sil
@@ -1,0 +1,267 @@
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -ownership-verifier-textual-error-dumper -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+import Builtin
+import Swift
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+struct Pair { var lhs: AnyObject; var rhs: AnyObject }
+
+struct WrapperStruct {
+  var cls : Klass
+}
+
+struct SmallCodesizeStruct {
+  var cls1 : Klass
+  var cls2 : Klass
+}
+
+sil shared [noinline] @blackhole_spl1 : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : $WrapperStruct):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil shared [noinline] @blackhole_spl1a : $@convention(thin) (@guaranteed Optional<WrapperStruct>) -> () {
+bb0(%0 : $Optional<WrapperStruct>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil shared [noinline] @blackhole_spl2a : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil shared [noinline] @blackhole_spl2b : $@convention(thin) (@guaranteed Optional<Klass>) -> () {
+bb0(%0 : $Optional<Klass>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil shared [noinline] @blackhole_spl3 : $@convention(thin) (@guaranteed AnyObject) -> () {
+bb0(%0 : $AnyObject):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil shared [noinline] @blackhole_spl3a : $@convention(thin) (@guaranteed Pair) -> () {
+bb0(%0 : $Pair):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+sil shared [noinline] @blackhole_spl3b : $@convention(thin) (AnyObject) -> () {
+bb0(%0 : $AnyObject):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// Borrow of forwarding casts are just like borrow of owned values
+// Borrow of the cast dest can be verified like any other owned value
+// Borrow of the cast src is only valid if its lifetime ends with end_borrow before the cast and can be verified like any other owned value
+// CHECK-NOT: Function: 'forwarding_value_cast_correct'
+sil [ossa] @forwarding_value_cast_correct : $@convention(thin) (@guaranteed Optional<WrapperStruct>) -> () {
+bb0(%0 : @guaranteed $Optional<WrapperStruct>):
+  %1 = copy_value %0 : $Optional<WrapperStruct>
+  %cast = unchecked_value_cast %1 : $Optional<WrapperStruct> to $WrapperStruct
+  %2 = begin_borrow %cast : $WrapperStruct
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  end_borrow %2 : $WrapperStruct
+  destroy_value %cast : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'forwarding_value_cast_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %1 = copy_value %0 : $Optional<WrapperStruct>   // users: %3, %2
+// CHECK: Consuming User:   %3 = unchecked_value_cast %1 : $Optional<WrapperStruct> to $WrapperStruct // user: %7
+// CHECK: Non Consuming User:   end_borrow %2 : $Optional<WrapperStruct>        // id: %6
+// CHECK: Block: bb0
+// CHECK-LABEL: Error#: 0. End Error in Function: 'forwarding_value_cast_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'forwarding_value_cast_incorrect'
+sil [ossa] @forwarding_value_cast_incorrect : $@convention(thin) (@guaranteed Optional<WrapperStruct>) -> () {
+bb0(%0 : @guaranteed $Optional<WrapperStruct>):
+  %1 = copy_value %0 : $Optional<WrapperStruct>
+  %2 = begin_borrow %1 : $Optional<WrapperStruct>
+  %cast = unchecked_value_cast %1 : $Optional<WrapperStruct> to $WrapperStruct
+  %func = function_ref @blackhole_spl1a : $@convention(thin) (@guaranteed Optional<WrapperStruct>) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed Optional<WrapperStruct>) -> ()
+  end_borrow %2 : $Optional<WrapperStruct>
+  destroy_value %cast : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-NOT: Function: 'forwarding_ref_cast_correct'
+sil [ossa] @forwarding_ref_cast_correct : $@convention(thin) (@guaranteed Optional<Klass>) -> () {
+bb0(%0 : @guaranteed $Optional<Klass>):
+  %1 = copy_value %0 : $Optional<Klass>
+  %cast = unchecked_ref_cast %1 : $Optional<Klass> to $Klass
+  %2 = begin_borrow %cast : $Klass
+  %func = function_ref @blackhole_spl2a : $@convention(thin) (@guaranteed Klass) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %2 : $Klass
+  destroy_value %cast : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'forwarding_ref_cast_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %1 = copy_value %0 : $Optional<Klass>           // users: %3, %2
+// CHECK: Consuming User:   %3 = unchecked_ref_cast %1 : $Optional<Klass> to $Klass // user: %7
+// CHECK: Non Consuming User:   end_borrow %2 : $Optional<Klass>                // id: %6
+// CHECK: Block: bb0
+// CHECK-LABEL: Error#: 0. End Error in Function: 'forwarding_ref_cast_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'forwarding_ref_cast_incorrect'
+sil [ossa] @forwarding_ref_cast_incorrect : $@convention(thin) (@guaranteed Optional<Klass>) -> () {
+bb0(%0 : @guaranteed $Optional<Klass>):
+  %1 = copy_value %0 : $Optional<Klass>
+  %2 = begin_borrow %1 : $Optional<Klass>
+  %cast = unchecked_ref_cast %1 : $Optional<Klass> to $Klass
+  %func = function_ref @blackhole_spl2b : $@convention(thin) (@guaranteed Optional<Klass>) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed Optional<Klass>) -> ()
+  end_borrow %2 : $Optional<Klass>
+  destroy_value %cast : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-NOT: Function: 'bitwise_cast_borrow_dest'
+sil [ossa] @bitwise_cast_borrow_dest : $@convention(thin) (@guaranteed Pair) -> () {
+bb0(%0 : @guaranteed $Pair):
+  %1 = copy_value %0 : $Pair
+  %cast = unchecked_bitwise_cast %1 : $Pair to $AnyObject
+  %2 = begin_borrow %cast : $AnyObject
+  %func = function_ref @blackhole_spl3 : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed AnyObject) -> ()
+  end_borrow %2 : $AnyObject
+  destroy_value %1 : $Pair
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-NOT: Function: 'bitwise_cast_borrow_src'
+sil [ossa] @bitwise_cast_borrow_src : $@convention(thin) (@guaranteed Pair) -> () {
+bb0(%0 : @guaranteed $Pair):
+  %1 = copy_value %0 : $Pair
+  %2 = begin_borrow %1 : $Pair
+  %cast = unchecked_bitwise_cast %1 : $Pair to $AnyObject
+  %func = function_ref @blackhole_spl3a : $@convention(thin) (@guaranteed Pair) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed Pair) -> ()
+  end_borrow %2 : $Pair
+  destroy_value %1 : $Pair
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-NOT: Function: 'bitwise_cast_of_borrowed_val'
+sil [ossa] @bitwise_cast_of_borrowed_val : $@convention(thin) (@guaranteed Pair) -> () {
+bb0(%0 : @guaranteed $Pair):
+  %1 = copy_value %0 : $Pair
+  %2 = begin_borrow %1 : $Pair
+  %cast = unchecked_bitwise_cast %2 : $Pair to $AnyObject
+  %func = function_ref @blackhole_spl3a : $@convention(thin) (@guaranteed Pair) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed Pair) -> ()
+  end_borrow %2 : $Pair
+  destroy_value %1 : $Pair
+  %res = tuple ()
+  return %res : $()
+}
+
+// Gap in verification. Verify unchecked_bitwise_cast correctly rdar://70558176
+// CHECK-NOT: Function: 'bitwise_cast_use_after_free'
+sil [ossa] @bitwise_cast_use_after_free : $@convention(thin) (@guaranteed Pair) -> () {
+bb0(%0 : @guaranteed $Pair):
+  %1 = copy_value %0 : $Pair
+  %cast = unchecked_bitwise_cast %1 : $Pair to $AnyObject
+  %func = function_ref @blackhole_spl3b : $@convention(thin) (AnyObject) -> ()
+  destroy_value %1 : $Pair
+  %call1 = apply %func(%cast) : $@convention(thin) (AnyObject) -> ()
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_cast_not_dominate_correct'
+sil [ossa] @borrowed_cast_not_dominate_correct : $@convention(thin) (@guaranteed Optional<WrapperStruct>, @guaranteed Optional<WrapperStruct>) -> () {
+bb0(%0 : @guaranteed $Optional<WrapperStruct>, %1 : @guaranteed $Optional<WrapperStruct>):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $Optional<WrapperStruct>
+  %cast0 = unchecked_value_cast %copy0 : $Optional<WrapperStruct> to $WrapperStruct
+  %borrow0 = begin_borrow %cast0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %cast0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %1 : $Optional<WrapperStruct>
+  %cast1 = unchecked_value_cast %copy1 : $Optional<WrapperStruct> to $WrapperStruct
+  %borrow1 = begin_borrow %cast1 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %cast1 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_cast_dominates_one_path'
+sil [ossa] @borrowed_cast_dominates_one_path : $@convention(thin) (@guaranteed Optional<WrapperStruct>, @guaranteed Optional<WrapperStruct>) -> () {
+bb0(%0 : @guaranteed $Optional<WrapperStruct>, %1 : @guaranteed $Optional<WrapperStruct>):
+  %copy1 = copy_value %1 : $Optional<WrapperStruct>
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $Optional<WrapperStruct>
+  %cast0 = unchecked_value_cast %copy0 : $Optional<WrapperStruct> to $WrapperStruct
+  %borrow0 = begin_borrow %cast0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %cast0 : $WrapperStruct)
+
+bb2:
+  %copy2 = copy_value %1 : $Optional<WrapperStruct>
+  %cast2 = unchecked_value_cast %copy2 : $Optional<WrapperStruct> to $WrapperStruct
+  %borrow1 = begin_borrow %cast2 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %cast2 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  destroy_value %copy1 : $Optional<WrapperStruct>
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_cast_dominates_one_path_loop'
+sil [ossa] @borrowed_cast_dominates_one_path_loop : $@convention(thin) (@guaranteed Optional<WrapperStruct>) -> () {
+bb0(%0 : @guaranteed $Optional<WrapperStruct>):
+  %1b = copy_value %0 : $Optional<WrapperStruct>
+  %cast0 = unchecked_value_cast %1b : $Optional<WrapperStruct> to $WrapperStruct
+  %1a = begin_borrow %cast0 : $WrapperStruct
+  br bb1(%1a : $WrapperStruct, %cast0 : $WrapperStruct)
+
+bb1(%2a : @guaranteed $WrapperStruct, %2b : @owned $WrapperStruct):
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = copy_value %2a : $WrapperStruct
+  %3a = begin_borrow %3 : $WrapperStruct
+  end_borrow %2a : $WrapperStruct
+  destroy_value %2b : $WrapperStruct
+  br bb1(%3a : $WrapperStruct, %3 : $WrapperStruct)
+
+bb3:
+  end_borrow %2a : $WrapperStruct
+  destroy_value %2b : $WrapperStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+

--- a/test/SIL/ownership-verifier/borrow_extract_validate.sil
+++ b/test/SIL/ownership-verifier/borrow_extract_validate.sil
@@ -1,0 +1,276 @@
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -ownership-verifier-textual-error-dumper -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+import Builtin
+import Swift
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+struct WrapperStruct {
+  var cls : Klass
+}
+
+sil shared [noinline] @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_extract_dominate_correct'
+sil [ossa] @borrowed_extract_dominate_correct : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> ()
+  %call1 = apply %func(%elem0) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %borrow0 : $WrapperStruct
+  destroy_value %copy0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_dominate_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %3 = begin_borrow %2 : $WrapperStruct
+// CHECK: Consuming User:   end_borrow %3 : $WrapperStruct
+// CHECK: Non Consuming User:   %7 = apply %6(%4) : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK: Block: bb0
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_extract_dominate_incorrect'
+sil [ossa] @borrowed_extract_dominate_incorrect : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  end_borrow %borrow0 : $WrapperStruct
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> ()
+  %call1 = apply %func(%elem0) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %copy0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_extract_dominate_discrepency_simple_correct'
+sil [ossa] @borrowed_extract_dominate_discrepency_simple_correct : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %borrow0 = begin_borrow %0 : $WrapperStruct
+  %elem = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %borrow1 = begin_borrow %elem : $Klass
+  br bb1(%borrow1 : $Klass)
+
+bb1(%borrow2 : @guaranteed $Klass):
+  end_borrow %borrow2 : $Klass
+  end_borrow %borrow0 : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'simple_extract_as_phi_arg_incorrect'
+// CHECK: Invalid End Borrow!
+// CHECK: Original Value: %0 = argument of bb0 : $WrapperStruct
+// CHECK: End Borrow:   br bb1(%1 : $Klass)
+// CHECK-LABEL: Error#: 0. End Error in Function: 'simple_extract_as_phi_arg_incorrect'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'simple_extract_as_phi_arg_incorrect'
+// CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
+// CHECK: Value: %3 = argument of bb1 : $Klass
+// CHECK-LABEL: Error#: 1. End Error in Function: 'simple_extract_as_phi_arg_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_extract_as_phi_arg_incorrect'
+sil [ossa] @simple_extract_as_phi_arg_incorrect : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %elem = struct_extract %0 : $WrapperStruct, #WrapperStruct.cls
+  br bb1(%elem : $Klass)
+
+bb1(%newelem : @guaranteed $Klass):
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: Found outside of lifetime use?!
+// CHECK: Value: %8 = argument of bb1 : $WrapperStruct             // user: %10
+// CHECK: Consuming User:   end_borrow %8 : $WrapperStruct                  
+// CHECK: Non Consuming User:   %12 = apply %11(%7) : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK: Block: bb1
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect1'
+// CHECK-LABEL: Error#: 1. Begin Error in Function: 'borrowed_extract_dominate_discrepency_incorrect1'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %7 = argument of bb1 : $Klass                     
+// CHECK: Consuming User:   end_borrow %7 : $Klass                          
+// CHECK: Non Consuming User:   %12 = apply %11(%7) : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK: Block: bb1
+// CHECK-LABEL: Error#: 1. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect1'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect1'
+sil [ossa] @borrowed_extract_dominate_discrepency_incorrect1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub0 = begin_borrow %elem0 : $Klass
+  br bb1(%borrowsub0 : $Klass, %borrow0 : $WrapperStruct)
+
+bb1(%borrowsub : @guaranteed $Klass, %newborrow : @guaranteed $WrapperStruct):
+  end_borrow %borrowsub : $Klass
+  end_borrow %newborrow : $WrapperStruct
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> ()
+  %call1 = apply %func(%borrowsub) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %copy0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_dominate_discrepency_incorrect2'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %2 = copy_value %0 : $WrapperStruct             
+// CHECK: Consuming User:   destroy_value %2 : $WrapperStruct               
+// CHECK: Non Consuming User:   end_borrow %8 : $WrapperStruct                  
+// CHECK: Block: bb1
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect2'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_extract_dominate_discrepency_incorrect2'
+sil [ossa] @borrowed_extract_dominate_discrepency_incorrect2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub0 = begin_borrow %elem0 : $Klass
+  br bb1(%borrowsub0 : $Klass, %borrow0 : $WrapperStruct)
+
+bb1(%borrowsub : @guaranteed $Klass, %newborrow : @guaranteed $WrapperStruct):
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %copy0 : $WrapperStruct
+  %call1 = apply %func(%borrowsub) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %borrowsub : $Klass
+  end_borrow %newborrow : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_extract_not_dominate_correct'
+sil [ossa] @borrowed_extract_not_dominate_correct : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub0 = begin_borrow %elem0 : $Klass
+  br bb3(%borrowsub0 : $Klass, %borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  %elem1 = struct_extract %borrow1 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub1 = begin_borrow %elem1 : $Klass
+  br bb3(%borrowsub1 : $Klass, %borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%subborrow : @guaranteed $Klass, %newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> ()
+  %call1 = apply %func(%subborrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %subborrow : $Klass
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_extract_not_dominate_incorrect1'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %13 = argument of bb3 : $Klass                    
+// CHECK: Consuming User:   end_borrow %13 : $Klass                         
+// CHECK: Non Consuming User:   %18 = apply %17(%13) : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_extract_not_dominate_incorrect1'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_extract_not_dominate_incorrect1'
+sil [ossa] @borrowed_extract_not_dominate_incorrect1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub0 = begin_borrow %elem0 : $Klass
+  br bb3(%borrowsub0 : $Klass, %borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  %elem1 = struct_extract %borrow1 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub1 = begin_borrow %elem1 : $Klass
+  br bb3(%borrowsub1 : $Klass, %borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%subborrow : @guaranteed $Klass, %newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %subborrow : $Klass
+  %func = function_ref @blackhole_spl1 : $@convention(thin) (@guaranteed Klass) -> ()
+  %call1 = apply %func(%subborrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_extract_dominates_one_path'
+sil [ossa] @borrowed_extract_dominates_one_path : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  %elem1 = struct_extract %borrow1 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub1 = begin_borrow %elem1 : $Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %borrowsub1 : $Klass
+  end_borrow %borrow1 : $WrapperStruct
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %elem0 = struct_extract %borrow0 : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub0 = begin_borrow %elem0 : $Klass
+  br bb3(%borrowsub0 : $Klass, %borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy2 = copy_value %1 : $WrapperStruct
+  br bb3(%borrowsub1 : $Klass, %borrow1 : $WrapperStruct, %copy2 : $WrapperStruct)
+
+bb3(%borrowsub : @guaranteed $Klass, %newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %borrowsub : $Klass
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  destroy_value %copy1 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_extract_dominates_one_path_loop'
+sil [ossa] @borrowed_extract_dominates_one_path_loop : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %1b = copy_value %0 : $WrapperStruct
+  %1a = begin_borrow %1b : $WrapperStruct
+  %elem0 = struct_extract %1a : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub0 = begin_borrow %elem0 : $Klass
+  br bb1(%borrowsub0 : $Klass, %1a : $WrapperStruct, %1b : $WrapperStruct)
+
+bb1(%borrowsub : @guaranteed $Klass, %2a : @guaranteed $WrapperStruct, %2b : @owned $WrapperStruct):
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = copy_value %2a : $WrapperStruct
+  %3a = begin_borrow %3 : $WrapperStruct
+  %elem1 = struct_extract %3a : $WrapperStruct, #WrapperStruct.cls
+  %borrowsub1 = begin_borrow %elem1 : $Klass
+  end_borrow %borrowsub : $Klass
+  end_borrow %2a : $WrapperStruct
+  destroy_value %2b : $WrapperStruct
+  br bb1(%borrowsub1 : $Klass, %3a : $WrapperStruct, %3 : $WrapperStruct)
+
+bb3:
+  end_borrow %borrowsub : $Klass
+  end_borrow %2a : $WrapperStruct
+  destroy_value %2b : $WrapperStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+

--- a/test/SIL/ownership-verifier/borrow_validate.sil
+++ b/test/SIL/ownership-verifier/borrow_validate.sil
@@ -1,0 +1,648 @@
+// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -ownership-verifier-textual-error-dumper -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+import Builtin
+import Swift
+
+//////////////////
+// Declarations //
+//////////////////
+
+class SuperKlass {}
+class Klass : SuperKlass {}
+
+struct WrapperStruct {
+  var cls : Klass
+}
+
+sil shared [noinline] @blackhole_spl : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+
+bb0(%0 : $WrapperStruct):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// owned val dominates the end_borrow
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_owned_val_dominates_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %1 = copy_value %0 : $WrapperStruct
+// CHECK: Consuming User:   destroy_value %1 : $WrapperStruct
+// CHECK: Non Consuming User:   end_borrow %4 : $WrapperStruct
+// CHECK: Block: bb1
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_owned_val_dominates_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_owned_val_dominates_incorrect'
+sil [ossa] @borrowed_owned_val_dominates_correct : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %1 = copy_value %0 : $WrapperStruct
+  %borrow = begin_borrow %1 : $WrapperStruct
+  br bb1(%borrow : $WrapperStruct)
+
+bb1(%2 : @guaranteed $WrapperStruct):
+  %func = function_ref @blackhole_spl : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  end_borrow %2 : $WrapperStruct
+  destroy_value %1 : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_owned_val_dominates_incorrect'
+sil [ossa] @borrowed_owned_val_dominates_incorrect : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %1 = copy_value %0 : $WrapperStruct
+  %borrow = begin_borrow %1 : $WrapperStruct
+  br bb1(%borrow : $WrapperStruct)
+
+bb1(%2 : @guaranteed $WrapperStruct):
+  %func = function_ref @blackhole_spl : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  destroy_value %1 : $WrapperStruct
+  end_borrow %2 : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_owned_val_dominates_and_is_phi_incorrect'
+// CHECK: Function: 'borrowed_owned_val_dominates_and_is_phi_incorrect'
+// CHECK: Found non consuming use outside of the lifetime being verified.
+// CHECK: Value:   %1 = copy_value %0 : $WrapperStruct
+// CHECK: User:   end_borrow %2 : $WrapperStruct
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_owned_val_dominates_and_is_phi_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_owned_val_dominates_and_is_phi_incorrect'
+sil [ossa] @borrowed_owned_val_dominates_and_is_phi_incorrect : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %1 = copy_value %0 : $WrapperStruct
+  %borrow = begin_borrow %1 : $WrapperStruct
+  br bb1(%1 : $WrapperStruct)
+
+bb1(%newowned : @owned $WrapperStruct):
+  %func = function_ref @blackhole_spl : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  %call1 = apply %func(%borrow) : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  end_borrow %borrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// borrowed operand dominates the end_borrow
+// CHECK-NOT: Function: 'borrowed_owned_val_dominates_diamond_correct'
+sil [ossa] @borrowed_owned_val_dominates_diamond_correct : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct)
+
+bb2:
+  %borrow1a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  end_borrow %borrow0 : $WrapperStruct
+  destroy_value %copy0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_owned_val_dominates_diamond_incorrect1'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %2 = copy_value %0 : $WrapperStruct
+// CHECK: Consuming User:   destroy_value %2 : $WrapperStruct
+// CHECK: Non Consuming User:   end_borrow %3 : $WrapperStruct
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_owned_val_dominates_diamond_incorrect1'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_owned_val_dominates_diamond_incorrect1'
+sil [ossa] @borrowed_owned_val_dominates_diamond_incorrect1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct)
+
+bb2:
+  %borrow1a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  destroy_value %copy0 : $WrapperStruct
+  end_borrow %borrow0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_owned_val_dominates_diamond_incorrect2'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value:   %2 = copy_value %0 : $WrapperStruct
+// CHECK: Consuming User:   destroy_value %2 : $WrapperStruct
+// CHECK: Non Consuming User:   end_borrow %3 : $WrapperStruct
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_owned_val_dominates_diamond_incorrect2'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_owned_val_dominates_diamond_incorrect2'
+sil [ossa] @borrowed_owned_val_dominates_diamond_incorrect2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct)
+
+bb2:
+  %borrow1a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct):
+  destroy_value %copy0 : $WrapperStruct
+  end_borrow %newborrowi : $WrapperStruct
+  end_borrow %borrow0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// guaranteed val borrowed
+// CHECK-NOT: Function: 'borrowed_guaranteed_val_dominates'
+sil [ossa] @borrowed_guaranteed_val_dominates : $@convention(thin) (@guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct):
+  %borrow = begin_borrow %0 : $WrapperStruct
+  br bb1(%borrow : $WrapperStruct)
+
+bb1(%2 : @guaranteed $WrapperStruct):
+  %func = function_ref @blackhole_spl : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  %call1 = apply %func(%2) : $@convention(thin) (@guaranteed WrapperStruct) -> ()
+  end_borrow %2 : $WrapperStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// owned val does not dominate the end_borrow
+// CHECK-NOT: Function: 'borrowed_owned_val_not_dominate_correct'
+sil [ossa] @borrowed_owned_val_not_dominate_correct : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrowed_owned_val_not_dominate_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %10 = argument of bb3 : $WrapperStruct
+// CHECK: Consuming User:   destroy_value %10 : $WrapperStruct
+// CHECK: Non Consuming User:   end_borrow %9 : $WrapperStruct
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrowed_owned_val_not_dominate_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'borrowed_owned_val_not_dominate_incorrect'
+sil [ossa] @borrowed_owned_val_not_dominate_incorrect : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  destroy_value %newowned : $WrapperStruct
+  end_borrow %newborrow : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrow_lifetime_discrepency'
+sil [ossa] @borrow_lifetime_discrepency : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct, %borrow0 : $WrapperStruct)
+
+bb2:
+  %borrow1 = begin_borrow %copy0 : $WrapperStruct
+  %borrow1a = begin_borrow %borrow1 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct, %borrow1 : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  end_borrow %newborrowo : $WrapperStruct
+  destroy_value %copy0 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrow_lifetime_nodiscrepency'
+sil [ossa] @borrow_lifetime_nodiscrepency : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow0 = begin_borrow %0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct)
+
+bb2:
+  %borrow1 = begin_borrow %1 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_owned_val_dominates_one_path'
+sil [ossa] @borrowed_owned_val_dominates_one_path : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy1 = copy_value %1 : $WrapperStruct
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy2 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %copy2 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  destroy_value %copy1 : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_owned_val_dominates_one_path_loop'
+sil [ossa] @borrowed_owned_val_dominates_one_path_loop : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1a = begin_borrow %0 : $Builtin.NativeObject
+  %1b = copy_value %0 : $Builtin.NativeObject
+  br bb1(%1a : $Builtin.NativeObject, %1b : $Builtin.NativeObject)
+
+bb1(%2a : @guaranteed $Builtin.NativeObject, %2b : @owned $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = copy_value %2a : $Builtin.NativeObject
+  %3a = begin_borrow %3 : $Builtin.NativeObject
+  end_borrow %2a : $Builtin.NativeObject
+  destroy_value %2b : $Builtin.NativeObject
+  br bb1(%3a : $Builtin.NativeObject, %3 : $Builtin.NativeObject)
+
+bb3:
+  end_borrow %2a : $Builtin.NativeObject
+  destroy_value %2b : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-NOT: Function: 'not_all_incoming_reborrows_have_owned_value'
+sil [ossa] @not_all_incoming_reborrows_have_owned_value : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy2 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %0 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %copy2 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// test to show we need to insert reborrow's of reborrows's into the worklist during validation of reborrows
+// CHECK-NOT: Function: 'chain_of_reborrows1'
+sil [ossa] @chain_of_reborrows1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy2 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %0 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %copy2 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  br bb4(%newborrow : $WrapperStruct, %newowned : $WrapperStruct)
+
+bb4(%newnewborrow : @guaranteed $WrapperStruct, %newnewowned : @owned $WrapperStruct):
+  end_borrow %newnewborrow : $WrapperStruct
+  destroy_value %newnewowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'chain_of_reborrows2'
+sil [ossa] @chain_of_reborrows2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  br bb3(%borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  cond_br undef, bb4, bb5
+
+bb4:
+  %borrow2 = begin_borrow %newborrow : $WrapperStruct
+  br bb6(%borrow2 : $WrapperStruct)
+
+bb5:
+  %borrow3 = begin_borrow %newborrow : $WrapperStruct
+  br bb6(%borrow3 : $WrapperStruct)
+
+bb6(%newnewborrow : @guaranteed $WrapperStruct):
+  end_borrow %newnewborrow : $WrapperStruct
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrowed_owned_val_not_a_phiarg'
+// test to show that we cannot assume the owned val is dominating if it is not passed an owned phi arg in a branch where the reborrow happens
+sil [ossa] @borrowed_owned_val_not_a_phiarg : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy2 = copy_value %1 : $WrapperStruct
+  %borrow1 = begin_borrow %0 : $WrapperStruct
+  br bb2a(%borrow1 : $WrapperStruct)
+
+bb2a(%borrow1a : @guaranteed $WrapperStruct):
+  br bb3(%borrow1a : $WrapperStruct, %copy2 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  end_borrow %newborrow : $WrapperStruct
+  destroy_value %newowned : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'infinite_loop'
+sil [ossa] @infinite_loop : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb4
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  br bb3(%borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb3(%newborrow : @guaranteed $WrapperStruct, %newowned : @owned $WrapperStruct):
+  br bb3(%newborrow : $WrapperStruct, %newowned : $WrapperStruct)
+
+bb4:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'diamond_within_loop'
+sil [ossa] @diamond_within_loop : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb5
+
+bb2:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0a = begin_borrow %copy0 : $WrapperStruct
+  br bb4(%borrow0a : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb3:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1a = begin_borrow %copy1 : $WrapperStruct
+  br bb4(%borrow1a : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb4(%newborrowi : @guaranteed $WrapperStruct, %copy : @owned $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  destroy_value %copy : $WrapperStruct
+  br bb1
+
+bb5:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'chain_diamond_within_loop'
+sil [ossa] @chain_diamond_within_loop : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bbret
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0a = begin_borrow %copy0 : $WrapperStruct
+  br bb5(%borrow0a : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb4:
+  %copy1 = copy_value %1 : $WrapperStruct
+  %borrow1a = begin_borrow %copy1 : $WrapperStruct
+  br bb5(%borrow1a : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb5(%newborrowo : @guaranteed $WrapperStruct, %copy : @owned $WrapperStruct):
+  cond_br undef, bb6, bb7
+
+bb6:
+  %borrowi1 = begin_borrow %newborrowo : $WrapperStruct
+  br bb8(%borrowi1 : $WrapperStruct)
+
+bb7:
+  %borrowi2 = begin_borrow %newborrowo : $WrapperStruct
+  br bb8(%borrowi2 : $WrapperStruct)
+
+bb8(%newborrowi : @guaranteed $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  end_borrow %newborrowo : $WrapperStruct
+  destroy_value %copy : $WrapperStruct
+  br bb1
+
+bbret:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'reborrow_at_loop_head'
+sil [ossa] @reborrow_at_loop_head : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0a = begin_borrow %copy0 : $WrapperStruct
+  br bb1(%borrow0a : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb1(%borrow : @guaranteed $WrapperStruct, %copy : @owned $WrapperStruct):
+  cond_br undef, bb2, bb3
+
+bb2:
+  %copyagain = copy_value %copy : $WrapperStruct
+  %borrowagain = begin_borrow %copyagain : $WrapperStruct
+  end_borrow %borrow : $WrapperStruct
+  destroy_value %copy : $WrapperStruct
+  br bb1(%borrowagain : $WrapperStruct, %copyagain : $WrapperStruct)
+
+bb3:
+  end_borrow %borrow : $WrapperStruct
+  destroy_value %copy : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'reborrow_at_loop_head_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %6 = argument of bb1 : $WrapperStruct
+// CHECK: Consuming User:   destroy_value %6 : $WrapperStruct
+// CHECK: Non Consuming User:   end_borrow %5 : $WrapperStruct
+// CHECK: Block: bb2
+// CHECK-LABEL: Error#: 0. End Error in Function: 'reborrow_at_loop_head_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'reborrow_at_loop_head_incorrect'
+sil [ossa] @reborrow_at_loop_head_incorrect : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0a = begin_borrow %copy0 : $WrapperStruct
+  br bb1(%borrow0a : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb1(%borrow : @guaranteed $WrapperStruct, %copy : @owned $WrapperStruct):
+  cond_br undef, bb2, bb3
+
+bb2:
+  %copyagain = copy_value %copy : $WrapperStruct
+  %borrowagain = begin_borrow %copyagain : $WrapperStruct
+  destroy_value %copy : $WrapperStruct
+  end_borrow %borrow : $WrapperStruct
+  br bb1(%borrowagain : $WrapperStruct, %copyagain : $WrapperStruct)
+
+bb3:
+  end_borrow %borrow : $WrapperStruct
+  destroy_value %copy : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-NOT: Function: 'borrow_unreachable_correct'
+sil [ossa] @borrow_unreachable_correct : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2:
+  unreachable
+}
+
+// CHECK-NOT: Function: 'test_borrow_checked_cast_switch_enum_control_flow'
+sil [ossa] @test_borrow_checked_cast_switch_enum_control_flow : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  checked_cast_br %0 : $Klass to SuperKlass, bb1, bb2
+
+bb1(%1 : @owned $SuperKlass):
+  destroy_value %1 : $SuperKlass
+  %none = enum $Optional<Klass>, #Optional.none!enumelt
+  %borrownone = begin_borrow %none : $Optional<Klass>
+  br bb3(%borrownone : $Optional<Klass>, %none : $Optional<Klass>)
+
+bb2(%2 : @owned $Klass):
+  %some = enum $Optional<Klass>, #Optional.some!enumelt, %2 : $Klass
+  %borrowsome = begin_borrow %some : $Optional<Klass>
+  br bb3(%borrowsome : $Optional<Klass>, %some : $Optional<Klass>)
+
+bb3(%borrow : @guaranteed $Optional<Klass>, %mKlass : @owned $Optional<Klass>):
+  end_borrow %borrow : $Optional<Klass>
+  destroy_value %mKlass : $Optional<Klass>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %12 = argument of bb3 : $Optional<Klass>
+// CHECK: Consuming User:   destroy_value %12 : $Optional<Klass>
+// CHECK: Non Consuming User:   end_borrow %11 : $Optional<Klass>
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
+// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
+sil [ossa] @test_borrow_checked_cast_switch_enum_control_flow_incorrect : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  checked_cast_br %0 : $Klass to SuperKlass, bb1, bb2
+
+bb1(%1 : @owned $SuperKlass):
+  destroy_value %1 : $SuperKlass
+  %none = enum $Optional<Klass>, #Optional.none!enumelt
+  %borrownone = begin_borrow %none : $Optional<Klass>
+  br bb3(%borrownone : $Optional<Klass>, %none : $Optional<Klass>)
+
+bb2(%2 : @owned $Klass):
+  %some = enum $Optional<Klass>, #Optional.some!enumelt, %2 : $Klass
+  %borrowsome = begin_borrow %some : $Optional<Klass>
+  br bb3(%borrowsome : $Optional<Klass>, %some : $Optional<Klass>)
+
+bb3(%borrow : @guaranteed $Optional<Klass>, %mKlass : @owned $Optional<Klass>):
+  destroy_value %mKlass : $Optional<Klass>
+  end_borrow %borrow : $Optional<Klass>
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION

 This updates how we model reborrow's lifetimes for ownership verification.
    Today we follow and combine a borrow's lifetime through phi args as well.
    Owned values lifetimes end at a phi arg. This discrepency in modeling
    lifetimes leads to the OwnershipVerifier raising errors incorrectly for
    cases such as this, where the borrow and the base value do not dominate
    the end_borrow:
    
    bb0:
      cond_br undef, bb1, bb2
    bb1:
      %copy0 = copy_value %0
      %borrow0 = begin_borrow %copy0
      br bb3(%borrow0, %copy0)
    bb2:
      %copy1 = copy_value %1
      %borrow1 = begin_borrow %copy1
      br bb3(%borrow1, %copy1)
    bb3(%borrow, %baseVal):
      end_borrow %borrow
      destroy_value %baseVal
    
This PR adds a new ReborrowVerifier. The ownership verifier collects borrow's
    lifetime ending users and populates the worklist of the ReborrowVerifier
    with reborrows and the corresponding base value.
    ReborrowVerifier then verifies that the lifetime of the reborrow is
    within the lifetime of the base value.
