### PR TITLE
[cxx-interop] Temporarily disable class-template-variadic test

### DIFF
--- a/test/Interop/Cxx/templates/class-template-variadic.swift
+++ b/test/Interop/Cxx/templates/class-template-variadic.swift
@@ -4,6 +4,7 @@
 //
 // We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: OS=windows-msvc
+// REQUIRES: fixing-after-30630
 
 import ClassTemplateVariadic
 import StdlibUnittest


### PR DESCRIPTION
It's failing after checking in https://github.com/apple/swift/pull/30630 and we want to fix the CI.