### PR TITLE
Change interfaces to accept a FileCollectorBase

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -28,7 +28,7 @@
 #include <system_error>
 
 namespace llvm {
-class FileCollector;
+class FileCollectorBase;
 }
 
 namespace clang {
@@ -81,7 +81,7 @@ class DependencyTracker {
 public:
   explicit DependencyTracker(
       IntermoduleDepTrackingMode Mode,
-      std::shared_ptr<llvm::FileCollector> FileCollector = {});
+      std::shared_ptr<llvm::FileCollectorBase> FileCollector = {});
 
   /// Adds a file as a dependency.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -23,7 +23,7 @@
 
 namespace llvm {
   class Triple;
-  class FileCollector;
+  class FileCollectorBase;
   template<typename Fn> class function_ref;
 }
 
@@ -172,9 +172,9 @@ public:
 
   /// Create a new clang::DependencyCollector customized to
   /// ClangImporter's specific uses.
-  static std::shared_ptr<clang::DependencyCollector>
-  createDependencyCollector(IntermoduleDepTrackingMode Mode,
-                            std::shared_ptr<llvm::FileCollector> FileCollector);
+  static std::shared_ptr<clang::DependencyCollector> createDependencyCollector(
+      IntermoduleDepTrackingMode Mode,
+      std::shared_ptr<llvm::FileCollectorBase> FileCollector);
 
   /// Append visible module names to \p names. Note that names are possibly
   /// duplicated, and not guaranteed to be ordered in any way.

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -24,14 +24,14 @@
 #include "swift/ClangImporter/ClangImporter.h"
 
 namespace llvm {
-class FileCollector;
+class FileCollectorBase;
 }
 
 namespace swift {
 
 DependencyTracker::DependencyTracker(
     IntermoduleDepTrackingMode Mode,
-    std::shared_ptr<llvm::FileCollector> FileCollector)
+    std::shared_ptr<llvm::FileCollectorBase> FileCollector)
     // NB: The ClangImporter believes it's responsible for the construction of
     // this instance, and it static_cast<>s the instance pointer to its own
     // subclass based on that belief. If you change this to be some other

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -326,13 +326,13 @@ class ClangImporterDependencyCollector : public clang::DependencyCollector
   llvm::StringSet<> ExcludedPaths;
   /// The FileCollector is used by LLDB to generate reproducers. It's not used
   /// by Swift to track dependencies.
-  std::shared_ptr<llvm::FileCollector> FileCollector;
+  std::shared_ptr<llvm::FileCollectorBase> FileCollector;
   const IntermoduleDepTrackingMode Mode;
 
 public:
   ClangImporterDependencyCollector(
       IntermoduleDepTrackingMode Mode,
-      std::shared_ptr<llvm::FileCollector> FileCollector)
+      std::shared_ptr<llvm::FileCollectorBase> FileCollector)
       : FileCollector(FileCollector), Mode(Mode) {}
 
   void excludePath(StringRef filename) {
@@ -378,7 +378,7 @@ public:
 std::shared_ptr<clang::DependencyCollector>
 ClangImporter::createDependencyCollector(
     IntermoduleDepTrackingMode Mode,
-    std::shared_ptr<llvm::FileCollector> FileCollector) {
+    std::shared_ptr<llvm::FileCollectorBase> FileCollector) {
   return std::make_shared<ClangImporterDependencyCollector>(Mode,
                                                             FileCollector);
 }


### PR DESCRIPTION
The FileCollectorBase is the common interface shared by different
implementations. In lldb, we implement our own lazy variant that allows
us to do the heavy lifting out-of-process instead of inside the signal
handler.

Depends on https://github.com/apple/llvm-project/pull/2041 being auto-merged into `main`.