### PR TITLE
SILCombiner: Use a substitution list with concrete type if we can cas…

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -291,6 +291,8 @@ private:
 
   bool canReplaceArg(FullApplySite Apply, const OpenedArchetypeInfo &OAI,
                      const ConcreteExistentialInfo &CEI, unsigned ArgIdx);
+  SILValue canCastArg(FullApplySite Apply, const OpenedArchetypeInfo &OAI,
+                      const ConcreteExistentialInfo &CEI, unsigned ArgIdx);
 
   SILInstruction *createApplyWithConcreteType(
       FullApplySite Apply,

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -994,6 +994,48 @@ struct ConcreteArgumentCopy {
   }
 };
 
+SILValue SILCombiner::canCastArg(FullApplySite Apply,
+                                 const OpenedArchetypeInfo &OAI,
+                                 const ConcreteExistentialInfo &CEI,
+                                 unsigned ArgIdx) {
+  if (!CEI.ConcreteValue || CEI.ConcreteType->isOpenedExistential() ||
+      !CEI.ConcreteValue->getType().isAddress())
+    return SILValue();
+
+  // Don't specialize apply instructions that return the callee's Arg type,
+  // because this optimization does not know how to substitute types in the
+  // users of this apply. In the function type substitution below, all
+  // references to OpenedArchetype will be substituted. So walk to type to
+  // find all possible references, such as returning Optional<Arg>.
+  if (Apply.getType().getASTType().findIf(
+          [&OAI](Type t) -> bool { return t->isEqual(OAI.OpenedArchetype); })) {
+    return SILValue();
+  }
+  // Bail out if any other arguments or indirect result that refer to the
+  // OpenedArchetype. The following optimization substitutes all occurrences
+  // of OpenedArchetype in the function signature, but will only rewrite the
+  // Arg operand.
+  //
+  // Note that the language does not allow Self to occur in contravariant
+  // position. However, SIL does allow this and it can happen as a result of
+  // upstream transformations. Since this is bail-out logic, it must handle
+  // all verifiable SIL.
+
+  // This bailout check is also needed for non-Self arguments [including Self].
+  unsigned NumApplyArgs = Apply.getNumArguments();
+  for (unsigned Idx = 0; Idx < NumApplyArgs; ++Idx) {
+    if (Idx == ArgIdx)
+      continue;
+    if (Apply.getArgument(Idx)->getType().getASTType().findIf(
+            [&OAI](Type t) -> bool {
+              return t->isEqual(OAI.OpenedArchetype);
+            })) {
+      return SILValue();
+    }
+  }
+  return Builder.createUncheckedAddrCast(
+      Apply.getLoc(), Apply.getArgument(ArgIdx), CEI.ConcreteValue->getType());
+}
 /// Rewrite the given method apply instruction in terms of the provided conrete
 /// type information.
 ///
@@ -1049,6 +1091,32 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
 
     // Check for Arg's concrete type propagation legality.
     if (!canReplaceArg(Apply, OAI, CEI, ArgIdx)) {
+
+      // As on last fall-back try to cast the argument.
+      if (auto cast = canCastArg(Apply, OAI, CEI, ArgIdx)) {
+        NewArgs.push_back(cast);
+        // Form a new set of substitutions where the argument is
+        // replaced with a concrete type.
+        NewCallSubs = NewCallSubs.subst(
+            [&](SubstitutableType *type) -> Type {
+              if (type == OAI.OpenedArchetype)
+                return CEI.ConcreteType;
+              return type;
+            },
+            [&](CanType origTy, Type substTy,
+                ProtocolDecl *proto) -> ProtocolConformanceRef {
+              if (origTy->isEqual(OAI.OpenedArchetype)) {
+                assert(substTy->isEqual(CEI.ConcreteType));
+                // Do a conformance lookup on this witness requirement using the
+                // existential's conformances. The witness requirement may be a
+                // base type of the existential's requirements.
+                return CEI.lookupExistentialConformance(proto);
+              }
+              return ProtocolConformanceRef(proto);
+            });
+        continue;
+      }
+      // Otherwise, use the original argument.
       NewArgs.push_back(Apply.getArgument(ArgIdx));
       continue;
     }

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -369,7 +369,8 @@ bb0(%0 : $*MutatingProto, %1 : $MStruct):
   %11 = open_existential_addr mutable_access %9 : $*MutatingProto to $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto
   // CHECK: [[M:%[0-9]+]] = witness_method $MStruct,
   %12 = witness_method $@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto, #MutatingProto.mutatingMethod : <Self where Self : MutatingProto> (inout Self) -> () -> (), %11 : $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
-  // CHECK: apply [[M]]<@opened("{{.*}}") MutatingProto>([[E]]) :
+  // CHECK:  [[C:%[0-9]+]] = unchecked_addr_cast [[E]] : $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto to $*MStruct
+  // CHECK: apply [[M]]<MStruct>([[C]]) :
   %13 = apply %12<@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto>(%11) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
   copy_addr [take] %9 to [initialization] %0 : $*MutatingProto
   dealloc_stack %9 : $*MutatingProto

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -470,7 +470,8 @@ sil [transparent] [reabstraction_thunk] @testDevirtExistentialEnumThunk : $@conv
 // CHECK: [[THUNK:%.*]] = function_ref @testDevirtExistentialEnumThunk : $@convention(thin) (UnsafeRawBufferPointer) -> (@out (), @error Error)
 // CHECK: [[TTF:%.*]] = thin_to_thick_function [[THUNK:%.*]] : $@convention(thin) (UnsafeRawBufferPointer) -> (@out (), @error Error) to $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out (), @error Error)
 // CHECK: [[WM:%.*]] = witness_method $Array<Int>, #ContiguousBytes.withUnsafeBytes : <Self where Self : ContiguousBytes><R> (Self) -> ((UnsafeRawBufferPointer) throws -> R) throws -> R : $@convention(witness_method: ContiguousBytes) <τ_0_0 where τ_0_0 : ContiguousBytes><τ_1_0> (@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out τ_1_0, @error Error), @in_guaranteed τ_0_0) -> (@out τ_1_0, @error Error)
-// CHECK: apply [nothrow] [[WM]]<@opened("8402EC1A-F35D-11E8-950A-D0817AD9F6DD") ContiguousBytes, ()>(%{{.*}}, [[TTF]], [[OPENED]]) : $@convention(witness_method: ContiguousBytes) <τ_0_0 where τ_0_0 : ContiguousBytes><τ_1_0> (@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out τ_1_0, @error Error), @in_guaranteed τ_0_0) -> (@out τ_1_0, @error Error)
+// CHECK: [[CAST:%.*]] = unchecked_addr_cast [[OPENED]]
+// CHECK: apply [nothrow] [[WM]]<Array<Int>, ()>(%{{.*}}, [[TTF]], [[CAST]]) : $@convention(witness_method: ContiguousBytes) <τ_0_0 where τ_0_0 : ContiguousBytes><τ_1_0> (@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out τ_1_0, @error Error), @in_guaranteed τ_0_0) -> (@out τ_1_0, @error Error)
 // CHECK: destroy_addr [[ALLOC_EXISTENTIAL]] : $*ContiguousBytes
 // CHECK-LABEL: } // end sil function 'testDevirtExistentialEnum'
 sil shared [noinline] @testDevirtExistentialEnum : $@convention(thin) (@guaranteed Array<Int>) -> () {

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -356,3 +356,37 @@ internal class OtherKlass {
   }
 }
 
+// Don't assert on this following example.
+
+public struct SomeValue {}
+
+public protocol MyVariableProtocol : class {
+}
+
+extension MyVariableProtocol where Self: MyBaseClass {
+  @inline(never)
+  public var myVariable : SomeValue {
+    print(self)
+    return SomeValue()
+  }
+}
+public class MyBaseClass : MyVariableProtocol {}
+
+fileprivate protocol NonClassProto {
+  var myVariable : SomeValue { get }
+}
+
+
+fileprivate class ConformerClass : MyBaseClass, NonClassProto {}
+
+
+@inline(never)
+private func repo(_ c: NonClassProto) {
+  let p : NonClassProto = c
+  print(p.myVariable)
+}
+
+public func entryPoint() {
+  let c = ConformerClass()
+  repo(c)
+}

--- a/test/SILOptimizer/sil_combiner_concrete_prop_all_args.sil
+++ b/test/SILOptimizer/sil_combiner_concrete_prop_all_args.sil
@@ -451,9 +451,10 @@ bb0(%0 : $*PPP):
 // CHECK: bb0:
 // CHECK:  [[ALLOC:%.*]] = alloc_stack $PPP, var, name "magic6"
 // CHECK:  alloc_ref $KKK
-// CHECK:  [[F:%.*]] = function_ref @$s21existential_transform14wrap_inout_ncp1as5Int32VAA3PPP_pz_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@inout τ_0_0) -> Int32
 // CHECK:  [[ADR:%.*]] = open_existential_addr mutable_access [[ALLOC]] : $*PPP to $*@opened("{{.*}}") PPP
-// CHECK:  apply [[F]]<@opened("{{.*}}") PPP>([[ADR]]) : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@inout τ_0_0) -> Int32
+// CHECK:  [[CAST:%.*]] = unchecked_addr_cast [[ADR]]
+// CHECK:  [[F:%.*]] = function_ref @$s21existential_transform14wrap_inout_ncp1as5Int32VAA3PPP_pz_tFTf4e_n4main3KKKC_Tg5 : $@convention(thin) (@inout KKK) -> Int32
+// CHECK:  apply [[F]]([[CAST]])
 // CHECK:  dealloc_stack %0 : $*PPP
 // CHECK-LABEL: } // end sil function '$s21existential_transform9inout_ncpyyF'
 sil hidden [noinline] @$s21existential_transform9inout_ncpyyF : $@convention(thin) () -> () {
@@ -500,9 +501,10 @@ bb0(%0 : $*PPPP):
 // CHECK: bb0:
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $PPPP, var, name "magic7"      
 // CHECK:   struct $SSSS ()                            
-// CHECK:   [[F:%.*]] = function_ref @$s21existential_transform21wrap_struct_inout_ncp1as5Int32VAA4PPPP_pz_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : PPPP> (@inout τ_0_0) -> Int32 
-// CHECK:   [[ADR:%.*]] = open_existential_addr mutable_access %0 : $*PPPP to $*@opened("{{.*}}") PPPP 
-// CHECK:   apply [[F]]<@opened("{{.*}}") PPPP>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : PPPP> (@inout τ_0_0) -> Int32 
+// CHECK:   [[ADR:%.*]] = open_existential_addr mutable_access %0 : $*PPPP to $*@opened("{{.*}}") PPPP
+// CHECK:   [[CAST:%.*]] = unchecked_addr_cast [[ADR]]
+// CHECK:   [[F:%.*]] = function_ref @$s21existential_transform21wrap_struct_inout_ncp1as5Int32VAA4PPPP_pz_tFTf4e_n4main4SSSSV_Tg5 : $@convention(thin) (@inout SSSS) -> Int32
+// CHECK:  apply [[F]]([[CAST]])
 // CHECK:   dealloc_stack [[ALLOC]] : $*PPPP
 // CHECK-LABEL: } // end sil function '$s21existential_transform16struct_inout_ncpyyF'
 sil hidden [noinline] @$s21existential_transform16struct_inout_ncpyyF : $@convention(thin) () -> () {


### PR DESCRIPTION
…t the apply operand

This works around an issue where using an apply with an unsubstituted
substitution map causes issues in downstream optimizations.

```
  %9 = alloc_stack $@opened("60E354F4-17B9-11EB-9427-ACDE48001122") NonClassProto
  copy_addr %8 to [initialization] %9 : $*@opened("60E354F4-17B9-11EB-9427-ACDE48001122") NonClassProto
  %11 = witness_method $ConformerClass, #NonClassProto.myVariable!getter : <Self where Self : NonClassProto> (Self) -> () -> SomeValue :
           $@convention(witness_method: NonClassProto) <τ_0_0 where τ_0_0 : NonClassProto> (@in_guaranteed τ_0_0) -> SomeValue
  apply %11<@opened("60E354F4-17B9-11EB-9427-ACDE48001122") NonClassProto>(%9) : $@convention(witness_method: NonClassProto) <τ_0_0 where τ_0_0 : NonClassProto> (@in_guaranteed τ_0_0) -> SomeValue
```

The problem arise when the devirtualizer replace
`witness_method $ConformerClass, #NonClassProto.myVariable!getter` with the
underlying implementation. That implementation for better or worse is further
constrained to `Self : ConformerClass` and applying an opened existential
which is not class constraint is a recipe for disaster. The proper
solution would probably be for the devirtualizer to insert the cast if necessary
and update the substitution list.
That fix will be left for another day though.

rdar://70582785
