### PR TITLE
[build] Use llvm matching value for CMake policy CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ if(POLICY CMP0076)
   cmake_policy(SET CMP0076 NEW)
 endif()
 
+# Don't clobber existing variable values when evaluating `option()` declarations.
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
Set policy [`CMP0077`](https://cmake.org/cmake/help/latest/policy/CMP0077.html) to `NEW`, which matches the value used by [llvm](https://github.com/apple/llvm-project/blob/46170cc2f5a9af3db7652ef119ecee0dbc78392d/llvm/CMakeLists.txt#L22-L24). This prevents `option()` from overwriting an existing value. This also prevents a cmake warning from being printed.