### PR TITLE
SILGen: Fix assertion failure when emitting foreign-to-native thunk for a method with inout 'self'

### DIFF
--- a/test/SILGen/Inputs/foreign_to_native_inout_self_helper.h
+++ b/test/SILGen/Inputs/foreign_to_native_inout_self_helper.h
@@ -1,0 +1,3 @@
+typedef struct {} MyIterator __attribute__((swift_name("MyIterator")));
+
+void MyIteratorNext(MyIterator *self) __attribute__((swift_name("MyIterator.next(self:)")));

--- a/test/SILGen/foreign_to_native_inout_self.swift
+++ b/test/SILGen/foreign_to_native_inout_self.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/foreign_to_native_inout_self_helper.h | %FileCheck %s
+
+protocol FakeIterator {
+  mutating func next()
+}
+
+extension MyIterator : FakeIterator {}
+
+// CHECK-LABEL: sil shared [serializable] [thunk] [ossa] @$sSo10MyIteratora4nextyyFTO : $@convention(method) (@inout MyIterator) -> () {
+// CHECK: bb0(%0 : $*MyIterator):
+// CHECK: [[FN:%.*]] = function_ref @MyIteratorNext : $@convention(c) (@inout MyIterator) -> ()
+// CHECK:   apply [[FN]](%0) : $@convention(c) (@inout MyIterator) -> ()
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+// CHECK: }


### PR DESCRIPTION
We import a non-const pointer 'self' type as a mutating method.

The getParameterTypes() helper method in SILGenBridging.cpp would
assert upon encountering the inout 'self' parameter, even though
emitForeignToNativeThunk() would still emit correct code as long
as the 'self' type was not bridged.

Relax the assertion a bit to hopefully still catch bugs where
other parameters are unexpectedly 'inout', but allow it on 'self',
and add a test.

Fixes <rdar://problem/70346482>.
