### PR TITLE
[concurrency] Overload resolution for async-looking ObjC methods

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -578,13 +578,15 @@ bool DisjunctionStep::shouldStopAt(const DisjunctionChoice &choice) const {
   auto delta = LastSolvedChoice->second - getCurrentScore();
   bool hasUnavailableOverloads = delta.Data[SK_Unavailable] > 0;
   bool hasFixes = delta.Data[SK_Fix] > 0;
+  bool hasAsyncMismatch = delta.Data[SK_AsyncSyncMismatch] > 0;
   auto isBeginningOfPartition = choice.isBeginningOfPartition();
 
   // Attempt to short-circuit evaluation of this disjunction only
-  // if the disjunction choice we are comparing to did not involve
-  // selecting unavailable overloads or result in fixes being
-  // applied to reach a solution.
-  return !hasUnavailableOverloads && !hasFixes &&
+  // if the disjunction choice we are comparing to did not involve:
+  //   1. selecting unavailable overloads
+  //   2. result in fixes being applied to reach a solution
+  //   3. selecting an overload that results in an async/sync mismatch
+  return !hasUnavailableOverloads && !hasFixes && !hasAsyncMismatch &&
          (isBeginningOfPartition ||
           shortCircuitDisjunctionAt(choice, lastChoice));
 }

--- a/test/Concurrency/Inputs/Delegate.h
+++ b/test/Concurrency/Inputs/Delegate.h
@@ -1,0 +1,21 @@
+#ifndef Delegate_h
+#define Delegate_h
+
+@import Foundation;
+
+@interface Request : NSObject
+
+@end
+
+@interface Delegate : NSObject
+
+- (void)makeRequest1:(Request * _Nonnull)request completionHandler:(void (^ _Nullable)(void))handler;
+
+- (void)makeRequest2:(NSObject * _Nonnull)request completionHandler:(void (^ _Nullable)(void))handler;
+
+- (void)makeRequest3:(Request * _Nullable)request completionHandler:(void (^ _Nullable)(void))handler;
+
+@end
+
+
+#endif

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-concurrency -typecheck -verify -import-objc-header %S/Inputs/Delegate.h %s
+
+// REQUIRES: objc_interop
+
+
+// overload resolution should pick sync version in a sync context
+func syncContext() {
+  let r = Request()
+  let d = Delegate()
+  d.makeRequest1(r) // NOTE: this use to trigger an overload resolution error, see SR-13760
+  d.makeRequest2(r)
+  d.makeRequest3(r)
+}
+
+// overload resolution should pick async version in an async context
+func asyncNoAwait() async {
+  let r = Request()
+  let d = Delegate()
+  d.makeRequest1(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+  d.makeRequest2(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+  d.makeRequest3(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+}
+
+
+func asyncWithAwait() async {
+  let r = Request()
+  let d = Delegate()
+  await d.makeRequest1(r)
+  await d.makeRequest2(r)
+  await d.makeRequest3(r)
+}


### PR DESCRIPTION
# Problem Summary

Suppose we have the following declaration for `Delegate` in ObjC:

```objc
#import <Foundation/Foundation.h>

@interface Request : NSObject

@end

@interface Delegate : NSObject

  // Error because request is _Nonnull AND not exactly 'NSObject'
- (void)addWork:(Request * _Nonnull)request completionHandler:(void (^ _Nullable)(void))handler;

@end
```

A call to a `Delegate.addWork(_: completionHandler :)` in Swift such as:

```swift
func f() {
  let r = Request()
  let d = Delegate()
  d.addWork(r)
}
```

is currently viewed as ambiguous when concurrency extensions are enabled, because of two factors that are simultaneously true:
1. async-looking ObjC methods with a completion handler are automatically made available with an `async` version.
2. the completion handler argument for `Delegate.addWork` is optional and is not provided at this call-site.

Here are the two overloads of `Delegate.addWork` that are considered by the constraint solver:

```
1. decl __ObjC.(file).Delegate.addWork(_:completionHandler:) : (Delegate) -> (Request, (() -> Void)?) -> Void
2. decl __ObjC.(file).Delegate.addWork : (Delegate) -> (Request) async -> Void
```

Currently, the problem is that if you get a bad ordering of overload options in the solver, where overload (2) is checked first, the solver decides to not consider other options (i.e., short-circuit) resulting in a selection of overload 2 despite it having a non-zero "badness" score because it results in a sync/async mismatch. This current patch tells the constraint solver to keep considering other options in this case (i.e., the mismatch) so that it lands correctly on overload 1, but more generally I think this change to short-circuiting is perhaps not a good solution.

In particular, I don't necessarily think this call-site is ambiguous if additional contextual information is available. For example, I believe it's not possible to call an async function (i.e., pick overload 2) from a synchronous context, even if the programmer tried to add an `await` to the call expression. This happens to be the case for `f` above. Additionally, even if the context of the call-site were asynchronous, the call-site is not marked with `await` so the only correct choice here is to pick overload 1. 

Thus, perhaps it's possible to filter out incorrect overloads during the enumeration of overload possibilities, or something along those lines? There is also some infrastructure for "favored" overloads that I'm not yet familiar with.

# Details

This PR fixes SR-13760 / rdar://70543421

TODO:
- [x] Fix bug.
- [x] Create regression test.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
