### PR TITLE
[Async CC] Ptrauth for parent context.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -137,6 +137,9 @@ struct PointerAuthOptions : clang::PointerAuthOptions {
 
   /// Resilient class stub initializer callbacks.
   PointerAuthSchema ResilientClassStubInitCallbacks;
+
+  /// The parent async context stored within a child async context.
+  PointerAuthSchema AsyncContextParent;
 };
 
 enum class JITDebugArtifact : unsigned {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2246,8 +2246,16 @@ public:
     // Set caller info into the context.
     { // caller context
       Explosion explosion;
-      explosion.add(IGF.getAsyncContext());
       auto fieldLayout = layout.getParentLayout();
+      auto *context = IGF.getAsyncContext();
+      if (auto schema = IGF.IGM.getOptions().PointerAuth.AsyncContextParent) {
+        Address fieldAddr =
+            fieldLayout.project(IGF, this->context, /*offsets*/ llvm::None);
+        auto authInfo = PointerAuthInfo::emit(
+            IGF, schema, fieldAddr.getAddress(), PointerAuthEntity());
+        context = emitPointerAuthSign(IGF, context, authInfo);
+      }
+      explosion.add(context);
       saveValue(fieldLayout, explosion, isOutlined);
     }
     { // caller executor

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -688,6 +688,10 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
   opts.ResilientClassStubInitCallbacks =
       PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Constant,
       SpecialPointerAuthDiscriminators::ResilientClassStubInitCallback);
+
+  opts.AsyncContextParent =
+      PointerAuthSchema(codeKey, /*address*/ true, Discrimination::Constant,
+                        SpecialPointerAuthDiscriminators::AsyncContextParent);
 }
 
 std::unique_ptr<llvm::TargetMachine>


### PR DESCRIPTION
Previously, none of the fields in the async context were signed.  Here, signing is added for the one field: the parent context.