### PR TITLE
[Async CC] Add remaining fields to context.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -103,6 +103,13 @@ AsyncContextLayout irgen::getAsyncContextLayout(
   auto parameters = substitutedType->getParameters();
   SILFunctionConventions fnConv(substitutedType, IGF.getSILModule());
 
+  auto addTaskContinuationFunction = [&]() {
+    auto ty = SILType();
+    auto &ti = IGF.IGM.getTaskContinuationFunctionPtrTypeInfo();
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+  };
+
   // AsyncContext * __ptrauth_swift_async_context_parent Parent;
   {
     auto ty = SILType();
@@ -113,12 +120,7 @@ AsyncContextLayout irgen::getAsyncContextLayout(
 
   // TaskContinuationFunction * __ptrauth_swift_async_context_resume
   //     ResumeParent;
-  {
-    auto ty = SILType();
-    auto &ti = IGF.IGM.getTaskContinuationFunctionPtrTypeInfo();
-    valTypes.push_back(ty);
-    typeInfos.push_back(&ti);
-  }
+  addTaskContinuationFunction();
 
   // ExecutorRef ResumeParentExecutor;
   {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -131,6 +131,16 @@ AsyncContextLayout irgen::getAsyncContextLayout(
   // ExecutorRef ResumeParentExecutor;
   addExecutor();
 
+  // AsyncContextFlags Flags;
+  {
+    auto ty = SILType::getPrimitiveObjectType(
+        BuiltinIntegerType::get(32, IGF.IGM.IRGen.SIL.getASTContext())
+            ->getCanonicalType());
+    const auto &ti = IGF.IGM.getTypeInfo(ty);
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+  }
+
   //   SwiftError *errorResult;
   auto errorCanType = IGF.IGM.Context.getExceptionType();
   auto errorType = SILType::getPrimitiveObjectType(errorCanType);

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -109,6 +109,12 @@ AsyncContextLayout irgen::getAsyncContextLayout(
     valTypes.push_back(ty);
     typeInfos.push_back(&ti);
   };
+  auto addExecutor = [&]() {
+    auto ty = SILType();
+    auto &ti = IGF.IGM.getSwiftExecutorPtrTypeInfo();
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+  };
 
   // AsyncContext * __ptrauth_swift_async_context_parent Parent;
   {
@@ -123,12 +129,7 @@ AsyncContextLayout irgen::getAsyncContextLayout(
   addTaskContinuationFunction();
 
   // ExecutorRef ResumeParentExecutor;
-  {
-    auto ty = SILType();
-    auto &ti = IGF.IGM.getSwiftExecutorPtrTypeInfo();
-    valTypes.push_back(ty);
-    typeInfos.push_back(&ti);
-  }
+  addExecutor();
 
   //   SwiftError *errorResult;
   auto errorCanType = IGF.IGM.Context.getExceptionType();

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -97,6 +97,8 @@ AsyncContextLayout irgen::getAsyncContextLayout(
   SmallVector<const TypeInfo *, 4> typeInfos;
   SmallVector<SILType, 4> valTypes;
   SmallVector<AsyncContextLayout::ArgumentInfo, 4> paramInfos;
+  bool isCoroutine = originalType->isCoroutine();
+  SmallVector<SILYieldInfo, 4> yieldInfos;
   SmallVector<SILResultInfo, 4> indirectReturnInfos;
   SmallVector<SILResultInfo, 4> directReturnInfos;
 
@@ -141,6 +143,11 @@ AsyncContextLayout irgen::getAsyncContextLayout(
     typeInfos.push_back(&ti);
   }
 
+  if (isCoroutine) {
+    // SwiftPartialFunction * __ptrauth(...) yieldToCaller?;
+    addTaskContinuationFunction();
+  }
+
   //   SwiftError *errorResult;
   auto errorCanType = IGF.IGM.Context.getExceptionType();
   auto errorType = SILType::getPrimitiveObjectType(errorCanType);
@@ -160,15 +167,33 @@ AsyncContextLayout irgen::getAsyncContextLayout(
     indirectReturnInfos.push_back(indirectResult);
   }
 
-  //     ResultTypes directResults...;
-  auto directResults = fnConv.getDirectSILResults();
-  for (auto result : directResults) {
-    auto ty =
-        fnConv.getSILType(result, IGF.IGM.getMaximalTypeExpansionContext());
-    auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
-    valTypes.push_back(ty);
-    typeInfos.push_back(&ti);
-    directReturnInfos.push_back(result);
+  // union {
+  if (isCoroutine) {
+    // SwiftPartialFunction * __ptrauth(...) resumeFromYield?
+    addTaskContinuationFunction();
+    // SwiftPartialFunction * __ptrauth(...) abortFromYield?
+    addTaskContinuationFunction();
+    // SwiftActor * __ptrauth(...) calleeActorDuringYield?
+    addExecutor();
+    // YieldTypes yieldValues...
+    for (auto yield : fnConv.getYields()) {
+      auto ty =
+          fnConv.getSILType(yield, IGF.IGM.getMaximalTypeExpansionContext());
+      auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      yieldInfos.push_back(yield);
+    }
+  } else {
+    //     ResultTypes directResults...;
+    for (auto result : fnConv.getDirectSILResults()) {
+      auto ty =
+          fnConv.getSILType(result, IGF.IGM.getMaximalTypeExpansionContext());
+      auto &ti = IGF.getTypeInfoForLowered(ty.getASTType());
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      directReturnInfos.push_back(result);
+    }
   }
 
   //   SelfType self?;
@@ -257,7 +282,8 @@ AsyncContextLayout irgen::getAsyncContextLayout(
       IGF.IGM, LayoutStrategy::Optimal, valTypes, typeInfos, IGF, originalType,
       substitutedType, substitutionMap, std::move(bindings),
       trailingWitnessInfo, errorType, canHaveValidError, paramInfos,
-      indirectReturnInfos, directReturnInfos, localContextInfo);
+      isCoroutine, yieldInfos, indirectReturnInfos, directReturnInfos,
+      localContextInfo);
 }
 
 AsyncContextLayout::AsyncContextLayout(
@@ -267,6 +293,7 @@ AsyncContextLayout::AsyncContextLayout(
     SubstitutionMap substitutionMap, NecessaryBindings &&bindings,
     Optional<TrailingWitnessInfo> trailingWitnessInfo, SILType errorType,
     bool canHaveValidError, ArrayRef<ArgumentInfo> argumentInfos,
+    bool isCoroutine, ArrayRef<SILYieldInfo> yieldInfos,
     ArrayRef<SILResultInfo> indirectReturnInfos,
     ArrayRef<SILResultInfo> directReturnInfos,
     Optional<AsyncContextLayout::ArgumentInfo> localContextInfo)
@@ -274,7 +301,8 @@ AsyncContextLayout::AsyncContextLayout(
                    fieldTypeInfos, /*typeToFill*/ nullptr),
       IGF(IGF), originalType(originalType), substitutedType(substitutedType),
       substitutionMap(substitutionMap), errorType(errorType),
-      canHaveValidError(canHaveValidError),
+      canHaveValidError(canHaveValidError), isCoroutine(isCoroutine),
+      yieldInfos(yieldInfos.begin(), yieldInfos.end()),
       directReturnInfos(directReturnInfos.begin(), directReturnInfos.end()),
       indirectReturnInfos(indirectReturnInfos.begin(),
                           indirectReturnInfos.end()),
@@ -284,6 +312,11 @@ AsyncContextLayout::AsyncContextLayout(
 #ifndef NDEBUG
   assert(fieldTypeInfos.size() == fieldTypes.size() &&
          "type infos don't match types");
+  if (isCoroutine) {
+    assert(directReturnInfos.empty());
+  } else {
+    assert(yieldInfos.empty());
+  }
   if (!bindings.empty()) {
     assert(fieldTypeInfos.size() >= 2 && "no field for bindings");
     auto fixedBindingsField =

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -96,7 +96,8 @@ namespace irgen {
       Parent = 0,
       ResumeParent = 1,
       ResumeParentExecutor = 2,
-      Error = 3,
+      Flags = 3,
+      Error = 4,
     };
     enum class FixedCount : unsigned {
       Parent = 1,
@@ -124,6 +125,7 @@ namespace irgen {
     unsigned getResumeParentExecutorIndex() {
       return (unsigned)FixedIndex::ResumeParentExecutor;
     }
+    unsigned getFlagsIndex() { return (unsigned)FixedIndex::Flags; }
     unsigned getErrorIndex() { return (unsigned)FixedIndex::Error; }
     unsigned getFirstIndirectReturnIndex() {
       return getErrorIndex() + getErrorCount();
@@ -176,6 +178,7 @@ namespace irgen {
     ElementLayout getResumeParentExecutorLayout() {
       return getElement(getResumeParentExecutorIndex());
     }
+    ElementLayout getFlagsLayout() { return getElement(getFlagsIndex()); }
     bool canHaveError() { return canHaveValidError; }
     ElementLayout getErrorLayout() { return getElement(getErrorIndex()); }
     unsigned getErrorCount() { return (unsigned)FixedCount::Error; }

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -239,8 +239,8 @@ namespace irgen {
         SubstitutionMap substitutionMap, NecessaryBindings &&bindings,
         Optional<TrailingWitnessInfo> trailingWitnessInfo, SILType errorType,
         bool canHaveValidError, ArrayRef<ArgumentInfo> argumentInfos,
-        ArrayRef<SILResultInfo> directReturnInfos,
         ArrayRef<SILResultInfo> indirectReturnInfos,
+        ArrayRef<SILResultInfo> directReturnInfos,
         Optional<ArgumentInfo> localContextInfo);
   };
 


### PR DESCRIPTION
A few fields either from the initial specification or from the declaration in Task.h had not yet been added to the layout of an async context.  Here, those remaining field are here added.  Specifically, the following fields are now part of the layout.
- `AsyncContextFlags Flags`
- `TaskContinuationFunction * __ptrauth(...) yieldToCaller?`
- `TaskContinuationFunction * __ptrauth(...) resumeFromYield?`
- `TaskContinuationFunction * __ptrauth(...) abortFromYield?`
- `ExecutorRef calleeActorDuringYield?`
- `YieldTypes yieldValues...`