### PR TITLE
Put the AvailabilityContext into the ExportContext

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2734,6 +2734,7 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
 
 ERROR(decl_from_hidden_module,none,
       "cannot use %0 %1 %select{here|as property wrapper here|"
+      "as result builder here|"
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; "
       "%select{%3 has been imported as implementation-only|"
@@ -2742,12 +2743,14 @@ ERROR(decl_from_hidden_module,none,
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 WARNING(decl_from_hidden_module_warn,none,
       "cannot use %0 %1 %select{in SPI|as property wrapper in SPI|"
+      "as result builder in SPI|"
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; "
       "%select{%3 has been imported as implementation-only}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 ERROR(conformance_from_implementation_only_module,none,
       "cannot use conformance of %0 to %1 %select{here|as property wrapper here|"
+      "as result builder here|"
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; "
       "%select{%3 has been imported as implementation-only|"

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1244,8 +1244,9 @@ public:
         if (!nominal)
           return false;
 
+        ExportContext where = ExportContext::forFunctionBody(dc, loc);
         if (auto reason = TypeChecker::checkDeclarationAvailability(
-                              nominal, loc, dc)) {
+                              nominal, where)) {
           ctx.Diags.diagnose(
               loc, diag::result_builder_missing_limited_availability,
               builderTransform.builderType);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 #include "CSDiagnostics.h"
 #include "TypeChecker.h"
+#include "TypeCheckAvailability.h"
 #include "TypeCheckType.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -5057,7 +5058,8 @@ bool ConstraintSystem::isDeclUnavailable(const Decl *D,
   }
 
   // If not, let's check contextual unavailability.
-  auto result = TypeChecker::checkDeclarationAvailability(D, loc, DC);
+  ExportContext where = ExportContext::forFunctionBody(DC, loc);
+  auto result = TypeChecker::checkDeclarationAvailability(D, where);
   return result.hasValue();
 }
 
@@ -5242,8 +5244,9 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   // If the setter is unavailable, then the keypath ought to be read-only
   // in this context.
   if (auto setter = storage->getOpaqueAccessor(AccessorKind::Set)) {
+    ExportContext where = ExportContext::forFunctionBody(DC, referenceLoc);
     auto maybeUnavail =
-        TypeChecker::checkDeclarationAvailability(setter, referenceLoc, DC);
+        TypeChecker::checkDeclarationAvailability(setter, where);
     if (maybeUnavail.hasValue()) {
       return true;
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4600,7 +4600,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   if (!ctx.isSwiftVersionAtLeast(5))
     diagnoseDeprecatedWritableKeyPath(E, DC);
   if (!ctx.LangOpts.DisableAvailabilityChecking)
-    diagAvailability(E, const_cast<DeclContext*>(DC));
+    diagnoseExprAvailability(E, const_cast<DeclContext*>(DC));
   if (ctx.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(DC, E);
   diagnoseConstantArgumentRequirement(E, DC);
@@ -4623,7 +4623,7 @@ void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {
       checkImplicitPromotionsInCondition(elt, ctx);
 
   if (!ctx.LangOpts.DisableAvailabilityChecking)
-    diagAvailability(S, const_cast<DeclContext*>(DC));
+    diagnoseStmtAvailability(S, const_cast<DeclContext*>(DC));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -29,7 +29,7 @@ using namespace swift;
 
 bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
                                                  const ValueDecl *D,
-                                                 ExportContext where) {
+                                                 const ExportContext &where) {
   auto fragileKind = where.getFragileFunctionKind();
   if (fragileKind.kind == FragileFunctionKind::None)
     return false;
@@ -112,7 +112,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 bool
 TypeChecker::diagnoseDeclRefExportability(SourceLoc loc,
                                           const ValueDecl *D,
-                                          ExportContext where) {
+                                          const ExportContext &where) {
   // Accessors cannot have exportability that's different than the storage,
   // so skip them for now.
   if (isa<AccessorDecl>(D))
@@ -160,7 +160,7 @@ TypeChecker::diagnoseDeclRefExportability(SourceLoc loc,
 bool
 TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                                               const RootProtocolConformance *rootConf,
-                                              ExportContext where) {
+                                              const ExportContext &where) {
   if (!where.mustOnlyReferenceExportedDecls())
     return false;
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1448,7 +1448,7 @@ public:
 /// Local variant to swift::getDisallowedOriginKind for downgrade to warnings.
 DisallowedOriginKind
 swift::getDisallowedOriginKind(const Decl *decl,
-                               ExportContext where,
+                               const ExportContext &where,
                                DowngradeToWarning &downgradeToWarning) {
   downgradeToWarning = DowngradeToWarning::No;
   ModuleDecl *M = decl->getModuleContext();
@@ -1826,7 +1826,7 @@ static void checkExtensionGenericParamAccess(const ExtensionDecl *ED) {
 }
 
 DisallowedOriginKind swift::getDisallowedOriginKind(const Decl *decl,
-                                                    ExportContext where) {
+                                                    const ExportContext &where) {
   auto downgradeToWarning = DowngradeToWarning::No;
   return getDisallowedOriginKind(decl, where, downgradeToWarning);
 }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1496,11 +1496,7 @@ class DeclAvailabilityChecker : public DeclVisitor<DeclAvailabilityChecker> {
     if (allowUnavailableProtocol)
       flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
 
-    auto loc = context->getLoc();
-    if (auto *varDecl = dyn_cast<VarDecl>(context))
-      loc = varDecl->getNameLoc();
-
-    diagnoseTypeAvailability(typeRepr, type, loc,
+    diagnoseTypeAvailability(typeRepr, type, context->getLoc(),
                              Where.withReason(reason), flags);
   }
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1591,10 +1591,18 @@ public:
               TP->getTypeRepr(), anyVar ? (Decl *)anyVar : (Decl *)PBD);
 
     // Check the property wrapper types.
-    if (anyVar)
-      for (auto attr : anyVar->getAttachedPropertyWrappers())
+    if (anyVar) {
+      for (auto attr : anyVar->getAttachedPropertyWrappers()) {
         checkType(attr->getType(), attr->getTypeRepr(), anyVar,
                   ExportabilityReason::PropertyWrapper);
+      }
+
+      if (auto attr = anyVar->getAttachedResultBuilder()) {
+        checkType(anyVar->getResultBuilderType(),
+                  attr->getTypeRepr(), anyVar,
+                  ExportabilityReason::ResultBuilder);
+      }
+    }
   }
 
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {
@@ -1683,6 +1691,12 @@ public:
   void visitFuncDecl(FuncDecl *FD) {
     visitAbstractFunctionDecl(FD);
     checkType(FD->getResultInterfaceType(), FD->getResultTypeRepr(), FD);
+
+    if (auto attr = FD->getAttachedResultBuilder()) {
+      checkType(FD->getResultBuilderType(),
+                attr->getTypeRepr(), FD,
+                ExportabilityReason::ResultBuilder);
+    }
   }
 
   void visitEnumElementDecl(EnumElementDecl *EED) {

--- a/lib/Sema/TypeCheckAccess.h
+++ b/lib/Sema/TypeCheckAccess.h
@@ -56,10 +56,10 @@ enum class DowngradeToWarning: bool {
 /// Returns the kind of origin, implementation-only import or SPI declaration,
 /// that restricts exporting \p decl from the given file and context.
 DisallowedOriginKind getDisallowedOriginKind(const Decl *decl,
-                                             ExportContext where);
+                                             const ExportContext &where);
 
 DisallowedOriginKind getDisallowedOriginKind(const Decl *decl,
-                                             ExportContext where,
+                                             const ExportContext &where,
                                              DowngradeToWarning &downgradeToWarning);
 
 } // end namespace swift

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1990,7 +1990,8 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
   }
 
   auto where = ExportContext::forDeclSignature(D);
-  diagnoseDeclAvailability(mainFunction, attr->getRange(), where, None);
+  diagnoseDeclAvailability(mainFunction, attr->getRange(), nullptr,
+                           where, None);
 
   auto *const func = FuncDecl::createImplicit(
       context, StaticSpellingKind::KeywordStatic,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2959,6 +2959,14 @@ public:
   explicit StmtAvailabilityWalker(ExportContext where)
     : Where(where) {}
 
+  /// We'll visit each element of a BraceStmt individually.
+  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    if (isa<BraceStmt>(S))
+      return std::make_pair(false, S);
+
+    return std::make_pair(true, S);
+  }
+
   /// We'll visit the expression from performSyntacticExprDiagnostics().
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     return std::make_pair(false, E);

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -205,12 +205,12 @@ diagnoseSubstitutionMapAvailability(SourceLoc loc,
                                     SubstitutionMap subs,
                                     ExportContext context);
 
-/// Run the Availability-diagnostics algorithm otherwise used in an expr
-/// context, but for non-expr contexts such as TypeDecls referenced from
-/// TypeReprs.
-bool diagnoseDeclAvailability(const ValueDecl *Decl,
+/// Diagnose uses of unavailable declarations. Returns true if a diagnostic
+/// was emitted.
+bool diagnoseDeclAvailability(const ValueDecl *D,
                               SourceRange R,
-                              ExportContext context,
+                              const ApplyExpr *call,
+                              ExportContext where,
                               DeclAvailabilityFlags flags = None);
 
 void diagnoseUnavailableOverride(ValueDecl *override,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -173,11 +173,11 @@ bool isExported(const ValueDecl *VD);
 bool isExported(const Decl *D);
 
 /// Diagnose uses of unavailable declarations in expressions.
-void diagAvailability(const Expr *E, DeclContext *DC);
+void diagnoseExprAvailability(const Expr *E, DeclContext *DC);
 
 /// Diagnose uses of unavailable declarations in statements (via patterns, etc),
 /// without walking into expressions.
-void diagAvailability(const Stmt *S, DeclContext *DC);
+void diagnoseStmtAvailability(const Stmt *S, DeclContext *DC);
 
 /// Diagnose uses of unavailable declarations in types.
 bool diagnoseTypeReprAvailability(const TypeRepr *T,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -193,36 +193,36 @@ void diagnoseStmtAvailability(const Stmt *S, DeclContext *DC,
 
 /// Diagnose uses of unavailable declarations in types.
 bool diagnoseTypeReprAvailability(const TypeRepr *T,
-                                  ExportContext context,
+                                  const ExportContext &context,
                                   DeclAvailabilityFlags flags = None);
 
 /// Diagnose uses of unavailable conformances in types.
 void diagnoseTypeAvailability(Type T, SourceLoc loc,
-                              ExportContext context,
+                              const ExportContext &context,
                               DeclAvailabilityFlags flags = None);
 
 /// Checks both a TypeRepr and a Type, but avoids emitting duplicate
 /// diagnostics by only checking the Type if the TypeRepr succeeded.
 void diagnoseTypeAvailability(const TypeRepr *TR, Type T, SourceLoc loc,
-                              ExportContext context,
+                              const ExportContext &context,
                               DeclAvailabilityFlags flags = None);
 
 bool
 diagnoseConformanceAvailability(SourceLoc loc,
                                 ProtocolConformanceRef conformance,
-                                ExportContext context);
+                                const ExportContext &context);
 
 bool
 diagnoseSubstitutionMapAvailability(SourceLoc loc,
                                     SubstitutionMap subs,
-                                    ExportContext context);
+                                    const ExportContext &context);
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
 bool diagnoseDeclAvailability(const ValueDecl *D,
                               SourceRange R,
                               const ApplyExpr *call,
-                              ExportContext where,
+                              const ExportContext &where,
                               DeclAvailabilityFlags flags = None);
 
 void diagnoseUnavailableOverride(ValueDecl *override,
@@ -233,7 +233,7 @@ void diagnoseUnavailableOverride(ValueDecl *override,
 /// marked as unavailable, either through "unavailable" or "obsoleted:".
 bool diagnoseExplicitUnavailability(const ValueDecl *D,
                                     SourceRange R,
-                                    ExportContext Where,
+                                    const ExportContext &Where,
                                     const ApplyExpr *call,
                                     DeclAvailabilityFlags Flags = None);
 
@@ -242,7 +242,7 @@ bool diagnoseExplicitUnavailability(const ValueDecl *D,
 bool diagnoseExplicitUnavailability(
     const ValueDecl *D,
     SourceRange R,
-    ExportContext Where,
+    const ExportContext &Where,
     DeclAvailabilityFlags Flags,
     llvm::function_ref<void(InFlightDiagnostic &)> attachRenameFixIts);
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -62,6 +62,7 @@ using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;
 enum class ExportabilityReason : unsigned {
   General,
   PropertyWrapper,
+  ResultBuilder,
   ExtensionWithPublicMembers,
   ExtensionWithConditionalConformances
 };
@@ -101,7 +102,7 @@ class ExportContext {
   unsigned Implicit : 1;
   unsigned Unavailable : 1;
   unsigned Platform : 8;
-  unsigned Reason : 2;
+  unsigned Reason : 3;
 
   ExportContext(DeclContext *DC,
                 AvailabilityContext runningOSVersion,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -37,7 +37,7 @@ using namespace swift;
 static EnumElementDecl *
 extractEnumElement(DeclContext *DC, SourceLoc UseLoc,
                    const VarDecl *constant) {
-  ExportContext where = ExportContext::forFunctionBody(DC);
+  ExportContext where = ExportContext::forFunctionBody(DC, UseLoc);
   diagnoseExplicitUnavailability(constant, UseLoc, where, nullptr);
 
   const FuncDecl *getter = constant->getAccessor(AccessorKind::Get);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1696,9 +1696,10 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
     }
 
     // Make sure we can reference the designated initializer correctly.
+    auto loc = fromCtor->getLoc();
     diagnoseDeclAvailability(
-        ctor, fromCtor->getLoc(), nullptr,
-        ExportContext::forFunctionBody(fromCtor));
+        ctor, loc, nullptr,
+        ExportContext::forFunctionBody(fromCtor, loc));
   }
 
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1697,7 +1697,7 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
 
     // Make sure we can reference the designated initializer correctly.
     diagnoseDeclAvailability(
-        ctor, fromCtor->getLoc(),
+        ctor, fromCtor->getLoc(), nullptr,
         ExportContext::forFunctionBody(fromCtor));
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1010,8 +1010,7 @@ diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 /// declaration is unavailable. Returns None is the declaration is
 /// definitely available.
 Optional<UnavailabilityReason>
-checkDeclarationAvailability(const Decl *D, SourceLoc referenceLoc,
-                             const DeclContext *referenceDC);
+checkDeclarationAvailability(const Decl *D, ExportContext where);
 
 /// Checks an "ignored" expression to see if it's okay for it to be ignored.
 ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -952,21 +952,21 @@ Expr *buildDefaultInitializer(Type type);
 /// \name Resilience diagnostics
 
 bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
-                                    ExportContext where);
+                                    const ExportContext &where);
 
 /// Given that a declaration is used from a particular context which
 /// exposes it in the interface of the current module, diagnose if it cannot
 /// reasonably be shared.
 bool diagnoseDeclRefExportability(SourceLoc loc,
                                   const ValueDecl *D,
-                                  ExportContext where);
+                                  const ExportContext &where);
 
 /// Given that a conformance is used from a particular context which
 /// exposes it in the interface of the current module, diagnose if the
 /// conformance is SPI or visible via an implementation-only import.
 bool diagnoseConformanceExportability(SourceLoc loc,
                                       const RootProtocolConformance *rootConf,
-                                      ExportContext where);
+                                      const ExportContext &where);
 
 /// \name Availability checking
 ///
@@ -1010,7 +1010,7 @@ diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 /// declaration is unavailable. Returns None is the declaration is
 /// definitely available.
 Optional<UnavailabilityReason>
-checkDeclarationAvailability(const Decl *D, ExportContext where);
+checkDeclarationAvailability(const Decl *D, const ExportContext &where);
 
 /// Checks an "ignored" expression to see if it's okay for it to be ignored.
 ///
@@ -1045,7 +1045,7 @@ const AvailableAttr *getDeprecated(const Decl *D);
 /// Callers can provide a lambda that adds additional information (such as a
 /// fixit hint) to the deprecation diagnostic, if it is emitted.
 void diagnoseIfDeprecated(SourceRange SourceRange,
-                          ExportContext Where,
+                          const ExportContext &Where,
                           const ValueDecl *DeprecatedDecl,
                           const ApplyExpr *Call);
 /// @}

--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -2,6 +2,16 @@
 
 // REQUIRES: OS=macosx
 
+@available(*, unavailable)
+@resultBuilder
+struct UnavailableBuilder {
+// expected-note@-1 {{'UnavailableBuilder' has been explicitly marked unavailable here}}
+  static func buildBlock() {}
+}
+
+@UnavailableBuilder public func usesUnavailableBuilder() {}
+// expected-error@-1 {{'UnavailableBuilder' is unavailable}}
+
 enum Either<T,U> {
   case first(T)
   case second(U)

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -18,8 +18,8 @@ func internalFunction() {}
 public func publicFunction() {}
 
 private struct PrivateStruct {}
-// expected-note@-1 3{{struct 'PrivateStruct' is not '@usableFromInline' or public}}
-// expected-note@-2 {{initializer 'init()' is not '@usableFromInline' or public}}
+// expected-note@-1 5{{struct 'PrivateStruct' is not '@usableFromInline' or public}}
+// expected-note@-2 2{{initializer 'init()' is not '@usableFromInline' or public}}
 struct InternalStruct {}
 // expected-note@-1 3{{struct 'InternalStruct' is not '@usableFromInline' or public}}
 // expected-note@-2 {{initializer 'init()' is not '@usableFromInline' or public}}
@@ -350,3 +350,10 @@ public struct PrivateInlinableCrash {
   // expected-error@-1 {{'@inlinable' attribute cannot be applied to stored properties}}
 }
 
+@inlinable public func nestedBraceStmtTest() {
+  if true {
+    let _: PrivateStruct = PrivateStruct()
+    // expected-error@-1 2{{struct 'PrivateStruct' is private and cannot be referenced from an '@inlinable' function}}
+    // expected-error@-2 {{initializer 'init()' is private and cannot be referenced from an '@inlinable' function}}
+  }
+}


### PR DESCRIPTION
Let's put OS version information into the ExportContext, so that we only have to perform the source location lookup once.