### PR TITLE
build: enable concurrency on Windows for real

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -201,7 +201,6 @@ cmake^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
-    -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES^
     -S "%source_root%\llvm-project\llvm" %exitOnError%
 
 cmake --build "%build_root%\llvm" %exitOnError%
@@ -263,6 +262,7 @@ cmake^
     -DLLVM_INSTALL_TOOLCHAIN_ONLY:BOOL=YES^
     -DSWIFT_BUILD_SOURCEKIT:BOOL=YES^
     -DSWIFT_ENABLE_SOURCEKIT_TESTS:BOOL=YES^
+    -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES^
     -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
     -DSWIFT_PARALLEL_LINK_JOBS=8^
     -DPYTHON_EXECUTABLE:PATH=%PYTHON_HOME%\python.exe^


### PR DESCRIPTION
This was applied to the wrong invocation which resulted in Concurrency
being disabled.  Thanks to @eeckstein for pointing out that concurrency
was unavailable for some reason.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
