### PR TITLE
[CodeCompletion] Fix a crash in collectPossibleReturnTypesFromContext

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1933,11 +1933,13 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
   // The enclosing closure might be a single expression closure or a function
   // builder closure. In such cases, the body elements are type checked with
   // the closure itself. So we need to try type checking the enclosing closure
-  // signature first.
+  // signature first unless it has already been type checked.
   if (auto CE = dyn_cast<ClosureExpr>(DC)) {
-    swift::typeCheckASTNodeAtLoc(CE->getParent(), CE->getLoc());
-    if (CE->getBodyState() != ClosureExpr::BodyState::ReadyForTypeChecking)
-      return false;
+    if (CE->getBodyState() == ClosureExpr::BodyState::Parsed) {
+      swift::typeCheckASTNodeAtLoc(CE->getParent(), CE->getLoc());
+      if (CE->getBodyState() != ClosureExpr::BodyState::ReadyForTypeChecking)
+        return false;
+    }
   }
 
   TypeChecker::typeCheckASTNode(finder.getRef(), DC,

--- a/validation-test/IDE/crashers_2_fixed/rdar69246891.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar69246891.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+class MyCls {
+  public init(body: (Int) throws -> Void) {}
+}
+
+func foo() {
+  MyCls { arg in
+    MyCls { #^COMPLETE^#
+    }
+  }
+}


### PR DESCRIPTION
Avoid re-typechecking for nested closures. For example:

```
  Something {
    Other {
      #^COMPLETE^#
    }
  }
```

If `Something` is successfully type checked but `Other` is failed, the outer closure has type, but the inner closure doesn't. In such state, when the type of `Other` is requested, the outer closure used to be re-typechecked. That may cause a crash because it may contain expressions CSGen doesn't expect.

rdar://problem/69246891
