### PR TITLE
[Parse] Remove unused declaration and diagnostic message

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1568,9 +1568,6 @@ ERROR(attr_specialize_unknown_parameter_name,none,
 ERROR(attr_specialize_expected_bool_value,none,
       "expected a boolean true or false value in '_specialize' attribute", ())
 
-WARNING(attr_specialize_export_true_no_op,none,
-        "'exported: true' has no effect in '_specialize' attribute", ())
-
 ERROR(attr_specialize_missing_parameter_label_or_where_clause,none,
       "expected a parameter label or a where clause in '_specialize' attribute", ())
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -624,7 +624,6 @@ bool Parser::parseSpecializeAttributeArguments(
                  ParamLabel);
       }
       if (ParamLabel == "exported") {
-        auto trueLoc = Tok.getLoc();
         bool isTrue = consumeIf(tok::kw_true);
         bool isFalse = consumeIf(tok::kw_false);
         if (!isTrue && !isFalse) {


### PR DESCRIPTION
Cleaning up a warning I had while working on other things. The diagnostic was added in #30962 (making export: true a noop) and partially removed in #32657 (adding support for export: true).