### PR TITLE
[DiagnosticsQol] Modify diagnostic macro into single DIAG

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -93,19 +93,13 @@ static_assert(sizeof(storedDiagnosticInfos) / sizeof(StoredDiagnosticInfo) ==
               "array size mismatch");
 
 static constexpr const char * const diagnosticStrings[] = {
-#define ERROR(ID, Options, Text, Signature) Text,
-#define WARNING(ID, Options, Text, Signature) Text,
-#define NOTE(ID, Options, Text, Signature) Text,
-#define REMARK(ID, Options, Text, Signature) Text,
+#define DIAG(KIND, ID, Options, Text, Signature) Text,
 #include "swift/AST/DiagnosticsAll.def"
     "<not a diagnostic>",
 };
 
 static constexpr const char *const debugDiagnosticStrings[] = {
-#define ERROR(ID, Options, Text, Signature) Text " [" #ID "]",
-#define WARNING(ID, Options, Text, Signature) Text " [" #ID "]",
-#define NOTE(ID, Options, Text, Signature) Text " [" #ID "]",
-#define REMARK(ID, Options, Text, Signature) Text " [" #ID "]",
+#define DIAG(KIND, ID, Options, Text, Signature) Text " [" #ID "]",
 #include "swift/AST/DiagnosticsAll.def"
     "<not a diagnostic>",
 };

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -78,14 +78,8 @@ enum LocalDiagID : uint32_t {
 
 // TODO: categorization
 static const constexpr StoredDiagnosticInfo storedDiagnosticInfos[] = {
-#define ERROR(ID, Options, Text, Signature)                                    \
-  StoredDiagnosticInfo(DiagnosticKind::Error, DiagnosticOptions::Options),
-#define WARNING(ID, Options, Text, Signature)                                  \
-  StoredDiagnosticInfo(DiagnosticKind::Warning, DiagnosticOptions::Options),
-#define NOTE(ID, Options, Text, Signature)                                     \
-  StoredDiagnosticInfo(DiagnosticKind::Note, DiagnosticOptions::Options),
-#define REMARK(ID, Options, Text, Signature)                                   \
-  StoredDiagnosticInfo(DiagnosticKind::Remark, DiagnosticOptions::Options),
+#define DIAG(KIND, ID, Options, Text, Signature)                               \
+  StoredDiagnosticInfo(KIND, DiagnosticOptions::Options),
 #include "swift/AST/DiagnosticsAll.def"
 };
 static_assert(sizeof(storedDiagnosticInfos) / sizeof(StoredDiagnosticInfo) ==

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -78,8 +78,14 @@ enum LocalDiagID : uint32_t {
 
 // TODO: categorization
 static const constexpr StoredDiagnosticInfo storedDiagnosticInfos[] = {
-#define DIAG(KIND, ID, Options, Text, Signature)                               \
-  StoredDiagnosticInfo(KIND, DiagnosticOptions::Options),
+#define ERROR(ID, Options, Text, Signature)                                    \
+  StoredDiagnosticInfo(DiagnosticKind::Error, DiagnosticOptions::Options),
+#define WARNING(ID, Options, Text, Signature)                                  \
+  StoredDiagnosticInfo(DiagnosticKind::Warning, DiagnosticOptions::Options),
+#define NOTE(ID, Options, Text, Signature)                                     \
+  StoredDiagnosticInfo(DiagnosticKind::Note, DiagnosticOptions::Options),
+#define REMARK(ID, Options, Text, Signature)                                   \
+  StoredDiagnosticInfo(DiagnosticKind::Remark, DiagnosticOptions::Options),
 #include "swift/AST/DiagnosticsAll.def"
 };
 static_assert(sizeof(storedDiagnosticInfos) / sizeof(StoredDiagnosticInfo) ==


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR addresses [SR-13774](https://bugs.swift.org/browse/SR-13774), which utilizes DefineDiagnosticMacros.h to shorten macro expansion (error, warning, note, remark) into DIAG.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13774.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
