### PR TITLE
[SR-13639][Diag] Don't diagnose local type declarations as unreachable

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -326,6 +326,11 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
           // Ignore all other implicit expressions.
           continue;
         }
+      } else if (auto D = ESD.dyn_cast<Decl*>()) {
+        // Local type declarations are not unreachable because they can appear
+        // after the declared type has already been used.
+        if (isa<TypeDecl>(D))
+          continue;
       }
       
       if (StmtType != UnknownStmtType) {

--- a/test/SILGen/local_types.swift
+++ b/test/SILGen/local_types.swift
@@ -4,7 +4,7 @@
 func function1() {
   return
 
-  class UnreachableClass {} // expected-warning {{code after 'return' will never be executed}}
+  class LocalClass {}
 }
 
 func function2() {
@@ -19,4 +19,4 @@ func function2() {
 
 // CHECK-LABEL: sil private [transparent] [ossa] @$s11local_types9function2yyFyycfU_1SL_V1xSivpfi : $@convention(thin) () -> Int
 
-// CHECK-LABEL: sil_vtable UnreachableClass
+// CHECK-LABEL: sil_vtable LocalClass

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-emit-sil %s -verify | %FileCheck %s
 
 func testUnreachableAfterReturn() -> Int {
   var x: Int = 3
@@ -144,5 +144,14 @@ func testUnreachableCatchClause() {
     print(error)
   } catch ErrorEnum.someError { // expected-warning {{case will never be executed}}
     print("some error")
+  }
+}
+
+func sr13639() -> Int {
+  return Foo.bar
+  struct Foo { // no-warning
+    static var bar = 0
+    // CHECK: sil private @$s16unreachable_code7sr13639SiyF3FooL_V7fooFuncyyF : $@convention(method) (Foo) -> ()
+    func fooFunc() {}
   }
 }


### PR DESCRIPTION
Local types can be used earlier within a scope than they were declared. We currently diagnose these type declarations as unreachable when they appear after a return, even though they may have been used prior to the return statement. This change stops that diagnostic.

Resolves [SR-13639](https://bugs.swift.org/browse/SR-13639), rdar://69845495

Note on local function declarations:
Currently we emit an unreachable code diagnostic when a function appears after a return statement. Because functions can't be used before they are declared (except inside of another local function), this is fine. However, if [the proposal to tweak local function scoping](https://forums.swift.org/t/clarify-scoping-behavior-with-local-functions/40558) were to be implemented, then we would similarly need to skip emitting a diagnostic here when a local function is defined after a return. 