### PR TITLE
[next] Update SourceBufferImporter to avoid getBuffer()

### DIFF
--- a/lib/ClangImporter/ClangSourceBufferImporter.cpp
+++ b/lib/ClangImporter/ClangSourceBufferImporter.cpp
@@ -39,20 +39,21 @@ SourceLoc ClangSourceBufferImporter::resolveSourceLocation(
   if (decomposedLoc.first.isInvalid())
     return loc;
 
-  auto buffer = clangSrcMgr.getBuffer(decomposedLoc.first);
+  auto clangFileID = decomposedLoc.first;
+  auto buffer = clangSrcMgr.getBufferOrFake(clangFileID);
   unsigned mirrorID;
 
-  auto mirrorIter = mirroredBuffers.find(buffer);
+  auto mirrorIter = mirroredBuffers.find(clangFileID);
   if (mirrorIter != mirroredBuffers.end()) {
     mirrorID = mirrorIter->second;
   } else {
     std::unique_ptr<llvm::MemoryBuffer> mirrorBuffer{
-      llvm::MemoryBuffer::getMemBuffer(buffer->getBuffer(),
-                                       buffer->getBufferIdentifier(),
+      llvm::MemoryBuffer::getMemBuffer(buffer.getBuffer(),
+                                       buffer.getBufferIdentifier(),
                                        /*RequiresNullTerminator=*/true)
     };
     mirrorID = swiftSourceManager.addNewSourceBuffer(std::move(mirrorBuffer));
-    mirroredBuffers[buffer] = mirrorID;
+    mirroredBuffers[clangFileID] = mirrorID;
   }
   loc = swiftSourceManager.getLocForOffset(mirrorID, decomposedLoc.second);
 

--- a/lib/ClangImporter/ClangSourceBufferImporter.h
+++ b/lib/ClangImporter/ClangSourceBufferImporter.h
@@ -44,7 +44,7 @@ class ClangSourceBufferImporter {
   // IntrusiveRefCntPtr to stay a ref-counting pointer.
   SmallVector<llvm::IntrusiveRefCntPtr<const clang::SourceManager>, 4>
     sourceManagersWithDiagnostics;
-  llvm::DenseMap<const llvm::MemoryBuffer *, unsigned> mirroredBuffers;
+  llvm::DenseMap<clang::FileID, unsigned> mirroredBuffers;
   SourceManager &swiftSourceManager;
 
 public:


### PR DESCRIPTION
This was recently removed from clang in https://reviews.llvm.org/D89427. Fixes rdar://70771582.

This PR doesn't fix all compilation failures in the next branch, but it should get us a little further into the Swift build.