### PR TITLE
[5.3] Fix a miscompile of global variables

### DIFF
--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -713,11 +713,6 @@ void SILGlobalOpt::reset() {
 
 void SILGlobalOpt::collect() {
   for (auto &F : *Module) {
-    // TODO: Add support for ownership.
-    if (F.hasOwnership()) {
-      continue;
-    }
-
     // Make sure to create an entry. This is important in case a global variable
     // (e.g. a public one) is not used inside the same module.
     if (F.isGlobalInit())

--- a/test/SILOptimizer/globalopt_ossa.sil
+++ b/test/SILOptimizer/globalopt_ossa.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+private var testGlobal: Int64
+
+sil_global private @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_token0 : $Builtin.Word
+
+sil_global private @$s4test10testGlobalSivp : $Int64
+
+sil private [ossa] @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_func0 : $@convention(c) () -> () {
+bb0:
+  alloc_global @$s4test10testGlobalSivp
+  %1 = global_addr @$s4test10testGlobalSivp : $*Int64
+  %2 = integer_literal $Builtin.Int64, 27
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil hidden [global_init] [ossa] @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_token0 : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_func0 : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$s4test10testGlobalSivp : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil [ossa] @dont_propagate_global_with_multiple_writes
+// CHECK:   [[V:%[0-9]+]] = load
+// CHECK:   return [[V]]
+// CHECK: } // end sil function 'dont_propagate_global_with_multiple_writes'
+sil [ossa] @dont_propagate_global_with_multiple_writes : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Int64
+  %5 = integer_literal $Builtin.Int64, 42
+  %6 = struct $Int64 (%5 : $Builtin.Int64)
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int64
+  store %6 to [trivial] %7 : $*Int64
+  end_access %7 : $*Int64
+  %33 = begin_access [read] [dynamic] [no_nested_conflict] %4 : $*Int64
+  %35 = load [trivial] %33 : $*Int64
+  end_access %33 : $*Int64
+  return %35 : $Int64
+}
+

--- a/test/SILOptimizer/globalopt_trivial_nontrivial.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial.sil
@@ -1,0 +1,133 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+
+// This tests GlobalOpt of a trivial global variable
+// Loads of trivial global variable initialized with a constant is replaced with the constant in GlobalOpt
+// This also tests GlobalOpt to be a no-op for a non-trivial global variable used in the same way
+// The difference in GlobalOpt for trivial v/s non-trivial values is shown in $bartrivial and $barnontrivial
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public struct TStruct {
+  let x: Int32
+  init(x: Int32)
+}
+
+let trivialglobal: TStruct
+
+public class TClass {
+  final let x: Int32
+  init(x: Int32)
+  deinit
+}
+
+let nontrivialglobal: TClass
+
+// CHECK-LABEL: sil_global hidden [let] @$trivialglobal : $TStruct = {
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  %initval = struct $TStruct ([[INT]] : $Int32)
+sil_global private @globalinit_trivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$trivialglobal : $TStruct
+
+sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$nontrivialglobal : $TClass
+
+sil private @globalinit_trivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$trivialglobal 
+  %1 = global_addr @$trivialglobal : $*TStruct 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = struct $TStruct (%3 : $Int32)              
+  store %4 to %1 : $*TStruct                      
+  %6 = tuple ()                                   
+  return %6 : $()                                 
+}
+
+// CHECK-LABEL: sil hidden [global_init] @$trivialglobal_unsafemutableaddressor :
+// CHECK: [[GLOBL:%.*]] = global_addr @$trivialglobal : $*TStruct
+// CHECK: [[GLOBL_ADDR:%.*]] = address_to_pointer [[GLOBL]] : $*TStruct to $Builtin.RawPointer
+// CHECK:  return [[GLOBL_ADDR]] : $Builtin.RawPointer
+// CHECK: } // end sil function '$trivialglobal_unsafemutableaddressor'
+sil hidden [global_init] @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_trivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_trivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$trivialglobal : $*TStruct 
+  %5 = address_to_pointer %4 : $*TStruct to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// $bartrivial's access to the trivial global variable via the accessor is optimized to the rhs of the init value 
+
+// CHECK-LABEL: sil hidden [noinline] @$bartrivial :
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  return [[INT]] : $Int32
+// CHECK-LABEL: } // end sil function '$bartrivial'
+sil hidden [noinline] @$bartrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TStruct 
+  %3 = struct_element_addr %2 : $*TStruct, #TStruct.x 
+  %4 = load %3 : $*Int32                          
+  return %4 : $Int32                              
+}
+
+// CHECK-LABEL: sil private @globalinit_nontrivialglobal_func :
+// CHECK: alloc_global @$nontrivialglobal 
+// CHECK: [[GLOBL_ADDR:%.*]] = global_addr @$nontrivialglobal : $*TClass 
+// CHECK: [[REF:%.*]] = alloc_ref $TClass                          
+// CHECK: store [[REF]] to [[GLOBL_ADDR]] : $*TClass 
+// CHECK: } // end sil function 'globalinit_nontrivialglobal_func'
+sil private @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$nontrivialglobal 
+  %1 = global_addr @$nontrivialglobal : $*TClass 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = alloc_ref $TClass                          
+  %7 = ref_element_addr %4 : $TClass, #TClass.x   
+  store %3 to %7 : $*Int32                        
+  store %4 to %1 : $*TClass                       
+  %10 = tuple ()                                  
+  return %10 : $()                                
+}
+
+sil hidden [global_init] @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_nontrivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_nontrivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$nontrivialglobal : $*TClass 
+  %5 = address_to_pointer %4 : $*TClass to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// $barnontrivial's access to the non-trivial global variable does not get optimized away 
+
+// CHECK-LABEL: sil hidden [noinline] @$barnontrivial :
+// CHECK: [[FUNC_REF:%.*]] = function_ref @$nontrivialglobal_unsafemutableaccessor :
+// CHECK: [[APPLY:%.*]] = apply [[FUNC_REF]]() :
+// CHECK-LABEL: } // end sil function '$barnontrivial'
+sil hidden [noinline] @$barnontrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TClass 
+  %3 = load %2 : $*TClass                         
+  %4 = ref_element_addr %3 : $TClass, #TClass.x   
+  %5 = load %4 : $*Int32                          
+  return %5 : $Int32                              
+}
+

--- a/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
@@ -1,0 +1,128 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public struct TStruct {
+  let x: Int32
+  init(x: Int32)
+}
+
+let trivialglobal: TStruct
+
+public class TClass {
+  final let x: Int32
+  init(x: Int32)
+  deinit
+}
+
+let nontrivialglobal: TClass
+
+// CHECK-LABEL: sil_global hidden [let] @$trivialglobal : $TStruct = {
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  %initval = struct $TStruct ([[INT]] : $Int32)
+sil_global private @globalinit_trivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$trivialglobal : $TStruct
+
+sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$nontrivialglobal : $TClass
+
+sil private [ossa] @globalinit_trivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$trivialglobal 
+  %1 = global_addr @$trivialglobal : $*TStruct 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = struct $TStruct (%3 : $Int32)              
+  store %4 to [trivial] %1 : $*TStruct                      
+  %6 = tuple ()                                   
+  return %6 : $()                                 
+}
+
+// CHECK-LABEL: sil hidden [global_init] [ossa] @$trivialglobal_unsafemutableaddressor :
+// CHECK: [[GLOBL:%.*]] = global_addr @$trivialglobal : $*TStruct
+// CHECK: [[GLOBL_ADDR:%.*]] = address_to_pointer [[GLOBL]] : $*TStruct to $Builtin.RawPointer
+// CHECK:  return [[GLOBL_ADDR]] : $Builtin.RawPointer
+// CHECK: } // end sil function '$trivialglobal_unsafemutableaddressor'
+sil hidden [global_init] [ossa] @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_trivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_trivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$trivialglobal : $*TStruct 
+  %5 = address_to_pointer %4 : $*TStruct to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// CHECK-LABEL: sil hidden [noinline] [ossa] @$bartrivial :
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  return [[INT]] : $Int32
+// CHECK-LABEL: } // end sil function '$bartrivial'
+sil hidden [noinline] [ossa] @$bartrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TStruct 
+  %3 = struct_element_addr %2 : $*TStruct, #TStruct.x 
+  %4 = load [trivial] %3 : $*Int32                          
+  return %4 : $Int32                              
+}
+
+// CHECK-LABEL: sil private [ossa] @globalinit_nontrivialglobal_func :
+// CHECK: alloc_global @$nontrivialglobal 
+// CHECK: [[GLOBL_ADDR:%.*]] = global_addr @$nontrivialglobal : $*TClass 
+// CHECK: [[REF:%.*]] = alloc_ref $TClass                          
+// CHECK: store [[REF]] to [init] [[GLOBL_ADDR]] : $*TClass 
+// CHECK: } // end sil function 'globalinit_nontrivialglobal_func'
+sil private [ossa] @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$nontrivialglobal 
+  %1 = global_addr @$nontrivialglobal : $*TClass 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = alloc_ref $TClass
+  %5 = begin_borrow %4 : $TClass                          
+  %6 = ref_element_addr %5 : $TClass, #TClass.x
+  store %3 to [trivial] %6 : $*Int32                        
+  end_borrow %5 : $TClass   
+  store %4 to [init] %1 : $*TClass                       
+  %10 = tuple ()                                  
+  return %10 : $()                                
+}
+
+sil hidden [global_init] [ossa] @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_nontrivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_nontrivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$nontrivialglobal : $*TClass 
+  %5 = address_to_pointer %4 : $*TClass to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// CHECK-LABEL: sil hidden [noinline] [ossa] @$barnontrivial :
+// CHECK: [[FUNC_REF:%.*]] = function_ref @$nontrivialglobal_unsafemutableaccessor :
+// CHECK: [[APPLY:%.*]] = apply [[FUNC_REF]]() :
+// CHECK-LABEL: } // end sil function '$barnontrivial'
+sil hidden [noinline] [ossa] @$barnontrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TClass 
+  %3 = load [copy] %2 : $*TClass                         
+  %3b = begin_borrow %3 : $TClass                          
+  %4 = ref_element_addr %3b : $TClass, #TClass.x
+  %5 = load [trivial] %4 : $*Int32 
+  end_borrow %3b : $TClass
+  destroy_value %3 : $TClass 
+  return %5 : $Int32                              
+}
+


### PR DESCRIPTION
This is a cherry pick of https://github.com/apple/swift/pull/32621

What we didn't know in the original PR is that it's actually fixing a bad miscompile in GlobalOpt, which was introduced in swift 5.1 by https://github.com/apple/swift/pull/22967.

* Radar: rdar://problem/70399912, Jira: https://bugs.swift.org/browse/SR-13748

* Explanation: In case a function is in ownership-SSA form, the global-variable-optimization skipped checking for accesses to global variables. This can lead to constant propagating a global variable (e.g. if it's an Int), even if there are multiple writes with different values to that variable. The weird thing is that we fixed the bug on the main branch since a while - without knowing that the change is actually a bug fix.

* Scope: The bug was introduced in Swift 5.1. It can result in miscompiles if an internal or private global (or static) variable is set to different constant values at multiple locations in the source code.

* Risk: Low. The bug was fixed on main since a while and the compiler tested since then. Also, the code change is trivial.

* Reviewer: @meg-gupta