### PR TITLE
 Add -allow-critical-edges flag.

### DIFF
--- a/test/SILOptimizer/copyforward_ossa.sil
+++ b/test/SILOptimizer/copyforward_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt  -enable-sil-verify-all %s -copy-forwarding -enable-copyforwarding -enable-destroyhoisting | %FileCheck %s
+// RUN: %target-sil-opt  -enable-sil-verify-all %s -copy-forwarding -enable-copyforwarding -enable-destroyhoisting -allow-critical-edges=false | %FileCheck %s
 
 // This is the ossa version of CopyForwarding tests
 sil_stage raw
@@ -209,9 +209,12 @@ bb1:                                              // Preds: bb0
   copy_addr %0 to [initialization] %5 : $*T     // id: %6
   %7 = apply %4<T>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %5 : $*T         // id: %8
-  br bb2                                          // id: %9
+  br bb3                                          // id: %9
 
-bb2:                                              // Preds: bb0 bb1
+bb2:
+  br bb3
+
+bb3:                                              // Preds: bb0 bb1
   destroy_addr %0 : $*T                           // id: %10
   %11 = tuple ()                                  // user: %12
   return %11 : $()                                // id: %12


### PR DESCRIPTION
Provide a mechanism to gradually migrate unit tests away from allowing
critical edges via -allow-critical-edges=false.

This will be the default in OSSA very soon, and will hopefully become
the default eventually for all SIL stages.

Note that not all required optimization pass changes have been
committed yet. I have pending changes in:
- SimplifyCFG
- SILCloner subclasses
- EagerSpecializer
- ArraySpecialization
- LoopUtils
- LoopRotate

There are multiple reasons we need to disallow critical edges:

1. Most passes do not perform CFG transformations. However, we often
need to split critical edges and remember to invalidate all SIL
analyses at the end of virtually every pass. This is very innefficient
and highly bug prone.

2. Many SIL analysis algorithms needs to reason about CFG
edges. Avoiding critical edges leads to far simpler and more efficient
designs when edges can be identified by blocks.

3. Handling block arguments on conditional branches create complexity
at the lowest level of the SIL interface. This complexity is difficult
to abstract over and bleeds until any algorithm that needs to reason
about phi operands. It's far easier to work with phis if we can easily
recover the phi operand with only a reference to the predecessor
block.

4. Attempting to preserve critical edges in high and mid level IR
blocks optimizations that otherwise have no business optimizing
branches. Branch optimization should always be defered to machine
level IR where the most relevant heuristics are employed to remove
unconditional branches. If code didn't need to be placed on a critical
edges, then a branch optimization can easily remove that code from the
critical edge.