### PR TITLE
Sema: Ban references to protocol extension members with opaque result types on an existential base

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4795,6 +4795,11 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
     return info;
   }
 
+  // Opaque result types of protocol extension members contain an invariant
+  // reference to 'Self'.
+  if (type->is<OpaqueTypeArchetypeType>())
+    return SelfReferenceInfo::forSelfRef(SelfReferencePosition::Invariant);
+
   // A direct reference to 'Self'.
   if (proto->getSelfInterfaceType()->isEqual(type))
     return SelfReferenceInfo::forSelfRef(position);

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -485,3 +485,28 @@ protocol SomeProtocolA {}
 protocol SomeProtocolB {}
 struct SomeStructC: SomeProtocolA, SomeProtocolB {}
 let someProperty: SomeProtocolA & some SomeProtocolB = SomeStructC() // expected-error {{'some' should appear at the beginning of a composition}}{{35-40=}}{{19-19=some }}
+
+// An opaque result type on a protocol extension member effectively
+// contains an invariant reference to 'Self', and therefore cannot
+// be referenced on an existential type.
+
+protocol OpaqueProtocol {}
+extension OpaqueProtocol {
+  var asSome: some OpaqueProtocol { return self }
+  func getAsSome() -> some OpaqueProtocol { return self }
+  subscript(_: Int) -> some OpaqueProtocol { return self }
+}
+
+func takesOpaqueProtocol(existential: OpaqueProtocol) {
+  // this is not allowed:
+  _ = existential.asSome // expected-error{{member 'asSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
+  _ = existential.getAsSome() // expected-error{{member 'getAsSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
+  _ = existential[0] // expected-error{{member 'subscript' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
+}
+
+func takesOpaqueProtocol<T : OpaqueProtocol>(generic: T) {
+  // these are all OK:
+  _ = generic.asSome
+  _ = generic.getAsSome()
+  _ = generic[0]
+}


### PR DESCRIPTION
The substituted type of the member reference is an OpaqueTypeArchetypeType
whose substitution map sends Self to the opened existential type for the
base value. Sema erases opened existential types to their upper bound, but
this is not a valid transformation in this case, because the 'Self' type
reference is invariant. Calling this member on two different existential
values would produce the same erased type, but this is wrong, because
it actually depends on the concrete type stored in the existential.

Fixes <https://bugs.swift.org/browse/SR-13419>, <rdar://problem/67451810>.
