### PR TITLE
[Concurrency] Only auto-import _Concurrency when auto-importing Swift.

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -763,7 +763,15 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
   }
 
   if (Invocation.shouldImportSwiftConcurrency()) {
-    pushImport(SWIFT_CONCURRENCY_NAME);
+    switch (imports.StdlibKind) {
+    case ImplicitStdlibKind::Builtin:
+    case ImplicitStdlibKind::None:
+      break;
+
+    case ImplicitStdlibKind::Stdlib:
+      pushImport(SWIFT_CONCURRENCY_NAME);
+      break;
+    }
   }
 
   imports.ShouldImportUnderlyingModule = frontendOpts.ImportUnderlyingModule;

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
 

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
 

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
 

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-generic-to-void.sil
+++ b/test/IRGen/async/run-call-generic-to-void.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printBool : $@convention(thin) (Bool) -> ()
 

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -15,6 +15,8 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
+
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
 

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-to-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64.sil
@@ -15,6 +15,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt32 : $@convention(thin) (Int32) -> ()

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 

--- a/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
@@ -14,6 +14,7 @@
 import Builtin
 import Swift
 import PrintShims
+import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()


### PR DESCRIPTION
This allows the standard library to build with concurrency enabled.
Fixes rdar://70700689.
