### PR TITLE
Rewrite SimplifyCFG trampoline removal to generalize it (avoid critical edges as a side-effect)

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5025,8 +5025,11 @@ public:
           SILValue op = i.getOperand(0);
           require(!state.Stack.empty(),
                   "stack dealloc with empty stack");
-          require(op == state.Stack.back(),
-                  "stack dealloc does not match most recent stack alloc");
+          if (op != state.Stack.back()) {
+            llvm::errs() << "Recent stack alloc: " << *state.Stack.back();
+            require(op == state.Stack.back(),
+                    "stack dealloc does not match most recent stack alloc");
+          }
           state.Stack.pop_back();
 
         } else if (isa<BeginAccessInst>(i) || isa<BeginApplyInst>(i)) {

--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1148,19 +1148,21 @@ sil [_semantics "array.check_subscript"] @checkbounds3 : $@convention(method) (I
 
 // CHECK-LABEL: sil @rangeCheck
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb2, bb1
+// CHECK:   cond_br {{.*}}, bb1, bb2
 // CHECK: bb1
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK:   br bb3
 // CHECK: bb2
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:   br bb4
+// CHECK: bb3
 // CHECK:   return
-// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
+// CHECK: bb4([[IV:%.*]] : $Builtin.Int64):
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb2, bb4
-// CHECK: bb4:
-// CHECK:   br bb3
+// CHECK:   cond_br {{.*}}, bb6, bb5
+// CHECK: bb5:
+// CHECK:   br bb4
 // CHECK: }
 sil @rangeCheck : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):
@@ -1197,21 +1199,23 @@ bb3(%15 : $Builtin.Int64):
 
 // CHECK-LABEL: sil @rangeCheck2
 // CHECK: bb0
-// CHECK:   cond_br {{.*}}, bb2, bb1
+// CHECK:   cond_br {{.*}}, bb1, bb2
 // CHECK: bb1
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK:   br bb3
 // CHECK: bb2
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:   br bb4
+// CHECK: bb3
 // CHECK:   return
-// CHECK: bb3([[IV:%.*]] : $Builtin.Int64):
+// CHECK: bb4([[IV:%.*]] : $Builtin.Int64):
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "xor_Int1"([[TRUE]]
 // CHECK:   builtin "or_Int1"([[FALSE]]
 // CHECK:   cond_fail
-// CHECK:   cond_br {{.*}}, bb2, bb4
-// CHECK: bb4:
-// CHECK:   br bb3
+// CHECK:   cond_br {{.*}}, bb6, bb5
+// CHECK: bb5:
+// CHECK:   br bb4
 // CHECK: }
 sil @rangeCheck2 : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int64):

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -453,18 +453,16 @@ bb5(%6 : $Int64):
   return %6 : $Int64
 }
 
-// Make sure that a conditional branch to a trampoline without parameters
-// gets eliminated by branching to a target of this trampoline.
+// Eliminate the trampoline from from a cond_br at bb5->bb3->bb4/
+// This becomes a cond_br at bb8->bb5
 // CHECK-LABEL: @elim_trampoline5
 // CHECK: cond_br
-// CHECK: bb3:
-// CHECK: cond_br
-// CHECK: bb4{{.*}}:
-// Last cond_br should branch directly to the target of a trampoline
-// instead of the original bb3
-// CHECK: cond_br {{.*}}, bb3, bb5
 // CHECK: bb5:
-// CHECK-NEXT: br bb4
+// CHECK: cond_br
+// CHECK: bb8{{.*}}:
+// CHECK: cond_br {{.*}}, bb5, bb9
+// CHECK: bb9:
+// CHECK-NEXT: br bb8
 // CHECK: }
 sil @elim_trampoline5 : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
@@ -1381,18 +1379,20 @@ bb3:
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum3
+// CHECK: [[ONE:%.*]] = integer_literal $Builtin.Int32, 2
+// CHECK: [[ONEVAL:%.*]] = struct $Int32 ([[ONE]] : $Builtin.Int32)
+// CHECK: [[THREE:%.*]] = integer_literal $Builtin.Int32, 3
+// CHECK: [[THREEVAL:%.*]] = struct $Int32 ([[THREE]] : $Builtin.Int32)
 // CHECK: switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb2, case #Optional.some!enumelt: bb1
 // CHECK: bb1:
-// CHECK-NEXT: br bb5
+// CHECK-NEXT: br bb5([[ONEVAL]]
 // CHECK: bb2:
-// CHECK-NEXT: switch_enum
+// CHECK-NEXT: switch_enum undef : $Optional<Int32>, case #Optional.none!enumelt: bb3, case #Optional.some!enumelt: bb4
 // CHECK: bb3:
-// CHECK-NEXT: br bb5
+// CHECK-NEXT: br bb5([[THREEVAL]]
 // CHECK: bb4:
-// CHECK-NEXT: br bb6
-// CHECK: bb5:
-// CHECK-NEXT: br bb6
-// CHECK: bb6({{.*}}):
+// CHECK-NEXT: br bb5([[ONEVAL]]
+// CHECK: bb5
 // CHECK-NEXT: return
 sil @jumpthread_switch_enum3 : $@convention(thin) (Optional<Int32>) -> Int32 {
 bb0(%0 : $Optional<Int32>):
@@ -1837,7 +1837,7 @@ bb2:
 
 // CHECK-LABEL: sil @dont_remove_cond_fail_wrong_const
 // CHECK:      bb0(%0 : $Builtin.Int1):
-// CHECK-NEXT:   cond_br %0, bb1, bb2
+// CHECK-NEXT:   cond_br %0, bb2, bb1
 sil @dont_remove_cond_fail_wrong_const : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   cond_br %0, bb1, bb2
@@ -1930,7 +1930,7 @@ bb3:
 // CHECK-LABEL: sil @dont_remove_cond_fail_same_cond_in_false
 // CHECK: bb0([[COND:%[0-9]*]]
 // CHECK-NEXT: cond_br
-// CHECK: bb1:
+// CHECK: bb2:
 // CHECK-NEXT: cond_fail [[COND]]
 // CHECK: return
 sil @dont_remove_cond_fail_same_cond_in_false : $@convention(thin)(Builtin.Int1, Builtin.Int1) -> () {
@@ -2051,13 +2051,13 @@ bb3(%a3 : $Builtin.Int1):
 // CHECK:      bb1:
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   integer_literal
-// CHECK-NEXT:   br bb4
+// CHECK-NEXT:   br bb5
 // CHECK:      bb2:
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   cond_br
 // CHECK:      bb3:
-// CHECK:        br bb4
-// CHECK:      bb4({{.*}}):
+// CHECK:        br bb6
+// CHECK:      bb5({{.*}}):
 // CHECK-NEXT:   apply
 // CHECK-NEXT:   cond_fail
 sil @dont_move_cond_fail_no_postdom : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
@@ -2202,19 +2202,19 @@ bb3 (%10: $Builtin.Int32):
 
 // CHECK-LABEL: sil @thread_objc_method_call_succ_block
 // CHECK: bb0
-// CHECK:  cond_br {{.*}}, bb1, bb2
+// CHECK:  cond_br {{.*}}, bb1, bb3
 // CHECK: bb1
 // CHECK:  objc_method
 // CHECK:  apply
 // CHECK:  strong_release
-// CHECK:  cond_br {{.*}}, bb3, bb4
-// CHECK: bb2
-// CHECK:  strong_release
-// CHECK:  cond_br {{.*}}, bb3, bb4
+// CHECK:  cond_br {{.*}}, bb2, bb6
 // CHECK: bb3
+// CHECK:  strong_release
+// CHECK:  cond_br {{.*}}, bb5, bb4
+// CHECK: bb7
 // CHECK:  cond_fail
-// CHECK:  br bb4
-// CHECK: bb4:
+// CHECK:  br bb8
+// CHECK: bb8:
 // CHECK:  strong_release
 // CHECK:  return
 
@@ -2248,20 +2248,20 @@ sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK: bb1:
 // CHECK:  [[INVADD:%.*]] = builtin "sadd
 // CHECK:  [[EXT:%.*]] = tuple_extract [[INVADD]]
-// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb2
+// CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb3
 
-// CHECK: bb2{{.*}}
-// CHECK:  br bb4({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
+// CHECK: bb3{{.*}}
+// CHECK:  br bb5({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
 
-// CHECK: bb4({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
+// CHECK: bb5({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
 // CHECK:  [[F:%.*]] = function_ref @f
 // CHECK:  apply [[F]]([[CUR]])
-// CHECK:  cond_br {{.*}}, bb5, bb6
+// CHECK:  cond_br {{.*}}, bb7, bb6
 
-// CHECK: bb5:
+// CHECK: bb7:
 // CHECK:   [[VARADD:%.*]] = builtin "sadd_with_overflow_Int32"([[NEXT]] : $Builtin.Int32
 // CHECK:   [[NEXT2:%.*]] = tuple_extract [[VARADD]]
-// CHECK:   br bb4({{.*}} : $Builtin.Int32, [[NEXT]] : $Builtin.Int32, [[NEXT2]]
+// CHECK:   br bb5({{.*}} : $Builtin.Int32, [[NEXT]] : $Builtin.Int32, [[NEXT2]]
 
 
 sil @switch_enum_jumpthreading_bug : $@convention(thin) (Optional<Builtin.Int32>, Builtin.Int1, Builtin.Int32, Builtin.Int1) -> Builtin.Int32 {
@@ -3047,7 +3047,7 @@ bb3(%11 : $String):
 // CHECK-LABEL: sil @dont_hang
 // CHECK:      bb6:
 // CHECK:        integer_literal $Builtin.Int64, 1
-// CHECK-NEXT:   br bb5
+// CHECK-NEXT:   br bb6
 // CHECK-NEXT: }
 sil @dont_hang : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/simplify_cfg_address_phi.sil
+++ b/test/SILOptimizer/simplify_cfg_address_phi.sil
@@ -148,7 +148,7 @@ sil @useAny : $@convention(thin) <V> (@in_guaranteed V) -> ()
 // CHECK: apply %{{.*}}<S>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK: [[FIELD:%.*]] = ref_element_addr %1 : $CC<R>, #CC.r
 // CHECK: debug_value_addr [[FIELD]] : $*R, let, name "u"
-// CHECK: apply %10<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply %{{.*}}<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK-LABEL: } // end sil function 'testDebugValue'
 sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
 bb0(%0 : $*S, %1 : $CC<R>, %2 : $Bool):

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -61,7 +61,7 @@ bb3(%35 : $()):                                   // Preds: bb2
 
 //CHECK-LABEL: remove_dead_args
 //CHECK-NOT: br bb2([[VAR_21:%[0-9]+]] : $Bool)
-//CHECK: bb2:
+//CHECK: bb3:
 //CHECK-NEXT: tuple ()
 //CHECK-NEXT: return
 sil @remove_dead_args: $@convention(thin) (Int32) -> () {
@@ -723,3 +723,92 @@ bb10(%18 : $Builtin.Int1):                        // Preds: bb2 bb5 bb9
   return %19 : $Bool                              // id: %19
 }
 
+// --- Test simplifyArguments; unwrap enum argument
+// This optimization should not be defeated by the existence of other
+// (unrelated) block arguments
+struct Payload {
+  init()
+}
+
+enum MyEnum {
+  case payload(Payload)
+}
+
+enum ThreeWay {
+  case one
+  case two
+  case three
+  @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: ThreeWay, _ b: ThreeWay) -> Bool
+  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
+}
+
+// CHECK-LABEL: sil hidden [noinline] @testUnwrapEnumArg : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   br bb1(undef : $Builtin.Int64, %{{.*}} : $Payload)
+// CHECK: bb1(%{{.*}} : $Builtin.Int64, %{{.*}} : $Payload):
+// CHECK:   alloc_stack $Payload
+// CHECK:   switch_enum undef : $ThreeWay, case #ThreeWay.one!enumelt: bb4, case #ThreeWay.two!enumelt: bb2, case #ThreeWay.three!enumelt: bb3
+// CHECK: bb2:
+// CHECK:   [[P2:%.*]] = load %{{.*}} : $*Payload
+// CHECK:   enum $MyEnum, #MyEnum.payload!enumelt, [[P2]] : $Payload
+// CHECK:   dealloc_stack %{{.*}} : $*Payload
+// CHECK:   br bb1(undef : $Builtin.Int64, [[P2]] : $Payload)
+// CHECK: bb3:
+// CHECK:   [[P3:%.*]] = load %{{.*}} : $*Payload
+// CHECK:   enum $MyEnum, #MyEnum.payload!enumelt, [[P3]] : $Payload
+// CHECK:   dealloc_stack %{{.*}} : $*Payload
+// CHECK:   br bb7
+// CHECK: bb4:
+// CHECK:   [[P4:%.*]] = load %{{.*}} : $*Payload
+// CHECK:   enum $MyEnum, #MyEnum.payload!enumelt, [[P4]] : $Payload
+// CHECK:   dealloc_stack %{{.*}} : $*Payload
+// CHECK:   cond_br undef, bb5, bb6
+// CHECK: bb5:
+// CHECK:   br bb7
+// CHECK: bb6:
+// CHECK:   br bb1(undef : $Builtin.Int64, [[P4]] : $Payload)
+// CHECK: bb7:
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'testUnwrapEnumArg'
+sil hidden [noinline] @testUnwrapEnumArg : $@convention(thin) () -> () {
+bb0:
+  %0 = struct $Payload (undef : $_UIntBuffer<UInt8>)
+  %1 = enum $MyEnum, #MyEnum.payload!enumelt, %0 : $Payload
+  br bb1(undef : $Builtin.Int64, %1 : $MyEnum)
+
+bb1(%3 : $Builtin.Int64, %4 : $MyEnum):
+  %5 = alloc_stack $Payload
+  %6 = unchecked_enum_data %4 : $MyEnum, #MyEnum.payload!enumelt
+  store %6 to %5 : $*Payload
+  %8 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, undef : $Builtin.Int64) : $Builtin.Int1
+  switch_enum undef : $ThreeWay, case #ThreeWay.one!enumelt: bb4, case #ThreeWay.two!enumelt: bb2, case #ThreeWay.three!enumelt: bb3
+
+bb2:
+  %10 = load %5 : $*Payload
+  %11 = enum $MyEnum, #MyEnum.payload!enumelt, %10 : $Payload
+  dealloc_stack %5 : $*Payload
+  br bb6(%11 : $MyEnum)
+
+bb3:
+  %14 = load %5 : $*Payload
+  %15 = enum $MyEnum, #MyEnum.payload!enumelt, %14 : $Payload
+  dealloc_stack %5 : $*Payload
+  br bb7
+
+bb4:
+  %18 = load %5 : $*Payload
+  %19 = enum $MyEnum, #MyEnum.payload!enumelt, %18 : $Payload
+  dealloc_stack %5 : $*Payload
+  cond_br undef, bb7, bb5
+
+bb5:
+  br bb6(%19 : $MyEnum)
+
+bb6(%23 : $MyEnum):
+  br bb1(undef : $Builtin.Int64, %23 : $MyEnum)
+
+bb7:
+  %25 = tuple ()
+  return %25 : $()
+}

--- a/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_jump_thread_crash.sil
@@ -7,7 +7,7 @@ import Swift
 import SwiftShims
 
 // CHECK-LABEL: sil @test_jump_threading
-// CHECK: bb4(%{{[0-9]+}} : $Builtin.Int64):
+// CHECK: bb5(%{{[0-9]+}} : $Builtin.Int64):
 // CHECK-NEXT: br bb1
 sil @test_jump_threading : $@convention(thin)  (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):


### PR DESCRIPTION
Avoid introducing new critical edges. Passes will end up resplitting
them, forcing SimplifyCFG to continually rerun. Also, we want to allow
SIL utilities to assume no critical edges, and avoid the need for
several passes to internally split edges and modify the CFG for no
reason.

Also, handle arbitrary block arguments which may be trivial and
unrelated to the real optimizations that trampoline removal exposes,
such as "unwrapping" enumeration-type arguments.

The previous code was an example of how to write an unstable
optimization. It could be defeated by other code in the function that
isn't directly related to the SSA graph being optimized. In general,
when an optimization can be defeated by unrelated code in the
function, that leads to instability which can be very hard to track
down (I spent multiple full days on this one). In this case, we have
enum-type branch args which need to be simplified by unwrapping
them. But, the existence of a trivial and entirely unrelated block
argument would defeat the optimization.