### PR TITLE
[presets] Introduce slimmer preset for lldb sanitizer testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -486,6 +486,47 @@ skip-test-watchos
 enable-asan
 enable-ubsan
 
+[preset: buildbot_incremental,lldb_asan_ubsan]
+mixin-preset=buildbot_incremental_base
+
+build-subdir=buildbot_incremental_lldb_asan_ubsan
+
+# Build a sanitized lldb. Don't build a sanitized clang/swift.
+lldb
+lldb-extra-cmake-args=-DLLVM_USE_SANITIZER=Address;Undefined
+
+# Build Release with debug info, so that we can symbolicate backtraces.
+release-debuginfo
+assertions
+
+# We need to build an unoptimized swift benchmark driver for stepper testing.
+# Ditto for the swift stdlib. (LLDB doesn't support stepping through optimized
+# swift code yet.)
+extra-cmake-options=-DSWIFT_BENCHMARK_UNOPTIMIZED_DRIVER:BOOL=1
+debug-swift-stdlib
+
+# Disable non-x86 building/testing.
+skip-build-ios
+skip-test-ios
+skip-build-tvos
+skip-test-tvos
+skip-build-watchos
+skip-test-watchos
+stdlib-deployment-targets=macosx-x86_64
+swift-primary-variant-sdk=OSX
+swift-primary-variant-arch=x86_64
+skip-test-swift
+skip-test-swiftpm
+skip-test-swift-driver
+skip-test-llbuild
+skip-test-cmark
+skip-test-playgroundsupport
+skip-test-swiftsyntax
+skip-test-skstresstester
+skip-test-swiftevolve
+indexstore-db=0
+sourcekit-lsp=0
+
 [preset: buildbot_incremental_asan,tools=DA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms
 


### PR DESCRIPTION
Add a new "buildbot_incremental,lldb_asan_ubsan" preset.

This differs from the existing "buildbot_incremental_asan_ubsan,tools=RDA,stdlib=RDA"
preset in the following ways:

- It builds the swift benchmarks, with an unoptimized benchmark driver.
  This is to enable stepper testing on CI. For more context, see:
  https://github.com/apple/llvm-project/pull/2059.

- It does not build a sanitized clang or swift. This can save a lot of
  time, and make reports from oss-lldb-asan bots more actionable.
  It also cuts down on redundant work, since clang & swift already have
  sanitizer bots. This does trade away some sanitized test coverage.

rdar://69589638
