### PR TITLE
SIL: Look through SILBoxType when checking for invalid non-escaping function value captures

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -289,6 +289,22 @@ static void diagnoseCaptureLoc(ASTContext &Context, DeclContext *DC,
   }
 }
 
+static bool isNonEscapingFunctionValue(SILValue value) {
+  auto type = value->getType().getASTType();
+
+  // Look through box types to handle mutable 'var' bindings.
+  if (auto boxType = dyn_cast<SILBoxType>(type)) {
+    for (auto field : boxType->getLayout()->getFields()) {
+      if (field.getLoweredType()->isNoEscape())
+        return true;
+    }
+
+    return false;
+  }
+
+  return type->isNoEscape();
+}
+
 // Diagnose this partial_apply if it captures a non-escaping value and has
 // an escaping use.
 static void checkPartialApply(ASTContext &Context, DeclContext *DC,
@@ -314,9 +330,8 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
 
     // Captures of noescape function types or tuples containing noescape
     // function types cannot escape.
-    if (value->getType().getASTType()->isNoEscape()) {
+    if (isNonEscapingFunctionValue(value))
       noEscapeCaptures.push_back(&oper);
-    }
   }
 
   // A partial_apply without non-escaping captures is always valid.
@@ -416,7 +431,7 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
 static void checkApply(ASTContext &Context, FullApplySite site) {
   auto isNoEscapeParam = [&](SILValue value) -> const ParamDecl * {
     // If the value is an escaping, do not enforce any restrictions.
-    if (!value->getType().getASTType()->isNoEscape())
+    if (!isNonEscapingFunctionValue(value))
       return nullptr;
 
     // If the value is not a function parameter, do not enforce any restrictions.

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -247,3 +247,12 @@ struct S {
       // expected-note@-2 {{pass a copy of 'self'}}
   }
 }
+
+// Test that we look through the SILBoxType used for a 'var' binding
+func badNoEscapeCaptureThroughVar(_ fn: () -> ()) {
+  var myFunc = fn // expected-warning {{never mutated}} // expected-note {{captured here}}
+
+  takesEscaping { // expected-error {{escaping closure captures non-escaping value}}
+    myFunc()
+  }
+}


### PR DESCRIPTION
While you can't write a noescape function type explicitly except
on a function-typed parameter, you can still assign the value of
such a parameter to another 'let' or 'var' with an inferred type.

We correctly handled the 'let' case, but in the 'var' case the
value is wrapped inside a SILBoxType, so we have to look through
that.

Fixes <rdar://problem/70822136>.