### PR TITLE
Experiment: Add -enable/disable-access-control-hacks flags

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -101,6 +101,9 @@ namespace swift {
     /// Should access control be respected?
     bool EnableAccessControl = true;
 
+    /// Should we simulate old access control behavior, downgrading certain errors to warnings?
+    bool EnableAccessControlHacks = true;
+
     /// Enable 'availability' restrictions for App Extensions.
     bool EnableAppExtensionRestrictions = false;
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -102,7 +102,7 @@ namespace swift {
     bool EnableAccessControl = true;
 
     /// Should we simulate old access control behavior, downgrading certain errors to warnings?
-    bool EnableAccessControlHacks = true;
+    bool EnableAccessControlHacks = false;
 
     /// Enable 'availability' restrictions for App Extensions.
     bool EnableAppExtensionRestrictions = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -302,6 +302,11 @@ def disable_access_control : Flag<["-"], "disable-access-control">,
 def enable_access_control : Flag<["-"], "enable-access-control">,
   HelpText<"Respect access control restrictions">;
 
+def disable_access_control_hacks : Flag<["-"], "disable-access-control-hacks">,
+  HelpText<"Don't simulate old access control behavior for compatibility">;
+def enable_access_control_hacks : Flag<["-"], "enable-access-control-hacks">,
+  HelpText<"Simulate old access control behavior for compatibility">;
+
 def code_complete_inits_in_postfix_expr : Flag<["-"], "code-complete-inits-in-postfix-expr">,
   HelpText<"Include initializers when completing a postfix expression">;
 def code_complete_call_pattern_heuristics : Flag<["-"], "code-complete-call-pattern-heuristics">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -397,6 +397,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_access_control);
   }
 
+  if (auto A = Args.getLastArg(OPT_enable_access_control_hacks,
+                               OPT_disable_access_control_hacks)) {
+    Opts.EnableAccessControlHacks
+      = A->getOption().matches(OPT_enable_access_control_hacks);
+  }
+
   if (auto A = Args.getLastArg(OPT_disable_typo_correction,
                                OPT_typo_correction_limit)) {
     if (A->getOption().matches(OPT_disable_typo_correction))

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -60,7 +60,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   DowngradeToWarning downgradeToWarning = DowngradeToWarning::No;
 
   // Swift 4.2 did not perform any checks for type aliases.
-  if (isa<TypeAliasDecl>(D)) {
+  if (Context.LangOpts.EnableAccessControlHacks &&
+      isa<TypeAliasDecl>(D)) {
     if (!Context.isSwiftVersionAtLeast(4, 2))
       return false;
     if (!Context.isSwiftVersionAtLeast(5))
@@ -74,7 +75,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   if (auto accessor = dyn_cast<AccessorDecl>(D)) {
     isAccessor = true;
 
-    if (!Context.isSwiftVersionAtLeast(5))
+    if (Context.LangOpts.EnableAccessControlHacks &&
+        !Context.isSwiftVersionAtLeast(5))
       downgradeToWarning = DowngradeToWarning::Yes;
 
     // For accessors, diagnose with the name of the storage instead of the
@@ -84,7 +86,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   // Swift 5.0 did not check the underlying types of local typealiases.
   // FIXME: Conditionalize this once we have a new language mode.
-  if (isa<TypeAliasDecl>(DC))
+  if (Context.LangOpts.EnableAccessControlHacks &&
+      isa<TypeAliasDecl>(DC))
     downgradeToWarning = DowngradeToWarning::Yes;
 
   auto diagID = diag::resilience_decl_unavailable;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2330,7 +2330,8 @@ bool swift::diagnoseExplicitUnavailability(
   // obsolete decls still map to valid ObjC runtime names, so behave correctly
   // at runtime, even though their use would produce an error outside of a
   // #keyPath expression.
-  bool warnInObjCKeyPath = Flags.contains(DeclAvailabilityFlag::ForObjCKeyPath);
+  bool warnInObjCKeyPath = (ctx.LangOpts.EnableAccessControlHacks &&
+                            Flags.contains(DeclAvailabilityFlag::ForObjCKeyPath));
 
   if (!Attr->Rename.empty()) {
     SmallString<32> newNameBuf;

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
-// RUN: %target-typecheck-verify-swift -swift-version 4.2
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-access-control-hacks
 
 public protocol PublicProto {
   func publicReq()

--- a/test/Compatibility/accessibility_where.swift
+++ b/test/Compatibility/accessibility_where.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-access-control-hacks
 
 private struct PrivateStruct {} // expected-note 6{{type declared here}}
 internal struct InternalStruct {} // expected-note 2{{type declared here}}

--- a/test/Compatibility/attr_inlinable_swift42.swift
+++ b/test/Compatibility/attr_inlinable_swift42.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4.2
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-testing
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-library-evolution
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-library-evolution -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-testing -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-library-evolution -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-library-evolution -enable-testing -enable-access-control-hacks
 
 enum InternalEnum {
   // expected-note@-1 {{type declared here}}

--- a/test/Compatibility/attr_inlinable_typealias_swift4.swift
+++ b/test/Compatibility/attr_inlinable_typealias_swift4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-access-control-hacks
 
 // No diagnostics at all in Swift 4.0 mode.
 

--- a/test/Compatibility/attr_inlinable_typealias_swift42.swift
+++ b/test/Compatibility/attr_inlinable_typealias_swift42.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4.2
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-access-control-hacks
 
 // Only warnings in Swift 4.2 mode.
 

--- a/test/Compatibility/attr_usableFromInline_swift4.swift
+++ b/test/Compatibility/attr_usableFromInline_swift4.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop
-// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-typecheck-verify-swift -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-access-control-hacks
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}

--- a/test/Compatibility/attr_usableFromInline_swift42.swift
+++ b/test/Compatibility/attr_usableFromInline_swift42.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop
-// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-access-control-hacks
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}

--- a/test/SILGen/guaranteed_normal_args.swift
+++ b/test/SILGen/guaranteed_normal_args.swift
@@ -28,9 +28,9 @@ protocol Sequence {
   func makeIterator() -> Iterator
 }
 
-enum Optional<T> {
-case none
-case some(T)
+public enum Optional<T> {
+  case none
+  case some(T)
 }
 
 extension Optional : ExpressibleByNilLiteral {

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 -enable-access-control-hacks
 
 public protocol PublicProto {
   func publicReq()

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-library-evolution %s | %FileCheck --check-prefix=RESILIENCE-ON %s
-// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-library-evolution -enable-testing %s | %FileCheck --check-prefix=RESILIENCE-ON %s
-// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s | %FileCheck --check-prefix=RESILIENCE-OFF %s
-// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s -enable-testing | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-library-evolution -enable-access-control-hacks %s | %FileCheck --check-prefix=RESILIENCE-ON %s
+// RUN: %target-swift-frontend -typecheck -swift-version 4.2 -verify -dump-ast -enable-library-evolution -enable-access-control-hacks -enable-testing %s | %FileCheck --check-prefix=RESILIENCE-ON %s
+// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -enable-access-control-hacks -dump-ast %s | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -enable-access-control-hacks -dump-ast %s -enable-testing | %FileCheck --check-prefix=RESILIENCE-OFF %s
 
 //
 // Public types with @frozen are always fixed layout

--- a/test/attr/attr_inlinable_typealias.swift
+++ b/test/attr/attr_inlinable_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-access-control-hacks
 
 private typealias PrivateAlias = Int
 // expected-note@-1 {{type alias 'PrivateAlias' is not '@usableFromInline' or public}}

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop
-// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-access-control-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing -enable-access-control-hacks
 
 @usableFromInline private func privateVersioned() {}
 // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}

--- a/test/expr/primary/keypath/keypath-objc.swift
+++ b/test/expr/primary/keypath/keypath-objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library  %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library  %s -verify -enable-access-control-hacks
 import ObjectiveC
 import Foundation
 

--- a/test/multifile/inlinable.swift
+++ b/test/multifile/inlinable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s %S/Inputs/inlinable-other.swift
+// RUN: %target-swift-frontend -typecheck -verify %s %S/Inputs/inlinable-other.swift -enable-access-control-hacks
 
 @frozen public struct HasInitExpr {
   public var hasInlinableInit = mutatingFunc(&OtherStruct.staticProp)


### PR DESCRIPTION
We have a few compatibility behaviors that are enabled in -swift-version 4 and -swift-version 4.2, where certain access control violation errors are either not diagnosed at all, or downgrade to warnings. We also have a couple of edge cases that we downgraded to a warning even in -swift-version 5, while waiting for a new language mode.

Swift 5.0 was released a while ago now, so I'm going to try disabling all the hacks to see what the fallout is. In the past, we've fixed other soundness holes in the type checker in a way that rejects invalid code. Ideally, we should do the same with access control. Violations here are not really good to report as warnings, because they can result in linker errors or invalid swift interface files.