### PR TITLE
[SR-13759] [Diag] Suggest inserting await when call is async

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1238,6 +1238,7 @@ public:
     if (isAutoClosure())
       diag = diag::async_call_without_await_in_autoclosure;
     ctx.Diags.diagnose(node.getStartLoc(), diag)
+        .fixItInsert(node.getStartLoc(), "await ")
         .highlight(highlight);
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -18,7 +18,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   // still async version...
   let _: Int = slowServer.doSomethingConflicted("thinking")
-  // expected-error@-1{{call is 'async' but is not marked with 'await'}}
+  // expected-error@-1{{call is 'async' but is not marked with 'await'}}{{16-16=await }}
 
   let _: String? = await try slowServer.fortune()
   let _: Int = await try slowServer.magicNumber(withSeed: 42)

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -59,7 +59,7 @@ func testOverloadedAsync() async {
   let _: String? = await overloadedOptDifference() // no warning
 
   let _ = await overloaded()
-  let _ = overloaded() // expected-error{{call is 'async' but is not marked with 'await'}}
+  let _ = overloaded() // expected-error{{call is 'async' but is not marked with 'await'}}{{11-11=await }}
 
   let fn = {
     overloaded()

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -7,7 +7,7 @@ func test1(asyncfp : () async -> Int, fp : () -> Int) async {
   _ = await asyncfp() + asyncfp()
   _ = await asyncfp() + fp()
   _ = await fp() + 42  // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
-  _ = asyncfp() // expected-error {{call is 'async' but is not marked with 'await'}}
+  _ = asyncfp() // expected-error {{call is 'async' but is not marked with 'await'}}{{7-7=await }}
 }
 
 func getInt() async -> Int { return 5 }
@@ -49,13 +49,13 @@ struct HasAsyncBad {
 }
 
 func testAutoclosure() async {
-  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
+  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}{{32-32=await }}
   await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 
   await acceptAutoclosureAsync(await getInt())
   await acceptAutoclosureNonAsync(await getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 
-  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
+  await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}{{32-32=await }}
   await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
 }
 
@@ -93,7 +93,7 @@ func testThrowingAndAsync() async throws {
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to handle error as optional value?}}
   // expected-note@-3{{did you mean to disable error propagation?}}
-  _ = try throwingAndAsync() // expected-error{{call is 'async' but is not marked with 'await'}}
+  _ = try throwingAndAsync() // expected-error{{call is 'async' but is not marked with 'await'}}{{11-11=await }}
 }
 
 func testExhaustiveDoCatch() async {


### PR DESCRIPTION
<!-- What's in this pull request? -->
When a call is `async` but is not marked with `await`, then we can suggest inserting `await `. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13759.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
