### PR TITLE
[AST] Account for parameter bridging in Clang type computation.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -665,7 +665,8 @@ def experimental_spi_imports :
 def experimental_print_full_convention :
  Flag<["-"], "experimental-print-full-convention">,
  HelpText<"When emitting a module interface or SIL, emit additional @convention"
-          " arguments, regardless of whether they were written in the source">;
+          " arguments, regardless of whether they were written in the source."
+          " Also requires -use-clang-function-types to be enabled.">;
 
 def experimental_one_way_closure_params :
   Flag<["-"], "experimental-one-way-closure-params">,

--- a/test/ClangImporter/blocks_returning_bool.swift
+++ b/test/ClangImporter/blocks_returning_bool.swift
@@ -1,5 +1,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -I %S/Inputs/ | %FileCheck %s
 
+// Check that bridging an @convention(c)'s function's @convention(block)
+// parameter to a Swift function type doesn't crash the compiler.
+// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -I %S/Inputs/ -o /dev/null -use-clang-function-types -experimental-print-full-convention
+
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/ClangImporter/blocks_returning_bool.swift
+++ b/test/ClangImporter/blocks_returning_bool.swift
@@ -2,7 +2,7 @@
 
 // Check that bridging an @convention(c)'s function's @convention(block)
 // parameter to a Swift function type doesn't crash the compiler.
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -I %S/Inputs/ -o /dev/null -use-clang-function-types -experimental-print-full-convention
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -I %S/Inputs/ -o /dev/null -use-clang-function-types -experimental-print-full-convention
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/clang-function-types.swift
+++ b/test/ClangImporter/clang-function-types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -sdk %clang-importer-sdk -enable-library-evolution %s -experimental-print-full-convention | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -sdk %clang-importer-sdk -enable-library-evolution %s -experimental-print-full-convention -use-clang-function-types | %FileCheck %s
 
 import ctypes
 

--- a/test/ModuleInterface/full-convention.swift
+++ b/test/ModuleInterface/full-convention.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -swift-version 5 -emit-module-interface-path - -enable-library-evolution %s -experimental-print-full-convention | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -swift-version 5 -emit-module-interface-path - -enable-library-evolution %s -experimental-print-full-convention -use-clang-function-types | %FileCheck %s
 
 import ctypes
 


### PR DESCRIPTION
Earlier, we assumed that only `@convention(c)` function types and `@convention(block)` function types were permitted in the components of an `@convention(c)` function type. However, that is not true because we may end up bridging a `@convention(block)` type (in parameter/return position of a `@convention(c)` function type) to a `@convention(swift)` type.