### PR TITLE
[CodeCompletion] Avoid prechecking twice when typeCheckForCodeCompletion is given a non-applicable expression (NFC)

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -326,14 +326,6 @@ TypeChecker::typeCheckExpression(
                                   "typecheck-expr", expr);
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
 
-  // First let's check whether given expression has a code completion
-  // token which requires special handling.
-  if (Context.CompletionCallback &&
-      typeCheckForCodeCompletion(target, [&](const constraints::Solution &S) {
-        Context.CompletionCallback->sawSolution(S);
-      }))
-    return None;
-
   // First, pre-check the expression, validating any types that occur in the
   // expression and folding sequence expressions.
   if (ConstraintSystem::preCheckExpression(
@@ -342,6 +334,15 @@ TypeChecker::typeCheckExpression(
     return None;
   }
   target.setExpr(expr);
+
+  // Check whether given expression has a code completion token which requires
+  // special handling.
+  if (Context.CompletionCallback &&
+      typeCheckForCodeCompletion(target, /*needsPrecheck*/false,
+                                 [&](const constraints::Solution &S) {
+        Context.CompletionCallback->sawSolution(S);
+      }))
+    return None;
 
   // Construct a constraint system from this expression.
   ConstraintSystemOptions csOptions = ConstraintSystemFlags::AllowFixes;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -591,7 +591,7 @@ FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 /// \returns `true` if target was applicable and it was possible to infer
 /// types for code completion, `false` othrewise.
 bool typeCheckForCodeCompletion(
-    constraints::SolutionApplicationTarget &target,
+    constraints::SolutionApplicationTarget &target, bool needsPrecheck,
     llvm::function_ref<void(const constraints::Solution &)> callback);
 
 /// Check the key-path expression.


### PR DESCRIPTION
For code completion within a multi-statement closure, typeCheckExpression will be called on the expression containing the closure, and potentially again on the expression within the closure body that contains the completion location.
In the first call, the typeCheckForCodeCompletion pre-checks the expression as part of determining whether a second call is going to be made (in which case the first is not applicable for completion purposes) or not. In the case where it's not applicable control is returned to the regular typeCheckExpression code path, which would then pre-check the expression again.

This just moves the pre-check in typeCheckExpression before the call out to typeCheckForCodeCompletion, and passes a bool to typeCheckForCodeCompletion to tell it not to pre-check. typeCheckForCodeCompletion still needs to support pre-checking for fallback cases when no separate typeCheckExpression call will be made due to errors in the outer expression, or when no typeCheckExpression call is made at all.