### PR TITLE
Mark Some Incremental Cross-Module Tests As Unsupported on Simulators

### DIFF
--- a/test/Incremental/CrossModule/external-cascade.swift
+++ b/test/Incremental/CrossModule/external-cascade.swift
@@ -1,6 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/external-cascade/* %t
 
+// No reason to run these tests on the simulator hosts rdar://70772320
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
+// UNSUPPORTED: CPU=i386 && OS=watchos
+
 //
 // This test establishes a chain of modules that all depend on a set of
 // bridging headers. This test ensures that changes to external dependencies -

--- a/test/Incremental/CrossModule/linear.swift
+++ b/test/Incremental/CrossModule/linear.swift
@@ -1,6 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/linear/* %t
 
+// No reason to run these tests on the simulator hosts rdar://70772320
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
+// UNSUPPORTED: CPU=i386 && OS=watchos
+
 //
 // This test establishes a "linear" chain of modules that import one another
 // and ensures that a cross-module incremental build does not needlessly

--- a/test/Incremental/CrossModule/transitive.swift
+++ b/test/Incremental/CrossModule/transitive.swift
@@ -1,6 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/transitive/* %t
 
+// No reason to run these tests on the simulator hosts rdar://70772320
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
+// UNSUPPORTED: CPU=i386 && OS=watchos
+
 //
 // This test establishes a "transitive" chain of modules that import one another
 // and ensures that a cross-module incremental build rebuilds all modules


### PR DESCRIPTION
Simulator hosts don't make good candidates for these tests, and they
appear to be acting up anyways.

rdar://70772320