### PR TITLE
[CodeCompletion] Fix crashes in TypeCheckASTNodeAtLocRequest

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1841,12 +1841,23 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
 
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto *brace = dyn_cast<BraceStmt>(S)) {
+        auto braceCharRange = Lexer::getCharSourceRangeFromSourceRange(
+            SM, brace->getSourceRange());
+        // Unless this brace contains the loc, there's nothing to do.
+        if (!braceCharRange.contains(Loc))
+          return {false, S};
+
+        // Reset the node found in a parent context.
+        if (!brace->isImplicit())
+          FoundNode = nullptr;
+
         for (ASTNode &node : brace->getElements()) {
           if (SM.isBeforeInBuffer(Loc, node.getStartLoc()))
             break;
 
           // NOTE: We need to check the character loc here because the target
-          // loc can be inside the last token of the node. i.e. interpolated string.
+          // loc can be inside the last token of the node. i.e. interpolated
+          // string.
           SourceLoc endLoc = Lexer::getLocForEndOfToken(SM, node.getEndLoc());
           if (SM.isBeforeInBuffer(endLoc, Loc) || endLoc == Loc)
             continue;
@@ -1858,8 +1869,9 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
 
           // Walk into the node to narrow down.
           node.walk(*this);
-        }
 
+          break;
+        }
         // Already walked into.
         return {false, nullptr};
       }

--- a/validation-test/IDE/crashers_2_fixed/rdar69246891.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar69246891.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE_2 -source-filename=%s
 
 class MyCls {
   public init(body: (Int) throws -> Void) {}
@@ -8,5 +9,13 @@ func foo() {
   MyCls { arg in
     MyCls { #^COMPLETE^#
     }
+  }
+}
+
+func receive(fn: () -> throws Void) {}
+
+func test2() {
+  receive {
+    switch #^COMPLETE_2^#
   }
 }


### PR DESCRIPTION
```
  receive {
    switch <HERE>
  }
```

In the current Parser implementation, if there's an error in `switch` subject, the `SwitchStmt` is not placed in the parsed AST.

When the type checker searches AST node at the location, it used to only find `receive { ... }` because that is the *innermost* node in the AST that contains the loc. But the decl context is the closure. This behavior used to cause crashes because `receive { ... }` is re-typechecked.

For solution, when finding the innermost AST node, clear the found node in parent context before walking into `BraceStmt`.

rdar://problem/69246891
