### PR TITLE
[Concurrency] Disallow global actor annotations on stored properties of structs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4267,6 +4267,8 @@ ERROR(global_actor_on_actor_class,none,
       "actor class %0 cannot have a global actor", (Identifier))
 ERROR(global_actor_on_local_variable,none,
       "local variable %0 cannot have a global actor", (DeclName))
+ERROR(global_actor_on_struct_property,none,
+      "stored property %0 of a struct cannot have a global actor", (DeclName))
 
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -406,6 +406,15 @@ GlobalActorAttributeRequest::evaluate(
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
       }
+
+      // Global actors don't make sense on a stored property of a struct.
+      if (var->hasStorage() && var->getDeclContext()->getSelfStructDecl() &&
+          var->isInstanceMember()) {
+        var->diagnose(diag::global_actor_on_struct_property, var->getName())
+          .highlight(globalActorAttr->getRangeWithAt());
+        return None;
+      }
+
     }
   } else if (isa<ExtensionDecl>(decl)) {
     // Extensions are okay.

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -64,7 +64,9 @@ struct OtherGlobalActor {
   _ = x
 }
 
-@GA1 struct X { }
+@GA1 struct X {
+  @GA1 var member: Int // expected-error{{stored property 'member' of a struct cannot have a global actor}}
+}
 
 struct Y {
   @GA1 subscript(i: Int) -> Int { i }


### PR DESCRIPTION
They don't make sense because stored properties of structs have the
isolation of their enclosure values. Fixes rdar://70881253
