### PR TITLE
[Concurrency] Ban non-escaping closures in @asyncHandler

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4135,6 +4135,9 @@ ERROR(asynchandler_async,none,
 ERROR(asynchandler_inout_parameter,none,
       "'inout' parameter is not allowed in '@asyncHandler' function",
       ())
+ERROR(asynchandler_noescape_closure_parameter,none,
+      "non-escaping closure parameter is not allowed in '@asyncHandler' function",
+      ())
 ERROR(asynchandler_mutating,none,
       "'@asyncHandler' function cannot be 'mutating'",
       ())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -87,6 +87,16 @@ static bool checkAsyncHandler(FuncDecl *func, bool diagnose) {
 
       return true;
     }
+
+    if (auto fnType = param->getInterfaceType()->getAs<FunctionType>()) {
+      if (fnType->isNoEscape()) {
+        if (diagnose) {
+          param->diagnose(diag::asynchandler_noescape_closure_parameter);
+        }
+
+        return true;
+      }
+    }
   }
 
   if (func->isMutating()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2217,19 +2217,6 @@ static Type validateParameterType(ParamDecl *decl) {
     }
   }
 
-  // async autoclosures can only occur as parameters to async functions.
-  if (decl->isAutoClosure()) {
-    if (auto fnType = Ty->getAs<FunctionType>()) {
-      if (fnType->isAsync() &&
-          !(isa<AbstractFunctionDecl>(dc) &&
-            cast<AbstractFunctionDecl>(dc)->isAsyncContext())) {
-        decl->diagnose(diag::async_autoclosure_nonasync_function);
-        if (auto func = dyn_cast<FuncDecl>(dc))
-          addAsyncNotes(func);
-      }
-    }
-  }
-
   return Ty;
 }
 

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -9,7 +9,11 @@ func globalAsyncFunction() async -> Int { 0 }
   let _ = await globalAsyncFunction()
 }
 
-@asyncHandler func asyncHandler2(fn: @autoclosure () async -> Int ) {
+@asyncHandler func asyncHandler2(fn: @autoclosure @escaping () async -> Int ) {
+  // okay, it's an async context
+}
+
+@asyncHandler func asyncHandler3(fn: @escaping () -> Int) {
   // okay, it's an async context
 }
 
@@ -28,6 +32,10 @@ func asyncHandlerBad3() throws { }
 @asyncHandler
 func asyncHandlerBad4(result: inout Int) { }
 // expected-error@-1{{'inout' parameter is not allowed in '@asyncHandler' function}}
+
+@asyncHandler
+func asyncHandlerBad5(result: () -> Int) { }
+// expected-error@-1{{non-escaping closure parameter is not allowed in '@asyncHandler' function}}
 
 actor class X {
   @asyncHandler func asyncHandlerMethod() { }


### PR DESCRIPTION
An asynchronous handler appears to be a synchronous function, but
actually runs its body in a detached task. That means that any
non-escaping closure parameters to the asynchronous handler will
effectively escape. Fixes rdar://70820569.
