### PR TITLE
[Parse] Move standalone_dollar_identifier diagnosis to Parser.

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -932,10 +932,8 @@ void Lexer::lexDollarIdent() {
     break;
   }
 
+  // If there is a standalone '$', treat it like an identifier.
   if (CurPtr == tokStart + 1) {
-    // It is an error to see a standalone '$'. Offer to replace '$' with '`$`'.
-    diagnose(tokStart, diag::standalone_dollar_identifier)
-      .fixItReplaceChars(getSourceLoc(tokStart), getSourceLoc(CurPtr), "`$`");
     return formToken(tok::identifier, tokStart);
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7719,11 +7719,13 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   bool AllowTopLevel = Flags.contains(PD_AllowTopLevel);
 
   const auto maybeDiagnoseInvalidCharInOperatorName = [this](const Token &Tk) {
-    if (Tk.is(tok::identifier) &&
-        DeclAttribute::getAttrKindFromString(Tk.getText()) ==
-          DeclAttrKind::DAK_Count) {
-      diagnose(Tk, diag::identifier_within_operator_name, Tk.getText());
-      return true;
+    if (Tk.is(tok::identifier)) {
+      if (Tk.getText().equals("$") ||
+          DeclAttribute::getAttrKindFromString(Tk.getText()) ==
+              DeclAttrKind::DAK_Count) {
+        diagnose(Tk, diag::identifier_within_operator_name, Tk.getText());
+        return true;
+      }
     } else if (Tk.isNot(tok::colon, tok::l_brace, tok::semi) &&
                Tk.isPunctuation()) {
       diagnose(Tk, diag::operator_name_invalid_char,

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -83,3 +83,6 @@ struct S {
 }
 
 let _ = S().$café // Okay
+
+infix operator $ // expected-error{{'$' is considered an identifier and must not appear within an operator name}} // SR-13092
+infix operator `$` // expected-error{{'$' is considered an identifier and must not appear within an operator name}} // SR-13092


### PR DESCRIPTION
<!-- What's in this pull request? -->
The compiler can't make up its mind as to whether $ is an identifier:

```
$ echo 'operator $' | swiftc -
<stdin>:1:10: error: '$' is not an identifier; use backticks to escape it
operator $
         ^
         `$`
<stdin>:1:10: error: '$' is considered an identifier and must not appear within an operator name
operator $
         ^
```
The first error should probably not be emitted in this context.

This PR moves dollar identifier diagnosis to Parser, and fixes the diagnosis for `identifier_within_operator_name`.

This is my first time committing to Swift repository, so if there are any issues, I'd appreciate any feedbacks! :) 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
[Resolves SR-13092.](https://bugs.swift.org/browse/SR-13092)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
