### PR TITLE
[benchmark] Add benchmarks for IndexPath's subscripts, max, min

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SWIFT_BENCH_MODULES
     single-source/Hash
     single-source/Histogram
     single-source/HTTP2StateMachine
+    single-source/IndexPathTest
     single-source/InsertCharacter
     single-source/IntegerParsing
     single-source/Integrate

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -10,52 +10,60 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TestsUtils
 import Foundation
+import TestsUtils
 
 let size = 200
 let tags: [BenchmarkCategory] = [.validation, .api, .IndexPath]
 
 public let IndexPathTest = [
-  BenchmarkInfo(name: "IndexPathSubscriptMutation", 
-  runFunction: { n in run_IndexPathSubscriptMutation(n * 1000, size)}, 
-  tags: tags),
-  BenchmarkInfo(name: "IndexPathSubscriptRangeMutation", 
-  runFunction: { n in run_IndexPathSubscriptRangeMutation(n * 1000, size)}, 
-  tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathSubscriptMutation",
+    runFunction: { n in run_IndexPathSubscriptMutation(n * 1000, size) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathSubscriptRangeMutation",
+    runFunction: { n in run_IndexPathSubscriptRangeMutation(n * 1000, size) },
+    tags: tags),
 
-  BenchmarkInfo(name: "IndexPathMaxBeginning", 
-  runFunction: { n in run_IndexPathMaxBeginning(n * 1000)}, 
-  tags: tags),
-  BenchmarkInfo(name: "IndexPathMaxMiddle", 
-  runFunction: { n in run_IndexPathMaxMiddle(n * 1000)}, 
-  tags: tags),
-  BenchmarkInfo(name: "IndexPathMaxEnd", 
-  runFunction: { n in run_IndexPathMaxEnd(n * 1000)}, 
-  tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathMaxBeginning",
+    runFunction: { n in run_IndexPathMaxBeginning(n * 1000) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathMaxMiddle",
+    runFunction: { n in run_IndexPathMaxMiddle(n * 1000) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathMaxEnd",
+    runFunction: { n in run_IndexPathMaxEnd(n * 1000) },
+    tags: tags),
 
-  BenchmarkInfo(name: "IndexPathMinBeginning", 
-  runFunction: { n in run_IndexPathMinBeginning(n * 1000)}, 
-  tags: tags),
-  BenchmarkInfo(name: "IndexPathMinMiddle", 
-  runFunction: { n in run_IndexPathMinMiddle(n * 1000)}, 
-  tags: tags),
-  BenchmarkInfo(name: "IndexPathMinEnd", 
-  runFunction: { n in run_IndexPathMinEnd(n * 1000)}, 
-  tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathMinBeginning",
+    runFunction: { n in run_IndexPathMinBeginning(n * 1000) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathMinMiddle",
+    runFunction: { n in run_IndexPathMinMiddle(n * 1000) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPathMinEnd",
+    runFunction: { n in run_IndexPathMinEnd(n * 1000) },
+    tags: tags),
 ]
 
 @inline(__always)
 func indexPath(_ size: Int, reversed: Bool = false) -> IndexPath {
-    let indexes = Array(0..<size)
-    return IndexPath(indexes: reversed ? indexes.reversed() : indexes)
+  let indexes = Array(0..<size)
+  return IndexPath(indexes: reversed ? indexes.reversed() : indexes)
 }
 
 @inline(__always)
 func indexPath(_ size: Int, middle: Int) -> IndexPath {
-    var indexes = Array(0..<size)
-    indexes.insert(middle, at: (indexes.count - 1) / 2)
-    return IndexPath(indexes: indexes)
+  var indexes = Array(0..<size)
+  indexes.insert(middle, at: (indexes.count - 1) / 2)
+  return IndexPath(indexes: indexes)
 }
 
 // Subscript Mutations
@@ -64,100 +72,122 @@ func indexPath(_ size: Int, middle: Int) -> IndexPath {
 func subscriptMutation(
   n: Int,
   mutations: Int,
-  mutate: (inout IndexPath, Int) -> ()) {
-    for _ in 0..<n {
-      var ip = indexPath(size)
-
-      for i in 0..<mutations {
-        mutate(&ip, i)
-      }
-
-      blackHole(ip)
+  mutate: (inout IndexPath, Int) -> Void
+) {
+  for _ in 0..<n {
+    var ip = indexPath(size)
+    for i in 0..<mutations {
+      mutate(&ip, i)
     }
+    blackHole(ip)
+  }
 }
 
 @inline(never)
 public func run_IndexPathSubscriptMutation(_ n: Int, _ count: Int) {
-  subscriptMutation(n: n,  mutations: count, mutate: { ip, i in
-		ip[i % 4] += 1
-  })
+  subscriptMutation(
+    n: n, mutations: count,
+    mutate: { ip, i in
+      ip[i % 4] += 1
+    })
 }
 
 @inline(never)
 public func run_IndexPathSubscriptRangeMutation(_ n: Int, _ count: Int) {
-  subscriptMutation(n: count, mutations: count, mutate: { ip, i in
-		ip[0..<i] += [i]
-  })
+  subscriptMutation(
+    n: count, mutations: count,
+    mutate: { ip, i in
+      ip[0..<i] += [i]
+    })
 }
 
 // Max, Min
 
 @inline(__always)
 func maxMin(
-  n: Int, 
-  creator: () -> IndexPath, 
-  maxMinFunc: (inout IndexPath) -> Int?) {
-    for _ in 0..<n {
-      var ip = creator()
-      let found = maxMinFunc(&ip) != nil
-      blackHole(found)
-    }
+  n: Int,
+  creator: () -> IndexPath,
+  maxMinFunc: (inout IndexPath) -> Int?
+) {
+  for _ in 0..<n {
+    var ip = creator()
+    let found = maxMinFunc(&ip) != nil
+    blackHole(found)
+  }
 }
 
 // Max
 
 @inline(never)
 public func run_IndexPathMaxBeginning(_ n: Int) {
-  maxMin(n: n, creator: {
-    indexPath(size, reversed: true)
-  }, maxMinFunc: { ip in
-    ip.max()
-  })
+  maxMin(
+    n: n,
+    creator: {
+      indexPath(size, reversed: true)
+    },
+    maxMinFunc: { ip in
+      ip.max()
+    })
 }
 
 @inline(never)
 public func run_IndexPathMaxMiddle(_ n: Int) {
-  maxMin(n: n, creator: {
-    indexPath(size, middle: size + 1)
-  }, maxMinFunc: { ip in
-    ip.max()
-  })
+  maxMin(
+    n: n,
+    creator: {
+      indexPath(size, middle: size + 1)
+    },
+    maxMinFunc: { ip in
+      ip.max()
+    })
 }
 
 @inline(never)
 public func run_IndexPathMaxEnd(_ n: Int) {
-  maxMin(n: n, creator: {
-    indexPath(size)
-  }, maxMinFunc: { ip in
-    ip.max()
-  })
+  maxMin(
+    n: n,
+    creator: {
+      indexPath(size)
+    },
+    maxMinFunc: { ip in
+      ip.max()
+    })
 }
 
 // Min
 
 @inline(never)
 public func run_IndexPathMinBeginning(_ n: Int) {
-  maxMin(n: n, creator: {
-   indexPath(size)
-  }, maxMinFunc: { ip in
-    ip.min()
-  })
+  maxMin(
+    n: n,
+    creator: {
+      indexPath(size)
+    },
+    maxMinFunc: { ip in
+      ip.min()
+    })
 }
 
 @inline(never)
 public func run_IndexPathMinMiddle(_ n: Int) {
-  maxMin(n: n, creator: {
-    indexPath(size, middle: -1)
-  }, maxMinFunc: { ip in
-    ip.min()
-  })
+  maxMin(
+    n: n,
+    creator: {
+      indexPath(size, middle: -1)
+    },
+    maxMinFunc: { ip in
+      ip.min()
+    })
 }
 
 @inline(never)
 public func run_IndexPathMinEnd(_ n: Int) {
-  maxMin(n: n, creator: {
-    indexPath(size, reversed: true)
-  }, maxMinFunc: { ip in
-    ip.min()
-  })
+  maxMin(
+    n: n,
+    creator: {
+      indexPath(size, reversed: true)
+    },
+    maxMinFunc: { ip in
+      ip.min()
+    })
 }

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -61,7 +61,8 @@ func indexPath(_ size: Int, middle: Int) -> IndexPath {
 // Subscript Mutations
 
 @inline(__always)
-func subscriptMutation(n: Int,
+func subscriptMutation(
+  n: Int,
   mutations: Int,
   mutate: (inout IndexPath, Int) -> ()) {
     for _ in 0..<n {
@@ -79,20 +80,21 @@ func subscriptMutation(n: Int,
 public func run_IndexPathSubscriptMutation(_ n: Int, _ count: Int) {
   subscriptMutation(n: n,  mutations: count, mutate: { ip, i in
 		ip[i % 4] += 1
-	})
+  })
 }
 
 @inline(never)
 public func run_IndexPathSubscriptRangeMutation(_ n: Int, _ count: Int) {
   subscriptMutation(n: count, mutations: count, mutate: { ip, i in
 		ip[0..<i] += [i]
-	})
+  })
 }
 
 // Max, Min
 
 @inline(__always)
-func maxMin(n: Int, 
+func maxMin(
+  n: Int, 
   creator: () -> IndexPath, 
   maxMinFunc: (inout IndexPath) -> Int?) {
     for _ in 0..<n {

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -23,35 +23,39 @@ let tags: [BenchmarkCategory] = [.validation, .api, .IndexPath]
 public let IndexPathTest = [
   BenchmarkInfo(
     name: "IndexPath.Subscript.Mutation",
-    runFunction: { n in
-      run_IndexPathSubscriptMutation(n * 10, size, increasingIndexPath)
-    },
+    runFunction: run_IndexPathSubscriptMutation,
     tags: tags,
     setUpFunction: { blackHole(increasingIndexPath) }),
   BenchmarkInfo(
     name: "IndexPath.Subscript.Range.Mutation",
-    runFunction: { n in
-      run_IndexPathSubscriptRangeMutation(n, size, increasingIndexPath)
-    },
+    runFunction: run_IndexPathSubscriptRangeMutation,
     tags: tags,
     setUpFunction: { blackHole(increasingIndexPath) }),
   BenchmarkInfo(
     name: "IndexPath.Max",
-    runFunction: { n in run_IndexPathMax(n * 10) },
-    tags: tags),
+    runFunction: run_IndexPathMax,
+    tags: tags,
+    setUpFunction: {
+      blackHole(decreasingIndexPath)
+      blackHole(increasingMaxMiddleIndexPath)
+      blackHole(increasingIndexPath)
+    }),
   BenchmarkInfo(
     name: "IndexPath.Min",
-    runFunction: { n in run_IndexPathMin(n * 10) },
-    tags: tags),
+    runFunction: run_IndexPathMin,
+    tags: tags,
+    setUpFunction: {
+      blackHole(increasingIndexPath)
+      blackHole(increasingMinMiddleIndexPath)
+      blackHole(decreasingIndexPath)
+    }),
 ]
 
-@inline(__always)
 func indexPath(_ size: Int, reversed: Bool = false) -> IndexPath {
   let indexes = Array(0..<size)
   return IndexPath(indexes: reversed ? indexes.reversed() : indexes)
 }
 
-@inline(__always)
 func indexPath(_ size: Int, middle: Int) -> IndexPath {
   var indexes = Array(0..<size)
   indexes.insert(middle, at: (indexes.count - 1) / 2)
@@ -76,22 +80,18 @@ func subscriptMutation(
 }
 
 @inline(never)
-public func run_IndexPathSubscriptMutation(
-  _ n: Int, _ count: Int, _ indexPath: IndexPath
-) {
+public func run_IndexPathSubscriptMutation(_ n: Int) {
   subscriptMutation(
-    n: n, mutations: count, indexPath: indexPath,
+    n: n * 10, mutations: size, indexPath: increasingIndexPath,
     mutate: { ip, i in
       ip[i % 4] += 1
     })
 }
 
 @inline(never)
-public func run_IndexPathSubscriptRangeMutation(
-  _ n: Int, _ count: Int, _ indexPath: IndexPath
-) {
+public func run_IndexPathSubscriptRangeMutation(_ n: Int) {
   subscriptMutation(
-    n: n, mutations: count, indexPath: indexPath,
+    n: n, mutations: size, indexPath: increasingIndexPath,
     mutate: { ip, i in
       ip[0..<i] += [i]
     })
@@ -101,12 +101,14 @@ public func run_IndexPathSubscriptRangeMutation(
 
 @inline(never)
 public func run_IndexPathMax(_ n: Int) {
-  for _ in 0..<n {
+  for _ in 0..<n * 10 {
     var val: Int?
     // Beginning max
     val = decreasingIndexPath.max()
+    blackHole(val)
     // Middle max
     val = increasingMaxMiddleIndexPath.max()
+    blackHole(val)
     // End max
     val = increasingIndexPath.max()
     blackHole(val)
@@ -117,12 +119,14 @@ public func run_IndexPathMax(_ n: Int) {
 
 @inline(never)
 public func run_IndexPathMin(_ n: Int) {
-  for _ in 0..<n {
+  for _ in 0..<n * 10 {
     var val: Int?
     // Beginning min
     val = increasingIndexPath.min()
+    blackHole(val)
     // Middle min
     val = increasingMinMiddleIndexPath.min()
+    blackHole(val)
     // End min
     val = decreasingIndexPath.min()
     blackHole(val)

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -18,38 +18,38 @@ let tags: [BenchmarkCategory] = [.validation, .api, .IndexPath]
 
 public let IndexPathTest = [
   BenchmarkInfo(
-    name: "IndexPathSubscriptMutation",
-    runFunction: { n in run_IndexPathSubscriptMutation(n * 1000, size) },
+    name: "IndexPath.Subscript.Mutation",
+    runFunction: { n in run_IndexPathSubscriptMutation(n * 60, size) },
     tags: tags),
   BenchmarkInfo(
-    name: "IndexPathSubscriptRangeMutation",
-    runFunction: { n in run_IndexPathSubscriptRangeMutation(n * 1000, size) },
-    tags: tags),
-
-  BenchmarkInfo(
-    name: "IndexPathMaxBeginning",
-    runFunction: { n in run_IndexPathMaxBeginning(n * 1000) },
-    tags: tags),
-  BenchmarkInfo(
-    name: "IndexPathMaxMiddle",
-    runFunction: { n in run_IndexPathMaxMiddle(n * 1000) },
-    tags: tags),
-  BenchmarkInfo(
-    name: "IndexPathMaxEnd",
-    runFunction: { n in run_IndexPathMaxEnd(n * 1000) },
+    name: "IndexPath.Subscript.Range.Mutation",
+    runFunction: { n in run_IndexPathSubscriptRangeMutation(n * 60, size) },
     tags: tags),
 
   BenchmarkInfo(
-    name: "IndexPathMinBeginning",
-    runFunction: { n in run_IndexPathMinBeginning(n * 1000) },
+    name: "IndexPath.Max.Beginning",
+    runFunction: { n in run_IndexPathMaxBeginning(n * 60) },
     tags: tags),
   BenchmarkInfo(
-    name: "IndexPathMinMiddle",
-    runFunction: { n in run_IndexPathMinMiddle(n * 1000) },
+    name: "IndexPath.Max.Middle",
+    runFunction: { n in run_IndexPathMaxMiddle(n * 60) },
     tags: tags),
   BenchmarkInfo(
-    name: "IndexPathMinEnd",
-    runFunction: { n in run_IndexPathMinEnd(n * 1000) },
+    name: "IndexPath.Max.End",
+    runFunction: { n in run_IndexPathMaxEnd(n * 60) },
+    tags: tags),
+
+  BenchmarkInfo(
+    name: "IndexPath.Min.Beginning",
+    runFunction: { n in run_IndexPathMinBeginning(n * 60) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPath.Min.Middle",
+    runFunction: { n in run_IndexPathMinMiddle(n * 60) },
+    tags: tags),
+  BenchmarkInfo(
+    name: "IndexPath.Min.End",
+    runFunction: { n in run_IndexPathMinEnd(n * 60) },
     tags: tags),
 ]
 
@@ -95,7 +95,7 @@ public func run_IndexPathSubscriptMutation(_ n: Int, _ count: Int) {
 @inline(never)
 public func run_IndexPathSubscriptRangeMutation(_ n: Int, _ count: Int) {
   subscriptMutation(
-    n: count, mutations: count,
+    n: n, mutations: count,
     mutate: { ip, i in
       ip[0..<i] += [i]
     })

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -63,18 +63,18 @@ func indexPath(_ size: Int,
 // Subscript Mutations
 
 @inline(__always)
-func subscriptMutation(n: Int,  
-	mutations: Int,
-	mutate: (inout IndexPath, Int) -> ()) {
+func subscriptMutation(n: Int,
+  mutations: Int,
+  mutate: (inout IndexPath, Int) -> ()) {
     for _ in 0..<n {
-		  var ip = indexPath(size)
+      var ip = indexPath(size)
 
-		  for i in 0..<mutations {
-			  mutate(&ip, i)
-		  }
-		
+      for i in 0..<mutations {
+        mutate(&ip, i)
+      }
+
       blackHole(ip)
-	}
+    }
 }
 
 @inline(never)

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -1,4 +1,4 @@
-//===--- IndexPathTest.swift -------------------------------------------===//
+//===--- IndexPathTest.swift ----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -46,15 +46,13 @@ public let IndexPathTest = [
 ]
 
 @inline(__always)
-func indexPath(_ size: Int, 
-  reversed: Bool = false) -> IndexPath {
+func indexPath(_ size: Int, reversed: Bool = false) -> IndexPath {
     let indexes = Array(0..<size)
     return IndexPath(indexes: reversed ? indexes.reversed() : indexes)
 }
 
 @inline(__always)
-func indexPath(_ size: Int, 
-  middle: Int) -> IndexPath {
+func indexPath(_ size: Int, middle: Int) -> IndexPath {
     var indexes = Array(0..<size)
     indexes.insert(middle, at: (indexes.count - 1) / 2)
     return IndexPath(indexes: indexes)
@@ -79,18 +77,14 @@ func subscriptMutation(n: Int,
 
 @inline(never)
 public func run_IndexPathSubscriptMutation(_ n: Int, _ count: Int) {
-  subscriptMutation(n: n, 
-  mutations: count, 
-  mutate: { ip, i in
+  subscriptMutation(n: n,  mutations: count, mutate: { ip, i in
 		ip[i % 4] += 1
 	})
 }
 
 @inline(never)
 public func run_IndexPathSubscriptRangeMutation(_ n: Int, _ count: Int) {
-  subscriptMutation(n: count, 
-  mutations: count, 
-  mutate: { ip, i in
+  subscriptMutation(n: count, mutations: count, mutate: { ip, i in
 		ip[0..<i] += [i]
 	})
 }

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -1,0 +1,167 @@
+//===--- IndexPathTest.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+import Foundation
+
+let size = 200
+let tags: [BenchmarkCategory] = [.validation, .api, .IndexPath]
+
+public let IndexPathTest = [
+  BenchmarkInfo(name: "IndexPathSubscriptMutation", 
+  runFunction: { n in run_IndexPathSubscriptMutation(n * 1000, size)}, 
+  tags: tags),
+  BenchmarkInfo(name: "IndexPathSubscriptRangeMutation", 
+  runFunction: { n in run_IndexPathSubscriptRangeMutation(n * 1000, size)}, 
+  tags: tags),
+
+  BenchmarkInfo(name: "IndexPathMaxBeginning", 
+  runFunction: { n in run_IndexPathMaxBeginning(n * 1000)}, 
+  tags: tags),
+  BenchmarkInfo(name: "IndexPathMaxMiddle", 
+  runFunction: { n in run_IndexPathMaxMiddle(n * 1000)}, 
+  tags: tags),
+  BenchmarkInfo(name: "IndexPathMaxEnd", 
+  runFunction: { n in run_IndexPathMaxEnd(n * 1000)}, 
+  tags: tags),
+
+  BenchmarkInfo(name: "IndexPathMinBeginning", 
+  runFunction: { n in run_IndexPathMinBeginning(n * 1000)}, 
+  tags: tags),
+  BenchmarkInfo(name: "IndexPathMinMiddle", 
+  runFunction: { n in run_IndexPathMinMiddle(n * 1000)}, 
+  tags: tags),
+  BenchmarkInfo(name: "IndexPathMinEnd", 
+  runFunction: { n in run_IndexPathMinEnd(n * 1000)}, 
+  tags: tags),
+]
+
+@inline(__always)
+func indexPath(_ size: Int, 
+  reversed: Bool = false) -> IndexPath {
+    let indexes = Array(0..<size)
+    return IndexPath(indexes: reversed ? indexes.reversed() : indexes)
+}
+
+@inline(__always)
+func indexPath(_ size: Int, 
+  middle: Int) -> IndexPath {
+    var indexes = Array(0..<size)
+    indexes.insert(middle, at: (indexes.count - 1) / 2)
+    return IndexPath(indexes: indexes)
+}
+
+// Subscript Mutations
+
+@inline(__always)
+func subscriptMutation(n: Int,  
+	mutations: Int,
+	mutate: (inout IndexPath, Int) -> ()) {
+    for _ in 0..<n {
+		  var ip = indexPath(size)
+
+		  for i in 0..<mutations {
+			  mutate(&ip, i)
+		  }
+		
+      blackHole(ip)
+	}
+}
+
+@inline(never)
+public func run_IndexPathSubscriptMutation(_ n: Int, _ count: Int) {
+  subscriptMutation(n: n, 
+  mutations: count, 
+  mutate: { ip, i in
+		ip[i % 4] += 1
+	})
+}
+
+@inline(never)
+public func run_IndexPathSubscriptRangeMutation(_ n: Int, _ count: Int) {
+  subscriptMutation(n: count, 
+  mutations: count, 
+  mutate: { ip, i in
+		ip[0..<i] += [i]
+	})
+}
+
+// Max, Min
+
+@inline(__always)
+func maxMin(n: Int, 
+  creator: () -> IndexPath, 
+  maxMinFunc: (inout IndexPath) -> Int?) {
+    for _ in 0..<n {
+      var ip = creator()
+      let found = maxMinFunc(&ip) != nil
+      blackHole(found)
+    }
+}
+
+// Max
+
+@inline(never)
+public func run_IndexPathMaxBeginning(_ n: Int) {
+  maxMin(n: n, creator: {
+    indexPath(size, reversed: true)
+  }, maxMinFunc: { ip in
+    ip.max()
+  })
+}
+
+@inline(never)
+public func run_IndexPathMaxMiddle(_ n: Int) {
+  maxMin(n: n, creator: {
+    indexPath(size, middle: size + 1)
+  }, maxMinFunc: { ip in
+    ip.max()
+  })
+}
+
+@inline(never)
+public func run_IndexPathMaxEnd(_ n: Int) {
+  maxMin(n: n, creator: {
+    indexPath(size)
+  }, maxMinFunc: { ip in
+    ip.max()
+  })
+}
+
+// Min
+
+@inline(never)
+public func run_IndexPathMinBeginning(_ n: Int) {
+  maxMin(n: n, creator: {
+   indexPath(size)
+  }, maxMinFunc: { ip in
+    ip.min()
+  })
+}
+
+@inline(never)
+public func run_IndexPathMinMiddle(_ n: Int) {
+  maxMin(n: n, creator: {
+    indexPath(size, middle: -1)
+  }, maxMinFunc: { ip in
+    ip.min()
+  })
+}
+
+@inline(never)
+public func run_IndexPathMinEnd(_ n: Int) {
+  maxMin(n: n, creator: {
+    indexPath(size, reversed: true)
+  }, maxMinFunc: { ip in
+    ip.min()
+  })
+}

--- a/benchmark/single-source/IndexPathTest.swift
+++ b/benchmark/single-source/IndexPathTest.swift
@@ -35,50 +35,14 @@ public let IndexPathTest = [
     },
     tags: tags,
     setUpFunction: { blackHole(increasingIndexPath) }),
-
   BenchmarkInfo(
-    name: "IndexPath.Max.Beginning",
-    runFunction: { n in 
-      run_IndexPathMaxBeginning(n * 25, decreasingIndexPath)
-    },
-    tags: tags,
-    setUpFunction: { blackHole(decreasingIndexPath) }),
+    name: "IndexPath.Max",
+    runFunction: { n in run_IndexPathMax(n * 10) },
+    tags: tags),
   BenchmarkInfo(
-    name: "IndexPath.Max.Middle",
-    runFunction: { n in
-      run_IndexPathMaxMiddle(n * 25, increasingMaxMiddleIndexPath)
-    },
-    tags: tags,
-    setUpFunction: { blackHole(increasingMaxMiddleIndexPath) }),
-  BenchmarkInfo(
-    name: "IndexPath.Max.End",
-    runFunction: { n in 
-      run_IndexPathMaxEnd(n * 25, increasingIndexPath) 
-    },
-    tags: tags,
-    setUpFunction: { blackHole(increasingIndexPath) }),
-
-  BenchmarkInfo(
-    name: "IndexPath.Min.Beginning",
-    runFunction: { n in 
-      run_IndexPathMinBeginning(n * 25, increasingIndexPath)
-    },
-    tags: tags,
-    setUpFunction: { blackHole(increasingIndexPath) }),
-  BenchmarkInfo(
-    name: "IndexPath.Min.Middle",
-    runFunction: { n in
-      run_IndexPathMinMiddle(n * 25, increasingMinMiddleIndexPath)
-    },
-    tags: tags,
-    setUpFunction: { blackHole(increasingMinMiddleIndexPath) }),
-  BenchmarkInfo(
-    name: "IndexPath.Min.End",
-    runFunction: { n in 
-      run_IndexPathMinEnd(n * 25, decreasingIndexPath) 
-    },
-    tags: tags,
-    setUpFunction: { blackHole(decreasingIndexPath) }),
+    name: "IndexPath.Min",
+    runFunction: { n in run_IndexPathMin(n * 10) },
+    tags: tags),
 ]
 
 @inline(__always)
@@ -133,81 +97,34 @@ public func run_IndexPathSubscriptRangeMutation(
     })
 }
 
-// Max, Min
-
-@inline(__always)
-func maxMin(
-  n: Int,
-  indexPath: IndexPath,
-  maxMinFunc: (inout IndexPath) -> Int?
-) {
-  for _ in 0..<n {
-    var ip = indexPath
-    let found = maxMinFunc(&ip) != nil
-    blackHole(found)
-  }
-}
-
 // Max
 
 @inline(never)
-public func run_IndexPathMaxBeginning(_ n: Int, _ indexPath: IndexPath) {
-  maxMin(
-    n: n,
-    indexPath: indexPath,
-    maxMinFunc: { ip in
-      ip.max()
-    })
-}
-
-@inline(never)
-public func run_IndexPathMaxMiddle(_ n: Int, _ indexPath: IndexPath) {
-  maxMin(
-    n: n,
-    indexPath: indexPath,
-    maxMinFunc: { ip in
-      ip.max()
-    })
-}
-
-@inline(never)
-public func run_IndexPathMaxEnd(_ n: Int, _ indexPath: IndexPath) {
-  maxMin(
-    n: n,
-    indexPath: indexPath,
-    maxMinFunc: { ip in
-      ip.max()
-    })
+public func run_IndexPathMax(_ n: Int) {
+  for _ in 0..<n {
+    var val: Int?
+    // Beginning max
+    val = decreasingIndexPath.max()
+    // Middle max
+    val = increasingMaxMiddleIndexPath.max()
+    // End max
+    val = increasingIndexPath.max()
+    blackHole(val)
+  }
 }
 
 // Min
 
 @inline(never)
-public func run_IndexPathMinBeginning(_ n: Int, _ indexPath: IndexPath) {
-  maxMin(
-    n: n,
-    indexPath: indexPath,
-    maxMinFunc: { ip in
-      ip.min()
-    })
-}
-
-@inline(never)
-public func run_IndexPathMinMiddle(_ n: Int, _ indexPath: IndexPath) {
-  maxMin(
-    n: n,
-    indexPath: indexPath,
-    maxMinFunc: { ip in
-      ip.min()
-    })
-}
-
-@inline(never)
-public func run_IndexPathMinEnd(_ n: Int, _ indexPath: IndexPath) {
-  maxMin(
-    n: n,
-    indexPath: indexPath,
-    maxMinFunc: { ip in
-      ip.min()
-    })
+public func run_IndexPathMin(_ n: Int) {
+  for _ in 0..<n {
+    var val: Int?
+    // Beginning min
+    val = increasingIndexPath.min()
+    // Middle min
+    val = increasingMinMiddleIndexPath.min()
+    // End min
+    val = decreasingIndexPath.min()
+    blackHole(val)
+  }
 }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -23,7 +23,7 @@ public enum BenchmarkCategory : String {
   // we know is important to measure.
   case validation
   // subsystems to validate and their subcategories.
-  case api, Array, String, Dictionary, Codable, Set, Data
+  case api, Array, String, Dictionary, Codable, Set, Data, IndexPath
   case sdk
   case runtime, refcount, metadata
   // Other general areas of compiled code validation.

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -86,6 +86,7 @@ import Hanoi
 import Hash
 import Histogram
 import HTTP2StateMachine
+import IndexPathTest
 import InsertCharacter
 import IntegerParsing
 import Integrate
@@ -274,6 +275,7 @@ registerBenchmark(Hanoi)
 registerBenchmark(HashTest)
 registerBenchmark(Histogram)
 registerBenchmark(HTTP2StateMachine)
+registerBenchmark(IndexPathTest)
 registerBenchmark(InsertCharacter)
 registerBenchmark(IntegerParsing)
 registerBenchmark(IntegrateTest)


### PR DESCRIPTION
Adds IndexPath benchmarks for the following, and is part of [SR-6789](https://bugs.swift.org/browse/SR-6789):
- `subscript(_:IndexPath.Index)`
- `subscript(_:Range<IndexPath.Index>)`
- `max()`
- `min()`

These are the added benchmarks:
- `IndexPathSubscriptMutation`: Increments an element at the given index by 1.
- `IndexPathSubscriptRangeMutation`: Adds an IndexPath to the given index range.
- `IndexPathMaxBeginning`: Checks max(), with the max value at the beginning.
- `IndexPathMaxMiddle`: Checks max(), with the max value at the middle.
- `IndexPathMaxEnd`: Checks max(), with the max value at the end.
- `IndexPathMinBeginning`: Checks min(), with the min value at the beginning.
- `IndexPathMinMiddle`: Checks min(), with the min value at the middle.
- `IndexPathMinEnd`: Checks min(), with the min value at the end

This is my first contribution; open to any comments!

Resolves [SR-13801](https://bugs.swift.org/browse/SR-13801)
