### PR TITLE
[cxx-interop] Support reference types in function templates.

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -46,3 +46,9 @@ decltype(auto) testAuto(T arg) {
 template <class T> struct Dep { using TT = T; };
 
 template <class T> void useDependentType(typename Dep<T>::TT) {}
+
+template <class T> void lvalueReference(T &ref) { ref = 42; }
+
+template <class T> void constLvalueReference(const T &) {}
+
+template <class T> void forwardingReference(T &&) {}

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -6,3 +6,6 @@
 // CHECK: func passThroughConst<T>(_ value: T) -> T
 // CHECK: func returns_template<R, T, U>(_ a: T, _ b: U) -> R
 // CHECK: func cannot_infer_template<T>()
+// CHECK: func lvalueReference<T>(_ ref: UnsafeMutablePointer<T>)
+// CHECK: func constLvalueReference<T>(_: UnsafePointer<T>)
+// CHECK: func forwardingReference<T>(_: UnsafeMutablePointer<T>)

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -22,6 +22,12 @@ FunctionTemplateTestSuite.test("add<T, U> where T, U == Int") {
   expectEqual(65, result)
 }
 
+FunctionTemplateTestSuite.test("lvalueReference<T> where T == Int") {
+  var value = 0
+  lvalueReference(&value)
+  expectEqual(value, 42)
+}
+
 // TODO: currently "Any" is imported as an Objective-C "id".
 // This doesn't work without the Objective-C runtime. 
 #if _runtime(_ObjC)


### PR DESCRIPTION
Support reference wrapped template params such as:
```
template <class T> void lvalueReference(T &ref)
```