### PR TITLE
[cxx-interop] Bail if the type a reference type is wrapping is unkown.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -506,6 +506,8 @@ namespace {
       Type pointeeType =
           Impl.importTypeIgnoreIUO(pointeeQualType, ImportTypeKind::Value,
                                    AllowNSUIntegerAsInt, Bridgeability::None);
+      if (!pointeeType)
+        return Type();
 
       if (pointeeQualType->isFunctionType()) {
         return importFunctionPointerLikeType(*type, pointeeType);

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -16,4 +16,8 @@ void setConstStaticIntRvalueRef(const int &&);
 auto getFuncRef() -> int (&)();
 auto getFuncRvalueRef() -> int (&&)();
 
+// We cannot import "_Atomic" types. Make sure we fail gracefully instead of
+// crashing when we have an "_Atomic" type or a reference to one.
+void dontImportAtomicRef(_Atomic(int)&) { }
+
 #endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -12,3 +12,5 @@
 // CHECK: func setConstStaticIntRvalueRef(_: UnsafePointer<Int32>)
 // CHECK: func getFuncRef() -> @convention(c) () -> Int32
 // CHECK: func getFuncRvalueRef() -> @convention(c) () -> Int32
+
+// CHECK-NOT: dontImportAtomicRef


### PR DESCRIPTION
If we can't find the type a reference type is wrapping (the pointee type), then don't import that type instead of crashing later.