### PR TITLE
[cxx-interop] Bail on dependent types (instead of crashing).

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -211,10 +211,9 @@ namespace {
 
     ImportResult VisitType(const Type*) = delete;
 
+    // TODO: Add support for dependent types (SR-13809).
 #define DEPENDENT_TYPE(Class, Base)                                            \
-  ImportResult Visit##Class##Type(const clang::Class##Type *) {                \
-    llvm_unreachable("Dependent types cannot be converted");                   \
-  }
+  ImportResult Visit##Class##Type(const clang::Class##Type *) { return Type(); }
 #define TYPE(Class, Base)
 #include "clang/AST/TypeNodes.inc"
 

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -36,6 +36,13 @@ decltype(auto) testAuto(T arg) {
   return arg;
 }
 
-// TODO: Add tests for Decltype, UnaryTransform, and TemplateSpecialization with a dependent type once those are supported.
+// TODO: Add tests for Decltype, UnaryTransform, and TemplateSpecialization with
+// a dependent type once those are supported.
 
 // TODO: Add test for DeducedTemplateSpecializationType once we support class templates.
+
+// TODO(SR-13809): We don't yet support dependent types but we still shouldn't
+// crash when importing one.
+template <class T> struct Dep { using TT = T; };
+
+template <class T> void useDependentType(typename Dep<T>::TT) {}


### PR DESCRIPTION
Just returns "Type()" instead of crashing at the "llvm_unreachable". This is a stop-gap solution until we support dependent types.