### PR TITLE
[membehavior] Fix base memory behavior/releasing of Load/Store for ownership

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -592,7 +592,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
 
   // Accessing memory
   SINGLE_VALUE_INST(LoadInst, load,
-                    SingleValueInstruction, MayRead, DoesNotRelease)
+                    SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
   SINGLE_VALUE_INST(LoadBorrowInst, load_borrow,
                     SingleValueInstruction, MayRead, DoesNotRelease)
   SINGLE_VALUE_INST(BeginBorrowInst, begin_borrow,
@@ -852,7 +852,7 @@ NON_VALUE_INST(BeginUnpairedAccessInst, begin_unpaired_access,
 NON_VALUE_INST(EndUnpairedAccessInst, end_unpaired_access,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 NON_VALUE_INST(StoreInst, store,
-               SILInstruction, MayWrite, DoesNotRelease)
+               SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(AssignInst, assign,
                SILInstruction, MayWrite, DoesNotRelease)
 NON_VALUE_INST(AssignByWrapperInst, assign_by_wrapper,

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -539,12 +539,29 @@ void FunctionSideEffects::analyzeInstruction(SILInstruction *I) {
         true;
     Traps = true;
     return;
-  case SILInstructionKind::LoadInst:
-    getEffectsOn(cast<LoadInst>(I)->getOperand())->Reads = true;
+  case SILInstructionKind::LoadBorrowInst: {
+    auto *effects = getEffectsOn(cast<LoadBorrowInst>(I)->getOperand());
+    effects->Reads = true;
     return;
-  case SILInstructionKind::StoreInst:
-    getEffectsOn(cast<StoreInst>(I)->getDest())->Writes = true;
+  }
+  case SILInstructionKind::LoadInst: {
+    auto *li = cast<LoadInst>(I);
+    auto *effects = getEffectsOn(cast<LoadInst>(I)->getOperand());
+    effects->Reads = true;
+    if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take)
+      effects->Writes = true;
+    if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Copy)
+      effects->Retains = true;
     return;
+  }
+  case SILInstructionKind::StoreInst: {
+    auto *si = cast<StoreInst>(I);
+    auto *effects = getEffectsOn(si->getDest());
+    effects->Writes = true;
+    if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign)
+      effects->Releases = true;
+    return;
+  }
   case SILInstructionKind::CondFailInst:
     Traps = true;
     return;


### PR DESCRIPTION
load, store in ossa can have side-effects and stores can release. Specifically:

Memory Behavior
---------------

* Load: unqualified, trivial, take have a read side-effect, but copy retains so
  has side-effects.

* Store: unqualified, trivial, init may write but assign releases so it may have
  side-effects.

Release Behavior
----------------

* Load: No changes.

* Store: May release if store has assign as an ownership qualifier.
