### PR TITLE
[Dependency Scanner] Add missing clang overlay dependencies for placeholder modules

### DIFF
--- a/lib/FrontendTool/ScanDependencies.cpp
+++ b/lib/FrontendTool/ScanDependencies.cpp
@@ -161,7 +161,7 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
   auto isSwift = knownDependencies.isSwiftTextualModule();
 
   // Find the dependencies of every module this module directly depends on.
-  std::vector<ModuleDependencyID> result;
+  std::set<ModuleDependencyID> result;
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {
     // Figure out what kind of module we need.
     bool onlyClangModule = !isSwift || module.first == dependsOn;
@@ -169,7 +169,7 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
     // Retrieve the dependencies for this module.
     if (auto found = ctx.getModuleDependencies(
             dependsOn, onlyClangModule, cache, ASTDelegate)) {
-      result.push_back({dependsOn, found->getKind()});
+      result.insert({dependsOn, found->getKind()});
     }
   }
 
@@ -215,13 +215,15 @@ static std::vector<ModuleDependencyID> resolveDirectDependencies(
         // This Clang module may have the same name as the Swift module we are resolving, so we
         // need to make sure we don't add a dependency from a Swift module to itself.
         if ((found->getKind() == ModuleDependenciesKind::SwiftTextual ||
-             found->getKind() == ModuleDependenciesKind::SwiftBinary) &&
-            clangDep != module.first)
-          result.push_back({clangDep, found->getKind()});
+             found->getKind() == ModuleDependenciesKind::SwiftBinary ||
+             found->getKind() == ModuleDependenciesKind::SwiftPlaceholder) &&
+            clangDep != module.first) {
+          result.insert({clangDep, found->getKind()});
+        }
       }
     }
   }
-  return result;
+  return std::vector<ModuleDependencyID>(result.begin(), result.end());
 }
 
 static void discoverCrosssImportOverlayDependencies(

--- a/test/ScanDependencies/can_import_placeholder.swift
+++ b/test/ScanDependencies/can_import_placeholder.swift
@@ -30,6 +30,9 @@ import SomeExternalModule
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
+// CHECK-NEXT: "swift": "F"
+// CHECK-NEXT: }
+// CHECK-NEXT: {
 // CHECK-NEXT: "swiftPlaceholder": "SomeExternalModule"
 // CHECK-NEXT: }
 // CHECK-NEXT: {
@@ -37,9 +40,6 @@ import SomeExternalModule
 // CHECK-NEXT: }
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "F"
 // CHECK-NEXT: }
 // CHECK-NEXT: ],
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -34,35 +34,35 @@ import SubE
 // CHECK-LABEL: "modulePath": "deps.swiftmodule",
 // CHECK-NEXT: sourceFiles
 // CHECK-NEXT: module_deps.swift
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "C"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "E"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "G"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "SubE"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "_cross_import_E"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "F"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "A"
-// CHECK-NEXT: }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "A"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "clang": "C"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "E"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "F"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "G"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "SubE"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "Swift"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "_cross_import_E"
+// CHECK-NEXT:   }
 // CHECK-NEXT: ],
 
 // CHECK:      "extraPcmArgs": [
@@ -82,6 +82,17 @@ import SubE
 // CHECK: "moduleDependencies": [
 // CHECK-NEXT: "F"
 // CHECK-NEXT: ]
+
+/// --------Swift module A
+// CHECK-LABEL: "modulePath": "A.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-NEXT:   "clang": "A"
+// CHECK-NEXT: }
+// CHECK-NEXT: {
+// CHECK-NEXT:   "swift": "Swift"
+// CHECK-NEXT: },
 
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "C.pcm",
@@ -120,14 +131,30 @@ import SubE
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 
+/// --------Swift module F
+// CHECK:      "modulePath": "F.swiftmodule",
+// CHECK-NEXT: "sourceFiles": [
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "clang": "F"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "Swift"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],
+
 /// --------Swift module G
 // CHECK-LABEL: "modulePath": "G.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
+// CHECK-NEXT:   "clang": "G"
 // CHECK-NEXT: },
 // CHECK-NEXT: {
-// CHECK-NEXT:   "clang": "G"
+// CHECK-NEXT:   "swift": "Swift"
 // CHECK-NEXT: },
 // CHECK-NEXT: {
 // CHECK-NEXT:   "swift": "SwiftOnoneSupport"
@@ -155,33 +182,6 @@ import SubE
 // CHECK: directDependencies
 // CHECK-NEXT: {
 // CHECK-NEXT: "clang": "SwiftShims"
-
-/// --------Swift module F
-// CHECK:      "modulePath": "F.swiftmodule",
-// CHECK-NEXT: "sourceFiles": [
-// CHECK-NEXT: ],
-// CHECK-NEXT: "directDependencies": [
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "Swift"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "clang": "F"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
-// CHECK-NEXT:   }
-// CHECK-NEXT: ],
-
-/// --------Swift module A
-// CHECK-LABEL: "modulePath": "A.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "clang": "A"
-// CHECK-NEXT: }
 
 /// --------Clang module B
 // CHECK-LABEL: "modulePath": "B.pcm"

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -16,6 +16,9 @@ import SubEWrapper
 // CHECK-NEXT:   "swift": "EWrapper"
 // CHECK-NEXT: },
 // CHECK-NEXT: {
+// CHECK-NEXT:   "swift": "F"
+// CHECK-NEXT: },
+// CHECK-NEXT: {
 // CHECK-NEXT:   "swift": "SubEWrapper"
 // CHECK-NEXT: },
 // CHECK-NEXT: {
@@ -26,8 +29,5 @@ import SubEWrapper
 // CHECK-NEXT: },
 // CHECK-NEXT: {
 // CHECK-NEXT:   "swift": "_cross_import_E"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "F"
 // CHECK-NEXT: }
 // CHECK-NEXT: ],

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -40,6 +40,9 @@ import SomeExternalModule
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
+// CHECK-NEXT: "swift": "F"
+// CHECK-NEXT: }
+// CHECK-NEXT: {
 // CHECK-NEXT: "swiftPlaceholder": "SomeExternalModule"
 // CHECK-NEXT: }
 // CHECK-NEXT: {
@@ -47,9 +50,6 @@ import SomeExternalModule
 // CHECK-NEXT: }
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "F"
 // CHECK-NEXT: }
 // CHECK-NEXT: ],
 

--- a/test/ScanDependencies/placholder_overlay_deps.swift
+++ b/test/ScanDependencies/placholder_overlay_deps.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Darwin\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/Darwin.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/Darwin.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Darwin.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s < %t/deps.json
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+import Metal
+
+// Ensure the dependency on Darwin is captured even though it is a placeholder
+
+// CHECK:   "modulePath": "Metal.swiftmodule",
+// CHECK-NEXT:   "sourceFiles": [
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "directDependencies": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "CoreFoundation"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "CoreGraphics"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swiftPlaceholder": "Darwin"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "Dispatch"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "Foundation"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "IOKit"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "clang": "Metal"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "ObjectiveC"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "Swift"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "swift": "XPC"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],


### PR DESCRIPTION
We were previously forgetting about these.
On top of that, make sure we treat accumulated dependencies as a set, because adding clang overlay dependencies may duplicate existing already-added dependencies for some module.
