### PR TITLE
[CMake] Pass -no_warn_inits to the linker to silence warnings about global initializers

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1291,6 +1291,10 @@ function(_add_swift_target_library_single target name)
         endif()
       endif()
     endif()
+
+    # Silence warnings about global initializers. We already have clang
+    # emitting warnings about global initializers when it compiles the code.
+    list(APPEND swiftlib_link_flags_all "-Xlinker -no_warn_inits")
   endif()
   target_link_libraries(${target} PRIVATE
     ${link_libraries})


### PR DESCRIPTION
We already get warnings from clang at compile time. For cases where we silence those, with SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN, these warnings are just noise.

rdar://problem/70445131