### PR TITLE
[CodeCompletion] Do not include decl in own (string interp) initializer

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -418,13 +418,14 @@ public:
 /// a decl inside its own initializer or a non-type decl before its definition.
 class UsableFilteringDeclConsumer final : public VisibleDeclConsumer {
   const SourceManager &SM;
+  const DeclContext *DC;
   SourceLoc Loc;
   VisibleDeclConsumer &ChainedConsumer;
 
 public:
-  UsableFilteringDeclConsumer(const SourceManager &SM, SourceLoc loc,
-                              VisibleDeclConsumer &consumer)
-      : SM(SM), Loc(loc), ChainedConsumer(consumer) {}
+  UsableFilteringDeclConsumer(const SourceManager &SM, const DeclContext *DC,
+                              SourceLoc loc, VisibleDeclConsumer &consumer)
+      : SM(SM), DC(DC), Loc(loc), ChainedConsumer(consumer) {}
 
   void foundDecl(ValueDecl *D, DeclVisibilityKind reason,
                  DynamicLookupInfo dynamicLookupInfo) override;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -149,9 +149,14 @@ void UsableFilteringDeclConsumer::foundDecl(ValueDecl *D,
     DeclVisibilityKind reason, DynamicLookupInfo dynamicLookupInfo) {
   // Skip when Loc is within the decl's own initializer
   if (auto *VD = dyn_cast<VarDecl>(D)) {
+    Expr *init = VD->getParentInitializer();
+    if (auto *PD = dyn_cast<ParamDecl>(D)) {
+      init = PD->getStructuralDefaultExpr();
+    }
+
     // Only check if the VarDecl has the same (or parent) context to avoid
-    // grabbing the end location for every decl
-    if (auto *init = VD->getParentInitializer()) {
+    // grabbing the end location for every decl with an initializer
+    if (init != nullptr) {
       auto *varContext = VD->getDeclContext();
       if (DC == varContext || DC->isChildContextOf(varContext)) {
         auto initRange = Lexer::getCharSourceRangeFromSourceRange(

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4652,8 +4652,9 @@ public:
                      : LookupKind::ValueInDeclContext;
     NeedLeadingDot = false;
 
-    UsableFilteringDeclConsumer UsableFilteringConsumer(Ctx.SourceMgr,
-        Ctx.SourceMgr.getCodeCompletionLoc(), *this);
+    UsableFilteringDeclConsumer UsableFilteringConsumer(
+        Ctx.SourceMgr, CurrDeclContext, Ctx.SourceMgr.getCodeCompletionLoc(),
+        *this);
     AccessFilteringDeclConsumer AccessFilteringConsumer(
         CurrDeclContext, UsableFilteringConsumer);
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1303,7 +1303,7 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
     return;
   }
   UsableFilteringDeclConsumer FilteringConsumer(DC->getASTContext().SourceMgr,
-                                                Loc, Consumer);
+                                                DC, Loc, Consumer);
   lookupVisibleDeclsImpl(FilteringConsumer, DC, IncludeTopLevel, Loc);
 }
 

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -82,6 +82,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_5 | %FileCheck %s -check-prefix=OWN_INIT_5
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_6 | %FileCheck %s -check-prefix=OWN_INIT_6
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_7 | %FileCheck %s -check-prefix=OWN_INIT_7
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_8 | %FileCheck %s -check-prefix=OWN_INIT_8
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_9 | %FileCheck %s -check-prefix=OWN_INIT_9
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_10 | %FileCheck %s -check-prefix=OWN_INIT_10
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_ACCESSOR_1 | %FileCheck %s -check-prefix=OWN_ACCESSOR_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_ACCESSOR_2 | %FileCheck %s -check-prefix=OWN_ACCESSOR_2
@@ -584,6 +587,9 @@ func sync() {}
 var ownInit2: () -> Void = { #^OWN_INIT_2^# }
 // OWN_INIT_2: Begin completions
 // OWN_INIT_2-NOT: ownInit2
+var ownInit8: Int = "\(#^OWN_INIT_8^#)"
+// OWN_INIT_8: Begin completions
+// OWN_INIT_8-NOT: ownInit8
 struct OwnInitTester {
   var ownInit3: Int = #^OWN_INIT_3^#
   // OWN_INIT_3: Begin completions
@@ -591,6 +597,9 @@ struct OwnInitTester {
   var ownInit4: () -> Void = { #^OWN_INIT_4^# }
   // OWN_INIT_4: Begin completions
   // OWN_INIT_4-NOT: ownInit4
+  var ownInit9: String = "\(#^OWN_INIT_9^#)"
+  // OWN_INIT_9: Begin completions
+  // OWN_INIT_9-NOT: ownInit9
 }
 func ownInitTesting() {
   var ownInit5: Int = #^OWN_INIT_5^#
@@ -599,6 +608,9 @@ func ownInitTesting() {
   var ownInit6: () -> Void = { #^OWN_INIT_6^# }
   // OWN_INIT_6: Begin completions
   // OWN_INIT_6-NOT: ownInit6
+  var ownInit10: String = "\(#^OWN_INIT_10^#)"
+  // OWN_INIT_10: Begin completions
+  // OWN_INIT_10-NOT: ownInit10
 }
 func ownInitTestingShadow(ownInit7: Int) {
   var ownInit7: Int = #^OWN_INIT_7^#

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -75,8 +75,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_1 | %FileCheck %s -check-prefix=IN_TUPLE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_2 | %FileCheck %s -check-prefix=IN_TUPLE_2
 
-// RUN-FIXME(rdar56755598): %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_1 | %FileCheck %s -check-prefix=OWN_INIT_1
-// RUN-FIXME(rdar56755598): %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_2 | %FileCheck %s -check-prefix=OWN_INIT_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_1 | %FileCheck %s -check-prefix=OWN_INIT_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_2 | %FileCheck %s -check-prefix=OWN_INIT_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_3 | %FileCheck %s -check-prefix=OWN_INIT_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_4 | %FileCheck %s -check-prefix=OWN_INIT_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_5 | %FileCheck %s -check-prefix=OWN_INIT_5
@@ -85,6 +85,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_8 | %FileCheck %s -check-prefix=OWN_INIT_8
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_9 | %FileCheck %s -check-prefix=OWN_INIT_9
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_10 | %FileCheck %s -check-prefix=OWN_INIT_10
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_11 | %FileCheck %s -check-prefix=OWN_INIT_11
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_12 | %FileCheck %s -check-prefix=OWN_INIT_12
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_ACCESSOR_1 | %FileCheck %s -check-prefix=OWN_ACCESSOR_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_ACCESSOR_2 | %FileCheck %s -check-prefix=OWN_ACCESSOR_2
@@ -611,6 +613,14 @@ func ownInitTesting() {
   var ownInit10: String = "\(#^OWN_INIT_10^#)"
   // OWN_INIT_10: Begin completions
   // OWN_INIT_10-NOT: ownInit10
+}
+func ownInitTestingParam(ownInit11: Int = #^OWN_INIT_11^#) {
+  // OWN_INIT_11: Begin completions
+  // OWN_INIT_11-NOT: Decl[LocalVar]{{.*}}ownInit11
+}
+func ownInitTestingParamInterp(ownInit12: String = "\(#^OWN_INIT_12^#)") {
+  // OWN_INIT_12: Begin completions
+  // OWN_INIT_12-NOT: Decl[LocalVar]{{.*}}ownInit12
 }
 func ownInitTestingShadow(ownInit7: Int) {
   var ownInit7: Int = #^OWN_INIT_7^#


### PR DESCRIPTION
Strings are a single token, so the previous check would treat
completions inside string interpolations as being outside of the
initializer.

Grab the end of the token from the Lexer, but wrap in a context check to
avoid performing that for every declaration found in the lookup.

Resolves rdar://70833348