### PR TITLE
stdlib: add `AppNotify.h` to the Shell module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -255,6 +255,13 @@ module WinSDK [system] {
     export *
   }
 
+  module AppNotify {
+    header "appnotify.h"
+    export *
+
+    link "appnotify.lib"
+  }
+
   module ShellAPI {
     header "shellapi.h"
     header "Shlwapi.h"


### PR DESCRIPTION
This header is a standalone header part of the shell subsystem which
allows application to get notification related to application
suspension.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
