### PR TITLE
[android] Split demangling tests for Android 32/64 bits.

### DIFF
--- a/test/Demangle/clang-function-types-android.swift
+++ b/test/Demangle/clang-function-types-android.swift
@@ -1,0 +1,26 @@
+// NOTE: manglings.txt should be kept in sync with the manglings in this file.
+
+// Make sure we are testing the right manglings.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-sil -o - -I %S/../Inputs/custom-modules -use-clang-function-types -module-name tmp -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-os-%target-cpu --check-prefix=CHECK-%target-ptrsize
+
+// Check that demangling works.
+
+// %t.input: "A ---> B" ==> "A"
+// RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings-with-clang-types.txt > %t.input
+// %t.check: "A ---> B" ==> "B"
+// RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings-with-clang-types.txt > %t.check
+// RUN: swift-demangle -classify < %t.input > %t.output
+// RUN: diff %t.check %t.output
+
+// REQUIRES: OS=linux-android || OS=linux-androideabi
+
+import ctypes
+
+public func f(_ k: @convention(c, cType: "size_t (*)(void)") () -> Int) {
+  let _ = k()
+}
+f(ctypes.returns_size_t) // OK: check that importing preserves Clang type
+
+// CHECK-32: sil @$s3tmp1fyySiyXzC9_ZTSPFjvEF
+// CHECK-64: sil @$s3tmp1fyySiyXzC9_ZTSPFmvEF
+

--- a/test/Demangle/clang-function-types.swift
+++ b/test/Demangle/clang-function-types.swift
@@ -16,6 +16,7 @@
 // check that here again.
 
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
 
 import ctypes
 

--- a/test/SIL/clang-function-types-android.swift
+++ b/test/SIL/clang-function-types-android.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-sil -swift-version 5 -use-clang-function-types -experimental-print-full-convention -o - | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: OS=linux-android ||  OS=linux-androideabi
+
+import ctypes
+
+public func f(g: @convention(c, cType: "void (*)(size_t)") (Int) -> ()) { g(0) }
+
+// CHECK-32: sil @$s4main1f1gyySiXzC9_ZTSPFvjE_tF : $@convention(thin) (@convention(c, cType: "void (*)(unsigned int)") @noescape (Int) -> ()) -> () {
+// CHECK-32: bb0(%0 : $@convention(c, cType: "void (*)(unsigned int)") @noescape (Int) -> ()):
+// CHECK-32:   debug_value %0 : $@convention(c, cType: "void (*)(unsigned int)") @noescape (Int) -> (), let, name "g", argno 1 // id: %1
+
+// CHECK-64: sil @$s4main1f1gyySiXzC9_ZTSPFvmE_tF : $@convention(thin) (@convention(c, cType: "void (*)(unsigned long)") @noescape (Int) -> ()) -> () {
+// CHECK-64: bb0(%0 : $@convention(c, cType: "void (*)(unsigned long)") @noescape (Int) -> ()):
+// CHECK-64:   debug_value %0 : $@convention(c, cType: "void (*)(unsigned long)") @noescape (Int) -> (), let, name "g", argno 1 // id: %1

--- a/test/SIL/clang-function-types-nonwindows.swift
+++ b/test/SIL/clang-function-types-nonwindows.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-sil -swift-version 5 -use-clang-function-types -experimental-print-full-convention -o - | %FileCheck %s
 
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
 
 import ctypes
 


### PR DESCRIPTION
`size_t` differs in 32 bit platforms like Android ARMv7 where it is
`unsigned int` instead of `unsigned long`. The mangling changes one of the
characters.

The original tests are disabled in Android, and they are replicated in
different files for Android, with both the 32 and the 64 bits versions
of the mangling and the function signatures.

The original tests are not modified in order to avoid complicated checks
to avoid platforms like iphonesimulator-i386, which is a 32 bit
platform, but still uses `unsigned long` as the underlying type for
`size_t`

Both tests started failing after #34057 landed in the Android 32 bits CI
machines.