### PR TITLE
[value-lifetime] Replace unsafe constructor that doesn't require uses to be specified with new constructors.

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -752,6 +752,17 @@ using all_true =
 template <class... Ts>
 using are_all_compound = all_true<std::is_compound<Ts>::value...>;
 
+/// Removes reference, pointer, const from T.
+template <typename T>
+struct remove_cpr {
+  using type =
+    typename std::remove_const<
+      typename std::remove_pointer<
+        typename std::remove_reference<T>
+      >
+    >::type;
+};
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_INTERLEAVE_H

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -937,7 +937,8 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
     // release it explicitly when the partial_apply is released.
     if (Apply.getKind() == ApplySiteKind::PartialApplyInst) {
       if (PAFrontier.empty()) {
-        ValueLifetimeAnalysis VLA(cast<PartialApplyInst>(Apply));
+        auto *PAI = cast<PartialApplyInst>(Apply);
+        ValueLifetimeAnalysis VLA(PAI, PAI->getUses());
         pass.CFGChanged |= !VLA.computeFrontier(
             PAFrontier, ValueLifetimeAnalysis::AllowToModifyCFG);
         assert(!PAFrontier.empty() &&


### PR DESCRIPTION
The new constructors do not do anything truly interesting beyond enabling the
ranges the constructor takes to use either SILInstructions or Operands
transparently without the user knowing.
