### PR TITLE
[SE-0491] Implement lookup and diagnostics for module selectors (MyMod::someName)

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -164,10 +164,13 @@ BridgedDeclNameRef_createParsed(BridgedASTContext cContext,
 
 class BridgedDeclNameLoc {
   const void *_Nullable LocationInfo;
-  size_t NumArgumentLabels;
+  uint32_t NumArgumentLabels;
+  bool HasModuleSelectorLoc;
 
 public:
-  BridgedDeclNameLoc() : LocationInfo(nullptr), NumArgumentLabels(0) {}
+  BridgedDeclNameLoc()
+    : LocationInfo(nullptr), NumArgumentLabels(0), HasModuleSelectorLoc(false)
+  {}
 
   BRIDGED_INLINE BridgedDeclNameLoc(swift::DeclNameLoc loc);
 

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -60,10 +60,12 @@ swift::DeclNameRef BridgedDeclNameRef::unbridged() const {
 
 BridgedDeclNameLoc::BridgedDeclNameLoc(swift::DeclNameLoc loc)
     : LocationInfo(loc.LocationInfo),
-      NumArgumentLabels(loc.NumArgumentLabels) {}
+      NumArgumentLabels(loc.NumArgumentLabels),
+      HasModuleSelectorLoc(loc.HasModuleSelectorLoc) {}
 
 swift::DeclNameLoc BridgedDeclNameLoc::unbridged() const {
-  return swift::DeclNameLoc(LocationInfo, NumArgumentLabels);
+  return swift::DeclNameLoc(LocationInfo, NumArgumentLabels,
+                            HasModuleSelectorLoc);
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3072,11 +3072,10 @@ public:
     return Name.getBaseIdentifier();
   }
 
-  /// Generates a DeclNameRef referring to this declaration with as much
-  /// specificity as possible.
-  DeclNameRef createNameRef() const {
-    return DeclNameRef(Name);
-  }
+  /// Generates a DeclNameRef referring to this declaration.
+  ///
+  /// \param moduleSelector If true, the name ref includes the module name.
+  DeclNameRef createNameRef(bool moduleSelector = false) const;
 
   /// Retrieve the C declaration name that names this function, or empty
   /// string if it has none.

--- a/include/swift/AST/DeclNameLoc.h
+++ b/include/swift/AST/DeclNameLoc.h
@@ -35,61 +35,69 @@ class DeclNameLoc {
 
   /// Source location information.
   ///
-  /// If \c NumArgumentLabels == 0, this is the SourceLoc for the base name.
-  /// Otherwise, it points to an array of SourceLocs, which contains:
+  /// If \c NumArgumentLabels == 0 and \c !HasModuleSelectorLoc, this is the
+  /// SourceLoc for the base name. Otherwise, it points to an array of
+  /// SourceLocs, which contains:
   /// * The base name location
+  /// * The module selector location
   /// * The left parentheses location
   /// * The right parentheses location
   /// * The locations of each of the argument labels.
   const void *LocationInfo;
 
   /// The number of argument labels stored in the name.
-  unsigned NumArgumentLabels;
+  uint32_t NumArgumentLabels;
+  bool HasModuleSelectorLoc;
 
   enum {
     BaseNameIndex = 0,
-    LParenIndex = 1,
-    RParenIndex = 2,
-    FirstArgumentLabelIndex = 3,
+    ModuleSelectorIndex = 1,
+    LParenIndex = 2,
+    RParenIndex = 3,
+    FirstArgumentLabelIndex = 4,
   };
 
   /// Retrieve a pointer to either the only source location that was
   /// stored or to the array of source locations that was stored.
   SourceLoc const * getSourceLocs() const {
-    if (NumArgumentLabels == 0) 
+    if (NumArgumentLabels == 0 && !HasModuleSelectorLoc)
       return reinterpret_cast<SourceLoc const *>(&LocationInfo);
 
     return reinterpret_cast<SourceLoc const *>(LocationInfo);
   }
 
-  DeclNameLoc(const void *LocationInfo, unsigned NumArgumentLabels)
-      : LocationInfo(LocationInfo), NumArgumentLabels(NumArgumentLabels) {}
+  DeclNameLoc(const void *LocationInfo, unsigned NumArgumentLabels,
+              bool HasModuleSelectorLoc)
+      : LocationInfo(LocationInfo), NumArgumentLabels(NumArgumentLabels),
+        HasModuleSelectorLoc(HasModuleSelectorLoc) {}
 
 public:
   /// Create an invalid declaration name location.
-  DeclNameLoc() : DeclNameLoc(nullptr, 0) {}
+  DeclNameLoc() : DeclNameLoc(nullptr, 0, false) {}
 
   /// Create declaration name location information for a base name.
   explicit DeclNameLoc(SourceLoc baseNameLoc)
-      : DeclNameLoc(baseNameLoc.getOpaquePointerValue(), 0) {}
+      : DeclNameLoc(baseNameLoc.getOpaquePointerValue(), 0, false) {}
 
   explicit DeclNameLoc(ASTContext &ctx, SourceLoc moduleSelectorLoc,
                        SourceLoc baseNameLoc)
-    : DeclNameLoc(baseNameLoc) { }
+    : DeclNameLoc(ctx, moduleSelectorLoc, baseNameLoc,
+                  SourceLoc(), {}, SourceLoc()) { }
 
   /// Create declaration name location information for a compound
   /// name.
   DeclNameLoc(ASTContext &ctx, SourceLoc baseNameLoc,
               SourceLoc lParenLoc,
               ArrayRef<SourceLoc> argumentLabelLocs,
-              SourceLoc rParenLoc);
+              SourceLoc rParenLoc)
+    : DeclNameLoc(ctx, SourceLoc(), baseNameLoc,
+                  lParenLoc, argumentLabelLocs, rParenLoc) { }
 
   DeclNameLoc(ASTContext &ctx, SourceLoc moduleSelectorLoc,
               SourceLoc baseNameLoc,
               SourceLoc lParenLoc,
               ArrayRef<SourceLoc> argumentLabelLocs,
-              SourceLoc rParenLoc)
-    : DeclNameLoc(ctx, baseNameLoc, lParenLoc, argumentLabelLocs, rParenLoc) { }
+              SourceLoc rParenLoc);
 
   /// Whether the location information is valid.
   bool isValid() const { return getBaseNameLoc().isValid(); }
@@ -125,11 +133,12 @@ public:
   }
 
   SourceLoc getModuleSelectorLoc() const {
-    return SourceLoc();
+    if (!HasModuleSelectorLoc) return SourceLoc();
+    return getSourceLocs()[ModuleSelectorIndex];
   }
 
   SourceLoc getStartLoc() const {
-    return getBaseNameLoc();
+    return HasModuleSelectorLoc ? getModuleSelectorLoc() : getBaseNameLoc();
   }
 
   SourceLoc getEndLoc() const {
@@ -138,9 +147,7 @@ public:
   
   /// Retrieve the complete source range for this declaration name.
   SourceRange getSourceRange() const {
-    if (NumArgumentLabels == 0) return getBaseNameLoc();
-
-    return SourceRange(getBaseNameLoc(), getRParenLoc());
+    return SourceRange(getStartLoc(), getEndLoc());
   }
 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1146,6 +1146,10 @@ ERROR(no_module_type,none,
       "no type named %0 in module %1", (DeclNameRef, Identifier))
 ERROR(ambiguous_module_type,none,
       "ambiguous type name %0 in module %1", (DeclNameRef, Identifier))
+ERROR(module_selector_dependent_member_type_not_allowed,none,
+      "module selector is not allowed on generic member type; associated types "
+      "with the same name are merged instead of shadowing one another",
+      ())
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (DeclNameRef, unsigned))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1195,6 +1195,12 @@ ERROR(wrong_module_selector,none,
       "%0 is not imported through module %1", (DeclName, Identifier))
 NOTE(note_change_module_selector,none,
      "did you mean module %0?", (Identifier))
+NOTE(note_remove_module_selector_local_decl,none,
+     "did you mean the local declaration?", ())
+NOTE(note_remove_module_selector_outer_type,none,
+     "did you mean an outer type member?", ())
+NOTE(note_add_explicit_self_with_module_selector,none,
+     "did you mean the member of 'self'?", ())
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %kindbase0?", (const ValueDecl *))
 NOTE(note_remapped_type,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8010,7 +8010,7 @@ ERROR(expected_macro_expansion_expr,PointsToFirstBadToken,
 ERROR(expected_macro_expansion_decls,PointsToFirstBadToken,
       "expected macro expansion to produce a declaration", ())
 ERROR(macro_undefined,PointsToFirstBadToken,
-      "no macro named %0", (DeclName))
+      "no macro named %0", (DeclNameRef))
 ERROR(external_macro_not_found,none,
       "external macro implementation type '%0.%1' could not be found for "
       "macro %2; %3", (StringRef, StringRef, DeclName, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1191,6 +1191,10 @@ ERROR(cannot_find_type_in_cast_expression,none,
       "type-casting operator expects a type on its right-hand side (got: %kind0)", (const ValueDecl *))
 ERROR(cannot_find_type_in_scope_did_you_mean,none,
       "cannot find type %0 in scope; did you mean to use '%1'?", (DeclNameRef, StringRef))
+ERROR(wrong_module_selector,none,
+      "%0 is not imported through module %1", (DeclName, Identifier))
+NOTE(note_change_module_selector,none,
+     "did you mean module %0?", (Identifier))
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %kindbase0?", (const ValueDecl *))
 NOTE(note_remapped_type,none,

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -769,6 +769,7 @@ class DeclNameRef {
 public:
   static DeclNameRef createSubscript();
   static DeclNameRef createConstructor();
+  static DeclNameRef createSelf(const ASTContext &ctx);
 
   DeclNameRef() : storage(DeclName()) { }
 

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -738,39 +738,75 @@ void simple_display(llvm::raw_ostream &out, DeclName name);
 /// An in-source reference to another declaration, including qualification
 /// information.
 class DeclNameRef {
-  DeclName FullName;
+  friend class ASTContext;
+  friend struct llvm::PointerLikeTypeTraits<DeclNameRef>;
+
+  /// Contains the name and module for a DeclNameRef with a module selector.
+  struct alignas(Identifier) SelectiveDeclNameRef : llvm::FoldingSetNode {
+    Identifier moduleSelector;   // Note: currently can never be empty().
+    DeclName fullName;
+
+    SelectiveDeclNameRef(Identifier moduleSelector, DeclName fullName)
+      : moduleSelector(moduleSelector), fullName(fullName) { }
+
+    /// Uniquing for the ASTContext.
+    static void Profile(llvm::FoldingSetNodeID &id, Identifier moduleSelector,
+                        DeclName fullName);
+
+    void Profile(llvm::FoldingSetNodeID &id) {
+      Profile(id, moduleSelector, fullName);
+    }
+  };
+
+  using Storage = llvm::PointerUnion<DeclName, SelectiveDeclNameRef *>;
+  Storage storage;
+
+  explicit DeclNameRef(void *_Nullable Opaque)
+    : storage(decltype(storage)::getFromOpaqueValue(Opaque)) { }
+
+  void initialize(ASTContext &C, Identifier moduleScope, DeclName fullName);
 
 public:
   static DeclNameRef createSubscript();
   static DeclNameRef createConstructor();
 
-  DeclNameRef() : FullName() { }
+  DeclNameRef() : storage(DeclName()) { }
 
-  void *_Nullable getOpaqueValue() const { return FullName.getOpaqueValue(); }
+  void *_Nullable getOpaqueValue() const {
+    return storage.getOpaqueValue();
+  }
   static DeclNameRef getFromOpaqueValue(void *_Nullable p);
 
   explicit DeclNameRef(ASTContext &C, Identifier moduleSelector,
-                       DeclName fullName)
-    : FullName(fullName) { }
+                       DeclName fullName) {
+    initialize(C, moduleSelector, fullName);
+  }
 
   explicit DeclNameRef(ASTContext &C, Identifier moduleSelector,
-                       DeclBaseName baseName, ArrayRef<Identifier> argLabels)
-    : FullName(C, baseName, argLabels) { }
+                       DeclBaseName baseName, ArrayRef<Identifier> argLabels) {
+    initialize(C, moduleSelector, DeclName(C, baseName, argLabels));
+  }
 
   explicit DeclNameRef(DeclName FullName)
-    : FullName(FullName) { }
+    : storage(FullName) { }
 
   bool hasModuleSelector() const {
-    return false;
+    return isa<SelectiveDeclNameRef *>(storage);
   }
 
   Identifier getModuleSelector() const {
-    return Identifier();
+    if (!hasModuleSelector())
+      return Identifier();
+
+    return cast<SelectiveDeclNameRef *>(storage)->moduleSelector;
   }
 
   /// The name of the declaration being referenced.
   DeclName getFullName() const {
-    return FullName;
+    if (!hasModuleSelector())
+      return cast<DeclName>(storage);
+
+    return cast<SelectiveDeclNameRef *>(storage)->fullName;
   }
 
   /// The base name of the declaration being referenced.
@@ -885,7 +921,7 @@ public:
 };
 
 inline DeclNameRef DeclNameRef::getFromOpaqueValue(void *_Nullable p) {
-  return DeclNameRef(DeclName::getFromOpaqueValue(p));
+  return DeclNameRef(p);
 }
 
 inline DeclNameRef DeclNameRef::withoutArgumentLabels(ASTContext &C) const {
@@ -1059,7 +1095,6 @@ namespace llvm {
   };
 
   // A DeclNameRef is "pointer like" just like DeclNames.
-  template<typename T> struct PointerLikeTypeTraits;
   template<>
   struct PointerLikeTypeTraits<swift::DeclNameRef> {
   public:
@@ -1069,7 +1104,7 @@ namespace llvm {
     static inline swift::DeclNameRef getFromVoidPointer(void *_Nullable ptr) {
       return swift::DeclNameRef::getFromOpaqueValue(ptr);
     }
-    enum { NumLowBitsAvailable = PointerLikeTypeTraits<swift::DeclName>::NumLowBitsAvailable };
+    enum { NumLowBitsAvailable = PointerLikeTypeTraits<swift::DeclNameRef::Storage>::NumLowBitsAvailable };
   };
 
   // DeclNameRefs hash just like DeclNames.

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -104,6 +104,9 @@ enum class ModuleLookupFlags : unsigned {
   /// If @abi attributes are present, return the decls representing the ABI,
   /// not the API.
   ABIProviding = 1 << 1,
+  /// The lookup is qualified by a module selector which has specified this
+  /// module explicitly.
+  HasModuleSelector = 1 << 2,
 };
 
 } // end namespace swift

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -481,6 +481,11 @@ public:
   void getDeclaredCrossImportBystanders(
       SmallVectorImpl<Identifier> &bystanderNames);
 
+  /// Returns the name that should be used for this module in a module
+  /// selector. For separately-imported overlays, this will be the declaring
+  /// module's name.
+  Identifier getNameForModuleSelector();
+
   /// Retrieve the ABI name of the module, which is used for metadata and
   /// mangling.
   Identifier getABIName() const;

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -53,6 +53,10 @@ void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 ///
 /// \param moduleOrFile The module or file unit to search, including imports.
 /// \param name The name to look up.
+/// \param hasModuleSelector Whether \p name was originally qualified by a
+///        module selector. This information is threaded through to underlying
+///        lookup calls; the callee is responsible for actually applying the
+///        module selector.
 /// \param[out] decls Any found decls will be added to this vector.
 /// \param lookupKind Whether this lookup is qualified or unqualified.
 /// \param resolutionKind What sort of decl is expected.
@@ -64,8 +68,11 @@ void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 /// \param options name lookup options. Currently only used to communicate the
 ///        NL_IncludeUsableFromInline option.
 void lookupInModule(const DeclContext *moduleOrFile,
-                    DeclName name, SmallVectorImpl<ValueDecl *> &decls,
-                    NLKind lookupKind, ResolutionKind resolutionKind,
+                    DeclName name,
+                    bool hasModuleSelector,
+                    SmallVectorImpl<ValueDecl *> &decls,
+                    NLKind lookupKind,
+                    ResolutionKind resolutionKind,
                     const DeclContext *moduleScopeContext,
                     SourceLoc loc, NLOptions options);
 

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -44,14 +44,14 @@ enum class ResolutionKind {
 
 void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 
-/// Performs a lookup into the given module and it's imports.
+/// Performs a lookup into the given module and its imports.
 ///
-/// If 'moduleOrFile' is a ModuleDecl, we search the module and it's
+/// If 'moduleOrFile' is a ModuleDecl, we search the module and its
 /// public imports. If 'moduleOrFile' is a SourceFile, we search the
 /// file's parent module, the module's public imports, and the source
 /// file's private imports.
 ///
-/// \param moduleOrFile The module or file unit whose imports to search.
+/// \param moduleOrFile The module or file unit to search, including imports.
 /// \param name The name to look up.
 /// \param[out] decls Any found decls will be added to this vector.
 /// \param lookupKind Whether this lookup is qualified or unqualified.
@@ -59,8 +59,10 @@ void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 /// \param moduleScopeContext The top-level context from which the lookup is
 ///        being performed, for checking access. This must be either a
 ///        FileUnit or a Module.
+/// \param loc Source location of the lookup. Used to add contextual options,
+///        such as disabling macro expansions inside macro arguments.
 /// \param options name lookup options. Currently only used to communicate the
-/// NL_IncludeUsableFromInline option.
+///        NL_IncludeUsableFromInline option.
 void lookupInModule(const DeclContext *moduleOrFile,
                     DeclName name, SmallVectorImpl<ValueDecl *> &decls,
                     NLKind lookupKind, ResolutionKind resolutionKind,

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -155,11 +155,18 @@ public:
       : Results(Results.begin(), Results.end()),
         IndexOfFirstOuterResult(indexOfFirstOuterResult) {}
 
+  using const_iterator = SmallVectorImpl<LookupResultEntry>::const_iterator;
+  const_iterator begin() const { return Results.begin(); }
+  const_iterator end() const {
+    return Results.begin() + IndexOfFirstOuterResult;
+  }
+
   using iterator = SmallVectorImpl<LookupResultEntry>::iterator;
   iterator begin() { return Results.begin(); }
   iterator end() {
     return Results.begin() + IndexOfFirstOuterResult;
   }
+
   unsigned size() const { return innerResults().size(); }
   bool empty() const { return innerResults().empty(); }
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -33,7 +33,7 @@
 
 namespace swift {
 class ASTContext;
-class DeclName;
+class DeclNameRef;
 class Type;
 class TypeDecl;
 class ValueDecl;
@@ -773,12 +773,12 @@ public:
   ///
   /// \param stopAfterInnermostBraceStmt If lookup should consider
   /// local declarations inside the innermost syntactic scope only.
-  static void lookupLocalDecls(SourceFile *, DeclName, SourceLoc,
+  static void lookupLocalDecls(SourceFile *, DeclNameRef, SourceLoc,
                                bool stopAfterInnermostBraceStmt,
                                ABIRole roleFilter,
                                SmallVectorImpl<ValueDecl *> &);
 
-  static void lookupLocalDecls(SourceFile *sf, DeclName name, SourceLoc loc,
+  static void lookupLocalDecls(SourceFile *sf, DeclNameRef name, SourceLoc loc,
                                bool stopAfterInnermostBraceStmt,
                                SmallVectorImpl<ValueDecl *> &results) {
     lookupLocalDecls(sf, name, loc, stopAfterInnermostBraceStmt,
@@ -786,7 +786,7 @@ public:
   }
 
   /// Returns the result if there is exactly one, nullptr otherwise.
-  static ValueDecl *lookupSingleLocalDecl(SourceFile *, DeclName, SourceLoc);
+  static ValueDecl *lookupSingleLocalDecl(SourceFile *, DeclNameRef, SourceLoc);
 
   /// Entry point to record the visible statement labels from the given
   /// point.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -486,6 +486,14 @@ public:
 /// \returns true if any declarations were removed, false otherwise.
 bool removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls);
 
+/// Remove any declarations in the given set that do not match the
+/// module selector, if it is not empty.
+///
+/// \returns true if any declarations were removed, false otherwise.
+bool removeOutOfModuleDecls(SmallVectorImpl<ValueDecl*> &decls,
+                            Identifier moduleSelector,
+                            const DeclContext *dc);
+
 /// Remove any declarations in the given set that are shadowed by
 /// other declarations in that set.
 ///
@@ -561,6 +569,7 @@ void tryExtractDirectlyReferencedNominalTypes(
 /// Once name lookup has gathered a set of results, perform any necessary
 /// steps to prune the result set before returning it to the caller.
 void pruneLookupResultSet(const DeclContext *dc, NLOptions options,
+                          Identifier moduleSelector,
                           SmallVectorImpl<ValueDecl *> &decls);
 
 /// Do nothing if debugClient is null.

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -488,7 +488,22 @@ public:
 private:
   friend SimpleRequest;
 
-  // Evaluation.
+  /// Performs a lookup into the given module and its imports.
+  ///
+  /// If 'moduleOrFile' is a ModuleDecl, we search the module and its
+  /// public imports. If 'moduleOrFile' is a SourceFile, we search the
+  /// file's parent module, the module's public imports, and the source
+  /// file's private imports.
+  ///
+  /// \param evaluator The request evaluator.
+  /// \param moduleOrFile The module or file unit to search, including imports.
+  /// \param name The name to look up.
+  /// \param lookupKind Whether this lookup is qualified or unqualified.
+  /// \param resolutionKind What sort of decl is expected.
+  /// \param moduleScopeContext The top-level context from which the lookup is
+  ///        being performed, for checking access. This must be either a
+  ///        FileUnit or a Module.
+  /// \param options Lookup options to apply.
   QualifiedLookupResult
   evaluate(Evaluator &evaluator, const DeclContext *moduleOrFile, DeclName name,
            NLKind lookupKind, namelookup::ResolutionKind resolutionKind,

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -475,13 +475,13 @@ using QualifiedLookupResult = SmallVector<ValueDecl *, 4>;
 class LookupInModuleRequest
     : public SimpleRequest<
           LookupInModuleRequest,
-          QualifiedLookupResult(const DeclContext *, DeclName, NLKind,
+          QualifiedLookupResult(const DeclContext *, DeclName, bool, NLKind,
                                 namelookup::ResolutionKind, const DeclContext *,
                                 NLOptions),
           RequestFlags::Uncached | RequestFlags::DependencySink> {
 public:
   LookupInModuleRequest(
-      const DeclContext *, DeclName, NLKind,
+      const DeclContext *, DeclName, bool, NLKind,
       namelookup::ResolutionKind, const DeclContext *,
       SourceLoc, NLOptions);
 
@@ -498,6 +498,10 @@ private:
   /// \param evaluator The request evaluator.
   /// \param moduleOrFile The module or file unit to search, including imports.
   /// \param name The name to look up.
+  /// \param hasModuleSelector Whether \p name was originally qualified by a
+  ///        module selector. This information is threaded through to underlying
+  ///        lookup calls; the callee is responsible for actually applying the
+  ///        module selector.
   /// \param lookupKind Whether this lookup is qualified or unqualified.
   /// \param resolutionKind What sort of decl is expected.
   /// \param moduleScopeContext The top-level context from which the lookup is
@@ -506,7 +510,8 @@ private:
   /// \param options Lookup options to apply.
   QualifiedLookupResult
   evaluate(Evaluator &evaluator, const DeclContext *moduleOrFile, DeclName name,
-           NLKind lookupKind, namelookup::ResolutionKind resolutionKind,
+           bool hasModuleSelector, NLKind lookupKind,
+           namelookup::ResolutionKind resolutionKind,
            const DeclContext *moduleScopeContext, NLOptions options) const;
 
 public:

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -276,6 +276,7 @@ LANGUAGE_FEATURE(InlineArrayTypeSugar, 483, "Type sugar for InlineArray")
 LANGUAGE_FEATURE(LifetimeDependenceMutableAccessors, 0, "Support mutable accessors returning ~Escapable results")
 LANGUAGE_FEATURE(InoutLifetimeDependence, 0, "Support @_lifetime(&)")
 SUPPRESSIBLE_LANGUAGE_FEATURE(NonexhaustiveAttribute, 487, "Nonexhaustive Enums")
+LANGUAGE_FEATURE(ModuleSelector, 491, "Module selectors (`Module::name` syntax)")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -532,9 +533,6 @@ EXPERIMENTAL_FEATURE(AllowRuntimeSymbolDeclarations, true)
 
 /// Allow use of `@c`
 EXPERIMENTAL_FEATURE(CDecl, false)
-
-/// Allow use of `Module::name` syntax
-EXPERIMENTAL_FEATURE(ModuleSelector, false)
 
 /// Allow use of `using` declaration that control default isolation
 /// in a file scope.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -186,6 +186,10 @@ enum class FixKind : uint8_t {
   /// no access control.
   AllowInaccessibleMember,
 
+  /// If a module selector prevented us from selecting a member, pretend that it
+  /// was not specified.
+  AllowMemberFromWrongModule,
+
   /// Allow KeyPaths to use AnyObject as root type
   AllowAnyObjectKeyPathRoot,
 
@@ -1939,6 +1943,25 @@ public:
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInaccessibleMember;
   }
+};
+
+class AllowMemberFromWrongModule final : public AllowInvalidMemberRef {
+  AllowMemberFromWrongModule(ConstraintSystem &cs, Type baseType,
+                             ValueDecl *member, DeclNameRef name,
+                             ConstraintLocator *locator)
+      : AllowInvalidMemberRef(cs, FixKind::AllowMemberFromWrongModule, baseType,
+                              member, name, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow reference to member from wrong module";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowMemberFromWrongModule *create(ConstraintSystem &cs, Type baseType,
+                                            ValueDecl *member, DeclNameRef name,
+                                            ConstraintLocator *locator);
 };
 
 class AllowAnyObjectKeyPathRoot final : public ConstraintFix {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2059,6 +2059,9 @@ struct MemberLookupResult {
     /// 'accesses' attributes of the init accessor and therefore canno
     /// t be referenced in its body.
     UR_UnavailableWithinInitAccessor,
+
+    /// The module selector in the `DeclNameRef` does not match this candidate.
+    UR_WrongModule
   };
 
   /// This is a list of considered (but rejected) candidates, along with a

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2935,6 +2935,14 @@ SourceRange TopLevelCodeDecl::getSourceRange() const {
   return Body? Body->getSourceRange() : SourceRange();
 }
 
+DeclNameRef ValueDecl::createNameRef(bool moduleSelector) const {
+  if (moduleSelector)
+    return DeclNameRef(getASTContext(), getModuleContext()->getName(),
+                       getName());
+
+  return DeclNameRef(getName());
+}
+
 static bool isPolymorphic(const AbstractStorageDecl *storage) {
   if (storage->shouldUseObjCDispatch())
     return true;

--- a/lib/AST/DeclNameLoc.cpp
+++ b/lib/AST/DeclNameLoc.cpp
@@ -20,16 +20,24 @@
 
 using namespace swift;
 
-DeclNameLoc::DeclNameLoc(ASTContext &ctx, SourceLoc baseNameLoc,
+DeclNameLoc::DeclNameLoc(ASTContext &ctx, SourceLoc moduleSelectorLoc,
+                         SourceLoc baseNameLoc,
                          SourceLoc lParenLoc,
                          ArrayRef<SourceLoc> argumentLabelLocs,
                          SourceLoc rParenLoc)
-  : NumArgumentLabels(argumentLabelLocs.size()) {
-  assert(NumArgumentLabels > 0 && "Use other constructor");
+    : NumArgumentLabels(argumentLabelLocs.size()),
+      HasModuleSelectorLoc(moduleSelectorLoc.isValid())
+{
+  if (NumArgumentLabels == 0 && !HasModuleSelectorLoc) {
+    LocationInfo = baseNameLoc.getOpaquePointerValue();
+    return;
+  }
 
   // Copy the location information into permanent storage.
-  auto storedLocs = ctx.Allocate<SourceLoc>(NumArgumentLabels + 3);
+  auto storedLocs =
+      ctx.Allocate<SourceLoc>(FirstArgumentLabelIndex + NumArgumentLabels);
   storedLocs[BaseNameIndex] = baseNameLoc;
+  storedLocs[ModuleSelectorIndex] = moduleSelectorLoc;
   storedLocs[LParenIndex] = lParenLoc;
   storedLocs[RParenIndex] = rParenLoc;
   std::memcpy(storedLocs.data() + FirstArgumentLabelIndex,

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -220,6 +220,10 @@ llvm::raw_ostream &DeclName::printPretty(llvm::raw_ostream &os) const {
   return print(os, /*skipEmptyArgumentNames=*/!isSpecial());
 }
 
+DeclNameRef DeclNameRef::createSelf(const ASTContext &ctx) {
+  return DeclNameRef(ctx.Id_self);
+}
+
 void DeclNameRef::dump() const {
   llvm::errs() << *this << "\n";
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -104,9 +104,6 @@ BuiltinUnit::LookupCache &BuiltinUnit::getCache() const {
 void BuiltinUnit::LookupCache::lookupValue(
        Identifier Name, NLKind LookupKind, const BuiltinUnit &M,
        SmallVectorImpl<ValueDecl*> &Result) {
-  // Only qualified lookup ever finds anything in the builtin module.
-  if (LookupKind != NLKind::QualifiedLookup) return;
-
   ValueDecl *&Entry = Cache[Name];
   ASTContext &Ctx = M.getParentModule()->getASTContext();
   if (!Entry) {
@@ -1073,6 +1070,11 @@ void ModuleDecl::lookupAvailabilityDomains(
 void BuiltinUnit::lookupValue(DeclName name, NLKind lookupKind,
                               OptionSet<ModuleLookupFlags> Flags,
                               SmallVectorImpl<ValueDecl*> &result) const {
+  // Only qualified lookup ever finds anything in the builtin module.
+  if (lookupKind != NLKind::QualifiedLookup
+        && !Flags.contains(ModuleLookupFlags::HasModuleSelector))
+    return;
+
   getCache().lookupValue(name.getBaseIdentifier(), lookupKind, *this, result);
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2564,6 +2564,12 @@ bool ModuleDecl::getRequiredBystandersIfCrossImportOverlay(
   return false;
 }
 
+Identifier ModuleDecl::getNameForModuleSelector() {
+  if (auto declaring = getDeclaringModuleIfCrossImportOverlay())
+    return declaring->getName();
+  return this->getName();
+}
+
 bool ModuleDecl::isClangHeaderImportModule() const {
   auto importer = getASTContext().getClangModuleLoader();
   if (!importer)

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -66,11 +66,16 @@ public:
   /// \param moduleScopeContext The top-level context from which the lookup is
   ///        being performed, for checking access. This must be either a
   ///        FileUnit or a Module.
+  /// \param hasModuleSelector Whether \p name was originally qualified by a
+  ///        module selector. This information is threaded through to underlying
+  ///        lookup calls; the callee is responsible for actually applying the
+  ///        module selector.
   /// \param options Lookup options to apply.
   void lookupInModule(SmallVectorImpl<ValueDecl *> &decls,
                       const DeclContext *moduleOrFile,
                       ImportPath::Access accessPath,
                       const DeclContext *moduleScopeContext,
+                      bool hasModuleSelector,
                       NLOptions options);
 };
 
@@ -173,6 +178,7 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
     const DeclContext *moduleOrFile,
     ImportPath::Access accessPath,
     const DeclContext *moduleScopeContext,
+    bool hasModuleSelector,
     NLOptions options) {
   assert(moduleOrFile->isModuleScopeContext());
 
@@ -189,7 +195,7 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
         selfOverlay = true;
       else
         lookupInModule(decls, overlay, accessPath, moduleScopeContext,
-                       options);
+                       hasModuleSelector, options);
     }
     // FIXME: This may not work gracefully if more than one of these lookups
     // finds something.
@@ -228,6 +234,8 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
     currentModuleLookupFlags |= ModuleLookupFlags::ExcludeMacroExpansions;
   if (options & NL_ABIProviding)
     currentModuleLookupFlags |= ModuleLookupFlags::ABIProviding;
+  if (hasModuleSelector)
+    currentModuleLookupFlags |= ModuleLookupFlags::HasModuleSelector;
 
   // Do the lookup into the current module.
   auto *module = moduleOrFile->getParentModule();
@@ -255,6 +263,7 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
     OptionSet<ModuleLookupFlags> importedModuleLookupFlags = {};
     if (options & NL_ABIProviding)
       currentModuleLookupFlags |= ModuleLookupFlags::ABIProviding;
+    // Do not propagate HasModuleSelector here; the selector wasn't specific.
 
     auto visitImport = [&](ImportedModule import,
                            const DeclContext *moduleScopeContext) {
@@ -357,27 +366,29 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
 QualifiedLookupResult
 LookupInModuleRequest::evaluate(
     Evaluator &evaluator, const DeclContext *moduleOrFile, DeclName name,
-    NLKind lookupKind, ResolutionKind resolutionKind,
+    bool hasModuleSelector, NLKind lookupKind, ResolutionKind resolutionKind,
     const DeclContext *moduleScopeContext, NLOptions options) const {
   assert(moduleScopeContext->isModuleScopeContext());
 
   QualifiedLookupResult decls;
   LookupByName lookup(moduleOrFile->getASTContext(), resolutionKind,
                       name, lookupKind);
-  lookup.lookupInModule(decls, moduleOrFile, {}, moduleScopeContext, options);
+  lookup.lookupInModule(decls, moduleOrFile, {}, moduleScopeContext,
+                        hasModuleSelector, options);
   return decls;
 }
 
 void namelookup::lookupInModule(const DeclContext *moduleOrFile,
                                 DeclName name,
+                                bool hasModuleSelector,
                                 SmallVectorImpl<ValueDecl *> &decls,
                                 NLKind lookupKind,
                                 ResolutionKind resolutionKind,
                                 const DeclContext *moduleScopeContext,
                                 SourceLoc loc, NLOptions options) {
   auto &ctx = moduleOrFile->getASTContext();
-  LookupInModuleRequest req(moduleOrFile, name, lookupKind, resolutionKind,
-                            moduleScopeContext, loc, options);
+  LookupInModuleRequest req(moduleOrFile, name, hasModuleSelector, lookupKind,
+                            resolutionKind, moduleScopeContext, loc, options);
   auto results = evaluateOrDefault(ctx.evaluator, req, {});
   decls.append(results.begin(), results.end());
 }
@@ -393,6 +404,7 @@ void namelookup::lookupVisibleDeclsInModule(
   auto &ctx = moduleOrFile->getASTContext();
   LookupVisibleDecls lookup(ctx, resolutionKind, lookupKind);
   lookup.lookupInModule(decls, moduleOrFile, accessPath, moduleScopeContext,
+                        /*hasModuleSelector=*/false,
                         NL_QualifiedDefault);
 }
 

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -51,10 +51,22 @@ public:
         resolutionKind(resolutionKind),
         respectAccessControl(!ctx.isAccessControlDisabled()) {}
 
-  /// Performs a qualified lookup into the given module and, if necessary, its
-  /// reexports.
+  /// Performs the qualified lookup requested by \p LookupStrategy into the
+  /// given module and, if necessary, its reexports.
   ///
-  /// The results are appended to \p decls.
+  /// If 'moduleOrFile' is a ModuleDecl, we search the module and its
+  /// public imports. If 'moduleOrFile' is a SourceFile, we search the
+  /// file's parent module, the module's public imports, and the source
+  /// file's private imports.
+  ///
+  /// \param[out] decls Results are appended to this vector.
+  /// \param moduleOrFile The module or file unit to search, including imports.
+  /// \param accessPath The access path that was imported; if not empty, only
+  ///                   the named declaration will be imported.
+  /// \param moduleScopeContext The top-level context from which the lookup is
+  ///        being performed, for checking access. This must be either a
+  ///        FileUnit or a Module.
+  /// \param options Lookup options to apply.
   void lookupInModule(SmallVectorImpl<ValueDecl *> &decls,
                       const DeclContext *moduleOrFile,
                       ImportPath::Access accessPath,
@@ -77,6 +89,10 @@ class LookupByName : public ModuleNameLookup<LookupByName> {
   const NLKind lookupKind;
 
 public:
+  /// \param ctx The AST context that the lookup will be performed in.
+  /// \param name The name that will be looked up.
+  /// \param lookupKind Whether this lookup is qualified or unqualified.
+  /// \param resolutionKind What sort of decl is expected.
   LookupByName(ASTContext &ctx, ResolutionKind resolutionKind,
                DeclName name, NLKind lookupKind)
     : Super(ctx, resolutionKind), name(name),
@@ -89,6 +105,10 @@ private:
     return true;
   }
 
+  /// \param module The module to search for declarations in.
+  /// \param path The access path that was imported; if not empty, only the
+  ///             named declaration will be imported.
+  /// \param[out] localDecls Results are appended to this vector.
   void doLocalLookup(ModuleDecl *module, ImportPath::Access path,
                      OptionSet<ModuleLookupFlags> flags,
                      SmallVectorImpl<ValueDecl *> &localDecls) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -361,6 +361,43 @@ enum class ConstructorComparison {
   Better,
 };
 
+bool swift::removeOutOfModuleDecls(SmallVectorImpl<ValueDecl*> &decls,
+                                   Identifier moduleSelector,
+                                   const DeclContext *dc) {
+  if (moduleSelector.empty())
+    return false;
+
+  ASTContext &ctx = dc->getASTContext();
+
+  // FIXME: Should we look this up relative to dc?
+  // We'd need a new ResolutionKind.
+  // FIXME: How can we diagnose this?
+  ModuleDecl *visibleFrom = ctx.getLoadedModule(moduleSelector);
+  if (!visibleFrom) {
+    LLVM_DEBUG(llvm::dbgs() << "no module " << moduleSelector << "\n");
+    bool clearedAny = !decls.empty();
+    decls.clear();
+    return clearedAny;
+  }
+
+  size_t initialCount = decls.size();
+  decls.erase(
+    std::remove_if(decls.begin(), decls.end(), [&](ValueDecl *decl) -> bool {
+      bool inScope = ctx.getImportCache().isImportedBy(decl->getModuleContext(),
+                                                       visibleFrom);
+
+      LLVM_DEBUG(decl->dumpRef(llvm::dbgs()));
+      LLVM_DEBUG(llvm::dbgs() << ": " << decl->getModuleContext()->getName()
+                              << (inScope ? " is " : " is NOT ")
+                              << "selected by " << visibleFrom->getName()
+                              << "\n");
+
+      return !inScope;
+    }),
+    decls.end());
+  return initialCount != decls.size();
+}
+
 /// Determines whether \p ctor1 is a "better" initializer than \p ctor2.
 static ConstructorComparison compareConstructors(ConstructorDecl *ctor1,
                                                  ConstructorDecl *ctor2,
@@ -2471,14 +2508,17 @@ bool namelookup::isInABIAttr(SourceFile *sourceFile, SourceLoc loc) {
 }
 
 void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
+                                      Identifier moduleSelector,
                                       SmallVectorImpl<ValueDecl *> &decls) {
   // If we're supposed to remove overridden declarations, do so now.
   if (options & NL_RemoveOverridden)
     removeOverriddenDecls(decls);
 
   // If we're supposed to remove shadowed/hidden declarations, do so now.
-  if (options & NL_RemoveNonVisible)
+  if (options & NL_RemoveNonVisible) {
+    removeOutOfModuleDecls(decls, moduleSelector, dc);
     removeShadowedDecls(decls, dc);
+  }
 
   ModuleDecl *M = dc->getParentModule();
   filterForDiscriminator(decls, M->getDebugClient());
@@ -2790,7 +2830,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     }
   }
 
-  pruneLookupResultSet(DC, options, decls);
+  pruneLookupResultSet(DC, options, member.getModuleSelector(), decls);
   if (auto *debugClient = DC->getParentModule()->getDebugClient()) {
     debugClient->finishLookupInNominals(DC, typeDecls, member.getFullName(),
                                         options, decls);
@@ -2842,7 +2882,7 @@ ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     }
   }
 
-  pruneLookupResultSet(DC, options, decls);
+  pruneLookupResultSet(DC, options, member.getModuleSelector(), decls);
 
   if (auto *debugClient = DC->getParentModule()->getDebugClient()) {
     debugClient->finishLookupInModule(DC, module, member.getFullName(),
@@ -2910,7 +2950,7 @@ AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
       decls.push_back(decl);
   }
 
-  pruneLookupResultSet(dc, options, decls);
+  pruneLookupResultSet(dc, options, member.getModuleSelector(), decls);
   if (auto *debugClient = dc->getParentModule()->getDebugClient()) {
     debugClient->finishLookupInAnyObject(dc, member.getFullName(), options,
                                          decls);

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -631,12 +631,12 @@ UnqualifiedLookupRequest::UnqualifiedLookupRequest(
 ) : SimpleRequest(contextualizeOptions(descriptor)) { }
 
 LookupInModuleRequest::LookupInModuleRequest(
-      const DeclContext *moduleOrFile, DeclName name, NLKind lookupKind,
-      namelookup::ResolutionKind resolutionKind,
+      const DeclContext *moduleOrFile, DeclName name, bool hasModuleSelector,
+      NLKind lookupKind, namelookup::ResolutionKind resolutionKind,
       const DeclContext *moduleScopeContext,
       SourceLoc loc, NLOptions options
- ) : SimpleRequest(moduleOrFile, name, lookupKind, resolutionKind,
-                   moduleScopeContext,
+ ) : SimpleRequest(moduleOrFile, name, hasModuleSelector, lookupKind,
+                   resolutionKind, moduleScopeContext,
                    contextualizeOptions(moduleOrFile, loc, options)) { }
 
 ModuleQualifiedLookupRequest::ModuleQualifiedLookupRequest(

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -249,8 +249,9 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
   }
 
   if (Loc.isValid() && DC->getParentSourceFile()) {
-    // Operator lookup is always global, for the time being.
-    if (!Name.isOperator())
+    // Operator lookup is always global, for the time being. Unqualified lookups
+    // with module selectors always start at global scope.
+    if (!Name.isOperator() && !Name.hasModuleSelector())
       lookInASTScopes();
   } else {
     assert((DC->isModuleScopeContext() || !DC->getParentSourceFile()) &&

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8130,9 +8130,10 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
     // There is no Clang module for this declaration, so perform lookup from
     // the main module. This will find declarations from the bridging header.
     namelookup::lookupInModule(
-        ctx.MainModule, ctx.getIdentifier(name), results,
-        NLKind::UnqualifiedLookup, namelookup::ResolutionKind::Overloadable,
-        ctx.MainModule, SourceLoc(), NL_UnqualifiedDefault);
+        ctx.MainModule, ctx.getIdentifier(name), /*hasModuleSelector=*/false,
+        results, NLKind::UnqualifiedLookup,
+        namelookup::ResolutionKind::Overloadable, ctx.MainModule, SourceLoc(),
+        NL_UnqualifiedDefault);
 
     // Filter out any declarations that didn't come from Clang.
     auto newEnd =

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -209,7 +209,8 @@ diagnoseIfModuleImportsShadowingDecl(ModuleInterfaceOptions const &Opts,
   using namespace namelookup;
 
   SmallVector<ValueDecl *, 4> decls;
-  lookupInModule(importedModule, importingModule->getName(), decls,
+  lookupInModule(importedModule, importingModule->getName(),
+                 /*hasModuleSelector=*/false, decls,
                  NLKind::UnqualifiedLookup, ResolutionKind::TypesOnly,
                  importedModule, SourceLoc(),
                  NL_UnqualifiedDefault | NL_IncludeUsableFromInline);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2768,7 +2768,7 @@ void Lexer::lexImpl() {
   case '\\': return formToken(tok::backslash, TokStart);
 
   case ':':
-    if (CurPtr[0] == ':' && LangOpts.hasFeature(Feature::ModuleSelector)) {
+    if (CurPtr[0] == ':') {
       CurPtr++;
       return formToken(tok::colon_colon, TokStart);
     }
@@ -2882,7 +2882,6 @@ Token Lexer::getTokenAtLocation(const SourceManager &SM, SourceLoc Loc,
   // Use fake language options; language options only affect validity
   // and the exact token produced.
   LangOptions FakeLangOpts;
-  FakeLangOpts.enableFeature(Feature::ModuleSelector);
 
   // Here we return comments as tokens because either the caller skipped
   // comments and normally we won't be at the beginning of a comment token

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4259,8 +4259,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
         .warnUntilSwiftVersion(6);
   }
 
-  bool hasModuleSelector = Context.LangOpts.hasFeature(Feature::ModuleSelector)
-                              && peekToken().is(tok::colon_colon);
+  bool hasModuleSelector = peekToken().is(tok::colon_colon);
 
   // If this not an identifier, the attribute is malformed.
   if (Tok.isNot(tok::identifier) &&

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2284,9 +2284,6 @@ unsigned Parser::isAtModuleSelector() {
 }
 
 std::optional<Located<Identifier>> Parser::parseModuleSelector() {
-  if (!Context.LangOpts.hasFeature(Feature::ModuleSelector))
-    return std::nullopt;
-
   if (!isAtModuleSelector())
     return std::nullopt;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7369,12 +7369,13 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
     case ConversionRestrictionKind::CGFloatToDouble:
     case ConversionRestrictionKind::DoubleToCGFloat: {
-      DeclName name(ctx, DeclBaseName::createConstructor(), Identifier());
+      // OK: Implicit conversion, no module selector to drop here.
+      DeclNameRef initRef(ctx, /*module selector=*/Identifier(),
+                          DeclBaseName::createConstructor(), { Identifier() });
 
       ConstructorDecl *decl = nullptr;
       SmallVector<ValueDecl *, 2> candidates;
-      dc->lookupQualified(toType->getAnyNominal(),
-                          DeclNameRef(name), SourceLoc(),
+      dc->lookupQualified(toType->getAnyNominal(), initRef, SourceLoc(),
                           NL_QualifiedDefault, candidates);
       for (auto *candidate : candidates) {
         auto *ctor = cast<ConstructorDecl>(candidate);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6378,7 +6378,8 @@ bool MemberFromWrongModuleFailure::diagnoseAsError() {
   emitDiagnosticAt(loc, diag::wrong_module_selector, Member->getName(),
                    Name.getModuleSelector());
 
-  Identifier actualModuleName = Member->getModuleContext()->getName();
+  Identifier actualModuleName =
+      Member->getModuleContext()->getNameForModuleSelector();
   ASSERT(actualModuleName != Name.getModuleSelector() &&
          "Module selector failure on member in same module?");
   emitDiagnosticAt(loc, diag::note_change_module_selector, actualModuleName)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1758,7 +1758,7 @@ class VarDeclMultipleReferencesChecker : public ASTWalker {
       if (name.isSimpleName(varDecl->getName()) && loc.isValid()) {
         auto *otherDecl =
             ASTScope::lookupSingleLocalDecl(DC->getParentSourceFile(),
-                                            name.getFullName(), loc);
+                                            name, loc);
         if (otherDecl == varDecl)
           ++count;
       }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1653,6 +1653,27 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an attempt to reference member from the wrong module with a module
+/// selector, e.g.
+///
+/// ```swift
+/// import Foo
+/// import Bar
+///
+/// SomeType.Bar::methodDefinedInFoo()
+/// ```
+class MemberFromWrongModuleFailure final : public FailureDiagnostic {
+  ValueDecl *Member;
+  DeclNameRef Name;
+
+public:
+  MemberFromWrongModuleFailure(const Solution &solution, DeclNameRef name,
+                               ValueDecl *member, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), Member(member), Name(name) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose an attempt to reference member marked as `mutating`
 /// on immutable base e.g. `let` variable:
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1210,6 +1210,21 @@ AllowInaccessibleMember::create(ConstraintSystem &cs, Type baseType,
       AllowInaccessibleMember(cs, baseType, member, name, locator);
 }
 
+bool AllowMemberFromWrongModule::diagnose(const Solution &solution,
+                                          bool asNote) const {
+  MemberFromWrongModuleFailure failure(solution, getMemberName(), getMember(),
+                                       getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowMemberFromWrongModule *
+AllowMemberFromWrongModule::create(ConstraintSystem &cs, Type baseType,
+                                   ValueDecl *member, DeclNameRef name,
+                                   ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowMemberFromWrongModule(cs, baseType, member, name, locator);
+}
+
 bool AllowAnyObjectKeyPathRoot::diagnose(const Solution &solution,
                                          bool asNote) const {
   AnyObjectKeyPathRootFailure failure(solution, getLocator());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4148,6 +4148,16 @@ namespace {
       auto macros = lookupMacros(moduleIdent, macroIdent, functionRefInfo,
                                  expr->getMacroRoles());
       if (macros.empty()) {
+        // Try removing a module selector if present.
+        if (macroIdent.hasModuleSelector()) {
+          auto anyMacroIdent = DeclNameRef(macroIdent.getFullName());
+          ModuleSelectorCorrection correction(
+            lookupMacros(moduleIdent, anyMacroIdent, functionRefInfo,
+                         expr->getMacroRoles()));
+          if (correction.diagnose(ctx, expr->getMacroNameLoc(), macroIdent))
+            return Type();
+        }
+
         ctx.Diags.diagnose(expr->getMacroNameLoc(), diag::macro_undefined,
                            macroIdent)
             .highlight(expr->getMacroNameLoc().getSourceRange());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1440,7 +1440,7 @@ namespace {
         if (!protocol)
           return Type();
 
-        auto macroIdent = ctx.getIdentifier(kind);
+        auto macroIdent = DeclNameRef(ctx.getIdentifier(kind));
         auto macros = lookupMacros(Identifier(), macroIdent,
                                    FunctionRefInfo::unappliedBaseName(),
                                    MacroRole::Expression);
@@ -4111,12 +4111,12 @@ namespace {
 
     /// Lookup all macros with the given macro name.
     SmallVector<OverloadChoice, 1> lookupMacros(DeclName moduleName,
-                                                DeclName macroName,
+                                                DeclNameRef macroName,
                                                 FunctionRefInfo functionRefInfo,
                                                 MacroRoles roles) {
       SmallVector<OverloadChoice, 1> choices;
       auto results = namelookup::lookupMacros(CurDC, DeclNameRef(moduleName),
-                                              DeclNameRef(macroName), roles);
+                                              macroName, roles);
       for (const auto &result : results) {
         // Ignore invalid results. This matches the OverloadedDeclRefExpr
         // logic.
@@ -4143,7 +4143,7 @@ namespace {
 
       // Look up the macros with this name.
       auto moduleIdent = expr->getModuleName().getBaseName();
-      auto macroIdent = expr->getMacroName().getBaseName();
+      auto macroIdent = expr->getMacroName().withoutArgumentLabels(ctx);
       FunctionRefInfo functionRefInfo = FunctionRefInfo::singleBaseNameApply();
       auto macros = lookupMacros(moduleIdent, macroIdent, functionRefInfo,
                                  expr->getMacroRoles());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -897,7 +897,7 @@ TypeVarRefCollector::walkToExprPre(Expr *expr) {
     auto loc = declRef->getLoc();
     if (name.isSimpleName() && loc.isValid()) {
       auto *SF = CS.DC->getParentSourceFile();
-      auto *D = ASTScope::lookupSingleLocalDecl(SF, name.getFullName(), loc);
+      auto *D = ASTScope::lookupSingleLocalDecl(SF, name, loc);
       inferTypeVars(D);
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10278,8 +10278,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     // high.
     if (auto *args = getArgumentList(memberLocator)) {
       SmallVector<Identifier, 4> scratch;
-      memberName.getFullName() = DeclName(ctx, memberName.getBaseName(),
-                                          args->getArgumentLabels(scratch));
+      memberName = memberName.withArgumentLabels(
+                                  ctx, args->getArgumentLabels(scratch));
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8627,6 +8627,9 @@ ConstraintSystem::simplifyConstructionConstraint(
   // variable T. T2 is the result type provided via the construction
   // constraint itself.
   addValueMemberConstraint(MetatypeType::get(valueType, getASTContext()),
+                           // OK: simplifyConstructionConstraint() is only used
+                           // for `T(...)` init calls, not `T.init(...)` calls,
+                           // so there's no module selector on `init`.
                            DeclNameRef::createConstructor(),
                            memberType,
                            useDC, functionRefInfo,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10301,8 +10301,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       }
     }
 
-    DeclName unprefixedName(context, memberName.getBaseName(), lookupLabels);
-    lookupName = DeclNameRef(unprefixedName);
+    lookupName = lookupName.withArgumentLabels(context, lookupLabels);
   }
 
   // Look for members within the base.

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1344,7 +1344,8 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
   // FIXME: Doesn't handle scoped testable imports correctly.
   assert(accessPath.size() == 1 && "can't handle sub-decl imports");
   SmallVector<ValueDecl *, 8> decls;
-  lookupInModule(topLevelModule, accessPath.front().Item, decls,
+  lookupInModule(topLevelModule, accessPath.front().Item,
+                 /*hasModuleSelector=*/true, decls,
                  NLKind::QualifiedLookup, ResolutionKind::Overloadable,
                  import->getDeclContext()->getModuleScopeContext(),
                  import->getLoc(), NL_QualifiedDefault);

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -560,8 +560,7 @@ static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC,
       }
     }
 
-    DeclName lookupName(context, Name.getBaseName(), lookupLabels);
-    LookupName = DeclNameRef(lookupName);
+    LookupName = Name.withArgumentLabels(context, lookupLabels);
   }
 
   LookupResult Lookup;
@@ -571,8 +570,7 @@ static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC,
 
   // First, look for a local binding in scope.
   if (Loc.isValid() && !Name.isOperator()) {
-    ASTScope::lookupLocalDecls(DC->getParentSourceFile(),
-                               LookupName.getFullName(), Loc,
+    ASTScope::lookupLocalDecls(DC->getParentSourceFile(), LookupName, Loc,
                                /*stopAfterInnermostBraceStmt=*/false,
                                ResultValues);
     for (auto *localDecl : ResultValues) {
@@ -2177,8 +2175,9 @@ VarDecl *PreCheckTarget::getImplicitSelfDeclForSuperContext(SourceLoc Loc) {
 
   // Do an actual lookup for 'self' in case it shows up in a capture list.
   auto *methodSelf = methodContext->getImplicitSelfDecl();
-  auto *lookupSelf = ASTScope::lookupSingleLocalDecl(DC->getParentSourceFile(),
-                                                     Ctx.Id_self, Loc);
+  auto *lookupSelf = ASTScope::lookupSingleLocalDecl(
+                                   DC->getParentSourceFile(),
+                                   DeclNameRef::createSelf(Ctx), Loc);
   if (lookupSelf && lookupSelf != methodSelf) {
     // FIXME: This is the wrong diagnostic for if someone manually declares a
     // variable named 'self' using backticks.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3006,6 +3006,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
   if (KitModule) {
     SmallVector<ValueDecl *, 1> decls;
     namelookup::lookupInModule(KitModule, Id_ApplicationDelegate,
+                               /*hasModuleSelector=*/false,
                                decls, NLKind::QualifiedLookup,
                                namelookup::ResolutionKind::TypesOnly,
                                SF, attr->getLocation(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3270,10 +3270,11 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
     }
 
     CS.addDisjunctionConstraint(typeEqualityConstraints, locator);
-    CS.addValueMemberConstraint(
-        nominal->getInterfaceType(), DeclNameRef(context.Id_main),
-        Type(mainType), declContext, FunctionRefInfo::singleBaseNameApply(), {},
-        locator);
+    CS.addValueMemberConstraint(nominal->getInterfaceType(),
+                                DeclNameRef(context.Id_main), // OK: Generated
+                                Type(mainType), declContext,
+                                FunctionRefInfo::singleBaseNameApply(), {},
+                                locator);
   }
 
   FuncDecl *mainFunction = nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -577,8 +577,8 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
         auto loc = declRef->getLoc();
         if (name.isSimpleName(ctx.Id_self)) {
           auto *otherSelfDecl =
-            ASTScope::lookupSingleLocalDecl(Decl->getParentSourceFile(),
-                                            name.getFullName(), loc);
+            ASTScope::lookupSingleLocalDecl(Decl->getParentSourceFile(), name,
+                                            loc);
           if (otherSelfDecl == Decl->getImplicitSelfDecl())
             myKind = BodyInitKind::Delegating;
         }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -757,7 +757,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
       else
         roleFilter = currentIsABIOnly ? ABIRole::ProvidesABI
                                       : ABIRole::ProvidesAPI;
-      ASTScope::lookupLocalDecls(currentFile, current->getBaseName(),
+      ASTScope::lookupLocalDecls(currentFile,
+                                 DeclNameRef(current->getBaseName()),
                                  current->getLoc(),
                                  /*stopAfterInnermostBraceStmt=*/true,
                                  roleFilter, otherDefinitions);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -1191,6 +1191,15 @@ ModuleSelectorCorrection(const LookupTypeResult &candidates) {
   }
 }
 
+ModuleSelectorCorrection::
+ModuleSelectorCorrection(const SmallVectorImpl<ValueDecl *> &candidates) {
+  for (auto result : candidates) {
+    auto owningModule = result->getModuleContext();
+    candidateModules.insert(
+      { owningModule->getName(), CandidateKind::ContextFree });
+  }
+}
+
 bool ModuleSelectorCorrection::diagnose(ASTContext &ctx,
                                         DeclNameLoc nameLoc,
                                         DeclNameRef originalName) const {

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -1176,7 +1176,7 @@ ModuleSelectorCorrection(const LookupResult &candidates) {
 
     auto owningModule = decl->getModuleContext();
     candidateModules.insert(
-      { owningModule->getName(), kind });
+      { owningModule->getNameForModuleSelector(), kind });
   }
 }
 
@@ -1187,7 +1187,7 @@ ModuleSelectorCorrection(const LookupTypeResult &candidates) {
   for (auto result : candidates) {
     auto owningModule = result.Member->getModuleContext();
     candidateModules.insert(
-      { owningModule->getName(), CandidateKind::ContextFree });
+      { owningModule->getNameForModuleSelector(), CandidateKind::ContextFree });
   }
 }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -1200,6 +1200,15 @@ ModuleSelectorCorrection(const SmallVectorImpl<ValueDecl *> &candidates) {
   }
 }
 
+ModuleSelectorCorrection::
+ModuleSelectorCorrection(const SmallVectorImpl<constraints::OverloadChoice> &candidates) {
+  for (auto result : candidates) {
+    auto owningModule = result.getDecl()->getModuleContext();
+    candidateModules.insert(
+      { owningModule->getNameForModuleSelector(), CandidateKind::ContextFree });
+  }
+}
+
 bool ModuleSelectorCorrection::diagnose(ASTContext &ctx,
                                         DeclNameLoc nameLoc,
                                         DeclNameRef originalName) const {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1493,18 +1493,8 @@ static Type diagnoseUnknownType(const TypeResolution &resolution,
 
   // Unqualified lookup case.
   if (parentType.isNull()) {
-    // Tailored diagnostic for custom attributes.
-    if (resolution.getOptions().is(TypeResolverContext::CustomAttr)) {
-      SmallString<64> scratch;
-      llvm::raw_svector_ostream scratchOS(scratch);
-      repr->getNameRef().printPretty(scratchOS);
-
-      diags.diagnose(repr->getNameLoc(), diag::unknown_attr_name, scratch);
-
-      return ErrorType::get(ctx);
-    }
-
-    if (repr->isSimpleUnqualifiedIdentifier(ctx.Id_Self)) {
+    if (!resolution.getOptions().is(TypeResolverContext::CustomAttr)
+          && repr->isSimpleUnqualifiedIdentifier(ctx.Id_Self)) {
       DeclContext *nominalDC = nullptr;
       NominalTypeDecl *nominal = nullptr;
       if ((nominalDC = dc->getInnermostTypeContext()) &&
@@ -1567,6 +1557,17 @@ static Type diagnoseUnknownType(const TypeResolution &resolution,
 
       // Don't try to recover here; we'll get more access-related diagnostics
       // downstream if we do.
+      return ErrorType::get(ctx);
+    }
+
+    // Tailored diagnostic for custom attributes.
+    if (resolution.getOptions().is(TypeResolverContext::CustomAttr)) {
+      SmallString<64> scratch;
+      llvm::raw_svector_ostream scratchOS(scratch);
+      repr->getNameRef().printPretty(scratchOS);
+
+      diags.diagnose(repr->getNameLoc(), diag::unknown_attr_name, scratch);
+
       return ErrorType::get(ctx);
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -193,8 +193,8 @@ static unsigned getGenericRequirementKind(TypeResolutionOptions options) {
 Type TypeResolution::resolveDependentMemberType(
     Type baseTy, DeclContext *DC, SourceRange baseRange,
     QualifiedIdentTypeRepr *repr) const {
-  // FIXME(ModQual): Reject qualified names immediately; they cannot be
-  // dependent member types.
+  // FIXME(ModQual): If module selector is present, check that it matches the
+  // protocol's module.
   Identifier refIdentifier = repr->getNameRef().getBaseIdentifier();
   ASTContext &ctx = DC->getASTContext();
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1495,8 +1495,11 @@ static Type diagnoseUnknownType(const TypeResolution &resolution,
   if (parentType.isNull()) {
     // Tailored diagnostic for custom attributes.
     if (resolution.getOptions().is(TypeResolverContext::CustomAttr)) {
-      diags.diagnose(repr->getNameLoc(), diag::unknown_attr_name,
-                     repr->getNameRef().getBaseIdentifier().str());
+      SmallString<64> scratch;
+      llvm::raw_svector_ostream scratchOS(scratch);
+      repr->getNameRef().printPretty(scratchOS);
+
+      diags.diagnose(repr->getNameLoc(), diag::unknown_attr_name, scratch);
 
       return ErrorType::get(ctx);
     }
@@ -5171,9 +5174,13 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       // Tailored diagnostic for custom attributes.
       if (options.is(TypeResolverContext::CustomAttr)) {
+        SmallString<64> scratch;
+        llvm::raw_svector_ostream scratchOS(scratch);
+        repr->getNameRef().printPretty(scratchOS);
+
         auto &ctx = resolution.getASTContext();
         ctx.Diags.diagnose(repr->getNameLoc(), diag::unknown_attr_name,
-                           repr->getNameRef().getBaseIdentifier().str());
+                           scratch);
 
         return ErrorType::get(ctx);
       }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -331,6 +331,7 @@ class ModuleSelectorCorrection {
 public:
   ModuleSelectorCorrection(const LookupResult &candidates);
   ModuleSelectorCorrection(const LookupTypeResult &candidates);
+  ModuleSelectorCorrection(const SmallVectorImpl<ValueDecl *> &candidates);
 
   /// Emit an error and warnings if there were any candidates.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -312,7 +312,20 @@ public:
 /// there are any results, the \c diagnose() method will emit an error and a
 /// set of fix-it notes.
 class ModuleSelectorCorrection {
-  using CandidateModule = Identifier;
+  enum class CandidateKind {
+    /// A declaration that is found without depending on context.
+    /// Usually either a top-level type or a member with an explicit base type.
+    ContextFree,
+    /// A member declaration accessed via implicit \c self .
+    MemberViaSelf,
+    /// A member declaration not accessed via implicit \c self (usually a static
+    /// member of an enclosing type).
+    MemberViaContext,
+    /// A local declaration.
+    Local
+  };
+
+  using CandidateModule = std::pair<Identifier, CandidateKind>;
   SmallSetVector<CandidateModule, 4> candidateModules;
 
 public:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -332,6 +332,7 @@ public:
   ModuleSelectorCorrection(const LookupResult &candidates);
   ModuleSelectorCorrection(const LookupTypeResult &candidates);
   ModuleSelectorCorrection(const SmallVectorImpl<ValueDecl *> &candidates);
+  ModuleSelectorCorrection(const SmallVectorImpl<constraints::OverloadChoice> &candidates);
 
   /// Emit an error and warnings if there were any candidates.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -95,9 +95,14 @@ class LookupTypeResult {
   SmallVector<LookupTypeResultEntry, 4> Results;
 
 public:
+  using const_iterator = SmallVectorImpl<LookupTypeResultEntry>::const_iterator;
+  const_iterator begin() const { return Results.begin(); }
+  const_iterator end() const { return Results.end(); }
+
   using iterator = SmallVectorImpl<LookupTypeResultEntry>::iterator;
   iterator begin() { return Results.begin(); }
   iterator end() { return Results.end(); }
+
   unsigned size() const { return Results.size(); }
 
   LookupTypeResultEntry operator[](unsigned index) const {
@@ -297,6 +302,29 @@ public:
   }
 
   CheckRequirementsResult getKind() const { return Kind; }
+};
+
+/// Helper type for diagnosing a lookup that failed merely because it was
+/// restricted by a module selector.
+///
+/// To use this, perform the lookup again without its module selector and
+/// construct a \c ModuleSelectorCorrection from the lookup result. If
+/// there are any results, the \c diagnose() method will emit an error and a
+/// set of fix-it notes.
+class ModuleSelectorCorrection {
+  using CandidateModule = Identifier;
+  SmallSetVector<CandidateModule, 4> candidateModules;
+
+public:
+  ModuleSelectorCorrection(const LookupResult &candidates);
+  ModuleSelectorCorrection(const LookupTypeResult &candidates);
+
+  /// Emit an error and warnings if there were any candidates.
+  ///
+  /// \returns \c true if an error was diagnosed.
+  bool diagnose(ASTContext &ctx,
+                DeclNameLoc nameLoc,
+                DeclNameRef originalName) const;
 };
 
 /// Describes the kind of checked cast operation being performed.

--- a/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftcrossimport/ctypes.swiftoverlay
+++ b/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftcrossimport/ctypes.swiftoverlay
@@ -1,0 +1,5 @@
+%YAML 1.2
+---
+version: 1
+modules:
+  - name: _ModuleSelectorTestingKit_ctypes

--- a/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftinterface
+++ b/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftinterface
@@ -1,0 +1,42 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ModuleSelectorTestingKit -swift-version 5
+
+import Swift
+
+// These types are identical; we just use them to test with different scope
+// selectors.
+
+public struct A {
+  public init(value: Swift.Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public struct B {
+  public init(value: Swift.Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public struct C {
+  public init(value: Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public struct D {
+  public init(value: Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+@propertyWrapper
+public struct available {
+  public init() {}
+  public var wrappedValue: Int { 0 }
+}
+
+@_functionBuilder
+public struct MyBuilder {
+  public static func buildBlock()
+}

--- a/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftinterface
+++ b/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftinterface
@@ -40,3 +40,6 @@ public struct available {
 public struct MyBuilder {
   public static func buildBlock()
 }
+
+@freestanding(expression) public macro ExprMacro() -> String = #file
+@attached(peer) public macro PeerMacro() = #externalMacro(module: "Fnord", type: "PeerMacro")

--- a/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftinterface
+++ b/test/NameLookup/Inputs/ModuleSelectorTestingKit.swiftinterface
@@ -41,5 +41,10 @@ public struct MyBuilder {
   public static func buildBlock()
 }
 
+public protocol ComparableIdentifiable {
+  associatedtype ID: Comparable
+  var id: ID { get }
+}
+
 @freestanding(expression) public macro ExprMacro() -> String = #file
 @attached(peer) public macro PeerMacro() = #externalMacro(module: "Fnord", type: "PeerMacro")

--- a/test/NameLookup/Inputs/_ModuleSelectorTestingKit_ctypes.swiftinterface
+++ b/test/NameLookup/Inputs/_ModuleSelectorTestingKit_ctypes.swiftinterface
@@ -1,0 +1,14 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name _ModuleSelectorTestingKit_ctypes -swift-version 5
+
+import Swift
+@_exported import ModuleSelectorTestingKit
+import ctypes
+
+public struct E {
+  public init(value: Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public func e() -> Void

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-builtin-module -enable-experimental-feature ModuleSelector
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-builtin-module -enable-experimental-feature ModuleSelector -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-builtin-module
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-builtin-module -enable-experimental-feature ParserASTGen
 
-// REQUIRES: swift_feature_ModuleSelector, swift_feature_ParserASTGen
+// REQUIRES: swift_feature_ParserASTGen
 
 // FIXME: This test doesn't really cover:
 //

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -129,8 +129,8 @@ extension B: @retroactive main::Equatable {
       // expected-error@-3 {{cannot infer contextual base in reference to member 'main::min'}}
 
       self = B.main::init(value: .min)
-      // FIXME improve: expected-error@-1 {{'B' cannot be constructed because it has no accessible initializers}}
-      // expected-error@-2 {{cannot infer contextual base in reference to member 'min'}}
+      // expected-error@-1 {{'init(value:)' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{16-20=ModuleSelectorTestingKit}}
     }
 
     self.main::myNegate()
@@ -183,7 +183,7 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
   @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
 
   mutating func myNegate() {
-  // expected-note@-1 {{did you mean 'myNegate'?}}
+  // expected-note@-1 {{'myNegate()' declared here}}
 
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
     // expected-error@-1 3{{'Int' is not imported through module 'ModuleSelectorTestingKit'}}
@@ -213,13 +213,15 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
-      // FIXME improve: expected-error@-1 {{type 'Int' has no member 'ModuleSelectorTestingKit::min'}}
+      // expected-error@-1 {{'min' is not imported through module 'ModuleSelectorTestingKit'}}
+      // expected-note@-2 {{did you mean module 'Swift'?}} {{50-74=Swift}}
 
       self = C.ModuleSelectorTestingKit::init(value: .min)
     }
 
     self.ModuleSelectorTestingKit::myNegate()
-    // FIXME improve: expected-error@-1 {{value of type 'C' has no member 'ModuleSelectorTestingKit::myNegate'}}
+    // expected-error@-1 {{'myNegate()' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'main'?}} {{10-34=main}}
 
     ModuleSelectorTestingKit::fatalError()
     // expected-error@-1 {{'fatalError' is not imported through module 'ModuleSelectorTestingKit'}}
@@ -261,7 +263,7 @@ extension D: @retroactive Swift::Equatable {
   // FIXME improve: expected-error@-1 {{replaced function 'Swift::negate()' could not be found}}
 
   mutating func myNegate() {
-    // expected-note@-1 {{did you mean 'myNegate'?}}
+  // expected-note@-1 {{'myNegate()' declared here}}
 
     let fn: (Swift::Int, Swift::Int) -> Swift::Int =
       (Swift::+)
@@ -285,12 +287,13 @@ extension D: @retroactive Swift::Equatable {
       // expected-error@-3 {{cannot infer contextual base in reference to member 'Swift::min'}}
 
       self = D.Swift::init(value: .min)
-      // FIXME improve: expected-error@-1 {{'D' cannot be constructed because it has no accessible initializers}}
-      // expected-error@-2 {{cannot infer contextual base in reference to member 'min'}}
+      // expected-error@-1 {{'init(value:)' is not imported through module 'Swift'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{16-21=ModuleSelectorTestingKit}}
     }
 
     self.Swift::myNegate()
-    // FIXME improve: expected-error@-1 {{value of type 'D' has no member 'Swift::myNegate'}}
+    // expected-error@-1 {{'myNegate()' is not imported through module 'Swift'}}
+    // expected-note@-2 {{did you mean module 'main'?}} {{10-15=main}}
 
     Swift::fatalError()
 
@@ -392,8 +395,8 @@ func badModuleNames() {
   // expected-note@-2 {{did you mean module 'Swift'?}} {{3-20=Swift}}
 
   _ = "foo".NonexistentModule::count
-  // FIXME improve: expected-error@-1 {{value of type 'String' has no member 'NonexistentModule::count'}}
-  // FIXME: expected-EVENTUALLY-note@-2 {{did you mean module 'Swift'?}} {{13-30=Swift}}
+  // expected-error@-1 {{'count' is not imported through module 'NonexistentModule'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{13-30=Swift}}
 
   let x: NonexistentModule::MyType = NonexistentModule::MyType()
   // expected-error@-1 {{cannot find type 'NonexistentModule::MyType' in scope}}

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -204,7 +204,7 @@ let mog: Never = fatalError()
 
 func localVarsCantBeAccessedByModuleSelector() {
   let mag: Int.Swift::Magnitude = main::mag
-  // expected-error@-1 {{use of local variable 'mag' before its declaration}}
+  // expected-error@-1 {{use of local variable 'main::mag' before its declaration}}
   // expected-note@-2 {{'mag' declared here}}
 
   let mog: Never = main::mog
@@ -267,8 +267,9 @@ func badModuleNames() {
   _ = "foo".NonexistentModule::count
 
   let x: NonexistentModule::MyType = NonexistentModule::MyType()
-  // expected-error@-1 {{cannot find type 'MyType' in scope}}
+  // expected-error@-1 {{cannot find type 'NonexistentModule::MyType' in scope}}
+  // expected-error@-2 {{cannot find 'NonexistentModule::MyType' in scope}}
 
   let y: A.NonexistentModule::MyChildType = fatalError()
-  // expected-error@-1 {{'MyChildType' is not a member type of struct 'ModuleSelectorTestingKit.A'}}
+  // expected-error@-1 {{'NonexistentModule::MyChildType' is not a member type of struct 'ModuleSelectorTestingKit.A'}}
 }

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -95,7 +95,8 @@ extension B: @retroactive main::Equatable {
   // @_derivative(of:)
 
   @_dynamicReplacement(for: main::negate())
-  // FIXME improve: expected-error@-1 {{replaced function 'main::negate()' could not be found}}
+  // expected-error@-1 {{'negate()' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{29-33=ModuleSelectorTestingKit}}
 
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
@@ -260,7 +261,8 @@ extension D: @retroactive Swift::Equatable {
   // @_derivative(of:)
 
   @_dynamicReplacement(for: Swift::negate())
-  // FIXME improve: expected-error@-1 {{replaced function 'Swift::negate()' could not be found}}
+  // expected-error@-1 {{'negate()' is not imported through module 'Swift'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{29-34=ModuleSelectorTestingKit}}
 
   mutating func myNegate() {
   // expected-note@-1 {{'myNegate()' declared here}}

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -40,6 +40,7 @@ extension A: @retroactive Swift::Equatable {
     let fn: (Swift::Int, Swift::Int) -> Swift::Int = (Swift::+)
 
     let magnitude: Int.Swift::Magnitude = main::magnitude
+    // expected-error@-1 {{cannot convert value of type 'Never' to specified type 'Int.Magnitude' (aka 'UInt')}}
 
     _ = (fn, magnitude)
 
@@ -78,18 +79,21 @@ extension B: @retroactive main::Equatable {
   // @_derivative(of:)
 
   @_dynamicReplacement(for: main::negate())
+  // FIXME improve: expected-error@-1 {{replaced function 'main::negate()' could not be found}}
 
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
       (main::+)
 
     let magnitude: Int.main::Magnitude = main::magnitude
+    // FIXME improve: expected-error@-1 {{'main::Magnitude' is not a member type of struct 'Swift.Int'}}
 
     _ = (fn, magnitude)
 
     if main::Bool.main::random() {
 
       main::negate()
+      // FIXME improve: expected-error@-1 {{cannot find 'main::negate' in scope}}
     }
     else {
       self = main::B(value: .main::min)
@@ -130,6 +134,7 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
       (ModuleSelectorTestingKit::+)
 
     let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
+    // FIXME improve: expected-error@-1 {{'ModuleSelectorTestingKit::Magnitude' is not a member type of struct 'Swift.Int'}}
 
     _ = (fn, magnitude)
 
@@ -169,6 +174,7 @@ extension D: @retroactive Swift::Equatable {
   // @_derivative(of:)
 
   @_dynamicReplacement(for: Swift::negate())
+  // FIXME improve: expected-error@-1 {{replaced function 'Swift::negate()' could not be found}}
 
   mutating func myNegate() {
 
@@ -176,12 +182,14 @@ extension D: @retroactive Swift::Equatable {
       (Swift::+)
 
     let magnitude: Int.Swift::Magnitude = Swift::magnitude
+    // expected-error@-1 {{cannot convert value of type 'Never' to specified type 'Int.Magnitude' (aka 'UInt')}}
 
     _ = (fn, magnitude)
 
     if Swift::Bool.Swift::random() {
 
       Swift::negate()
+      // FIXME improve: expected-error@-1 {{cannot find 'Swift::negate' in scope}}
     }
     else {
       self = Swift::D(value: .Swift::min)

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -1,0 +1,274 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -enable-experimental-feature ParserASTGen
+
+// REQUIRES: swift_feature_ModuleSelector, swift_feature_ParserASTGen
+
+// FIXME: This test doesn't really cover:
+//
+// * Whether X::foo finds foos in X's re-exports
+// * Whether we handle access paths correctly
+// * Interaction with ClangImporter
+// * Cross-import overlays
+// * Key path dynamic member lookup
+// * Custom type attributes (and coverage of type attrs generally is sparse)
+// * Macros
+//
+// It also might not cover all combinations of name lookup paths and inputs.
+
+import ModuleSelectorTestingKit
+
+import ctypes.bits
+import struct ModuleSelectorTestingKit::A
+
+let magnitude: Never = fatalError()
+
+// Test correct code using `A`
+
+extension ModuleSelectorTestingKit::A {}
+
+extension A: @retroactive Swift::Equatable {
+  @_implements(Swift::Equatable, ==(_:_:))
+  public static func equals(_: ModuleSelectorTestingKit::A, _: ModuleSelectorTestingKit::A) -> Swift::Bool {
+    Swift::fatalError()
+  }
+
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+
+  @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
+  mutating func myNegate() {
+    let fn: (Swift::Int, Swift::Int) -> Swift::Int = (Swift::+)
+
+    let magnitude: Int.Swift::Magnitude = main::magnitude
+
+    _ = (fn, magnitude)
+
+    if Swift::Bool.Swift::random() {
+      self.ModuleSelectorTestingKit::negate()
+    }
+    else {
+      self = ModuleSelectorTestingKit::A(value: .Swift::min)
+      self = A.ModuleSelectorTestingKit::init(value: .min)
+    }
+
+    self.main::myNegate()
+
+    Swift::fatalError()
+
+    _ = \ModuleSelectorTestingKit::A.magnitude
+    _ = \A.ModuleSelectorTestingKit::magnitude
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+// Test resolution of main:: using `B`
+
+extension main::B {}
+
+extension B: @retroactive main::Equatable {
+
+  @_implements(main::Equatable, ==(_:_:))
+
+  public static func equals(_: main::B, _: main::B) -> main::Bool {
+    main::fatalError()
+  }
+
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+
+  @_dynamicReplacement(for: main::negate())
+
+  mutating func myNegate() {
+    let fn: (main::Int, main::Int) -> main::Int =
+      (main::+)
+
+    let magnitude: Int.main::Magnitude = main::magnitude
+
+    _ = (fn, magnitude)
+
+    if main::Bool.main::random() {
+
+      main::negate()
+    }
+    else {
+      self = main::B(value: .main::min)
+
+      self = B.main::init(value: .min)
+    }
+
+    self.main::myNegate()
+
+    main::fatalError()
+
+    _ = \main::A.magnitude
+    _ = \A.main::magnitude
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+// Test resolution of ModuleSelectorTestingKit:: using `C`
+
+extension ModuleSelectorTestingKit::C {}
+
+extension C: @retroactive ModuleSelectorTestingKit::Equatable {
+
+  @_implements(ModuleSelectorTestingKit::Equatable, ==(_:_:))
+
+  public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool {
+    ModuleSelectorTestingKit::fatalError()
+  }
+
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+
+  @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
+
+  mutating func myNegate() {
+    let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
+      (ModuleSelectorTestingKit::+)
+
+    let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
+
+    _ = (fn, magnitude)
+
+    if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
+
+      ModuleSelectorTestingKit::negate()
+    }
+    else {
+      self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
+
+      self = C.ModuleSelectorTestingKit::init(value: .min)
+    }
+
+    self.ModuleSelectorTestingKit::myNegate()
+
+    ModuleSelectorTestingKit::fatalError()
+
+    _ = \ModuleSelectorTestingKit::A.magnitude
+    _ = \A.ModuleSelectorTestingKit::magnitude
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+// Test resolution of Swift:: using `D`
+
+extension Swift::D {}
+
+extension D: @retroactive Swift::Equatable {
+
+  @_implements(Swift::Equatable, ==(_:_:))
+  public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool {
+    Swift::fatalError()
+  }
+
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+
+  @_dynamicReplacement(for: Swift::negate())
+
+  mutating func myNegate() {
+
+    let fn: (Swift::Int, Swift::Int) -> Swift::Int =
+      (Swift::+)
+
+    let magnitude: Int.Swift::Magnitude = Swift::magnitude
+
+    _ = (fn, magnitude)
+
+    if Swift::Bool.Swift::random() {
+
+      Swift::negate()
+    }
+    else {
+      self = Swift::D(value: .Swift::min)
+
+      self = D.Swift::init(value: .min)
+    }
+
+    self.Swift::myNegate()
+
+    Swift::fatalError()
+
+    _ = \Swift::A.magnitude
+    _ = \A.Swift::magnitude
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+let mog: Never = fatalError()
+
+func localVarsCantBeAccessedByModuleSelector() {
+  let mag: Int.Swift::Magnitude = main::mag
+  // expected-error@-1 {{use of local variable 'mag' before its declaration}}
+  // expected-note@-2 {{'mag' declared here}}
+
+  let mog: Never = main::mog
+}
+
+struct AvailableUser {
+  @available(macOS 10.15, *) var use1: String { "foo" }
+
+  @main::available() var use2
+
+  @ModuleSelectorTestingKit::available() var use4
+  // no-error
+
+  @Swift::available() var use5
+}
+
+func builderUser2(@main::MyBuilder fn: () -> Void) {}
+
+func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
+
+func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
+
+// Error cases
+
+func decl1(
+  p1: main::A,
+  label p2: inout A,
+  label p3: @escaping () -> A
+) {
+  switch Optional(main::p2) {
+  case Optional.some(let decl1i):
+    // expected-warning@-1 {{immutable value 'decl1i' was never used; consider replacing with '_' or removing it}}
+    break
+  case .none:
+    break
+  }
+
+  switch Optional(main::p2) {
+  case let Optional.some(decl1j):
+    // expected-warning@-1 {{immutable value 'decl1j' was never used; consider replacing with '_' or removing it}}
+    break
+  case .none:
+    break
+  }
+
+  switch Optional(main::p2) {
+ case let decl1k?:
+    // expected-warning@-1 {{immutable value 'decl1k' was never used; consider replacing with '_' or removing it}}
+    break
+  case .none:
+    break
+  }
+}
+
+typealias decl5 = main::Bool
+
+func badModuleNames() {
+  NonexistentModule::print()
+
+  _ = "foo".NonexistentModule::count
+
+  let x: NonexistentModule::MyType = NonexistentModule::MyType()
+  // expected-error@-1 {{cannot find type 'MyType' in scope}}
+
+  let y: A.NonexistentModule::MyChildType = fatalError()
+  // expected-error@-1 {{'MyChildType' is not a member type of struct 'ModuleSelectorTestingKit.A'}}
+}

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-builtin-module -enable-experimental-feature ModuleSelector
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-builtin-module -enable-experimental-feature ModuleSelector -enable-experimental-feature ParserASTGen
 
 // REQUIRES: swift_feature_ModuleSelector, swift_feature_ParserASTGen
 
@@ -18,6 +18,8 @@ import ModuleSelectorTestingKit
 
 import ctypes.bits
 import struct ModuleSelectorTestingKit::A
+
+import Builtin
 
 let magnitude: Never = fatalError()
 
@@ -350,4 +352,8 @@ func badModuleNames() {
 
   let y: A.NonexistentModule::MyChildType = fatalError()
   // expected-error@-1 {{'NonexistentModule::MyChildType' is not a member type of struct 'ModuleSelectorTestingKit.A'}}
+}
+
+func builtinModuleLookups(_ int: Builtin::Int64) -> Builtin::Int64 {
+  return Builtin::int_bswap_Int64(int)
 }

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -428,3 +428,15 @@ func concurrencyModuleLookups(
   // expected-error@-1 {{'withTaskCancellationHandler' is not imported through module 'ModuleSelectorTestingKit'}}
   // expected-note@-2 {{did you mean module 'Swift'?}} {{9-33=Swift}}
 }
+
+func dependentTypeLookup<T, U, V, W, X>(_: T, _: U, _: V, _: W, _: X) where
+  T: Identifiable, T: ComparableIdentifiable, T.ID == Int,
+  U: Identifiable, U: ComparableIdentifiable, U.Swift::ID == Int,
+  // expected-error@-1 {{module selector is not allowed on generic member type; associated types with the same name are merged instead of shadowing one another}} {{49-56=}}
+  V: Identifiable, V: ComparableIdentifiable, V.ModuleSelectorTestingKit::ID == Int,
+  // expected-error@-1 {{module selector is not allowed on generic member type; associated types with the same name are merged instead of shadowing one another}} {{49-75=}}
+  W: Identifiable, W: ComparableIdentifiable, W.ctypes::ID == Int,
+  // expected-error@-1 {{module selector is not allowed on generic member type; associated types with the same name are merged instead of shadowing one another}} {{49-57=}}
+  X: Identifiable, X: ComparableIdentifiable, X.NonexistentModule::ID == Int
+  // expected-error@-1 {{module selector is not allowed on generic member type; associated types with the same name are merged instead of shadowing one another}} {{49-68=}}
+{}

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -148,7 +148,8 @@ extension B: @retroactive main::Equatable {
     // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{none}}
 
     _ = #main::ExprMacro
-    // expected-error@-1 {{no macro named 'main::ExprMacro'}}
+    // expected-error@-1 {{'ExprMacro' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{10-14=ModuleSelectorTestingKit}}
   }
 
   @main::PeerMacro func thingy() {}
@@ -307,7 +308,8 @@ extension D: @retroactive Swift::Equatable {
     // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{none}}
 
     _ = #Swift::ExprMacro
-    // expected-error@-1 {{no macro named 'Swift::ExprMacro'}}
+    // expected-error@-1 {{'ExprMacro' is not imported through module 'Swift'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{10-15=ModuleSelectorTestingKit}}
   }
 
   @Swift::PeerMacro func thingy() {}
@@ -330,25 +332,29 @@ struct AvailableUser {
   @available(macOS 10.15, *) var use1: String { "foo" }
 
   @main::available() var use2
-  // FIXME improve: expected-error@-1 {{unknown attribute 'main::available'}}
-  // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
+  // expected-error@-1 {{'available' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{4-8=ModuleSelectorTestingKit}}
+  // FIXME suppress: expected-error@-3 {{type annotation missing in pattern}}
 
   @ModuleSelectorTestingKit::available() var use4
   // no-error
 
   @Swift::available() var use5
-  // FIXME improve: expected-error@-1 {{unknown attribute 'Swift::available'}}
-  // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
+  // expected-error@-1 {{'available' is not imported through module 'Swift'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{4-9=ModuleSelectorTestingKit}}
+  // FIXME suppress: expected-error@-3 {{type annotation missing in pattern}}
 }
 
 func builderUser2(@main::MyBuilder fn: () -> Void) {}
-// FIXME improve: expected-error@-1 {{unknown attribute 'main::MyBuilder'}}
+// expected-error@-1 {{'MyBuilder' is not imported through module 'main'}}
+// expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{20-24=ModuleSelectorTestingKit}}
 
 func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
 // no-error
 
 func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
-// FIXME improve: expected-error@-1 {{unknown attribute 'Swift::MyBuilder'}}
+// expected-error@-1 {{'MyBuilder' is not imported through module 'Swift'}}
+// expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{20-25=ModuleSelectorTestingKit}}
 
 // Error cases
 

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -141,6 +141,7 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
 
       ModuleSelectorTestingKit::negate()
+      // expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::negate' in scope}}
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
@@ -209,11 +210,11 @@ extension D: @retroactive Swift::Equatable {
 }
 
 let mog: Never = fatalError()
+// expected-note@-1 {{did you mean 'mog'?}}
 
 func localVarsCantBeAccessedByModuleSelector() {
   let mag: Int.Swift::Magnitude = main::mag
-  // expected-error@-1 {{use of local variable 'main::mag' before its declaration}}
-  // expected-note@-2 {{'mag' declared here}}
+  // expected-error@-1 {{cannot find 'main::mag' in scope}}
 
   let mog: Never = main::mog
 }

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -111,6 +111,8 @@ extension B: @retroactive main::Equatable {
       // expected-error@-2 {{cannot infer contextual base in reference to member 'main::min'}}
 
       self = B.main::init(value: .min)
+      // FIXME improve: expected-error@-1 {{'B' cannot be constructed because it has no accessible initializers}}
+      // expected-error@-2 {{cannot infer contextual base in reference to member 'min'}}
     }
 
     self.main::myNegate()
@@ -119,7 +121,9 @@ extension B: @retroactive main::Equatable {
     // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
 
     _ = \main::A.magnitude
+    // FIXME improve: expected-error@-1 {{'main::A' in scope}} -- different diagnostic wording for legacy parser vs. ASTGen
     _ = \A.main::magnitude
+    // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'main::magnitude'}}
   }
 
   // FIXME: Can we test @convention(witness_method:)?
@@ -167,11 +171,13 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
+      // FIXME improve: expected-error@-1 {{type 'Int' has no member 'ModuleSelectorTestingKit::min'}}
 
       self = C.ModuleSelectorTestingKit::init(value: .min)
     }
 
     self.ModuleSelectorTestingKit::myNegate()
+    // FIXME improve: expected-error@-1 {{value of type 'C' has no member 'ModuleSelectorTestingKit::myNegate'}}
 
     ModuleSelectorTestingKit::fatalError()
     // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::fatalError' in scope}}
@@ -225,14 +231,19 @@ extension D: @retroactive Swift::Equatable {
       // expected-error@-2 {{cannot infer contextual base in reference to member 'Swift::min'}}
 
       self = D.Swift::init(value: .min)
+      // FIXME improve: expected-error@-1 {{'D' cannot be constructed because it has no accessible initializers}}
+      // expected-error@-2 {{cannot infer contextual base in reference to member 'min'}}
     }
 
     self.Swift::myNegate()
+    // FIXME improve: expected-error@-1 {{value of type 'D' has no member 'Swift::myNegate'}}
 
     Swift::fatalError()
 
     _ = \Swift::A.magnitude
+    // FIXME improve: expected-error@-1 {{'Swift::A' in scope}} -- different diagnostic wording for legacy parser vs. ASTGen
     _ = \A.Swift::magnitude
+    // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'Swift::magnitude'}}
   }
 
   // FIXME: Can we test @convention(witness_method:)?
@@ -309,6 +320,8 @@ func badModuleNames() {
   // expected-error@-1 {{cannot find 'NonexistentModule::print' in scope}}
 
   _ = "foo".NonexistentModule::count
+  // FIXME improve: expected-error@-1 {{value of type 'String' has no member 'NonexistentModule::count'}}
+  // FIXME: expected-EVENTUALLY-note@-2 {{did you mean module 'Swift'?}} {{13-30=Swift}}
 
   let x: NonexistentModule::MyType = NonexistentModule::MyType()
   // expected-error@-1 {{cannot find type 'NonexistentModule::MyType' in scope}}

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -309,6 +309,7 @@ func decl1(
   label p3: @escaping () -> A
 ) {
   switch Optional(main::p2) {
+  // expected-error@-1 {{cannot find 'main::p2' in scope}}
   case Optional.some(let decl1i):
     break
   case .none:
@@ -316,6 +317,7 @@ func decl1(
   }
 
   switch Optional(main::p2) {
+  // expected-error@-1 {{cannot find 'main::p2' in scope}}
   case let Optional.some(decl1j):
     break
   case .none:
@@ -323,6 +325,7 @@ func decl1(
   }
 
   switch Optional(main::p2) {
+  // expected-error@-1 {{cannot find 'main::p2' in scope}}
  case let decl1k?:
     break
   case .none:

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -87,7 +87,8 @@ extension B: @retroactive main::Equatable {
     // expected-error@-4 {{'Bool' is not imported through module 'main'}}
     // expected-note@-5 {{did you mean module 'Swift'?}} {{56-60=Swift}}
     main::fatalError()
-    // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
+    // expected-error@-1 {{'fatalError' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{5-9=Swift}}
   }
 
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -103,7 +104,9 @@ extension B: @retroactive main::Equatable {
     // expected-note@-3 {{did you mean module 'Swift'?}} {{25-29=Swift}}
     // expected-note@-4 {{did you mean module 'Swift'?}} {{39-43=Swift}}
       (main::+)
-      // FIXME improve: expected-error@-1 {{cannot find operator 'main::+' in scope}}
+      // expected-error@-1 {{'+' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'Swift'?}} {{8-12=Swift}}
+      // expected-note@-3 {{did you mean module '_Concurrency'?}} {{8-12=_Concurrency}} FIXME: Accept and suggest 'Swift::' instead?
 
     let magnitude: Int.main::Magnitude = main::magnitude
     // expected-error@-1 {{'Magnitude' is not imported through module 'main'}}
@@ -112,15 +115,18 @@ extension B: @retroactive main::Equatable {
     _ = (fn, magnitude)
 
     if main::Bool.main::random() {
-      // FIXME improve: expected-error@-1 {{cannot find 'main::Bool' in scope}}
+      // expected-error@-1 {{'Bool' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'Swift'?}} {{8-12=Swift}}
 
       main::negate()
-      // FIXME improve: expected-error@-1 {{cannot find 'main::negate' in scope}}
+      // expected-error@-1 {{'negate' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{7-11=self.ModuleSelectorTestingKit}}
     }
     else {
       self = main::B(value: .main::min)
-      // FIXME improve: expected-error@-1 {{cannot find 'main::B' in scope}}
-      // expected-error@-2 {{cannot infer contextual base in reference to member 'main::min'}}
+      // expected-error@-1 {{'B' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{14-18=ModuleSelectorTestingKit}}
+      // expected-error@-3 {{cannot infer contextual base in reference to member 'main::min'}}
 
       self = B.main::init(value: .min)
       // FIXME improve: expected-error@-1 {{'B' cannot be constructed because it has no accessible initializers}}
@@ -130,13 +136,15 @@ extension B: @retroactive main::Equatable {
     self.main::myNegate()
 
     main::fatalError()
-    // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
+    // expected-error@-1 {{'fatalError' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{5-9=Swift}}
 
     _ = \main::A.magnitude
     // expected-error@-1 {{'A' is not imported through module 'main'}}
     // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{10-14=ModuleSelectorTestingKit}}
     _ = \A.main::magnitude
-    // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'main::magnitude'}}
+    // expected-error@-1 {{'magnitude' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{none}}
 
     _ = #main::ExprMacro
     // expected-error@-1 {{no macro named 'main::ExprMacro'}}
@@ -165,7 +173,8 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
     // expected-note@-2 {{did you mean module 'Swift'?}} {{96-120=Swift}}
 
     ModuleSelectorTestingKit::fatalError()
-    // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::fatalError' in scope}}
+    // expected-error@-1 {{'fatalError' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{5-29=Swift}}
   }
 
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -174,26 +183,33 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
   @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
 
   mutating func myNegate() {
+  // expected-note@-1 {{did you mean 'myNegate'?}}
+
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
     // expected-error@-1 3{{'Int' is not imported through module 'ModuleSelectorTestingKit'}}
     // expected-note@-2 {{did you mean module 'Swift'?}} {{14-38=Swift}}
     // expected-note@-3 {{did you mean module 'Swift'?}} {{45-69=Swift}}
     // expected-note@-4 {{did you mean module 'Swift'?}} {{79-103=Swift}}
       (ModuleSelectorTestingKit::+)
-      // FIXME improve: expected-error@-1 {{cannot find operator 'ModuleSelectorTestingKit::+' in scope}}
+      // expected-error@-1 {{'+' is not imported through module 'ModuleSelectorTestingKit'}}
+      // expected-note@-2 {{did you mean module 'Swift'?}} {{8-32=Swift}}
+      // expected-note@-3 {{did you mean module '_Concurrency'?}} {{8-32=_Concurrency}} FIXME: Accept and suggest 'Swift::' instead?
 
     let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
     // expected-error@-1 {{'Magnitude' is not imported through module 'ModuleSelectorTestingKit'}}
     // expected-note@-2 {{did you mean module 'Swift'?}} {{24-48=Swift}}
-    // FIXME improve: expected-error@-3 {{cannot find 'ModuleSelectorTestingKit::magnitude' in scope}}
+    // expected-error@-3 {{'magnitude' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-4 {{did you mean the local declaration?}} {{62-88=}}
 
     _ = (fn, magnitude)
 
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
-    // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::Bool' in scope}}
+    // expected-error@-1 {{'Bool' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{8-32=Swift}}
 
       ModuleSelectorTestingKit::negate()
-      // expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::negate' in scope}}
+      // expected-error@-1 {{'negate' is not imported through module 'ModuleSelectorTestingKit'}}
+      // expected-note@-2 {{did you mean the member of 'self'?}} {{7-7=self.}}
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
@@ -206,7 +222,8 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
     // FIXME improve: expected-error@-1 {{value of type 'C' has no member 'ModuleSelectorTestingKit::myNegate'}}
 
     ModuleSelectorTestingKit::fatalError()
-    // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::fatalError' in scope}}
+    // expected-error@-1 {{'fatalError' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{5-29=Swift}}
 
     _ = \ModuleSelectorTestingKit::A.magnitude
     _ = \A.ModuleSelectorTestingKit::magnitude
@@ -244,24 +261,28 @@ extension D: @retroactive Swift::Equatable {
   // FIXME improve: expected-error@-1 {{replaced function 'Swift::negate()' could not be found}}
 
   mutating func myNegate() {
+    // expected-note@-1 {{did you mean 'myNegate'?}}
 
     let fn: (Swift::Int, Swift::Int) -> Swift::Int =
       (Swift::+)
 
     let magnitude: Int.Swift::Magnitude = Swift::magnitude
-    // expected-error@-1 {{cannot find 'Swift::magnitude' in scope}}
+    // expected-error@-1 {{'magnitude' is not imported through module 'Swift'}}
+    // expected-note@-2 {{did you mean the local declaration?}} {{43-50=}}
 
     _ = (fn, magnitude)
 
     if Swift::Bool.Swift::random() {
 
       Swift::negate()
-      // FIXME improve: expected-error@-1 {{cannot find 'Swift::negate' in scope}}
+      // expected-error@-1 {{'negate' is not imported through module 'Swift'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{7-12=self.ModuleSelectorTestingKit}}
     }
     else {
       self = Swift::D(value: .Swift::min)
-      // FIXME improve: expected-error@-1 {{cannot find 'Swift::D' in scope}}
-      // expected-error@-2 {{cannot infer contextual base in reference to member 'Swift::min'}}
+      // expected-error@-1 {{'D' is not imported through module 'Swift'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{14-19=ModuleSelectorTestingKit}}
+      // expected-error@-3 {{cannot infer contextual base in reference to member 'Swift::min'}}
 
       self = D.Swift::init(value: .min)
       // FIXME improve: expected-error@-1 {{'D' cannot be constructed because it has no accessible initializers}}
@@ -277,7 +298,8 @@ extension D: @retroactive Swift::Equatable {
     // expected-error@-1 {{'A' is not imported through module 'Swift'}}
     // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{10-15=ModuleSelectorTestingKit}}
     _ = \A.Swift::magnitude
-    // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'Swift::magnitude'}}
+    // expected-error@-1 {{'magnitude' is not imported through module 'Swift'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{none}}
 
     _ = #Swift::ExprMacro
     // expected-error@-1 {{no macro named 'Swift::ExprMacro'}}
@@ -293,7 +315,8 @@ let mog: Never = fatalError()
 
 func localVarsCantBeAccessedByModuleSelector() {
   let mag: Int.Swift::Magnitude = main::mag
-  // expected-error@-1 {{cannot find 'main::mag' in scope}}
+  // expected-error@-1 {{'mag' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean the local declaration?}} {{35-41=}}
 
   let mog: Never = main::mog
 }
@@ -332,7 +355,8 @@ func decl1(
   label p3: @escaping () -> A
 ) {
   switch Optional(main::p2) {
-  // expected-error@-1 {{cannot find 'main::p2' in scope}}
+  // expected-error@-1 {{'p2' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean the local declaration?}} {{19-25=}}
   case Optional.some(let decl1i):
     break
   case .none:
@@ -340,7 +364,8 @@ func decl1(
   }
 
   switch Optional(main::p2) {
-  // expected-error@-1 {{cannot find 'main::p2' in scope}}
+  // expected-error@-1 {{'p2' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean the local declaration?}} {{19-25=}}
   case let Optional.some(decl1j):
     break
   case .none:
@@ -348,7 +373,8 @@ func decl1(
   }
 
   switch Optional(main::p2) {
-  // expected-error@-1 {{cannot find 'main::p2' in scope}}
+  // expected-error@-1 {{'p2' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean the local declaration?}} {{19-25=}}
  case let decl1k?:
     break
   case .none:
@@ -362,7 +388,8 @@ typealias decl5 = main::Bool
 
 func badModuleNames() {
   NonexistentModule::print()
-  // expected-error@-1 {{cannot find 'NonexistentModule::print' in scope}}
+  // expected-error@-1 {{'print' is not imported through module 'NonexistentModule'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{3-20=Swift}}
 
   _ = "foo".NonexistentModule::count
   // FIXME improve: expected-error@-1 {{value of type 'String' has no member 'NonexistentModule::count'}}

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -69,18 +69,23 @@ extension A: @retroactive Swift::Equatable {
 // Test resolution of main:: using `B`
 
 extension main::B {}
-// FIXME improve: expected-error@-1 {{cannot find type 'main::B' in scope}}
+// expected-error@-1 {{'B' is not imported through module 'main'}}
+// expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{11-15=ModuleSelectorTestingKit}}
 
 extension B: @retroactive main::Equatable {
-  // FIXME improve: expected-error@-1 {{cannot find type 'main::Equatable' in scope}}
+  // expected-error@-1 {{'Equatable' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{27-31=Swift}}
 
   @_implements(main::Equatable, ==(_:_:))
-  // FIXME improve: expected-error@-1 {{cannot find type 'main::Equatable' in scope}}
+  // expected-error@-1 {{'Equatable' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{16-20=Swift}}
 
   public static func equals(_: main::B, _: main::B) -> main::Bool {
-  // FIXME improve: expected-error@-1 {{cannot find type 'main::B' in scope}}
-  // FIXME improve: expected-error@-2 {{cannot find type 'main::B' in scope}}
-  // FIXME improve: expected-error@-3 {{cannot find type 'main::Bool' in scope}}
+    // expected-error@-1 2{{'B' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{32-36=ModuleSelectorTestingKit}}
+    // expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{44-48=ModuleSelectorTestingKit}}
+    // expected-error@-4 {{'Bool' is not imported through module 'main'}}
+    // expected-note@-5 {{did you mean module 'Swift'?}} {{56-60=Swift}}
     main::fatalError()
     // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
   }
@@ -93,12 +98,16 @@ extension B: @retroactive main::Equatable {
 
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
-    // FIXME improve: expected-error@-1 3{{cannot find type 'main::Int' in scope}}
+    // expected-error@-1 3{{'Int' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{14-18=Swift}}
+    // expected-note@-3 {{did you mean module 'Swift'?}} {{25-29=Swift}}
+    // expected-note@-4 {{did you mean module 'Swift'?}} {{39-43=Swift}}
       (main::+)
       // FIXME improve: expected-error@-1 {{cannot find operator 'main::+' in scope}}
 
     let magnitude: Int.main::Magnitude = main::magnitude
-    // FIXME improve: expected-error@-1 {{'main::Magnitude' is not a member type of struct 'Swift.Int'}}
+    // expected-error@-1 {{'Magnitude' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{24-28=Swift}}
 
     _ = (fn, magnitude)
 
@@ -124,7 +133,8 @@ extension B: @retroactive main::Equatable {
     // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
 
     _ = \main::A.magnitude
-    // FIXME improve: expected-error@-1 {{'main::A' in scope}} -- different diagnostic wording for legacy parser vs. ASTGen
+    // expected-error@-1 {{'A' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{10-14=ModuleSelectorTestingKit}}
     _ = \A.main::magnitude
     // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'main::magnitude'}}
 
@@ -143,13 +153,16 @@ extension B: @retroactive main::Equatable {
 extension ModuleSelectorTestingKit::C {}
 
 extension C: @retroactive ModuleSelectorTestingKit::Equatable {
-// FIXME improve: expected-error@-1 {{cannot find type 'ModuleSelectorTestingKit::Equatable' in scope}}
+  // expected-error@-1 {{'Equatable' is not imported through module 'ModuleSelectorTestingKit'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{27-51=Swift}}
 
   @_implements(ModuleSelectorTestingKit::Equatable, ==(_:_:))
-  // FIXME improve: expected-error@-1 {{cannot find type 'ModuleSelectorTestingKit::Equatable' in scope}}
+  // expected-error@-1 {{'Equatable' is not imported through module 'ModuleSelectorTestingKit'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{16-40=Swift}}
 
   public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool {
-  // FIXME improve: expected-error@-1 {{cannot find type 'ModuleSelectorTestingKit::Bool' in scope}}
+    // expected-error@-1 {{'Bool' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{96-120=Swift}}
 
     ModuleSelectorTestingKit::fatalError()
     // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::fatalError' in scope}}
@@ -162,13 +175,17 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
 
   mutating func myNegate() {
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
-    // FIXME improve: expected-error@-1 3{{cannot find type 'ModuleSelectorTestingKit::Int' in scope}}
+    // expected-error@-1 3{{'Int' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{14-38=Swift}}
+    // expected-note@-3 {{did you mean module 'Swift'?}} {{45-69=Swift}}
+    // expected-note@-4 {{did you mean module 'Swift'?}} {{79-103=Swift}}
       (ModuleSelectorTestingKit::+)
       // FIXME improve: expected-error@-1 {{cannot find operator 'ModuleSelectorTestingKit::+' in scope}}
 
     let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
-    // FIXME improve: expected-error@-1 {{'ModuleSelectorTestingKit::Magnitude' is not a member type of struct 'Swift.Int'}}
-    // FIXME improve: expected-error@-2 {{cannot find 'ModuleSelectorTestingKit::magnitude' in scope}}
+    // expected-error@-1 {{'Magnitude' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{24-48=Swift}}
+    // FIXME improve: expected-error@-3 {{cannot find 'ModuleSelectorTestingKit::magnitude' in scope}}
 
     _ = (fn, magnitude)
 
@@ -206,15 +223,17 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
 // Test resolution of Swift:: using `D`
 
 extension Swift::D {}
-// FIXME improve: expected-error@-1 {{cannot find type 'Swift::D' in scope}}
+// expected-error@-1 {{'D' is not imported through module 'Swift'}}
+// expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{11-16=ModuleSelectorTestingKit}}
 
 extension D: @retroactive Swift::Equatable {
 // Caused by Swift::D failing to typecheck in `equals(_:_:)`: expected-error@-1 *{{extension outside of file declaring struct 'D' prevents automatic synthesis of '==' for protocol 'Equatable'}} expected-note@-1 *{{add stubs for conformance}}
 
   @_implements(Swift::Equatable, ==(_:_:))
   public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool {
-  // expected-error@-1 {{cannot find type 'Swift::D' in scope}}
-  // expected-error@-2 {{cannot find type 'Swift::D' in scope}}
+  // expected-error@-1 2{{'D' is not imported through module 'Swift'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{32-37=ModuleSelectorTestingKit}}
+  // expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{45-50=ModuleSelectorTestingKit}}
     Swift::fatalError() // no-error -- not typechecking function bodies
   }
 
@@ -255,7 +274,8 @@ extension D: @retroactive Swift::Equatable {
     Swift::fatalError()
 
     _ = \Swift::A.magnitude
-    // FIXME improve: expected-error@-1 {{'Swift::A' in scope}} -- different diagnostic wording for legacy parser vs. ASTGen
+    // expected-error@-1 {{'A' is not imported through module 'Swift'}}
+    // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{10-15=ModuleSelectorTestingKit}}
     _ = \A.Swift::magnitude
     // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'Swift::magnitude'}}
 
@@ -306,7 +326,8 @@ func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
 
 func decl1(
   p1: main::A,
-  // FIXME: expected-error@-1 {{cannot find type 'main::A' in scope}}
+  // expected-error@-1 {{'A' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{7-11=ModuleSelectorTestingKit}}
   label p2: inout A,
   label p3: @escaping () -> A
 ) {
@@ -336,7 +357,8 @@ func decl1(
 }
 
 typealias decl5 = main::Bool
-// FIXME improve: expected-error@-1 {{cannot find type 'main::Bool' in scope}}
+// expected-error@-1 {{'Bool' is not imported through module 'main'}}
+// expected-note@-2 {{did you mean module 'Swift'?}} {{19-23=Swift}}
 
 func badModuleNames() {
   NonexistentModule::print()

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -11,7 +11,6 @@
 // * Cross-import overlays
 // * Key path dynamic member lookup
 // * Custom type attributes (and coverage of type attrs generally is sparse)
-// * Macros
 //
 // It also might not cover all combinations of name lookup paths and inputs.
 
@@ -58,6 +57,8 @@ extension A: @retroactive Swift::Equatable {
 
     _ = \ModuleSelectorTestingKit::A.magnitude
     _ = \A.ModuleSelectorTestingKit::magnitude
+
+    _ = #ModuleSelectorTestingKit::ExprMacro
   }
 
   // FIXME: Can we test @convention(witness_method:)?
@@ -124,7 +125,13 @@ extension B: @retroactive main::Equatable {
     // FIXME improve: expected-error@-1 {{'main::A' in scope}} -- different diagnostic wording for legacy parser vs. ASTGen
     _ = \A.main::magnitude
     // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'main::magnitude'}}
+
+    _ = #main::ExprMacro
+    // expected-error@-1 {{no macro named 'main::ExprMacro'}}
   }
+
+  @main::PeerMacro func thingy() {}
+  // expected-error@-1 {{unknown attribute 'main::PeerMacro'}}
 
   // FIXME: Can we test @convention(witness_method:)?
 }
@@ -184,7 +191,12 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
 
     _ = \ModuleSelectorTestingKit::A.magnitude
     _ = \A.ModuleSelectorTestingKit::magnitude
+
+    _ = #ModuleSelectorTestingKit::ExprMacro
   }
+
+  @ModuleSelectorTestingKit::PeerMacro func thingy() {}
+  // expected-error@-1 {{external macro implementation type 'Fnord.PeerMacro' could not be found for macro 'PeerMacro()'; plugin for module 'Fnord' not found}}
 
   // FIXME: Can we test @convention(witness_method:)?
 }
@@ -244,7 +256,13 @@ extension D: @retroactive Swift::Equatable {
     // FIXME improve: expected-error@-1 {{'Swift::A' in scope}} -- different diagnostic wording for legacy parser vs. ASTGen
     _ = \A.Swift::magnitude
     // FIXME improve: expected-error@-1 {{value of type 'A' has no member 'Swift::magnitude'}}
+
+    _ = #Swift::ExprMacro
+    // expected-error@-1 {{no macro named 'Swift::ExprMacro'}}
   }
+
+  @Swift::PeerMacro func thingy() {}
+  // expected-error@-1 {{unknown attribute 'Swift::PeerMacro'}}
 
   // FIXME: Can we test @convention(witness_method:)?
 }
@@ -262,25 +280,25 @@ struct AvailableUser {
   @available(macOS 10.15, *) var use1: String { "foo" }
 
   @main::available() var use2
-  // FIXME improve: expected-error@-1 {{unknown attribute 'available'}}
+  // FIXME improve: expected-error@-1 {{unknown attribute 'main::available'}}
   // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
 
   @ModuleSelectorTestingKit::available() var use4
   // no-error
 
   @Swift::available() var use5
-  // FIXME improve: expected-error@-1 {{unknown attribute 'available'}}
+  // FIXME improve: expected-error@-1 {{unknown attribute 'Swift::available'}}
   // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
 }
 
 func builderUser2(@main::MyBuilder fn: () -> Void) {}
-// FIXME improve: expected-error@-1 {{unknown attribute 'MyBuilder'}}
+// FIXME improve: expected-error@-1 {{unknown attribute 'main::MyBuilder'}}
 
 func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
 // no-error
 
 func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
-// FIXME improve: expected-error@-1 {{unknown attribute 'MyBuilder'}}
+// FIXME improve: expected-error@-1 {{unknown attribute 'Swift::MyBuilder'}}
 
 // Error cases
 

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -66,13 +66,20 @@ extension A: @retroactive Swift::Equatable {
 // Test resolution of main:: using `B`
 
 extension main::B {}
+// FIXME improve: expected-error@-1 {{cannot find type 'main::B' in scope}}
 
 extension B: @retroactive main::Equatable {
+  // FIXME improve: expected-error@-1 {{cannot find type 'main::Equatable' in scope}}
 
   @_implements(main::Equatable, ==(_:_:))
+  // FIXME improve: expected-error@-1 {{cannot find type 'main::Equatable' in scope}}
 
   public static func equals(_: main::B, _: main::B) -> main::Bool {
+  // FIXME improve: expected-error@-1 {{cannot find type 'main::B' in scope}}
+  // FIXME improve: expected-error@-2 {{cannot find type 'main::B' in scope}}
+  // FIXME improve: expected-error@-3 {{cannot find type 'main::Bool' in scope}}
     main::fatalError()
+    // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
   }
 
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -83,7 +90,9 @@ extension B: @retroactive main::Equatable {
 
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
+    // FIXME improve: expected-error@-1 3{{cannot find type 'main::Int' in scope}}
       (main::+)
+      // FIXME improve: expected-error@-1 {{cannot find operator 'main::+' in scope}}
 
     let magnitude: Int.main::Magnitude = main::magnitude
     // FIXME improve: expected-error@-1 {{'main::Magnitude' is not a member type of struct 'Swift.Int'}}
@@ -91,12 +100,15 @@ extension B: @retroactive main::Equatable {
     _ = (fn, magnitude)
 
     if main::Bool.main::random() {
+      // FIXME improve: expected-error@-1 {{cannot find 'main::Bool' in scope}}
 
       main::negate()
       // FIXME improve: expected-error@-1 {{cannot find 'main::negate' in scope}}
     }
     else {
       self = main::B(value: .main::min)
+      // FIXME improve: expected-error@-1 {{cannot find 'main::B' in scope}}
+      // expected-error@-2 {{cannot infer contextual base in reference to member 'main::min'}}
 
       self = B.main::init(value: .min)
     }
@@ -104,6 +116,7 @@ extension B: @retroactive main::Equatable {
     self.main::myNegate()
 
     main::fatalError()
+    // FIXME improve: expected-error@-1 {{cannot find 'main::fatalError' in scope}}
 
     _ = \main::A.magnitude
     _ = \A.main::magnitude
@@ -117,11 +130,16 @@ extension B: @retroactive main::Equatable {
 extension ModuleSelectorTestingKit::C {}
 
 extension C: @retroactive ModuleSelectorTestingKit::Equatable {
+// FIXME improve: expected-error@-1 {{cannot find type 'ModuleSelectorTestingKit::Equatable' in scope}}
 
   @_implements(ModuleSelectorTestingKit::Equatable, ==(_:_:))
+  // FIXME improve: expected-error@-1 {{cannot find type 'ModuleSelectorTestingKit::Equatable' in scope}}
 
   public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool {
+  // FIXME improve: expected-error@-1 {{cannot find type 'ModuleSelectorTestingKit::Bool' in scope}}
+
     ModuleSelectorTestingKit::fatalError()
+    // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::fatalError' in scope}}
   }
 
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -131,14 +149,18 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
 
   mutating func myNegate() {
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
+    // FIXME improve: expected-error@-1 3{{cannot find type 'ModuleSelectorTestingKit::Int' in scope}}
       (ModuleSelectorTestingKit::+)
+      // FIXME improve: expected-error@-1 {{cannot find operator 'ModuleSelectorTestingKit::+' in scope}}
 
     let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
     // FIXME improve: expected-error@-1 {{'ModuleSelectorTestingKit::Magnitude' is not a member type of struct 'Swift.Int'}}
+    // FIXME improve: expected-error@-2 {{cannot find 'ModuleSelectorTestingKit::magnitude' in scope}}
 
     _ = (fn, magnitude)
 
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
+    // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::Bool' in scope}}
 
       ModuleSelectorTestingKit::negate()
       // expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::negate' in scope}}
@@ -152,6 +174,7 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
     self.ModuleSelectorTestingKit::myNegate()
 
     ModuleSelectorTestingKit::fatalError()
+    // FIXME improve: expected-error@-1 {{cannot find 'ModuleSelectorTestingKit::fatalError' in scope}}
 
     _ = \ModuleSelectorTestingKit::A.magnitude
     _ = \A.ModuleSelectorTestingKit::magnitude
@@ -163,12 +186,16 @@ extension C: @retroactive ModuleSelectorTestingKit::Equatable {
 // Test resolution of Swift:: using `D`
 
 extension Swift::D {}
+// FIXME improve: expected-error@-1 {{cannot find type 'Swift::D' in scope}}
 
 extension D: @retroactive Swift::Equatable {
+// Caused by Swift::D failing to typecheck in `equals(_:_:)`: expected-error@-1 *{{extension outside of file declaring struct 'D' prevents automatic synthesis of '==' for protocol 'Equatable'}} expected-note@-1 *{{add stubs for conformance}}
 
   @_implements(Swift::Equatable, ==(_:_:))
   public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool {
-    Swift::fatalError()
+  // expected-error@-1 {{cannot find type 'Swift::D' in scope}}
+  // expected-error@-2 {{cannot find type 'Swift::D' in scope}}
+    Swift::fatalError() // no-error -- not typechecking function bodies
   }
 
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -183,7 +210,7 @@ extension D: @retroactive Swift::Equatable {
       (Swift::+)
 
     let magnitude: Int.Swift::Magnitude = Swift::magnitude
-    // expected-error@-1 {{cannot convert value of type 'Never' to specified type 'Int.Magnitude' (aka 'UInt')}}
+    // expected-error@-1 {{cannot find 'Swift::magnitude' in scope}}
 
     _ = (fn, magnitude)
 
@@ -194,6 +221,8 @@ extension D: @retroactive Swift::Equatable {
     }
     else {
       self = Swift::D(value: .Swift::min)
+      // FIXME improve: expected-error@-1 {{cannot find 'Swift::D' in scope}}
+      // expected-error@-2 {{cannot infer contextual base in reference to member 'Swift::min'}}
 
       self = D.Swift::init(value: .min)
     }
@@ -210,7 +239,6 @@ extension D: @retroactive Swift::Equatable {
 }
 
 let mog: Never = fatalError()
-// expected-note@-1 {{did you mean 'mog'?}}
 
 func localVarsCantBeAccessedByModuleSelector() {
   let mag: Int.Swift::Magnitude = main::mag
@@ -223,29 +251,36 @@ struct AvailableUser {
   @available(macOS 10.15, *) var use1: String { "foo" }
 
   @main::available() var use2
+  // FIXME improve: expected-error@-1 {{unknown attribute 'available'}}
+  // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
 
   @ModuleSelectorTestingKit::available() var use4
   // no-error
 
   @Swift::available() var use5
+  // FIXME improve: expected-error@-1 {{unknown attribute 'available'}}
+  // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
 }
 
 func builderUser2(@main::MyBuilder fn: () -> Void) {}
+// FIXME improve: expected-error@-1 {{unknown attribute 'MyBuilder'}}
 
 func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
+// no-error
 
 func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
+// FIXME improve: expected-error@-1 {{unknown attribute 'MyBuilder'}}
 
 // Error cases
 
 func decl1(
   p1: main::A,
+  // FIXME: expected-error@-1 {{cannot find type 'main::A' in scope}}
   label p2: inout A,
   label p3: @escaping () -> A
 ) {
   switch Optional(main::p2) {
   case Optional.some(let decl1i):
-    // expected-warning@-1 {{immutable value 'decl1i' was never used; consider replacing with '_' or removing it}}
     break
   case .none:
     break
@@ -253,7 +288,6 @@ func decl1(
 
   switch Optional(main::p2) {
   case let Optional.some(decl1j):
-    // expected-warning@-1 {{immutable value 'decl1j' was never used; consider replacing with '_' or removing it}}
     break
   case .none:
     break
@@ -261,7 +295,6 @@ func decl1(
 
   switch Optional(main::p2) {
  case let decl1k?:
-    // expected-warning@-1 {{immutable value 'decl1k' was never used; consider replacing with '_' or removing it}}
     break
   case .none:
     break
@@ -269,9 +302,11 @@ func decl1(
 }
 
 typealias decl5 = main::Bool
+// FIXME improve: expected-error@-1 {{cannot find type 'main::Bool' in scope}}
 
 func badModuleNames() {
   NonexistentModule::print()
+  // expected-error@-1 {{cannot find 'NonexistentModule::print' in scope}}
 
   _ = "foo".NonexistentModule::count
 

--- a/test/NameLookup/module_selector_cross_import.swift
+++ b/test/NameLookup/module_selector_cross_import.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -enable-cross-import-overlays
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -enable-experimental-feature ParserASTGen -enable-cross-import-overlays
+
+// REQUIRES: swift_feature_ModuleSelector, swift_feature_ParserASTGen
+
+import ModuleSelectorTestingKit
+import ctypes
+
+func crossImportLookups(
+  _: E,
+  _: ModuleSelectorTestingKit::E,
+  _: _ModuleSelectorTestingKit_ctypes::E,
+  _: Swift::E
+  // expected-error@-1 {{'E' is not imported through module 'Swift'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{6-11=ModuleSelectorTestingKit}}
+) {
+  e()
+  ModuleSelectorTestingKit::e()
+  _ModuleSelectorTestingKit_ctypes::e()
+  Swift::e()
+  // expected-error@-1 {{'e' is not imported through module 'Swift'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{3-8=ModuleSelectorTestingKit}}
+}

--- a/test/NameLookup/module_selector_cross_import.swift
+++ b/test/NameLookup/module_selector_cross_import.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -enable-cross-import-overlays
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -enable-experimental-feature ParserASTGen -enable-cross-import-overlays
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-cross-import-overlays
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ParserASTGen -enable-cross-import-overlays
 
-// REQUIRES: swift_feature_ModuleSelector, swift_feature_ParserASTGen
+// REQUIRES: swift_feature_ParserASTGen
 
 import ModuleSelectorTestingKit
 import ctypes

--- a/test/Parse/module_selector.swift
+++ b/test/Parse/module_selector.swift
@@ -1,10 +1,10 @@
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -parse -verify-additional-prefix legacy-
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-feature ModuleSelector -parse -verify-additional-prefix new- -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -parse -verify-additional-prefix legacy-
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -parse -verify-additional-prefix new- -enable-experimental-feature ParserASTGen
 
 // Make sure the lack of the experimental flag disables the feature:
 // RUN: not %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs 2>/dev/null
 
-// REQUIRES: swift_feature_ModuleSelector, swift_feature_ParserASTGen
+// REQUIRES: swift_feature_ParserASTGen
 
 // ModuleSelectorImports
 import struct ModuleSelectorTestingKit::A

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -1,8 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
-// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-experimental-feature ModuleSelector
-// REQUIRES: swift_feature_ModuleSelector
-
 func f0(_ x: Int, y: Int, z: Int) { }
 func f1(_ x: Int, while: Int) { }
 func f2(_ x: Int, `let` _: Int) { }

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -543,8 +543,8 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
     }
   } else {
     namelookup::lookupInModule(DC->getModuleScopeContext(),
-                               VD->getBaseName(), results,
-                               NLKind::UnqualifiedLookup,
+                               VD->getBaseName(), /*hasModuleSelector=*/false,
+                               results, NLKind::UnqualifiedLookup,
                                namelookup::ResolutionKind::Overloadable,
                                DC->getModuleScopeContext(),
                                VD->getLoc(),


### PR DESCRIPTION
This pull request implements the lookup behavior, including tailored diagnostics, for "module selectors", which allow references to declarations to be unambiguously prefixed with a module they can be found through:

```
class MyClass: ObjectiveC::NSObject {}  // OK, ObjectiveC defines NSObject
class MyClass: Foundation::NSObject {}  // OK, Foundation re-exports NSObject
class MyClass: Swift::NSObject {}       // error, Swift does not re-export or define NSObject
class MyClass: MyModule::NSObject {}    // error, MyModule does not re-export or define NSObject
```

Since SE-0491 has been approved and this PR is sufficient to make them functional, it also changes them from an experimental feature to an ordinary on-by-default language feature.

Parsing for this feature has already landed in #84362. Conditional emission into module interface files will land in a future PR.

This work was previously in PR #28834, which was closed during the master-to-main transition.

Fixes rdar://problem/19481048.