### PR TITLE
[cxx-interop] Support class templates containing typedefs.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3255,6 +3255,10 @@ namespace {
         return nullptr;
       }
 
+      // TODO(SR-13809): fix this once we support dependent types.
+      if (decl->getTypeForDecl()->isDependentType())
+        return nullptr;
+
       // Don't import nominal types that are over-aligned.
       if (Impl.isOverAligned(decl))
         return nullptr;

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-typedef.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-typedef.h
@@ -1,0 +1,15 @@
+// Make sure that we can import a type that uses a "dependent type" after being
+// specialized (i.e. "size_type" in "Lander").
+template <class T> struct Lander;
+
+template <>
+struct Lander<void> {};
+
+template <class T> struct Lander {
+  typedef unsigned long size_type;
+  // Make sure we don't crash here. Before being specialized, "size_type" is
+  // technically a depedent type because it expands to "Lander<T>::size_type".
+  void test(size_type) { }
+};
+
+using Surveyor = Lander<char>;

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -53,3 +53,7 @@ module ClassTemplateNonTypeParameter {
 module ClassTemplateTemplateParameter {
   header "class-template-template-parameter.h"
 }
+
+module ClassTemplateWithTypedef {
+  header "class-template-with-typedef.h"
+}

--- a/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct __CxxTemplateInst6LanderIcE {
+// CHECK:   typealias size_type = UInt
+// CHECK:   init()
+// CHECK:   mutating func test(_: UInt)
+// CHECK: }
+// CHECK: typealias Surveyor = __CxxTemplateInst6LanderIcE


### PR DESCRIPTION
This prevents an assertion in "isOverAligned" caused by class templates that contain and use typedefs.