### PR TITLE
[LookupVisibleDecls] Include protocol members when finding 'subscript(dynamicMember:)'

### DIFF
--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1095,8 +1095,8 @@ static void lookupVisibleDynamicMemberLookupDecls(
       { ctx, DeclBaseName::createSubscript(), { ctx.Id_dynamicMember} });
 
   SmallVector<ValueDecl *, 2> subscripts;
-  dc->lookupQualified(baseType, subscriptName, NL_QualifiedDefault,
-                      subscripts);
+  dc->lookupQualified(baseType, subscriptName,
+                      NL_QualifiedDefault | NL_ProtocolMembers, subscripts);
 
   for (ValueDecl *VD : subscripts) {
     auto *subscript = dyn_cast<SubscriptDecl>(VD);

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -23,6 +23,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testNested2 | %FileCheck %s -check-prefix=testNested2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testCycle1 | %FileCheck %s -check-prefix=testCycle1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testCycle2 | %FileCheck %s -check-prefix=testCycle2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=testSubscriptOnProtocolExt | %FileCheck %s -check-prefix=testSubscriptOnProtocolExt
 
 struct Point {
   var x: Int
@@ -384,4 +385,27 @@ struct CycleC<T> {
 func testCycle2(r: CycleA<Point>) {
   r.#^testCycle2^#
 // testCycle2: Begin completions
+}
+
+protocol DynamicLookupProto {
+    associatedtype Content
+}
+extension DynamicLookupProto {
+    subscript<T>(dynamicMember key: KeyPath<Content, T>) -> T {
+      fatalError()
+    }
+}
+
+@dynamicMemberLookup
+struct DynamicLookupConcrete : DynamicLookupProto {
+    typealias Content = Point
+}
+
+func testSubscriptOnProtocolExtension(dyn: DynamicLookupConcrete) {
+    dyn.#^testSubscriptOnProtocolExt^#
+// testSubscriptOnProtocolExt: Begin completions
+// testSubscriptOnProtocolExt: Keyword[self]/CurrNominal:          self[#DynamicLookupConcrete#];
+// testSubscriptOnProtocolExt: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testSubscriptOnProtocolExt: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testSubscriptOnProtocolExt: End completions
 }


### PR DESCRIPTION
```swift
  struct Point { var x, y: Int }
  protocol P {}
  extension P {
    subscript<T>(dynamicMember key: KeyPath<Point, T>) -> T
  }
  @dynamicMemberLookup struct S: P {}

  S().<HERE>
```

Previously, completion couldn't suggest `x` and `y` because it couldn't find `subscript(dynamicMember:)` on `S` type. Include `NL_ProtocolMembers` when finding the subscript.

rdar://problem/71008072
