### PR TITLE
[ConstraintSystem] Ignore value-to-optional conversions to correctly …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2616,11 +2616,22 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
         if (!shouldAttemptFixes())
           return getTypeMatchFailure(locator);
 
+        SmallVector<LocatorPathElt, 4> path;
+        auto anchor = locator.getLocatorParts(path);
+
+        // If the path ends at `optional payload` it means that this
+        // check is part of an implicit value-to-optional conversion,
+        // and it could be safely dropped.
+        if (!path.empty() && path.back().is<LocatorPathElt::OptionalPayload>())
+          path.pop_back();
+
         // Determine whether this conformance mismatch is
-        // associate with argument to a call, and if so
+        // associated with argument to a call, and if so
         // produce a tailored fix.
-        if (auto last = locator.last()) {
-          if (last->is<LocatorPathElt::ApplyArgToParam>()) {
+        if (!path.empty()) {
+          auto last = path.back();
+
+          if (last.is<LocatorPathElt::ApplyArgToParam>()) {
             auto *fix = AllowArgumentMismatch::create(
                 *this, type1, proto, getConstraintLocator(locator));
 
@@ -2643,21 +2654,19 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
           //
           // Once either reacher locators or better diagnostic presentation for
           // nested type failures is available this check could be removed.
-          if (last->is<LocatorPathElt::FunctionResult>())
+          if (last.is<LocatorPathElt::FunctionResult>())
             return getTypeMatchFailure(locator);
 
           // If instance types didn't line up correctly, let's produce a
           // diagnostic which mentions them together with their metatypes.
-          if (last->is<LocatorPathElt::InstanceType>())
+          if (last.is<LocatorPathElt::InstanceType>())
             return getTypeMatchFailure(locator);
 
         } else { // There are no elements in the path
-          auto anchor = locator.getAnchor();
           if (!(isExpr<AssignExpr>(anchor) || isExpr<CoerceExpr>(anchor)))
             return getTypeMatchFailure(locator);
         }
 
-        auto anchor = locator.getAnchor();
         if (isExpr<CoerceExpr>(anchor)) {
           auto *fix = ContextualMismatch::create(
               *this, type1, type2, getConstraintLocator(locator));

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -422,3 +422,13 @@ func test_sr_11609() {
   let _: String = foo()
   // expected-error@-1 {{local function 'foo' requires that 'String' conform to 'Initable'}}
 }
+
+// rdar://70814576 -- failed to produce a diagnostic when implicit value-to-optional conversion is involved.
+func rdar70814576() {
+  struct S {}
+
+  func test(_: Fooable?) {
+  }
+
+  test(S()) // expected-error {{argument type 'S' does not conform to expected type 'Fooable'}}
+}


### PR DESCRIPTION
…detect conformance failures

If there is a conformance failure related to existential conversion
let's ignore that fact that there could be an implicit value-to-optional
conversion involved, because it's not the main issue in cases like
that.

Resolves: rdar://problem/70814576

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
