### PR TITLE
[TypeChecker] Do not attempt to skip typechecking for didSet

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/NonInlinableFunctionSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/NonInlinableFunctionSkippingChecker.cpp
@@ -65,6 +65,12 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
   if (isa<DestructorDecl>(func) || isa<ConstructorDecl>(func))
     return false;
 
+  // See DeclChecker::shouldSkipBodyTypechecking. Can't skip didSet for now.
+  if (auto *AD = dyn_cast<AccessorDecl>(func)) {
+    if (AD->getAccessorKind() == AccessorKind::DidSet)
+      return false;
+  }
+
   // If none of those conditions trip, then this is something that _should_
   // be serialized in the module even when we're skipping non-inlinable
   // function bodies.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2332,6 +2332,13 @@ public:
     if (!AFD->getBodySourceRange().isValid())
       return false;
 
+    // didSet runs typechecking to determine whether to keep its parameter,
+    // so never try to skip.
+    if (auto *AD = dyn_cast<AccessorDecl>(AFD)) {
+      if (AD->getAccessorKind() == AccessorKind::DidSet)
+        return false;
+    }
+
     // If we're gonna serialize the body, we can't skip it.
     if (AFD->getResilienceExpansion() == ResilienceExpansion::Minimal)
       return false;

--- a/test/Frontend/skip-non-inlinable-function-bodies.swift
+++ b/test/Frontend/skip-non-inlinable-function-bodies.swift
@@ -157,6 +157,18 @@ public struct Struct {
     }
   }
 
+  public var willSetVar: Int = 1 {
+    willSet {
+      _blackHole("willSet body") // CHECK-NOT: "willSet body"
+    }
+  }
+
+  public var didSetVar: Int = 1 {
+    didSet {
+      _blackHole("didSet body") // CHECK-NOT: "didSet body"
+    }
+  }
+
   @_transparent
   public func transparentFunc() {
     _blackHole("@_transparent method body") // CHECK: "@_transparent method body"

--- a/validation-test/compiler_crashers_2_fixed/rdar70739449.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar70739449.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-module %s -experimental-skip-non-inlinable-function-bodies
+
+struct Foo {
+  var fieldWithDidSet : Int {
+    didSet {
+      let local = oldValue
+    }
+  }
+}


### PR DESCRIPTION
15f8eb45ea594298fe2e60c5356481a4744393ef (see PR#26632) introduced
refined didSet semantics where the `oldValue` parameter is skipped if it
isn't used. This would perform typechecking, but later try to set the
body to skipped and thus fire an assert.

For now, do not attempt to skip typechecking of didSet accessors. Still
skip outputting their SIL though.
