### PR TITLE
ASTScope: Fix assertion with pattern bindings that don't introduce any variables

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -544,13 +544,16 @@ ScopeCreator::addPatternBindingToScopeTree(PatternBindingDecl *patternBinding,
   if (auto *var = patternBinding->getSingleVar())
     addChildrenForKnownAttributes(var, parentScope);
 
-  auto *insertionPoint = parentScope;
+  bool isLocalBinding = false;
   for (auto i : range(patternBinding->getNumPatternEntries())) {
-    bool isLocalBinding = false;
     if (auto *varDecl = patternBinding->getAnchoringVarDecl(i)) {
       isLocalBinding = varDecl->getDeclContext()->isLocalContext();
+      break;
     }
+  }
 
+  auto *insertionPoint = parentScope;
+  for (auto i : range(patternBinding->getNumPatternEntries())) {
     Optional<SourceLoc> endLocForBinding = None;
     if (isLocalBinding) {
       endLocForBinding = endLoc;

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -131,4 +131,8 @@ if true {
   _ = s
 }
 
-
+// ASTScope assertion
+func patternBindingWithTwoEntries() {
+  let x2 = 1, (_, _) = (1, 2)
+  // expected-warning@-1 {{immutable value 'x2' was never used; consider replacing with '_' or removing it}}
+}


### PR DESCRIPTION
We would get confused if we saw a PatternBindingDecl where
one entry introduced a binding, and the other did not.

Thanks to @DougGregor for the test case!
