### PR TITLE
VisualC: remove unnecessary submodule

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -16,11 +16,6 @@ module visualc [system] {
     export *
   }
 
-  module vadefs {
-    header "vadefs.h"
-    export *
-  }
-
   module vcruntime {
     header "vcruntime.h"
     export *


### PR DESCRIPTION
`vadefs.h` is also provided by clang, there should be no need to have it in visualc as well.
Besides, this header doesn't seem to be used anywhere in the project.