### PR TITLE
[Concurrency] Implement type checking for 'async let' declarations.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -588,6 +588,12 @@ SIMPLE_DECL_ATTR(_specializeExtension, SpecializeExtension,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   105)
 
+CONTEXTUAL_SIMPLE_DECL_ATTR(async, Async,
+  DeclModifier | OnVar | OnFunc | ConcurrencyOnly |
+  ABIBreakingToAdd | ABIBreakingToRemove |
+  APIBreakingToAdd | APIBreakingToRemove,
+  106)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4727,6 +4727,9 @@ public:
   /// getSpecifier() == Specifier::Default.
   bool isLet() const { return getIntroducer() == Introducer::Let; }
 
+  /// Is this an "async let" property?
+  bool isAsyncLet() const;
+
   Introducer getIntroducer() const {
     return Introducer(Bits.VarDecl.Introducer);
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1784,7 +1784,7 @@ public:
   /// Is the pattern binding entry for this variable  currently being computed?
   bool isComputingPatternBindingEntry(const VarDecl *vd) const;
 
-  /// Is this an "async let" declaration.
+  /// Is this an "async let" declaration?
   bool isAsyncLet() const;
 
   /// Gets the text of the initializer expression for the pattern entry at the

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1784,6 +1784,9 @@ public:
   /// Is the pattern binding entry for this variable  currently being computed?
   bool isComputingPatternBindingEntry(const VarDecl *vd) const;
 
+  /// Is this an "async let" declaration.
+  bool isAsyncLet() const;
+
   /// Gets the text of the initializer expression for the pattern entry at the
   /// given index, stripping out inactive branches of any #ifs inside the
   /// expression.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -324,6 +324,8 @@ ERROR(func_decl_expected_arrow,none,
 ERROR(operator_static_in_protocol,none,
       "operator '%0' declared in protocol must be 'static'",
       (StringRef))
+ERROR(async_func_modifier,none,
+      "'async' must be written after the parameter list of a function", ())
 
 // Enum
 ERROR(expected_lbrace_enum,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4067,6 +4067,8 @@ ERROR(throwing_interpolation_without_try,none,
       "interpolation can throw but is not marked with 'try'", ())
 ERROR(throwing_call_without_try,none,
       "call can throw but is not marked with 'try'", ())
+ERROR(throwing_async_let_without_try,none,
+      "reading 'async let' can throw but is not marked with 'try'", ())
 NOTE(note_forgot_try,none,
       "did you mean to use 'try'?", ())
 NOTE(note_error_to_optional,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4118,6 +4118,15 @@ NOTE(protocol_witness_async_conflict,none,
 ERROR(async_autoclosure_nonasync_function,none,
       "'async' autoclosure parameter in a non-'async' function", ())
 
+ERROR(async_not_let,none,
+      "'async' can only be used with 'let' declarations", ())
+ERROR(async_let_not_local,none,
+      "'async let' can only be used on local declarations", ())
+ERROR(async_let_not_initialized,none,
+      "'async let' binding requires an initializer expression", ())
+ERROR(async_let_no_variables,none,
+      "'async let' requires at least one named variable", ())
+
 ERROR(asynchandler_non_func,none,
       "'@asyncHandler' can only be applied to functions",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4087,6 +4087,9 @@ ERROR(async_call_without_await,none,
       "call is 'async' but is not marked with 'await'", ())
 ERROR(async_call_without_await_in_autoclosure,none,
       "call is 'async' in an autoclosure argument that is not marked with 'await'", ())
+ERROR(async_call_without_await_in_async_let,none,
+      "call is 'async' in an 'async let' initializer that is not marked "
+      "with 'await'", ())
 WARNING(no_async_in_await,none,
         "no calls to 'async' functions occur within 'await' expression", ())
 ERROR(async_call_in_illegal_context,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4098,9 +4098,9 @@ ERROR(await_in_illegal_context,none,
       "%select{<<ERROR>>|a default argument|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}0",
       (unsigned))
 ERROR(async_in_nonasync_function,none,
-      "%select{'async'|'await'}0 in %select{a function|an autoclosure}1 that "
-      "does not support concurrency",
-      (bool, bool))
+      "%select{'async'|'await'|'async let'}0 in "
+      "%select{a function|an autoclosure}1 that does not support concurrency",
+      (unsigned, bool))
 NOTE(note_add_async_to_function,none,
      "add 'async' to function %0 to make it asynchronous", (DeclName))
 NOTE(note_add_asynchandler_to_function,none,
@@ -4126,6 +4126,12 @@ ERROR(async_let_not_initialized,none,
       "'async let' binding requires an initializer expression", ())
 ERROR(async_let_no_variables,none,
       "'async let' requires at least one named variable", ())
+ERROR(async_let_without_await,none,
+      "reference to async let %0 is not marked with 'await'", (DeclName))
+ERROR(async_let_in_illegal_context,none,
+      "async let %0 cannot be referenced in "
+      "%select{<<ERROR>>|a default argument|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}1",
+      (DeclName, unsigned))
 
 ERROR(asynchandler_non_func,none,
       "'@asyncHandler' can only be applied to functions",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3903,7 +3903,10 @@ public:
 
     // An autoclosure with type (Self) -> (Args...) -> Result. Formed from type
     // checking a partial application.
-    DoubleCurryThunk = 2
+    DoubleCurryThunk = 2,
+
+    // An autoclosure with type () -> Result that was formed for an async let.
+    AsyncLet = 3,
   };
 
   AutoClosureExpr(Expr *Body, Type ResultTy, unsigned Discriminator,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4373,7 +4373,8 @@ public:
   /// Build implicit autoclosure expression wrapping a given expression.
   /// Given expression represents computed result of the closure.
   Expr *buildAutoClosureExpr(Expr *expr, FunctionType *closureType,
-                             bool isDefaultWrappedValue = false);
+                             bool isDefaultWrappedValue = false,
+                             bool isAsyncLetWrapper = false);
 
   /// Builds a type-erased return expression that can be used in dynamic
   /// replacement.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1545,6 +1545,13 @@ StaticSpellingKind PatternBindingDecl::getCorrectStaticSpelling() const {
   return getCorrectStaticSpellingForDecl(this);
 }
 
+bool PatternBindingDecl::isAsyncLet() const {
+  if (auto var = getAnchoringVarDecl(0))
+    return var->isAsyncLet();
+
+  return false;
+}
+
 
 bool PatternBindingDecl::hasStorage() const {
   // Walk the pattern, to check to see if any of the VarDecls included in it

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5740,6 +5740,10 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   return true;
 }
 
+bool VarDecl::isAsyncLet() const {
+  return getAttrs().hasAttribute<AsyncAttr>();
+}
+
 void ParamDecl::setSpecifier(Specifier specifier) {
   // FIXME: Revisit this; in particular shouldn't __owned parameters be
   // ::Let also?

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2031,6 +2031,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
 
   switch (getThunkKind()) {
   case AutoClosureExpr::Kind::None:
+  case AutoClosureExpr::Kind::AsyncLet:
     break;
 
   case AutoClosureExpr::Kind::SingleCurryThunk: {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6558,6 +6558,19 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
 
   diagnoseWhereClauseInGenericParamList(GenericParams);
 
+  // If there was an 'async' modifier, put it in the right place for a function.
+  bool isAsync = asyncLoc.isValid();
+  if (auto asyncAttr = Attributes.getAttribute<AsyncAttr>()) {
+    SourceLoc insertLoc = Lexer::getLocForEndOfToken(
+        SourceMgr, BodyParams->getRParenLoc());
+
+    diagnose(asyncAttr->getLocation(), diag::async_func_modifier)
+      .fixItRemove(asyncAttr->getRange())
+      .fixItInsert(insertLoc, " async");
+    asyncAttr->setInvalid();
+    isAsync = true;
+  }
+
   // Create the decl for the func and add it to the parent scope.
   auto *FD = FuncDecl::create(Context, StaticLoc, StaticSpelling,
                               FuncLoc, FullName, NameLoc,

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -447,8 +447,15 @@ bool SILDeclRef::isTransparent() const {
 
   if (hasAutoClosureExpr()) {
     auto *ace = getAutoClosureExpr();
-    if (ace->getThunkKind() == AutoClosureExpr::Kind::None)
+    switch (ace->getThunkKind()) {
+    case AutoClosureExpr::Kind::None:
       return true;
+
+    case AutoClosureExpr::Kind::AsyncLet:
+    case AutoClosureExpr::Kind::DoubleCurryThunk:
+    case AutoClosureExpr::Kind::SingleCurryThunk:
+      break;
+    }
   }
 
   if (hasDecl()) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7900,7 +7900,9 @@ static Expr *wrapAsyncLetInitializer(
   // child task.
   auto closureType = FunctionType::get({ }, initializerType, extInfo);
   ASTContext &ctx = dc->getASTContext();
-  Expr *autoclosureExpr = cs.buildAutoClosureExpr(initializer, closureType);
+  Expr *autoclosureExpr = cs.buildAutoClosureExpr(
+      initializer, closureType, /*isDefaultWrappedValue=*/false,
+      /*isAsyncLetWrapper=*/true);
 
   // Call the autoclosure so that the AST types line up. SILGen will ignore the
   // actual calls and translate them into a different mechanism.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7881,6 +7881,49 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
   return diagnosedAnyErrors;
 }
 
+/// For the initializer of an `async let`, wrap it in an autoclosure and then
+/// a call to that autoclosure, so that the code for the child task is captured
+/// entirely within the autoclosure. This captures the semantics of the
+/// operation but not the timing, e.g., the call itself will actually occur
+/// when one of the variables in the async let is referenced.
+static Expr *wrapAsyncLetInitializer(
+      ConstraintSystem &cs, Expr *initializer, DeclContext *dc) {
+  // Form the autoclosure type. It is always 'async', and will be 'throws'.
+  Type initializerType = initializer->getType();
+  bool throws = TypeChecker::canThrow(initializer);
+  auto extInfo = ASTExtInfoBuilder()
+    .withAsync()
+    .withThrows(throws)
+    .build();
+
+  // Form the autoclosure expression. The actual closure here encapsulates the
+  // child task.
+  auto closureType = FunctionType::get({ }, initializerType, extInfo);
+  ASTContext &ctx = dc->getASTContext();
+  Expr *autoclosureExpr = cs.buildAutoClosureExpr(initializer, closureType);
+
+  // Call the autoclosure so that the AST types line up. SILGen will ignore the
+  // actual calls and translate them into a different mechanism.
+  auto autoclosureCall = CallExpr::createImplicit(
+      ctx, autoclosureExpr, { }, { });
+  autoclosureCall->setType(initializerType);
+  autoclosureCall->setThrows(throws);
+
+  // For a throwing expression, wrap the call in a 'try'.
+  Expr *resultInit = autoclosureCall;
+  if (throws) {
+    resultInit = new (ctx) TryExpr(
+        SourceLoc(), resultInit, initializerType, /*implicit=*/true);
+  }
+
+  // Wrap the call in an 'await'.
+  resultInit = new (ctx) AwaitExpr(
+      SourceLoc(), resultInit, initializerType, /*implicit=*/true);
+
+  cs.cacheExprTypes(resultInit);
+  return resultInit;
+}
+
 /// Apply the given solution to the initialization target.
 ///
 /// \returns the resulting initialization expression.
@@ -7953,6 +7996,16 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
     resultTarget.setPattern(coercedPattern);
   } else {
     return None;
+  }
+
+  // For an async let, wrap the initializer appropriately to make it a child
+  // task.
+  if (auto patternBinding = target.getInitializationPatternBindingDecl()) {
+    if (patternBinding->isAsyncLet()) {
+      resultTarget.setExpr(
+          wrapAsyncLetInitializer(
+            cs, resultTarget.getAsExpr(), resultTarget.getDeclContext()));
+    }
   }
 
   return resultTarget;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4662,7 +4662,8 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
 
 Expr *ConstraintSystem::buildAutoClosureExpr(Expr *expr,
                                              FunctionType *closureType,
-                                             bool isDefaultWrappedValue) {
+                                             bool isDefaultWrappedValue,
+                                             bool isAsyncLetWrapper) {
   auto &Context = DC->getASTContext();
   bool isInDefaultArgumentContext = false;
   if (auto *init = dyn_cast<Initializer>(DC)) {
@@ -4683,6 +4684,9 @@ Expr *ConstraintSystem::buildAutoClosureExpr(Expr *expr,
       expr, newClosureType, AutoClosureExpr::InvalidDiscriminator, DC);
 
   closure->setParameterList(ParameterList::createEmpty(Context));
+
+  if (isAsyncLetWrapper)
+    closure->setThunkKind(AutoClosureExpr::Kind::AsyncLet);
 
   Expr *result = closure;
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1495,8 +1495,16 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
                   const AbstractClosureExpr *CE) {
       // If the closure's type was inferred to be noescape, then it doesn't
       // need qualification.
-      return !AnyFunctionRef(const_cast<AbstractClosureExpr *>(CE))
-               .isKnownNoEscape();
+      if (AnyFunctionRef(const_cast<AbstractClosureExpr *>(CE))
+               .isKnownNoEscape())
+        return false;
+
+      if (auto autoclosure = dyn_cast<AutoClosureExpr>(CE)) {
+        if (autoclosure->getThunkKind() == AutoClosureExpr::Kind::AsyncLet)
+          return false;
+      }
+
+      return true;
     }
 
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -344,6 +344,59 @@ public:
 
     (void)nominal->isGlobalActor();
   }
+
+  void visitAsyncAttr(AsyncAttr *attr) {
+    auto var = dyn_cast<VarDecl>(D);
+    if (!var)
+      return;
+
+    auto patternBinding = var->getParentPatternBinding();
+    if (!patternBinding)
+      return; // already diagnosed
+
+    // "Async" modifier can only be applied to local declarations.
+    if (!patternBinding->getDeclContext()->isLocalContext()) {
+      diagnoseAndRemoveAttr(attr, diag::async_let_not_local);
+      return;
+    }
+
+    // Check each of the pattern binding entries.
+    bool diagnosedVar = false;
+    for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      auto pattern = patternBinding->getPattern(index);
+
+      // Look for variables bound by this pattern.
+      bool foundAnyVariable = false;
+      bool isLet = true;
+      pattern->forEachVariable([&](VarDecl *var) {
+        if (!var->isLet())
+          isLet = false;
+        foundAnyVariable = true;
+      });
+
+      // Each entry must bind at least one named variable, so that there is
+      // something to "await".
+      if (!foundAnyVariable) {
+        diagnose(pattern->getLoc(), diag::async_let_no_variables);
+        attr->setInvalid();
+        return;
+      }
+
+      // Async can only be used on an "async let".
+      if (!isLet && !diagnosedVar) {
+        diagnose(patternBinding->getLoc(), diag::async_not_let)
+          .fixItReplace(patternBinding->getLoc(), "let");
+        diagnosedVar = true;
+      }
+
+      // Each pattern entry must have an initializer expression.
+      if (patternBinding->getEqualLoc(index).isInvalid()) {
+        diagnose(pattern->getLoc(), diag::async_let_not_initialized);
+        attr->setInvalid();
+        return;
+      }
+    }
+  }
 };
 } // end anonymous namespace
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1516,6 +1516,7 @@ namespace  {
     UNINTERESTING_ATTR(Actor)
     UNINTERESTING_ATTR(ActorIndependent)
     UNINTERESTING_ATTR(GlobalActor)
+    UNINTERESTING_ATTR(Async)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -533,6 +533,13 @@ public:
     return result;
   }
 
+  /// Classify a single expression without considering its enclosing context.
+  ThrowingKind classifyExpr(Expr *expr) {
+    FunctionBodyClassifier classifier(*this);
+    expr->walk(classifier);
+    return classifier.Result;
+  }
+
 private:
   /// Classify a throwing function according to our local knowledge of
   /// its implementation.
@@ -2014,4 +2021,8 @@ void TypeChecker::checkPropertyWrapperEffects(
   auto &ctx = binding->getASTContext();
   CheckEffectsCoverage checker(ctx, Context::forPatternBinding(binding));
   expr->walk(checker);
+}
+
+bool TypeChecker::canThrow(Expr *expr) {
+  return ApplyClassifier().classifyExpr(expr) == ThrowingKind::Throws;
 }

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1638,15 +1638,16 @@ private:
     scope.enterSubFunction();
     scope.resetCoverageForAutoclosureBody();
 
-    // Curry thunks aren't actually a call to the asynchronous function.
-    // Assume that async is covered in such contexts.
     switch (E->getThunkKind()) {
     case AutoClosureExpr::Kind::DoubleCurryThunk:
     case AutoClosureExpr::Kind::SingleCurryThunk:
+      // Curry thunks aren't actually a call to the asynchronous function.
+      // Assume that async is covered in such contexts.
       Flags.set(ContextFlags::IsAsyncCovered);
       break;
 
     case AutoClosureExpr::Kind::None:
+    case AutoClosureExpr::Kind::AsyncLet:
       break;
     }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1062,6 +1062,9 @@ void checkInitializerEffects(Initializer *I, Expr *E);
 void checkEnumElementEffects(EnumElementDecl *D, Expr *expr);
 void checkPropertyWrapperEffects(PatternBindingDecl *binding, Expr *expr);
 
+/// Whether the given expression can throw.
+bool canThrow(Expr *expr);
+
 /// If an expression references 'self.init' or 'super.init' in an
 /// initializer context, returns the implicit 'self' decl of the constructor.
 /// Otherwise, return nil.

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+actor class MyActor {
+  let immutable: Int = 17
+  var text: [String] = []
+
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 2 {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func asynchronous() async -> String { synchronous() }
+
+  func testAsyncLetIsolation() async {
+    async let x = self.synchronous()
+    // expected-error @-1{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
+
+    async let y = await self.asynchronous()
+
+    async let z = synchronous()
+    // expected-error @-1{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
+    // FIXME: expected-error @-2{{call to method 'synchronous' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    // FIXME: expected-note @-3{{reference 'self.' explicitly}}
+
+    var localText = text // expected-note{{var declared here}}
+    async let w = localText.removeLast()
+    // expected-warning@-1{{local var 'localText' is unsafe to reference in code that may execute concurrently}}
+
+    _ = await x
+    _ = await y
+    _ = await z
+    _ = await w
+  }
+}

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -16,8 +16,6 @@ actor class MyActor {
 
     async let z = synchronous()
     // expected-error @-1{{actor-isolated instance method 'synchronous()' is unsafe to reference in code that may execute concurrently}}
-    // FIXME: expected-error @-2{{call to method 'synchronous' in closure requires explicit use of 'self' to make capture semantics explicit}}
-    // FIXME: expected-note @-3{{reference 'self.' explicitly}}
 
     var localText = text // expected-note{{var declared here}}
     async let w = localText.removeLast()

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -54,3 +54,12 @@ func testAwaitExpr() async {
   let myFuture = MyFuture()
   let _ = myFuture.await()
 }
+
+func getIntSomeday() async -> Int { 5 }
+
+func testAsyncLet() async {
+  async let x = await getIntSomeday()
+  _ = x
+}
+
+async func asyncIncorrectly() { } // expected-error{{'async' must be written after the parameter list of a function}}{{1-7=}}{{30-30= async}}

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -59,7 +59,7 @@ func getIntSomeday() async -> Int { 5 }
 
 func testAsyncLet() async {
   async let x = await getIntSomeday()
-  _ = x
+  _ = await x
 }
 
 async func asyncIncorrectly() { } // expected-error{{'async' must be written after the parameter list of a function}}{{1-7=}}{{30-30= async}}

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -25,3 +25,13 @@ func testAsyncFunc() async {
   await x = 1
   _ = y2
 }
+
+// Cooking example
+func chopVegetables() async throws -> [String] { [] }
+func marinateMeat() async -> String { "MEAT" }
+
+func cook() async throws {
+  async let veggies = await try chopVegetables(), meat = await marinateMeat()
+  _ = await try veggies
+  _ = await meat
+}

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+async let x = 1 // okay
+
+struct X {
+  async let x = 1 // expected-error{{'async let' can only be used on local declarations}}
+}
+
+func testAsyncFunc() async {
+  async let (z1, z2) = (2, 3)
+  async let (_, _) = (2, 3)
+  async let x2 = 1
+
+  async var x = 17 // expected-error{{'async' can only be used with 'let' declarations}}{{9-12=let}}
+  async let (_, _) = (1, 2), y2 = 7 // expected-error{{'async let' requires at least one named variable}}
+  async let y: Int // expected-error{{'async let' binding requires an initializer expression}}
+  _ = x
+  _ = y
+  _ = z1
+  _ = z2
+  _ = x2
+  x = 1
+  _ = y2
+}

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -6,6 +6,7 @@ async let x = 1 // okay
 
 struct X {
   async let x = 1 // expected-error{{'async let' can only be used on local declarations}}
+  // FIXME: expected-error@-1{{'async' call cannot occur in a property initializer}}
 }
 
 func testAsyncFunc() async {

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -16,11 +16,11 @@ func testAsyncFunc() async {
   async var x = 17 // expected-error{{'async' can only be used with 'let' declarations}}{{9-12=let}}
   async let (_, _) = (1, 2), y2 = 7 // expected-error{{'async let' requires at least one named variable}}
   async let y: Int // expected-error{{'async let' binding requires an initializer expression}}
-  _ = x
+  _ = await x
   _ = y
-  _ = z1
-  _ = z2
-  _ = x2
-  x = 1
+  _ = await z1
+  _ = await z2
+  _ = await x2
+  await x = 1
   _ = y2
 }

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -164,10 +164,10 @@ func testAsyncLet() async throws {
   }
 }
 
-// expected-note@+2 2{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}
-// expected-note@+1 2{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}}
+// expected-note@+2 3{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}
+// expected-note@+1 3{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}}
 func testAsyncLetOutOfAsync() {
-  async let x = 1 // ERROR?
+  async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}
 
   _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
   _ = x // expected-error{{'async let' in a function that does not support concurrency}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -148,6 +148,9 @@ func validAsyncFunction() async throws {
 // Async let checking
 func mightThrow() throws { }
 
+func getIntUnsafely() throws -> Int { 0 }
+func getIntUnsafelyAsync() async throws -> Int { 0 }
+
 extension Error {
   var number: Int { 0 }
 }
@@ -162,6 +165,16 @@ func testAsyncLet() async throws {
   } catch let e where e.number == x { // expected-error{{async let 'x' cannot be referenced in a catch guard expression}}
   } catch {
   }
+
+  async let x1 = getIntUnsafely() // expected-error{{call can throw but is not marked with 'try'}}
+  // expected-note@-1{{did you mean to use 'try'}}
+  // expected-note@-2{{did you mean to handle error as optional value?}}
+  // expected-note@-3{{did you mean to disable error propagation?}}
+
+  async let x2 = getInt() // expected-error{{call is 'async' in an 'async let' initializer that is not marked with 'await'}}
+
+  _ = await x1
+  _ = await x2
 }
 
 // expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -173,8 +173,15 @@ func testAsyncLet() async throws {
 
   async let x2 = getInt() // expected-error{{call is 'async' in an 'async let' initializer that is not marked with 'await'}}
 
-  _ = await x1
+  async let x3 = try getIntUnsafely()
+  async let x4 = try! getIntUnsafely()
+  async let x5 = try? getIntUnsafely()
+
+  _ = await x1 // expected-error{{reading 'async let' can throw but is not marked with 'try'}}
   _ = await x2
+  _ = await try x3
+  _ = await x4
+  _ = await x5
 }
 
 // expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -144,3 +144,32 @@ func invalidAsyncFunction() async {
 func validAsyncFunction() async throws {
   _ = try await throwingAndAsync()
 }
+
+// Async let checking
+func mightThrow() throws { }
+
+extension Error {
+  var number: Int { 0 }
+}
+
+func testAsyncLet() async throws {
+  async let x = await getInt()
+  print(x) // expected-error{{reference to async let 'x' is not marked with 'await'}}
+  print(await x)
+
+  do {
+    try mightThrow()
+  } catch let e where e.number == x { // expected-error{{async let 'x' cannot be referenced in a catch guard expression}}
+  } catch {
+  }
+}
+
+// expected-note@+2 2{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}
+// expected-note@+1 2{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}}
+func testAsyncLetOutOfAsync() {
+  async let x = 1 // ERROR?
+
+  _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
+  _ = x // expected-error{{'async let' in a function that does not support concurrency}}
+}
+

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -164,10 +164,11 @@ func testAsyncLet() async throws {
   }
 }
 
-// expected-note@+2 3{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}
-// expected-note@+1 3{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}}
+// expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}
+// expected-note@+1 4{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}}
 func testAsyncLetOutOfAsync() {
   async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}
+  // FIXME: expected-error@-1{{'async' in a function that does not support concurrency}}
 
   _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
   _ = x // expected-error{{'async let' in a function that does not support concurrency}}

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -171,7 +171,7 @@ DECL_NODES = [
                        'required', 'static', 'unowned', 'weak', 'private',
                        'fileprivate', 'internal', 'public', 'open',
                        'mutating', 'nonmutating', 'indirect', '__consuming',
-                       'actor'
+                       'actor', 'async'
                    ]),
              Child('DetailLeftParen', kind='LeftParenToken', is_optional=True),
              Child('Detail', kind='IdentifierToken', is_optional=True),


### PR DESCRIPTION
Implement parsing and type checking for 'async let' declarations. 'async let' allows one to create child tasks that execute concurrently with the current task. This covers:
* Declaring `async let` declarations within asynchronous functions
* Ensuring that access to an `async let` declaration is covered by `await` (and `try`, if the initializer could throw an error)
* Treating the initializer as a concurrently-executing child task, by injecting it into an escaping autoclosure, which (e.g.) takes it out of the actor isolation domain

Covers the type checking portion of rdar://70101851.