### PR TITLE
[Async CC] Forward task and executor through partial apply forwarder.

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1227,9 +1227,8 @@ public:
   }
   llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
     Explosion asyncExplosion;
-    asyncExplosion.add(llvm::Constant::getNullValue(subIGF.IGM.SwiftTaskPtrTy));
-    asyncExplosion.add(
-        llvm::Constant::getNullValue(subIGF.IGM.SwiftExecutorPtrTy));
+    asyncExplosion.add(subIGF.getAsyncTask());
+    asyncExplosion.add(subIGF.getAsyncExecutor());
     asyncExplosion.add(contextBuffer);
     if (dynamicFunction &&
         dynamicFunction->kind == DynamicFunction::Kind::PartialApply) {
@@ -1308,6 +1307,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
 
   IRGenFunction subIGF(IGM, fwd);
+  subIGF.setAsync(origType->isAsync());
   if (IGM.DebugInfo)
     IGM.DebugInfo->emitArtificialFunction(subIGF, fwd);
 


### PR DESCRIPTION
Previously, the task and executor values passed to a partial apply forwarder were being ignored. Here, they are passed along to the partially applied function.