### PR TITLE
[CodeCompletion] Add XFAIL to swift-ide-test

### DIFF
--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -407,7 +407,7 @@ func testTypeInTupleType6() {
 }
 
 func testTypeInTupleType7() {
-  var localVar: (a: b: #^TYPE_IN_TUPLE_TYPE_7?skip=FIXME^#
+  var localVar: (a: b: #^TYPE_IN_TUPLE_TYPE_7?xfail=FIXME^#
 }
 
 //===---


### PR DESCRIPTION
In `-batch-code-completion` mode, add a token parameter `xfail={reason}`. When (*all*) 'FileCheck' succeeds on the token, it is considered "unexpected pass", and the test fails.

rdar://problem/71021285
