### PR TITLE
[ownership] Add a few test cases that show that the reborrow verifier handles recursive reborrows correctly.

### DIFF
--- a/test/SIL/ownership-verifier/borrow_validate.sil
+++ b/test/SIL/ownership-verifier/borrow_validate.sil
@@ -2,7 +2,6 @@
 // REQUIRES: asserts
 
 import Builtin
-import Swift
 
 //////////////////
 // Declarations //
@@ -13,6 +12,11 @@ class Klass : SuperKlass {}
 
 struct WrapperStruct {
   var cls : Klass
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
 }
 
 sil shared [noinline] @blackhole_spl : $@convention(thin) (@guaranteed WrapperStruct) -> () {
@@ -258,6 +262,96 @@ bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $Wrapper
   %ret = tuple ()
   return %ret : $()
 }
+
+// CHECK-NOT: Function: 'borrow_lifetime_discrepency_2'
+sil [ossa] @borrow_lifetime_discrepency_2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct, %borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %0 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  %borrow1a = begin_borrow %borrow1 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct, %borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $WrapperStruct, %base : @owned $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  end_borrow %newborrowo : $WrapperStruct
+  destroy_value %base : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrow_lifetime_discrepency_incorrect_1'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %13 = argument of bb3 : $WrapperStruct            // user: %15
+// CHECK: Consuming User:   destroy_value %13 : $WrapperStruct              // id: %15
+// CHECK: Non Consuming User:   end_borrow %12 : $WrapperStruct                 // id: %16
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrow_lifetime_discrepency_incorrect_1'
+// CHECK-NOT: Error#: 1.
+sil [ossa] @borrow_lifetime_discrepency_incorrect_1 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct, %borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %0 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  %borrow1a = begin_borrow %borrow1 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct, %borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $WrapperStruct, %base : @owned $WrapperStruct):
+  end_borrow %newborrowi : $WrapperStruct
+  destroy_value %base : $WrapperStruct
+  end_borrow %newborrowo : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'borrow_lifetime_discrepency_incorrect_2'
+// CHECK: Found outside of lifetime use?!
+// CHECK: Value: %12 = argument of bb3 : $WrapperStruct            // user: %14
+// CHECK: Consuming User:   end_borrow %12 : $WrapperStruct                 // id: %14
+// CHECK: Non Consuming User:   end_borrow %11 : $WrapperStruct                 // id: %15
+// CHECK: Block: bb3
+// CHECK-LABEL: Error#: 0. End Error in Function: 'borrow_lifetime_discrepency_incorrect_2'
+// CHECK-NOT: Error#: 1.
+sil [ossa] @borrow_lifetime_discrepency_incorrect_2 : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
+bb0(%0 : @guaranteed $WrapperStruct, %1 : @guaranteed $WrapperStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0 = copy_value %0 : $WrapperStruct
+  %borrow0 = begin_borrow %copy0 : $WrapperStruct
+  %borrow0a = begin_borrow %borrow0 : $WrapperStruct
+  br bb3(%borrow0a : $WrapperStruct, %borrow0 : $WrapperStruct, %copy0 : $WrapperStruct)
+
+bb2:
+  %copy1 = copy_value %0 : $WrapperStruct
+  %borrow1 = begin_borrow %copy1 : $WrapperStruct
+  %borrow1a = begin_borrow %borrow1 : $WrapperStruct
+  br bb3(%borrow1a : $WrapperStruct, %borrow1 : $WrapperStruct, %copy1 : $WrapperStruct)
+
+bb3(%newborrowi : @guaranteed $WrapperStruct, %newborrowo : @guaranteed $WrapperStruct, %base : @owned $WrapperStruct):
+  end_borrow %newborrowo : $WrapperStruct
+  end_borrow %newborrowi : $WrapperStruct
+  destroy_value %base : $WrapperStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+
 
 // CHECK-NOT: Function: 'borrow_lifetime_nodiscrepency'
 sil [ossa] @borrow_lifetime_nodiscrepency : $@convention(thin) (@guaranteed WrapperStruct, @guaranteed WrapperStruct) -> () {
@@ -601,27 +695,27 @@ bb0(%0 : @owned $Klass):
 
 bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass
-  %none = enum $Optional<Klass>, #Optional.none!enumelt
-  %borrownone = begin_borrow %none : $Optional<Klass>
-  br bb3(%borrownone : $Optional<Klass>, %none : $Optional<Klass>)
+  %none = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  %borrownone = begin_borrow %none : $FakeOptional<Klass>
+  br bb3(%borrownone : $FakeOptional<Klass>, %none : $FakeOptional<Klass>)
 
 bb2(%2 : @owned $Klass):
-  %some = enum $Optional<Klass>, #Optional.some!enumelt, %2 : $Klass
-  %borrowsome = begin_borrow %some : $Optional<Klass>
-  br bb3(%borrowsome : $Optional<Klass>, %some : $Optional<Klass>)
+  %some = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %2 : $Klass
+  %borrowsome = begin_borrow %some : $FakeOptional<Klass>
+  br bb3(%borrowsome : $FakeOptional<Klass>, %some : $FakeOptional<Klass>)
 
-bb3(%borrow : @guaranteed $Optional<Klass>, %mKlass : @owned $Optional<Klass>):
-  end_borrow %borrow : $Optional<Klass>
-  destroy_value %mKlass : $Optional<Klass>
+bb3(%borrow : @guaranteed $FakeOptional<Klass>, %mKlass : @owned $FakeOptional<Klass>):
+  end_borrow %borrow : $FakeOptional<Klass>
+  destroy_value %mKlass : $FakeOptional<Klass>
   %9999 = tuple()
   return %9999 : $()
 }
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
 // CHECK: Found outside of lifetime use?!
-// CHECK: Value: %12 = argument of bb3 : $Optional<Klass>
-// CHECK: Consuming User:   destroy_value %12 : $Optional<Klass>
-// CHECK: Non Consuming User:   end_borrow %11 : $Optional<Klass>
+// CHECK: Value: %12 = argument of bb3 : $FakeOptional<Klass>
+// CHECK: Consuming User:   destroy_value %12 : $FakeOptional<Klass>
+// CHECK: Non Consuming User:   end_borrow %11 : $FakeOptional<Klass>
 // CHECK: Block: bb3
 // CHECK-LABEL: Error#: 0. End Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
@@ -631,18 +725,18 @@ bb0(%0 : @owned $Klass):
 
 bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass
-  %none = enum $Optional<Klass>, #Optional.none!enumelt
-  %borrownone = begin_borrow %none : $Optional<Klass>
-  br bb3(%borrownone : $Optional<Klass>, %none : $Optional<Klass>)
+  %none = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  %borrownone = begin_borrow %none : $FakeOptional<Klass>
+  br bb3(%borrownone : $FakeOptional<Klass>, %none : $FakeOptional<Klass>)
 
 bb2(%2 : @owned $Klass):
-  %some = enum $Optional<Klass>, #Optional.some!enumelt, %2 : $Klass
-  %borrowsome = begin_borrow %some : $Optional<Klass>
-  br bb3(%borrowsome : $Optional<Klass>, %some : $Optional<Klass>)
+  %some = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %2 : $Klass
+  %borrowsome = begin_borrow %some : $FakeOptional<Klass>
+  br bb3(%borrowsome : $FakeOptional<Klass>, %some : $FakeOptional<Klass>)
 
-bb3(%borrow : @guaranteed $Optional<Klass>, %mKlass : @owned $Optional<Klass>):
-  destroy_value %mKlass : $Optional<Klass>
-  end_borrow %borrow : $Optional<Klass>
+bb3(%borrow : @guaranteed $FakeOptional<Klass>, %mKlass : @owned $FakeOptional<Klass>):
+  destroy_value %mKlass : $FakeOptional<Klass>
+  end_borrow %borrow : $FakeOptional<Klass>
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
I also removed this tests dependency on the Swift module which speeds up running
with a debug compiler.

I am finishing up a generic RAUW value1 with value2 regardless of ownership. I
want to depend on this behavior, so I wanted to put a test into tree to make
sure it works/keeps on working.
