### PR TITLE
[CSGen] Turn invalid decls into holes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3726,6 +3726,9 @@ ERROR(capture_across_type_decl,none,
       "%0 declaration cannot close over value %1 defined in outer scope",
       (DescriptiveDeclKind, Identifier))
 
+ERROR(reference_to_invalid_decl,none,
+      "cannot reference invalid declaration %0", (DeclName))
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Statements
 //------------------------------------------------------------------------------

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2070,6 +2070,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static AllowRefToInvalidDecl *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
 };

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -281,6 +281,10 @@ enum class FixKind : uint8_t {
 
   /// Resolve type of `nil` by providing a contextual type.
   SpecifyContextualTypeForNil,
+
+  /// Allow expressions to reference invalid declarations by turning
+  /// them into holes.
+  AllowRefToInvalidDecl,
 };
 
 class ConstraintFix {
@@ -2053,6 +2057,21 @@ public:
 
   static SpecifyContextualTypeForNil *create(ConstraintSystem & cs,
                                              ConstraintLocator * locator);
+};
+
+class AllowRefToInvalidDecl final : public ConstraintFix {
+  AllowRefToInvalidDecl(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowRefToInvalidDecl, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore invalid declaration reference";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowRefToInvalidDecl *create(ConstraintSystem &cs,
+                                       ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7002,3 +7002,21 @@ bool MissingContextualTypeForNil::diagnoseAsError() {
   emitDiagnostic(diag::unresolved_nil_literal);
   return true;
 }
+
+bool ReferenceToInvalidDeclaration::diagnoseAsError() {
+  auto *decl = castToExpr<DeclRefExpr>(getAnchor())->getDecl();
+  assert(decl);
+
+  auto &DE = getASTContext().Diags;
+  // This problem should have been already diagnosed during
+  // validation of the declaration.
+  if (DE.hadAnyError())
+    return true;
+
+  // If no errors have been emitted yet, let's emit one
+  // about reference to an invalid declaration.
+
+  emitDiagnostic(diag::reference_to_invalid_decl, decl->getName());
+  emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2281,6 +2281,21 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnostic situations where AST node references an invalid declaration.
+///
+/// \code
+/// let foo = doesntExist // or something invalid
+/// foo(42)
+/// \endcode
+class ReferenceToInvalidDeclaration final : public FailureDiagnostic {
+public:
+  ReferenceToInvalidDeclaration(const Solution &solution,
+                                ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1618,7 +1618,8 @@ SpecifyContextualTypeForNil::create(ConstraintSystem &cs,
 
 bool AllowRefToInvalidDecl::diagnose(const Solution &solution,
                                      bool asNote) const {
-  return false;
+  ReferenceToInvalidDeclaration failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowRefToInvalidDecl *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1615,3 +1615,14 @@ SpecifyContextualTypeForNil::create(ConstraintSystem &cs,
                                     ConstraintLocator *locator) {
   return new (cs.getAllocator()) SpecifyContextualTypeForNil(cs, locator);
 }
+
+bool AllowRefToInvalidDecl::diagnose(const Solution &solution,
+                                     bool asNote) const {
+  return false;
+}
+
+AllowRefToInvalidDecl *
+AllowRefToInvalidDecl::create(ConstraintSystem &cs,
+                              ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowRefToInvalidDecl(cs, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10144,7 +10144,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyLabelToAssociateTrailingClosure:
   case FixKind::AllowKeyPathWithoutComponents:
   case FixKind::IgnoreInvalidResultBuilderBody:
-  case FixKind::SpecifyContextualTypeForNil: {
+  case FixKind::SpecifyContextualTypeForNil:
+  case FixKind::AllowRefToInvalidDecl: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -30,6 +30,7 @@
   // expected-error@-1 {{cannot find 'CGRect' in scope}}
 
   let (r, s) = square.divided(atDistance: 50, from: .minXEdge)
+  // expected-error@-1 {{type of expression is ambiguous without more context}}
 #endif
 
 #if canImport(MixedWithHeader)

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -5,7 +5,7 @@
 import CoreCooling
 import CFAndObjC
 
-func assertUnmanaged<T>(_ t: Unmanaged<T>) {}
+func assertUnmanaged<T>(_ t: Unmanaged<T>) {} // expected-note {{in call to function 'assertUnmanaged'}}
 func assertManaged<T: AnyObject>(_ t: T) {}
 
 func test0(_ fridge: CCRefrigerator) {
@@ -15,7 +15,7 @@ func test0(_ fridge: CCRefrigerator) {
 func test1(_ power: Unmanaged<CCPowerSupply>) {
   assertUnmanaged(power)
   let fridge = CCRefrigeratorCreate(power) // expected-error {{cannot convert value of type 'Unmanaged<CCPowerSupply>' to expected argument type 'CCPowerSupply?'}}
-  assertUnmanaged(fridge)
+  assertUnmanaged(fridge) // expected-error {{generic parameter 'T' could not be inferred}}
 }
 
 func test2() {

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -650,6 +650,6 @@ struct PatternBindingWithTwoVars3 { var x = y, y = x }
 
 // https://bugs.swift.org/browse/SR-9015
 func sr9015() {
-  let closure1 = { closure2() } // expected-error {{circular reference}} expected-note {{through reference here}} expected-note {{through reference here}} expected-error {{unable to infer closure}}
-  let closure2 = { closure1() } // expected-note {{through reference here}} expected-note {{through reference here}} expected-note {{through reference here}} expected-error {{unable to infer closure}}
+  let closure1 = { closure2() } // expected-error {{circular reference}} expected-note {{through reference here}} expected-note {{through reference here}}
+  let closure2 = { closure1() } // expected-note {{through reference here}} expected-note {{through reference here}} expected-note {{through reference here}}
 }

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -184,8 +184,8 @@ class SomeClass {
 // Implicit conversions (in this case to @convention(block)) are ok.
 @_silgen_name("whatever") 
 func takeNoEscapeAsObjCBlock(_: @noescape @convention(block) () -> Void)  // expected-error{{unknown attribute 'noescape'}}
-func takeNoEscapeTest2(_ fn : @noescape () -> ()) {  // expected-error{{unknown attribute 'noescape'}}
-  takeNoEscapeAsObjCBlock(fn)
+func takeNoEscapeTest2(_ fn : @noescape () -> ()) {  // expected-error{{unknown attribute 'noescape'}} expected-note {{parameter 'fn' is implicitly non-escaping}}
+  takeNoEscapeAsObjCBlock(fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 }
 
 // Autoclosure implies noescape..
@@ -290,14 +290,14 @@ typealias CompletionHandler = (_ success: Bool) -> ()
 
 var escape : CompletionHandlerNE
 var escapeOther : CompletionHandler
-func doThing1(_ completion: (_ success: Bool) -> ()) {
-  escape = completion
+func doThing1(_ completion: (_ success: Bool) -> ()) { // expected-note {{parameter 'completion' is implicitly non-escaping}}
+  escape = completion // expected-error {{assigning non-escaping parameter 'completion' to an @escaping closure}}
 }
 func doThing2(_ completion: CompletionHandlerNE) {
   escape = completion
 }
-func doThing3(_ completion: CompletionHandler) {
-  escape = completion
+func doThing3(_ completion: CompletionHandler) { // expected-note {{parameter 'completion' is implicitly non-escaping}}
+  escape = completion // expected-error {{assigning non-escaping parameter 'completion' to an @escaping closure}}
 }
 func doThing4(_ completion: @escaping CompletionHandler) {
   escapeOther = completion

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -119,7 +119,6 @@ assert(f0(1) == 1)
 var selfRef = { selfRef() }
 // expected-note@-1 2{{through reference here}}
 // expected-error@-2 {{circular reference}}
-// expected-error@-3 {{unable to infer closure type in the current context}}
 
 var nestedSelfRef = {
   var recursive = { nestedSelfRef() }

--- a/validation-test/Sema/SwiftUI/rdar70880670.swift
+++ b/validation-test/Sema/SwiftUI/rdar70880670.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+var foo = doesntExist // expected-error {{cannot find 'doesntExist' in scope}}
+
+struct ContentView: View {
+  var body: some View {
+    VStack {
+      Text(verbatim: foo)
+    }
+  }
+}

--- a/validation-test/Sema/type_checker_perf/slow/fast-operator-typechecking.swift
+++ b/validation-test/Sema/type_checker_perf/slow/fast-operator-typechecking.swift
@@ -5,6 +5,7 @@ func checksum(value: UInt16) -> UInt16 {
   var checksum = (((value >> 2) ^ (value >> 8) ^ (value >> 12) ^ (value >> 14)) & 0x01) << 1
   // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time}}
   checksum |= (((value) ^ (value >> UInt16(4)) ^ (value >> UInt16(6)) ^ (value >> UInt16(10))) & 0x01)
+  // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time}}
   checksum ^= 0x02
   return checksum
 }


### PR DESCRIPTION
Instead of failing constraint generation upon encountering
an invalid declaration, let's turn that declaration into a
potential hole and keep going. Doing so enables the solver
to reach a solution and diagnose any other issue with
expression.

Resolves: rdar://70880670

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
