### PR TITLE
[NFC] Construct AsyncContextLayout from module.

### DIFF
--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -105,7 +105,7 @@ namespace irgen {
       ResumeParentExecutor = 1,
       Error = 1,
     };
-    IRGenFunction &IGF;
+    IRGenModule &IGM;
     CanSILFunctionType originalType;
     CanSILFunctionType substitutedType;
     SubstitutionMap substitutionMap;
@@ -254,9 +254,9 @@ namespace irgen {
     // indexing of the function parameters, *not* the indexing of
     // AsyncContextLayout.
     SILType getParameterType(unsigned index) {
-      SILFunctionConventions origConv(substitutedType, IGF.getSILModule());
+      SILFunctionConventions origConv(substitutedType, IGM.getSILModule());
       return origConv.getSILArgumentType(
-          index, IGF.IGM.getMaximalTypeExpansionContext());
+          index, IGM.getMaximalTypeExpansionContext());
     }
     unsigned getArgumentCount() { return argumentInfos.size(); }
     bool hasTrailingWitnesses() { return (bool)trailingWitnessInfo; }
@@ -283,7 +283,7 @@ namespace irgen {
 
     AsyncContextLayout(
         IRGenModule &IGM, LayoutStrategy strategy, ArrayRef<SILType> fieldTypes,
-        ArrayRef<const TypeInfo *> fieldTypeInfos, IRGenFunction &IGF,
+        ArrayRef<const TypeInfo *> fieldTypeInfos,
         CanSILFunctionType originalType, CanSILFunctionType substitutedType,
         SubstitutionMap substitutionMap, NecessaryBindings &&bindings,
         Optional<TrailingWitnessInfo> trailingWitnessInfo, SILType errorType,
@@ -294,18 +294,18 @@ namespace irgen {
         Optional<ArgumentInfo> localContextInfo);
   };
 
-  llvm::Value *getDynamicAsyncContextSize(IRGenFunction &IGF,
-                                          AsyncContextLayout layout,
-                                          CanSILFunctionType functionType,
-                                          llvm::Value *thickContext);
-  AsyncContextLayout getAsyncContextLayout(IRGenFunction &IGF,
+  AsyncContextLayout getAsyncContextLayout(IRGenModule &IGM,
                                            SILFunction *function);
 
-  AsyncContextLayout getAsyncContextLayout(IRGenFunction &IGF,
+  AsyncContextLayout getAsyncContextLayout(IRGenModule &IGM,
                                            CanSILFunctionType originalType,
                                            CanSILFunctionType substitutedType,
                                            SubstitutionMap substitutionMap);
 
+  llvm::Value *getDynamicAsyncContextSize(IRGenFunction &IGF,
+                                          AsyncContextLayout layout,
+                                          CanSILFunctionType functionType,
+                                          llvm::Value *thickContext);
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention);
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1067,7 +1067,7 @@ public:
       : PartialApplicationForwarderEmission(
             IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
             substType, outType, subs, layout, conventions),
-        layout(getAsyncContextLayout(subIGF, origType, substType, subs)),
+        layout(getAsyncContextLayout(subIGF.IGM, origType, substType, subs)),
         currentArgumentIndex(outType->getNumParameters()) {
     task = origParams.claimNext();
     executor = origParams.claimNext();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1175,7 +1175,7 @@ public:
 } // end anonymous namespace
 
 static AsyncContextLayout getAsyncContextLayout(IRGenSILFunction &IGF) {
-  return getAsyncContextLayout(IGF, IGF.CurSILFn);
+  return getAsyncContextLayout(IGF.IGM, IGF.CurSILFn);
 }
 
 namespace {
@@ -3064,7 +3064,7 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
                                                 i->getSubstCalleeType());
     llvm::Value *innerContext = std::get<1>(result);
     auto layout =
-        getAsyncContextLayout(*this, i->getOrigCalleeType(),
+        getAsyncContextLayout(IGM, i->getOrigCalleeType(),
                               i->getSubstCalleeType(), i->getSubstitutionMap());
     auto size = getDynamicAsyncContextSize(
         *this, layout, i->getOrigCalleeType(), innerContext);


### PR DESCRIPTION
Previously, an `IRGenFunction` was being passed to the functions that construct an `AsyncContextLayout`.  That was not actually necessary and prevented construction of the layout in contexts where no `IRGenFunction` was present.  Here that requirement is eased to requiring an `IRGenModule` which is indeed required to construct an `AsyncContextLayout`.