### PR TITLE
[DerivedConformance] Correctly set access of derived 'hash(into:)'

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -552,7 +552,8 @@ deriveHashable_hashInto(
       /*GenericParams=*/nullptr, params, returnType, parentDC);
   hashDecl->setBodySynthesizer(bodySynthesizer);
 
-  hashDecl->copyFormalAccessFrom(derived.Nominal);
+  hashDecl->copyFormalAccessFrom(derived.Nominal,
+                                 /*sourceIsParentContext=*/true);
 
   derived.addMembersToConformanceContext({hashDecl});
 

--- a/test/IDE/complete_rdar71005827.swift
+++ b/test/IDE/complete_rdar71005827.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+private enum GlobalPrivateE {
+    case foo, bar
+}
+
+func testGlobalPrivate(val: GlobalPrivateE) {
+    val.#^GLOBALPRIVATE^#
+// GLOBALPRIVATE: Begin completions, 3 items
+// GLOBALPRIVATE-DAG: Keyword[self]/CurrNominal:          self[#GlobalPrivateE#];
+// GLOBALPRIVATE-DAG: Decl[InstanceVar]/CurrNominal:      hashValue[#Int#];
+// GLOBALPRIVATE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#into: &Hasher#})[#Void#];
+// GLOBALPRIVATE: End completions
+}
+
+func testLocal() {
+    enum LocalE {
+        case foo, bar
+    }
+    var val = LocalE.foo
+    val.#^LOCAL^#
+// LOCAL: Begin completions, 3 items
+// LOCAL-DAG: Keyword[self]/CurrNominal:          self[#LocalE#];
+// LOCAL-DAG: Decl[InstanceVar]/CurrNominal:      hashValue[#Int#];
+// LOCAL-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#into: &Hasher#})[#Void#];
+// LOCAL: End completions
+}


### PR DESCRIPTION
If the access level of the target type is `private`, derived `hash(into:)` used to be created with `private` access. But it should be as accessible as the enclosing type.

rdar://problem/71005827
