### PR TITLE
[cxx-interop] Bail on redefined macros.

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -322,14 +322,16 @@ static Optional<std::pair<llvm::APSInt, Type>>
   return None;
 }
 
-
 static ValueDecl *importMacro(ClangImporter::Implementation &impl,
-                              DeclContext *DC,
-                              Identifier name,
-                              const clang::MacroInfo *macro,
-                              ClangNode ClangN,
+                              llvm::SmallSet<StringRef, 4> &visitedMacros,
+                              DeclContext *DC, Identifier name,
+                              const clang::MacroInfo *macro, ClangNode ClangN,
                               clang::QualType castType) {
   if (name.empty()) return nullptr;
+
+  assert(visitedMacros.count(name.str()) &&
+         "Add the name of the macro to visitedMacros before calling this "
+         "function.");
 
   auto numTokens = macro->getNumTokens();
   auto tokenI = macro->tokens_begin(), tokenE = macro->tokens_end();
@@ -427,9 +429,15 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
         auto macroID = impl.getClangPreprocessor().getMacroInfo(clangID);
         if (macroID && macroID != macro) {
+          // If we've already visited this macro, then bail to prevent an
+          // infinite loop. Otherwise, record that we're going to visit it.
+          if (!visitedMacros.insert(clangID->getName()).second)
+            return nullptr;
+
           // FIXME: This was clearly intended to pass the cast type down, but
           // doing so would be a behavior change.
-          return importMacro(impl, DC, name, macroID, ClangN, /*castType*/{});
+          return importMacro(impl, visitedMacros, DC, name, macroID, ClangN,
+                             /*castType*/ {});
         }
       }
 
@@ -686,8 +694,11 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
     DC = ImportedHeaderUnit;
   }
 
-  auto valueDecl = ::importMacro(*this, DC, name, macro, macroNode,
-                                 /*castType*/{});
+  llvm::SmallSet<StringRef, 4> visitedMacros;
+  visitedMacros.insert(name.str());
+  auto valueDecl =
+      ::importMacro(*this, visitedMacros, DC, name, macro, macroNode,
+                    /*castType*/ {});
 
   // Update the entry for the value we just imported.
   // It's /probably/ the last entry in ImportedMacros[name], but there's an

--- a/test/Interop/C/macros/Inputs/module.modulemap
+++ b/test/Interop/C/macros/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module RedefinedMacro {
+  header "redefined-macro.h"
+}

--- a/test/Interop/C/macros/Inputs/redefined-macro.h
+++ b/test/Interop/C/macros/Inputs/redefined-macro.h
@@ -1,0 +1,15 @@
+#define FOO 0
+#define TMP_FOO FOO
+#undef FOO
+#define FOO TMP_FOO
+
+#define ONE TWO
+#define TWO THREE
+#define THREE ONE
+
+#define THE_MAX THREE
+#undef THREE
+#define THREE THE_MAX
+
+#define BAR 0
+#define BAZ BAR

--- a/test/Interop/C/macros/redefined-macro.swift
+++ b/test/Interop/C/macros/redefined-macro.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=RedefinedMacro -I %S/Inputs -source-filename=x | %FileCheck %s
+
+// We cannot import redefined macros.
+// CHECK-NOT: FOO
+// CHECK-NOT: TMP_FOO
+// CHECK-NOT: THREE
+// CHECK-NOT: THE_MAX
+
+// CHECK: var BAR
+// CHECK: var BAZ


### PR DESCRIPTION
This is a stop-gap fix to prevent an infinite loop. Refs SR-13828.