### PR TITLE
[concurrency] some small bug fixes

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2511,6 +2511,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
   auto innerExtInfo =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
                                       funcType->isThrowing())
+          .withAsync(funcType->isAsync())
           .build();
 
   return CanAnyFunctionType::get(

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1595,8 +1595,6 @@ public:
     verifySILFunctionType(resultInfo);
     require(resultInfo->getExtInfo().hasContext(),
             "result of closure cannot have a thin function type");
-    require(!resultInfo->isAsync() || PAI->getFunction()->isAsync(),
-            "cannot call an async function from a non async function");
 
     checkApplyTypeDependentArguments(PAI);
 
@@ -1745,8 +1743,6 @@ public:
                                     "result of function_ref");
     require(!fnType->getExtInfo().hasContext(),
             "function_ref should have a context-free function result");
-    require(!fnType->isAsync() || FRI->getFunction()->isAsync(),
-            "cannot call an async function from a non-async function");
 
     // Note: in SingleFunction mode, we relax some of these checks because
     // we may not have linked everything yet.
@@ -2921,8 +2917,6 @@ public:
   void checkWitnessMethodInst(WitnessMethodInst *AMI) {
     auto methodType = requireObjectType(SILFunctionType, AMI,
                                         "result of witness_method");
-    require(!methodType->isAsync() || AMI->getFunction()->isAsync(),
-            "cannot call an async function from a non-async function");
 
     auto *protocol
       = dyn_cast<ProtocolDecl>(AMI->getMember().getDecl()->getDeclContext());
@@ -3078,8 +3072,6 @@ public:
                                         "result of class_method");
     require(!methodType->getExtInfo().hasContext(),
             "result method must be of a context-free function type");
-    require(!methodType->isAsync() || CMI->getFunction()->isAsync(),
-            "cannot call an async function from a non-async function");
 
     SILType operandType = CMI->getOperand()->getType();
     require(operandType.isClassOrClassMetatype(),

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -451,6 +451,9 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
     }
   }
   
+  if (!F.isAsync())
+    return;
+
   if (auto *funcDecl =
         dyn_cast_or_null<AbstractFunctionDecl>(FunctionDC->getAsDecl())) {
     auto actorIsolation = getActorIsolation(funcDecl);

--- a/test/IRGen/async/async_calls_verifier.sil
+++ b/test/IRGen/async/async_calls_verifier.sil
@@ -36,11 +36,11 @@ bb0:
 }
 
 // CHECK-LABEL: Begin Error in function nonasync_apply_caller
-// CHECK: SIL verification failed: cannot call an async function from a non-async function: !fnType->isAsync() || FRI->getFunction()->isAsync()
+// CHECK: SIL verification failed: cannot call an async function from a non async function: !calleeConv.funcTy->isAsync() || AI->getFunction()->isAsync()
 // CHECK: Verifying instruction:
-// CHECK: ->   // function_ref asynccallee1
+// CHECK:      // function_ref asynccallee1
 // CHECK:   %0 = function_ref @asynccallee1 : $@convention(thin) @async () -> () // user: %1
-// CHECK:      %1 = apply %0() : $@convention(thin) @async () -> ()
+// CHECK: ->  %1 = apply %0() : $@convention(thin) @async () -> ()
 // CHECK-LABEL: End Error in function nonasync_apply_caller
 sil [ossa] @nonasync_apply_caller : $@convention(thin) () -> () {
 bb0:
@@ -62,11 +62,11 @@ bb2(%result_error : $Error):
 }
 
 // CHECK-LABEL: Begin Error in function nonasync_try_apply_caller
-// CHECK: SIL verification failed: cannot call an async function from a non-async function: !fnType->isAsync() || FRI->getFunction()->isAsync()
+// CHECK: SIL verification failed: cannot call an async function from a non async function: !calleeConv.funcTy->isAsync() || AI->getFunction()->isAsync()
 // CHECK: Verifying instruction:
-// CHECK: ->   // function_ref asynccallee2
+// CHECK:      // function_ref asynccallee2
 // CHECK:   %0 = function_ref @asynccallee2 : $@convention(thin) @async () -> ((), @error Error) // user: %1
-// CHECK:      try_apply %0() : $@convention(thin) @async () -> ((), @error Error), normal bb1, error bb2 // id: %1
+// CHECK: ->  try_apply %0() : $@convention(thin) @async () -> ((), @error Error), normal bb1, error bb2 // id: %1
 // CHECK-LABEL: End Error in function nonasync_try_apply_caller
 sil [ossa] @nonasync_try_apply_caller : $@convention(thin) () -> () {
 bb0:
@@ -86,13 +86,7 @@ bb0:
   return %2 : $@async @callee_owned () -> ()
 }
 
-// CHECK-LABEL: Begin Error in function nonasync_partial_apply_caller
-// CHECK: SIL verification failed: cannot call an async function from a non-async function: !fnType->isAsync() || FRI->getFunction()->isAsync()
-// CHECK: Verifying instruction:
-// CHECK: ->   // function_ref asynccallee1
-// CHECK:   %0 = function_ref @asynccallee1 : $@convention(thin) @async () -> () // user: %1
-// CHECK:      %1 = partial_apply %0() : $@convention(thin) @async () -> () // user: %2
-// CHECK-LABEL: End Error in function nonasync_partial_apply_caller
+// CHECK-NOT: Function: 'nonasync_partial_apply_caller'
 sil [ossa] @nonasync_partial_apply_caller : $@convention(thin) () -> @owned @async @callee_owned () -> () {
 bb0:
   %1 = function_ref @asynccallee1 : $@async @convention(thin) () -> ()
@@ -113,10 +107,10 @@ bb0(%t : $*T):
 }
 
 // CHECK-LABEL: Begin Error in function nonasync_witness_method_caller
-// CHECK: SIL verification failed: cannot call an async function from a non-async function: !methodType->isAsync() || AMI->getFunction()->isAsync()
+// CHECK: SIL verification failed: cannot call an async function from a non async function: !calleeConv.funcTy->isAsync() || AI->getFunction()->isAsync()
 // CHECK: Verifying instruction:
-// CHECK: ->   %1 = witness_method $T, #P.printMe : <Self where Self : P> (Self) -> () async -> Int64 : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // user: %2
-// CHECK:      %2 = apply %1<T>(%0) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // user: %3
+// CHECK:      %1 = witness_method $T, #P.printMe : <Self where Self : P> (Self) -> () async -> Int64 : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // user: %2
+// CHECK: ->   %2 = apply %1<T>(%0) : $@convention(witness_method: P) @async <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64 // user: %3
 // CHECK-LABEL: End Error in function nonasync_witness_method_caller
 sil hidden @nonasync_witness_method_caller : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64 {
 bb0(%t : $*T):
@@ -141,11 +135,11 @@ bb0(%int : $Int64, %instance : $S):
 }
 
 // CHECK-LABEL: Begin Error in function nonasync_class_method_caller
-// CHECK: SIL verification failed: cannot call an async function from a non-async function: !methodType->isAsync() || CMI->getFunction()->isAsync()
+// CHECK: SIL verification failed: cannot call an async function from a non async function: !calleeConv.funcTy->isAsync() || AI->getFunction()->isAsync()
 // CHECK: Verifying instruction:
 // CHECK:    %1 = argument of bb0 : $S                      // users: %3, %2
-// CHECK: ->   %2 = class_method %1 : $S, #S.method : (S) -> (Int64) async -> (), $@convention(method) @async (Int64, @guaranteed S) -> () // user: %3
-// CHECK:      %3 = apply %2(%0, %1) : $@convention(method) @async (Int64, @guaranteed S) -> ()
+// CHECK:      %2 = class_method %1 : $S, #S.method : (S) -> (Int64) async -> (), $@convention(method) @async (Int64, @guaranteed S) -> () // user: %3
+// CHECK: ->   %3 = apply %2(%0, %1) : $@convention(method) @async (Int64, @guaranteed S) -> ()
 // CHECK-LABEL: End Error in function nonasync_class_method_caller
 sil hidden @nonasync_class_method_caller : $@convention(thin) (Int64, S) -> () {
 bb0(%int : $Int64, %instance : $S):

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -47,6 +47,13 @@ actor class MyActor {
     await callee(p)
   }
 
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC13dontInsertHTESiyF : $@convention(method) (@guaranteed MyActor) -> Int {
+  // CHECK-NOT:   hop_to_executor
+  // CHECK:     } // end sil function '$s4test7MyActorC13dontInsertHTESiyF'
+  func dontInsertHTE() -> Int {
+    return p
+  }
+
   init() {
     p = 27
   }

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -57,7 +57,7 @@ struct GlobalActor {
   static var shared: MyActor = MyActor()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4test0A11GlobalActoryyYF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A11GlobalActoryyYF : $@convention(thin) @async () -> () {
 // CHECK:   [[F:%[0-9]+]] = function_ref @$s4test11GlobalActorV6sharedAA02MyC0Cvau : $@convention(thin) () -> Builtin.RawPointer
 // CHECK:   [[P:%[0-9]+]] = apply [[F]]() : $@convention(thin) () -> Builtin.RawPointer
 // CHECK:   [[A:%[0-9]+]] = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*MyActor
@@ -75,7 +75,7 @@ struct GenericGlobalActorWithGetter<T> {
   static var shared: MyActor { return MyActor() }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4test0A28GenericGlobalActorWithGetteryyYF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A28GenericGlobalActorWithGetteryyYF : $@convention(thin) @async () -> () {
 // CHECK:     [[MT:%[0-9]+]] = metatype $@thin GenericGlobalActorWithGetter<Int>.Type
 // CHECK:     [[F:%[0-9]+]] = function_ref @$s4test28GenericGlobalActorWithGetterV6sharedAA02MyD0CvgZ : $@convention(method) <τ_0_0> (@thin GenericGlobalActorWithGetter<τ_0_0>.Type) -> @owned MyActor
 // CHECK:     [[A:%[0-9]+]] = apply [[F]]<Int>([[MT]]) : $@convention(method) <τ_0_0> (@thin GenericGlobalActorWithGetter<τ_0_0>.Type) -> @owned MyActor


### PR DESCRIPTION
* SILVerifier: don't complain about async function pointers created in non-async functions
     It's possible to materialize an async function pointer, e.g. with partial_apply, in a non-async function - as long as no async function is called.
* SIL: set the @async attribute for top-level functions correctly
* SILGen: only emit hop_to_executor instructions in async functions.