### PR TITLE
[Async CC] Add constant "pointer" for async func.

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -293,6 +293,11 @@ class LinkEntity {
     /// the metadata cache once.
     CanonicalPrespecializedGenericTypeCachingOnceToken,
 
+    /// The same as AsyncFunctionPointer but with a different stored value, for
+    /// use by TBDGen.
+    /// The pointer is a AbstractStorageDecl*.
+    AsyncFunctionPointerAST,
+
     /// The pointer is a SILFunction*.
     DynamicallyReplaceableFunctionKey,
 
@@ -410,6 +415,13 @@ class LinkEntity {
     /// passed to swift_getCanonicalSpecializedMetadata.
     /// The pointer is a canonical TypeBase*.
     NoncanonicalSpecializedGenericTypeMetadataCacheVariable,
+
+    /// Provides the data required to invoke an async function using the async
+    /// calling convention in the form of the size of the context to allocate
+    /// and the relative address of the function to call with that allocated
+    /// context.
+    /// The pointer is a SILFunction*.
+    AsyncFunctionPointer,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
@@ -418,7 +430,7 @@ class LinkEntity {
   }
 
   static bool isDeclKind(Kind k) {
-    return k <= Kind::CanonicalPrespecializedGenericTypeCachingOnceToken;
+    return k <= Kind::AsyncFunctionPointerAST;
   }
   static bool isTypeKind(Kind k) {
     return k >= Kind::ProtocolWitnessTableLazyAccessFunction;
@@ -1088,6 +1100,21 @@ public:
     return entity;
   }
 
+  static LinkEntity forAsyncFunctionPointer(SILFunction *silFunction) {
+    LinkEntity entity;
+    entity.Pointer = silFunction;
+    entity.SecondaryPointer = nullptr;
+    entity.Data = LINKENTITY_SET_FIELD(
+        Kind, unsigned(LinkEntity::Kind::AsyncFunctionPointer));
+    return entity;
+  }
+
+  static LinkEntity forAsyncFunctionPointer(AbstractFunctionDecl *decl) {
+    LinkEntity entity;
+    entity.setForDecl(Kind::AsyncFunctionPointerAST, decl);
+    return entity;
+  }
+
   void mangle(llvm::raw_ostream &out) const;
   void mangle(SmallVectorImpl<char> &buffer) const;
   std::string mangleAsString() const;
@@ -1110,14 +1137,15 @@ public:
   }
 
   bool hasSILFunction() const {
-    return getKind() == Kind::SILFunction ||
+    return getKind() == Kind::AsyncFunctionPointer ||
            getKind() == Kind::DynamicallyReplaceableFunctionVariable ||
-           getKind() == Kind::DynamicallyReplaceableFunctionKey;
+           getKind() == Kind::DynamicallyReplaceableFunctionKey ||
+           getKind() == Kind::SILFunction;
   }
 
   SILFunction *getSILFunction() const {
     assert(hasSILFunction());
-    return reinterpret_cast<SILFunction*>(Pointer);
+    return reinterpret_cast<SILFunction *>(Pointer);
   }
 
   SILGlobalVariable *getSILGlobalVariable() const {

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -67,6 +67,7 @@ protected:
   void emitToUnmappedExplosion(Explosion &out);
   virtual void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) = 0;
   void emitYieldsToExplosion(Explosion &out);
+  virtual FunctionPointer getCalleeFunctionPointer() = 0;
   llvm::CallInst *emitCallSite();
 
   CallEmission(IRGenFunction &IGF, llvm::Value *selfValue, Callee &&callee)

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1838,106 +1838,161 @@ void irgen::extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
     out.add(returned);
 }
 
-static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
-                                 Explosion &in, Explosion &out,
-                                 TemporarySet &temporaries, bool isOutlined);
-
-llvm::Value *irgen::getDynamicAsyncContextSize(IRGenFunction &IGF,
-                                               AsyncContextLayout layout,
-                                               CanSILFunctionType functionType,
-                                               llvm::Value *thickContext) {
-  // TODO: This calculation should be extracted out into a standalone function
+std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
+    IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
+    FunctionPointer functionPointer, llvm::Value *thickContext,
+    std::pair<bool, bool> values) {
+  assert(values.first || values.second);
+  bool emitFunction = values.first;
+  bool emitSize = values.second;
+  // TODO: This calculation should be extracted out into standalone functions
   //       emitted on-demand per-module to improve codesize.
-  switch (functionType->getRepresentation()) {
+  switch (representation) {
   case SILFunctionTypeRepresentation::Thick: {
     // If the called function is thick, the size of the called function's
-    // async context may not be statically knowable.
+    // async context is not statically knowable.
     //
     // Specifically, if the thick function was produced by a partial_apply,
     // the function which was originally partially applied determines the
     // size of the needed async context.  That original function isn't known
     // statically.  The dynamic size is available within the context as an
     // i32 at the first index: <{ %swift.refcounted*, /*size*/ i32, ... }>.
+    // In this case, the function pointer is actually a pointer to an llvm
+    // function.
     //
     // On the other hand, if the thick function was produced by a
     // thin_to_thick_function, then the context will be nullptr.  In that
-    // case, the size of the needed async context is known statically to
-    // be the size dictated by the function signature.
+    // case, the dynamic size of the needed async context is available within
+    // the struct, an AsyncFunctionPointer pointed to by the "function" pointer
+    // as an i32 at the second index: <{ /*fn rel addr*/ i32, /*size*/ i32 }>.
     //
     // We are currently emitting into some basic block.  To handle these two
     // cases, we need to branch based on whether the context is nullptr; each
-    // branch must then determine the size in the manner appropriate to it.
-    // Finally, both blocks must join back together to make the call:
+    // branch must then determine the size and function pointer in the manner
+    // appropriate to it.  Finally, both blocks must join back together to make
+    // the call:
     //
-    // SIL:      IR:
-    // +-----+           +-------------------------+
-    // |.....|           |%cond = %ctx == nullptr  |
-    // |apply|           |br %cond, static, dynamic|
-    // |.....|           +--------/--------------\-+
-    // +-----+                   /                \
-    //           +-static-------+        +-dynamic----------------------------------------------+
-    //           |%size = K     |        |%layout = bitcast %context to <{%swift.context*, i32}>|
-    //           |br join(%size)|        |%size_addr = getelementptr %layout, i32 1, i32 0      |
-    //           +-----\--------+        |%size = load %size_addr                               |
-    //                  \                |br join(%size)                                        |
-    //                   \               +------------------------------------------------------+
-    //                    \                   /
-    //           +-join(%size)-----------------------------------------------------------+
-    //           |%dataAddr = swift_taskAlloc(%task, %size)                              |
-    //           |%async_context = bitcast %dataAddr to ASYNC_CONTEXT(static_callee_type)|
-    //           |... // populate the fields %context with arguments                     |
-    //           |call %callee(%async_context, %context)                                 |
-    //           +-----------------------------------------------------------------------+
-    auto *staticSizeBlock = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
-    auto *dynamicSizeBlock = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
+    //                      +-------------------------+
+    //                      |%cond = %ctx == nullptr  |
+    //     +----------------|br %cond, thin, thick    |----------------------+
+    //     |                +-------------------------+                      |
+    //     |                                                                 |
+    //     V                                                                 |
+    // +-thin-------------------------------------------+                    |
+    // |%afp = bitcast %fp to %swift.async_func_pointer*|                    |
+    // |%size_ptr = getelementptr %afp, i32 0, i32 1    |                    |
+    // |%size = load %size_ptr                          |                    |
+    // |%offset_ptr = getelementptr %afp, i32 0, i32 1  |                    |
+    // |%offset = load i32 %offset_ptr                  |                    |
+    // |%offset64 = sext %offset to i64                 |                    |
+    // |%raw_fp = add %offset64, %offset_ptr            |                    |
+    // |br join(%raw_fp, %size)                         |                    |
+    // +------------------------------------------------+                    |
+    //     |                                                                 |
+    //     |                                                                 V
+    //     |                +-thick--------------------------------------------+
+    //     |                |%layout = bitcast %ctx to <{%swift.context*, i32}>|
+    //     |                |%size_addr = getelementptr %layout, i32 0, i32 1  |
+    //     |                |%size = load %size_addr                           |
+    //     |                |br join(%fp, %size)                               |
+    //     |                +---/----------------------------------------------+
+    //     |                   /
+    //     |                  /
+    //     V                 V
+    // +-join(%fn, %size)------------------------------------------------------+
+    // |%dataAddr = swift_taskAlloc(%task, %size)                              |
+    // |%async_context = bitcast %dataAddr to ASYNC_CONTEXT(static_callee_type)|
+    // |... // populate the fields %ctx with arguments                         |
+    // |call %fn(%async_context, %ctx)                                         |
+    // +-----------------------------------------------------------------------+
+    auto *thinBlock = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
+    auto *thickBlock = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
     auto *joinBlock = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
 
     auto hasThickContext =
         IGF.Builder.CreateICmpNE(thickContext, IGF.IGM.RefCountedNull);
-    IGF.Builder.CreateCondBr(hasThickContext, dynamicSizeBlock,
-                             staticSizeBlock);
+    IGF.Builder.CreateCondBr(hasThickContext, thickBlock, thinBlock);
 
-    SmallVector<std::pair<llvm::BasicBlock *, llvm::Value *>, 2> phiValues;
-    {
-      IGF.Builder.emitBlock(staticSizeBlock);
-      auto size = getAsyncContextSize(layout);
-      auto *sizeValue =
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, size.getValue());
-      phiValues.push_back({staticSizeBlock, sizeValue});
-      IGF.Builder.CreateBr(joinBlock);
-    }
-
-    {
-      IGF.Builder.emitBlock(dynamicSizeBlock);
-      SmallVector<const TypeInfo *, 4> argTypeInfos;
-      SmallVector<SILType, 4> argValTypes;
-      auto int32ASTType =
-          BuiltinIntegerType::get(32, IGF.IGM.IRGen.SIL.getASTContext())
-              ->getCanonicalType();
-      auto int32SILType = SILType::getPrimitiveObjectType(int32ASTType);
-      const TypeInfo &int32TI = IGF.IGM.getTypeInfo(int32SILType);
-      argValTypes.push_back(int32SILType);
-      argTypeInfos.push_back(&int32TI);
-      HeapLayout layout(IGF.IGM, LayoutStrategy::Optimal, argValTypes,
-                        argTypeInfos,
-                        /*typeToFill*/ nullptr, NecessaryBindings());
-      auto castThickContext =
-          layout.emitCastTo(IGF, thickContext, "context.prefix");
-      auto sizeLayout = layout.getElement(0);
-      auto sizeAddr = sizeLayout.project(IGF, castThickContext,
-                                         /*NonFixedOffsets*/ llvm::None);
-      auto *sizeValue = IGF.Builder.CreateLoad(sizeAddr);
-      phiValues.push_back({dynamicSizeBlock, sizeValue});
-      IGF.Builder.CreateBr(joinBlock);
-    }
-
-    {
-      IGF.Builder.emitBlock(joinBlock);
-      auto *phi = IGF.Builder.CreatePHI(IGF.IGM.Int32Ty, phiValues.size());
-      for (auto &entry : phiValues) {
-        phi->addIncoming(entry.second, entry.first);
+    SmallVector<std::pair<llvm::BasicBlock *, llvm::Value *>, 2> fnPhiValues;
+    SmallVector<std::pair<llvm::BasicBlock *, llvm::Value *>, 2> sizePhiValues;
+    { // thin
+      IGF.Builder.emitBlock(thinBlock);
+      if (emitFunction) {
+        auto *uncastFnPtr = functionPointer.getPointer(IGF);
+        auto *fnPtr = IGF.Builder.CreateBitCast(uncastFnPtr, IGF.IGM.Int8PtrTy);
+        fnPhiValues.push_back({thinBlock, fnPtr});
       }
-      return phi;
+      if (emitSize) {
+        auto *ptr = functionPointer.getRawPointer();
+        auto *descriptorPtr =
+            IGF.Builder.CreateBitCast(ptr, IGF.IGM.AsyncFunctionPointerPtrTy);
+        auto *sizePtr = IGF.Builder.CreateStructGEP(descriptorPtr, 1);
+        auto *size =
+            IGF.Builder.CreateLoad(sizePtr, IGF.IGM.getPointerAlignment());
+        sizePhiValues.push_back({thinBlock, size});
+      }
+      IGF.Builder.CreateBr(joinBlock);
+    }
+
+    { // thick
+      IGF.Builder.emitBlock(thickBlock);
+      if (emitFunction) {
+        auto *uncastFnPtr = functionPointer.getRawPointer();
+        auto *fnPtr = IGF.Builder.CreateBitCast(uncastFnPtr, IGF.IGM.Int8PtrTy);
+        fnPhiValues.push_back({thickBlock, fnPtr});
+      }
+      if (emitSize) {
+        SmallVector<const TypeInfo *, 4> argTypeInfos;
+        SmallVector<SILType, 4> argValTypes;
+        auto int32ASTType =
+            BuiltinIntegerType::get(32, IGF.IGM.IRGen.SIL.getASTContext())
+                ->getCanonicalType();
+        auto int32SILType = SILType::getPrimitiveObjectType(int32ASTType);
+        const TypeInfo &int32TI = IGF.IGM.getTypeInfo(int32SILType);
+        argValTypes.push_back(int32SILType);
+        argTypeInfos.push_back(&int32TI);
+        HeapLayout layout(IGF.IGM, LayoutStrategy::Optimal, argValTypes,
+                          argTypeInfos,
+                          /*typeToFill*/ nullptr, NecessaryBindings());
+        auto castThickContext =
+            layout.emitCastTo(IGF, thickContext, "context.prefix");
+        auto sizeLayout = layout.getElement(0);
+        auto sizeAddr = sizeLayout.project(IGF, castThickContext,
+                                           /*NonFixedOffsets*/ llvm::None);
+        auto *sizeValue = IGF.Builder.CreateLoad(sizeAddr);
+        sizePhiValues.push_back({thickBlock, sizeValue});
+      }
+      IGF.Builder.CreateBr(joinBlock);
+    }
+
+    { // join
+      IGF.Builder.emitBlock(joinBlock);
+      llvm::Value *fn = nullptr;
+      llvm::PHINode *fnPhi = nullptr;
+      llvm::PHINode *sizePhi = nullptr;
+      if (emitFunction) {
+        fnPhi = IGF.Builder.CreatePHI(IGF.IGM.Int8PtrTy, fnPhiValues.size());
+      }
+      if (emitSize) {
+        sizePhi = IGF.Builder.CreatePHI(IGF.IGM.Int32Ty, sizePhiValues.size());
+      }
+      if (emitFunction) {
+        assert(fnPhi);
+        for (auto &entry : fnPhiValues) {
+          fnPhi->addIncoming(entry.second, entry.first);
+        }
+        fn = IGF.Builder.CreateBitCast(
+            fnPhi, functionPointer.getFunctionType()->getPointerTo());
+      }
+      llvm::Value *size = nullptr;
+      if (emitSize) {
+        assert(sizePhi);
+        for (auto &entry : sizePhiValues) {
+          sizePhi->addIncoming(entry.second, entry.first);
+        }
+        size = sizePhi;
+      }
+      return {fn, size};
     }
   }
   case SILFunctionTypeRepresentation::Thin:
@@ -1947,12 +2002,26 @@ llvm::Value *irgen::getDynamicAsyncContextSize(IRGenFunction &IGF,
   case SILFunctionTypeRepresentation::WitnessMethod:
   case SILFunctionTypeRepresentation::Closure:
   case SILFunctionTypeRepresentation::Block: {
-    auto size = getAsyncContextSize(layout);
-    auto *sizeValue = llvm::ConstantInt::get(IGF.IGM.Int32Ty, size.getValue());
-    return sizeValue;
+    llvm::Value *fn = nullptr;
+    if (emitFunction) {
+      fn = functionPointer.getPointer(IGF);
+    }
+    llvm::Value *size = nullptr;
+    if (emitSize) {
+      auto *ptr = functionPointer.getRawPointer();
+      auto *descriptorPtr =
+          IGF.Builder.CreateBitCast(ptr, IGF.IGM.AsyncFunctionPointerPtrTy);
+      auto *sizePtr = IGF.Builder.CreateStructGEP(descriptorPtr, 1);
+      size = IGF.Builder.CreateLoad(sizePtr, IGF.IGM.getPointerAlignment());
+    }
+    return {fn, size};
   }
   }
 }
+
+static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
+                                 Explosion &in, Explosion &out,
+                                 TemporarySet &temporaries, bool isOutlined);
 
 namespace {
 
@@ -1965,6 +2034,9 @@ public:
     setFromCallee();
   }
 
+  FunctionPointer getCalleeFunctionPointer() override {
+    return getCallee().getFunctionPointer().getAsFunction(IGF);
+  }
   SILType getParameterType(unsigned index) override {
     SILFunctionConventions origConv(getCallee().getOrigFunctionType(),
                                     IGF.getSILModule());
@@ -2164,6 +2236,7 @@ class AsyncCallEmission final : public CallEmission {
   Address contextBuffer;
   Size contextSize;
   Address context;
+  llvm::Value *calleeFunction = nullptr;
   llvm::Value *thickContext = nullptr;
   Optional<AsyncContextLayout> asyncContextLayout;
 
@@ -2199,8 +2272,10 @@ public:
     assert(!context.isValid());
     auto layout = getAsyncContextLayout();
     // Allocate space for the async arguments.
-    auto *dynamicContextSize32 = getDynamicAsyncContextSize(
-        IGF, layout, CurCallee.getOrigFunctionType(), thickContext);
+    llvm::Value *dynamicContextSize32;
+    std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
+        IGF, CurCallee.getOrigFunctionType()->getRepresentation(),
+        CurCallee.getFunctionPointer(), thickContext);
     auto *dynamicContextSize =
         IGF.Builder.CreateZExt(dynamicContextSize32, IGF.IGM.SizeTy);
     std::tie(contextBuffer, contextSize) = emitAllocAsyncContext(
@@ -2223,6 +2298,11 @@ public:
   void setFromCallee() override {
     super::setFromCallee();
     thickContext = CurCallee.getSwiftContext();
+  }
+  FunctionPointer getCalleeFunctionPointer() override {
+    return FunctionPointer(
+        FunctionPointer::KindTy::Function, calleeFunction, PointerAuthInfo(),
+        IGF.IGM.getSignature(getCallee().getSubstFunctionType()));
   }
   SILType getParameterType(unsigned index) override {
     return getAsyncContextLayout().getParameterType(index);
@@ -2369,7 +2449,8 @@ llvm::CallInst *CallEmission::emitCallSite() {
   EmittedCall = true;
 
   // Make the call and clear the arguments array.
-  const auto &fn = getCallee().getFunctionPointer();
+  FunctionPointer fn = getCalleeFunctionPointer();
+  assert(fn.getKind() == FunctionPointer::KindTy::Function);
   auto fnTy = fn.getFunctionType();
 
   // Coerce argument types for those cases where the IR type required
@@ -2427,6 +2508,7 @@ llvm::CallInst *CallEmission::emitCallSite() {
 
 llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
                                       ArrayRef<llvm::Value*> args) {
+  assert(fn.getKind() == FunctionPointer::KindTy::Function);
   SmallVector<llvm::OperandBundleDef, 1> bundles;
 
   // Add a pointer-auth bundle if necessary.
@@ -2437,11 +2519,11 @@ llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
     bundles.emplace_back("ptrauth", bundleArgs);
   }
 
-  assert(!isTrapIntrinsic(fn.getPointer()) && "Use CreateNonMergeableTrap");
+  assert(!isTrapIntrinsic(fn.getRawPointer()) && "Use CreateNonMergeableTrap");
   llvm::CallInst *call = IRBuilderBase::CreateCall(
       cast<llvm::FunctionType>(
-          fn.getPointer()->getType()->getPointerElementType()),
-      fn.getPointer(), args, bundles);
+          fn.getRawPointer()->getType()->getPointerElementType()),
+      fn.getRawPointer(), args, bundles);
   call->setAttributes(fn.getAttributes());
   call->setCallingConv(fn.getCallingConv());
   return call;
@@ -4275,7 +4357,7 @@ void IRGenFunction::emitScalarReturn(SILType returnResultType,
 /// Modify the given variable to hold a pointer whose type is the
 /// LLVM lowering of the given function type, and return the signature
 /// for the type.
-static Signature emitCastOfFunctionPointer(IRGenFunction &IGF,
+Signature irgen::emitCastOfFunctionPointer(IRGenFunction &IGF,
                                            llvm::Value *&fnPtr,
                                            CanSILFunctionType fnType) {
   // Figure out the function type.
@@ -4309,7 +4391,8 @@ Callee irgen::getBlockPointerCallee(IRGenFunction &IGF,
                                         invokeFnPtrAddr.getAddress(),
                                         info.OrigFnType);
 
-  FunctionPointer fn(invokeFnPtr, authInfo, sig);
+  FunctionPointer fn(FunctionPointer::KindTy::Function, invokeFnPtr, authInfo,
+                     sig);
 
   return Callee(std::move(info), fn, blockPtr);
 }
@@ -4321,7 +4404,7 @@ Callee irgen::getSwiftFunctionPointerCallee(
   auto authInfo =
     PointerAuthInfo::forFunctionPointer(IGF.IGM, calleeInfo.OrigFnType);
 
-  FunctionPointer fn(fnPtr, authInfo, sig);
+  FunctionPointer fn(calleeInfo.OrigFnType, fnPtr, authInfo, sig);
   if (castOpaqueToRefcountedContext) {
     assert(dataPtr && dataPtr->getType() == IGF.IGM.OpaquePtrTy &&
            "Expecting trivial closure context");
@@ -4337,32 +4420,59 @@ Callee irgen::getCFunctionPointerCallee(IRGenFunction &IGF,
   auto authInfo =
     PointerAuthInfo::forFunctionPointer(IGF.IGM, calleeInfo.OrigFnType);
 
-  FunctionPointer fn(fnPtr, authInfo, sig);
+  FunctionPointer fn(FunctionPointer::KindTy::Function, fnPtr, authInfo, sig);
 
   return Callee(std::move(calleeInfo), fn);
 }
 
-FunctionPointer
-FunctionPointer::forDirect(IRGenModule &IGM, llvm::Constant *fnPtr,
-                           CanSILFunctionType fnType) {
-  return forDirect(fnPtr, IGM.getSignature(fnType));
+FunctionPointer FunctionPointer::forDirect(IRGenModule &IGM,
+                                           llvm::Constant *fnPtr,
+                                           CanSILFunctionType fnType) {
+  return forDirect(fnType, fnPtr, IGM.getSignature(fnType));
 }
 
-FunctionPointer
-FunctionPointer::forExplosionValue(IRGenFunction &IGF, llvm::Value *fnPtr,
-                                   CanSILFunctionType fnType) {
+StringRef FunctionPointer::getName(IRGenModule &IGM) const {
+  assert(isConstant());
+  switch (Kind.value) {
+  case KindTy::Value::Function:
+    return getRawPointer()->getName();
+  case KindTy::Value::AsyncFunctionPointer:
+    return IGM
+        .getSILFunctionForAsyncFunctionPointer(
+            cast<llvm::Constant>(getDirectPointer()->getOperand(0)))
+        ->getName();
+  }
+}
+
+llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
+  switch (Kind.value) {
+  case KindTy::Value::Function:
+    return Value;
+  case KindTy::Value::AsyncFunctionPointer:
+    auto *descriptorPtr =
+        IGF.Builder.CreateBitCast(Value, IGF.IGM.AsyncFunctionPointerPtrTy);
+    auto *addrPtr = IGF.Builder.CreateStructGEP(descriptorPtr, 0);
+    return IGF.emitLoadOfRelativePointer(
+        Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
+        /*expectedType*/ getFunctionType()->getPointerTo());
+  }
+}
+
+FunctionPointer FunctionPointer::forExplosionValue(IRGenFunction &IGF,
+                                                   llvm::Value *fnPtr,
+                                                   CanSILFunctionType fnType) {
   // Bitcast out of an opaque pointer type.
   assert(fnPtr->getType() == IGF.IGM.Int8PtrTy);
   auto sig = emitCastOfFunctionPointer(IGF, fnPtr, fnType);
   auto authInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
 
-  return FunctionPointer(fnPtr, authInfo, sig);
+  return FunctionPointer(fnType, fnPtr, authInfo, sig);
 }
 
 llvm::Value *
 FunctionPointer::getExplosionValue(IRGenFunction &IGF,
                                    CanSILFunctionType fnType) const {
-  llvm::Value *fnPtr = getPointer();
+  llvm::Value *fnPtr = getRawPointer();
 
   // Re-sign to the appropriate schema for this function pointer type.
   auto resultAuthInfo = PointerAuthInfo::forFunctionPointer(IGF.IGM, fnType);
@@ -4374,4 +4484,8 @@ FunctionPointer::getExplosionValue(IRGenFunction &IGF,
   fnPtr = IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.Int8PtrTy);
 
   return fnPtr;
+}
+
+FunctionPointer FunctionPointer::getAsFunction(IRGenFunction &IGF) const {
+  return FunctionPointer(KindTy::Function, getPointer(IGF), AuthInfo, Sig);
 }

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -302,12 +302,24 @@ namespace irgen {
                                            CanSILFunctionType substitutedType,
                                            SubstitutionMap substitutionMap);
 
-  llvm::Value *getDynamicAsyncContextSize(IRGenFunction &IGF,
-                                          AsyncContextLayout layout,
-                                          CanSILFunctionType functionType,
-                                          llvm::Value *thickContext);
+  /// Given an async function, get the pointer to the function to be called and
+  /// the size of the context to be allocated.
+  ///
+  /// \param values Whether any code should be emitted to retrieve the function
+  ///               pointer and the size, respectively.  If false is passed, no
+  ///               code will be emitted to generate that value and null will
+  ///               be returned for it.
+  ///
+  /// \return {function, size}
+  std::pair<llvm::Value *, llvm::Value *> getAsyncFunctionAndSize(
+      IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
+      FunctionPointer functionPointer, llvm::Value *thickContext,
+      std::pair<bool, bool> values = {true, true});
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention);
+
+  Signature emitCastOfFunctionPointer(IRGenFunction &IGF, llvm::Value *&fnPtr,
+                                      CanSILFunctionType fnType);
 
   /// Does the given function have a self parameter that should be given
   /// the special treatment for self parameters?

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2531,12 +2531,12 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
     auto &schema = IGF.getOptions().PointerAuth.SwiftClassMethods;
     auto authInfo =
       PointerAuthInfo::emit(IGF, schema, slot.getAddress(), method);
-    return FunctionPointer(fnPtr, authInfo, signature);
+    return FunctionPointer(methodType, fnPtr, authInfo, signature);
   }
   case ClassMetadataLayout::MethodInfo::Kind::DirectImpl: {
     auto fnPtr = llvm::ConstantExpr::getBitCast(methodInfo.getDirectImpl(),
                                            signature.getType()->getPointerTo());
-    return FunctionPointer::forDirect(fnPtr, signature);
+    return FunctionPointer::forDirect(methodType, fnPtr, signature);
   }
   }
   

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2522,7 +2522,7 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
     IGF.IGM.getClassMetadataLayout(classDecl).getMethodInfo(IGF, method);
   switch (methodInfo.getKind()) {
   case ClassMetadataLayout::MethodInfo::Kind::Offset: {
-    auto offset = methodInfo.getOffsett();
+    auto offset = methodInfo.getOffset();
 
     auto slot = IGF.emitAddressAtOffset(metadata, offset,
                                         signature.getType()->getPointerTo(),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2543,7 +2543,8 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
       LinkEntity::forDynamicallyReplaceableFunctionVariable(f);
   LinkEntity keyEntity =
       LinkEntity::forDynamicallyReplaceableFunctionKey(f);
-  Signature signature = getSignature(f->getLoweredFunctionType());
+  auto silFunctionType = f->getLoweredFunctionType();
+  Signature signature = getSignature(silFunctionType);
 
   // Create and initialize the first link entry for the chain of replacements.
   // The first implementation is initialized with 'implFn'.
@@ -2602,9 +2603,9 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
   auto authEntity = PointerAuthEntity(f);
   auto authInfo = PointerAuthInfo::emit(IGF, schema, fnPtrAddr, authEntity);
 
-  auto *Res = IGF.Builder.CreateCall(FunctionPointer(realReplFn, authInfo,
-                                                     signature),
-                                     forwardedArgs);
+  auto *Res = IGF.Builder.CreateCall(
+      FunctionPointer(silFunctionType, realReplFn, authInfo, signature),
+      forwardedArgs);
   Res->setTailCall();
   if (IGF.CurFn->getReturnType()->isVoidTy())
     IGF.Builder.CreateRetVoid();
@@ -2657,8 +2658,10 @@ static void emitDynamicallyReplaceableThunk(IRGenModule &IGM,
                         ? PointerAuthEntity(keyEntity.getSILFunction())
                         : PointerAuthEntity::Special::TypeDescriptor;
   auto authInfo = PointerAuthInfo::emit(IGF, schema, fnPtrAddr, authEntity);
-  auto *Res = IGF.Builder.CreateCall(
-      FunctionPointer(typeFnPtr, authInfo, signature), forwardedArgs);
+  auto *Res =
+      IGF.Builder.CreateCall(FunctionPointer(FunctionPointer::KindTy::Function,
+                                             typeFnPtr, authInfo, signature),
+                             forwardedArgs);
 
   Res->setTailCall();
   if (implFn->getReturnType()->isVoidTy())
@@ -2730,7 +2733,8 @@ void IRGenModule::emitDynamicReplacementOriginalFunctionThunk(SILFunction *f) {
 
   auto entity = LinkEntity::forSILFunction(f, true);
 
-  Signature signature = getSignature(f->getLoweredFunctionType());
+  auto fnType = f->getLoweredFunctionType();
+  Signature signature = getSignature(fnType);
   addLLVMFunctionAttributes(f, signature);
 
   LinkInfo implLink = LinkInfo::get(*this, entity, ForDefinition);
@@ -2774,7 +2778,7 @@ void IRGenModule::emitDynamicReplacementOriginalFunctionThunk(SILFunction *f) {
       IGF, schema, fnPtrAddr,
       PointerAuthEntity(f->getDynamicallyReplacedFunction()));
   auto *Res = IGF.Builder.CreateCall(
-      FunctionPointer(typeFnPtr, authInfo, signature), forwardedArgs);
+      FunctionPointer(fnType, typeFnPtr, authInfo, signature), forwardedArgs);
 
   if (implFn->getReturnType()->isVoidTy())
     IGF.Builder.CreateRetVoid();

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -55,7 +55,6 @@ namespace irgen {
       CanSILFunctionType outType, Explosion &out, bool isOutlined);
   CanType getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
                                   bool isNoEscape);
-
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -251,7 +251,7 @@ getAccessorForComputedComponent(IRGenModule &IGM,
                                forwardedArgs);
     }
     auto fnPtr = FunctionPointer::forDirect(IGM, accessorFn,
-                                          accessor->getLoweredFunctionType());
+                                            accessor->getLoweredFunctionType());
     auto call = IGF.Builder.CreateCall(fnPtr, forwardedArgs.claimAll());
     
     if (call->getType()->isVoidTy())

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5281,3 +5281,16 @@ bool irgen::methodRequiresReifiedVTableEntry(IRGenModule &IGM,
              llvm::dbgs() << " can be elided\n");
   return false;
 }
+
+llvm::GlobalValue *irgen::emitAsyncFunctionPointer(IRGenModule &IGM,
+                                                   SILFunction *function,
+                                                   Size size) {
+  ConstantInitBuilder initBuilder(IGM);
+  ConstantStructBuilder builder(
+      initBuilder.beginStruct(IGM.AsyncFunctionPointerTy));
+  builder.addRelativeAddress(
+      IGM.getAddrOfSILFunction(function, NotForDefinition));
+  builder.addInt32(size.getValue());
+  return cast<llvm::GlobalValue>(IGM.defineAsyncFunctionPointer(
+      function, builder.finishAndCreateFuture()));
+}

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3119,8 +3119,12 @@ namespace {
       // The class is fragile. Emit a direct reference to the vtable entry.
       llvm::Constant *ptr;
       if (entry) {
-        ptr = IGM.getAddrOfSILFunction(entry->getImplementation(),
-                                       NotForDefinition);
+        if (entry->getImplementation()->isAsync()) {
+          ptr = IGM.getAddrOfAsyncFunctionPointer(entry->getImplementation());
+        } else {
+          ptr = IGM.getAddrOfSILFunction(entry->getImplementation(),
+                                         NotForDefinition);
+        }
       } else {
         // The method is removed by dead method elimination.
         // It should be never called. We add a pointer to an error function.

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -32,6 +32,7 @@ namespace swift {
   class FileUnit;
   class FuncDecl;
   enum class ResilienceExpansion : unsigned;
+  struct SILDeclRef;
   class SILType;
   class VarDecl;
   enum class SpecialProtocol : uint8_t;
@@ -181,6 +182,8 @@ namespace irgen {
                                           GenericSignature sig,
                                           ArrayRef<Requirement> requirements);
 
+  llvm::GlobalValue *emitAsyncFunctionPointer(IRGenModule &IGM,
+                                              SILFunction *function, Size size);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -657,7 +657,8 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
   Selector selector(method);
   llvm::Value *selectorValue = IGF.emitObjCSelectorRefLoad(selector.str());
 
-  auto fn = FunctionPointer::forDirect(messenger, sig);
+  auto fn = FunctionPointer::forDirect(FunctionPointer::KindTy::Function,
+                                       messenger, sig);
   return Callee(std::move(info), fn, receiverValue, selectorValue);
 }
 

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -431,7 +431,8 @@ static FunctionPointer emitLoadOfValueWitnessFunction(IRGenFunction &IGF,
                                     IGF.getOptions().PointerAuth.ValueWitnesses,
                                         slot, index);
 
-  return FunctionPointer(witness, authInfo, signature);
+  return FunctionPointer(FunctionPointer::KindTy::Function, witness, authInfo,
+                         signature);
 }
 
 /// Given a type metadata pointer, load one of the function
@@ -477,12 +478,13 @@ IRGenFunction::emitValueWitnessFunctionRef(SILType type,
       assert(discriminator && "no saved discriminator for value witness fn!");
       authInfo = PointerAuthInfo(schema.getKey(), discriminator);
     }
-    return FunctionPointer(witness, authInfo, signature);
+    return FunctionPointer(FunctionPointer::KindTy::Function, witness, authInfo,
+                           signature);
   }
   
   auto vwtable = emitValueWitnessTableRef(type, &metadataSlot);
   auto witness = emitLoadOfValueWitnessFunction(*this, vwtable, index);
-  setScopedLocalTypeDataForLayout(type, key, witness.getPointer());
+  setScopedLocalTypeDataForLayout(type, key, witness.getPointer(*this));
   if (auto &authInfo = witness.getAuthInfo()) {
     setScopedLocalTypeDataForLayout(type,
                         LocalTypeDataKind::forValueWitnessDiscriminator(index),

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -71,9 +71,11 @@ llvm::Value *irgen::emitPointerAuthStrip(IRGenFunction &IGF,
 FunctionPointer irgen::emitPointerAuthResign(IRGenFunction &IGF,
                                              const FunctionPointer &fn,
                                           const PointerAuthInfo &newAuthInfo) {
-  llvm::Value *fnPtr = emitPointerAuthResign(IGF, fn.getPointer(),
+  // TODO: Handle resigning AsyncFunctionPointers.
+  assert(fn.getKind().value == FunctionPointer::KindTy::Value::Function);
+  llvm::Value *fnPtr = emitPointerAuthResign(IGF, fn.getPointer(IGF),
                                              fn.getAuthInfo(), newAuthInfo);
-  return FunctionPointer(fnPtr, newAuthInfo, fn.getSignature());
+  return FunctionPointer(fn.getKind(), fnPtr, newAuthInfo, fn.getSignature());
 }
 
 llvm::Value *irgen::emitPointerAuthResign(IRGenFunction &IGF,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1336,7 +1336,11 @@ public:
       SILFunction *Func = entry.getMethodWitness().Witness;
       llvm::Constant *witness = nullptr;
       if (Func) {
-        witness = IGM.getAddrOfSILFunction(Func, NotForDefinition);
+        if (Func->isAsync()) {
+          witness = IGM.getAddrOfAsyncFunctionPointer(Func);
+        } else {
+          witness = IGM.getAddrOfSILFunction(Func, NotForDefinition);
+        }
       } else {
         // The method is removed by dead method elimination.
         // It should be never called. We add a pointer to an error function.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3341,7 +3341,7 @@ FunctionPointer irgen::emitWitnessMethodValue(IRGenFunction &IGF,
   auto &schema = IGF.getOptions().PointerAuth.ProtocolWitnesses;
   auto authInfo = PointerAuthInfo::emit(IGF, schema, slot, member);
 
-  return FunctionPointer(witnessFnPtr, authInfo, signature);
+  return FunctionPointer(fnType, witnessFnPtr, authInfo, signature);
 }
 
 FunctionPointer irgen::emitWitnessMethodValue(

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -206,7 +206,9 @@ public:
   emitLoadOfRelativeIndirectablePointer(Address addr, bool isFar,
                                         llvm::PointerType *expectedType,
                                         const llvm::Twine &name = "");
-
+  llvm::Value *emitLoadOfRelativePointer(Address addr, bool isFar,
+                                         llvm::PointerType *expectedType,
+                                         const llvm::Twine &name = "");
 
   llvm::Value *emitAllocObjectCall(llvm::Value *metadata, llvm::Value *size,
                                    llvm::Value *alignMask,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -590,9 +590,12 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   DynamicReplacementKeyTy = createStructType(*this, "swift.dyn_repl_key",
                                              {RelativeAddressTy, Int32Ty});
 
+  AsyncFunctionPointerTy = createStructType(*this, "swift.async_func_pointer",
+                                            {RelativeAddressTy, Int32Ty});
   SwiftContextTy = createStructType(*this, "swift.context", {});
   SwiftTaskTy = createStructType(*this, "swift.task", {});
   SwiftExecutorTy = createStructType(*this, "swift.executor", {});
+  AsyncFunctionPointerPtrTy = AsyncFunctionPointerTy->getPointerTo(DefaultAS);
   SwiftContextPtrTy = SwiftContextTy->getPointerTo(DefaultAS);
   SwiftTaskPtrTy = SwiftTaskTy->getPointerTo(DefaultAS);
   SwiftExecutorPtrTy = SwiftExecutorTy->getPointerTo(DefaultAS);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -723,9 +723,11 @@ public:
       *DynamicReplacementLinkEntryPtrTy; // %link_entry*
   llvm::StructType *DynamicReplacementKeyTy; // { i32, i32}
 
+  llvm::StructType *AsyncFunctionPointerTy; // { i32, i32 }
   llvm::StructType *SwiftContextTy;
   llvm::StructType *SwiftTaskTy;
   llvm::StructType *SwiftExecutorTy;
+  llvm::PointerType *AsyncFunctionPointerPtrTy;
   llvm::PointerType *SwiftContextPtrTy;
   llvm::PointerType *SwiftTaskPtrTy;
   llvm::PointerType *SwiftExecutorPtrTy;
@@ -1387,6 +1389,11 @@ public:
 
   /// Cast the given constant to i8*.
   llvm::Constant *getOpaquePtr(llvm::Constant *pointer);
+
+  llvm::Constant *getAddrOfAsyncFunctionPointer(SILFunction *function);
+  llvm::Constant *defineAsyncFunctionPointer(SILFunction *function,
+                                             ConstantInit init);
+  SILFunction *getSILFunctionForAsyncFunctionPointer(llvm::Constant *afp);
 
   llvm::Function *getAddrOfDispatchThunk(SILDeclRef declRef,
                                          ForDefinition_t forDefinition);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -430,6 +430,17 @@ std::string LinkEntity::mangleAsString() const {
     return mangler.mangleSILDifferentiabilityWitnessKey(
         {getSILDifferentiabilityWitness()->getOriginalFunction()->getName(),
          getSILDifferentiabilityWitness()->getConfig()});
+  case Kind::AsyncFunctionPointer: {
+    std::string Result(getSILFunction()->getName());
+    Result.append("AD");
+    return Result;
+  }
+  case Kind::AsyncFunctionPointerAST: {
+    std::string Result;
+    Result = mangler.mangleEntity(getDecl());
+    Result.append("AD");
+    return Result;
+  }
   }
   llvm_unreachable("bad entity kind!");
 }
@@ -663,8 +674,12 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::DynamicallyReplaceableFunctionKey:
     return getSILFunction()->getLinkage();
 
+  case Kind::AsyncFunctionPointer:
   case Kind::SILFunction:
     return getSILFunction()->getEffectiveSymbolLinkage();
+
+  case Kind::AsyncFunctionPointerAST:
+    return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);
 
   case Kind::DynamicallyReplaceableFunctionImpl:
   case Kind::DynamicallyReplaceableFunctionKeyAST:
@@ -712,6 +727,8 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::ProtocolDescriptor:
   case Kind::OpaqueTypeDescriptor:
     return true;
+  case Kind::AsyncFunctionPointer:
+  case Kind::AsyncFunctionPointerAST:
   case Kind::PropertyDescriptor:
   case Kind::DispatchThunk:
   case Kind::DispatchThunkInitializer:
@@ -780,6 +797,8 @@ bool LinkEntity::isContextDescriptor() const {
 
 llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
   switch (getKind()) {
+  case Kind::AsyncFunctionPointer:
+    return IGM.AsyncFunctionPointerTy;
   case Kind::ModuleDescriptor:
   case Kind::ExtensionDescriptor:
   case Kind::AnonymousDescriptor:
@@ -909,6 +928,7 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   case Kind::MethodDescriptorAllocator:
   case Kind::OpaqueTypeDescriptor:
     return Alignment(4);
+  case Kind::AsyncFunctionPointer:
   case Kind::ObjCClassRef:
   case Kind::ObjCClass:
   case Kind::TypeMetadataLazyCacheVariable:
@@ -951,6 +971,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
       return getSILGlobalVariable()->getDecl()->isWeakImported(module);
     }
     return false;
+  case Kind::AsyncFunctionPointer:
   case Kind::DynamicallyReplaceableFunctionKey:
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::SILFunction: {
@@ -977,6 +998,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
     return false;
   }
 
+  case Kind::AsyncFunctionPointerAST:
   case Kind::DispatchThunk:
   case Kind::DispatchThunkInitializer:
   case Kind::DispatchThunkAllocator:
@@ -1053,6 +1075,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
 
 DeclContext *LinkEntity::getDeclContextForEmission() const {
   switch (getKind()) {
+  case Kind::AsyncFunctionPointerAST:
   case Kind::DispatchThunk:
   case Kind::DispatchThunkInitializer:
   case Kind::DispatchThunkAllocator:
@@ -1095,6 +1118,7 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
     return getType()->getClassOrBoundGenericClass()->getDeclContext();
 
+  case Kind::AsyncFunctionPointer:
   case Kind::SILFunction:
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::DynamicallyReplaceableFunctionKey:

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -188,7 +188,7 @@ public:
 
     Kind getKind() const { return TheKind; }
     
-    Offset getOffsett() const {
+    Offset getOffset() const {
       assert(getKind() == Kind::Offset);
       return TheOffset;
     }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -720,6 +720,10 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
                        AFD->getGenericSignature()));
 
   visitDefaultArguments(AFD, AFD->getParameters());
+
+  if (AFD->isAsyncContext()) {
+    addSymbol(LinkEntity::forAsyncFunctionPointer(AFD));
+  }
 }
 
 void TBDGenVisitor::visitFuncDecl(FuncDecl *FD) {

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -29,6 +29,7 @@ class S {
   init()
 }
 
+// CHECK-LL: @classinstanceSInt64ToVoidAD =
 // CHECK-LL: define hidden swiftcc void @classinstanceSInt64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]+}} {
 sil hidden @classinstanceSInt64ToVoid : $@async @convention(method) (Int64, @guaranteed S) -> () {
 bb0(%int : $Int64, %instance : $S):

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -29,6 +29,7 @@ class S {
   init()
 }
 
+// CHECK-LL: @classinstanceSVoidToVoidAD =
 // CHECK-LL: define hidden swiftcc void @classinstanceSVoidToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @classinstanceSVoidToVoid : $@async @convention(method) (@guaranteed S) -> () {
 bb0(%instance : $S):

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -37,6 +37,7 @@ bb0(%int : $Int64, %S_type : $@thin S.Type):
   return %instance : $S
 }
 
+// CHECK-LL: @existentialToVoidAD =
 // CHECK-LL: define hidden swiftcc void @existentialToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @existentialToVoid : $@async @convention(thin) (@in_guaranteed P) -> () {
 bb0(%existential : $*P):

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
+// CHECK-LL: @genericToGenericAD =
 // CHECK-LL: define hidden swiftcc void @genericToGeneric(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @genericToGeneric : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T {
 bb0(%out : $*T, %in : $*T):

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-generic-to-void.sil
+++ b/test/IRGen/async/run-call-generic-to-void.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 
+// CHECK-LL: @genericToVoidAD =
 // CHECK-LL: define hidden swiftcc void @genericToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @genericToVoid : $@async @convention(thin) <T> (@in_guaranteed T) -> () {
 bb0(%instance : $*T):

--- a/test/IRGen/async/run-call-generic-to-void.sil
+++ b/test/IRGen/async/run-call-generic-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printBool : $@convention(thin) (Bool) -> ()
 
+// CHECK-LL: @genericEquatableAndGenericEquatableToBoolAD =
 // CHECK-LL: define hidden swiftcc void @genericEquatableAndGenericEquatableToBool(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @genericEquatableAndGenericEquatableToBool : $@async @convention(thin) <T where T : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool {
 bb0(%0 : $*T, %1 : $*T):

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
+// CHECK-LL: @int64AndInt64ToVoidAD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @int64AndInt64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @int64AndInt64ToVoid : $@async @convention(thin) (Int64, Int64) -> () {
 entry(%int1: $Int64, %int2: $Int64):

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
+// CHECK-LL: @int64ToVoidAD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @int64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @int64ToVoid : $@async @convention(thin) (Int64) -> () {
 entry(%int: $Int64):

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -33,6 +33,7 @@ struct I : P {
   init(int: Int64)
 }
 
+// CHECK-LL: @callPrintMeAD =
 // CHECK-LL: define hidden swiftcc void @callPrintMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @callPrintMe : $@async @convention(method) <Self where Self : P> (@in_guaranteed Self) -> Int64 {
 bb0(%self : $*Self):

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -29,6 +29,7 @@ struct I : P {
   init(int: Int64)
 }
 
+// CHECK-LL: @I_printMeAD =
 // CHECK-LL-LABEL: define hidden swiftcc void @I_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @I_printMe : $@async @convention(method) (I) -> Int64 {
 bb0(%self : $I):

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -25,6 +25,7 @@ struct S {
   init(storage: Int64)
 }
 
+// CHECK-LL: @structinstanceSInt64ToVoidAD =
 // CHECK-LL: define hidden swiftcc void @structinstanceSInt64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @structinstanceSInt64ToVoid : $@async @convention(method) (Int64, S) -> () {
 bb0(%int : $Int64, %self : $S):

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -99,6 +99,7 @@ bb5:
   br bb2
 }
 
+// CHECK-LL: @voidThrowsToIntAD =
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -98,6 +98,7 @@ bb5:
   br bb2
 }
 
+// CHECK-LL: @voidThrowsToIntAD =
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 entry:

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -99,6 +99,7 @@ bb5:
   br bb2
 }
 
+// CHECK-LL: @voidThrowsToIntAD =
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -99,6 +99,7 @@ bb5:
   br bb2
 }
 
+// CHECK-LL: @voidThrowsToIntAD =
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 entry:

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -100,6 +100,7 @@ bb5:
   br bb2
 }
 
+// CHECK-LL: @voidThrowsToIntAD =
 // CHECK-LL: define hidden swiftcc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -36,6 +36,7 @@ bb0(%int : $Int64, %S_type : $@thin S.Type):
   return %instance : $S
 }
 
+// CHECK-LL: @voidToExistentialAD =
 // CHECK-LL: define hidden swiftcc void @voidToExistential(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @voidToExistential : $@async @convention(thin) () -> @out P {
 bb0(%out : $*P):

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
+// CHECK-LL: @voidToInt64AndInt64AD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @voidToInt64AndInt64(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @voidToInt64AndInt64 : $@async @convention(thin) () -> (Int64, Int64) {
   %int_literal1 = integer_literal $Builtin.Int64, 42

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-to-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64.sil
@@ -19,6 +19,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
+// CHECK-LL: @voidToInt64AD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @voidToInt64(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @voidToInt64 : $@async @convention(thin) () -> (Int64) {
   %int_literal = integer_literal $Builtin.Int64, 42

--- a/test/IRGen/async/run-call-void-to-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 
 import Builtin

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -101,6 +101,7 @@ bb0(%0 : $@thin Big.Type):
   return %62 : $Big
 }
 
+// CHECK-LL: @getBigAD =
 // CHECK-LL: define hidden swiftcc void @getBig(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @getBig : $@async @convention(thin) () -> Big {
 bb0:

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -45,6 +45,7 @@ bb0(%out_addr : $*T, %in_addr : $*T, %self : $I):
   return %value : $Int64
 }
 
+// CHECK-LL: @I_P_printMeAD =
 // CHECK-LL: define internal swiftcc void @I_P_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil private [transparent] [thunk] @I_P_printMe : $@convention(witness_method: P) @async <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed I) -> (Int64, @out τ_0_0) {
 bb0(%out_addr : $*τ_0_0, %in_addr : $*τ_0_0, %self_addr : $*I):

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -29,6 +29,9 @@ struct I : P {
   init(int: Int64)
 }
 
+// CHECK-LL: @I_printMeAD =
+// CHECK-LL: @I_P_printMeAD =
+
 // CHECK-LL-LABEL: define hidden swiftcc void @I_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @I_printMe : $@async @convention(method) (I) -> Int64 {
 bb0(%self : $I):

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-convertfunction-int64-to-void.sil
+++ b/test/IRGen/async/run-convertfunction-int64-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -57,6 +57,7 @@ sil_vtable S {
   #S.deinit!deallocator: @S_deallocating_deinit
 }
 
+// CHECK-LL: @classinstanceSToVoidAD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @classinstanceSToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @classinstanceSToVoid : $@async @convention(thin) (@owned S) -> () {
 entry(%c : $S):

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -19,6 +19,7 @@ import _Concurrency
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
+// CHECK-LL: @inGenericAndInoutGenericToGenericAD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @inGenericAndInoutGenericToGeneric(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 // CHECK-LL: define internal swiftcc void @"$s017inGenericAndInoutb2ToB0TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
 sil @inGenericAndInoutGenericToGeneric : $@async @convention(thin) <T> (@in T, @inout T) -> @out T {

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -45,6 +45,7 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   return %out : $Int32
 }
 
+// CHECK-LL: @closureAD =
 // CHECK-LL: define internal swiftcc void @closure(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}}
 // CHECK-LL: define internal swiftcc void @"$s7closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}}
 sil hidden @createPartialApply : $@async @convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64 {

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -61,6 +61,7 @@ sil_vtable C {
 
 struct S { var x: C, y: C }
 
+// CHECK-LL: @structClassInstanceClassInstanceAndInt64ToInt64AD =
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @structClassInstanceClassInstanceAndInt64ToInt64(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 // CHECK-LL: define internal swiftcc void @"$s019structClassInstancebc10AndInt64ToE0TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}, %swift.refcounted* swiftself {{%[0-9]*}}) {{#[0-9]*}} {
 sil @structClassInstanceClassInstanceAndInt64ToInt64 : $@async @convention(thin) (Int64, @guaranteed S) -> Int64 {

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -39,6 +39,9 @@ entry(%value : $A2<A3>):
   return %result : $()
 }
 
+// CHECK-LL: @amethodAD =
+// CHECK-LL: @repoAD =
+
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @amethod(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error) {
 entry(%a2_at_a3_addr : $*A2<A3>):

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -32,6 +32,7 @@ sil_witness_table <T> BaseProducer<T> : Q module main {
 public class WeakBox<T> {}
 sil_vtable WeakBox {}
 
+// CHECK-LL: @takingQAD =
 // CHECK-LL: define hidden swiftcc void @takingQ(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil hidden @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> () {
 entry(%box : $WeakBox<τ_0_0>):

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_oC_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift

--- a/test/IRGen/async/run-thintothick-int64-to-void.sil
+++ b/test/IRGen/async/run-thintothick-int64-to-void.sil
@@ -10,6 +10,7 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
 
 import Builtin
 import Swift


### PR DESCRIPTION
An AsyncFunctionPointer, defined in Task.h, is a struct consisting of two i32s: (1) the relative address of the async function and (2) the size of the async context to be allocated when calling that function.

Here, such structs are emitted for every async SILFunction that is emitted.  Furthermore, pointers to these new structs rather than pointers directly to async functions are passed around.  The async context size is now read out of these function pointers and used to allocate the async context.  This will enable the size constants to be rewritten by an LLVM pass with the ideal storage space to minimize additional allocations.

The following tasks need to be completed before merge:
- [x] Avoiding AsyncFunctionPointers for partial apply forwarders.
- [x] Using SILFunction as the value for the AsyncFunctionPointer LinkEntity.
- [x] Using a LinkEntity for TBDGen of AsyncFunctionPointers.
- [x] Avoiding extracting function pointers from AsyncFunctionPointers during thin_to_thick and convert_function lowering.
- [x] Pointer authentication for function pointers.

The following related task will be completed in follow-on PRs:
- Referring directly to async functions when particular callees are known rather than loading the function pointers from AsyncFunctionPointer structs.