### PR TITLE
platform: add WIC (Windows Imaging Component) to the SDK

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -340,6 +340,13 @@ module WinSDK [system] {
     export *
   }
 
+  module WIC {
+    header "wincodec.h"
+    export *
+
+    link "windowscodecs.lib"
+  }
+
   module WinBase {
     header "winbase.h"
     export *


### PR DESCRIPTION
The Windows Imaging Component does not get included by any of the other
headers.  Explicitly add a submodule for the component.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
