### PR TITLE
Update ticket number

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -843,8 +843,8 @@ extension SIMD where Scalar: FloatingPoint {
   
   /// Returns the sum of the scalars in the vector.
   // SWIFT_ENABLE_TENSORFLOW: We have changed `@_alwaysEmitIntoClient` to `@inlinable`, to work
-  // around TF-1103.
-  // TODO(TF-1103): Change `@inlinable` back to `@_alwaysEmitIntoClient`.
+  // around SR-13689.
+  // TODO(SR-13689): Change `@inlinable` back to `@_alwaysEmitIntoClient`.
   @inlinable
   public func sum() -> Scalar {
     // Implementation note: this eventually be defined to lower to either


### PR DESCRIPTION
The bug filed for this workaround has since been moved. [TF-1103](https://bugs.swift.org/browse/TF-1103) redirects to [SR-13689](https://bugs.swift.org/browse/SR-13689). This updates the code to reflect the correct ticket number.

