### PR TITLE
[Concurrency] Add a builtin to get the current task in an async function

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -492,12 +492,6 @@ BUILTIN_SIL_OPERATION(ConvertStrongToUnownedUnsafe, "convertStrongToUnownedUnsaf
 /// now.
 BUILTIN_SIL_OPERATION(ConvertUnownedUnsafeToGuaranteed, "convertUnownedUnsafeToGuaranteed", Special)
 
-// getCurrentAsyncTask: () -> Builtin.NativeObject
-//
-// Retrieve the pointer to the task in which the current asynchronous
-// function is executing.
-BUILTIN_SIL_OPERATION(GetCurrentAsyncTask, "getCurrentAsyncTask", Special)
-
 /// applyDerivative
 BUILTIN_SIL_OPERATION(ApplyDerivative, "applyDerivative", Special)
 
@@ -722,6 +716,12 @@ BUILTIN_MISC_OPERATION(IntInstrprofIncrement, "int_instrprof_increment", "", Spe
 #define BUILTIN_MISC_OPERATION_WITH_SILGEN(Id, Name, Attrs, Overload) \
   BUILTIN_MISC_OPERATION(Id, Name, Attrs, Overload)
 #endif
+
+// getCurrentAsyncTask: () -> Builtin.NativeObject
+//
+// Retrieve the pointer to the task in which the current asynchronous
+// function is executing.
+BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentAsyncTask, "getCurrentAsyncTask", "n", Special)
 
 /// globalStringTablePointer has type String -> Builtin.RawPointer.
 /// It returns an immortal, global string table pointer for strings constructed

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -492,6 +492,12 @@ BUILTIN_SIL_OPERATION(ConvertStrongToUnownedUnsafe, "convertStrongToUnownedUnsaf
 /// now.
 BUILTIN_SIL_OPERATION(ConvertUnownedUnsafeToGuaranteed, "convertUnownedUnsafeToGuaranteed", Special)
 
+// getCurrentAsyncTask: () -> Builtin.NativeObject
+//
+// Retrieve the pointer to the task in which the current asynchronous
+// function is executing.
+BUILTIN_SIL_OPERATION(GetCurrentAsyncTask, "getCurrentAsyncTask", Special)
+
 /// applyDerivative
 BUILTIN_SIL_OPERATION(ApplyDerivative, "applyDerivative", Special)
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1341,6 +1341,10 @@ static ValueDecl *getConvertUnownedUnsafeToGuaranteed(ASTContext &ctx,
   return builder.build(id);
 }
 
+static ValueDecl *getGetCurrentAsyncTask(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(id, { }, ctx.TheNativeObjectType);
+}
+
 static ValueDecl *getPoundAssert(ASTContext &Context, Identifier Id) {
   auto int1Type = BuiltinIntegerType::get(1, Context);
   auto optionalRawPointerType = BoundGenericEnumType::get(
@@ -2466,6 +2470,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::ConvertUnownedUnsafeToGuaranteed:
     return getConvertUnownedUnsafeToGuaranteed(Context, Id);
+
+  case BuiltinValueKind::GetCurrentAsyncTask:
+    return getGetCurrentAsyncTask(Context, Id);
 
   case BuiltinValueKind::PoundAssert:
     return getPoundAssert(Context, Id);

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -211,6 +211,13 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     return;
   }
 
+  // getCurrentAsyncTask has no arguments.
+  if (Builtin.ID == BuiltinValueKind::GetCurrentAsyncTask) {
+    auto task = IGF.getAsyncTask();
+    out.add(IGF.Builder.CreateBitCast(task, IGF.IGM.RefCountedPtrTy));
+    return;
+  }
+
   // Everything else cares about the (rvalue) argument.
 
   // If this is an LLVM IR intrinsic, lower it to an intrinsic call.

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1033,6 +1033,7 @@ ANY_OWNERSHIP_BUILTIN(IntInstrprofIncrement)
   }
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, COWBufferForReading)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, UnsafeGuaranteed)
+CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, GetCurrentAsyncTask)
 #undef CONSTANT_OWNERSHIP_BUILTIN
 
 // Builtins that should be lowered to SIL instructions so we should never see

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -1033,8 +1033,15 @@ ANY_OWNERSHIP_BUILTIN(IntInstrprofIncrement)
   }
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, COWBufferForReading)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, UnsafeGuaranteed)
-CONSTANT_OWNERSHIP_BUILTIN(Owned, MustBeInvalidated, GetCurrentAsyncTask)
 #undef CONSTANT_OWNERSHIP_BUILTIN
+
+#define SHOULD_NEVER_VISIT_BUILTIN(ID)                              \
+  OperandOwnershipKindMap OperandOwnershipKindBuiltinClassifier::visit##ID(    \
+      BuiltinInst *, StringRef) {                                              \
+    llvm_unreachable("Builtin should never be visited! E.x.: It may not have arguments"); \
+  }
+SHOULD_NEVER_VISIT_BUILTIN(GetCurrentAsyncTask)
+#undef SHOULD_NEVER_VISIT_BUILTIN
 
 // Builtins that should be lowered to SIL instructions so we should never see
 // them.

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -570,6 +570,12 @@ UNOWNED_OR_NONE_DEPENDING_ON_RESULT(ZeroInitializer)
 
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *BI) {
+  if (auto kind = BI->getBuiltinKind()) {
+    // The current async task is kept alive by the caller.
+    if (*kind == BuiltinValueKind::GetCurrentAsyncTask)
+      return ValueOwnershipKind::Unowned;
+  }
+
   // For now, just conservatively say builtins are None. We need to use a
   // builtin in here to guarantee correctness.
   return ValueOwnershipKindBuiltinVisitor().visit(BI);

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -541,6 +541,7 @@ CONSTANT_OWNERSHIP_BUILTIN(None, PoundAssert)
 CONSTANT_OWNERSHIP_BUILTIN(None, TypePtrAuthDiscriminator)
 CONSTANT_OWNERSHIP_BUILTIN(None, IntInstrprofIncrement)
 CONSTANT_OWNERSHIP_BUILTIN(None, GlobalStringTablePointer)
+CONSTANT_OWNERSHIP_BUILTIN(Owned, GetCurrentAsyncTask)
 
 #undef CONSTANT_OWNERSHIP_BUILTIN
 
@@ -570,12 +571,6 @@ UNOWNED_OR_NONE_DEPENDING_ON_RESULT(ZeroInitializer)
 
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *BI) {
-  if (auto kind = BI->getBuiltinKind()) {
-    // The current async task is kept alive by the caller.
-    if (*kind == BuiltinValueKind::GetCurrentAsyncTask)
-      return ValueOwnershipKind::Unowned;
-  }
-
   // For now, just conservatively say builtins are None. We need to use a
   // builtin in here to guarantee correctness.
   return ValueOwnershipKindBuiltinVisitor().visit(BI);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1736,6 +1736,14 @@ public:
       verifyLLVMIntrinsic(BI, BI->getIntrinsicInfo().ID);
       return;
     }
+
+    // Check that 'getCurrentAsyncTask' only occurs within an async function.
+    if (BI->getBuiltinKind() &&
+        *BI->getBuiltinKind() == BuiltinValueKind::GetCurrentAsyncTask) {
+      require(F.isAsync(),
+          "getCurrentAsyncTask builtin can only be used in an async function");
+      return;
+    }
   }
   
   void checkFunctionRefBaseInst(FunctionRefBaseInst *FRI) {

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1393,6 +1393,18 @@ static ManagedValue emitBuiltinConvertUnownedUnsafeToGuaranteed(
   return SGF.B.createMarkDependence(loc, guaranteedNonTrivialRefMV, baseMV);
 }
 
+// Emit SIL for the named builtin: getCurrentAsyncTask.
+static ManagedValue emitBuiltinGetCurrentAsyncTask(
+    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
+    PreparedArguments &&preparedArgs, SGFContext C) {
+  ASTContext &ctx = SGF.getASTContext();
+  auto apply = SGF.B.createBuiltin(
+      loc,
+      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetCurrentAsyncTask)),
+      SGF.getLoweredType(ctx.TheNativeObjectType), SubstitutionMap(), { });
+  return ManagedValue::forUnmanaged(apply);
+}
+
 Optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1402,6 +1402,7 @@ static ManagedValue emitBuiltinGetCurrentAsyncTask(
       loc,
       ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetCurrentAsyncTask)),
       SGF.getLoweredType(ctx.TheNativeObjectType), SubstitutionMap(), { });
+  SGF.enterEndLifetimeCleanup(apply);
   return ManagedValue::forUnmanaged(apply);
 }
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1402,8 +1402,7 @@ static ManagedValue emitBuiltinGetCurrentAsyncTask(
       loc,
       ctx.getIdentifier(getBuiltinName(BuiltinValueKind::GetCurrentAsyncTask)),
       SGF.getLoweredType(ctx.TheNativeObjectType), SubstitutionMap(), { });
-  SGF.enterEndLifetimeCleanup(apply);
-  return ManagedValue::forUnmanaged(apply);
+  return SGF.emitManagedRValueWithEndLifetimeCleanup(apply);
 }
 
 Optional<SpecializedEmitter>

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1347,9 +1347,10 @@ public:
 };
 } // end anonymous namespace
 
-CleanupHandle SILGenFunction::enterEndLifetimeCleanup(SILValue value) {
+ManagedValue SILGenFunction::emitManagedRValueWithEndLifetimeCleanup(
+    SILValue value) {
   Cleanups.pushCleanup<EndLifetimeCleanup>(value);
-  return Cleanups.getTopCleanup();
+  return ManagedValue::forUnmanaged(value);
 }
 
 namespace {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2000,7 +2000,10 @@ public:
   
   /// Enter a cleanup to emit a ReleaseValue/DestroyAddr of the specified value.
   CleanupHandle enterDestroyCleanup(SILValue valueOrAddr);
-  
+
+  /// Enter cleanup to emit an EndLifetime operation for the given value.
+  CleanupHandle enterEndLifetimeCleanup(SILValue value);
+
   /// Enter a cleanup to emit a DeinitExistentialAddr or DeinitExistentialBox
   /// of the specified value.
   CleanupHandle enterDeinitExistentialCleanup(CleanupState state,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2001,8 +2001,19 @@ public:
   /// Enter a cleanup to emit a ReleaseValue/DestroyAddr of the specified value.
   CleanupHandle enterDestroyCleanup(SILValue valueOrAddr);
 
-  /// Enter cleanup to emit an EndLifetime operation for the given value.
-  CleanupHandle enterEndLifetimeCleanup(SILValue value);
+  /// Return an owned managed value for \p value that is cleaned up using an end_lifetime instruction.
+  ///
+  /// The end_lifetime cleanup is not placed into the ManagedValue itself and
+  /// thus can not be forwarded. This means that the ManagedValue is treated
+  /// as a +0 value. This means that the owned value will be copied by SILGen
+  /// if it is ever needed as a +1 value (meaning any time that the value
+  /// escapes).
+  ///
+  /// DISCUSSION: end_lifetime ends the lifetime of an owned value in OSSA
+  /// without resulting in a destroy being emitted. This cleanup should only
+  /// be used for owned values that do not need to be destroyed if they do not
+  /// escape the current call frame but need to be copied if they escape.
+  ManagedValue emitManagedRValueWithEndLifetimeCleanup(SILValue value);
 
   /// Enter a cleanup to emit a DeinitExistentialAddr or DeinitExistentialBox
   /// of the specified value.

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -140,6 +140,7 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::GlobalStringTablePointer:
     case BuiltinValueKind::COWBufferForReading:
     case BuiltinValueKind::IntInstrprofIncrement:
+    case BuiltinValueKind::GetCurrentAsyncTask:
       return false;
 
     // Handle some rare builtins that may be sensitive to object lifetime

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -14,5 +14,6 @@ bb0:
   %0 = builtin "getCurrentAsyncTask"() : $Builtin.NativeObject
   // CHECK-NEXT: [[TASK_COPY:%.*]] = call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[TASK]])
   %1 = copy_value %0 : $Builtin.NativeObject
+  end_lifetime %0 : $Builtin.NativeObject
   return %1 : $Builtin.NativeObject
 }

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -enable-experimental-concurrency -enable-objc-interop  -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-objc
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-objc-interop -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-native
+
+// REQUIRES: concurrency
+
+sil_stage canonical
+
+import Builtin
+
+// CHECK-LABEL: define hidden swiftcc void @get_task(%swift.task* %0, %swift.executor* %1, %swift.context* %2)
+sil hidden [ossa] @get_task : $@async @convention(thin) () -> @owned Builtin.NativeObject {
+bb0:
+  // CHECK: [[TASK:%.*]] = bitcast %swift.task* %0 to %swift.refcounted*
+  %0 = builtin "getCurrentAsyncTask"() : $Builtin.NativeObject
+  // CHECK-NEXT: [[TASK_COPY:%.*]] = call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[TASK]])
+  %1 = copy_value %0 : $Builtin.NativeObject
+  return %1 : $Builtin.NativeObject
+}

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency -parse-stdlib | %FileCheck %s
+// REQUIRES: concurrency
+
+struct X {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test1XV14getCurrentTaskBoyYF
+  func getCurrentTask() async -> Builtin.NativeObject {
+    // CHECK: builtin "getCurrentAsyncTask"() : $Builtin.NativeObject
+    return Builtin.getCurrentAsyncTask()
+  }
+}


### PR DESCRIPTION
This introduces a new builtin, `getCurrentAsyncTask()`, that produces a
reference to the current task. This builtin can only be used within
`async` functions, and IR generation merely grabs the task argument
and packages it up.

The type of this function is `() -> Builtin.NativeObject`, because we
don't currently have a Swift-level representation of tasks, and can
probably handle everything through builtins or runtime calls.
