### PR TITLE
[Runtime] Use os_unfair_lock for Mutex and StaticMutex on Darwin.

### DIFF
--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -72,40 +72,6 @@ public:
   }
 };
 
-/// A ConditionVariable that works with Mutex to allow -- as an example --
-/// multi-threaded producers and consumers to signal each other in a safe way.
-class ConditionVariable {
-  friend class ConditionMutex;
-  friend class StaticConditionMutex;
-
-  ConditionVariable(const ConditionVariable &) = delete;
-  ConditionVariable &operator=(const ConditionVariable &) = delete;
-  ConditionVariable(ConditionVariable &&) = delete;
-  ConditionVariable &operator=(ConditionVariable &&) = delete;
-
-public:
-  ConditionVariable() { ConditionPlatformHelper::init(Handle); }
-  ~ConditionVariable() { ConditionPlatformHelper::destroy(Handle); }
-
-  /// Notifies one waiter (if any exists) that the condition has been met.
-  ///
-  /// Note: To avoid missed notification it is best hold the related mutex
-  //        lock when calling notifyOne.
-  void notifyOne() { ConditionPlatformHelper::notifyOne(Handle); }
-
-  /// Notifies all waiters (if any exists) that the condition has been met.
-  ///
-  /// Note: To avoid missed notification it is best hold the related mutex
-  //        lock when calling notifyAll.
-  void notifyAll() { ConditionPlatformHelper::notifyAll(Handle); }
-
-private:
-  ConditionHandle Handle;
-};
-
-using ScopedNotifyOne = ScopedNotifyOneT<ConditionVariable>;
-using ScopedNotifyAll = ScopedNotifyAllT<ConditionVariable>;
-
 /// Compile time adjusted stack based object that locks/unlocks the supplied
 /// Mutex type. Use the provided typedefs instead of this directly.
 template <typename T, bool Inverted> class ScopedLockT {
@@ -136,28 +102,221 @@ private:
   T &Lock;
 };
 
-class Mutex;
-class ConditionMutex;
-class StaticMutex;
-class StaticConditionMutex;
+/// A ConditionVariable that works with Mutex to allow -- as an example --
+/// multi-threaded producers and consumers to signal each other in a safe way.
+class ConditionVariable {
+  friend class ConditionMutex;
+  friend class StaticConditionVariable;
 
-/// A stack based object that locks the supplied mutex on construction
-/// and unlocks it on destruction.
-///
-/// Precondition: Mutex unlocked by this thread, undefined otherwise.
-typedef ScopedLockT<Mutex, false> ScopedLock;
-typedef ScopedLockT<ConditionMutex, false> ConditionScopedLock;
-typedef ScopedLockT<StaticMutex, false> StaticScopedLock;
-typedef ScopedLockT<StaticConditionMutex, false> StaticConditionScopedLock;
+  ConditionVariable(const ConditionVariable &) = delete;
+  ConditionVariable &operator=(const ConditionVariable &) = delete;
+  ConditionVariable(ConditionVariable &&) = delete;
+  ConditionVariable &operator=(ConditionVariable &&) = delete;
 
-/// A stack based object that unlocks the supplied mutex on construction
-/// and relocks it on destruction.
-///
-/// Precondition: Mutex locked by this thread, undefined otherwise.
-typedef ScopedLockT<Mutex, true> ScopedUnlock;
-typedef ScopedLockT<ConditionMutex, true> ConditionScopedUnlock;
-typedef ScopedLockT<StaticMutex, true> StaticScopedUnlock;
-typedef ScopedLockT<StaticConditionMutex, true> StaticConditionScopedUnlock;
+public:
+  ConditionVariable() { ConditionPlatformHelper::init(Handle); }
+  ~ConditionVariable() { ConditionPlatformHelper::destroy(Handle); }
+
+  /// Notifies one waiter (if any exists) that the condition has been met.
+  ///
+  /// Note: To avoid missed notification it is best hold the related mutex
+  //        lock when calling notifyOne.
+  void notifyOne() { ConditionPlatformHelper::notifyOne(Handle); }
+
+  /// Notifies all waiters (if any exists) that the condition has been met.
+  ///
+  /// Note: To avoid missed notification it is best hold the related mutex
+  //        lock when calling notifyAll.
+  void notifyAll() { ConditionPlatformHelper::notifyAll(Handle); }
+
+private:
+  ConditionHandle Handle;
+
+public:
+  /// A Mutex object that also supports ConditionVariables.
+  ///
+  /// This is NOT a recursive mutex.
+  class Mutex {
+
+    Mutex(const Mutex &) = delete;
+    Mutex &operator=(const Mutex &) = delete;
+    Mutex(Mutex &&) = delete;
+    Mutex &operator=(Mutex &&) = delete;
+
+  public:
+    /// Constructs a non-recursive mutex.
+    ///
+    /// If `checked` is true the mutex will attempt to check for misuse and
+    /// fatalError when detected. If `checked` is false (the default) the
+    /// mutex will make little to no effort to check for misuse (more
+    /// efficient).
+    explicit Mutex(bool checked = false) {
+      MutexPlatformHelper::init(Handle, checked);
+    }
+    ~Mutex() { MutexPlatformHelper::destroy(Handle); }
+
+    /// The lock() method has the following properties:
+    /// - Behaves as an atomic operation.
+    /// - Blocks the calling thread until exclusive ownership of the mutex
+    ///   can be obtained.
+    /// - Prior m.unlock() operations on the same mutex synchronize-with
+    ///   this lock operation.
+    /// - The behavior is undefined if the calling thread already owns
+    ///   the mutex (likely a deadlock).
+    /// - Does not throw exceptions but will halt on error (fatalError).
+    void lock() { MutexPlatformHelper::lock(Handle); }
+
+    /// The unlock() method has the following properties:
+    /// - Behaves as an atomic operation.
+    /// - Releases the calling thread's ownership of the mutex and
+    ///   synchronizes-with the subsequent successful lock operations on
+    ///   the same object.
+    /// - The behavior is undefined if the calling thread does not own
+    ///   the mutex.
+    /// - Does not throw exceptions but will halt on error (fatalError).
+    void unlock() { MutexPlatformHelper::unlock(Handle); }
+
+    /// The try_lock() method has the following properties:
+    /// - Behaves as an atomic operation.
+    /// - Attempts to obtain exclusive ownership of the mutex for the calling
+    ///   thread without blocking. If ownership is not obtained, returns
+    ///   immediately. The function is allowed to spuriously fail and return
+    ///   even if the mutex is not currently owned by another thread.
+    /// - If try_lock() succeeds, prior unlock() operations on the same object
+    ///   synchronize-with this operation. lock() does not synchronize with a
+    ///   failed try_lock()
+    /// - The behavior is undefined if the calling thread already owns
+    ///   the mutex (likely a deadlock)?
+    /// - Does not throw exceptions but will halt on error (fatalError).
+    bool try_lock() { return MutexPlatformHelper::try_lock(Handle); }
+
+    /// Releases lock, waits on supplied condition, and relocks before
+    /// returning.
+    ///
+    /// Precondition: Mutex held by this thread, undefined otherwise.
+    void wait(ConditionVariable &condition) {
+      ConditionPlatformHelper::wait(condition.Handle, Handle);
+    }
+
+    /// Acquires lock before calling the supplied critical section and releases
+    /// lock on return from critical section.
+    ///
+    /// This call can block while waiting for the lock to become available.
+    ///
+    /// For example the following mutates value while holding the mutex lock.
+    ///
+    /// ```
+    ///   mutex.lock([&value] { value++; });
+    /// ```
+    ///
+    /// Precondition: Mutex not held by this thread, undefined otherwise.
+    template <typename CriticalSection>
+    auto withLock(CriticalSection criticalSection)
+        -> decltype(criticalSection()) {
+      ScopedLock guard(*this);
+      return criticalSection();
+    }
+
+    /// Acquires lock before calling the supplied critical section. If critical
+    /// section returns `false` then it will wait on the supplied condition and
+    /// call the critical section again when wait returns (after acquiring
+    /// lock). If critical section returns `true` (done) it will no longer wait,
+    /// it will release the lock and return (lockOrWait returns to caller).
+    ///
+    /// This call can block while waiting for the lock to become available.
+    ///
+    /// For example the following will loop waiting on the condition until
+    /// `value > 0`. It will then "consume" that value and stop looping.
+    /// ...all while being correctly protected by mutex.
+    ///
+    /// ```
+    ///   mutex.withLockOrWait(condition, [&value] {
+    ///     if (value > 0) {
+    ///       value--;
+    ///       return true;
+    ///     }
+    ///    return false;
+    ///   });
+    /// ```
+    ///
+    /// Precondition: Mutex not held by this thread, undefined otherwise.
+    template <typename CriticalSection>
+    void withLockOrWait(ConditionVariable &condition,
+                        CriticalSection criticalSection) {
+      withLock([&] {
+        while (!criticalSection()) {
+          wait(condition);
+        }
+      });
+    }
+
+    /// Acquires lock before calling the supplied critical section and on return
+    /// from critical section it notifies one waiter of supplied condition and
+    /// then releases the lock.
+    ///
+    /// This call can block while waiting for the lock to become available.
+    ///
+    /// For example the following mutates value while holding the mutex lock and
+    /// then notifies one condition waiter about this change.
+    ///
+    /// ```
+    ///   mutex.withLockThenNotifyOne(condition, [&value] { value++; });
+    /// ```
+    ///
+    /// Precondition: Mutex not held by this thread, undefined otherwise.
+    template <typename CriticalSection>
+    auto withLockThenNotifyOne(ConditionVariable &condition,
+                               CriticalSection criticalSection)
+        -> decltype(criticalSection()) {
+      return withLock([&] {
+        ScopedNotifyOne guard(condition);
+        return criticalSection();
+      });
+    }
+
+    /// Acquires lock before calling the supplied critical section and on return
+    /// from critical section it notifies all waiters of supplied condition and
+    /// then releases the lock.
+    ///
+    /// This call can block while waiting for the lock to become available.
+    ///
+    /// For example the following mutates value while holding the mutex lock and
+    /// then notifies all condition waiters about this change.
+    ///
+    /// ```
+    ///   mutex.withLockThenNotifyAll(condition, [&value] { value++; });
+    /// ```
+    ///
+    /// Precondition: Mutex not held by this thread, undefined otherwise.
+    template <typename CriticalSection>
+    auto withLockThenNotifyAll(ConditionVariable &condition,
+                               CriticalSection criticalSection)
+        -> decltype(criticalSection()) {
+      return withLock([&] {
+        ScopedNotifyAll guard(condition);
+        return criticalSection();
+      });
+    }
+
+    /// A stack based object that locks the supplied mutex on construction
+    /// and unlocks it on destruction.
+    ///
+    /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+    typedef ScopedLockT<Mutex, false> ScopedLock;
+
+    /// A stack based object that unlocks the supplied mutex on construction
+    /// and relocks it on destruction.
+    ///
+    /// Precondition: Mutex locked by this thread, undefined otherwise.
+    typedef ScopedLockT<Mutex, true> ScopedUnlock;
+
+  private:
+    ConditionMutexHandle Handle;
+  };
+
+  using ScopedNotifyOne = ScopedNotifyOneT<ConditionVariable>;
+  using ScopedNotifyAll = ScopedNotifyAllT<ConditionVariable>;
+};
 
 /// A Mutex object that supports `BasicLockable` and `Lockable` C++ concepts.
 /// See http://en.cppreference.com/w/cpp/concept/BasicLockable
@@ -236,174 +395,20 @@ public:
     return criticalSection();
   }
 
+  /// A stack based object that locks the supplied mutex on construction
+  /// and unlocks it on destruction.
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  typedef ScopedLockT<Mutex, false> ScopedLock;
+
+  /// A stack based object that unlocks the supplied mutex on construction
+  /// and relocks it on destruction.
+  ///
+  /// Precondition: Mutex locked by this thread, undefined otherwise.
+  typedef ScopedLockT<Mutex, true> ScopedUnlock;
+
 private:
   MutexHandle Handle;
-};
-
-/// A Mutex object that also supports ConditionVariables.
-///
-/// This is NOT a recursive mutex.
-class ConditionMutex {
-
-  ConditionMutex(const ConditionMutex &) = delete;
-  ConditionMutex &operator=(const ConditionMutex &) = delete;
-  ConditionMutex(ConditionMutex &&) = delete;
-  ConditionMutex &operator=(ConditionMutex &&) = delete;
-
-public:
-  /// Constructs a non-recursive mutex.
-  ///
-  /// If `checked` is true the mutex will attempt to check for misuse and
-  /// fatalError when detected. If `checked` is false (the default) the
-  /// mutex will make little to no effort to check for misuse (more efficient).
-  explicit ConditionMutex(bool checked = false) {
-    MutexPlatformHelper::init(Handle, checked);
-  }
-  ~ConditionMutex() { MutexPlatformHelper::destroy(Handle); }
-
-  /// The lock() method has the following properties:
-  /// - Behaves as an atomic operation.
-  /// - Blocks the calling thread until exclusive ownership of the mutex
-  ///   can be obtained.
-  /// - Prior m.unlock() operations on the same mutex synchronize-with
-  ///   this lock operation.
-  /// - The behavior is undefined if the calling thread already owns
-  ///   the mutex (likely a deadlock).
-  /// - Does not throw exceptions but will halt on error (fatalError).
-  void lock() { MutexPlatformHelper::lock(Handle); }
-
-  /// The unlock() method has the following properties:
-  /// - Behaves as an atomic operation.
-  /// - Releases the calling thread's ownership of the mutex and
-  ///   synchronizes-with the subsequent successful lock operations on
-  ///   the same object.
-  /// - The behavior is undefined if the calling thread does not own
-  ///   the mutex.
-  /// - Does not throw exceptions but will halt on error (fatalError).
-  void unlock() { MutexPlatformHelper::unlock(Handle); }
-
-  /// The try_lock() method has the following properties:
-  /// - Behaves as an atomic operation.
-  /// - Attempts to obtain exclusive ownership of the mutex for the calling
-  ///   thread without blocking. If ownership is not obtained, returns
-  ///   immediately. The function is allowed to spuriously fail and return
-  ///   even if the mutex is not currently owned by another thread.
-  /// - If try_lock() succeeds, prior unlock() operations on the same object
-  ///   synchronize-with this operation. lock() does not synchronize with a
-  ///   failed try_lock()
-  /// - The behavior is undefined if the calling thread already owns
-  ///   the mutex (likely a deadlock)?
-  /// - Does not throw exceptions but will halt on error (fatalError).
-  bool try_lock() { return MutexPlatformHelper::try_lock(Handle); }
-
-  /// Releases lock, waits on supplied condition, and relocks before returning.
-  ///
-  /// Precondition: Mutex held by this thread, undefined otherwise.
-  void wait(ConditionVariable &condition) {
-    ConditionPlatformHelper::wait(condition.Handle, Handle);
-  }
-
-  /// Acquires lock before calling the supplied critical section and releases
-  /// lock on return from critical section.
-  ///
-  /// This call can block while waiting for the lock to become available.
-  ///
-  /// For example the following mutates value while holding the mutex lock.
-  ///
-  /// ```
-  ///   mutex.lock([&value] { value++; });
-  /// ```
-  ///
-  /// Precondition: Mutex not held by this thread, undefined otherwise.
-  template <typename CriticalSection>
-  auto withLock(CriticalSection criticalSection) -> decltype(criticalSection()){
-    ConditionScopedLock guard(*this);
-    return criticalSection();
-  }
-
-  /// Acquires lock before calling the supplied critical section. If critical
-  /// section returns `false` then it will wait on the supplied condition and
-  /// call the critical section again when wait returns (after acquiring lock).
-  /// If critical section returns `true` (done) it will no longer wait, it
-  /// will release the lock and return (lockOrWait returns to caller).
-  ///
-  /// This call can block while waiting for the lock to become available.
-  ///
-  /// For example the following will loop waiting on the condition until
-  /// `value > 0`. It will then "consume" that value and stop looping.
-  /// ...all while being correctly protected by mutex.
-  ///
-  /// ```
-  ///   mutex.withLockOrWait(condition, [&value] {
-  ///     if (value > 0) {
-  ///       value--;
-  ///       return true;
-  ///     }
-  ///    return false;
-  ///   });
-  /// ```
-  ///
-  /// Precondition: Mutex not held by this thread, undefined otherwise.
-  template <typename CriticalSection>
-  void withLockOrWait(ConditionVariable &condition,
-                      CriticalSection criticalSection) {
-    withLock([&] {
-      while (!criticalSection()) {
-        wait(condition);
-      }
-    });
-  }
-
-  /// Acquires lock before calling the supplied critical section and on return
-  /// from critical section it notifies one waiter of supplied condition and
-  /// then releases the lock.
-  ///
-  /// This call can block while waiting for the lock to become available.
-  ///
-  /// For example the following mutates value while holding the mutex lock and
-  /// then notifies one condition waiter about this change.
-  ///
-  /// ```
-  ///   mutex.withLockThenNotifyOne(condition, [&value] { value++; });
-  /// ```
-  ///
-  /// Precondition: Mutex not held by this thread, undefined otherwise.
-  template <typename CriticalSection>
-  auto withLockThenNotifyOne(ConditionVariable &condition,
-                             CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
-    return withLock([&] {
-      ScopedNotifyOne guard(condition);
-      return criticalSection();
-    });
-  }
-
-  /// Acquires lock before calling the supplied critical section and on return
-  /// from critical section it notifies all waiters of supplied condition and
-  /// then releases the lock.
-  ///
-  /// This call can block while waiting for the lock to become available.
-  ///
-  /// For example the following mutates value while holding the mutex lock and
-  /// then notifies all condition waiters about this change.
-  ///
-  /// ```
-  ///   mutex.withLockThenNotifyAll(condition, [&value] { value++; });
-  /// ```
-  ///
-  /// Precondition: Mutex not held by this thread, undefined otherwise.
-  template <typename CriticalSection>
-  auto withLockThenNotifyAll(ConditionVariable &condition,
-                             CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
-    return withLock([&] {
-      ScopedNotifyAll guard(condition);
-      return criticalSection();
-    });
-  }
-
-private:
-  ConditionMutexHandle Handle;
 };
 
 /// Compile time adjusted stack based object that locks/unlocks the supplied
@@ -642,8 +647,6 @@ private:
 ///
 /// Use ConditionVariable instead unless you need static allocation.
 class StaticConditionVariable {
-  friend class StaticConditionMutex;
-
   StaticConditionVariable(const StaticConditionVariable &) = delete;
   StaticConditionVariable &operator=(const StaticConditionVariable &) = delete;
   StaticConditionVariable(StaticConditionVariable &&) = delete;
@@ -663,12 +666,104 @@ public:
   /// See ConditionVariable::notifyAll
   void notifyAll() { ConditionPlatformHelper::notifyAll(Handle); }
 
+  using ScopedNotifyOne = ScopedNotifyOneT<StaticConditionVariable>;
+  using ScopedNotifyAll = ScopedNotifyAllT<StaticConditionVariable>;
+
+  /// A static allocation variant of ConditionVariable::Mutex.
+  ///
+  /// Use ConditionVariable::Mutex instead unless you need static allocation.
+  class StaticMutex {
+
+    StaticMutex(const StaticMutex &) = delete;
+    StaticMutex &operator=(const StaticMutex &) = delete;
+    StaticMutex(StaticMutex &&) = delete;
+    StaticMutex &operator=(StaticMutex &&) = delete;
+
+  public:
+#if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
+    constexpr
+#endif
+        StaticMutex()
+        : Handle(MutexPlatformHelper::conditionStaticInit()) {
+    }
+
+    /// See Mutex::lock
+    void lock() { MutexPlatformHelper::lock(Handle); }
+
+    /// See Mutex::unlock
+    void unlock() { MutexPlatformHelper::unlock(Handle); }
+
+    /// See Mutex::try_lock
+    bool try_lock() { return MutexPlatformHelper::try_lock(Handle); }
+
+    /// See Mutex::wait
+    void wait(StaticConditionVariable &condition) {
+      ConditionPlatformHelper::wait(condition.Handle, Handle);
+    }
+    void wait(ConditionVariable &condition) {
+      ConditionPlatformHelper::wait(condition.Handle, Handle);
+    }
+
+    /// See Mutex::lock
+    template <typename CriticalSection>
+    auto withLock(CriticalSection criticalSection)
+        -> decltype(criticalSection()) {
+      ScopedLock guard(*this);
+      return criticalSection();
+    }
+
+    /// See Mutex::withLockOrWait
+    template <typename CriticalSection>
+    void withLockOrWait(StaticConditionVariable &condition,
+                        CriticalSection criticalSection) {
+      withLock([&] {
+        while (!criticalSection()) {
+          wait(condition);
+        }
+      });
+    }
+
+    /// See Mutex::withLockThenNotifyOne
+    template <typename CriticalSection>
+    auto withLockThenNotifyOne(StaticConditionVariable &condition,
+                               CriticalSection criticalSection)
+        -> decltype(criticalSection()) {
+      return withLock([&] {
+        StaticConditionVariable::ScopedNotifyOne guard(condition);
+        return criticalSection();
+      });
+    }
+
+    /// See Mutex::withLockThenNotifyAll
+    template <typename CriticalSection>
+    auto withLockThenNotifyAll(StaticConditionVariable &condition,
+                               CriticalSection criticalSection)
+        -> decltype(criticalSection()) {
+      return withLock([&] {
+        StaticConditionVariable::ScopedNotifyAll guard(condition);
+        return criticalSection();
+      });
+    }
+
+    /// A stack based object that locks the supplied mutex on construction
+    /// and unlocks it on destruction.
+    ///
+    /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+    typedef ScopedLockT<StaticMutex, false> ScopedLock;
+
+    /// A stack based object that unlocks the supplied mutex on construction
+    /// and relocks it on destruction.
+    ///
+    /// Precondition: Mutex locked by this thread, undefined otherwise.
+    typedef ScopedLockT<StaticMutex, true> ScopedUnlock;
+
+  private:
+    ConditionMutexHandle Handle;
+  };
+
 private:
   ConditionHandle Handle;
 };
-
-using StaticScopedNotifyOne = ScopedNotifyOneT<StaticConditionVariable>;
-using StaticScopedNotifyAll = ScopedNotifyAllT<StaticConditionVariable>;
 
 /// A static allocation variant of Mutex.
 ///
@@ -701,91 +796,24 @@ public:
   template <typename CriticalSection>
   auto withLock(CriticalSection criticalSection)
       -> decltype(criticalSection()) {
-    StaticScopedLock guard(*this);
+    ScopedLock guard(*this);
     return criticalSection();
   }
+
+  /// A stack based object that locks the supplied mutex on construction
+  /// and unlocks it on destruction.
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  typedef ScopedLockT<StaticMutex, false> ScopedLock;
+
+  /// A stack based object that unlocks the supplied mutex on construction
+  /// and relocks it on destruction.
+  ///
+  /// Precondition: Mutex locked by this thread, undefined otherwise.
+  typedef ScopedLockT<StaticMutex, true> ScopedUnlock;
 
 private:
   MutexHandle Handle;
-};
-
-/// A static allocation variant of ConditionMutex.
-///
-/// Use ConditionMutex instead unless you need static allocation.
-class StaticConditionMutex {
-
-  StaticConditionMutex(const StaticMutex &) = delete;
-  StaticConditionMutex &operator=(const StaticMutex &) = delete;
-  StaticConditionMutex(StaticMutex &&) = delete;
-  StaticConditionMutex &operator=(StaticMutex &&) = delete;
-
-public:
-#if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
-  constexpr
-#endif
-      StaticConditionMutex()
-      : Handle(MutexPlatformHelper::conditionStaticInit()) {
-  }
-
-  /// See Mutex::lock
-  void lock() { MutexPlatformHelper::lock(Handle); }
-
-  /// See Mutex::unlock
-  void unlock() { MutexPlatformHelper::unlock(Handle); }
-
-  /// See Mutex::try_lock
-  bool try_lock() { return MutexPlatformHelper::try_lock(Handle); }
-
-  /// See Mutex::wait
-  void wait(StaticConditionVariable &condition) {
-    ConditionPlatformHelper::wait(condition.Handle, Handle);
-  }
-  void wait(ConditionVariable &condition) {
-    ConditionPlatformHelper::wait(condition.Handle, Handle);
-  }
-
-  /// See Mutex::lock
-  template <typename CriticalSection>
-  auto withLock(CriticalSection criticalSection) -> decltype(criticalSection()){
-    StaticConditionScopedLock guard(*this);
-    return criticalSection();
-  }
-
-  /// See Mutex::withLockOrWait
-  template <typename CriticalSection>
-  void withLockOrWait(StaticConditionVariable &condition,
-                      CriticalSection criticalSection) {
-    withLock([&] {
-      while (!criticalSection()) {
-        wait(condition);
-      }
-    });
-  }
-
-  /// See Mutex::withLockThenNotifyOne
-  template <typename CriticalSection>
-  auto withLockThenNotifyOne(StaticConditionVariable &condition,
-                             CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
-    return withLock([&] {
-      StaticScopedNotifyOne guard(condition);
-      return criticalSection();
-    });
-  }
-
-  /// See Mutex::withLockThenNotifyAll
-  template <typename CriticalSection>
-  auto withLockThenNotifyAll(StaticConditionVariable &condition,
-                             CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
-    return withLock([&] {
-      StaticScopedNotifyAll guard(condition);
-      return criticalSection();
-    });
-  }
-
-private:
-  ConditionMutexHandle Handle;
 };
 
 /// A static allocation variant of ReadWriteLock.
@@ -914,6 +942,18 @@ public:
   void unlock() { Ptr->unlock(); }
 
   bool try_lock() { return Ptr->try_lock(); }
+
+  /// A stack based object that locks the supplied mutex on construction
+  /// and unlocks it on destruction.
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  typedef ScopedLockT<IndirectMutex, false> ScopedLock;
+
+  /// A stack based object that unlocks the supplied mutex on construction
+  /// and relocks it on destruction.
+  ///
+  /// Precondition: Mutex locked by this thread, undefined otherwise.
+  typedef ScopedLockT<IndirectMutex, true> ScopedUnlock;
 
 private:
   Mutex *Ptr;

--- a/include/swift/Runtime/MutexPThread.h
+++ b/include/swift/Runtime/MutexPThread.h
@@ -20,11 +20,22 @@
 
 #include <pthread.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+#include <os/lock.h>
+#define HAS_OS_UNFAIR_LOCK 1
+#endif
+
 namespace swift {
 
 typedef pthread_cond_t ConditionHandle;
-typedef pthread_mutex_t MutexHandle;
+typedef pthread_mutex_t ConditionMutexHandle;
 typedef pthread_rwlock_t ReadWriteLockHandle;
+
+#if HAS_OS_UNFAIR_LOCK
+typedef os_unfair_lock MutexHandle;
+#else
+typedef pthread_mutex_t MutexHandle;
+#endif
 
 #if defined(__CYGWIN__) || defined(__ANDROID__) || defined(__HAIKU__) || defined(__wasi__)
 // At the moment CYGWIN pthreads implementation doesn't support the use of
@@ -59,7 +70,7 @@ struct ConditionPlatformHelper {
   static void destroy(ConditionHandle &condition);
   static void notifyOne(ConditionHandle &condition);
   static void notifyAll(ConditionHandle &condition);
-  static void wait(ConditionHandle &condition, MutexHandle &mutex);
+  static void wait(ConditionHandle &condition, ConditionMutexHandle &mutex);
 };
 
 /// PThread low-level implementation that supports Mutex
@@ -72,21 +83,48 @@ struct MutexPlatformHelper {
 #else
   static
 #endif
-      MutexHandle
-      staticInit() {
+      ConditionMutexHandle
+      conditionStaticInit() {
     return PTHREAD_MUTEX_INITIALIZER;
   };
+#if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
+  static constexpr
+#else
+  static
+#endif
+  MutexHandle
+  staticInit() {
+#if HAS_OS_UNFAIR_LOCK
+    return OS_UNFAIR_LOCK_INIT;
+#else
+    return PTHREAD_MUTEX_INITIALIZER;
+#endif  
+  }
+  static void init(ConditionMutexHandle &mutex, bool checked = false);
+  static void destroy(ConditionMutexHandle &mutex);
+  static void lock(ConditionMutexHandle &mutex);
+  static void unlock(ConditionMutexHandle &mutex);
+  static bool try_lock(ConditionMutexHandle &mutex);
+
+  // The ConditionMutexHandle versions handle everything on-Apple platforms.
+#if HAS_OS_UNFAIR_LOCK
+
   static void init(MutexHandle &mutex, bool checked = false);
   static void destroy(MutexHandle &mutex);
   static void lock(MutexHandle &mutex);
   static void unlock(MutexHandle &mutex);
   static bool try_lock(MutexHandle &mutex);
 
+  // os_unfair_lock always checks for errors, so just call through.
+  static void unsafeLock(MutexHandle &mutex) { lock(mutex); }
+  static void unsafeUnlock(MutexHandle &mutex) { unlock(mutex); }
+#endif
+
   // The unsafe versions don't do error checking.
-  static void unsafeLock(MutexHandle &mutex) {
+  static void unsafeLock(ConditionMutexHandle &mutex) {
     (void)pthread_mutex_lock(&mutex);
   }
-  static void unsafeUnlock(MutexHandle &mutex) {
+  static void unsafeUnlock(ConditionMutexHandle &mutex) {
     (void)pthread_mutex_unlock(&mutex);
   }
 };

--- a/include/swift/Runtime/MutexSingleThreaded.h
+++ b/include/swift/Runtime/MutexSingleThreaded.h
@@ -22,6 +22,7 @@
 namespace swift {
 
 typedef void* ConditionHandle;
+typedef void* ConditionMutexHandle;
 typedef void* MutexHandle;
 typedef void* ReadWriteLockHandle;
 
@@ -44,6 +45,9 @@ struct ConditionPlatformHelper {
 
 struct MutexPlatformHelper {
   static constexpr MutexHandle staticInit() { return nullptr; }
+  static constexpr ConditionMutexHandle conditionStaticInit() {
+    return nullptr;
+  }
   static void init(MutexHandle &mutex, bool checked = false) {}
   static void destroy(MutexHandle &mutex) {}
   static void lock(MutexHandle &mutex) {}

--- a/include/swift/Runtime/MutexWin32.h
+++ b/include/swift/Runtime/MutexWin32.h
@@ -25,6 +25,7 @@
 namespace swift {
 
 typedef CONDITION_VARIABLE ConditionHandle;
+typedef SRWLOCK ConditionMutexHandle;
 typedef SRWLOCK MutexHandle;
 typedef SRWLOCK ReadWriteLockHandle;
 
@@ -51,6 +52,9 @@ struct ConditionPlatformHelper {
 
 struct MutexPlatformHelper {
   static constexpr MutexHandle staticInit() { return SRWLOCK_INIT; }
+  static constexpr ConditionMutexHandle conditionStaticInit() {
+    return SRWLOCK_INIT;
+  }
   static void init(MutexHandle &mutex, bool checked = false) {
     InitializeSRWLock(&mutex);
   }

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -28,7 +28,7 @@ using namespace swift;
 
 /// A lock used to protect management of task-specific status
 /// record locks.
-static StaticMutex StatusRecordLockLock;
+static StaticConditionMutex StatusRecordLockLock;
 
 namespace {
 
@@ -91,13 +91,13 @@ public:
   }
 
   /// Wait on the queue until there's an unlock.
-  void waitForUnlock(StaticScopedLock &globalLock) {
+  void waitForUnlock(StaticConditionScopedLock &globalLock) {
     assert(Locked);
 
     // Flag that we're waiting, then drop the global lock.
     NumUnlockWaiters++;
     {
-      StaticScopedLock globalUnlock(StatusRecordLockLock);
+      StaticConditionScopedLock globalUnlock(StatusRecordLockLock);
 
       // Attempt to acquire the locking-thread lock, thereby
       // waiting until the locking thread unlocks the record.
@@ -121,7 +121,7 @@ public:
   /// Wake up any threads that were waiting for unlock.  Must be
   /// called by the locking thread.
   void unlock() {
-    StaticScopedLock globalLock(StatusRecordLockLock);
+    StaticConditionScopedLock globalLock(StatusRecordLockLock);
     assert(Locked);
     Locked = false;
 
@@ -158,7 +158,7 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
   assert(oldStatus.isLocked());
 
   // Acquire the lock.
-  StaticScopedLock globalLock(StatusRecordLockLock);
+  StaticConditionScopedLock globalLock(StatusRecordLockLock);
 
   while (true) {
     // Check that oldStatus is still correct.

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -28,7 +28,7 @@ using namespace swift;
 
 /// A lock used to protect management of task-specific status
 /// record locks.
-static StaticConditionMutex StatusRecordLockLock;
+static StaticConditionVariable::StaticMutex StatusRecordLockLock;
 
 namespace {
 
@@ -91,18 +91,20 @@ public:
   }
 
   /// Wait on the queue until there's an unlock.
-  void waitForUnlock(StaticConditionScopedLock &globalLock) {
+  void
+  waitForUnlock(StaticConditionVariable::StaticMutex::ScopedLock &globalLock) {
     assert(Locked);
 
     // Flag that we're waiting, then drop the global lock.
     NumUnlockWaiters++;
     {
-      StaticConditionScopedLock globalUnlock(StatusRecordLockLock);
+      StaticConditionVariable::StaticMutex::ScopedUnlock globalUnlock(
+          StatusRecordLockLock);
 
       // Attempt to acquire the locking-thread lock, thereby
       // waiting until the locking thread unlocks the record.
       {
-        ScopedLock acquirePrivateLock(LockingThreadLock);
+        Mutex::ScopedLock acquirePrivateLock(LockingThreadLock);
       }
 
       // Now reacquire the global lock.
@@ -121,7 +123,8 @@ public:
   /// Wake up any threads that were waiting for unlock.  Must be
   /// called by the locking thread.
   void unlock() {
-    StaticConditionScopedLock globalLock(StatusRecordLockLock);
+    StaticConditionVariable::StaticMutex::ScopedLock globalLock(
+        StatusRecordLockLock);
     assert(Locked);
     Locked = false;
 
@@ -158,7 +161,8 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
   assert(oldStatus.isLocked());
 
   // Acquire the lock.
-  StaticConditionScopedLock globalLock(StatusRecordLockLock);
+  StaticConditionVariable::StaticMutex::ScopedLock globalLock(
+      StatusRecordLockLock);
 
   while (true) {
     // Check that oldStatus is still correct.

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -100,7 +100,7 @@ enum class ConcurrencyRequest {
 };
 
 struct ConcurrencyControl {
-  Mutex Lock;
+  ConditionMutex Lock;
   ConditionVariable Queue;
 
   ConcurrencyControl() = default;

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -100,7 +100,7 @@ enum class ConcurrencyRequest {
 };
 
 struct ConcurrencyControl {
-  ConditionMutex Lock;
+  ConditionVariable::Mutex Lock;
   ConditionVariable Queue;
 
   ConcurrencyControl() = default;

--- a/stdlib/public/runtime/MutexPThread.cpp
+++ b/stdlib/public/runtime/MutexPThread.cpp
@@ -114,6 +114,29 @@ bool MutexPlatformHelper::try_lock(pthread_mutex_t &mutex) {
                           /* returnFalseOnEBUSY = */ true);
 }
 
+#if HAS_OS_UNFAIR_LOCK
+
+void MutexPlatformHelper::init(os_unfair_lock &lock, bool checked) {
+  (void)checked; // Unfair locks are always checked.
+  lock = OS_UNFAIR_LOCK_INIT;
+}
+
+void MutexPlatformHelper::destroy(os_unfair_lock &lock) {}
+
+void MutexPlatformHelper::lock(os_unfair_lock &lock) {
+  os_unfair_lock_lock(&lock);
+}
+
+void MutexPlatformHelper::unlock(os_unfair_lock &lock) {
+  os_unfair_lock_unlock(&lock);
+}
+
+bool MutexPlatformHelper::try_lock(os_unfair_lock &lock) {
+  return os_unfair_lock_trylock(&lock);
+}
+
+#endif
+
 void ReadWriteLockPlatformHelper::init(pthread_rwlock_t &rwlock) {
   reportError(pthread_rwlock_init(&rwlock, nullptr));
 }

--- a/unittests/runtime/Mutex.cpp
+++ b/unittests/runtime/Mutex.cpp
@@ -47,7 +47,7 @@ TEST(MutexTest, BasicLockableThreaded) {
 }
 
 TEST(ConditionMutexTest, BasicLockableThreaded) {
-  ConditionMutex mutex(/* checked = */ true);
+  ConditionVariable::Mutex mutex(/* checked = */ true);
   basicLockableThreaded(mutex);
 }
 
@@ -133,22 +133,22 @@ template <typename SL, typename M> void scopedLockThreaded(M &mutex) {
 
 TEST(MutexTest, ScopedLockThreaded) {
   Mutex mutex(/* checked = */ true);
-  scopedLockThreaded<ScopedLock>(mutex);
+  scopedLockThreaded<Mutex::ScopedLock>(mutex);
 }
 
 TEST(ConditionMutexTest, ScopedLockThreaded) {
-  ConditionMutex mutex(/* checked = */ true);
-  scopedLockThreaded<ConditionScopedLock>(mutex);
+  ConditionVariable::Mutex mutex(/* checked = */ true);
+  scopedLockThreaded<ConditionVariable::Mutex::ScopedLock>(mutex);
 }
 
 TEST(StaticMutexTest, ScopedLockThreaded) {
   static StaticMutex Mutex;
-  scopedLockThreaded<StaticScopedLock>(Mutex);
+  scopedLockThreaded<StaticMutex::ScopedLock>(Mutex);
 }
 
 TEST(StaticConditionMutexTest, ScopedLockThreaded) {
-  static StaticConditionMutex Mutex;
-  scopedLockThreaded<StaticConditionScopedLock>(Mutex);
+  static StaticConditionVariable::StaticMutex Mutex;
+  scopedLockThreaded<StaticConditionVariable::StaticMutex::ScopedLock>(Mutex);
 }
 
 TEST(SmallMutexTest, ScopedLockThreaded) {
@@ -181,31 +181,34 @@ void scopedUnlockUnderScopedLockThreaded(M &mutex) {
 
 TEST(MutexTest, ScopedUnlockUnderScopedLockThreaded) {
   Mutex mutex(/* checked = */ true);
-  scopedUnlockUnderScopedLockThreaded<ScopedLock, ScopedUnlock>(mutex);
+  scopedUnlockUnderScopedLockThreaded<Mutex::ScopedLock, Mutex::ScopedUnlock>(
+      mutex);
 }
 
 TEST(ConditionMutexTest, ScopedUnlockUnderScopedLockThreaded) {
-  ConditionMutex mutex(/* checked = */ true);
-  scopedUnlockUnderScopedLockThreaded<ConditionScopedLock,
-                                      ConditionScopedUnlock>(mutex);
+  ConditionVariable::Mutex mutex(/* checked = */ true);
+  scopedUnlockUnderScopedLockThreaded<ConditionVariable::Mutex::ScopedLock,
+                                      ConditionVariable::Mutex::ScopedUnlock>(
+      mutex);
 }
 
 TEST(StaticMutexTest, ScopedUnlockUnderScopedLockThreaded) {
   static StaticMutex Mutex;
-  scopedUnlockUnderScopedLockThreaded<StaticScopedLock, StaticScopedUnlock>(
-      Mutex);
+  scopedUnlockUnderScopedLockThreaded<StaticMutex::ScopedLock,
+                                      StaticMutex::ScopedUnlock>(Mutex);
 }
 
 TEST(StaticConditionMutexTest, ScopedUnlockUnderScopedLockThreaded) {
-  static StaticConditionMutex Mutex;
-  scopedUnlockUnderScopedLockThreaded<StaticConditionScopedLock,
-                                      StaticConditionScopedUnlock>(Mutex);
+  static StaticConditionVariable::StaticMutex Mutex;
+  scopedUnlockUnderScopedLockThreaded<
+      StaticConditionVariable::StaticMutex::ScopedLock,
+      StaticConditionVariable::StaticMutex::ScopedUnlock>(Mutex);
 }
 
 TEST(SmallMutexTest, ScopedUnlockUnderScopedLockThreaded) {
   SmallMutex mutex(/* checked = */ true);
-  scopedUnlockUnderScopedLockThreaded<ScopedLockT<SmallMutex, false>,
-                                      ScopedLockT<SmallMutex, true>>(mutex);
+  scopedUnlockUnderScopedLockThreaded<SmallMutex::ScopedLock,
+                                      SmallMutex::ScopedUnlock>(mutex);
 }
 
 template <typename M> void criticalSectionThreaded(M &mutex) {
@@ -232,7 +235,7 @@ TEST(MutexTest, CriticalSectionThreaded) {
 }
 
 TEST(ConditionMutexTest, CriticalSectionThreaded) {
-  ConditionMutex mutex(/* checked = */ true);
+  ConditionVariable::Mutex mutex(/* checked = */ true);
   criticalSectionThreaded(mutex);
 }
 
@@ -242,7 +245,7 @@ TEST(StaticMutexTest, CriticalSectionThreaded) {
 }
 
 TEST(StaticConditionMutexTest, CriticalSectionThreaded) {
-  static StaticConditionMutex Mutex;
+  static StaticConditionVariable::StaticMutex Mutex;
   criticalSectionThreaded(Mutex);
 }
 
@@ -290,16 +293,17 @@ void conditionThreaded(M &mutex, C &condition) {
 }
 
 TEST(MutexTest, ConditionThreaded) {
-  ConditionMutex mutex(/* checked = */ true);
+  ConditionVariable::Mutex mutex(/* checked = */ true);
   ConditionVariable condition;
-  conditionThreaded<ConditionScopedLock, ConditionScopedUnlock>(mutex,
-                                                                condition);
+  conditionThreaded<ConditionVariable::Mutex::ScopedLock,
+                    ConditionVariable::Mutex::ScopedUnlock>(mutex, condition);
 }
 
 TEST(StaticMutexTest, ConditionThreaded) {
-  static StaticConditionMutex mutex;
+  static StaticConditionVariable::StaticMutex mutex;
   static StaticConditionVariable condition;
-  conditionThreaded<StaticConditionScopedLock, StaticConditionScopedUnlock>(
+  conditionThreaded<StaticConditionVariable::StaticMutex::ScopedLock,
+                    StaticConditionVariable::StaticMutex::ScopedUnlock>(
       mutex, condition);
 }
 
@@ -347,17 +351,17 @@ void conditionLockOrWaitLockThenNotifyThreaded(M &mutex, C &condition) {
 }
 
 TEST(MutexTest, ConditionLockOrWaitLockThenNotifyThreaded) {
-  ConditionMutex mutex(/* checked = */ true);
+  ConditionVariable::Mutex mutex(/* checked = */ true);
   ConditionVariable condition;
-  conditionLockOrWaitLockThenNotifyThreaded<ConditionScopedUnlock>(mutex,
-                                                                   condition);
+  conditionLockOrWaitLockThenNotifyThreaded<
+      ConditionVariable::Mutex::ScopedUnlock>(mutex, condition);
 }
 
 TEST(StaticMutexTest, ConditionLockOrWaitLockThenNotifyThreaded) {
-  static StaticConditionMutex mutex;
+  static StaticConditionVariable::StaticMutex mutex;
   static StaticConditionVariable condition;
-  conditionLockOrWaitLockThenNotifyThreaded<StaticConditionScopedUnlock>(
-      mutex, condition);
+  conditionLockOrWaitLockThenNotifyThreaded<
+      StaticConditionVariable::StaticMutex::ScopedUnlock>(mutex, condition);
 }
 
 template <typename SRL, bool Locking, typename RW>

--- a/unittests/runtime/Mutex.cpp
+++ b/unittests/runtime/Mutex.cpp
@@ -46,7 +46,17 @@ TEST(MutexTest, BasicLockableThreaded) {
   basicLockableThreaded(mutex);
 }
 
+TEST(ConditionMutexTest, BasicLockableThreaded) {
+  ConditionMutex mutex(/* checked = */ true);
+  basicLockableThreaded(mutex);
+}
+
 TEST(StaticMutexTest, BasicLockableThreaded) {
+  static StaticMutex mutex;
+  basicLockableThreaded(mutex);
+}
+
+TEST(StaticConditionMutexTest, BasicLockableThreaded) {
   static StaticMutex mutex;
   basicLockableThreaded(mutex);
 }
@@ -126,9 +136,19 @@ TEST(MutexTest, ScopedLockThreaded) {
   scopedLockThreaded<ScopedLock>(mutex);
 }
 
+TEST(ConditionMutexTest, ScopedLockThreaded) {
+  ConditionMutex mutex(/* checked = */ true);
+  scopedLockThreaded<ConditionScopedLock>(mutex);
+}
+
 TEST(StaticMutexTest, ScopedLockThreaded) {
   static StaticMutex Mutex;
   scopedLockThreaded<StaticScopedLock>(Mutex);
+}
+
+TEST(StaticConditionMutexTest, ScopedLockThreaded) {
+  static StaticConditionMutex Mutex;
+  scopedLockThreaded<StaticConditionScopedLock>(Mutex);
 }
 
 TEST(SmallMutexTest, ScopedLockThreaded) {
@@ -164,10 +184,22 @@ TEST(MutexTest, ScopedUnlockUnderScopedLockThreaded) {
   scopedUnlockUnderScopedLockThreaded<ScopedLock, ScopedUnlock>(mutex);
 }
 
+TEST(ConditionMutexTest, ScopedUnlockUnderScopedLockThreaded) {
+  ConditionMutex mutex(/* checked = */ true);
+  scopedUnlockUnderScopedLockThreaded<ConditionScopedLock,
+                                      ConditionScopedUnlock>(mutex);
+}
+
 TEST(StaticMutexTest, ScopedUnlockUnderScopedLockThreaded) {
   static StaticMutex Mutex;
   scopedUnlockUnderScopedLockThreaded<StaticScopedLock, StaticScopedUnlock>(
       Mutex);
+}
+
+TEST(StaticConditionMutexTest, ScopedUnlockUnderScopedLockThreaded) {
+  static StaticConditionMutex Mutex;
+  scopedUnlockUnderScopedLockThreaded<StaticConditionScopedLock,
+                                      StaticConditionScopedUnlock>(Mutex);
 }
 
 TEST(SmallMutexTest, ScopedUnlockUnderScopedLockThreaded) {
@@ -199,8 +231,18 @@ TEST(MutexTest, CriticalSectionThreaded) {
   criticalSectionThreaded(mutex);
 }
 
+TEST(ConditionMutexTest, CriticalSectionThreaded) {
+  ConditionMutex mutex(/* checked = */ true);
+  criticalSectionThreaded(mutex);
+}
+
 TEST(StaticMutexTest, CriticalSectionThreaded) {
   static StaticMutex Mutex;
+  criticalSectionThreaded(Mutex);
+}
+
+TEST(StaticConditionMutexTest, CriticalSectionThreaded) {
+  static StaticConditionMutex Mutex;
   criticalSectionThreaded(Mutex);
 }
 
@@ -248,15 +290,17 @@ void conditionThreaded(M &mutex, C &condition) {
 }
 
 TEST(MutexTest, ConditionThreaded) {
-  Mutex mutex(/* checked = */ true);
+  ConditionMutex mutex(/* checked = */ true);
   ConditionVariable condition;
-  conditionThreaded<ScopedLock, ScopedUnlock>(mutex, condition);
+  conditionThreaded<ConditionScopedLock, ConditionScopedUnlock>(mutex,
+                                                                condition);
 }
 
 TEST(StaticMutexTest, ConditionThreaded) {
-  static StaticMutex mutex;
+  static StaticConditionMutex mutex;
   static StaticConditionVariable condition;
-  conditionThreaded<StaticScopedLock, StaticScopedUnlock>(mutex, condition);
+  conditionThreaded<StaticConditionScopedLock, StaticConditionScopedUnlock>(
+      mutex, condition);
 }
 
 template <typename SU, typename M, typename C>
@@ -303,16 +347,17 @@ void conditionLockOrWaitLockThenNotifyThreaded(M &mutex, C &condition) {
 }
 
 TEST(MutexTest, ConditionLockOrWaitLockThenNotifyThreaded) {
-  Mutex mutex(/* checked = */ true);
+  ConditionMutex mutex(/* checked = */ true);
   ConditionVariable condition;
-  conditionLockOrWaitLockThenNotifyThreaded<ScopedUnlock>(mutex, condition);
+  conditionLockOrWaitLockThenNotifyThreaded<ConditionScopedUnlock>(mutex,
+                                                                   condition);
 }
 
 TEST(StaticMutexTest, ConditionLockOrWaitLockThenNotifyThreaded) {
-  static StaticMutex mutex;
+  static StaticConditionMutex mutex;
   static StaticConditionVariable condition;
-  conditionLockOrWaitLockThenNotifyThreaded<StaticScopedUnlock>(mutex,
-                                                                condition);
+  conditionLockOrWaitLockThenNotifyThreaded<StaticConditionScopedUnlock>(
+      mutex, condition);
 }
 
 template <typename SRL, bool Locking, typename RW>


### PR DESCRIPTION
`os_unfair_lock` is much smaller than `pthread_mutex_t` (4 bytes versus 64) and a bit faster.

However, it doesn't support condition variables. Most of our uses of `Mutex` don't use condition variables, but a few do. Introduce `ConditionMutex` and `StaticConditionMutex`, which allow condition variables and continue to use `pthread_mutex_t`.

On all other platforms, we use the same backing mutex type for both `Mutex` and `ConditionMutex`.

rdar://problem/45412121