### PR TITLE
[re-apply][cxx-interop] Support class templates containing typedefs.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3255,6 +3255,10 @@ namespace {
         return nullptr;
       }
 
+      // TODO(SR-13809): fix this once we support dependent types.
+      if (decl->getTypeForDecl()->isDependentType())
+        return nullptr;
+
       // Don't import nominal types that are over-aligned.
       if (Impl.isOverAligned(decl))
         return nullptr;

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-typedef.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-typedef.h
@@ -1,0 +1,15 @@
+// Make sure that we can import a type that uses a "dependent type" after being
+// specialized (i.e. "size_type" in "Lander").
+template <class T> struct Lander;
+
+template <>
+struct Lander<void> {};
+
+template <class T> struct Lander {
+  typedef unsigned long size_type;
+  // Make sure we don't crash here. Before being specialized, "size_type" is
+  // technically a depedent type because it expands to "Lander<T>::size_type".
+  void test(size_type) { }
+};
+
+using Surveyor = Lander<char>;

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -53,3 +53,7 @@ module ClassTemplateNonTypeParameter {
 module ClassTemplateTemplateParameter {
   header "class-template-template-parameter.h"
 }
+
+module ClassTemplateWithTypedef {
+  header "class-template-with-typedef.h"
+}

--- a/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct __CxxTemplateInst6LanderIcE {
+// CHECK:   typealias size_type = {{UInt|UInt32}}
+// CHECK:   init()
+// CHECK:   mutating func test(_: {{UInt|UInt32}})
+// CHECK: }
+// CHECK: typealias Surveyor = __CxxTemplateInst6LanderIcE


### PR DESCRIPTION
This prevents an assertion in "isOverAligned" caused class templates that contain and use typedefs.

Re-landing 7f2b0aad2be0a3ed30ef831d4d883d2e4a1048fc after being reverted in 5ef0136356a6b03ab939db52409d2c7acae5bb7f.

Refs #34590 and #34557.