### PR TITLE
[cxx-interop] Don't crash for unkown inline-operator.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3650,7 +3650,7 @@ void ClangImporter::Implementation::lookupValue(
   if (name.isOperator()) {
     for (auto entry : table.lookupMemberOperators(name.getBaseName())) {
       if (isVisibleClangEntry(entry)) {
-        if (auto decl = dyn_cast<ValueDecl>(
+        if (auto decl = dyn_cast_or_null<ValueDecl>(
                 importDeclReal(entry->getMostRecentDecl(), CurrentVersion)))
           consumer.foundDecl(decl, DeclVisibilityKind::VisibleAtTopLevel);
       }

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -8,4 +8,8 @@ struct LoadableIntWrapper {
   }
 };
 
+struct HasDeletedOperator {
+  void operator!=(HasDeletedOperator) const = delete;
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -3,3 +3,6 @@
 // CHECK: struct LoadableIntWrapper {
 // CHECK:   static func - (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK: }
+
+// CHECK: struct HasDeletedOperator {
+// CHECK: }


### PR DESCRIPTION
Skip unknown or unimportable inline operators (such as deleted operator members) instead of crashing.