### PR TITLE
[ResultBuilders] Account for a fact that re-write of a statement can fail

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1158,6 +1158,12 @@ public:
             stmt,
             ResultBuilderTarget{ResultBuilderTarget::TemporaryVar,
                                   std::move(captured)});
+
+        // Re-write of statements that envolve type-checking
+        // could fail, such a failure terminates the walk.
+        if (!finalStmt)
+          return nullptr;
+
         newElements.push_back(finalStmt);
         continue;
       }
@@ -1512,7 +1518,7 @@ BraceStmt *swift::applyResultBuilderTransform(
           rewriteTarget) {
   BuilderClosureRewriter rewriter(solution, dc, applied, rewriteTarget);
   auto captured = rewriter.takeCapturedStmt(body);
-  return cast<BraceStmt>(
+  return cast_or_null<BraceStmt>(
     rewriter.visitBraceStmt(
       body,
       ResultBuilderTarget::forReturn(applied.returnExpr),

--- a/validation-test/Sema/SwiftUI/rdar70256351.swift
+++ b/validation-test/Sema/SwiftUI/rdar70256351.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct ContentView: View {
+  @State private var currentPage = "1"
+
+  var body: some View {
+    switch currentPage {
+    case 1: // expected-error {{expression pattern of type 'Int' cannot match values of type 'String'}}
+            // expected-note@-1 {{overloads for '~=' exist with these partially matching parameter lists: (Substring, String)}}
+      Text("1")
+    default:
+      Text("default")
+    }
+  }
+}


### PR DESCRIPTION
If one of the statements in the result builder body fails to
apply solution, let's fail entire rewrite attempt, otherwise
type-checker would end up with AST that has null pointers for
some child nodes.

Resolves: rdar://problem/70256351

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
