### PR TITLE
[Concurrency] Nurseries are now `Task.Group`s

### DIFF
--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -124,9 +124,8 @@ public:
 /// A status record which states that a task has one or
 /// more active child tasks.
 class ChildTaskStatusRecord : public TaskStatusRecord {
-  /// FIXME: should this be an array?  How are things like task
-  /// nurseries supposed to actually manage this?  Should it be
-  /// atomically moodifiable?
+  /// FIXME: should this be an array?  How are things like task groups supposed
+  /// to actually manage this?  Should it be atomically modifiable?
   AsyncTask *FirstChild;
 
 public:

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -19,7 +19,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   _TimeTypes.swift
   TaskAlloc.cpp
   TaskStatus.cpp
-  TaskNurseries.swift
+  TaskGroup.swift
   Mutex.cpp
 
   SWIFT_MODULE_DEPENDS_OSX Darwin

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -13,59 +13,67 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
-// ==== Task Nursery -----------------------------------------------------------
+// ==== Task Group -------------------------------------------------------------
 
 extension Task {
 
-  /// Starts a new nursery which provides a scope in which a dynamic number of
+  /// Starts a new task group which provides a scope in which a dynamic number of
   /// tasks may be spawned.
   ///
-  /// Tasks added to the nursery by `nursery.add()` will automatically be
-  /// awaited on when the scope exits.
+  /// Tasks added to the group by `group.add()` will automatically be awaited on
+  /// when the scope exits. If the group exits by throwing, all added tasks will
+  /// be cancelled and their results discarded.
   ///
   /// ### Implicit awaiting
-  /// When results of tasks added to the nursery need to be collected, one will
-  /// gather task's results using the `while let result = await nursery.next() { ... }`
-  /// pattern.
+  /// When results of tasks added to the group need to be collected, one can
+  /// gather their results using the following pattern:
+  ///
+  ///     while let result = await group.next() {
+  ///       // some accumulation logic (e.g. sum += result)
+  ///     }
   ///
   /// ### Cancellation
-  /// If any of the tasks throws the nursery and all of its tasks will be cancelled,
-  /// and the error will be re-thrown by `withNursery`.
+  /// If an error is thrown out of the task group, all of its remaining tasks
+  /// will be cancelled and the `withGroup` call will rethrow that error.
+  ///
+  /// Individual tasks throwing results in their corresponding `try group.next()`
+  /// call throwing, giving a chance to handle individual errors or letting the
+  /// error be rethrown by the group.
   ///
   /// Postcondition:
-  /// Once `withNursery` returns it is guaranteed that the *nursery* is *empty*.
+  /// Once `withGroup` returns it is guaranteed that the `group` is *empty*.
   ///
   /// This is achieved in the following way:
   /// - if the body returns normally:
-  ///   - the nursery will await any not yet complete tasks,
+  ///   - the group will await any not yet complete tasks,
   ///     - if any of those tasks throws, the remaining tasks will be cancelled,
-  ///   - once the `withNursery` returns the nursery is guaranteed to be empty.
+  ///   - once the `withGroup` returns the group is guaranteed to be empty.
   /// - if the body throws:
-  ///   - all tasks remaining in the nursery will be automatically cancelled.
-  ///
-  // TODO: Do we have to add a different nursery type to accommodate throwing
+  ///   - all tasks remaining in the group will be automatically cancelled.
+  // TODO: Do we have to add a different group type to accommodate throwing
   //       tasks without forcing users to use Result?  I can't think of how that
   //       could be propagated out of the callback body reasonably, unless we
   //       commit to doing multi-statement closure typechecking.
-  public static func withNursery<TaskResult, BodyResult>(
+  public static func withGroup<TaskResult, BodyResult>(
     resultType: TaskResult.Type,
     returning returnType: BodyResult.Type = BodyResult.self,
-    body: (inout Nursery<TaskResult>) async throws -> BodyResult
+    body: (inout Task.Group<TaskResult>) async throws -> BodyResult
   ) async rethrows -> BodyResult {
     fatalError("\(#function) not implemented yet.")
   }
 
-  /// A nursery provides a scope within which a dynamic number of tasks may be
-  /// started and added to the nursery.
+  /// A task group serves as storage for dynamically started tasks.
+  ///
+  /// Its intended use is with the
   /* @unmoveable */
-  public struct Nursery<TaskResult> {
+  public struct Group<TaskResult> {
     /// No public initializers
     private init() {}
 
     // Swift will statically prevent this type from being copied or moved.
     // For now, that implies that it cannot be used with generics.
 
-    /// Add a child task to the nursery.
+    /// Add a child task to the group.
     ///
     /// ### Error handling
     /// Operations are allowed to throw.
@@ -75,7 +83,7 @@ extension Task {
     ///
     /// - Parameters:
     ///   - overridingPriority: override priority of the operation task
-    ///   - operation: operation to execute and add to the nursery
+    ///   - operation: operation to execute and add to the group
     public mutating func add(
       overridingPriority: Priority? = nil,
       operation: () async throws -> TaskResult
@@ -86,11 +94,11 @@ extension Task {
     /// Add a child task and return a `Task.Handle` that can be used to manage it.
     ///
     /// The task's result is accessible either via the returned `handle` or the
-    /// `nursery.next()` function (as any other `add`-ed task).
+    /// `group.next()` function (as any other `add`-ed task).
     ///
     /// - Parameters:
     ///   - overridingPriority: override priority of the operation task
-    ///   - operation: operation to execute and add to the nursery
+    ///   - operation: operation to execute and add to the group
     public mutating func addWithHandle(
       overridingPriority: Priority? = nil,
       operation: () async throws -> TaskResult
@@ -106,20 +114,20 @@ extension Task {
       fatalError("\(#function) not implemented yet.")
     }
 
-    /// Query whether the nursery has any remaining tasks.
+    /// Query whether the group has any remaining tasks.
     ///
-    /// Nurseries are always empty upon entry to the `withNursery` body, and
-    /// become empty again when `withNursery` returns (either by awaiting on all
+    /// Task groups are always empty upon entry to the `withGroup` body, and
+    /// become empty again when `withGroup` returns (either by awaiting on all
     /// pending tasks or cancelling them).
     ///
-    /// - Returns: `true` if the nursery has no pending tasks, `false` otherwise.
+    /// - Returns: `true` if the group has no pending tasks, `false` otherwise.
     public var isEmpty: Bool {
       fatalError("\(#function) not implemented yet.")
     }
 
-    /// Cancel all the remaining tasks in the nursery.
+    /// Cancel all the remaining tasks in the group.
     ///
-    /// A cancelled nursery will not will NOT accept new tasks being added into it.
+    /// A cancelled group will not will NOT accept new tasks being added into it.
     ///
     /// Any results, including errors thrown by tasks affected by this
     /// cancellation, are silently discarded.


### PR DESCRIPTION
Rename as discussed in meeting @DougGregor @rjmccall 

We decided to use `Task.Group` for now rather than the confusing `Nursery` term.

I also considered calling the type `ScopedGroup` because it is only to be used with `Task.withGroup { ...` and there may be a new one which we'd allow to store; and that one would be a normal Group or something similar perhaps. But we've not done that yet so not jumping ahead just yet. This will be better to work on once we have the basic infra working.

rdar://70141994

