### PR TITLE
[ownership] Now that we allow reborrows eliminate isForwardingSubValue it is dead.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -692,12 +692,8 @@ public:
   /// potentially have to the UseLifetimeConstraint associated with that
   /// ownership kind
   ///
-  /// NOTE: This is implemented in OperandOwnershipKindMapClassifier.cpp.
-  ///
-  /// NOTE: The default argument isSubValue is a temporary staging flag that
-  /// will be removed once borrow scoping is checked by the normal verifier.
-  OperandOwnershipKindMap
-  getOwnershipKindMap(bool isForwardingSubValue = false) const;
+  /// NOTE: This is implemented in OperandOwnership.cpp.
+  OperandOwnershipKindMap getOwnershipKindMap() const;
 
   /// Returns true if this operand acts as a use that consumes its associated
   /// value.

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -35,7 +35,6 @@ private:
   LLVM_ATTRIBUTE_UNUSED SILModule &mod;
 
   const Operand &op;
-  bool checkingSubObject;
 
 public:
   /// Create a new OperandOwnershipKindClassifier.
@@ -45,13 +44,8 @@ public:
   /// should be the subobject and Value should be the parent object. An example
   /// of where one would want to do this is in the case of value projections
   /// like struct_extract.
-  OperandOwnershipKindClassifier(
-      SILModule &mod, const Operand &op,
-      bool checkingSubObject)
-      : mod(mod), op(op),
-        checkingSubObject(checkingSubObject) {}
-
-  bool isCheckingSubObject() const { return checkingSubObject; }
+  OperandOwnershipKindClassifier(SILModule &mod, const Operand &op)
+      : mod(mod), op(op) {}
 
   SILValue getValue() const { return op.get(); }
 
@@ -552,15 +546,6 @@ OperandOwnershipKindClassifier::visitReturnInst(ReturnInst *ri) {
 
 OperandOwnershipKindMap
 OperandOwnershipKindClassifier::visitEndBorrowInst(EndBorrowInst *i) {
-  // If we are checking a subobject, make sure that we are from a guaranteed
-  // basic block argument.
-  if (isCheckingSubObject()) {
-    auto *phiArg = cast<SILPhiArgument>(op.get());
-    (void)phiArg;
-    return Map::compatibilityMap(ValueOwnershipKind::Guaranteed,
-                                 UseLifetimeConstraint::MustBeLive);
-  }
-
   /// An end_borrow is modeled as invalidating the guaranteed value preventing
   /// any further uses of the value.
   return Map::compatibilityMap(ValueOwnershipKind::Guaranteed,
@@ -1054,10 +1039,7 @@ OperandOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *bi) {
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
-OperandOwnershipKindMap
-Operand::getOwnershipKindMap(bool isForwardingSubValue) const {
-  OperandOwnershipKindClassifier classifier(
-      getUser()->getModule(), *this,
-      isForwardingSubValue);
+OperandOwnershipKindMap Operand::getOwnershipKindMap() const {
+  OperandOwnershipKindClassifier classifier(getUser()->getModule(), *this);
   return classifier.visit(const_cast<SILInstruction *>(getUser()));
 }

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -180,13 +180,8 @@ bool SILValueOwnershipChecker::check() {
 
 bool SILValueOwnershipChecker::isCompatibleDefUse(
     Operand *op, ValueOwnershipKind ownershipKind) {
-  bool isGuaranteedSubValue = false;
-  if (ownershipKind == ValueOwnershipKind::Guaranteed &&
-      isGuaranteedForwardingInst(op->getUser())) {
-    isGuaranteedSubValue = true;
-  }
   auto *user = op->getUser();
-  auto opOwnershipKindMap = op->getOwnershipKindMap(isGuaranteedSubValue);
+  auto opOwnershipKindMap = op->getOwnershipKindMap();
   // If our ownership kind doesn't match, track that we found an error, emit
   // an error message optionally and then continue.
   if (opOwnershipKindMap.canAcceptKind(ownershipKind)) {


### PR DESCRIPTION
We only used this in one place that was not needed since we do reborrow verification instead of using the old model for borrowed phi arguments.