### PR TITLE
[cxx-interop] Support function templates inside a namespace.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3732,7 +3732,8 @@ namespace {
     ParameterList *getNonSelfParamList(
         DeclContext *dc, const clang::FunctionDecl *decl,
         Optional<unsigned> selfIdx, ArrayRef<Identifier> argNames,
-        bool allowNSUIntegerAsInt, bool isAccessor) {
+        bool allowNSUIntegerAsInt, bool isAccessor,
+        ArrayRef<GenericTypeParamDecl *> genericParams) {
       if (bool(selfIdx)) {
         assert(((decl->getNumParams() == argNames.size() + 1) || isAccessor) &&
                (*selfIdx < decl->getNumParams()) && "where's self?");
@@ -3748,7 +3749,7 @@ namespace {
       }
       return Impl.importFunctionParameterList(
           dc, decl, nonSelfParams, decl->isVariadic(), allowNSUIntegerAsInt,
-          argNames, /*genericParams=*/{});
+          argNames, genericParams);
     }
 
     Decl *importGlobalAsInitializer(const clang::FunctionDecl *decl,
@@ -3886,7 +3887,7 @@ namespace {
 
         bodyParams =
             getNonSelfParamList(dc, decl, selfIdx, name.getArgumentNames(),
-                                allowNSUIntegerAsInt, !name);
+                                allowNSUIntegerAsInt, !name, templateParams);
 
         importedType =
             Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -52,3 +52,16 @@ template <class T> void lvalueReference(T &ref) { ref = 42; }
 template <class T> void constLvalueReference(const T &) {}
 
 template <class T> void forwardingReference(T &&) {}
+
+namespace Orbiters {
+
+template<class T>
+void galileo(T) { }
+
+template<class T, class U>
+void cassini(T, U) { }
+
+template<class T>
+void magellan(T&) { }
+
+}

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -6,6 +6,13 @@
 // CHECK: func passThroughConst<T>(_ value: T) -> T
 // CHECK: func returns_template<R, T, U>(_ a: T, _ b: U) -> R
 // CHECK: func cannot_infer_template<T>()
+
 // CHECK: func lvalueReference<T>(_ ref: UnsafeMutablePointer<T>)
 // CHECK: func constLvalueReference<T>(_: UnsafePointer<T>)
 // CHECK: func forwardingReference<T>(_: UnsafeMutablePointer<T>)
+
+// CHECK: enum Orbiters {
+// CHECK:   static func galileo<T>(_: T)
+// CHECK:   static func cassini<T, U>(_: T, _: U)
+// CHECK:   static func magellan<T>(_: UnsafeMutablePointer<T>)
+// CHECK: }


### PR DESCRIPTION
Thread "templateParams" through the call to find the function parameter types when the function is in a namespace.

This was an oversight of mine in #33053.