### PR TITLE
[Runtime] Fix incorrect free() of constant strings in TypeLookupError.

### DIFF
--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -20,6 +20,7 @@
 
 #include "swift/Basic/TaggedUnion.h"
 #include "swift/Runtime/Portability.h"
+#include <string.h>
 
 namespace swift {
 
@@ -115,8 +116,14 @@ public:
   }
 
   /// Construct a TypeLookupError that just returns a constant C string.
-  TypeLookupError(const char *str)
-      : TypeLookupError([=] { return const_cast<char *>(str); }) {}
+  TypeLookupError(const char *str) {
+    Context = const_cast<char *>(str);
+    Fn = [](void *context, Command command, void *param) -> void * {
+      // The context pointer is the string and works for both copying the string
+      // and copying the context. Other commands don't need to do anything.
+      return context;
+    };
+  }
 
   /// Construct a TypeLookupError that creates a string using asprintf. The passed-in
   /// format string and arguments are passed directly to swift_asprintf when

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -32,6 +32,7 @@ add_swift_unittest(SwiftBasicTests
   ThreadSafeRefCntPointerTest.cpp
   TransformRangeTest.cpp
   TreeScopedHashTableTest.cpp
+  TypeLookupError.cpp
   UnicodeTest.cpp
   ValueEnumeratorTest.cpp
   ${generated_tests}

--- a/unittests/Basic/TypeLookupError.cpp
+++ b/unittests/Basic/TypeLookupError.cpp
@@ -1,0 +1,55 @@
+//===--- TypeLookupError.cpp - TypeLookupError Tests ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Demangling/TypeLookupError.h"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace swift;
+
+TEST(TypeLookupError, ConstantString) {
+  auto error = TypeLookupError("testing testing");
+  char *str = error.copyErrorString();
+  ASSERT_STREQ(str, "testing testing");
+  error.freeErrorString(str);
+}
+
+TEST(TypeLookupError, FormatString) {
+  auto error = TypeLookupError("%d %d %d %d %d %d %d %d %d %d", 0, 1, 2, 3, 4,
+                               5, 6, 7, 8, 9, 10);
+  char *str = error.copyErrorString();
+  ASSERT_STREQ(str, "0 1 2 3 4 5 6 7 8 9");
+  error.freeErrorString(str);
+}
+
+TEST(TypeLookupError, Copying) {
+  std::vector<TypeLookupError> vec;
+
+  {
+    auto originalError = TypeLookupError("%d %d %d %d %d %d %d %d %d %d", 0, 1,
+                                         2, 3, 4, 5, 6, 7, 8, 9, 10);
+    for (int i = 0; i < 5; i++)
+      vec.push_back(originalError);
+  }
+
+  for (auto &error : vec) {
+    char *str = error.copyErrorString();
+    ASSERT_STREQ(str, "0 1 2 3 4 5 6 7 8 9");
+    error.freeErrorString(str);
+  }
+
+  auto extractedError = vec[4];
+  vec.clear();
+  char *str = extractedError.copyErrorString();
+  ASSERT_STREQ(str, "0 1 2 3 4 5 6 7 8 9");
+  extractedError.freeErrorString(str);
+}


### PR DESCRIPTION
Also add a test to catch this, and exercise the other functionality of this class.