### PR TITLE
[concurrency] fixes to enable building swift with concurrency on by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -241,6 +241,9 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
+    /// Disable the implicit import of the _Concurrency module.
+    bool DisableImplicitConcurrencyModuleImport = false;
+
     /// Should we check the target OSs of serialized modules to see that they're
     /// new enough?
     bool EnableTargetOSChecking = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -286,6 +286,10 @@ def disable_clangimporter_source_import : Flag<["-"],
   "disable-clangimporter-source-import">,
   HelpText<"Disable ClangImporter and forward all requests straight the DWARF importer.">;
 
+def disable_implicit_concurrency_module_import : Flag<["-"],
+  "disable-implicit-concurrency-module-import">,
+  HelpText<"Disable the implicit import of the _Concurrency module.">;
+
 def disable_arc_opts : Flag<["-"], "disable-arc-opts">,
   HelpText<"Don't run SIL ARC optimization passes.">;
 def disable_ossa_opts : Flag<["-"], "disable-ossa-opts">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -376,6 +376,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
+  Opts.DisableImplicitConcurrencyModuleImport |=
+    Args.hasArg(OPT_disable_implicit_concurrency_module_import);
+
   Opts.EnableSubstSILFunctionTypesForFunctionValues |=
     Args.hasArg(OPT_enable_subst_sil_function_types_for_function_values);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -708,7 +708,8 @@ CompilerInstance::openModuleDoc(const InputFile &input) {
 }
 
 bool CompilerInvocation::shouldImportSwiftConcurrency() const {
-  return getLangOptions().EnableExperimentalConcurrency;
+  return getLangOptions().EnableExperimentalConcurrency
+      && !getLangOptions().DisableImplicitConcurrencyModuleImport;
 }
 
 /// Implicitly import the SwiftOnoneSupport module in non-optimized

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1657,6 +1657,12 @@ function(add_swift_target_library name)
     list(APPEND SWIFTLIB_DEPENDS clang)
   endif()
 
+  # Turn off implicit import of _Concurrency when building libraries
+  if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS 
+                      "-Xfrontend;-disable-implicit-concurrency-module-import")
+  endif()
+
   # If we are building this library for targets, loop through the various
   # SDKs building the variants of this library.
   list_intersect(

--- a/test/ImportResolution/disable-implicit-concurrency-module-import.swift
+++ b/test/ImportResolution/disable-implicit-concurrency-module-import.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -disable-implicit-concurrency-module-import
+// REQUIRES: concurrency
+
+
+protocol P : Actor { } // expected-error{{cannot find type 'Actor' in scope}}


### PR DESCRIPTION
The main issue when building the compiler with concurrency enabled by default comes up when the build system begins to build the standard library, etc. The error emitted during the build says that the `_Concurrency` Swift module was not found. After some discussion with Doug, the best way to fix this issue is to add a flag to the frontend that disables the implicit inclusion of `_Concurrency` by the compiler, and add that flag when building those libraries during the build of Swift.

Resolves rdar://71045297

TODO
- [x] Add flag to disable implicit import of `_Concurrency` module
- [x] Augment build system to use the new flag
- [x] Add regression test