### PR TITLE
[Sema] Add flag to optimize building swiftmodule files preserving type info for LLDB

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -391,7 +391,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
 
@@ -415,7 +415,11 @@ protected:
     Synthesized : 1,
 
     /// Whether this member's body consists of a single expression.
-    HasSingleExpressionBody : 1
+    HasSingleExpressionBody : 1,
+
+    /// Whether peeking into this function detected nested type declarations.
+    /// This is set when skipping over the decl at parsing.
+    HasNestedTypeDeclarations : 1
   );
 
   SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2+1,
@@ -5544,6 +5548,7 @@ protected:
     Bits.AbstractFunctionDecl.Throws = Throws;
     Bits.AbstractFunctionDecl.Synthesized = false;
     Bits.AbstractFunctionDecl.HasSingleExpressionBody = false;
+    Bits.AbstractFunctionDecl.HasNestedTypeDeclarations = false;
   }
 
   void setBodyKind(BodyKind K) {
@@ -5688,6 +5693,16 @@ public:
   /// Provide the parsed body for the function.
   void setBodyParsed(BraceStmt *S) {
     setBody(S, BodyKind::Parsed);
+  }
+
+  /// Was there a nested type declaration detected when parsing this
+  /// function was skipped?
+  bool hasNestedTypeDeclarations() const {
+    return Bits.AbstractFunctionDecl.HasNestedTypeDeclarations;
+  }
+
+  void setHasNestedTypeDeclarations(bool value) {
+    Bits.AbstractFunctionDecl.HasNestedTypeDeclarations = value;
   }
 
   /// Note that parsing for the body was delayed.

--- a/include/swift/Basic/FunctionBodySkipping.h
+++ b/include/swift/Basic/FunctionBodySkipping.h
@@ -23,6 +23,9 @@ enum class FunctionBodySkipping : uint8_t {
   None,
   /// Only non-inlinable function bodies should be skipped.
   NonInlinable,
+  /// Only non-inlinable functions bodies without type definitions should
+  /// be skipped.
+  NonInlinableWithoutTypes,
   /// All function bodies should be skipped, where not otherwise required
   /// for type inference.
   All

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -297,6 +297,10 @@ def experimental_skip_non_inlinable_function_bodies:
   Flag<["-"], "experimental-skip-non-inlinable-function-bodies">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Skip type-checking and SIL generation for non-inlinable function bodies">;
+def experimental_skip_non_inlinable_function_bodies_without_types:
+  Flag<["-"], "experimental-skip-non-inlinable-function-bodies-without-types">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Skip work on non-inlinable function bodies that do not declare nested types">;
 def profile_stats_events: Flag<["-"], "profile-stats-events">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Profile changes to stats in -stats-output-dir">;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -687,7 +687,10 @@ public:
 
   /// Skip a braced block (e.g. function body). The current token must be '{'.
   /// Returns \c true if the parser hit the eof before finding matched '}'.
-  bool skipBracedBlock();
+  ///
+  /// Set \c HasNestedTypeDeclarations to true if a token for a type
+  /// declaration is detected in the skipped block.
+  bool skipBracedBlock(bool &HasNestedTypeDeclarations);
 
   /// Skip over SIL decls until we encounter the start of a Swift decl or eof.
   void skipSILUntilSwiftDecl();

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -195,7 +195,9 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction) &&
       (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) ||
-       Args.hasArg(OPT_experimental_skip_all_function_bodies))) {
+       Args.hasArg(OPT_experimental_skip_all_function_bodies) ||
+       Args.hasArg(
+         OPT_experimental_skip_non_inlinable_function_bodies_without_types))) {
     Diags.diagnose(SourceLoc(), diag::cannot_emit_ir_skipping_function_bodies);
     return true;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -716,6 +716,12 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.DebugTimeExpressions |=
       Args.hasArg(OPT_debug_time_expression_type_checking);
 
+  // Check for SkipFunctionBodies arguments in order from skipping less to
+  // skipping more.
+  if (Args.hasArg(
+        OPT_experimental_skip_non_inlinable_function_bodies_without_types))
+    Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinableWithoutTypes;
+
   // If asked to perform InstallAPI, go ahead and enable non-inlinable function
   // body skipping.
   if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) ||

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2345,6 +2345,14 @@ public:
         FunctionBodySkipping::All)
       return true;
 
+    // If we want all types (for LLDB) we can't skip functions with nested
+    // types. We could probably improve upon this and type-check only the
+    // nested types instead for better performances.
+    if (AFD->hasNestedTypeDeclarations() &&
+        getASTContext().TypeCheckerOpts.SkipFunctionBodies ==
+          FunctionBodySkipping::NonInlinableWithoutTypes)
+      return false;
+
     // Only skip functions where their body won't be serialized
     return AFD->getResilienceExpansion() != ResilienceExpansion::Minimal;
   }


### PR DESCRIPTION
Add a new frontend flag `-experimental-skip-non-inlinable-function-bodies-without-types` to skip parsing and type-checking non-inlinable functions bodies that don't define nested types. This flag can be used as an alternative to `-experimental-skip-non-inlinable-function-bodies` to keep all type info used by LLDB.

rdar://problem/71130519