### PR TITLE
[Diagnostic] Improve diagnostics for situations with ambiguity caused by conformance requirements

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1672,20 +1672,6 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
   if (!anchor)
     return impact;
 
-  // If this is a conditional requirement failure associated with a
-  // call, let's increase impact of the fix to show that such failure
-  // makes member/function unreachable in current context or with
-  // given arguments.
-  if (auto last = locator.last()) {
-    if (last->isConditionalRequirement()) {
-      if (auto *expr = getAsExpr(anchor)) {
-        auto *parent = cs.getParentExpr(expr);
-        if (parent && isa<ApplyExpr>(parent))
-          return 5;
-      }
-    }
-  }
-
   // If this requirement is associated with a member reference and it
   // was possible to check it before overload choice is bound, that means
   // types came from the context (most likely Self, or associated type(s))

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -180,7 +180,8 @@ func dictionaryToNSDictionary() {
 // In this case, we should not implicitly convert Dictionary to NSDictionary.
 struct NotEquatable {}
 func notEquatableError(_ d: Dictionary<Int, NotEquatable>) -> Bool {
-  return d == d // expected-error{{referencing operator function '==' on 'Dictionary' requires that 'NotEquatable' conform to 'Equatable'}}
+  // There is a note attached to a requirement `requirement from conditional conformance of 'Dictionary<Int, NotEquatable>' to 'Equatable'`
+  return d == d // expected-error{{operator function '==' requires that 'NotEquatable' conform to 'Equatable'}}
 }
 
 // NSString -> String

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -216,14 +216,11 @@ func rdar46459603() {
   let e = E.foo(value: "String")
   var arr = ["key": e]
 
-  // FIXME(rdar://problem/64844584) - on iOS simulator this diagnostic is flaky,
-  // either `referencing operator function '==' on 'Equatable'` or `operator function '==' requires`
   _ = arr.values == [e]
-  // expected-error@-1 {{requires that 'Dictionary<String, E>.Values' conform to 'Equatable'}}
-  // expected-error@-2 {{cannot convert value of type '[E]' to expected argument type 'Dictionary<String, E>.Values'}}
+  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'Dictionary<String, E>.Values' and '[E]'}}
   _ = [arr.values] == [[e]]
-  // expected-error@-1 {{requires that 'Dictionary<String, E>.Values' conform to 'Equatable'}}
-  // expected-error@-2 {{cannot convert value of type '[E]' to expected element type 'Dictionary<String, E>.Values'}}
+  // expected-error@-1 {{referencing operator function '==' on 'Array' requires that 'E' conform to 'Equatable'}} expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
+  // expected-error@-2 {{cannot convert value of type 'Dictionary<String, E>.Values' to expected element type '[E]'}}
 }
 
 // SR-10843

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -413,9 +413,9 @@ extension Foo: P where Bar: P {
 extension BinaryInteger {
   var foo: Self {
     return self <= 1
-            ? 1 // expected-error {{cannot convert return expression of type 'Int' to return type 'Self'}}
+            ? 1
             : (2...self).reduce(1, *)
-            // expected-error@-1 {{cannot convert value of type 'Self' to expected argument type 'Int'}} {{20-20=Int(}} {{24-24=)}}
+            // expected-error@-1 {{referencing instance method 'reduce' on 'ClosedRange' requires that 'Self.Stride' conform to 'SignedInteger'}}
   }
 }
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -307,7 +307,8 @@ struct NotEquatable {}
 func arrayComparison(_ x: [NotEquatable], y: [NotEquatable], p: UnsafeMutablePointer<NotEquatable>) {
   var x = x
   // Don't allow implicit array-to-pointer conversions in operators.
-  let a: Bool = x == y // expected-error{{referencing operator function '==' on 'Array' requires that 'NotEquatable' conform to 'Equatable'}}
+  // There is a note attached to declaration - requirement from conditional conformance of '[NotEquatable]' to 'Equatable'
+  let a: Bool = x == y // expected-error{{operator function '==' requires that 'NotEquatable' conform to 'Equatable'}}
   let _: Bool = p == &x  // Allowed!
 }
 

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -204,8 +204,7 @@ func sr8150_mutable(obj: SR8150Box) {
     sr8150_helper1(opt)
     // expected-error@-1 {{cannot convert value of type 'Bar?' to expected argument type 'Double'}} {{23-23=?.rawValue ?? <#default value#>}}
     sr8150_helper1(opt ?? Bar.a)
-    // expected-error@-1 {{no exact matches in call to global function 'sr8150_helper1'}}
-    // expected-note@-2  {{candidate expects value of type 'Bar' for parameter #0}} {{20-20=(}} {{32-32=).rawValue}}
+    // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{20-20=(}} {{32-32=).rawValue}}
     let _: Double? = opt
     // expected-error@-1 {{cannot convert value of type 'Bar?' to specified type 'Double?'}} {{25-25=?.rawValue}}
   }

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -53,8 +53,9 @@ protocol Bindable: class { }
 
 extension Bindable {
   func test<Value>(to targetKeyPath: ReferenceWritableKeyPath<Self, Value>, change: Value?) {
+    // There is also a note attached to declaration - requirement from conditional conformance of 'Optional<Value>' to 'Equatable'
     if self[keyPath:targetKeyPath] != change {
-      // expected-error@-1 {{binary operator '!=' cannot be applied to operands of type 'Value' and 'Value?'}}
+      // expected-error@-1 {{operator function '!=' requires that 'Value' conform to 'Equatable'}}
       self[keyPath: targetKeyPath] = change!
     }
   }

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -4,5 +4,6 @@ class NotEquatable {}
 
 func test_ArrayOfNotEquatableIsNotEquatable() {
   var a = [ NotEquatable(), NotEquatable() ]
-  if a == a {} // expected-error {{referencing operator function '==' on 'Array' requires that 'NotEquatable' conform to 'Equatable'}}
+  // There is also a note attached to declaration - requirement from conditional conformance of '[NotEquatable]' to 'Equatable'
+  if a == a {} // expected-error {{operator function '==' requires that 'NotEquatable' conform to 'Equatable'}}
 }

--- a/test/stdlib/KeyPathAppending.swift
+++ b/test/stdlib/KeyPathAppending.swift
@@ -61,7 +61,7 @@ func mismatchedAppends<T, U, V>(readOnlyLeft: KeyPath<T, U>,
   // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
 
   _ = writableRight.appending(path: readOnlyLeft)
-  // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
+  // expected-error@-1 {{instance method 'appending(path:)' requires that 'KeyPath<U, V>' inherit from 'KeyPath<U, T>'}}
 
   _ = writableRight.appending(path: writableLeft)
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<T, U>' to expected argument type 'WritableKeyPath<V, U>'}}
@@ -71,7 +71,7 @@ func mismatchedAppends<T, U, V>(readOnlyLeft: KeyPath<T, U>,
   // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
 
   _ = referenceRight.appending(path: readOnlyLeft)
-  // expected-error@-1 {{no exact matches in call to instance method 'appending'}}
+  // expected-error@-1 {{instance method 'appending(path:)' requires that 'KeyPath<U, V>' inherit from 'KeyPath<U, T>'}}
 
   _ = referenceRight.appending(path: writableLeft)
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<T, U>' to expected argument type 'WritableKeyPath<V, U>'}}


### PR DESCRIPTION
- Adjust `diagnoseAmbiguity` to use a local slice of overloads

Solver re-opens stdlib array and dictionary types to maintain subtyping which means
that in diagnostics mode it's possible to produce two solutions that have a different 
number of type variables but are otherwise equivalent. Such cases should be diagnosed
as if there was just one viable solution.

- Don't increase a score for conditional requirement failures

Remove an artificial rule that increased score of solutions with conditional requirement
failures, assuming that such failures always lead to member unviability, which is not
the case.

This also helps code completion to produce a better match set when optional types
are involved.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
