### PR TITLE
[SR-11992] Check variable usage within closures

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3194,6 +3194,20 @@ performTopLevelDeclDiagnostics(TopLevelCodeDecl *TLCD) {
   TLCD->walk(checker);
 }
 
+/// Perform diagnostics on closure body.
+void swift::performClosureBodyDiagnostics(ClosureExpr *closure) {
+  if (auto *ACE = dyn_cast<AbstractClosureExpr>(closure)) {
+    // Skip if we aleady checked variable usage.
+    if (isa<TopLevelCodeDecl>(ACE->getParent()) ||
+        isa<AbstractFunctionDecl>(ACE->getParent())) {
+      return;
+    }
+  }
+  auto &ctx = closure->getASTContext();
+  VarDeclUsageChecker checker(closure, ctx.Diags);
+  closure->walk(checker);
+}
+
 /// Perform diagnostics for func/init/deinit declarations.
 void swift::performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD) {
   // Don't produce these diagnostics for implicitly generated code.

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -44,6 +44,9 @@ void performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD);
 
 /// Perform diagnostics on the top level code declaration.
 void performTopLevelDeclDiagnostics(TopLevelCodeDecl *TLCD);
+
+/// Perform diagnostics on closure body.
+void performClosureBodyDiagnostics(ClosureExpr *closure);
   
 /// Emit a fix-it to set the access of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2087,6 +2087,10 @@ bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
     closure->setBody(body, closure->hasSingleExpressionBody());
   }
   closure->setBodyState(ClosureExpr::BodyState::SeparatelyTypeChecked);
+  
+  if (!HadError)
+    performClosureBodyDiagnostics(closure);
+  
   return HadError;
 }
 

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -47,10 +47,10 @@ var osx_init_osx = osx() // OK
 var osx_extension_init_osx = osx() // expected-error {{'osx()' is unavailable}}
 
 @available(OSX, unavailable)
-var osx_inner_init_osx = { let inner_var = osx() } // OK
+var osx_inner_init_osx = { let _ = osx() } // OK
 
 @available(OSXApplicationExtension, unavailable)
-var osx_extension_inner_init_osx = { let inner_var = osx() } // expected-error {{'osx()' is unavailable}}
+var osx_extension_inner_init_osx = { let _ = osx() } // expected-error {{'osx()' is unavailable}}
 
 struct Outer {
   @available(OSX, unavailable)
@@ -90,10 +90,10 @@ struct Outer {
   var (osx_extension_init_deconstruct1_only_osx, _) = osx_pair() // expected-error {{'osx_pair()' is unavailable}}
 
   @available(OSX, unavailable)
-  var osx_inner_init_osx = { let inner_var = osx() } // OK
+  var osx_inner_init_osx = { let _ = osx() } // OK
   
   @available(OSXApplicationExtension, unavailable)
-  var osx_extension_inner_init_osx = { let inner_var = osx() } // expected-error {{'osx()' is unavailable}}
+  var osx_extension_inner_init_osx = { let _ = osx() } // expected-error {{'osx()' is unavailable}}
 }
 
 extension Outer {

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -504,3 +504,92 @@ func testVariablesBoundInPatterns() {
     break
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Top Level Closures
+//===----------------------------------------------------------------------===//
+
+var closure_var_unused: () -> Int = {
+  var unused = 42 // expected-warning {{initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+  return 12
+}
+
+var closure_let_unused: () -> Int = {
+  let unused = 42 // expected-warning {{initialization of immutable value 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+  return 12
+}
+
+var closure_var_never_mutated: () -> Int = {
+  var unmutated = 42 // expected-warning {{variable 'unmutated' was never mutated; consider changing to 'let' constant}}
+  return unmutated
+}
+
+func nested_closures() {
+  var _: () -> Int = {
+    var unused = 42 // expected-warning {{initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+    return 12
+  }
+  
+  var _: () -> Int = {
+    let unused = 42 // expected-warning {{initialization of immutable value 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+    return 12
+  }
+  
+  var _: () -> Int = {
+    var unmutated = 42 // expected-warning {{variable 'unmutated' was never mutated; consider changing to 'let' constant}}
+    return unmutated
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Nested Scope Closures
+//===----------------------------------------------------------------------===//
+
+class A {
+  lazy var lazyvar_var_unused: Int = {
+    var unused = 42 // expected-warning {{initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+    return 12
+  }()
+  
+  lazy var lazyvar_let_unused: Int = {
+    let unused = 42 // expected-warning {{initialization of immutable value 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+    return 12
+  }()
+  
+  lazy var lazyvar_var_never_mutated: Int = {
+    var unmutated = 42 // expected-warning {{variable 'unmutated' was never mutated; consider changing to 'let' constant}}
+    return unmutated
+  }()
+  
+  var closure_var_unused: () -> Int = {
+    var unused = 42 // expected-warning {{initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+    return 12
+  }
+  
+  var closure_let_unused: () -> Int = {
+    let unused = 42 // expected-warning {{initialization of immutable value 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+    return 12
+  }
+  
+  var closure_var_never_mutated: () -> Int = {
+    var unmutated = 42 // expected-warning {{variable 'unmutated' was never mutated; consider changing to 'let' constant}}
+    return unmutated
+  }
+  
+  func nested_closures() {
+    var _: () -> Int = {
+      var unused = 42 // expected-warning {{initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+      return 12
+    }
+    
+    var _: () -> Int = {
+      let unused = 42 // expected-warning {{initialization of immutable value 'unused' was never used; consider replacing with assignment to '_' or removing it}}
+      return 12
+    }
+    
+    var _: () -> Int = {
+      var unmutated = 42 // expected-warning {{variable 'unmutated' was never mutated; consider changing to 'let' constant}}
+      return unmutated
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
Variables that are never used or mutated are not diagnosed within closure bodies that are not at the top level. This is because closure bodies were never checked with `VarDeclUsageChecker` unless they were at the top level. This pull request adds `swift::performClosureBodyDiagnostics` which performs the same variable usage check as top level declarations and AFDs.

#### Examples:

Before this PR:

```swift
class Foo {
    lazy var x: Int = {
        var y = 42 // no warning
        var z = 42 // no warning
        return z
    }()
}
```

After this PR:
```swift
class Foo {
    lazy var x: Int = {
        var y = 42 // warning: initialization of variable 'y' was never used; consider replacing with assignment to '_' or removing it
        var z = 42 // warning: variable 'z' was never mutated; consider changing to 'let' constant
        return z
    }()
}
```

#### Links
Resolves SR-11992 and SR-13821

Tagging @rintaro.