### PR TITLE
[CSApply] Adjust @autoclosure locator to point to argument expression…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5813,9 +5813,11 @@ Expr *ExprRewriter::coerceCallArguments(
       //   - new types are propagated to constraint system
       auto *closureType = param.getPlainType()->castTo<FunctionType>();
 
+      auto argLoc = getArgLocator(argIdx, paramIdx, param.getParameterFlags());
+
       arg = coerceToType(
           arg, closureType->getResult(),
-          locator.withPathElement(ConstraintLocator::AutoclosureResult));
+          argLoc.withPathElement(ConstraintLocator::AutoclosureResult));
 
       if (shouldInjectWrappedValuePlaceholder) {
         // If init(wrappedValue:) takes an autoclosure, then we want


### PR DESCRIPTION
… being coerced to result type

While applying type inferred for autoclosure to argument use locator
that records argument/param indices to make it possible for
`coerceToType` to simplify it down to underlying argument expression
if necessary.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
