### PR TITLE
Parse: Only diagnose dollar-prefixed identifiers that are Swift declarations

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -930,9 +930,7 @@ bool Parser::parseDifferentiabilityParametersClause(
         return true;
       }
       Identifier paramName;
-      if (parseIdentifier(paramName, paramLoc,
-                          diag::diff_params_clause_expected_parameter))
-        return true;
+      paramLoc = consumeIdentifier(paramName, /*diagnoseDollarPrefix=*/false);
       parameters.push_back(
           ParsedAutoDiffParameter::getNamedParameter(paramLoc, paramName));
       break;
@@ -1966,8 +1964,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
     
     Identifier name;
-    consumeIdentifier(&name);
-    
+    consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
+
     auto range = SourceRange(Loc, Tok.getRange().getStart());
 
     if (!consumeIf(tok::r_paren)) {
@@ -2545,7 +2543,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
 
     Identifier name;
-    consumeIdentifier(&name, /*allowDollarIdentifier=*/true);
+    consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
 
     auto range = SourceRange(Loc, Tok.getRange().getStart());
 
@@ -4418,6 +4416,7 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
     }
     importPath.push_back(Identifier(), Tok.getLoc());
     if (parseAnyIdentifier(importPath.back().Item,
+                           /*diagnoseDollarPrefix=*/false,
                            diag::expected_identifier_in_decl, "import"))
       return nullptr;
     HasNext = consumeIf(tok::period);
@@ -4543,7 +4542,7 @@ parseIdentifierDeclName(Parser &P, Identifier &Result, SourceLoc &Loc,
                         StringRef DeclKindName,
                         llvm::function_ref<bool(const Token &)> canRecover) {
   if (P.Tok.is(tok::identifier)) {
-    Loc = P.consumeIdentifier(&Result);
+    Loc = P.consumeIdentifier(Result, /*diagnoseDollarPrefix=*/true);
 
     // We parsed an identifier for the declaration. If we see another
     // identifier, it might've been a single identifier that got broken by a
@@ -5457,7 +5456,7 @@ static ParameterList *parseOptionalAccessorArgument(SourceLoc SpecifierLoc,
         EndLoc = StartLoc;
     } else {
       // We have a name.
-      NameLoc = P.consumeIdentifier(&Name);
+      NameLoc = P.consumeIdentifier(Name, /*diagnoseDollarPrefix=*/true);
 
       auto DiagID =
          Kind == AccessorKind::Set ? diag::expected_rparen_set_name :
@@ -7737,7 +7736,7 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
                                        SyntaxKind::IdentifierList);
 
         Identifier name;
-        auto loc = consumeIdentifier(&name);
+        auto loc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
         identifiers.emplace_back(name, loc);
 
         while (Tok.is(tok::comma)) {
@@ -7745,7 +7744,7 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
 
           if (Tok.is(tok::identifier)) {
             Identifier name;
-            auto loc = consumeIdentifier(&name);
+            auto loc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
             identifiers.emplace_back(name, loc);
           } else {
             if (Tok.isNot(tok::eof)) {
@@ -7762,7 +7761,7 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
                                      SyntaxKind::IdentifierList);
 
       Identifier name;
-      auto nameLoc = consumeIdentifier(&name);
+      auto nameLoc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
       identifiers.emplace_back(name, nameLoc);
 
       if (isPrefix || isPostfix) {
@@ -7833,7 +7832,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
 
   Identifier name;
   SourceLoc nameLoc;
-  if (parseIdentifier(name, nameLoc, diag::expected_precedencegroup_name)) {
+  if (parseIdentifier(name, nameLoc, /*diagnoseDollarPrefix=*/true,
+                      diag::expected_precedencegroup_name)) {
     // If the identifier is missing or a keyword or something, try to
     // skip the entire body.
     if (!Tok.isAtStartOfLine() && Tok.isNot(tok::eof) &&
@@ -8039,7 +8039,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
           return abortBody();
         }
         Identifier name;
-        SourceLoc nameLoc = consumeIdentifier(&name);
+        SourceLoc nameLoc = consumeIdentifier(name,
+                                              /*diagnoseDollarPrefix=*/false);
         relations.push_back({nameLoc, name, nullptr});
 
         if (skipUnspacedCodeCompleteToken())

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1500,7 +1500,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
         peekToken().isNot(tok::period, tok::period_prefix, tok::l_paren)) {
       DeferringContextRAII Deferring(*SyntaxContext);
       Identifier name;
-      SourceLoc loc = consumeIdentifier(&name, /*allowDollarIdentifier=*/true);
+      SourceLoc loc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/false);
       auto introducer = (InVarOrLetPattern != IVOLP_InVar
                          ? VarDecl::Introducer::Let
                          : VarDecl::Introducer::Var);
@@ -2114,8 +2114,7 @@ DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
   SourceLoc baseNameLoc;
   if (Tok.isAny(tok::identifier, tok::kw_Self, tok::kw_self)) {
     Identifier baseNameId;
-    baseNameLoc = consumeIdentifier(
-        &baseNameId, /*allowDollarIdentifier=*/true);
+    baseNameLoc = consumeIdentifier(baseNameId, /*diagnoseDollarPrefix=*/false);
     baseName = baseNameId;
   } else if (flags.contains(DeclNameFlag::AllowOperators) &&
              Tok.isAnyOperator()) {
@@ -2490,7 +2489,7 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
 
       } else {
         // Otherwise, the name is a new declaration.
-        consumeIdentifier(&name);
+        consumeIdentifier(name, /*diagnoseDollarPrefix=*/true);
         equalLoc = consumeToken(tok::equal);
 
         auto ExprResult = parseExpr(diag::expected_init_capture_specifier);
@@ -2569,7 +2568,7 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
         Identifier name;
         SourceLoc nameLoc;
         if (Tok.is(tok::identifier)) {
-          nameLoc = consumeIdentifier(&name);
+          nameLoc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/true);
         } else {
           nameLoc = consumeToken(tok::kw__);
         }
@@ -3233,7 +3232,7 @@ ParserResult<Expr> Parser::parseExprPoundUnknown(SourceLoc LSquareLoc) {
          PoundLoc.getAdvancedLoc(1) == Tok.getLoc());
 
   Identifier Name;
-  SourceLoc NameLoc = consumeIdentifier(&Name);
+  SourceLoc NameLoc = consumeIdentifier(Name, /*diagnoseDollarPrefix=*/false);
 
   // Parse arguments if exist.
   SourceLoc LParenLoc, RParenLoc;
@@ -3670,6 +3669,7 @@ Parser::parsePlatformVersionConstraintSpec() {
   }
 
   if (parseIdentifier(PlatformIdentifier, PlatformLoc,
+                      /*diagnoseDollarPrefix=*/false,
                       diag::avail_query_expected_platform_name)) {
     return nullptr;
   }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -71,7 +71,7 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
     // Parse the name of the parameter.
     Identifier Name;
     SourceLoc NameLoc;
-    if (parseIdentifier(Name, NameLoc,
+    if (parseIdentifier(Name, NameLoc, /*diagnoseDollarPrefix=*/true,
                         diag::expected_generics_parameter_name)) {
       Result.setIsParseError();
       break;
@@ -307,7 +307,8 @@ ParserStatus Parser::parseGenericWhereClause(
               ->isKnownLayout()) {
         // Parse a layout constraint.
         Identifier LayoutName;
-        auto LayoutLoc = consumeIdentifier(&LayoutName);
+        auto LayoutLoc = consumeIdentifier(LayoutName,
+                                           /*diagnoseDollarPrefix=*/false);
         auto LayoutInfo = parseLayoutConstraint(LayoutName);
         if (!LayoutInfo->isKnownLayout()) {
           // There was a bug in the layout constraint.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -975,7 +975,7 @@ ParserResult<Pattern> Parser::parsePattern() {
   case tok::identifier: {
     PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
     Identifier name;
-    SourceLoc loc = consumeIdentifier(&name);
+    SourceLoc loc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/true);
     if (Tok.isIdentifierOrUnderscore() && !Tok.isContextualDeclKeyword())
       diagnoseConsecutiveIDs(name.str(), loc,
                              introducer == VarDecl::Introducer::Let
@@ -1054,7 +1054,7 @@ Parser::parsePatternTupleElement() {
 
   // If the tuple element has a label, parse it.
   if (Tok.is(tok::identifier) && peekToken().is(tok::colon)) {
-    LabelLoc = consumeIdentifier(&Label);
+    LabelLoc = consumeIdentifier(Label, /*diagnoseDollarPrefix=*/true);
     consumeToken(tok::colon);
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -903,12 +903,12 @@ bool Parser::StructureMarkerRAII::pushStructureMarker(
 //===----------------------------------------------------------------------===//
 
 bool Parser::parseIdentifier(Identifier &Result, SourceLoc &Loc,
-                             const Diagnostic &D) {
+                             const Diagnostic &D, bool diagnoseDollarPrefix) {
   switch (Tok.getKind()) {
   case tok::kw_self:
   case tok::kw_Self:
   case tok::identifier:
-    Loc = consumeIdentifier(&Result);
+    Loc = consumeIdentifier(Result, diagnoseDollarPrefix);
     return false;
   default:
     checkForInputIncomplete();
@@ -930,9 +930,10 @@ bool Parser::parseSpecificIdentifier(StringRef expected, SourceLoc &loc,
 /// parseAnyIdentifier - Consume an identifier or operator if present and return
 /// its name in Result.  Otherwise, emit an error and return true.
 bool Parser::parseAnyIdentifier(Identifier &Result, SourceLoc &Loc,
-                                const Diagnostic &D) {
+                                const Diagnostic &D,
+                                bool diagnoseDollarPrefix) {
   if (Tok.is(tok::identifier)) {
-    Loc = consumeIdentifier(&Result);
+    Loc = consumeIdentifier(Result, diagnoseDollarPrefix);
     return false;
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3528,8 +3528,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     SourceLoc KindLoc = P.Tok.getLoc();
     if (P.consumeIf(tok::kw_var))
       KindId = P.Context.getIdentifier("var");
-    else if (P.parseIdentifier(KindId, KindLoc, diag::expected_tok_in_sil_instr,
-                               "kind"))
+    else if (P.parseIdentifier(KindId, KindLoc, /*diagnoseDollarPrefix=*/false,
+                               diag::expected_tok_in_sil_instr, "kind"))
       return true;
 
     if (P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
@@ -5783,7 +5783,8 @@ bool SILParserState::parseDeclSIL(Parser &P) {
           &isWithoutActuallyEscapingThunk, &Semantics,
           &SpecAttrs, &ClangDecl, &MRK, FunctionState, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_function_name) ||
-      P.parseIdentifier(FnName, FnNameLoc, diag::expected_sil_function_name) ||
+      P.parseIdentifier(FnName, FnNameLoc, /*diagnoseDollarPrefix=*/false,
+                        diag::expected_sil_function_name) ||
       P.parseToken(tok::colon, diag::expected_sil_type))
     return true;
   {
@@ -6009,7 +6010,8 @@ bool SILParserState::parseSILGlobal(Parser &P) {
                            &isLet, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
-      P.parseIdentifier(GlobalName, NameLoc, diag::expected_sil_value_name) ||
+      P.parseIdentifier(GlobalName, NameLoc, /*diagnoseDollarPrefix=*/false,
+                        diag::expected_sil_value_name) ||
       P.parseToken(tok::colon, diag::expected_sil_type))
     return true;
 
@@ -6095,6 +6097,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
   if (!P.consumeIf(tok::r_paren)) {
     KeyPathPatternComponent parsedComponent;
     if (P.parseIdentifier(ComponentKind, ComponentLoc,
+                          /*diagnoseDollarPrefix=*/false,
                           diag::expected_tok_in_sil_instr, "component kind")
         || SP.parseKeyPathPatternComponent(parsedComponent, OperandTypes,
                  ComponentLoc, ComponentKind, InstLoc,
@@ -6316,22 +6319,18 @@ static CanType parseAssociatedTypePath(Parser &P, SILParser &SP,
 static ProtocolConformanceRef
 parseRootProtocolConformance(Parser &P, SILParser &SP, Type ConformingTy,
                              ProtocolDecl *&proto) {
-  Identifier ModuleKeyword, ModuleName;
+  const StringRef ModuleKeyword = "module";
+  Identifier ModuleName;
   SourceLoc Loc, KeywordLoc;
   proto = parseProtocolDecl(P, SP);
   if (!proto)
     return ProtocolConformanceRef();
 
-  if (P.parseIdentifier(ModuleKeyword, KeywordLoc,
-                        diag::expected_tok_in_sil_instr, "module") ||
-      SP.parseSILIdentifier(ModuleName, Loc,
-                            diag::expected_sil_value_name))
+  if (P.parseSpecificIdentifier(
+          ModuleKeyword, KeywordLoc,
+          Diagnostic(diag::expected_tok_in_sil_instr, ModuleKeyword)) ||
+      SP.parseSILIdentifier(ModuleName, Loc, diag::expected_sil_value_name))
     return ProtocolConformanceRef();
-
-  if (ModuleKeyword.str() != "module") {
-    P.diagnose(KeywordLoc, diag::expected_tok_in_sil_instr, "module");
-    return ProtocolConformanceRef();
-  }
 
   // Calling lookupConformance on a BoundGenericType will return a specialized
   // conformance. We use UnboundGenericType to find the normal conformance.
@@ -6460,9 +6459,10 @@ static bool parseSILWitnessTableEntry(
   Identifier EntryKeyword;
   SourceLoc KeywordLoc;
   if (P.parseIdentifier(EntryKeyword, KeywordLoc,
-        diag::expected_tok_in_sil_instr,
-        "method, associated_type, associated_type_protocol, base_protocol"
-        ", no_default"))
+                        /*diagnoseDollarPrefix=*/false,
+                        diag::expected_tok_in_sil_instr,
+                        "method, associated_type, associated_type_protocol"
+                        ", base_protocol, no_default"))
     return true;
 
   if (EntryKeyword.str() == "no_default") {
@@ -6894,11 +6894,8 @@ llvm::Optional<llvm::coverage::Counter> SILParser::parseSILCoverageExpr(
     auto LHS = parseSILCoverageExpr(Builder);
     if (!LHS)
       return None;
-    Identifier Operator;
-    SourceLoc Loc;
-    if (P.parseAnyIdentifier(Operator, Loc,
-                             diag::sil_coverage_invalid_operator))
-      return None;
+    const Identifier Operator = P.Context.getIdentifier(P.Tok.getText());
+    const SourceLoc Loc = P.consumeToken();
     if (Operator.str() != "+" && Operator.str() != "-") {
       P.diagnose(Loc, diag::sil_coverage_invalid_operator);
       return None;

--- a/test/AutoDiff/Parse/differentiable_attr_parse.swift
+++ b/test/AutoDiff/Parse/differentiable_attr_parse.swift
@@ -92,6 +92,11 @@ func two(x: Float, y: Float) -> Float {
   return x + y
 }
 
+@differentiable(wrt: $x) // ok
+func two(x: Float, y: Float) -> Float {
+  return x + y
+}
+
 /// Bad
 
 // expected-error @+1 {{expected 'wrt:' or 'where'}}


### PR DESCRIPTION
The `cannot declare entity named '$...'` error was allowed to be emitted on identifiers that are not themselves declarations.

