### PR TITLE
[NFC][ConstraintGraph] Address fixme and switch CG::Component dependsOn type

### DIFF
--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -228,14 +228,13 @@ public:
     /// The constraints in this component.
     TinyPtrVector<Constraint *> constraints;
 
-  public:
     /// The set of components that this component depends on, such that
     /// the partial solutions of the those components need to be available
     /// before this component can be solved.
     ///
-    /// FIXME: Use a TinyPtrVector here.
-    std::vector<unsigned> dependsOn;
+    SmallVector<unsigned, 2> dependencies;
 
+  public:
     Component(unsigned solutionIndex) : solutionIndex(solutionIndex) { }
 
     /// Whether this component represents an orphaned constraint.
@@ -249,6 +248,11 @@ public:
     const TinyPtrVector<Constraint *> &getConstraints() const {
       return constraints;
     }
+
+    /// Records a component which this component depends on.
+    void recordDependency(const Component &component);
+
+    ArrayRef<unsigned> getDependencies() const { return dependencies; }
 
     unsigned getNumDisjunctions() const { return numDisjunctions; }
   };

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -125,7 +125,7 @@ void SplitterStep::computeFollowupSteps(
     unsigned solutionIndex = components[i].solutionIndex;
 
     // If there are no dependencies, build a normal component step.
-    if (components[i].dependsOn.empty()) {
+    if (components[i].getDependencies().empty()) {
       steps.push_back(std::make_unique<ComponentStep>(
           CS, solutionIndex, &Components[i], std::move(components[i]),
           PartialSolutions[solutionIndex]));
@@ -135,7 +135,7 @@ void SplitterStep::computeFollowupSteps(
     // Note that the partial results from any dependencies of this component
     // need not be included in the final merged results, because they'll
     // already be part of the partial results for this component.
-    for (auto dependsOn : components[i].dependsOn) {
+    for (auto dependsOn : components[i].getDependencies()) {
       IncludeInMergedResults[dependsOn] = false;
     }
 
@@ -265,13 +265,13 @@ StepResult DependentComponentSplitterStep::take(bool prevFailed) {
 
   // Figure out the sets of partial solutions that this component depends on.
   SmallVector<const SmallVector<Solution, 4> *, 2> dependsOnSets;
-  for (auto index : Component.dependsOn) {
+  for (auto index : Component.getDependencies()) {
     dependsOnSets.push_back(&AllPartialSolutions[index]);
   }
 
   // Produce all combinations of partial solutions for the inputs.
   SmallVector<std::unique_ptr<SolverStep>, 4> followup;
-  SmallVector<unsigned, 2> indices(Component.dependsOn.size(), 0);
+  SmallVector<unsigned, 2> indices(Component.getDependencies().size(), 0);
   auto dependsOnSetsRef = llvm::makeArrayRef(dependsOnSets);
   do {
     // Form the set of input partial solutions.
@@ -296,8 +296,9 @@ StepResult DependentComponentSplitterStep::resume(bool prevFailed) {
 
 void DependentComponentSplitterStep::print(llvm::raw_ostream &Out) {
   Out << "DependentComponentSplitterStep for dependencies on [";
-  interleave(Component.dependsOn, [&](unsigned index) { Out << index; },
-             [&] { Out << ", "; });
+  interleave(
+      Component.getDependencies(), [&](unsigned index) { Out << index; },
+      [&] { Out << ", "; });
   Out << "]\n";
 }
 

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -313,7 +313,7 @@ public:
     : SolverStep(cs, allPartialSolutions[index]), Constraints(constraints),
       Index(index), Component(std::move(component)),
       AllPartialSolutions(allPartialSolutions) {
-    assert(!Component.dependsOn.empty() && "Should use ComponentStep");
+    assert(!Component.getDependencies().empty() && "Should use ComponentStep");
     injectConstraints();
   }
 
@@ -421,7 +421,7 @@ public:
       Constraints->push_back(constraint);
     }
 
-    assert(component.dependsOn.empty());
+    assert(component.getDependencies().empty());
   }
 
   /// Create a component step that composes existing partial solutions before
@@ -437,7 +437,8 @@ public:
           Constraints(constraints),
           DependsOnPartialSolutions(std::move(dependsOnPartialSolutions)) {
     TypeVars = component.typeVars;
-    assert(DependsOnPartialSolutions.size() == component.dependsOn.size());
+    assert(DependsOnPartialSolutions.size() ==
+           component.getDependencies().size());
 
     for (auto constraint : component.getConstraints()) {
       constraints->erase(constraint);

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -674,7 +674,7 @@ namespace {
             if (validComponents.count(inAdj) == 0)
               continue;
 
-            component.dependsOn.push_back(getComponent(inAdj).solutionIndex);
+            component.recordDependency(getComponent(inAdj));
           }
         }
       }
@@ -1054,6 +1054,10 @@ void ConstraintGraph::Component::addConstraint(Constraint *constraint) {
   constraints.push_back(constraint);
 }
 
+void ConstraintGraph::Component::recordDependency(const Component &component) {
+  dependencies.push_back(component.solutionIndex);
+}
+
 SmallVector<ConstraintGraph::Component, 1>
 ConstraintGraph::computeConnectedComponents(
            ArrayRef<TypeVariableType *> typeVars) {
@@ -1277,13 +1281,13 @@ void ConstraintGraph::printConnectedComponents(
                  out << ' ';
                });
 
-    if (component.dependsOn.empty())
+    if (component.getDependencies().empty())
       continue;
 
     // Print all of the one-way components.
     out << " depends on ";
     llvm::interleave(
-        component.dependsOn,
+        component.getDependencies(),
         [&](unsigned index) { out << index; },
         [&] { out << ", "; }
       );


### PR DESCRIPTION
Minor NFC changing the member type. Seems like `TinyPointerVector` is only for pointers, so a `SmallVector` should be good in this case.

