### PR TITLE
Make the compiler understand what StringRef is.

### DIFF
--- a/include/swift/Syntax/TokenKinds.h
+++ b/include/swift/Syntax/TokenKinds.h
@@ -17,6 +17,9 @@
 #ifndef SWIFT_TOKENKINDS_H
 #define SWIFT_TOKENKINDS_H
 
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
 namespace swift {
 enum class tok {
 #define TOKEN(X) X,


### PR DESCRIPTION
This commit makes the header ready for stand-alone usage.
