### PR TITLE
[windows] Partial revert #34143. Remove XFAIL.

### DIFF
--- a/test/Frontend/crash-in-user-code.swift
+++ b/test/Frontend/crash-in-user-code.swift
@@ -8,8 +8,6 @@
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
 
-// XFAIL: MSVC_VER=15.0
-
 // CHECK: Stack dump:
 // CHECK-NEXT: Program arguments:
 // CHECK-NEXT: Swift version


### PR DESCRIPTION
The test started working in the last week, for unknown reasons.

Remove the XFAIL line, but keep the infra for detecting the MSVC version
for the tests. It might be useful later.

If the test starts failing again, and nobody has any idea why, the best
path forward might be marking it as UNSUPPORTED.
