### PR TITLE
[ownership] Change switch_enum to be a true forwarding instructions.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -40,6 +40,7 @@
 #include "swift/Strings.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -7318,6 +7319,20 @@ public:
   }
 };
 
+class OwnershipForwardingTermInst : public TermInst {
+  ValueOwnershipKind ownershipKind;
+
+protected:
+  OwnershipForwardingTermInst(SILInstructionKind kind,
+                              SILDebugLocation debugLoc,
+                              ValueOwnershipKind ownershipKind)
+      : TermInst(kind, debugLoc), ownershipKind(ownershipKind) {}
+
+public:
+  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
+  void setOwnershipKind(ValueOwnershipKind newKind) { ownershipKind = newKind; }
+};
+
 /// UnreachableInst - Position in the code which would be undefined to reach.
 /// These are always implicitly generated, e.g. when falling off the end of a
 /// function or after a no-return function call.
@@ -7806,9 +7821,9 @@ public:
   }
 };
 
-/// Common implementation for the switch_enum and
-/// switch_enum_addr instructions.
-class SwitchEnumInstBase : public TermInst {
+/// Common implementation for the switch_enum and switch_enum_addr instructions.
+template <typename BaseTy>
+class SwitchEnumInstBase : public BaseTy {
   FixedOperandList<1> Operands;
 
   // Tail-allocated after the SwitchEnumInst record are:
@@ -7837,48 +7852,97 @@ class SwitchEnumInstBase : public TermInst {
   }
 
 protected:
+  template <typename... Rest>
   SwitchEnumInstBase(
       SILInstructionKind Kind, SILDebugLocation DebugLoc, SILValue Operand,
       SILBasicBlock *DefaultBB,
       ArrayRef<std::pair<EnumElementDecl *, SILBasicBlock *>> CaseBBs,
-      Optional<ArrayRef<ProfileCounter>> Counts, ProfileCounter DefaultCount);
+      Optional<ArrayRef<ProfileCounter>> Counts, ProfileCounter DefaultCount,
+      Rest &&... rest)
+      : BaseTy(Kind, DebugLoc, std::forward<Rest>(rest)...),
+        Operands(this, Operand) {
+    SILInstruction::Bits.SEIBase.HasDefault = bool(DefaultBB);
+    SILInstruction::Bits.SEIBase.NumCases = CaseBBs.size();
+    // Initialize the case and successor arrays.
+    auto *cases = getCaseBuf();
+    auto *succs = getSuccessorBuf();
+    for (unsigned i = 0, size = CaseBBs.size(); i < size; ++i) {
+      cases[i] = CaseBBs[i].first;
+      if (Counts) {
+        ::new (succs + i)
+            SILSuccessor(this, CaseBBs[i].second, Counts.getValue()[i]);
+      } else {
+        ::new (succs + i) SILSuccessor(this, CaseBBs[i].second);
+      }
+    }
 
-  template <typename SWITCH_ENUM_INST>
+    if (hasDefault()) {
+      ::new (succs + getNumCases()) SILSuccessor(this, DefaultBB, DefaultCount);
+    }
+  }
+
+  template <typename SWITCH_ENUM_INST, typename... RestTys>
   static SWITCH_ENUM_INST *createSwitchEnum(
       SILDebugLocation DebugLoc, SILValue Operand, SILBasicBlock *DefaultBB,
       ArrayRef<std::pair<EnumElementDecl *, SILBasicBlock *>> CaseBBs,
       SILFunction &F, Optional<ArrayRef<ProfileCounter>> Counts,
-      ProfileCounter DefaultCount);
+      ProfileCounter DefaultCount, RestTys &&... restArgs);
 
 public:
   /// Clean up tail-allocated successor records for the switch cases.
-  ~SwitchEnumInstBase();
+  ~SwitchEnumInstBase() {
+    // Destroy the successor records to keep the CFG up to date.
+    auto *succs = getSuccessorBuf();
+    for (unsigned i = 0, end = getNumCases() + hasDefault(); i < end; ++i) {
+      succs[i].~SILSuccessor();
+    }
+  }
 
   SILValue getOperand() const { return Operands[0].get(); }
 
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 
-  SuccessorListTy getSuccessors() {
+  TermInst::SuccessorListTy getSuccessors() {
     return MutableArrayRef<SILSuccessor>{getSuccessorBuf(),
                            static_cast<size_t>(getNumCases() + hasDefault())};
   }
 
-  unsigned getNumCases() const {
-    return SILInstruction::Bits.SwitchEnumInstBase.NumCases;
-  }
+  unsigned getNumCases() const { return SILInstruction::Bits.SEIBase.NumCases; }
+
   std::pair<EnumElementDecl*, SILBasicBlock*>
   getCase(unsigned i) const {
     assert(i < getNumCases() && "case out of bounds");
     return {getCaseBuf()[i], getSuccessorBuf()[i].getBB()};
   }
+
   ProfileCounter getCaseCount(unsigned i) const {
     assert(i < getNumCases() && "case out of bounds");
     return getSuccessorBuf()[i].getCount();
   }
 
   // Swap the cases at indices \p i and \p j.
-  void swapCase(unsigned i, unsigned j);
+  void swapCase(unsigned i, unsigned j) {
+    assert(i < getNumCases() && "First index is out of bounds?!");
+    assert(j < getNumCases() && "Second index is out of bounds?!");
+
+    auto *succs = getSuccessorBuf();
+
+    // First grab our destination blocks.
+    SILBasicBlock *iBlock = succs[i].getBB();
+    SILBasicBlock *jBlock = succs[j].getBB();
+
+    // Then destroy the sil successors and reinitialize them with the new things
+    // that they are pointing at.
+    succs[i].~SILSuccessor();
+    ::new (succs + i) SILSuccessor(this, jBlock);
+    succs[j].~SILSuccessor();
+    ::new (succs + j) SILSuccessor(this, iBlock);
+
+    // Now swap our cases.
+    auto *cases = getCaseBuf();
+    std::swap(cases[i], cases[j]);
+  }
 
   /// Return the block that will be branched to on the specified enum
   /// case.
@@ -7893,22 +7957,69 @@ public:
   }
 
   /// If the default refers to exactly one case decl, return it.
-  NullablePtr<EnumElementDecl> getUniqueCaseForDefault();
+  NullablePtr<EnumElementDecl> getUniqueCaseForDefault() {
+    auto enumValue = getOperand();
+    SILType enumType = enumValue->getType();
+
+    auto *f = SILInstruction::getFunction();
+    if (!enumType.isEffectivelyExhaustiveEnumType(f))
+      return nullptr;
+
+    EnumDecl *decl = enumType.getEnumOrBoundGenericEnum();
+    assert(decl && "switch_enum operand is not an enum");
+
+    SmallPtrSet<EnumElementDecl *, 4> unswitchedElts;
+    for (auto elt : decl->getAllElements())
+      unswitchedElts.insert(elt);
+
+    for (unsigned i = 0, e = getNumCases(); i != e; ++i) {
+      auto Entry = getCase(i);
+      unswitchedElts.erase(Entry.first);
+    }
+
+    if (unswitchedElts.size() == 1)
+      return *unswitchedElts.begin();
+
+    return nullptr;
+  }
 
   /// If the given block only has one enum element decl matched to it,
   /// return it.
-  NullablePtr<EnumElementDecl> getUniqueCaseForDestination(SILBasicBlock *BB);
+  NullablePtr<EnumElementDecl>
+  getUniqueCaseForDestination(SILBasicBlock *block) {
+    SILValue value = getOperand();
+    SILType enumType = value->getType();
+    EnumDecl *decl = enumType.getEnumOrBoundGenericEnum();
+    assert(decl && "switch_enum operand is not an enum");
+    (void)decl;
 
-  bool hasDefault() const {
-    return SILInstruction::Bits.SwitchEnumInstBase.HasDefault;
+    EnumElementDecl *eltDecl = nullptr;
+    for (unsigned i : range(getNumCases())) {
+      auto entry = getCase(i);
+      if (entry.second == block) {
+        if (eltDecl != nullptr)
+          return nullptr;
+        eltDecl = entry.first;
+      }
+    }
+    if (!eltDecl && hasDefault() && getDefaultBB() == block) {
+      return getUniqueCaseForDefault();
+    }
+    return eltDecl;
   }
+
+  bool hasDefault() const { return SILInstruction::Bits.SEIBase.HasDefault; }
 
   SILBasicBlock *getDefaultBB() const {
     assert(hasDefault() && "doesn't have a default");
     return getSuccessorBuf()[getNumCases()];
   }
 
-  NullablePtr<SILBasicBlock> getDefaultBBOrNull() const;
+  NullablePtr<SILBasicBlock> getDefaultBBOrNull() const {
+    if (!hasDefault())
+      return nullptr;
+    return getDefaultBB();
+  }
 
   ProfileCounter getDefaultCount() const {
     assert(hasDefault() && "doesn't have a default");
@@ -7925,7 +8036,7 @@ public:
 /// passed into the corresponding destination block as an argument.
 class SwitchEnumInst
     : public InstructionBase<SILInstructionKind::SwitchEnumInst,
-                             SwitchEnumInstBase> {
+                             SwitchEnumInstBase<OwnershipForwardingTermInst>> {
   friend SILBuilder;
 
 private:
@@ -7937,7 +8048,7 @@ private:
       Optional<ArrayRef<ProfileCounter>> CaseCounts,
       ProfileCounter DefaultCount)
       : InstructionBase(DebugLoc, Operand, DefaultBB, CaseBBs, CaseCounts,
-                        DefaultCount) {}
+                        DefaultCount, Operand.getOwnershipKind()) {}
   static SwitchEnumInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILBasicBlock *DefaultBB,
          ArrayRef<std::pair<EnumElementDecl *, SILBasicBlock *>> CaseBBs,
@@ -7948,7 +8059,7 @@ private:
 /// A switch on an enum's discriminator in memory.
 class SwitchEnumAddrInst
     : public InstructionBase<SILInstructionKind::SwitchEnumAddrInst,
-                             SwitchEnumInstBase> {
+                             SwitchEnumInstBase<TermInst>> {
   friend SILBuilder;
 
 private:

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -362,11 +362,24 @@ protected:
   IBWTO_BITFIELD(SwitchValueInst, TermInst, 1,
     HasDefault : 1
   );
-  SWIFT_INLINE_BITFIELD_FULL(SwitchEnumInstBase, TermInst, 1+32,
+
+  // Special handling for SwitchEnumInstBase.
+  //
+  // We assume all subsequent SwitchEnumBit uses do not use any further bits.
+  SWIFT_INLINE_BITFIELD(SEIBase, TermInst, 32-NumTermInstBits,
+    // Does this switch enum inst have a default block.
     HasDefault : 1,
-    : NumPadBits,
-    NumCases : 32
+    // Number of cases 
+    NumCases : 31 - NumTermInstBits;
+    template <typename BaseTy>
+    friend class SwitchEnumInstBase;
   );
+
+#define SEIB_BITFIELD_EMPTY(T, U) \
+  IBWTO_BITFIELD_EMPTY(T, U)
+
+  SEIB_BITFIELD_EMPTY(SwitchEnumInst, SEIBase);
+  SEIB_BITFIELD_EMPTY(SwitchEnumAddrInst, SEIBase);
 
   SWIFT_INLINE_BITFIELD_EMPTY(MultipleValueInstruction, SILInstruction);
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -429,6 +429,10 @@ public:
   SILType getEnumElementType(EnumElementDecl *elt, SILModule &M,
                              TypeExpansionContext context) const;
 
+  /// Given that this is an enum type, return true if this type is effectively
+  /// exhausted.
+  bool isEffectivelyExhaustiveEnumType(SILFunction *f);
+
   /// Given that this is a tuple type, return the lowered type of the
   /// given tuple element.  The result will have the same value
   /// category as the base type.

--- a/include/swift/SIL/TerminatorUtils.h
+++ b/include/swift/SIL/TerminatorUtils.h
@@ -1,0 +1,149 @@
+//===--- TerminatorUtils.h ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// ADTs for working with various forms of terminators.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_TERMINATORUTILS_H
+#define SWIFT_SIL_TERMINATORUTILS_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILInstruction.h"
+
+#include "llvm/ADT/PointerUnion.h"
+
+namespace swift {
+
+/// An ADT for writing generic code against SwitchEnumAddrInst and
+/// SwitchEnumInst.
+///
+/// We use this instead of SwitchEnumInstBase for this purpose in order to avoid
+/// the need for templating SwitchEnumInstBase from causing this ADT type of
+/// usage to require templates.
+class SwitchEnumTermInst {
+  PointerUnion<SwitchEnumAddrInst *, SwitchEnumInst *> value;
+
+public:
+  SwitchEnumTermInst(SwitchEnumAddrInst *seai) : value(seai) {}
+  SwitchEnumTermInst(SwitchEnumInst *seai) : value(seai) {}
+  SwitchEnumTermInst(SILInstruction *i) : value(nullptr) {
+    if (auto *seai = dyn_cast<SwitchEnumAddrInst>(i)) {
+      value = seai;
+      return;
+    }
+
+    if (auto *sei = dyn_cast<SwitchEnumInst>(i)) {
+      value = sei;
+      return;
+    }
+  }
+
+  SwitchEnumTermInst(const SILInstruction *i)
+      : SwitchEnumTermInst(const_cast<SILInstruction *>(i)) {}
+
+  operator TermInst *() const {
+    if (auto *seai = value.dyn_cast<SwitchEnumAddrInst *>())
+      return seai;
+    return value.get<SwitchEnumInst *>();
+  }
+
+  TermInst *operator*() const {
+    if (auto *seai = value.dyn_cast<SwitchEnumAddrInst *>())
+      return seai;
+    return value.get<SwitchEnumInst *>();
+  }
+
+  TermInst *operator->() const {
+    if (auto *seai = value.dyn_cast<SwitchEnumAddrInst *>())
+      return seai;
+    return value.get<SwitchEnumInst *>();
+  }
+
+  operator bool() const { return bool(value); }
+
+  SILValue getOperand() {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getOperand();
+    return value.get<SwitchEnumAddrInst *>()->getOperand();
+  }
+
+  unsigned getNumCases() {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getNumCases();
+    return value.get<SwitchEnumAddrInst *>()->getNumCases();
+  }
+
+  std::pair<EnumElementDecl *, SILBasicBlock *> getCase(unsigned i) const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getCase(i);
+    return value.get<SwitchEnumAddrInst *>()->getCase(i);
+  }
+
+  SILBasicBlock *getCaseDestination(EnumElementDecl *decl) const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getCaseDestination(decl);
+    return value.get<SwitchEnumAddrInst *>()->getCaseDestination(decl);
+  }
+
+  ProfileCounter getCaseCount(unsigned i) const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getCaseCount(i);
+    return value.get<SwitchEnumAddrInst *>()->getCaseCount(i);
+  }
+
+  ProfileCounter getDefaultCount() const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getDefaultCount();
+    return value.get<SwitchEnumAddrInst *>()->getDefaultCount();
+  }
+
+  bool hasDefault() const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->hasDefault();
+    return value.get<SwitchEnumAddrInst *>()->hasDefault();
+  }
+
+  SILBasicBlock *getDefaultBB() const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getDefaultBB();
+    return value.get<SwitchEnumAddrInst *>()->getDefaultBB();
+  }
+
+  NullablePtr<SILBasicBlock> getDefaultBBOrNull() const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getDefaultBBOrNull();
+    return value.get<SwitchEnumAddrInst *>()->getDefaultBBOrNull();
+  }
+
+  /// If the default refers to exactly one case decl, return it.
+  NullablePtr<EnumElementDecl> getUniqueCaseForDefault() const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getUniqueCaseForDefault();
+    return value.get<SwitchEnumAddrInst *>()->getUniqueCaseForDefault();
+  }
+
+  /// If the given block only has one enum element decl matched to it,
+  /// return it.
+  NullablePtr<EnumElementDecl>
+  getUniqueCaseForDestination(SILBasicBlock *BB) const {
+    if (auto *sei = value.dyn_cast<SwitchEnumInst *>())
+      return sei->getUniqueCaseForDestination(BB);
+    return value.get<SwitchEnumAddrInst *>()->getUniqueCaseForDestination(BB);
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -36,6 +36,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/TerminatorUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/Basic/TargetInfo.h"
@@ -3516,12 +3517,12 @@ static void addIncomingSILArgumentsToPHINodes(IRGenSILFunction &IGF,
 }
 
 static llvm::BasicBlock *emitBBMapForSwitchEnum(
-        IRGenSILFunction &IGF,
-        SmallVectorImpl<std::pair<EnumElementDecl*, llvm::BasicBlock*>> &dests,
-        SwitchEnumInstBase *inst) {
-  for (unsigned i = 0, e = inst->getNumCases(); i < e; ++i) {
-    auto casePair = inst->getCase(i);
-    
+    IRGenSILFunction &IGF,
+    SmallVectorImpl<std::pair<EnumElementDecl *, llvm::BasicBlock *>> &dests,
+    SwitchEnumTermInst inst) {
+  for (unsigned i = 0, e = inst.getNumCases(); i < e; ++i) {
+    auto casePair = inst.getCase(i);
+
     // If the destination BB accepts the case argument, set up a waypoint BB so
     // we can feed the values into the argument's PHI node(s).
     //
@@ -3533,10 +3534,10 @@ static llvm::BasicBlock *emitBBMapForSwitchEnum(
     else
       dests.push_back({casePair.first, IGF.getLoweredBB(casePair.second).bb});
   }
-  
+
   llvm::BasicBlock *defaultDest = nullptr;
-  if (inst->hasDefault())
-    defaultDest = IGF.getLoweredBB(inst->getDefaultBB()).bb;
+  if (inst.hasDefault())
+    defaultDest = IGF.getLoweredBB(inst.getDefaultBB()).bb;
   return defaultDest;
 }
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1817,54 +1817,6 @@ SelectEnumAddrInst *SelectEnumAddrInst::create(
       false /*HasOwnership*/);
 }
 
-SwitchEnumInstBase::SwitchEnumInstBase(
-    SILInstructionKind Kind, SILDebugLocation Loc, SILValue Operand,
-    SILBasicBlock *DefaultBB,
-    ArrayRef<std::pair<EnumElementDecl *, SILBasicBlock *>> CaseBBs,
-    Optional<ArrayRef<ProfileCounter>> CaseCounts, ProfileCounter DefaultCount)
-    : TermInst(Kind, Loc), Operands(this, Operand) {
-  SILInstruction::Bits.SwitchEnumInstBase.HasDefault = bool(DefaultBB);
-  SILInstruction::Bits.SwitchEnumInstBase.NumCases = CaseBBs.size();
-  // Initialize the case and successor arrays.
-  auto *cases = getCaseBuf();
-  auto *succs = getSuccessorBuf();
-  for (unsigned i = 0, size = CaseBBs.size(); i < size; ++i) {
-    cases[i] = CaseBBs[i].first;
-    if (CaseCounts) {
-      ::new (succs + i)
-          SILSuccessor(this, CaseBBs[i].second, CaseCounts.getValue()[i]);
-    } else {
-      ::new (succs + i) SILSuccessor(this, CaseBBs[i].second);
-    }
-  }
-
-  if (hasDefault()) {
-    ::new (succs + getNumCases()) SILSuccessor(this, DefaultBB, DefaultCount);
-  }
-}
-
-void SwitchEnumInstBase::swapCase(unsigned i, unsigned j) {
-  assert(i < getNumCases() && "First index is out of bounds?!");
-  assert(j < getNumCases() && "Second index is out of bounds?!");
-
-  auto *succs = getSuccessorBuf();
-
-  // First grab our destination blocks.
-  SILBasicBlock *iBlock = succs[i].getBB();
-  SILBasicBlock *jBlock = succs[j].getBB();
-
-  // Then destroy the sil successors and reinitialize them with the new things
-  // that they are pointing at.
-  succs[i].~SILSuccessor();
-  ::new (succs + i) SILSuccessor(this, jBlock);
-  succs[j].~SILSuccessor();
-  ::new (succs + j) SILSuccessor(this, iBlock);
-
-  // Now swap our cases.
-  auto *cases = getCaseBuf();
-  std::swap(cases[i], cases[j]);
-}
-
 namespace {
   template <class Inst> EnumElementDecl *
   getUniqueCaseForDefaultValue(Inst *inst, SILValue enumValue) {
@@ -1927,20 +1879,13 @@ NullablePtr<EnumElementDecl> SelectEnumInstBase::getSingleTrueElement() const {
   return *TrueElement;
 }
 
-SwitchEnumInstBase::~SwitchEnumInstBase() {
-  // Destroy the successor records to keep the CFG up to date.
-  auto *succs = getSuccessorBuf();
-  for (unsigned i = 0, end = getNumCases() + hasDefault(); i < end; ++i) {
-    succs[i].~SILSuccessor();
-  }
-}
-
-template <typename SWITCH_ENUM_INST>
-SWITCH_ENUM_INST *SwitchEnumInstBase::createSwitchEnum(
+template <typename BaseTy>
+template <typename SWITCH_ENUM_INST, typename... RestTys>
+SWITCH_ENUM_INST *SwitchEnumInstBase<BaseTy>::createSwitchEnum(
     SILDebugLocation Loc, SILValue Operand, SILBasicBlock *DefaultBB,
     ArrayRef<std::pair<EnumElementDecl *, SILBasicBlock *>> CaseBBs,
     SILFunction &F, Optional<ArrayRef<ProfileCounter>> CaseCounts,
-    ProfileCounter DefaultCount) {
+    ProfileCounter DefaultCount, RestTys &&... restArgs) {
   // Allocate enough room for the instruction with tail-allocated
   // EnumElementDecl and SILSuccessor arrays. There are `CaseBBs.size()` decls
   // and `CaseBBs.size() + (DefaultBB ? 1 : 0)` successors.
@@ -1951,41 +1896,9 @@ SWITCH_ENUM_INST *SwitchEnumInstBase::createSwitchEnum(
       sizeof(SWITCH_ENUM_INST) + sizeof(EnumElementDecl *) * numCases +
           sizeof(SILSuccessor) * numSuccessors,
       alignof(SWITCH_ENUM_INST));
-  return ::new (buf) SWITCH_ENUM_INST(Loc, Operand, DefaultBB, CaseBBs,
-                                      CaseCounts, DefaultCount);
-}
-
-NullablePtr<EnumElementDecl> SwitchEnumInstBase::getUniqueCaseForDefault() {
-  return getUniqueCaseForDefaultValue(this, getOperand());
-}
-
-NullablePtr<EnumElementDecl>
-SwitchEnumInstBase::getUniqueCaseForDestination(SILBasicBlock *BB) {
-  SILValue value = getOperand();
-  SILType enumType = value->getType();
-  EnumDecl *decl = enumType.getEnumOrBoundGenericEnum();
-  assert(decl && "switch_enum operand is not an enum");
-  (void)decl;
-
-  EnumElementDecl *D = nullptr;
-  for (unsigned i = 0, e = getNumCases(); i != e; ++i) {
-    auto Entry = getCase(i);
-    if (Entry.second == BB) {
-      if (D != nullptr)
-        return nullptr;
-      D = Entry.first;
-    }
-  }
-  if (!D && hasDefault() && getDefaultBB() == BB) {
-    return getUniqueCaseForDefault();
-  }
-  return D;
-}
-
-NullablePtr<SILBasicBlock> SwitchEnumInstBase::getDefaultBBOrNull() const {
-  if (!hasDefault())
-    return nullptr;
-  return getDefaultBB();
+  return ::new (buf)
+      SWITCH_ENUM_INST(Loc, Operand, DefaultBB, CaseBBs, CaseCounts,
+                       DefaultCount, std::forward<RestTys>(restArgs)...);
 }
 
 SwitchEnumInst *SwitchEnumInst::create(

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -16,26 +16,27 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "swift/Strings.h"
-#include "swift/Demangling/Demangle.h"
-#include "swift/Basic/QuotedString.h"
-#include "swift/SIL/SILPrintContext.h"
-#include "swift/SIL/ApplySite.h"
-#include "swift/SIL/CFG.h"
-#include "swift/SIL/SILFunction.h"
-#include "swift/SIL/SILCoverageMap.h"
-#include "swift/SIL/SILDebugScope.h"
-#include "swift/SIL/SILDeclRef.h"
-#include "swift/SIL/SILModule.h"
-#include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/SILVTable.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/QuotedString.h"
 #include "swift/Basic/STLExtras.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/CFG.h"
+#include "swift/SIL/SILCoverageMap.h"
+#include "swift/SIL/SILDebugScope.h"
+#include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILPrintContext.h"
+#include "swift/SIL/SILVTable.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/TerminatorUtils.h"
+#include "swift/Strings.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "llvm/ADT/APFloat.h"
@@ -47,10 +48,9 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormattedStream.h"
 #include <set>
-
 
 using namespace swift;
 using ID = SILPrintContext::ID;
@@ -2111,27 +2111,27 @@ public:
     if (SII->hasDefault())
       *this << ", default " << Ctx.getID(SII->getDefaultBB());
   }
-  
-  void printSwitchEnumInst(SwitchEnumInstBase *SOI) {
-    *this << getIDAndType(SOI->getOperand());
-    for (unsigned i = 0, e = SOI->getNumCases(); i < e; ++i) {
+
+  void printSwitchEnumInst(SwitchEnumTermInst SOI) {
+    *this << getIDAndType(SOI.getOperand());
+    for (unsigned i = 0, e = SOI.getNumCases(); i < e; ++i) {
       EnumElementDecl *elt;
       SILBasicBlock *dest;
-      std::tie(elt, dest) = SOI->getCase(i);
+      std::tie(elt, dest) = SOI.getCase(i);
       *this << ", case " << SILDeclRef(elt, SILDeclRef::Kind::EnumElement)
             << ": " << Ctx.getID(dest);
-      if (SOI->getCaseCount(i)) {
-        *this << " !case_count(" << SOI->getCaseCount(i).getValue() << ")";
+      if (SOI.getCaseCount(i)) {
+        *this << " !case_count(" << SOI.getCaseCount(i).getValue() << ")";
       }
     }
-    if (SOI->hasDefault()) {
-      *this << ", default " << Ctx.getID(SOI->getDefaultBB());
-      if (SOI->getDefaultCount()) {
-        *this << " !default_count(" << SOI->getDefaultCount().getValue() << ")";
+    if (SOI.hasDefault()) {
+      *this << ", default " << Ctx.getID(SOI.getDefaultBB());
+      if (SOI.getDefaultCount()) {
+        *this << " !default_count(" << SOI.getDefaultCount().getValue() << ")";
       }
     }
   }
-  
+
   void visitSwitchEnumInst(SwitchEnumInst *SOI) {
     printSwitchEnumInst(SOI);
   }

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -687,3 +687,10 @@ TypeBase::replaceSubstitutedSILFunctionTypesWithUnsubstituted(SILModule &M) cons
     return t;
   });
 }
+
+bool SILType::isEffectivelyExhaustiveEnumType(SILFunction *f) {
+  EnumDecl *decl = getEnumOrBoundGenericEnum();
+  assert(decl && "Called for a non enum type");
+  return decl->isEffectivelyExhaustive(f->getModule().getSwiftModule(),
+                                       f->getResilienceExpansion());
+}

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -17,6 +17,7 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/TerminatorUtils.h"
 
 using namespace swift;
 
@@ -97,6 +98,12 @@ static SILBasicBlock *getNthEdgeBlock(SwitchInstTy *S, unsigned edgeIdx) {
   return S->getCase(edgeIdx).second;
 }
 
+static SILBasicBlock *getNthEdgeBlock(SwitchEnumTermInst S, unsigned edgeIdx) {
+  if (S.getNumCases() == edgeIdx)
+    return S.getDefaultBB();
+  return S.getCase(edgeIdx).second;
+}
+
 void swift::getEdgeArgs(TermInst *T, unsigned edgeIdx, SILBasicBlock *newEdgeBB,
                         llvm::SmallVectorImpl<SILValue> &args) {
   switch (T->getKind()) {
@@ -159,8 +166,8 @@ void swift::getEdgeArgs(TermInst *T, unsigned edgeIdx, SILBasicBlock *newEdgeBB,
   // destination block to figure this out.
   case SILInstructionKind::SwitchEnumInst:
   case SILInstructionKind::SwitchEnumAddrInst: {
-    auto SEI = cast<SwitchEnumInstBase>(T);
-    auto *succBB = getNthEdgeBlock(SEI, edgeIdx);
+    SwitchEnumTermInst branch(T);
+    auto *succBB = getNthEdgeBlock(branch, edgeIdx);
     assert(succBB->getNumArguments() < 2 && "Can take at most one argument");
     if (!succBB->getNumArguments())
       return;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4280,6 +4280,13 @@ public:
           require(dest->getArguments().size() == 1,
                   "switch_enum destination for case w/ args must take 1 "
                   "argument");
+          if (!dest->getArgument(0)->getType().isTrivial(*SOI->getFunction())) {
+            require(
+                dest->getArgument(0)->getOwnershipKind().isCompatibleWith(
+                    SOI->getOwnershipKind()),
+                "Switch enum non-trivial destination arg must have ownership "
+                "kind that is compatible with the switch_enum's operand");
+          }
         } else {
           require(dest->getArguments().empty() ||
                       dest->getArguments().size() == 1,
@@ -4327,6 +4334,12 @@ public:
             SOI->getOperand()->getType(),
             "Switch enum default block should have one argument that is "
             "the same as the input type");
+        auto defaultKind =
+            SOI->getDefaultBB()->getArgument(0)->getOwnershipKind();
+        require(
+            defaultKind.isCompatibleWith(SOI->getOperand().getOwnershipKind()),
+            "Switch enum default block arg must have same ownership kind "
+            "as operand");
       } else if (!F.hasOwnership()) {
         require(SOI->getDefaultBB()->args_empty(),
                 "switch_enum default destination must take no arguments");

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -25,6 +25,7 @@
 #include "swift/SILOptimizer/Differentiation/PullbackCloner.h"
 #include "swift/SILOptimizer/Differentiation/Thunk.h"
 
+#include "swift/SIL/TerminatorUtils.h"
 #include "swift/SIL/TypeSubstCloner.h"
 #include "swift/SILOptimizer/PassManager/PrettyStackTrace.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
@@ -256,34 +257,32 @@ public:
         createTrampolineBasicBlock(cbi, pbStructVal, cbi->getFalseBB()));
   }
 
-  void visitSwitchEnumInstBase(SwitchEnumInstBase *inst) {
+  void visitSwitchEnumTermInst(SwitchEnumTermInst inst) {
     // Build pullback struct value for original block.
-    auto *pbStructVal = buildPullbackValueStructValue(inst);
+    auto *pbStructVal = buildPullbackValueStructValue(*inst);
 
     // Create trampoline successor basic blocks.
     SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 4> caseBBs;
-    for (unsigned i : range(inst->getNumCases())) {
-      auto caseBB = inst->getCase(i);
+    for (unsigned i : range(inst.getNumCases())) {
+      auto caseBB = inst.getCase(i);
       auto *trampolineBB =
           createTrampolineBasicBlock(inst, pbStructVal, caseBB.second);
       caseBBs.push_back({caseBB.first, trampolineBB});
     }
     // Create trampoline default basic block.
     SILBasicBlock *newDefaultBB = nullptr;
-    if (auto *defaultBB = inst->getDefaultBBOrNull().getPtrOrNull())
+    if (auto *defaultBB = inst.getDefaultBBOrNull().getPtrOrNull())
       newDefaultBB = createTrampolineBasicBlock(inst, pbStructVal, defaultBB);
 
     // Create a new `switch_enum` instruction.
     switch (inst->getKind()) {
     case SILInstructionKind::SwitchEnumInst:
-      getBuilder().createSwitchEnum(inst->getLoc(),
-                                    getOpValue(inst->getOperand()),
-                                    newDefaultBB, caseBBs);
+      getBuilder().createSwitchEnum(
+          inst->getLoc(), getOpValue(inst.getOperand()), newDefaultBB, caseBBs);
       break;
     case SILInstructionKind::SwitchEnumAddrInst:
-      getBuilder().createSwitchEnumAddr(inst->getLoc(),
-                                        getOpValue(inst->getOperand()),
-                                        newDefaultBB, caseBBs);
+      getBuilder().createSwitchEnumAddr(
+          inst->getLoc(), getOpValue(inst.getOperand()), newDefaultBB, caseBBs);
       break;
     default:
       llvm_unreachable("Expected `switch_enum` or `switch_enum_addr`");
@@ -291,11 +290,11 @@ public:
   }
 
   void visitSwitchEnumInst(SwitchEnumInst *sei) {
-    visitSwitchEnumInstBase(sei);
+    visitSwitchEnumTermInst(sei);
   }
 
   void visitSwitchEnumAddrInst(SwitchEnumAddrInst *seai) {
-    visitSwitchEnumInstBase(seai);
+    visitSwitchEnumTermInst(seai);
   }
 
   void visitCheckedCastBranchInst(CheckedCastBranchInst *ccbi) {

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -227,9 +227,15 @@ void OwnershipLiveRange::insertEndBorrowsAtDestroys(
 static void convertInstructionOwnership(SILInstruction *i,
                                         ValueOwnershipKind oldOwnership,
                                         ValueOwnershipKind newOwnership) {
-  // If this is a term inst, just convert all of its incoming values that are
-  // owned to be guaranteed.
+  // If this is a term inst...
   if (auto *ti = dyn_cast<TermInst>(i)) {
+    // First see if it is an ownership forwarding term inst. In such a case,
+    // change the ownership kind as appropriate.
+    if (auto *ofti = dyn_cast<OwnershipForwardingTermInst>(ti))
+      if (ofti->getOwnershipKind() == oldOwnership)
+        ofti->setOwnershipKind(newOwnership);
+
+    // Then convert all of its incoming values that are owned to be guaranteed.
     for (auto &succ : ti->getSuccessors()) {
       auto *succBlock = succ.getBB();
 

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-simplify-cfg"
+
 #include "swift/AST/Module.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/Dominance.h"
@@ -19,6 +20,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
+#include "swift/SIL/TerminatorUtils.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ProgramTerminationAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
@@ -2743,34 +2745,34 @@ bool SimplifyCFG::canonicalizeSwitchEnums() {
   bool Changed = false;
   for (auto &BB : Fn) {
     TermInst *TI = BB.getTerminator();
-  
-    auto *SWI = dyn_cast<SwitchEnumInstBase>(TI);
+
+    SwitchEnumTermInst SWI(TI);
     if (!SWI)
       continue;
-    
-    if (!SWI->hasDefault())
+
+    if (!SWI.hasDefault())
       continue;
 
-    NullablePtr<EnumElementDecl> elementDecl = SWI->getUniqueCaseForDefault();
+    NullablePtr<EnumElementDecl> elementDecl = SWI.getUniqueCaseForDefault();
     if (!elementDecl)
       continue;
     
     // Construct a new instruction by copying all the case entries.
     SmallVector<std::pair<EnumElementDecl*, SILBasicBlock*>, 4> CaseBBs;
-    for (int idx = 0, numIdcs = SWI->getNumCases(); idx < numIdcs; ++idx) {
-      CaseBBs.push_back(SWI->getCase(idx));
+    for (int idx = 0, numIdcs = SWI.getNumCases(); idx < numIdcs; ++idx) {
+      CaseBBs.push_back(SWI.getCase(idx));
     }
     // Add the default-entry of the original instruction as case-entry.
-    CaseBBs.push_back(std::make_pair(elementDecl.get(), SWI->getDefaultBB()));
+    CaseBBs.push_back(std::make_pair(elementDecl.get(), SWI.getDefaultBB()));
 
-    if (isa<SwitchEnumInst>(SWI)) {
-      SILBuilderWithScope(SWI)
-          .createSwitchEnum(SWI->getLoc(), SWI->getOperand(), nullptr, CaseBBs);
+    if (isa<SwitchEnumInst>(*SWI)) {
+      SILBuilderWithScope(SWI).createSwitchEnum(SWI->getLoc(), SWI.getOperand(),
+                                                nullptr, CaseBBs);
     } else {
-      assert(isa<SwitchEnumAddrInst>(SWI) &&
+      assert(isa<SwitchEnumAddrInst>(*SWI) &&
              "unknown switch_enum instruction");
       SILBuilderWithScope(SWI).createSwitchEnumAddr(
-          SWI->getLoc(), SWI->getOperand(), nullptr, CaseBBs);
+          SWI->getLoc(), SWI.getOperand(), nullptr, CaseBBs);
     }
     SWI->eraseFromParent();
     Changed = true;

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -17,6 +17,11 @@ struct NativeObjectPair {
   var obj2 : Builtin.NativeObject
 }
 
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
 ///////////
 // Tests //
 ///////////
@@ -837,3 +842,4 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
+

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -192,60 +192,6 @@ bb0(%0 : @owned $Optional<Builtin.NativeObject>):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Function: 'switch_enum_mismatching_argument_guaranteed_to_owned'
-// CHECK: Have operand with incompatible ownership?!
-// CHECK: Value: %0 = argument of bb0
-// CHECK: User:   switch_enum %0
-// CHECK: Conv: guaranteed
-// CHECK: OwnershipMap:
-// CHECK: -- OperandOwnershipKindMap --
-// CHECK: unowned:  No.
-// CHECK: owned: Yes. Liveness: LifetimeEnding
-// CHECK: guaranteed:  No.
-// CHECK: any: Yes. Liveness: NonLifetimeEnding
-sil [ossa] @switch_enum_mismatching_argument_guaranteed_to_owned : $@convention(thin) (@guaranteed Optional<Builtin.NativeObject>) -> () {
-bb0(%0 : @guaranteed $Optional<Builtin.NativeObject>):
-  switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
-
-bb1(%1 : @owned $Builtin.NativeObject):
-  destroy_value %1 : $Builtin.NativeObject
-  br bb3
-
-bb2:
-  br bb3
-
-bb3:
-  %9999 = tuple()
-  return %9999 : $()
-}
-
-// CHECK-LABEL: Function: 'switch_enum_mismatching_argument_owned_to_guaranteed'
-// CHECK: Have operand with incompatible ownership?!
-// CHECK: Value: %0 = argument of bb0 : $Optional<Builtin.NativeObject>
-// CHECK: User:   switch_enum %0 : $Optional<Builtin.NativeObject>
-// CHECK: Conv: owned
-// CHECK: OwnershipMap:
-// CHECK: -- OperandOwnershipKindMap --
-// CHECK: unowned:  No.
-// CHECK: owned:  No.
-// CHECK: guaranteed: Yes. Liveness: NonLifetimeEnding
-// CHECK: any: Yes. Liveness: NonLifetimeEnding
-sil [ossa] @switch_enum_mismatching_argument_owned_to_guaranteed : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> () {
-bb0(%0 : @owned $Optional<Builtin.NativeObject>):
-  switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
-
-bb1(%1 : @guaranteed $Builtin.NativeObject):
-  br bb3
-
-bb2:
-  br bb3
-
-bb3:
-  %9999 = tuple()
-  return %9999 : $()
-}
-
-
 // CHECK-LABEL: Function: 'switch_enum_guaranteed_arg_outlives_original_value'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>


### PR DESCRIPTION
This means that we actually store the ownership kind in the SwitchEnum rather than always inferring from the phi args.

The only funky part about the PR is that I needed to make SwitchEnumInstBase a templated thing meaning that I ran into problems since it was also used as an ADT in certain contexts. I worked around that by introducing a true ADT SwitchEnumTermInst for those situations.