### PR TITLE
[ownership] Move type dependent operand check out of the main visitor to eliminate another returning of an empty map from the visitor.

### DIFF
--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -622,9 +622,11 @@ OperandOwnershipKindClassifier::visitFullApply(FullApplySite apply) {
     return Map::allLive();
   }
 
-  // If we have a type dependent operand, return an empty map.
-  if (apply.getInstruction()->isTypeDependentOperand(op))
-    return Map();
+  // We should have early exited if we saw a type dependent operand, so we
+  // should never hit this.
+  //
+  // Lets just assert to be careful though.
+  assert(!apply.getInstruction()->isTypeDependentOperand(op));
 
   unsigned argIndex = apply.getCalleeArgIndex(op);
   auto conv = apply.getSubstCalleeConv();
@@ -1024,6 +1026,8 @@ OperandOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *bi) {
 //===----------------------------------------------------------------------===//
 
 OperandOwnershipKindMap Operand::getOwnershipKindMap() const {
+  if (isTypeDependent())
+    return OperandOwnershipKindMap();
   OperandOwnershipKindClassifier classifier(getUser()->getModule(), *this);
   return classifier.visit(const_cast<SILInstruction *>(getUser()));
 }


### PR DESCRIPTION
I may turn this into an assert, but for now I am preserving the current behavior
albeit moving the bad behavior out of the visitor to the front of the API.
