### PR TITLE
Build libdispatch with its own module cache

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2319,7 +2319,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_CXX_COMPILER:PATH="${CLANG_BIN}/clang++"
                     -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
                     -DCMAKE_Swift_COMPILER:PATH="${SWIFTC_BIN}"
-                    -DCMAKE_Swift_FLAGS:PATH="-module-cache-path \"${module_cache}\""
+                    -DCMAKE_Swift_FLAGS:STRING="-module-cache-path \"${module_cache}\""
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2319,6 +2319,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_CXX_COMPILER:PATH="${CLANG_BIN}/clang++"
                     -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
                     -DCMAKE_Swift_COMPILER:PATH="${SWIFTC_BIN}"
+                    -DCMAKE_Swift_FLAGS:PATH="-module-cache-path \"${module_cache}\""
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
                     -DCMAKE_INSTALL_LIBDIR:PATH="lib"
 


### PR DESCRIPTION
Some of the bots in CI run multiple jobs, so we need to be sure
libdispatch compilations do not attempt to share the module cache.

Addresses rdar://68100533