### PR TITLE
[Concurrency] Don't import _Concurrency implicitly when building a module

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -709,7 +709,9 @@ CompilerInstance::openModuleDoc(const InputFile &input) {
 
 bool CompilerInvocation::shouldImportSwiftConcurrency() const {
   return getLangOptions().EnableExperimentalConcurrency
-      && !getLangOptions().DisableImplicitConcurrencyModuleImport;
+      && !getLangOptions().DisableImplicitConcurrencyModuleImport &&
+      getFrontendOptions().InputMode !=
+        FrontendOptions::ParseInputMode::SwiftModuleInterface;
 }
 
 /// Implicitly import the SwiftOnoneSupport module in non-optimized


### PR DESCRIPTION
Another fix for rdar://71045297.
