### PR TITLE
[ownership] Fix assert to test the right thing semantically in the linear lifetime checker.

### DIFF
--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -29,6 +29,7 @@
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILUndef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
@@ -549,7 +550,8 @@ LinearLifetimeChecker::Error LinearLifetimeChecker::checkValueImpl(
     Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback,
     Optional<function_ref<void(Operand *)>>
         nonConsumingUseOutsideLifetimeCallback) {
-  assert((!consumingUses.empty() || !deadEndBlocks.empty()) &&
+  assert((!consumingUses.empty()
+          || deadEndBlocks.isDeadEnd(value->getParentBlock())) &&
          "Must have at least one consuming user?!");
 
   State state(value, visitedBlocks, errorBuilder, leakingBlockCallback,

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -41,6 +41,7 @@ protocol MyFakeAnyObject : Klass {
 
 final class Klass {
   var base: Klass
+  let baseLet: Klass
 }
 
 extension Klass : MyFakeAnyObject {
@@ -2804,5 +2805,30 @@ bb2(%2 : @owned ${ var Builtin.NativeObject }):
   %user = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   apply %user(%4) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   destroy_value %2 : ${ var Builtin.NativeObject }
+  unreachable
+}
+
+// Just make sure that we do not crash on this code and convert the 2nd load
+// [copy] to a load_borrow.
+//
+// CHECK-LABEL: sil [ossa] @inproper_dead_end_block_crasher_test : $@convention(thin) (Builtin.RawPointer) -> () {
+// CHECK: load_borrow
+// CHECK: load_borrow
+// CHECK: } // end sil function 'inproper_dead_end_block_crasher_test'
+sil [ossa] @inproper_dead_end_block_crasher_test : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Klass
+  %2 = load_borrow %1 : $*Klass
+  %3 = ref_element_addr %2 : $Klass, #Klass.baseLet
+  %4 = load [copy] %3 : $*Klass
+  %f = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %f(%4) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %4 : $Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
   unreachable
 }


### PR DESCRIPTION
I think this assert was just testing the wrong thing. Specifically, it is trying
to say that either the given value has a consuming use or it is post-dominated
by dead end blocks.

Instead of checking that directly by using DeadEndBlocks::isDeadEnd(), it was
using a different empty check that caused the assert to actually semantically
say that:

A value must have a lifetime ending use *or* the dead end blocks analysis must
have found at least one block at all in the function that is reachable from a
function terminating terminator (e.x.: return).

This is clearly not the former and was causing the linear lifetime error to hit
this assert in certain cases.

<rdar://problem/70690127>
