### PR TITLE
[concurrency] allow code to shadow definitions in implicit _Concurrency module

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -510,6 +510,21 @@ static void recordShadowedDeclsAfterTypeMatch(
         }
       }
 
+      // Next, prefer any other module over the _Concurrency module.
+      if (auto concurModule = ctx.getLoadedModule(ctx.Id_Concurrency)) {
+        if ((firstModule == concurModule) != (secondModule == concurModule)) {
+          // If second module is _Concurrency, then it is shadowed by first.
+          if (secondModule == concurModule) {
+            shadowed.insert(secondDecl);
+            continue;
+          }
+
+          // Otherwise, the first declaration is shadowed by the second.
+          shadowed.insert(firstDecl);
+          break;
+        }
+      }
+
       // The Foundation overlay introduced Data.withUnsafeBytes, which is
       // treated as being ambiguous with SwiftNIO's Data.withUnsafeBytes
       // extension. Apply a special-case name shadowing rule to use the

--- a/test/Concurrency/Inputs/ShadowsConcur.swift
+++ b/test/Concurrency/Inputs/ShadowsConcur.swift
@@ -1,0 +1,5 @@
+
+public struct Task {
+  public var someProperty : String = "123"
+  public init() { }
+}

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/ShadowsConcur.swiftmodule -module-name ShadowsConcur %S/Inputs/ShadowsConcur.swift
+// RUN: %target-typecheck-verify-swift -I %t -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+
+import ShadowsConcur
+
+func f(_ t : Task) -> Bool {
+  return t.someProperty == "123"
+}
+
+func g(_: _Concurrency.Task) {}


### PR DESCRIPTION
To reduce the impact of source compatibility breakages with the proposed concurrency extensions, this PR implements the same type of shadowing rule that applies to the Swift standard library: unqualified references to declarations imported from both the `_Concurrency` module and some other module `A` will always prefer module `A`'s declaration.

Resolves rdar://71045297

TODO:
- [x] patch name resolution
- [x] regression test: test unqualified references
- [x] test qualified references