### PR TITLE
Front-end: add a front-end action to print supported features of the compiler

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -75,6 +75,10 @@ TYPE("module-trace",        ModuleTrace,               "trace.json",      "")
 // Complete dependency information for the given Swift files as JSON.
 TYPE("json-dependencies",   JSONDependencies,          "dependencies.json",      "")
 
+// Complete feature information for the given Swift compiler.
+TYPE("json-features",       JSONFeatures,              "features.json",   "")
+
+
 TYPE("index-data",          IndexData,                 "",                "")
 TYPE("yaml-opt-record",     YAMLOptRecord,             "opt.yaml",        "")
 TYPE("bitstream-opt-record",BitstreamOptRecord,        "opt.bitstream",   "")

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -136,6 +136,7 @@ public:
     ScanDependencies,        ///< Scan dependencies of Swift source files
     ScanClangDependencies,   ///< Scan dependencies of a Clang module
     PrintVersion,       ///< Print version information.
+    PrintFeature,       ///< Print supported feature of this compiler
   };
 
   /// Indicates the action the user requested that the frontend perform.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1106,6 +1106,10 @@ def scan_clang_dependencies : Flag<["-"], "scan-clang-dependencies">,
   HelpText<"Scan dependencies of the given Clang module">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
+def emit_supported_features : Flag<["-"], "emit-supported-features">,
+  HelpText<"Emit a JSON file including all supported compiler features">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+
 def disable_parser_lookup : Flag<["-"], "disable-parser-lookup">,
   Flags<[FrontendOption]>,
   HelpText<"Disable parser lookup & use ASTScope lookup only (experimental)">;

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -83,6 +83,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
   case file_types::TY_SwiftOverlayFile:
   case file_types::TY_JSONDependencies:
+  case file_types::TY_JSONFeatures:
     return true;
   case file_types::TY_Image:
   case file_types::TY_Object:
@@ -155,6 +156,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_SwiftModuleInterfaceFile:
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
   case file_types::TY_JSONDependencies:
+  case file_types::TY_JSONFeatures:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -205,6 +207,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
+  case file_types::TY_JSONFeatures:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2054,6 +2054,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_SwiftCrossImportDir:
       case file_types::TY_SwiftOverlayFile:
       case file_types::TY_JSONDependencies:
+      case file_types::TY_JSONFeatures:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -599,6 +599,8 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
     return "-emit-imported-modules";
   case file_types::TY_JSONDependencies:
     return "-scan-dependencies";
+  case file_types::TY_JSONFeatures:
+    return "-emit-supported-features";
   case file_types::TY_IndexData:
     return "-typecheck";
   case file_types::TY_Remapping:
@@ -870,6 +872,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ClangModuleFile:
     case file_types::TY_IndexData:
     case file_types::TY_JSONDependencies:
+    case file_types::TY_JSONFeatures:
       llvm_unreachable("Cannot be output from backend job");
     case file_types::TY_Swift:
     case file_types::TY_dSYM:

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -414,7 +414,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::CompileModuleFromInterface;
   if (Opt.matches(OPT_typecheck_module_from_interface))
     return FrontendOptions::ActionType::TypecheckModuleFromInterface;
-
+  if (Opt.matches(OPT_emit_supported_features))
+    return FrontendOptions::ActionType::PrintFeature;
   llvm_unreachable("Unhandled mode option");
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -56,6 +56,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::EmitAssembly:
   case ActionType::EmitIR:
@@ -81,6 +82,7 @@ bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return true;
   default:
     return false;
@@ -103,6 +105,7 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -134,6 +137,7 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::REPL:
   case ActionType::Parse:
@@ -175,6 +179,7 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
   case ActionType::EmitPCH:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
@@ -305,6 +310,8 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
     return TY_JSONDependencies;
+  case ActionType::PrintFeature:
+    return TY_JSONFeatures;
   }
   llvm_unreachable("unhandled action");
 }
@@ -327,6 +334,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::REPL:
   case ActionType::DumpPCM:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -372,6 +380,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -428,6 +437,7 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::EmitSIL:
   case ActionType::EmitSIB:
@@ -463,6 +473,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -502,6 +513,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -547,6 +559,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -592,6 +605,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -639,6 +653,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
+  case ActionType::PrintFeature:
     return true;
 
   case ActionType::NoneAction:
@@ -687,6 +702,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return true;
   }
   llvm_unreachable("unhandled action");
@@ -714,6 +730,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -762,6 +779,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::ScanClangDependencies:
   case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
     return false;
   case ActionType::Immediate:
   case ActionType::REPL:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -48,6 +48,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/UUID.h"
+#include "swift/Option/Options.h"
 #include "swift/Frontend/DiagnosticVerifier.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -1842,6 +1843,51 @@ static bool printSwiftVersion(const CompilerInvocation &Invocation) {
   return false;
 }
 
+static void printSingleFrontendOpt(llvm::opt::OptTable &table, options::ID id,
+                                   llvm::raw_ostream &OS) {
+  if (table.getOption(id).hasFlag(options::FrontendOption)) {
+    auto name = StringRef(table.getOptionName(id));
+    if (!name.empty()) {
+      OS << "    \"" << name << "\",\n";
+    }
+  }
+}
+
+static bool printSwiftFeature(CompilerInstance &instance) {
+  ASTContext &context = instance.getASTContext();
+  const CompilerInvocation &invocation = instance.getInvocation();
+  const FrontendOptions &opts = invocation.getFrontendOptions();
+  std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
+  std::error_code EC;
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
+
+  if (out.has_error() || EC) {
+    context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,
+                           EC.message());
+    out.clear_error();
+    return true;
+  }
+  std::unique_ptr<llvm::opt::OptTable> table = createSwiftOptTable();
+
+  out << "{\n";
+  SWIFT_DEFER {
+    out << "}\n";
+  };
+  out << "  \"SupportedArguments\": [\n";
+#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
+               HELPTEXT, METAVAR, VALUES)                                      \
+  printSingleFrontendOpt(*table, swift::options::OPT_##ID, out);
+#include "swift/Option/Options.inc"
+#undef OPTION
+  out << "    \"LastOption\"\n";
+  out << "  ],\n";
+  out << "  \"SupportedFeatures\": [\n";
+  // Print supported featur names here.
+  out << "    \"LastFeature\"\n";
+  out << "  ]\n";
+  return false;
+}
+
 static bool
 withSemanticAnalysis(CompilerInstance &Instance, FrontendObserver *observer,
                      llvm::function_ref<bool(CompilerInstance &)> cont) {
@@ -1904,6 +1950,8 @@ static bool performAction(CompilerInstance &Instance,
     return Context.hadError();
   case FrontendOptions::ActionType::PrintVersion:
     return printSwiftVersion(Instance.getInvocation());
+  case FrontendOptions::ActionType::PrintFeature:
+    return printSwiftFeature(Instance);
   case FrontendOptions::ActionType::REPL:
     llvm::report_fatal_error("Compiler-internal integrated REPL has been "
                              "removed; use the LLDB-enhanced REPL instead.");

--- a/test/Frontend/emit-supported-features.swift
+++ b/test/Frontend/emit-supported-features.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-supported-features %s | %FileCheck %s
+
+// CHECK: "SupportedArguments"
+// CHECK: "emit-module"
+// CHECK: "LastOption"
+// CHECK: "SupportedFeatures"
+// CHECK: "LastFeature"


### PR DESCRIPTION
This could help swift-driver to check whether a compiler feature is supported so
it could adjust arguments accordingly.