### PR TITLE
[Dependency Scanner] Share `ModuleDependenciesCache` as a part of the CompilerInstance

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -416,6 +416,10 @@ class CompilerInstance {
   std::unique_ptr<Lowering::TypeConverter> TheSILTypes;
   std::unique_ptr<DiagnosticVerifier> DiagVerifier;
 
+  /// A cache describing the set of inter-module dependencies that have been queried.
+  /// Null if not present.
+  std::unique_ptr<ModuleDependenciesCache> ModDepCache;
+
   /// Null if no tracker.
   std::unique_ptr<DependencyTracker> DepTracker;
   /// If there is no stats output directory by the time the
@@ -487,6 +491,8 @@ public:
   DependencyTracker *getDependencyTracker() { return DepTracker.get(); }
   const DependencyTracker *getDependencyTracker() const { return DepTracker.get(); }
 
+  ModuleDependenciesCache *getModuleDependencyCache() { return ModDepCache.get(); }
+
   UnifiedStatsReporter *getStatsReporter() const { return Stats.get(); }
 
   /// Retrieve the main module containing the files being compiled.
@@ -552,6 +558,7 @@ private:
   bool setUpVirtualFileSystemOverlays();
   void setUpLLVMArguments();
   void setUpDiagnosticOptions();
+  void setUpModuleDependencyCacheIfNeeded();
   bool setUpModuleLoaders();
   bool setUpInputs();
   bool setUpASTContextIfNeeded();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -321,10 +321,21 @@ void CompilerInstance::setupDependencyTrackerIfNeeded() {
   DepTracker = std::make_unique<DependencyTracker>(*collectionMode);
 }
 
+void CompilerInstance::setUpModuleDependencyCacheIfNeeded() {
+  const auto &Invocation = getInvocation();
+  const auto &opts = Invocation.getFrontendOptions();
+  if (opts.RequestedAction == FrontendOptions::ActionType::ScanDependencies ||
+      opts.RequestedAction == FrontendOptions::ActionType::ScanClangDependencies) {
+    ModDepCache = std::make_unique<ModuleDependenciesCache>();
+  }
+}
+
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   Invocation = Invok;
 
   setupDependencyTrackerIfNeeded();
+
+  setUpModuleDependencyCacheIfNeeded();
 
   // If initializing the overlay file system fails there's no sense in
   // continuing because the compiler will read the wrong files.


### PR DESCRIPTION
This will allow individual module scans in batch-scanning mode to share the already-scanned Swift and Clang module dependencies, and avoid instantiating a new Clang `DependencyScanningService` for each batch entry.

Performance-improvement anecdote:
A simple experiment was carried out which performs a batch scan of all modules involved in planning a build of SwiftPM. The input batch includes 126 entries (scan entry-points), with 21 distinct Swift modules and 27 distinct Clang modules (many Clang modules are scanned multiple times, at different target versions). For this experiment, this modification reduces the total time taken from ~34 seconds to ~6.