### PR TITLE
[DiagnosticsQoI] Supe up the NSObject Inheritance Diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4531,6 +4531,9 @@ ERROR(invalid_objc_decl,none,
       "properties, and subscript declarations can be declared @objc", ())
 ERROR(invalid_objc_swift_rooted_class,none,
       "only classes that inherit from NSObject can be declared @objc", ())
+NOTE(invalid_objc_swift_root_class_insert_nsobject,none,
+     "inherit from 'NSObject' to silence this error", ())
+
 ERROR(invalid_nonobjc_decl,none,
       "only class members and extensions of classes can be declared @nonobjc", ())
 ERROR(invalid_nonobjc_extension,none,

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1155,13 +1155,28 @@ static Optional<ObjCReason> shouldMarkClassAsObjC(const ClassDecl *CD) {
     // (Leave a hole for test cases.)
     if (ancestry.contains(AncestryFlags::ObjC) &&
         !ancestry.contains(AncestryFlags::ClangImported)) {
-      if (ctx.LangOpts.EnableObjCAttrRequiresFoundation)
+      if (ctx.LangOpts.EnableObjCAttrRequiresFoundation) {
         ctx.Diags.diagnose(attr->getLocation(),
                            diag::invalid_objc_swift_rooted_class)
           .fixItRemove(attr->getRangeWithAt());
-      if (!ctx.LangOpts.EnableObjCInterop)
+        // If the user has not spelled out a superclass, offer to insert
+        // 'NSObject'. We could also offer to replace the existing superclass,
+        // but that's a touch aggressive.
+         if (CD->getInherited().empty()) {
+           auto nameEndLoc = Lexer::getLocForEndOfToken(ctx.SourceMgr,
+                                                        CD->getNameLoc());
+           CD->diagnose(diag::invalid_objc_swift_root_class_insert_nsobject)
+             .fixItInsert(nameEndLoc, ": NSObject");
+         } else if (CD->getSuperclass().isNull()) {
+           CD->diagnose(diag::invalid_objc_swift_root_class_insert_nsobject)
+             .fixItInsert(CD->getInherited().front().getLoc(), "NSObject, ");
+         }
+      }
+
+      if (!ctx.LangOpts.EnableObjCInterop) {
         ctx.Diags.diagnose(attr->getLocation(), diag::objc_interop_disabled)
           .fixItRemove(attr->getRangeWithAt());
+      }
     }
 
     return ObjCReason(ObjCReason::ExplicitlyObjC);

--- a/test/Sema/objc_attr_fixit_nsobject.swift
+++ b/test/Sema/objc_attr_fixit_nsobject.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -typecheck -verify -enable-objc-interop %s
+// RUN: %target-swift-frontend -typecheck -verify -enable-objc-interop -parse-as-library %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+class NonObjCBase {}
+protocol NonObjCProto {}
+
+@objc class AddSuper {} // expected-error {{only classes that inherit from NSObject can be declared @objc}} {{1-7=}}
+// expected-note@-1 {{inherit from 'NSObject' to silence this error}} {{21-21=: NSObject}}
+
+@objc class InsertSuper: NonObjCProto {} // expected-error {{only classes that inherit from NSObject can be declared @objc}} {{1-7=}}
+// expected-note@-1 {{inherit from 'NSObject' to silence this error}} {{26-26=NSObject, }}
+
+@objc class NoNote: NonObjCBase {} // expected-error {{only classes that inherit from NSObject can be declared @objc}} {{1-7=}}

--- a/test/Sema/objc_attr_requires_module_1.swift
+++ b/test/Sema/objc_attr_requires_module_1.swift
@@ -6,6 +6,7 @@
 // this test cover both cases.
 
 @objc class Foo {} // expected-error {{@objc attribute used without importing module 'Foundation'}} expected-error {{only classes that inherit from NSObject can be declared @objc}} {{1-7=}}
+// expected-note@-1 {{inherit from 'NSObject' to silence this error}} {{16-16=: NSObject}}
 
 #if false
 #endif

--- a/test/Sema/objc_attr_requires_module_2.swift
+++ b/test/Sema/objc_attr_requires_module_2.swift
@@ -4,3 +4,4 @@ class Foo {}
 _ = Foo()
 
 @objc class NSFoo {} // expected-error {{@objc attribute used without importing module 'Foundation'}} expected-error {{only classes that inherit from NSObject can be declared @objc}} {{1-7=}}
+// expected-note@-1 {{inherit from 'NSObject' to silence this error}} {{18-18=: NSObject}}


### PR DESCRIPTION
When ObjC interop is enabled, we complain when the user spells a class
that doesn't inherit from NSObject, but still has @objc attached to it.
We should offer a bit more help here. Let's check to see if we can
insert NSObject into their inheritance clause.

rdar://70548656