### PR TITLE
[cxx-interop] Don't import C++ objects that we can't destroy.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3499,7 +3499,7 @@ namespace {
 
         if (auto dtor = cxxRecordDecl->getDestructor()) {
           if (dtor->isDeleted() || dtor->getAccess() != clang::AS_public) {
-            result->setIsCxxNonTrivial(true);
+            return nullptr;
           }
         }
       }

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -112,6 +112,17 @@ struct StructWithSubobjectPrivateDefaultedDestructor {
   StructWithPrivateDefaultedDestructor subobject;
 };
 
+struct StructWithDeletedDestructor {
+  ~StructWithDeletedDestructor() = delete;
+};
+
+struct StructWithInheritedDeletedDestructor
+    : StructWithDeletedDestructor {};
+
+struct StructWithSubobjectDeletedDestructor {
+  StructWithDeletedDestructor subobject;
+};
+
 // Tests for common sets of special member functions.
 
 struct StructTriviallyCopyableMovable {

--- a/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
@@ -142,21 +142,6 @@ func pass(s: StructWithSubobjectDefaultedDestructor) {
   // CHECK: bb0(%0 : $StructWithSubobjectDefaultedDestructor):
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithPrivateDefaultedDestructor)
-func pass(s: StructWithPrivateDefaultedDestructor) {
-  // CHECK: bb0(%0 : $*StructWithPrivateDefaultedDestructor):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithInheritedPrivateDefaultedDestructor)
-func pass(s: StructWithInheritedPrivateDefaultedDestructor) {
-  // CHECK: bb0(%0 : $*StructWithInheritedPrivateDefaultedDestructor):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithSubobjectPrivateDefaultedDestructor)
-func pass(s: StructWithSubobjectPrivateDefaultedDestructor) {
-  // CHECK: bb0(%0 : $*StructWithSubobjectPrivateDefaultedDestructor):
-}
-
 // Tests for common sets of special member functions.
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructTriviallyCopyableMovable)
@@ -172,9 +157,4 @@ func pass(s: StructNonCopyableTriviallyMovable) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructNonCopyableNonMovable)
 func pass(s: StructNonCopyableNonMovable) {
   // CHECK: bb0(%0 : $*StructNonCopyableNonMovable):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructDeletedDestructor)
-func pass(s: StructDeletedDestructor) {
-  // CHECK: bb0(%0 : $*StructDeletedDestructor):
 }

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// Make sure we don't import objects that we can't destroy.
+// CHECK-NOT: StructWithPrivateDefaultedDestructor
+// CHECK-NOT: StructWithInheritedPrivateDefaultedDestructor
+// CHECK-NOT: StructWithSubobjectPrivateDefaultedDestructor
+// CHECK-NOT: StructWithDeletedDestructor
+// CHECK-NOT: StructWithInheritedDeletedDestructor
+// CHECK-NOT: StructWithSubobjectDeletedDestructor


### PR DESCRIPTION
Don't import C++ objects if they have a public destructor that is not deleted.