### PR TITLE
[windows] Mark crash-in-user-code as UNSUPPORTED in VS2017

### DIFF
--- a/test/Frontend/crash-in-user-code.swift
+++ b/test/Frontend/crash-in-user-code.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
+// UNSUPPORTED: MSVC_VER=15.0
 
 // CHECK: Stack dump:
 // CHECK-NEXT: Program arguments:


### PR DESCRIPTION
The test is very flaky. It works and stops working randomly for no
apparent reason. To avoid future problems, and since VS2019 keeps
working without these problems, mark the tests as unsupported to avoid
the noise.

See also #34143 and #34625.