### PR TITLE
AccessPath: Add init_enum_data_addr to "access projections" set.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1239,6 +1239,7 @@ inline Operand *getAccessProjectionOperand(SingleValueInstruction *svi) {
   case SILInstructionKind::TupleElementAddrInst:
   case SILInstructionKind::IndexAddrInst:
   case SILInstructionKind::TailAddrInst:
+  case SILInstructionKind::InitEnumDataAddrInst:
   // open_existential_addr and unchecked_take_enum_data_addr are problematic
   // because they both modify memory and are access projections. Ideally, they
   // would not be casts, but will likely be eliminated with opaque values.

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -927,6 +927,7 @@ public:
       // Ignore everything in getAccessProjectionOperand that is an access
       // projection with no affect on the access path.
       assert(isa<OpenExistentialAddrInst>(projectedAddr)
+             || isa<InitEnumDataAddrInst>(projectedAddr)
              || isa<UncheckedTakeEnumDataAddrInst>(projectedAddr)
              || isa<ProjectBoxInst>(projectedAddr));
     }
@@ -1389,6 +1390,10 @@ AccessPathDefUseTraversal::visitSingleValueUser(SingleValueInstruction *svi,
     pushUsers(svi, dfs);
     return IgnoredUse;
   }
+
+  case SILInstructionKind::InitEnumDataAddrInst:
+    pushUsers(svi, dfs);
+    return IgnoredUse;
 
   // open_existential_addr and unchecked_take_enum_data_addr are classified as
   // access projections, but they also modify memory. Both see through them and

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -333,8 +333,9 @@ func testInitGenericEnum<T>(t: T) -> GenericEnum<T>? {
 // CHECK:   copy_addr %1 to [initialization] [[ADR1]] : $*T
 // CHECK:   [[STK:%.*]] = alloc_stack $GenericEnum<T>
 // CHECK:   [[ENUMDATAADDR:%.*]] = init_enum_data_addr [[STK]]
-// CHECK-NOT: begin_access
-// CHECK:   copy_addr [take] [[ADR1]] to [initialization] [[ENUMDATAADDR]] : $*T
+// CHECK:   [[ACCESSENUM:%.*]] = begin_access [modify] [unsafe] [[ENUMDATAADDR]] : $*T
+// CHECK:   copy_addr [take] [[ADR1]] to [initialization] [[ACCESSENUM]] : $*T
+// CHECK:   end_access [[ACCESSENUM]] : $*T
 // CHECK:   inject_enum_addr
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]]
 // CHECK:   copy_addr [take] %{{.*}} to [[ACCESS]] : $*GenericEnum<T>

--- a/test/SILOptimizer/accesspath_uses.sil
+++ b/test/SILOptimizer/accesspath_uses.sil
@@ -866,3 +866,54 @@ bb5:
   %999 = tuple ()
   return %999 : $()
 }
+
+// CHECK-LABEL: @test_init_enum_addr
+// CHECK: ###For MemOp:   store %0 to [init] %2 : $*AnyObject
+// CHECK: Stack   %1 = alloc_stack $Optional<AnyObject>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  store %0 to [init] %{{.*}} : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %{{.*}} = load [copy] %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+// CHECK: Stack   %1 = alloc_stack $Optional<AnyObject>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  store %0 to [init] %{{.*}} : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %{{.*}} = load [copy] %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+// CHECK: ###For MemOp:   %5 = load [copy] %1 : $*Optional<AnyObject>
+// CHECK: Stack   %1 = alloc_stack $Optional<AnyObject>
+// CHECK: Path: ()
+// CHECK: Exact Uses {
+// CHECK-NEXT:  store %0 to [init] %{{.*}} : $*AnyObject
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  %{{.*}} = load [copy] %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  dealloc_stack %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT: }
+sil [ossa] @test_init_enum_addr : $@convention(thin) (@owned AnyObject) -> @owned Optional<AnyObject> {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack $Optional<AnyObject>
+  %2 = init_enum_data_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+  store %0 to [init] %2 : $*AnyObject
+  inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+  %5 = load [copy] %1 : $*Optional<AnyObject>
+  dealloc_stack %1 : $*Optional<AnyObject>
+  return %5 : $Optional<AnyObject>
+}

--- a/test/SILOptimizer/load_borrow_verify.sil
+++ b/test/SILOptimizer/load_borrow_verify.sil
@@ -58,3 +58,22 @@ bb0(%0 : $Int64):
   end_access %33 : $*Int64
   return %35 : $Int64
 }
+
+// CHECK-LABEL: sil [ossa] @test_borrow_init_enum_addr : $@convention(thin) (@owned AnyObject) -> () {
+// CHECK: bb0(%0 : @owned $AnyObject):
+// CHECK: [[ALLOC:%.*]] = alloc_stack $Optional<AnyObject>
+// CHECK: init_enum_data_addr [[ALLOC]] : $*Optional<AnyObject>, #Optional.some!enumelt
+// CHECK: load_borrow [[ALLOC]] : $*Optional<AnyObject>
+// CHECK-LABEL: } // end sil function 'test_borrow_init_enum_addr'
+sil [ossa] @test_borrow_init_enum_addr : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack $Optional<AnyObject>
+  %2 = init_enum_data_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+  store %0 to [init] %2 : $*AnyObject
+  inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
+  %5 = load_borrow %1 : $*Optional<AnyObject>
+  end_borrow %5 : $Optional<AnyObject>
+  dealloc_stack %1 : $*Optional<AnyObject>
+  %99 = tuple ()
+  return %99 : $()
+}


### PR DESCRIPTION
AccessPath was treating init_enum_data_addr as an address base, which
is not ideal. It should be able to identify the underlying enum object
as the base. This issue was caught by LoadBorrowImmutabilityChecker
during SIL verification.

Instead handle init_enum_data_addr as a access projection that does
not affect the access path. I expect this SIL pattern to disappear
with SIL opaque values, but it still needs to be handled properly
after lowering addresses.

Functionality changes:

- any user of AccessPath now sees enum initialization stores as writes
  to the underlying enum object

- SILGen now generates begin/end access markers for enum
  initialization patterns. (Originally, we did not "see through"
  init_enum_data_addr because we didn't want to generate these
  markers, but that behavior was inconsistent and problematic).

Fixes rdar://70725514 fatal error encountered during compilation;
Unknown instruction: init_enum_data_addr)

