### PR TITLE
[Concurrency] Avoid importing 'async' overloads.

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -460,6 +460,7 @@ bool omitNeedlessWords(StringRef &baseName,
                        const InheritedNameSet *allPropertyNames,
                        Optional<unsigned> completionHandlerIndex,
                        Optional<StringRef> completionHandlerName,
+                       bool appendAsyncToBaseName,
                        StringScratchSpace &scratch);
 
 /// If the name has a completion-handler suffix, strip off that suffix.

--- a/lib/ClangImporter/IAMInference.cpp
+++ b/lib/ClangImporter/IAMInference.cpp
@@ -448,7 +448,7 @@ private:
     baseName = humbleBaseName.userFacingName();
     bool didOmit =
         omitNeedlessWords(baseName, argStrs, "", "", "", paramTypeNames, false,
-                          false, nullptr, None, None, scratch);
+                          false, nullptr, None, None, false, scratch);
     SmallVector<Identifier, 8> argLabels;
     for (auto str : argStrs)
       argLabels.push_back(getIdentifier(str));

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -436,9 +436,10 @@ private:
   /// Look for a method that will import to have the same name as the
   /// given method after importing the Nth parameter as an elided error
   /// parameter.
-  bool hasErrorMethodNameCollision(const clang::ObjCMethodDecl *method,
-                                   unsigned paramIndex,
-                                   StringRef suffixToStrip);
+  bool hasMethodNameCollision(const clang::ObjCMethodDecl *method,
+                              unsigned paramIndex,
+                              StringRef suffixToStrip,
+                              bool isForAsync);
 
   /// Test to see if there is a value with the same name as 'proposedName' in
   /// the same module as the decl
@@ -459,7 +460,8 @@ private:
                       SmallVectorImpl<StringRef> &paramNames,
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName,
-                      Optional<ForeignErrorConvention::Info> errorInfo);
+                      Optional<ForeignErrorConvention::Info> errorInfo,
+                      bool &appendAsyncToBaseName);
 
   EffectiveClangContext determineEffectiveContext(const clang::NamedDecl *,
                                                   const clang::DeclContext *,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4876,7 +4876,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
                                 getTypeNameForOmission(contextType),
                                 paramTypes, returnsSelf, false,
                                 /*allPropertyNames=*/nullptr,
-                                None, None, scratch))
+                                None, None, false, scratch))
     return None;
 
   /// Retrieve a replacement identifier.
@@ -4931,7 +4931,8 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   OmissionTypeName contextTypeName = getTypeNameForOmission(contextType);
   if (::omitNeedlessWords(name, { }, "", typeName, contextTypeName, { },
                           /*returnsSelf=*/false, true,
-                          /*allPropertyNames=*/nullptr, None, None, scratch)) {
+                          /*allPropertyNames=*/nullptr, None, None, false,
+                          scratch)) {
     return Context.getIdentifier(name);
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -14,14 +14,27 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: (Int) -> Void = slowServer.completionHandler
 
   // async version
-  let _: Int = await slowServer.doSomethingConflicted("thinking")
+  let _: Int = await slowServer.doSomethingConflictedAsync("thinking")
 
-  // still async version...
+  // okay, sync version
   let _: Int = slowServer.doSomethingConflicted("thinking")
-  // expected-error@-1{{call is 'async' but is not marked with 'await'}}{{16-16=await }}
 
   let _: String? = await try slowServer.fortune()
   let _: Int = await try slowServer.magicNumber(withSeed: 42)
+
+  let _: String = slowServer.magicName(withSeed: 42)
+  let _: String = await try slowServer.magicNameAsync(withSeed: 42)
+
+  let _: String = try slowServer.boringName(withSeed: 42)
+  let _: String = await try slowServer.boringNameAsync(withSeed: 42)
+
+  let _: String = slowServer.confusingName()
+  let _: String = await try slowServer.confusingNameAsync()
+
+  let _: String = slowServer.amazingName(5)
+  let _: String = await try slowServer.amazingNameAsync()
+
+  let _: String = await try slowServer.terrifyingName()
 
   await slowServer.serverRestart("localhost")
   await slowServer.server("localhost", atPriorityRestart: 0.8)

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -16,16 +16,16 @@ func syncContext() {
 func asyncNoAwait() async {
   let r = Request()
   let d = Delegate()
-  d.makeRequest1(r) // expected-error {{call is 'async' but is not marked with 'await'}}
-  d.makeRequest2(r) // expected-error {{call is 'async' but is not marked with 'await'}}
-  d.makeRequest3(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+  d.makeRequest1Async(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+  d.makeRequest2Async(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+  d.makeRequest3Async(r) // expected-error {{call is 'async' but is not marked with 'await'}}
 }
 
 
 func asyncWithAwait() async {
   let r = Request()
   let d = Delegate()
-  await d.makeRequest1(r)
-  await d.makeRequest2(r)
-  await d.makeRequest3(r)
+  await d.makeRequest1Async(r)
+  await d.makeRequest2Async(r)
+  await d.makeRequest3Async(r)
 }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -10,7 +10,7 @@
 // CHECK-DAG:     func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK-DAG:     func doSomethingSlow(_ operation: String) async -> Int
 // CHECK-DAG:     func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)
-// CHECK-DAG:     func doSomethingDangerous(_ operation: String) async throws -> String
+// CHECK-DAG:     func doSomethingDangerousAsync(_ operation: String) async throws -> String
 // CHECK-DAG:     func checkAvailability(completionHandler: @escaping (Bool) -> Void)
 // CHECK-DAG:     func checkAvailability() async -> Bool
 // CHECK-DAG:     func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -14,6 +14,20 @@
 -(void)getMagicNumberAsynchronouslyWithSeed:(NSInteger)seed completionHandler:(void (^)(NSInteger, NSError * _Nullable))handler;
 @property(readwrite) void (^completionHandler)(NSInteger);
 
+-(NSString *)magicNameWithSeed:(NSInteger)seed;
+-(void)magicNameAsynchronouslyWithSeed:(NSInteger)seed completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler;
+
+-(NSString * _Nullable)boringNameWithSeed:(NSInteger)seed error:(NSError **)error;
+-(void)boringNameAsynchronouslyWithSeed:(NSInteger)seed completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler;
+
+-(NSString *)confusingName;
+-(void)confusingNameAsynchronouslyWithCompletionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler;
+
+-(NSString *)amazingName:(NSInteger)integer;
+-(void)amazingNameAsynchronouslyWithCompletionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler;
+
+-(void)terrifyingNameWithCompletionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler;
+
 -(void)doSomethingConflicted:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
 -(NSInteger)doSomethingConflicted:(NSString *)operation;
 -(void)server:(NSString *)name restartWithCompletionHandler:(void (^)(void))block;

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -43,10 +43,10 @@
 @end
 
 @protocol ConcurrentProtocol
--(void)askUserToSolvePuzzle:(NSString *)puzzle completionHandler:(void (^ _Nullable)(NSString * _Nullable, NSError * _Nullable))completionHandler;
+-(void)askUserToSolvePuzzle:(NSString *)puzzle completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))completionHandler;
 
 @optional
--(void)askUserToJumpThroughHoop:(NSString *)hoop completionHandler:(void (^ _Nullable)(NSString *))completionHandler;
+-(void)askUserToJumpThroughHoop:(NSString *)hoop completionHandler:(void (^)(NSString *))completionHandler;
 @end
 
 #pragma clang assume_nonnull end

--- a/test/decl/protocol/conforms/objc_async.swift
+++ b/test/decl/protocol/conforms/objc_async.swift
@@ -14,12 +14,12 @@ class C1: ConcurrentProtocol {
 
 // Conform via completion-handler method
 class C2: ConcurrentProtocol {
-  func askUser(toSolvePuzzle puzzle: String, completionHandler: ((String?, Error?) -> Void)?) {
-    completionHandler?("hello", nil)
+  func askUser(toSolvePuzzle puzzle: String, completionHandler: (String?, Error?) -> Void) {
+    completionHandler("hello", nil)
   }
 
-  func askUser(toJumpThroughHoop hoop: String, completionHandler: ((String) -> Void)?) {
-    completionHandler?("hello")
+  func askUser(toJumpThroughHoop hoop: String, completionHandler: (String) -> Void) {
+    completionHandler("hello")
   }
 }
 
@@ -29,8 +29,8 @@ class C3: ConcurrentProtocol {
   func askUser(toSolvePuzzle puzzle: String) async throws -> String { "" }
 
   // expected-error@+1{{'askUser(toSolvePuzzle:completionHandler:)' with Objective-C selector 'askUserToSolvePuzzle:completionHandler:' conflicts with method 'askUser(toSolvePuzzle:)' with the same Objective-C selector}}
-  func askUser(toSolvePuzzle puzzle: String, completionHandler: ((String?, Error?) -> Void)?) {
-    completionHandler?("hello", nil)
+  func askUser(toSolvePuzzle puzzle: String, completionHandler: (String?, Error?) -> Void) {
+    completionHandler("hello", nil)
   }
 }
 
@@ -43,11 +43,11 @@ class C5 {
 }
 
 extension C5: ConcurrentProtocol {
-  func askUser(toSolvePuzzle puzzle: String, completionHandler: ((String?, Error?) -> Void)?) {
-    completionHandler?("hello", nil)
+  func askUser(toSolvePuzzle puzzle: String, completionHandler: (String?, Error?) -> Void) {
+    completionHandler("hello", nil)
   }
 
-  func askUser(toJumpThroughHoop hoop: String, completionHandler: ((String) -> Void)?) {
-    completionHandler?("hello")
+  func askUser(toJumpThroughHoop hoop: String, completionHandler: (String) -> Void) {
+    completionHandler("hello")
   }
 }


### PR DESCRIPTION
When importing a method as `async`, look whether it would overload a
synchronous method. If so, append the `Async` suffix to the base name
to keep it out of the way of the original function.
