### PR TITLE
[test] Fix test/SourceKit/CursorInfo/invalid_offset

### DIFF
--- a/test/SourceKit/CursorInfo/invalid_offset.swift
+++ b/test/SourceKit/CursorInfo/invalid_offset.swift
@@ -1,15 +1,12 @@
 let a = 12
 
 // rdar://problem/30346106
-// Invalid offset should trigger a crash.
+// Invalid offset should not trigger a crash.
 
 // RUN: not %sourcekitd-test 2>&1 \
 // RUN:   -req=open %s -- %s == \
 // RUN:   -req=edit -async -offset=0 -length=200 -replace='' %s -- %s == \
-// RUN:   -req=cursor -offset=250 %s -- %s \
-// RUN: | %FileCheck %s
+// RUN:   -req=cursor -offset=250 %s -- %s
 
 // rdar://problem/38162017
 // REQUIRES: OS=macosx
-
-// CHECK: (Request Failed): Unable to resolve the start of the token


### PR DESCRIPTION
This test was intended to catch a crash on invalid offset, but in rare
cases it was failing spuriously, because the error message depends on
non-deterministic behaviour. It's sufficient for this test that it
doesn't crash.

rdar://63187529