### PR TITLE
[ownership] Convert ValueOwnershipKind to have an Invalid state instead of using optional.

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2886,5 +2886,8 @@ ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,
       });
 
   // Then merge all of our ownership kinds. Assert if we fail to merge.
-  ownershipKind = *ValueOwnershipKind::merge(ownershipKindRange);
+  ownershipKind = ValueOwnershipKind::merge(ownershipKindRange);
+  assert(ownershipKind != ValueOwnershipKind::Invalid &&
+         "Conflicting ownership kinds when creating term inst from function "
+         "result info?!");
 }

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -198,6 +198,8 @@ ValueOwnershipKind::ValueOwnershipKind(const SILFunction &F, SILType Type,
 
 StringRef ValueOwnershipKind::asString() const {
   switch (Value) {
+  case ValueOwnershipKind::Invalid:
+    return "invalid";
   case ValueOwnershipKind::Unowned:
     return "unowned";
   case ValueOwnershipKind::Owned:
@@ -215,21 +217,27 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
   return os << kind.asString();
 }
 
-Optional<ValueOwnershipKind>
-ValueOwnershipKind::merge(ValueOwnershipKind RHS) const {
-  auto LHSVal = Value;
-  auto RHSVal = RHS.Value;
+ValueOwnershipKind ValueOwnershipKind::merge(ValueOwnershipKind rhs) const {
+  auto lhsVal = Value;
+  auto rhsVal = rhs.Value;
 
-  // Any merges with anything.
-  if (LHSVal == ValueOwnershipKind::None) {
-    return ValueOwnershipKind(RHSVal);
-  }
-  // Any merges with anything.
-  if (RHSVal == ValueOwnershipKind::None) {
-    return ValueOwnershipKind(LHSVal);
-  }
+  // If either lhs or rhs are invalid, return invalid.
+  if (lhsVal == ValueOwnershipKind::Invalid ||
+      rhsVal == ValueOwnershipKind::Invalid)
+    return ValueOwnershipKind::Invalid;
 
-  return (LHSVal == RHSVal) ? Optional<ValueOwnershipKind>(*this) : llvm::None;
+  // None merges with anything.
+  if (lhsVal == ValueOwnershipKind::None)
+    return ValueOwnershipKind(rhsVal);
+  if (rhsVal == ValueOwnershipKind::None)
+    return ValueOwnershipKind(lhsVal);
+
+  // At this point, if the two ownership kinds don't line up, the merge fails.
+  if (lhsVal != rhsVal)
+    return ValueOwnershipKind::Invalid;
+
+  // Otherwise, we are good, return *this.
+  return *this;
 }
 
 ValueOwnershipKind::ValueOwnershipKind(StringRef S) {

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -225,7 +225,7 @@ ValueOwnershipKindClassifier::visitForwardingInst(SILInstruction *i,
         return op.get().getOwnershipKind();
       }));
 
-  if (!mergedValue.hasValue()) {
+  if (!mergedValue) {
     // If we have mismatched SILOwnership and sil ownership is not enabled,
     // just return None for staging purposes. If SILOwnership is enabled, then
     // we must assert!
@@ -235,7 +235,7 @@ ValueOwnershipKindClassifier::visitForwardingInst(SILInstruction *i,
     llvm_unreachable("Forwarding inst with mismatching ownership kinds?!");
   }
 
-  return mergedValue.getValue();
+  return mergedValue;
 }
 
 #define FORWARDING_OWNERSHIP_INST(INST)                                        \
@@ -341,7 +341,7 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitApplyInst(ApplyInst *ai) {
     llvm_unreachable("Forwarding inst with mismatching ownership kinds?!");
   }
 
-  return *mergedOwnershipKind;
+  return mergedOwnershipKind;
 }
 
 ValueOwnershipKind ValueOwnershipKindClassifier::visitLoadInst(LoadInst *LI) {

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -487,6 +487,8 @@ bool SILValueOwnershipChecker::gatherUsers(
 bool SILValueOwnershipChecker::checkFunctionArgWithoutLifetimeEndingUses(
     SILFunctionArgument *arg) {
   switch (arg->getOwnershipKind()) {
+  case ValueOwnershipKind::Invalid:
+    llvm_unreachable("Invalid ownership kind used?!");
   case ValueOwnershipKind::Guaranteed:
   case ValueOwnershipKind::Unowned:
   case ValueOwnershipKind::None:
@@ -507,6 +509,8 @@ bool SILValueOwnershipChecker::checkFunctionArgWithoutLifetimeEndingUses(
 bool SILValueOwnershipChecker::checkYieldWithoutLifetimeEndingUses(
     BeginApplyResult *yield, ArrayRef<Operand *> regularUses) {
   switch (yield->getOwnershipKind()) {
+  case ValueOwnershipKind::Invalid:
+    llvm_unreachable("Invalid ownership kind used?!");
   case ValueOwnershipKind::Unowned:
   case ValueOwnershipKind::None:
     return true;

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -388,7 +388,7 @@ static void verifyHelper(ArrayRef<ManagedValue> values,
                          NullablePtr<SILGenFunction> SGF = nullptr) {
 // This is a no-op in non-assert builds.
 #ifndef NDEBUG
-  auto result = Optional<ValueOwnershipKind>(ValueOwnershipKind::None);
+  ValueOwnershipKind result = ValueOwnershipKind::None;
   Optional<bool> sameHaveCleanups;
   for (ManagedValue v : values) {
     assert((!SGF || !v.getType().isLoadable(SGF.get()->F) ||
@@ -408,8 +408,8 @@ static void verifyHelper(ArrayRef<ManagedValue> values,
 
     // This variable is here so that if the assert below fires, the current
     // reduction value is still available.
-    auto newResult = result.getValue().merge(kind);
-    assert(newResult.hasValue());
+    auto newResult = result.merge(kind);
+    assert(newResult);
     result = newResult;
   }
 #endif

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -496,6 +496,8 @@ SILFunction *getOrCreateReabstractionThunk(SILOptFunctionBuilder &fb,
   // Owned values need to be destroyed.
   for (auto arg : valuesToCleanup) {
     switch (arg.getOwnershipKind()) {
+    case ValueOwnershipKind::Invalid:
+      llvm_unreachable("Invalid ownership kind?!");
     case ValueOwnershipKind::Guaranteed:
       builder.emitEndBorrowOperation(loc, arg);
       break;

--- a/test/SIL/ownership-verifier/undef.sil
+++ b/test/SIL/ownership-verifier/undef.sil
@@ -20,6 +20,7 @@ struct MyInt {
 // CHECK-NEXT: Operand Ownership Map:
 // CHECK-NEXT: Op #: 0
 // CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
+// CHECK-NEXT: invalid:  No.
 // CHECK-NEXT: unowned:  No.
 // CHECK-NEXT: owned: Yes. Liveness: LifetimeEnding
 // CHECK-NEXT: guaranteed:  No.
@@ -28,6 +29,7 @@ struct MyInt {
 // CHECK-NEXT: Operand Ownership Map:
 // CHECK-NEXT: Op #: 0
 // CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
+// CHECK-NEXT: invalid:  No.
 // CHECK-NEXT: unowned:  No.
 // CHECK-NEXT: owned: Yes. Liveness: LifetimeEnding
 // CHECK-NEXT: guaranteed:  No.
@@ -36,6 +38,7 @@ struct MyInt {
 // CHECK-NEXT: Operand Ownership Map:
 // CHECK-NEXT: Op #: 0
 // CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
+// CHECK-NEXT: invalid:  No.
 // CHECK-NEXT: unowned:  No.
 // CHECK-NEXT: owned: Yes. Liveness: LifetimeEnding
 // CHECK-NEXT: guaranteed:  No.
@@ -44,6 +47,7 @@ struct MyInt {
 // CHECK-NEXT: Operand Ownership Map:
 // CHECK-NEXT: Op #: 0
 // CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
+// CHECK-NEXT: invalid:  No.
 // CHECK-NEXT: unowned:  No.
 // CHECK-NEXT: owned: No.
 // CHECK-NEXT: guaranteed:  No.


### PR DESCRIPTION
At Andy's request. If it creates too much noise in covered switches, we may go
back to the original.
