### PR TITLE
[NFC] Add back a higher polynomial threshold for rdar18360240.swift.gyb

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes %s
+// RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes --polynomial-threshold 1.5 %s
 // REQUIRES: asserts,no_asan
 
 let empty: [Int] = []


### PR DESCRIPTION
This threshold was accidentally removed in https://github.com/apple/swift/pull/34399, but the performance of this test didn't change with that PR because I left the CSGen hack supporting this case in place for now.
