### PR TITLE
[android] Add support for x86_64 arch

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -349,6 +349,9 @@ def apply_default_arguments(toolchain, args):
         elif args.android_arch == "aarch64":
             args.stdlib_deployment_targets.append(
                 StdlibDeploymentTarget.Android.aarch64.name)
+        elif args.android_arch == "x86_64":
+            args.stdlib_deployment_targets.append(
+                StdlibDeploymentTarget.Android.x86_64.name)
 
     # Infer platform flags from manually-specified configure targets.
     # This doesn't apply to Darwin platforms, as they are

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -414,7 +414,8 @@ function verify_host_is_supported() {
       | watchsimulator-arm64    \
       | watchos-armv7k          \
       | android-armv7           \
-      | android-aarch64)
+      | android-aarch64         \
+      | android-x86_64)
         ;;
       *)
         echo "Unknown host tools target: ${host}"
@@ -457,6 +458,10 @@ function set_build_options_for_host() {
         android-armv7)
             SWIFT_HOST_TRIPLE="armv7-unknown-linux-androideabi"
             llvm_target_arch="ARM"
+            ;;
+        android-x86_64)
+            SWIFT_HOST_TRIPLE="x86_64-unknown-linux-android${ANDROID_API_LEVEL}"
+            llvm_target_arch="X86"
             ;;
         linux-armv6)
             SWIFT_HOST_TRIPLE="armv6-unknown-linux-gnueabihf"

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1087,10 +1087,10 @@ def create_argument_parser():
                     android.adb.commands.DEVICE_TEMP_DIR))
 
     option('--android-arch', store,
-           choices=['armv7', 'aarch64'],
+           choices=['armv7', 'aarch64', 'x86_64'],
            default='armv7',
-           help='The Android target architecture when building for Android. '
-                'Currently only armv7 and aarch64 are supported. '
+           help='The target architecture when building for Android. '
+                'Currently, only armv7, aarch64, and x86_64 are supported. '
                 '%(default)s is the default.')
 
     # -------------------------------------------------------------------------

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -201,7 +201,7 @@ class StdlibDeploymentTarget(object):
 
     Cygwin = Platform("cygwin", archs=["x86_64"])
 
-    Android = AndroidPlatform("android", archs=["armv7", "aarch64"])
+    Android = AndroidPlatform("android", archs=["armv7", "aarch64", "x86_64"])
 
     Windows = Platform("windows", archs=["x86_64"])
 


### PR DESCRIPTION
I was able to cross-compile the stdlib, corelibs, and SPM using this pull and a tweaked #33724. I have kicked off a full toolchain build and ~will~no further update to this pull ~if~was needed, termux/termux-packages#6014.

@compnerd and @vgorloff, looks like you two have been building this before.