### PR TITLE
[runtime] Adjust file/line information in fatal error messages to match compiler diagnostics

### DIFF
--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -49,12 +49,12 @@ void _swift_stdlib_reportFatalErrorInFile(
 ) {
   char *log;
   swift_asprintf(
-      &log, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
-      prefixLength, prefix,
-      messageLength, message,
-      (messageLength ? ": " : ""),
+      &log, "%.*s:%" PRIu32 ": %.*s%s%.*s\n",
       fileLength, file,
-      line);
+      line,
+      prefixLength, prefix,
+      (messageLength > 0 ? ": " : ""),
+      messageLength, message);
 
   swift_reportError(flags, log);
   free(log);
@@ -89,10 +89,10 @@ void _swift_stdlib_reportUnimplementedInitializerInFile(
   char *log;
   swift_asprintf(
       &log,
-      "%.*s: %" PRIu32 ": %" PRIu32 ": Fatal error: Use of unimplemented "
+      "%.*s:%" PRIu32 ": Fatal error: Use of unimplemented "
       "initializer '%.*s' for class '%.*s'\n",
       fileLength, file,
-      line, column,
+      line,
       initNameLength, initName,
       classNameLength, className);
 

--- a/test/PlaygroundTransform/implicit_return_never.swift
+++ b/test/PlaygroundTransform/implicit_return_never.swift
@@ -13,7 +13,7 @@
 
 func f() -> Int {
     fatalError()
-// CRASH-CHECK: {{[fF]}}atal error: file {{.*}}/main.swift, line [[@LINE-1]]
+// CRASH-CHECK: {{.*}}/main.swift:[[@LINE-1]]: Fatal error
 }
 
 f()

--- a/test/PlaygroundTransform/placeholder.swift
+++ b/test/PlaygroundTransform/placeholder.swift
@@ -10,12 +10,11 @@
 // status doesn't reflect whether its child process crashed or not. So "not
 // --crash %target-run ..." always fails when testing for the iOS Simulator.
 // not.py also works on win32, where ! does not.
-// Checking for ".[Ff]atal" because of d03a575279c.
 
 func f(crash crash: Bool) -> Int {
   if crash {
     return <#T#>
-    // CRASH-CHECK: {{[fF]}}atal error: attempt to evaluate editor placeholder: file {{.*}}/main.swift, line [[@LINE-1]]
+    // CRASH-CHECK: {{.*}}/main.swift:[[@LINE-1]]: Fatal error: attempt to evaluate editor placeholder
   } else {
     return 42
   }

--- a/test/attr/ApplicationMain/attr_main_throws_prints_error.swift
+++ b/test/attr/ApplicationMain/attr_main_throws_prints_error.swift
@@ -9,7 +9,7 @@
 
 enum Err : Error { case or }
 
-// CHECK: Fatal error: Error raised at top level: main.Err.or:
+// CHECK: Fatal error: Error raised at top level: main.Err.or
 @main
 struct S {
     static func main() throws {

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -121,7 +121,7 @@ ErrorTests.test("try!/location")
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration()
-                        ? "main/Error.swift, line 128"
+                        ? "main/Error.swift:128"
                         : "")
   .code {
     expectCrashLater()

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -36,7 +36,7 @@ OptionalTraps.test("UnwrapNone/location")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration()
-                        ? "OptionalTraps.swift, line 45"
+                        ? "OptionalTraps.swift:45:"
                         : "")
   .code {
   expectCrashLater()

--- a/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildCrashesDuringShutdown.swift
+++ b/validation-test/StdlibUnittest/ChildProcessShutdown/FailIfChildCrashesDuringShutdown.swift
@@ -32,7 +32,7 @@ TestSuiteChildCrashes.test("passes") {
 // CHECK: [ RUN      ] TestSuiteChildCrashes.passes
 // CHECK: [       OK ] TestSuiteChildCrashes.passes
 // CHECK: TestSuiteChildCrashes: All tests passed
-// CHECK: stderr>>> Fatal error: Crash at exit:
+// CHECK: stderr>>> {{.*}}Fatal error: Crash at exit
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: The child process failed during shutdown, aborting.
 // CHECK: abort()

--- a/validation-test/StdlibUnittest/CrashingTests.swift
+++ b/validation-test/StdlibUnittest/CrashingTests.swift
@@ -40,7 +40,7 @@ TestSuiteCrashes.test("crashesUnexpectedly1") {
   fatalErrorWithDelayIfNeeded("This should crash")
 }
 // CHECK: stdout>>> crashesUnexpectedly1
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly1
 
@@ -64,7 +64,7 @@ TestSuiteCrashes.test("crashesUnexpectedly2") {
   fatalErrorWithDelayIfNeeded("This should crash")
 }
 // CHECK: stdout>>> crashesUnexpectedly2
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly2
 
@@ -89,7 +89,7 @@ TestSuiteCrashes.test("crashesAsExpected1") {
   fatalErrorWithDelayIfNeeded("This should crash")
 }
 // CHECK: stdout>>> crashesAsExpected1
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesAsExpected1
 
@@ -114,7 +114,7 @@ TestSuiteCrashes.test("crashesUnexpectedlyXfail")
   fatalErrorWithDelayIfNeeded("This should crash")
 }
 // CHECK: stdout>>> crashesUnexpectedlyXfail
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [    XFAIL ] TestSuiteCrashes.crashesUnexpectedlyXfail
 
@@ -125,7 +125,7 @@ TestSuiteCrashes.test("crashesAsExpectedXfail")
   fatalErrorWithDelayIfNeeded("This should crash")
 }
 // CHECK: stdout>>> crashesAsExpectedXfail
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [   UXPASS ] TestSuiteCrashes.crashesAsExpectedXfail
 
@@ -136,7 +136,7 @@ TestSuiteCrashes.test("crashesWithMessagePasses")
   fatalErrorWithDelayIfNeeded("This should crash")
 }
 // CHECK: stdout>>> abcd
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesWithMessagePasses
 
@@ -147,7 +147,7 @@ TestSuiteCrashes.test("crashesWithMessageFails")
   fatalErrorWithDelayIfNeeded("unexpected message")
 }
 // CHECK: stdout>>> This should crash
-// CHECK: stderr>>> Fatal error: unexpected message:
+// CHECK: stderr>>> {{.*}}Fatal error: unexpected message
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: did not find expected string after crash: "This should crash"
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesWithMessageFails
@@ -162,7 +162,7 @@ TestSuiteCrashes.test("crashesWithMultipleMessagesPasses")
   fatalErrorWithDelayIfNeeded("This should crash and your little dog too")
 }
 // CHECK: stdout>>> abcd
-// CHECK: stderr>>> Fatal error: This should crash and your little dog too:
+// CHECK: stderr>>> {{.*}}Fatal error: This should crash and your little dog too
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesWithMultipleMessagesPasses
 
@@ -177,7 +177,7 @@ TestSuiteCrashes.test("crashesWithMultipleMessagesFails")
   fatalErrorWithDelayIfNeeded("unexpected message and your little dog too")
 }
 // CHECK: stdout>>> This should crash
-// CHECK: stderr>>> Fatal error: unexpected message and your little dog too:
+// CHECK: stderr>>> {{.*}}Fatal error: unexpected message and your little dog too
 // CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: did not find expected string after crash: "This should crash"
 // CHECK: did not find expected string after crash: "big dog"


### PR DESCRIPTION
In debug configurations, fatal error messages include file & line number information. This update presents this information in a format matching the diagnostic conventions used by the compiler, which can be a slight productivity boost.

Code compiled with optimizations enabled (which is most production code) does not output this information, so it isn’t affected by this change.

Original format:

```
    Fatal error: A suffusion of yellow: file calc.swift, line 5
```

New format:

```
    calc.swift:5: Fatal error: A suffusion of yellow
```

Resolves rdar://68484891
