### PR TITLE
Remove `--dispatch-build-dir` and `--foundation-build-dir` args from swiftpm bootstrap script

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -72,10 +72,13 @@ class SwiftPM(product.Product):
         dispatch_build_dir = os.path.join(
             build_root, '%s-%s' % ("libdispatch", host_target))
 
-        if os.path.exists(dispatch_build_dir):
-            helper_cmd += [
-                "--dispatch-build-dir", dispatch_build_dir
-            ]
+        # SWIFT_ENABLE_TENSORFLOW
+        # Don't pass in this arg since it interferes with yams.
+        # if os.path.exists(dispatch_build_dir):
+        #     helper_cmd += [
+        #         "--dispatch-build-dir", dispatch_build_dir
+        #     ]
+        # SWIFT_ENABLE_TENSORFLOW END
 
         # Pass Foundation directory down if we built it
         foundation_build_dir = os.path.join(

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -73,21 +73,21 @@ class SwiftPM(product.Product):
             build_root, '%s-%s' % ("libdispatch", host_target))
 
         # SWIFT_ENABLE_TENSORFLOW
-        # Don't pass in this arg since it interferes with yams.
+        # Don't pass in these args since they interfere with yams.
         # if os.path.exists(dispatch_build_dir):
         #     helper_cmd += [
         #         "--dispatch-build-dir", dispatch_build_dir
         #     ]
-        # SWIFT_ENABLE_TENSORFLOW END
 
         # Pass Foundation directory down if we built it
         foundation_build_dir = os.path.join(
             build_root, '%s-%s' % ("foundation", host_target))
 
-        if os.path.exists(foundation_build_dir):
-            helper_cmd += [
-                "--foundation-build-dir", foundation_build_dir
-            ]
+        # if os.path.exists(foundation_build_dir):
+        #     helper_cmd += [
+        #         "--foundation-build-dir", foundation_build_dir
+        #     ]
+        # SWIFT_ENABLE_TENSORFLOW END
 
         # Pass Cross compile host info
         if self.has_cross_compile_hosts(self.args):


### PR DESCRIPTION
After #34643, this resolves a clash with dispatch libs when building yams:

```
/swift-base/swift/swift-nightly-install/usr/lib/swift/dispatch/module.modulemap:1:8: error: redefinition of module 'Dispatch'
module Dispatch {
       ^
```