### PR TITLE
[Protocol checker] Eliminate ordering dependency with "unsatisfied" check

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1566,7 +1566,7 @@ isUnsatisfiedReq(ConformanceChecker &checker,
         if (otherReq == req)
           continue;
 
-        if (conformance->hasWitness(otherReq))
+        if (conformance->getWitness(otherReq))
           return false;
       }
     }


### PR DESCRIPTION
When checking whether an `@objc` protocol requirement is considered
satisfied by another requirement with the same selector, make sure
to use "getWitness" (rather than "hasWitness") to avoid order
dependencies in the computation. These are fantastically hard
to reproduce in small test cases.
