### PR TITLE
[AST] Preserve l-valueness of covariant result type after replacement

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -809,13 +809,16 @@ Type TypeBase::getWithoutParens() {
 Type TypeBase::replaceCovariantResultType(Type newResultType,
                                           unsigned uncurryLevel) {
   if (uncurryLevel == 0) {
-    if (auto objectType = getOptionalObjectType()) {
+    bool isLValue = is<LValueType>();
+
+    auto loadedTy = getWithoutSpecifierType();
+    if (auto objectType = loadedTy->getOptionalObjectType()) {
       assert(!newResultType->getOptionalObjectType());
-      return OptionalType::get(
+      newResultType = OptionalType::get(
           objectType->replaceCovariantResultType(newResultType, uncurryLevel));
     }
 
-    return newResultType;
+    return isLValue ? LValueType::get(newResultType) : newResultType;
   }
 
   // Determine the input and result types of this function.

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar71167129.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar71167129.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+final class Whatever {
+  static var instance: Self!
+
+  static var shared: Self {
+    return instance ?? {
+      instance = Self()
+      return instance
+    }
+  }
+}


### PR DESCRIPTION
It's possible that covariant result type is wrapped in l-value.
Just like currently preserved optionality, transformation should
maintain l-valueness of a result type as well.

Resolves rdar://problem/71167129

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
