### PR TITLE
Remove `--dispatch-build-dir` and `--foundation-build-dir` args from swift-driver bootstrap script

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -106,14 +106,19 @@ def run_build_script_helper(action, host_target, product, args):
         '--ninja-bin', product.toolchain.ninja,
         '--cmake-bin', product.toolchain.cmake,
     ]
-    if os.path.exists(dispatch_build_dir):
-        helper_cmd += [
-            '--dispatch-build-dir', dispatch_build_dir
-        ]
-    if os.path.exists(foundation_build_dir):
-        helper_cmd += [
-            '--foundation-build-dir', foundation_build_dir
-        ]
+
+    # SWIFT_ENABLE_TENSORFLOW
+    # Don't pass in these args since they interfere with yams.
+    # if os.path.exists(dispatch_build_dir):
+    #     helper_cmd += [
+    #         '--dispatch-build-dir', dispatch_build_dir
+    #     ]
+    # if os.path.exists(foundation_build_dir):
+    #     helper_cmd += [
+    #         '--foundation-build-dir', foundation_build_dir
+    #     ]
+    # SWIFT_ENABLE_TENSORFLOW END
+
     if args.verbose_build:
         helper_cmd.append('--verbose')
 


### PR DESCRIPTION
After #34643, this resolves a clash with dispatch and foundation libs when building yams:

```
/swift-base/swift/swift-nightly-install/usr/lib/swift/dispatch/module.modulemap:1:8: error: redefinition of module 'Dispatch'
module Dispatch {
       ^
```