### PR TITLE
[concurrency] Allow calls to sync actor functions to be interpreted as async

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4213,9 +4213,10 @@ ERROR(actor_isolated_concurrent_access,none,
         "actor-isolated %0 %1 is unsafe to reference in code "
         "that may execute concurrently",
         (DescriptiveDeclKind, DeclName))
-NOTE(actor_isolated_method,none,
-     "only asynchronous methods can be used outside the actor instance; "
-     "do you want to add 'async'?", ())
+NOTE(actor_isolated_sync_func,none,
+     "calls to %0 %1 from outside of its actor context are "
+     "implicitly asynchronous",
+     (DescriptiveDeclKind, DeclName))
 NOTE(actor_mutable_state,none,
      "mutable state is only available within the actor instance", ())
 WARNING(shared_mutable_state_access,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -584,6 +584,7 @@ namespace {
   class ActorIsolationChecker : public ASTWalker {
     ASTContext &ctx;
     SmallVector<const DeclContext *, 4> contextStack;
+    SmallVector<ApplyExpr*, 4> applyStack;
 
     const DeclContext *getDeclContext() const {
       return contextStack.back();
@@ -625,27 +626,45 @@ namespace {
       }
 
       if (auto apply = dyn_cast<ApplyExpr>(expr)) {
+        applyStack.push_back(apply);  // record this encounter
+
         // If this is a call to a partial apply thunk, decompose it to check it
         // like based on the original written syntax, e.g., "self.method".
         if (auto partialApply = decomposePartialApplyThunk(
                 apply, Parent.getAsExpr())) {
           if (auto memberRef = findMemberReference(partialApply->fn)) {
+            // NOTE: partially-applied thunks are never annotated as 
+            // implicitly async, regardless of whether they are escaping.
+            // So, we do not pass the ApplyExpr along to checkMemberReference.
             checkMemberReference(
                 partialApply->base, memberRef->first, memberRef->second,
                 partialApply->isEscaping);
 
             partialApply->base->walk(*this);
+
+            // manual clean-up since normal traversal is skipped
+            assert(applyStack.back() == apply);
+            applyStack.pop_back();
+
             return { false, expr };
           }
         }
       }
 
+      // NOTE: SelfApplyExpr is a subtype of ApplyExpr
       if (auto call = dyn_cast<SelfApplyExpr>(expr)) {
         Expr *fn = call->getFn()->getValueProvidingExpr();
         if (auto memberRef = findMemberReference(fn)) {
           checkMemberReference(
-              call->getArg(), memberRef->first, memberRef->second);
+              call->getArg(), memberRef->first, memberRef->second, 
+              /*isEscapingPartialApply=*/false, call);
+
           call->getArg()->walk(*this);
+
+          // manual clean-up since normal traversal is skipped
+          assert(applyStack.back() == dyn_cast<ApplyExpr>(expr));
+          applyStack.pop_back();
+
           return { false, expr };
         }
       }
@@ -657,6 +676,11 @@ namespace {
       if (auto *closure = dyn_cast<AbstractClosureExpr>(expr)) {
         assert(contextStack.back() == closure);
         contextStack.pop_back();
+      }
+
+      if (auto *apply = dyn_cast<ApplyExpr>(expr)) {
+        assert(applyStack.back() == apply);
+        applyStack.pop_back();
       }
 
       return expr;
@@ -835,9 +859,39 @@ namespace {
     /// Check a reference to an entity within a global actor.
     bool checkGlobalActorReference(
         ValueDecl *value, SourceLoc loc, Type globalActor) {
+
+      /// Returns true if this global actor reference is the callee of an Apply.
+      /// NOTE: This check mutates the identified ApplyExpr if it returns true!
+      auto inspectForImplicitlyAsync = [&] () -> bool {
+
+        // Is this global actor reference outside of an ApplyExpr?
+        if (applyStack.size() == 0)
+          return false;
+
+        // Check our applyStack metadata from the traversal.
+        // Our goal is to identify whether this global actor reference appears
+        // as the called value of the enclosing ApplyExpr. We cannot simply
+        // inspect Parent here because of expressions like (callee)()
+        ApplyExpr *apply = applyStack.back();
+        Expr *fn = apply->getFn()->getValueProvidingExpr();
+        if (auto memberRef = findMemberReference(fn)) {
+          auto concDecl = memberRef->first;
+          if (value == concDecl.getDecl() && !apply->implicitlyAsync()) {
+            // then this ValueDecl appears as the called value of the ApplyExpr.
+            apply->setImplicitlyAsync(true);
+            return true;
+          }
+        }
+
+        return false;
+      };
+
       switch (auto contextIsolation =
                   getInnermostIsolatedContext(getDeclContext())) {
       case ActorIsolation::ActorInstance:
+        if (inspectForImplicitlyAsync())
+          return false;
+
         ctx.Diags.diagnose(
             loc, diag::global_actor_from_instance_actor_context,
             value->getDescriptiveKind(), value->getName(), globalActor,
@@ -850,6 +904,12 @@ namespace {
         if (contextIsolation.getGlobalActor()->isEqual(globalActor))
           return false;
 
+        // Otherwise, we check if this decl reference is the callee of the
+        // enclosing Apply, making it OK as an implicitly async call.
+        if (inspectForImplicitlyAsync())
+          return false;
+
+        // Otherwise, this is a problematic global actor decl reference.
         ctx.Diags.diagnose(
             loc, diag::global_actor_from_other_global_actor_context,
             value->getDescriptiveKind(), value->getName(), globalActor,
@@ -860,6 +920,9 @@ namespace {
 
       case ActorIsolation::Independent:
       case ActorIsolation::IndependentUnsafe:
+        if (inspectForImplicitlyAsync())
+          return false;
+
         ctx.Diags.diagnose(
             loc, diag::global_actor_from_independent_context,
             value->getDescriptiveKind(), value->getName(), globalActor);
@@ -867,7 +930,8 @@ namespace {
         return true;
 
       case ActorIsolation::Unspecified:
-        // Okay.
+        // Okay no matter what, but still must inspect for implicitly async.
+        inspectForImplicitlyAsync();
         return false;
       }
       llvm_unreachable("unhandled actor isolation kind!");
@@ -918,9 +982,12 @@ namespace {
     }
 
     /// Check a reference with the given base expression to the given member.
+    /// Returns true iff the member reference refers to actor-isolated state
+    /// in an invalid or unsafe way such that a diagnostic was emitted.
     bool checkMemberReference(
         Expr *base, ConcreteDeclRef memberRef, SourceLoc memberLoc,
-        bool isEscapingPartialApply = false) {
+        bool isEscapingPartialApply = false, 
+        ApplyExpr *maybeImplicitAsync = nullptr) {
       if (!base || !memberRef)
         return false;
 
@@ -934,6 +1001,11 @@ namespace {
         // Must reference actor-isolated state on 'self'.
         auto selfVar = getSelfReference(base);
         if (!selfVar) {
+          // actor-isolated non-self calls are implicitly async and thus OK.
+          if (maybeImplicitAsync && isa<AbstractFunctionDecl>(member)) {
+            maybeImplicitAsync->setImplicitlyAsync(true);
+            return false;
+          }
           ctx.Diags.diagnose(
               memberLoc, diag::actor_isolated_non_self_reference,
               member->getDescriptiveKind(),

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -720,10 +720,9 @@ namespace {
       // FIXME: Make this diagnostic more sensitive to the isolation context
       // of the declaration.
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-        // FIXME: We'd like to insert 'async' at the appropriate place, but
-        // FuncDecl/AbstractFunctionDecl doesn't have the right source-location
-        // information to do so.
-        func->diagnose(diag::actor_isolated_method);
+        func->diagnose(diag::actor_isolated_sync_func, 
+          decl->getDescriptiveKind(),
+          decl->getName());
       } else if (isa<VarDecl>(decl)) {
         decl->diagnose(diag::actor_mutable_state);
       } else {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -463,7 +463,7 @@ public:
     auto fnType = type->getAs<AnyFunctionType>();
     if (!fnType) return Classification::forInvalidCode();
 
-    bool isAsync = fnType->isAsync();
+    bool isAsync = fnType->isAsync() || E->implicitlyAsync();
     
     // If the function doesn't throw at all, we're done here.
     if (!fnType->isThrowing())

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -1,0 +1,177 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+actor class BankAccount {
+
+  private var curBalance : Int
+
+  private var accountHolder : String = "unknown"
+
+  // expected-note@+1 2 {{mutable state is only available within the actor instance}}
+  var owner : String {
+    get { accountHolder }
+    set { accountHolder = newValue }
+  }
+
+  init(initialDeposit : Int) {
+    curBalance = initialDeposit
+  }
+
+  // NOTE: this func is accessed through both async and sync calls.
+  // expected-note@+1 {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func balance() -> Int { return curBalance }
+
+  // expected-note@+1 {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func deposit(_ amount : Int) -> Int {
+    guard amount >= 0 else { return 0 }
+
+    curBalance = curBalance + amount
+    return curBalance
+  }
+
+  func canWithdraw(_ amount : Int) -> Bool { 
+    // call 'balance' from sync through self
+    return self.balance() >= amount
+  }
+
+  func testSelfBalance() async {
+    _ = await balance() // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
+  }
+
+  // returns the amount actually withdrawn
+  func withdraw(_ amount : Int) -> Int {
+    guard canWithdraw(amount) else { return 0 }
+
+    curBalance = curBalance - amount
+    return amount
+  }
+
+  // returns the balance of this account following the transfer
+  func transferAll(from : BankAccount) async -> Int {
+    // call sync methods on another actor
+    let amountTaken = await from.withdraw(from.balance())
+    return deposit(amountTaken)
+  }
+
+  func greaterThan(other : BankAccount) async -> Bool {
+    return await balance() > other.balance()
+  }
+
+  func testTransactions() {
+    _ = deposit(withdraw(deposit(withdraw(balance()))))
+  }
+
+} // end actor class
+
+func someAsyncFunc() async {
+  let deposit1 = 120, deposit2 = 45
+  let a = BankAccount(initialDeposit: 0)
+  let b = BankAccount(initialDeposit: deposit2)
+
+  let _ = await a.deposit(deposit1)
+  let afterXfer = await a.transferAll(from: b)
+  let reportedBal = await a.balance()
+  
+  // check on account A
+  guard afterXfer == (deposit1 + deposit2) && afterXfer == reportedBal else {
+    print("BUG 1!")
+    return
+  }
+
+  // check on account B
+  guard await b.balance() == 0 else {
+    print("BUG 2!")
+    return
+  }
+
+  _ = await a.deposit(b.withdraw(a.deposit(b.withdraw(b.balance()))))
+
+  print("ok!")
+}
+
+
+//////////////////
+// check for appropriate error messages
+//////////////////
+
+extension BankAccount {
+  func totalBalance(including other: BankAccount) async -> Int {
+    return balance() 
+          + other.balance()  // expected-error{{call is 'async' but is not marked with 'await'}}
+  }
+
+  func breakAccounts(other: BankAccount) async {
+    _ = other.deposit(  // expected-error{{call is 'async' but is not marked with 'await'}}
+          other.withdraw( // expected-error{{call is 'async' but is not marked with 'await'}}
+            self.deposit(
+              other.withdraw( // expected-error{{call is 'async' but is not marked with 'await'}}
+                other.balance())))) // expected-error{{call is 'async' but is not marked with 'await'}}
+  }
+}
+
+func anotherAsyncFunc() async {
+  let a = BankAccount(initialDeposit: 34)
+  let b = BankAccount(initialDeposit: 35)
+
+  _ = a.deposit(1)  // expected-error{{call is 'async' but is not marked with 'await'}}
+  _ = b.balance()   // expected-error{{call is 'async' but is not marked with 'await'}}
+  
+  _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can only be referenced inside the actor}}
+
+  a.owner = "cat" // expected-error{{actor-isolated property 'owner' can only be referenced inside the actor}}
+  _ = b.owner // expected-error{{actor-isolated property 'owner' can only be referenced inside the actor}}
+
+}
+
+// expected-note@+2 {{add 'async' to function 'regularFunc()' to make it asynchronous}}
+// expected-note@+1 {{add '@asyncHandler' to function 'regularFunc()' to create an implicit asynchronous context}}
+func regularFunc() {
+  let a = BankAccount(initialDeposit: 34)
+
+  _ = a.deposit //expected-error{{actor-isolated instance method 'deposit' can only be referenced inside the actor}}
+
+  _ = a.deposit(1)  // expected-error{{'async' in a function that does not support concurrency}}
+}
+
+
+actor class TestActor {}
+
+@globalActor
+struct BananaActor {
+  static var shared: TestActor { TestActor() }
+}
+
+@globalActor
+struct OrangeActor {
+  static var shared: TestActor { TestActor() }
+}
+
+func blender(_ peeler : () -> Void) {
+  peeler()
+}
+
+@BananaActor func wisk(_ something : Any) { } // expected-note 4 {{only asynchronous methods can be used outside the actor instance}}
+
+@BananaActor func peelBanana() { } // expected-note 2 {{only asynchronous methods can be used outside the actor instance}}
+
+@OrangeActor func makeSmoothie() async {
+  await wisk({})
+  await wisk(1)
+  await (peelBanana)()
+  await (((((peelBanana)))))()
+  await (((wisk)))((wisk)((wisk)(1)))
+
+  blender((peelBanana)) // expected-error {{global function 'peelBanana()' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+  await wisk(peelBanana) // expected-error {{global function 'peelBanana()' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+
+  await wisk(wisk)  // expected-error {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+  await (((wisk)))(((wisk))) // expected-error {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+
+  // expected-warning@+2 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-error@+1 {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+  await {wisk}()(1)
+
+  // expected-warning@+2 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-error@+1 {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+  await (true ? wisk : {n in return})(1)
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -34,7 +34,7 @@ actor class MyActor: MySuperActor {
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 21{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 20{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
   func asynchronous() async -> String { synchronous() }
 }
 
@@ -44,6 +44,7 @@ extension MyActor {
     set { }
   }
 
+  // expected-note@+1 {{add 'async' to function 'actorIndependentFunc(otherActor:)' to make it asynchronous}}
   @actorIndependent func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from an '@actorIndependent' context}}
@@ -64,7 +65,8 @@ extension MyActor {
     otherActor.actorIndependentVar = 17
 
     // Global actors
-    syncGlobalActorFunc() /// expected-error{{global function 'syncGlobalActorFunc()' isolated to global actor 'SomeGlobalActor' can not be referenced from an '@actorIndependent' context}}
+    syncGlobalActorFunc() /// expected-error{{'async' in a function that does not support concurrency}}
+    _ = syncGlobalActorFunc // expected-error{{global function 'syncGlobalActorFunc()' isolated to global actor 'SomeGlobalActor' can not be referenced from an '@actorIndependent' context}}
 
     // Global data is okay if it is immutable.
     _ = immutableGlobal
@@ -102,9 +104,9 @@ extension MyActor {
     _ = super[0]
 
     // Accesses on other actors can only reference immutable data or
-    // call asychronous methods
+    // call methods
     _ = otherActor.immutable // okay
-    _ = otherActor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced on 'self'}}
+    _ = otherActor.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
     _ = await otherActor.asynchronous()
     _ = otherActor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced on 'self'}}
 
@@ -120,7 +122,7 @@ extension MyActor {
     Self.synchronousStatic()
 
     // Global actors
-    syncGlobalActorFunc() // expected-error{{global function 'syncGlobalActorFunc()' isolated to global actor 'SomeGlobalActor' can not be referenced from actor 'MyActor'}}
+    syncGlobalActorFunc() // expected-error{{call is 'async' but is not marked with 'await'}}
     await asyncGlobalActorFunc()
 
     // Closures.
@@ -197,15 +199,22 @@ struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
-@SomeGlobalActor func syncGlobalActorFunc() { } // expected-note 3{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
-@SomeGlobalActor func asyncGlobalActorFunc() async { }
+@SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+@SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
-@SomeOtherGlobalActor func syncOtherGlobalActorFunc() { } // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+@SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
 
 @SomeOtherGlobalActor func asyncOtherGlobalActorFunc() async {
-  syncGlobalActorFunc() // expected-error{{global function 'syncGlobalActorFunc()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'SomeOtherGlobalActor'}}
+  await syncGlobalActorFunc()
   await asyncGlobalActorFunc()
 }
+
+// test global actor funcs that are marked asyncHandler
+@SomeGlobalActor func goo1() async {
+  let _ = goo2
+  goo2()
+}
+@asyncHandler @SomeOtherGlobalActor func goo2() { await goo1() }
 
 extension MyActor {
   @SomeGlobalActor func onGlobalActor(otherActor: MyActor) async {
@@ -213,8 +222,8 @@ extension MyActor {
     syncGlobalActorFunc()
     await asyncGlobalActorFunc()
 
-    // Other global actors are not okay
-    syncOtherGlobalActorFunc() // expected-error{{global function 'syncOtherGlobalActorFunc()' isolated to global actor 'SomeOtherGlobalActor' can not be referenced from different global actor 'SomeGlobalActor'}}
+    // Other global actors are ok if marked with 'await'
+    await syncOtherGlobalActorFunc()
     await asyncOtherGlobalActorFunc()
 
     _ = immutable
@@ -238,7 +247,8 @@ extension MyActor {
     // Accesses on other actors can only reference immutable data or
     // call asychronous methods
     _ = otherActor.immutable // okay
-    _ = otherActor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced on 'self'}}
+    _ = otherActor.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
+    _ = otherActor.synchronous  // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced on 'self'}}
     _ = await otherActor.asynchronous()
     _ = otherActor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced on 'self'}}
   }
@@ -251,8 +261,11 @@ struct GenericStruct<T> {
     f() // okay
   }
 
+  // expected-note@+2 {{add '@asyncHandler' to function 'h()' to create an implicit asynchronous context}}
+  // expected-note@+1 {{add 'async' to function 'h()' to make it asynchronous}}
   @GenericGlobalActor<String> func h() {
-    f() // expected-error{{instance method 'f()' isolated to global actor 'GenericGlobalActor<T>' can not be referenced from different global actor 'GenericGlobalActor<String>'}}
+    f() // expected-error{{'async' in a function that does not support concurrency}}
+    _ = f // expected-error{{instance method 'f()' isolated to global actor 'GenericGlobalActor<T>' can not be referenced from different global actor 'GenericGlobalActor<String>'}}
   }
 }
 
@@ -276,8 +289,9 @@ func testGlobalRestrictions(actor: MyActor) async {
   _ = await actor.asynchronous()
   _ = actor.immutable
 
-  // Synchronous operations and mutable state references are not.
-  _ = actor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced inside the actor}}
+  // Synchronous operations are ok, mutable state references are not.
+  _ = actor.synchronous // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced inside the actor}}
+  _ = actor.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
   _ = actor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced inside the actor}}
   _ = actor[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can only be referenced inside the actor}}
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -19,7 +19,7 @@ func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
 actor class MySuperActor {
   var superState: Int = 25 // expected-note {{mutable state is only available within the actor instance}}
 
-  func superMethod() { } // expected-note 3 {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func superMethod() { } // expected-note 3 {{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
   func superAsyncMethod() async { }
 
   subscript (index: Int) -> String { // expected-note 3{{subscript declared here}}
@@ -34,7 +34,7 @@ actor class MyActor: MySuperActor {
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 20{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 20{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
   func asynchronous() async -> String { synchronous() }
 }
 
@@ -199,7 +199,7 @@ struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
-@SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+@SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note{{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
 @SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
@@ -255,7 +255,7 @@ extension MyActor {
 }
 
 struct GenericStruct<T> {
-  @GenericGlobalActor<T> func f() { } // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  @GenericGlobalActor<T> func f() { } // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> func g() {
     f() // okay

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -5,7 +5,7 @@ actor class MyActor {
   let immutable: Int = 17
   var text: [String] = []
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 2 {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 2 {{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
   func asynchronous() async -> String { synchronous() }
 
   func testAsyncLetIsolation() async {
@@ -26,4 +26,12 @@ actor class MyActor {
     _ = await z
     _ = await w
   }
+}
+
+func outside() async {
+  let a = MyActor()
+  async let x = a.synchronous() // expected-error {{call is 'async' in an 'async let' initializer that is not marked with 'await'}}
+  async let y = await a.synchronous()
+  _ = await x
+  _ = await y
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -33,19 +33,25 @@ protocol P2 {
 }
 
 class C1: P1 {
-  func method() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method() { } // expected-note {{only asynchronous methods can be used outside the actor instance}}
 
+  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
   @OtherGlobalActor func testMethod() {
-    method() // expected-error{{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+    method() // expected-error {{'async' in a function that does not support concurrency}}
+    _ = method  // expected-error {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
   }
 }
 
 class C2: P2 {
-  func method1() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method1() { }  // expected-note{{only asynchronous methods can be used outside the actor instance}}
   func method2() { }
 
+  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
   @OtherGlobalActor func testMethod() {
-    method1() // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+    method1() // expected-error{{'async' in a function that does not support concurrency}}
+    _ = method1 // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
     method2() // okay
   }
 }
@@ -54,19 +60,19 @@ class C2: P2 {
 // Global actor inference for classes and extensions
 // ----------------------------------------------------------------------
 @SomeGlobalActor class C3 {
-  func method1() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method1() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 }
 
 extension C3 {
-  func method2() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method2() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 }
 
 class C4: C3 {
-  func method3() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method3() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 }
 
 extension C4 {
-  func method4() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method4() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 }
 
 class C5 {
@@ -74,21 +80,32 @@ class C5 {
 }
 
 @SomeGlobalActor extension C5 {
-  func method2() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method2() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 }
 
+// expected-note@+2 5 {{add '@asyncHandler' to function 'testGlobalActorInference(c3:c4:c5:)' to create an implicit asynchronous context}}
+// expected-note@+1 5 {{add 'async' to function 'testGlobalActorInference(c3:c4:c5:)' to make it asynchronous}}
 @OtherGlobalActor func testGlobalActorInference(c3: C3, c4: C4, c5: C5) {
   // Propagation via class annotation
-  c3.method1() // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
-  c3.method2() // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  c3.method1() // expected-error{{'async' in a function that does not support concurrency}}
+  c3.method2() // expected-error{{'async' in a function that does not support concurrency}}
+  
+  _ = c3.method1  // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  _ = c3.method2  // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 
   // Propagation via subclassing
-  c4.method3() // expected-error{{instance method 'method3()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
-  c4.method4() // expected-error{{instance method 'method4()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  c4.method3() // expected-error{{'async' in a function that does not support concurrency}}
+  c4.method4() // expected-error{{'async' in a function that does not support concurrency}}
+
+  _ = c4.method3  // expected-error{{instance method 'method3()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  _ = c4.method4  // expected-error{{instance method 'method4()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 
   // Propagation in an extension.
   c5.method1() // OK: no propagation
-  c5.method2() // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  c5.method2() // expected-error{{'async' in a function that does not support concurrency}}
+
+  _ = c5.method1  // OK
+  _ = c5.method2 // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 }
 
 protocol P3 {
@@ -105,6 +122,8 @@ class C6: P2, P3 {
   func testMethod() {
     method1() // okay: no inference
     method2() // okay: no inference
+    let _ = method1 // okay: no inference
+    let _ = method2 // okay: no inference
   }
 }
 
@@ -121,13 +140,16 @@ actor class GenericSuper<T> {
 }
 
 actor class GenericSub<T> : GenericSuper<[T]> {
-  override func method() { } // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  override func method() { }  // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
   @actorIndependent override func method3() { } // expected-error{{actor-independent instance method 'method3()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
 
+  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
   @OtherGlobalActor func testMethod() {
-    method() // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[T]>' can not be referenced from different global actor 'OtherGlobalActor'}}
+    method() // expected-error{{'async' in a function that does not support concurrency}}
+    _ = method  // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[T]>' can not be referenced from different global actor 'OtherGlobalActor'}}
   }
 }
 
@@ -146,10 +168,29 @@ struct OtherContainer<U> {
 
   // Ensure that substitutions work properly when inheriting.
   class Subclass3<V> : Container<(U, V)>.Superclass2 {
-    func method() { } // expected-note{{only asynchronous methods can be used outside the actor instance}}
+    func method() { } // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
 
-    @OtherGlobalActor func testMethod() {
-      method() // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[(U, V)]>' can not be referenced from different global actor 'OtherGlobalActor'}}
+    @OtherGlobalActor func testMethod() async {
+      await method()
+      let _ = method  // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[(U, V)]>' can not be referenced from different global actor 'OtherGlobalActor'}}
     }
   }
+}
+
+// ----------------------------------------------------------------------
+// Global actor inference for unspecified contexts
+// ----------------------------------------------------------------------
+
+@SomeGlobalActor func foo() { sibling() }
+
+@SomeGlobalActor func sibling() { foo() }
+
+func bar() async {
+  foo() // expected-error{{call is 'async' but is not marked with 'await'}}
+}
+
+// expected-note@+2 {{add '@asyncHandler' to function 'barSync()' to create an implicit asynchronous context}}
+// expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}}
+func barSync() {
+  foo() // expected-error{{'async' in a function that does not support concurrency}}
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -33,7 +33,7 @@ protocol P2 {
 }
 
 class C1: P1 {
-  func method() { } // expected-note {{only asynchronous methods can be used outside the actor instance}}
+  func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
   // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
@@ -44,7 +44,7 @@ class C1: P1 {
 }
 
 class C2: P2 {
-  func method1() { }  // expected-note{{only asynchronous methods can be used outside the actor instance}}
+  func method1() { }  // expected-note{{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
   func method2() { }
 
   // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
@@ -60,19 +60,19 @@ class C2: P2 {
 // Global actor inference for classes and extensions
 // ----------------------------------------------------------------------
 @SomeGlobalActor class C3 {
-  func method1() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func method1() { }  // expected-note {{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
 }
 
 extension C3 {
-  func method2() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func method2() { }  // expected-note {{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
 }
 
 class C4: C3 {
-  func method3() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func method3() { }  // expected-note {{calls to instance method 'method3()' from outside of its actor context are implicitly asynchronous}}
 }
 
 extension C4 {
-  func method4() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func method4() { }  // expected-note {{calls to instance method 'method4()' from outside of its actor context are implicitly asynchronous}}
 }
 
 class C5 {
@@ -80,7 +80,7 @@ class C5 {
 }
 
 @SomeGlobalActor extension C5 {
-  func method2() { }  // expected-note {{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  func method2() { }  // expected-note {{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
 }
 
 // expected-note@+2 5 {{add '@asyncHandler' to function 'testGlobalActorInference(c3:c4:c5:)' to create an implicit asynchronous context}}
@@ -140,7 +140,7 @@ actor class GenericSuper<T> {
 }
 
 actor class GenericSub<T> : GenericSuper<[T]> {
-  override func method() { }  // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+  override func method() { }  // expected-note{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
   @actorIndependent override func method3() { } // expected-error{{actor-independent instance method 'method3()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
@@ -168,7 +168,7 @@ struct OtherContainer<U> {
 
   // Ensure that substitutions work properly when inheriting.
   class Subclass3<V> : Container<(U, V)>.Superclass2 {
-    func method() { } // expected-note{{only asynchronous methods can be used outside the actor instance; do you want to add 'async'?}}
+    func method() { } // expected-note{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
     @OtherGlobalActor func testMethod() async {
       await method()


### PR DESCRIPTION
In the current proposal for Actors, we have the following restrictions:

1. "[...] synchronous instance methods of actor classes are actor-isolated and, therefore, not available from outside the actor instance."

2. "[...] synchronous functions may only be invoked by the specific actor instance itself, and not even by any other instance of the same actor class."

Some discussion about this proposal [1] led to the suggestion that loosens these restrictions:

Synchronous methods of an actor class are available to code outside of an actor instance (i.e., can be accessed outside of `self`). But, such synchronous calls will be automatically treated as an async call, requiring the use of `await`, etc.

There is tentative support for this loosened restriction right now. This PR implements the suggestion in the type checker.

[1] https://forums.swift.org/t/concurrency-actors-actor-isolation/41613/75

Resolves rdar://71253835

TODO:

- [x] basic implementation
- [x] regression tests
- [x] Fix crash when binding an actor-isolated sync global actor function in a `let`.
- [x] Check on & possibly fix interaction of implicitly async & `async let`
