### PR TITLE
Fix Crashes When Resolving Clang Types For Unrepresentable UnsafePointers

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -572,7 +572,10 @@ ClangTypeConverter::visitBoundGenericType(BoundGenericType *type) {
     return ClangASTContext.getPointerType(clangTy);
   }
   case StructKind::UnsafePointer: {
-    return ClangASTContext.getPointerType(convert(argCanonicalTy).withConst());
+    auto clangTy = convert(argCanonicalTy);
+    if (clangTy.isNull())
+      return clang::QualType();
+    return ClangASTContext.getPointerType(clangTy.withConst());
   }
 
   case StructKind::CFunctionPointer: {
@@ -592,6 +595,8 @@ ClangTypeConverter::visitBoundGenericType(BoundGenericType *type) {
 
   case StructKind::SIMD: {
     clang::QualType scalarTy = convert(argCanonicalTy);
+    if (scalarTy.isNull())
+      return clang::QualType();
     auto numEltsString = swiftStructDecl->getName().str();
     numEltsString.consume_front("SIMD");
     unsigned numElts;

--- a/validation-test/compiler_crashers_2_fixed/rdar67360656.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar67360656.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+public typealias GUID = (a: UInt32, b: UInt16, c: UInt16, d: UInt8, e: UInt8, f: UInt8, g: UInt8, h: UInt8, i: UInt8, j: UInt8, k: UInt8)
+let function1: @convention(c) (UnsafePointer<GUID>) -> Void


### PR DESCRIPTION
If the underlying pointer type was not representable in C, we would
attempt to form a pointer type with a null underlying type and crash.

rdar://67360656