### PR TITLE
[AST] Fix AutoDiff crasher in optimized builds.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -654,7 +654,9 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
   // When the decl is context-free, we should get loc from source buffer.
   if (!getDeclContext())
     return getLocFromSource();
-  auto *File = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
+  FileUnit *File = dyn_cast<FileUnit>(getDeclContext()->getModuleScopeContext());
+  if (!File)
+    return getLocFromSource();
   switch(File->getKind()) {
   case FileUnitKind::Source:
     return getLocFromSource();

--- a/test/AutoDiff/compiler_crashers_fixed/rdar71191415-nested-differentiation-of-extension-method-optimized.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar71191415-nested-differentiation-of-extension-method-optimized.swift
@@ -1,0 +1,33 @@
+// RUN: %target-build-swift -O %s
+
+// rdar://71191415
+
+import _Differentiation
+
+protocol P {
+    @differentiable
+    func req(_ input: Float) -> Float
+}
+
+extension P {
+    @differentiable
+    func foo(_ input: Float) -> Float {
+        return req(input)
+    }
+}
+
+struct Dummy: P {
+    @differentiable
+    func req(_ input: Float) -> Float {
+        input
+    }
+}
+
+struct DummyComposition: P {
+    var layer = Dummy()
+
+    @differentiable
+    func req(_ input: Float) -> Float {
+        layer.foo(input)
+    }
+}


### PR DESCRIPTION
`getModuleScopeContext()` can produce a `ModuleDecl *` instead of a `FileUnit *`, which happens to be the case for generic-specialized derivative functions defined in protocol extensions.

Resolves rdar://71191415.