### PR TITLE
[ownership] Eliminate OperandOwnershipKindMap in favor of OwnershipConstraint

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -149,6 +149,15 @@ void BorrowingOperandKind::print(llvm::raw_ostream &os) const {
   case Kind::Branch:
     os << "Branch";
     return;
+  case Kind::Apply:
+    os << "Apply";
+    return;
+  case Kind::TryApply:
+    os << "TryApply";
+    return;
+  case Kind::Yield:
+    os << "Yield";
+    return;
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }
@@ -189,6 +198,12 @@ void BorrowingOperand::visitLocalEndScopeInstructions(
     }
     return;
   }
+  // These are instantaneous borrow scopes so there aren't any special end
+  // scope instructions.
+  case BorrowingOperandKind::Apply:
+  case BorrowingOperandKind::TryApply:
+  case BorrowingOperandKind::Yield:
+    return;
   case BorrowingOperandKind::Branch:
     return;
   }
@@ -197,7 +212,10 @@ void BorrowingOperand::visitLocalEndScopeInstructions(
 void BorrowingOperand::visitBorrowIntroducingUserResults(
     function_ref<void(BorrowedValue)> visitor) const {
   switch (kind) {
+  case BorrowingOperandKind::Apply:
+  case BorrowingOperandKind::TryApply:
   case BorrowingOperandKind::BeginApply:
+  case BorrowingOperandKind::Yield:
     llvm_unreachable("Never has borrow introducer results!");
   case BorrowingOperandKind::BeginBorrow: {
     auto value = *BorrowedValue::get(cast<BeginBorrowInst>(op->getUser()));

--- a/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
@@ -29,8 +29,7 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   for (auto *op : bbi->getUses()) {
     if (!op->isLifetimeEnding()) {
       // Make sure that this operand can accept our arguments kind.
-      auto map = op->getOwnershipKindMap();
-      if (map.canAcceptKind(kind))
+      if (op->canAcceptKind(kind))
         continue;
       return false;
     }

--- a/lib/SILOptimizer/UtilityPasses/OwnershipDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/OwnershipDumper.cpp
@@ -34,10 +34,10 @@ static void dumpInstruction(SILInstruction &ii) {
 
   auto ops = ii.getAllOperands();
   if (!ops.empty()) {
-    llvm::outs() << "Operand Ownership Map:\n";
+    llvm::outs() << "Ownership Constraint:\n";
     for (const auto &op : ops) {
       llvm::outs() << "Op #: " << op.getOperandNumber() << "\n"
-                   << "Ownership Map: " << op.getOwnershipKindMap();
+                      "Constraint: " << op.getOwnershipConstraint() << "\n";
     }
   }
 

--- a/test/SIL/ownership-verifier/undef.sil
+++ b/test/SIL/ownership-verifier/undef.sil
@@ -17,41 +17,21 @@ struct MyInt {
 
 // CHECK-LABEL: *** Dumping Function: 'undef_addresses_have_any_ownership'
 // CHECK: Visiting: {{.*}}%0 = mark_uninitialized [var] undef : $*Klass
-// CHECK-NEXT: Operand Ownership Map:
+// CHECK-NEXT: Ownership Constraint:
 // CHECK-NEXT: Op #: 0
-// CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK-NEXT: any:  No.
-// CHECK-NEXT: unowned:  No.
-// CHECK-NEXT: owned: Yes. Liveness: LifetimeEnding
-// CHECK-NEXT: guaranteed:  No.
-// CHECK-NEXT: any: Yes. Liveness: NonLifetimeEnding
+// CHECK-NEXT: Constraint: <Constraint Kind:owned LifetimeConstraint:LifetimeEnding>
 // CHECK: Visiting: {{.*}}%1 = mark_uninitialized [var] undef : $Klass
-// CHECK-NEXT: Operand Ownership Map:
+// CHECK-NEXT: Ownership Constraint:
 // CHECK-NEXT: Op #: 0
-// CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK-NEXT: any:  No.
-// CHECK-NEXT: unowned:  No.
-// CHECK-NEXT: owned: Yes. Liveness: LifetimeEnding
-// CHECK-NEXT: guaranteed:  No.
-// CHECK-NEXT: any: Yes. Liveness: NonLifetimeEnding
+// CHECK-NEXT: Constraint: <Constraint Kind:owned LifetimeConstraint:LifetimeEnding>
 // CHECK: Visiting: {{.*}}%3 = mark_uninitialized [var] undef : $*Builtin.Int32
-// CHECK-NEXT: Operand Ownership Map:
+// CHECK-NEXT: Ownership Constraint:
 // CHECK-NEXT: Op #: 0
-// CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK-NEXT: any:  No.
-// CHECK-NEXT: unowned:  No.
-// CHECK-NEXT: owned: Yes. Liveness: LifetimeEnding
-// CHECK-NEXT: guaranteed:  No.
-// CHECK-NEXT: any: Yes. Liveness: NonLifetimeEnding
+// CHECK-NEXT: Constraint: <Constraint Kind:owned LifetimeConstraint:LifetimeEnding>
 // CHECK: Visiting: {{.*}}%4 = struct $MyInt (undef : $Builtin.Int32)
-// CHECK-NEXT: Operand Ownership Map:
+// CHECK-NEXT: Ownership Constraint:
 // CHECK-NEXT: Op #: 0
-// CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK-NEXT: any:  No.
-// CHECK-NEXT: unowned:  No.
-// CHECK-NEXT: owned: No.
-// CHECK-NEXT: guaranteed:  No.
-// CHECK-NEXT: any: Yes. Liveness: NonLifetimeEnding
+// CHECK_NEXT: Constraint: <Constraint Kind:none LifetimeConstraint:NonLifetimeEnding>
 sil [ossa] @undef_addresses_have_any_ownership : $@convention(thin) () -> () {
 bb0:
   %0 = mark_uninitialized [var] undef : $*Klass

--- a/test/SILOptimizer/ownership-kind-dumper.sil
+++ b/test/SILOptimizer/ownership-kind-dumper.sil
@@ -8,24 +8,16 @@ class Klass {}
 
 // CHECK-LABEL: Dumping Function: 'foo'
 // CHECK: Visiting:   %1 = unchecked_ref_cast %0 : $Builtin.NativeObject to $Klass
-// CHECK: Operand Ownership Map:
+// CHECK: Ownership Constraint:
 // CHECK: Op #: 0
-// CHECK: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK: unowned:  No.
-// CHECK: owned: Yes. Liveness: LifetimeEnding
-// CHECK: guaranteed:  No.
-// CHECK: any: Yes. Liveness: NonLifetimeEnding
+// CHECK: Constraint: <Constraint Kind:owned LifetimeConstraint:LifetimeEnding>
 // CHECK: Results Ownership Kinds:
 // CHECK: Result:   %1 = unchecked_ref_cast %0 : $Builtin.NativeObject to $Klass
 // CHECK: Kind: owned
 // CHECK: Visiting:   return %1 : $Klass
-// CHECK: Operand Ownership Map:
+// CHECK: Ownership Constraint:
 // CHECK: Op #: 0
-// CHECK: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK: unowned:  No.
-// CHECK: owned: Yes. Liveness: LifetimeEnding
-// CHECK: guaranteed:  No.
-// CHECK: any: Yes. Liveness: NonLifetimeEnding
+// CHECK: Constraint: <Constraint Kind:owned LifetimeConstraint:LifetimeEnding>
 sil [ossa] @foo : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Klass {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = unchecked_ref_cast %0 : $Builtin.NativeObject to $Klass


### PR DESCRIPTION
I also used this as a moment to clarify the lattice that related
ValueOwnershipKind and OwnershipConstraint.
