### PR TITLE
Platform: add SensorsAPI to the WinSDK modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -335,6 +335,14 @@ module WinSDK [system] {
     export *
   }
 
+  module Sensors {
+    header "sensors.h"
+    header "SensorsApi.h"
+    export *
+
+    link "sensorsapi.lib"
+  }
+
   module User {
     header "WinUser.h"
     export *


### PR DESCRIPTION
The SensorsAPI headers are not part of the Windows umbrella header and
do not get pulled into the module through some transitive set.
Explicitly list the SensorsAPIs contract into the WinSDK modulemap to
allow use of the api contract from Swift.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
