### PR TITLE
build: ensure that we build swift-apis in the correct variant

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tensorflow.py
+++ b/utils/swift_build_support/swift_build_support/products/tensorflow.py
@@ -64,6 +64,8 @@ class TensorFlowSwiftAPIs(product.Product):
                 self.toolchain.cmake,
                 '-G', 'Ninja',
                 '-D', 'BUILD_SHARED_LIBS=YES',
+                '-D', 'CMAKE_BUILD_TYPE={}'.format(
+                    'Release' if self.is_release() else 'Debug'),
                 '-D', 'CMAKE_INSTALL_PREFIX={}'.format(
                     self.install_toolchain_path(host_target)),
                 '-D', 'CMAKE_MAKE_PROGRAM={}'.format(self.toolchain.ninja),


### PR DESCRIPTION
Ensure that we explicitly configure the build type for the swift-apis
build when building the toolchain.  This ensures that we do not end up
with debug mode binaries.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
