### PR TITLE
[ownership] Try harder to make sure we do not propagate ownership info when ownership is disabled.

### DIFF
--- a/lib/SIL/IR/SILUndef.cpp
+++ b/lib/SIL/IR/SILUndef.cpp
@@ -16,6 +16,8 @@
 using namespace swift;
 
 static ValueOwnershipKind getOwnershipKindForUndef(SILType type, const SILFunction &f) {
+  if (!f.hasOwnership())
+    return OwnershipKind::None;
   if (type.isAddress() || type.isTrivial(f))
     return OwnershipKind::None;
   return OwnershipKind::Owned;

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -583,6 +583,19 @@ ValueOwnershipKindClassifier::visitBuiltinInst(BuiltinInst *BI) {
 //===----------------------------------------------------------------------===//
 
 ValueOwnershipKind SILValue::getOwnershipKind() const {
+  // If we do not have an undef, we should always be able to get to our function
+  // here. If we do not have ownership enabled, just return none for everything
+  // to short circuit ownership optimizations. If we have an undef we may still
+  // get some results that are slightly wonky but hopefully when we lower
+  // ownership we remove that.
+  //
+  // We assume that any time we are in SILBuilder and call this without having a
+  // value in a block yet, ossa is enabled.
+  if (auto *block = Value->getParentBlock())
+    if (auto *f = block->getParent())
+      if (!f->hasOwnership())
+        return OwnershipKind::None;
+
   ValueOwnershipKindClassifier Classifier;
   auto result = Classifier.visit(const_cast<ValueBase *>(Value));
   assert(result && "Returned ownership kind invalid on values");

--- a/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
@@ -45,9 +45,7 @@ bb0(%0 : $@differentiable @callee_guaranteed (Float) -> Float):
 // CHECK: bb0([[ARG:%.*]] : $@differentiable @callee_guaranteed (Float) -> Float):
 // CHECK:   [[ORIG_FN:%.*]] = differentiable_function_extract [original] [[ARG]]
 // CHECK:   [[JVP_FN:%.*]] = differentiable_function_extract [jvp] [[ARG]]
-// CHECK:   strong_retain [[JVP_FN]]
 // CHECK:   [[VJP_FN:%.*]] = differentiable_function_extract [vjp] [[ARG]]
-// CHECK:   strong_retain [[VJP_FN]]
 // CHECK:   differentiable_function [parameters 0] [results 0] [[ORIG_FN]] : {{.*}} with_derivative {[[JVP_FN]] : {{.*}}, [[VJP_FN]] : {{.*}}}
 // CHECK: }
 
@@ -134,8 +132,6 @@ bb0(%0 : $Class):
 // CHECK-LABEL: sil @test_class_method_partial_apply
 // CHECK: bb0([[ARG:%.*]] : $Class):
 // CHECK:  [[ORIG_FN:%.*]] = class_method [[ARG]] : $Class, #Class.method
-// CHECK:  strong_retain [[ARG]]
-// CHECK:  strong_retain [[ARG]]
 // CHECK:  [[ORIG_FN_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[ORIG_FN]]([[ARG]])
 // CHECK:  [[JVP_FN:%.*]] = class_method [[ARG]] : $Class, #Class.method!jvp.SU
 // CHECK:  [[JVP_FN_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[JVP_FN]]([[ARG]])

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1591,11 +1591,12 @@ bb0(%0 : $Builtin.NativeObject):
   return undef : $()
 }
 
-// CHECK-LABEL: sil @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 // CHECK: unchecked_ownership_conversion {{%.*}} : $Builtin.NativeObject, @guaranteed to @owned
-sil @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+sil [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+  end_lifetime %1 : $Builtin.NativeObject
   return undef : $()
 }
 


### PR DESCRIPTION
Specifically, I made it so that assuming our instruction is inserted into a
block already that we:

1. Return a constraint of {OwnershipKind::Any, UseLifetimeConstraint::NonLifetimeEnding}.
2. Return OwnershipKind::None for all values.

Noticed above I said that if the instruction is already inserted into a block
then we do this. The reason why is that if this is called before an instruction
is inserted into a block, we can't get access to the SILFunction that has the
information on whether or not we are in OSSA form. The only time this can happen
is if one is using these APIs from within SILBuilder since SILBuilder is the
only place where we allow this to happen. In SILBuilder, we already know whether
or not our function is in ossa or not and already does different things as
appropriate (namely in non-ossa does not call getOwnershipKind()). So we know
that if these APIs are called in such a situation, we will only be calling it if
we are in OSSA already. Given that, we just assume we are in OSSA if we do not
have a function.

To make sure that no mistakes are made as a result of that assumption, I put in
a verifier check that all values when ownership is disabled return a
OwnershipKind::None from getOwnershipKind().

The main upside to this is this means that we can write code for both
OSSA/non-OSSA and write code for non-None ownership without needing to check if
ownership is enabled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
