### PR TITLE
Add features file describing new available flags

### DIFF
--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -6,3 +6,28 @@ add_dependencies(swiftOption
 target_link_libraries(swiftOption PRIVATE
   swiftBasic)
 
+set(features_file_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
+set(features_file_dest "${CMAKE_BINARY_DIR}/share/swift/features.json")
+
+add_custom_command(
+  OUTPUT
+    ${features_file_dest}
+  COMMAND
+    ${CMAKE_COMMAND} -E copy ${features_file_src} ${features_file_dest}
+  DEPENDS
+    ${features_file_src}
+)
+
+add_custom_target(swift-features-file DEPENDS ${features_file_dest})
+
+add_dependencies(swiftOption swift-features-file)
+
+swift_install_in_component(
+  FILES
+    ${features_file_dest}
+  DESTINATION
+    "share/swift"
+  COMPONENT
+    compiler
+)
+

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -1,0 +1,10 @@
+{
+  "features": [
+    {
+      "name": "experimental-skip-all-function-bodies"
+    },
+    {
+      "name": "experimental-allow-module-with-compiler-errors"
+    }
+  ]
+}


### PR DESCRIPTION
The only available method to check for features at the moment is through
version checks. This is errorprone and doesn't work well for OSS
toolchains or locally built compilers.

features.json is intended to communicate to build systems that a new
flag is available, in order to assist with a transitional period where
not all supported toolchains may have a particular flag. It is *not*
intended to be a comprehensive report of all flags available.

Note that the names are intended to be features, so while they may match
up to the corresponding flag name, this isn't necessarily the case.