### PR TITLE
[sil] When parsing if we find an error when parsing a SILBasicBlock emit a misc error showing the block that failed.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -618,6 +618,9 @@ ERROR(sil_basicblock_redefinition,none,
       "redefinition of basic block %0", (Identifier))
 ERROR(sil_basicblock_arg_rparen,none,
       "expected ')' in basic block argument list", ())
+// A backup error in case we are returned that we have an error but a diagnostic
+// was not emitted.
+ERROR(sil_failed_parse_basicblock, none, "Failed to parse SIL basic block", ())
 
 // SIL Functions
 ERROR(expected_sil_function_name,none,

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5880,8 +5880,11 @@ bool SILParserState::parseDeclSIL(Parser &P) {
       };
 
       do {
-        if (FunctionState.parseSILBasicBlock(B))
+        auto startLoc = P.Tok.getLoc();
+        if (FunctionState.parseSILBasicBlock(B)) {
+          P.Diags.diagnose(startLoc, diag::sil_failed_parse_basicblock);
           return true;
+        }
       } while (P.Tok.isNot(tok::r_brace) && P.Tok.isNot(tok::eof));
 
       SourceLoc RBraceLoc;


### PR DESCRIPTION
Otherwise, if for some reason we did not emit a diagnostic, we will just emit an
empty SILModule without any diagnostic which can be really confusing. This
ensures at least something is emitted.

I wanted to do this only if we actually emitted an error, but given that once we
emit a first error, we can't tell if we emitted more errors (we only know that
we emitted errors), we always emit this diagnostic on error. That is better than
just being confused about an empty sil module being output.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
