### PR TITLE
Unconditionally Record Type Body Fingerprints

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -873,8 +873,6 @@ public:
   /// available.
   Optional<std::string> getBodyFingerprint() const;
 
-  bool areTokensHashedForThisBodyInsteadOfInterfaceHash() const;
-
 private:
   /// Add a member to the list for iteration purposes, but do not notify the
   /// subclass that we have done so.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1022,11 +1022,6 @@ Optional<std::string> IterableDeclContext::getBodyFingerprint() const {
       .fingerprint;
 }
 
-bool IterableDeclContext::areTokensHashedForThisBodyInsteadOfInterfaceHash()
-    const {
-  return true;
-}
-
 /// Return the DeclContext to compare when checking private access in
 /// Swift 4 mode. The context returned is the type declaration if the context
 /// and the type declaration are in the same file, otherwise it is the types

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1024,11 +1024,6 @@ Optional<std::string> IterableDeclContext::getBodyFingerprint() const {
 
 bool IterableDeclContext::areTokensHashedForThisBodyInsteadOfInterfaceHash()
     const {
-  // Do not keep separate hashes for extension bodies because the dependencies
-  // can miss the addition of a member in an extension because there is nothing
-  // corresponding to the fingerprinted nominal dependency node.
-  if (isa<ExtensionDecl>(this))
-    return false;
   return true;
 }
 

--- a/test/Incremental/Fingerprints/Inputs/extension-adds-member/definesAB-after.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-adds-member/definesAB-after.swift
@@ -3,7 +3,7 @@ struct A {
 struct B {
 }
 extension A {
-  var x: Int {17}
+  init(_ x: String = "") {}
 }
 extension B {
 }


### PR DESCRIPTION
We used to disable these for extensions, which meant changes to extensions would pessimistically cause every decl in the file to be considered dirty.

The test here was incorrect - there was no use of `A.x`, and computed properties do not contribute to the implicit initializer generated for the struct `A`, so there was no reason to rebuild the other file. I've corrected the test to introduce an overload of the default initializer instead, which will actually detect if we fail to track the member use here.