### PR TITLE
Add an Assert To Make Sure the SIL Parser Emits Diagnostics

### DIFF
--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -84,6 +84,14 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
   if (hadError) {
     // The rest of the SIL pipeline expects well-formed SIL, so if we encounter
     // a parsing error, just return an empty SIL module.
+    //
+    // Because the SIL parser's notion of failing with an error is distinct from
+    // the ASTContext's notion of having emitted a diagnostic, it's possible for
+    // the parser to fail silently without emitting a diagnostic. This assertion
+    // ensures that +asserts builds will fail fast. If you crash here, please go
+    // back and add a diagnostic after identifying where the SIL parser failed.
+    assert(SF->getASTContext().hadError() &&
+           "Failed to parse SIL but did not emit any errors!");
     return SILModule::createEmptyModule(desc.context, desc.conv, desc.opts);
   }
   return silMod;


### PR DESCRIPTION
In #34693, we discovered the SIL parser can silently fail. Try to detect
this in +asserts builds.