### PR TITLE
[Concurrency] Implement basic runtime support for task futures.

### DIFF
--- a/include/swift/ABI/MetadataKind.def
+++ b/include/swift/ABI/MetadataKind.def
@@ -85,8 +85,8 @@ METADATAKIND(HeapGenericLocalVariable,
 METADATAKIND(ErrorObject,
              1 | MetadataKindIsNonType | MetadataKindIsRuntimePrivate)
 
-/// A heap-allocated simple task.
-METADATAKIND(SimpleTask,
+/// A heap-allocated task.
+METADATAKIND(Task,
              2 | MetadataKindIsNonType | MetadataKindIsRuntimePrivate)
 
 // getEnumeratedMetadataKind assumes that all the enumerated values here

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -326,7 +326,8 @@ public:
     /// fragment.
     static size_t storageOffset(const Metadata *resultType)  {
       size_t offset = sizeof(FutureFragment);
-      size_t alignment = std::max(resultType->vw_alignment(), alignof(void *));
+      size_t alignment =
+          std::max(resultType->vw_alignment(), alignof(SwiftError *));
       return (offset + alignment - 1) & ~(alignment - 1);
     }
 
@@ -334,7 +335,7 @@ public:
     /// result type.
     static size_t fragmentSize(const Metadata *resultType) {
       return storageOffset(resultType) +
-          std::max(resultType->vw_size(), sizeof(void *));
+          std::max(resultType->vw_size(), sizeof(SwiftError *));
     }
   };
 
@@ -463,7 +464,8 @@ public:
 /// task.
 ///
 /// This type matches the ABI of a function `<T> () async throws -> T`, which
-/// is used to describe futures.
+/// is the type used by `Task.runDetached` and `Task.group.add` to create
+/// futures.
 class FutureAsyncContext : public AsyncContext {
 public:
   SwiftError *errorResult = nullptr;

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -364,15 +364,16 @@ public:
   /// executor.
   void completeFuture(AsyncContext *context, ExecutorRef executor);
 
+  static bool classof(const Job *job) {
+    return job->isAsyncTask();
+  }
+
+private:
   /// Access the next waiting task, which establishes a singly linked list of
   /// tasks that are waiting on a future.
   AsyncTask *&getNextWaitingTask() {
     return reinterpret_cast<AsyncTask *&>(
         SchedulerPrivate[NextWaitingTaskIndex]);
-  }
-
-  static bool classof(const Job *job) {
-    return job->isAsyncTask();
   }
 };
 

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -31,6 +31,7 @@ class AsyncContext;
 class Executor;
 class Job;
 struct OpaqueValue;
+struct SwiftError;
 class TaskStatusRecord;
 
 /// An ExecutorRef isn't necessarily just a pointer to an executor
@@ -321,6 +322,12 @@ public:
     OpaqueValue *getStoragePtr() {
       return reinterpret_cast<OpaqueValue *>(
           reinterpret_cast<char *>(this) + storageOffset(resultType));
+    }
+
+    /// Retrieve the error.
+    SwiftError *&getError() {
+      return *reinterpret_cast<SwiftError **>(
+           reinterpret_cast<char *>(this) + storageOffset(resultType));
     }
 
     /// Compute the offset of the storage from the base of the future

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -246,7 +246,7 @@ public:
   public:
     /// Describes the status of the future.
     ///
-    /// Futures always being in the "Executing" state, and will always
+    /// Futures always begin in the "Executing" state, and will always
     /// make a single state change to either Success or Error.
     enum class Status : uintptr_t {
       /// The future is executing or ready to execute. The storage
@@ -266,7 +266,6 @@ public:
     std::atomic<Status> status;
 
     /// Queue containing all of the tasks that are waiting in `get()`.
-    /// FIXME: do we also need a context pointer for each?
     std::atomic<AsyncTask*> waitQueue;
 
     /// The type of the result that will be produced by the future.
@@ -298,8 +297,6 @@ public:
           reinterpret_cast<char *>(this) + storageOffset(resultType));
     }
 
-    /// Retrieve a reference to the storage of the 
-
     /// Compute the offset of the storage from the base of the future
     /// fragment.
     static size_t storageOffset(const Metadata *resultType)  {
@@ -329,9 +326,8 @@ public:
   ///
   /// \returns the status of the future. If this result is
   /// \c Executing, then \c waitingTask has been added to the
-  /// wait queue and will be scheduled when the future completes or
-  /// is cancelled. Otherwise, the future has completed and can be
-  /// queried.
+  /// wait queue and will be scheduled when the future completes. Otherwise,
+  /// the future has completed and can be queried.
   FutureFragment::Status waitFuture(AsyncTask *waitingTask);
 
   /// Complete this future.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -271,7 +271,7 @@ public:
       /// Mask used for the low status bits in a wait queue item.
       static const uintptr_t statusMask = 0x03;
 
-      const uintptr_t storage;
+      uintptr_t storage;
 
       Status getStatus() const {
         return static_cast<Status>(storage & statusMask);

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -333,7 +333,9 @@ public:
 
     /// Determine the size of the future fragment given a particular future
     /// result type.
-    static size_t fragmentSize(const Metadata *resultType);
+    static size_t fragmentSize(const Metadata *resultType) {
+      return storageOffset(resultType) + resultType->vw_size();
+    }
   };
 
   bool isFuture() const { return Flags.task_isFuture(); }

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -65,16 +65,14 @@ AsyncTaskAndContext swift_task_create_f(JobFlags flags,
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTaskAndContext swift_task_create_future(
     JobFlags flags, AsyncTask *parent, const Metadata *futureResultType,
-    const AsyncFunctionPointer<void()> *function,
-    size_t resultOffset, size_t errorOffset);
+    const AsyncFunctionPointer<void()> *function);
 
 /// Create a task object with a future which will run the given
 /// function.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTaskAndContext swift_task_create_future_f(
     JobFlags flags, AsyncTask *parent, const Metadata *futureResultType,
-    AsyncFunctionType<void()> *function, size_t initialContextSize,
-    size_t resultOffset, size_t errorOffset);
+    AsyncFunctionType<void()> *function, size_t initialContextSize);
 
 /// Allocate memory in a task.
 ///

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -49,6 +49,33 @@ AsyncTaskAndContext swift_task_create_f(JobFlags flags,
                                         AsyncFunctionType<void()> *function,
                                         size_t initialContextSize);
 
+/// Create a task object with a future which will run the given
+/// function.
+///
+/// The task is not yet scheduled.
+///
+/// If a parent task is provided, flags.task_hasChildFragment() must
+/// be true, and this must be called synchronously with the parent.
+/// The parent is responsible for creating a ChildTaskStatusRecord.
+/// TODO: should we have a single runtime function for creating a task
+/// and doing this child task status record management?
+///
+/// flags.task_isFuture must be set. \c futureResultType is the type
+///
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+AsyncTaskAndContext swift_task_create_future(
+    JobFlags flags, AsyncTask *parent, const Metadata *futureResultType,
+    const AsyncFunctionPointer<void()> *function,
+    size_t resultOffset, size_t errorOffset);
+
+/// Create a task object with no future which will run the given
+/// function.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+AsyncTaskAndContext swift_task_create_future_f(
+    JobFlags flags, AsyncTask *parent, const Metadata *futureResultType,
+    AsyncFunctionType<void()> *function, size_t initialContextSize,
+    size_t resultOffset, size_t errorOffset);
+
 /// Allocate memory in a task.
 ///
 /// This must be called synchronously with the task.
@@ -82,6 +109,34 @@ void swift_task_cancel(AsyncTask *task);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority
 swift_task_escalate(AsyncTask *task, JobPriority newPriority);
+
+/// The result of waiting for a task future.
+struct TaskFutureWaitResult {
+  enum Kind : uintptr_t {
+    /// The waiting task has been added to the future's wait queue, and will
+    /// be scheduled once the future has completed.
+    Waiting,
+
+    /// The future succeeded and produced a result value. \c storage points
+    /// at that value.
+    Success,
+
+    /// The future finished by throwing an error. \c storage is that error
+    /// existential.
+    Error,
+  };
+
+  Kind kind;
+  OpaqueValue *storage;
+};
+
+/// Wait for a future task to complete.
+///
+/// This can be called from any thread.
+///
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+TaskFutureWaitResult
+swift_task_future_wait(AsyncTask *task, AsyncTask *waitingTask);
 
 /// Add a status record to a task.  The record should not be
 /// modified while it is registered with a task.

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -68,7 +68,7 @@ AsyncTaskAndContext swift_task_create_future(
     const AsyncFunctionPointer<void()> *function,
     size_t resultOffset, size_t errorOffset);
 
-/// Create a task object with no future which will run the given
+/// Create a task object with a future which will run the given
 /// function.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTaskAndContext swift_task_create_future_f(

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -103,9 +103,6 @@ void AsyncTask::completeFuture(AsyncContext *context, ExecutorRef executor) {
     // Find the next waiting task.
     auto nextWaitingTask = waitingTask->getNextWaitingTask();
 
-    // Remove this task from the list.
-    waitingTask->getNextWaitingTask() = nullptr;
-
     // TODO: schedule this task on the executor rather than running it
     // directly.
     waitingTask->run(executor);
@@ -198,7 +195,8 @@ AsyncTaskAndContext swift::swift_task_create_future_f(
     JobFlags flags, AsyncTask *parent, const Metadata *futureResultType,
     AsyncFunctionType<void()> *function, size_t initialContextSize) {
   assert((futureResultType != nullptr) == flags.task_isFuture());
-  assert((futureResultType != nullptr) == flags.task_isFuture());
+  assert(!flags.task_isFuture() ||
+         initialContextSize >= sizeof(FutureAsyncContext));
   assert((parent != nullptr) == flags.task_isChildTask());
 
   // Figure out the size of the header.

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -34,7 +34,7 @@ void FutureFragment::destroy() {
     break;
 
   case Status::Error:
-    swift_unknownObjectRelease(getStoragePtr());
+    swift_unknownObjectRelease(reinterpret_cast<OpaqueValue *>(getError()));
     break;
   }
 }
@@ -300,8 +300,7 @@ swift::swift_task_future_wait(AsyncTask *task, AsyncTask *waitingTask) {
    case FutureFragment::Status::Error:
       return TaskFutureWaitResult{
           TaskFutureWaitResult::Error,
-          *reinterpret_cast<OpaqueValue **>(
-            task->futureFragment()->getStoragePtr())};
+          reinterpret_cast<OpaqueValue *>(task->futureFragment()->getError())};
   }
 }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -23,10 +23,6 @@
 using namespace swift;
 using FutureFragment = AsyncTask::FutureFragment;
 
-size_t FutureFragment::fragmentSize(const Metadata *resultType) {
-  return storageOffset(resultType) + resultType->vw_size();
-}
-
 void FutureFragment::destroy() {
   auto queueHead = waitQueue.load(std::memory_order_acquire);
   switch (queueHead.getStatus()) {

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -64,7 +64,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask) {
     }
 
     // Put the waiting task at the beginning of the wait queue.
-    waitingTask->NextWaitingTask = queueHead.getTask();
+    waitingTask->getNextWaitingTask() = queueHead.getTask();
     auto newQueueHead = WaitQueueItem::get(Status::Executing, waitingTask);
     if (fragment->waitQueue.compare_exchange_weak(
             queueHead, newQueueHead, std::memory_order_release,
@@ -119,10 +119,10 @@ void AsyncTask::completeFuture(AsyncContext *context, ExecutorRef executor) {
   auto waitingTask = queueHead.getTask();
   while (waitingTask) {
     // Find the next waiting task.
-    auto nextWaitingTask = waitingTask->NextWaitingTask;
+    auto nextWaitingTask = waitingTask->getNextWaitingTask();
 
     // Remove this task from the list.
-    waitingTask->NextWaitingTask = nullptr;
+    waitingTask->getNextWaitingTask() = nullptr;
 
     // TODO: schedule this task on the executor rather than running it
     // directly.

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -97,7 +97,7 @@ void AsyncTask::completeFuture(AsyncContext *context, ExecutorRef executor) {
       newQueueHead, std::memory_order_acquire);
   assert(queueHead.getStatus() == Status::Executing);
 
-  // Notify every
+  // Schedule every waiting task on the executor.
   auto waitingTask = queueHead.getTask();
   while (waitingTask) {
     // Find the next waiting task.

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -55,6 +55,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 
   if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
     list(APPEND PLATFORM_SOURCES
+      TaskFuture.cpp
       TaskStatus.cpp
       )
     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
@@ -66,6 +67,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   set(LLVM_OPTIONAL_SOURCES
     weak.mm
     Refcounting.mm
+    TaskFuture.cpp
     TaskStatus.cpp)
 
   add_swift_unittest(SwiftRuntimeTests

--- a/unittests/runtime/TaskFuture.cpp
+++ b/unittests/runtime/TaskFuture.cpp
@@ -1,0 +1,127 @@
+//===--- TaskFuture.cpp - Unit tests for the task futures API -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/Metadata.h"
+#include "swift/Demangling/ManglingMacros.h"
+#include "swift/Basic/STLExtras.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+template <class T> struct FutureContext;
+
+template <class T>
+using InvokeFunctionRef =
+  llvm::function_ref<void(AsyncTask *task,
+                          ExecutorRef executor,
+                          FutureContext<T> *context)>;
+
+using BodyFunctionRef =
+  llvm::function_ref<void(AsyncTask *task)>;
+
+template <class Storage> struct PODFutureContext : AsyncContext {
+  alignas(Storage) char resultStorage[sizeof(Storage)];
+  void *errorStorage;
+};
+
+template <class Storage> struct FutureContext : PODFutureContext<Storage> {
+  InvokeFunctionRef<Storage> storedInvokeFn;
+
+  Storage& getStorage() {
+    return *reinterpret_cast<Storage *>(&this->resultStorage[0]);
+  }
+};
+
+// Disable template argument deduction.
+template <class T>
+using undeduced =
+  typename std::enable_if<std::is_same<T, T>::value, T>::type;
+
+template <class T>
+SWIFT_CC(swift)
+static void futureTaskInvokeFunction(AsyncTask *task, ExecutorRef executor,
+                                     AsyncContext *context) {
+  auto futureContext = static_cast<FutureContext<T>*>(context);
+  futureContext->storedInvokeFn(task, executor, futureContext);
+
+  // Return to finish off the task.
+  // In a normal situation we'd need to free the context, but here
+  // we know we're at the top level.
+  futureContext->ResumeParent(task, executor, futureContext);
+}
+
+template <class T>
+static void withFutureTask(const Metadata *resultType,
+                           undeduced<InvokeFunctionRef<T>> invokeFn,
+                           BodyFunctionRef body) {
+  JobFlags flags = JobKind::Task;
+  flags.task_setIsFuture(true);
+
+  auto taskAndContext =
+    swift_task_create_future_f(flags, /*parent*/ nullptr, resultType,
+                               &futureTaskInvokeFunction<T>,
+                               sizeof(FutureContext<T>),
+                               offsetof(PODFutureContext<T>, resultStorage),
+                               offsetof(PODFutureContext<T>, errorStorage));
+
+  auto futureContext =
+    static_cast<FutureContext<T>*>(taskAndContext.InitialContext);
+  futureContext->getStorage() = 42; // Magic number.
+  futureContext->storedInvokeFn = invokeFn;
+
+  // Forward our owning reference to the task into its execution,
+  // causing it to be destroyed when it completes.
+  body(taskAndContext.Task);
+}
+
+static ExecutorRef createFakeExecutor(uintptr_t value) {
+  return {reinterpret_cast<Executor*>(value)};
+}
+}
+
+extern const FullMetadata<OpaqueMetadata> METADATA_SYM(Si);
+
+TEST(TaskFutureTest, intFuture) {
+  auto createdExecutor = createFakeExecutor(1234);
+  bool hasRun = false;
+
+  withFutureTask<intptr_t>(
+      reinterpret_cast<const Metadata *>(&METADATA_SYM(Si)),
+      [&](AsyncTask *task, ExecutorRef executor,
+          FutureContext<intptr_t> *context) {
+    // The storage should be what we initialized it to earlier.
+    EXPECT_EQ(42, context->getStorage());
+
+    // The error storage should have been cleared out for us.
+    EXPECT_EQ(nullptr, context->errorStorage);
+
+    // Store something in the future.
+    context->getStorage() = 17;
+
+    hasRun = true;
+  }, [&](AsyncTask *task) {
+    // Run the task, which should fill in the future.
+    EXPECT_FALSE(hasRun);
+    task->run(createdExecutor);
+    EXPECT_TRUE(hasRun);
+
+    // "Wait" for the future, which must have completed by now.
+    auto waitResult = swift_task_future_wait(task, nullptr);
+    EXPECT_EQ(TaskFutureWaitResult::Success, waitResult.kind);
+
+    // Make sure we got the result value we expect.
+    EXPECT_EQ(17, *reinterpret_cast<intptr_t *>(waitResult.storage));
+  });
+}
+

--- a/unittests/runtime/TaskFuture.cpp
+++ b/unittests/runtime/TaskFuture.cpp
@@ -120,39 +120,6 @@ static TestObject *allocTestObject(size_t *addr, size_t value) {
   return result;
 }
 
-TEST(TaskFutureTest, intFuture) {
-  auto createdExecutor = createFakeExecutor(1234);
-  bool hasRun = false;
-
-  withFutureTask<intptr_t>(
-      reinterpret_cast<const Metadata *>(&METADATA_SYM(Si)), 42,
-      [&](AsyncTask *task, ExecutorRef executor,
-          FutureContext<intptr_t> *context) {
-    // The storage should be what we initialized it to earlier.
-    EXPECT_EQ(42, context->getStorage());
-
-    // The error storage should have been cleared out for us.
-    EXPECT_EQ(nullptr, context->errorResult);
-
-    // Store something in the future.
-    context->getStorage() = 17;
-
-    hasRun = true;
-  }, [&](AsyncTask *task) {
-    // Run the task, which should fill in the future.
-    EXPECT_FALSE(hasRun);
-    task->run(createdExecutor);
-    EXPECT_TRUE(hasRun);
-
-    // "Wait" for the future, which must have completed by now.
-    auto waitResult = swift_task_future_wait(task, nullptr);
-    EXPECT_EQ(TaskFutureWaitResult::Success, waitResult.kind);
-
-    // Make sure we got the result value we expect.
-    EXPECT_EQ(17, *reinterpret_cast<intptr_t *>(waitResult.storage));
-  });
-}
-
 TEST(TaskFutureTest, objectFuture) {
   auto createdExecutor = createFakeExecutor(1234);
   bool hasRun = false;

--- a/unittests/runtime/TaskFuture.cpp
+++ b/unittests/runtime/TaskFuture.cpp
@@ -196,7 +196,7 @@ TEST(TaskFutureTest, objectFuture) {
     EXPECT_EQ(object, *reinterpret_cast<TestObject **>(waitResult.storage));
 
     // Make sure the object hasn't been destroyed.
-    EXPECT_EQ(7, objectValueOnComplete);
+    EXPECT_EQ(size_t(7), objectValueOnComplete);
 
     // Okay, release the task. This should destroy the object.
     swift_release(task);


### PR DESCRIPTION
Extend AsyncTask and the concurrency runtime with basic support for
task futures. AsyncTasks with futures contain a future fragment with
information about the type produced by the future, and where the
future will put the result value or the thrown error in the initial
context.

We still don't have the ability to schedule the waiting tasks on an
executor when the future completes, so this isn't useful for anything
just test, and we can only test limited code paths.
