### PR TITLE
Fix issues with discontiguous-slice assignment

### DIFF
--- a/stdlib/public/core/DiscontiguousSlice.swift
+++ b/stdlib/public/core/DiscontiguousSlice.swift
@@ -168,9 +168,25 @@ extension MutableCollection {
       DiscontiguousSlice(base: self, subranges: subranges)
     }
     set {
-      for i in newValue.indices {
-        self[i.base] = newValue[i]
+      var indexOfReplacement = newValue.startIndex
+      for range in subranges.ranges {
+        _debugPrecondition(!range.isEmpty, "Empty range in a range set")
+        
+        var indexToReplace = range.lowerBound
+        repeat {
+          _precondition(
+            indexOfReplacement < newValue.endIndex,
+            "Attempt to replace discontinuous slice with too few elements")
+          
+          self[indexToReplace] = newValue[indexOfReplacement]
+          self.formIndex(after: &indexToReplace)
+          newValue.formIndex(after: &indexOfReplacement)
+        } while indexToReplace < range.upperBound
       }
+      
+      _precondition(
+        indexOfReplacement == newValue.endIndex,
+        "Attempt to replace discontinuous slice with too many elements")
     }
   }
 }

--- a/validation-test/StdlibUnittest/RangeSet.swift
+++ b/validation-test/StdlibUnittest/RangeSet.swift
@@ -357,6 +357,39 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
       }
     }
   }
+
+  RangeSetTests.test("DiscontiguousSliceMutating") {
+    var initial = Array(1...20)
+    let none = initial.subranges(where: { $0.isMultiple(of: 100) })
+    initial[none] = initial[none]
+    expectEqualSequence(1...20, initial)
+    
+    let evens = initial.subranges(where: { $0.isMultiple(of: 2) })
+    let odds = initial.subranges(where: { !$0.isMultiple(of: 2) })
+    initial[evens] = initial[odds]
+    expectEqualSequence(
+      [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15, 17, 17, 19, 19],
+      initial
+    )
+  }
+
+  RangeSetTests.test("DiscontiguousSliceMutating/TooLarge") {
+    var initial = Array(1...21)
+    let evens = initial.subranges(where: { $0.isMultiple(of: 2) })
+    let odds = initial.subranges(where: { !$0.isMultiple(of: 2) })
+
+    expectCrashLater()
+    initial[evens] = initial[odds]
+  }
+
+  RangeSetTests.test("DiscontiguousSliceMutating/TooSmall") {
+    var initial = Array(1...21)
+    let evens = initial.subranges(where: { $0.isMultiple(of: 2) })
+    let odds = initial.subranges(where: { !$0.isMultiple(of: 2) })
+
+    expectCrashLater()
+    initial[odds] = initial[evens]
+  }
 }
 
 runAllTests()


### PR DESCRIPTION
The mutating collection subscript for discontiguous slices assigns to the wrong group of indices. This fixes the behavior and adds test coverage.

rdar://problem/70690643
