### PR TITLE
Remove workaround for SR-13820

### DIFF
--- a/include/swift/SILOptimizer/Analysis/FunctionOrder.h
+++ b/include/swift/SILOptimizer/Analysis/FunctionOrder.h
@@ -31,6 +31,7 @@ public:
   typedef TinyPtrVector<SILFunction *> SCC;
 
 private:
+  SILModule &M;
   llvm::SmallVector<SCC, 32> TheSCCs;
   llvm::SmallVector<SILFunction *, 32> TheFunctions;
 
@@ -43,33 +44,24 @@ private:
   llvm::SmallSetVector<SILFunction *, 4> DFSStack;
 
 public:
-  // SWIFT_ENABLE_TENSORFLOW
-  BottomUpFunctionOrder(BasicCalleeAnalysis *BCA)
-      : BCA(BCA), NextDFSNum(0) {}
-
-  /// DFS on 'F' to compute bottom up order
-  void computeBottomUpOrder(SILFunction *F) {
-     DFS(F);
-  }
-
-  /// DFS on all functions in the module to compute bottom up order
-  void computeBottomUpOrder(SILModule *M) {
-    for (auto &F : *M)
-      DFS(&F);
-  }
-  // SWIFT_ENABLE_TENSORFLOW END
+  BottomUpFunctionOrder(SILModule &M, BasicCalleeAnalysis *BCA)
+      : M(M), BCA(BCA), NextDFSNum(0) {}
 
   /// Get the SCCs in bottom-up order.
   ArrayRef<SCC> getSCCs() {
+    if (!TheSCCs.empty())
+      return TheSCCs;
+
+    FindSCCs(M);
     return TheSCCs;
   }
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// Get a flattened view of all functions in all the SCCs in bottom-up order
-  ArrayRef<SILFunction *> getBottomUpOrder() {
-  // SWIFT_ENABLE_TENSORFLOW END
+  /// Get a flattened view of all functions in all the SCCs in
+  /// bottom-up order
+  ArrayRef<SILFunction *> getFunctions() {
     if (!TheFunctions.empty())
       return TheFunctions;
+
     for (auto SCC : getSCCs())
       for (auto *F : SCC)
         TheFunctions.push_back(F);
@@ -79,6 +71,7 @@ public:
 
 private:
   void DFS(SILFunction *F);
+  void FindSCCs(SILModule &M);
 };
 
 } // end namespace swift

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -73,3 +73,8 @@ void BottomUpFunctionOrder::DFS(SILFunction *Start) {
     TheSCCs.push_back(CurrentSCC);
   }
 }
+
+void BottomUpFunctionOrder::FindSCCs(SILModule &M) {
+  for (auto &F : M)
+    DFS(&F);
+}

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -533,11 +533,8 @@ runFunctionPasses(unsigned FromTransIdx, unsigned ToTransIdx) {
     return;
 
   BasicCalleeAnalysis *BCA = getAnalysis<BasicCalleeAnalysis>();
-  // SWIFT_ENABLE_TENSORFLOW
-  BottomUpFunctionOrder BottomUpOrder(BCA);
-  BottomUpOrder.computeBottomUpOrder(Mod);
-  auto BottomUpFunctions = BottomUpOrder.getBottomUpOrder();
-  // SWIFT_ENABLE_TENSORFLOW END
+  BottomUpFunctionOrder BottomUpOrder(*Mod, BCA);
+  auto BottomUpFunctions = BottomUpOrder.getFunctions();
 
   assert(FunctionWorklist.empty() && "Expected empty function worklist!");
 
@@ -590,49 +587,6 @@ runFunctionPasses(unsigned FromTransIdx, unsigned ToTransIdx) {
       ++Entry.PipelineIdx;
     }
     clearRestartPipeline();
-
-    // SWIFT_ENABLE_TENSORFLOW
-    if (TailIdx == (FunctionWorklist.size() - 1))  {
-      // No new functions to process
-      continue;
-    }
-
-    // Compute the bottom up order of the new functions and the callees in it
-    BottomUpFunctionOrder SubBottomUpOrder(BCA);
-    // Initialize BottomUpFunctionOrder with new functions
-    for (auto It = FunctionWorklist.begin() + TailIdx + 1;
-         It != FunctionWorklist.end(); It++) {
-      SubBottomUpOrder.computeBottomUpOrder(It->F);
-    }
-    auto NewFunctionsBottomUp = SubBottomUpOrder.getBottomUpOrder();
-    SmallPtrSet<SILFunction *, 8> NewBottomUpSet(NewFunctionsBottomUp.begin(),
-                                                 NewFunctionsBottomUp.end());
-
-    // Remove all the functions in the new bottom up order from FunctionWorklist
-    llvm::DenseMap<SILFunction *, WorklistEntry> FunctionsToReorder;
-    auto RemoveFn = [&FunctionsToReorder,
-                     &NewBottomUpSet](WorklistEntry Entry) {
-      if (NewBottomUpSet.find(Entry.F) == NewBottomUpSet.end()) {
-        return false;
-      }
-      FunctionsToReorder.insert(std::make_pair(Entry.F, Entry));
-      return true;
-    };
-    std::remove_if(FunctionWorklist.begin(), FunctionWorklist.end(), RemoveFn);
-    FunctionWorklist.erase((FunctionWorklist.begin() + FunctionWorklist.size() -
-                            FunctionsToReorder.size()),
-                           FunctionWorklist.end());
-
-    // Add back the functions in the new bottom up order to the FunctionWorklist
-    for (auto it = NewFunctionsBottomUp.rbegin();
-         it != NewFunctionsBottomUp.rend(); it++) {
-      auto Entry = FunctionsToReorder.find(*it);
-      if (Entry == FunctionsToReorder.end()) {
-        continue;
-      }
-      FunctionWorklist.push_back((*Entry).second);
-    }
-    // SWIFT_ENABLE_TENSORFLOW END
   }
 }
 

--- a/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
@@ -35,10 +35,8 @@ class FunctionOrderPrinterPass : public SILModuleTransform {
   /// The entry point to the transformation.
   void run() override {
     BCA = getAnalysis<BasicCalleeAnalysis>();
-    // SWIFT_ENABLE_TENSORFLOW
-    BottomUpFunctionOrder Orderer(BCA);
-    Orderer.computeBottomUpOrder(getModule());
-    // SWIFT_ENABLE_TENSORFLOW END
+    auto &M = *getModule();
+    BottomUpFunctionOrder Orderer(M, BCA);
 
     llvm::outs() << "Bottom up function order:\n";
     auto SCCs = Orderer.getSCCs();

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -91,11 +91,9 @@ public class C<R> {
 // IR-LABEL: ret void
 
 // IR: ![[BOOL:[0-9]+]] = !DICompositeType({{.*}}name: "Bool"
+// IR: ![[LET_BOOL:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[BOOL]])
 // IR: ![[INT:[0-9]+]] = !DICompositeType({{.*}}name: "Int"
 // IR: ![[LET_INT:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[INT]])
-// SWIFT_ENABLE_TENSORFLOW
-// IR: ![[LET_BOOL:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[BOOL]])
-// SWIFT_ENABLE_TENSORFLOW END
 // IR: ![[TAU_0_0:[0-9]+]] = {{.*}}DW_TAG_structure_type, name: "$sxD",
 // IR: ![[LET_TAU_0_0:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TAU_0_0]])
 // IR: ![[TAU_1_0:[0-9]+]] = {{.*}}DW_TAG_structure_type, name: "$sqd__D",


### PR DESCRIPTION
<!-- What's in this pull request? -->
#30710 was reverted in #34477 and SR-13820 was filed. This patch removes the workaround to bring `tensorflow` in line with `main`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves TF-1350.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
