### PR TITLE
[silgen] Make SwitchCaseFullExpr use an ArgumentScope instead of just a Scope.

### DIFF
--- a/lib/SILGen/ArgumentScope.h
+++ b/lib/SILGen/ArgumentScope.h
@@ -61,6 +61,8 @@ public:
     formalEvalScope.verify();
   }
 
+  bool isValid() const { return normalScope.isValid(); }
+
 private:
   void popImpl() {
     // We must always pop the formal eval scope before the normal scope since

--- a/lib/SILGen/SwitchEnumBuilder.cpp
+++ b/lib/SILGen/SwitchEnumBuilder.cpp
@@ -22,11 +22,11 @@ using namespace Lowering;
 //===----------------------------------------------------------------------===//
 
 SwitchCaseFullExpr::SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc)
-    : SGF(SGF), scope(SGF.Cleanups, loc), loc(loc), branchDest() {}
+    : SGF(SGF), scope(SGF, loc), loc(loc), branchDest() {}
 
 SwitchCaseFullExpr::SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc,
                                        SwitchCaseBranchDest branchDest)
-    : SGF(SGF), scope(SGF.Cleanups, loc), loc(loc), branchDest(branchDest) {}
+    : SGF(SGF), scope(SGF, loc), loc(loc), branchDest(branchDest) {}
 
 void SwitchCaseFullExpr::exitAndBranch(SILLocation loc,
                                        ArrayRef<SILValue> branchArgs) {

--- a/lib/SILGen/SwitchEnumBuilder.h
+++ b/lib/SILGen/SwitchEnumBuilder.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILGEN_SWITCHENUMBUILDER_H
 #define SWIFT_SILGEN_SWITCHENUMBUILDER_H
 
+#include "ArgumentScope.h"
 #include "Scope.h"
 
 namespace swift {
@@ -52,7 +53,7 @@ struct SwitchCaseBranchDest {
 /// This scope is also exposed to the debug info.
 class SwitchCaseFullExpr {
   SILGenFunction &SGF;
-  Scope scope;
+  ArgumentScope scope;
   CleanupLocation loc;
   SwitchCaseBranchDest branchDest;
 

--- a/test/SILGen/Inputs/objc_bridging_nsurl.h
+++ b/test/SILGen/Inputs/objc_bridging_nsurl.h
@@ -1,0 +1,8 @@
+
+@import Foundation;
+
+@interface ObjCKlass : NSObject
+
+@property(nonatomic, copy, nullable) NSURL *outputURL;
+
+@end

--- a/test/SILGen/objc_bridging_url.swift
+++ b/test/SILGen/objc_bridging_url.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-silgen -import-objc-header %S/Inputs/objc_bridging_nsurl.h %s
+
+// REQUIRES: objc_interop
+
+// Make sure we do not crash on this
+
+protocol P {
+  var outputURL : URL? { get set }
+}
+
+extension ObjCKlass : P {}


### PR DESCRIPTION
Otherwise, if we move in a formal access cleanup value into switch emission
using a cleanup cloner, we will improperly have a formal access cleanup that
will be invalidated by a normal Scope which violates SILGen invariants. Also in
a certain sense the bindings performed by SILGenPattern that do this type of
forwarding are arguments in a certain sense so it seems reasonable to do this.

<rdar://problem/70736924>
