### PR TITLE
stdlib: add availability attributes to the COW debug checking functions.

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -346,10 +346,12 @@ internal func _class_getInstancePositiveExtentSize(_ theClass: AnyClass) -> Int 
 }
 
 #if INTERNAL_CHECKS_ENABLED
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @usableFromInline
 @_silgen_name("_swift_isImmutableCOWBuffer")
 internal func _swift_isImmutableCOWBuffer(_ object: AnyObject) -> Bool
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @usableFromInline
 @_silgen_name("_swift_setImmutableCOWBuffer")
 internal func _swift_setImmutableCOWBuffer(_ object: AnyObject, _ immutable: Bool) -> Bool

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -44,5 +44,3 @@ Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
 Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
 Struct _RuntimeFunctionCounters is a new API without @available attribute
-Func _swift_isImmutableCOWBuffer(_:) is a new API without @available attribute
-Func _swift_setImmutableCOWBuffer(_:_:) is a new API without @available attribute


### PR DESCRIPTION
This is only relevant for assert builds of the library.
Fixes an undefined symbol error if an executable, compiled with an assert build of the stdlib, is back deployed on a platform which does not support lazy symbol binding.

rdar://problem/71201102
