### PR TITLE
Revert "Use AccessPath in LICM and split loads for combine load/store hoisting"

### DIFF
--- a/include/swift/SIL/LoopInfo.h
+++ b/include/swift/SIL/LoopInfo.h
@@ -60,8 +60,6 @@ public:
     }
   }
 
-  SILFunction *getFunction() const { return getHeader()->getParent(); }
-
 private:
   friend class llvm::LoopInfoBase<SILBasicBlock, SILLoop>;
 

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1369,7 +1369,7 @@ public:
   // Result visitNonAccess(SILValue base);
   // Result visitPhi(SILPhiArgument *phi);
   // Result visitStorageCast(SingleValueInstruction *cast, Operand *sourceOper);
-  // Result visitAccessProjection(SingleValueInstruction *projectedAddr,
+  // Result visitAccessProjection(SingleValueInstruction *cast,
   //                              Operand *sourceOper);
 
   Result visit(SILValue sourceAddr);
@@ -1476,82 +1476,6 @@ Result AccessUseDefChainVisitor<Impl, Result>::visit(SILValue sourceAddr) {
     return asImpl().visitUnidentified(sourceAddr);
 
   return asImpl().visitNonAccess(sourceAddr);
-}
-
-} // end namespace swift
-
-//===----------------------------------------------------------------------===//
-//                          AccessUseDefChainCloner
-//===----------------------------------------------------------------------===//
-
-namespace swift {
-
-/// Clone all projections and casts on the access use-def chain until either the
-/// specified predicate is true or the access base is reached.
-///
-/// This will not clone ref_element_addr or ref_tail_addr because those aren't
-/// part of the access chain.
-template <typename UnaryPredicate>
-class AccessUseDefChainCloner
-    : public AccessUseDefChainVisitor<AccessUseDefChainCloner<UnaryPredicate>,
-                                      SILValue> {
-  UnaryPredicate predicate;
-  SILInstruction *insertionPoint;
-
-public:
-  AccessUseDefChainCloner(UnaryPredicate predicate,
-                          SILInstruction *insertionPoint)
-      : predicate(predicate), insertionPoint(insertionPoint) {}
-
-  // Recursive main entry point
-  SILValue cloneUseDefChain(SILValue addr) {
-    if (!predicate(addr))
-      return addr;
-
-    return this->visit(addr);
-  }
-
-  // Recursively clone an address on the use-def chain.
-  SingleValueInstruction *cloneProjection(SingleValueInstruction *projectedAddr,
-                                          Operand *sourceOper) {
-    SILValue projectedSource = cloneUseDefChain(sourceOper->get());
-    SILInstruction *clone = projectedAddr->clone(insertionPoint);
-    clone->setOperand(sourceOper->getOperandNumber(), projectedSource);
-    return cast<SingleValueInstruction>(clone);
-  }
-
-  // MARK: Visitor implementation
-
-  SILValue visitBase(SILValue base, AccessedStorage::Kind kind) {
-    assert(false && "access base cannot be cloned");
-  }
-
-  SILValue visitNonAccess(SILValue base) {
-    assert(false && "unknown address root cannot be cloned");
-    return SILValue();
-  }
-
-  SILValue visitPhi(SILPhiArgument *phi) {
-    assert(false && "unexpected phi on access path");
-    return SILValue();
-  }
-
-  SILValue visitStorageCast(SingleValueInstruction *cast, Operand *sourceOper) {
-    return cloneProjection(cast, sourceOper);
-  }
-
-  SILValue visitAccessProjection(SingleValueInstruction *projectedAddr,
-                                 Operand *sourceOper) {
-    return cloneProjection(projectedAddr, sourceOper);
-  }
-};
-
-template <typename UnaryPredicate>
-SILValue cloneUseDefChain(SILValue addr, SILInstruction *insertionPoint,
-                          UnaryPredicate shouldFollowUse) {
-  return AccessUseDefChainCloner<UnaryPredicate>(shouldFollowUse,
-                                                 insertionPoint)
-      .cloneUseDefChain(addr);
 }
 
 } // end namespace swift

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -122,13 +122,14 @@ public:
       phiArg->getIncomingPhiValues(pointerWorklist);
   }
 
-  void visitStorageCast(SingleValueInstruction *cast, Operand *sourceOper) {
+  void visitStorageCast(SingleValueInstruction *projectedAddr,
+                        Operand *sourceOper) {
     // Allow conversions to/from pointers and addresses on disjoint phi paths
     // only if the underlying useDefVisitor allows it.
     if (storageCastTy == IgnoreStorageCast)
       pointerWorklist.push_back(sourceOper->get());
     else
-      visitNonAccess(cast);
+      visitNonAccess(projectedAddr);
   }
 
   void visitAccessProjection(SingleValueInstruction *projectedAddr,
@@ -206,7 +207,8 @@ public:
     return this->asImpl().visitNonAccess(phiArg);
   }
 
-  SILValue visitStorageCast(SingleValueInstruction *, Operand *sourceAddr) {
+  SILValue visitStorageCast(SingleValueInstruction *projectedAddr,
+                            Operand *sourceAddr) {
     assert(storageCastTy == IgnoreStorageCast);
     return sourceAddr->get();
   }
@@ -301,11 +303,12 @@ public:
   }
 
   // Override visitStorageCast to avoid seeing through arbitrary address casts.
-  SILValue visitStorageCast(SingleValueInstruction *cast, Operand *sourceAddr) {
+  SILValue visitStorageCast(SingleValueInstruction *projectedAddr,
+                            Operand *sourceAddr) {
     if (storageCastTy == StopAtStorageCast)
-      return visitNonAccess(cast);
+      return visitNonAccess(projectedAddr);
 
-    return SuperTy::visitStorageCast(cast, sourceAddr);
+    return SuperTy::visitStorageCast(projectedAddr, sourceAddr);
   }
 };
 

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -15,7 +15,6 @@
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
-#include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILInstruction.h"
@@ -62,8 +61,8 @@ static bool mayWriteTo(AliasAnalysis *AA, InstSet &SideEffectInsts,
   return false;
 }
 
-/// Returns a non-null StoreInst if \p I is a store to \p accessPath.
-static StoreInst *isStoreToAccess(SILInstruction *I, AccessPath accessPath) {
+/// Returns true if \p I is a store to \p addr.
+static StoreInst *isStoreToAddr(SILInstruction *I, SILValue addr) {
   auto *SI = dyn_cast<StoreInst>(I);
   if (!SI)
     return nullptr;
@@ -72,91 +71,53 @@ static StoreInst *isStoreToAccess(SILInstruction *I, AccessPath accessPath) {
   if (SI->getOwnershipQualifier() == StoreOwnershipQualifier::Init)
     return nullptr;
 
-  auto storeAccessPath = AccessPath::compute(SI->getDest());
-  if (accessPath != storeAccessPath)
+  if (SI->getDest() != addr)
     return nullptr;
 
   return SI;
 }
 
-struct LoadWithAccess {
-  LoadInst *li = nullptr;
-  AccessPath accessPath;
-
-  operator bool() { return li != nullptr; }
-};
-
-static LoadWithAccess doesLoadOverlapAccess(SILInstruction *I,
-                                            AccessPath accessPath) {
+/// Returns true if \p I is a load from \p addr or a projected address from
+/// \p addr.
+static LoadInst *isLoadFromAddr(SILInstruction *I, SILValue addr) {
   auto *LI = dyn_cast_or_null<LoadInst>(I);
   if (!LI)
-    return LoadWithAccess();
+    return nullptr;
 
-  // TODO: handle LoadOwnershipQualifier::Take
+  // TODO: handle StoreOwnershipQualifier::Take
   if (LI->getOwnershipQualifier() == LoadOwnershipQualifier::Take)
-    return LoadWithAccess();
+    return nullptr;
 
-  AccessPath loadAccessPath = AccessPath::compute(LI->getOperand());
-  if (!loadAccessPath.isValid())
-    return LoadWithAccess();
-
-  // Don't use AccessPath::mayOverlap. We only want definite overlap.
-  if (loadAccessPath.contains(accessPath)
-      || accessPath.contains(loadAccessPath)) {
-    return {LI, loadAccessPath};
-  }
-  return LoadWithAccess();
-}
-
-/// Returns a valid LoadWithAccess if \p I is a load from \p accessPath or a
-/// projected address from \p accessPath.
-static LoadWithAccess isLoadWithinAccess(SILInstruction *I,
-                                         AccessPath accessPath) {
-  auto loadWithAccess = doesLoadOverlapAccess(I, accessPath);
-  if (!loadWithAccess)
-    return loadWithAccess;
-
-  // Make sure that any additional path components beyond the store's access
-  // path can be converted to value projections during projectLoadValue (it
-  // currently only supports StructElementAddr and TupleElementAddr).
-  auto storePathNode = accessPath.getPathNode();
-  auto loadPathNode = loadWithAccess.accessPath.getPathNode();
-  SILValue loadAddr = loadWithAccess.li->getOperand();
-  while (loadPathNode != storePathNode) {
-    if (!isa<StructElementAddrInst>(loadAddr)
-        && !isa<TupleElementAddrInst>(loadAddr)) {
-      return LoadWithAccess();
+  SILValue v = LI->getOperand();
+  for (;;) {
+    if (v == addr) {
+      return LI;
+    } else if (isa<StructElementAddrInst>(v) || isa<TupleElementAddrInst>(v)) {
+      v = cast<SingleValueInstruction>(v)->getOperand(0);
+    } else {
+      return nullptr;
     }
-    loadAddr = cast<SingleValueInstruction>(loadAddr)->getOperand(0);
-    loadPathNode = loadPathNode.getParent();
   }
-  return loadWithAccess;
 }
 
 /// Returns true if all instructions in \p SideEffectInsts which may alias with
-/// \p access are either loads or stores from \p access.
-///
-/// \p storeAddr is only needed for AliasAnalysis until we have an interface
-/// that supports AccessPath.
+/// \p addr are either loads or stores from \p addr.
 static bool isOnlyLoadedAndStored(AliasAnalysis *AA, InstSet &SideEffectInsts,
                                   ArrayRef<LoadInst *> Loads,
                                   ArrayRef<StoreInst *> Stores,
-                                  SILValue storeAddr, AccessPath accessPath) {
+                                  SILValue addr) {
   for (auto *I : SideEffectInsts) {
-    // Pass the original address value until we can fix AA
-    if (AA->mayReadOrWriteMemory(I, storeAddr)
-        && !isStoreToAccess(I, accessPath)
-        && !isLoadWithinAccess(I, accessPath)) {
+    if (AA->mayReadOrWriteMemory(I, addr) &&
+        !isStoreToAddr(I, addr) && !isLoadFromAddr(I, addr)) {
       return false;
     }
   }
   for (auto *LI : Loads) {
-    if (AA->mayReadFromMemory(LI, storeAddr)
-        && !doesLoadOverlapAccess(LI, accessPath))
+    if (AA->mayReadFromMemory(LI, addr) && !isLoadFromAddr(LI, addr))
       return false;
   }
   for (auto *SI : Stores) {
-    if (AA->mayWriteToMemory(SI, storeAddr) && !isStoreToAccess(SI, accessPath))
+    if (AA->mayWriteToMemory(SI, addr) && !isStoreToAddr(SI, addr))
       return false;
   }
   return true;
@@ -505,7 +466,6 @@ class LoopTreeOptimization {
   llvm::DenseMap<SILLoop *, std::unique_ptr<LoopNestSummary>>
       LoopNestSummaryMap;
   SmallVector<SILLoop *, 8> BotUpWorkList;
-  InstSet toDelete;
   SILLoopInfo *LoopInfo;
   AliasAnalysis *AA;
   SideEffectAnalysis *SEA;
@@ -526,12 +486,10 @@ class LoopTreeOptimization {
   InstVector SinkDown;
 
   /// Load and store instructions that we may be able to move out of the loop.
-  /// All loads and stores within a block must be in instruction order to
-  /// simplify replacement of values after SSA update.
   InstVector LoadsAndStores;
 
-  /// All access paths of the \p LoadsAndStores instructions.
-  llvm::SetVector<AccessPath> LoadAndStoreAddrs;
+  /// All addresses of the \p LoadsAndStores instructions.
+  llvm::SetVector<SILValue> LoadAndStoreAddrs;
 
   /// Hoistable Instructions that need special treatment
   /// e.g. begin_access
@@ -564,22 +522,11 @@ protected:
   /// Collect a set of instructions that can be hoisted
   void analyzeCurrentLoop(std::unique_ptr<LoopNestSummary> &CurrSummary);
 
-  SingleValueInstruction *splitLoad(SILValue splitAddress,
-                                    ArrayRef<AccessPath::Index> remainingPath,
-                                    SILBuilder &builder,
-                                    SmallVectorImpl<LoadInst *> &Loads,
-                                    unsigned ldStIdx);
-
-  /// Given an \p accessPath that is only loaded and stored, split loads that
-  /// are wider than \p accessPath.
-  bool splitLoads(SmallVectorImpl<LoadInst *> &Loads, AccessPath accessPath,
-                  SILValue storeAddr);
-
   /// Optimize the current loop nest.
   bool optimizeLoop(std::unique_ptr<LoopNestSummary> &CurrSummary);
 
-  /// Move all loads and stores from/to \p accessPath out of the \p loop.
-  void hoistLoadsAndStores(AccessPath accessPath, SILLoop *loop);
+  /// Move all loads and stores from/to \p addr out of the \p loop.
+  void hoistLoadsAndStores(SILValue addr, SILLoop *loop, InstVector &toDelete);
 
   /// Move all loads and stores from all addresses in LoadAndStoreAddrs out of
   /// the \p loop.
@@ -812,8 +759,6 @@ static bool analyzeBeginAccess(BeginAccessInst *BI,
 // We *need* to discover all SideEffectInsts -
 // even if the loop is otherwise skipped!
 // This is because outer loops will depend on the inner loop's writes.
-//
-// This may split some loads into smaller loads.
 void LoopTreeOptimization::analyzeCurrentLoop(
     std::unique_ptr<LoopNestSummary> &CurrSummary) {
   InstSet &sideEffects = CurrSummary->SideEffectInsts;
@@ -930,23 +875,11 @@ void LoopTreeOptimization::analyzeCurrentLoop(
 
   // Collect memory locations for which we can move all loads and stores out
   // of the loop.
-  //
-  // Note: The Loads set and LoadsAndStores set may mutate during this loop.
   for (StoreInst *SI : Stores) {
-    // Use AccessPathWithBase to recover a base address that can be used for
-    // newly inserted memory operations. If we instead teach hoistLoadsAndStores
-    // how to rematerialize global_addr, then we don't need this base.
-    auto access = AccessPathWithBase::compute(SI->getDest());
-    auto accessPath = access.accessPath;
-    if (accessPath.isValid() && isLoopInvariant(access.base, Loop)) {
-      if (isOnlyLoadedAndStored(AA, sideEffects, Loads, Stores, SI->getDest(),
-                                accessPath)) {
-        if (!LoadAndStoreAddrs.count(accessPath)) {
-          if (splitLoads(Loads, accessPath, SI->getDest())) {
-            LoadAndStoreAddrs.insert(accessPath);
-          }
-        }
-      }
+    SILValue addr = SI->getDest();
+    if (isLoopInvariant(addr, Loop) &&
+        isOnlyLoadedAndStored(AA, sideEffects, Loads, Stores, addr)) {
+      LoadAndStoreAddrs.insert(addr);
     }
   }
   if (!FixLifetimes.empty()) {
@@ -972,172 +905,6 @@ void LoopTreeOptimization::analyzeCurrentLoop(
   }
 }
 
-// Recursively determine whether the innerAddress is a direct tuple or struct
-// projection chain from outerPath. Populate \p reversePathIndices with the path
-// difference.
-static bool
-computeInnerAccessPath(AccessPath::PathNode outerPath,
-                       AccessPath::PathNode innerPath, SILValue innerAddress,
-                       SmallVectorImpl<AccessPath::Index> &reversePathIndices) {
-  if (outerPath == innerPath)
-    return true;
-
-  if (!isa<StructElementAddrInst>(innerAddress)
-      && !isa<TupleElementAddrInst>(innerAddress)) {
-    return false;
-  }
-  assert(ProjectionIndex(innerAddress).Index
-         == innerPath.getIndex().getSubObjectIndex());
-
-  reversePathIndices.push_back(innerPath.getIndex());
-  SILValue srcAddr = cast<SingleValueInstruction>(innerAddress)->getOperand(0);
-  if (!computeInnerAccessPath(outerPath, innerPath.getParent(), srcAddr,
-                              reversePathIndices)) {
-    return false;
-  }
-  return true;
-}
-
-/// Split a load from \p outerAddress recursively following remainingPath.
-///
-/// Creates a load with identical \p accessPath and a set of
-/// non-overlapping loads. Add the new non-overlapping loads to HoistUp.
-///
-/// \p ldstIdx is the index into LoadsAndStores of the original outer load.
-///
-/// Return the aggregate produced by merging the loads.
-SingleValueInstruction *LoopTreeOptimization::splitLoad(
-    SILValue splitAddress, ArrayRef<AccessPath::Index> remainingPath,
-    SILBuilder &builder, SmallVectorImpl<LoadInst *> &Loads, unsigned ldstIdx) {
-  auto loc = LoadsAndStores[ldstIdx]->getLoc();
-  // Recurse until we have a load that matches accessPath.
-  if (remainingPath.empty()) {
-    // Create a load that matches the stored access path.
-    LoadInst *load = builder.createLoad(loc, splitAddress,
-                                        LoadOwnershipQualifier::Unqualified);
-    Loads.push_back(load);
-    // Replace the outer load in the list of loads and stores to hoist and
-    // sink. LoadsAndStores must remain in instruction order.
-    LoadsAndStores[ldstIdx] = load;
-    LLVM_DEBUG(llvm::dbgs() << "Created load from stored path: " << *load);
-    return load;
-  }
-  auto recordDisjointLoad = [&](LoadInst *newLoad) {
-    Loads.push_back(newLoad);
-    LoadsAndStores.insert(LoadsAndStores.begin() + ldstIdx + 1, newLoad);
-  };
-  auto subIndex = remainingPath.back().getSubObjectIndex();
-  SILType loadTy = splitAddress->getType();
-  if (CanTupleType tupleTy = loadTy.getAs<TupleType>()) {
-    SmallVector<SILValue, 4> elements;
-    for (int tupleIdx : range(tupleTy->getNumElements())) {
-      auto *projection = builder.createTupleElementAddr(
-          loc, splitAddress, tupleIdx, loadTy.getTupleElementType(tupleIdx));
-      SILValue elementVal;
-      if (tupleIdx == subIndex) {
-        elementVal = splitLoad(projection, remainingPath.drop_back(), builder,
-                               Loads, ldstIdx);
-      } else {
-        elementVal = builder.createLoad(loc, projection,
-                                        LoadOwnershipQualifier::Unqualified);
-        recordDisjointLoad(cast<LoadInst>(elementVal));
-      }
-      elements.push_back(elementVal);
-    }
-    return builder.createTuple(loc, elements);
-  }
-  auto structTy = loadTy.getStructOrBoundGenericStruct();
-  assert(structTy && "tuple and struct elements are checked earlier");
-  auto &module = builder.getModule();
-  auto expansionContext = builder.getFunction().getTypeExpansionContext();
-
-  SmallVector<SILValue, 4> elements;
-  int fieldIdx = 0;
-  for (auto *field : structTy->getStoredProperties()) {
-    SILType fieldTy = loadTy.getFieldType(field, module, expansionContext);
-    auto *projection =
-        builder.createStructElementAddr(loc, splitAddress, field, fieldTy);
-    SILValue fieldVal;
-    if (fieldIdx++ == subIndex)
-      fieldVal = splitLoad(projection, remainingPath.drop_back(), builder,
-                           Loads, ldstIdx);
-    else {
-      fieldVal = builder.createLoad(loc, projection,
-                                    LoadOwnershipQualifier::Unqualified);
-      recordDisjointLoad(cast<LoadInst>(fieldVal));
-    }
-    elements.push_back(fieldVal);
-  }
-  return builder.createStruct(loc, loadTy.getObjectType(), elements);
-}
-
-/// Find all loads that contain \p accessPath. Split them into a load with
-/// identical accessPath and a set of non-overlapping loads. Add the new
-/// non-overlapping loads to LoadsAndStores and HoistUp.
-///
-/// TODO: The \p storeAddr parameter is only needed until we have an
-/// AliasAnalysis interface that handles AccessPath.
-bool LoopTreeOptimization::splitLoads(SmallVectorImpl<LoadInst *> &Loads,
-                                      AccessPath accessPath,
-                                      SILValue storeAddr) {
-  // The Loads set may mutate during this loop, but we only want to visit the
-  // original set.
-  for (unsigned loadsIdx = 0, endIdx = Loads.size(); loadsIdx != endIdx;
-       ++loadsIdx) {
-    auto *load = Loads[loadsIdx];
-    if (toDelete.count(load))
-      continue;
-
-    if (!AA->mayReadFromMemory(load, storeAddr))
-      continue;
-
-    AccessPath loadAccessPath = AccessPath::compute(load->getOperand());
-    if (accessPath.contains(loadAccessPath))
-      continue;
-
-    assert(loadAccessPath.contains(accessPath));
-    LLVM_DEBUG(llvm::dbgs() << "Overlaps with loop stores: " << *load);
-    SmallVector<AccessPath::Index, 4> reversePathIndices;
-    if (!computeInnerAccessPath(loadAccessPath.getPathNode(),
-                                accessPath.getPathNode(), storeAddr,
-                                reversePathIndices)) {
-      return false;
-    }
-    // Found a load wider than the store to accessPath.
-    //
-    // SplitLoads is called for each unique access path in the loop that is
-    // only loaded from and stored to and this loop takes time proportional to:
-    //   num-wide-loads x num-fields x num-loop-memops
-    //
-    // For each load wider than the store, it creates a new load for each field
-    // in that type. Each new load is inserted in the LoadsAndStores vector.  To
-    // avoid super-linear behavior for large types (e.g. giant tuples), limit
-    // growth of new loads to an arbitrary constant factor per access path.
-    if (Loads.size() >= endIdx + 6) {
-      LLVM_DEBUG(llvm::dbgs() << "...Refusing to split more loads\n");
-      return false;
-    }
-    LLVM_DEBUG(llvm::dbgs() << "...Splitting load\n");
-
-    unsigned ldstIdx = [this, load]() {
-      auto ldstIter = llvm::find(LoadsAndStores, load);
-      assert(ldstIter != LoadsAndStores.end() && "outerLoad missing");
-      return std::distance(LoadsAndStores.begin(), ldstIter);
-    }();
-
-    SILBuilderWithScope builder(load);
-
-    SILValue aggregateVal = splitLoad(load->getOperand(), reversePathIndices,
-                                      builder, Loads, ldstIdx);
-
-    load->replaceAllUsesWith(aggregateVal);
-    auto iterAndInserted = toDelete.insert(load);
-    (void)iterAndInserted;
-    assert(iterAndInserted.second && "the same load should only be split once");
-  }
-  return true;
-}
-
 bool LoopTreeOptimization::optimizeLoop(
     std::unique_ptr<LoopNestSummary> &CurrSummary) {
   auto *CurrentLoop = CurrSummary->Loop;
@@ -1152,37 +919,26 @@ bool LoopTreeOptimization::optimizeLoop(
   currChanged |= sinkInstructions(CurrSummary, DomTree, LoopInfo, SinkDown);
   currChanged |=
       hoistSpecialInstruction(CurrSummary, DomTree, LoopInfo, SpecialHoist);
-
-  assert(toDelete.empty() && "only hostAllLoadsAndStores deletes");
   return currChanged;
 }
 
 /// Creates a value projection from \p rootVal based on the address projection
-/// from \a rootVal to \a addr.
-static SILValue projectLoadValue(SILValue addr, AccessPath accessPath,
-                                 SILValue rootVal, AccessPath rootAccessPath,
-                                 SILInstruction *beforeInst) {
-  if (accessPath == rootAccessPath)
+/// from \a rootAddr to \a addr.
+static SILValue projectLoadValue(SILValue addr, SILValue rootAddr,
+                                 SILValue rootVal, SILInstruction *beforeInst) {
+  if (addr == rootAddr)
     return rootVal;
 
-  auto pathNode = accessPath.getPathNode();
-  int elementIdx = pathNode.getIndex().getSubObjectIndex();
   if (auto *SEI = dyn_cast<StructElementAddrInst>(addr)) {
-    assert(ProjectionIndex(SEI).Index == elementIdx);
-    SILValue val = projectLoadValue(
-        SEI->getOperand(),
-        AccessPath(accessPath.getStorage(), pathNode.getParent(), 0),
-        rootVal, rootAccessPath, beforeInst);
+    SILValue val = projectLoadValue(SEI->getOperand(), rootAddr, rootVal,
+                                    beforeInst);
     SILBuilder B(beforeInst);
     return B.createStructExtract(beforeInst->getLoc(), val, SEI->getField(),
                                  SEI->getType().getObjectType());
   }
   if (auto *TEI = dyn_cast<TupleElementAddrInst>(addr)) {
-    assert(ProjectionIndex(TEI).Index == elementIdx);
-    SILValue val = projectLoadValue(
-        TEI->getOperand(),
-        AccessPath(accessPath.getStorage(), pathNode.getParent(), 0),
-        rootVal, rootAccessPath, beforeInst);
+    SILValue val = projectLoadValue(TEI->getOperand(), rootAddr, rootVal,
+                                    beforeInst);
     SILBuilder B(beforeInst);
     return B.createTupleExtract(beforeInst->getLoc(), val, TEI->getFieldIndex(),
                                 TEI->getType().getObjectType());
@@ -1190,17 +946,12 @@ static SILValue projectLoadValue(SILValue addr, AccessPath accessPath,
   llvm_unreachable("unknown projection");
 }
 
-/// Returns true if all stores to \p addr commonly dominate the loop exits.
-static bool
-storesCommonlyDominateLoopExits(AccessPath accessPath,
-                                SILLoop *loop,
-                                ArrayRef<SILBasicBlock *> exitingBlocks) {
+/// Returns true if all stores to \p addr commonly dominate the loop exitst of
+/// \p loop.
+static bool storesCommonlyDominateLoopExits(SILValue addr, SILLoop *loop,
+                                      ArrayRef<SILBasicBlock *> exitingBlocks) {
   SmallPtrSet<SILBasicBlock *, 16> stores;
-  SmallVector<Operand *, 8> uses;
-  // Collect as many recognizable stores as possible. It's ok if not all stores
-  // are collected.
-  accessPath.collectUses(uses, AccessUseType::Exact, loop->getFunction());
-  for (Operand *use : uses) {
+  for (Operand *use : addr->getUses()) {
     SILInstruction *user = use->getUser();
     if (isa<StoreInst>(user))
       stores.insert(user->getParent());
@@ -1279,26 +1030,24 @@ storesCommonlyDominateLoopExits(AccessPath accessPath,
   return true;
 }
 
-void LoopTreeOptimization::
-hoistLoadsAndStores(AccessPath accessPath, SILLoop *loop) {
-  SmallVector<SILBasicBlock *, 4> exitingAndLatchBlocks;
-  loop->getExitingAndLatchBlocks(exitingAndLatchBlocks);
+void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, InstVector &toDelete) {
+
+  SmallVector<SILBasicBlock *, 4> exitingBlocks;
+  loop->getExitingBlocks(exitingBlocks);
 
   // This is not a requirement for functional correctness, but we don't want to
   // _speculatively_ load and store the value (outside of the loop).
-  if (!storesCommonlyDominateLoopExits(accessPath, loop,
-                                       exitingAndLatchBlocks))
+  if (!storesCommonlyDominateLoopExits(addr, loop, exitingBlocks))
     return;
 
   // Inserting the stores requires the exit edges to be not critical.
-  for (SILBasicBlock *exitingOrLatchBlock : exitingAndLatchBlocks) {
-    for (unsigned idx = 0, e = exitingOrLatchBlock->getSuccessors().size();
+  for (SILBasicBlock *exitingBlock : exitingBlocks) {
+    for (unsigned idx = 0, e = exitingBlock->getSuccessors().size();
          idx != e; ++idx) {
       // exitingBlock->getSuccessors() must not be moved out of this loop,
       // because the successor list is invalidated by splitCriticalEdge.
-      if (!loop->contains(exitingOrLatchBlock->getSuccessors()[idx])) {
-        splitCriticalEdge(exitingOrLatchBlock->getTerminator(), idx, DomTree,
-                          LoopInfo);
+      if (!loop->contains(exitingBlock->getSuccessors()[idx])) {
+        splitCriticalEdge(exitingBlock->getTerminator(), idx, DomTree, LoopInfo);
       }
     }
   }
@@ -1308,46 +1057,30 @@ hoistLoadsAndStores(AccessPath accessPath, SILLoop *loop) {
 
   // Initially load the value in the loop pre header.
   SILBuilder B(preheader->getTerminator());
-  SILValue storeAddr;
+  auto *initialLoad = B.createLoad(preheader->getTerminator()->getLoc(), addr,
+                                   LoadOwnershipQualifier::Unqualified);
+  LLVM_DEBUG(llvm::dbgs() << "Creating preload " << *initialLoad);
+
   SILSSAUpdater ssaUpdater;
+  ssaUpdater.initialize(initialLoad->getType());
+  ssaUpdater.addAvailableValue(preheader, initialLoad);
 
   // Set all stored values as available values in the ssaUpdater.
   // If there are multiple stores in a block, only the last one counts.
   Optional<SILLocation> loc;
   for (SILInstruction *I : LoadsAndStores) {
-    if (auto *SI = isStoreToAccess(I, accessPath)) {
+    if (auto *SI = isStoreToAddr(I, addr)) {
       loc = SI->getLoc();
 
       // If a store just stores the loaded value, bail. The operand (= the load)
       // will be removed later, so it cannot be used as available value.
       // This corner case is suprisingly hard to handle, so we just give up.
-      if (isLoadWithinAccess(dyn_cast<LoadInst>(SI->getSrc()), accessPath))
+      if (isLoadFromAddr(dyn_cast<LoadInst>(SI->getSrc()), addr))
         return;
 
-      if (!storeAddr) {
-        storeAddr = SI->getDest();
-        ssaUpdater.initialize(storeAddr->getType().getObjectType());
-      } else if (SI->getDest()->getType() != storeAddr->getType()) {
-        // This transformation assumes that the values of all stores in the loop
-        // must be interchangeable. It won't work if stores different types
-        // because of casting or payload extraction even though they have the
-        // same access path.
-        return;
-      }
       ssaUpdater.addAvailableValue(SI->getParent(), SI->getSrc());
     }
   }
-  assert(storeAddr && "hoistLoadsAndStores requires a store in the loop");
-  SILValue initialAddr = cloneUseDefChain(
-      storeAddr, preheader->getTerminator(), [&](SILValue srcAddr) {
-        // Clone projections until the address dominates preheader.
-        return !DomTree->dominates(srcAddr->getParentBlock(), preheader);
-      });
-  LoadInst *initialLoad =
-      B.createLoad(preheader->getTerminator()->getLoc(), initialAddr,
-                   LoadOwnershipQualifier::Unqualified);
-  LLVM_DEBUG(llvm::dbgs() << "Creating preload " << *initialLoad);
-  ssaUpdater.addAvailableValue(preheader, initialLoad);
 
   // Remove all stores and replace the loads with the current value.
   SILBasicBlock *currentBlock = nullptr;
@@ -1358,45 +1091,37 @@ hoistLoadsAndStores(AccessPath accessPath, SILLoop *loop) {
       currentBlock = block;
       currentVal = SILValue();
     }
-    if (auto *SI = isStoreToAccess(I, accessPath)) {
+    if (auto *SI = isStoreToAddr(I, addr)) {
       LLVM_DEBUG(llvm::dbgs() << "Deleting reloaded store " << *SI);
       currentVal = SI->getSrc();
-      toDelete.insert(SI);
-      continue;
+      toDelete.push_back(SI);
+    } else if (auto *LI = isLoadFromAddr(I, addr)) {
+      // If we didn't see a store in this block yet, get the current value from
+      // the ssaUpdater.
+      if (!currentVal)
+        currentVal = ssaUpdater.getValueInMiddleOfBlock(block);
+      SILValue projectedValue = projectLoadValue(LI->getOperand(), addr,
+                                                 currentVal, LI);
+      LLVM_DEBUG(llvm::dbgs() << "Replacing stored load " << *LI << " with "
+                 << projectedValue);
+      LI->replaceAllUsesWith(projectedValue);
+      toDelete.push_back(LI);
     }
-    auto loadWithAccess = isLoadWithinAccess(I, accessPath);
-    if (!loadWithAccess) {
-      continue;
-    }
-    // If we didn't see a store in this block yet, get the current value from
-    // the ssaUpdater.
-    if (!currentVal)
-      currentVal = ssaUpdater.getValueInMiddleOfBlock(block);
-
-    LoadInst *load = loadWithAccess.li;
-    auto loadAddress = load->getOperand();
-    SILValue projectedValue = projectLoadValue(
-        loadAddress, loadWithAccess.accessPath, currentVal, accessPath, load);
-    LLVM_DEBUG(llvm::dbgs() << "Replacing stored load " << *load << " with "
-                            << projectedValue);
-    load->replaceAllUsesWith(projectedValue);
-    toDelete.insert(load);
   }
 
   // Store back the value at all loop exits.
-  for (SILBasicBlock *exitingOrLatchBlock : exitingAndLatchBlocks) {
-    for (SILBasicBlock *succ : exitingOrLatchBlock->getSuccessors()) {
-      if (loop->contains(succ))
-        continue;
-
-      assert(succ->getSinglePredecessorBlock()
-             && "should have split critical edges");
-      SILBuilder B(succ->begin());
-      auto *SI = B.createStore(
-          loc.getValue(), ssaUpdater.getValueInMiddleOfBlock(succ), initialAddr,
-          StoreOwnershipQualifier::Unqualified);
-      (void)SI;
-      LLVM_DEBUG(llvm::dbgs() << "Creating loop-exit store " << *SI);
+  for (SILBasicBlock *exitingBlock : exitingBlocks) {
+    for (SILBasicBlock *succ : exitingBlock->getSuccessors()) {
+      if (!loop->contains(succ)) {
+        assert(succ->getSinglePredecessorBlock() &&
+               "should have split critical edges");
+        SILBuilder B(succ->begin());
+        auto *SI = B.createStore(loc.getValue(),
+                                 ssaUpdater.getValueInMiddleOfBlock(succ), addr,
+                                 StoreOwnershipQualifier::Unqualified);
+        (void)SI;
+        LLVM_DEBUG(llvm::dbgs() << "Creating loop-exit store " << *SI);
+      }
     }
   }
 
@@ -1405,20 +1130,17 @@ hoistLoadsAndStores(AccessPath accessPath, SILLoop *loop) {
 }
 
 bool LoopTreeOptimization::hoistAllLoadsAndStores(SILLoop *loop) {
-  for (AccessPath accessPath : LoadAndStoreAddrs) {
-    hoistLoadsAndStores(accessPath, loop);
+  InstVector toDelete;
+  for (SILValue addr : LoadAndStoreAddrs) {
+    hoistLoadsAndStores(addr, loop, toDelete);
   }
   LoadsAndStores.clear();
   LoadAndStoreAddrs.clear();
 
-  if (toDelete.empty())
-    return false;
-
   for (SILInstruction *I : toDelete) {
-    recursivelyDeleteTriviallyDeadInstructions(I, /*force*/ true);
+    I->eraseFromParent();
   }
-  toDelete.clear();
-  return true;
+  return !toDelete.empty();
 }
 
 namespace {

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -634,19 +634,15 @@ struct Index {
 // -----------------------------------------------------------------------------
 // Test combined load/store hoisting/sinking with obvious aliasing loads
 
-// The loop contains loads and stores to the same accesspath: %3 alloc_stack -> #0 -> #0
-// However, they don't share the same projection instructions.
-// LICM should still hoist the loads and sink the stores in a combined transformation.
-//
 // CHECK-LABEL: sil shared @testCombinedLdStAliasingLoad : $@convention(method) (Int64) -> Int64 {
 // CHECK: bb0(%0 : $Int64):
-// CHECK: store {{.*}} to %{{.*}} : $*Int64
-// CHECK: load %{{.*}} : $*Int64
-// CHECK: br bb1
+// CHECK: store
 // CHECK-NOT: {{(load|store)}}
-// CHECK: bb3:
-// CHECK-NOT: {{(load|store)}}
-// CHECK: store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb1:
+// CHECK-NEXT: load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT: store %{{.*}} to %{{.*}} : $*Int64
+// CHECK-NEXT: load %{{.*}} : $*Builtin.Int64
+// CHECK-NEXT: cond_br
 // CHECK-NOT: {{(load|store)}}
 // CHECK-LABEL: } // end sil function 'testCombinedLdStAliasingLoad'
 sil shared @testCombinedLdStAliasingLoad : $@convention(method) (Int64) -> Int64 {
@@ -772,10 +768,25 @@ sil @getRange : $@convention(thin) () -> Range<Int64>
 // CHECK-LABEL: sil shared @testLICMReducedCombinedLdStExtraProjection : $@convention(method) (Int64) -> Int64 {
 // CHECK: bb0(%0 : $Int64):
 // CHECK:   store %0 to %{{.*}} : $*Int64
-// CHECK:   load %{{.*}} : $*Int64
 // CHECK-NOT: {{(load|store)}}
-// CHECK: bb7:
-// CHECK-NEXT: store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb1(%{{.*}} : $Builtin.Int64):
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   load %{{.*}} : $*Builtin.Int64
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   builtin "cmp_eq_Int64"
+// CHECK-NEXT: cond_br
+// CHECK: bb3:
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb4:
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb5:
+// CHECK:   function_ref @getRange : $@convention(thin) () -> Range<Int64>
+// CHECK:   apply %{{.*}}() : $@convention(thin) () -> Range<Int64>
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int64
+// CHECK: bb6:
+// CHECK:   load %{{.*}} : $*Builtin.Int64
+// CHECK:   builtin "cmp_eq_Int64"
+// CHECK:   cond_br
 // CHECK-NOT: {{(load|store)}}
 // CHECK-LABEL: } // end sil function 'testLICMReducedCombinedLdStExtraProjection'
 sil shared @testLICMReducedCombinedLdStExtraProjection : $@convention(method) (Int64) -> Int64 {
@@ -921,400 +932,4 @@ bb4:
 bb5:
   %99 = tuple ()
   return %99 : $()
-}
-
-// Test load splitting with a loop-invariant stored value. The loop
-// will be empty after combined load/store hoisting/sinking.
-//
-// TODO: sink a struct_extract (or other non-side-effect instructions)
-//        with no uses in the loop.
-//
-// CHECK-LABEL: sil shared @testLoadSplit : $@convention(method) (Int64, Builtin.RawPointer) -> (Index, Int64, Builtin.Int64) {
-// CHECK:         [[PRELOAD:%.*]] = load %{{.*}} : $*Int64
-// CHECK:         [[STOREDVAL:%.*]] = struct_extract %0 : $Int64, #Int64._value
-// CHECK:         br bb1([[PRELOAD]] : $Int64)
-// CHECK:       bb1([[PHI:%.*]] : $Int64):
-// CHECK-NEXT:    [[OUTERVAL:%.*]] = struct $Index ([[PHI]] : $Int64)
-// CHECK-NEXT:    cond_br undef, bb2, bb3
-// CHECK:       bb2:
-// CHECK-NEXT:    br bb1(%0 : $Int64)
-// CHECK:       bb3:
-// CHECK-NEXT:    store %0 to %{{.*}} : $*Int64
-// CHECK-NEXT:    tuple ([[OUTERVAL]] : $Index, [[PHI]] : $Int64, [[STOREDVAL]] : $Builtin.Int64)
-// CHECK-LABEL: } // end sil function 'testLoadSplit'
-sil shared @testLoadSplit : $@convention(method) (Int64, Builtin.RawPointer) -> (Index, Int64, Builtin.Int64) {
-bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %1 : $Builtin.RawPointer to $*Index
-  %middleAddr1 = struct_element_addr %outerAddr1 : $*Index, #Index.value
-  br bb1
-
-bb1:
-  %val1 = load %outerAddr1 : $*Index
-  %val2 = load %middleAddr1 : $*Int64
-  %outerAddr2 = pointer_to_address %1 : $Builtin.RawPointer to $*Index
-  %middleAddr2 = struct_element_addr %outerAddr2 : $*Index, #Index.value
-  store %0 to %middleAddr2 : $*Int64
-  %innerAddr1 = struct_element_addr %middleAddr1 : $*Int64, #Int64._value
-  %val3 = load %innerAddr1 : $*Builtin.Int64
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  %result = tuple (%val1 : $Index, %val2 : $Int64, %val3 : $Builtin.Int64)
-  return %result : $(Index, Int64, Builtin.Int64)
-}
-
-// Test load splitting with a loop-varying stored value.
-// CHECK-LABEL: sil shared @testLoadSplitPhi : $@convention(method) (Int64, Builtin.RawPointer) -> (Index, Int64, Builtin.Int64) {
-// CHECK:        [[PRELOAD:%.*]] = load %{{.*}} : $*Int64
-// CHECK:        br bb1(%4 : $Int64)
-// CHECK:      bb1([[PHI:%.*]] : $Int64):
-// CHECK-NEXT:   [[OUTERVAL:%.*]] = struct $Index ([[PHI]] : $Int64)
-// CHECK-NEXT:   [[EXTRACT:%.*]] = struct_extract [[PHI]] : $Int64, #Int64._value
-// CHECK-NEXT:   builtin "uadd_with_overflow_Int32"([[EXTRACT]] : $Builtin.Int64
-// CHECK-NEXT:   tuple_extract
-// CHECK-NEXT:   [[ADD:%.*]] = struct $Int64
-// CHECK-NEXT:   cond_br undef, bb2, bb3
-// CHECK:      bb2:
-// CHECK-NEXT:   br bb1([[ADD]] : $Int64)
-// CHECK:      bb3:
-// CHECK-NEXT:   store [[ADD]] to %{{.*}} : $*Int64
-// CHECK-NEXT:   tuple ([[OUTERVAL]] : $Index, [[ADD]] : $Int64, [[EXTRACT]] : $Builtin.Int64)
-// CHECK-LABEL: } // end sil function 'testLoadSplitPhi'
-sil shared @testLoadSplitPhi : $@convention(method) (Int64, Builtin.RawPointer) -> (Index, Int64, Builtin.Int64) {
-bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %1 : $Builtin.RawPointer to $*Index
-  %middleAddr1 = struct_element_addr %outerAddr1 : $*Index, #Index.value
-  %innerAddr1 = struct_element_addr %middleAddr1 : $*Int64, #Int64._value
-  br bb1
-
-bb1:
-  %outerVal = load %outerAddr1 : $*Index
-  %innerVal = load %innerAddr1 : $*Builtin.Int64
-  %one = integer_literal $Builtin.Int64, 1
-  %zero = integer_literal $Builtin.Int1, 0
-  %add = builtin "uadd_with_overflow_Int32"(%innerVal : $Builtin.Int64, %one : $Builtin.Int64, %zero : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %inc = tuple_extract %add : $(Builtin.Int64, Builtin.Int1), 0
-  %outerAddr2 = pointer_to_address %1 : $Builtin.RawPointer to $*Index
-  %middleAddr2 = struct_element_addr %outerAddr2 : $*Index, #Index.value
-  %newVal = struct $Int64 (%inc : $Builtin.Int64)
-  store %newVal to %middleAddr2 : $*Int64
-  %middleVal = load %middleAddr1 : $*Int64
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  %result = tuple (%outerVal : $Index, %middleVal : $Int64, %innerVal : $Builtin.Int64)
-  return %result : $(Index, Int64, Builtin.Int64)
-}
-
-struct State {
-  @_hasStorage var valueSet: (Int64, Int64, Int64) { get set }
-  @_hasStorage var singleValue: Int64 { get set }
-}
-
-// Test the we can remove a store to an individual tuple element when
-// the struct containing the tuple is used within the loop.
-// The optimized loop should only contain the add operation and a phi, with no memory access.
-//
-// CHECK-LABEL: sil shared @testTupleSplit : $@convention(method) (Builtin.RawPointer) -> State {
-// CHECK:   bb0(%0 : $Builtin.RawPointer):
-// CHECK:     [[HOISTADR:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 0
-// ...Preload stored element #1
-// CHECK:     [[PRELOADADR:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 1
-// CHECK:     [[PRELOAD:%.*]] = load [[PRELOADADR]] : $*Int64
-// ...Split element 0
-// CHECK:     [[SPLIT0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 0
-// CHECK:     [[ELT0:%.*]] = load [[SPLIT0]] : $*Int64
-// ...Split element 2
-// CHECK:     [[SPLIT2:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 2
-// CHECK:     [[ELT2:%.*]] = load [[SPLIT2]] : $*Int64
-// ...Split State.singlevalue
-// CHECK:     [[SINGLEADR:%.*]] = struct_element_addr %{{.*}} : $*State, #State.singleValue
-// CHECK:     [[SINGLEVAL:%.*]] = load [[SINGLEADR]] : $*Int64
-// ...Hoisted element 0
-// CHECK:     [[HOISTLOAD:%.*]] = load [[HOISTADR]] : $*Int64
-// CHECK:     [[HOISTVAL:%.*]] = struct_extract [[HOISTLOAD]] : $Int64, #Int64._value
-// CHECK:     br bb1([[PRELOAD]] : $Int64)
-// ...Loop
-// CHECK:   bb1([[PHI:%.*]] : $Int64):
-// CHECK-NEXT: [[TUPLE:%.*]] = tuple ([[ELT0]] : $Int64, [[PHI]] : $Int64, [[ELT2]] : $Int64)
-// CHECK-NEXT: [[STRUCT:%.*]] = struct $State ([[TUPLE]] : $(Int64, Int64, Int64), [[SINGLEVAL]] : $Int64)
-// CHECK-NEXT: [[ADDEND:%.*]] = struct_extract [[PHI]] : $Int64, #Int64._value
-// CHECK-NEXT: [[UADD:%.*]] = builtin "uadd_with_overflow_Int32"([[HOISTVAL]] : $Builtin.Int64, [[ADDEND]] : $Builtin.Int64, %{{.*}} : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-// CHECK-NEXT: [[ADDVAL:%.*]] = tuple_extract [[UADD]] : $(Builtin.Int64, Builtin.Int1), 0
-// CHECK-NEXT: [[ADDINT:%.*]] = struct $Int64 ([[ADDVAL]] : $Builtin.Int64)
-// CHECK-NEXT: cond_br undef, bb2, bb3
-// CHECK:   bb2:
-// CHECK-NEXT: br bb1([[ADDINT]] : $Int64)
-// CHECK:   bb3:
-// CHECK-NEXT:  store [[ADDINT]] to [[PRELOADADR]] : $*Int64
-// CHECK-NEXT:  return [[STRUCT]] : $State
-// CHECK-LABEL: } // end sil function 'testTupleSplit'
-sil shared @testTupleSplit : $@convention(method) (Builtin.RawPointer) -> State {
-bb0(%0 : $Builtin.RawPointer):
-  %stateAddr = pointer_to_address %0 : $Builtin.RawPointer to $*State
-  %tupleAddr0 = struct_element_addr %stateAddr : $*State, #State.valueSet
-  %elementAddr0 = tuple_element_addr %tupleAddr0 : $*(Int64, Int64, Int64), 0
-  %tupleAddr1 = struct_element_addr %stateAddr : $*State, #State.valueSet
-  %elementAddr1 = tuple_element_addr %tupleAddr1 : $*(Int64, Int64, Int64), 1
-  %tupleAddr11 = struct_element_addr %stateAddr : $*State, #State.valueSet
-  %elementAddr11 = tuple_element_addr %tupleAddr11 : $*(Int64, Int64, Int64), 1
-  br bb1
-
-bb1:
-  %state = load %stateAddr : $*State
-  %element0 = load %elementAddr0 : $*Int64
-  %val0 = struct_extract %element0 : $Int64, #Int64._value
-  %element1 = load %elementAddr1 : $*Int64
-  %val1 = struct_extract %element1 : $Int64, #Int64._value
-  %zero = integer_literal $Builtin.Int1, 0
-  %add = builtin "uadd_with_overflow_Int32"(%val0 : $Builtin.Int64, %val1 : $Builtin.Int64, %zero : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
-  %addVal = tuple_extract %add : $(Builtin.Int64, Builtin.Int1), 0
-  %addInt = struct $Int64 (%addVal : $Builtin.Int64)
-  store %addInt to %elementAddr11 : $*Int64
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  return %state : $State
-}
-
-// Test multiple stores to disjoint access paths with a single load
-// that spans both of them. The load should be split and hosited and
-// and the stores be sunk.
-// testCommonSplitLoad
-// CHECK-LABEL: sil shared @testCommonSplitLoad : $@convention(method) (Int64, Builtin.RawPointer) -> (Int64, Int64, Int64) {
-// CHECK: bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-// CHECK:   [[ELT0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 0
-// CHECK:   [[V0:%.*]] = load [[ELT0]] : $*Int64
-// CHECK:   [[ELT2:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 2
-// CHECK:   [[V2:%.*]] = load [[ELT2]] : $*Int64
-// CHECK:   [[ELT1:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64, Int64), 1
-// CHECK:   [[V1:%.*]] = load [[ELT1]] : $*Int64
-// CHECK:   br bb1([[V0]] : $Int64, [[V2]] : $Int64)
-//
-// Nothing in this loop except phis...
-// CHECK: bb1([[PHI0:%.*]] : $Int64, [[PHI2:%.*]] : $Int64):
-// CHECK-NEXT: [[RESULT:%.*]] = tuple ([[PHI0]] : $Int64, [[V1]] : $Int64, [[PHI2]] : $Int64)
-// CHECK-NEXT: cond_br undef, bb2, bb3
-// CHECK: bb2:
-// CHECK-NEXT: br bb1(%0 : $Int64, %0 : $Int64)
-//
-// Stores are all sunk...
-// CHECK: bb3:
-// CHECK:   store %0 to [[ELT2]] : $*Int64
-// CHECK:   store %0 to [[ELT0]] : $*Int64
-// CHECK:   return [[RESULT]] : $(Int64, Int64, Int64)
-// CHECK-LABEL: } // end sil function 'testCommonSplitLoad'
-sil shared @testCommonSplitLoad : $@convention(method) (Int64, Builtin.RawPointer) -> (Int64, Int64, Int64) {
-bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %1 : $Builtin.RawPointer to $*(Int64, Int64, Int64)
-  br bb1
-
-bb1:
-  %val1 = load %outerAddr1 : $*(Int64, Int64, Int64)
-  %elementAddr0 = tuple_element_addr %outerAddr1 : $*(Int64, Int64, Int64), 0
-  store %0 to %elementAddr0 : $*Int64
-  %elementAddr2 = tuple_element_addr %outerAddr1 : $*(Int64, Int64, Int64), 2
-  store %0 to %elementAddr2 : $*Int64
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  return %val1 : $(Int64, Int64, Int64)
-}
-
-// Two stores, one to the outer tuple and one to the inner tuple. This
-// results in two access paths that are only loaded/stored to.  First
-// split the outer tuple when processing the outer access path, then
-// the inner tuple when processing the inner access path. All loads
-// should be hoisted and all stores should be sunk.
-//
-// CHECK-LABEL: sil shared @testResplit : $@convention(method) (Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
-// CHECK: bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-// CHECK:   [[ELT_0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, (Int64, Int64)), 0
-// CHECK:   [[V0:%.*]] = load [[ELT_0]] : $*Int64
-// CHECK:   [[ELT_1a:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, (Int64, Int64)), 1
-// CHECK:   [[ELT_1_0:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64), 0
-// CHECK:   [[V_1_0:%.*]] = load [[ELT_1_0]] : $*Int64
-// CHECK:   [[ELT_1b:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, (Int64, Int64)), 1
-// CHECK:   [[ELT_1_1:%.*]] = tuple_element_addr %{{.*}} : $*(Int64, Int64), 1
-// CHECK:   [[V_1_1:%.*]] = load [[ELT_1_1]] : $*Int64
-// CHECK: br bb1([[V_0:%.*]] : $Int64, [[V_1_0]] : $Int64)
-//
-// Nothing in this loop except phis and tuple reconstruction...
-// CHECK: bb1([[PHI_0:%.*]] : $Int64, [[PHI_1_0:%.*]] : $Int64):
-// CHECK:   [[INNER:%.*]] = tuple ([[PHI_1_0]] : $Int64, [[V_1_1]] : $Int64)
-// CHECK:   [[OUTER:%.*]] = tuple ([[PHI_0]] : $Int64, [[INNER]] : $(Int64, Int64))
-// CHECK:   cond_br undef, bb2, bb3
-// CHECK: bb2:
-// CHECK:   br bb1(%0 : $Int64, %0 : $Int64)
-//
-// The two stores are sunk...
-// CHECK: bb3:
-// CHECK:   store %0 to [[ELT_1_0]] : $*Int64
-// CHECK:   store %0 to [[ELT_0]] : $*Int64
-// CHECK:   return [[OUTER]] : $(Int64, (Int64, Int64))
-// CHECK-LABEL: } // end sil function 'testResplit'
-sil shared @testResplit : $@convention(method) (Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
-bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %1 : $Builtin.RawPointer to $*(Int64, (Int64, Int64))
-  br bb1
-
-bb1:
-  %val1 = load %outerAddr1 : $*(Int64, (Int64, Int64))
-  %elementAddr0 = tuple_element_addr %outerAddr1 : $*(Int64, (Int64, Int64)), 0
-  store %0 to %elementAddr0 : $*Int64
-  %elementAddr1 = tuple_element_addr %outerAddr1 : $*(Int64, (Int64, Int64)), 1
-  %elementAddr10 = tuple_element_addr %elementAddr1 : $*(Int64, Int64), 0
-  store %0 to %elementAddr10 : $*Int64
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  return %val1 : $(Int64, (Int64, Int64))
-}
-
-// Two stores to overlapping accesspaths. Combined load/store hoisting
-// cannot currently handle stores to overlapping accesspaths, so
-// nothing is optimized.
-// CHECK-LABEL: sil shared @testTwoStores : $@convention(method) (Int64, Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
-// CHECK-LABEL: bb0(%0 : $Int64, %1 : $Int64, %2 : $Builtin.RawPointer):
-// CHECK-NOT: load
-// CHECK:   br bb1
-// CHECK: bb1:
-// CHECK:   load %{{.*}} : $*(Int64, (Int64, Int64))
-// CHECK:   store {{.*}} : $*(Int64, Int64)
-// CHECK:   store {{.*}} : $*Int64
-// CHECK:   cond_br undef, bb2, bb3
-// CHECK-NOT: store
-// CHECK-LABEL: } // end sil function 'testTwoStores'
-sil shared @testTwoStores : $@convention(method) (Int64, Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
-bb0(%0 : $Int64, %1: $Int64, %2 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %2 : $Builtin.RawPointer to $*(Int64, (Int64, Int64))
-  br bb1
-
-bb1:
-  %val1 = load %outerAddr1 : $*(Int64, (Int64, Int64))
-  %elementAddr1 = tuple_element_addr %outerAddr1 : $*(Int64, (Int64, Int64)), 1
-  %tuple = tuple (%0 : $Int64, %1: $Int64)
-  store %tuple to %elementAddr1 : $*(Int64, Int64)
-  %elementAddr10 = tuple_element_addr %elementAddr1 : $*(Int64, Int64), 0
-  store %1 to %elementAddr10 : $*Int64
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  return %val1 : $(Int64, (Int64, Int64))
-}
-
-// Two wide loads. The first can be successfully split and the second
-// half hoisted. The second cannot be split because of a pointer
-// cast. Make sure two remaining loads and the store are still in the loop.
-//
-// CHECK-LABEL: sil hidden @testSplitNonStandardProjection : $@convention(method) (Int64, Builtin.RawPointer) -> ((Int64, (Int64, Int64)), (Int64, Int64)) {
-// CHECK: bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-//
-// The first load was split, so one half is hoisted.
-// CHECK:   [[V1:%.*]] = load %{{.*}} : $*Int64
-// CHECK:   br bb1
-// CHECK: bb1:
-// CHECK:   [[V0:%.*]] = load %{{.*}} : $*Int64
-// CHECK:   [[INNER:%.*]] = tuple ([[V0]] : $Int64, [[V1]] : $Int64)
-// CHECK:   store %0 to %{{.*}} : $*Int64
-// CHECK:   [[OUTER:%.*]] = load %{{.*}} : $*(Int64, (Int64, Int64))
-// CHECK:   cond_br undef, bb2, bb3
-// CHECK: bb2:
-// CHECK:   br bb1
-// CHECK: bb3:
-// CHECK:   [[RESULT:%.*]] = tuple ([[OUTER]] : $(Int64, (Int64, Int64)), [[INNER]] : $(Int64, Int64))
-// CHECK:   return [[RESULT]] : $((Int64, (Int64, Int64)), (Int64, Int64))
-// CHECK-LABEL: } // end sil function 'testSplitNonStandardProjection'
-sil hidden @testSplitNonStandardProjection  : $@convention(method) (Int64, Builtin.RawPointer) -> ((Int64, (Int64, Int64)), (Int64, Int64)) {
-bb0(%0 : $Int64, %1 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %1 : $Builtin.RawPointer to $*(Int64, (Int64, Int64))
-  br bb1
-
-bb1:
-  %elt1 = tuple_element_addr %outerAddr1 : $*(Int64, (Int64, Int64)), 1
-  %ptr = address_to_pointer %elt1 : $*(Int64, Int64) to $Builtin.RawPointer
-  %ptrAdr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*(Int64, Int64)
-  %val2 = load %ptrAdr : $*(Int64, Int64)
-  %eltptr0 = tuple_element_addr %ptrAdr : $*(Int64, Int64), 0
-  store %0 to %eltptr0 : $*Int64
-  // Process the outermost load after splitting the inner load
-  %val1 = load %outerAddr1 : $*(Int64, (Int64, Int64))
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  %result = tuple (%val1 : $(Int64, (Int64, Int64)), %val2 : $(Int64, Int64))
-  return %result : $((Int64, (Int64, Int64)), (Int64, Int64))
-}
-
-// CHECK-LABEL: sil shared @testSameTwoStores : $@convention(method) (Int64, Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
-// CHECK: bb0(%0 : $Int64, %1 : $Int64, %2 : $Builtin.RawPointer):
-// CHECK: [[ELT_1:%.*]] = tuple_element_addr %3 : $*(Int64, (Int64, Int64)), 1
-// CHECK: [[V1:%.*]] = load %4 : $*(Int64, Int64)
-// CHECK: [[ELT_0:%.*]] = tuple_element_addr %3 : $*(Int64, (Int64, Int64)), 0
-// CHECK: [[V0:%.*]] = load %6 : $*Int64
-// CHECK: [[ARG0:%.*]] = tuple (%0 : $Int64, %0 : $Int64)
-// CHECK: [[ARG0_0:%.*]] = tuple_extract %8 : $(Int64, Int64), 0
-// CHECK: [[ARG1:%.*]] = tuple (%1 : $Int64, %1 : $Int64)
-// CHECK:   br bb1([[V1]] : $(Int64, Int64))
-// CHECK: bb1([[PHI:%.*]] : $(Int64, Int64)):
-// CHECK:   [[LOOPVAL:%.*]] = tuple ([[V0]] : $Int64, [[PHI]] : $(Int64, Int64))
-// CHECK:   cond_br undef, bb2, bb3
-// CHECK: bb2:
-// CHECK:   br bb1([[ARG1]] : $(Int64, Int64))
-// CHECK: bb3:
-// CHECK:   store [[ARG1]] to [[ELT_1]] : $*(Int64, Int64)
-// CHECK:   [[EXTRACT0:%.*]] = tuple_extract [[LOOPVAL]] : $(Int64, (Int64, Int64)), 0
-// CHECK:   [[EXTRACT1:%.*]] = tuple_extract [[LOOPVAL]] : $(Int64, (Int64, Int64)), 1
-// CHECK:   [[EXTRACT1_1:%.*]] = tuple_extract [[EXTRACT1]] : $(Int64, Int64), 1
-// CHECK:   [[TUPLE1:%.*]] = tuple ([[ARG0_0]] : $Int64, [[EXTRACT1_1]] : $Int64)
-// CHECK:   [[RESULT:%.*]] = tuple ([[EXTRACT0]] : $Int64, [[TUPLE1]] : $(Int64, Int64))
-// CHECK:   return [[RESULT]] : $(Int64, (Int64, Int64))
-// CHECK-LABEL: } // end sil function 'testSameTwoStores'
-sil shared @testSameTwoStores : $@convention(method) (Int64, Int64, Builtin.RawPointer) -> (Int64, (Int64, Int64)) {
-bb0(%0 : $Int64, %1: $Int64, %2 : $Builtin.RawPointer):
-  %outerAddr1 = pointer_to_address %2 : $Builtin.RawPointer to $*(Int64, (Int64, Int64))
-  br bb1
-
-bb1:
-  %val = load %outerAddr1 : $*(Int64, (Int64, Int64))
-  %elementAddr1 = tuple_element_addr %outerAddr1 : $*(Int64, (Int64, Int64)), 1
-  %tupleA = tuple (%0 : $Int64, %0: $Int64)
-  store %tupleA to %elementAddr1 : $*(Int64, Int64)
-  %elementAddr10 = tuple_element_addr %elementAddr1 : $*(Int64, Int64), 0
-  %val10 = load %elementAddr10 : $*Int64
-  %tupleB = tuple (%1 : $Int64, %1: $Int64)
-  store %tupleB to %elementAddr1 : $*(Int64, Int64)
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb1
-
-bb3:
-  %extract0 = tuple_extract %val : $(Int64, (Int64, Int64)), 0
-  %extract1 = tuple_extract %val : $(Int64, (Int64, Int64)), 1
-  %extract11 = tuple_extract %extract1 : $(Int64, Int64), 1
-  %inner = tuple (%val10 : $Int64, %extract11: $Int64)
-  %outer = tuple (%extract0 : $Int64, %inner: $(Int64, Int64))
-  return %outer : $(Int64, (Int64, Int64))
 }


### PR DESCRIPTION
Reverts apple/swift#33987. Apparently the Windows build failed, although it seems unlikely that this would be affected by the platform.