### PR TITLE
[cxx-interop] Support nested C++ record types.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1813,7 +1813,13 @@ ASTMangler::getSpecialManglingContext(const ValueDecl *decl,
         hasNameForLinkage = !clangDecl->getDeclName().isEmpty();
       if (hasNameForLinkage) {
         auto *clangDC = clangDecl->getDeclContext();
-        if (isa<clang::NamespaceDecl>(clangDC)) return None;
+        // In C, "nested" structs, unions, enums, etc. will become sibilings:
+        //   struct Foo { struct Bar { }; }; -> struct Foo { }; struct Bar { };
+        // Whereas in C++, nested records will actually be nested. So if this is
+        // a C++ record, simply treat it like a namespace and exit early.
+        if (isa<clang::NamespaceDecl>(clangDC) ||
+            isa<clang::CXXRecordDecl>(clangDC))
+          return None;
         assert(clangDC->getRedeclContext()->isTranslationUnit() &&
                "non-top-level Clang types not supported yet");
         (void)clangDC;

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -41,3 +41,7 @@ module SynthesizedInitializers {
 module DebugInfo {
   header "debug-info.h"
 }
+
+module NestedRecords {
+  header "nested-records.h"
+}

--- a/test/Interop/Cxx/class/Inputs/nested-records.h
+++ b/test/Interop/Cxx/class/Inputs/nested-records.h
@@ -1,0 +1,45 @@
+struct S1 {
+  struct S2 {
+    bool A : 1;
+  };
+};
+
+struct S3 {
+  struct S4 { };
+};
+
+union U1 {
+    union U2 {};
+};
+
+union U3 {
+    enum E1 {};
+};
+
+union U4 {
+    struct S5 {};
+};
+
+struct S6 {
+    enum E3 {};
+};
+
+struct S7 {
+  union U5 {
+      union U6 {};
+  };
+};
+
+struct S8 {
+  struct S9 {
+      union U7 {};
+  };
+};
+
+struct S10 {
+  union U8 {
+      enum E4 {};
+  };
+};
+
+// TODO: Nested class templates (SR-13853).

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=NestedRecords -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct S1 {
+// CHECK:   struct S2 {
+// CHECK:     var A: Bool
+// CHECK:   }
+// CHECK: }
+
+// CHECK: struct S3 {
+// CHECK:   struct S4 {
+// CHECK:   }
+// CHECK: }
+
+// CHECK: struct U1 {
+// CHECK:   struct U2 {
+// CHECK:   }
+// CHECK: }
+ 
+// CHECK: struct U3 {
+// CHECK:   struct E1 : Equatable, RawRepresentable {
+// CHECK:     typealias RawValue = {{UInt32|Int32}}
+// CHECK:   }
+// CHECK: }
+ 
+// CHECK: struct U4 {
+// CHECK:   struct S5 {
+// CHECK:   }
+// CHECK: }
+ 
+// CHECK: struct S6 {
+// CHECK:   struct E3 : Equatable, RawRepresentable {
+// CHECK:     typealias RawValue = {{UInt32|Int32}}
+// CHECK:   }
+// CHECK:   init()
+// CHECK: }
+ 
+// CHECK: struct S7 {
+// CHECK:   struct U5 {
+// CHECK:     struct U6 {
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+ 
+// CHECK: struct S8 {
+// CHECK:   struct S9 {
+// CHECK:     struct U7 {
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+ 
+// CHECK: struct S10 {
+// CHECK:   struct U8 {
+// CHECK:     struct E4 : Equatable, RawRepresentable {
+// CHECK:       typealias RawValue = {{UInt32|Int32}}
+// CHECK:     }
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
Simply returns "None" for C++ records in "getSpecialManglingContext" (same logic as namespaces) to prevent an assertion.