### PR TITLE
[CodeCompletion][Sema][Parse] Migrate unresolved member completion to the solver-based completion implementation

### DIFF
--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -18,6 +18,11 @@
 #ifndef SWIFT_SEMA_CODECOMPLETIONTYPECHECKING_H
 #define SWIFT_SEMA_CODECOMPLETIONTYPECHECKING_H
 
+#include "swift/Basic/LLVM.h"
+#include "swift/AST/Type.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
 namespace swift {
   class Decl;
   class DeclContext;
@@ -32,7 +37,7 @@ namespace swift {
   class TypeCheckCompletionCallback {
   public:
     /// Called for each solution produced while  type-checking an expression
-    /// containing a code completion expression.
+    /// that the code completion expression participates in.
     virtual void sawSolution(const constraints::Solution &solution) = 0;
     virtual ~TypeCheckCompletionCallback() {}
   };
@@ -78,6 +83,39 @@ namespace swift {
 
     void sawSolution(const constraints::Solution &solution) override;
   };
+
+  /// Used to collect and store information needed to perform unresolved member
+  /// completion (\c CompletionKind::UnresolvedMember ) from the solutions
+  /// formed during expression type-checking.
+  class UnresolvedMemberTypeCheckCompletionCallback: public TypeCheckCompletionCallback {
+  public:
+    struct Result {
+      Type ExpectedTy;
+      bool IsSingleExpressionBody;
+    };
+
+  private:
+    CodeCompletionExpr *CompletionExpr;
+    SmallVector<Result, 4> Results;
+    bool GotCallback = false;
+
+  public:
+    UnresolvedMemberTypeCheckCompletionCallback(CodeCompletionExpr *CompletionExpr)
+    : CompletionExpr(CompletionExpr) {}
+
+    ArrayRef<Result> getResults() const { return Results; }
+
+    /// True if at least one solution was passed via the \c sawSolution
+    /// callback.
+    bool gotCallback() const { return GotCallback; }
+
+    /// Typecheck the code completion expression in its outermost expression
+    /// context, calling \c sawSolution for each solution formed.
+    void fallbackTypeCheck(DeclContext *DC);
+
+    void sawSolution(const constraints::Solution &solution) override;
+  };
+
 }
 
 #endif

--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -54,7 +54,7 @@ namespace swift {
       SmallVector<Type, 4> ExpectedTypes;
       bool ExpectsNonVoid;
       bool BaseIsStaticMetaType;
-      bool IsSingleExpressionBody;
+      bool IsImplicitSingleExpressionReturn;
     };
 
   private:
@@ -91,7 +91,7 @@ namespace swift {
   public:
     struct Result {
       Type ExpectedTy;
-      bool IsSingleExpressionBody;
+      bool IsImplicitSingleExpressionReturn;
     };
 
   private:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2845,6 +2845,10 @@ public:
     return TypeVariables.count(typeVar) > 0;
   }
 
+  /// Whether the given expression's source range contains the code
+  /// completion location.
+  bool containsCodeCompletionLoc(Expr *expr) const;
+
   void setClosureType(const ClosureExpr *closure, FunctionType *type) {
     assert(closure);
     assert(type && "Expected non-null type");

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -48,12 +48,12 @@ struct ExpectedTypeContext {
   ///
   /// Since the input may be incomplete, we take into account that the types are
   /// only a hint.
-  bool isSingleExpressionBody = false;
+  bool isImplicitSingleExpressionReturn = false;
   bool preferNonVoid = false;
 
   bool empty() const { return possibleTypes.empty(); }
   bool requiresNonVoid() const {
-    if (isSingleExpressionBody)
+    if (isImplicitSingleExpressionReturn)
       return false;
     if (preferNonVoid)
       return true;
@@ -65,9 +65,9 @@ struct ExpectedTypeContext {
   }
 
   ExpectedTypeContext() = default;
-  ExpectedTypeContext(ArrayRef<Type> types, bool isSingleExpressionBody)
+  ExpectedTypeContext(ArrayRef<Type> types, bool isImplicitSingleExprReturn)
       : possibleTypes(types.begin(), types.end()),
-        isSingleExpressionBody(isSingleExpressionBody) {}
+        isImplicitSingleExpressionReturn(isImplicitSingleExprReturn) {}
 };
 
 class CodeCompletionResultBuilder {

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -82,7 +82,7 @@ class ExprContextInfo {
   SmallVector<PossibleParamInfo, 2> PossibleParams;
   SmallVector<FunctionTypeAndDecl, 2> PossibleCallees;
   Expr *AnalyzedExpr = nullptr;
-  bool singleExpressionBody = false;
+  bool implicitSingleExpressionReturn = false;
 
 public:
   ExprContextInfo(DeclContext *DC, Expr *TargetExpr);
@@ -90,12 +90,14 @@ public:
   // Returns a list of possible context types.
   ArrayRef<Type> getPossibleTypes() const { return PossibleTypes; }
 
-  /// Whether the type context comes from a single-expression body, e.g.
-  /// `foo({ here })`.
+  /// Whether the type context comes from a single-expression body without
+  /// and explicit return e.g. `foo({ <here> })` and not foo({ return <here>}).
   ///
-  /// If the input may be incomplete, such as in code-completion, take into
+  /// Since the input may be incomplete, such as in code-completion, take into
   /// account that the types returned by `getPossibleTypes()` are only a hint.
-  bool isSingleExpressionBody() const { return singleExpressionBody; }
+  bool isImplicitSingleExpressionReturn() const {
+    return implicitSingleExpressionReturn;
+  }
 
   // Returns a list of possible argument label names.
   // Valid only if \c getKind() is \c CallArgument.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3581,26 +3581,22 @@ Parser::parseExprCollectionElement(Optional<bool> &isDictionary) {
     return Element;
 
   // Parse the ':'.
-  if (!consumeIf(tok::colon)) {
-    if (Element.hasCodeCompletion()) {
-      // Return the completion expression itself so we can analyze the type
-      // later.
-      return Element;
+  ParserResult<Expr> Value;
+  if (consumeIf(tok::colon)) {
+    // Parse the value.
+    Value = parseExpr(diag::expected_value_in_dictionary_literal);
+    if (Value.isNull()) {
+      if (!Element.hasCodeCompletion()) {
+        Value = makeParserResult(Value, new (Context) ErrorExpr(PreviousLoc));
+      } else {
+        Value = makeParserResult(Value,
+                                 new (Context) CodeCompletionExpr(PreviousLoc));
+      }
     }
+  } else {
     diagnose(Tok, diag::expected_colon_in_dictionary_literal);
-    return ParserStatus(Element) | makeParserError();
-  }
-
-  // Parse the value.
-  auto Value = parseExpr(diag::expected_value_in_dictionary_literal);
-
-  if (Value.isNull()) {
-    if (!Element.hasCodeCompletion()) {
-      Value = makeParserResult(Value, new (Context) ErrorExpr(PreviousLoc));
-    } else {
-      Value = makeParserResult(Value,
-                               new (Context) CodeCompletionExpr(PreviousLoc));
-    }
+    Value = makeParserResult(makeParserError(),
+                             new (Context) ErrorExpr(SourceRange()));
   }
 
   // Make a tuple of Key Value pair.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1384,7 +1384,8 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     // under-constrained due to e.g. lack of expressions on the
     // right-hand side of the token, which are required for a
     // regular type-check.
-    if (dstLocator->directlyAt<CodeCompletionExpr>())
+    if (dstLocator->directlyAt<CodeCompletionExpr>() ||
+        srcLocator->directlyAt<CodeCompletionExpr>())
       return None;
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1020,7 +1020,7 @@ namespace {
       // independent of the wider expression containing the ErrorExpr, so
       // there's no point attempting to produce a solution for it.
       SourceRange range = E->getSourceRange();
-      if (range.isInvalid() ||
+      if (range.isValid() &&
           CS.getASTContext().SourceMgr.rangeContainsCodeCompletionLoc(range))
         return nullptr;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1019,9 +1019,7 @@ namespace {
       // ErrorExpr's OriginalExpr (valid sub-expression) if it had one,
       // independent of the wider expression containing the ErrorExpr, so
       // there's no point attempting to produce a solution for it.
-      SourceRange range = E->getSourceRange();
-      if (range.isValid() &&
-          CS.getASTContext().SourceMgr.rangeContainsCodeCompletionLoc(range))
+      if (CS.containsCodeCompletionLoc(E))
         return nullptr;
 
       return HoleType::get(CS.getASTContext(), E);

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -32,74 +32,83 @@ using namespace constraints;
 #define DEBUG_TYPE "Constraint solver overall"
 STATISTIC(NumDiscardedSolutions, "Number of solutions discarded");
 
+static StringRef getScoreKindName(ScoreKind kind) {
+  switch (kind) {
+  case SK_Hole:
+    return "hole in the constraint system";
+
+  case SK_Unavailable:
+    return "use of an unavailable declaration";
+
+  case SK_AsyncSyncMismatch:
+    return "async/synchronous mismatch";
+
+  case SK_ForwardTrailingClosure:
+    return "forward scan when matching a trailing closure";
+
+  case SK_Fix:
+    return "attempting to fix the source";
+
+  case SK_DisfavoredOverload:
+    return "disfavored overload";
+
+  case SK_ForceUnchecked:
+    return "force of an implicitly unwrapped optional";
+
+  case SK_UserConversion:
+    return "user conversion";
+
+  case SK_FunctionConversion:
+    return "function conversion";
+
+  case SK_NonDefaultLiteral:
+    return "non-default literal";
+
+  case SK_CollectionUpcastConversion:
+    return "collection upcast conversion";
+
+  case SK_ValueToOptional:
+    return "value to optional";
+
+  case SK_EmptyExistentialConversion:
+    return "empty-existential conversion";
+
+  case SK_KeyPathSubscript:
+    return "key path subscript";
+
+  case SK_ValueToPointerConversion:
+    return "value-to-pointer conversion";
+  }
+}
+
 void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
-  unsigned index = static_cast<unsigned>(kind);
-  CurrentScore.Data[index] += value;
+  if (isForCodeCompletion()) {
+    switch (kind) {
+    case SK_NonDefaultLiteral:
+      // Don't increase score for non-default literals in expressions involving
+      // a code completion. In the below example, members of EnumA and EnumB
+      // should be ranked equally:
+      //   func overloaded(_ x: Float, _ y: EnumA) {}
+      //   func overloaded(_ x: Int, _ y: EnumB) {}
+      //   func overloaded(_ x: Float) -> EnumA {}
+      //   func overloaded(_ x: Int) -> EnumB {}
+      //
+      //   overloaded(1, .<complete>) {}
+      //   overloaded(1).<complete>
+      return;
+    default:
+      break;
+    }
+  }
 
   if (isDebugMode() && value > 0) {
     if (solverState)
       llvm::errs().indent(solverState->depth * 2);
-    llvm::errs() << "(increasing score due to ";
-    switch (kind) {
-    case SK_Hole:
-      llvm::errs() << "hole in the constraint system";
-      break;
-
-    case SK_Unavailable:
-      llvm::errs() << "use of an unavailable declaration";
-      break;
-
-    case SK_AsyncSyncMismatch:
-      llvm::errs() << "async/synchronous mismatch";
-      break;
-
-    case SK_ForwardTrailingClosure:
-      llvm::errs() << "forward scan when matching a trailing closure";
-      break;
-
-    case SK_Fix:
-      llvm::errs() << "attempting to fix the source";
-      break;
-
-    case SK_DisfavoredOverload:
-      llvm::errs() << "disfavored overload";
-      break;
-
-    case SK_ForceUnchecked:
-      llvm::errs() << "force of an implicitly unwrapped optional";
-      break;
-
-    case SK_UserConversion:
-      llvm::errs() << "user conversion";
-      break;
-
-    case SK_FunctionConversion:
-      llvm::errs() << "function conversion";
-      break;
-
-    case SK_NonDefaultLiteral:
-      llvm::errs() << "non-default literal";
-      break;
-        
-    case SK_CollectionUpcastConversion:
-      llvm::errs() << "collection upcast conversion";
-      break;
-        
-    case SK_ValueToOptional:
-      llvm::errs() << "value to optional";
-      break;
-    case SK_EmptyExistentialConversion:
-      llvm::errs() << "empty-existential conversion";
-      break;
-    case SK_KeyPathSubscript:
-      llvm::errs() << "key path subscript";
-      break;
-    case SK_ValueToPointerConversion:
-      llvm::errs() << "value-to-pointer conversion";
-      break;
-    }
-    llvm::errs() << ")\n";
+    llvm::errs() << "(increasing score due to " << getScoreKindName(kind) << ")\n";
   }
+
+  unsigned index = static_cast<unsigned>(kind);
+  CurrentScore.Data[index] += value;
 }
 
 bool ConstraintSystem::worseThanBestSolution() const {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -378,6 +378,13 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
   return *AlternativeLiteralTypes[index];
 }
 
+bool ConstraintSystem::containsCodeCompletionLoc(Expr *expr) const {
+  SourceRange range = expr->getSourceRange();
+  if (range.isInvalid())
+    return false;
+  return Context.SourceMgr.rangeContainsCodeCompletionLoc(range);
+}
+
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
     ASTNode anchor, ArrayRef<ConstraintLocator::PathElement> path) {
   auto summaryFlags = ConstraintLocator::getSummaryFlagsForPath(path);

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -776,9 +776,11 @@ static bool isForPatternMatch(SolutionApplicationTarget &target) {
   return false;
 }
 
-/// Remove any solutions from the provided vector with a score less than the best solution's.
+/// Remove any solutions from the provided vector that both require fixes and have a
+/// score worse than the best.
 static void filterSolutions(SolutionApplicationTarget &target,
-                            SmallVectorImpl<Solution> &solutions) {
+                            SmallVectorImpl<Solution> &solutions,
+                            CodeCompletionExpr *completionExpr) {
   // FIXME: this is only needed because in pattern matching position, the
   // code completion expression always becomes an expression pattern, which
   // requires the ~= operator to be defined on the type being matched against.
@@ -791,23 +793,32 @@ static void filterSolutions(SolutionApplicationTarget &target,
   // completion. That only generates the 'nil' completion, which is rarely what
   // the user intends to write in this position and shouldn't be preferred over
   // the other formed solutions (which require fixes). We should generate enum
-  // pattern completions separately.
-  if (isForPatternMatch(target))
-    return;
+  // pattern completions separately, but for now ignore the
+  // _OptionalNilComparisonType solution.
+  if (isForPatternMatch(target)) {
+    solutions.erase(llvm::remove_if(solutions, [&](const Solution &S) {
+      ASTContext &ctx = S.getConstraintSystem().getASTContext();
+      if (!S.hasType(completionExpr))
+        return false;
+      if (auto ty = S.getResolvedType(completionExpr))
+        if (auto *NTD = ty->getAnyNominal())
+          return NTD->getBaseIdentifier() == ctx.Id_OptionalNilComparisonType;
+      return false;
+    }), solutions.end());
+  }
 
   if (solutions.size() <= 1)
     return;
 
-  auto min = std::min_element(solutions.begin(), solutions.end(),
-                              [](const Solution &a, const Solution &b) {
+  Score minScore = std::min_element(solutions.begin(), solutions.end(),
+                                    [](const Solution &a, const Solution &b) {
     return a.getFixedScore() < b.getFixedScore();
-  });
-  auto fixStart = llvm::partition(solutions, [&](const Solution &S) {
-    return S.getFixedScore() == min->getFixedScore();
-  });
+  })->getFixedScore();
 
-  if (fixStart != solutions.begin() && fixStart != solutions.end())
-    solutions.erase(fixStart, solutions.end());
+  llvm::erase_if(solutions, [&](const Solution &S) {
+    return S.getFixedScore().Data[SK_Fix] != 0 &&
+        S.getFixedScore() > minScore;
+  });
 }
 
 /// When solving for code completion we still consider solutions with holes as
@@ -899,8 +910,9 @@ bool TypeChecker::typeCheckForCodeCompletion(
       return CompletionResult::Fallback;
 
     // FIXME: instead of filtering, expose the score and viability to clients.
-    // Only keep the solution(s) with the best score.
-    filterSolutions(target, solutions);
+    // Remove any solutions that both require fixes and have a score that is
+    // worse than the best.
+    filterSolutions(target, solutions, contextAnalyzer.getCompletionExpr());
 
     // Similarly, if the type-check didn't produce any solutions, fall back
     // to type-checking a sub-expression in isolation.
@@ -1078,70 +1090,108 @@ void DotExprTypeCheckCompletionCallback::fallbackTypeCheck() {
       [&](const Solution &S) { sawSolution(S); });
 }
 
+void UnresolvedMemberTypeCheckCompletionCallback::
+fallbackTypeCheck(DeclContext *DC) {
+  assert(!gotCallback());
+
+  CompletionContextFinder finder(DC);
+  if (!finder.hasCompletionExpr())
+    return;
+
+  auto fallback = finder.getFallbackCompletionExpr();
+  if (!fallback)
+    return;
+
+
+  SolutionApplicationTarget completionTarget(fallback->E, fallback->DC,
+                                             CTP_Unused, Type(),
+                                             /*isDiscared=*/true);
+  TypeChecker::typeCheckForCodeCompletion(
+      completionTarget, /*needsPrecheck*/true,
+      [&](const Solution &S) { sawSolution(S); });
+}
+
+static Type getTypeForCompletion(const constraints::Solution &S, Expr *E) {
+  auto &CS = S.getConstraintSystem();
+
+  // To aid code completion, we need to attempt to convert type holes
+  // back into underlying generic parameters if possible, since type
+  // of the code completion expression is used as "expected" (or contextual)
+  // type so it's helpful to know what requirements it has to filter
+  // the list of possible member candidates e.g.
+  //
+  // \code
+  // func test<T: P>(_: [T]) {}
+  //
+  // test(42.#^MEMBERS^#)
+  // \code
+  //
+  // It's impossible to resolve `T` in this case but code completion
+  // expression should still have a type of `[T]` instead of `[<<hole>>]`
+  // because it helps to produce correct contextual member list based on
+  // a conformance requirement associated with generic parameter `T`.
+  if (isa<CodeCompletionExpr>(E)) {
+    auto completionTy = S.getType(E).transform([&](Type type) -> Type {
+      if (auto *typeVar = type->getAs<TypeVariableType>())
+        return S.getFixedType(typeVar);
+      return type;
+    });
+
+    return S.simplifyType(completionTy.transform([&](Type type) {
+      if (auto *hole = type->getAs<HoleType>()) {
+        if (auto *typeVar =
+                hole->getOriginator().dyn_cast<TypeVariableType *>()) {
+          if (auto *GP = typeVar->getImpl().getGenericParameter()) {
+            // Code completion depends on generic parameter type being
+            // represented in terms of `ArchetypeType` since it's easy
+            // to extract protocol requirements from it.
+            if (auto *GPD = GP->getDecl())
+              return GPD->getInnermostDeclContext()->mapTypeIntoContext(GP);
+          }
+        }
+
+        return Type(CS.getASTContext().TheUnresolvedType);
+      }
+
+      return type;
+    }));
+  }
+
+  return S.getResolvedType(E);
+};
+
+static bool isSingleExpressionBodyCompletion(ConstraintSystem &CS,
+                                             Expr *CompletionExpr) {
+  Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
+  if (!ParentExpr) {
+    return CS.getContextualTypePurpose(CompletionExpr) == CTP_ReturnSingleExpr;
+  }
+  if (auto *ParentCE = dyn_cast<ClosureExpr>(ParentExpr)) {
+    if (ParentCE->hasSingleExpressionBody() &&
+        ParentCE->getSingleExpressionBody() == CompletionExpr) {
+      ASTNode Last = ParentCE->getBody()->getLastElement();
+      return !Last.isStmt(StmtKind::Return) || Last.isImplicit();
+    }
+  }
+  return false;
+}
+
 void DotExprTypeCheckCompletionCallback::
 sawSolution(const constraints::Solution &S) {
   GotCallback = true;
   auto &CS = S.getConstraintSystem();
-
-  auto GetType = [&](Expr *E) {
-    // To aid code completion, we need to attempt to convert type holes
-    // back into underlying generic parameters if possible, since type
-    // of the code completion expression is used as "expected" (or contextual)
-    // type so it's helpful to know what requirements it has to filter
-    // the list of possible member candidates e.g.
-    //
-    // \code
-    // func test<T: P>(_: [T]) {}
-    //
-    // test(42.#^MEMBERS^#)
-    // \code
-    //
-    // It's impossible to resolve `T` in this case but code completion
-    // expression should still have a type of `[T]` instead of `[<<hole>>]`
-    // because it helps to produce correct contextual member list based on
-    // a conformance requirement associated with generic parameter `T`.
-    if (isa<CodeCompletionExpr>(E)) {
-      auto completionTy = S.getType(E).transform([&](Type type) -> Type {
-        if (auto *typeVar = type->getAs<TypeVariableType>())
-          return S.getFixedType(typeVar);
-        return type;
-      });
-
-      return S.simplifyType(completionTy.transform([&](Type type) {
-        if (auto *hole = type->getAs<HoleType>()) {
-          if (auto *typeVar =
-                  hole->getOriginator().dyn_cast<TypeVariableType *>()) {
-            if (auto *GP = typeVar->getImpl().getGenericParameter()) {
-              // Code completion depends on generic parameter type being
-              // represented in terms of `ArchetypeType` since it's easy
-              // to extract protocol requirements from it.
-              if (auto *GPD = GP->getDecl())
-                return GPD->getInnermostDeclContext()->mapTypeIntoContext(GP);
-            }
-          }
-
-          return Type(CS.getASTContext().TheUnresolvedType);
-        }
-
-        return type;
-      }));
-    }
-
-    return S.getResolvedType(E);
-  };
-
   auto *ParsedExpr = CompletionExpr->getBase();
   auto *SemanticExpr = ParsedExpr->getSemanticsProvidingExpr();
 
-  auto BaseTy = GetType(ParsedExpr);
+  auto BaseTy = getTypeForCompletion(S, ParsedExpr);
   // If base type couldn't be determined (e.g. because base expression
   // is an invalid reference), let's not attempt to do a lookup since
   // it wouldn't produce any useful results anyway.
-  if (!BaseTy || BaseTy->is<UnresolvedType>())
+  if (!BaseTy || BaseTy->getRValueType()->is<UnresolvedType>())
     return;
 
   auto *Locator = CS.getConstraintLocator(SemanticExpr);
-  Type ExpectedTy = GetType(CompletionExpr);
+  Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
   Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
   if (!ParentExpr)
     ExpectedTy = CS.getContextualType(CompletionExpr);
@@ -1153,31 +1203,45 @@ sawSolution(const constraints::Solution &S) {
 
   auto Key = std::make_pair(BaseTy, ReferencedDecl);
   auto Ret = BaseToSolutionIdx.insert({Key, Results.size()});
-  if (!Ret.second && ExpectedTy) {
-    Results[Ret.first->getSecond()].ExpectedTypes.push_back(ExpectedTy);
-  } else {
+  if (Ret.second) {
     bool ISDMT = S.isStaticallyDerivedMetatype(ParsedExpr);
-    bool SingleExprBody = false;
+    bool SingleExprBody = isSingleExpressionBodyCompletion(CS, CompletionExpr);
     bool DisallowVoid = ExpectedTy
                             ? !ExpectedTy->isVoid()
                             : !ParentExpr && CS.getContextualTypePurpose(
                                                  CompletionExpr) != CTP_Unused;
 
-    if (!ParentExpr) {
-      if (CS.getContextualTypePurpose(CompletionExpr) == CTP_ReturnSingleExpr)
-        SingleExprBody = true;
-    } else if (auto *ParentCE = dyn_cast<ClosureExpr>(ParentExpr)) {
-      if (ParentCE->hasSingleExpressionBody() &&
-          ParentCE->getSingleExpressionBody() == CompletionExpr) {
-        ASTNode Last = ParentCE->getBody()->getLastElement();
-        if (!Last.isStmt(StmtKind::Return) || Last.isImplicit())
-          SingleExprBody = true;
-      }
-    }
-
     Results.push_back(
         {BaseTy, ReferencedDecl, {}, DisallowVoid, ISDMT, SingleExprBody});
     if (ExpectedTy)
       Results.back().ExpectedTypes.push_back(ExpectedTy);
+  } else if (ExpectedTy) {
+    auto &ExpectedTys = Results[Ret.first->getSecond()].ExpectedTypes;
+    auto IsEqual = [&](Type Ty) { return ExpectedTy->isEqual(Ty); };
+    if (!llvm::any_of(ExpectedTys, IsEqual))
+      ExpectedTys.push_back(ExpectedTy);
   }
+}
+
+void UnresolvedMemberTypeCheckCompletionCallback::
+sawSolution(const constraints::Solution &S) {
+  GotCallback = true;
+
+  auto &CS = S.getConstraintSystem();
+  Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
+  // If the type couldn't be determined (e.g. because there isn't any context
+  // to derive it from), let's not attempt to do a lookup since it wouldn't
+  // produce any useful results anyway.
+  if (!ExpectedTy || ExpectedTy->is<UnresolvedType>())
+    return;
+
+  // If ExpectedTy is a duplicate of any other result, ignore this solution.
+  if (llvm::any_of(Results, [&](const Result &R) {
+    return R.ExpectedTy->isEqual(ExpectedTy);
+  })) {
+    return;
+  }
+
+  bool SingleExprBody = isSingleExpressionBodyCompletion(CS, CompletionExpr);
+  Results.push_back({ExpectedTy, SingleExprBody});
 }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -613,7 +613,10 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 // SUBSCRIPT_2-NEXT: Pattern/ExprSpecific: {#default: String#}[#String#];
 
   let _ = obj[42, .#^SUBSCRIPT_2_DOT^#
-// SUBSCRIPT_2_DOT-NOT: Begin completions
+// Note: we still provide completions despite the missing label - there's a fixit to add it in later.
+// SUBSCRIPT_2_DOT: Begin completions
+// SUBSCRIPT_2_DOT: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init()[#String#]; name=init()
+// SUBSCRIPT_2_DOT: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init({#(c): Character#})[#String#]; name=init(c: Character)
 
   let _ = obj[42, default: #^SUBSCRIPT_3^#
 // SUBSCRIPT_3: Begin completions

--- a/test/IDE/complete_call_as_function.swift
+++ b/test/IDE/complete_call_as_function.swift
@@ -110,13 +110,9 @@ func testCallAsFunctionOverloaded(fn: Functor) {
 //OVERLOADED_ARG2_LABEL: End completions
 
   fn(h: .left, v: .#^OVERLOADED_ARG2_VALUE^#)
-// FIXME: Should only suggest 'up' and 'down' (rdar://problem/60346573).
-//OVERLOADED_ARG2_VALUE: Begin completions, 6 items
+//OVERLOADED_ARG2_VALUE: Begin completions, 3 items
 //OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: up[#Functor.Vertical#];
 //OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: down[#Functor.Vertical#];
 //OVERLOADED_ARG2_VALUE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Functor.Vertical#})[#(into: inout Hasher) -> Void#];
-//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: left[#Functor.Horizontal#];
-//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: right[#Functor.Horizontal#];
-//OVERLOADED_ARG2_VALUE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Functor.Horizontal#})[#(into: inout Hasher) -> Void#];
 //OVERLOADED_ARG2_VALUE: End completions
 }

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -118,9 +118,9 @@ struct Vegetarian: EatsFruit, EatsVegetables { }
 func testVegetarian(chef: Chef<Vegetarian>) {
   chef.cook(.#^CONDITIONAL_OVERLOAD_ARG^#)
 // CONDITIONAL_OVERLOAD_ARG: Begin completions, 4 items
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]:     apple[#Fruit#]; name=apple
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:    apple[#Fruit#]; name=apple
 // CONDITIONAL_OVERLOAD_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:    hash({#(self): Fruit#})[#(into: inout Hasher) -> Void#]; name=hash(self: Fruit)
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]:     broccoli[#Vegetable#]; name=broccoli
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:    broccoli[#Vegetable#]; name=broccoli
 // CONDITIONAL_OVERLOAD_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:    hash({#(self): Vegetable#})[#(into: inout Hasher) -> Void#]; name=hash(self: Vegetable)
 // CONDITIONAL_OVERLOAD_ARG: End completions
 
@@ -128,7 +128,12 @@ func testVegetarian(chef: Chef<Vegetarian>) {
   let _ = chefMeta.init(.#^CONDITIONAL_OVERLOAD_INIT_ARG^#)
 
   chef.eat(.#^CONDITIONAL_INAPPLICABLE_ARG^#)
-// CONDITIONAL_INAPPLICABLE_ARG-NOT: Begin completion
+// Note: 'eat' is from an inapplicable constrained extension. We complete as if the user intends to addess that later
+//       (e.g. by adding the missing 'Meat' conformance to 'Vegetarian' - clearly not the intention here - but replace 'Meat' with 'Equatable').
+// CONDITIONAL_INAPPLICABLE_ARG: Begin completions, 2 items
+// CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: chicken[#Meat#]; name=chicken
+// CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Meat#})[#(into: inout Hasher) -> Void#]; name=hash(self: Meat)
+// CONDITIONAL_INAPPLICABLE_ARG: End completions
 }
 
 // rdar://problem/53401609

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -9,8 +9,8 @@ enum MyEnum {
 
 @propertyWrapper
 struct MyStruct {
-  var value: MyEnum
-  init(initialValue: MyEnum) {}
+  var wrappedValue: MyEnum
+  init(wrappedValue: MyEnum) {}
   init(arg1: MyEnum, arg2: Int) {}
 }
 
@@ -21,7 +21,7 @@ struct TestStruct {
   @MyStruct(#^AFTER_PAREN^#
   var test1
 // AFTER_PAREN: Begin completions, 2 items
-// AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#initialValue: MyEnum#}[')'][#MyStruct#]; name=initialValue: MyEnum
+// AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#wrappedValue: MyEnum#}[')'][#MyStruct#]; name=wrappedValue: MyEnum
 // AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg1: MyEnum#}, {#arg2: Int#}[')'][#MyStruct#]; name=arg1: MyEnum, arg2: Int
 // AFTER_PAREN: End completions
 
@@ -35,8 +35,8 @@ struct TestStruct {
   @MyStruct(arg1: .#^ARG_MyEnum_DOT^#
   var test3
 // ARG_MyEnum_DOT: Begin completions, 3 items
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]:     east[#MyEnum#]; name=east
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]:     west[#MyEnum#]; name=west
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     east[#MyEnum#]; name=east
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     west[#MyEnum#]; name=west
 // ARG_MyEnum_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MyEnum#})[#(into: inout Hasher) -> Void#];
 // ARG_MyEnum_DOT: End completions
 

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -153,7 +153,7 @@ struct TestSingleExprClosureUnresolved {
 }
 // TestSingleExprClosureUnresolved: Begin completions
 // TestSingleExprClosureUnresolved-NOT: notMine
-// TestSingleExprClosureUnresolved: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprClosureUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprClosureUnresolved-NOT: notMine
 // TestSingleExprClosureUnresolved: End completions
 
@@ -268,7 +268,7 @@ struct TestSingleExprFuncUnresolved {
 
 // TestSingleExprFuncUnresolved: Begin completions
 // TestSingleExprFuncUnresolved-NOT: notMine
-// TestSingleExprFuncUnresolved: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprFuncUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprFuncUnresolved-NOT: notMine
 // TestSingleExprFuncUnresolved: End completions
 }
@@ -378,7 +378,7 @@ struct TestSingleExprAccessorUnresolved {
 
 // TestSingleExprAccessorUnresolved: Begin completions
 // TestSingleExprAccessorUnresolved-NOT: notMine
-// TestSingleExprAccessorUnresolved: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprAccessorUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprAccessorUnresolved-NOT: notMine
 // TestSingleExprAccessorUnresolved: End completions
 }
@@ -530,7 +530,7 @@ struct TestSingleExprSubscriptUnresolved {
 
 // TestSingleExprSubscriptUnresolved: Begin completions
 // TestSingleExprSubscriptUnresolved-NOT: notMine
-// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprSubscriptUnresolved-NOT: notMine
 // TestSingleExprSubscriptUnresolved: End completions
 }
@@ -635,7 +635,7 @@ enum TopLevelEnum {
   case foo
 }
 
-// TopLevelEnum: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: foo[#TopLevelEnum#];
+// TopLevelEnum: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#TopLevelEnum#];
 
 var testAccessorUnresolvedTopLevel: TopLevelEnum {
   .#^testAccessorUnresolvedTopLevel^#

--- a/test/IDE/complete_sr13271.swift
+++ b/test/IDE/complete_sr13271.swift
@@ -48,7 +48,7 @@ func test() {
     .#^B^#
   }
 // B: Begin completions, 2 items
-// B-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: baz[#B#]; name=baz
+// B-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: baz[#B#]; name=baz
 // B-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#B#]; name=init()
 // B: End completions
 }

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -522,7 +522,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 enum A { case aaa }
 enum B { case bbb }
 // UNRESOLVED_B-NOT: aaa
-// UNRESOLVED_B: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]:     bbb[#B#]; name=bbb
+// UNRESOLVED_B: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bbb[#B#]; name=bbb
 // UNRESOLVED_B-NOT: aaa
 
 struct AA {

--- a/test/IDE/complete_string_interpolation.swift
+++ b/test/IDE/complete_string_interpolation.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD_INT -swift-version=5 | %FileCheck %s -check-prefix=OVERLOAD_INT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD_INTLITERAL -swift-version=5 | %FileCheck %s -check-prefix=OVERLOAD_INTLITERAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD_FLT -swift-version=5 | %FileCheck %s -check-prefix=OVERLOAD_FLT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOAD_FLTLITERAL -swift-version=5 | %FileCheck %s -check-prefix=OVERLOAD_FLT
 
 struct Messenger {
   init() {}
@@ -31,19 +33,24 @@ struct MsgInterpolation: StringInterpolationProtocol {
 var messenger = Messenger()
 func testMessenger(intVal: Int, fltVal: Float) {
   messenger.send("  \(intVal, format: .#^OVERLOAD_INT^#) ")
-// OVERLOAD_INT: Begin completions, 5 items
+// OVERLOAD_INT: Begin completions, 3 items
 // OVERLOAD_INT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
 // OVERLOAD_INT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
 // OVERLOAD_INT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
-// OVERLOAD_INT-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
-// OVERLOAD_INT-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_INT: End completions
 
+  messenger.send("  \(5, format: .#^OVERLOAD_INTLITERAL^#, extraneousArg: 10) ")
+// OVERLOAD_INTLITERAL: Begin completions, 5 items
+// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
+// OVERLOAD_INTLITERAL-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_INTLITERAL: End completions
+
   messenger.send("  \(fltVal, format: .#^OVERLOAD_FLT^#) ")
-// OVERLOAD_FLT: Begin completions, 5 items
-// OVERLOAD_FLT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
-// OVERLOAD_FLT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
-// OVERLOAD_FLT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
+  messenger.send("  \(5.0, format: .#^OVERLOAD_FLTLITERAL^#) ")
+// OVERLOAD_FLT: Begin completions, 2 items
 // OVERLOAD_FLT-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_FLT-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_FLT: End completions

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -28,8 +28,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_19 | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_20 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_21 | %FileCheck %s -check-prefix=UNRESOLVED_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_22 | %FileCheck %s -check-prefix=UNRESOLVED_1_NOTIDEAL
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_22_noreturn | %FileCheck %s -check-prefix=UNRESOLVED_1_NOTIDEAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_22 | %FileCheck %s -check-prefix=UNRESOLVED_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_22_noreturn | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_23 | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_24 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_25 | %FileCheck %s -check-prefix=UNRESOLVED_3
@@ -45,9 +45,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_34 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_35 | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_36 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_37 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_37 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_38 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_39 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_39 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_40 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_41 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_42 | %FileCheck %s -check-prefix=UNRESOLVED_3
@@ -78,7 +78,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_1 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_2 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_3 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_U
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_4 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT_NOTIDEAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_4 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_CLOSURE_1 | %FileCheck %s -check-prefix=STATIC_CLOSURE_1
 
@@ -119,8 +119,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_2 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_3 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_4 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_5 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_6 | %FileCheck %s -check-prefix=UNRESOLVED_3_NOTIDEAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_5 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_6 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_CONDITION | %FileCheck %s -check-prefix=TERNARY_CONDITION
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERLOADED_CLOSURE_RETURN | %FileCheck %s -check-prefix=OVERLOADED_CLOSURE_RETURN
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AUTOCLOSURE | %FileCheck %s -check-prefix=UNRESOLVED_3
@@ -229,15 +229,6 @@ class C2 {
 // UNRESOLVED_1-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
 // UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal:        NotOption[#Int#]; name=NotOption
 // UNRESOLVED_1-NOT:  NotStaticOption
-
-// UNRESOLVED_1_NOTIDEAL:  Begin completions
-// UNRESOLVED_1_NOTIDEAL-NOT:  SomeEnum1
-// UNRESOLVED_1_NOTIDEAL-NOT:  SomeEnum2
-// UNRESOLVED_1_NOTIDEAL-DAG:  Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
-// UNRESOLVED_1_NOTIDEAL-DAG:  Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
-// UNRESOLVED_1_NOTIDEAL-DAG:  Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
-// UNRESOLVED_1_NOTIDEAL-DAG:  Decl[StaticVar]/CurrNominal:        NotOption[#Int#]; name=NotOption
-// UNRESOLVED_1_NOTIDEAL-NOT:  NotStaticOption
 }
 
 class C3 {
@@ -277,24 +268,15 @@ class C4 {
     var _: SomeEnum1??? = .#^UNRESOLVED_OPT_3^#
   }
 }
+
+// Exhaustive to make sure we don't include `SomeOptions1`, `SomeOptions2`, `none` or `some` entries.
 // UNRESOLVED_3: Begin completions, 3 items
 // UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
 // UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
 // UNRESOLVED_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#]; name=hash(self: SomeEnum1)
-// UNRESOLVED_3-NOT: SomeOptions1
-// UNRESOLVED_3-NOT: SomeOptions2
-// UNRESOLVED_3-NOT: none
-// UNRESOLVED_3-NOT: some(
+// UNRESOLVED_3: End completions
 
-// UNRESOLVED_3_NOTIDEAL: Begin completions, 3 items
-// UNRESOLVED_3_NOTIDEAL-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
-// UNRESOLVED_3_NOTIDEAL-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
-// UNRESOLVED_3_NOTIDEAL-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#]; name=hash(self: SomeEnum1)
-// UNRESOLVED_3_NOTIDEAL-NOT: SomeOptions1
-// UNRESOLVED_3_NOTIDEAL-NOT: SomeOptions2
-// UNRESOLVED_3_NOTIDEAL-NOT: none
-// UNRESOLVED_3_NOTIDEAL-NOT: some(
-
+// Exhaustive to make sure we don't include `init({#(some):` or `init({#nilLiteral:` entries
 // UNRESOLVED_3_OPT: Begin completions, 9 items
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
@@ -304,10 +286,10 @@ class C4 {
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U) -> U?#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U?) -> U?#];
-// UNRESOLVED_3_OPT-NOT: init({#(some):
-// UNRESOLVED_3_OPT-NOT: init({#nilLiteral:
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1>#})[#(into: inout Hasher) -> Void#];
+// UNRESOLVED_3_OPT: End completions
 
+// Exhaustive to make sure we don't include `init({#(some):` or `init({#nilLiteral:` entries
 // UNRESOLVED_3_OPTOPTOPT: Begin completions, 9 items
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
@@ -317,9 +299,8 @@ class C4 {
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#SomeEnum1??#})[#Optional<SomeEnum1??>#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws -> U) -> U?#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws -> U?) -> U?#];
-// UNRESOLVED_3_OPTOPTOPT-NOT: init({#(some):
-// UNRESOLVED_3_OPTOPTOPT-NOT: init({#nilLiteral:
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1??>#})[#(into: inout Hasher) -> Void#];
+// UNRESOLVED_3_OPTOPTOPT: End completions
 
 enum Somewhere {
   case earth, mars
@@ -621,16 +602,10 @@ case let .#^GENERIC_4^#
 // GENERIC_1_INT-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: create({#Int#})[#Generic<Int>#];
 // GENERIC_1_INT: End completions
 
-// GENERIC_1_INT_NOTIDEAL: Begin completions
-// GENERIC_1_INT_NOTIDEAL-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: contains({#content: Int#})[#Generic<Int>#];
-// GENERIC_1_INT_NOTIDEAL-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: empty[#Generic<Int>#];
-// GENERIC_1_INT_NOTIDEAL-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: create({#Int#})[#Generic<Int>#];
-// GENERIC_1_INT_NOTIDEAL: End completions
-
 // GENERIC_1_U: Begin completions
-// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: contains({#content: U#})[#Generic<U>#];
-// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: empty[#Generic<U>#];
-// GENERIC_1_U-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: create({#U#})[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: contains({#content: U#})[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: empty[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: create({#U#})[#Generic<U>#];
 // GENERIC_1_U: End completions
 
 struct HasCreator {
@@ -656,11 +631,11 @@ struct HasOverloaded {
 func testOverload(val: HasOverloaded) {
   let _ = val.takeEnum(.#^OVERLOADED_METHOD_1^#)
 // OVERLOADED_METHOD_1: Begin completions, 6 items
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
 // OVERLOADED_METHOD_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: East[#SomeEnum2#]; name=East
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: West[#SomeEnum2#]; name=West
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: East[#SomeEnum2#]; name=East
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: West[#SomeEnum2#]; name=West
 // OVERLOADED_METHOD_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum2#})[#(into: inout Hasher) -> Void#];
 // OVERLOADED_METHOD_1: End completions
 
@@ -820,11 +795,11 @@ func testClosureReturnTypeForOverloaded() {
     .#^OVERLOADED_CLOSURE_RETURN^#
   }
 // OVERLOADED_CLOSURE_RETURN: Begin completions, 6 items
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: South[#SomeEnum1#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: North[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#];
 // OVERLOADED_CLOSURE_RETURN-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: East[#SomeEnum2#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: West[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: East[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: West[#SomeEnum2#];
 // OVERLOADED_CLOSURE_RETURN-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): SomeEnum2#})[#(into: inout Hasher) -> Void#];
 // OVERLOADED_CLOSURE_RETURN: End completions
 }
@@ -857,10 +832,10 @@ func testSameType() {
   testSugarType(.#^SUGAR_TYPE^#
 // Ensure results aren't duplicated.
 // SUGAR_TYPE: Begin completions, 9 items
-// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: South[#SomeEnum1#];
-// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: North[#SomeEnum1#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// SUGAR_TYPE-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Optional<SomeEnum1>#];
+// SUGAR_TYPE-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1?#];
 // SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1>#];
 // SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U) -> U?#];

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -52,7 +52,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_41 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_42 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_43 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_44 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_44 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_AVAIL_1 | %FileCheck %s -check-prefix=ENUM_AVAIL_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPTIONS_AVAIL_1 | %FileCheck %s -check-prefix=OPTIONS_AVAIL_1

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1410,6 +1410,9 @@ func testTypeCheckWithUnsolvedVariables3() {
 // TC_UNSOLVED_VARIABLES_3-NEXT: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<Int>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_3-NEXT: Decl[InstanceMethod]/CurrNominal: add({#(t): Int#})[#BuilderStyle<Int>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_3-NEXT: Decl[InstanceMethod]/CurrNominal: get()[#Int#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_3-NEXT: Keyword[self]/CurrNominal: self[#BuilderStyle<Double>#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_3-NEXT: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<Double>#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_3-NEXT: Decl[InstanceMethod]/CurrNominal: add({#(t): Double#})[#BuilderStyle<Double>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_3-NEXT: End completions
 
 func testTypeCheckNil() {


### PR DESCRIPTION
Following on from updating regular member completion, this hooks up unresolved member completion (i.e. `.<complete here>`) to the `typeCheckForCodeCompletion` API to generate completions from all solutions the constraint solver produces (even those requiring fixes), rather than relying on a single solution being applied to the AST (if any). This lets us produce unresolved member completions even when the contextual type is ambiguous or involves errors.

Whenever `typeCheckExpression` is called on an expression containing a code completion expression and a `TypeCheckCompletionCallback` has been set, each solution formed is passed to the callback so the type of the completion expression can be extracted and used to lookup up the members to return.

Resolves rdar://problem/71378252