### PR TITLE
[nfc] Remove unneeded void cast of clangDC.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1816,7 +1816,6 @@ ASTMangler::getSpecialManglingContext(const ValueDecl *decl,
         if (isa<clang::NamespaceDecl>(clangDC)) return None;
         assert(clangDC->getRedeclContext()->isTranslationUnit() &&
                "non-top-level Clang types not supported yet");
-        (void)clangDC;
         return ASTMangler::ObjCContext;
       }
     }


### PR DESCRIPTION
This is just a simple cleanup. Refs #34730.