### PR TITLE
[ConstraintSystem] Infer some of the bindings attributes on demand

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -462,7 +462,6 @@ void ConstraintSystem::PotentialBindings::finalize(
   // If there are no bindings, typeVar may be a hole.
   if (cs.shouldAttemptFixes() && Bindings.empty() &&
       TypeVar->getImpl().canBindToHole()) {
-    IsHole = true;
     // If the base of the unresolved member reference like `.foo`
     // couldn't be resolved we'd want to bind it to a hole at the
     // very last moment possible, just like generic parameters.
@@ -695,7 +694,7 @@ bool ConstraintSystem::PotentialBindings::isViable(
 
 bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
     Constraint *disjunction) const {
-  if (IsHole || FullyBound)
+  if (isHole() || FullyBound)
     return false;
 
   // If this bindings are for a closure and there are no holes,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -513,17 +513,6 @@ void ConstraintSystem::PotentialBindings::finalize(
       std::rotate(AnyTypePos, AnyTypePos + 1, Bindings.end());
     }
   }
-
-  // Determine if the bindings only constrain the type variable from above with
-  // an existential type; such a binding is not very helpful because it's
-  // impossible to enumerate the existential type's subtypes.
-  if (!Bindings.empty()) {
-    SubtypeOfExistentialType =
-        llvm::all_of(Bindings, [](const PotentialBinding &binding) {
-          return binding.BindingType->isExistentialType() &&
-                 binding.Kind == AllowedBindingKind::Subtypes;
-        });
-  }
 }
 
 Optional<ConstraintSystem::PotentialBindings>

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -972,20 +972,6 @@ bool ConstraintSystem::PotentialBindings::infer(
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
   case ConstraintKind::OptionalObject: {
-    // If there is a `bind param` constraint associated with
-    // current type variable, result should be aware of that
-    // fact. Binding set might be incomplete until
-    // this constraint is resolved, because we currently don't
-    // look-through constraints expect to `subtype` to try and
-    // find related bindings.
-    // This only affects type variable that appears one the
-    // right-hand side of the `bind param` constraint and
-    // represents result type of the closure body, because
-    // left-hand side gets types from overload choices.
-    if (constraint->getKind() == ConstraintKind::BindParam &&
-        constraint->getSecondType()->isEqual(TypeVar))
-      PotentiallyIncomplete = true;
-
     auto binding =
         cs.getPotentialBindingForRelationalConstraint(*this, constraint);
     if (!binding)

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -22,6 +22,64 @@
 using namespace swift;
 using namespace constraints;
 
+bool ConstraintSystem::PotentialBindings::isPotentiallyIncomplete() const {
+  // Generic parameters are always potentially incomplete.
+  if (isGenericParameter())
+    return true;
+
+  // If current type variable is associated with a code completion token
+  // it's possible that it doesn't have enough contextual information
+  // to be resolved to anything so let's delay considering it until everything
+  // else is resolved.
+  if (AssociatedCodeCompletionToken)
+    return true;
+
+  auto *locator = TypeVar->getImpl().getLocator();
+  if (!locator)
+    return false;
+
+  if (locator->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>()) {
+    // If subtyping is allowed and this is a result of an implicit member chain,
+    // let's delay binding it to an optional until its object type resolved too or
+    // it has been determined that there is no possibility to resolve it. Otherwise
+    // we might end up missing solutions since it's allowed to implicitly unwrap
+    // base type of the chain but it can't be done early - type variable
+    // representing chain's result type has a different l-valueness comparing
+    // to generic parameter of the optional.
+    if (llvm::any_of(Bindings, [&](const PotentialBinding &binding) {
+          if (binding.Kind != AllowedBindingKind::Subtypes)
+            return false;
+
+          auto objectType = binding.BindingType->getOptionalObjectType();
+          return objectType && objectType->isTypeVariableOrMember();
+        }))
+      return true;
+  }
+
+  if (isHole()) {
+    // If the base of the unresolved member reference like `.foo`
+    // couldn't be resolved we'd want to bind it to a hole at the
+    // very last moment possible, just like generic parameters.
+    if (locator->isLastElement<LocatorPathElt::MemberRefBase>())
+      return true;
+
+    // Delay resolution of the code completion expression until
+    // the very end to give it a chance to be bound to some
+    // contextual type even if it's a hole.
+    if (locator->directlyAt<CodeCompletionExpr>())
+      return true;
+
+    // Delay resolution of the `nil` literal to a hole until
+    // the very end to give it a change to be bound to some
+    // other type, just like code completion expression which
+    // relies solely on contextual information.
+    if (locator->directlyAt<NilLiteralExpr>())
+      return true;
+  }
+
+  return false;
+}
+
 void ConstraintSystem::PotentialBindings::inferTransitiveProtocolRequirements(
     const ConstraintSystem &cs,
     llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>
@@ -466,25 +524,19 @@ void ConstraintSystem::PotentialBindings::finalize(
     // couldn't be resolved we'd want to bind it to a hole at the
     // very last moment possible, just like generic parameters.
     auto *locator = TypeVar->getImpl().getLocator();
-    if (locator->isLastElement<LocatorPathElt::MemberRefBase>())
-      PotentiallyIncomplete = true;
 
     // Delay resolution of the code completion expression until
     // the very end to give it a chance to be bound to some
     // contextual type even if it's a hole.
-    if (locator->directlyAt<CodeCompletionExpr>()) {
+    if (locator->directlyAt<CodeCompletionExpr>())
       FullyBound = true;
-      PotentiallyIncomplete = true;
-    }
 
     // Delay resolution of the `nil` literal to a hole until
     // the very end to give it a change to be bound to some
     // other type, just like code completion expression which
     // relies solely on contextual information.
-    if (locator->directlyAt<NilLiteralExpr>()) {
+    if (locator->directlyAt<NilLiteralExpr>())
       FullyBound = true;
-      PotentiallyIncomplete = true;
-    }
 
     // If this type variable is associated with a code completion token
     // and it failed to infer any bindings let's adjust hole's locator
@@ -874,10 +926,8 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
     // bindings and use it when forming a hole if there are no other bindings
     // available.
     if (auto *locator = bindingTypeVar->getImpl().getLocator()) {
-      if (locator->directlyAt<CodeCompletionExpr>()) {
+      if (locator->directlyAt<CodeCompletionExpr>())
         result.AssociatedCodeCompletionToken = locator->getAnchor();
-        result.PotentiallyIncomplete = true;
-      }
     }
 
     switch (constraint->getKind()) {
@@ -914,24 +964,6 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
     if (typeVar->getImpl().canBindToLValue() !=
         otherTypeVar->getImpl().canBindToLValue())
       return None;
-  }
-
-  // If subtyping is allowed and this is a result of an implicit member chain,
-  // let's delay binding it to an optional until its object type resolved too or
-  // it has been determined that there is no possibility to resolve it. Otherwise
-  // we might end up missing solutions since it's allowed to implicitly unwrap
-  // base type of the chain but it can't be done early - type variable
-  // representing chain's result type has a different l-valueness comparing
-  // to generic parameter of the optional.
-  if (kind == AllowedBindingKind::Subtypes) {
-    auto *locator = typeVar->getImpl().getLocator();
-    if (locator &&
-        locator->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>()) {
-      auto objectType = type->getOptionalObjectType();
-      if (objectType && objectType->isTypeVariableOrMember()) {
-        result.PotentiallyIncomplete = true;
-      }
-    }
   }
 
   if (type->is<InOutType>() && !typeVar->getImpl().canBindToInOut())

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -678,9 +678,6 @@ void ConstraintSystem::PotentialBindings::addPotentialBinding(
   if (!isViable(binding))
     return;
 
-  if (binding.isDefaultableBinding())
-    ++NumDefaultableBindings;
-
   Bindings.push_back(std::move(binding));
 }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1113,7 +1113,7 @@ bool ConstraintGraph::contractEdges() {
       bool isNotContractable = true;
       if (auto bindings = CS.inferBindingsFor(tyvar1)) {
         // Holes can't be contracted.
-        if (bindings.IsHole)
+        if (bindings.isHole())
           continue;
 
         for (auto &binding : bindings.Bindings) {


### PR DESCRIPTION
One step closer to being able to make potential binding inference incremental.

Let's make most of the flags in `PotentialBindings` be computed on demand based
on information captured in the bindings, including:

- `IsHole` - could be determined based on a presence of a single binding to a hole type;
- `NumDefaultableBindings` - just a number of bindings originated in defaultable constraint;
- `IsPotentiallyIncomplete` - determined based on bindings and locator;
- `SubtypeOfExistentialType` - determined based on recorded bindings;

Most of the flags here are only used for ranking and recorded in a `BindingScore`
so don't have to be re-computed multiple times.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
