### PR TITLE
Disable parse-time name lookup in swift-ide-test

### DIFF
--- a/include/swift/AST/GenericParamList.h
+++ b/include/swift/AST/GenericParamList.h
@@ -324,6 +324,9 @@ public:
     if (WhereLoc.isInvalid())
       return SourceRange();
 
+    if (Requirements.empty())
+      return WhereLoc;
+
     auto endLoc = Requirements.back().getSourceRange().End;
     return SourceRange(WhereLoc, endLoc);
   }
@@ -352,16 +355,18 @@ class alignas(RequirementRepr) TrailingWhereClause final :
   friend TrailingObjects;
 
   SourceLoc WhereLoc;
+  SourceLoc EndLoc;
 
   /// The number of requirements. The actual requirements are tail-allocated.
   unsigned NumRequirements;
 
-  TrailingWhereClause(SourceLoc whereLoc,
+  TrailingWhereClause(SourceLoc whereLoc, SourceLoc endLoc,
                       ArrayRef<RequirementRepr> requirements);
 
 public:
   /// Create a new trailing where clause with the given set of requirements.
-  static TrailingWhereClause *create(ASTContext &ctx, SourceLoc whereLoc,
+  static TrailingWhereClause *create(ASTContext &ctx,
+                                     SourceLoc whereLoc, SourceLoc endLoc,
                                      ArrayRef<RequirementRepr> requirements);
 
   /// Retrieve the location of the 'where' keyword.
@@ -379,8 +384,7 @@ public:
 
   /// Compute the source range containing this trailing where clause.
   SourceRange getSourceRange() const {
-    return SourceRange(WhereLoc,
-                       getRequirements().back().getSourceRange().End);
+    return SourceRange(WhereLoc, EndLoc);
   }
 
   void print(llvm::raw_ostream &OS, bool printWhereKeyword) const;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1689,8 +1689,9 @@ public:
   parseFreestandingGenericWhereClause(GenericContext *genCtx);
 
   ParserStatus parseGenericWhereClause(
-      SourceLoc &WhereLoc, SmallVectorImpl<RequirementRepr> &Requirements,
-      bool &FirstTypeInComplete, bool AllowLayoutConstraints = false);
+      SourceLoc &WhereLoc, SourceLoc &EndLoc,
+      SmallVectorImpl<RequirementRepr> &Requirements,
+      bool AllowLayoutConstraints = false);
 
   ParserStatus
   parseProtocolOrAssociatedTypeWhereClause(TrailingWhereClause *&trailingWhere,

--- a/lib/AST/GenericParamList.cpp
+++ b/lib/AST/GenericParamList.cpp
@@ -110,9 +110,9 @@ GenericTypeParamDecl *GenericParamList::lookUpGenericParam(
 }
 
 TrailingWhereClause::TrailingWhereClause(
-                       SourceLoc whereLoc,
+                       SourceLoc whereLoc, SourceLoc endLoc,
                        ArrayRef<RequirementRepr> requirements)
-  : WhereLoc(whereLoc),
+  : WhereLoc(whereLoc), EndLoc(endLoc),
     NumRequirements(requirements.size())
 {
   std::uninitialized_copy(requirements.begin(), requirements.end(),
@@ -122,8 +122,9 @@ TrailingWhereClause::TrailingWhereClause(
 TrailingWhereClause *TrailingWhereClause::create(
                        ASTContext &ctx,
                        SourceLoc whereLoc,
+                       SourceLoc endLoc,
                        ArrayRef<RequirementRepr> requirements) {
   unsigned size = totalSizeToAlloc<RequirementRepr>(requirements.size());
   void *mem = ctx.Allocate(size, alignof(TrailingWhereClause));
-  return new (mem) TrailingWhereClause(whereLoc, requirements);
+  return new (mem) TrailingWhereClause(whereLoc, endLoc, requirements);
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3813,7 +3813,7 @@ void Parser::setLocalDiscriminator(ValueDecl *D) {
     return;
 
   if (auto TD = dyn_cast<TypeDecl>(D))
-    if (!getScopeInfo().isInactiveConfigBlock())
+    if (!InInactiveClauseEnvironment)
       SF.LocalTypeDecls.insert(TD);
 
   const Identifier name = D->getBaseIdentifier();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -717,13 +717,12 @@ bool Parser::parseSpecializeAttributeArguments(
 
   // Parse the where clause.
   if (Tok.is(tok::kw_where)) {
-    SourceLoc whereLoc;
+    SourceLoc whereLoc, endLoc;
     SmallVector<RequirementRepr, 4> requirements;
-    bool firstTypeInComplete;
-    parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete,
+    parseGenericWhereClause(whereLoc, endLoc, requirements,
                             /* AllowLayoutConstraints */ true);
     TrailingWhereClause =
-        TrailingWhereClause::create(Context, whereLoc, requirements);
+        TrailingWhereClause::create(Context, whereLoc, endLoc, requirements);
   }
   return true;
 }
@@ -1053,12 +1052,12 @@ bool Parser::parseDifferentiableAttributeArguments(
 
   // Parse a trailing 'where' clause if any.
   if (Tok.is(tok::kw_where)) {
-    SourceLoc whereLoc;
+    SourceLoc whereLoc, endLoc;
     SmallVector<RequirementRepr, 4> requirements;
-    bool firstTypeInComplete;
-    parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete,
+    parseGenericWhereClause(whereLoc, endLoc, requirements,
                             /*AllowLayoutConstraints*/ true);
-    whereClause = TrailingWhereClause::create(Context, whereLoc, requirements);
+    whereClause =
+        TrailingWhereClause::create(Context, whereLoc, endLoc, requirements);
   }
   return false;
 }
@@ -4878,19 +4877,17 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   TrailingWhereClause *trailingWhereClause = nullptr;
   bool trailingWhereHadCodeCompletion = false;
   if (Tok.is(tok::kw_where)) {
-    SourceLoc whereLoc;
+    SourceLoc whereLoc, endLoc;
     SmallVector<RequirementRepr, 4> requirements;
-    bool firstTypeInComplete;
-    auto whereStatus = parseGenericWhereClause(whereLoc, requirements,
-                                               firstTypeInComplete);
+    auto whereStatus = parseGenericWhereClause(whereLoc, endLoc, requirements);
     if (whereStatus.hasCodeCompletion()) {
       if (isCodeCompletionFirstPass())
         return whereStatus;
       trailingWhereHadCodeCompletion = true;
     }
     if (!requirements.empty()) {
-      trailingWhereClause = TrailingWhereClause::create(Context, whereLoc,
-                                                        requirements);
+      trailingWhereClause =
+          TrailingWhereClause::create(Context, whereLoc, endLoc, requirements);
     }
     status |= whereStatus;
   }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -140,11 +140,11 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
 
   // Parse the optional where-clause.
   SourceLoc WhereLoc;
+  SourceLoc EndLoc;
   SmallVector<RequirementRepr, 4> Requirements;
-  bool FirstTypeInComplete;
   if (Tok.is(tok::kw_where) &&
-      parseGenericWhereClause(WhereLoc, Requirements,
-                              FirstTypeInComplete).isErrorOrHasCompletion()) {
+      parseGenericWhereClause(WhereLoc, EndLoc, Requirements)
+        .isErrorOrHasCompletion()) {
     Invalid = true;
   }
   
@@ -261,16 +261,14 @@ Parser::diagnoseWhereClauseInGenericParamList(const GenericParamList *
 ///   same-type-requirement:
 ///     type-identifier '==' type
 ParserStatus Parser::parseGenericWhereClause(
-               SourceLoc &WhereLoc,
+               SourceLoc &WhereLoc, SourceLoc &EndLoc,
                SmallVectorImpl<RequirementRepr> &Requirements,
-               bool &FirstTypeInComplete,
                bool AllowLayoutConstraints) {
   SyntaxParsingContext ClauseContext(SyntaxContext,
                                      SyntaxKind::GenericWhereClause);
   ParserStatus Status;
   // Parse the 'where'.
   WhereLoc = consumeToken(tok::kw_where);
-  FirstTypeInComplete = false;
   SyntaxParsingContext ReqListContext(SyntaxContext,
                                       SyntaxKind::GenericRequirementList);
   bool HasNextReq;
@@ -283,7 +281,7 @@ ParserStatus Parser::parseGenericWhereClause(
     if (Tok.is(tok::code_complete)) {
       if (CodeCompletion)
         CodeCompletion->completeGenericRequirement();
-      consumeToken(tok::code_complete);
+      EndLoc = consumeToken(tok::code_complete);
       Status.setHasCodeCompletionAndIsError();
       break;
     }
@@ -295,7 +293,6 @@ ParserStatus Parser::parseGenericWhereClause(
     if (FirstType.hasCodeCompletion()) {
       BodyContext->setTransparent();
       Status.setHasCodeCompletionAndIsError();
-      FirstTypeInComplete = true;
     }
 
     if (FirstType.isNull()) {
@@ -383,8 +380,10 @@ ParserStatus Parser::parseGenericWhereClause(
     }
   } while (HasNextReq);
 
-  if (Requirements.empty())
-    WhereLoc = SourceLoc();
+  if (!Requirements.empty())
+    EndLoc = Requirements.back().getSourceRange().End;
+  else if (EndLoc.isInvalid())
+    EndLoc = WhereLoc;
 
   return Status;
 }
@@ -396,31 +395,26 @@ parseFreestandingGenericWhereClause(GenericContext *genCtx) {
   assert(Tok.is(tok::kw_where) && "Shouldn't call this without a where");
 
   SmallVector<RequirementRepr, 4> Requirements;
-  SourceLoc WhereLoc;
-  bool FirstTypeInComplete;
-  auto result = parseGenericWhereClause(WhereLoc, Requirements,
-                                        FirstTypeInComplete);
-  if (result.isErrorOrHasCompletion() || Requirements.empty())
-    return result;
+  SourceLoc WhereLoc, EndLoc;
+  auto result = parseGenericWhereClause(WhereLoc, EndLoc, Requirements);
 
   genCtx->setTrailingWhereClause(
-      TrailingWhereClause::create(Context, WhereLoc, Requirements));
+      TrailingWhereClause::create(Context, WhereLoc, EndLoc, Requirements));
 
-  return ParserStatus();
+  return result;
 }
 
 /// Parse a where clause after a protocol or associated type declaration.
 ParserStatus Parser::parseProtocolOrAssociatedTypeWhereClause(
     TrailingWhereClause *&trailingWhere, bool isProtocol) {
   assert(Tok.is(tok::kw_where) && "Shouldn't call this without a where");
-  SourceLoc whereLoc;
+  SourceLoc whereLoc, endLoc;
   SmallVector<RequirementRepr, 4> requirements;
-  bool firstTypeInComplete;
   auto whereStatus =
-      parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete);
+      parseGenericWhereClause(whereLoc, endLoc, requirements);
   if (whereStatus.isSuccess() && !whereStatus.hasCodeCompletion()) {
     trailingWhere =
-        TrailingWhereClause::create(Context, whereLoc, requirements);
+        TrailingWhereClause::create(Context, whereLoc, endLoc, requirements);
   } else if (whereStatus.hasCodeCompletion()) {
     return whereStatus;
   }

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -635,7 +635,7 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
       // Don't evaluate if it's in '-parse' mode, etc.
       shouldEvaluatePoundIfDecls() &&
       // If it's in inactive #if ... #endif block, there's no point to do it.
-      !getScopeInfo().isInactiveConfigBlock() &&
+      !InInactiveClauseEnvironment &&
       // If this directive contains code completion location, 'isActive' is
       // determined solely by which block has the completion token.
       !codeCompletionClauseLoc.isValid();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3820,6 +3820,7 @@ int main(int argc, char *argv[]) {
   InitInvok.setModuleName(options::ModuleName);
 
   InitInvok.setSDKPath(options::SDK);
+  InitInvok.getLangOptions().DisableParserLookup = true;
   InitInvok.getLangOptions().CollectParsedToken = true;
   InitInvok.getLangOptions().BuildSyntaxTree = true;
   InitInvok.getLangOptions().RequestEvaluatorGraphVizPath =


### PR DESCRIPTION
I have some leftover patches from my work on ASTScope. A couple of places that create an ASTContext without a CompilerInvocation still had parser lookup enabled; swift-ide-test is one of them.