### PR TITLE
[Async CC] Resolve metadata from class instances.

### DIFF
--- a/test/IRGen/async/Inputs/class-1instance-void_to_void.swift
+++ b/test/IRGen/async/Inputs/class-1instance-void_to_void.swift
@@ -1,0 +1,8 @@
+import _Concurrency
+
+public class Clazz {
+  public init() {}
+  public func classinstanceVoidToVoid() async {
+    print(self)
+  }
+}

--- a/test/IRGen/async/run-call-resilient-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-resilient-classinstance-void-to-void.sil
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ResilientClass)) %S/Inputs/class-1instance-void_to_void.swift -Xfrontend -enable-experimental-concurrency -module-name ResilientClass -emit-module -emit-module-path %t/ResilientClass.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(ResilientClass)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim -lResilientClass | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims -lResilientClass %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) %t/%target-library-name(ResilientClass) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
+
+
+import Builtin
+import Swift
+import PrintShims
+import _Concurrency
+import ResilientClass
+
+sil public_external [exact_self_class] @$s14ResilientClass5ClazzCACycfC : $@convention(method) (@thick Clazz.Type) -> @owned Clazz
+
+// Defined in _Concurrency
+sil public_external @$s12_Concurrency8runAsyncyyyyYcF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_case(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+sil @test_case : $@convention(thin) @async () -> () {
+  %s_type = metatype $@thick Clazz.Type
+  %allocating_init = function_ref @$s14ResilientClass5ClazzCACycfC : $@convention(method) (@thick Clazz.Type) -> @owned Clazz
+  %instance = apply %allocating_init(%s_type) : $@convention(method) (@thick Clazz.Type) -> @owned Clazz
+  %classinstanceVoidToVoid = class_method %instance : $Clazz, #Clazz.classinstanceVoidToVoid : (Clazz) -> () async -> (), $@convention(method) @async (@guaranteed Clazz) -> ()
+  strong_retain %instance : $Clazz
+  %result = apply %classinstanceVoidToVoid(%instance) : $@convention(method) @async (@guaranteed Clazz) -> () // CHECK: ResilientClass.Clazz
+  strong_release %instance : $Clazz
+
+  %out = tuple ()
+  return %out : $()
+}
+
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+
+  %2 = function_ref @test_case : $@convention(thin) @async () -> ()
+  %3 = thin_to_thick_function %2 : $@convention(thin) @async () -> () to $@async @callee_guaranteed () -> ()
+  %4 = function_ref @$s12_Concurrency8runAsyncyyyyYcF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+
+  %6 = integer_literal $Builtin.Int32, 0
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  return %7 : $Int32
+}

--- a/test/IRGen/async/run-call-struct_five_bools-to-void.sil
+++ b/test/IRGen/async/run-call-struct_five_bools-to-void.sil
@@ -41,6 +41,9 @@ entry(%pack : $Pack):
   return %printGeneric_result1 : $()
 }
 
+// Defined in _Concurrency
+sil public_external @$s12_Concurrency8runAsyncyyyyYcF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+
 // CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_case(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
 sil @test_case : $@async @convention(thin) () -> () {
   
@@ -64,12 +67,13 @@ sil @test_case : $@async @convention(thin) () -> () {
 
 sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  
-  %test_case = function_ref @test_case : $@convention(thin) @async () -> ()
-  %result = apply %test_case() : $@convention(thin) @async () -> ()
 
-  %2 = integer_literal $Builtin.Int32, 0
-  %3 = struct $Int32 (%2 : $Builtin.Int32)
-  return %3 : $Int32
+  %2 = function_ref @test_case : $@convention(thin) @async () -> ()
+  %3 = thin_to_thick_function %2 : $@convention(thin) @async () -> () to $@async @callee_guaranteed () -> ()
+  %4 = function_ref @$s12_Concurrency8runAsyncyyyyYcF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+
+  %6 = integer_literal $Builtin.Int32, 0
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  return %7 : $Int32
 }
-

--- a/validation-test/compiler_crashers_2_fixed/rdar71260862.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71260862.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend %s -emit-ir -enable-library-evolution -enable-experimental-concurrency
+
+public class X {
+  public func f() async { }
+}


### PR DESCRIPTION
Metadata for an instance of a type is resolved by extracting it from an instance of the class.  When doing method lookup for an instance method of a resilient class, the lowered self value was being obtained from the list of arguments directly by indexing.  That does not apply to async functions where self is embedded within the async context.  Here, the self parameter is extracted from the async context so that the metadata can in turn be extracted from it.

rdar://problem/71260862