### PR TITLE
[Async CC] Never map to native explosions.

### DIFF
--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -17,10 +17,15 @@ class Value;
 }
 
 namespace swift {
+
+class SILArgument;
+
 namespace irgen {
 
 class Explosion;
 struct GenericRequirement;
+class LoadableTypeInfo;
+class TypeInfo;
 
 class EntryPointArgumentEmission {
 
@@ -44,6 +49,12 @@ public:
   virtual llvm::Value *getSelfWitnessTable() = 0;
   virtual llvm::Value *getSelfMetadata() = 0;
   virtual llvm::Value *getCoroutineBuffer() = 0;
+  virtual Explosion
+  explosionForObject(IRGenFunction &IGF, unsigned index, SILArgument *param,
+                     SILType paramTy, const LoadableTypeInfo &loadableParamTI,
+                     const LoadableTypeInfo &loadableArgTI,
+                     std::function<Explosion(unsigned index, unsigned size)>
+                         explosionForArgument) = 0;
 };
 
 } // end namespace irgen

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1262,6 +1262,42 @@ public:
   llvm::Value *getCoroutineBuffer() override {
     return allParamValues.claimNext();
   }
+  Explosion
+  explosionForObject(IRGenFunction &IGF, unsigned index, SILArgument *param,
+                     SILType paramTy, const LoadableTypeInfo &loadableParamTI,
+                     const LoadableTypeInfo &loadableArgTI,
+                     std::function<Explosion(unsigned index, unsigned size)>
+                         explosionForArgument) override {
+    Explosion paramValues;
+    // If the explosion must be passed indirectly, load the value from the
+    // indirect address.
+    auto &nativeSchema = loadableArgTI.nativeParameterValueSchema(IGF.IGM);
+    if (nativeSchema.requiresIndirect()) {
+      Explosion paramExplosion = explosionForArgument(index, 1);
+      Address paramAddr =
+          loadableParamTI.getAddressForPointer(paramExplosion.claimNext());
+      if (loadableParamTI.getStorageType() != loadableArgTI.getStorageType())
+        paramAddr =
+            loadableArgTI.getAddressForPointer(IGF.Builder.CreateBitCast(
+                paramAddr.getAddress(),
+                loadableArgTI.getStorageType()->getPointerTo()));
+      loadableArgTI.loadAsTake(IGF, paramAddr, paramValues);
+    } else {
+      if (!nativeSchema.empty()) {
+        // Otherwise, we map from the native convention to the type's explosion
+        // schema.
+        Explosion nativeParam;
+        unsigned size = nativeSchema.size();
+        Explosion paramExplosion = explosionForArgument(index, size);
+        paramExplosion.transferInto(nativeParam, size);
+        paramValues = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeParam,
+                                                 param->getType());
+      } else {
+        assert(loadableParamTI.getSchema().empty());
+      }
+    }
+    return paramValues;
+  };
 
 public:
   using SyncEntryPointArgumentEmission::requiresIndirectResult;
@@ -1312,10 +1348,8 @@ public:
     return loadValue(contextLayout);
   }
   Explosion getArgumentExplosion(unsigned index, unsigned size) override {
-    assert(size > 0);
     auto argumentLayout = layout.getArgumentLayout(index);
     auto result = loadExplosion(argumentLayout);
-    assert(result.size() == size);
     return result;
   }
   bool requiresIndirectResult(SILType retType) override { return false; }
@@ -1380,6 +1414,14 @@ public:
     llvm_unreachable(
         "async functions do not use a fixed size coroutine buffer");
   }
+  Explosion
+  explosionForObject(IRGenFunction &IGF, unsigned index, SILArgument *param,
+                     SILType paramTy, const LoadableTypeInfo &loadableParamTI,
+                     const LoadableTypeInfo &loadableArgTI,
+                     std::function<Explosion(unsigned index, unsigned size)>
+                         explosionForArgument) override {
+    return explosionForArgument(index, 1);
+  };
 };
 
 std::unique_ptr<NativeCCEntryPointArgumentEmission>
@@ -1654,8 +1696,9 @@ static ArrayRef<SILArgument *> emitEntryPointIndirectReturn(
 }
 
 template <typename ExplosionForArgument>
-static void bindParameter(IRGenSILFunction &IGF, unsigned index,
-                          SILArgument *param, SILType paramTy,
+static void bindParameter(IRGenSILFunction &IGF,
+                          NativeCCEntryPointArgumentEmission &emission,
+                          unsigned index, SILArgument *param, SILType paramTy,
                           ExplosionForArgument explosionForArgument) {
   // Pull out the parameter value and its formal type.
   auto &paramTI = IGF.getTypeInfo(IGF.CurSILFn->mapTypeIntoContext(paramTy));
@@ -1664,36 +1707,11 @@ static void bindParameter(IRGenSILFunction &IGF, unsigned index,
   // If the SIL parameter isn't passed indirectly, we need to map it
   // to an explosion.
   if (param->getType().isObject()) {
-    Explosion paramValues;
     auto &loadableParamTI = cast<LoadableTypeInfo>(paramTI);
-    auto &loadableArgTI = cast<LoadableTypeInfo>(paramTI);
-    // If the explosion must be passed indirectly, load the value from the
-    // indirect address.
-    auto &nativeSchema = argTI.nativeParameterValueSchema(IGF.IGM);
-    if (nativeSchema.requiresIndirect()) {
-      Explosion paramExplosion = explosionForArgument(index, 1);
-      Address paramAddr =
-          loadableParamTI.getAddressForPointer(paramExplosion.claimNext());
-      if (paramTI.getStorageType() != argTI.getStorageType())
-        paramAddr =
-            loadableArgTI.getAddressForPointer(IGF.Builder.CreateBitCast(
-                paramAddr.getAddress(),
-                loadableArgTI.getStorageType()->getPointerTo()));
-      loadableArgTI.loadAsTake(IGF, paramAddr, paramValues);
-    } else {
-      if (!nativeSchema.empty()) {
-        // Otherwise, we map from the native convention to the type's explosion
-        // schema.
-        Explosion nativeParam;
-        unsigned size = nativeSchema.size();
-        Explosion paramExplosion = explosionForArgument(index, size);
-        paramExplosion.transferInto(nativeParam, size);
-        paramValues = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeParam,
-                                                 param->getType());
-      } else {
-        assert(paramTI.getSchema().empty());
-      }
-    }
+    auto &loadableArgTI = cast<LoadableTypeInfo>(argTI);
+    auto paramValues =
+        emission.explosionForObject(IGF, index, param, paramTy, loadableParamTI,
+                                    loadableArgTI, explosionForArgument);
     IGF.setLoweredExplosion(param, paramValues);
     return;
   }
@@ -1760,7 +1778,7 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
     params = params.drop_back();
 
     bindParameter(
-        IGF, 0, selfParam,
+        IGF, *emission, 0, selfParam,
         conv.getSILArgumentType(conv.getNumSILArguments() - 1,
                                 IGF.IGM.getMaximalTypeExpansionContext()),
         [&](unsigned startIndex, unsigned size) {
@@ -1784,7 +1802,7 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
   unsigned i = 0;
   for (SILArgument *param : params) {
     auto argIdx = conv.getSILArgIndexOfFirstParam() + i;
-    bindParameter(IGF, i, param,
+    bindParameter(IGF, *emission, i, param,
                   conv.getSILArgumentType(
                       argIdx, IGF.IGM.getMaximalTypeExpansionContext()),
                   [&](unsigned index, unsigned size) {

--- a/test/IRGen/async/run-call-struct_five_bools-to-void.sil
+++ b/test/IRGen/async/run-call-struct_five_bools-to-void.sil
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: CPU=arm64e
+
+
+import Builtin
+import Swift
+import PrintShims
+import _Concurrency
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+struct Pack {
+  public let a: Bool
+  public let b: Bool
+  public let c: Bool
+  public let d: Bool
+  public let e: Bool
+}
+
+// CHECK-LL: @test_caseAD =
+
+sil @structPackToVoid : $@async @convention(thin) (Pack) -> () {
+entry(%pack : $Pack):
+  %pack_addr = alloc_stack $Pack
+  store %pack to %pack_addr : $*Pack
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %printGeneric_result1 = apply %printGeneric<Pack>(%pack_addr) : $@convention(thin) <T> (@in_guaranteed T) -> () //CHECK: Pack(a: true, b: false, c: true, d: false, e: true)
+  dealloc_stack %pack_addr : $*Pack
+  
+  return %printGeneric_result1 : $()
+}
+
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_case(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+sil @test_case : $@async @convention(thin) () -> () {
+  
+  %a_literal = integer_literal $Builtin.Int1, -1
+  %a = struct $Bool (%a_literal : $Builtin.Int1)
+  %b_literal = integer_literal $Builtin.Int1, 0
+  %b = struct $Bool (%b_literal : $Builtin.Int1)
+  %c_literal = integer_literal $Builtin.Int1, -1
+  %c = struct $Bool (%c_literal : $Builtin.Int1)
+  %d_literal = integer_literal $Builtin.Int1, 0
+  %d = struct $Bool (%d_literal : $Builtin.Int1)
+  %e_literal = integer_literal $Builtin.Int1, -1
+  %e = struct $Bool (%a_literal : $Builtin.Int1)
+
+  %pack = struct $Pack (%a : $Bool, %b : $Bool, %c : $Bool, %d : $Bool, %e : $Bool)
+
+  %structPackToVoid = function_ref @structPackToVoid : $@async @convention(thin) (Pack) -> ()
+  %result = apply %structPackToVoid(%pack) : $@async @convention(thin) (Pack) -> ()
+  return %result : $()
+}
+
+sil @main : $@async @convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  
+  %test_case = function_ref @test_case : $@convention(thin) @async () -> ()
+  %result = apply %test_case() : $@convention(thin) @async () -> ()
+
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %3 : $Int32
+}
+

--- a/validation-test/compiler_crashers_2_fixed/rdar71260972.sil
+++ b/validation-test/compiler_crashers_2_fixed/rdar71260972.sil
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend %s -emit-ir -enable-experimental-concurrency -parse-sil
+
+import Swift
+
+struct Pack {
+  public let a: Bool
+  public let b: Bool
+  public let c: Bool
+  public let d: Bool
+  public let e: Bool
+}
+
+public struct Strukt {
+  public let rawValue: Int
+}
+
+class Clazz { }
+
+sil_vtable Clazz {
+}
+
+sil @$foo : $@convention(method) @async (@guaranteed Pack, @guaranteed Array<Strukt>, @guaranteed Clazz) -> () {
+bb0(%0 : $Pack, %1 : $Array<Strukt>, %2 : $Clazz):
+  %result = tuple ()
+  return %result : $()
+}


### PR DESCRIPTION
Previously, when lowering the entry point of an async function, the parameters were lowered to explosions that matched those of sync functions, namely native explosions.  That is incorrect for async functions where the structured values are within the async context.  Here, that error is fixed, by adding a new customization point to NativeCCEntryPointArgumentEmission which behaves as before for sync functions but which simply extracts an argument from the async context for async functions.

rdar://problem/71260972