### PR TITLE
Update RawRepresentable conformance of Hashable

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -184,11 +184,6 @@ public func != <T: Equatable>(lhs: T, rhs: T) -> Bool
 // rather than rawValue; the difference is subtle, but it can be fatal.)
 extension RawRepresentable where RawValue: Hashable, Self: Hashable {
   @inlinable // trivial
-  public var hashValue: Int {
-    return rawValue.hashValue
-  }
-
-  @inlinable // trivial
   public func hash(into hasher: inout Hasher) {
     hasher.combine(rawValue)
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Update RawRepresentable conformance of Hashable by Removing deprecated `hashValue`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12445 & SR-13851

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
