### PR TITLE
[stdlib] Make UBP nil/count checks debug-mode only

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -401,9 +401,9 @@ extension Unsafe${Mutable}BufferPointer {
   public init(
     @_nonEphemeral start: Unsafe${Mutable}Pointer<Element>?, count: Int
   ) {
-    _precondition(
+    _debugPrecondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
-    _precondition(
+    _debugPrecondition(
       count == 0 || start != nil,
       "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     _position = start

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -432,8 +432,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   public init(
     @_nonEphemeral start: Unsafe${Mutable}RawPointer?, count: Int
   ) {
-    _precondition(count >= 0, "${Self} with negative count")
-    _precondition(count == 0 || start != nil,
+    _debugPrecondition(count >= 0, "${Self} with negative count")
+    _debugPrecondition(count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
     _position = start
     _end = start.map { $0 + count }


### PR DESCRIPTION
Currently: Creating a buffer with a negative `count`, or a `nil` pointer and non-zero `count` (in violation of the initialiser's documentation) traps in every build mode. This is unfortunate, since these conditions are difficult for the compiler to prove and eliminate.

After this change: Violating the documentation is a user error and will only trap in debug mode. As with other operations on unsafe buffers (e.g. out of bounds subscripting), they will not trap in release mode.