### PR TITLE
Modify driver tests to support swift-driver json and path differences

### DIFF
--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -6,42 +6,42 @@
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -driver-show-incremental -output-file-map %t/output.json 2>&1 |%FileCheck %s -check-prefix=MUST-EXEC
 
 // MUST-EXEC-NOT: warning
-// MUST-EXEC: inputs: ["./main.swift"], output: {object: "./main.o", swift-dependencies: "./main.swiftdeps"}
-// MUST-EXEC: inputs: ["./other.swift"], output: {object: "./other.o", swift-dependencies: "./other.swiftdeps"}
-// MUST-EXEC: inputs: ["./yet-another.swift"], output: {object: "./yet-another.o", swift-dependencies: "./yet-another.swiftdeps"}
+// MUST-EXEC: inputs: ["{{(\.\/)?}}main.swift"], output: {object: "{{(\.\/)?}}main.o", swift-dependencies: "{{(\.\/)?}}main.swiftdeps"}
+// MUST-EXEC: inputs: ["{{(\.\/)?}}other.swift"], output: {object: "{{(\.\/)?}}other.o", swift-dependencies: "{{(\.\/)?}}other.swiftdeps"}
+// MUST-EXEC: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {object: "{{(\.\/)?}}yet-another.o", swift-dependencies: "{{(\.\/)?}}yet-another.swiftdeps"}
 // MUST-EXEC: Disabling incremental build: could not read build record
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0], "./yet-another.swift": [443865900, 0]}, build_time: [443865901, 0]}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// NO-EXEC: inputs: ["./main.swift"], output: {{[{].*[}]}}, condition: check-dependencies
-// NO-EXEC: inputs: ["./other.swift"], output: {{[{].*[}]}}, condition: check-dependencies
-// NO-EXEC: inputs: ["./yet-another.swift"], output: {{[{].*[}]}}, condition: check-dependencies
+// NO-EXEC: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}, condition: check-dependencies
+// NO-EXEC: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}, condition: check-dependencies
+// NO-EXEC: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]}}, condition: check-dependencies
 
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": !private [443865900, 0], "./yet-another.swift": !dirty [443865900, 0]}, build_time: [443865901, 0]}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=BUILD-RECORD
 
-// BUILD-RECORD: inputs: ["./main.swift"], output: {{[{].*[}]}}, condition: check-dependencies{{$}}
-// BUILD-RECORD: inputs: ["./other.swift"], output: {{[{].*[}]}}, condition: run-without-cascading{{$}}
-// BUILD-RECORD: inputs: ["./yet-another.swift"], output: {{[{].*[}]$}}
+// BUILD-RECORD: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}, condition: check-dependencies{{$}}
+// BUILD-RECORD: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}, condition: run-without-cascading{{$}}
+// BUILD-RECORD: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]$}}
 
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift ./added.swift -incremental -output-file-map %t/output.json 2>&1 > %t/added.txt
 // RUN: %FileCheck %s -check-prefix=BUILD-RECORD < %t/added.txt
 // RUN: %FileCheck %s -check-prefix=FILE-ADDED < %t/added.txt
 
-// FILE-ADDED: inputs: ["./added.swift"], output: {{[{].*[}]}}, condition: newly-added{{$}}
+// FILE-ADDED: inputs: ["{{(\.\/)?}}added.swift"], output: {{[{].*[}]}}, condition: newly-added{{$}}
 
 // RUN: %{python} %S/Inputs/touch.py 443865960 %t/main.swift
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=BUILD-RECORD-PLUS-CHANGE
-// BUILD-RECORD-PLUS-CHANGE: inputs: ["./main.swift"], output: {{[{].*[}]}}, condition: run-without-cascading
-// BUILD-RECORD-PLUS-CHANGE: inputs: ["./other.swift"], output: {{[{].*[}]}}, condition: run-without-cascading{{$}}
-// BUILD-RECORD-PLUS-CHANGE: inputs: ["./yet-another.swift"], output: {{[{].*[}]$}}
+// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}, condition: run-without-cascading
+// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}, condition: run-without-cascading{{$}}
+// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]$}}
 
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=FILE-REMOVED
-// FILE-REMOVED: inputs: ["./main.swift"], output: {{[{].*[}]$}}
-// FILE-REMOVED: inputs: ["./other.swift"], output: {{[{].*[}]$}}
+// FILE-REMOVED: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]$}}
+// FILE-REMOVED: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]$}}
 // FILE-REMOVED-NOT: yet-another.swift
 
 
@@ -49,6 +49,6 @@
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=INVALID-RECORD
 
 // INVALID-RECORD-NOT: warning
-// INVALID-RECORD: inputs: ["./main.swift"], output: {{[{].*[}]$}}
-// INVALID-RECORD: inputs: ["./other.swift"], output: {{[{].*[}]$}}
-// INVALID-RECORD: inputs: ["./yet-another.swift"], output: {{[{].*[}]$}}
+// INVALID-RECORD: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]$}}
+// INVALID-RECORD: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]$}}
+// INVALID-RECORD: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]$}}

--- a/test/Driver/working-directory.swift
+++ b/test/Driver/working-directory.swift
@@ -13,7 +13,7 @@
 // In another driver mode.
 // RUN: cd %t && %swift_driver -driver-print-jobs -working-directory %/S/Inputs -F. | %FileCheck %s -check-prefix=REPL
 // RUN: cd %t && %swift_driver -driver-print-jobs -deprecated-integrated-repl -working-directory %/S/Inputs -F. | %FileCheck %s -check-prefix=REPL
-// REPL: -F {{\\?"?}}SOURCE_DIR/test/Driver/Inputs{{(\\\\(\\\\)?)|/}}.
+// REPL: -F {{\\?"?}}SOURCE_DIR/test/Driver/Inputs
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%/S/Inputs -c -module-name m main.swift lib.swift | %FileCheck %s -check-prefix=MULTI_INPUT
 // MULTI_INPUT: SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}main.swift
@@ -25,12 +25,12 @@
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -F . | %FileCheck %s -check-prefix=SEARCH_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -F. | %FileCheck %s -check-prefix=SEARCH_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -F=. | %FileCheck %s -check-prefix=SEARCH_PATH
-// SEARCH_PATH: -F {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}.
+// SEARCH_PATH: -F {{"?}}SOURCE_DIR/test/Driver/Inputs
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -L . | %FileCheck %s -check-prefix=L_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -L. | %FileCheck %s -check-prefix=L_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -L=. | %FileCheck %s -check-prefix=L_PATH
-// L_PATH: -L {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}.
+// L_PATH: -L {{"?}}SOURCE_DIR/test/Driver/Inputs
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -disable-bridging-pch -import-objc-header bridging-header.h | %FileCheck %s -check-prefix=OBJC_HEADER1
 // OBJC_HEADER1: -import-objc-header {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}bridging-header.h

--- a/validation-test/Driver/Dependencies/rdar23148987.swift
+++ b/validation-test/Driver/Dependencies/rdar23148987.swift
@@ -8,15 +8,15 @@
 
 // CHECK-1-NOT: warning
 // CHECK-1: {{^{$}}
-// CHECK-1: "kind": "began"
-// CHECK-1: "name": "compile"
-// CHECK-1: ".\/main.swift"
+// CHECK-1-DAG: "kind"{{ ?}}: "began"
+// CHECK-1-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-1: {{^}$}}
 
 // CHECK-1: {{^{$}}
-// CHECK-1: "kind": "began"
-// CHECK-1: "name": "compile"
-// CHECK-1: ".\/helper.swift"
+// CHECK-1-DAG: "kind"{{ ?}}: "began"
+// CHECK-1-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-1: {{^}$}}
 
 // RUN: ls %t/ | %FileCheck -check-prefix=CHECK-LS %s
@@ -28,15 +28,15 @@
 
 // CHECK-1-SKIPPED-NOT: warning
 // CHECK-1-SKIPPED: {{^{$}}
-// CHECK-1-SKIPPED: "kind": "skipped"
-// CHECK-1-SKIPPED: "name": "compile"
-// CHECK-1-SKIPPED: ".\/main.swift"
+// CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // CHECK-1-SKIPPED: {{^{$}}
-// CHECK-1-SKIPPED: "kind": "skipped"
-// CHECK-1-SKIPPED: "name": "compile"
-// CHECK-1-SKIPPED: ".\/helper.swift"
+// CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // RUN: cp %S/Inputs/rdar23148987/helper-2.swift %t/helper.swift
@@ -45,15 +45,15 @@
 
 // CHECK-2-NOT: warning
 // CHECK-2: {{^{$}}
-// CHECK-2: "kind": "began"
-// CHECK-2: "name": "compile"
-// CHECK-2: ".\/helper.swift"
+// CHECK-2-DAG: "kind"{{ ?}}: "began"
+// CHECK-2-DAG: "name"{{ ?}}: "compile"
+// CHECK-2-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-2: {{^}$}}
 
 // CHECK-2: {{^{$}}
-// CHECK-2: "kind": "began"
-// CHECK-2: "name": "compile"
-// CHECK-2: ".\/main.swift"
+// CHECK-2-DAG: "kind"{{ ?}}: "began"
+// CHECK-2-DAG: "name"{{ ?}}: "compile"
+// CHECK-2-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-2: {{^}$}}
 
 func test(obj: Test) {

--- a/validation-test/Driver/Dependencies/rdar23148987.swift
+++ b/validation-test/Driver/Dependencies/rdar23148987.swift
@@ -10,13 +10,13 @@
 // CHECK-1: {{^{$}}
 // CHECK-1-DAG: "kind"{{ ?}}: "began"
 // CHECK-1-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-1-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-1: {{^}$}}
 
 // CHECK-1: {{^{$}}
 // CHECK-1-DAG: "kind"{{ ?}}: "began"
 // CHECK-1-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-1-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-1: {{^}$}}
 
 // RUN: ls %t/ | %FileCheck -check-prefix=CHECK-LS %s
@@ -30,13 +30,13 @@
 // CHECK-1-SKIPPED: {{^{$}}
 // CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
 // CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-1-SKIPPED-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // CHECK-1-SKIPPED: {{^{$}}
 // CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
 // CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-1-SKIPPED-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // RUN: cp %S/Inputs/rdar23148987/helper-2.swift %t/helper.swift
@@ -47,13 +47,13 @@
 // CHECK-2: {{^{$}}
 // CHECK-2-DAG: "kind"{{ ?}}: "began"
 // CHECK-2-DAG: "name"{{ ?}}: "compile"
-// CHECK-2-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-2-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-2: {{^}$}}
 
 // CHECK-2: {{^{$}}
 // CHECK-2-DAG: "kind"{{ ?}}: "began"
 // CHECK-2-DAG: "name"{{ ?}}: "compile"
-// CHECK-2-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-2-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-2: {{^}$}}
 
 func test(obj: Test) {

--- a/validation-test/Driver/Dependencies/rdar25405605.swift
+++ b/validation-test/Driver/Dependencies/rdar25405605.swift
@@ -10,13 +10,13 @@
 // CHECK-1: {{^{$}}
 // CHECK-1-DAG: "kind"{{ ?}}: "began"
 // CHECK-1-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-1-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-1: {{^}$}}
 
 // CHECK-1: {{^{$}}
 // CHECK-1-DAG: "kind"{{ ?}}: "began"
 // CHECK-1-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-1-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-1: {{^}$}}
 
 // RUN: ls %t/ | %FileCheck -check-prefix=CHECK-LS %s
@@ -30,13 +30,13 @@
 // CHECK-1-SKIPPED: {{^{$}}
 // CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
 // CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-1-SKIPPED-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // CHECK-1-SKIPPED: {{^{$}}
 // CHECK-1-SKIPPED-DAG: "kind"{{ ?}} "skipped"
 // CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
-// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-1-SKIPPED-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // RUN: cp %S/Inputs/rdar25405605/helper-2.swift %t/helper.swift
@@ -47,13 +47,13 @@
 // CHECK-2: {{^{$}}
 // CHECK-2-DAG: "kind"{{ ?}}: "began"
 // CHECK-2-DAG: "name"{{ ?}}: "compile"
-// CHECK-2-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-2-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-2: {{^}$}}
 
 // CHECK-2: {{^{$}}
 // CHECK-2-DAG: "kind"{{ ?}}: "skipped"
 // CHECK-2-DAG: "name"{{ ?}}: "compile"
-// CHECK-2-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-2-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-2: {{^}$}}
 
 // RUN: cp %S/Inputs/rdar25405605/helper-3.swift %t/helper.swift
@@ -66,13 +66,13 @@
 // CHECK-3: {{^{$}}
 // CHECK-3-DAG: "kind"{{ ?}}: "began"
 // CHECK-3-DAG: "name"{{ ?}}: "compile"
-// CHECK-3-DAG: "{{(\.\/)?}}helper.swift"
+// CHECK-3-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-3: {{^}$}}
 
 // CHECK-3: {{^{$}}
 // CHECK-3-DAG: "kind"{{ ?}}: "began"
 // CHECK-3-DAG: "name"{{ ?}}: "compile"
-// CHECK-3-DAG: "{{(\.\/)?}}main.swift"
+// CHECK-3-DAG: "{{(\.\\\/)?}}main.swift"
 // CHECK-3: {{^}$}}
 
 func foo(_ value: Foo) -> Bool {

--- a/validation-test/Driver/Dependencies/rdar25405605.swift
+++ b/validation-test/Driver/Dependencies/rdar25405605.swift
@@ -34,7 +34,7 @@
 // CHECK-1-SKIPPED: {{^}$}}
 
 // CHECK-1-SKIPPED: {{^{$}}
-// CHECK-1-SKIPPED-DAG: "kind"{{ ?}} "skipped"
+// CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
 // CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
 // CHECK-1-SKIPPED-DAG: "{{(\.\\\/)?}}helper.swift"
 // CHECK-1-SKIPPED: {{^}$}}

--- a/validation-test/Driver/Dependencies/rdar25405605.swift
+++ b/validation-test/Driver/Dependencies/rdar25405605.swift
@@ -8,15 +8,15 @@
 
 // CHECK-1-NOT: warning
 // CHECK-1: {{^{$}}
-// CHECK-1: "kind": "began"
-// CHECK-1: "name": "compile"
-// CHECK-1: ".\/main.swift"
+// CHECK-1-DAG: "kind"{{ ?}}: "began"
+// CHECK-1-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-1: {{^}$}}
 
 // CHECK-1: {{^{$}}
-// CHECK-1: "kind": "began"
-// CHECK-1: "name": "compile"
-// CHECK-1: ".\/helper.swift"
+// CHECK-1-DAG: "kind"{{ ?}}: "began"
+// CHECK-1-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-1: {{^}$}}
 
 // RUN: ls %t/ | %FileCheck -check-prefix=CHECK-LS %s
@@ -28,15 +28,15 @@
 
 // CHECK-1-SKIPPED-NOT: warning
 // CHECK-1-SKIPPED: {{^{$}}
-// CHECK-1-SKIPPED: "kind": "skipped"
-// CHECK-1-SKIPPED: "name": "compile"
-// CHECK-1-SKIPPED: ".\/main.swift"
+// CHECK-1-SKIPPED-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // CHECK-1-SKIPPED: {{^{$}}
-// CHECK-1-SKIPPED: "kind": "skipped"
-// CHECK-1-SKIPPED: "name": "compile"
-// CHECK-1-SKIPPED: ".\/helper.swift"
+// CHECK-1-SKIPPED-DAG: "kind"{{ ?}} "skipped"
+// CHECK-1-SKIPPED-DAG: "name"{{ ?}}: "compile"
+// CHECK-1-SKIPPED-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-1-SKIPPED: {{^}$}}
 
 // RUN: cp %S/Inputs/rdar25405605/helper-2.swift %t/helper.swift
@@ -45,15 +45,15 @@
 
 // CHECK-2-NOT: warning
 // CHECK-2: {{^{$}}
-// CHECK-2: "kind": "began"
-// CHECK-2: "name": "compile"
-// CHECK-2: ".\/helper.swift"
+// CHECK-2-DAG: "kind"{{ ?}}: "began"
+// CHECK-2-DAG: "name"{{ ?}}: "compile"
+// CHECK-2-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-2: {{^}$}}
 
 // CHECK-2: {{^{$}}
-// CHECK-2: "kind": "skipped"
-// CHECK-2: "name": "compile"
-// CHECK-2: ".\/main.swift"
+// CHECK-2-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-2-DAG: "name"{{ ?}}: "compile"
+// CHECK-2-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-2: {{^}$}}
 
 // RUN: cp %S/Inputs/rdar25405605/helper-3.swift %t/helper.swift
@@ -64,15 +64,15 @@
 
 // CHECK-3-NOT: warning
 // CHECK-3: {{^{$}}
-// CHECK-3: "kind": "began"
-// CHECK-3: "name": "compile"
-// CHECK-3: ".\/helper.swift"
+// CHECK-3-DAG: "kind"{{ ?}}: "began"
+// CHECK-3-DAG: "name"{{ ?}}: "compile"
+// CHECK-3-DAG: "{{(\.\/)?}}helper.swift"
 // CHECK-3: {{^}$}}
 
 // CHECK-3: {{^{$}}
-// CHECK-3: "kind": "began"
-// CHECK-3: "name": "compile"
-// CHECK-3: ".\/main.swift"
+// CHECK-3-DAG: "kind"{{ ?}}: "began"
+// CHECK-3-DAG: "name"{{ ?}}: "compile"
+// CHECK-3-DAG: "{{(\.\/)?}}main.swift"
 // CHECK-3: {{^}$}}
 
 func foo(_ value: Foo) -> Bool {


### PR DESCRIPTION
These changes allow the tests to run (still fail, but with an actual cause): https://github.com/apple/swift-driver/pull/365/commits/4d590a7e91b6b2f6fb38db9bd1b658233bded7d9