### PR TITLE
[sil][value-lifetime] Add ValueLifetimeAnalysis::FrontierImpl = SmallVectorImpl<SILInstruction *>

### DIFF
--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -54,6 +54,10 @@ public:
   /// end the value's lifetime.
   using Frontier = SmallVector<SILInstruction *, 4>;
 
+  /// A type erased version of frontier so callers can customize the inline
+  /// size.
+  using FrontierImpl = SmallVectorImpl<SILInstruction *>;
+
   /// Constructor for the value \p def with a specific range of users.
   ///
   /// We templatize over the RangeTy so that we can initialize
@@ -106,7 +110,7 @@ public:
   ///
   /// If \p deBlocks is provided, all dead-end blocks are ignored. This
   /// prevents unreachable-blocks to be included in the frontier.
-  bool computeFrontier(Frontier &frontier, Mode mode,
+  bool computeFrontier(FrontierImpl &frontier, Mode mode,
                        DeadEndBlocks *deBlocks = nullptr);
 
   ArrayRef<std::pair<TermInst *, unsigned>> getCriticalEdges() {
@@ -125,7 +129,7 @@ public:
   }
 
   /// Checks if there is a dealloc_ref inside the value's live range.
-  bool containsDeallocRef(const Frontier &frontier);
+  bool containsDeallocRef(const FrontierImpl &frontier);
 
   /// For debug dumping.
   void dump() const;
@@ -159,7 +163,7 @@ private:
 /// Otherwise \p valueOrStackLoc must be a value type and in this case, inserts
 /// destroy_value at each instruction of the \p frontier.
 void endLifetimeAtFrontier(SILValue valueOrStackLoc,
-                           const ValueLifetimeAnalysis::Frontier &frontier,
+                           const ValueLifetimeAnalysis::FrontierImpl &frontier,
                            SILBuilderContext &builderCtxt,
                            InstModCallbacks callbacks);
 

--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -90,7 +90,7 @@ SILInstruction *ValueLifetimeAnalysis::findLastUserInBlock(SILBasicBlock *bb) {
   llvm_unreachable("Expected to find use of value in block!");
 }
 
-bool ValueLifetimeAnalysis::computeFrontier(Frontier &frontier, Mode mode,
+bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
                                             DeadEndBlocks *deBlocks) {
   assert(!isAliveAtBeginOfBlock(getFunction()->getEntryBlock()) &&
          "Can't compute frontier for def which does not dominate all uses");
@@ -287,7 +287,7 @@ blockContainsDeallocRef(SILBasicBlock *bb,
   return false;
 }
 
-bool ValueLifetimeAnalysis::containsDeallocRef(const Frontier &frontier) {
+bool ValueLifetimeAnalysis::containsDeallocRef(const FrontierImpl &frontier) {
   SmallPtrSet<SILBasicBlock *, 8> frontierBlocks;
   // Search in live blocks where the value is not alive until the end of the
   // block, i.e. the live range is terminated by a frontier instruction.
@@ -326,7 +326,8 @@ void ValueLifetimeAnalysis::dump() const {
 }
 
 void swift::endLifetimeAtFrontier(
-    SILValue valueOrStackLoc, const ValueLifetimeAnalysis::Frontier &frontier,
+    SILValue valueOrStackLoc,
+    const ValueLifetimeAnalysis::FrontierImpl &frontier,
     SILBuilderContext &builderCtxt, InstModCallbacks callbacks) {
   for (SILInstruction *endPoint : frontier) {
     SILBuilderWithScope builder(endPoint, builderCtxt);


### PR DESCRIPTION
Otherwise, one is always forced to use ValueLifetimeAnalysis::Frontier, a
SmallVector<SILInstruction *, 4>. This may not be a size appropriate for every
problem, so it makes sense to provide Frontier as a good rule of thumb, but use
FrontierImpl on the actual API boundary to loosen the constraint if the user
wishes to do so.

----

Should be NFC.