### PR TITLE
[Frontend] Disable skipping any function bodies for SwiftOnoneSupport

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -128,7 +128,8 @@ ERROR(error_mode_cannot_emit_interface,none,
 ERROR(error_mode_cannot_emit_module_summary,none,
       "this mode does not support emitting module summary files", ())
 ERROR(cannot_emit_ir_skipping_function_bodies,none,
-      "-experimental-skip-*-function-bodies do not support emitting IR", ())
+      "the -experimental-skip-*-function-bodies* flags do not support "
+      "emitting IR", ())
 
 WARNING(emit_reference_dependencies_without_primary_file,none,
   "ignoring -emit-reference-dependencies (requires -primary-file)", ())
@@ -415,9 +416,9 @@ ERROR(expectation_missing_opening_braces,none,
 ERROR(expectation_missing_closing_braces,none,
       "didn't find '}}' to match '{{' in expectation", ())
 
-WARNING(module_incompatible_with_skip_non_inlinable_function_bodies,none,
-        "module '%0' cannot be built with "
-        "-experimental-skip-non-inlinable-function-bodies; this option has "
+WARNING(module_incompatible_with_skip_function_bodies,none,
+        "module '%0' cannot be built with any of the "
+        "-experimental-skip-*-function-bodies* flags; they have "
         "been automatically disabled", (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -744,15 +744,15 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_experimental_skip_all_function_bodies))
     Opts.SkipFunctionBodies = FunctionBodySkipping::All;
 
-  if (Opts.SkipFunctionBodies == FunctionBodySkipping::NonInlinable &&
+  if (Opts.SkipFunctionBodies != FunctionBodySkipping::None &&
       FrontendOpts.ModuleName == SWIFT_ONONE_SUPPORT) {
-    // Disable this optimization if we're compiling SwiftOnoneSupport, because
-    // we _definitely_ need to look inside every declaration to figure out
-    // what gets prespecialized.
+    // Disable these optimizations if we're compiling SwiftOnoneSupport,
+    // because we _definitely_ need to look inside every declaration to figure
+    // out what gets prespecialized.
     Opts.SkipFunctionBodies = FunctionBodySkipping::None;
     Diags.diagnose(
         SourceLoc(),
-        diag::module_incompatible_with_skip_non_inlinable_function_bodies,
+        diag::module_incompatible_with_skip_function_bodies,
         SWIFT_ONONE_SUPPORT);
   }
 

--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -7,12 +7,13 @@
 // RUN: not %target-swift-frontend -c %s -experimental-skip-non-inlinable-function-bodies-without-types %s 2>&1 | %FileCheck %s --check-prefix ERROR
 // RUN: not %target-swift-frontend -emit-ir %s -experimental-skip-all-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
 // RUN: not %target-swift-frontend -c %s -experimental-skip-all-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
-// ERROR: -experimental-skip-*-function-bodies do not support emitting IR
+// ERROR: the -experimental-skip-*-function-bodies* flags do not support emitting IR
 
-// Warn when trying to build SwiftONoneSupport with skip non-inlinable
-// function bodies enabled
+// Warn when trying to build SwiftONoneSupport with any skip enabled
 // RUN: %target-swift-frontend -typecheck -experimental-skip-non-inlinable-function-bodies -module-name SwiftOnoneSupport %s 2>&1 | %FileCheck %s --check-prefix WARNING
-// WARNING: module 'SwiftOnoneSupport' cannot be built with -experimental-skip-non-inlinable-function-bodies; this option has been automatically disabled
+// RUN: %target-swift-frontend -typecheck -experimental-skip-non-inlinable-function-bodies-without-types -module-name SwiftOnoneSupport %s 2>&1 | %FileCheck %s --check-prefix WARNING
+// RUN: %target-swift-frontend -typecheck -experimental-skip-all-function-bodies -module-name SwiftOnoneSupport %s 2>&1 | %FileCheck %s --check-prefix WARNING
+// WARNING: module 'SwiftOnoneSupport' cannot be built with any of the -experimental-skip-*-function-bodies* flags; they have been automatically disabled
 
 // Check skipped bodies are neither typechecked nor SILgen'd
 // RUN: %target-swift-frontend -emit-sil -emit-sorted-sil -experimental-skip-non-inlinable-function-bodies -debug-forbid-typecheck-prefix NEVERTYPECHECK -debug-forbid-typecheck-prefix INLINENOTYPECHECK %s -o %t/Skip.noninlinable.sil


### PR DESCRIPTION
I don't imagine this will ever be a real problem since only the non-inlinable function body skipping is used when compiling SwiftOnoneSupport. But since the intention seems to be to disable any skipping (which was previously just non-inlinable), I've changed the check to do that.