### PR TITLE
Emit Objective-C resilient class stubs for concrete subclasses of generic subclasses of NSObject

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1085,8 +1085,6 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
   
   std::string encodingString;
 
-  auto fnClangTy = fnType->getClangTypeInfo().getType();
-
   // Return type.
   {
     auto clangType = IGM.getClangType(resultType.getASTType());

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1636,7 +1636,7 @@ public:
   bool hasObjCResilientClassStub(ClassDecl *D);
 
   /// Emit a resilient class stub.
-  void emitObjCResilientClassStub(ClassDecl *D);
+  llvm::Constant *emitObjCResilientClassStub(ClassDecl *D, bool isPublic);
 
 private:
   llvm::Constant *

--- a/test/IRGen/class_update_callback_with_stub.swift
+++ b/test/IRGen/class_update_callback_with_stub.swift
@@ -105,7 +105,7 @@ import resilient_objc_class
 // -- ... but they do appear in the stub list
 
 // CHECK-LABEL: @objc_class_stubs = internal global
-// CHECK-SAME: @"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMs"
+// CHECK-SAME: @"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMt"
 // CHECK-SAME: , section "__DATA,__objc_stublist,regular,no_dead_strip"
 
 // -- The category list
@@ -128,7 +128,7 @@ import resilient_objc_class
 
 
 // -- Class symbol for NSObject-derived class points at the class stub
-// CHECK: @"OBJC_CLASS_$__TtC31class_update_callback_with_stub25ResilientNSObjectSubclass" = alias %objc_class_stub, %objc_class_stub* @"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMs"
+// CHECK: @"OBJC_CLASS_$__TtC31class_update_callback_with_stub25ResilientNSObjectSubclass" = alias %objc_class_stub, {{.*}} @"$s31class_update_callback_with_stub25ResilientNSObjectSubclassCMt"
 
 
 // -- Metadata update callbacks referenced from class stubs

--- a/test/IRGen/objc_generic_class_stub.swift
+++ b/test/IRGen/objc_generic_class_stub.swift
@@ -1,0 +1,19 @@
+
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+public class GenericNSObjectSubclass<T> : NSObject {}
+
+public class ConcreteNSObjectSubclass : GenericNSObjectSubclass<Int> {}
+
+// Note the stub here is internal; it's only purpose is to appear in the stub list
+// so that it can be realized by objc_copyClassList():
+
+// CHECK-LABEL: @"$s23objc_generic_class_stub24ConcreteNSObjectSubclassCMt" = internal global %objc_full_class_stub { i64 0, i64 1, %objc_class* (%objc_class*, i8*)* @"$s23objc_generic_class_stub24ConcreteNSObjectSubclassCMU" }
+
+// CHECK-LABEL: @objc_class_stubs = internal global {{.*}} @"$s23objc_generic_class_stub24ConcreteNSObjectSubclassCMt" {{.*}}, section "__DATA,__objc_stublist,regular,no_dead_strip"


### PR DESCRIPTION
Fixes <rdar://problem/71194117>.