### PR TITLE
Disable an assert in LinearLifetimeChecker pending design changes.

### DIFF
--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -551,9 +551,17 @@ LinearLifetimeChecker::Error LinearLifetimeChecker::checkValueImpl(
     Optional<function_ref<void(SILBasicBlock *)>> leakingBlockCallback,
     Optional<function_ref<void(Operand *)>>
         nonConsumingUseOutsideLifetimeCallback) {
-  assert((!consumingUses.empty()
-          || deadEndBlocks.isDeadEnd(value->getParentBlock())) &&
-         "Must have at least one consuming user?!");
+  // FIXME: rdar://71240363. This assert does not make sense because
+  // consumingUses in some cases only contains the destroying uses. Owned values
+  // may not be destroyed because they may be converted to
+  // ValueOwnershipKind::None on all paths reaching a return. Instead, this
+  // utility needs to find liveness first considering all uses (or at least all
+  // uses that may be on a lifetime boundary). We probably then won't need this
+  // assert, but I'm leaving the FIXME as a placeholder for that work.
+  //
+  // assert((!consumingUses.empty()
+  //        || deadEndBlocks.isDeadEnd(value->getParentBlock())) &&
+  //       "Must have at least one consuming user?!");
 
   State state(value, visitedBlocks, errorBuilder, leakingBlockCallback,
               nonConsumingUseOutsideLifetimeCallback, consumingUses,


### PR DESCRIPTION
This assert does not make sense because consumingUses in some cases
only contains the destroying uses. Owned values may not be destroyed
because they may be converted to ValueOwnershipKind::None on all paths
reaching a return. Instead, this utility needs to find liveness first
considering all uses (or at least all uses that may be on a lifetime
boundary). We probably then won't need this assert, but I'm leaving
the FIXME as a placeholder for that work.

Fixes rdar://71240363.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
