### PR TITLE
Sema: Fix source range of 'lazy' property getter

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1361,7 +1361,8 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
 
   Body.push_back(new (Ctx) ReturnStmt(SourceLoc(), Tmp2DRE, /*implicit*/true));
 
-  return { BraceStmt::create(Ctx, VD->getLoc(), Body, VD->getLoc(),
+  auto Range = InitValue->getSourceRange();
+  return { BraceStmt::create(Ctx, Range.Start, Body, Range.End,
                              /*implicit*/true),
            /*isTypeChecked=*/true };
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar70732736.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar70732736.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+struct Horse {}
+
+class Reproducer {
+    lazy var barn: Any = {
+        class Barn {
+            var horse: Horse {
+                return Horse()
+            }
+        }
+        return Barn()
+    }()
+}
+


### PR DESCRIPTION
The source range of the getter's body was set incorrectly;
both the start and the end were the property's location.

Instead, let's use the source range of the initializer
expression, which fixes an assertion in name lookup.

Fixes <rdar://problem/70732736>.