### PR TITLE
Sema: Still diagnose '@objc' even if Foundation was imported

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1051,25 +1051,25 @@ static void diagnoseObjCAttrWithoutFoundation(ObjCAttr *attr, Decl *decl) {
     return;
 
   auto &ctx = SF->getASTContext();
-  if (ctx.LangOpts.EnableObjCInterop) {
-    // Don't diagnose in a SIL file.
-    if (SF->Kind == SourceFileKind::SIL)
-      return;
 
-    // Don't diagnose for -disable-objc-attr-requires-foundation-module.
-    if (!ctx.LangOpts.EnableObjCAttrRequiresFoundation)
-      return;
+  if (!ctx.LangOpts.EnableObjCInterop) {
+    ctx.Diags.diagnose(attr->getLocation(), diag::objc_interop_disabled)
+      .fixItRemove(attr->getRangeWithAt());
+    return;
   }
+
+  // Don't diagnose in a SIL file.
+  if (SF->Kind == SourceFileKind::SIL)
+    return;
+
+  // Don't diagnose for -disable-objc-attr-requires-foundation-module.
+  if (!ctx.LangOpts.EnableObjCAttrRequiresFoundation)
+    return;
 
   // If we have the Foundation module, @objc is okay.
   auto *foundation = ctx.getLoadedModule(ctx.Id_Foundation);
   if (foundation && ctx.getImportCache().isImportedBy(foundation, SF))
     return;
-
-  if (!ctx.LangOpts.EnableObjCInterop) {
-    ctx.Diags.diagnose(attr->getLocation(), diag::objc_interop_disabled)
-      .fixItRemove(attr->getRangeWithAt());
-  }
 
   ctx.Diags.diagnose(attr->getLocation(),
                      diag::attr_used_without_required_module, attr,

--- a/test/SourceKit/Sema/objc_attr_without_import.swift
+++ b/test/SourceKit/Sema/objc_attr_without_import.swift
@@ -2,7 +2,7 @@
 // RUN: %FileCheck -input-file=%t.response %s
 // This tests that we are not crashing in SILGen.
 
-// CHECK: @objc attribute used without importing module
+// CHECK: {{Objective-C interoperability is disabled|@objc attribute used without importing module}}
 @objc protocol Communicate {
   var name: String { get }
 }

--- a/validation-test/compiler_crashers_2_fixed/sr13713.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13713.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -disable-objc-interop -module-name Foundation
+
+// Make sure we diagnose this even if the current module is named 'Foundation':
+@objc protocol Horse { // expected-error {{Objective-C interoperability is disabled}}
+  func ride()
+}
+
+func rideHorse(_ horse: Horse) {
+  horse.ride()
+}


### PR DESCRIPTION
We checked for an import of a module named 'Foundation' before
checking if Objective-C interoperability was enabled, which
would lead to hilarious results.

Fixes <https://bugs.swift.org/browse/SR-13713> / <rdar://problem/70140319>.