### PR TITLE
[AutoDiff] NFC: Add negative tests for library evolution mode crashers.

### DIFF
--- a/test/AutoDiff/compiler_crashers/sr13865-library-evolution-mode-crasher-property-differentiation.swift
+++ b/test/AutoDiff/compiler_crashers/sr13865-library-evolution-mode-crasher-property-differentiation.swift
@@ -1,0 +1,66 @@
+// RUN: not --crash %target-swift-frontend -c -enable-library-evolution %s
+// REQUIRES: asserts
+
+// SR-13865: AutoDiff crasher on property derivatives in library evolution mode.
+
+import _Differentiation
+
+public struct Struct: Differentiable {
+  var stored: Float
+
+  // Test property.
+  @differentiable
+  public var property: Float {
+    stored
+  }
+}
+
+// Assertion failed: ((!dyn_cast_or_null<VarDecl>(Loc.getAsASTNode<Decl>()) || Var) && "location is a VarDecl, but SILDebugVariable is empty"), function createAllocStack, file .../swift/include/swift/SIL/SILBuilder.h, line 418.
+// Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project and the crash backtrace.
+// Stack dump:
+// 0.	Program arguments: swift-frontend -c test2.swift -enable-library-evolution
+// 1.	Swift version 5.3-dev (LLVM f681f671e2e9538, Swift 36090faaded56c2)
+// 2.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for test2.test2)
+// 3.	While running pass #157 SILModuleTransform "Differentiation".
+// 4.	While processing // differentiability witness for Struct.property.getter
+// sil_differentiability_witness [serialized] [parameters 0] [results 0] @$s5test26StructV8propertySfvg : $@convention(method) (@in_guaranteed Struct) -> Float {
+// }
+// 
+//  on SIL function "@$s5test26StructV8propertySfvg".
+//  for getter for property (at test2.swift:8:14)
+// 5.	While generating VJP for SIL function "@$s5test26StructV8propertySfvg".
+//  for getter for property (at test2.swift:8:14)
+// 6.	While generating pullback for SIL function "@$s5test26StructV8propertySfvg".
+//  for getter for property (at test2.swift:8:14)
+// 0  swift-frontend           0x000000010de4a185 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
+// 1  swift-frontend           0x000000010de490c8 llvm::sys::RunSignalHandlers() + 248
+// 2  swift-frontend           0x000000010de4a766 SignalHandler(int) + 262
+// 3  libsystem_platform.dylib 0x00007fff2035bd7d _sigtramp + 29
+// 4  libsystem_platform.dylib 000000000000000000 _sigtramp + 18446603339975770784
+// 5  libsystem_c.dylib        0x00007fff2026c741 abort + 120
+// 6  libsystem_c.dylib        0x00007fff2026bb18 err + 0
+// 7  swift-frontend           0x000000010e1cb063 swift::SILBuilder::createAllocStack(swift::SILLocation, swift::SILType, llvm::Optional<swift::SILDebugVariable>, bool) (.cold.2) + 35
+// 8  swift-frontend           0x000000010a06716b swift::SILBuilder::createAllocStack(swift::SILLocation, swift::SILType, llvm::Optional<swift::SILDebugVariable>, bool) + 315
+// 9  swift-frontend           0x0000000109af96d3 swift::autodiff::PullbackCloner::Implementation::visitLoadOperation(swift::SingleValueInstruction*) + 275
+// 10 swift-frontend           0x0000000109aec37b swift::autodiff::PullbackCloner::Implementation::visit(swift::SILInstruction*) + 203
+// 11 swift-frontend           0x0000000109ae8196 swift::autodiff::PullbackCloner::Implementation::visitSILBasicBlock(swift::SILBasicBlock*) + 838
+// 12 swift-frontend           0x0000000109ae5504 swift::autodiff::PullbackCloner::Implementation::run() + 7268
+// 13 swift-frontend           0x0000000109b077d3 swift::autodiff::VJPCloner::Implementation::run() + 1539
+// 14 swift-frontend           0x0000000109c4e0b4 (anonymous namespace)::DifferentiationTransformer::canonicalizeDifferentiabilityWitness(swift::SILFunction*, swift::SILDifferentiabilityWitness*, swift::autodiff::DifferentiationInvoker, swift::IsSerialized_t) + 7172
+// 15 swift-frontend           0x0000000109c4bafa (anonymous namespace)::Differentiation::run() + 1530
+// 16 swift-frontend           0x0000000109c9c86e swift::SILPassManager::runModulePass(unsigned int) + 558
+// 17 swift-frontend           0x0000000109ca144a swift::SILPassManager::execute() + 666
+// 18 swift-frontend           0x0000000109c996a8 swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) + 72
+// 19 swift-frontend           0x0000000109c99643 swift::ExecuteSILPipelineRequest::evaluate(swift::Evaluator&, swift::SILPipelineExecutionDescriptor) const + 51
+// 20 swift-frontend           0x0000000109cbc83d swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::evaluateRequest(swift::ExecuteSILPipelineRequest const&, swift::Evaluator&) + 29
+// 21 swift-frontend           0x0000000109ca3a37 llvm::Expected<swift::ExecuteSILPipelineRequest::OutputType> swift::Evaluator::getResultUncached<swift::ExecuteSILPipelineRequest>(swift::ExecuteSILPipelineRequest const&) + 375
+// 22 swift-frontend           0x0000000109c998d4 swift::executePassPipelinePlan(swift::SILModule*, swift::SILPassPipelinePlan const&, bool, swift::irgen::IRGenModule*) + 68
+// 23 swift-frontend           0x0000000109ca6507 swift::runSILDiagnosticPasses(swift::SILModule&) + 87
+// 24 swift-frontend           0x00000001096dd7bc swift::CompilerInstance::performSILProcessing(swift::SILModule*) + 60
+// 25 swift-frontend           0x00000001095c4aa5 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 901
+// 26 swift-frontend           0x00000001095c44fc performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 636
+// 27 swift-frontend           0x00000001095ba328 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 4632
+// 28 swift-frontend           0x0000000109551fee main + 846
+// 29 libdyld.dylib            0x00007fff20332689 start + 1
+// 30 libdyld.dylib            0x0000000000000004 start + 18446603339975940476
+// [1]    21458 abort      xcrun $SWIFT_NINJA_BUILD_DIR/bin/swift-frontend -c test2.swift

--- a/test/AutoDiff/compiler_crashers/sr13866-library-evolution-mode-tbdgen-crasher-protocool-requirement.swift
+++ b/test/AutoDiff/compiler_crashers/sr13866-library-evolution-mode-tbdgen-crasher-protocool-requirement.swift
@@ -1,0 +1,46 @@
+// RUN: not --crash %target-swift-frontend -c -enable-library-evolution %s
+// REQUIRES: asserts
+
+// SR-13865: AutoDiff crasher on property derivatives in library evolution mode.
+
+import _Differentiation
+
+public protocol P: Differentiable {
+    @differentiable(wrt: self)
+    func foo(_ input: Float) -> Float
+}
+
+// TBDGen duplicate symbol: ...
+// Assertion failed: (false && "TBDGen symbol appears twice"), function addSymbolInternal, file .../swift/lib/TBDGen/TBDGen.cpp, line 79.
+// Stack dump:
+// 0.	Program arguments: swift-frontend -c test.swift -enable-library-evolution
+// 1.	Swift version 5.3-dev (LLVM 618cb952e0f199a, Swift db830811093c5d2)
+// 2.	While evaluating request PublicSymbolsRequest(Generate TBD for module test.test)
+// 0  swift-frontend           0x000000010d5fb0e5 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
+// 1  swift-frontend           0x000000010d5fa028 llvm::sys::RunSignalHandlers() + 248
+// 2  swift-frontend           0x000000010d5fb6c6 SignalHandler(int) + 262
+// 3  libsystem_platform.dylib 0x00007fff203dad7d _sigtramp + 29
+// 4  libsystem_platform.dylib 000000000000000000 _sigtramp + 18446603339975250592
+// 5  libsystem_c.dylib        0x00007fff202e9720 abort + 120
+// 6  libsystem_c.dylib        0x00007fff202e89d6 err + 0
+// 7  swift-frontend           0x000000010d76f5d7 swift::tbdgen::TBDGenVisitor::addSymbolInternal(llvm::StringRef, llvm::MachO::SymbolKind, swift::SymbolSource) (.cold.1) + 87
+// 8  swift-frontend           0x00000001090e084f swift::tbdgen::TBDGenVisitor::addSymbolInternal(llvm::StringRef, llvm::MachO::SymbolKind, swift::SymbolSource) + 111
+// 9  swift-frontend           0x00000001090e3287 swift::tbdgen::TBDGenVisitor::addSymbol(llvm::StringRef, swift::SymbolSource, llvm::MachO::SymbolKind) + 119
+// 10 swift-frontend           0x00000001090e34f0 swift::tbdgen::TBDGenVisitor::addDispatchThunk(swift::SILDeclRef) + 272
+// 11 swift-frontend           0x00000001090ea556 swift::SILWitnessVisitor<swift::tbdgen::TBDGenVisitor::visitProtocolDecl(swift::ProtocolDecl*)::WitnessVisitor>::addAutoDiffDerivativeMethodsIfRequired(swift::AbstractFunctionDecl*, swift::SILDeclRef::Kind) + 326
+// 12 swift-frontend           0x00000001090ea086 swift::SILWitnessVisitor<swift::tbdgen::TBDGenVisitor::visitProtocolDecl(swift::ProtocolDecl*)::WitnessVisitor>::visitProtocolDecl(swift::ProtocolDecl*) + 934
+// 13 swift-frontend           0x00000001090e786b swift::tbdgen::TBDGenVisitor::visitProtocolDecl(swift::ProtocolDecl*) + 283
+// 14 swift-frontend           0x00000001090e6c82 swift::tbdgen::TBDGenVisitor::visit(swift::Decl*) + 274
+// 15 swift-frontend           0x00000001090e7e7b swift::tbdgen::TBDGenVisitor::visitFile(swift::FileUnit*) + 283
+// 16 swift-frontend           0x00000001090e817c swift::tbdgen::TBDGenVisitor::visit(swift::TBDGenDescriptor const&) + 620
+// 17 swift-frontend           0x00000001090e88ca swift::PublicSymbolsRequest::evaluate(swift::Evaluator&, swift::TBDGenDescriptor) const + 250
+// 18 swift-frontend           0x00000001090ef0ed swift::SimpleRequest<swift::PublicSymbolsRequest, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > (swift::TBDGenDescriptor), (swift::RequestFlags)1>::evaluateRequest(swift::PublicSymbolsRequest const&, swift::Evaluator&) + 77
+// 19 swift-frontend           0x00000001090ebeee llvm::Expected<swift::PublicSymbolsRequest::OutputType> swift::Evaluator::getResultUncached<swift::PublicSymbolsRequest>(swift::PublicSymbolsRequest const&) + 494
+// 20 swift-frontend           0x00000001090e8977 swift::getPublicSymbols(swift::TBDGenDescriptor) + 135
+// 21 swift-frontend           0x0000000108d98481 swift::validateTBD(swift::ModuleDecl*, llvm::Module const&, swift::TBDGenOptions const&, bool) + 97
+// 22 swift-frontend           0x0000000108d8362d performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 2925
+// 23 swift-frontend           0x0000000108d8289c performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 636
+// 24 swift-frontend           0x0000000108d7ae31 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 4625
+// 25 swift-frontend           0x0000000108d127fe main + 846
+// 26 libdyld.dylib            0x00007fff203b1631 start + 1
+// [1]    77664 abort      xcrun $SWIFT_NINJA_BUILD_DIR/bin/swift-frontend -c test.swift


### PR DESCRIPTION
Add negative tests for SR-13865 and SR-13866.