### PR TITLE
[Concurrency] Annotate closures with their actor isolation.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3553,6 +3553,79 @@ public:
   }
 };
 
+/// Actor isolation for a closure.
+class ClosureActorIsolation {
+public:
+  enum Kind {
+    /// The closure is independent of any actor.
+    Independent,
+
+    /// The closure is tied to the actor instance described by the given
+    /// \c VarDecl*, which is the (captured) `self` of an actor.
+    ActorInstance,
+
+    /// The closure is tied to the global actor described by the given type.
+    GlobalActor,
+  };
+
+private:
+    /// The actor to which this closure is isolated.
+    ///
+    /// There are three possible states:
+    ///   - NULL: The closure is independent of any actor.
+    ///   - VarDecl*: The 'self' variable for the actor instance to which
+    ///     this closure is isolated. It will always have a type that conforms
+    ///     to the \c Actor protocol.
+    ///   - Type: The type of the global actor on which
+  llvm::PointerUnion<VarDecl *, Type> storage;
+
+  ClosureActorIsolation(VarDecl *selfDecl) : storage(selfDecl) { }
+  ClosureActorIsolation(Type globalActorType) : storage(globalActorType) { }
+
+public:
+  ClosureActorIsolation() : storage() { }
+
+  static ClosureActorIsolation forIndependent() {
+    return ClosureActorIsolation();
+  }
+
+  static ClosureActorIsolation forActorInstance(VarDecl *selfDecl) {
+    return ClosureActorIsolation(selfDecl);
+  }
+
+  static ClosureActorIsolation forGlobalActor(Type globalActorType) {
+    return ClosureActorIsolation(globalActorType);
+  }
+
+  /// Determine the kind of isolation.
+  Kind getKind() const {
+    if (storage.isNull())
+      return Kind::Independent;
+
+    if (storage.is<VarDecl *>())
+      return Kind::ActorInstance;
+
+    return Kind::GlobalActor;
+  }
+
+  /// Whether the closure is isolated at all.
+  explicit operator bool() const {
+    return getKind() != Kind::Independent;
+  }
+
+  /// Whether the closure is isolated at all.
+  operator Kind() const {
+    return getKind();
+  }
+
+  VarDecl *getActorInstance() const {
+    return storage.dyn_cast<VarDecl *>();
+  }
+
+  Type getGlobalActor() const {
+    return storage.dyn_cast<Type>();
+  }
+};
 
 /// A base class for closure expressions.
 class AbstractClosureExpr : public DeclContext, public Expr {
@@ -3560,6 +3633,9 @@ class AbstractClosureExpr : public DeclContext, public Expr {
 
   /// The set of parameters.
   ParameterList *parameterList;
+
+  /// Actor isolation of the closure.
+  ClosureActorIsolation actorIsolation;
 
 public:
   AbstractClosureExpr(ExprKind Kind, Type FnType, bool Implicit,
@@ -3624,6 +3700,12 @@ public:
   ///
   /// Only valid when \c hasSingleExpressionBody() is true.
   Expr *getSingleExpressionBody() const;
+
+  ClosureActorIsolation getActorIsolation() const { return actorIsolation; }
+
+  void setActorIsolation(ClosureActorIsolation actorIsolation) {
+    this->actorIsolation = actorIsolation;
+  }
 
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_AbstractClosureExpr &&

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2505,6 +2505,22 @@ public:
     printCommon(E, name);
     PrintWithColorRAII(OS, DiscriminatorColor)
       << " discriminator=" << E->getDiscriminator();
+
+    switch (auto isolation = E->getActorIsolation()) {
+    case ClosureActorIsolation::Independent:
+      break;
+
+    case ClosureActorIsolation::ActorInstance:
+      PrintWithColorRAII(OS, CapturesColor) << " actor-isolated="
+        << isolation.getActorInstance()->printRef();
+      break;
+
+    case ClosureActorIsolation::GlobalActor:
+      PrintWithColorRAII(OS, CapturesColor) << " global-actor-isolated="
+        << isolation.getGlobalActor().getString();
+      break;
+    }
+
     if (!E->getCaptureInfo().isTrivial()) {
       OS << " ";
       E->getCaptureInfo().print(PrintWithColorRAII(OS, CapturesColor).getOS());

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4612,7 +4612,6 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   if (ctx.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(DC, E);
   diagnoseConstantArgumentRequirement(E, DC);
-  checkActorIsolation(E, DC);
 }
 
 void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -22,14 +22,19 @@
 
 namespace swift {
 
+class AbstractFunctionDecl;
 class ActorIsolation;
 class ASTContext;
 class ClassDecl;
 class ConcreteDeclRef;
 class Decl;
 class DeclContext;
+class EnumElementDecl;
 class Expr;
 class FuncDecl;
+class Initializer;
+class PatternBindingDecl;
+class TopLevelCodeDecl;
 class TypeBase;
 class ValueDecl;
 
@@ -38,7 +43,12 @@ class ValueDecl;
 void addAsyncNotes(FuncDecl *func);
 
 /// Check actor isolation rules.
-void checkActorIsolation(const Expr *expr, const DeclContext *dc);
+void checkTopLevelActorIsolation(TopLevelCodeDecl *decl);
+void checkFunctionActorIsolation(AbstractFunctionDecl *decl);
+void checkInitializerActorIsolation(Initializer *init, Expr *expr);
+void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
+void checkPropertyWrapperActorIsolation(
+    PatternBindingDecl *binding, Expr *expr);
 
 /// The isolation restriction in effect for a given declaration that is
 /// referenced from source.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1201,6 +1201,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
       if (TypeChecker::typeCheckExpression(
               exprToCheck, ED,
               /*contextualInfo=*/{rawTy, CTP_EnumCaseRawValue})) {
+        checkEnumElementActorIsolation(elt, exprToCheck);
         TypeChecker::checkEnumElementEffects(elt, exprToCheck);
       }
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -910,12 +910,13 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), ErrorType::get(ctx));
   }
 
-  checkInitializerActorIsolation(dc, initExpr);
-  TypeChecker::checkInitializerEffects(dc, initExpr);
-
   // Walk the checked initializer and contextualize any closures
   // we saw there.
   TypeChecker::contextualizeInitializer(dc, initExpr);
+
+  checkInitializerActorIsolation(dc, initExpr);
+  TypeChecker::checkInitializerEffects(dc, initExpr);
+
   return initExpr;
 }
 
@@ -1746,10 +1747,9 @@ public:
           auto *initContext = cast_or_null<PatternBindingInitializer>(
               PBD->getInitContext(i));
           if (initContext) {
-            // Check safety of error-handling in the declaration, too.
+            TypeChecker::contextualizeInitializer(initContext, init);
             checkInitializerActorIsolation(initContext, init);
             TypeChecker::checkInitializerEffects(initContext, init);
-            TypeChecker::contextualizeInitializer(initContext, init);
           }
         }
       }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -910,6 +910,7 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), ErrorType::get(ctx));
   }
 
+  checkInitializerActorIsolation(dc, initExpr);
   TypeChecker::checkInitializerEffects(dc, initExpr);
 
   // Walk the checked initializer and contextualize any closures
@@ -1746,6 +1747,7 @@ public:
               PBD->getInitContext(i));
           if (initContext) {
             // Check safety of error-handling in the declaration, too.
+            checkInitializerActorIsolation(initContext, init);
             TypeChecker::checkInitializerEffects(initContext, init);
             TypeChecker::contextualizeInitializer(initContext, init);
           }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -16,6 +16,7 @@
 
 #include "TypeChecker.h"
 #include "TypeCheckAvailability.h"
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckType.h"
 #include "MiscDiagnostics.h"
 #include "swift/Subsystems.h"
@@ -2066,6 +2067,7 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
   if (!hadError)
     performAbstractFuncDeclDiagnostics(AFD);
 
+  checkFunctionActorIsolation(AFD);
   TypeChecker::checkFunctionEffects(AFD);
   TypeChecker::computeCaptures(AFD);
 
@@ -2108,6 +2110,7 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   BraceStmt *Body = TLCD->getBody();
   StmtChecker(TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
+  checkTopLevelActorIsolation(TLCD);
   checkTopLevelEffects(TLCD);
   performTopLevelDeclDiagnostics(TLCD);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2067,9 +2067,9 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
   if (!hadError)
     performAbstractFuncDeclDiagnostics(AFD);
 
+  TypeChecker::computeCaptures(AFD);
   checkFunctionActorIsolation(AFD);
   TypeChecker::checkFunctionEffects(AFD);
-  TypeChecker::computeCaptures(AFD);
 
   return hadError ? errorBody() : body;
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -18,6 +18,7 @@
 #include "CodeSynthesis.h"
 #include "TypeChecker.h"
 #include "TypeCheckAvailability.h"
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckDecl.h"
 #include "TypeCheckType.h"
 #include "swift/AST/ASTContext.h"
@@ -2508,6 +2509,7 @@ static void typeCheckSynthesizedWrapperInitializer(
           dyn_cast_or_null<Initializer>(pbd->getInitContext(i))) {
     TypeChecker::contextualizeInitializer(initializerContext, initializer);
   }
+  checkPropertyWrapperActorIsolation(pbd, initializer);
   TypeChecker::checkPropertyWrapperEffects(pbd, initializer);
 }
 

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-frontend -dump-ast %s -enable-experimental-concurrency | %FileCheck %s
+// REQUIRES: concurrency
+
+func acceptClosure<T>(_: () -> T) { }
+func acceptEscapingClosure<T>(_: @escaping () -> T) { }
+
+func acceptAsyncClosure<T>(_: () async -> T) { }
+func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
+
+actor class MyActor {
+  func method() async -> String { "" }
+}
+
+extension MyActor {
+  // CHECK-LABEL: testClosureIsolation
+  func testClosureIsolation() async {
+    // CHECK: acceptAsyncClosure
+    // CHECK: closure_expr
+    // CHECK-SAME: actor-isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
+    acceptAsyncClosure { await method() }
+
+    // CHECK: acceptAsyncClosure
+    // CHECK: closure_expr
+    // CHECK-NOT: actor-isolated
+    acceptAsyncClosure { () async in print("hello") }
+
+    // CHECK: acceptEscapingAsyncClosure
+    // CHECK: closure_expr
+    // CHECK-NOT: actor-isolated
+    acceptEscapingAsyncClosure { await self.method() }
+
+    // CHECK: acceptEscapingAsyncClosure
+    // CHECK: closure_expr
+    // CHECK-NOT:actor-isolated
+    acceptEscapingAsyncClosure { () async in print("hello") }
+  }
+}
+
+actor class SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+func someAsyncFunc() async { }
+
+// CHECK-LABEL: someGlobalActorFunc
+@SomeGlobalActor func someGlobalActorFunc() async {
+  // CHECK: acceptAsyncClosure
+  // CHECK: closure_expr
+  // CHECK-SAME: global-actor-isolated=SomeGlobalActor
+  acceptAsyncClosure { await someAsyncFunc() }
+
+  // CHECK: acceptAsyncClosure
+  // CHECK: closure_expr
+  // CHECK-SAME: global-actor-isolated=SomeGlobalActor
+  acceptAsyncClosure { () async in print("hello") }
+
+  // CHECK: acceptEscapingAsyncClosure
+  // CHECK: closure_expr
+  // CHECK-NOT: actor-isolated
+  acceptEscapingAsyncClosure { await someAsyncFunc() }
+
+  // CHECK: acceptEscapingAsyncClosure
+  // CHECK: closure_expr
+  // CHECK-NOT:actor-isolated
+  acceptEscapingAsyncClosure { () async in print("hello") }
+
+}


### PR DESCRIPTION
Compute the actor isolation for every closure, noting whether it is
part of an actor instance (and which 'self' variable describes the
instance), global actor, or independent of any actor. This information
is required for propertly generating `hop_to_executor` instructions in
SIL.

Fixes rdar://71126554.