### PR TITLE
[Concurrency] Introduce a small executable test using asynchronous futures

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -146,6 +146,11 @@ extension Task {
     public func cancel() {
       Builtin.cancelAsyncTask(task)
     }
+
+    @available(*, deprecated, message: "This is a temporary hack")
+    public func run() {
+      runTask(task)
+    }
   }
 }
 
@@ -267,9 +272,6 @@ extension Task {
     let (task, context) =
       Builtin.createAsyncTaskFuture(flags.bits, nil, operation)
 
-    // FIXME: Launch the task on an executor... somewhere....
-    runTask(task)
-
     return Handle<T>(task: task)
   }
 
@@ -316,11 +318,6 @@ extension Task {
     // Create the asynchronous task future.
     let (task, context) =
       Builtin.createAsyncTaskFuture(flags.bits, nil, operation)
-
-    print(task)
-
-    // FIXME: Launch the task on an executor... somewhere....
-    runTask(task)
 
     return Handle<T>(task: task)
   }

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -1,0 +1,40 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+import Dispatch
+
+extension DispatchQueue {
+  func async<R>(execute: @escaping () async -> R) -> Task.Handle<R> {
+    let handle = Task.runDetached(operation: execute)
+
+    // Run the task
+    _ = { self.async { handle.run() } }()
+
+    return handle
+  }
+}
+
+func test(name: String) {
+  let taskHandle = DispatchQueue.main.async { () async -> String in
+    return "Hello \(name) from async world"
+  }
+
+  _ = DispatchQueue.main.async { () async in
+    // CHECK: Sleeping
+    print("Sleeping...")
+    sleep(2)
+    let result = await try! taskHandle.get()
+    // CHECK: Hello Ted from async world
+    print(result)
+    assert(result == "Hello Ted from async world")
+    exit(0)
+  }
+
+  print("Main task")
+}
+
+test(name: "Ted")
+
+dispatchMain()

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -16,9 +16,14 @@ extension DispatchQueue {
   }
 }
 
+func formGreeting(name: String) async -> String {
+  return "Hello \(name) from async world"
+}
+
 func test(name: String) {
   let taskHandle = DispatchQueue.main.async { () async -> String in
-    return "Hello \(name) from async world"
+    let greeting = await formGreeting(name: name)
+    return greeting + "!"
   }
 
   _ = DispatchQueue.main.async { () async in
@@ -28,7 +33,7 @@ func test(name: String) {
     let result = await try! taskHandle.get()
     // CHECK: Hello Ted from async world
     print(result)
-    assert(result == "Hello Ted from async world")
+    assert(result == "Hello Ted from async world!")
     exit(0)
   }
 


### PR DESCRIPTION
Rather than immediately running the task synchronously within
runDetached, return the handle to the newly-created task. Add a method
task.Handle.run() to execute the task. This is just a temporary hack
that should not persist in the API, but it lets us launch tasks on a
particular Dispatch queue:

```swift
extension DispatchQueue {
  func async<R>(execute: @escaping () async -> R) -> Task.Handle<R> {
    let handle = Task.runDetached(operation: execute)

    // Run the task
    _ = { self.async { handle.run() } }()

    return handle
  }
}
```

One can pass asynchronous work to DispatchQueue.async, which will
schedule that work on the dispatch queue and return a handle. Another
asynchronous task can then read the result.

Yay for rdar://71125519.
