### PR TITLE
Temporarily disable IRGen/objc_generic_class_stub.swift

### DIFF
--- a/test/IRGen/objc_generic_class_stub.swift
+++ b/test/IRGen/objc_generic_class_stub.swift
@@ -5,6 +5,8 @@
 
 // REQUIRES: objc_interop
 
+// REQUIRES: rdar71476765
+
 import Foundation
 
 public class GenericNSObjectSubclass<T> : NSObject {}


### PR DESCRIPTION
Broken by:
Emit Objective-C resilient class stubs for concrete
subclasses of generic subclasses of NSObject #34766
https://github.com/apple/swift/pull/34766

Workaround for rdar://71476765

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
