### PR TITLE
[sil] Add a small helper to SILBuilder to get the loc of the builder's current insertion point.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -268,8 +268,9 @@ public:
   //===--------------------------------------------------------------------===//
 
   bool hasValidInsertionPoint() const { return BB != nullptr; }
-  SILBasicBlock *getInsertionBB() { return BB; }
-  SILBasicBlock::iterator getInsertionPoint() { return InsertPt; }
+  SILBasicBlock *getInsertionBB() const { return BB; }
+  SILBasicBlock::iterator getInsertionPoint() const { return InsertPt; }
+  SILLocation getInsertionPointLoc() const { return InsertPt->getLoc(); }
 
   /// insertingAtEndOfBlock - Return true if the insertion point is at the end
   /// of the current basic block.  False if we're inserting before an existing
@@ -319,8 +320,6 @@ public:
   void setInsertionPoint(SILFunction::iterator BBIter) {
     setInsertionPoint(&*BBIter);
   }
-
-  SILBasicBlock *getInsertionPoint() const { return BB; }
 
   //===--------------------------------------------------------------------===//
   // Instruction Tracking


### PR DESCRIPTION
I also added const to a few methods as well.

This is useful when using:

```
SILBuilderWithScope::insertAfter(function_ref<void (SILBuilder)>)
```

to create instructions using the SILBuilder's insertion point's loc.
