### PR TITLE
[ownership] Teach CanonicalizeInstruction how to eliminate trivial copies/borrows.

### DIFF
--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -347,31 +347,29 @@ func testArrayUninitializedIntrinsicNested(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
 // CHECK: [ACTIVE]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %15 = apply %14<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   [[ARRAY:%.*]] = apply %14<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 // CHECK: [USEFUL]   %17 = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %19 = apply %18<Float>(%17) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%20**, %21) = destructure_tuple %19 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%20, **%21**) = destructure_tuple %19 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [ACTIVE]   %22 = pointer_to_address %21 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [ACTIVE]   %23 = begin_borrow %15 : $Array<Float>
-// CHECK: [USEFUL]   %24 = integer_literal $Builtin.IntLiteral, 0
-// CHECK: [USEFUL]   %25 = metatype $@thin Int.Type
+// CHECK: [USEFUL]   %23 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %24 = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %27 = apply %26(%24, %25) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   %26 = apply %25(%23, %24) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %29 = apply %28<Float>(%22, %27, %23) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
-// CHECK: [VARIED]   %30 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %31 = index_addr %22 : $*Float, %30 : $Builtin.Word
-// CHECK: [ACTIVE]   %32 = begin_borrow %15 : $Array<Float>
-// CHECK: [USEFUL]   %33 = integer_literal $Builtin.IntLiteral, 1
-// CHECK: [USEFUL]   %34 = metatype $@thin Int.Type
+// CHECK: [NONE]   %28 = apply %27<Float>(%22, %26, %15) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [VARIED]   %29 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %30 = index_addr %22 : $*Float, %29 : $Builtin.Word
+// CHECK: [USEFUL]   %31 = integer_literal $Builtin.IntLiteral, 1
+// CHECK: [USEFUL]   %32 = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %36 = apply %35(%33, %34) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   %34 = apply %33(%31, %32) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %38 = apply %37<Float>(%31, %36, %32) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [NONE]   %36 = apply %35<Float>(%30, %34, %15) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %40 = apply %39<Float>(%20) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %38 = apply %37<Float>(%20) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 // TF-978: Test array literal initialized with `apply` indirect results.
 struct Wrapper<T: Differentiable>: Differentiable {
@@ -733,16 +731,13 @@ func testClassModifyAccessor(_ c: inout C) {
 // CHECK: [VARIED]   %4 = load [copy] %3 : $*C
 // CHECK: [ACTIVE]   %6 = begin_access [read] [static] %0 : $*C
 // CHECK: [VARIED]   %7 = load [copy] %6 : $*C
-// CHECK: [VARIED]   %9 = begin_borrow %7 : $C
-// CHECK: [VARIED]   %10 = class_method %9 : $C, #C.float!getter : (C) -> () -> Float, $@convention(method) (@guaranteed C) -> Float
-// CHECK: [VARIED]   %11 = apply %10(%9) : $@convention(method) (@guaranteed C) -> Float
-// CHECK: [VARIED]   %14 = begin_borrow %4 : $C
-// CHECK: [VARIED]   %15 = class_method %14 : $C, #C.float!modify : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Float
-// CHECK: [VARIED] (**%16**, %17) = begin_apply %15(%14) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Float
-// CHECK: [VARIED] (%16, **%17**) = begin_apply %15(%14) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Float
+// CHECK: [VARIED]   %9 = class_method %7 : $C, #C.float!getter : (C) -> () -> Float, $@convention(method) (@guaranteed C) -> Float
+// CHECK: [VARIED]   %10 = apply %9(%7) : $@convention(method) (@guaranteed C) -> Float
+// CHECK: [VARIED]   %12 = class_method %4 : $C, #C.float!modify : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Float
+// CHECK: [VARIED] (**%13**, %14) = begin_apply %12(%4) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Float
+// CHECK: [VARIED] (%13, **%14**) = begin_apply %12(%4) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Float
 // CHECK: [NONE]   // function_ref static Float.*= infix(_:_:)
-// CHECK: [NONE]   %19 = apply %18(%16, %11, %2) : $@convention(method) (@inout Float, Float, @thin Float.Type) -> ()
-// CHECK: [NONE]   %23 = tuple ()
+// CHECK: [NONE]   %16 = apply %15(%13, %10, %2) : $@convention(method) (@inout Float, Float, @thin Float.Type) -> ()
 
 //===----------------------------------------------------------------------===//
 // Enum differentiation

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -714,7 +714,7 @@ func modify(_ s: Struct, _ x: Float) -> Float {
 func tupleArrayLiteralInitialization(_ x: Float, _ y: Float) -> Float {
   // `Array<(Float, Float)>` does not conform to `Differentiable`.
   let array = [(x * y, x * y)]
-  // expected-note @+1 {{cannot differentiate through a non-differentiable argument; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at: }} {{15-15=)}}
+  // expected-note @-1 {{cannot differentiate through a non-differentiable argument; do you want to use 'withoutDerivative(at:)'?}} {{15-15=withoutDerivative(at: }} {{31-31=)}}
   return array[0].0
 }
 

--- a/test/IRGen/alloc_box.swift
+++ b/test/IRGen/alloc_box.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=SILGenCleanup -primary-file %s -emit-ir -o - | %FileCheck %s
 
 func f() -> Bool? { return nil }
 

--- a/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
+++ b/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
@@ -19,12 +19,12 @@
 // CHECK:   destroy_value %7 : ${ var Int }, loc {{.*}}:33:11, scope 3
 // CHECK:   %13 = partial_apply [callee_guaranteed] %10(%11) : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
 // CHECK:   debug_value %13 : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 3
-// CHECK:   %15 = begin_borrow %13 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
-// CHECK:   %16 = copy_value %15 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
-// CHECK:   end_borrow %15 : $@callee_guaranteed () -> Int
+// There used to be a begin_borrow here. We leave an emptyline here to preserve line numbers.
+// CHECK:   %15 = copy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
+// There used to be an end_borrow here. We leave an emptyline here to preserve line numbers.
 // CHECK:   destroy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:35:1, scope 3
 // CHECK:   destroy_value %0 : ${ var Int }, loc {{.*}}:35:1, scope 3
-// CHECK:   return %16 : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 3
+// CHECK:   return %15 : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 3
 // CHECK: }
 
 

--- a/test/SILOptimizer/constantprop-wrongscope.swift
+++ b/test/SILOptimizer/constantprop-wrongscope.swift
@@ -13,7 +13,7 @@
 // instructions surrounding it.
 
 // CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:22:19, scope 2
-// CHECK:   dealloc_stack %13 : $*Optional<Any>, loc {{.*}}:22:23, scope 2
+// CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:22:23, scope 2
 // CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:22:23, scope 2
 // CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:22:7, scope 2
 

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -4,8 +4,27 @@ import Builtin
 
 sil_stage raw
 
-import Swift
-import SwiftShims
+class Klass {}
+class SubKlass : Klass {}
+
+sil @use_klass_guaranteed : $@convention(thin) (@guaranteed Klass) -> ()
+sil @use_klass_owned : $@convention(thin) (@owned Klass) -> ()
+sil @use_klass_unowned : $@convention(thin) (Klass) -> ()
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+sil @use_fakeoptional_klass_guaranteed : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
+
+struct Int {
+  var _value : Builtin.Int32
+}
+
+struct UInt8 {
+  var _value : Builtin.Int8
+}
 
 // CHECK-LABEL: sil [ossa] @struct_extract_load_to_load_struct_element_addr
 // CHECK: bb0([[IN:%[0-9]+]] : $*UInt8):
@@ -91,30 +110,26 @@ bb0(%0 : $*(Builtin.Int8, Builtin.Int8)):
 
 struct X1 {
   @_hasStorage @_hasInitialValue let a: Int { get }
-  @_hasStorage @_hasInitialValue var obj1: AnyObject { get set }
-  @_hasStorage @_hasInitialValue var obj2: AnyObject { get set }
-  init(a: Int, obj1: AnyObject, obj2: AnyObject)
+  @_hasStorage @_hasInitialValue var obj1: Builtin.NativeObject { get set }
+  @_hasStorage @_hasInitialValue var obj2: Builtin.NativeObject { get set }
+  init(a: Int, obj1: Builtin.NativeObject, obj2: Builtin.NativeObject)
 }
 
-// CHECK-LABEL: sil private [ossa] @testLoadNontrivial : $@convention(thin) (@inout_aliasable X1) -> (Int, @owned AnyObject, @owned AnyObject) {
+// CHECK-LABEL: sil private [ossa] @testLoadNontrivial : $@convention(thin) (@inout_aliasable X1) -> (Int, @owned Builtin.NativeObject, @owned Builtin.NativeObject) {
 // CHECK-LABEL: bb0(%0 : $*X1):
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*X1
 // CHECK: [[AA:%.*]] = struct_element_addr [[ACCESS]] : $*X1, #X1.a
 // CHECK: load [trivial] [[AA]] : $*Int
 // CHECK: [[OA1:%.*]] = struct_element_addr [[ACCESS]] : $*X1, #X1.obj1
-// CHECK: [[OV1:%.*]] = load [copy] [[OA1]] : $*AnyObject
+// CHECK: [[OV1:%.*]] = load [copy] [[OA1]] : $*Builtin.NativeObject
 // CHECK: [[OA2:%.*]] = struct_element_addr [[ACCESS]] : $*X1, #X1.obj2
-// CHECK: [[OV2:%.*]] = load [copy] [[OA2]] : $*AnyObject
+// CHECK: [[OV2:%.*]] = load [copy] [[OA2]] : $*Builtin.NativeObject
 // CHECK: end_access [[ACCESS]] : $*X1
-// CHECK: [[B1:%.*]] = begin_borrow [[OV1]] : $AnyObject
-// CHECK: copy_value [[B1]] : $AnyObject
-// CHECK: end_borrow [[B1]] : $AnyObject
-// CHECK: [[B2:%.*]] = begin_borrow [[OV2]] : $AnyObject
-// CHECK: copy_value [[B2]] : $AnyObject
-// CHECK: end_borrow [[B2]] : $AnyObject
+// CHECK: copy_value [[OV1]] : $Builtin.NativeObject
+// CHECK: copy_value [[OV2]] : $Builtin.NativeObject
 // CHECK: return
 // CHECK-LABEL: } // end sil function 'testLoadNontrivial'
-sil private [ossa] @testLoadNontrivial : $@convention(thin) (@inout_aliasable X1) -> (Int, @owned AnyObject, @owned AnyObject) {
+sil private [ossa] @testLoadNontrivial : $@convention(thin) (@inout_aliasable X1) -> (Int, @owned Builtin.NativeObject, @owned Builtin.NativeObject) {
 bb0(%0 : $*X1):
   %access = begin_access [read] [unknown] %0 : $*X1
   %load = load [copy] %access : $*X1
@@ -126,44 +141,44 @@ bb0(%0 : $*X1):
 
   %borrow1 = begin_borrow %load : $X1
   %o1 = struct_extract %borrow1 : $X1, #X1.obj1
-  %copy1 = copy_value %o1 : $AnyObject
+  %copy1 = copy_value %o1 : $Builtin.NativeObject
   end_borrow %borrow1 : $X1
 
   %borrow2 = begin_borrow %load : $X1
   %o2 = struct_extract %borrow2 : $X1, #X1.obj2
-  %copy2 = copy_value %o2 : $AnyObject
+  %copy2 = copy_value %o2 : $Builtin.NativeObject
   end_borrow %borrow2 : $X1
 
   destroy_value %load : $X1
 
-  %result = tuple (%a : $Int, %copy1 : $AnyObject, %copy2 : $AnyObject)
-  return %result : $(Int, AnyObject, AnyObject)
+  %result = tuple (%a : $Int, %copy1 : $Builtin.NativeObject, %copy2 : $Builtin.NativeObject)
+  return %result : $(Int, Builtin.NativeObject, Builtin.NativeObject)
 }
 
 struct X2 {
-  @_hasStorage @_hasInitialValue var obj: AnyObject { get set }
+  @_hasStorage @_hasInitialValue var obj: Builtin.NativeObject { get set }
 }
 
 struct X3 {
   @_hasStorage @_hasInitialValue var x2: X2 { get set }
 }
 
-// CHECK-LABEL: sil private [ossa] @testStoreNontrivial : $@convention(thin) (@inout X3, @guaranteed AnyObject) -> () {
-// CHECK-LABEL: bb0(%0 : $*X3, %1 : @guaranteed $AnyObject):
-// CHECK: [[CP:%.*]] = copy_value %1 : $AnyObject
+// CHECK-LABEL: sil private [ossa] @testStoreNontrivial : $@convention(thin) (@inout X3, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0(%0 : $*X3, %1 : @guaranteed $Builtin.NativeObject):
+// CHECK: [[CP:%.*]] = copy_value %1 : $Builtin.NativeObject
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*X3
-// CHECK: [[X2:%.*]] = struct $X2 ([[CP]] : $AnyObject)
+// CHECK: [[X2:%.*]] = struct $X2 ([[CP]] : $Builtin.NativeObject)
 // CHECK: [[X3:%.*]] = struct $X3 ([[X2]] : $X2)
 // CHECK: store [[X3]] to [assign] [[ACCESS]] : $*X3
 // CHECK: end_access [[ACCESS]] : $*X3
-// CHECK-LABEL: } // end sil function 'testStoreNontrivial'
-sil private [ossa] @testStoreNontrivial : $@convention(thin) (@inout X3, @guaranteed AnyObject) -> () {
-bb0(%0 : $*X3, %1 : @guaranteed $AnyObject):
-  %4 = copy_value %1 : $AnyObject
+// CHECK: } // end sil function 'testStoreNontrivial'
+sil private [ossa] @testStoreNontrivial : $@convention(thin) (@inout X3, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*X3, %1 : @guaranteed $Builtin.NativeObject):
+  %4 = copy_value %1 : $Builtin.NativeObject
   %5 = begin_access [modify] [unknown] %0 : $*X3
   %6 = struct_element_addr %5 : $*X3, #X3.x2
   %7 = struct_element_addr %6 : $*X2, #X2.obj
-  store %4 to [assign] %7 : $*AnyObject
+  store %4 to [assign] %7 : $*Builtin.NativeObject
   end_access %5 : $*X3
   %12 = tuple ()
   return %12 : $()


### PR DESCRIPTION
I am going to be using in inst-simplify/sil-combine/canonicalize instruction a
RAUW everything against everything API (*). This creates some extra ARC
traffic/borrows. It is going to be useful to have some simple peepholes that
gets rid of some of the extraneous traffic.

(*) Noting that we are not going to support replacing non-trivial
OwnershipKind::None values with non-trivial OwnershipKind::* values. This is a
corner case that only comes up with non-trivial enums that have a non-payloaded
or trivial enum case. It is much more complex to implement that transform, but
it is an edge case, so we are just not going to support those for now.

----

I also eliminated the dependence of SILGenCleanup on Swift/SwiftShims. This
speeds up iterating on the test case with a debug compiler since we don't need
those modules.