### PR TITLE
[5.3] Pull in changes from PR 34323, 34327, 34445 and 34495

### DIFF
--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -713,11 +713,6 @@ void SILGlobalOpt::reset() {
 
 void SILGlobalOpt::collect() {
   for (auto &F : *Module) {
-    // TODO: Add support for ownership.
-    if (F.hasOwnership()) {
-      continue;
-    }
-
     // Make sure to create an entry. This is important in case a global variable
     // (e.g. a public one) is not used inside the same module.
     if (F.isGlobalInit())

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -481,7 +481,7 @@ bool TempRValueOptPass::tryOptimizeCopyIntoTemp(CopyAddrInst *copyInst) {
     // our base, we fail since those would be re-initializations.
     if (auto *li = dyn_cast<LoadInst>(user)) {
       if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
-        continue;
+        return false;
       }
     }
 
@@ -621,7 +621,7 @@ TempRValueOptPass::tryOptimizeStoreIntoTemp(StoreInst *si) {
     // our base, we fail since those would be re-initializations.
     if (auto *li = dyn_cast<LoadInst>(user)) {
       if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
-        continue;
+        return {std::next(si->getIterator()), false};
       }
     }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1565,7 +1565,10 @@ static bool isInsideCompatibleUnavailableDeclaration(
   auto IsUnavailable = [platform](const Decl *D) {
     auto EnclosingUnavailable =
         D->getAttrs().getUnavailable(D->getASTContext());
-    return EnclosingUnavailable && EnclosingUnavailable->Platform == platform;
+    return EnclosingUnavailable &&
+        (EnclosingUnavailable->Platform == platform ||
+         inheritsAvailabilityFromPlatform(platform,
+           EnclosingUnavailable->Platform));
   };
 
   return someEnclosingDeclMatches(ReferenceRange, ReferenceDC, IsUnavailable);

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1227,7 +1227,7 @@ extension Array: RangeReplaceableCollection {
       // elements. It reduces code size, because the following code
       // can be removed by the optimizer by constant folding this check in a
       // generic specialization.
-      if newElements is [Element] {
+      if S.self == [Element].self {
         _internalInvariant(remainder.next() == nil)
         return
       }

--- a/test/SILOptimizer/globalopt_ossa.sil
+++ b/test/SILOptimizer/globalopt_ossa.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+private var testGlobal: Int64
+
+sil_global private @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_token0 : $Builtin.Word
+
+sil_global private @$s4test10testGlobalSivp : $Int64
+
+sil private [ossa] @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_func0 : $@convention(c) () -> () {
+bb0:
+  alloc_global @$s4test10testGlobalSivp
+  %1 = global_addr @$s4test10testGlobalSivp : $*Int64
+  %2 = integer_literal $Builtin.Int64, 27
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to [trivial] %1 : $*Int64
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil hidden [global_init] [ossa] @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_token0 : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_33_00F4D2139E6BDDFEC71E5005B67B5674_func0 : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$s4test10testGlobalSivp : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil [ossa] @dont_propagate_global_with_multiple_writes
+// CHECK:   [[V:%[0-9]+]] = load
+// CHECK:   return [[V]]
+// CHECK: } // end sil function 'dont_propagate_global_with_multiple_writes'
+sil [ossa] @dont_propagate_global_with_multiple_writes : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %2 = function_ref @$s4test10testGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %3 = apply %2() : $@convention(thin) () -> Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Int64
+  %5 = integer_literal $Builtin.Int64, 42
+  %6 = struct $Int64 (%5 : $Builtin.Int64)
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int64
+  store %6 to [trivial] %7 : $*Int64
+  end_access %7 : $*Int64
+  %33 = begin_access [read] [dynamic] [no_nested_conflict] %4 : $*Int64
+  %35 = load [trivial] %33 : $*Int64
+  end_access %33 : $*Int64
+  return %35 : $Int64
+}
+

--- a/test/SILOptimizer/globalopt_trivial_nontrivial.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial.sil
@@ -1,0 +1,133 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+
+// This tests GlobalOpt of a trivial global variable
+// Loads of trivial global variable initialized with a constant is replaced with the constant in GlobalOpt
+// This also tests GlobalOpt to be a no-op for a non-trivial global variable used in the same way
+// The difference in GlobalOpt for trivial v/s non-trivial values is shown in $bartrivial and $barnontrivial
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public struct TStruct {
+  let x: Int32
+  init(x: Int32)
+}
+
+let trivialglobal: TStruct
+
+public class TClass {
+  final let x: Int32
+  init(x: Int32)
+  deinit
+}
+
+let nontrivialglobal: TClass
+
+// CHECK-LABEL: sil_global hidden [let] @$trivialglobal : $TStruct = {
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  %initval = struct $TStruct ([[INT]] : $Int32)
+sil_global private @globalinit_trivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$trivialglobal : $TStruct
+
+sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$nontrivialglobal : $TClass
+
+sil private @globalinit_trivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$trivialglobal 
+  %1 = global_addr @$trivialglobal : $*TStruct 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = struct $TStruct (%3 : $Int32)              
+  store %4 to %1 : $*TStruct                      
+  %6 = tuple ()                                   
+  return %6 : $()                                 
+}
+
+// CHECK-LABEL: sil hidden [global_init] @$trivialglobal_unsafemutableaddressor :
+// CHECK: [[GLOBL:%.*]] = global_addr @$trivialglobal : $*TStruct
+// CHECK: [[GLOBL_ADDR:%.*]] = address_to_pointer [[GLOBL]] : $*TStruct to $Builtin.RawPointer
+// CHECK:  return [[GLOBL_ADDR]] : $Builtin.RawPointer
+// CHECK: } // end sil function '$trivialglobal_unsafemutableaddressor'
+sil hidden [global_init] @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_trivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_trivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$trivialglobal : $*TStruct 
+  %5 = address_to_pointer %4 : $*TStruct to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// $bartrivial's access to the trivial global variable via the accessor is optimized to the rhs of the init value 
+
+// CHECK-LABEL: sil hidden [noinline] @$bartrivial :
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  return [[INT]] : $Int32
+// CHECK-LABEL: } // end sil function '$bartrivial'
+sil hidden [noinline] @$bartrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TStruct 
+  %3 = struct_element_addr %2 : $*TStruct, #TStruct.x 
+  %4 = load %3 : $*Int32                          
+  return %4 : $Int32                              
+}
+
+// CHECK-LABEL: sil private @globalinit_nontrivialglobal_func :
+// CHECK: alloc_global @$nontrivialglobal 
+// CHECK: [[GLOBL_ADDR:%.*]] = global_addr @$nontrivialglobal : $*TClass 
+// CHECK: [[REF:%.*]] = alloc_ref $TClass                          
+// CHECK: store [[REF]] to [[GLOBL_ADDR]] : $*TClass 
+// CHECK: } // end sil function 'globalinit_nontrivialglobal_func'
+sil private @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$nontrivialglobal 
+  %1 = global_addr @$nontrivialglobal : $*TClass 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = alloc_ref $TClass                          
+  %7 = ref_element_addr %4 : $TClass, #TClass.x   
+  store %3 to %7 : $*Int32                        
+  store %4 to %1 : $*TClass                       
+  %10 = tuple ()                                  
+  return %10 : $()                                
+}
+
+sil hidden [global_init] @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_nontrivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_nontrivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$nontrivialglobal : $*TClass 
+  %5 = address_to_pointer %4 : $*TClass to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// $barnontrivial's access to the non-trivial global variable does not get optimized away 
+
+// CHECK-LABEL: sil hidden [noinline] @$barnontrivial :
+// CHECK: [[FUNC_REF:%.*]] = function_ref @$nontrivialglobal_unsafemutableaccessor :
+// CHECK: [[APPLY:%.*]] = apply [[FUNC_REF]]() :
+// CHECK-LABEL: } // end sil function '$barnontrivial'
+sil hidden [noinline] @$barnontrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TClass 
+  %3 = load %2 : $*TClass                         
+  %4 = ref_element_addr %3 : $TClass, #TClass.x   
+  %5 = load %4 : $*Int32                          
+  return %5 : $Int32                              
+}
+

--- a/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
@@ -1,0 +1,128 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -global-opt | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public struct TStruct {
+  let x: Int32
+  init(x: Int32)
+}
+
+let trivialglobal: TStruct
+
+public class TClass {
+  final let x: Int32
+  init(x: Int32)
+  deinit
+}
+
+let nontrivialglobal: TClass
+
+// CHECK-LABEL: sil_global hidden [let] @$trivialglobal : $TStruct = {
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  %initval = struct $TStruct ([[INT]] : $Int32)
+sil_global private @globalinit_trivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$trivialglobal : $TStruct
+
+sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
+
+sil_global hidden [let] @$nontrivialglobal : $TClass
+
+sil private [ossa] @globalinit_trivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$trivialglobal 
+  %1 = global_addr @$trivialglobal : $*TStruct 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = struct $TStruct (%3 : $Int32)              
+  store %4 to [trivial] %1 : $*TStruct                      
+  %6 = tuple ()                                   
+  return %6 : $()                                 
+}
+
+// CHECK-LABEL: sil hidden [global_init] [ossa] @$trivialglobal_unsafemutableaddressor :
+// CHECK: [[GLOBL:%.*]] = global_addr @$trivialglobal : $*TStruct
+// CHECK: [[GLOBL_ADDR:%.*]] = address_to_pointer [[GLOBL]] : $*TStruct to $Builtin.RawPointer
+// CHECK:  return [[GLOBL_ADDR]] : $Builtin.RawPointer
+// CHECK: } // end sil function '$trivialglobal_unsafemutableaddressor'
+sil hidden [global_init] [ossa] @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_trivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_trivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$trivialglobal : $*TStruct 
+  %5 = address_to_pointer %4 : $*TStruct to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// CHECK-LABEL: sil hidden [noinline] [ossa] @$bartrivial :
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]] : $Builtin.Int32)
+// CHECK:  return [[INT]] : $Int32
+// CHECK-LABEL: } // end sil function '$bartrivial'
+sil hidden [noinline] [ossa] @$bartrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$trivialglobal_unsafemutableaddressor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TStruct 
+  %3 = struct_element_addr %2 : $*TStruct, #TStruct.x 
+  %4 = load [trivial] %3 : $*Int32                          
+  return %4 : $Int32                              
+}
+
+// CHECK-LABEL: sil private [ossa] @globalinit_nontrivialglobal_func :
+// CHECK: alloc_global @$nontrivialglobal 
+// CHECK: [[GLOBL_ADDR:%.*]] = global_addr @$nontrivialglobal : $*TClass 
+// CHECK: [[REF:%.*]] = alloc_ref $TClass                          
+// CHECK: store [[REF]] to [init] [[GLOBL_ADDR]] : $*TClass 
+// CHECK: } // end sil function 'globalinit_nontrivialglobal_func'
+sil private [ossa] @globalinit_nontrivialglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$nontrivialglobal 
+  %1 = global_addr @$nontrivialglobal : $*TClass 
+  %2 = integer_literal $Builtin.Int32, 10         
+  %3 = struct $Int32 (%2 : $Builtin.Int32)        
+  %4 = alloc_ref $TClass
+  %5 = begin_borrow %4 : $TClass                          
+  %6 = ref_element_addr %5 : $TClass, #TClass.x
+  store %3 to [trivial] %6 : $*Int32                        
+  end_borrow %5 : $TClass   
+  store %4 to [init] %1 : $*TClass                       
+  %10 = tuple ()                                  
+  return %10 : $()                                
+}
+
+sil hidden [global_init] [ossa] @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_nontrivialglobal_token : $*Builtin.Word 
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer 
+  %2 = function_ref @globalinit_nontrivialglobal_func : $@convention(c) () -> () 
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$nontrivialglobal : $*TClass 
+  %5 = address_to_pointer %4 : $*TClass to $Builtin.RawPointer 
+  return %5 : $Builtin.RawPointer                 
+}
+
+// CHECK-LABEL: sil hidden [noinline] [ossa] @$barnontrivial :
+// CHECK: [[FUNC_REF:%.*]] = function_ref @$nontrivialglobal_unsafemutableaccessor :
+// CHECK: [[APPLY:%.*]] = apply [[FUNC_REF]]() :
+// CHECK-LABEL: } // end sil function '$barnontrivial'
+sil hidden [noinline] [ossa] @$barnontrivial : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = function_ref @$nontrivialglobal_unsafemutableaccessor : $@convention(thin) () -> Builtin.RawPointer 
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer 
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*TClass 
+  %3 = load [copy] %2 : $*TClass                         
+  %3b = begin_borrow %3 : $TClass                          
+  %4 = ref_element_addr %3b : $TClass, #TClass.x
+  %5 = load [trivial] %4 : $*Int32 
+  end_borrow %3b : $TClass
+  destroy_value %3 : $TClass 
+  return %5 : $Int32                              
+}
+

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -610,15 +610,12 @@ bb3:
 
 sil [ossa] @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
-// Now that we support ossa, eliminate the alloc_stack and change the load
-// [take] to a load [copy] in the process.
+// We do not support this in 5.3.
 //
 // CHECK-LABEL: sil [ossa] @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK-NOT: alloc_stack
-// CHECK:   [[VAL:%.*]] = load [copy] %0 : $*Builtin.NativeObject
-// CHECK:   apply %{{.*}}([[VAL]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-// CHECK:   destroy_value [[VAL]] : $Builtin.NativeObject
+// CHECK: alloc_stack
+// CHECK: load [take]
 // CHECK-LABEL: } // end sil function 'copyWithLoadRelease'
 sil [ossa] @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
@@ -633,14 +630,11 @@ bb0(%0 : $*Builtin.NativeObject):
   return %v : $()
 }
 
-// Remove a copy that is released via a load. Leave the load [take] alone since
-// our copy_addr is taking from source.
+// We do not support this in 5.3.
 //
 // CHECK-LABEL: sil [ossa] @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK:   [[V:%.*]] = load [take] %0 : $*Builtin.NativeObject
-// CHECK:   apply %{{.*}}([[V]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-// CHECK:   destroy_value [[V]] : $Builtin.NativeObject
+// CHECK:   alloc_stack
 // CHECK-LABEL: } // end sil function 'takeWithLoadRelease'
 sil [ossa] @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
@@ -675,12 +669,11 @@ bb0(%0 : $*GS<Builtin.NativeObject>):
   return %v : $()
 }
 
-// Make sure that when we convert the load [take] to a load [copy], we hoist the
-// load of src /before/ the destroy of %0.
+// We do not support this on 5.3.
+//
 // CHECK-LABEL: sil [ossa] @hoist_load_copy_to_src_copy_addr_site : $@convention(thin) (@owned GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
 // CHECK: bb0([[ARG:%.*]] : @owned
-// CHECK:   apply {{%.*}}([[ARG]])
-// CHECK:   return [[ARG]]
+// CHECK: alloc_stack
 // CHECK: } // end sil function 'hoist_load_copy_to_src_copy_addr_site'
 sil [ossa] @hoist_load_copy_to_src_copy_addr_site : $@convention(thin) (@owned GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
 bb0(%0 : @owned $GS<Builtin.NativeObject>):
@@ -693,24 +686,11 @@ bb0(%0 : @owned $GS<Builtin.NativeObject>):
   return %obj : $GS<Builtin.NativeObject>
 }
 
+// We do not support this on 5.3.
+//
 // CHECK-LABEL: sil [ossa] @hoist_load_copy_to_src_copy_addr_site_two_takes : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
 // CHECK: bb0([[ARG:%.*]] :
-// CHECK:   [[COPY_1:%.*]] = load [copy] [[ARG]]
-// CHECK:   [[COPY_2:%.*]] = load [copy] [[ARG]]
-// CHECK:   destroy_addr [[ARG]]
-// CHECK:   cond_br undef, bb1, bb2
-//
-// CHECK: bb1:
-// CHECK:   destroy_value [[COPY_1]]
-// CHECK:   br bb3([[COPY_2]] :
-//
-// CHECK: bb2:
-// CHECK:   destroy_value [[COPY_2]]
-// CHECK:   br bb3([[COPY_1]] :
-//
-// CHECK: bb3([[RESULT:%.*]] : @owned
-// CHECK:   apply {{%.*}}([[RESULT]])
-// CHECK:   return [[RESULT]]
+// CHECK: alloc_stack
 // CHECK: } // end sil function 'hoist_load_copy_to_src_copy_addr_site_two_takes'
 sil [ossa] @hoist_load_copy_to_src_copy_addr_site_two_takes : $@convention(thin) (@in GS<Builtin.NativeObject>) -> @owned GS<Builtin.NativeObject> {
 bb0(%0 : $*GS<Builtin.NativeObject>):
@@ -1016,12 +996,11 @@ bb0(%0 : $*Klass):
 sil [ossa] @store_getP : $@convention(thin) () -> @out Optional<P>
 sil [ossa] @store_takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
-// Now that we support ossa, eliminate the alloc_stack and change the load
-// [take] to a load [copy] in the process.
+// We do not support this on 5.3.
 //
 // CHECK-LABEL: sil [ossa] @store_copyWithLoadRelease : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : @guaranteed $Builtin.NativeObject):
-// CHECK-NOT: alloc_stack
+// CHECK: alloc_stack
 // CHECK-LABEL: } // end sil function 'store_copyWithLoadRelease'
 sil [ossa] @store_copyWithLoadRelease : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
@@ -1037,11 +1016,10 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return %v : $()
 }
 
-// Remove a copy that is released via a load. Leave the load [take] alone since
-// our copy_addr is taking from source.
+// We do not support this on 5.3.
 //
 // CHECK-LABEL: sil [ossa] @store_takeWithLoadRelease : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK-NOT: alloc_stack
+// CHECK: alloc_stack
 // CHECK-LABEL: } // end sil function 'store_takeWithLoadRelease'
 sil [ossa] @store_takeWithLoadRelease : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -140,3 +140,27 @@ protocol P: Builtin.AnyObject {
 }
 
 extension X: P {}
+
+// Test platform inheritance for iOS unavailability.
+// rdar://68597591
+
+@available(iOS, unavailable)
+public struct UnavailableOniOS { } // expected-note 2 {{'UnavailableOniOS' has been explicitly marked unavailable here}}
+
+@available(iOS, unavailable)
+func unavailableOniOS(_ p: UnavailableOniOS) { } // ok
+
+func functionUsingAnUnavailableType(_ p: UnavailableOniOS) { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+
+public extension UnavailableOniOS { } // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
+
+@available(iOS, unavailable)
+public extension UnavailableOniOS { // ok
+  func someMethod(_ p: UnavailableOniOS) { }
+}
+
+@available(iOS, unavailable)
+@available(macCatalyst, introduced: 13.0)
+public struct AvailableOnMacCatalyst { }
+
+public extension AvailableOnMacCatalyst { } // ok

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -1110,6 +1110,15 @@ ArrayTestSuite.test("BridgedToObjC.Nonverbatim.RoundtripThroughSwiftArray") {
   }
 }
 
+ArrayTestSuite.test("append(contentsOf: NSArray)") {
+  // A stray runtime `is` test caused this particular operation to fail in 5.3.
+  // rdar://70448247
+  let nsarray: NSArray = [2, 3, 4]
+  var array: [Any] = [1]
+  array.append(contentsOf: nsarray)
+  expectEqual(array as? [Int], [1, 2, 3, 4])
+}
+
 ArrayTestSuite.setUp {
   resetLeaksOfDictionaryKeysValues()
   resetLeaksOfObjCDictionaryKeysValues()


### PR DESCRIPTION
Pull in changes from: 

* [5.3] Fix a miscompile of global variables
* [5.3][stdlib] Fix Array.append(contentsOf:) for arguments of type NSArray 
* [temp-rvalue-opt] Disable handling of load [take] in temp-rvalue-elim. 
* [5.3][Sema] Consider inherited platform unavailability to silence diagnostics 
