### PR TITLE
IRGen: Allow calling a pre-defined async silgen_name function using the async convention

### DIFF
--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -155,14 +155,18 @@ namespace irgen {
 
     Signature Sig;
 
+    bool isFunctionPointerWithoutContext = false;
+
   public:
     /// Construct a FunctionPointer for an arbitrary pointer value.
     /// We may add more arguments to this; try to use the other
     /// constructors/factories if possible.
     explicit FunctionPointer(KindTy kind, llvm::Value *value,
                              PointerAuthInfo authInfo,
-                             const Signature &signature)
-        : Kind(kind), Value(value), AuthInfo(authInfo), Sig(signature) {
+                             const Signature &signature,
+                             bool isWithoutCtxt = false)
+        : Kind(kind), Value(value), AuthInfo(authInfo), Sig(signature),
+          isFunctionPointerWithoutContext(isWithoutCtxt) {
       // The function pointer should have function type.
       assert(value->getType()->getPointerElementType()->isFunctionTy());
       // TODO: maybe assert similarity to signature.getType()?
@@ -170,8 +174,9 @@ namespace irgen {
 
     // Temporary only!
     explicit FunctionPointer(KindTy kind, llvm::Value *value,
-                             const Signature &signature)
-        : FunctionPointer(kind, value, PointerAuthInfo(), signature) {}
+                             const Signature &signature, bool
+                             isWithoutCtxt = false)
+        : FunctionPointer(kind, value, PointerAuthInfo(), signature, isWithoutCtxt) {}
 
     static FunctionPointer forDirect(IRGenModule &IGM,
                                      llvm::Constant *value,
@@ -243,6 +248,10 @@ namespace irgen {
 
     /// Form a FunctionPointer whose KindTy is ::Function.
     FunctionPointer getAsFunction(IRGenFunction &IGF) const;
+
+    bool useStaticContextSize() const {
+      return isFunctionPointerWithoutContext;
+    }
   };
 
   class Callee {

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -313,7 +313,8 @@ namespace irgen {
   std::pair<llvm::Value *, llvm::Value *> getAsyncFunctionAndSize(
       IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
       FunctionPointer functionPointer, llvm::Value *thickContext,
-      std::pair<bool, bool> values = {true, true});
+      std::pair<bool, bool> values = {true, true},
+      Size initialContextSize = Size(0));
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention);
 

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-concurrency | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-concurrency | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: concurrency
 
@@ -8,3 +8,19 @@ public func f() async { }
 // CHECK: "$s5async1gyyYKF"
 public func g() async throws { }
 
+
+public class SomeClass {}
+
+@_silgen_name("swift_task_future_wait")
+public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
+
+// CHECK: define{{.*}} swiftcc void @"$s5async8testThisyyAA9SomeClassCnYF"(%swift.task* %0, %swift.executor* %1, %swift.context* %2)
+// CHECK-64: call swiftcc i8* @swift_task_alloc(%swift.task* %0, i64 64)
+// CHECK: tail call swiftcc void @swift_task_future_wait(
+public func testThis(_ task: __owned SomeClass) async {
+  do {
+    let _ = try await task_future_wait(task)
+  } catch _ {
+    print("error")
+  }
+}


### PR DESCRIPTION
The function can then be implemented in the runtime.

Note: This is a temporary hack.
