### PR TITLE
[TypeChecker] Find outermost paren or tuple while checking invalid `i…

### DIFF
--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -266,3 +266,23 @@ func testWritePrefixIterator() {
   var underflow = (1..<10).makeIterator()
   var (writtenCount, afterLastWritten) = a.writePrefix(from: underflow) // expected-error {{passing value of type 'IndexingIterator<(Range<Int>)>' to an inout parameter requires explicit '&'}} {{62-62=&}}
 }
+
+// rdar://problem/71356981 - wrong error message for state passed as inout with ampersand within parentheses
+func look_through_parens_when_checking_inout() {
+  struct Point {
+    var x: Int = 0
+    var y: Int = 0
+  }
+
+  func modifyPoint(_ point: inout Point, _: Int = 42) {}
+  func modifyPoint(_ point: inout Point, msg: String) {}
+  func modifyPoint(source: inout Point) {}
+
+  var point = Point(x: 0, y: 0)
+  modifyPoint((&point)) // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
+  modifyPoint(((&point))) // expected-error {{use of extraneous '&}} {{17-18=(}} {{15-16=&}}
+  modifyPoint(source: (&point)) // expected-error {{use of extraneous '&}} {{24-25=(}} {{23-24=&}}
+  modifyPoint(source: ((&point))) // expected-error {{use of extraneous '&}} {{25-26=(}} {{23-24=&}}
+  modifyPoint((&point), 0) // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
+  modifyPoint((&point), msg: "") // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -841,7 +841,7 @@ func inoutTests(_ arr: inout Int) {
 
   inoutTests((&x, 24).0) // expected-error {{use of extraneous '&'}}
 
-  inoutTests((&x)) // expected-error {{use of extraneous '&'}}
+  inoutTests((&x)) // expected-error {{use of extraneous '&'}} {{15-16=(}} {{14-15=&}}
   inoutTests(&x)
   
   // <rdar://problem/17489894> inout not rejected as operand to assignment operator


### PR DESCRIPTION
…nout` use

Unwrap `InOutExpr` from all parens until the outermost paren or a tuple
to support calls like `foo(((&bar)))` or `foo(x: (&bar))`.

Resolves: rdar://problem/71356981

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
