### PR TITLE
[android] Mark Interpreter/async as an executable test.

### DIFF
--- a/test/Interpreter/async.swift
+++ b/test/Interpreter/async.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/main | %FileCheck %s
 
 // REQUIRES: concurrency
+// REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: CPU=arm64e
 


### PR DESCRIPTION
Tests that need to execute need to be marked as such so they can be
skipped in platforms that are cross-compiled and do not have a target
platform available.

This situation happens in the Android CI machines.

Introduced in #34746.
