### PR TITLE
[windows] Set TMP and TEMP, as well as TMPDIR.

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -55,6 +55,8 @@ set install_directory=%build_root%\Library\Developer\Toolchains\unknown-Asserts-
 
 md %build_root%\tmp
 set TMPDIR=%build_root%\tmp
+set TMP=%build_root%\tmp
+set TEMP=%build_root%\tmp
 
 md %build_root%\tmp\org.llvm.clang.9999
 set CUSTOM_CLANG_MODULE_CACHE=%build_root%\tmp\org.llvm.clang.9999


### PR DESCRIPTION
Seems that Windows uses TMP and TEMP (more details about why two in
https://devblogs.microsoft.com/oldnewthing/20150417-00/?p=44213), but
doesn't seem to use TMPDIR at all.

The changes set all three to the same value. I am not removing TMPDIR
just in case. It seems to avoid creating files in the other temporal
directories for the compilation and testing.

This temp directory should be clean up by the CI machines when
recreating the new working directory for the next build. Let's hope we
can stop having to babysit the CI servers every month.

