### PR TITLE
[Serialization] Fix crashes when allowing compiler errors in modules

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -150,6 +150,9 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(bool preferTypeRepr,
 
   class ShouldPrintForModuleInterface : public ShouldPrintChecker {
     bool shouldPrint(const Decl *D, const PrintOptions &options) override {
+      if (!D)
+        return false;
+
       // Skip anything that is marked `@_implementationOnly` itself.
       if (D->getAttrs().hasAttribute<ImplementationOnlyAttr>())
         return false;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -532,12 +532,17 @@ void AccessScope::dump() const {
 
   if (auto *decl = getDeclContext()->getAsDecl()) {
     llvm::errs() << Decl::getKindName(decl->getKind()) << " ";
-    if (auto *ext = dyn_cast<ExtensionDecl>(decl))
-      llvm::errs() << ext->getExtendedNominal()->getName();
-    else if (auto *named = dyn_cast<ValueDecl>(decl))
+    if (auto *ext = dyn_cast<ExtensionDecl>(decl)) {
+      auto *extended = ext->getExtendedNominal();
+      if (extended)
+        llvm::errs() << extended->getName();
+      else
+        llvm::errs() << "(null)";
+    } else if (auto *named = dyn_cast<ValueDecl>(decl)) {
       llvm::errs() << named->getName();
-    else
+    } else {
       llvm::errs() << (const void *)decl;
+    }
 
     SourceLoc loc = decl->getLoc();
     if (loc.isValid()) {

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -247,7 +247,8 @@ static bool printModuleInterfaceDecl(Decl *D,
     // a cross-module extension.
     if (!extensionHasClangNode(Ext)) {
       auto ExtendedNominal = Ext->getExtendedNominal();
-      if (Ext->getModuleContext() == ExtendedNominal->getModuleContext())
+      if (!ExtendedNominal ||
+          Ext->getModuleContext() == ExtendedNominal->getModuleContext())
         return false;
     }
   }

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -47,7 +47,7 @@ public:
     /// (2) Walk over all ExtensionDecls to determine conformances.
     if (auto *e = dyn_cast<ExtensionDecl>(D)) {
       auto *ntd = e->getExtendedNominal();
-      if (!isa<ProtocolDecl>(ntd)) {
+      if (ntd && !isa<ProtocolDecl>(ntd)) {
         for (auto *conformance : e->getLocalConformances()) {
           if (isa<NormalProtocolConformance>(conformance)) {
             auto *proto = conformance->getProtocol();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1355,7 +1355,8 @@ void Serializer::writeASTBlockEntity(
   using namespace decls_block;
 
   // The conformance must be complete, or we can't serialize it.
-  assert(conformance->isComplete());
+  assert(conformance->isComplete() ||
+         getASTContext().LangOpts.AllowModuleWithCompilerErrors);
   assert(NormalConformancesToSerialize.hasRef(conformance));
 
   auto protocol = conformance->getProtocol();
@@ -1541,6 +1542,8 @@ static bool shouldSerializeMember(Decl *D) {
   case DeclKind::Extension:
   case DeclKind::Module:
   case DeclKind::PrecedenceGroup:
+    if (D->getASTContext().LangOpts.AllowModuleWithCompilerErrors)
+      return false;
     llvm_unreachable("decl should never be a member");
 
   case DeclKind::MissingMember:
@@ -5050,7 +5053,9 @@ static void collectInterestingNestedDeclarations(
         if (!nominalParent) {
           const DeclContext *DC = member->getDeclContext();
           nominalParent = DC->getSelfNominalTypeDecl();
-          assert(nominalParent && "parent context is not a type or extension");
+          assert(nominalParent ||
+                 nestedType->getASTContext().LangOpts.AllowModuleWithCompilerErrors &&
+                 "parent context is not a type or extension");
         }
         nestedTypeDecls[nestedType->getName()].push_back({
           S.addDeclRef(nominalParent),
@@ -5115,8 +5120,10 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
           .push_back({ getKindForTable(D), addDeclRef(D) });
       } else if (auto ED = dyn_cast<ExtensionDecl>(D)) {
         const NominalTypeDecl *extendedNominal = ED->getExtendedNominal();
-        extensionDecls[extendedNominal->getName()]
-          .push_back({ extendedNominal, addDeclRef(D) });
+        if (extendedNominal) {
+          extensionDecls[extendedNominal->getName()]
+            .push_back({ extendedNominal, addDeclRef(D) });
+        }
       } else if (auto OD = dyn_cast<OperatorDecl>(D)) {
         operatorDecls[OD->getName()]
           .push_back({ getStableFixity(OD->getFixity()), addDeclRef(D) });

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -346,7 +346,10 @@ static bool shouldIncludeDecl(Decl *D, bool ExcludeDoubleUnderscore) {
     return false;
 
   if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
-    return shouldIncludeDecl(ED->getExtendedNominal(), ExcludeDoubleUnderscore);
+    auto *extended = ED->getExtendedNominal();
+    if (!extended)
+      return false;
+    return shouldIncludeDecl(extended, ExcludeDoubleUnderscore);
   }
   if (ExcludeDoubleUnderscore && hasDoubleUnderscore(D)) {
     return false;

--- a/test/SourceKit/Misc/Inputs/errors-a.swift
+++ b/test/SourceKit/Misc/Inputs/errors-a.swift
@@ -55,7 +55,7 @@ public protocol InvalidProtocol : undefined {
 public struct InvalidStruct : undefined, InvalidProtocol {
   typealias Item = undefined
 
-  public let memberA: Int = undefined {
+  public let memberA: Int {
     willSet(newVal invalid) {
       print("Setting value \(newVal)")
     }
@@ -71,10 +71,10 @@ public struct InvalidStruct : undefined, InvalidProtocol {
       print("Set value \(oldValue)")
     }
   }
-  public var memberC: undefined {
+  public var memberC: undefined = {
     return undefined
   }()
-  public lazy var memberD: undefined {
+  public lazy var memberD: undefined = {
     return undefined
   }()
   public var memberE: undefined {
@@ -84,5 +84,13 @@ public struct InvalidStruct : undefined, InvalidProtocol {
 
   mutating func set(item: Item) {
     undefined
+  }
+}
+
+public extension undefined {
+  public enum ValidEnum: String {
+    case a
+    case b
+    case c
   }
 }

--- a/test/SourceKit/Misc/Inputs/errors-c.swift
+++ b/test/SourceKit/Misc/Inputs/errors-c.swift
@@ -1,0 +1,5 @@
+extension
+
+extension InvalidStruct {
+
+extension InvalidProtocol

--- a/test/SourceKit/Misc/load-module-with-errors.swift
+++ b/test/SourceKit/Misc/load-module-with-errors.swift
@@ -1,21 +1,79 @@
 import errors
 
-func foo() {
+func testInvalidGlobalCursor() {
   invalidGlobalMissingInit = ""
+}
 
-  let bar: InvalidStruct
-  bar.memberB
+func testInvalidFuncCursor() {
   invalidPartialFunc()
-  bar.
+}
 
-  let baz: ;
+func testInvalidStructCursor() {
+  let foo: InvalidStruct
+  foo.memberB
+}
 
+func testInvalidStructMemberCompletion() {
+  let foo: InvalidStruct
+  foo.#^INVALID-MEMBER^#
+  // INVALID-MEMBER: Begin completions
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberA[#Int#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberB[#<<error type>>#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberC[#<<error type>>#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberD[#<<error type>>#];
+  // INVALID-MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      memberE[#<<error type>>#];
+  // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         add({#<<error type>>#})[#Void#];
+  // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         get()[#InvalidStruct.Item#];
+  // INVALID-MEMBER-DAG: Decl[InstanceMethod]/Super:         set({#item: InvalidStruct.Item#})[#Void#];
+  // INVALID-MEMBER: End completions
+}
+
+func testInvalidTypeCompletion() {
+  let foo: #^INVALID-TYPE^#;
+  // INVALID-TYPE: Begin completions
+  // INVALID-TYPE-DAG: Decl[Enum]/OtherModule[errors]:     InvalidEnum[#InvalidEnum#];
+  // INVALID-TYPE-DAG: Decl[Class]/OtherModule[errors]:    InvalidClass[#InvalidClass#];
+  // INVALID-TYPE-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct#];
+  // INVALID-TYPE-DAG: Decl[Struct]/OtherModule[errors]:   InvalidStruct[#InvalidStruct#];
+  // INVALID-TYPE-DAG: Decl[TypeAlias]/OtherModule[errors]: InvalidAlias[#InvalidAlias#];
+  // INVALID-TYPE-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub1[#InvalidClassSub1#];
+  // INVALID-TYPE-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub2[#InvalidClassSub2#];
+  // INVALID-TYPE-DAG: Decl[Protocol]/OtherModule[errors]: InvalidProtocol[#InvalidProtocol#];
+  // INVALID-TYPE: End completions
+}
+
+func testInvalidTopLevelCompletion() {
+  #^INVALID-TOP^#
+  // INVALID-TOP: Begin completions
+  // INVALID-TOP-DAG: Decl[Enum]/OtherModule[errors]:     InvalidEnum[#InvalidEnum#];
+  // INVALID-TOP-DAG: Decl[Class]/OtherModule[errors]:    InvalidClass[#InvalidClass#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidGenericFuncBody({#param: T#})[#T#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidPartialFunc()[#Void#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncBody()[#Void#];
+  // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalClosureBody[#<<error type>>#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncSignature()[#Void#];
+  // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalMissingInit[#String#];
+  // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidGenericStruct[#InvalidGenericStruct#];
+  // INVALID-TOP-DAG: Decl[Struct]/OtherModule[errors]:   InvalidStruct[#InvalidStruct#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: typeUsesFunc({#pe: InvalidEnum#}, {#pa: <<error type>>#}, {#pp: InvalidProtocol#}, {#ps: InvalidStruct#}, {#pg: <<error type>>#}, {#pc: InvalidClass#})[#Int#];
+  // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalKeypath[#InvalidStruct.Type#];
+  // INVALID-TOP-DAG: Decl[TypeAlias]/OtherModule[errors]: InvalidAlias[#InvalidAlias#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidGenericFuncType({#param: T#})[#<<error type>>#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncType()[#<<error type>>#];
+  // INVALID-TOP-DAG: Decl[GlobalVar]/OtherModule[errors]: invalidGlobalClosureType[#() -> ()#];
+  // INVALID-TOP-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub1[#InvalidClassSub1#];
+  // INVALID-TOP-DAG: Decl[Class]/OtherModule[errors]:    InvalidClassSub2[#InvalidClassSub2#];
+  // INVALID-TOP-DAG: Decl[Protocol]/OtherModule[errors]: InvalidProtocol[#InvalidProtocol#];
+  // INVALID-TOP-DAG: Decl[FreeFunction]/OtherModule[errors]: invalidFuncThrows()[' throws'][#<<error type>>#];
+  // INVALID-TOP: End completions
 }
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors -primary-file %S/Inputs/errors-a.swift %S/Inputs/errors-b.swift -module-name errors -o %t/errors.a.swiftmodule
-// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors %S/Inputs/errors-a.swift -primary-file %S/Inputs/errors-b.swift -module-name errors -o %t/errors.b.swiftmodule
-// RUN: %target-swift-frontend -merge-modules -emit-module -experimental-allow-module-with-compiler-errors %t/errors.a.swiftmodule %t/errors.b.swiftmodule -module-name errors -o %t/errors.swiftmodule
+
+// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors -primary-file %S/Inputs/errors-a.swift %S/Inputs/errors-b.swift %S/Inputs/errors-c.swift -module-name errors -o %t/errors.a.swiftmodule
+// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors %S/Inputs/errors-a.swift -primary-file %S/Inputs/errors-b.swift %S/Inputs/errors-c.swift -module-name errors -o %t/errors.b.swiftmodule
+// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors %S/Inputs/errors-a.swift %S/Inputs/errors-b.swift -primary-file %S/Inputs/errors-c.swift -module-name errors -o %t/errors.c.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -emit-module -experimental-allow-module-with-compiler-errors %t/errors.a.swiftmodule %t/errors.b.swiftmodule %t/errors.c.swiftmodule -module-name errors -o %t/errors.swiftmodule
 
 // Read the module back in to make sure it can be deserialized
 // RUN: %target-swift-ide-test -print-module -source-filename dummy -module-to-print errors -I %t | %FileCheck %s
@@ -47,8 +105,8 @@ func foo() {
 // CHECK: typealias Item = <<error type>>
 // CHECK: let memberA: Int
 // CHECK: let memberB: <<error type>>
-// CHECK: var memberC: <<error type>> { get }
-// CHECK: lazy var memberD: <<error type>> { mutating get }
+// CHECK: var memberC: <<error type>>
+// CHECK: lazy var memberD: <<error type>>
 // CHECK: var memberE: <<error type>>
 // CHECK: mutating func set(item: <<error type>>)
 // CHECK: func invalidFuncBody()
@@ -64,62 +122,23 @@ func foo() {
 // CHECK: func invalidPartialFunc()
 // CHECK: func typeUsesFunc
 
+// Check completions
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t-completions -I %t
+
 // Check cursor info for the various symbols
 // RUN: %sourcekitd-test -req=cursor -pos=4:3 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 // CHECK-GLOBAL: source.lang.swift.ref.var.global
 // CHECK-GLOBAL: invalidGlobalMissingInit
 
-// RUN: %sourcekitd-test -req=cursor -pos=6:12 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-STRUCT
-// CHECK-STRUCT: source.lang.swift.ref.struct
-// CHECK-STRUCT: InvalidStruct
-
-// : %sourcekitd-test -req=cursor -pos=7:7 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-MEMBER
-// CHECK-MEMBER: source.lang.swift.ref.var.instance
-// CHECK-MEMBER: memberB
-
 // RUN: %sourcekitd-test -req=cursor -pos=8:3 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-FUNC
 // CHECK-FUNC: source.lang.swift.ref.function.free
 // CHECK-FUNC: invalidPartialFunc
 
-// Check completions
-// RUN: %sourcekitd-test -req=complete -pos=9:7 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-MEMBER-COMPLETE
-// CHECK-MEMBER-COMPLETE: key.name: "add(
-// CHECK-MEMBER-COMPLETE: key.name: "get(
-// CHECK-MEMBER-COMPLETE: key.name: "memberA"
-// CHECK-MEMBER-COMPLETE: key.name: "memberB"
-// CHECK-MEMBER-COMPLETE: key.name: "memberC"
-// CHECK-MEMBER-COMPLETE: key.name: "memberD"
-// CHECK-MEMBER-COMPLETE: key.name: "memberE"
-// CHECK-MEMBER-COMPLETE: key.name: "set(
+// RUN: %sourcekitd-test -req=cursor -pos=12:12 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-STRUCT
+// CHECK-STRUCT: source.lang.swift.ref.struct
+// CHECK-STRUCT: InvalidStruct
 
-// RUN: %sourcekitd-test -req=complete -pos=11:11 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-TYPE-COMPLETE
-// CHECK-TYPE-COMPLETE: key.name: "InvalidAlias"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidClass"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidClassSub1"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidClassSub2"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidEnum"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidGenericStruct"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidProtocol"
-// CHECK-TYPE-COMPLETE: key.name: "InvalidStruct"
-
-// RUN: %sourcekitd-test -req=complete -pos=12:1 %s -- -I %t -target %target-triple %s | %FileCheck %s -check-prefix=CHECK-GLOBAL-COMPLETE
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidAlias"
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidClass"
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidClassSub1"
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidClassSub2"
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidEnum"
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidFuncBody(
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidFuncSignature(
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidFuncThrows(
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidFuncType(
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidGenericFuncBody(
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidGenericFuncType(
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidGenericStruct"
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidGlobalClosureBody"
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidGlobalClosureType
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidGlobalKeypath
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidGlobalMissingInit
-// CHECK-GLOBAL-COMPLETE: key.name: "invalidPartialFunc(
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidProtocol"
-// CHECK-GLOBAL-COMPLETE: key.name: "InvalidStruct"
-// CHECK-GLOBAL-COMPLETE: key.name: "typeUsesFunc(
+// Currently doesn't work for any members with invalid types, even within the same module: rdar://71514163
+// RUN: %sourcekitd-test -req=cursor -pos=13:7 %s -- -I %t -target %target-triple %s | not %FileCheck %s -check-prefix=CHECK-MEMBER
+// CHECK-MEMBER: source.lang.swift.ref.var.instance
+// CHECK-MEMBER: memberB

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -92,8 +92,11 @@ public:
     if (auto module = dyn_cast<ModuleDecl>(dc)) {
       out << module->getName() << ".";
     } else if (auto extension = dyn_cast<ExtensionDecl>(dc)) {
-      printDecl(out, extension->getExtendedNominal());
-      out << ".";
+      auto *extended = extension->getExtendedNominal();
+      if (extended) {
+        printDecl(out, extended);
+        out << ".";
+      }
     } else if (auto decl = dyn_cast_or_null<ValueDecl>(dc->getAsDecl())) {
       printDecl(out, decl);
       out << ".";


### PR DESCRIPTION
I've been running the stress tester off and on locally while changing it to support building with -experiment-allow-modules-with-compiler-errors. This PR fixes a bunch of crashes it found, mostly to do with `getExtendedNominal` in `ExtensionDecl` possibly being null.