### PR TITLE
Fix misspellings

### DIFF
--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -27,7 +27,7 @@ namespace irgen {
 /// Construct a ConstantInt from an IntegerLiteralInst.
 llvm::Constant *emitConstantInt(IRGenModule &IGM, IntegerLiteralInst *ILI);
 
-/// Construct a zero from a zero intializer BuiltinInst.
+/// Construct a zero from a zero initializer BuiltinInst.
 llvm::Constant *emitConstantZero(IRGenModule &IGM, BuiltinInst *Bi);
 
 /// Construct a ConstantFP from a FloatLiteralInst.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -70,7 +70,7 @@ static ParserStatus parseDefaultArgument(
   SourceLoc equalLoc = P.consumeToken();
 
   if (P.SF.Kind == SourceFileKind::Interface) {
-    // Swift module interfaces don't synthesize inherited intializers and
+    // Swift module interfaces don't synthesize inherited initializers and
     // instead include them explicitly in subclasses. Since the
     // \c DefaultArgumentKind of these initializers is \c Inherited, this is
     // represented textually as `= super` in the interface.

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -629,7 +629,7 @@ void TBDGenVisitor::addDerivativeConfiguration(AbstractFunctionDecl *original,
 /// the initializer given a decl.
 /// The rule is that structs and convenience init of classes emit a
 /// dynamic replacement for the allocator.
-/// Designated init of classes emit a dynamic replacement for the intializer.
+/// Designated init of classes emit a dynamic replacement for the initializer.
 /// This is because the super class init call is emitted to the initializer and
 /// needs to be dynamic.
 static bool shouldUseAllocatorMangling(const AbstractFunctionDecl *afd) {

--- a/test/AutoDiff/Sema/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/transpose_attr_type_checking.swift
@@ -516,7 +516,7 @@ extension Struct where T: Differentiable, T == T.TangentVector {
     fatalError()
   }
 
-  // Test instance transpose for static original intializer.
+  // Test instance transpose for static original initializer.
   // TODO(TF-1015): Add improved instance/static member mismatch error.
   // expected-error @+1 {{referenced declaration 'init' could not be resolved}}
   @transpose(of: init, wrt: 0)


### PR DESCRIPTION
Replace “intializer” with “initializer”