### PR TITLE
[sil] Element shadowing of SILInstruction::getKind() by renaming MarkUninitializedInst::get{,MarkUninitialized}Kind().

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1287,9 +1287,9 @@ void
 SILCloner<ImplClass>::visitMarkUninitializedInst(MarkUninitializedInst *Inst) {
   SILValue OpValue = getOpValue(Inst->getOperand());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  recordClonedInstruction(
-      Inst, getBuilder().createMarkUninitialized(getOpLocation(Inst->getLoc()),
-                                                 OpValue, Inst->getKind()));
+  recordClonedInstruction(Inst, getBuilder().createMarkUninitialized(
+                                    getOpLocation(Inst->getLoc()), OpValue,
+                                    Inst->getMarkUninitializedKind()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4124,8 +4124,7 @@ private:
         ThisKind(K) {}
 
 public:
-
-  Kind getKind() const { return ThisKind; }
+  Kind getMarkUninitializedKind() const { return ThisKind; }
 
   bool isVar() const { return ThisKind == Var; }
   bool isRootSelf() const {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1451,7 +1451,7 @@ public:
   }
 
   void visitMarkUninitializedInst(MarkUninitializedInst *MU) {
-    switch (MU->getKind()) {
+    switch (MU->getMarkUninitializedKind()) {
     case MarkUninitializedInst::Var: *this << "[var] "; break;
     case MarkUninitializedInst::RootSelf:  *this << "[rootself] "; break;
     case MarkUninitializedInst::CrossModuleRootSelf:
@@ -1466,7 +1466,7 @@ public:
       *this << "[delegatingselfallocated] ";
       break;
     }
-    
+
     *this << getIDAndType(MU->getOperand());
   }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -194,7 +194,7 @@ public:
 
   /// True if this is an initializer that initializes stored properties.
   bool isNonDelegatingInit() const {
-    switch (MemoryInst->getKind()) {
+    switch (MemoryInst->getMarkUninitializedKind()) {
     case MarkUninitializedInst::Var:
       return false;
     case MarkUninitializedInst::RootSelf:
@@ -210,7 +210,8 @@ public:
   }
 
   bool isRootSelf() const {
-    return MemoryInst->getKind() == MarkUninitializedInst::RootSelf;
+    return MemoryInst->getMarkUninitializedKind() ==
+           MarkUninitializedInst::RootSelf;
   }
 
   bool isDelegatingSelfAllocated() const {

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -158,7 +158,7 @@ const ParamDecl *getParamDeclFromOperand(SILValue value) {
 bool isUseOfSelfInInitializer(Operand *oper) {
   if (auto *PBI = dyn_cast<ProjectBoxInst>(oper->get())) {
     if (auto *MUI = dyn_cast<MarkUninitializedInst>(PBI->getOperand())) {
-      switch (MUI->getKind()) {
+      switch (MUI->getMarkUninitializedKind()) {
       case MarkUninitializedInst::Kind::Var:
         return false;
       case MarkUninitializedInst::Kind::RootSelf:

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -518,7 +518,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
     auto *User = HeapBox->getSingleUse()->getUser();
     if (auto *MUI = dyn_cast<MarkUninitializedInst>(User)) {
       HeapBox = MUI;
-      Kind = MUI->getKind();
+      Kind = MUI->getMarkUninitializedKind();
     }
   }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1382,7 +1382,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     break;
   }
   case SILInstructionKind::MarkUninitializedInst: {
-    unsigned Attr = (unsigned)cast<MarkUninitializedInst>(&SI)->getKind();
+    unsigned Attr =
+        (unsigned)cast<MarkUninitializedInst>(&SI)->getMarkUninitializedKind();
     writeOneOperandExtraAttributeLayout(SI.getKind(), Attr, SI.getOperand(0));
     break;
   }


### PR DESCRIPTION
Interestingly this problem can only occur if one invokes
MarkUninitializedInst::getKind() directly. Once our instruction is just a
SILInstruction, we call the appropriate method so we didn't notice it.

I used Xcode's refactoring functionality to find all of the invocation
locations.
