### PR TITLE
[Clang importer] Make sure we mirror protocol decls for all names.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7459,14 +7459,15 @@ void SwiftDeclConverter::importNonOverriddenMirroredMethods(DeclContext *dc,
 
     // Import the method.
     auto proto = entries[i].second;
-    if (auto imported =
-            Impl.importMirroredDecl(objcMethod, dc, getVersion(), proto)) {
-      members.push_back(imported);
-
-      for (auto alternate : Impl.getAlternateDecls(imported))
-        if (imported->getDeclContext() == alternate->getDeclContext())
-          members.push_back(alternate);
-    }
+    Impl.forEachDistinctName(objcMethod,
+      [&](ImportedName name, ImportNameVersion version) {
+        if (auto imported =
+              Impl.importMirroredDecl(objcMethod, dc, version, proto)) {
+          if (imported->getDeclContext() == dc)
+            members.push_back(imported);
+        }
+        return true;
+    });
   }
 }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -25,6 +25,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   await slowServer.serverRestart("localhost")
   await slowServer.server("localhost", atPriorityRestart: 0.8)
+
+  _ = await slowServer.allOperations()
 }
 
 func testSlowServerSynchronous(slowServer: SlowServer) {
@@ -36,4 +38,6 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
   slowServer.doSomethingSlow("mail") { i in
     _ = i
   }
+
+  _ = slowServer.allOperations
 }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -6,7 +6,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
 
-// CHECK-LABEL: class SlowServer : NSObject {
+// CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
 // CHECK-DAG:     func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK-DAG:     func doSomethingSlow(_ operation: String) async -> Int
 // CHECK-DAG:     func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -3,7 +3,12 @@
 
 #pragma clang assume_nonnull begin
 
-@interface SlowServer : NSObject
+@protocol ServiceProvider
+@property(readonly) NSArray<NSString *> *allOperations;
+-(void)allOperationsWithCompletionHandler:(void (^)(NSArray<NSString *> *))completion;
+@end
+
+@interface SlowServer : NSObject <ServiceProvider>
 -(void)doSomethingSlow:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
 -(void)doSomethingDangerous:(NSString *)operation completionHandler:(void (^ _Nullable)(NSString *_Nullable, NSError * _Nullable))handler;
 -(void)checkAvailabilityWithCompletionHandler:(void (^)(BOOL isAvailable))completionHandler;


### PR DESCRIPTION
When mirroring declarations from protocols, make sure to mirror for
all potential imported names. Otherwise, we might miss out on one or
the other of an async import or a completion-handler import of the
same method.

Fixes rdar://71429577.
