### PR TITLE
[Concurrency] Emit @asyncHandler bodies as traps.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -517,7 +517,14 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
              fd->getResultInterfaceType(), fd->hasThrows(), fd->getThrowsLoc());
   prepareEpilog(true, fd->hasThrows(), CleanupLocation(fd));
 
-  emitStmt(fd->getTypecheckedBody());
+  if (fd->isAsyncHandler()) {
+    // Async handlers are need to have their bodies emitted into a
+    // detached task.
+    // FIXME: Actually implement these properly.
+    B.createBuiltinTrap(fd->getTypecheckedBody());
+  } else {
+    emitStmt(fd->getTypecheckedBody());
+  }
 
   emitEpilog(fd);
 


### PR DESCRIPTION
@asyncHandler is currently unimplemented in SILGen, and will cause
SIL verifier assertions if used. Rather than trigger assertions, emit
a trap for the body. Obviously, this is a temporary hack.
