### PR TITLE
[CMake] Always configure 'swift/Config.h'

### DIFF
--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,3 +1,6 @@
+configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
+              ESCAPE_QUOTES @ONLY)
+
 add_subdirectory(Runtime)
 
 if(SWIFT_BUILD_REMOTE_MIRROR)
@@ -5,8 +8,6 @@ if(SWIFT_BUILD_REMOTE_MIRROR)
 endif()
 
 if(SWIFT_INCLUDE_TOOLS)
-  configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
-                ESCAPE_QUOTES @ONLY)
   add_subdirectory(Option)
   add_subdirectory(Parse)
   add_subdirectory(Syntax)


### PR DESCRIPTION
Currently `swift/Config.h` is only configured when SWIFT_INCLUDE_TOOLS
is enabled. There is no good reason the two should be related as the
header file is not specific to the Swift tools and is used all over the
code base.