### PR TITLE
[ownership] Add a subclass for all OwnershipForwarding instructions and fix the classof to the various ownership abstract classes so isa/dyn_cast work.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -35,12 +35,13 @@ bool isValueAddressOrTrivial(SILValue v);
 /// These operations forward both owned and guaranteed ownership.
 bool isOwnershipForwardingValueKind(SILNodeKind kind);
 
-/// Is this an instruction that can forward both owned and guaranteed ownership
+/// Is this an operand that can forward both owned and guaranteed ownership
 /// kinds.
-bool isOwnershipForwardingInst(SILInstruction *i);
+bool isOwnershipForwardingUse(Operand *op);
 
-/// Is this an instruction that can forward guaranteed ownership.
-bool isGuaranteedForwardingInst(SILInstruction *i);
+/// Is this an operand that forwards guaranteed ownership from its value to a
+/// result of the using instruction.
+bool isGuaranteedForwardingUse(Operand *op);
 
 /// These operations forward guaranteed ownership, but don't necessarily forward
 /// owned values.
@@ -54,12 +55,12 @@ bool isGuaranteedForwardingValue(SILValue value);
 /// forward guaranteed ownership.
 bool isOwnedForwardingValueKind(SILNodeKind kind);
 
-/// Does this SILInstruction 'forward' owned ownership, but may not be able to
-/// forward guaranteed ownership.
-bool isOwnedForwardingInstruction(SILInstruction *inst);
-
-/// Does this value 'forward' owned ownership, but may not be able to forward
+/// Does this operand 'forward' owned ownership, but may not be able to forward
 /// guaranteed ownership.
+bool isOwnedForwardingUse(Operand *use);
+
+/// Is this value the result of an instruction that 'forward's owned ownership,
+/// but may not be able to forward guaranteed ownership.
 ///
 /// This will be either a multiple value instruction resuilt, a single value
 /// instruction that forwards or an argument that forwards the ownership from a
@@ -78,6 +79,10 @@ public:
   void setOwnershipKind(ValueOwnershipKind newKind) const;
   void replaceOwnershipKind(ValueOwnershipKind oldKind,
                             ValueOwnershipKind newKind) const;
+
+  OwnershipForwardingInst *getUser() const {
+    return cast<OwnershipForwardingInst>(use->getUser());
+  }
 };
 
 /// Returns true if the instruction is a 'reborrow'.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -856,38 +856,95 @@ inline SingleValueInstruction *SILNode::castToSingleValueInstruction() {
   }
 }
 
-#define DEFINE_ABSTRACT_SINGLE_VALUE_INST_BOILERPLATE(ID)       \
-  static bool classof(const SILNode *node) {                    \
-    return node->getKind() >= SILNodeKind::First_##ID &&        \
-           node->getKind() <= SILNodeKind::Last_##ID;           \
-  }                                                             \
-  static bool classof(const SingleValueInstruction *inst) {     \
-    return inst->getKind() >= SILInstructionKind::First_##ID && \
-           inst->getKind() <= SILInstructionKind::Last_##ID;    \
+#define DEFINE_ABSTRACT_SINGLE_VALUE_INST_BOILERPLATE(ID)                      \
+  static bool classof(const SILNode *node) {                                   \
+    return node->getKind() >= SILNodeKind::First_##ID &&                       \
+           node->getKind() <= SILNodeKind::Last_##ID;                          \
+  }                                                                            \
+  static bool classof(const SingleValueInstruction *inst) {                    \
+    return inst->getKind() >= SILInstructionKind::First_##ID &&                \
+           inst->getKind() <= SILInstructionKind::Last_##ID;                   \
   }
+
+/// Abstract base class used for isa checks on instructions to determine if they
+/// forward ownership and to verify that the set of ownership instructions and
+/// the ownership utilities stay in sync via assertions.
+///
+/// NOTE: We assume that the constructor for the instruction subclass that
+/// initializes the kind field on our object is run before our constructor runs.
+class OwnershipForwardingInst {
+  ValueOwnershipKind ownershipKind;
+
+protected:
+  OwnershipForwardingInst(SILInstructionKind kind,
+                          ValueOwnershipKind ownershipKind)
+      : ownershipKind(ownershipKind) {
+    assert(classof(kind) && "Invalid subclass?!");
+  }
+
+public:
+  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
+
+  void setOwnershipKind(ValueOwnershipKind newKind) { ownershipKind = newKind; }
+
+  static bool classof(const SILNode *node) {
+    if (auto *i = dyn_cast<SILInstruction>(node))
+      return classof(i);
+    return false;
+  }
+
+  // Defined inline below due to forward declaration issues.
+  static bool classof(const SILInstruction *inst);
+
+  /// Define inline below due to forward declaration issues.
+  static bool classof(SILInstructionKind kind);
+};
 
 /// A single value inst that forwards a static ownership from one (or all) of
 /// its operands.
 ///
 /// The ownership kind is set on construction and afterwards must be changed
 /// explicitly using setOwnershipKind().
-class OwnershipForwardingSingleValueInst : public SingleValueInstruction {
-  ValueOwnershipKind ownershipKind;
-
+class OwnershipForwardingSingleValueInst : public SingleValueInstruction,
+                                           public OwnershipForwardingInst {
 protected:
   OwnershipForwardingSingleValueInst(SILInstructionKind kind,
                                      SILDebugLocation debugLoc, SILType ty,
                                      ValueOwnershipKind ownershipKind)
       : SingleValueInstruction(kind, debugLoc, ty),
-        ownershipKind(ownershipKind) {
-    assert(ownershipKind);
+        OwnershipForwardingInst(kind, ownershipKind) {
+    assert(classof(kind) && "classof missing new subclass?!");
   }
 
 public:
-  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
-  void setOwnershipKind(ValueOwnershipKind newOwnershipKind) {
-    ownershipKind = newOwnershipKind;
-    assert(ownershipKind);
+  static bool classof(const SILNode *node) {
+    if (auto *i = dyn_cast<SILInstruction>(node))
+      return classof(i);
+    return false;
+  }
+
+  static bool classof(SILInstructionKind kind) {
+    switch (kind) {
+    case SILInstructionKind::MarkUninitializedInst:
+    case SILInstructionKind::StructInst:
+    case SILInstructionKind::ObjectInst:
+    case SILInstructionKind::TupleInst:
+    case SILInstructionKind::EnumInst:
+    case SILInstructionKind::UncheckedEnumDataInst:
+    case SILInstructionKind::SelectValueInst:
+    case SILInstructionKind::OpenExistentialRefInst:
+    case SILInstructionKind::InitExistentialRefInst:
+    case SILInstructionKind::MarkDependenceInst:
+    case SILInstructionKind::LinearFunctionInst:
+    case SILInstructionKind::DifferentiableFunctionInst:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  static bool classof(const SILInstruction *inst) {
+    return classof(inst->getKind());
   }
 };
 
@@ -4430,19 +4487,42 @@ public:
 
 /// A conversion inst that produces a static OwnershipKind set upon the
 /// instruction's construction.
-class OwnershipForwardingConversionInst : public ConversionInst {
-  ValueOwnershipKind ownershipKind;
-
+class OwnershipForwardingConversionInst : public ConversionInst,
+                                          public OwnershipForwardingInst {
 protected:
   OwnershipForwardingConversionInst(SILInstructionKind kind,
                                     SILDebugLocation debugLoc, SILType ty,
                                     ValueOwnershipKind ownershipKind)
-      : ConversionInst(kind, debugLoc, ty), ownershipKind(ownershipKind) {}
+      : ConversionInst(kind, debugLoc, ty),
+        OwnershipForwardingInst(kind, ownershipKind) {
+    assert(classof(kind) && "classof missing subclass?!");
+  }
 
 public:
-  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
-  void setOwnershipKind(ValueOwnershipKind newOwnershipKind) {
-    ownershipKind = newOwnershipKind;
+  static bool classof(const SILNode *node) {
+    if (auto *i = dyn_cast<SILInstruction>(node))
+      return classof(i);
+    return false;
+  }
+
+  static bool classof(const SILInstruction *inst) {
+    return classof(inst->getKind());
+  }
+
+  static bool classof(SILInstructionKind kind) {
+    switch (kind) {
+    case SILInstructionKind::ConvertFunctionInst:
+    case SILInstructionKind::UpcastInst:
+    case SILInstructionKind::UncheckedRefCastInst:
+    case SILInstructionKind::UncheckedValueCastInst:
+    case SILInstructionKind::RefToBridgeObjectInst:
+    case SILInstructionKind::BridgeObjectToRefInst:
+    case SILInstructionKind::ThinToThickFunctionInst:
+    case SILInstructionKind::UnconditionalCheckedCastInst:
+      return true;
+    default:
+      return false;
+    }
   }
 };
 
@@ -5610,9 +5690,8 @@ public:
 };
 
 /// A select enum inst that produces a static OwnershipKind.
-class OwnershipForwardingSelectEnumInstBase : public SelectEnumInstBase {
-  ValueOwnershipKind ownershipKind;
-
+class OwnershipForwardingSelectEnumInstBase : public SelectEnumInstBase,
+                                              public OwnershipForwardingInst {
 protected:
   OwnershipForwardingSelectEnumInstBase(
       SILInstructionKind kind, SILDebugLocation debugLoc, SILType type,
@@ -5620,12 +5699,26 @@ protected:
       ProfileCounter defaultCount, ValueOwnershipKind ownershipKind)
       : SelectEnumInstBase(kind, debugLoc, type, defaultValue, caseCounts,
                            defaultCount),
-        ownershipKind(ownershipKind) {}
+        OwnershipForwardingInst(kind, ownershipKind) {
+    assert(classof(kind) && "classof missing subclass");
+  }
 
 public:
-  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
-  void setOwnershipKind(ValueOwnershipKind newOwnershipKind) {
-    ownershipKind = newOwnershipKind;
+  static bool classof(const SILNode *node) {
+    if (auto *i = dyn_cast<SILInstruction>(node))
+      return classof(i);
+    return false;
+  }
+
+  static bool classof(const SILInstruction *i) { return classof(i->getKind()); }
+
+  static bool classof(SILInstructionKind kind) {
+    switch (kind) {
+    case SILInstructionKind::SelectEnumInst:
+      return true;
+    default:
+      return false;
+    }
   }
 };
 
@@ -7327,18 +7420,31 @@ public:
   }
 };
 
-class OwnershipForwardingTermInst : public TermInst {
-  ValueOwnershipKind ownershipKind;
-
+class OwnershipForwardingTermInst : public TermInst,
+                                    public OwnershipForwardingInst {
 protected:
   OwnershipForwardingTermInst(SILInstructionKind kind,
                               SILDebugLocation debugLoc,
                               ValueOwnershipKind ownershipKind)
-      : TermInst(kind, debugLoc), ownershipKind(ownershipKind) {}
+      : TermInst(kind, debugLoc), OwnershipForwardingInst(kind, ownershipKind) {
+    assert(classof(kind));
+  }
 
 public:
-  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
-  void setOwnershipKind(ValueOwnershipKind newKind) { ownershipKind = newKind; }
+  static bool classof(const SILNode *node) {
+    if (auto *i = dyn_cast<SILInstruction>(node))
+      return classof(i);
+    return false;
+  }
+
+  static bool classof(const SILInstruction *inst) {
+    return classof(inst->getKind());
+  }
+
+  static bool classof(SILInstructionKind kind) {
+    return kind == SILInstructionKind::SwitchEnumInst ||
+           kind == SILInstructionKind::CheckedCastBranchInst;
+  }
 };
 
 /// UnreachableInst - Position in the code which would be undefined to reach.
@@ -8771,19 +8877,33 @@ SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
 }
 
 class OwnershipForwardingMultipleValueInstruction
-    : public MultipleValueInstruction {
-  ValueOwnershipKind ownershipKind;
-
+    : public MultipleValueInstruction,
+      public OwnershipForwardingInst {
 public:
   OwnershipForwardingMultipleValueInstruction(SILInstructionKind kind,
                                               SILDebugLocation loc,
                                               ValueOwnershipKind ownershipKind)
-      : MultipleValueInstruction(kind, loc), ownershipKind(ownershipKind) {}
+      : MultipleValueInstruction(kind, loc),
+        OwnershipForwardingInst(kind, ownershipKind) {
+    assert(classof(kind) && "Missing subclass from classof?!");
+  }
 
-  /// Returns the preferred ownership kind of this multiple value instruction.
-  ValueOwnershipKind getOwnershipKind() const { return ownershipKind; }
-  void setOwnershipKind(ValueOwnershipKind newOwnershipKind) {
-    ownershipKind = newOwnershipKind;
+  static bool classof(const SILNode *n) {
+    if (auto *i = dyn_cast<SILInstruction>(n))
+      return classof(i);
+    return false;
+  }
+
+  static bool classof(const SILInstruction *i) { return classof(i->getKind()); }
+
+  static bool classof(SILInstructionKind kind) {
+    switch (kind) {
+    case SILInstructionKind::DestructureTupleInst:
+    case SILInstructionKind::DestructureStructInst:
+      return true;
+    default:
+      return false;
+    }
   }
 };
 
@@ -8951,6 +9071,22 @@ inline void SILSuccessor::pred_iterator::cacheBasicBlock() {
 // Declared in SILValue.h
 inline bool Operand::isTypeDependent() const {
   return getUser()->isTypeDependentOperand(*this);
+}
+
+inline bool OwnershipForwardingInst::classof(const SILInstruction *inst) {
+  return OwnershipForwardingSingleValueInst::classof(inst) ||
+         OwnershipForwardingTermInst::classof(inst) ||
+         OwnershipForwardingConversionInst::classof(inst) ||
+         OwnershipForwardingSelectEnumInstBase::classof(inst) ||
+         OwnershipForwardingMultipleValueInstruction::classof(inst);
+}
+
+inline bool OwnershipForwardingInst::classof(SILInstructionKind kind) {
+  return OwnershipForwardingSingleValueInst::classof(kind) ||
+         OwnershipForwardingTermInst::classof(kind) ||
+         OwnershipForwardingConversionInst::classof(kind) ||
+         OwnershipForwardingSelectEnumInstBase::classof(kind) ||
+         OwnershipForwardingMultipleValueInstruction::classof(kind);
 }
 
 } // end swift namespace

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -319,7 +319,7 @@ FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
   OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
       INST##Inst *i) {                                                         \
     assert(i->getNumOperands() && "Expected to have non-zero operands");       \
-    assert(isGuaranteedForwardingInst(i) &&                                    \
+    assert(isGuaranteedForwardingValueKind(SILNodeKind(i->getKind())) &&       \
            "Expected an ownership forwarding inst");                           \
     return {OwnershipKind::OWNERSHIP,                                          \
             UseLifetimeConstraint::USE_LIFETIME_CONSTRAINT};                   \

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -326,7 +326,7 @@ bool SILValueOwnershipChecker::gatherUsers(
     // Example: A guaranteed parameter of a co-routine.
 
     // Now check if we have a non guaranteed forwarding inst...
-    if (!isGuaranteedForwardingInst(user)) {
+    if (!isGuaranteedForwardingUse(op)) {
       // First check if we are visiting an operand that is a consuming use...
       if (op->isLifetimeEnding()) {
         // If its underlying value is our original value, then this is a true

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1003,7 +1003,7 @@ public:
     // Check the SILLLocation attached to the instruction.
     checkInstructionsSILLocation(I);
 
-    // Check ownership.
+    // Check ownership and types.
     SILFunction *F = I->getFunction();
     assert(F && "Expected value base with parent function");
 

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -296,7 +296,7 @@ static bool canSafelyJoinSimpleRange(SILValue cviOperand,
   // NOTE: This use may be any type of consuming use and may not be a
   // destroy_value.
   auto *cviConsumer = cvi->getSingleConsumingUse();
-  if (!cviConsumer || isOwnedForwardingInstruction(cviConsumer->getUser())) {
+  if (!cviConsumer || isOwnedForwardingUse(cviConsumer)) {
     return false;
   }
 

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -72,7 +72,7 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
     // support it though if we need to.
     auto *ti = dyn_cast<TermInst>(user);
     if ((ti && !ti->isTransformationTerminator()) ||
-        !isGuaranteedForwardingInst(user) ||
+        !isGuaranteedForwardingUse(op) ||
         1 != count_if(user->getOperandValues(
                           true /*ignore type dependent operands*/),
                       [&](SILValue v) {

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -121,7 +121,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
 
   /// The default visitor.
   bool visitSILInstruction(SILInstruction *i) {
-    assert(!isGuaranteedForwardingInst(i) &&
+    assert(!isGuaranteedForwardingValueKind(SILNodeKind(i->getKind())) &&
            "Should have forwarding visitor for all ownership forwarding "
            "instructions");
     return false;


### PR DESCRIPTION
I think what was happening here was that we were using one of the superclass
classofs and were getting lucky since in the place I was using this I was
guaranteed to have single value instructions and that is what I wrote as my
first case X ).

I also added more robust checks tieing the older isGuaranteed...* APIs to the
ForwardingOperand API. I also eliminated the notion of Branch being an owned
forwarding instruction. We only used this in one place in the compiler (when
finding owned value introducers), yet we treat a phi as an introducer, so we
would never hit a branch in our search since we would stop at the phi argument.
The bigger picture here is that this means that all "forwarding instructions"
either forward ownership for everything or for everything but owned/unowned.

And for those listening in, I did find one instruction that was from an
ownership forwarding subclass but was not marked as forwarding:
DifferentiableFunctionInst. With this change, we can no longer by mistake have
such errors enter the code base.
