### PR TITLE
[ConstraintSystem] Detect and diagnose extraneous return(s) in result build body

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5461,8 +5461,8 @@ NOTE(previous_result_builder_here, none,
 ERROR(result_builder_arguments, none,
       "result builder attributes cannot have arguments", ())
 ERROR(result_builder_disabled_by_return, none,
-      "application of result builder %0 disabled by explicit 'return' "
-      "statement", (Type))
+      "cannot use explicit 'return' statement in the body of result builder %0",
+      (Type))
 WARNING(result_builder_disabled_by_return_warn, none,
         "application of result builder %0 disabled by explicit 'return' "
         "statement", (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5460,7 +5460,10 @@ NOTE(previous_result_builder_here, none,
      "previous result builder specified here", ())
 ERROR(result_builder_arguments, none,
       "result builder attributes cannot have arguments", ())
-WARNING(result_builder_disabled_by_return, none,
+ERROR(result_builder_disabled_by_return, none,
+      "application of result builder %0 disabled by explicit 'return' "
+      "statement", (Type))
+WARNING(result_builder_disabled_by_return_warn, none,
         "application of result builder %0 disabled by explicit 'return' "
         "statement", (Type))
 NOTE(result_builder_remove_attr, none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2023,7 +2023,8 @@ public:
                                                ConstraintLocator *locator);
 };
 
-class IgnoreInvalidResultBuilderBody final : public ConstraintFix {
+class IgnoreInvalidResultBuilderBody : public ConstraintFix {
+protected:
   enum class ErrorInPhase {
     PreCheck,
     ConstraintGeneration,
@@ -2060,6 +2061,22 @@ public:
 private:
   static IgnoreInvalidResultBuilderBody *
   create(ConstraintSystem &cs, ErrorInPhase phase, ConstraintLocator *locator);
+};
+
+class IgnoreResultBuilderWithReturnStmts final
+    : public IgnoreInvalidResultBuilderBody {
+  Type BuilderType;
+
+  IgnoreResultBuilderWithReturnStmts(ConstraintSystem &cs, Type builderTy,
+                                     ConstraintLocator *locator)
+      : IgnoreInvalidResultBuilderBody(cs, ErrorInPhase::PreCheck, locator),
+        BuilderType(builderTy) {}
+
+public:
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static IgnoreResultBuilderWithReturnStmts *
+  create(ConstraintSystem &cs, Type builderTy, ConstraintLocator *locator);
 };
 
 class SpecifyContextualTypeForNil final : public ConstraintFix {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1671,7 +1671,7 @@ ConstraintSystem::matchResultBuilder(
   if (InvalidResultBuilderBodies.count(fn)) {
     (void)recordFix(
         IgnoreInvalidResultBuilderBody::duringConstraintGeneration(
-            *this, getConstraintLocator(fn.getBody())));
+            *this, getConstraintLocator(fn.getAbstractClosureExpr())));
     return getTypeMatchSuccess();
   }
 
@@ -1690,13 +1690,25 @@ ConstraintSystem::matchResultBuilder(
       return getTypeMatchFailure(locator);
 
     if (recordFix(IgnoreInvalidResultBuilderBody::duringPreCheck(
-            *this, getConstraintLocator(fn.getBody()))))
+            *this, getConstraintLocator(fn.getAbstractClosureExpr()))))
       return getTypeMatchFailure(locator);
 
     return getTypeMatchSuccess();
   }
 
   case ResultBuilderBodyPreCheck::HasReturnStmt:
+    // Diagnostic mode means that solver couldn't reach any viable
+    // solution, so let's diagnose presence of a `return` statement
+    // in the closure body.
+    if (shouldAttemptFixes()) {
+      if (recordFix(IgnoreResultBuilderWithReturnStmts::create(
+              *this, builderType,
+              getConstraintLocator(fn.getAbstractClosureExpr()))))
+        return getTypeMatchFailure(locator);
+
+      return getTypeMatchSuccess();
+    }
+
     // If the body has a return statement, suppress the transform but
     // continue solving the constraint system.
     return None;
@@ -1744,7 +1756,7 @@ ConstraintSystem::matchResultBuilder(
 
       if (recordFix(
               IgnoreInvalidResultBuilderBody::duringConstraintGeneration(
-                  *this, getConstraintLocator(fn.getBody()))))
+                  *this, getConstraintLocator(fn.getAbstractClosureExpr()))))
         return getTypeMatchFailure(locator);
 
       return getTypeMatchSuccess();

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1554,7 +1554,7 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
 
     ctx.Diags.diagnose(
         returnStmts.front()->getReturnLoc(),
-        diag::result_builder_disabled_by_return, builderType);
+        diag::result_builder_disabled_by_return_warn, builderType);
 
     // Note that one can remove the result builder attribute.
     auto attr = func->getAttachedResultBuilder();

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1424,7 +1424,7 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     // If the whole body is being ignored due to a pre-check failure,
     // let's not record a fix about result type since there is
     // just not enough context to infer it without a body.
-    if (cs.hasFixFor(cs.getConstraintLocator(closure->getBody()),
+    if (cs.hasFixFor(cs.getConstraintLocator(closure),
                      FixKind::IgnoreInvalidResultBuilderBody))
       return None;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7052,3 +7052,22 @@ bool ReferenceToInvalidDeclaration::diagnoseAsError() {
   emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
   return true;
 }
+
+bool InvalidReturnInResultBuilderBody::diagnoseAsError() {
+  auto *closure = castToExpr<ClosureExpr>(getAnchor());
+
+  auto returnStmts = TypeChecker::findReturnStatements(closure);
+  assert(!returnStmts.empty());
+
+  auto loc = returnStmts.front()->getReturnLoc();
+  emitDiagnosticAt(loc, diag::result_builder_disabled_by_return, BuilderType);
+
+  // Note that one can remove all of the return statements.
+  {
+    auto diag = emitDiagnosticAt(loc, diag::result_builder_remove_returns);
+    for (auto returnStmt : returnStmts)
+      diag.fixItRemove(returnStmt->getReturnLoc());
+  }
+
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2308,6 +2308,26 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose use of `return` statements in a body of a result builder.
+///
+/// \code
+/// struct S : Builder {
+///   var foo: some Builder {
+///     return EmptyBuilder()
+///   }
+/// }
+/// \endcode
+class InvalidReturnInResultBuilderBody final : public FailureDiagnostic {
+  Type BuilderType;
+
+public:
+  InvalidReturnInResultBuilderBody(const Solution &solution, Type builderTy,
+                                   ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), BuilderType(builderTy) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1644,3 +1644,15 @@ AllowRefToInvalidDecl::create(ConstraintSystem &cs,
                               ConstraintLocator *locator) {
   return new (cs.getAllocator()) AllowRefToInvalidDecl(cs, locator);
 }
+
+bool IgnoreResultBuilderWithReturnStmts::diagnose(const Solution &solution,
+                                                  bool asNote) const {
+  return false;
+}
+
+IgnoreResultBuilderWithReturnStmts *
+IgnoreResultBuilderWithReturnStmts::create(ConstraintSystem &cs, Type builderTy,
+                                           ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      IgnoreResultBuilderWithReturnStmts(cs, builderTy, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1647,7 +1647,8 @@ AllowRefToInvalidDecl::create(ConstraintSystem &cs,
 
 bool IgnoreResultBuilderWithReturnStmts::diagnose(const Solution &solution,
                                                   bool asNote) const {
-  return false;
+  InvalidReturnInResultBuilderBody failure(solution, BuilderType, getLocator());
+  return failure.diagnose(asNote);
 }
 
 IgnoreResultBuilderWithReturnStmts *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1579,7 +1579,7 @@ bool IgnoreInvalidResultBuilderBody::diagnose(const Solution &solution,
     return true; // Already diagnosed by `matchResultBuilder`.
   }
 
-  auto *S = getAnchor().get<Stmt *>();
+  auto *S = castToExpr<ClosureExpr>(getAnchor())->getBody();
 
   class PreCheckWalker : public ASTWalker {
     DeclContext *DC;

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -286,6 +286,21 @@ struct MyTuplifiedStruct {
   }
 }
 
+func test_invalid_return_type_in_body() {
+  tuplify(true) { _ -> (Void, Int) in
+    tuplify(false) { condition in
+      if condition {
+        return 42 // expected-error {{application of result builder 'TupleBuilder' disabled by explicit 'return' statement}}
+        // expected-note@-1 {{remove 'return' statements to apply the result builder}} {{9-16=}}
+      } else {
+        1
+      }
+    }
+
+    42
+  }
+}
+
 // Check that we're performing syntactic use diagnostics.
 func acceptMetatype<T>(_: T.Type) -> Bool { true }
 

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -290,7 +290,7 @@ func test_invalid_return_type_in_body() {
   tuplify(true) { _ -> (Void, Int) in
     tuplify(false) { condition in
       if condition {
-        return 42 // expected-error {{application of result builder 'TupleBuilder' disabled by explicit 'return' statement}}
+        return 42 // expected-error {{cannot use explicit 'return' statement in the body of result builder 'TupleBuilder'}}
         // expected-note@-1 {{remove 'return' statements to apply the result builder}} {{9-16=}}
       } else {
         1


### PR DESCRIPTION
This is (hopefully) the last source of "failed to produce a diagnostic" related to result builder
where having a `return` would just assume that body is a regular closure just to fail a bit later.

Instead of doing that (in diagnostic mode) let's mark body with explicit returns as invalid and
carry on solving to diagnose it if it was possible to reach a solution, this would also mean
that situations where nested result builders have `return` statements are going to be correctly
diagnosed.

Resolves: rdar://problem/66709164

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
