### PR TITLE
[sil] Add a non-const version of SILPhiArgument *BranchInst::getArgForOperand(Operand *)

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7581,9 +7581,15 @@ public:
   SILValue getArg(unsigned i) const { return getAllOperands()[i].get(); }
 
   /// Return the SILPhiArgument for the given operand.
+  const SILPhiArgument *getArgForOperand(const Operand *oper) const {
+    auto *self = const_cast<BranchInst *>(this);
+    return self->getArgForOperand(oper);
+  }
+
+  /// Return the SILPhiArgument for the given operand.
   ///
   /// See SILArgument.cpp.
-  const SILPhiArgument *getArgForOperand(const Operand *oper) const;
+  SILPhiArgument *getArgForOperand(const Operand *oper);
 };
 
 /// A conditional branch.

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -300,7 +300,7 @@ TermInst *SILPhiArgument::getSingleTerminator() const {
   return const_cast<SILBasicBlock *>(predBlock)->getTerminator();
 }
 
-const SILPhiArgument *BranchInst::getArgForOperand(const Operand *oper) const {
+SILPhiArgument *BranchInst::getArgForOperand(const Operand *oper) {
   assert(oper->getUser() == this);
   return cast<SILPhiArgument>(
       getDestBB()->getArgument(oper->getOperandNumber()));


### PR DESCRIPTION
Just a useful API.