### PR TITLE
[semantic-arc] Eliminate simple recursive copy without borrows involved.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -18,6 +18,7 @@
 
 #include "OwnershipPhiOperand.h"
 #include "SemanticARCOptVisitor.h"
+#include "swift/SIL/LinearLifetimeChecker.h"
 
 using namespace swift;
 using namespace swift::semanticarc;
@@ -450,6 +451,65 @@ bool SemanticARCOptVisitor::tryJoiningCopyValueLiveRangeWithOperand(
   return false;
 }
 
+/// Given an owned value that is completely enclosed within its parent owned
+/// value and is not consumed, eliminate the copy.
+bool SemanticARCOptVisitor::tryPerformOwnedCopyValueOptimization(
+    CopyValueInst *cvi) {
+  if (ctx.onlyGuaranteedOpts)
+    return false;
+
+  auto originalValue = cvi->getOperand();
+  if (originalValue.getOwnershipKind() != OwnershipKind::Owned)
+    return false;
+
+  // TODO: Add support for forwarding insts here.
+  SmallVector<DestroyValueInst *, 8> destroyingUses;
+  SmallVector<Operand *, 32> allCopyUses;
+  for (auto *use : cvi->getUses()) {
+    // First just stash our use so we have /all uses/.
+    allCopyUses.push_back(use);
+
+    // Then if we are not a lifetime ending use, just continue.
+    if (!use->isLifetimeEnding()) {
+      continue;
+    }
+
+    // Otherwise, if we have a destroy value lifetime ending use, stash that.
+    if (auto *dvi = dyn_cast<DestroyValueInst>(use->getUser())) {
+      destroyingUses.push_back(dvi);
+      continue;
+    }
+
+    // Otherwise, just bail for now.
+    return false;
+  }
+
+  // NOTE: We do not actually care if the parent's lifetime ends with
+  // destroy_values. All we care is that it is lifetime ending and the use isn't
+  // a forwarding instruction.
+  SmallVector<Operand *, 8> parentLifetimeEndingUses;
+  for (auto *origValueUse : originalValue->getUses())
+    if (origValueUse->isLifetimeEnding() &&
+        !isa<OwnershipForwardingInst>(origValueUse->getUser()))
+      parentLifetimeEndingUses.push_back(origValueUse);
+
+  // Ok, we have an owned value. If we do not have any non-destroying consuming
+  // uses, see if all of our uses (ignoring destroying uses) are within our
+  // parent owned value's lifetime.
+  SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
+  LinearLifetimeChecker checker(visitedBlocks, ctx.getDeadEndBlocks());
+  if (!checker.validateLifetime(originalValue, parentLifetimeEndingUses,
+                                allCopyUses))
+    return false;
+
+  // Ok, we can perform our transform. Eliminate all of our destroy value insts,
+  // and then RAUW our copy value with our parent value.
+  while (!destroyingUses.empty())
+    eraseInstruction(destroyingUses.pop_back_val());
+  eraseAndRAUWSingleValueInstruction(cvi, cvi->getOperand());
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
@@ -469,6 +529,10 @@ bool SemanticARCOptVisitor::visitCopyValueInst(CopyValueInst *cvi) {
 
   // Then try to perform the guaranteed copy value optimization.
   if (performGuaranteedCopyValueOptimization(cvi)) {
+    return true;
+  }
+
+  if (tryPerformOwnedCopyValueOptimization(cvi)) {
     return true;
   }
 

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -196,6 +196,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi);
   bool eliminateDeadLiveRangeCopyValue(CopyValueInst *cvi);
   bool tryJoiningCopyValueLiveRangeWithOperand(CopyValueInst *cvi);
+  bool tryPerformOwnedCopyValueOptimization(CopyValueInst *cvi);
 };
 
 } // namespace semanticarc

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -21,11 +21,14 @@ sil @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 sil @get_owned_obj : $@convention(thin) () -> @owned Builtin.NativeObject
 sil @unreachable_guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> MyNever
 sil @inout_user : $@convention(thin) (@inout FakeOptional<NativeObjectPair>) -> ()
+sil @get_native_object : $@convention(thin) () -> @owned Builtin.NativeObject
 
 struct NativeObjectPair {
   var obj1 : Builtin.NativeObject
   var obj2 : Builtin.NativeObject
 }
+
+sil @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
 
 struct FakeOptionalNativeObjectPairPair {
   var pair1 : FakeOptional<NativeObjectPair>
@@ -34,6 +37,7 @@ struct FakeOptionalNativeObjectPairPair {
 sil @inout_user2 : $@convention(thin) (@inout FakeOptionalNativeObjectPairPair) -> ()
 
 sil @get_nativeobject_pair : $@convention(thin) () -> @owned NativeObjectPair
+sil @consume_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
 
 protocol MyFakeAnyObject : Klass {
   func myFakeMethod()
@@ -2868,3 +2872,208 @@ bb3(%result : @owned $FakeOptional<Builtin.NativeObject>):
   dealloc_stack %allocStack : $*Builtin.NativeObject
   return %result : $FakeOptional<Builtin.NativeObject>
 }
+
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case : $@convention(thin) () -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case'
+sil [ossa] @simple_recursive_copy_case : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  %3 = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_value %1 : $NativeObjectPair
+  destroy_value %pair : $NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case_2 : $@convention(thin) () -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case_2'
+sil [ossa] @simple_recursive_copy_case_2 : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  destroy_value %pair : $NativeObjectPair
+  %3 = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_value %1 : $NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We fail in this case since the lifetime of %pair ends too early and our
+// joined lifetime analysis is too simplistic to handle this case.
+//
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case_3 : $@convention(thin) () -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case_3'
+sil [ossa] @simple_recursive_copy_case_3 : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  %3 = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  %consumeFunc = function_ref @consume_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
+  apply %consumeFunc(%pair) : $@convention(thin) (@owned NativeObjectPair) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  (%1a, %1b) = destructure_struct %1 : $NativeObjectPair
+  %ownedUser = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %ownedUser(%1a) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %ownedUser(%1b) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  br bb3
+
+bb2:
+  destroy_value %1 : $NativeObjectPair
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This case fails due to the destructure of our parent object even though the
+// lifetimes line up. We don't support destructures here yet.
+//
+// TODO: Handle this!
+//
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case_4 : $@convention(thin) () -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case_4'
+sil [ossa] @simple_recursive_copy_case_4 : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  %3 = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  %consumeFunc = function_ref @consume_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
+  destroy_value %1 : $NativeObjectPair
+  (%pair1, %pair2) = destructure_struct %pair : $NativeObjectPair
+  %ownedUser = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %ownedUser(%pair1) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %ownedUser(%pair2) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This case fails due to the destructure of our parent object even though the
+// lifetimes line up. We don't support destructures here yet.
+//
+// TODO: Handle this!
+//
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case_5 : $@convention(thin) () -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case_5'
+sil [ossa] @simple_recursive_copy_case_5 : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  %3 = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  %consumeFunc = function_ref @consume_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
+  (%pair1, %pair2) = destructure_struct %pair : $NativeObjectPair
+  %ownedUser = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  destroy_value %1 : $NativeObjectPair
+  apply %ownedUser(%pair1) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  apply %ownedUser(%pair2) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure we do not eliminate copies where only the destroy_value is outside
+// of the lifetime of the parent value, but a begin_borrow extends the lifetime
+// of the value.
+//
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case_destroying_use_out_of_lifetime : $@convention(thin) () -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case_destroying_use_out_of_lifetime'
+sil [ossa] @simple_recursive_copy_case_destroying_use_out_of_lifetime : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %pairBorrow = begin_borrow %pair : $NativeObjectPair
+  %3 = struct_extract %pairBorrow : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %pairBorrow : $NativeObjectPair
+  cond_br undef, bb1, bb2
+
+bb1:
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  destroy_value %pair : $NativeObjectPair
+  %3a = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  apply %gUserFun(%3a) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_value %1 : $NativeObjectPair
+  br bb3
+
+bb2:
+  destroy_value %pair : $NativeObjectPair
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Second version of the test that consumes the pair in case we make the
+// lifetime joining smart enough to handle the original case.
+//
+// CHECK-LABEL: sil [ossa] @simple_recursive_copy_case_destroying_use_out_of_lifetime_2 : $@convention(thin) () -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'simple_recursive_copy_case_destroying_use_out_of_lifetime_2'
+sil [ossa] @simple_recursive_copy_case_destroying_use_out_of_lifetime_2 : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @get_object_pair : $@convention(thin) () -> @owned NativeObjectPair
+  %pair = apply %f() : $@convention(thin) () -> @owned NativeObjectPair
+  %pairBorrow = begin_borrow %pair : $NativeObjectPair
+  %3 = struct_extract %pairBorrow : $NativeObjectPair, #NativeObjectPair.obj1
+  %gUserFun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %gUserFun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %pairBorrow : $NativeObjectPair
+  cond_br undef, bb1, bb2
+
+bb1:
+  %1 = copy_value %pair : $NativeObjectPair
+  %2 = begin_borrow %1 : $NativeObjectPair
+  destroy_value %pair : $NativeObjectPair
+  %3a = struct_extract %2 : $NativeObjectPair, #NativeObjectPair.obj1
+  apply %gUserFun(%3a) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_value %1 : $NativeObjectPair
+  br bb3
+
+bb2:
+  %consumePair = function_ref @consume_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
+  apply %consumePair(%pair) : $@convention(thin) (@owned NativeObjectPair) -> ()
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
This doesn't happen as much as the guaranteed + owned value optimization but can
occur once we start eliminating borrow scopes. I noticed that I needed this when
looking at the arbitrary RAUW for ownership API.
