### PR TITLE
Coalesce multiple `Unsafe*Continuation` definitions.

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -24,15 +24,15 @@ public struct PartialAsyncTask {
 public struct UnsafeContinuation<T> {
   private var context: UnsafeRawPointer
 
-  public func resume(_: __owned T) { }
+  public func resume(returning: __owned T) { }
 }
 
 @frozen
 public struct UnsafeThrowingContinuation<T> {
   private var context: UnsafeRawPointer
 
-  public func resume(_: __owned T) { }
-  public func fail(_: __owned Error) { }
+  public func resume(returning: __owned T) { }
+  public func resume(throwing: __owned Error) { }
 }
 
 #if _runtime(_ObjC)
@@ -45,7 +45,7 @@ internal func _resumeUnsafeContinuation<T>(
   _ continuation: UnsafeContinuation<T>,
   _ value: __owned T
 ) {
-  continuation.resume(value)
+  continuation.resume(returning: value)
 }
 
 @_alwaysEmitIntoClient
@@ -54,7 +54,7 @@ internal func _resumeUnsafeThrowingContinuation<T>(
   _ continuation: UnsafeThrowingContinuation<T>,
   _ value: __owned T
 ) {
-  continuation.resume(value)
+  continuation.resume(returning: value)
 }
 
 @_alwaysEmitIntoClient
@@ -63,7 +63,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
   _ continuation: UnsafeThrowingContinuation<T>,
   _ error: __owned Error
 ) {
-  continuation.fail(error)
+  continuation.resume(throwing: error)
 }
 
 #endif

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -347,43 +347,6 @@ extension Task {
 // ==== UnsafeContinuation -----------------------------------------------------
 
 extension Task {
-  public struct UnsafeContinuation<T> {
-    /// Return a value into the continuation and make the task schedulable.
-    ///
-    /// The task will never run synchronously, even if the task does not
-    /// need to be resumed on a specific executor.
-    ///
-    /// This is appropriate when the caller is something "busy", like an event
-    /// loop, and doesn't want to be potentially delayed by arbitrary work.
-    public func resume(returning: T) {
-      fatalError("\(#function) not implemented yet.")
-    }
-  }
-
-  public struct UnsafeThrowingContinuation<T, E: Error> {
-    /// Return a value into the continuation and make the task schedulable.
-    ///
-    /// The task will never run synchronously, even if the task does not
-    /// need to be resumed on a specific executor.
-    ///
-    /// This is appropriate when the caller is something "busy", like an event
-    /// loop, and doesn't want to be potentially delayed by arbitrary work.
-    public func resume(returning: T) {
-      fatalError("\(#function) not implemented yet.")
-    }
-
-    /// Resume the continuation with an error and make the task schedulable.
-    ///
-    /// The task will never run synchronously, even if the task does not
-    /// need to be resumed on a specific executor.
-    ///
-    /// This is appropriate when the caller is something "busy", like an event
-    /// loop, and doesn't want to be potentially delayed by arbitrary work.
-    public func resume(throwing: E) {
-      fatalError("\(#function) not implemented yet.")
-    }
-  }
-
   /// The operation functions must resume the continuation *exactly once*.
   ///
   /// The continuation will not begin executing until the operation function returns.
@@ -405,7 +368,7 @@ extension Task {
   /// This function returns instantly and will never suspend.
   /* @instantaneous */
   public static func withUnsafeThrowingContinuation<T>(
-    operation: (UnsafeThrowingContinuation<T, Error>) -> Void
+    operation: (UnsafeThrowingContinuation<T>) -> Void
   ) async throws -> T {
     fatalError("\(#function) not implemented yet.")
   }

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -43,7 +43,7 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
-  let _: String = Task.withUnsafeContinuation { continuation in // expected-error{{cannot convert value of type '(_) async -> ()' to expected argument type '(Task.UnsafeContinuation<String>) -> Void'}}
+  let _: String = Task.withUnsafeContinuation { continuation in // expected-error{{cannot convert value of type '(_) async -> ()' to expected argument type '(UnsafeContinuation<String>) -> Void'}}
     let s = await someAsyncFunc() // rdar://70610141 for getting a better error message here
     continuation.resume(returning: s)
   }


### PR DESCRIPTION
We somehow ended up with a set hidden in `Task` as well as a set at top level. SILGen currently
hooks into the top-level ones, so shed the `Task`-namespaced versions for now.