### PR TITLE
SILGen: Update emitForeignToNativeThunk to handle async methods.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1662,11 +1662,19 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
       getConstantInfo(getTypeExpansionContext(), foreignDeclRef);
   auto foreignFnTy = foreignCI.SILFnType;
 
-  // Find the foreign error convention and 'self' parameter index.
+  // Find the foreign error/async convention and 'self' parameter index.
+  bool hasError = false;
+  Optional<ForeignAsyncConvention> foreignAsync;
+  if (nativeFnTy->isAsync()) {
+    foreignAsync = fd->getForeignAsyncConvention();
+    assert(foreignAsync && "couldn't find foreign async convention?!");
+  }
   Optional<ForeignErrorConvention> foreignError;
   if (nativeFnTy->hasErrorResult()) {
+    hasError = true;
     foreignError = fd->getForeignErrorConvention();
-    assert(foreignError && "couldn't find foreign error convention!");
+    assert((foreignError || foreignAsync)
+           && "couldn't find foreign error or async convention for foreign error!");
   }
   ImportAsMemberStatus memberStatus = fd->getImportAsMemberStatus();
 
@@ -1707,7 +1715,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
 
   // Set up the throw destination if necessary.
   CleanupLocation cleanupLoc(fd);
-  if (foreignError) {
+  if (hasError) {
     prepareRethrowEpilog(cleanupLoc);
   }
 
@@ -1719,14 +1727,20 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     SmallVector<ManagedValue, 8> args;
     unsigned foreignArgIndex = 0;
 
-    // A helper function to add a function error argument in the
+    // A helper function to add a placeholder for a foreign argument in the
     // appropriate position.
-    auto maybeAddForeignErrorArg = [&] {
-      if (foreignError &&
-          foreignArgIndex == foreignError->getErrorParameterIndex()) {
+    auto maybeAddForeignArg = [&]() -> bool {
+      if ((foreignError
+           && foreignArgIndex == foreignError->getErrorParameterIndex())
+          || (foreignAsync
+              && foreignArgIndex == foreignAsync->completionHandlerParamIndex()))
+      {
         args.push_back(ManagedValue());
         ++foreignArgIndex;
+        return true;
       }
+      
+      return false;
     };
 
     {
@@ -1768,7 +1782,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
           llvm_unreachable("unsupported convention");
         }
 
-        maybeAddForeignErrorArg();
+        while (maybeAddForeignArg());
 
         bool isSelf = (hasSelfParam && nativeParamIndex == params.size() - 1);
 
@@ -1825,7 +1839,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
       }
     }
 
-    maybeAddForeignErrorArg();
+    while (maybeAddForeignArg());
     
     // Call the original.
     auto subs = getForwardingSubstitutionMap();
@@ -1846,7 +1860,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
                                    bridgedFormalResultType),
         nativeFormalResultType,
         foreignError,
-        {}, // TODO foreignAsync
+        foreignAsync,
         ImportAsMemberStatus());
 
     auto init = indirectResult

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// REQUIRES: objc_interop
+
+import Foundation
+import ObjCConcurrency
+
+@objc protocol SlowServing {
+    func requestInt() async -> Int
+    func requestString() async -> String
+    func requestIntAndString() async -> (Int, String)
+    func tryRequestIntAndString() async throws -> (Int, String)
+}
+
+// CHECK-LABEL: sil {{.*}}@{{.*}}15testSlowServing
+func testSlowServing(p: SlowServing) async throws {
+    // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int) -> (), τ_0_0) -> ()
+    let _: Int = await p.requestInt()
+    // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (NSString) -> (), τ_0_0) -> ()
+    let _: String = await p.requestString()
+    // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int, NSString) -> (), τ_0_0) -> ()
+    let _: (Int, String) = await p.requestIntAndString()
+    // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int, Optional<NSString>, Optional<NSError>) -> (), τ_0_0) -> ()
+    let _: (Int, String) = try await p.tryRequestIntAndString()
+}
+
+/*
+class SlowSwiftServer: NSObject, SlowServing {
+    func requestInt() async -> Int { return 0 }
+    func requestString() async -> String { return "" }
+    func requestIntAndString() async -> (Int, String) { return (0, "") }
+    func tryRequestIntAndString() async throws -> (Int, String) { return (0, "") }
+}
+*/
+
+protocol NativelySlowServing {
+    func doSomethingSlow(_: String) async -> Int
+    func findAnswer() async throws -> String
+    func serverRestart(_: String) async
+    func findMultipleAnswers() async throws -> (String, Int)
+}
+
+extension SlowServer: NativelySlowServing {}


### PR DESCRIPTION
So if we use an ObjC imported as async to conform to a Swift protocol, delegate a Swift subclass initializer, etc.,
we generate the conversion thunk to the Swift calling convention for the imported API.