### PR TITLE
[IRGen] Pack extra data pattern structs.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4234,6 +4234,7 @@ namespace {
     PartialPattern buildExtraDataPattern() {
       ConstantInitBuilder builder(IGM);
       auto init = builder.beginStruct();
+      init.setPacked(true);
 
       struct Scanner : StructMetadataScanner<Scanner> {
         GenericStructMetadataBuilder &Outer;
@@ -4602,6 +4603,7 @@ namespace {
     PartialPattern buildExtraDataPattern() {
       ConstantInitBuilder builder(IGM);
       auto init = builder.beginStruct();
+      init.setPacked(true);
 
       auto &layout = IGM.getMetadataLayout(Target);
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -665,6 +665,10 @@ swift::swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description
                 "enum metadata header unexpectedly has extra members");
   static_assert(sizeof(EnumMetadata) == sizeof(ValueMetadata),
                 "enum metadata unexpectedly has extra members");
+  assert(!pattern->hasExtraDataPattern() ||
+         (extraDataSize == (pattern->getExtraDataPattern()->OffsetInWords +
+                            pattern->getExtraDataPattern()->SizeInWords) *
+                               sizeof(void *)));
 
   size_t totalSize = sizeof(FullMetadata<ValueMetadata>) + extraDataSize;
 

--- a/test/IRGen/enum_value_semantics_future.sil
+++ b/test/IRGen/enum_value_semantics_future.sil
@@ -161,7 +161,7 @@ enum GenericFixedLayout<T> {
 // CHECK-SAME: }>
 
 // CHECK: @"$s27enum_value_semantics_future18GenericFixedLayoutOWV" = internal constant %swift.enum_vwtable
-// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { i64 } zeroinitializer
+// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant <{ i64 }> zeroinitializer
 
 // CHECK-LABEL: @"$s27enum_value_semantics_future18GenericFixedLayoutOMn" = hidden constant
 // CHECK-SAME:    [16 x i8*]* @"$s27enum_value_semantics_future18GenericFixedLayoutOMI"
@@ -177,7 +177,7 @@ enum GenericFixedLayout<T> {
 //   Value witness table.
 // CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.enum_vwtable* @"$s27enum_value_semantics_future18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i16, i16 }>, <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 3) to i64)) to i32)
 //   Extra data pattern.
-// CHECK-SAME: i32 trunc (i64 sub (i64 ptrtoint ({ i64 }* [[EXTRA_DATA_PATTERN]] to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i16, i16 }>, <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 4) to i64)) to i32)
+// CHECK-SAME: i32 trunc (i64 sub (i64 ptrtoint (<{ i64 }>* [[EXTRA_DATA_PATTERN]] to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32, i32, i16, i16 }>, <{ i32, i32, i32, i32, i32, i16, i16 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 4) to i64)) to i32)
 // CHECK-SAME:  }>
 
 sil @single_payload_nontrivial_copy_destroy : $(@owned SinglePayloadNontrivial) -> () {

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -8,7 +8,7 @@ import Builtin
 
 // -- Generic structs with fixed layout should have no completion function
 //    and emit the field offset vector as part of the pattern.
-// CHECK:       [[PATTERN:@.*]] = internal constant { i32, i32, i32, [4 x i8] } { i32 0, i32 1, i32 8, [4 x i8] zeroinitializer }, align 8
+// CHECK:       [[PATTERN:@.*]] = internal constant <{ i32, i32, i32, [4 x i8] }> <{ i32 0, i32 1, i32 8, [4 x i8] zeroinitializer }>, align 8
 // CHECK-LABEL: @"$s15generic_structs18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
 // CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s15generic_structs18FixedLayoutGenericVMi"
@@ -19,7 +19,7 @@ import Builtin
 // -- vwtable pointer
 // CHECK-SAME:   @"$s15generic_structs18FixedLayoutGenericVWV"
 // -- extra data pattern
-// CHECK-SAME: { i32, i32, i32, [4 x i8] }* [[PATTERN]]
+// CHECK-SAME: <{ i32, i32, i32, [4 x i8] }>* [[PATTERN]]
 // CHECK-SAME: i16 1,
 // CHECK-SAME: i16 2 }>
 

--- a/test/IRGen/generic_structs_future.sil
+++ b/test/IRGen/generic_structs_future.sil
@@ -9,7 +9,7 @@ import Builtin
 
 // -- Generic structs with fixed layout should have no completion function
 //    and emit the field offset vector as part of the pattern.
-// CHECK:       [[PATTERN:@.*]] = internal constant { i32, i32, i32, [4 x i8], i64 } { i32 0, i32 1, i32 8, [4 x i8] zeroinitializer, i64 0 }, align 8
+// CHECK:       [[PATTERN:@.*]] = internal constant <{ i32, i32, i32, [4 x i8], i64 }> <{ i32 0, i32 1, i32 8, [4 x i8] zeroinitializer, i64 0 }>, align 8
 // CHECK-LABEL: @"$s22generic_structs_future18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
 // CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s22generic_structs_future18FixedLayoutGenericVMi"
@@ -20,7 +20,7 @@ import Builtin
 // -- vwtable pointer
 // CHECK-SAME:   @"$s22generic_structs_future18FixedLayoutGenericVWV"
 // -- extra data pattern
-// CHECK-SAME: { i32, i32, i32, [4 x i8], i64 }* [[PATTERN]]
+// CHECK-SAME: <{ i32, i32, i32, [4 x i8], i64 }>* [[PATTERN]]
 // CHECK-SAME: i16 1,
 // CHECK-SAME: i16 3 }>
 

--- a/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-no_payload_size-trailing_flags.swift
@@ -5,7 +5,7 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { i64 } zeroinitializer, align [[ALIGNMENT]]
+// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant <{ i64 }> zeroinitializer, align [[ALIGNMENT]]
 
 //      CHECK: @"$s4main6EitherOMP" = internal constant <{ 
 //           :   i32, 
@@ -68,9 +68,9 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         { 
+// CHECK-SAME:         <{ 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         i32* getelementptr inbounds (

--- a/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-no_trailing_flags.swift
@@ -6,10 +6,10 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 
-//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { [[INT]] } { 
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant <{ [[INT]] }> <{ 
 // The payload size is 8: the larger payload is the size of an Int64.
 // CHECK-SAME:   [[INT]] 8
-// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 
 //      CHECK: @"$s4main6EitherOMP" = internal constant <{ 
@@ -55,7 +55,7 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         { [[INT]] }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         <{ [[INT]] }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         i32* getelementptr inbounds (

--- a/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-payload_size-trailing_flags.swift
@@ -6,11 +6,11 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 
-//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { [[INT]], i64 } { 
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant <{ [[INT]], i64 }> <{ 
 // The payload size is 8: the larger payload is the size of an Int64.
 // CHECK-SAME:   [[INT]] 8, 
 // CHECK-SAME:   i64 0 
-// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 
 
 //      CHECK: @"$s4main6EitherOMP" = internal constant <{ 
@@ -56,7 +56,7 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         { [[INT]], i64 }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         <{ [[INT]], i64 }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         i32* getelementptr inbounds (

--- a/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-no_trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-no_trailing_flags.swift
@@ -5,17 +5,17 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]]  = internal constant { 
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]]  = internal constant <{ 
 // CHECK-SAME:     i32
 // CHECK-SAME:   , i32
 // CHECK-SAME:   , i32
 //           :   , [4 x i8] 
-// CHECK-SAME: } { 
+// CHECK-SAME: }> <{ 
 // CHECK-SAME:   i32 0, 
 // CHECK-SAME:   i32 8, 
 // CHECK-SAME:   i32 16
 //           :   , [4 x i8] zeroinitializer 
-// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 //      CHECK: @"$s4main4PairVMP" = internal constant <{ 
 //           :   i32, 
 //           :   i32, 
@@ -60,11 +60,11 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         { i32
+// CHECK-SAME:         <{ i32
 // CHECK-SAME:         , i32
 // CHECK-SAME:         , i32
 //           :         , [4 x i8] 
-// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         i32* getelementptr inbounds (

--- a/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-field_offsets-trailing_flags.swift
@@ -5,19 +5,19 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]]  = internal constant { 
+//      CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]]  = internal constant <{ 
 // CHECK-SAME:   i32, 
 // CHECK-SAME:   i32, 
 // CHECK-SAME:   i32,
 //           :   , [4 x i8], 
 // CHECK-SAME:   i64 
-// CHECK-SAME: } { 
+// CHECK-SAME: }> <{ 
 // CHECK-SAME:   i32 0, 
 // CHECK-SAME:   i32 8, 
 // CHECK-SAME:   i32 16, 
 //           :   [4 x i8] zeroinitializer, 
 // CHECK-SAME:   i64 0 
-// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK-SAME: }>, align [[ALIGNMENT]]
 //      CHECK: @"$s4main4PairVMP" = internal constant <{ 
 //           :   i32, 
 //           :   i32, 
@@ -62,13 +62,13 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         { 
+// CHECK-SAME:         <{ 
 // CHECK-SAME:           i32, 
 // CHECK-SAME:           i32, 
 // CHECK-SAME:           i32, 
 //           :           [4 x i8], 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         i32* getelementptr inbounds (

--- a/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-trailing_flags.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-no_field_offsets-trailing_flags.swift
@@ -5,7 +5,7 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant { i64 } zeroinitializer, align [[ALIGNMENT]]
+// CHECK: [[EXTRA_DATA_PATTERN:@[0-9]+]] = internal constant <{ i64 }> zeroinitializer, align [[ALIGNMENT]]
 
 //      CHECK: @"$s4main4PairVMP" = internal constant <{ 
 //           :   i32, 
@@ -68,9 +68,9 @@
 //           :   i32 trunc (
 // CHECK-SAME:     [[INT]] sub (
 // CHECK-SAME:       [[INT]] ptrtoint (
-// CHECK-SAME:         { 
+// CHECK-SAME:         <{ 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }* [[EXTRA_DATA_PATTERN]] to [[INT]]
+// CHECK-SAME:         }>* [[EXTRA_DATA_PATTERN]] to [[INT]]
 // CHECK-SAME:       ), 
 // CHECK-SAME:       [[INT]] ptrtoint (
 // CHECK-SAME:         i32* getelementptr inbounds (


### PR DESCRIPTION
Previously, the extra data pattern structs for struct and enums were not packed.

On 32 bit, this resulted in an extra data pattern struct which was 4 bytes too large whenever there was an odd number of fields in the struct.  The result was writing past the end of the allocated struct.  That bug only caused occasional crashes because (1) for the most part there was additional space beyond the end of the allocation intended for the struct metadata in the bump allocator and (2) while half of the trailing flags field would be overwritten, those bits of the trailing flags being nonzero did not have an observable effect since those bits of the trailing flags field are not yet used.

Here, the structs are marked packed, resulting in the appropriate size for the extra data pattern structs on 32 bit platforms.

rdar://problem/68997282