### PR TITLE
[concurrency] SILGen: emit hop_to_executor instructions in actor-isolated closures.

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -843,6 +843,10 @@ public:
                       Type resultType, DeclContext *DC,
                       bool throws, SourceLoc throwsLoc);
 
+  /// Initializes 'actor' with the loaded shared instance of the \p globalActor
+  /// type.
+  void loadGlobalActor(Type globalActor);
+
   /// Create SILArguments in the entry block that bind a single value
   /// of the given parameter suitably for being forwarded.
   void bindParameterForForwarding(ParamDecl *param,

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -47,6 +47,17 @@ actor class MyActor {
     await callee(p)
   }
 
+
+  // CHECK-LABEL: sil private [ossa] @$s4test7MyActorC0A7ClosureSiyYFSiyYXEfU_ : $@convention(thin) @async (@guaranteed MyActor) -> Int {
+  // CHECK:        [[COPIED_SELF:%[0-9]+]] = copy_value %0 : $MyActor
+  // CHECK:        [[BORROWED_SELF:%[0-9]+]] = begin_borrow [[COPIED_SELF]] : $MyActor
+  // CHECK:        hop_to_executor [[BORROWED_SELF]] : $MyActor 
+  // CHECK:        = apply
+  // CHECK:      } // end sil function '$s4test7MyActorC0A7ClosureSiyYFSiyYXEfU_'
+  func testClosure() async -> Int {
+    return await { () async in p }()
+  }
+
   // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC13dontInsertHTESiyF : $@convention(method) (@guaranteed MyActor) -> Int {
   // CHECK-NOT:   hop_to_executor
   // CHECK:     } // end sil function '$s4test7MyActorC13dontInsertHTESiyF'
@@ -75,6 +86,20 @@ struct GlobalActor {
 // CHECK: } // end sil function '$s4test0A11GlobalActoryyYF'
 @GlobalActor
 func testGlobalActor() async {
+}
+
+// CHECK-LABEL: sil private [ossa] @$s4test0A22GlobalActorWithClosureyyYFyyYXEfU_ : $@convention(thin) @async () -> () {
+// CHECK:   [[F:%[0-9]+]] = function_ref @$s4test11GlobalActorV6sharedAA02MyC0Cvau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:   [[P:%[0-9]+]] = apply [[F]]() : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:   [[A:%[0-9]+]] = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*MyActor
+// CHECK:   [[ACC:%[0-9]+]] = begin_access [read] [dynamic] [[A]] : $*MyActor
+// CHECK:   [[L:%[0-9]+]] = load [copy] [[ACC]] : $*MyActor
+// CHECK:   [[B:%[0-9]+]] = begin_borrow [[L]] : $MyActor
+// CHECK:   hop_to_executor [[B]] : $MyActor
+// CHECK: } // end sil function '$s4test0A22GlobalActorWithClosureyyYFyyYXEfU_'
+@GlobalActor
+func testGlobalActorWithClosure() async {
+  await { () async in }()
 }
 
 @globalActor


### PR DESCRIPTION
This is the second part after emitting hop_to_executor instructions in regular functions (https://github.com/apple/swift/pull/34540)
