### PR TITLE
Two small SIL verifier improvements

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -61,6 +61,9 @@ static llvm::cl::opt<bool> AbortOnFailure(
 static llvm::cl::opt<bool> ContinueOnFailure("verify-continue-on-failure",
                                              llvm::cl::init(false));
 
+static llvm::cl::opt<bool> DumpModuleOnFailure("verify-dump-module-on-failure",
+                                             llvm::cl::init(false));
+
 static llvm::cl::opt<bool> VerifyDIHoles(
                               "verify-di-holes",
                               llvm::cl::init(true));
@@ -712,8 +715,11 @@ public:
 
     llvm::dbgs() << "In function:\n";
     F.print(llvm::dbgs());
-    llvm::dbgs() << "In module:\n";
-    F.getModule().print(llvm::dbgs());
+    if (DumpModuleOnFailure) {
+      // Don't do this by default because modules can be _very_ large.
+      llvm::dbgs() << "In module:\n";
+      F.getModule().print(llvm::dbgs());
+    }
 
     // We abort by default because we want to always crash in
     // the debugger.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1504,14 +1504,6 @@ public:
             "cannot call coroutine with normal apply");
     require(!calleeConv.funcTy->isAsync() || AI->getFunction()->isAsync(),
             "cannot call an async function from a non async function");
-
-    // Check that if the apply is of a noreturn callee, make sure that an
-    // unreachable is the next instruction.
-    if (AI->getModule().getStage() == SILStage::Raw ||
-        !AI->isCalleeNoReturn())
-      return;
-    require(isa<UnreachableInst>(std::next(SILBasicBlock::iterator(AI))),
-            "No return apply without an unreachable as a next instruction.");
   }
 
   void checkTryApplyInst(TryApplyInst *AI) {


### PR DESCRIPTION
* Don't enforce that there must be an unreachable after a no-return apply.

This condition does not hold after each pass. It's only the case after running some cleanup-passes.
This verifier condition makes it impossible to bisect the optimization passes.

* Don't dump the whole module in case of a verifier failure, because modules can be _very_ large.

Only dump the module if the new option -verify-dump-module-on-failure is set.
