### PR TITLE
[stdlib][NFC] Remove extraneous comment from Integers.swift

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -58,9 +58,7 @@ extension ExpressibleByIntegerLiteral
 /// =============================================
 ///
 /// To add `AdditiveArithmetic` protocol conformance to your own custom type,
-/// implement the required operators, and provide a static `zero` property
-/// using a type that can represent the magnitude of any value of your custom
-/// type.
+/// implement the required operators, and provide a static `zero` property.
 public protocol AdditiveArithmetic: Equatable {
   /// The zero value.
   ///

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -58,7 +58,7 @@ extension ExpressibleByIntegerLiteral
 /// =============================================
 ///
 /// To add `AdditiveArithmetic` protocol conformance to your own custom type,
-/// implement the required operators, and provide a static `zero` property.
+/// implement the required operators and provide a static `zero` property.
 public protocol AdditiveArithmetic: Equatable {
   /// The zero value.
   ///


### PR DESCRIPTION
The doc comment for `AdditiveArithmetic` had inapplicable wording about “magnitude”, which appears to have been inadvertently copied over from `Numeric`.