### PR TITLE
[Frontend] Intro flag to remark on loaded modules location

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -909,7 +909,7 @@ REMARK(cross_import_added,none,
        (Identifier, Identifier, Identifier))
 
 REMARK(module_loaded,none,
-       "loaded module from %0",
+       "loaded module at %0",
        (StringRef))
 
 // Operator decls

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -908,6 +908,10 @@ REMARK(cross_import_added,none,
        "import of %0 and %1 triggered a cross-import of %2",
        (Identifier, Identifier, Identifier))
 
+REMARK(module_loaded,none,
+       "loaded module from %0",
+       (StringRef))
+
 // Operator decls
 ERROR(ambiguous_operator_decls,none,
       "ambiguous operator declarations found for operator", ())

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -129,6 +129,9 @@ namespace swift {
     /// overlay.
     bool EnableCrossImportRemarks = false;
 
+    /// Emit a remark after loading a module.
+    bool EnableModuleLoadingRemarks = false;
+
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -336,6 +336,10 @@ def emit_cross_import_remarks : Flag<["-"], "Rcross-import">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark if a cross-import of a module is triggered.">;
 
+def remark_loading_module : Flag<["-"], "Rmodule-loading">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit a remark and file path of each loaded module">;
+
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1921,6 +1921,11 @@ ASTContext::getModule(ImportPath::Module ModulePath) {
   auto moduleID = ModulePath[0];
   for (auto &importer : getImpl().ModuleLoaders) {
     if (ModuleDecl *M = importer->loadModule(moduleID.Loc, ModulePath)) {
+      if (LangOpts.EnableModuleLoadingRemarks) {
+        Diags.diagnose(nullptr,
+                       diag::module_loaded,
+                       M->getModuleFilename());
+      }
       return M;
     }
   }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1922,7 +1922,7 @@ ASTContext::getModule(ImportPath::Module ModulePath) {
   for (auto &importer : getImpl().ModuleLoaders) {
     if (ModuleDecl *M = importer->loadModule(moduleID.Loc, ModulePath)) {
       if (LangOpts.EnableModuleLoadingRemarks) {
-        Diags.diagnose(nullptr,
+        Diags.diagnose(ModulePath.getSourceRange().Start,
                        diag::module_loaded,
                        M->getModuleFilename());
       }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -577,6 +577,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableCrossImportRemarks = Args.hasArg(OPT_emit_cross_import_remarks);
 
+  Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
+
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   std::string TargetArgScratch;

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -1,0 +1,14 @@
+/// Test the -Rmodule-loading flag.
+// RUN: %empty-directory(%t)
+
+/// Create a simple module and interface.
+// RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/TestModule.swiftinterface -swift-version 5
+
+/// Use -Rmodule-loading in a client and look for the diagnostics output.
+// RUN: %target-swift-frontend -typecheck %s -I %t -Rmodule-loading 2>&1 | %FileCheck %s
+
+import TestModule
+// CHECK: remark: loaded module from {{.*}}SwiftShims-{{.*}}.pcm
+// CHECK: remark: loaded module from {{.*}}Swift.swiftmodule{{.*}}.swiftmodule
+// CHECK: remark: loaded module from {{.*}}TestModule.swiftinterface

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -9,6 +9,6 @@
 // RUN: %target-swift-frontend -typecheck %s -I %t -Rmodule-loading 2>&1 | %FileCheck %s
 
 import TestModule
-// CHECK: remark: loaded module from {{.*}}SwiftShims-{{.*}}.pcm
-// CHECK: remark: loaded module from {{.*}}Swift.swiftmodule{{.*}}.swiftmodule
-// CHECK: remark: loaded module from {{.*}}TestModule.swiftinterface
+// CHECK: remark: loaded module at {{.*}}SwiftShims-{{.*}}.pcm
+// CHECK: remark: loaded module at {{.*}}Swift.swiftmodule{{.*}}.swiftmodule
+// CHECK: remark: loaded module at {{.*}}TestModule.swiftinterface


### PR DESCRIPTION
Passing the frontend flag `-Rmodule-loading` makes the compiler emit remarks with the path of every module loaded. The path for Swift modules is either the swiftinterface file for modules built with library evolution or the binary swiftmodule otherwise. The path for clangmodules is always in the cache, it could be improved.

The output can be verbose. Here's a short extract of the output for a simple SwiftUI app:

```
<unknown>:0: remark: loaded module at /Users/xymus/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/2VJP7CNCGWRF0/SwiftShims-18ZF6992O9H75.pcm
<unknown>:0: remark: loaded module at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator14.2.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
<unknown>:0: remark: loaded module at /Users/xymus/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/2VJP7CNCGWRF0/os-1HVC6DNXVU37C.pcm
<unknown>:0: remark: loaded module at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator14.2.sdk/usr/lib/swift/os.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
/.../SwiftUITemplate/ContentView.swift:8:8: remark: loaded module at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator14.2.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
import SwiftUI
       ^
```