### PR TITLE
Allow the creation of a shadow variable when the type is a refcounted pointer

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -758,7 +758,7 @@ public:
     if (IGM.IRGen.Opts.DisableDebuggerShadowCopies ||
         IGM.IRGen.Opts.shouldOptimize() || IsAnonymous ||
         isa<llvm::AllocaInst>(Storage) || isa<llvm::UndefValue>(Storage) ||
-        Storage->getType() == IGM.RefCountedPtrTy || !needsShadowCopy(Storage))
+        !needsShadowCopy(Storage))
       return Storage;
 
     // Emit a shadow copy.

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -759,9 +759,10 @@ func generic_unsafeGuaranteed_test<T: AnyObject>(_ t : T) -> T {
 }
 
 // CHECK-LABEL: define {{.*}} @{{.*}}unsafeGuaranteed_test
-// CHECK:  [[LOCAL:%.*]] = alloca %swift.refcounted*
+// CHECK:  [[LOCAL1:%.*]] = alloca %swift.refcounted*
+// CHECK:  [[LOCAL2:%.*]] = alloca %swift.refcounted*
 // CHECK:  call %swift.refcounted* @swift_retain(%swift.refcounted* returned %0)
-// CHECK:  store %swift.refcounted* %0, %swift.refcounted** [[LOCAL]]
+// CHECK:  store %swift.refcounted* %0, %swift.refcounted** [[LOCAL2]]
 // CHECK-NOT:  call void @swift_release(%swift.refcounted* %0)
 // CHECK:  ret %swift.refcounted* %0
 func unsafeGuaranteed_test(_ x: Builtin.NativeObject) -> Builtin.NativeObject {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR allows the creation of shadow variables when dealing of variable whose type is as a refcounted pointer in -O0. This allows debug information to survive when it otherwise wouldn't. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13208](https://bugs.swift.org/browse/SR-13208).

@adrian-prantl @vedantk 
