### PR TITLE
[Concurrency] Implement Task.currentPriority

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -127,6 +127,10 @@ public:
     return Flags.isAsyncTask();
   }
 
+  JobPriority getPriority() const {
+    return Flags.getPriority();
+  }
+
   /// Run this job.
   void run(ExecutorRef currentExecutor);
 };

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -173,6 +173,10 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_removeStatusRecord(AsyncTask *task,
                                    TaskStatusRecord *record);
 
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+JobPriority
+swift_task_getPriority(AsyncTask* task);
+
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {
 ///      case none

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -351,3 +351,7 @@ void swift::swift_task_future_wait(
 void swift::swift_task_run(AsyncTask *taskToRun) {
   taskToRun->run(ExecutorRef::noPreference());
 }
+
+JobPriority swift::swift_task_getPriority(AsyncTask *task) {
+  return task->getPriority();
+}

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -44,7 +44,8 @@ extension Task {
   /// This function returns instantly and will never suspend.
   /* @instantaneous */
   public static func currentPriority() async -> Priority {
-    fatalError("\(#function) not implemented yet.")
+    let task = Builtin.getCurrentAsyncTask()
+    return getPriority(task)
   }
 
   /// Task priority may inform decisions an `Executor` makes about how and when
@@ -80,6 +81,7 @@ extension Task {
   ///       similar to Darwin Dispatch's QoS; bearing in mind that priority is not as
   ///       much of a thing on other platforms (i.e. server side Linux systems).
   public enum Priority: Int, Comparable {
+    // Values must be same as defined by the internal `JobPriority`.
     case userInteractive = 0x21
     case userInitiated   = 0x19
     case `default`       = 0x15
@@ -413,6 +415,9 @@ extension Task {
 
 @_silgen_name("swift_task_run")
 public func runTask(_ task: __owned Builtin.NativeObject)
+
+@_silgen_name("swift_task_getPriority")
+public func getPriority(_ task: __owned Builtin.NativeObject) -> Task.Priority
 
 public func runAsync(_ asyncFun: @escaping () async -> ()) {
   let childTask = Builtin.createAsyncTask(0, nil, asyncFun)

--- a/test/Concurrency/Runtime/async_task_priority_basic.swift
+++ b/test/Concurrency/Runtime/async_task_priority_basic.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) | %FileCheck %s --dump-input always
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+import Dispatch
+
+// ==== ------------------------------------------------------------------------
+// MARK: "Infrastructure" for the tests
+
+extension DispatchQueue {
+  func async<R>(operation: @escaping () async -> R) -> Task.Handle<R> {
+    let handle = Task.runDetached(operation: operation)
+
+    // Run the task
+    _ = { self.async { handle.run() } }() // force invoking the non-async version
+
+    return handle
+  }
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Tests
+
+func test_getPriority() {
+  _ = DispatchQueue.main.async { () async in
+    let p = await Task.currentPriority()
+    // CHECK: priority: userInteractive
+    print("priority: \(p)")
+    assert(p == Task.Priority.userInteractive)
+    exit(0)
+  }
+}
+
+test_getPriority()
+
+dispatchMain()


### PR DESCRIPTION
Implements Task.currentPriority so we can start passing it when we spawn children

Part of rdar://70141994