### PR TITLE
[Serialization] Serialize Clang types for non-modular headers.

### DIFF
--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -53,8 +53,10 @@ public:
           Impl.SwiftContext.getSwiftDeclForExportedClangDecl(decl))
       return swiftDecl;
 
-    // Otherwise we have no way to find it.
-    return StableSerializationPath();
+    // Allow serialization for non-modular headers as well, with the hope that
+    // we find the same header when doing unqualified lookup during
+    // deserialization.
+    return findImportedPath(named);
   }
 
 private:

--- a/test/ClangImporter/unserializable-clang-function-types.swift
+++ b/test/ClangImporter/unserializable-clang-function-types.swift
@@ -1,6 +1,0 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -sdk %clang-importer-sdk -enable-library-evolution %s -experimental-print-full-convention -verify
-
-import ctypes
-
-public var f1 : UnserializableFunctionPointer?
-// expected-error@-1 {{cannot export the underlying C type of the function type 'UnserializableFunctionPointer' (aka '@convention(c) () -> Optional<OpaquePointer>'); it may use anonymous types or types defined outside of a module}}

--- a/test/Serialization/Inputs/non-modular-header.h
+++ b/test/Serialization/Inputs/non-modular-header.h
@@ -1,0 +1,3 @@
+typedef struct {
+  int x;
+} PlaceholderType;

--- a/test/Serialization/non-modular-clang-type.swift
+++ b/test/Serialization/non-modular-clang-type.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -enable-testing -module-name NonModularApp -emit-module -o %t/NonModularApp.swiftmodule -import-objc-header %S/Inputs/non-modular-header.h -DNON_MODULAR_APP -use-clang-function-types 2>&1 | %FileCheck %s
+
+// CHECK: Clang function type is not serializable
+
+#if NON_MODULAR_APP
+import ctypes
+struct S {
+  static func f(_ : @convention(c, cType: "void (*)(PlaceholderType, size_t)") (PlaceholderType, Int) -> ()) {}
+}
+#endif

--- a/test/Serialization/non-modular-clang-type.swift
+++ b/test/Serialization/non-modular-clang-type.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -enable-testing -module-name NonModularApp -emit-module -o %t/NonModularApp.swiftmodule -import-objc-header %S/Inputs/non-modular-header.h -DNON_MODULAR_APP -use-clang-function-types 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -enable-testing -module-name NonModularApp -emit-module -o %t/NonModularApp.swiftmodule -import-objc-header %S/Inputs/non-modular-header.h -DNON_MODULAR_APP -use-clang-function-types
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -module-name NonModularAppTest -I %t -DNON_MODULAR_APP_TEST
 
 // CHECK: Clang function type is not serializable
 
@@ -8,4 +9,10 @@ import ctypes
 struct S {
   static func f(_ : @convention(c, cType: "void (*)(PlaceholderType, size_t)") (PlaceholderType, Int) -> ()) {}
 }
+#endif
+
+#if NON_MODULAR_APP_TEST
+@testable import NonModularApp
+
+S.f({ _, _ in })
 #endif


### PR DESCRIPTION
Since frameworks have modularized headers, this is only a problem for app targets which use non-modular headers. Such an app target's swiftmodule may be used by a test module. If we have an `@convention(c)` function type with a non-trivial C type in such an app target, it is probably safe to serialize it optimistically and hope that the test target imports the same headers.