### PR TITLE
[windows][msvc2017] Avoid initializer list constructor ambiguity.

### DIFF
--- a/include/swift/Basic/Fingerprint.h
+++ b/include/swift/Basic/Fingerprint.h
@@ -124,7 +124,7 @@ private:
   ///
   /// Very well, LLVM. A default value you shall have.
   friend class llvm::yaml::IO;
-  Fingerprint() : Core{DIGEST_LENGTH, '0'} {}
+  Fingerprint() : Core(DIGEST_LENGTH, '0') {}
 };
 
 void simple_display(llvm::raw_ostream &out, const Fingerprint &fp);


### PR DESCRIPTION
MSVC2017 seems to not fallback to the correct overloaded constructor
when an initializer list constructor seems to be used, but only fails
because the conversion rules. Using parenthesis instead of braces seems
to indicate MSVC2017 the right constructor to use, and should work in
the rest of the compilers as well.

Seems that MSVC2019 is more resilient to this ambiguity.

Introduced in #34808 and started failing https://ci-external.swift.org/job/oss-swift-windows-x86_64/5953/
