### PR TITLE
[CMake] Extend copy-legacy-layouts dependency to swiftmodules

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -801,6 +801,7 @@ function(_compile_swift_files
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${swift_ide_test_dependency}
           ${create_dirs_dependency_target}
+          ${copy_legacy_layouts_dep}
         COMMENT "Generating ${module_file}")
 
     if(SWIFTFILE_STATIC)
@@ -857,6 +858,7 @@ function(_compile_swift_files
           ${SWIFTFILE_DEPENDS}
           ${swift_ide_test_dependency}
           ${obj_dirs_dependency_target}
+          ${copy_legacy_layouts_dep}
         COMMENT
           "Generating ${maccatalyst_module_file}")
 
@@ -880,6 +882,7 @@ function(_compile_swift_files
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${create_dirs_dependency_target}
+          ${copy_legacy_layouts_dep}
         COMMENT "Generating ${sib_file}"
         EXCLUDE_FROM_ALL)
     set("${dependency_sib_target_out_var_name}" "${sib_dependency_target}" PARENT_SCOPE)
@@ -896,6 +899,7 @@ function(_compile_swift_files
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${create_dirs_dependency_target}
+          ${copy_legacy_layouts_dep}
         COMMENT "Generating ${sibopt_file}"
         EXCLUDE_FROM_ALL)
     set("${dependency_sibopt_target_out_var_name}" "${sibopt_dependency_target}" PARENT_SCOPE)
@@ -913,6 +917,7 @@ function(_compile_swift_files
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${create_dirs_dependency_target}
+          ${copy_legacy_layouts_dep}
           COMMENT "Generating ${sibgen_file}"
           EXCLUDE_FROM_ALL)
     set("${dependency_sibgen_target_out_var_name}" "${sibgen_dependency_target}" PARENT_SCOPE)


### PR DESCRIPTION
... and other products as well.

Before this change, the dependency was enforced only for stdlib object
files -- since according to the Ninja dependency graph other libraries
can be scheduled as soon as the swiftmodules are ready, there is a
chance that we attempt to build those before legacy layouts are copied.

Addresses rdar://71559791