### PR TITLE
Partially revert Float16 availability changes

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1352,7 +1352,13 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
 
 ${SelfDocComment}
 @frozen
+%  if bits == 16:
+@available(iOS 14, tvOS 14, watchOS 7, *)
+@available(OSX, unavailable)
+@available(macCatalyst, unavailable)
+%  else:
 @available(*, unavailable, message: "${Self} is not available on target platform.")
+%  end
 public struct ${Self} {
   /// Creates a value initialized to zero.
   @_transparent

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1354,7 +1354,7 @@ ${SelfDocComment}
 @frozen
 %  if bits == 16:
 @available(iOS 14, tvOS 14, watchOS 7, *)
-@available(OSX, unavailable)
+@available(macOS, unavailable)
 @available(macCatalyst, unavailable)
 %  else:
 @available(*, unavailable, message: "${Self} is not available on target platform.")


### PR DESCRIPTION
Specifically, when building for macOS/x86_64, use the old availability annotation instead of marking Float16 unconditionally unavailable to give downstream clients a window to adjust their own annotations. Update to https://github.com/apple/swift/pull/34821.

Addresses: <rdar://problem/71627096>
