### PR TITLE
[test] Update SILOptimizer/OSLogFullOptTest.swift

### DIFF
--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -134,7 +134,6 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-NEXT: bitcast %TSo7NSArrayC* %0 to i8*
     // CHECK-NEXT: tail call i8* @llvm.objc.retain
     // CHECK-NEXT: [[NSARRAY_ARG:%.+]] = tail call i8* @llvm.objc.retain
-    // CHECK: tail call %swift.refcounted* @swift_retain
     // CHECK: tail call swiftcc i1 @"${{.*}}isLoggingEnabled{{.*}}"()
     // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
 
@@ -183,7 +182,6 @@ func testNSObjectInterpolation(nsArray: NSArray) {
   
     // CHECK: [[EXIT]]:
     // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
-    // CHECK-NEXT: tail call void @swift_release
     // CHECK-NEXT: ret void
 }
 


### PR DESCRIPTION
After recent changes we have eliminated one of the retain/release pairs.

rdar://71641343