### PR TITLE
[test] Temporarily disable AutoDiff tests failing with optimizations

### DIFF
--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -5,6 +5,9 @@
 // iphonesimulator-i386-specific failures.
 // REQUIRES: CPU=x86_64
 
+// rdar://71642726 this test is crashing with optimizations.
+// REQUIRES: swift_test_mode_optimize_none
+
 import _Differentiation
 import StdlibUnittest
 

--- a/test/AutoDiff/validation-test/zero_tangent_vector_initializer.swift
+++ b/test/AutoDiff/validation-test/zero_tangent_vector_initializer.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// rdar://71642726 this test is crashing with optimizations.
+// REQUIRES: swift_test_mode_optimize_none
 
 import _Differentiation
 import StdlibUnittest


### PR DESCRIPTION
These recently started failing when optimized. Disable while we
investigate and fix.

rdar://71642726