### PR TITLE
[stdlib][SR-13883] Avoid advancing past representable bounds when striding

### DIFF
--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -238,7 +238,7 @@ extension Strideable where Self: FixedWidthInteger & SignedInteger {
           : (Self(Self.Stride(value) + distance), false)
     return overflow
       ? (.min, distance < (0 as Self.Stride) ? .min : .max)
-      : (.max, partialValue)
+      : (nil, partialValue)
   }
 }
 
@@ -253,7 +253,7 @@ extension Strideable where Self: FixedWidthInteger & UnsignedInteger {
       : current.value.addingReportingOverflow(Self(distance))
     return overflow
       ? (.min, distance < (0 as Self.Stride) ? .min : .max)
-      : (.max, partialValue)
+      : (nil, partialValue)
   }
 }
 

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -2,14 +2,14 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %target-run-simple-swift -swift-version=3
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
 

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -213,10 +213,9 @@ StrideTestSuite.test("FloatingPointStride/rounding error") {
     // possible will produce better results more often than not (see SR-6377).
     //
     // If checking of end bounds has been inadvertently modified such that we're
-    // computing the sum of the penultimate element and the stride (in this
-    // case, `5.5 + 0.9`), then the last element will be omitted here. This
-    // is not the desired behavior, as the result reflects error accumulation
-    // (in this case, `(1 as Float).addingProduct(0.9, 5) + 0.9`).
+    // computing the distance from the penultimate element to the end (in this
+    // case, `6.3999996 - (1 as Float).addingProduct(0.9, 5)`), then the last
+    // element will be omitted here.
     //
     // Therefore, if the test has failed, there may have been a regression in
     // the bounds-checking logic of `Stride*Iterator`. Restore the expected

--- a/validation-test/stdlib/Stride.swift
+++ b/validation-test/stdlib/Stride.swift
@@ -9,11 +9,15 @@ var StrideTestSuite = TestSuite("Stride")
 StrideTestSuite.test("to") {
   checkSequence(Array(0...4), stride(from: 0, to: 5, by: 1))
   checkSequence(Array(1...5).reversed(), stride(from: 5, to: 0, by: -1))
+  checkSequence(stride(from: 0, to: 127, by: 3).map { Int8($0) },
+                stride(from: 0, to: 127 as Int8, by: 3))
 }
 
 StrideTestSuite.test("through") {
   checkSequence(Array(0...5), stride(from: 0, through: 5, by: 1))
   checkSequence(Array(0...5).reversed(), stride(from: 5, through: 0, by: -1))
+  checkSequence(stride(from: 0, through: 127, by: 3).map { Int8($0) },
+                stride(from: 0, through: 127 as Int8, by: 3))
 }
 
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes the issue where trapping occurs in the following code:

```swift
let a = Array(stride(from: 0, through: Int8.max, by: 3))
let b = Array(stride(from: 0, to: Int8.max, by: 3))
```

In brief, the problem arises because `Stride*Iterator` attempts to advance to the next value before testing if that value is past the end, but this will trap if a past-the-end value is not representable (for instance, when we're working with fixed-width integers).

<strike>
To solve this problem, we perform a check before actually advancing.

In order to avoid issues surrounding rounding error for floating-point types, we take advantage of the internal implementation logic to skip this check when `_current.index` isn't `nil` <strike> or `0`</strike> (i.e., when we use the specialized `Strideable._step` implementation that takes advantage of floating-point fused multiply-add).
</strike>

Appropriate tests are added.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13883](https://bugs.swift.org/browse/SR-13883), [SR-2016](https://bugs.swift.org/browse/SR-2016).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
