### PR TITLE
[AutoDiff] [Sema] Reject function types where all parameters are '@noDerivative'.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4472,13 +4472,19 @@ ERROR(differentiable_function_type_invalid_parameter,none,
       "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
       "function type is '@differentiable%select{|(linear)}1'"
       "%select{|; did you want to add '@noDerivative' to this parameter?}2",
-      (StringRef, /*tangentVectorEqualsSelf*/ bool,
+      (StringRef, /*isLinear*/ bool,
        /*hasValidDifferentiabilityParameter*/ bool))
 ERROR(differentiable_function_type_invalid_result,none,
       "result type '%0' does not conform to 'Differentiable'"
       "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
       "function type is '@differentiable%select{|(linear)}1'",
       (StringRef, bool))
+ERROR(differentiable_function_type_no_differentiability_parameters, 
+      none,
+      "'@differentiable' function type requires at least one differentiability "
+      "parameter, i.e. a non-'@noDerivative' parameter whose type conforms to "
+      "'Differentiable'%select{| with its 'TangentVector' equal to itself}0",
+      (/*isLinear*/ bool))
 
 // SIL
 ERROR(opened_non_protocol,none,

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -119,6 +119,18 @@ let _: (@noDerivative Float, Float) -> Float
 
 let _: @differentiable (Float, @noDerivative Float) -> Float // okay
 
+// expected-error @+1 {{'@differentiable' function type requires at least one differentiability parameter, i.e. a non-'@noDerivative' parameter whose type conforms to 'Differentiable'}}
+let _: @differentiable (@noDerivative Float) -> Float
+
+// expected-error @+1 {{'@differentiable' function type requires at least one differentiability parameter, i.e. a non-'@noDerivative' parameter whose type conforms to 'Differentiable'}}
+let _: @differentiable (@noDerivative Float, @noDerivative Int) -> Float
+
+// expected-error @+1 {{'@differentiable' function type requires at least one differentiability parameter, i.e. a non-'@noDerivative' parameter whose type conforms to 'Differentiable'}}
+let _: @differentiable (@noDerivative Float, @noDerivative Float) -> Float
+
+// expected-error @+1 {{parameter type 'Int' does not conform to 'Differentiable' and satisfy 'Int == Int.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+let _: @differentiable(linear) (@noDerivative Float, Int) -> Float
+
 // expected-error @+1 {{'@noDerivative' may only be used on parameters of '@differentiable' function types}}
 let _: (Float) -> @noDerivative Float
 


### PR DESCRIPTION
A `@differentiable` function type require at least 1 differentiability parameter. This PR adds a diagnostic that rejects cases where all parameters are marked with `@noDerivative`. This fixes a compiler crasher.

```swift
test2.swift:3:24: error: '@differentiable' function type requires at least one differentiability parameter, i.e. a non-'@noDerivative' parameter whose type conforms to 'Differentiable'
let _: @differentiable (@noDerivative Float) -> Float = { _ in 0 }
                       ^~~~~~~~~~~~~~~~~~~~~
test2.swift:4:32: error: '@differentiable' function type requires at least one differentiability parameter, i.e. a non-'@noDerivative' parameter whose type conforms to 'Differentiable' with its 'TangentVector' equal to itself
let _: @differentiable(linear) (@noDerivative Float, @noDerivative Int) -> Float = { _, _ in 0 }
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```