### PR TITLE
[cxx-interop] Fix assertion to allow variadic members.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3738,7 +3738,9 @@ namespace {
         assert(((decl->getNumParams() == argNames.size() + 1) || isAccessor) &&
                (*selfIdx < decl->getNumParams()) && "where's self?");
       } else {
-        assert(decl->getNumParams() == argNames.size() || isAccessor);
+        unsigned numParamsAdjusted =
+            decl->getNumParams() + (decl->isVariadic() ? 1 : 0);
+        assert(numParamsAdjusted == argNames.size() || isAccessor);
       }
 
       SmallVector<const clang::ParmVarDecl *, 4> nonSelfParams;

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -21,6 +21,11 @@ template <class R, class T, class U> R returns_template(T a, U b) {
 // Same here:
 template <class T> void cannot_infer_template() {}
 
+struct HasVariadicMemeber {
+  void test1(...) {}
+  void test2(int, ...) {}
+};
+
 // TODO: We should support these types. Until then, make sure we don't crash when importing.
 template<class... Ts>
 void testPackExpansion(Ts...) { }

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -7,6 +7,13 @@
 // CHECK: func returns_template<R, T, U>(_ a: T, _ b: U) -> R
 // CHECK: func cannot_infer_template<T>()
 
+// CHECK: struct HasVariadicMemeber {
+// CHECK:   @available(*, unavailable, message: "Variadic function is unavailable")
+// CHECK:   mutating func test1(_ varargs: Any...)
+// CHECK:   @available(*, unavailable, message: "Variadic function is unavailable")
+// CHECK:   mutating func test2(_: Int32, _ varargs: Any...)
+// CHECK: }
+
 // CHECK: func lvalueReference<T>(_ ref: UnsafeMutablePointer<T>)
 // CHECK: func constLvalueReference<T>(_: UnsafePointer<T>)
 // CHECK: func forwardingReference<T>(_: UnsafeMutablePointer<T>)


### PR DESCRIPTION
Simply fixes an assertion to allow variadic member functions. These currently cannot be used but shouldn't cause a crash and can still be imported "correctly."