### PR TITLE
[cxx-interop] Support forward declared records inside other records.

### DIFF
--- a/test/Interop/Cxx/class/Inputs/nested-records.h
+++ b/test/Interop/Cxx/class/Inputs/nested-records.h
@@ -65,4 +65,27 @@ struct HasForwardDeclaredTemplateChild {
 
 // TODO: Nested class templates (SR-13853).
 
+namespace NestedDeclIsAFirstForwardDeclaration {
+
+struct ForwardDeclaresFriend {
+  friend struct ForwardDeclaredFriend;
+  friend void takesFriend(struct ForwardDeclaredFriend f);
+};
+
+struct ForwardDeclaredFriend { };
+
+inline void takesFriend(ForwardDeclaredFriend b) { }
+
+struct HasNestedForwardDeclaration {
+  struct IsNestedForwardDeclaration;
+};
+
+struct HasNestedForwardDeclaration::IsNestedForwardDeclaration {
+  int a;
+};
+
+inline void takesHasNestedForwardDeclaration(HasNestedForwardDeclaration) { }
+
+}
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_NESTED_RECORDS_H

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -74,3 +74,22 @@
 // CHECK:   }
 // CHECK:   init()
 // CHECK: }
+
+// CHECK: extension NestedDeclIsAFirstForwardDeclaration {
+// CHECK:   struct ForwardDeclaresFriend {
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   struct ForwardDeclaredFriend {
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   static func takesFriend(_ b: NestedDeclIsAFirstForwardDeclaration.ForwardDeclaredFriend)
+// CHECK:   struct HasNestedForwardDeclaration {
+// CHECK:     struct IsNestedForwardDeclaration {
+// CHECK:       var a: Int32
+// CHECK:       init()
+// CHECK:       init(a: Int32)
+// CHECK:     }
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   static func takesHasNestedForwardDeclaration(_: NestedDeclIsAFirstForwardDeclaration.HasNestedForwardDeclaration)
+// CHECK: }


### PR DESCRIPTION
The pattern:
```
    struct X { friend struct Y; }; struct Y {};
```
is fairly common. But before this commit, we would crash while attempting to add "Y" as a child of "X". This commit simply checks if the child record is a declaration or definition. If the former, it bails (and the "child" record will be imported where it's defined).