### PR TITLE
test: repair Autodiff/validation-test/optional-property on Win32

### DIFF
--- a/test/AutoDiff/validation-test/optional-property.swift
+++ b/test/AutoDiff/validation-test/optional-property.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -o /dev/null 2>&1 %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -module-name null -o /dev/null 2>&1 %s | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: asserts
 


### PR DESCRIPTION
The test relies on the module name being `null`.  This is implied by the
`-o /dev/null`.  However, that is not guaranteed.  Explicitly use the
desired module name.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
