### PR TITLE
build: handle spaces better when boostrapping Ninja

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -58,17 +58,19 @@ class NinjaBuilder(product.ProductBuilder):
             osx_version_min = self.args.darwin_deployment_version_osx
             assert sysroot is not None
             env = {
-                "CXX": self.toolchain.cxx,
+                "CXX": shell._quote(self.toolchain.cxx),
                 "CFLAGS": (
                     "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
-                ).format(sysroot=sysroot, osx_version=osx_version_min),
+                ).format(sysroot=shell._quote(sysroot),
+                         osx_version=osx_version_min),
                 "LDFLAGS": (
                     "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
-                ).format(sysroot=sysroot, osx_version=osx_version_min),
+                ).format(sysroot=shell._quote(sysroot),
+                         osx_version=osx_version_min),
             }
         elif self.toolchain.cxx:
             env = {
-                "CXX": self.toolchain.cxx,
+                "CXX": shell._quote(self.toolchain.cxx),
             }
 
         # Ninja can only be built in-tree.  Copy the source tree to the build


### PR DESCRIPTION
IF Xcode is installed into a location with spaces, we would fail to
compile due to improper quoting.  Quote the paths to ensure that ninja
can bootstrap properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
