### PR TITLE
[cxx-interop] Use cached record when possible.

### DIFF
--- a/test/Interop/Cxx/class/Inputs/linked-records.h
+++ b/test/Interop/Cxx/class/Inputs/linked-records.h
@@ -1,0 +1,39 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_LINKED_RECORDS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_LINKED_RECORDS_H
+
+namespace Space {
+
+class C;
+
+struct A {
+  struct B {
+    B(int) {}
+    B(char) {}
+    B(const C *) {}
+  };
+};
+
+struct C {
+  struct D {
+    A::B B;
+  };
+};
+
+struct E {
+  static void test(const C *);
+};
+
+} // namespace Space
+
+struct M {};
+
+struct F {
+  union {
+    struct {
+    } c;
+    M m;
+  };
+  M m2;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_LINKED_RECORDS_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -57,3 +57,7 @@ module NestedRecords {
   header "nested-records.h"
   requires cplusplus
 }
+
+module LinkedRecords {
+  header "linked-records.h"
+}

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=LinkedRecords -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: enum Space {
+// CHECK:   struct C {
+// CHECK:     struct D {
+// CHECK:       var B: Space.A.B
+// CHECK:       init(B: Space.A.B)
+// CHECK:     }
+// CHECK:   }
+// CHECK:   struct A {
+// CHECK:     struct B {
+// CHECK:       init(_: Int32)
+// CHECK:       init(_: CChar)
+// CHECK:     }
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   struct E {
+// CHECK:     init()
+// CHECK:     static func test(_: UnsafePointer<Space.C>!)
+// CHECK:   }
+// CHECK: }
+
+// CHECK: struct M {
+// CHECK:   init()
+// CHECK: }
+// CHECK: struct F {
+// CHECK:   struct __Unnamed_union___Anonymous_field0 {
+// CHECK:     struct __Unnamed_struct_c {
+// CHECK:       init()
+// CHECK:     }
+// CHECK:     var c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c
+// CHECK:     var m: M
+// CHECK:     init()
+// CHECK:     init(c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c)
+// CHECK:     init(m: M)
+// CHECK:   }
+// CHECK:   var __Anonymous_field0: F.__Unnamed_union___Anonymous_field0
+// CHECK:   var c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c
+// CHECK:   var m: M
+// CHECK:   var m2: M
+// CHECK:   init()
+// CHECK:   init(_ __Anonymous_field0: F.__Unnamed_union___Anonymous_field0, m2: M)
+// CHECK: }


### PR DESCRIPTION
It is not completely uncommon for a record to get imported while importing its members (for example, if the member points back to the parent record). In this case, simply use the already-imported record. This should improve performance but also prevent an error where a member accidentally had two parents.

This patch also moves around some of the member import/add logic to allow for the above "optimization."

