### PR TITLE
[cxx-interop] Bail on functions that use unimportable types.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3888,6 +3888,10 @@ namespace {
         bodyParams =
             getNonSelfParamList(dc, decl, selfIdx, name.getArgumentNames(),
                                 allowNSUIntegerAsInt, !name, templateParams);
+        // If we can't import a param for some reason (ex. it's a dependent
+        // type), bail.
+        if (!bodyParams)
+          return nullptr;
 
         importedType =
             Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -64,4 +64,19 @@ void cassini(T, U) { }
 template<class T>
 void magellan(T&) { }
 
-}
+} // namespace Orbiters
+
+// We can't import these (and may never be able to in the case of "_Atomic"),
+// but don't crash while trying.
+namespace Unimportable {
+
+template <class> struct Dependent {};
+template <class T> void takesDependent(Dependent<T> d) {}
+
+void takesAtomic(_Atomic(int) a) {}
+
+struct HasImposibleMember {
+  void memberTakesAtomic(_Atomic(int) a) {}
+};
+
+} // namespace Unimportable


### PR DESCRIPTION
We already fixed this for "global" functions. This is a more generic solution that works for "nested" functions as well. (Members or functions in a namespace.)