### PR TITLE
Windows Build: Add notes for multi-line commands when using PowerShell

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -4,6 +4,8 @@ Visual Studio 2017 or newer is needed to build Swift on Windows. The free Commun
 
 The commands below (with the exception of installing Visual Studio) must be entered in the "**x64 Native** Tools Command Prompt for VS2017" (or VS2019, VS2019 Preview depending on the Visual Studio that you are using) in the Start Menu. This sets environment variables to select the correct target platform.
 
+All the commands below are written in Command Prompt. While using PowerShell, You need to replace `^` with <code>`</code> (backtick) at the end of each line.
+
 ## Install dependencies
 
 ### Visual Studio


### PR DESCRIPTION
<!-- What's in this pull request? -->
On Windows, we have two shells:
- Command Prompt
- PowerShell

The use of PowerShell is increasing. Since all the commands of this file is written in Command Prompt, we need to add a note for whose who do not know this difference.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
