### PR TITLE
build: handle spaces in Xcode better (NFC)

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -479,8 +479,8 @@ function set_build_options_for_host() {
         watchos-*           | \
         watchsimulator-*)
             swift_cmake_options+=(
-              -DPython2_EXECUTABLE=$(xcrun -f python2.7)
-              -DPython3_EXECUTABLE=$(xcrun -f python3)
+              -DPython2_EXECUTABLE="$(xcrun -f python2.7)"
+              -DPython3_EXECUTABLE="$(xcrun -f python3)"
             )
             case ${host} in
                 macosx-x86_64)


### PR DESCRIPTION
Quote the path to the python interpreter.  Without this change, using a
path with a space in it will prevent CMake from configuring as the
python interpreter's path will be split.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
