### PR TITLE
test: handle spaces in paths better on macOS tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -435,8 +435,8 @@ if kIsWindows:
                                                                            config.swift_test_options,
                                                                            config.swift_driver_test_options)) )
 else:
-    config.substitutions.append( ('%swift_driver', "env SDKROOT=%s %r %s %s %s" % (config.variant_sdk, config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
-    config.substitutions.append( ('%swiftc_driver', "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s" % (config.variant_sdk, config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+    config.substitutions.append( ('%swift_driver', "env SDKROOT=%s %r %s %s %s" % (shell_quote(config.variant_sdk), config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+    config.substitutions.append( ('%swiftc_driver', "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s" % (shell_quote(config.variant_sdk), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
 config.substitutions.append( ('%sil-opt', "%r %s %s" % (config.sil_opt, mcp_opt, config.sil_test_options)) )
 config.substitutions.append( ('%sil-func-extractor', "%r %s" % (config.sil_func_extractor, mcp_opt)) )
 config.substitutions.append( ('%sil-llvm-gen', "%r %s" % (config.sil_llvm_gen, mcp_opt)) )


### PR DESCRIPTION
Ensure that we quote the path to the SDKROOT which may contain spaces.
Failure to so will break the path into multiple components (split on
spaces) and generate an invalid command.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
