### PR TITLE
[typelowering] Eliminate typelowering usage of And*Fold APIs

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1076,7 +1076,7 @@ namespace {
         return;
       }
 
-      B.emitReleaseValueAndFold(loc, aggValue);
+      B.createReleaseValue(loc, aggValue, B.getDefaultAtomicity());
     }
 
     void
@@ -1254,7 +1254,7 @@ namespace {
         B.createDestroyValue(loc, value);
         return;
       }
-      B.emitReleaseValueAndFold(loc, value);
+      B.createReleaseValue(loc, value, B.getDefaultAtomicity());
     }
 
     void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
@@ -1415,7 +1415,7 @@ namespace {
         B.createDestroyValue(loc, value);
         return;
       }
-      B.emitStrongReleaseAndFold(loc, value);
+      B.createStrongRelease(loc, value, B.getDefaultAtomicity());
     }
   };
 
@@ -1501,13 +1501,13 @@ namespace {
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
                             SILValue addr) const override {
       if (!isTrivial())
-        B.emitDestroyAddrAndFold(loc, addr);
+        B.createDestroyAddr(loc, addr);
     }
 
     void emitDestroyRValue(SILBuilder &B, SILLocation loc,
                            SILValue value) const override {
       if (!isTrivial())
-        B.emitDestroyAddrAndFold(loc, value);
+        B.createDestroyAddr(loc, value);
     }
 
     SILValue emitCopyValue(SILBuilder &B, SILLocation loc,

--- a/test/SILGen/unsafevalue.swift
+++ b/test/SILGen/unsafevalue.swift
@@ -45,7 +45,9 @@ public struct UnsafeValue<Element: AnyObject> {
   // CANONICAL-LABEL: sil [transparent] [serialized] @$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC : $@convention(method) <Element where Element : AnyObject> (@guaranteed Element, @thin UnsafeValue<Element>.Type) -> UnsafeValue<Element> {
   // CANONICAL: bb0([[INPUT_ELEMENT:%.*]] : $Element,
   // CANONICAL-NEXT: debug_value
+  // CANONICAL-NEXT: strong_retain [[INPUT_ELEMENT]]
   // CANONICAL-NEXT: [[UNMANAGED_ELEMENT:%.*]] = ref_to_unmanaged [[INPUT_ELEMENT]]
+  // CANONICAL-NEXT: strong_release [[INPUT_ELEMENT]]
   // CANONICAL-NEXT: [[RESULT:%.*]] = struct $UnsafeValue<Element> ([[UNMANAGED_ELEMENT]] : $@sil_unmanaged Element)
   // CANONICAL-NEXT: return [[RESULT]]
   // CANONICAL: } // end sil function '$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC'

--- a/test/SILOptimizer/mem2reg_resilient.sil
+++ b/test/SILOptimizer/mem2reg_resilient.sil
@@ -8,13 +8,15 @@ public struct ResilientStruct {
     var x: AnyObject
 }
 
-// CHECK-LABEL: sil @mem2reg_debug_value_addr
+// CHECK-LABEL: sil @mem2reg_debug_value_addr :
 // CHECK:       bb0(%0 : $*ResilientStruct):
-// CHECK-NEXT:    %1 = load %0 : $*ResilientStruct
-// CHECK-NEXT:    debug_value %1 : $ResilientStruct
-// CHECK-NEXT:    %3 = tuple ()
-// CHECK-NEXT:    return %3 : $()
-
+// CHECK-NEXT:    %1 = load %0
+// CHECK-NEXT:    retain_value %1
+// CHECK-NEXT:    debug_value %1
+// CHECK-NEXT:    release_value %1
+// CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    return {{%.*}} : $()
+// CHECK: } // end sil function 'mem2reg_debug_value_addr'
 sil @mem2reg_debug_value_addr : $@convention(thin) (@in_guaranteed ResilientStruct) -> () {
 bb0(%0 : $*ResilientStruct):
   %1 = alloc_stack $ResilientStruct

--- a/test/SILOptimizer/ownership_model_eliminator_resilience.sil
+++ b/test/SILOptimizer/ownership_model_eliminator_resilience.sil
@@ -1,4 +1,3 @@
-
 // RUN: %target-sil-opt -ownership-model-eliminator -enable-library-evolution %s | %FileCheck %s
 
 // copy_value and destroy_value operations are lowered away, except for
@@ -36,7 +35,9 @@ bb0(%0 : @guaranteed $Saddle):
 // CHECK:       bb0(%0 : $Saddle):
 // CHECK:         strong_retain %0 : $Saddle
 // CHECK:         %2 = enum $Animal, #Animal.horse!enumelt, %0 : $Saddle
-// CHECK:         release_value %2 : $Animal
-// CHECK:         %4 = tuple ()
-// CHECK:         return %4 : $()
+// CHECK:         retain_value %2
+// CHECK:         release_value %2
+// CHECK:         release_value %2
+// CHECK:         %6 = tuple ()
+// CHECK:         return %6 : $()
 // CHECK:       }


### PR DESCRIPTION
The only real change in this PR is the last commit. The last commit removes the usage from typelowering of the emit*AndFoldAPIs. This is an actively harmful foot gun since these APIs can eliminate destroy_values yet:

1. Are used in Builder APIs. Its counter-intuitive that Builder APIs should erase instructions (that is it is a "footman").
2. Do not provide a callback so that callers can erase the instruction themselves after updating state.

This has been an issue I have wanted to fix for a long time but the large number of tests that needed to be updated at -Onone. The initial commits (and some other commits I landed recently) make it so that we only have a very small delta at -Onone (meaning I needed to only update a few tests).

So now we can eliminate the footgun!