### PR TITLE
[stdlib] Simplify buffer pointer initialization.

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -499,7 +499,8 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeBufferPointer<Element>>) {
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
-    self.init(start: base, count: slice.count)
+    let count = slice.endIndex &- slice.startIndex
+    self.init(start: base, count: count)
   }
 
 %  end
@@ -526,7 +527,8 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeMutableBufferPointer<Element>>) {
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
-    self.init(start: base, count: slice.count)
+    let count = slice.endIndex &- slice.startIndex
+    self.init(start: base, count: count)
   }
 
   /// Deallocates the memory block previously allocated at this buffer pointer’s 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -512,7 +512,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   @inlinable
   public init(rebasing slice: Slice<UnsafeRawBufferPointer>) {
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
-    self.init(start: base, count: slice.count)
+    let count = slice.endIndex &- slice.startIndex
+    self.init(start: base, count: count)
   }
 %  end # !mutable
 
@@ -539,7 +540,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   @inlinable
   public init(rebasing slice: Slice<UnsafeMutableRawBufferPointer>) {
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
-    self.init(start: base, count: slice.count)
+    let count = slice.endIndex &- slice.startIndex
+    self.init(start: base, count: count)
   }
 
   /// A pointer to the first byte of the buffer.


### PR DESCRIPTION
UnsafeRawBufferPointer was not made self-slicing, but is instead sliced
by Slice<UnsafeRawBufferPointer>. When working with
UnsafeRawBufferPointer objects it is quite common to want to transform
back into the underlying collection, which is why the
UnsafeRawBufferPointer provides a constructor from its subsequence:
UnsafeRawBufferPointer.init(rebasing:).

Unfortunately for an initializer on this extremely low-level type, this
initializer is surprisingly expensive. When disassembled on Linux it
emits 7 separate traps and 11 branches. This relative heft means this
method often gets outlined, which is a shame, as several of the branches
could often be eliminated due to checks elsewhere in functions where
this initializer is used.

Almost all of these branches and almost all of the traps are
unnecessary. We can remove them by noting that it is impossible to
construct a Slice whose endIndex is earlier than its startIndex. All
Slice inits are constructed with bounds expressed as Range, and Range
enforces ordering on its endpoints.

For this reason, we can do unchecked arithmetic on the start and end
index of the slice, and remove 5 traps in one fell swoop. This greatly
cheapens the cost of the initializer, improving its odds of being
inlined and having even more of its branches optimised away.

For what it's worth, I also considered trying to remove the last two
preconditions. Unfortunately I concluded I couldn't confidently do that.
I wanted to remove them based on the premise that a valid Slice must
have indices that were in-bounds for its parent Collection, and so we
could safely assume that if the parent base address was nil the count
would have to be zero, and that adding start index to the base address
would definitely not overflow. However, the existence of the
Slice.init(base:bounds:) constructor led me to be a bit suspicions of
removing those checks. Given that
UnsafeRawBufferPointer.init(start:count:) enforces those invariants, I
decided it was safest for us to continue to do that.
