### PR TITLE
[AutoDiff] Update manifesto to link to the initial proposal.

### DIFF
--- a/docs/DifferentiableProgramming.md
+++ b/docs/DifferentiableProgramming.md
@@ -1,7 +1,9 @@
 # Differentiable Programming Manifesto
 
 *   Authors: [Richard Wei], [Dan Zheng], [Marc Rasi], [Bart Chrzaszcz]
-*   Status: Partially implemented on master, feature gated under `import _Differentiation`
+*   Status:
+    * Partially implemented on main, feature gated under `import _Differentiation`
+    * Initial proposal [pitched](https://forums.swift.org/t/differentiable-programming-for-gradient-based-machine-learning/42147) with a significantly scoped-down subset of features. Please refer to the linked pitch thread for the latest design discussions and changes.
 
 ## Table of contents
 


### PR DESCRIPTION
Add a link to the pitch thread for the feature-reduced proposal to avoid [possible confusion](https://forums.swift.org/t/differentiable-programming-for-gradient-based-machine-learning/42147/58) :)