### PR TITLE
[Concurrency] Implement SIL generation for "async let".

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -327,10 +327,9 @@ SILGenModule::getConformanceToBridgedStoredNSError(SILLocation loc, Type type) {
   return SwiftModule->lookupConformance(type, proto);
 }
 
-static FuncDecl *
-lookUpResumeContinuationIntrinsic(ASTContext &C,
-                                  Optional<FuncDecl*> &cache,
-                                  StringRef name) {
+static FuncDecl *lookupConcurrencyIntrinsic(ASTContext &C,
+                                            Optional<FuncDecl*> &cache,
+                                            StringRef name) {
   if (cache)
     return *cache;
   
@@ -356,21 +355,42 @@ lookUpResumeContinuationIntrinsic(ASTContext &C,
 }
 
 FuncDecl *
+SILGenModule::getRunChildTask() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    RunChildTask,
+                                    "_runChildTask");
+}
+
+FuncDecl *
+SILGenModule::getTaskFutureGet() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    TaskFutureGet,
+                                    "_taskFutureGet");
+}
+
+FuncDecl *
+SILGenModule::getTaskFutureGetThrowing() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    TaskFutureGetThrowing,
+                                    "_taskFutureGetThrowing");
+}
+
+FuncDecl *
 SILGenModule::getResumeUnsafeContinuation() {
-  return lookUpResumeContinuationIntrinsic(getASTContext(),
-                                           ResumeUnsafeContinuation,
-                                           "_resumeUnsafeContinuation");
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    ResumeUnsafeContinuation,
+                                    "_resumeUnsafeContinuation");
 }
 FuncDecl *
 SILGenModule::getResumeUnsafeThrowingContinuation() {
-  return lookUpResumeContinuationIntrinsic(getASTContext(),
-                                           ResumeUnsafeThrowingContinuation,
-                                           "_resumeUnsafeThrowingContinuation");
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    ResumeUnsafeThrowingContinuation,
+                                    "_resumeUnsafeThrowingContinuation");
 }
 FuncDecl *
 SILGenModule::getResumeUnsafeThrowingContinuationWithError() {
-  return lookUpResumeContinuationIntrinsic(getASTContext(),
-                                 ResumeUnsafeThrowingContinuationWithError,
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    ResumeUnsafeThrowingContinuationWithError,
                                  "_resumeUnsafeThrowingContinuationWithError");
 }
 

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -119,6 +119,10 @@ public:
 
   Optional<ProtocolConformance *> NSErrorConformanceToError;
 
+  Optional<FuncDecl*> RunChildTask;
+  Optional<FuncDecl*> TaskFutureGet;
+  Optional<FuncDecl*> TaskFutureGetThrowing;
+
   Optional<FuncDecl*> ResumeUnsafeContinuation;
   Optional<FuncDecl*> ResumeUnsafeThrowingContinuation;
   Optional<FuncDecl*> ResumeUnsafeThrowingContinuationWithError;
@@ -472,6 +476,15 @@ public:
 
   /// Retrieve the conformance of NSError to the Error protocol.
   ProtocolConformance *getNSErrorConformanceToError();
+
+  /// Retrieve the _Concurrency._runChildTask intrinsic.
+  FuncDecl *getRunChildTask();
+
+  /// Retrieve the _Concurrency._taskFutureGet intrinsic.
+  FuncDecl *getTaskFutureGet();
+
+  /// Retrieve the _Concurrency._taskFutureGetThrowing intrinsic.
+  FuncDecl *getTaskFutureGetThrowing();
 
   /// Retrieve the _Concurrency._resumeUnsafeContinuation intrinsic.
   FuncDecl *getResumeUnsafeContinuation();

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1409,14 +1409,7 @@ static ManagedValue emitBuiltinGetCurrentAsyncTask(
 static ManagedValue emitBuiltinCancelAsyncTask(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     ArrayRef<ManagedValue> args, SGFContext C) {
-  ASTContext &ctx = SGF.getASTContext();
-  auto argument = args[0].borrow(SGF, loc).forward(SGF);
-  auto apply = SGF.B.createBuiltin(
-      loc,
-      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CancelAsyncTask)),
-      SGF.getLoweredType(ctx.TheEmptyTupleType), SubstitutionMap(),
-      { argument });
-  return ManagedValue::forUnmanaged(apply);
+  return SGF.emitCancelAsyncTask(loc, args[0].borrow(SGF, loc).forward(SGF));
 }
 
 // Emit SIL for the named builtin: createAsyncTask.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -428,8 +428,8 @@ public:
     auto &lowering = SGF.getTypeLowering(vd->getType());
     
     // Decide whether we need a temporary stack buffer to evaluate this 'let'.
-    // There are three cases we need to handle here: parameters, initialized (or
-    // bound) decls, and uninitialized ones.
+    // There are four cases we need to handle here: parameters, initialized (or
+    // bound) decls, uninitialized ones, and async let declarations.
     bool needsTemporaryBuffer;
     bool isUninitialized = false;
 
@@ -438,6 +438,13 @@ public:
     if (vd->getParentPatternBinding() && !vd->getParentInitializer()) {
       // If this is a let-value without an initializer, then we need a temporary
       // buffer.  DI will make sure it is only assigned to once.
+      needsTemporaryBuffer = true;
+      isUninitialized = true;
+    } else if (vd->isAsyncLet()) {
+      // If this is an async let, treat it like a let-value without an
+      // initializer. The initializer runs concurrently in a child task,
+      // and value will be initialized at the point the variable in the
+      // async let is used.
       needsTemporaryBuffer = true;
       isUninitialized = true;
     } else {
@@ -1130,12 +1137,53 @@ SILGenFunction::emitInitializationForVarDecl(VarDecl *vd, bool forceImmutable) {
 
 void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
                                         unsigned idx) {
+
+
   auto initialization = emitPatternBindingInitialization(PBD->getPattern(idx),
                                                          JumpDest::invalid());
 
-  // If an initial value expression was specified by the decl, emit it into
-  // the initialization. Otherwise, mark it uninitialized for DI to resolve.
-  if (auto *Init = PBD->getExecutableInit(idx)) {
+  // If this is an async let, create a child task to compute the initializer
+  // value.
+  if (PBD->isAsyncLet()) {
+    // Look through the implicit await (if present), try (if present), and
+    // call to reach the autoclosure that computes the value.
+    auto *init = PBD->getExecutableInit(idx);
+    if (auto awaitExpr = dyn_cast<AwaitExpr>(init))
+      init = awaitExpr->getSubExpr();
+    if (auto tryExpr = dyn_cast<TryExpr>(init))
+      init = tryExpr->getSubExpr();
+    init = cast<CallExpr>(init)->getFn();
+    assert(isa<AutoClosureExpr>(init) &&
+           "Could not find async let autoclosure");
+    bool isThrowing = init->getType()->castTo<AnyFunctionType>()->isThrowing();
+
+    // Emit the closure for the child task.
+    SILValue childTask;
+    {
+      FullExpr Scope(Cleanups, CleanupLocation(init));
+      SILLocation loc(PBD);
+      childTask = emitRunChildTask(
+          loc,
+          init->getType(),
+          emitRValue(init).getScalarValue()
+        ).forward(*this);
+    }
+
+    // Destroy the task at the end of the scope.
+    enterDestroyCleanup(childTask);
+
+    // Push a cleanup that will cancel the child task at the end of the scope.
+    enterCancelAsyncTaskCleanup(childTask);
+
+    // Save the child task so we can await it as needed.
+    AsyncLetChildTasks[{PBD, idx}] = { childTask, isThrowing };
+
+    // Mark as uninitialized; actual initialization will occur when the
+    // variables are referenced.
+    initialization->finishUninitialized(*this);
+  } else if (auto *Init = PBD->getExecutableInit(idx)) {
+    // If an initial value expression was specified by the decl, emit it into
+    // the initialization.
     FullExpr Scope(Cleanups, CleanupLocation(Init));
 
     auto *var = PBD->getSingleVar();
@@ -1155,6 +1203,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
 
     emitExprInto(Init, initialization.get(), SILLocation(PBD));
   } else {
+    // Otherwise, mark it uninitialized for DI to resolve.
     initialization->finishUninitialized(*this);
   }
 }
@@ -1410,6 +1459,35 @@ CleanupHandle SILGenFunction::enterDeinitExistentialCleanup(
   assert(addr->getType().isAddress());
   Cleanups.pushCleanupInState<DeinitExistentialCleanup>(state, addr,
                                                       concreteFormalType, repr);
+  return Cleanups.getTopCleanup();
+}
+
+namespace {
+  /// A cleanup that cancels an asynchronous task.
+  class CancelAsyncTaskCleanup: public Cleanup {
+    SILValue task;
+  public:
+    CancelAsyncTaskCleanup(SILValue task) : task(task) { }
+
+    void emit(SILGenFunction &SGF, CleanupLocation l,
+              ForUnwind_t forUnwind) override {
+      SILValue borrowedTask = SGF.B.createBeginBorrow(l, task);
+      SGF.emitCancelAsyncTask(l, borrowedTask);
+      SGF.B.createEndBorrow(l, borrowedTask);
+    }
+
+    void dump(SILGenFunction &) const override {
+#ifndef NDEBUG
+      llvm::errs() << "CancelAsyncTaskCleanup\n"
+                   << "Task:" << task << "\n";
+#endif
+    }
+  };
+} // end anonymous namespace
+
+CleanupHandle SILGenFunction::enterCancelAsyncTaskCleanup(SILValue task) {
+  Cleanups.pushCleanupInState<CancelAsyncTaskCleanup>(
+      CleanupState::Active, task);
   return Cleanups.getTopCleanup();
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4447,7 +4447,7 @@ namespace {
 
     /// Top-level entrypoint.
     void emit(CanType destType, RValue &&src) {
-      visitTupleType(cast<TupleType>(destType), std::move(src));
+      visit(destType, std::move(src));
       assert(DestLVQueue.empty() && "didn't consume all l-values!");
     }
 
@@ -4555,6 +4555,87 @@ RValue RValueEmitter::visitAssignExpr(AssignExpr *E, SGFContext C) {
   FullExpr scope(SGF.Cleanups, CleanupLocation(E));
   emitSimpleAssignment(SGF, E, E->getDest(), E->getSrc());
   return SGF.emitEmptyTupleRValue(E, C);
+}
+
+namespace {
+  /// A visitor for creating a flattened list of LValues from a
+  /// pattern.
+  class PatternLValueEmitter
+      : public PatternVisitor<PatternLValueEmitter, Type> {
+
+    SILGenFunction &SGF;
+
+    SGFAccessKind TheAccessKind;
+
+    /// A flattened list of l-values.
+    SmallVectorImpl<Optional<LValue>> &Results;
+
+  public:
+    PatternLValueEmitter(SILGenFunction &SGF, SGFAccessKind accessKind,
+                         SmallVectorImpl<Optional<LValue>> &results)
+      : SGF(SGF), TheAccessKind(accessKind), Results(results) {}
+
+#define USE_SUBPATTERN(Kind) \
+    Type visit##Kind##Pattern(Kind##Pattern *pattern) { \
+      return visit(pattern->getSubPattern());            \
+    }
+
+    USE_SUBPATTERN(Paren)
+    USE_SUBPATTERN(Typed)
+    USE_SUBPATTERN(Binding)
+#undef USE_SUBPATTERN
+
+#define PATTERN(Kind, Parent)
+#define REFUTABLE_PATTERN(Kind, Parent) \
+    Type visit##Kind##Pattern(Kind##Pattern *pattern) { \
+      llvm_unreachable("No refutable patterns here");    \
+    }
+#include "swift/AST/PatternNodes.def"
+
+    Type visitTuplePattern(TuplePattern *pattern) {
+      SmallVector<TupleTypeElt, 4> tupleElts;
+      for (auto &element : pattern->getElements()) {
+        Type elementType = visit(element.getPattern());
+        tupleElts.push_back(
+            TupleTypeElt(elementType, element.getLabel()));
+      }
+
+      return TupleType::get(tupleElts, SGF.getASTContext());
+    }
+
+    Type visitNamedPattern(NamedPattern *pattern) {
+      Type type = LValueType::get(pattern->getDecl()->getType());
+      auto declRef = new (SGF.getASTContext()) DeclRefExpr(
+          pattern->getDecl(), DeclNameLoc(), /*Implicit=*/true,
+          AccessSemantics::Ordinary, type);
+
+      Results.push_back(SGF.emitLValue(declRef, TheAccessKind));
+
+      return type;
+    }
+
+    Type visitAnyPattern(AnyPattern *pattern) {
+      // Discard the value at this position.
+      Results.push_back(None);
+
+      return LValueType::get(pattern->getType());
+    }
+  };
+}
+
+void SILGenFunction::emitAssignToPatternVars(
+    SILLocation loc, Pattern *destPattern, RValue &&src) {
+  FormalEvaluationScope writeback(*this);
+
+  // Produce a flattened queue of LValues.
+  SmallVector<Optional<LValue>, 4> destLVs;
+  CanType destType = PatternLValueEmitter(
+      *this, SGFAccessKind::Write, destLVs).visit(destPattern)
+    ->getCanonicalType();
+
+  // Recurse on the type of the destination, pulling LValues as
+  // needed from the queue we built up before.
+  TupleLValueAssigner(*this, loc, destLVs).emit(destType, std::move(src));
 }
 
 void SILGenFunction::emitBindOptionalAddress(SILLocation loc,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -866,8 +866,9 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
       auto wrappedInfo = var->getPropertyWrapperBackingPropertyInfo();
       auto param = params->get(0);
       auto *placeholder = wrappedInfo.wrappedValuePlaceholder;
-      opaqueValue.emplace(*this, placeholder->getOpaqueValuePlaceholder(),
-                          maybeEmitValueOfLocalVarDecl(param));
+      opaqueValue.emplace(
+          *this, placeholder->getOpaqueValuePlaceholder(),
+          maybeEmitValueOfLocalVarDecl(param, AccessKind::Read));
 
       assert(value == wrappedInfo.initializeFromOriginal);
     }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -397,7 +397,14 @@ public:
   /// emitted. The map is queried to produce the lvalue for a DeclRefExpr to
   /// a local variable.
   llvm::DenseMap<ValueDecl*, VarLoc> VarLocs;
- 
+
+  /// Mapping from each async let clause to the child task that will produce
+  /// the initializer value for that clause and a Boolean value indicating
+  /// whether the task can throw.
+  llvm::SmallDenseMap<std::pair<PatternBindingDecl *, unsigned>,
+                      std::pair<SILValue, bool /*isThrowing*/> >
+      AsyncLetChildTasks;
+
   /// When rebinding 'self' during an initializer delegation, we have to be
   /// careful to preserve the object at 1 retain count during the delegation
   /// because of assumptions in framework code. This enum tracks the state of
@@ -1257,7 +1264,8 @@ public:
                                          SGFAccessKind accessKind);
 
   // FIXME: demote this to private state.
-  ManagedValue maybeEmitValueOfLocalVarDecl(VarDecl *var);
+  ManagedValue maybeEmitValueOfLocalVarDecl(
+      VarDecl *var, AccessKind accessKind);
 
   /// Produce an RValue for a reference to the specified declaration,
   /// with the given type and in response to the specified expression.  Try to
@@ -1320,6 +1328,14 @@ public:
                        PreparedArguments &&optionalSubscripts,
                        ArgumentSource &&value,
                        bool isOnSelfParameter);
+
+  ManagedValue emitRunChildTask(
+      SILLocation loc, Type functionType, ManagedValue taskFunction);
+
+  ManagedValue emitCancelAsyncTask(SILLocation loc, SILValue task);
+
+  void completeAsyncLetChildTask(
+      PatternBindingDecl *patternBinding, unsigned index);
 
   bool maybeEmitMaterializeForSetThunk(ProtocolConformanceRef conformance,
                                        SILLinkage linkage,
@@ -1466,6 +1482,12 @@ public:
                                 LValue &&src, LValue &&dest);
   void emitCopyLValueInto(SILLocation loc, LValue &&src,
                           Initialization *dest);
+
+  /// Emit an assignment to the variables in the destination pattern, given
+  /// an rvalue source that has the same type as the pattern.
+  void emitAssignToPatternVars(
+      SILLocation loc, Pattern *destPattern, RValue &&src);
+
   ManagedValue emitAddressOfLValue(SILLocation loc, LValue &&src,
                                    TSanKind tsanKind = TSanKind::None);
   ManagedValue emitBorrowedLValue(SILLocation loc, LValue &&src,
@@ -2025,6 +2047,9 @@ public:
                                               SILValue addr,
                                               CanType concreteFormalType,
                                               ExistentialRepresentation repr);
+
+  /// Enter a cleanup to cancel the given task.
+  CleanupHandle enterCancelAsyncTaskCleanup(SILValue task);
 
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, SGFAccessKind accessKind,

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -1,0 +1,82 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency -parse-stdlib -sil-verify-all | %FileCheck %s
+// REQUIRES: concurrency
+
+import Swift
+import _Concurrency
+
+func getInt() async -> Int { 0 }
+func getString() async -> String { "" }
+func getStringThrowingly() async throws -> String { "" }
+func getIntAndString() async -> (Int, String) { (5, "hello") }
+
+enum SomeError: Error {
+  case boom
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A11AsyncLetIntSiyYF : $@convention(thin) @async () -> Int
+func testAsyncLetInt() async -> Int {
+  // CHECK: [[I:%.*]] = mark_uninitialized [var] %0
+  // CHECK: [[CLOSURE:%.*]] = function_ref @$s4test0A11AsyncLetIntSiyYFSiyYcfu_ : $@convention(thin) @async () -> Int
+  // CHECK: [[THICK_CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) @async () -> Int to $@async @callee_guaranteed () -> Int
+  // CHECK: [[REABSTRACT_THUNK:%.*]] = function_ref @$sSiIegHd_Sis5Error_pIegHrzo_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
+  // CHECK: [[REABSTRACT_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[THICK_CLOSURE]]) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
+  // CHECK: [[CLOSURE_ARG:%.*]] = convert_function [[REABSTRACT_CLOSURE]] : $@async @callee_guaranteed () -> (@out Int, @error Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
+  // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @$s12_Concurrency13_runChildTask9operationBoxyYKc_tYlF : $@convention(thin) @async <τ_0_0> (@guaranteed @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
+  // CHECK: [[CHILD_TASK:%.*]] = apply [[RUN_CHILD_TASK]]<Int>([[CLOSURE_ARG]]) : $@convention(thin) @async <τ_0_0> (@guaranteed @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
+  async let i = await getInt()
+
+  // CHECK: [[FUTURE_GET:%.*]] = function_ref @$s12_Concurrency14_taskFutureGetyxBoYlF : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+  // CHECK: [[INT_RESULT:%.*]] = alloc_stack $Int
+  // CHECK: apply [[FUTURE_GET]]<Int>([[INT_RESULT]], [[CHILD_TASK]]) : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+  // CHECK: [[INT_RESULT_VALUE:%.*]] = load [trivial] [[INT_RESULT]] : $*Int
+  // CHECK: assign [[INT_RESULT_VALUE]] to [[I]] : $*Int
+  return await i
+
+  // CHECK: [[BORROW_CHILD_TASK:%.*]] = begin_borrow [[CHILD_TASK]] : $Builtin.NativeObject
+  // CHECK-NEXT: builtin "cancelAsyncTask"([[BORROW_CHILD_TASK]] : $Builtin.NativeObject) : $()
+  // CHECK-NEXT: end_borrow [[BORROW_CHILD_TASK]] : $Builtin.NativeObject
+  
+  // CHECK: destroy_value [[CHILD_TASK]] : $Builtin.NativeObject 
+}
+
+func testAsyncLetWithThrows(cond: Bool) async throws -> String {
+  async let i = await getInt()
+  async let s = await getString()
+
+  if cond {
+    throw SomeError.boom
+  }
+  
+  return await s
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A14AsyncLetThrowsSSyYKF : $@convention(thin) @async () -> (@owned String, @error Error) {
+func testAsyncLetThrows() async throws -> String {
+  async let s = await try getStringThrowingly()
+
+  // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @$s12_Concurrency22_taskFutureGetThrowingyxBoYKlF : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> (@out τ_0_0, @error Error)
+  // CHECK: try_apply [[RUN_CHILD_TASK]]<String>
+  return await try s
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A14DecomposeAwait4condSiSb_tYF : $@convention(thin) @async (Bool) -> Int {
+func testDecomposeAwait(cond: Bool) async -> Int {
+  // CHECK: [[I_VAR:%.*]] = alloc_stack $Int, let, name "i"
+  // CHECK: [[I:%.*]] = mark_uninitialized [var] [[I_VAR]] : $*Int
+  // CHECK: [[S_VAR:%.*]] = alloc_stack $String, let, name "s"
+  // CHECK: [[S:%.*]] = mark_uninitialized [var] [[S_VAR]] : $*String
+  async let (i, s) = await getIntAndString()
+
+  if cond {
+    // CHECK: [[FUTURE_GET:%.*]] = function_ref @$s12_Concurrency14_taskFutureGetyxBoYlF : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+    // CHECK: [[TUPLE_RESULT:%.*]] = alloc_stack $(Int, String)
+    // CHECK: apply [[FUTURE_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}) : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+    // CHECK: [[TUPLE_RESULT_VAL:%.*]] = load [take] [[TUPLE_RESULT]] : $*(Int, String)
+    // CHECK: ([[FIRST_VAL:%.*]], [[SECOND_VAL:%.*]]) = destructure_tuple [[TUPLE_RESULT_VAL]] : $(Int, String)
+    // CHECK: assign [[FIRST_VAL]] to [[I]] : $*Int
+    // CHECK: assign [[SECOND_VAL]] to [[S]] : $*String
+    return await Int(s)!
+  }
+
+  return await i
+}


### PR DESCRIPTION
Implement SIL generation for "async let" constructs, which involves:

1. Creating a child task future at the point of declaration of the "async let",
which runs the initializer in an async closure.
2. Entering a cleanup to destroy the child task.
3. Entering a cleanup to cancel the child task.
4. Waiting for the child task when any of the variables is reference.
5. Decomposing the result of the child task to write the results into the
appropriate variables.

Implements rdar://71123479.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
