### PR TITLE
[SR-13899] [Sema] Adjustments on coerce to checked cast diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1108,9 +1108,13 @@ ERROR(missing_unwrap_optional_try,none,
       "value of optional type %0 not unwrapped; did you mean to use 'try!' "
       "or chain with '?'?",
      (Type))
-ERROR(missing_forced_downcast,none,
-      "%0 is not convertible to %1; "
-      "did you mean to use 'as!' to force downcast?", (Type, Type))
+ERROR(cannot_coerce_to_type, none,
+      "%0 is not convertible to %1", (Type, Type))
+NOTE(missing_forced_downcast, none,
+     "did you mean to use 'as!' to force downcast?", ())
+NOTE(missing_optional_downcast, none,
+     "did you mean to use 'as?' to conditionally downcast?", ())
+     
 WARNING(coercion_may_fail_warning,none,
         "coercion from %0 to %1 may fail; use 'as?' or 'as!' instead",
         (Type, Type))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1728,20 +1728,25 @@ public:
                              Type expectedType, ConstraintLocator *locator);
 };
 
-/// Replace a coercion ('as') with a forced checked cast ('as!').
+/// Replace a coercion ('as') with runtime checked cast ('as!' or 'as?').
 class CoerceToCheckedCast final : public ContextualMismatch {
   CoerceToCheckedCast(ConstraintSystem &cs, Type fromType, Type toType,
-                      ConstraintLocator *locator)
+                      bool useConditionalCast, ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::CoerceToCheckedCast, fromType, toType,
-                           locator) {}
+                           locator),
+        UseConditionalCast(useConditionalCast) {}
+  bool UseConditionalCast = false;
 
 public:
-  std::string getName() const override { return "as to as!"; }
+  std::string getName() const override {
+    return UseConditionalCast ? "as to as?" : "as to as!";
+  }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static CoerceToCheckedCast *attempt(ConstraintSystem &cs, Type fromType,
-                                      Type toType, ConstraintLocator *locator);
+                                      Type toType, bool useConditionalCast,
+                                      ConstraintLocator *locator);
 };
 
 class RemoveInvalidCall final : public ConstraintFix {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1075,7 +1075,7 @@ bool MissingExplicitConversionFailure::diagnoseAsError() {
     } else {
       // Emit error diagnostic.
       emitDiagnostic(diag::cannot_coerce_to_type, fromType, toType);
-      // Emit and return note suggesting as! where the fixit will be placed.
+      // Emit and return note suggesting as! where the fix-it will be placed.
       return emitDiagnostic(diag::missing_forced_downcast);
     }
   };

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1939,12 +1939,15 @@ protected:
   bool diagnoseMisplacedMissingArgument() const;
 };
 
-/// Replace a coercion ('as') with a forced checked cast ('as!').
-class MissingForcedDowncastFailure final : public ContextualFailure {
+/// Replace a coercion ('as') with a runtime checked cast ('as!' or 'as?').
+class InvalidCoercionFailure final : public ContextualFailure {
+  bool UseConditionalCast;
+
 public:
-  MissingForcedDowncastFailure(const Solution &solution, Type fromType,
-                               Type toType, ConstraintLocator *locator)
-      : ContextualFailure(solution, fromType, toType, locator) {}
+  InvalidCoercionFailure(const Solution &solution, Type fromType, Type toType,
+                         bool useConditionalCast, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator),
+        UseConditionalCast(useConditionalCast) {}
 
   ASTNode getAnchor() const override;
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -131,13 +131,14 @@ TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
 
 bool CoerceToCheckedCast::diagnose(const Solution &solution,
                                    bool asNote) const {
-  MissingForcedDowncastFailure failure(solution, getFromType(), getToType(),
-                                       getLocator());
+  InvalidCoercionFailure failure(solution, getFromType(), getToType(),
+                                 UseConditionalCast, getLocator());
   return failure.diagnose(asNote);
 }
 
 CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
                                                   Type fromType, Type toType,
+                                                  bool useConditionalCast,
                                                   ConstraintLocator *locator) {
   // If any of the types has a type variable, don't add the fix.
   if (fromType->hasTypeVariable() || toType->hasTypeVariable())
@@ -159,7 +160,7 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
     return nullptr;
 
   return new (cs.getAllocator())
-      CoerceToCheckedCast(cs, fromType, toType, locator);
+      CoerceToCheckedCast(cs, fromType, toType, useConditionalCast, locator);
 }
 
 bool TreatArrayLiteralAsDictionary::diagnose(const Solution &solution,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3551,9 +3551,26 @@ bool ConstraintSystem::repairFailures(
                                   getConstraintLocator(coercion->getSubExpr())))
         return true;
 
-      // Repair a coercion ('as') with a forced checked cast ('as!').
-      if (auto *coerceToCheckCastFix = CoerceToCheckedCast::attempt(
-              *this, lhs, rhs, getConstraintLocator(locator))) {
+      // If the result type of the coercion has an value to optional conversion
+      // we can instead suggest the conditional downcast as it is safer in
+      // situations like conditional binding.
+      auto useConditionalCast = llvm::any_of(
+          ConstraintRestrictions,
+          [&](std::tuple<Type, Type, ConversionRestrictionKind> restriction) {
+            ConversionRestrictionKind restrictionKind;
+            Type type1, type2;
+            std::tie(type1, type2, restrictionKind) = restriction;
+
+            if (restrictionKind != ConversionRestrictionKind::ValueToOptional)
+              return false;
+
+            return rhs->isEqual(type1);
+          });
+
+      // Repair a coercion ('as') with a runtime checked cast ('as!' or 'as?').
+      if (auto *coerceToCheckCastFix =
+              CoerceToCheckedCast::attempt(*this, lhs, rhs, useConditionalCast,
+                                           getConstraintLocator(locator))) {
         conversionsOrFixes.push_back(coerceToCheckCastFix);
         return true;
       }
@@ -9560,8 +9577,8 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
         loc->isLastElement<LocatorPathElt::ApplyArgToParam>() ||
         loc->isForOptionalTry()) {
       if (restriction == ConversionRestrictionKind::Superclass) {
-        if (auto *fix =
-                CoerceToCheckedCast::attempt(*this, fromType, toType, loc))
+        if (auto *fix = CoerceToCheckedCast::attempt(
+                *this, fromType, toType, /*useConditionalCast*/ false, loc))
           return !recordFix(fix, impact);
       }
       

--- a/test/ClangImporter/Dispatch_test.swift
+++ b/test/ClangImporter/Dispatch_test.swift
@@ -15,7 +15,8 @@ func test2(_ queue: DispatchQueue) {
 
   // Make sure the dispatch types are actually distinct types!
   let _ = queue as DispatchSource // expected-error {{cannot convert value of type 'DispatchQueue' to type 'DispatchSource' in coercion}}
-  let _ = base as DispatchSource // expected-error {{'NSObjectProtocol' is not convertible to 'DispatchSource'; did you mean to use 'as!' to force downcast?}}
+  let _ = base as DispatchSource // expected-error {{'NSObjectProtocol' is not convertible to 'DispatchSource'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
 }
 
 extension dispatch_queue_t {} // expected-error {{'dispatch_queue_t' is unavailable}}

--- a/test/ClangImporter/Security_test.swift
+++ b/test/ClangImporter/Security_test.swift
@@ -6,7 +6,8 @@ import Security
 
 _ = kSecClass as CFString
 _ = kSecClassGenericPassword as CFString
-_ = kSecClassGenericPassword as CFDictionary // expected-error {{'CFString?' is not convertible to 'CFDictionary'}} {{30-32=as!}}
+_ = kSecClassGenericPassword as CFDictionary // expected-error {{'CFString?' is not convertible to 'CFDictionary'}} 
+// expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{30-32=as!}}
 
 func testIntegration() {
   // Based on code in <rdar://problem/17162475>.

--- a/test/ClangImporter/objc_bridging_custom.swift
+++ b/test/ClangImporter/objc_bridging_custom.swift
@@ -218,11 +218,16 @@ func testExplicitConversion(objc: APPManufacturerInfo<NSString>,
                             swift: ManufacturerInfo<NSString>) {
   // Bridging to Swift
   let _ = objc as ManufacturerInfo<NSString>
-  let _ = objc as ManufacturerInfo<NSNumber> // expected-error{{'APPManufacturerInfo<NSString>' is not convertible to 'ManufacturerInfo<NSNumber>'; did you mean to use 'as!' to force downcast?}}
-  let _ = objc as ManufacturerInfo<NSObject> // expected-error{{'APPManufacturerInfo<NSString>' is not convertible to 'ManufacturerInfo<NSObject>'; did you mean to use 'as!' to force downcast?}}
+  let _ = objc as ManufacturerInfo<NSNumber> // expected-error{{'APPManufacturerInfo<NSString>' is not convertible to 'ManufacturerInfo<NSNumber>'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
+  let _ = objc as ManufacturerInfo<NSObject> // expected-error{{'APPManufacturerInfo<NSString>' is not convertible to 'ManufacturerInfo<NSObject>'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
 
   // Bridging to Objective-C
   let _ = swift as APPManufacturerInfo<NSString>
-  let _ = swift as APPManufacturerInfo<NSNumber> // expected-error{{'ManufacturerInfo<NSString>' is not convertible to 'APPManufacturerInfo<NSNumber>'; did you mean to use 'as!' to force downcast?}}
-  let _ = swift as APPManufacturerInfo<NSObject> // expected-error{{'ManufacturerInfo<NSString>' is not convertible to 'APPManufacturerInfo<NSObject>'; did you mean to use 'as!' to force downcast?}}
+  let _ = swift as APPManufacturerInfo<NSNumber> // expected-error{{'ManufacturerInfo<NSString>' is not convertible to 'APPManufacturerInfo<NSNumber>'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{17-19=as!}}
+  let _ = swift as APPManufacturerInfo<NSObject> // expected-error{{'ManufacturerInfo<NSString>' is not convertible to 'APPManufacturerInfo<NSObject>'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{17-19=as!}}
+
 }

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -540,10 +540,12 @@ func testStrangeSelectors(obj: StrangeSelectors) {
 
 func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
                            plainObj: NSObject, plainCell: SomeCell) {
-  _ = obj as NSObject // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'NSObject'; did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
+  _ = obj as NSObject // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'NSObject'}} 
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
   _ = obj as NSObjectProtocol
   _ = obj as NSCopying
-  _ = obj as SomeCell // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'SomeCell'; did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
+  _ = obj as SomeCell // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'SomeCell'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
 
   _ = cell as NSObject
   _ = cell as NSObjectProtocol

--- a/test/Constraints/ErrorBridging.swift
+++ b/test/Constraints/ErrorBridging.swift
@@ -37,7 +37,8 @@ var ns4 = compo as NSError
 ns4 = compo // expected-error{{cannot assign value of type 'HairyError & Runcible' to type 'NSError'}}
 
 let e1 = ns1 as? FooError
-let e1fix = ns1 as FooError // expected-error{{did you mean to use 'as!'}} {{17-19=as!}}
+let e1fix = ns1 as FooError // expected-error {{'NSError' is not convertible to 'FooError'}}
+// expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{17-19=as!}}
 
 let esub = ns1 as Error
 let esub2 = ns1 as? Error // expected-warning{{conditional cast from 'NSError' to 'Error' always succeeds}}

--- a/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -57,17 +57,17 @@ func bridgeNSNumberBackToSpecificType(object: ${ObjectType},
                                       dictBoth: [${ObjectType}: ${ObjectType}],
                                       set: Set<${ObjectType}>) {
 %   for Type in ValueTypes:
-  _ = object as ${Type} // expected-error{{use 'as!'}}
+  _ = object as ${Type} // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
   _ = object is ${Type}
   _ = object as? ${Type}
   _ = object as! ${Type}
 
-  _ = optional as ${Type}? // expected-error{{use 'as!'}}
+  _ = optional as ${Type}? // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
   _ = optional is ${Type}?
   _ = optional as? ${Type}?
   _ = optional as! ${Type}?
 
-  _ = optional as ${Type} // expected-error{{use 'as!'}}
+  _ = optional as ${Type} // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
   _ = optional is ${Type}
   _ = optional as? ${Type}
   _ = optional as! ${Type}
@@ -82,7 +82,7 @@ func bridgeNSNumberBackToSpecificType(object: ${ObjectType},
   _ = dictKeys as? [${Type}: Any]
   _ = dictKeys as! [${Type}: Any]
 
-  _ = dictKeys as [${Type}: AnyObject] // expected-error{{use 'as!'}}
+  _ = dictKeys as [${Type}: AnyObject] // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
   _ = dictKeys is [${Type}: AnyObject]
   _ = dictKeys as? [${Type}: AnyObject]
   _ = dictKeys as! [${Type}: AnyObject]
@@ -92,7 +92,7 @@ func bridgeNSNumberBackToSpecificType(object: ${ObjectType},
   _ = dictValues as? [AnyHashable: ${Type}]
   _ = dictValues as! [AnyHashable: ${Type}]
 
-  _ = dictValues as [NSObject: ${Type}] // expected-error{{use 'as!'}}
+  _ = dictValues as [NSObject: ${Type}] // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
   _ = dictValues is [NSObject: ${Type}]
   _ = dictValues as? [NSObject: ${Type}]
   _ = dictValues as! [NSObject: ${Type}]
@@ -107,7 +107,7 @@ func bridgeNSNumberBackToSpecificType(object: ${ObjectType},
   _ = dictBoth as? [${Type}: ${ObjectType}]
   _ = dictBoth as! [${Type}: ${ObjectType}]
 
-  _ = dictBoth as [${Type}: ${Type}] // expected-error{{use 'as!'}}
+  _ = dictBoth as [${Type}: ${Type}] // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
   _ = dictBoth is [${Type}: ${Type}]
   _ = dictBoth as? [${Type}: ${Type}]
   _ = dictBoth as! [${Type}: ${Type}]

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -124,16 +124,24 @@ func arrayToNSArray() {
 // NSArray -> Array
 func nsArrayToArray(_ nsa: NSArray) {
   var arr1: [AnyObject] = nsa // expected-error{{'NSArray' is not implicitly convertible to '[AnyObject]'; did you mean to use 'as' to explicitly convert?}} {{30-30= as [AnyObject]}}
-  var _: [BridgedClass] = nsa // expected-error{{'NSArray' is not convertible to '[BridgedClass]'}} {{30-30= as! [BridgedClass]}}
-  var _: [OtherClass] = nsa // expected-error{{'NSArray' is not convertible to '[OtherClass]'}} {{28-28= as! [OtherClass]}}
-  var _: [BridgedStruct] = nsa // expected-error{{'NSArray' is not convertible to '[BridgedStruct]'}} {{31-31= as! [BridgedStruct]}}
-  var _: [NotBridgedStruct] = nsa // expected-error{{use 'as!' to force downcast}}
+  var _: [BridgedClass] = nsa // expected-error{{'NSArray' is not convertible to '[BridgedClass]'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{30-30= as! [BridgedClass]}}
+  var _: [OtherClass] = nsa // expected-error{{'NSArray' is not convertible to '[OtherClass]'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{28-28= as! [OtherClass]}}
+  var _: [BridgedStruct] = nsa // expected-error{{'NSArray' is not convertible to '[BridgedStruct]'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{31-31= as! [BridgedStruct]}}
+  var _: [NotBridgedStruct] = nsa // expected-error{{'NSArray' is not convertible to '[NotBridgedStruct]'}}
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{34-34= as! [NotBridgedStruct]}}
 
   var _: [AnyObject] = nsa as [AnyObject]
-  var _: [BridgedClass] = nsa as [BridgedClass] // expected-error{{'NSArray' is not convertible to '[BridgedClass]'; did you mean to use 'as!' to force downcast?}} {{31-33=as!}}
-  var _: [OtherClass] = nsa as [OtherClass] // expected-error{{'NSArray' is not convertible to '[OtherClass]'; did you mean to use 'as!' to force downcast?}} {{29-31=as!}}
-  var _: [BridgedStruct] = nsa as [BridgedStruct] // expected-error{{'NSArray' is not convertible to '[BridgedStruct]'; did you mean to use 'as!' to force downcast?}} {{32-34=as!}}
-  var _: [NotBridgedStruct] = nsa as [NotBridgedStruct] // expected-error{{use 'as!' to force downcast}}
+  var _: [BridgedClass] = nsa as [BridgedClass] // expected-error{{'NSArray' is not convertible to '[BridgedClass]'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{31-33=as!}}
+  var _: [OtherClass] = nsa as [OtherClass] // expected-error{{'NSArray' is not convertible to '[OtherClass]'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{29-31=as!}}
+  var _: [BridgedStruct] = nsa as [BridgedStruct] // expected-error{{'NSArray' is not convertible to '[BridgedStruct]'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{32-34=as!}}
+  var _: [NotBridgedStruct] = nsa as [NotBridgedStruct] // expected-error{{'NSArray' is not convertible to '[NotBridgedStruct]'}}
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{35-37=as!}}
 
   var arr6: Array = nsa as Array
   arr6 = arr1
@@ -211,7 +219,8 @@ func rdar18330319(_ s: String, d: [String : AnyObject]) {
 func rdar19551164a(_ s: String, _ a: [String]) {}
 func rdar19551164b(_ s: NSString, _ a: NSArray) {
   rdar19551164a(s, a) // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}{{18-18= as String}}
-  // expected-error@-1{{'NSArray' is not convertible to '[String]'; did you mean to use 'as!' to force downcast?}}{{21-21= as! [String]}}
+  // expected-error@-1{{'NSArray' is not convertible to '[String]'}}
+  // expected-note@-2 {{did you mean to use 'as!' to force downcast?}}{{21-21= as! [String]}}
 }
 
 // rdar://problem/19695671

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -252,11 +252,13 @@ func test_coercions_with_overloaded_operator(str: String, optStr: String?, veryO
 
   _ = (str ?? "") as Int // expected-error {{cannot convert value of type 'String' to type 'Int' in coercion}}
   _ = (optStr ?? "") as Int // expected-error {{cannot convert value of type 'String' to type 'Int' in coercion}}
-  _ = (optStr ?? "") as Int? // expected-error {{'String' is not convertible to 'Int?'; did you mean to use 'as!' to force downcast?}}
+  _ = (optStr ?? "") as Int? // expected-error {{'String' is not convertible to 'Int?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{22-24=as!}}
 
   _ = (str ^^^ "") as Int // expected-error {{cannot convert value of type 'String' to type 'Int' in coercion}}
   _ = (optStr ^^^ "") as Int // expected-error {{cannot convert value of type 'String' to type 'Int' in coercion}}
-  _ = (optStr ^^^ "") as Int? // expected-error {{'String' is not convertible to 'Int?'; did you mean to use 'as!' to force downcast?}}
+  _ = (optStr ^^^ "") as Int? // expected-error {{'String' is not convertible to 'Int?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{23-25=as!}}
 
   _ = ([] ?? []) as String // expected-error {{cannot convert value of type '[Any]' to type 'String' in coercion}}
   _ = ([""] ?? []) as [Int: Int] // expected-error {{cannot convert value of type '[String]' to type '[Int : Int]' in coercion}}
@@ -290,7 +292,8 @@ func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [Strin
   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
   _ = dict as [String: String] // expected-error {{cannot convert value of type '[String : Int]' to type '[String : String]' in coercion}}
   // expected-note@-1 {{arguments to generic parameter 'Value' ('Int' and 'String') are expected to be equal}}
-  _ = dict as [String: String]? // expected-error {{'[String : Int]' is not convertible to '[String : String]?'; did you mean to use 'as!' to force downcast?}}
+  _ = dict as [String: String]? // expected-error {{'[String : Int]' is not convertible to '[String : String]?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{12-14=as!}}
   _ = (dict as [String: Int]?) as [String: Int] // expected-error {{value of optional type '[String : Int]?' must be unwrapped to a value of type '[String : Int]'}}
   // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
   // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -81,7 +81,8 @@ func optionalityMismatchingCasts(f: CGFloat, n: NSNumber, fooo: CGFloat???,
                                  nooo: NSNumber???) {
   _ = f as NSNumber?
   _ = f as NSNumber??
-  let _ = fooo as NSNumber?? // expected-error{{'CGFloat???' is not convertible to 'NSNumber??'; did you mean to use 'as!' to force downcast?}}
+  let _ = fooo as NSNumber?? // expected-error{{'CGFloat???' is not convertible to 'NSNumber??'}}
+  //expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
   let _ = fooo as NSNumber???? // okay: injects extra optionals
 }
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -77,7 +77,8 @@ func forgotOptionalBang(_ a: A, obj: AnyObject) {
 
 func forgotAnyObjectBang(_ obj: AnyObject) {
   var a = A()
-  a = obj // expected-error{{'AnyObject' is not convertible to 'A'; did you mean to use 'as!' to force downcast?}}{{10-10= as! A}}
+  a = obj // expected-error{{'AnyObject' is not convertible to 'A'}}
+  //expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{10-10= as! A}}
   _ = a
 }
 

--- a/test/Constraints/rdar45511837.swift
+++ b/test/Constraints/rdar45511837.swift
@@ -18,7 +18,8 @@ class Foo<Bar: NSObject> {
 
   lazy var foo: () -> Void = {
     // TODO: improve diagnostic message
-    _ = self.foobar + nil // expected-error {{'Bar' is not convertible to 'String'; did you mean to use 'as!' to force downcast?}}
-    // expected-error@-1 {{'nil' is not compatible with expected argument type 'String'}}
+    _ = self.foobar + nil // expected-error {{'Bar' is not convertible to 'String'}}
+    // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
+    // expected-error@-2 {{'nil' is not compatible with expected argument type 'String'}}
   }
 }

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -182,7 +182,8 @@ let _: Int = try? foo() // expected-error {{value of optional type 'Int?' not un
 class X {}
 func test(_: X) {}
 func producesObject() throws -> AnyObject { return X() }
-test(try producesObject()) // expected-error {{'AnyObject' is not convertible to 'X'; did you mean to use 'as!' to force downcast?}} {{26-26= as! X}}
+test(try producesObject()) // expected-error {{'AnyObject' is not convertible to 'X'}} 
+// expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{26-26= as! X}}
 
 _ = "a\(try maybeThrow())b"
 _ = try "a\(maybeThrow())b"

--- a/test/Parse/try_swift5.swift
+++ b/test/Parse/try_swift5.swift
@@ -183,7 +183,8 @@ let _: Int = try? foo() // expected-error {{value of optional type 'Int?' not un
 class X {}
 func test(_: X) {}
 func producesObject() throws -> AnyObject { return X() }
-test(try producesObject()) // expected-error {{'AnyObject' is not convertible to 'X'; did you mean to use 'as!' to force downcast?}} {{26-26= as! X}}
+test(try producesObject()) // expected-error {{'AnyObject' is not convertible to 'X'}} 
+// expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{26-26= as! X}}
 
 _ = "a\(try maybeThrow())b"
 _ = try "a\(maybeThrow())b"

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -85,7 +85,8 @@ class C1 {
     var x: Int = self // expected-error{{cannot convert value of type 'Self.Type' to specified type 'Int'}}
 
     // Can't utter Self within the body of a method.
-    var c1 = C1(int: 5) as Self // expected-error{{'C1' is not convertible to 'Self'; did you mean to use 'as!' to force downcast?}}
+    var c1 = C1(int: 5) as Self // expected-error{{'C1' is not convertible to 'Self'}}
+    // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{25-27=as!}}
 
     if b { return self.init(int: 5) }
 

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -98,7 +98,8 @@ class OuterGenericClass<T> {
 func f5<T, U>(x: T, y: U) {
   struct Local { // expected-error {{type 'Local' cannot be nested in generic function 'f5(x:y:)'}}
     func f() {
-      _ = 17 as T // expected-error{{'Int' is not convertible to 'T'}} {{14-16=as!}}
+      _ = 17 as T // expected-error{{'Int' is not convertible to 'T'}} 
+      // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{14-16=as!}}
       _ = 17 as U // okay: refers to 'U' declared within the local class
     }
     typealias U = Int

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -141,3 +141,16 @@ _ = sr6022 as! AnyObject // expected-warning {{forced cast from '() -> Any' to '
 _ = sr6022 as? AnyObject // expected-warning {{conditional cast from '() -> Any' to 'AnyObject' always succeeds}}
 _ = sr6022_1 as! Any // expected-warning {{forced cast from '() -> ()' to 'Any' always succeeds; did you mean to use 'as'?}}
 _ = sr6022_1 as? Any // expected-warning {{conditional cast from '() -> ()' to 'Any' always succeeds}}
+
+// SR-13899
+let any: Any = 1
+if let int = any as Int { // expected-error {{'Any' is not convertible to 'Int'}}
+// expected-note@-1 {{did you mean to use 'as?' to conditionally downcast?}} {{18-20=as?}}
+}
+
+let _ = any as Int // expected-error {{'Any' is not convertible to 'Int'}}
+// expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{13-15=as!}}
+let _: Int = any as Int // expected-error {{'Any' is not convertible to 'Int'}}
+// expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{18-20=as!}}
+let _: Int? = any as Int // expected-error {{'Any' is not convertible to 'Int'}}
+// expected-note@-1 {{did you mean to use 'as?' to conditionally downcast?}} {{19-21=as?}}

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -72,13 +72,15 @@ var c: AnyObject = C3()
 //if let castX = c as! C4? {}
 
 // XXX TODO: Only suggest replacing 'as' with 'as!' if it would fix the error.
-C3() as C4 // expected-error {{'C3' is not convertible to 'C4'; did you mean to use 'as!' to force downcast?}} {{6-8=as!}}
+C3() as C4 // expected-error {{'C3' is not convertible to 'C4'}} 
+// expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{6-8=as!}}
 C3() as C5 // expected-error {{cannot convert value of type 'C3' to type 'C5' in coercion}}
 
 // Diagnostic shouldn't include @lvalue in type of c3.
 var c3 = C3()
 // XXX TODO: This should not suggest `as!`
-c3 as C4 // expected-error {{'C3' is not convertible to 'C4'; did you mean to use 'as!' to force downcast?}} {{4-6=as!}}
+c3 as C4 // expected-error {{'C3' is not convertible to 'C4'}} 
+// expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{4-6=as!}}
 
 // <rdar://problem/19495142> Various incorrect diagnostics for explicit type conversions
 1 as Double as Float // expected-error{{cannot convert value of type 'Double' to type 'Float' in coercion}}
@@ -102,12 +104,14 @@ _ = "hello" as! String // expected-warning{{forced cast of 'String' to same type
 
 // <rdar://problem/19499340> QoI: Nimble as -> as! changes not covered by Fix-Its
 func f(_ x : String) {}
-f("what" as Any as String) // expected-error {{'Any' is not convertible to 'String'; did you mean to use 'as!' to force downcast?}} {{17-19=as!}}
+f("what" as Any as String) // expected-error {{'Any' is not convertible to 'String'}} 
+// expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{17-19=as!}}
 f(1 as String) // expected-error{{cannot convert value of type 'Int' to type 'String' in coercion}}
 
 // <rdar://problem/19650402> Swift compiler segfaults while running the annotation tests
 let s : AnyObject = C3()
-s as C3 // expected-error{{'AnyObject' is not convertible to 'C3'; did you mean to use 'as!' to force downcast?}} {{3-5=as!}}
+s as C3 // expected-error{{'AnyObject' is not convertible to 'C3'}} 
+// expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{3-5=as!}}
 
 // SR-6022
 func sr6022() -> Any { return 0 }

--- a/test/expr/cast/cf.swift
+++ b/test/expr/cast/cf.swift
@@ -36,7 +36,8 @@ func testCFToNative(_ cfStr: CFString, cfMutableStr: CFMutableString) {
 
 func testNativeToCF(_ str: String) {
   var cfStr = str as CFString
-  var cfMutableStr = str as CFMutableString // expected-error{{'String' is not convertible to 'CFMutableString'}} {{26-28=as!}}
+  var cfMutableStr = str as CFMutableString // expected-error{{'String' is not convertible to 'CFMutableString'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{26-28=as!}}
 }
 
 func testCFToAnyObject(_ cfStr: CFString, cfMutableStr: CFMutableString,
@@ -53,7 +54,8 @@ func testAnyObjectToCF(_ anyObject: AnyObject) {
   var _: CFTree = anyObject as! CFTree
 
   // No implicit conversions.
-  cfStr = anyObject // expected-error{{'AnyObject' is not convertible to 'CFString'; did you mean to use 'as!' to force downcast?}} {{20-20= as! CFString}}
+  cfStr = anyObject // expected-error{{'AnyObject' is not convertible to 'CFString'}} 
+  // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{20-20= as! CFString}}
   _ = cfStr
 }
 

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -114,7 +114,8 @@ func basicSubtyping(
   // let _ = Unrelated() as AnyObject
   // let _ = Unrelated() as? AnyObject
 
-  let _ = anyObject as Unrelated // expected-error {{'AnyObject' is not convertible to 'Unrelated'; did you mean to use 'as!' to force downcast?}}
+  let _ = anyObject as Unrelated // expected-error {{'AnyObject' is not convertible to 'Unrelated'}}
+  //expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{21-23=as!}}
   let _ = anyObject as? Unrelated
 
   // No-ops
@@ -199,13 +200,16 @@ func basicSubtyping(
   let _: Base<Int> & P2 = baseAndP2.protocolSelfReturn()
 
   // Downcasts
-  let _ = baseAndP2 as Derived // expected-error {{did you mean to use 'as!' to force downcast?}}
+  let _ = baseAndP2 as Derived //expected-error {{'Base<Int> & P2' is not convertible to 'Derived'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{21-23=as!}}
   let _ = baseAndP2 as? Derived
   
-  let _ = baseAndP2 as Derived & P3 // expected-error {{did you mean to use 'as!' to force downcast?}}
+  let _ = baseAndP2 as Derived & P3 // expected-error {{'Base<Int> & P2' is not convertible to 'Derived & P3'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{21-23=as!}}
   let _ = baseAndP2 as? Derived & P3
 
-  let _ = base as Derived & P2 // expected-error {{did you mean to use 'as!' to force downcast?}}
+  let _ = base as Derived & P2 //expected-error {{'Base<Int>' is not convertible to 'Derived & P2'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
   let _ = base as? Derived & P2
 
   // Invalid cases


### PR DESCRIPTION
<!-- What's in this pull request? -->
Based on https://forums.swift.org/t/missing-conditional-cast-fix-it/42282 
This proposes to adjust coerce to checked cast diagnostic to be broken into the diagnostic and fix-it note.
Also, cases were the coercion result has a value to optional restriction e.g. conditional binding 
```swift
let any: Any = 1
if let int = any as Int { // an `as!` here would lead to another malformed code because conditional binding expects an optional type

}
```
we suggest conditional downcast  `as?` instead of force downcast.

The break into a note is more like a proposal not really the SR, so let me know what you think :) 

cc @dan-zheng 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13899.

