### PR TITLE
[autodiff] When asserts are enabled, verify all autodiff compiler generated functions.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/JVPCloner.h
+++ b/include/swift/SILOptimizer/Differentiation/JVPCloner.h
@@ -47,6 +47,8 @@ public:
   /// Performs JVP generation on the empty JVP function. Returns true if any
   /// error occurs.
   bool run();
+
+  SILFunction &getJVP() const;
 };
 
 } // end namespace autodiff

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -31,6 +31,9 @@
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "llvm/ADT/DenseMap.h"
 
+using namespace swift;
+using namespace autodiff;
+
 namespace swift {
 namespace autodiff {
 
@@ -379,6 +382,8 @@ public:
 
   /// Run JVP generation. Returns true on error.
   bool run();
+
+  SILFunction &getJVP() const { return *jvp; }
 
   void postProcess(SILInstruction *orig, SILInstruction *cloned) {
     if (errorOccurred)
@@ -1727,7 +1732,16 @@ bool JVPCloner::Implementation::run() {
   return errorOccurred;
 }
 
-bool JVPCloner::run() { return impl.run(); }
-
 } // end namespace autodiff
 } // end namespace swift
+
+bool JVPCloner::run() {
+  bool foundError = impl.run();
+#ifndef NDEBUG
+  if (!foundError)
+    getJVP().verify();
+#endif
+  return foundError;
+}
+
+SILFunction &JVPCloner::getJVP() const { return impl.getJVP(); }

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -1019,7 +1019,14 @@ bool VJPCloner::Implementation::run() {
   return errorOccurred;
 }
 
-bool VJPCloner::run() { return impl.run(); }
+bool VJPCloner::run() {
+  bool foundError = impl.run();
+#ifndef NDEBUG
+  if (!foundError)
+    getVJP().verify();
+#endif
+  return foundError;
+}
 
 } // end namespace autodiff
 } // end namespace swift


### PR DESCRIPTION
This ensures that any invalid SIL generated by these cloners is caught
immediately at the source when asserts are enabled improving productivity.
