### PR TITLE
Replace -march=core2 with -mcx16 

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -286,6 +286,8 @@ function(_add_host_variant_c_compile_flags target)
 
   if(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
     if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
+      # The -mcx16 flag gives us 16-byte cas and provides support
+      # for machines with older processors 
       target_compile_options(${target} PRIVATE -mcx16)
     endif()
   endif()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -286,9 +286,7 @@ function(_add_host_variant_c_compile_flags target)
 
   if(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
     if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
-      # this is the minimum architecture that supports 16 byte CAS, which is
-      # necessary to avoid a dependency to libatomic
-      target_compile_options(${target} PRIVATE -march=core2)
+      target_compile_options(${target} PRIVATE -mcx16)
     endif()
   endif()
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -286,8 +286,15 @@ function(_add_host_variant_c_compile_flags target)
 
   if(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
     if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
-      # The -mcx16 flag gives us 16-byte cas and provides support
-      # for machines with older processors 
+      # We support all x86 architectures that support the -mcx16 flag. 
+      # This flag ensures that was have a 16-byte cas.
+      # NOTE: This used to be -march=core2. The reason why we changed this was 
+      # that this caused the following problems:
+      #   1. Setting core2 allows for the usage of intel-specific instructions 
+      #      (e.g. SSSE3) causing binary incompatibility issues on AMD processors.
+      #   2. There are intel processors older than core2-duo that support cx16. 
+      #      If we compiled for core2, we could use newer intel intrinsics than 
+      #      these older processors would support. 
       target_compile_options(${target} PRIVATE -mcx16)
     endif()
   endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -308,8 +308,15 @@ function(_add_target_variant_c_compile_flags)
 
   if("${CFLAGS_SDK}" STREQUAL "LINUX")
     if(${CFLAGS_ARCH} STREQUAL x86_64)
-      # The -mcx16 flag gives us 16-byte cas and provides support
-      # for machines with older processors
+      # We support all x86 architectures that support the -mcx16 flag.
+      # This flag ensures that was have a 16-byte cas.
+      # NOTE: This used to be -march=core2. The reason why we changed this was
+      # that this caused the following problems:
+      #   1. Setting core2 allows for the usage of intel-specific instructions
+      #      (e.g. SSSE3) causing binary incompatibility issues on AMD processors.
+      #   2. There are intel processors older than core2-duo that support cx16.
+      #      If we compiled for core2, we could use newer intel intrinsics than
+      #      these older processors would support.
       list(APPEND result "-mcx16")
     endif()
   endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -308,6 +308,8 @@ function(_add_target_variant_c_compile_flags)
 
   if("${CFLAGS_SDK}" STREQUAL "LINUX")
     if(${CFLAGS_ARCH} STREQUAL x86_64)
+      # The -mcx16 flag gives us 16-byte cas and provides support
+      # for machines with older processors
       list(APPEND result "-mcx16")
     endif()
   endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -308,8 +308,7 @@ function(_add_target_variant_c_compile_flags)
 
   if("${CFLAGS_SDK}" STREQUAL "LINUX")
     if(${CFLAGS_ARCH} STREQUAL x86_64)
-      # this is the minimum architecture that supports 16 byte CAS, which is necessary to avoid a dependency to libatomic
-      list(APPEND result "-march=core2")
+      list(APPEND result "-mcx16")
     endif()
   endif()
 


### PR DESCRIPTION
The core2 processor supports SSSE3 instructions, which older AMD processors, like the Opteron 2419 EE, don't; Swift crashes immediately on these older processors. [This was reported against the Fedora Swift package](https://bugzilla.redhat.com/show_bug.cgi?id=1888848)  and this PR reflects [this Fedora-specific patch](https://src.fedoraproject.org/rpms/swift-lang/blob/master/f/oldamd.patch).

I also removed the comment above the line as I figured it no longer properly reflected the purpose of the code below and wasn't sure what note would properly reflect what was going on.
