### PR TITLE
[Concurrency] Tweak where concurrency tests run

### DIFF
--- a/test/Concurrency/Runtime/async_task_priority_basic.swift
+++ b/test/Concurrency/Runtime/async_task_priority_basic.swift
@@ -6,6 +6,12 @@
 
 import Dispatch
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 // ==== ------------------------------------------------------------------------
 // MARK: "Infrastructure" for the tests
 

--- a/test/Concurrency/Runtime/async_task_priority_basic.swift
+++ b/test/Concurrency/Runtime/async_task_priority_basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) | %FileCheck %s --dump-input always
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s --dump-input always
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch

--- a/test/Concurrency/Runtime/async_task_priority_basic.swift
+++ b/test/Concurrency/Runtime/async_task_priority_basic.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// XFAIL: CPU=arm64e
 
 import Dispatch
 

--- a/test/Concurrency/Runtime/async_task_priority_basic.swift
+++ b/test/Concurrency/Runtime/async_task_priority_basic.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) | %FileCheck %s --dump-input always
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: OS=macosx
+// REQUIRES: libdispatch
 
 import Dispatch
 

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -7,6 +7,12 @@
 
 import Dispatch
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 extension DispatchQueue {
   func async<R>(execute: @escaping () async throws -> R) -> Task.Handle<R> {
     let handle = Task.runDetached(operation: execute)

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: OS=macosx
+// REQUIRES: libdispatch
 // XFAIL: CPU=arm64e
 
 import Dispatch

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -7,6 +7,12 @@
 
 import Dispatch
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 extension DispatchQueue {
   func async<R>(execute: @escaping () async throws -> R) -> Task.Handle<R> {
     let handle = Task.runDetached(operation: execute)

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: OS=macosx
+// REQUIRES: libdispatch
 // XFAIL: CPU=arm64e
 
 import Dispatch

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency


### PR DESCRIPTION
They need libdispatch (whether on macOS or anywhere else) but don't yet work with arm64e.