### PR TITLE
driver: forward driver invocation to the new driver by default

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -193,8 +193,5 @@ WARNING(warn_drv_darwin_sdk_invalid_settings, none,
 REMARK(remark_forwarding_to_new_driver, none,
        "new Swift driver at '%0' will be used", (StringRef))
 
-REMARK(remark_forwarding_driver_not_there, none,
-      "new Swift driver at '%0' cannot be found; C++ driver will be used", (StringRef))
-
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/test/Driver/opt-record.swift
+++ b/test/Driver/opt-record.swift
@@ -8,7 +8,8 @@
 // RUN: %target-swiftc_driver -O -wmo -save-optimization-record -save-optimization-record-passes unknown -save-optimization-record-path %t/optrecordmod-filtered.opt.yaml %s -module-name optrecordmod -o %t/opt-record 2>&1 | %FileCheck -allow-empty %s
 // RUN: %FileCheck -allow-empty -check-prefix=YAML-FILTERED %s < %t/optrecordmod-filtered.opt.yaml
 
-// CHECK-NOT: remark
+// CHECK-NOT: warning
+// CHECK-NOT: error
 
 var a: Int = 1
 

--- a/test/Driver/tools_directory.swift
+++ b/test/Driver/tools_directory.swift
@@ -6,18 +6,18 @@
 // RUN: %swiftc_driver -### -target x86_64-linux-unknown -tools-directory /Something/obviously/fake %s 2>&1 | %FileCheck -check-prefix BINUTILS %s
 
 // CLANGSUB: swift
-// CLANGSUB-SAME: -o [[OBJECTFILE:.*]]
+// CLANGSUB: -o [[OBJECTFILE:.*]]
 // CLANGSUB: swift-autolink-extract{{(\.exe)?"?}} [[OBJECTFILE]]
-// CLANGSUB-SAME: -o {{"?}}[[AUTOLINKFILE:.*]]
+// CLANGSUB: -o {{"?}}[[AUTOLINKFILE:.*]]
 // CLANGSUB: {{[^ ]+(\\\\|/)}}Inputs{{/|\\\\}}fake-toolchain{{/|\\\\}}clang
 // CLANGSUB-DAG: [[OBJECTFILE]]
 // CLANGSUB-DAG: @[[AUTOLINKFILE]]
 // CLANGSUB: -o tools_directory
 
 // BINUTILS: swift
-// BINUTILS-SAME: -o [[OBJECTFILE:.*]]
+// BINUTILS: -o [[OBJECTFILE:.*]]
 // BINUTILS: swift-autolink-extract{{(\.exe)?"?}} [[OBJECTFILE]]
-// BINUTILS-SAME: -o {{"?}}[[AUTOLINKFILE:.*]]
+// BINUTILS: -o {{"?}}[[AUTOLINKFILE:.*]]
 // BINUTILS: clang
 // BINUTILS-DAG: [[OBJECTFILE]]
 // BINUTILS-DAG: @[[AUTOLINKFILE]]
@@ -31,6 +31,6 @@
 // RUN: %swiftc_driver -### -target x86_64-apple-macosx10.9 -tools-directory %S/Inputs/fake-toolchain %s 2>&1 | %FileCheck -check-prefix LDSUB %s
 
 // LDSUB: swift
-// LDSUB-SAME: -o [[OBJECTFILE:.*]]
+// LDSUB: -o [[OBJECTFILE:.*]]
 // LDSUB: {{[^ ]+(\\\\|/)}}Inputs{{/|\\\\}}fake-toolchain{{(\\\\|/)ld"?}} [[OBJECTFILE]]
 // LDSUB: -o tools_directory

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -126,6 +126,24 @@ static bool shouldRunAsSubcommand(StringRef ExecName,
   return true;
 }
 
+static bool shouldDisallowNewDriver(StringRef ExecName,
+                                    const ArrayRef<const char *> argv) {
+  // We are not invoking the driver, so don't forward.
+  if (ExecName != "swift" && ExecName != "swiftc") {
+    return true;
+  }
+  // If user specified using the old driver, don't forward.
+  if (llvm::find_if(argv, [](const char* arg) {
+    return StringRef(arg) == "-disallow-use-new-driver";
+  }) != argv.end()) {
+    return true;
+  }
+  if (llvm::sys::Process::GetEnv("SWIFT_USE_OLD_DRIVER").hasValue()) {
+    return true;
+  }
+  return false;
+}
+
 static int run_driver(StringRef ExecName,
                        const ArrayRef<const char *> argv) {
   // Handle integrated tools.
@@ -160,23 +178,16 @@ static int run_driver(StringRef ExecName,
   DiagnosticEngine Diags(SM);
   Diags.addConsumer(PDC);
 
-  std::string newDriverName;
+  std::string newDriverName = "swift-driver-new";
   if (auto driverNameOp = llvm::sys::Process::GetEnv("SWIFT_USE_NEW_DRIVER")) {
     newDriverName = driverNameOp.getValue();
   }
-  auto disallowForwarding = llvm::find_if(argv, [](const char* arg) {
-    return StringRef(arg) == "-disallow-use-new-driver";
-  }) != argv.end();
   // Forwarding calls to the swift driver if the C++ driver is invoked as `swift`
   // or `swiftc`, and an environment variable SWIFT_USE_NEW_DRIVER is defined.
-  if (!newDriverName.empty() && !disallowForwarding &&
-      (ExecName == "swift" || ExecName == "swiftc")) {
+  if (!shouldDisallowNewDriver(ExecName, argv)) {
     SmallString<256> NewDriverPath(llvm::sys::path::parent_path(Path));
     llvm::sys::path::append(NewDriverPath, newDriverName);
-    if (!llvm::sys::fs::exists(NewDriverPath)) {
-      Diags.diagnose(SourceLoc(), diag::remark_forwarding_driver_not_there,
-                     NewDriverPath);
-    } else {
+    if (llvm::sys::fs::exists(NewDriverPath)) {
       SmallVector<const char *, 256> subCommandArgs;
       // Rewrite the program argument.
       subCommandArgs.push_back(NewDriverPath.c_str());


### PR DESCRIPTION
The qualification process of the new Swift driver showed promising result. With this change, we'll use the new driver by default and also provide two mechanisms (an environment var and a compiler argument) for users to opt-out.

rdar://71817843