### PR TITLE
[Async CC] Always add full type metadata to bindings.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2748,8 +2748,16 @@ void NecessaryBindings::save(IRGenFunction &IGF, Address buffer) const {
 void NecessaryBindings::addTypeMetadata(CanType type) {
   assert(!isa<InOutType>(type));
 
+  // If the bindings are for an async function, we will always need the type
+  // metadata.  The opportunities to reconstruct it available in the context of
+  // partial apply forwarders are not available here.
+  if (forAsyncFunction()) {
+    addRequirement({type, nullptr});
+    return;
+  }
+
   // Bindings are only necessary at all if the type is dependent.
-  if (!type->hasArchetype() && !forAsyncFunction())
+  if (!type->hasArchetype())
     return;
 
   // Break down structural types so that we don't eagerly pass metadata

--- a/validation-test/compiler_crashers_2_fixed/rdar71816041.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71816041.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -enable-experimental-concurrency
+
+func getIntAndString() async -> (Int, String) { (5, "1") }
+
+func testDecompose() async -> Int {
+  async let (i, s) = await getIntAndString()
+  return await i
+}


### PR DESCRIPTION
NecessaryBindings are used by both async functions and partial apply forwarders.  The latter are able to avoid bindings in some cases because a new function is generated where the information that would otherwise be available in the bindings can be made available.  That is not the case for async functions.  A generic async function requires all of the metadata and witness tables be passed along to it: unlike a partial apply forwarder it isn't in any way specialized so this information can't be recovered.

Previously, metadata bindings were always passed along to async functions.  However, destructuring that can be done for partial apply forwarders was still being applied.  This resulted in an inappropriate and unexpected number of bindings in NecessaryBindings.

Here, that destructuring is avoided for metadata passed to async functions.

Now, the full metadata required by async functions are passed along to them as necessary.

rdar://problem/71816041