### PR TITLE
Enable GenericSpecializer on OSSA by default

### DIFF
--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -28,10 +28,6 @@
 
 using namespace swift;
 
-// For testing during bring up.
-static llvm::cl::opt<bool> EnableGenericSpecializerWithOwnership(
-    "sil-generic-specializer-enable-ownership", llvm::cl::init(false));
-
 namespace {
 
 class GenericSpecializer : public SILFunctionTransform {
@@ -41,10 +37,6 @@ class GenericSpecializer : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
     SILFunction &F = *getFunction();
-
-    // TODO: We should be able to handle ownership.
-    if (F.hasOwnership() && !EnableGenericSpecializerWithOwnership)
-      return;
 
     LLVM_DEBUG(llvm::dbgs() << "***** GenericSpecializer on function:"
                             << F.getName() << " *****\n");

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -136,5 +136,5 @@ class GenericRuncer<T> : Gizmo {
 }
 
 // CHECK: define internal swiftcc void [[PARTIAL_FORWARDING_THUNK]](%swift.refcounted* swiftself %0) {{.*}} {
-// CHECK: @"$ss12StaticStringV14withUTF8BufferyxxSRys5UInt8VGXElFxAFXEfU_"
+// CHECK: @"$ss12StaticStringV14withUTF8BufferyxxSRys5UInt8VGXElFxAFXEfU_yt_Tgq5"
 // CHECK: }

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -23,7 +23,7 @@ let globalTestOptions: TestOptions = [.first, .second, .third, .fourth]
 // CHECK-NEXT:   builtin
 // CHECK-NEXT:   integer_literal {{.*}}, 15
 // CHECK-NEXT:   struct $Int
-// CHECK-NEXT:   struct $TestOptions
+// CHECK:        struct $TestOptions
 // CHECK-NEXT:   return
 public func returnTestOptions() -> TestOptions {
     return [.first, .second, .third, .fourth]
@@ -32,8 +32,8 @@ public func returnTestOptions() -> TestOptions {
 // CHECK-LABEL: sil @{{.*}}returnEmptyTestOptions{{.*}}
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   integer_literal {{.*}}, 0
-// CHECK-NEXT:   builtin "onFastPath"() : $()
 // CHECK-NEXT:   struct $Int
+// CHECK:        builtin "onFastPath"() : $()
 // CHECK-NEXT:   struct $TestOptions
 // CHECK-NEXT:   return
 public func returnEmptyTestOptions() -> TestOptions {

--- a/test/SILOptimizer/specialize_default_witness_ossa.sil
+++ b/test/SILOptimizer/specialize_default_witness_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -sil-generic-specializer-enable-ownership -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_default_witness_resilience_ossa.sil
+++ b/test/SILOptimizer/specialize_default_witness_resilience_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-library-evolution -enable-sil-verify-all -generic-specializer -sil-generic-specializer-enable-ownership %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-library-evolution -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_inherited_ossa.sil
+++ b/test/SILOptimizer/specialize_inherited_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -module-name inherit -sil-generic-specializer-enable-ownership %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -module-name inherit %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/specialize_metatypes_with_nondefault_representation_ossa.sil
+++ b/test/SILOptimizer/specialize_metatypes_with_nondefault_representation_ossa.sil
@@ -1,0 +1,61 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -generic-specializer | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// This test checks that we properly distinguish in between the specialized
+// functions for the @thick, @thin, and @objc_metatype metatypes.
+//
+// This can occur if we do not properly mangle in the metatype representation
+// into the name of functions and thus reuse the incorrect already specialized
+// method instead of the new specialized method.
+
+sil_stage canonical
+
+import Builtin
+
+protocol AnyObject {}
+
+sil [noinline] @tmp : $@convention(thin) <T> () -> (@out T) {
+bb0(%0 : $*T):
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tmp2 : $@convention(thin) () -> () {
+// CHECK: [[FUN1:%[0-9]+]] = function_ref @$s3tmp4main9AnyObject_pXmT_Tg5 : $@convention(thin) () -> @thick AnyObject.Type
+// CHECK-NEXT: apply [[FUN1]]
+// CHECK: [[FUN2:%[0-9]+]] = function_ref @$s3tmp4main9AnyObject_pXmo_Tg5 : $@convention(thin) () -> @objc_metatype AnyObject.Type
+// CHECK-NEXT: apply [[FUN2]]
+// CHECK: [[FUN3:%[0-9]+]] = function_ref @$s3tmpBi32_XMT_Tg5 : $@convention(thin) () -> @thick Builtin.Int32.Type
+// CHECK-NEXT: apply [[FUN3]]
+// CHECK: [[FUN4:%[0-9]+]] = function_ref @$s3tmpBi32_XMo_Tg5 : $@convention(thin) () -> @objc_metatype Builtin.Int32.Type
+// CHECK-NEXT: apply [[FUN4]]
+// CHECK: [[FUN5:%[0-9]+]] = function_ref @$s3tmpBi32_XMt_Tg5 : $@convention(thin) () -> @thin Builtin.Int32.Type
+// CHECK-NEXT: apply [[FUN5]]
+sil [ossa] @tmp2 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @tmp : $@convention(thin) <T> () -> (@out T)
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <@thick AnyObject.Type>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <@thick AnyObject.Type>, 0
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <@objc_metatype AnyObject.Type>
+  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <@objc_metatype AnyObject.Type>, 0
+  %4 = apply %0<@thick AnyObject.Type>(%1a) : $@convention(thin) <T> () -> (@out T)
+  %5 = apply %0<@objc_metatype AnyObject.Type>(%2a) : $@convention(thin) <T> () -> (@out T)
+
+  %6 = alloc_box $<τ_0_0> { var τ_0_0 } <@thick Builtin.Int32.Type>
+  %6a = project_box %6 : $<τ_0_0> { var τ_0_0 } <@thick Builtin.Int32.Type>, 0
+  %7 = alloc_box $<τ_0_0> { var τ_0_0 } <@objc_metatype Builtin.Int32.Type>
+  %7a = project_box %7 : $<τ_0_0> { var τ_0_0 } <@objc_metatype Builtin.Int32.Type>, 0
+  %8 = alloc_box $<τ_0_0> { var τ_0_0 } <@thin Builtin.Int32.Type>
+  %8a = project_box %8 : $<τ_0_0> { var τ_0_0 } <@thin Builtin.Int32.Type>, 0
+  %9 = apply %0<@thick Builtin.Int32.Type>(%6a) : $@convention(thin) <T> () -> (@out T)
+  %10 = apply %0<@objc_metatype Builtin.Int32.Type>(%7a) : $@convention(thin) <T> () -> (@out T)
+  %11 = apply %0<@thin Builtin.Int32.Type>(%8a) : $@convention(thin) <T> () -> (@out T)
+  destroy_value %8 : $<τ_0_0> { var τ_0_0 } <@thin Builtin.Int32.Type>
+  destroy_value %7 : $<τ_0_0> { var τ_0_0 } <@objc_metatype Builtin.Int32.Type>
+  destroy_value %6 : $<τ_0_0> { var τ_0_0 } <@thick Builtin.Int32.Type>
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <@objc_metatype AnyObject.Type>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <@thick AnyObject.Type>
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/specialize_no_definition_ossa.sil
+++ b/test/SILOptimizer/specialize_no_definition_ossa.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -save-optimization-record-path=%t.yaml -o /dev/null %/s
+// RUN: %FileCheck %s < %t.yaml
+
+import Builtin
+import Swift
+
+sil_stage canonical
+
+// CHECK:      --- !Missed
+// CHECK-NEXT: Pass:            sil-generic-specializer
+// CHECK-NEXT: Name:            sil.NoDef
+// CHECK-NEXT: DebugLoc:
+// CHECK:         File:            {{.*}}/specialize_no_definition_ossa.sil
+// CHECK:         Line:            33
+// CHECK:         Column:          8
+// CHECK-NEXT: Function:        foo
+// CHECK-NEXT: Args:
+// CHECK-NEXT:   - String:          'Unable to specialize generic function '
+// CHECK-NEXT:   - Callee:          '"bar"'
+// CHECK-NEXT:     DebugLoc:
+// CHECK:             File:            {{.*}}/specialize_no_definition_ossa.sil
+// CHECK:             Line:            32
+// CHECK:             Column:          21
+// CHECK-NEXT:   - String:          ' since definition is not visible'
+// CHECK-NEXT: ...
+sil hidden [ossa] @foo : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 2          
+  %1 = struct $Int64 (%0 : $Builtin.Int64)          
+  %2 = alloc_stack $Int64                           
+  store %1 to [trivial] %2 : $*Int64                          
+  %4 = function_ref @bar : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () 
+  %5 = apply %4<Int64>(%2) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+  dealloc_stack %2 : $*Int64                        
+  %7 = tuple ()                                   
+  return %7 : $()                                 
+}
+
+sil hidden_external @bar : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()

--- a/test/SILOptimizer/specialize_opaque_ossa.sil
+++ b/test/SILOptimizer/specialize_opaque_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -generic-specializer -sil-generic-specializer-enable-ownership %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_opaque_result_types_ossa.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types_ossa.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/opaque_result_types.swift -module-name External -emit-module -emit-module-path %t/External.swiftmodule
-// RUN: %target-sil-opt -I %t -enable-sil-verify-all %s -generic-specializer -sil-generic-specializer-enable-ownership | %FileCheck %s
+// RUN: %target-sil-opt -I %t -enable-sil-verify-all %s -generic-specializer | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -sil-partial-specialization -generic-specializer -sil-generic-specializer-enable-ownership  %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-partial-specialization -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_reabstraction_ossa.sil
+++ b/test/SILOptimizer/specialize_reabstraction_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer -sil-generic-specializer-enable-ownership %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_recursive_generics_ossa.sil
+++ b/test/SILOptimizer/specialize_recursive_generics_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -generic-specializer -cse -sil-generic-specializer-enable-ownership | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -generic-specializer -cse | %FileCheck %s
 
 // Check that SIL cloner can correctly handle specialization of recursive
 // functions with generic arguments.


### PR DESCRIPTION
This was already supported, but was under a flag. Enabled by default and converted left over tests.