### PR TITLE
[AutoDiff] Properly destruct 'AutoDiffLinearMapContext'.

### DIFF
--- a/stdlib/public/runtime/AutoDiffSupport.cpp
+++ b/stdlib/public/runtime/AutoDiffSupport.cpp
@@ -19,6 +19,7 @@ using namespace llvm;
 
 SWIFT_CC(swift)
 static void destroyLinearMapContext(SWIFT_CONTEXT HeapObject *obj) {
+  static_cast<AutoDiffLinearMapContext *>(obj)->~AutoDiffLinearMapContext();
   free(obj);
 }
 


### PR DESCRIPTION
Add a missing call to `~AutoDiffLinearMapContext()` in the runtime (initially added in #34886).