### PR TITLE
[Sema] Warn on @_spi imports of modules built from their public interface

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1784,6 +1784,10 @@ ERROR(spi_attribute_on_protocol_requirement,none,
 ERROR(spi_attribute_on_frozen_stored_properties,none,
       "stored property %0 cannot be declared '@_spi' in a '@frozen' struct",
       (DeclName))
+WARNING(spi_attribute_on_import_of_public_module,none,
+        "importation of %0 has an ineffective '@_spi' attribute; "
+        "it was built from the public interface at %1",
+        (DeclName, StringRef))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1785,8 +1785,8 @@ ERROR(spi_attribute_on_frozen_stored_properties,none,
       "stored property %0 cannot be declared '@_spi' in a '@frozen' struct",
       (DeclName))
 WARNING(spi_attribute_on_import_of_public_module,none,
-        "importation of %0 has an ineffective '@_spi' attribute; "
-        "it was built from the public interface at %1",
+        "'@_spi' import of %0 will not include any SPI symbols; "
+        "%0 was built from the public interface at %1",
         (DeclName, StringRef))
 
 // Opaque return types

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1030,6 +1030,21 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
       }
     }
   }
+
+  if (auto ID = dyn_cast<ImportDecl>(D)) {
+    auto importedModule = ID->getModule();
+    if (importedModule) {
+      auto path = importedModule->getModuleFilename();
+      if (llvm::sys::path::extension(path) == ".swiftinterface" &&
+          !path.endswith(".private.swiftinterface")) {
+        // If the module was built from the public swiftinterface, it can't
+        // have any SPI.
+        diagnose(attr->getLocation(),
+                 diag::spi_attribute_on_import_of_public_module,
+                 importedModule->getName(), path);
+      }
+    }
+  }
 }
 
 static bool checkObjCDeclContext(Decl *D) {

--- a/test/SPI/experimental_spi_imports_type_check.swift
+++ b/test/SPI/experimental_spi_imports_type_check.swift
@@ -16,11 +16,6 @@
 // RUN: %target-typecheck-verify-swift -DCLIENT -I %t
 // RUN: %target-swift-frontend -typecheck %s -DCLIENT -DCLIENT_LOAD_CORE -I %t
 
-/// Test with the public swiftinterface file, the SPI is unknown.
-// RUN: rm %t/LibPublic.private.swiftinterface
-// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
-// RUN: %target-typecheck-verify-swift -DCLIENT -DCLIENT_LOAD_CORE -I %t
-
 #if LIB_CORE
 
 public struct CoreStruct {

--- a/test/SPI/warn_on_ineffective_spi_import.swift
+++ b/test/SPI/warn_on_ineffective_spi_import.swift
@@ -16,4 +16,4 @@
 // RUN: rm %t/SPIHelper.private.swiftinterface
 // RUN: %target-typecheck-verify-swift -I %t
 
-@_spi(SPIHelper) import SPIHelper // expected-warning {{importation of 'SPIHelper' has an ineffective '@_spi' attribute; it was built from the public interface at}}
+@_spi(SPIHelper) import SPIHelper // expected-warning {{'@_spi' import of 'SPIHelper' will not include any SPI symbols; 'SPIHelper' was built from the public interface at}}

--- a/test/SPI/warn_on_ineffective_spi_import.swift
+++ b/test/SPI/warn_on_ineffective_spi_import.swift
@@ -1,0 +1,19 @@
+/// Test the warning on an SPI import of the public interface of a module.
+
+// RUN: %empty-directory(%t)
+
+/// Compile the SPI lib.
+// RUN: %target-swift-frontend -enable-experimental-prespecialization -emit-module %S/Inputs/spi_helper.swift -module-name SPIHelper -emit-module-path %t/SPIHelper.swiftmodule -emit-module-interface-path %t/SPIHelper.swiftinterface -emit-private-module-interface-path %t/SPIHelper.private.swiftinterface -enable-library-evolution -swift-version 5 -parse-as-library
+
+/// Reading from swiftmodule, no warning.
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+/// Reading from .private.swiftinterface, no warning.
+// RUN: rm %t/SPIHelper.swiftmodule
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+/// Reading from the public .swiftinterface should produce the warning.
+// RUN: rm %t/SPIHelper.private.swiftinterface
+// RUN: %target-typecheck-verify-swift -I %t
+
+@_spi(SPIHelper) import SPIHelper // expected-warning {{importation of 'SPIHelper' has an ineffective '@_spi' attribute; it was built from the public interface at}}


### PR DESCRIPTION
This warning should help understand missing SPI diagnostics when the
compiler loads a public module when a private one is expected.

rdar://71859081