### PR TITLE
[concurrency] implement lowering of implicitly async calls

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -546,6 +546,10 @@ public:
     return cast<EnumElementDecl>(Constant.getDecl());
   }
 
+  ValueDecl *getDecl() {
+    return Constant.getDecl();
+  }
+
   CalleeTypeInfo createCalleeTypeInfo(SILGenFunction &SGF,
                                       Optional<SILDeclRef> constant,
                                       SILType formalFnType) const & {
@@ -3646,6 +3650,7 @@ class CallEmission {
   Callee callee;
   FormalEvaluationScope initialWritebackScope;
   unsigned expectedSiteCount;
+  bool implicitlyAsync;
 
 public:
   /// Create an emission for a call of the given callee.
@@ -3653,7 +3658,8 @@ public:
                FormalEvaluationScope &&writebackScope)
       : SGF(SGF), callee(std::move(callee)),
         initialWritebackScope(std::move(writebackScope)),
-        expectedSiteCount(callee.getParameterListCount()) {}
+        expectedSiteCount(callee.getParameterListCount()),
+        implicitlyAsync(false) {}
 
   /// A factory method for decomposing the apply expr \p e into a call
   /// emission.
@@ -3687,6 +3693,11 @@ public:
   bool isEnumElementConstructor() {
     return (callee.kind == Callee::Kind::EnumElement);
   }
+
+  /// Sets a flag that indicates whether this call be treated as being 
+  /// implicitly async, i.e., it requires a hop_to_executor prior to 
+  /// invoking the sync callee, etc.
+  void setImplicitlyAsync(bool flag) { implicitlyAsync = flag; }
 
   CleanupHandle applyCoroutine(SmallVectorImpl<ManagedValue> &yields);
 
@@ -3912,11 +3923,15 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
 
   auto mv = callee.getFnValue(SGF, borrowedSelf);
 
+  Optional<ValueDecl*> calleeDeclInfo;
+  if (implicitlyAsync)
+    calleeDeclInfo = callee.getDecl();
+
   // Emit the uncurried call.
   return SGF.emitApply(
       std::move(resultPlan), std::move(argScope), uncurriedLoc.getValue(), mv,
       callee.getSubstitutions(), uncurriedArgs, calleeTypeInfo, options,
-      uncurriedContext);
+      uncurriedContext, calleeDeclInfo);
 }
 
 static void emitPseudoFunctionArguments(SILGenFunction &SGF,
@@ -4224,6 +4239,8 @@ CallEmission CallEmission::forApplyExpr(SILGenFunction &SGF, ApplyExpr *e) {
 
     emission.addCallSite(apply.callSite, std::move(preparedArgs),
                          apply.callSite->throws());
+
+    emission.setImplicitlyAsync(apply.callSite->implicitlyAsync());
   }
 
   return emission;
@@ -4266,6 +4283,31 @@ bool SILGenModule::isNonMutatingSelfIndirect(SILDeclRef methodRef) {
   return self.isFormalIndirect();
 }
 
+Optional<SILValue> SILGenFunction::EmitLoadActorExecutorForCallee(
+                                                  SILGenFunction *SGF, 
+                                                  ValueDecl *calleeVD,
+                                                  ArrayRef<ManagedValue> args) {
+  if (auto *funcDecl = dyn_cast_or_null<AbstractFunctionDecl>(calleeVD)) {
+    auto actorIso = getActorIsolation(funcDecl);
+    switch (actorIso.getKind()) {
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Independent:
+      case ActorIsolation::IndependentUnsafe:
+        break;
+
+      case ActorIsolation::ActorInstance: {
+        assert(args.size() > 0 && "no self argument for actor-instance call?");
+        auto calleeSelf = args.back();
+        return calleeSelf.borrow(*SGF, SGF->F.getLocation()).getValue();
+      }
+
+      case ActorIsolation::GlobalActor:
+        return SGF->emitLoadGlobalActorExecutor(actorIso.getGlobalActor());
+    }
+  }
+  return None;
+}
+
 //===----------------------------------------------------------------------===//
 //                           Top Level Entrypoints
 //===----------------------------------------------------------------------===//
@@ -4279,7 +4321,8 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
                                  ManagedValue fn, SubstitutionMap subs,
                                  ArrayRef<ManagedValue> args,
                                  const CalleeTypeInfo &calleeTypeInfo,
-                                 ApplyOptions options, SGFContext evalContext) {
+                                 ApplyOptions options, SGFContext evalContext,
+                                 Optional<ValueDecl *> implicitlyAsyncApply) {
   auto substFnType = calleeTypeInfo.substFnType;
   auto substResultType = calleeTypeInfo.substResultType;
 
@@ -4365,15 +4408,31 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
            subs.getGenericSignature().getCanonicalSignature());
   }
 
-  auto rawDirectResult = [&] {
+  // The presence of `implicitlyAsyncApply` indicates that the callee is a 
+  // synchronous function isolated to an actor other than our own.
+  // Such functions require the caller to hop to the callee's executor
+  // prior to invoking the callee.
+  if (implicitlyAsyncApply.hasValue()) {
+    assert(F.isAsync() && "cannot hop_to_executor in a non-async func!");
+
+    auto calleeVD = implicitlyAsyncApply.getValue();
+    auto maybeExecutor = EmitLoadActorExecutorForCallee(this, calleeVD, args);
+
+    assert(maybeExecutor.hasValue());
+    B.createHopToExecutor(loc, maybeExecutor.getValue());
+  }
+
+  SILValue rawDirectResult;
+  {
     SmallVector<SILValue, 1> rawDirectResults;
     emitRawApply(*this, loc, fn, subs, args, substFnType, options,
                  indirectResultAddrs, rawDirectResults);
     assert(rawDirectResults.size() == 1);
-    return rawDirectResults[0];
-  }();
+    rawDirectResult = rawDirectResults[0];
+  }
 
-  if (substFnType->isAsync())
+  // hop back to the current executor
+  if (substFnType->isAsync() || implicitlyAsyncApply.hasValue())
     emitHopToCurrentExecutor(loc);
 
   // Pop the argument scope.
@@ -4482,7 +4541,7 @@ RValue SILGenFunction::emitMonomorphicApply(
       *this, calleeTypeInfo, loc, evalContext);
   ArgumentScope argScope(*this, loc);
   return emitApply(std::move(resultPlan), std::move(argScope), loc, fn, {},
-                   args, calleeTypeInfo, options, evalContext);
+                   args, calleeTypeInfo, options, evalContext, None);
 }
 
 /// Emit either an 'apply' or a 'try_apply', with the error branch of
@@ -4768,7 +4827,7 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
   ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, ctx);
   ArgumentScope argScope(*this, loc);
   return emitApply(std::move(resultPlan), std::move(argScope), loc, mv, subMap,
-                   finalArgs, calleeTypeInfo, ApplyOptions::None, ctx);
+                   finalArgs, calleeTypeInfo, ApplyOptions::None, ctx, None);
 }
 
 StringRef SILGenFunction::getMagicFunctionString() {

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -243,7 +243,7 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
       SGF.emitApply(std::move(resultPlan), std::move(argScope), loc,
                     ManagedValue::forUnmanaged(witnessRef), subs,
                     {objcValue, ManagedValue::forUnmanaged(metatypeValue)},
-                    calleeTypeInfo, ApplyOptions::None, context);
+                    calleeTypeInfo, ApplyOptions::None, context, None);
   return std::move(result).getAsSingleValue(SGF, loc);
 }
 
@@ -1875,7 +1875,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     ManagedValue resultMV =
         emitApply(std::move(resultPlan), std::move(argScope), fd,
                   ManagedValue::forUnmanaged(fn), subs, args,
-                  calleeTypeInfo, ApplyOptions::None, context)
+                  calleeTypeInfo, ApplyOptions::None, context, None)
             .getAsSingleValue(*this, fd);
 
     if (indirectResult) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2271,7 +2271,7 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
                captures);
 
   return emitApply(std::move(resultPtr), std::move(argScope), loc, fnRef,
-                   subs, captures, calleeTypeInfo, ApplyOptions::None, C);
+                   subs, captures, calleeTypeInfo, ApplyOptions::None, C, None);
 }
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
@@ -2294,7 +2294,7 @@ RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
   ArgumentScope argScope(*this, loc);
   return emitApply(std::move(resultPlan), std::move(argScope), loc, fnRef,
-                   subs, {}, calleeTypeInfo, ApplyOptions::None, C);
+                   subs, {}, calleeTypeInfo, ApplyOptions::None, C, None);
 }
 
 RValue RValueEmitter::visitDestructureTupleExpr(DestructureTupleExpr *E,
@@ -3201,7 +3201,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
                      loc, ManagedValue::forUnmanaged(equalsWitness),
                      equatableSub,
                      {lhsArg, rhsArg, metatyValue},
-                     equalsInfo, ApplyOptions::None, SGFContext())
+                     equalsInfo, ApplyOptions::None, SGFContext(), None)
           .getUnmanagedSingleValue(subSGF, loc);
       }
       

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -835,6 +835,27 @@ public:
   void mergeCleanupBlocks();
 
   //===--------------------------------------------------------------------===//
+  // Concurrency
+  //===--------------------------------------------------------------------===//
+
+  /// Generates code into the given SGF that obtains the callee function's 
+  /// executor, if the function is actor-isolated.
+  /// @returns a SILValue representing the executor, if an executor exists.
+  static Optional<SILValue> EmitLoadActorExecutorForCallee(
+                                                  SILGenFunction *SGF, 
+                                                  ValueDecl *calleeVD,
+                                                  ArrayRef<ManagedValue> args);
+
+  /// Generates code to obtain the executor given the actor's decl.
+  /// @returns a SILValue representing the executor.
+  SILValue emitLoadActorExecutor(VarDecl *actorDecl);
+
+  /// Generates the code to obtain the executor for the shared instance 
+  /// of the \p globalActor based on the type.
+  /// @returns a SILValue representing the executor.
+  SILValue emitLoadGlobalActorExecutor(Type globalActor);
+
+  //===--------------------------------------------------------------------===//
   // Memory management
   //===--------------------------------------------------------------------===//
 
@@ -851,10 +872,6 @@ public:
   uint16_t emitProlog(ParameterList *paramList, ParamDecl *selfParam,
                       Type resultType, DeclContext *DC,
                       bool throws, SourceLoc throwsLoc);
-
-  /// Initializes 'actor' with the loaded shared instance of the \p globalActor
-  /// type.
-  void loadGlobalActor(Type globalActor);
 
   /// Create SILArguments in the entry block that bind a single value
   /// of the given parameter suitably for being forwarded.
@@ -1544,7 +1561,8 @@ public:
                    SILLocation loc, ManagedValue fn, SubstitutionMap subs,
                    ArrayRef<ManagedValue> args,
                    const CalleeTypeInfo &calleeTypeInfo, ApplyOptions options,
-                   SGFContext evalContext);
+                   SGFContext evalContext, 
+                   Optional<ValueDecl *> implicitlyAsyncApply);
 
   RValue emitApplyOfDefaultArgGenerator(SILLocation loc,
                                         ConcreteDeclRef defaultArgsOwner,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4485,6 +4485,8 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
 // Concurrency
 //===----------------------------------------------------------------------===//
 
+/// If the current function is associated with an actor, then this
+/// function emits a hop_to_executor to that actor's executor at loc.
 void SILGenFunction::emitHopToCurrentExecutor(SILLocation loc) {
   if (actor)
     B.createHopToExecutor(loc, actor);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -621,6 +621,38 @@ namespace {
       contextStack.push_back(dc);
     }
 
+    /// Searches the applyStack from back to front for the inner-most CallExpr
+    /// and marks that CallExpr as implicitly async. 
+    ///
+    /// NOTE: Crashes if no CallExpr was found.
+    /// 
+    /// For example, for global actor function `curryAdd`, if we have:
+    ///     ((curryAdd 1) 2)
+    /// then we want to mark the inner-most CallExpr, `(curryAdd 1)`.
+    ///
+    /// The same goes for calls to member functions, such as calc.add(1, 2),
+    /// aka ((add calc) 1 2), looks like this:
+    /// 
+    ///  (call_expr
+    ///    (dot_syntax_call_expr
+    ///      (declref_expr add)
+    ///      (declref_expr calc))
+    ///    (tuple_expr 
+    ///      ...))
+    ///
+    /// and we reach up to mark the CallExpr.
+    void markNearestCallAsImplicitlyAsync() {
+      assert(applyStack.size() > 0 && "not contained within an Apply?");
+
+      const auto End = applyStack.rend();
+      for (auto I = applyStack.rbegin(); I != End; ++I)
+        if (auto call = dyn_cast<CallExpr>(*I)) {
+          call->setImplicitlyAsync(true);
+          return;
+        }
+      llvm_unreachable("expected a CallExpr in applyStack!");
+    }
+
     bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
     bool shouldWalkIntoTapExpression() override { return false; }
@@ -661,10 +693,9 @@ namespace {
           if (auto memberRef = findMemberReference(partialApply->fn)) {
             // NOTE: partially-applied thunks are never annotated as 
             // implicitly async, regardless of whether they are escaping.
-            // So, we do not pass the ApplyExpr along to checkMemberReference.
             checkMemberReference(
                 partialApply->base, memberRef->first, memberRef->second,
-                partialApply->isEscaping);
+                partialApply->isEscaping, /*maybeImplicitAsync=*/false);
 
             partialApply->base->walk(*this);
 
@@ -683,7 +714,7 @@ namespace {
         if (auto memberRef = findMemberReference(fn)) {
           checkMemberReference(
               call->getArg(), memberRef->first, memberRef->second, 
-              /*isEscapingPartialApply=*/false, call);
+              /*isEscapingPartialApply=*/false, /*maybeImplicitAsync=*/true);
 
           call->getArg()->walk(*this);
 
@@ -903,7 +934,7 @@ namespace {
           auto concDecl = memberRef->first;
           if (value == concDecl.getDecl() && !apply->implicitlyAsync()) {
             // then this ValueDecl appears as the called value of the ApplyExpr.
-            apply->setImplicitlyAsync(true);
+            markNearestCallAsImplicitlyAsync();
             return true;
           }
         }
@@ -1012,7 +1043,7 @@ namespace {
     bool checkMemberReference(
         Expr *base, ConcreteDeclRef memberRef, SourceLoc memberLoc,
         bool isEscapingPartialApply = false, 
-        ApplyExpr *maybeImplicitAsync = nullptr) {
+        bool maybeImplicitAsync = false) {
       if (!base || !memberRef)
         return false;
 
@@ -1028,7 +1059,7 @@ namespace {
         if (!selfVar) {
           // actor-isolated non-self calls are implicitly async and thus OK.
           if (maybeImplicitAsync && isa<AbstractFunctionDecl>(member)) {
-            maybeImplicitAsync->setImplicitlyAsync(true);
+            markNearestCallAsImplicitlyAsync();
             return false;
           }
           ctx.Diags.diagnose(

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -185,3 +185,33 @@ func blender(_ peeler : () -> Void) {
 @OrangeActor func quinoa() async {
   rice() // expected-error {{call is 'async' but is not marked with 'await'}}
 }
+
+///////////
+// check various curried applications to ensure we mark the right expression.
+
+actor class Calculator {
+  func addCurried(_ x : Int) -> ((Int) -> Int) { 
+    return { (_ y : Int) in x + y }
+  }
+
+  func add(_ x : Int, _ y : Int) -> Int {
+    return x + y
+  }
+}
+
+@BananaActor func bananaAdd(_ x : Int) -> ((Int) -> Int) { 
+  return { (_ y : Int) in x + y }
+}
+
+@OrangeActor func doSomething() async {
+  let _ = (await bananaAdd(1))(2)
+  let _ = await (await bananaAdd(1))(2) // expected-warning{{no calls to 'async' functions occur within 'await' expression}}
+
+  let calc = Calculator()
+  
+  let _ = (await calc.addCurried(1))(2)
+  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no calls to 'async' functions occur within 'await' expression}}
+
+  let plusOne = await calc.addCurried(await calc.add(0, 1))
+  let _ = plusOne(2)
+}


### PR DESCRIPTION
If a call is to a synchronous function that is isolated to a different actor, then the call is treated as implicitly async. An earlier PR #34678 implemented the first part of this, which is to mark such calls in the AST as being implicitly async. This PR finishes the implementation by lowering / expanding that annotation during SILGen.

Resolves rdar://71606265
