### PR TITLE
The runtime function swift_autoDiffCreateLinearMapContext was recently added

### DIFF
--- a/test/AutoDiff/stdlib/simd.swift
+++ b/test/AutoDiff/stdlib/simd.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
+// UNSUPPORTED: use_os_stdlib
+
 import _Differentiation
 import StdlibUnittest
 

--- a/test/AutoDiff/validation-test/address_only_tangentvector.swift
+++ b/test/AutoDiff/validation-test/address_only_tangentvector.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
+// UNSUPPORTED: use_os_stdlib
+
 import StdlibUnittest
 import DifferentiationUnittest
 

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
+// UNSUPPORTED: use_os_stdlib
+
 import StdlibUnittest
 import _Differentiation
 

--- a/test/AutoDiff/validation-test/inout_parameters.swift
+++ b/test/AutoDiff/validation-test/inout_parameters.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
+// UNSUPPORTED: use_os_stdlib
+
 // `inout` parameter differentiation tests.
 
 import DifferentiationUnittest


### PR DESCRIPTION
So these tests fail with missing symbols if the test is deployed with stdlib's on older OSes

rdar://71900166