### PR TITLE
[test] Fix test regressions in backdeployment bots

### DIFF
--- a/test/PlaygroundTransform/implicit_return_never.swift
+++ b/test/PlaygroundTransform/implicit_return_never.swift
@@ -5,6 +5,9 @@
 // RUN: %{python} %S/../Inputs/not.py "%target-run %t/main --crash" 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
 // REQUIRES: executable_test
 
+// The runtime error format changed after the 5.3 release.
+// UNSUPPORTED: use_os_stdlib
+
 // NOTE: not.py is used above instead of "not --crash" because simctl's exit
 // status doesn't reflect whether its child process crashed or not. So "not
 // --crash %target-run ..." always fails when testing for the iOS Simulator.

--- a/test/PlaygroundTransform/placeholder.swift
+++ b/test/PlaygroundTransform/placeholder.swift
@@ -6,6 +6,9 @@
 // RUN: %{python} %S/../Inputs/not.py "%target-run %t/main --crash" 2>&1 | %FileCheck -check-prefix=CRASH-CHECK %s
 // REQUIRES: executable_test
 
+// The runtime error format changed after the 5.3 release.
+// UNSUPPORTED: use_os_stdlib
+
 // NOTE: not.py is used above instead of "not --crash" because simctl's exit
 // status doesn't reflect whether its child process crashed or not. So "not
 // --crash %target-run ..." always fails when testing for the iOS Simulator.

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -6,6 +6,18 @@
 
 import StdlibUnittest
 
+func shouldCheckErrorLocation() -> Bool {
+  // Location information for runtime traps is only emitted in debug builds.
+  guard _isDebugAssertConfiguration() else { return false }
+  // The runtime error location format changed after the 5.3 release.
+  // (https://github.com/apple/swift/pull/34665)
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    return true
+  } else {
+    return false
+  }
+}
+
 var ErrorTests = TestSuite("Error")
 
 var NoisyErrorLifeCount = 0
@@ -108,7 +120,7 @@ enum SillyError: Error { case JazzHands }
 ErrorTests.test("try!")
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches(_isDebugAssertConfiguration()
+  .crashOutputMatches(shouldCheckErrorLocation()
                         ? "'try!' expression unexpectedly raised an error: "
                           + "main.SillyError.JazzHands"
                         : "")
@@ -120,8 +132,8 @@ ErrorTests.test("try!")
 ErrorTests.test("try!/location")
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches(_isDebugAssertConfiguration()
-                        ? "main/Error.swift:128"
+  .crashOutputMatches(shouldCheckErrorLocation()
+                        ? "main/Error.swift:140"
                         : "")
   .code {
     expectCrashLater()

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -20,6 +20,18 @@ func returnNil() -> AnyObject? {
 
 var OptionalTraps = TestSuite("OptionalTraps")
 
+func shouldCheckErrorLocation() -> Bool {
+  // Location information for runtime traps is only emitted in debug builds.
+  guard _isDebugAssertConfiguration() else { return false }
+  // The runtime error location format changed after the 5.3 release.
+  // (https://github.com/apple/swift/pull/34665)
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    return true
+  } else {
+    return false
+  }
+}
+
 OptionalTraps.test("UnwrapNone")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -35,8 +47,8 @@ OptionalTraps.test("UnwrapNone/location")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches(_isDebugAssertConfiguration()
-                        ? "OptionalTraps.swift:45:"
+  .crashOutputMatches(shouldCheckErrorLocation()
+                        ? "OptionalTraps.swift:57:"
                         : "")
   .code {
   expectCrashLater()


### PR DESCRIPTION
https://github.com/apple/swift/pull/34665 changed trap messages in debug builds, but the new format obviously doesn't apply in back deployment scenarios.

Resolves rdar://71902574.
