### PR TITLE
[AST] Fix conversion for Unmanaged<T> in ClangTypeConverter.

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -564,8 +564,10 @@ ClangTypeConverter::visitBoundGenericType(BoundGenericType *type) {
   case StructKind::Invalid:
     return clang::QualType();
 
-  case StructKind::UnsafeMutablePointer:
   case StructKind::Unmanaged:
+    return convert(argCanonicalTy);
+
+  case StructKind::UnsafeMutablePointer:
   case StructKind::AutoreleasingUnsafeMutablePointer: {
     auto clangTy = convert(argCanonicalTy);
     if (clangTy.isNull())

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -68,5 +68,5 @@ import Foundation
 // CHECK-NEXT: %[[T12:.+]] = phi i{{32|64}} [ 0, %[[L7]] ], [ %[[T5]], %[[L2]] ]
 // CHECK-NEXT: %[[T13:.+]] = bitcast %T25unmanaged_objc_throw_func9SR_9035_CC* %{{.+}} to i8*
 // CHECK-NEXT: call void @llvm.objc.release(i8* %[[T13]])
-// CHECK-NEXT: %[[T14:.+]] = inttoptr i{{32|64}} %[[T12]] to %struct.__CFArray**
-// CHECK-NEXT: ret %struct.__CFArray** %[[T14]]
+// CHECK-NEXT: %[[T14:.+]] = inttoptr i{{32|64}} %[[T12]] to %struct.__CFArray*
+// CHECK-NEXT: ret %struct.__CFArray* %[[T14]]


### PR DESCRIPTION
Already approved earlier as first commit in https://github.com/apple/swift/pull/34914. Splitting out for convenience.