### PR TITLE
[diagnostic-verifier] Add LLVM Options so that Diagnostic Verifier aborts when it emits error diagnostics

### DIFF
--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -104,6 +104,10 @@ private:
       StringRef BufferName, std::vector<llvm::SMDiagnostic> &Errors,
       std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics);
 
+  void diagnoseExpectedDiagnosticsThatDidntAppear(
+      StringRef InputFile, ArrayRef<ExpectedDiagnosticInfo> ExpectedDiagnostics,
+      std::vector<llvm::SMDiagnostic> &Errors);
+
   /// verifyFile - After the file has been processed, check to see if we
   /// got all of the expected diagnostics and check to see if there were any
   /// unexpected ones.

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -95,6 +95,11 @@ private:
     bool HadUnexpectedDiag;
   };
 
+  void verifyAllExpectedDiagnosticsAppeared(
+      StringRef BufferName, StringRef InputFile,
+      std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics,
+      std::vector<llvm::SMDiagnostic> &Errors);
+
   /// verifyFile - After the file has been processed, check to see if we
   /// got all of the expected diagnostics and check to see if there were any
   /// unexpected ones.

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -100,6 +100,10 @@ private:
       std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics,
       std::vector<llvm::SMDiagnostic> &Errors);
 
+  void diagnoseIncorrectDiagnostics(
+      StringRef BufferName, std::vector<llvm::SMDiagnostic> &Errors,
+      std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics);
+
   /// verifyFile - After the file has been processed, check to see if we
   /// got all of the expected diagnostics and check to see if there were any
   /// unexpected ones.

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -79,6 +79,11 @@ public:
 
   virtual bool finishProcessing() override;
 
+  /// Forward declaration of struct only used in internal impl so it can be used
+  /// in internal helper methods on this class. It is only declared, not defined
+  /// in any header.
+  struct ExpectedDiagnosticInfo;
+
 private:
   /// Result of verifying a file.
   struct Result {

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -29,12 +29,14 @@
 using namespace swift;
 
 namespace swift {
+
 struct ExpectedFixIt {
   const char *StartLoc, *EndLoc; // The loc of the {{ and }}'s.
   unsigned StartCol;
   unsigned EndCol;
   std::string Text;
 };
+
 } // end namespace swift
 
 namespace {
@@ -42,7 +44,9 @@ namespace {
 static constexpr StringLiteral fixitExpectationNoneString("none");
 static constexpr StringLiteral educationalNotesSpecifier("educational-notes=");
 
-struct ExpectedDiagnosticInfo {
+} // anonymous namespace
+
+struct DiagnosticVerifier::ExpectedDiagnosticInfo {
   // This specifies the full range of the "expected-foo {{}}" specifier.
   const char *ExpectedStart, *ExpectedEnd = nullptr;
 
@@ -85,6 +89,9 @@ struct ExpectedDiagnosticInfo {
                          DiagnosticKind Classification)
       : ExpectedStart(ExpectedStart), Classification(Classification) {}
 };
+namespace {
+using ExpectedDiagnosticInfo = DiagnosticVerifier::ExpectedDiagnosticInfo;
+} // anonymous namespace
 
 static std::string getDiagKindString(DiagnosticKind Kind) {
   switch (Kind) {
@@ -237,7 +244,6 @@ verifyUnknown(SourceManager &SM,
   }
   return HadError;
 }
-} // end anonymous namespace
 
 static unsigned getColumnNumber(StringRef buffer, llvm::SMLoc loc) {
   assert(loc.getPointer() >= buffer.data());


### PR DESCRIPTION
Otherwise, it can be hard to figure out why the diagnostic verifier is actually failing. This change does this by:

1. Splitting up the huge method DiagnosticVerifier::verifyFile()[~632 lines of code in one method!] into several subroutines that have semantic names that tell big picture what the code is trying to do there.

2. Then I added `llvm::cl::opt<bool>` options that a compiler developer can use to cause the verifier to abort at the beginning of each of these helper functions. This lets one easily drop down into the debugger at the point where the "incorrect diagnostic" or "unexpected diagnostic" error occurs.