### PR TITLE
stdlib: build the `swift::atomic<T>` on Windows

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -248,18 +248,6 @@ function(_add_host_variant_c_compile_flags target)
     endif()
   endif()
 
-  # The concurrency library uses double-word atomics.  MSVC's std::atomic
-  # uses a spin lock for this, so to get reasonable behavior we have to
-  # implement it ourselves using _InterlockedCompareExchange128.
-  # clang-cl requires us to enable the `cx16` feature to use this intrinsic.
-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
-    if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
-      if(CMAKE_C_COMPILER_ID MATCHES Clang)
-        target_compile_options(${target} PRIVATE -mcx16)
-      endif()
-    endif()
-  endif()
-
   if(LLVM_ENABLE_ASSERTIONS)
     target_compile_options(${target} PRIVATE -UNDEBUG)
   else()

--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -67,7 +67,8 @@ public:
 };
 
 // FIXME: get this to build reliably
-#if 0 && defined(_WIN64)
+#if defined(_WIN64)
+
 #include <intrin.h>
 
 /// MSVC's std::atomic uses an inline spin lock for 16-byte atomics,

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -259,6 +259,18 @@ function(_add_target_variant_c_compile_flags)
     if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
       list(APPEND result "-U_DEBUG")
     endif()
+
+    # The concurrency library uses double-word atomics.  MSVC's std::atomic
+    # uses a spin lock for this, so to get reasonable behavior we have to
+    # implement it ourselves using _InterlockedCompareExchange128.
+    # clang-cl requires us to enable the `cx16` feature to use this intrinsic.
+    if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
+      if(SWIFT_COMPILER_IS_MSVC_LIKE)
+        list(APPEND result /clang:-mcx16)
+      else()
+        list(APPEND result -mcx16)
+      endif()
+    endif()
   endif()
 
   if(${CFLAGS_SDK} STREQUAL ANDROID)


### PR DESCRIPTION
Enable the `std::atomic<T>` type on Windows for better runtime
performance characteristics.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
