### PR TITLE
[SourceKit] Fix flakey completion tests

### DIFF
--- a/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_avoid_check.swift
@@ -21,11 +21,10 @@ func foo() {
 // RUN:   %s \
 // RUN: )
 // RUN: INPUT_DIR=%S/Inputs/checkdeps
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
 
 // RUN: cp -R $INPUT_DIR/MyProject %t/
 // RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: touch -t 202001010101 %t/Frameworks/ClangFW.framework/Headers/*
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
@@ -36,11 +35,11 @@ func foo() {
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Modify framework (c)' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
 // RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
+// RUN:   -shell -- touch -t 210001010101 %t/Frameworks/ClangFW.framework/Headers/*  == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 // RUN:   -shell -- echo '### Checking dependencies' == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_bridged.swift
@@ -20,27 +20,26 @@ func foo() {
 // RUN:   %s \
 // RUN: )
 // RUN: INPUT_DIR=%S/Inputs/checkdeps
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
 
 // RUN: cp -R $INPUT_DIR/MyProject %t/
 // RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Modify bridging header library file' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
 // RUN:   -shell -- cp -R $INPUT_DIR/MyProject_mod/LocalCFunc.h %t/MyProject/ == \
+// RUN:   -shell -- touch -t 210001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -shell -- touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
 
 // RUN:   | %FileCheck %s

--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -20,27 +20,26 @@ func foo() {
 // RUN:   %s \
 // RUN: )
 // RUN: INPUT_DIR=%S/Inputs/checkdeps
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
 
 // RUN: cp -R $INPUT_DIR/MyProject %t/
 // RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
+// RUN: touch -t 202001010101 %t/Frameworks/ClangFW.framework/Headers/*
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Modify framework (c)' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
 // RUN:   -shell -- cp -R $INPUT_DIR/ClangFW.framework_mod/* %t/Frameworks/ClangFW.framework/ == \
+// RUN:   -shell -- touch -t 210001010101 %t/Frameworks/ClangFW.framework/Headers/* == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -shell -- touch -t 202001010101 %t/Frameworks/ClangFW.framework/Headers/* == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
 
 // RUN:   | %FileCheck %s

--- a/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_otherfile.swift
@@ -20,27 +20,26 @@ func foo() {
 // RUN:   %s \
 // RUN: )
 // RUN: INPUT_DIR=%S/Inputs/checkdeps
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
 
 // RUN: cp -R $INPUT_DIR/MyProject %t/
+// RUN: touch -t 202001010101 %t/MyProject/Library.swift
 // RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo "### Modify local library file" == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
 // RUN:   -shell -- cp -R $INPUT_DIR/MyProject_mod/Library.swift %t/MyProject/ == \
+// RUN:   -shell -- touch -t 210001010101 %t/MyProject/Library.swift == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -shell -- touch -t 202001010101 %t/MyProject/Library.swift == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
 
 // RUN:   | %FileCheck %s

--- a/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_ownfile.swift
@@ -35,8 +35,6 @@ func foo(val: MyStruct) {
 // RUN:   %t/test.swift \
 // RUN: )
 // RUN: INPUT_DIR=%S/Inputs/checkdeps
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
 
 // RUN: cp -R $INPUT_DIR/MyProject %t/
 // RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
@@ -44,26 +42,27 @@ func foo(val: MyStruct) {
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
 
 // RUN: cp %t/State1.swift %t/test.swift
+// RUN: touch -t 202001010101 %t/test.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \
 
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
 // RUN:   -shell -- echo "### Modify own file - 1" == \
 // RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
+// RUN:   -shell -- touch -t 210001010101 %t/test.swift == \
 // RUN:   -req=complete -pos=5:9 %t/test.swift -- ${COMPILER_ARGS[@]} == \
 
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
 // RUN:   -shell -- echo "### Modify own file - 2" == \
 // RUN:   -shell -- cp %t/State1.swift %t/test.swift == \
+// RUN:   -shell -- touch -t 210001010102 %t/test.swift == \
 // RUN:   -req=complete -pos=5:4 %t/test.swift -- ${COMPILER_ARGS[@]} == \
 
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
 // RUN:   -shell -- echo "### Modify own file - 3" == \
 // RUN:   -shell -- cp %t/State2.swift %t/test.swift == \
+// RUN:   -shell -- touch -t 210001010103 %t/test.swift == \
 // RUN:   -req=complete -pos=5:9 %t/test.swift -- ${COMPILER_ARGS[@]} \
 // RUN:   | %FileCheck %s
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -20,27 +20,26 @@ func foo() {
 // RUN:   %s \
 // RUN: )
 // RUN: INPUT_DIR=%S/Inputs/checkdeps
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
 
 // RUN: cp -R $INPUT_DIR/MyProject %t/
 // RUN: cp -R $INPUT_DIR/ClangFW.framework %t/Frameworks/
 // RUN: %empty-directory(%t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src/Funcs.swift
+// RUN: touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Modify framework (s)' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
 // RUN:   -shell --  %target-swift-frontend -emit-module -module-name SwiftFW -o %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name $INPUT_DIR/SwiftFW_src_mod/Funcs.swift == \
+// RUN    -shell -- touch -t 210001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} == \
 
 // RUN:   -shell -- echo '### Fast completion' == \
-// RUN:   -shell -- sleep $SLEEP_TIME == \
+// RUN:   -shell -- touch -t 202001010101 %t/Frameworks/SwiftFW.framework/Modules/SwiftFW.swiftmodule/%target-swiftmodule-name == \
 // RUN:   -req=complete -pos=5:3 %s -- ${COMPILER_ARGS[@]} \
 
 // RUN:   | %FileCheck %s


### PR DESCRIPTION
A previous change updated the checkdep tests to move the sleep before
copying over files. This fixed cases where the modification time would
be the same second as the dependency check. Unfortunately this
introduced a slightly different form of flakiness - if the sleep went
too long, the completion that was meant to re-use the AST would see that
it's time to check dependencies and thus skip the fast completion path.

One fix for that would be to add a smaller sleep before, a longer sleep
after, and increase the dependency check time. That increases the
runtime of the tests even further though, so instead just update the
timestamps manually to be in the past/future in order to invoke the path
we want to test. This also allows a 0 dependency check time (ie. always
check), which makes the tests even faster.

Resolves rdar://71861446