### PR TITLE
Fix Mac Catalyst test dependency failures

### DIFF
--- a/stdlib/private/BlocksRuntimeStubs/CMakeLists.txt
+++ b/stdlib/private/BlocksRuntimeStubs/CMakeLists.txt
@@ -6,7 +6,7 @@ foreach(SDK ${SWIFT_SDKS})
   foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
     get_swift_test_build_flavors(build_flavors "${SDK}")
 
-    foreach(BUILD_FLAVOR build_flavors)
+    foreach(BUILD_FLAVOR ${build_flavors})
       get_swift_test_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}" "${BUILD_FLAVOR}")
 
       set(test_bin_dir "${SWIFT_BINARY_DIR}/test${VARIANT_SUFFIX}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -207,8 +207,8 @@ foreach(SDK ${SWIFT_SDKS})
       # Configure variables for this subdirectory.
       set(VARIANT_SDK "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_PATH}")
       get_swift_test_variant_suffix(VARIANT_SUFFIX "${SDK}" "${ARCH}" "${BUILD_FLAVOR}")
+      get_swift_test_variant_suffix(DEFAULT_OSX_VARIANT_SUFFIX "${SDK}" "${ARCH}" "default")
       get_swift_test_versioned_target_triple(VARIANT_TRIPLE "${SDK}" "${ARCH}" "${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}" "${BUILD_FLAVOR}")
-      get_swift_test_default_osx_variant_suffix(DEFAULT_OSX_VARIANT_SUFFIX "${VARIANT_SUFFIX}" "${BUILD_FLAVOR}")
 
       # A directory where to put the xUnit-style XML test results.
       set(SWIFT_TEST_RESULTS_DIR

--- a/test/cmake/modules/SwiftTestUtils.cmake
+++ b/test/cmake/modules/SwiftTestUtils.cmake
@@ -35,14 +35,3 @@ function(get_swift_test_versioned_target_triple variant_triple_out_var sdk arch 
 
   set(${variant_triple_out_var} "${variant_triple}" PARENT_SCOPE)
 endfunction()
-
-# Get the default OSX variant suffix for test targets
-function(get_swift_test_default_osx_variant_suffix suffix_out_var original_variant_suffix build_flavor)
-  set(suffix "")
-  if(build_flavor STREQUAL "ios-like")
-    set(suffix "${variant_suffix}")
-  endif()
-
-  set(${suffix_out_var} "${suffix}" PARENT_SCOPE)
-endfunction()
-


### PR DESCRIPTION
A CMake refactoring in apple/swift#34859 caused failures in Mac Catalyst configurations which are not tested in open source. This PR corrects these issues.

Fixes rdar://71897958.