### PR TITLE
[SymbolGraph][CursorInfo] Add option to SourceKit's CursorInfo request to include the SymbolGraph JSON

### DIFF
--- a/include/swift/SymbolGraphGen/SymbolGraphGen.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphGen.h
@@ -26,8 +26,10 @@ namespace symbolgraphgen {
 int emitSymbolGraphForModule(ModuleDecl *M, const SymbolGraphOptions &Options);
 
 /// Print a Symbol Graph containing a single node for the given decl.
-/// \returns true without printing if the provided node kind is unsupported.
-bool printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
+///
+/// \returns \c EXIT_SUCCESS if the kind of the provided node is supported and
+/// its Symbo lGraph was printed, or \c EXIT_FAILURE otherwise.
+int printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
                              bool InSynthesizedExtensions,
                              const SymbolGraphOptions &Options,
                              llvm::raw_ostream &OS);

--- a/include/swift/SymbolGraphGen/SymbolGraphGen.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphGen.h
@@ -14,13 +14,23 @@
 #define SWIFT_SYMBOLGRAPHGEN_SYMBOLGRAPHGEN_H
 
 #include "swift/AST/Module.h"
+#include "swift/AST/Type.h"
 #include "SymbolGraphOptions.h"
 
 namespace swift {
+class ValueDecl;
+
 namespace symbolgraphgen {
 
 /// Emit a Symbol Graph JSON file for a module.
 int emitSymbolGraphForModule(ModuleDecl *M, const SymbolGraphOptions &Options);
+
+/// Print a Symbol Graph containing a single node for the given decl.
+/// \returns true without printing if the provided node kind is unsupported.
+bool printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
+                             bool InSynthesizedExtensions,
+                             const SymbolGraphOptions &Options,
+                             llvm::raw_ostream &OS);
 
 } // end namespace symbolgraphgen
 } // end namespace swift

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -750,8 +750,14 @@ class PrintAST : public ASTVisitor<PrintAST> {
       else if (auto *ED = dyn_cast<ExtensionDecl>(Current))
         subMap = CurrentType->getContextSubstitutionMap(M, ED);
       else {
+        Decl *subTarget = Current;
+        if (isa<ParamDecl>(Current)) {
+          auto *DC = Current->getDeclContext();
+          if (auto *FD = dyn_cast<AbstractFunctionDecl>(DC))
+            subTarget = FD;
+        }
         subMap = CurrentType->getMemberSubstitutionMap(
-          M, cast<ValueDecl>(Current));
+          M, cast<ValueDecl>(subTarget));
       }
 
       T = T.subst(subMap, SubstFlags::DesugarMemberTypes);

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -140,9 +140,11 @@ void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
   USR.clear();
 
   auto ShouldLink = Name.str() != "Self";
-  if (const auto *TD = T->getAnyNominal()) {
-    if (SG->isImplicitlyPrivate(TD)) {
-      ShouldLink = false;
+  if (T) {
+    if (const auto *TD = T->getAnyNominal()) {
+      if (SG->isImplicitlyPrivate(TD)) {
+        ShouldLink = false;
+      }
     }
   }
 

--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -47,7 +47,7 @@ void Edge::serialize(llvm::json::OStream &OS) const {
           ConformanceExtension->getGenericRequirements(),
           ConformanceExtension->getExtendedNominal()
               ->getDeclContext()->getSelfNominalTypeDecl(),
-                                FilteredRequirements);
+          FilteredRequirements);
       if (!FilteredRequirements.empty()) {
         OS.attributeArray("swiftConstraints", [&](){
           for (const auto &Req :

--- a/lib/SymbolGraphGen/JSON.cpp
+++ b/lib/SymbolGraphGen/JSON.cpp
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericParamList.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/Type.h"
 #include "JSON.h"
 
 void swift::symbolgraphgen::serialize(const llvm::VersionTuple &VT,
@@ -115,10 +117,75 @@ void swift::symbolgraphgen::serialize(const swift::GenericTypeParamType *Param,
   });
 }
 
+void
+swift::symbolgraphgen::filterGenericParams(
+    TypeArrayView<GenericTypeParamType> GenericParams,
+    SmallVectorImpl<const GenericTypeParamType*> &FilteredParams,
+    SubstitutionMap SubMap) {
+
+  for (auto Param : GenericParams) {
+    if (const auto *GPD = Param->getDecl()) {
+
+      // Ignore the implicit Self param
+      if (GPD->isImplicit()) {
+        if (!isa<ExtensionDecl>(GPD->getDeclContext()))
+          continue;
+
+        // Extension decls (and their children) refer to implicit copies of the
+        // explicit params of the nominal they extend. Don't filter those out.
+        auto *ED = cast<ExtensionDecl>(GPD->getDeclContext());
+        if (auto *NTD = ED->getExtendedNominal()) {
+          if (auto *GPL = NTD->getGenericParams()) {
+            auto ImplicitAndSameName = [&](GenericTypeParamDecl *NominalGPD) {
+              return NominalGPD->isImplicit() &&
+                  GPD->getName() == NominalGPD->getName();
+            };
+            if (llvm::any_of(GPL->getParams(), ImplicitAndSameName))
+              continue;
+          }
+        }
+      }
+
+      // Ignore parameters that have been substituted.
+      if (!SubMap.empty()) {
+        Type SubTy = Type(Param).subst(SubMap);
+        if (!SubTy->hasError() && SubTy.getPointer() != Param) {
+          if (!SubTy->is<ArchetypeType>()) {
+            continue;
+          }
+          auto AT = SubTy->castTo<ArchetypeType>();
+          if (!AT->getInterfaceType()->isEqual(Param)) {
+            continue;
+          }
+        }
+      }
+
+      FilteredParams.push_back(Param);
+    }
+  }
+}
+
+static bool containsParams(swift::Type Ty, llvm::ArrayRef<const swift::GenericTypeParamType*> Others) {
+  return Ty.findIf([&](swift::Type T) -> bool {
+    if (auto AT = T->getAs<swift::ArchetypeType>()) {
+      T = AT->getInterfaceType();
+    }
+
+    for (auto *Param: Others) {
+      if (T->isEqual(const_cast<swift::GenericTypeParamType*>(Param)))
+        return true;
+    }
+    return false;
+  });
+}
+
 void swift::symbolgraphgen::filterGenericRequirements(
     ArrayRef<Requirement> Requirements,
     const NominalTypeDecl *Self,
-    SmallVectorImpl<Requirement> &FilteredRequirements) {
+    SmallVectorImpl<Requirement> &FilteredRequirements,
+    SubstitutionMap SubMap,
+    ArrayRef<const GenericTypeParamType *> FilteredParams) {
+
   for (const auto &Req : Requirements) {
     if (Req.getKind() == RequirementKind::Layout) {
       continue;
@@ -130,10 +197,29 @@ void swift::symbolgraphgen::filterGenericRequirements(
     if (Req.getSecondType()->getAnyNominal() == Self) {
       continue;
     }
-    FilteredRequirements.push_back(Req);
+
+    // Ignore requirements that don't involve the filtered set of generic
+    // parameters after substitution.
+    if (!SubMap.empty()) {
+      Type SubFirst = Req.getFirstType().subst(SubMap);
+      if (SubFirst->hasError())
+        SubFirst = Req.getFirstType();
+      Type SubSecond = Req.getSecondType().subst(SubMap);
+      if (SubSecond->hasError())
+        SubSecond = Req.getSecondType();
+
+      if (!containsParams(SubFirst, FilteredParams) &&
+          !containsParams(SubSecond, FilteredParams))
+        continue;
+
+      // Use the same requirement kind with the substituted types.
+      FilteredRequirements.emplace_back(Req.getKind(), SubFirst, SubSecond);
+    } else {
+      // Use the original requirement.
+      FilteredRequirements.push_back(Req);
+    }
   }
 }
-
 void
 swift::symbolgraphgen::filterGenericRequirements(const ExtensionDecl *Extension,
     SmallVectorImpl<Requirement> &FilteredRequirements) {

--- a/lib/SymbolGraphGen/JSON.h
+++ b/lib/SymbolGraphGen/JSON.h
@@ -19,6 +19,7 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/VersionTuple.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Type.h"
 
 namespace swift {
@@ -41,16 +42,20 @@ void serialize(const llvm::VersionTuple &VT, llvm::json::OStream &OS);
 void serialize(const llvm::Triple &T, llvm::json::OStream &OS);
 void serialize(const ExtensionDecl *Extension, llvm::json::OStream &OS);
 void serialize(const Requirement &Req, llvm::json::OStream &OS);
-void serialize(const swift::GenericTypeParamType *Param,
-               llvm::json::OStream &OS);
+void serialize(const swift::GenericTypeParamType *Param, llvm::json::OStream &OS);
 
+void filterGenericParams(
+    TypeArrayView<GenericTypeParamType> GenericParams,
+    SmallVectorImpl<const GenericTypeParamType*> &FilteredParams,
+    SubstitutionMap SubMap = {});
 
 /// Filter generic requirements on an extension that aren't relevant
 /// for documentation.
-void
-filterGenericRequirements(ArrayRef<Requirement> Requirements,
-                          const NominalTypeDecl *Self,
-                          SmallVectorImpl<Requirement> &FilteredRequirements);
+void filterGenericRequirements(
+    ArrayRef<Requirement> Requirements, const NominalTypeDecl *Self,
+    SmallVectorImpl<Requirement> &FilteredRequirements,
+    SubstitutionMap SubMap = {},
+    ArrayRef<const GenericTypeParamType *> FilteredParams = {});
 
 /// Filter generic requirements on an extension that aren't relevant
 /// for documentation.

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -15,6 +15,7 @@
 
 #include "llvm/Support/JSON.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Markup/Markup.h"
 
@@ -30,6 +31,7 @@ class Symbol {
   /// The symbol graph in which this symbol resides.
   SymbolGraph *Graph;
   const ValueDecl *VD;
+  Type BaseType;
   const NominalTypeDecl *SynthesizedBaseTypeDecl;
 
   void serializeKind(StringRef Identifier, StringRef DisplayName,
@@ -72,7 +74,8 @@ class Symbol {
 
 public:
   Symbol(SymbolGraph *Graph, const ValueDecl *VD,
-         const NominalTypeDecl *SynthesizedBaseTypeDecl);
+         const NominalTypeDecl *SynthesizedBaseTypeDecl,
+         Type BaseTypeForSubstitution = Type());
 
   void serialize(llvm::json::OStream &OS) const;
 
@@ -84,12 +87,8 @@ public:
     return VD;
   }
 
-  Type getSynthesizedBaseType() const {
-    if (SynthesizedBaseTypeDecl) {
-      return SynthesizedBaseTypeDecl->getDeclaredInterfaceType();
-    } else {
-      return Type();
-    }
+  Type getBaseType() const {
+    return BaseType;
   }
 
   const NominalTypeDecl *getSynthesizedBaseTypeDecl() const {
@@ -102,6 +101,8 @@ public:
   void printPath(llvm::raw_ostream &OS) const;
 
   void getUSR(SmallVectorImpl<char> &USR) const;
+
+  static bool supportsKind(DeclKind Kind);
 };
 
 } // end namespace symbolgraphgen
@@ -117,6 +118,7 @@ template <> struct DenseMapInfo<Symbol> {
       DenseMapInfo<SymbolGraph *>::getEmptyKey(),
       DenseMapInfo<const swift::ValueDecl *>::getEmptyKey(),
       DenseMapInfo<const swift::NominalTypeDecl *>::getTombstoneKey(),
+      DenseMapInfo<swift::Type>::getEmptyKey(),
     };
   }
   static inline Symbol getTombstoneKey() {
@@ -124,6 +126,7 @@ template <> struct DenseMapInfo<Symbol> {
       DenseMapInfo<SymbolGraph *>::getTombstoneKey(),
       DenseMapInfo<const swift::ValueDecl *>::getTombstoneKey(),
       DenseMapInfo<const swift::NominalTypeDecl *>::getTombstoneKey(),
+      DenseMapInfo<swift::Type>::getTombstoneKey(),
     };
   }
   static unsigned getHashValue(const Symbol S) {
@@ -131,13 +134,16 @@ template <> struct DenseMapInfo<Symbol> {
     H ^= DenseMapInfo<SymbolGraph *>::getHashValue(S.getGraph());
     H ^= DenseMapInfo<const swift::ValueDecl *>::getHashValue(S.getSymbolDecl());
     H ^= DenseMapInfo<const swift::NominalTypeDecl *>::getHashValue(S.getSynthesizedBaseTypeDecl());
+    H ^= DenseMapInfo<swift::Type>::getHashValue(S.getBaseType());
     return H;
   }
   static bool isEqual(const Symbol LHS, const Symbol RHS) {
     return LHS.getGraph() == RHS.getGraph() &&
         LHS.getSymbolDecl() == RHS.getSymbolDecl() &&
         LHS.getSynthesizedBaseTypeDecl() ==
-            RHS.getSynthesizedBaseTypeDecl();
+            RHS.getSynthesizedBaseTypeDecl() &&
+        DenseMapInfo<swift::Type>::
+            isEqual(LHS.getBaseType(), RHS.getBaseType());
   }
 };
 } // end namespace llvm

--- a/lib/SymbolGraphGen/SymbolGraph.h
+++ b/lib/SymbolGraphGen/SymbolGraph.h
@@ -74,11 +74,17 @@ struct SymbolGraph {
    */
   llvm::DenseSet<Edge> Edges;
 
+  /**
+   True if this graph is for a single symbol, rather than an entire module.
+   */
+  bool IsForSingleNode;
+
   SymbolGraph(SymbolGraphASTWalker &Walker,
               ModuleDecl &M,
               Optional<ModuleDecl *> ExtendedModule,
               markup::MarkupContext &Ctx,
-              Optional<llvm::VersionTuple> ModuleVersion = None);
+              Optional<llvm::VersionTuple> ModuleVersion = None,
+              bool IsForSingleNode = false);
 
   // MARK: - Utilities
 
@@ -217,7 +223,7 @@ struct SymbolGraph {
 
   /// Get the overall declaration for a symbol.
   void
-  serializeDeclarationFragments(StringRef Key, Type T,
+  serializeDeclarationFragments(StringRef Key, Type T, Type BaseTy,
                                 llvm::json::OStream &OS);
 
   /// Returns `true` if the declaration has a name that makes it

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -100,13 +100,13 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
   return Success;
 }
 
-bool symbolgraphgen::
+int symbolgraphgen::
 printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
                         bool InSynthesizedExtension,
                         const SymbolGraphOptions &Options,
                         llvm::raw_ostream &OS) {
   if (!Symbol::supportsKind(D->getKind()))
-    return true;
+    return EXIT_FAILURE;
 
   llvm::json::OStream JOS(OS, Options.PrettyPrint ? 2 : 0);
   ModuleDecl *MD = D->getModuleContext();
@@ -121,5 +121,5 @@ printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
   Symbol MySym(&Graph, D, NTD, BaseTy);
   Graph.recordNode(MySym);
   Graph.serialize(JOS);
-  return false;
+  return EXIT_SUCCESS;
 }

--- a/test/SourceKit/ConformingMethods/basic.swift
+++ b/test/SourceKit/ConformingMethods/basic.swift
@@ -27,11 +27,11 @@ func testing(obj: C) {
 }
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s > %t.response
+// RUN:   -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='[$s8MyModule7Target2PD;$s8MyModule7Target1PD]' -- -module-name MyModule %s > %t.response
 // RUN: %diff -u %s.response %t.response
 // RUN: %sourcekitd-test \
 // RUN:   -req=global-config -req-opts=completion_max_astcontext_reuse_count=0 == \
-// RUN:   -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s | %FileCheck %s --check-prefix=DISABLED
+// RUN:   -req=conformingmethods -pos=26:14 -repeat-request=2 %s -req-opts=expectedtypes='[$s8MyModule7Target2PD;$s8MyModule7Target1PD]' -- -module-name MyModule %s | %FileCheck %s --check-prefix=DISABLED
 
 // DISABLED-NOT: key.reuseastcontext
 // DISABLED: key.members: [

--- a/test/SourceKit/ConformingMethods/generics.swift
+++ b/test/SourceKit/ConformingMethods/generics.swift
@@ -17,7 +17,7 @@ func test<X>(value: S<X>) {
   value.
 }
 
-// RUN: %sourcekitd-test -req=conformingmethods -pos=12:10 %s -req-opts=expectedtypes='$s8MyModule5ProtoPD' -- -module-name MyModule %s > %t.response.1
+// RUN: %sourcekitd-test -req=conformingmethods -pos=12:10 %s -req-opts=expectedtypes='[$s8MyModule5ProtoPD]' -- -module-name MyModule %s > %t.response.1
 // RUN: %diff -u %s.response.1 %t.response.1
-// RUN: %sourcekitd-test -req=conformingmethods -pos=17:8 %s -req-opts=expectedtypes='$s8MyModule5ProtoPD' -- -module-name MyModule %s > %t.response.2
+// RUN: %sourcekitd-test -req=conformingmethods -pos=17:8 %s -req-opts=expectedtypes='[$s8MyModule5ProtoPD]' -- -module-name MyModule %s > %t.response.2
 // RUN: %diff -u %s.response.2 %t.response.2

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -742,7 +742,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK88-NEXT: $s
 // CHECK88-NEXT: <Declaration>func hasLocalizationKey2()</Declaration>
 // CHECK88-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hasLocalizationKey2</decl.name>()</decl.function.free>
-// CHECK88-NEXT: <Function file="{{[^"]+}}cursor_info.swift" line="216" column="6"><Name>hasLocalizationKey2()</Name><USR>s:11cursor_info19hasLocalizationKey2yyF</USR><Declaration>func hasLocalizationKey2()</Declaration><CommentParts></CommentParts></Function
+// CHECK88-NEXT: <Function file="{{[^"]+}}cursor_info.swift" line="216" column="6"><Name>hasLocalizationKey2()</Name><USR>s:11cursor_info19hasLocalizationKey2yyF</USR><Declaration>func hasLocalizationKey2()</Declaration><CommentParts></CommentParts></Function>
 // CHECK88-NEXT: <LocalizationKey>ABC</LocalizationKey>
 
 // RUN: %sourcekitd-test -req=cursor -pos=219:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK89 %s

--- a/test/SourceKit/CursorInfo/cursor_info_cross_import_common_case.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_cross_import_common_case.swift
@@ -24,16 +24,30 @@ fromOverlaidClangFrameworkOverlay()
 fromOverlaidClangFrameworkCrossImport()
 
 
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=10:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks %s  | %FileCheck -check-prefix=CHECKSWIFT %s
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=11:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks %s  | %FileCheck -check-prefix=CHECKSWIFT %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=10:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks %s  | %FileCheck -check-prefixes=CHECKSWIFT,CHECKNOBYSTANDERS %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=11:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks %s  | %FileCheck -check-prefixes=CHECKSWIFT,CHECKBYSTANDERS %s
 
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=16:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKCLANG %s
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=17:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKCLANG %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=16:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefixes=CHECKCLANG,CHECKNOBYSTANDERS %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=17:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefixes=CHECKCLANG,CHECKBYSTANDERS %s
 
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=22:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKOVERLAID %s
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=23:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKOVERLAID %s
-// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=24:1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefix=CHECKOVERLAID %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=22:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefixes=CHECKOVERLAID,CHECKNOBYSTANDERS %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=23:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefixes=CHECKOVERLAID,CHECKNOBYSTANDERS %s
+// RUN: %sourcekitd-test -req=cursor -print-raw-response -pos=24:1 -req-opts=retrieve_symbol_graph=1 %s -- -target %target-triple -Xfrontend -enable-cross-import-overlays -I %t/include -I %t/lib/swift -F %t/Frameworks  %s | %FileCheck -check-prefixes=CHECKOVERLAID,CHECKBYSTANDERS %s
 
 // CHECKSWIFT: key.modulename: "SwiftFramework"
+// CHECKSWIFT:      key.symbol_graph: "{
+// CHECKSWIFT-SAME:   \"module\":{
+// CHECKSWIFT-SAME:      \"name\":\"SwiftFramework\"
+
 // CHECKCLANG: key.modulename: "ClangFramework"
+// CHECKCLANG:      key.symbol_graph: "{
+// CHECKCLANG-SAME:   \"module\":{
+// CHECKCLANG-SAME:      \"name\":\"ClangFramework\"
+
 // CHECKOVERLAID: key.modulename: "OverlaidClangFramework"
+// CHECKOVERLAID:      key.symbol_graph: "{
+// CHECKOVERLAID-SAME:   \"module\":{
+// CHECKOVERLAID-SAME:      \"name\":\"OverlaidClangFramework\"
+
+// CHECKBYSTANDERS:  \"bystanders\":[\"BystandingLibrary\"]
+// CHECKNOBYSTANDERS-NOT: \"bystanders\":

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -56,9 +56,186 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: (<Type usr="s:13cursor_stdlib2S1V">S1</Type>
 // CHECK-REPLACEMENT3: sorted()</RelatedName>
 
-// RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
+// RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=18:8 %s -- %s -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT4: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:13cursor_stdlib2S1V">S1</Type>)</Declaration>
+// CHECK-REPLACEMENT4: SYMBOL GRAPH BEGIN
+// CHECK-REPLACEMENT4: {
+// CHECK-REPLACEMENT4:   "module": {
+// CHECK-REPLACEMENT4:     "name": "Swift",
+// CHECK-REPLACEMENT4:   },
+// CHECK-REPLACEMENT4:   "relationships": [
+// CHECK-REPLACEMENT4:     {
+// CHECK-REPLACEMENT4:       "kind": "memberOf",
+// CHECK-REPLACEMENT4:       "source": "s:Sa6appendyyxnF",
+// CHECK-REPLACEMENT4:       "target": "s:Sa"
+// CHECK-REPLACEMENT4:     }
+// CHECK-REPLACEMENT4:   ],
+// CHECK-REPLACEMENT4:   "symbols": [
+// CHECK-REPLACEMENT4:     {
+// CHECK-REPLACEMENT4:       "accessLevel": "public",
+// CHECK-REPLACEMENT4:       "declarationFragments": [
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "keyword",
+// CHECK-REPLACEMENT4:           "spelling": "mutating"
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "text",
+// CHECK-REPLACEMENT4:           "spelling": " "
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "keyword",
+// CHECK-REPLACEMENT4:           "spelling": "func"
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "text",
+// CHECK-REPLACEMENT4:           "spelling": " "
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "identifier",
+// CHECK-REPLACEMENT4:           "spelling": "append"
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "text",
+// CHECK-REPLACEMENT4:           "spelling": "("
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "externalParam",
+// CHECK-REPLACEMENT4:           "spelling": "_"
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "text",
+// CHECK-REPLACEMENT4:           "spelling": " "
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "internalParam",
+// CHECK-REPLACEMENT4:           "spelling": "newElement"
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "text",
+// CHECK-REPLACEMENT4:           "spelling": ": "
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "typeIdentifier",
+// CHECK-REPLACEMENT4:           "preciseIdentifier": "s:13cursor_stdlib2S1V",
+// CHECK-REPLACEMENT4:           "spelling": "S1"
+// CHECK-REPLACEMENT4:         },
+// CHECK-REPLACEMENT4:         {
+// CHECK-REPLACEMENT4:           "kind": "text",
+// CHECK-REPLACEMENT4:           "spelling": ")"
+// CHECK-REPLACEMENT4:         }
+// CHECK-REPLACEMENT4:       ],
+// CHECK-REPLACEMENT4:       "docComment": {
+// CHECK-REPLACEMENT4:         "lines": [
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "text": "Adds a new element at the end of the array."
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:         ]
+// CHECK-REPLACEMENT4:       },
+// CHECK-REPLACEMENT4:       "functionSignature": {
+// CHECK-REPLACEMENT4:         "parameters": [
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "declarationFragments": [
+// CHECK-REPLACEMENT4:               {
+// CHECK-REPLACEMENT4:                 "kind": "identifier",
+// CHECK-REPLACEMENT4:                 "spelling": "newElement"
+// CHECK-REPLACEMENT4:               },
+// CHECK-REPLACEMENT4:               {
+// CHECK-REPLACEMENT4:                 "kind": "text",
+// CHECK-REPLACEMENT4:                 "spelling": ": "
+// CHECK-REPLACEMENT4:               },
+// CHECK-REPLACEMENT4:               {
+// CHECK-REPLACEMENT4:                 "kind": "typeIdentifier",
+// CHECK-REPLACEMENT4:                 "preciseIdentifier": "s:13cursor_stdlib2S1V",
+// CHECK-REPLACEMENT4:                 "spelling": "S1"
+// CHECK-REPLACEMENT4:               }
+// CHECK-REPLACEMENT4:             ],
+// CHECK-REPLACEMENT4:             "name": "newElement"
+// CHECK-REPLACEMENT4:           }
+// CHECK-REPLACEMENT4:         ],
+// CHECK-REPLACEMENT4:         "returns": [
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": "()"
+// CHECK-REPLACEMENT4:           }
+// CHECK-REPLACEMENT4:         ]
+// CHECK-REPLACEMENT4:       },
+// CHECK-REPLACEMENT4:       "identifier": {
+// CHECK-REPLACEMENT4:         "interfaceLanguage": "swift",
+// CHECK-REPLACEMENT4:         "precise": "s:Sa6appendyyxnF"
+// CHECK-REPLACEMENT4:       },
+// CHECK-REPLACEMENT4:       "kind": {
+// CHECK-REPLACEMENT4:         "displayName": "Instance Method",
+// CHECK-REPLACEMENT4:         "identifier": "swift.method"
+// CHECK-REPLACEMENT4:       },
+// CHECK-REPLACEMENT4:       "names": {
+// CHECK-REPLACEMENT4:         "navigator": [
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "keyword",
+// CHECK-REPLACEMENT4:             "spelling": "func"
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": " "
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "identifier",
+// CHECK-REPLACEMENT4:             "spelling": "append"
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": "("
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "typeIdentifier",
+// CHECK-REPLACEMENT4:             "preciseIdentifier": "s:13cursor_stdlib2S1V",
+// CHECK-REPLACEMENT4:             "spelling": "S1"
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": ")"
+// CHECK-REPLACEMENT4:           }
+// CHECK-REPLACEMENT4:         ],
+// CHECK-REPLACEMENT4:         "subHeading": [
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "keyword",
+// CHECK-REPLACEMENT4:             "spelling": "func"
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": " "
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "identifier",
+// CHECK-REPLACEMENT4:             "spelling": "append"
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": "("
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "typeIdentifier",
+// CHECK-REPLACEMENT4:             "preciseIdentifier": "s:13cursor_stdlib2S1V",
+// CHECK-REPLACEMENT4:             "spelling": "S1"
+// CHECK-REPLACEMENT4:           },
+// CHECK-REPLACEMENT4:           {
+// CHECK-REPLACEMENT4:             "kind": "text",
+// CHECK-REPLACEMENT4:             "spelling": ")"
+// CHECK-REPLACEMENT4:           }
+// CHECK-REPLACEMENT4:         ],
+// CHECK-REPLACEMENT4:         "title": "append(_:)"
+// CHECK-REPLACEMENT4:       },
+// CHECK-REPLACEMENT4:       "pathComponents": [
+// CHECK-REPLACEMENT4:         "Array",
+// CHECK-REPLACEMENT4:         "append(_:)"
+// CHECK-REPLACEMENT4:       ],
+// CHECK-REPLACEMENT4:       "swiftExtension": {
+// CHECK-REPLACEMENT4:         "extendedModule": "Swift"
+// CHECK-REPLACEMENT4:       }
+// CHECK-REPLACEMENT4:     }
+// CHECK-REPLACEMENT4:   ]
+// CHECK-REPLACEMENT4: }
+// CHECK-REPLACEMENT4: SYMBOL GRAPH END
 
 // RUN: %sourcekitd-test -req=cursor -pos=21:10 %s -- %s -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-MODULE-GROUP1 %s
 // CHECK-MODULE-GROUP1: MODULE GROUPS BEGIN

--- a/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
+++ b/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
@@ -37,4 +37,3 @@ func test() {
 // CHECK-NEXT: SYSTEM
 // CHECK-NEXT: <Declaration>func someFunc()</Declaration>
 // CHECK-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>someFunc</decl.name>()</decl.function.free>
-// CHECK-NEXT: </LocalizationKey>

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
@@ -1,0 +1,860 @@
+/// Something about x
+let x = 1
+_ = x
+
+/**
+ Something about y
+ */
+private var y: String { return "hello" }
+_ = y
+
+/// Something about
+/// Foo
+struct Foo<T> {
+    /** Something about bar */
+    func bar(x: T) where T: Equatable {}
+}
+Foo<Int>().bar(x: 1)
+Foo<String>().bar(x: "hello")
+
+extension Foo where T == Int {
+    func blah() {
+        bar(x: 4)
+    }
+}
+
+/// MyEnum doc.
+enum MyEnum {
+    /// Text in a code line with no indicated semantic meaning.
+    case someCase
+}
+
+// RUN:  %sourcekitd-test -req=cursor -pos=2:5 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKX %s
+// RUN:  %sourcekitd-test -req=cursor -pos=3:5 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKX %s
+
+// RUN:  %sourcekitd-test -req=cursor -pos=8:13 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKY %s
+// RUN:  %sourcekitd-test -req=cursor -pos=9:5 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKY %s
+
+// RUN:  %sourcekitd-test -req=cursor -pos=13:8 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKFOO %s
+// RUN:  %sourcekitd-test -req=cursor -pos=17:1 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKFOO %s
+// RUN:  %sourcekitd-test -req=cursor -pos=18:1 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKFOO %s
+// RUN:  %sourcekitd-test -req=cursor -pos=20:11 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CHECKFOO %s
+
+// RUN:  %sourcekitd-test -req=cursor -pos=15:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefixes=CHECKBAR_ALL,CHECKBAR_GEN %s
+// RUN:  %sourcekitd-test -req=cursor -pos=17:12 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefixes=CHECKBAR_ALL,CHECKBAR_INT %s
+// RUN:  %sourcekitd-test -req=cursor -pos=22:9 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefixes=CHECKBAR_ALL,CHECKBAR_INT %s
+// RUN:  %sourcekitd-test -req=cursor -pos=18:15 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefixes=CHECKBAR_ALL,CHECKBAR_STR %s
+
+// RUN:  %sourcekitd-test -req=cursor -pos=29:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefixes=CHECKCASE %s
+
+
+// CHECKX: SYMBOL GRAPH BEGIN
+// CHECKX: {
+// CHECKX:   "metadata": {
+// CHECKX:     "formatVersion": {
+// CHECKX:       "major":
+// CHECKX:       "minor":
+// CHECKX:       "patch":
+// CHECKX:     },
+// CHECKX:     "generator":
+// CHECKX:   },
+// CHECKX:   "module": {
+// CHECKX:     "name": "cursor_symbol_graph",
+// CHECKX:     "platform": {
+// CHECKX:       "architecture":
+// CHECKX:       "operatingSystem":
+// CHECKX:       "vendor":
+// CHECKX:     }
+// CHECKX:   },
+// CHECKX:   "relationships": [],
+// CHECKX:   "symbols": [
+// CHECKX:     {
+// CHECKX:       "accessLevel": "internal",
+// CHECKX:       "declarationFragments": [
+// CHECKX:         {
+// CHECKX:           "kind": "keyword",
+// CHECKX:           "spelling": "let"
+// CHECKX:         },
+// CHECKX:         {
+// CHECKX:           "kind": "text",
+// CHECKX:           "spelling": " "
+// CHECKX:         },
+// CHECKX:         {
+// CHECKX:           "kind": "identifier",
+// CHECKX:           "spelling": "x"
+// CHECKX:         },
+// CHECKX:         {
+// CHECKX:           "kind": "text",
+// CHECKX:           "spelling": ": "
+// CHECKX:         },
+// CHECKX:         {
+// CHECKX:           "kind": "typeIdentifier",
+// CHECKX:           "preciseIdentifier": "s:Si",
+// CHECKX:           "spelling": "Int"
+// CHECKX:         }
+// CHECKX:       ],
+// CHECKX:       "docComment": {
+// CHECKX:         "lines": [
+// CHECKX:           {
+// CHECKX:             "range": {
+// CHECKX:               "end": {
+// CHECKX:                 "character": 21,
+// CHECKX:                 "line": 0
+// CHECKX:               },
+// CHECKX:               "start": {
+// CHECKX:                 "character": 4,
+// CHECKX:                 "line": 0
+// CHECKX:               }
+// CHECKX:             },
+// CHECKX:             "text": "Something about x"
+// CHECKX:           }
+// CHECKX:         ]
+// CHECKX:       },
+// CHECKX:       "identifier": {
+// CHECKX:         "interfaceLanguage": "swift",
+// CHECKX:         "precise": "s:19cursor_symbol_graph1xSivp"
+// CHECKX:       },
+// CHECKX:       "kind": {
+// CHECKX:         "displayName": "Global Variable",
+// CHECKX:         "identifier": "swift.var"
+// CHECKX:       },
+// CHECKX:       "location": {
+// CHECKX:         "position": {
+// CHECKX:           "character": 4,
+// CHECKX:           "line": 1
+// CHECKX:         },
+// CHECKX:         "uri": "{{.*}}cursor_symbol_graph.swift"
+// CHECKX:       },
+// CHECKX:       "names": {
+// CHECKX:         "navigator": [
+// CHECKX:           {
+// CHECKX:             "kind": "keyword",
+// CHECKX:             "spelling": "let"
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "text",
+// CHECKX:             "spelling": " "
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "identifier",
+// CHECKX:             "spelling": "x"
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "text",
+// CHECKX:             "spelling": ": "
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "typeIdentifier",
+// CHECKX:             "preciseIdentifier": "s:Si",
+// CHECKX:             "spelling": "Int"
+// CHECKX:           }
+// CHECKX:         ],
+// CHECKX:         "subHeading": [
+// CHECKX:           {
+// CHECKX:             "kind": "keyword",
+// CHECKX:             "spelling": "let"
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "text",
+// CHECKX:             "spelling": " "
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "identifier",
+// CHECKX:             "spelling": "x"
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "text",
+// CHECKX:             "spelling": ": "
+// CHECKX:           },
+// CHECKX:           {
+// CHECKX:             "kind": "typeIdentifier",
+// CHECKX:             "preciseIdentifier": "s:Si",
+// CHECKX:             "spelling": "Int"
+// CHECKX:           }
+// CHECKX:         ],
+// CHECKX:         "title": "x"
+// CHECKX:       },
+// CHECKX:       "pathComponents": [
+// CHECKX:         "x"
+// CHECKX:       ]
+// CHECKX:     }
+// CHECKX:   ]
+// CHECKX: }
+// CHECKX: SYMBOL GRAPH END
+
+
+// CHECKY: SYMBOL GRAPH BEGIN
+// CHECKY: {
+// CHECKY:   "metadata": {
+// CHECKY:     "formatVersion": {
+// CHECKY:       "major":
+// CHECKY:       "minor":
+// CHECKY:       "patch":
+// CHECKY:     },
+// CHECKY:     "generator":
+// CHECKY:   },
+// CHECKY:   "module": {
+// CHECKY:     "name": "cursor_symbol_graph",
+// CHECKY:     "platform": {
+// CHECKY:       "architecture":
+// CHECKY:       "operatingSystem":
+// CHECKY:       "vendor":
+// CHECKY:     }
+// CHECKY:   },
+// CHECKY:   "relationships": [],
+// CHECKY:   "symbols": [
+// CHECKY:     {
+// CHECKY:       "accessLevel": "private",
+// CHECKY:       "declarationFragments": [
+// CHECKY:         {
+// CHECKY:           "kind": "keyword",
+// CHECKY:           "spelling": "private"
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "text",
+// CHECKY:           "spelling": " "
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "keyword",
+// CHECKY:           "spelling": "var"
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "text",
+// CHECKY:           "spelling": " "
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "identifier",
+// CHECKY:           "spelling": "y"
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "text",
+// CHECKY:           "spelling": ": "
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "typeIdentifier",
+// CHECKY:           "preciseIdentifier": "s:SS",
+// CHECKY:           "spelling": "String"
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "text",
+// CHECKY:           "spelling": " { "
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "keyword",
+// CHECKY:           "spelling": "get"
+// CHECKY:         },
+// CHECKY:         {
+// CHECKY:           "kind": "text",
+// CHECKY:           "spelling": " }"
+// CHECKY:         }
+// CHECKY:       ],
+// CHECKY:       "docComment": {
+// CHECKY:         "lines": [
+// CHECKY:           {
+// CHECKY:             "range": {
+// CHECKY:               "end": {
+// CHECKY:                 "character": 18,
+// CHECKY:                 "line": 5
+// CHECKY:               },
+// CHECKY:               "start": {
+// CHECKY:                 "character": 1,
+// CHECKY:                 "line": 5
+// CHECKY:               }
+// CHECKY:             },
+// CHECKY:             "text": "Something about y"
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "range": {
+// CHECKY:               "end": {
+// CHECKY:                 "character": 1,
+// CHECKY:                 "line": 6
+// CHECKY:               },
+// CHECKY:               "start": {
+// CHECKY:                 "character": 1,
+// CHECKY:                 "line": 6
+// CHECKY:               }
+// CHECKY:             },
+// CHECKY:             "text": ""
+// CHECKY:           }
+// CHECKY:         ]
+// CHECKY:       },
+// CHECKY:       "identifier": {
+// CHECKY:         "interfaceLanguage": "swift",
+// CHECKY:         "precise": "s:19cursor_symbol_graph1y33_153B1E8D9396FFABCE21DE5D3EC1833ALLSSvp"
+// CHECKY:       },
+// CHECKY:       "kind": {
+// CHECKY:         "displayName": "Global Variable",
+// CHECKY:         "identifier": "swift.var"
+// CHECKY:       },
+// CHECKY:       "location": {
+// CHECKY:         "position": {
+// CHECKY:           "character": 12,
+// CHECKY:           "line": 7
+// CHECKY:         },
+// CHECKY:         "uri": "{{.*}}cursor_symbol_graph.swift"
+// CHECKY:       },
+// CHECKY:       "names": {
+// CHECKY:         "navigator": [
+// CHECKY:           {
+// CHECKY:             "kind": "keyword",
+// CHECKY:             "spelling": "var"
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "text",
+// CHECKY:             "spelling": " "
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "identifier",
+// CHECKY:             "spelling": "y"
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "text",
+// CHECKY:             "spelling": ": "
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "typeIdentifier",
+// CHECKY:             "preciseIdentifier": "s:SS",
+// CHECKY:             "spelling": "String"
+// CHECKY:           }
+// CHECKY:         ],
+// CHECKY:         "subHeading": [
+// CHECKY:           {
+// CHECKY:             "kind": "keyword",
+// CHECKY:             "spelling": "var"
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "text",
+// CHECKY:             "spelling": " "
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "identifier",
+// CHECKY:             "spelling": "y"
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "text",
+// CHECKY:             "spelling": ": "
+// CHECKY:           },
+// CHECKY:           {
+// CHECKY:             "kind": "typeIdentifier",
+// CHECKY:             "preciseIdentifier": "s:SS",
+// CHECKY:             "spelling": "String"
+// CHECKY:           }
+// CHECKY:         ],
+// CHECKY:         "title": "y"
+// CHECKY:       },
+// CHECKY:       "pathComponents": [
+// CHECKY:         "y"
+// CHECKY:       ]
+// CHECKY:     }
+// CHECKY:   ]
+// CHECKY: }
+// CHECKY: SYMBOL GRAPH END
+
+
+// CHECKFOO: SYMBOL GRAPH BEGIN
+// CHECKFOO: {
+// CHECKFOO:   "metadata": {
+// CHECKFOO:     "formatVersion": {
+// CHECKFOO:       "major":
+// CHECKFOO:       "minor":
+// CHECKFOO:       "patch":
+// CHECKFOO:     },
+// CHECKFOO:     "generator":
+// CHECKFOO:   },
+// CHECKFOO:   "module": {
+// CHECKFOO:     "name": "cursor_symbol_graph",
+// CHECKFOO:     "platform": {
+// CHECKFOO:       "architecture":
+// CHECKFOO:       "operatingSystem":
+// CHECKFOO:       "vendor":
+// CHECKFOO:     }
+// CHECKFOO:   },
+// CHECKFOO:   "relationships": [],
+// CHECKFOO:   "symbols": [
+// CHECKFOO:     {
+// CHECKFOO:       "accessLevel": "internal",
+// CHECKFOO:       "declarationFragments": [
+// CHECKFOO:         {
+// CHECKFOO:           "kind": "keyword",
+// CHECKFOO:           "spelling": "struct"
+// CHECKFOO:         },
+// CHECKFOO:         {
+// CHECKFOO:           "kind": "text",
+// CHECKFOO:           "spelling": " "
+// CHECKFOO:         },
+// CHECKFOO:         {
+// CHECKFOO:           "kind": "identifier",
+// CHECKFOO:           "spelling": "Foo"
+// CHECKFOO:         },
+// CHECKFOO:         {
+// CHECKFOO:           "kind": "text",
+// CHECKFOO:           "spelling": "<"
+// CHECKFOO:         },
+// CHECKFOO:         {
+// CHECKFOO:           "kind": "genericParameter",
+// CHECKFOO:           "spelling": "T"
+// CHECKFOO:         },
+// CHECKFOO:         {
+// CHECKFOO:           "kind": "text",
+// CHECKFOO:           "spelling": ">"
+// CHECKFOO:         }
+// CHECKFOO:       ],
+// CHECKFOO:       "docComment": {
+// CHECKFOO:         "lines": [
+// CHECKFOO:           {
+// CHECKFOO:             "range": {
+// CHECKFOO:               "end": {
+// CHECKFOO:                 "character": 19,
+// CHECKFOO:                 "line": 10
+// CHECKFOO:               },
+// CHECKFOO:               "start": {
+// CHECKFOO:                 "character": 4,
+// CHECKFOO:                 "line": 10
+// CHECKFOO:               }
+// CHECKFOO:             },
+// CHECKFOO:             "text": "Something about"
+// CHECKFOO:           },
+// CHECKFOO:           {
+// CHECKFOO:             "range": {
+// CHECKFOO:               "end": {
+// CHECKFOO:                 "character": 7,
+// CHECKFOO:                 "line": 11
+// CHECKFOO:               },
+// CHECKFOO:               "start": {
+// CHECKFOO:                 "character": 4,
+// CHECKFOO:                 "line": 11
+// CHECKFOO:               }
+// CHECKFOO:             },
+// CHECKFOO:             "text": "Foo"
+// CHECKFOO:           }
+// CHECKFOO:         ]
+// CHECKFOO:       },
+// CHECKFOO:       "identifier": {
+// CHECKFOO:         "interfaceLanguage": "swift",
+// CHECKFOO:         "precise": "s:19cursor_symbol_graph3FooV"
+// CHECKFOO:       },
+// CHECKFOO:       "kind": {
+// CHECKFOO:         "displayName": "Structure",
+// CHECKFOO:         "identifier": "swift.struct"
+// CHECKFOO:       },
+// CHECKFOO:       "location": {
+// CHECKFOO:         "position": {
+// CHECKFOO:           "character": 7,
+// CHECKFOO:           "line": 12
+// CHECKFOO:         },
+// CHECKFOO:         "uri": "{{.*}}cursor_symbol_graph.swift"
+// CHECKFOO:       },
+// CHECKFOO:       "names": {
+// CHECKFOO:         "navigator": [
+// CHECKFOO:           {
+// CHECKFOO:             "kind": "identifier",
+// CHECKFOO:             "spelling": "Foo"
+// CHECKFOO:           }
+// CHECKFOO:         ],
+// CHECKFOO:         "subHeading": [
+// CHECKFOO:           {
+// CHECKFOO:             "kind": "keyword",
+// CHECKFOO:             "spelling": "struct"
+// CHECKFOO:           },
+// CHECKFOO:           {
+// CHECKFOO:             "kind": "text",
+// CHECKFOO:             "spelling": " "
+// CHECKFOO:           },
+// CHECKFOO:           {
+// CHECKFOO:             "kind": "identifier",
+// CHECKFOO:             "spelling": "Foo"
+// CHECKFOO:           }
+// CHECKFOO:         ],
+// CHECKFOO:         "title": "Foo"
+// CHECKFOO:       },
+// CHECKFOO:       "pathComponents": [
+// CHECKFOO:         "Foo"
+// CHECKFOO:       ],
+// CHECKFOO:       "swiftGenerics": {
+// CHECKFOO:         "parameters": [
+// CHECKFOO:           {
+// CHECKFOO:             "depth": 0,
+// CHECKFOO:             "index": 0,
+// CHECKFOO:             "name": "T"
+// CHECKFOO:           }
+// CHECKFOO:         ]
+// CHECKFOO:       }
+// CHECKFOO:     }
+// CHECKFOO:   ]
+// CHECKFOO: }
+
+
+// CHECKBAR_ALL: SYMBOL GRAPH BEGIN
+// CHECKBAR_ALL: {
+// CHECKBAR_ALL:   "metadata": {
+// CHECKBAR_ALL:     "formatVersion": {
+// CHECKBAR_ALL:       "major":
+// CHECKBAR_ALL:       "minor":
+// CHECKBAR_ALL:       "patch":
+// CHECKBAR_ALL:     },
+// CHECKBAR_ALL:     "generator":
+// CHECKBAR_ALL:   },
+// CHECKBAR_ALL:   "module": {
+// CHECKBAR_ALL:     "name": "cursor_symbol_graph",
+// CHECKBAR_ALL:     "platform": {
+// CHECKBAR_ALL:       "architecture":
+// CHECKBAR_ALL:       "operatingSystem":
+// CHECKBAR_ALL:       "vendor":
+// CHECKBAR_ALL:     }
+// CHECKBAR_ALL:   },
+// CHECKBAR_ALL:   "relationships": [
+// CHECKBAR_ALL:     {
+// CHECKBAR_ALL:       "kind": "memberOf",
+// CHECKBAR_ALL:       "source": "s:19cursor_symbol_graph3FooV3bar1xyx_tSQRzlF",
+// CHECKBAR_ALL:       "target": "s:19cursor_symbol_graph3FooV"
+// CHECKBAR_ALL:     }
+// CHECKBAR_ALL:   ],
+// CHECKBAR_ALL:   "symbols": [
+// CHECKBAR_ALL:     {
+// CHECKBAR_ALL:       "accessLevel": "internal",
+// CHECKBAR_ALL:       "declarationFragments": [
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "keyword",
+// CHECKBAR_ALL:           "spelling": "func"
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "text",
+// CHECKBAR_ALL:           "spelling": " "
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "identifier",
+// CHECKBAR_ALL:           "spelling": "bar"
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "text",
+// CHECKBAR_ALL:           "spelling": "("
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "externalParam",
+// CHECKBAR_ALL:           "spelling": "x"
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "text",
+// CHECKBAR_ALL:           "spelling": ": "
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "typeIdentifier",
+// CHECKBAR_GEN:           "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
+// CHECKBAR_GEN:           "spelling": "T"
+// CHECKBAR_INT:           "preciseIdentifier": "s:Si",
+// CHECKBAR_INT:           "spelling": "Int"
+// CHECKBAR_STR:           "preciseIdentifier": "s:SS",
+// CHECKBAR_STR:           "spelling": "String"
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         {
+// CHECKBAR_ALL:           "kind": "text",
+// CHECKBAR_GEN:           "spelling": ") "
+// CHECKBAR_INT:           "spelling": ")"
+// CHECKBAR_STR:           "spelling": ")"
+// CHECKBAR_INT-NOT:       where
+// CHECKBAR_STR-NOT:       where
+// CHECKBAR_GEN:         },
+// CHECKBAR_GEN:         {
+// CHECKBAR_GEN:           "kind": "keyword",
+// CHECKBAR_GEN:           "spelling": "where"
+// CHECKBAR_GEN:         },
+// CHECKBAR_GEN:         {
+// CHECKBAR_GEN:           "kind": "text",
+// CHECKBAR_GEN:           "spelling": " "
+// CHECKBAR_GEN:         },
+// CHECKBAR_GEN:         {
+// CHECKBAR_GEN:           "kind": "typeIdentifier",
+// CHECKBAR_GEN:           "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
+// CHECKBAR_GEN:           "spelling": "T"
+// CHECKBAR_GEN:         },
+// CHECKBAR_GEN:         {
+// CHECKBAR_GEN:           "kind": "text",
+// CHECKBAR_GEN:           "spelling": " : "
+// CHECKBAR_GEN:         },
+// CHECKBAR_GEN:         {
+// CHECKBAR_GEN:           "kind": "typeIdentifier",
+// CHECKBAR_GEN:           "preciseIdentifier": "s:SQ",
+// CHECKBAR_GEN:           "spelling": "Equatable"
+// CHECKBAR_ALL:         }
+// CHECKBAR_ALL:       ],
+// CHECKBAR_ALL:       "docComment": {
+// CHECKBAR_ALL:         "lines": [
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "range": {
+// CHECKBAR_ALL:               "end": {
+// CHECKBAR_ALL:                 "character": 28,
+// CHECKBAR_ALL:                 "line": 13
+// CHECKBAR_ALL:               },
+// CHECKBAR_ALL:               "start": {
+// CHECKBAR_ALL:                 "character": 8,
+// CHECKBAR_ALL:                 "line": 13
+// CHECKBAR_ALL:               }
+// CHECKBAR_ALL:             },
+// CHECKBAR_ALL:             "text": "Something about bar "
+// CHECKBAR_ALL:           }
+// CHECKBAR_ALL:         ]
+// CHECKBAR_ALL:       },
+// CHECKBAR_ALL:       "functionSignature": {
+// CHECKBAR_ALL:         "parameters": [
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "declarationFragments": [
+// CHECKBAR_ALL:               {
+// CHECKBAR_ALL:                 "kind": "identifier",
+// CHECKBAR_ALL:                 "spelling": "x"
+// CHECKBAR_ALL:               },
+// CHECKBAR_ALL:               {
+// CHECKBAR_ALL:                 "kind": "text",
+// CHECKBAR_ALL:                 "spelling": ": "
+// CHECKBAR_ALL:               },
+// CHECKBAR_ALL:               {
+// CHECKBAR_ALL:                 "kind": "typeIdentifier",
+// CHECKBAR_GEN:                 "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
+// CHECKBAR_GEN:                 "spelling": "T"
+// CHECKBAR_INT:                 "preciseIdentifier": "s:Si",
+// CHECKBAR_INT:                 "spelling": "Int"
+// CHECKBAR_STR:                 "preciseIdentifier": "s:SS",
+// CHECKBAR_STR:                 "spelling": "String"
+// CHECKBAR_ALL:               }
+// CHECKBAR_ALL:             ],
+// CHECKBAR_ALL:             "name": "x"
+// CHECKBAR_ALL:           }
+// CHECKBAR_ALL:         ],
+// CHECKBAR_ALL:         "returns": [
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": "()"
+// CHECKBAR_ALL:           }
+// CHECKBAR_ALL:         ]
+// CHECKBAR_ALL:       },
+// CHECKBAR_ALL:       "identifier": {
+// CHECKBAR_ALL:         "interfaceLanguage": "swift",
+// CHECKBAR_ALL:         "precise": "s:19cursor_symbol_graph3FooV3bar1xyx_tSQRzlF"
+// CHECKBAR_ALL:       },
+// CHECKBAR_ALL:       "kind": {
+// CHECKBAR_ALL:         "displayName": "Instance Method",
+// CHECKBAR_ALL:         "identifier": "swift.method"
+// CHECKBAR_ALL:       },
+// CHECKBAR_ALL:       "location": {
+// CHECKBAR_ALL:         "position": {
+// CHECKBAR_ALL:           "character": 9,
+// CHECKBAR_ALL:           "line": 14
+// CHECKBAR_ALL:         },
+// CHECKBAR_ALL:         "uri": "{{.*}}cursor_symbol_graph.swift"
+// CHECKBAR_ALL:       },
+// CHECKBAR_ALL:       "names": {
+// CHECKBAR_ALL:         "navigator": [
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "keyword",
+// CHECKBAR_ALL:             "spelling": "func"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": " "
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "identifier",
+// CHECKBAR_ALL:             "spelling": "bar"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": "("
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "externalParam",
+// CHECKBAR_ALL:             "spelling": "x"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": ": "
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "typeIdentifier",
+// CHECKBAR_GEN:             "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
+// CHECKBAR_GEN:             "spelling": "T"
+// CHECKBAR_INT:             "preciseIdentifier": "s:Si",
+// CHECKBAR_INT:             "spelling": "Int"
+// CHECKBAR_STR:             "preciseIdentifier": "s:SS",
+// CHECKBAR_STR:             "spelling": "String"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": ")"
+// CHECKBAR_ALL:           }
+// CHECKBAR_ALL:         ],
+// CHECKBAR_ALL:         "subHeading": [
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "keyword",
+// CHECKBAR_ALL:             "spelling": "func"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": " "
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "identifier",
+// CHECKBAR_ALL:             "spelling": "bar"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": "("
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "externalParam",
+// CHECKBAR_ALL:             "spelling": "x"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": ": "
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "typeIdentifier",
+// CHECKBAR_GEN:             "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
+// CHECKBAR_GEN:             "spelling": "T"
+// CHECKBAR_INT:             "preciseIdentifier": "s:Si",
+// CHECKBAR_INT:             "spelling": "Int"
+// CHECKBAR_STR:             "preciseIdentifier": "s:SS",
+// CHECKBAR_STR:             "spelling": "String"
+// CHECKBAR_ALL:           },
+// CHECKBAR_ALL:           {
+// CHECKBAR_ALL:             "kind": "text",
+// CHECKBAR_ALL:             "spelling": ")"
+// CHECKBAR_ALL:           }
+// CHECKBAR_ALL:         ],
+// CHECKBAR_ALL:         "title": "bar(x:)"
+// CHECKBAR_ALL:       },
+// CHECKBAR_ALL:       "pathComponents": [
+// CHECKBAR_ALL:         "Foo",
+// CHECKBAR_ALL:         "bar(x:)"
+// CHECKBAR_GEN:       ],
+// CHECKBAR_INT-NOT:   "swiftGenerics":
+// CHECKBAR_STR-NOT:   "swiftGenerics":
+// CHECKBAR_GEN:       "swiftGenerics": {
+// CHECKBAR_GEN:         "constraints": [
+// CHECKBAR_GEN:           {
+// CHECKBAR_GEN:             "kind": "conformance",
+// CHECKBAR_GEN:             "lhs": "T",
+// CHECKBAR_GEN:             "rhs": "Equatable"
+// CHECKBAR_GEN:           }
+// CHECKBAR_GEN:         ],
+// CHECKBAR_GEN:         "parameters": [
+// CHECKBAR_GEN:           {
+// CHECKBAR_GEN:             "depth": 0,
+// CHECKBAR_GEN:             "index": 0,
+// CHECKBAR_GEN:             "name": "T"
+// CHECKBAR_GEN:           }
+// CHECKBAR_GEN:         ]
+// CHECKBAR_GEN:       }
+// CHECKBAR_ALL:     }
+// CHECKBAR_ALL:   ]
+// CHECKBAR_ALL: }
+
+
+// CHECKCASE: SYMBOL GRAPH BEGIN
+// CHECKCASE: {
+// CHECKCASE:   "metadata": {
+// CHECKCASE:     "formatVersion": {
+// CHECKCASE:       "major":
+// CHECKCASE:       "minor":
+// CHECKCASE:       "patch":
+// CHECKCASE:     },
+// CHECKCASE:     "generator":
+// CHECKCASE:   },
+// CHECKCASE:   "module": {
+// CHECKCASE:     "name": "cursor_symbol_graph",
+// CHECKCASE:     "platform":
+// CHECKCASE:   },
+// CHECKCASE:   "relationships": [
+// CHECKCASE:     {
+// CHECKCASE:       "kind": "memberOf",
+// CHECKCASE:       "source": "s:19cursor_symbol_graph6MyEnumO8someCaseyA2CmF",
+// CHECKCASE:       "target": "s:19cursor_symbol_graph6MyEnumO"
+// CHECKCASE:     }
+// CHECKCASE:   ],
+// CHECKCASE:   "symbols": [
+// CHECKCASE:     {
+// CHECKCASE:       "accessLevel": "internal",
+// CHECKCASE:       "declarationFragments": [
+// CHECKCASE:         {
+// CHECKCASE:           "kind": "keyword",
+// CHECKCASE:           "spelling": "case"
+// CHECKCASE:         },
+// CHECKCASE:         {
+// CHECKCASE:           "kind": "text",
+// CHECKCASE:           "spelling": " "
+// CHECKCASE:         },
+// CHECKCASE:         {
+// CHECKCASE:           "kind": "identifier",
+// CHECKCASE:           "spelling": "someCase"
+// CHECKCASE:         }
+// CHECKCASE:       ],
+// CHECKCASE:       "docComment": {
+// CHECKCASE:         "lines": [
+// CHECKCASE:           {
+// CHECKCASE:             "range": {
+// CHECKCASE:               "end": {
+// CHECKCASE:                 "character": 63,
+// CHECKCASE:                 "line": 27
+// CHECKCASE:               },
+// CHECKCASE:               "start": {
+// CHECKCASE:                 "character": 8,
+// CHECKCASE:                 "line": 27
+// CHECKCASE:               }
+// CHECKCASE:             },
+// CHECKCASE:             "text": "Text in a code line with no indicated semantic meaning."
+// CHECKCASE:           }
+// CHECKCASE:         ]
+// CHECKCASE:       },
+// CHECKCASE:       "identifier": {
+// CHECKCASE:         "interfaceLanguage": "swift",
+// CHECKCASE:         "precise": "s:19cursor_symbol_graph6MyEnumO8someCaseyA2CmF"
+// CHECKCASE:       },
+// CHECKCASE:       "kind": {
+// CHECKCASE:         "displayName": "Case",
+// CHECKCASE:         "identifier": "swift.enum.case"
+// CHECKCASE:       },
+// CHECKCASE:       "location": {
+// CHECKCASE:         "position": {
+// CHECKCASE:           "character": 9,
+// CHECKCASE:           "line": 28
+// CHECKCASE:         },
+// CHECKCASE:         "uri": "{{.*}}cursor_symbol_graph.swift"
+// CHECKCASE:       },
+// CHECKCASE:       "names": {
+// CHECKCASE:         "navigator": [
+// CHECKCASE:           {
+// CHECKCASE:             "kind": "keyword",
+// CHECKCASE:             "spelling": "case"
+// CHECKCASE:           },
+// CHECKCASE:           {
+// CHECKCASE:             "kind": "text",
+// CHECKCASE:             "spelling": " "
+// CHECKCASE:           },
+// CHECKCASE:           {
+// CHECKCASE:             "kind": "identifier",
+// CHECKCASE:             "spelling": "someCase"
+// CHECKCASE:           }
+// CHECKCASE:         ],
+// CHECKCASE:         "subHeading": [
+// CHECKCASE:           {
+// CHECKCASE:             "kind": "keyword",
+// CHECKCASE:             "spelling": "case"
+// CHECKCASE:           },
+// CHECKCASE:           {
+// CHECKCASE:             "kind": "text",
+// CHECKCASE:             "spelling": " "
+// CHECKCASE:           },
+// CHECKCASE:           {
+// CHECKCASE:             "kind": "identifier",
+// CHECKCASE:             "spelling": "someCase"
+// CHECKCASE:           }
+// CHECKCASE:         ],
+// CHECKCASE:         "title": "someCase"
+// CHECKCASE:       },
+// CHECKCASE:       "pathComponents": [
+// CHECKCASE:         "MyEnum",
+// CHECKCASE:         "someCase"
+// CHECKCASE:       ]
+// CHECKCASE:     }
+// CHECKCASE:   ]
+// CHECKCASE: }
+// CHECKCASE: SYMBOL GRAPH END

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_generics.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_generics.swift
@@ -1,0 +1,215 @@
+
+struct Simple<T: Equatable, U: Sequence> {
+  func simple<V>(v: V) where V: Hashable {}
+  func assoc<V>(v: V, w: T, p: U) where U.Element == T, V: Equatable {}
+}
+
+extension Simple where T == Int {
+  func concrete(t: T) {}
+  func testCall(x: U) where U.Element == T {
+    assoc(v: "hello", w: 1, p: x)
+  }
+}
+
+func foo() {
+  Simple<String, [String]>.init().assoc(v: 1, w: "a", p: ["hello"])
+}
+
+
+// RUN:  %sourcekitd-test -req=cursor -pos=3:8 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=SIMPLE %s
+// RUN:  %sourcekitd-test -req=cursor -pos=4:8 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=ASSOC %s
+// RUN:  %sourcekitd-test -req=cursor -pos=8:8 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CONCRETE %s
+// RUN:  %sourcekitd-test -req=cursor -pos=10:5 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=ASSOCCALL_EXT  %s
+// RUN:  %sourcekitd-test -req=cursor -pos=15:35 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=ASSOCCALL_MEMBER  %s
+
+// SIMPLE: "functionSignature": {
+// SIMPLE:         "spelling": "v"
+// SIMPLE:         "spelling": ": "
+// SIMPLE:         "spelling": "V"
+// SIMPLE: }
+// SIMPLE: "swiftGenerics": {
+// SIMPLE:   "constraints": [
+// SIMPLE:     {
+// SIMPLE:       "kind": "conformance",
+// SIMPLE:       "lhs": "T",
+// SIMPLE:       "rhs": "Equatable"
+// SIMPLE:     },
+// SIMPLE:     {
+// SIMPLE:       "kind": "conformance",
+// SIMPLE:       "lhs": "U",
+// SIMPLE:       "rhs": "Sequence"
+// SIMPLE:     },
+// SIMPLE:     {
+// SIMPLE:       "kind": "conformance",
+// SIMPLE:       "lhs": "V",
+// SIMPLE:       "rhs": "Hashable"
+// SIMPLE:     }
+// SIMPLE:   ],
+// SIMPLE:   "parameters": [
+// SIMPLE:     {
+// SIMPLE:       "depth": 0,
+// SIMPLE:       "index": 0,
+// SIMPLE:       "name": "T"
+// SIMPLE:     },
+// SIMPLE:     {
+// SIMPLE:       "depth": 0,
+// SIMPLE:       "index": 1,
+// SIMPLE:       "name": "U"
+// SIMPLE:     },
+// SIMPLE:     {
+// SIMPLE:       "depth": 1,
+// SIMPLE:       "index": 0,
+// SIMPLE:       "name": "V"
+// SIMPLE:     }
+// SIMPLE:   ]
+// SIMPLE: }
+
+
+// ASSOC: "functionSignature": {
+// ASSOC:         "spelling": "v"
+// ASSOC:         "spelling": ": "
+// ASSOC:         "spelling": "V"
+// ASSOC:         "spelling": "w"
+// ASSOC:         "spelling": ": "
+// ASSOC:         "spelling": "T"
+// ASSOC:         "spelling": "p"
+// ASSOC:         "spelling": ": "
+// ASSOC:         "spelling": "U"
+// ASSOC: }
+// ASSOC: "swiftGenerics": {
+// ASSOC:   "constraints": [
+// ASSOC:     {
+// ASSOC:       "kind": "conformance",
+// ASSOC:       "lhs": "T",
+// ASSOC:       "rhs": "Equatable"
+// ASSOC:     },
+// ASSOC:     {
+// ASSOC:       "kind": "sameType",
+// ASSOC:       "lhs": "T",
+// ASSOC:       "rhs": "U.Element"
+// ASSOC:     },
+// ASSOC:     {
+// ASSOC:       "kind": "conformance",
+// ASSOC:       "lhs": "U",
+// ASSOC:       "rhs": "Sequence"
+// ASSOC:     }
+// ASSOC:   ],
+// ASSOC:   "parameters": [
+// ASSOC:     {
+// ASSOC:       "depth": 0,
+// ASSOC:       "index": 0,
+// ASSOC:       "name": "T"
+// ASSOC:     },
+// ASSOC:     {
+// ASSOC:       "depth": 0,
+// ASSOC:       "index": 1,
+// ASSOC:       "name": "U"
+// ASSOC:     },
+// ASSOC:     {
+// ASSOC:       "depth": 1,
+// ASSOC:       "index": 0,
+// ASSOC:       "name": "V"
+// ASSOC:     }
+// ASSOC:   ]
+// ASSOC: }
+
+
+// CONCRETE: "functionSignature": {
+// CONCRETE:         "spelling": "t"
+// CONCRETE:         "spelling": ": "
+// CONCRETE:         "spelling": "T"
+// CONCRETE: }
+// CONCRETE: "swiftGenerics": {
+// CONCRETE:   "constraints": [
+// CONCRETE:     {
+// CONCRETE:       "kind": "sameType",
+// CONCRETE:       "lhs": "T",
+// CONCRETE:       "rhs": "Int"
+// CONCRETE:     },
+// CONCRETE:     {
+// CONCRETE:       "kind": "conformance",
+// CONCRETE:       "lhs": "U",
+// CONCRETE:       "rhs": "Sequence"
+// CONCRETE:     }
+// CONCRETE:   ],
+// CONCRETE:   "parameters": [
+// CONCRETE:     {
+// CONCRETE:       "depth": 0,
+// CONCRETE:       "index": 0,
+// CONCRETE:       "name": "T"
+// CONCRETE:     },
+// CONCRETE:     {
+// CONCRETE:       "depth": 0,
+// CONCRETE:       "index": 1,
+// CONCRETE:       "name": "U"
+// CONCRETE:     }
+// CONCRETE:   ]
+// CONCRETE: }
+
+
+// ASSOCCALL_EXT: "functionSignature": {
+// ASSOCCALL_EXT:         "spelling": "v"
+// ASSOCCALL_EXT:         "spelling": ": "
+// ASSOCCALL_EXT:         "spelling": "V"
+// ASSOCCALL_EXT:         "spelling": "w"
+// ASSOCCALL_EXT:         "spelling": ": "
+// ASSOCCALL_EXT:         "spelling": "Int"
+// ASSOCCALL_EXT:         "spelling": "p"
+// ASSOCCALL_EXT:         "spelling": ": "
+// ASSOCCALL_EXT:         "spelling": "U"
+// ASSOCCALL_EXT: "swiftGenerics": {
+// ASSOCCALL_EXT:   "constraints": [
+// ASSOCCALL_EXT:     {
+// ASSOCCALL_EXT:       "kind": "conformance",
+// ASSOCCALL_EXT:       "lhs": "U",
+// ASSOCCALL_EXT:       "rhs": "Sequence"
+// ASSOCCALL_EXT:     },
+// ASSOCCALL_EXT:     {
+// ASSOCCALL_EXT:       "kind": "conformance",
+// ASSOCCALL_EXT:       "lhs": "V",
+// ASSOCCALL_EXT:       "rhs": "Equatable"
+// ASSOCCALL_EXT:     }
+// ASSOCCALL_EXT:   ],
+// ASSOCCALL_EXT:   "parameters": [
+// ASSOCCALL_EXT:     {
+// ASSOCCALL_EXT:       "depth": 0,
+// ASSOCCALL_EXT:       "index": 1,
+// ASSOCCALL_EXT:       "name": "U"
+// ASSOCCALL_EXT:     },
+// ASSOCCALL_EXT:     {
+// ASSOCCALL_EXT:       "depth": 1,
+// ASSOCCALL_EXT:       "index": 0,
+// ASSOCCALL_EXT:       "name": "V"
+// ASSOCCALL_EXT:     }
+// ASSOCCALL_EXT:   ]
+// ASSOCCALL_EXT: }
+
+
+// ASSOCCALL_MEMBER: "functionSignature": {
+// ASSOCCALL_MEMBER:         "spelling": "v"
+// ASSOCCALL_MEMBER:         "spelling": ": "
+// ASSOCCALL_MEMBER:         "spelling": "V"
+// ASSOCCALL_MEMBER:         "spelling": "w"
+// ASSOCCALL_MEMBER:         "spelling": ": "
+// ASSOCCALL_MEMBER:         "spelling": "String"
+// ASSOCCALL_MEMBER:         "spelling": "p"
+// ASSOCCALL_MEMBER:         "spelling": ": ["
+// ASSOCCALL_MEMBER:         "spelling": "String"
+// ASSOCCALL_MEMBER:         "spelling": "]"
+// ASSOCCALL_MEMBER: },
+// ASSOCCALL_MEMBER: "swiftGenerics": {
+// ASSOCCALL_MEMBER:   "constraints": [
+// ASSOCCALL_MEMBER:     {
+// ASSOCCALL_MEMBER:       "kind": "conformance",
+// ASSOCCALL_MEMBER:       "lhs": "V",
+// ASSOCCALL_MEMBER:       "rhs": "Equatable"
+// ASSOCCALL_MEMBER:     }
+// ASSOCCALL_MEMBER:   ],
+// ASSOCCALL_MEMBER:   "parameters": [
+// ASSOCCALL_MEMBER:     {
+// ASSOCCALL_MEMBER:       "depth": 1,
+// ASSOCCALL_MEMBER:       "index": 0,
+// ASSOCCALL_MEMBER:       "name": "V"
+// ASSOCCALL_MEMBER:     }
+// ASSOCCALL_MEMBER:   ]
+// ASSOCCALL_MEMBER: }

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -4,6 +4,7 @@ func callObjC() {
   fooFuncWithComment5()
 }
 
+// REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=4:3 -req-opts=retrieve_symbol_graph=1 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp -target %target-triple %s | %FileCheck %s
 // CHECK: SYMBOL GRAPH BEGIN
 // CHECK: {

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -1,0 +1,108 @@
+import Foo
+
+func callObjC() {
+  fooFuncWithComment5()
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:3 -req-opts=retrieve_symbol_graph=1 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp -target %target-triple %s | %FileCheck %s
+// CHECK: SYMBOL GRAPH BEGIN
+// CHECK: {
+// CHECK:   "metadata": {
+// CHECK:     "formatVersion": {
+// CHECK:       "major":
+// CHECK:       "minor":
+// CHECK:       "patch":
+// CHECK:     },
+// CHECK:     "generator":
+// CHECK:   },
+// CHECK:   "module": {
+// CHECK:     "name": "Foo",
+// CHECK:     "platform": {
+// CHECK-NOT:   "architecture": "",
+// CHECK:     }
+// CHECK:   },
+// CHECK:   "relationships": [],
+// CHECK:   "symbols": [
+// CHECK:     {
+// CHECK:       "accessLevel": "public",
+// CHECK:       "declarationFragments": [
+// CHECK:         {
+// CHECK:           "kind": "keyword",
+// CHECK:           "spelling": "func"
+// CHECK:         },
+// CHECK:         {
+// CHECK:           "kind": "text",
+// CHECK:           "spelling": " "
+// CHECK:         },
+// CHECK:         {
+// CHECK:           "kind": "identifier",
+// CHECK:           "spelling": "fooFuncWithComment5"
+// CHECK:         },
+// CHECK:         {
+// CHECK:           "kind": "text",
+// CHECK:           "spelling": "()"
+// CHECK:         }
+// CHECK:       ],
+// CHECK:       "functionSignature": {
+// CHECK:         "returns": [
+// CHECK:           {
+// CHECK:             "kind": "typeIdentifier",
+// CHECK:             "preciseIdentifier": "s:s4Voida",
+// CHECK:             "spelling": "Void"
+// CHECK:           }
+// CHECK:         ]
+// CHECK:       },
+// CHECK:       "identifier": {
+// CHECK:         "interfaceLanguage": "swift",
+// CHECK:         "precise": "c:@F@fooFuncWithComment5"
+// CHECK:       },
+// CHECK:       "kind": {
+// CHECK:         "displayName": "Function",
+// CHECK:         "identifier": "swift.func"
+// CHECK:       },
+// CHECK:       "names": {
+// CHECK:         "navigator": [
+// CHECK:           {
+// CHECK:             "kind": "keyword",
+// CHECK:             "spelling": "func"
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "kind": "text",
+// CHECK:             "spelling": " "
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "kind": "identifier",
+// CHECK:             "spelling": "fooFuncWithComment5"
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "kind": "text",
+// CHECK:             "spelling": "()"
+// CHECK:           }
+// CHECK:         ],
+// CHECK:         "subHeading": [
+// CHECK:           {
+// CHECK:             "kind": "keyword",
+// CHECK:             "spelling": "func"
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "kind": "text",
+// CHECK:             "spelling": " "
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "kind": "identifier",
+// CHECK:             "spelling": "fooFuncWithComment5"
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "kind": "text",
+// CHECK:             "spelling": "()"
+// CHECK:           }
+// CHECK:         ],
+// CHECK:         "title": "fooFuncWithComment5()"
+// CHECK:       },
+// CHECK:       "pathComponents": [
+// CHECK:         "fooFuncWithComment5()"
+// CHECK:       ]
+// CHECK:     }
+// CHECK:   ]
+// CHECK: }
+// CHECK: SYMBOL GRAPH END

--- a/test/SourceKit/ExpressionType/filtered.swift
+++ b/test/SourceKit/ExpressionType/filtered.swift
@@ -1,7 +1,4 @@
-// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='s:8filtered4ProtP;s:8filtered5Prot1P' -- %s | %FileCheck %s -check-prefix=BOTH
-// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='s:8filtered5Prot1P' -- %s | %FileCheck %s -check-prefix=PROTO1
-// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='s:8filtered6Proto2P' -- %s | %FileCheck %s -check-prefix=PROTO2
-
+// RUN lines at the end - offset sensitive
 protocol Prot {}
 
 protocol Prot1 {}
@@ -39,54 +36,58 @@ class Proto2Conformer: Proto2 {}
 func foo(_ c: Proto2Conformer) { _ = c }
 
 // BOTH: <ExpressionTypes>
-// BOTH: (503, 507): Clas
+// BOTH: (126, 130): Clas
 // BOTH: conforming to: s:8filtered4ProtP
-// BOTH: (545, 549): Clas
+// BOTH: (168, 172): Clas
 // BOTH: conforming to: s:8filtered4ProtP
-// BOTH: (609, 613): Stru
-// BOTH: conforming to: s:8filtered4ProtP
-// BOTH: conforming to: s:8filtered5Prot1P
-// BOTH: (651, 655): Stru
+// BOTH: (232, 236): Stru
 // BOTH: conforming to: s:8filtered4ProtP
 // BOTH: conforming to: s:8filtered5Prot1P
-// BOTH: (811, 838): Clas
-// BOTH: conforming to: s:8filtered4ProtP
-// BOTH: (811, 832): Clas
-// BOTH: conforming to: s:8filtered4ProtP
-// BOTH: (811, 821): Clas
-// BOTH: conforming to: s:8filtered4ProtP
-// BOTH: (811, 815): Clas
-// BOTH: conforming to: s:8filtered4ProtP
-// BOTH: (877, 904): Stru
+// BOTH: (274, 278): Stru
 // BOTH: conforming to: s:8filtered4ProtP
 // BOTH: conforming to: s:8filtered5Prot1P
-// BOTH: (877, 898): Stru
+// BOTH: (434, 461): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (434, 455): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (434, 444): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (434, 438): Clas
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: (500, 527): Stru
 // BOTH: conforming to: s:8filtered4ProtP
 // BOTH: conforming to: s:8filtered5Prot1P
-// BOTH: (877, 887): Stru
+// BOTH: (500, 521): Stru
 // BOTH: conforming to: s:8filtered4ProtP
 // BOTH: conforming to: s:8filtered5Prot1P
-// BOTH: (877, 881): Stru
+// BOTH: (500, 510): Stru
+// BOTH: conforming to: s:8filtered4ProtP
+// BOTH: conforming to: s:8filtered5Prot1P
+// BOTH: (500, 504): Stru
 // BOTH: conforming to: s:8filtered4ProtP
 // BOTH: conforming to: s:8filtered5Prot1P
 // BOTH: </ExpressionTypes>
 
 // PROTO1: <ExpressionTypes>
-// PROTO1: (609, 613): Stru
+// PROTO1: (232, 236): Stru
 // PROTO1: conforming to: s:8filtered5Prot1P
-// PROTO1: (651, 655): Stru
+// PROTO1: (274, 278): Stru
 // PROTO1: conforming to: s:8filtered5Prot1P
-// PROTO1: (877, 904): Stru
+// PROTO1: (500, 527): Stru
 // PROTO1: conforming to: s:8filtered5Prot1P
-// PROTO1: (877, 898): Stru
+// PROTO1: (500, 521): Stru
 // PROTO1: conforming to: s:8filtered5Prot1P
-// PROTO1: (877, 887): Stru
+// PROTO1: (500, 510): Stru
 // PROTO1: conforming to: s:8filtered5Prot1P
-// PROTO1: (877, 881): Stru
+// PROTO1: (500, 504): Stru
 // PROTO1: conforming to: s:8filtered5Prot1P
 // PROTO1: </ExpressionTypes>
 
 // PROTO2: <ExpressionTypes>
-// PROTO2: (999, 1000): Proto2Conformer
+// PROTO2: (622, 623): Proto2Conformer
 // PROTO2: conforming to: s:8filtered6Proto2P
 // PROTO2: </ExpressionTypes>
+
+// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='[s:8filtered4ProtP;s:8filtered5Prot1P]' -- %s | %FileCheck %s -check-prefix=BOTH
+// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='[s:8filtered5Prot1P]' -- %s | %FileCheck %s -check-prefix=PROTO1
+// RUN: %sourcekitd-test -req=collect-type %s -req-opts=expectedtypes='[s:8filtered6Proto2P]' -- %s | %FileCheck %s -check-prefix=PROTO2

--- a/test/SourceKit/Misc/mixed_completion_sequence.swift
+++ b/test/SourceKit/Misc/mixed_completion_sequence.swift
@@ -35,7 +35,7 @@ func testing(obj: C) {
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=complete -pos=29:14 %s -- %s -module-name MyModule == \
-// RUN:   -req=conformingmethods -pos=29:14 -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' %s -- %s -module-name MyModule == \
+// RUN:   -req=conformingmethods -pos=29:14 -req-opts=expectedtypes='[$s8MyModule7Target2PD;$s8MyModule7Target1PD]' %s -- %s -module-name MyModule == \
 // RUN:   -req=typecontextinfo -pos=32:33 %s -- %s -module-name MyModule == \
 // RUN:   -req=complete -pos=29:14 %s -- %s -module-name MyModule > %t.response
 // RUN: %diff -u %s.response %t.response

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -402,6 +402,8 @@ struct CursorInfoData {
   /// Fully annotated XML pretty printed declaration.
   /// FIXME: this should eventually replace \c AnnotatedDeclaration.
   StringRef FullyAnnotatedDeclaration;
+  /// The SymbolGraph JSON for this declaration.
+  StringRef SymbolGraph;
   /// Non-empty if the symbol was imported from a clang module.
   StringRef ModuleName;
   /// Non-empty if a generated interface editor document has previously been
@@ -745,8 +747,9 @@ public:
 
   virtual void
   getCursorInfo(StringRef Filename, unsigned Offset, unsigned Length,
-                bool Actionables, bool CancelOnSubsequentRequest,
-                ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+                bool Actionables, bool SymbolGraph,
+                bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+                Optional<VFSOptions> vfsOptions,
        std::function<void(const RequestResult<CursorInfoData> &)> Receiver) = 0;
 
   virtual void getNameInfo(StringRef Filename, unsigned Offset,

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(SourceKitSwiftLang PRIVATE
   swiftSerialization
   swiftSyntax
   swiftOption
+  swiftSymbolGraphGen
   libcmark_static
   # Clang dependencies.
   clangIndex

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -557,8 +557,9 @@ public:
 
   void
   getCursorInfo(StringRef Filename, unsigned Offset, unsigned Length,
-                bool Actionables, bool CancelOnSubsequentRequest,
-                ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+                bool Actionables, bool SymbolGraph,
+                bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+                Optional<VFSOptions> vfsOptions,
                 std::function<void(const RequestResult<CursorInfoData> &)> Receiver) override;
 
   void getNameInfo(StringRef Filename, unsigned Offset,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1083,9 +1083,11 @@ static void handleSemanticRequest(
       Req.getInt64(KeyLength, Length, /*isOptional=*/true);
       int64_t Actionables = false;
       Req.getInt64(KeyRetrieveRefactorActions, Actionables, /*isOptional=*/true);
+      int64_t SymbolGraph = false;
+      Req.getInt64(KeyRetrieveSymbolGraph, SymbolGraph, /*isOptional=*/true);
       return Lang.getCursorInfo(
-          *SourceFile, Offset, Length, Actionables, CancelOnSubsequentRequest,
-          Args, std::move(vfsOptions),
+          *SourceFile, Offset, Length, Actionables, SymbolGraph,
+          CancelOnSubsequentRequest, Args, std::move(vfsOptions),
           [Rec](const RequestResult<CursorInfoData> &Result) {
             reportCursorInfo(Result, Rec);
           });
@@ -1165,7 +1167,7 @@ static void handleSemanticRequest(
 
     SmallVector<const char *, 8> ExpectedProtocols;
     if (Req.getStringArray(KeyExpectedTypes, ExpectedProtocols, true))
-      return Rec(createErrorRequestInvalid("invalid 'key.interested_protocols'"));
+      return Rec(createErrorRequestInvalid("invalid 'key.expectedtypes'"));
     int64_t CanonicalTy = false;
     Req.getInt64(KeyCanonicalizeType, CanonicalTy, /*isOptional=*/true);
     return Lang.collectExpressionTypes(*SourceFile, Args, ExpectedProtocols,
@@ -1844,6 +1846,8 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
     Elem.set(KeyTypeUsr, Info.TypeUSR);
   if (!Info.ContainerTypeUSR.empty())
     Elem.set(KeyContainerTypeUsr, Info.ContainerTypeUSR);
+  if (!Info.SymbolGraph.empty())
+    Elem.set(KeySymbolGraph, Info.SymbolGraph);
 
   return Rec(RespBuilder.createResponse());
 }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -148,7 +148,7 @@ public:
     Semaphore sema(0);
 
     TestCursorInfo TestInfo;
-    getLang().getCursorInfo(DocName, Offset, 0, false, false, Args, None,
+    getLang().getCursorInfo(DocName, Offset, 0, false, false, false, Args, None,
       [&](const RequestResult<CursorInfoData> &Result) {
         assert(!Result.isCancelled());
         if (Result.isError()) {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -161,6 +161,8 @@ UID_KEYS = [
     KEY('IsNonProtocolType', 'key.is_non_protocol_type'),
     KEY('RefactorActions', 'key.refactor_actions'),
     KEY('RetrieveRefactorActions', 'key.retrieve_refactor_actions'),
+    KEY('SymbolGraph', 'key.symbol_graph'),
+    KEY('RetrieveSymbolGraph', 'key.retrieve_symbol_graph'),
     KEY('ActionUID', 'key.actionuid'),
     KEY('ActionUnavailableReason', 'key.actionunavailablereason'),
     KEY('CompileID', 'key.compileid'),


### PR DESCRIPTION
Adds a new `key.retrieve_symbol_graph` option to the request. When set to 1 the JSON for a SymbolGraph containing a single node corresponding to the symbol at the cursor position will be included in the response under `key.symbol_graph`.
    
This extends the SymbolGraph with a new entry point to get a graph for a single symbol, and to additionally support type substitution to match the existing CursorInfo behavior (e.g. so that when invoked on `first` in `Array<Int>().first`, the type is reported as `Int?` rather than `Element?`).
    
Resolves rdar://problem/70551509