### PR TITLE
[AutoDiff] WIP: Use owned callee convention for linear maps.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Differentiation/ADContext.h
@@ -50,7 +50,7 @@ struct NestedApplyInfo {
   AutoDiffConfig config;
   /// The original pullback type before reabstraction. `None` if the pullback
   /// type is not reabstracted.
-  Optional<CanSILFunctionType> originalPullbackType;
+  CanSILFunctionType originalPullbackType;
 };
 
 /// Per-module contextual information for the Differentiation pass.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -339,10 +339,10 @@ getDifferentiabilityParameters(SILFunctionType *originalFnTy,
 /// Collects the semantic results of the given function type in
 /// `originalResults`. The semantic results are formal results followed by
 /// `inout` parameters, in type order.
-static void
-getSemanticResults(SILFunctionType *functionType, IndexSubset *parameterIndices,
-                   IndexSubset *&inoutParameterIndices,
-                   SmallVectorImpl<SILResultInfo> &originalResults) {
+static void getAutoDiffSemanticResults(
+    SILFunctionType *functionType, IndexSubset *parameterIndices,
+    IndexSubset *&inoutParameterIndices,
+    SmallVectorImpl<SILResultInfo> &originalResults) {
   auto &C = functionType->getASTContext();
   SmallVector<unsigned, 4> inoutParamIndices;
   // Collect original formal results.
@@ -361,9 +361,10 @@ getSemanticResults(SILFunctionType *functionType, IndexSubset *parameterIndices,
       IndexSubset::get(C, parameterIndices->getCapacity(), inoutParamIndices);
 }
 
-static CanGenericSignature buildDifferentiableGenericSignature(CanGenericSignature sig,
-                                                               CanType tanType,
-                                                               CanType origTypeOfAbstraction) {
+static CanGenericSignature
+buildDifferentiableGenericSignature(CanGenericSignature sig,
+                                    CanType tanType,
+                                    CanType origTypeOfAbstraction) {
   if (!sig)
     return sig;
 
@@ -504,8 +505,8 @@ static CanSILFunctionType getAutoDiffDifferentialType(
 
   IndexSubset *inoutParamIndices;
   SmallVector<SILResultInfo, 2> originalResults;
-  getSemanticResults(originalFnTy, parameterIndices, inoutParamIndices,
-                     originalResults);
+  getAutoDiffSemanticResults(originalFnTy, parameterIndices, inoutParamIndices,
+                             originalResults);
 
   SmallVector<SILParameterInfo, 4> diffParams;
   getDifferentiabilityParameters(originalFnTy, parameterIndices, diffParams);
@@ -569,7 +570,7 @@ static CanSILFunctionType getAutoDiffDifferentialType(
   }
   return SILFunctionType::get(
       GenericSignature(), SILFunctionType::ExtInfo(), SILCoroutineKind::None,
-      ParameterConvention::Direct_Guaranteed, differentialParams, {},
+      ParameterConvention::Direct_Owned, differentialParams, {},
       differentialResults, None, substitutions,
       /*invocationSubstitutions*/ SubstitutionMap(), ctx);
 }
@@ -588,8 +589,8 @@ static CanSILFunctionType getAutoDiffPullbackType(
 
   IndexSubset *inoutParamIndices;
   SmallVector<SILResultInfo, 2> originalResults;
-  getSemanticResults(originalFnTy, parameterIndices, inoutParamIndices,
-                     originalResults);
+  getAutoDiffSemanticResults(originalFnTy, parameterIndices, inoutParamIndices,
+                             originalResults);
 
   // Given a type, returns its formal SIL parameter info.
   auto getTangentParameterConventionForOriginalResult =
@@ -726,7 +727,7 @@ static CanSILFunctionType getAutoDiffPullbackType(
   }
   return SILFunctionType::get(
       GenericSignature(), SILFunctionType::ExtInfo(), SILCoroutineKind::None,
-      ParameterConvention::Direct_Guaranteed, pullbackParams, {},
+      ParameterConvention::Direct_Owned, pullbackParams, {},
       pullbackResults, None, substitutions,
       /*invocationSubstitutions*/ SubstitutionMap(), ctx);
 }
@@ -2020,6 +2021,29 @@ static CanSILFunctionType getSILFunctionType(
     DestructureResults destructurer(expansionContext, TC, conventions,
                                     results);
     destructurer.destructure(origResultType, substFormalResultType);
+  }
+
+  // If it's a derivative function, its linear map result has `@callee_owned`
+  // convention.
+  if (origType.isDerivativeFunctionType()) {
+    assert(results.size() == 2);
+    auto &linearMapResult = results[1];
+    auto linearMapType = linearMapResult.getInterfaceType()
+                             ->getAs<SILFunctionType>();
+    auto newLinearMapType = SILFunctionType::get(
+        linearMapType->getInvocationGenericSignature(),
+        linearMapType->getExtInfo(),
+        linearMapType->getCoroutineKind(),
+        ParameterConvention::Direct_Owned,
+        linearMapType->getParameters(),
+        linearMapType->getYields(),
+        linearMapType->getResults(),
+        linearMapType->getOptionalErrorResult(),
+        linearMapType->getPatternSubstitutions(),
+        linearMapType->getInvocationSubstitutions(),
+        linearMapType->getASTContext(),
+        linearMapType->getWitnessMethodConformanceOrInvalid());
+    linearMapResult = linearMapResult.getWithInterfaceType(newLinearMapType);
   }
 
   // Lower the capture context parameters, if any.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1144,32 +1144,70 @@ static ManagedValue emitBuiltinAutoDiffApplyDerivativeFunction(
   assert(origFnVal->getType().isTrivial(SGF.F));
   assert(derivativeFn->getType().isTrivial(SGF.F));
 
-  // Do the apply for the indirect result case.
+  auto getCalleeGuaranteedType = [&](CanSILFunctionType type) {
+    return SILFunctionType::get(
+        GenericSignature(),
+        type->getExtInfo(),
+        type->getCoroutineKind(),
+        ParameterConvention::Direct_Guaranteed,
+        type->getParameters(),
+        type->getYields(),
+        type->getResults(),
+        type->getOptionalErrorResult(),
+        type->getPatternSubstitutions(),
+        type->getInvocationSubstitutions(),
+        SGF.getASTContext());
+  };
+
+  // When there are indirect reslts, emit a tuple result into the result buffer.
   if (derivativeFnType->hasIndirectFormalResults()) {
-    auto indResBuffer = SGF.getBufferForExprResult(
-        loc, derivativeFnType->getAllResultsInterfaceType(), C);
+    auto linearMapType = CanSILFunctionType(
+        derivativeFnType->getDirectFormalResults().begin()
+            ->getInterfaceType()->castTo<SILFunctionType>());
+    auto calleeGuaranteedLinearMapType = getCalleeGuaranteedType(linearMapType);
+    auto origResultType = derivativeFnType->getIndirectFormalResults().begin()
+        ->getInterfaceType();
+    auto tupleResultType = SILType::getPrimitiveObjectType(
+        TupleType::get(
+            {TupleTypeElt(origResultType),
+             TupleTypeElt(calleeGuaranteedLinearMapType)},
+            SGF.getASTContext())->getCanonicalType());
+    auto indResBuffer = SGF.getBufferForExprResult(loc, tupleResultType, C);
     SmallVector<SILValue, 3> applyArgs;
     applyArgs.push_back(SGF.B.createTupleElementAddr(loc, indResBuffer, 0));
     for (auto origFnArgVal : origFnArgVals)
       applyArgs.push_back(origFnArgVal);
-    auto differential = SGF.B.createApply(loc, derivativeFn, SubstitutionMap(),
-                                          applyArgs);
-
-    derivativeFn = SILValue();
-
-    SGF.B.createStore(loc, differential,
-                      SGF.B.createTupleElementAddr(loc, indResBuffer, 1),
-                      StoreOwnershipQualifier::Init);
+    auto linearMap = SGF.emitManagedRValueWithCleanup(
+        SGF.B.createApply(loc, derivativeFn, SubstitutionMap(), applyArgs));
+    // Reabstract the linear map to `@callee_guaranteed` since that matches the
+    // lowered type of AST closure types.
+    linearMap = SGF.emitTransformedAutoDiffLinearMap(
+        linearMap, kind.getLinearMapKind(), linearMapType,
+        calleeGuaranteedLinearMapType, /*reorderSelf*/ false);
+    linearMap.forwardInto(
+        SGF, loc, SGF.B.createTupleElementAddr(loc, indResBuffer, 1));
     return SGF.manageBufferForExprResult(
         indResBuffer, SGF.getTypeLowering(indResBuffer->getType()), C);
   }
 
-  // Do the apply for the direct result case.
-  auto resultTuple = SGF.B.createApply(
+  // Otherwise, use the tuple result from the application directly (with
+  // necessary reabstractions).
+  SILValue resultTuple = SGF.B.createApply(
       loc, derivativeFn, SubstitutionMap(), origFnArgVals);
-
-  derivativeFn = SILValue();
-
+  auto *destructure = SGF.B.createDestructureTuple(loc, resultTuple);
+  auto origResult =
+      SGF.emitManagedRValueWithCleanup(destructure->getResult(0));
+  auto linearMap =
+      SGF.emitManagedRValueWithCleanup(destructure->getResult(1));
+  auto linearMapType = linearMap.getType().getAs<SILFunctionType>();
+  // Reabstract the linear map to `@callee_guaranteed` since that matches the
+  // lowered type of AST closure types.
+  linearMap = SGF.emitTransformedAutoDiffLinearMap(
+      linearMap, kind.getLinearMapKind(),
+      linearMapType, getCalleeGuaranteedType(linearMapType),
+      /*reorderSelf*/ false);
+  resultTuple = SGF.B.createTuple(
+      loc, {origResult.forward(SGF), linearMap.forward(SGF)});
   return SGF.emitManagedRValueWithCleanup(resultTuple);
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1995,18 +1995,23 @@ public:
   // Differentiation thunks
   //===--------------------------------------------------------------------===//
 
-  /// Get or create a thunk for reabstracting and self-reordering
-  /// differentials/pullbacks returned by user-defined JVP/VJP functions, and
-  /// apply it to the given differential/pullback.
+  /// Transform the given linear map function using a thunk that reabstracts and
+  /// optionally reorders the `self` parameter.
   ///
   /// If `reorderSelf` is true, reorder self so that it appears as:
   /// - The last parameter, for differentials.
   /// - The last result, for pullbacks.
-  ManagedValue getThunkedAutoDiffLinearMap(ManagedValue linearMap,
-                                           AutoDiffLinearMapKind linearMapKind,
-                                           CanSILFunctionType fromType,
-                                           CanSILFunctionType toType,
-                                           bool reorderSelf);
+  ManagedValue emitTransformedAutoDiffLinearMap(
+      ManagedValue linearMap, AutoDiffLinearMapKind linearMapKind,
+      CanSILFunctionType substFromType, CanSILFunctionType substToType,
+      bool reorderSelf);
+
+  /// Emits a derivative function by transforming the given derivative
+  /// function's returned derivative.
+  ManagedValue emitDerivativeWithTransformedLinearMap(
+      ManagedValue derivativeFn, AutoDiffLinearMapKind linearMapKind,
+      CanSILFunctionType substLinearMapFromType,
+      CanSILFunctionType substLinearMapToType);
 
   //===---------------------------------------------------------------------===//
   // Distributed Actors

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3205,11 +3205,16 @@ CanSILFunctionType SILGenFunction::buildThunkType(
     if (F.getLoweredFunctionType()->isPseudogeneric())
       extInfoBuilder = extInfoBuilder.withIsPseudogeneric();
 
+  ParameterConvention contextConvention;
+  if (getTypeLowering(sourceType).isTrivial()) {
+    contextConvention = ParameterConvention::Direct_Unowned;
+  } else {
+    contextConvention = sourceType->isCalleeConsumed()
+                            ? ParameterConvention::Direct_Owned
+                            : ParameterConvention::Direct_Guaranteed;
+  }
+
   // Add the function type as the parameter.
-  auto contextConvention =
-      getTypeLowering(sourceType).isTrivial()
-          ? ParameterConvention::Direct_Unowned
-          : ParameterConvention::Direct_Guaranteed;
   SmallVector<SILParameterInfo, 4> params;
   params.append(expectedType->getParameters().begin(),
                 expectedType->getParameters().end());
@@ -3655,17 +3660,18 @@ static SILValue joinElements(ArrayRef<SILValue> elements, SILBuilder &builder,
 }
 
 /// Adapted from `SILGenModule::getOrCreateReabstractionThunk`.
-ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
+ManagedValue SILGenFunction::emitTransformedAutoDiffLinearMap(
     ManagedValue linearMap, AutoDiffLinearMapKind linearMapKind,
-    CanSILFunctionType fromType, CanSILFunctionType toType, bool reorderSelf) {
+    CanSILFunctionType substFromType, CanSILFunctionType substToType,
+    bool reorderSelf) {
   // Compute the thunk type.
   SubstitutionMap interfaceSubs;
   GenericEnvironment *genericEnv = nullptr;
   // Ignore subst types.
   CanType inputSubstType, outputSubstType;
   CanType dynamicSelfType;
-  fromType = fromType->getUnsubstitutedType(getModule());
-  toType = toType->getUnsubstitutedType(getModule());
+  auto fromType = substFromType->getUnsubstitutedType(getModule());
+  auto toType = substToType->getUnsubstitutedType(getModule());
   auto thunkType =
       buildThunkType(fromType, toType, inputSubstType, outputSubstType,
                      genericEnv, interfaceSubs, dynamicSelfType);
@@ -3698,6 +3704,7 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
   auto *thunk = fb.getOrCreateSharedFunction(
       loc, name, thunkDeclType, IsBare, IsTransparent, IsSerialized,
       ProfileCounter(), IsReabstractionThunk, IsNotDynamic, IsNotDistributed);
+  thunk->setInlineStrategy(AlwaysInline);
 
   // Partially-apply the thunk to `linearMap` and return the thunked value.
   auto getThunkedResult = [&]() {
@@ -3712,6 +3719,10 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
     }
     auto thunkedFn = createPartialApplyOfThunk(
         *this, loc, thunk, interfaceSubs, dynamicSelfType, toType, linearMap);
+    if (thunkedFn.getType().getASTType() != substToType) {
+      thunkedFn = B.createConvertFunction(
+          loc, thunkedFn, SILType::getPrimitiveObjectType(substToType));
+    }
     if (!toType->isNoEscape())
       return thunkedFn;
     // Handle escaping to noescape conversion.
@@ -3859,9 +3870,16 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
     arguments.push_back(load.getValue());
   }
 
-  auto *linearMapArg = thunk->getArgumentsWithoutIndirectResults().back();
-  auto *apply = thunkSGF.B.createApply(loc, linearMapArg, SubstitutionMap(),
-                                       arguments);
+  auto linearMapArg = thunkArguments.back();
+  SILValue linearMapArgToApply;
+  if (fromType->isCalleeConsumed()) {
+    assert(linearMapArg.getOwnershipKind() == OwnershipKind::Owned);
+    linearMapArgToApply = linearMapArg.forward(thunkSGF);
+  } else {
+    linearMapArgToApply = linearMapArg.borrow(thunkSGF, loc).getValue();
+  }
+  auto *apply = thunkSGF.B.createApply(
+      loc, linearMapArgToApply, SubstitutionMap(), arguments);
 
   // Get return elements.
   SmallVector<SILValue, 4> results;
@@ -4077,7 +4095,7 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
   auto linearMap = thunkSGF.emitManagedRValueWithCleanup(directResults.back());
   assert(linearMap.getType().castTo<SILFunctionType>() == linearMapFnType);
   auto linearMapKind = kind.getLinearMapKind();
-  linearMap = thunkSGF.getThunkedAutoDiffLinearMap(
+  linearMap = thunkSGF.emitTransformedAutoDiffLinearMap(
       linearMap, linearMapKind, linearMapFnType, targetLinearMapFnType,
       reorderSelf);
   auto typeExpansionContext = thunkSGF.getTypeExpansionContext();
@@ -4093,14 +4111,6 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
     linearMapResultType = SILType::getPrimitiveType(
         tupleType->getElementTypes().back()->getCanonicalType(),
         conv.getSILResultType(typeExpansionContext).getCategory());
-  }
-
-  auto targetLinearMapUnsubstFnType =
-      SILType::getPrimitiveObjectType(targetLinearMapFnType);
-  if (linearMap.getType() != targetLinearMapUnsubstFnType) {
-    linearMap = thunkSGF.B.createConvertFunction(
-        loc, linearMap, targetLinearMapUnsubstFnType,
-        /*withoutActuallyEscaping*/ false);
   }
 
   // Return original results and thunked differential/pullback.

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1290,10 +1290,9 @@ public:
           });
     }
 
-    // Call the differential.
+    // Call the differential.  It is `@callee_owned` so the `apply` consumes it.
     auto *differentialCall =
         diffBuilder.createApply(loc, differential, SubstitutionMap(), diffArgs);
-    diffBuilder.emitDestroyValueOperation(loc, differential);
 
     // Get the original `apply` results.
     SmallVector<SILValue, 8> origDirectResults;

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -256,7 +256,7 @@ public:
 
     auto *pullbackPartialApply = Builder.createPartialApply(
         loc, pullbackRef, vjpSubstMap, {partialApplyArg},
-        ParameterConvention::Direct_Guaranteed);
+        ParameterConvention::Direct_Owned);
     auto pullbackType = vjp->getLoweredFunctionType()
                             ->getResults()
                             .back()
@@ -628,7 +628,7 @@ public:
 
     // Record desired/actual VJP indices.
     // Temporarily set original pullback type to `None`.
-    NestedApplyInfo info{config, /*originalPullbackType*/ None};
+    NestedApplyInfo info{config, /*originalPullbackType*/ CanSILFunctionType()};
     auto insertion = context.getNestedApplyInfo().try_emplace(ai, info);
     auto &nestedApplyInfo = insertion.first->getSecond();
     nestedApplyInfo = info;
@@ -676,23 +676,22 @@ public:
     // Checkpoint the pullback.
     auto *pullbackDecl = pullbackInfo.lookUpLinearMapDecl(ai);
 
-    // If actual pullback type does not match lowered pullback type, reabstract
-    // the pullback using a thunk.
+    // The actual pullback type will have a different abstraction pattern than
+    // the type lowered from the AST type. Here we perform a bitcast to avoid
+    // performing unnecessary reabstraction. The pullback function is the only
+    // thing that will use these closures, and it will bitcast these closures
+    // back to their original type.
+    // FIXME: Switch to using tuples so that we don't have to perform this
+    // conversion.
     auto actualPullbackType =
         getOpType(pullback->getType()).getAs<SILFunctionType>();
+    nestedApplyInfo.originalPullbackType = actualPullbackType;
     auto loweredPullbackType =
         getOpType(getLoweredType(pullbackDecl->getInterfaceType()))
             .castTo<SILFunctionType>();
-    if (!loweredPullbackType->isEqual(actualPullbackType)) {
-      // Set non-reabstracted original pullback type in nested apply info.
-      nestedApplyInfo.originalPullbackType = actualPullbackType;
-      SILOptFunctionBuilder fb(context.getTransform());
-      pullback = reabstractFunction(
-          getBuilder(), fb, ai->getLoc(), pullback, loweredPullbackType,
-          [this](SubstitutionMap subs) -> SubstitutionMap {
-            return this->getOpSubstitutionMap(subs);
-          });
-    }
+    pullback = builder.createUncheckedBitCast(
+        ai->getLoc(), pullback,
+        SILType::getPrimitiveObjectType(loweredPullbackType));
     pullbackValues[ai->getParent()].push_back(pullback);
 
     // Some instructions that produce the callee may have been cloned.


### PR DESCRIPTION
Switch to `@callee_owned` callee convention for all linear map functions (differentials and pullbacks) returned from derivative functions. This reduces a half of reference counting operations in compiler-generated derivatives, and enables child linear maps that are called in linear maps to be destroyed right after the call.

Background: Before this patch, linear map functions took an `@owned` context and had `@callee_guaranteed` callee convention. It was a suboptimal design because
1. All linear maps in AD-generated code are called exactly once. The context's parameter convention is `@owned` because we want to consume the context as early as possible, but doing so in combination with `@callee_guaranteed` convention leads to an unnecessary pair of retain (in the partial application forwarder) and release (in the caller). As a result, the entire context was kept alive until the entire outer pullback returns.
2. Pullbacks' allocation and deallocation follow a strict stack discipline, so we really want to consume pullbacks as early as possible and not retain unused memory.

Resolves rdar://71892494.