### PR TITLE
SILOptimizer: update alias analysis in TempRValueOpt and TempLValueOpt

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -164,7 +164,16 @@ public:
   }
   
   virtual void initialize(SILPassManager *PM) override;
-  
+
+  /// Explicitly invalidate an instruction.
+  ///
+  /// This can be useful to update the alias analysis within a pass.
+  /// It's needed if e.g. \p inst is an address projection and its operand gets
+  /// replaced with a different underlying object.
+  void invalidateInstruction(SILInstruction *inst) {
+    handleDeleteNotification(inst);
+  }
+
   /// Perform an alias query to see if V1, V2 refer to the same values.
   AliasResult alias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
                     SILType TBAAType2 = SILType());

--- a/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
+++ b/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
@@ -253,6 +253,7 @@ bool TempLValueOptPass::tempLValueOpt(CopyAddrInst *copyInst) {
         user->eraseFromParent();
         break;
       default:
+        AA->invalidateInstruction(user);
         use->set(destination);
     }
   }

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -506,6 +506,8 @@ bool TempRValueOptPass::tryOptimizeCopyIntoTemp(CopyAddrInst *copyInst) {
   while (!tempObj->use_empty()) {
     Operand *use = *tempObj->use_begin();
     SILInstruction *user = use->getUser();
+    aa->invalidateInstruction(user);
+
     switch (user->getKind()) {
     case SILInstructionKind::DestroyAddrInst:
     case SILInstructionKind::DeallocStackInst:

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -249,3 +249,36 @@ bb0(%0 : $*T, %1 : $*T):
   return %78 : $()
 }
 
+class Child { }
+
+struct Parent {
+  var c : Child
+}
+
+sil @gen_child : $@convention(thin) () -> @out Child
+
+// Check that alias analysis is invalidated correctly and that the pass does
+// not produce invalid SIL (which would trigger a MemoryLifetime failure).
+//
+// CHECK-LABEL: sil [ossa] @invalidateAliasAnalysis :
+// CHECK:   copy_addr
+// CHECK: } // end sil function 'invalidateAliasAnalysis'
+sil [ossa] @invalidateAliasAnalysis : $@convention(thin) (@owned Child) -> () {
+bb0(%0 :@owned  $Child):
+  %2 = alloc_stack $Parent 
+  %4 = alloc_stack $Child
+  store %0 to [init] %4 : $*Child
+  %7 = alloc_stack $Child 
+  %func = function_ref @gen_child : $@convention(thin) () -> @out Child
+  %10 = apply %func(%7) : $@convention(thin)() -> @out Child
+  %11 = struct_element_addr %2 : $*Parent, #Parent.c
+  copy_addr [take] %7 to [initialization] %11 : $*Child
+  dealloc_stack %7 : $*Child
+  copy_addr [take] %4 to %11 : $*Child
+  %17 = tuple ()
+  dealloc_stack %4 : $*Child
+  destroy_addr %2 : $*Parent
+  dealloc_stack %2 : $*Parent
+  %res = tuple ()
+  return %res : $()
+}


### PR DESCRIPTION
When instructions are changed within a pass in a way that affects subsequent alias queries in the same pass run,
their alias analysis information must be invalidated.
Otherwise it can result in miscompiles and/or invalid SIL.

rdar://71924430
