### PR TITLE
Temporarily disable test in optimize mode

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -7,6 +7,9 @@
 // RUN: %target-codesign %t/Dictionary && %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
 
+// rdar71933996
+// UNSUPPORTED: swift_test_mode_optimize
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
The test failed on oss-swift_tools-RA_stdlib-RD_test-simulator

rdar://71933996
