### PR TITLE
Fix availability for one of the Float16 tests.

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -383,9 +383,7 @@ fileprivate func expectDescription(_ expected: String, _ object: ${FloatType},
 //   that is closest (as an infinitely-precise real number) to the original
 //   binary float (interpreted as an infinitely-precise real number).
 % if FloatType == 'Float16':
-@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-@available(macOS, unavailable)
-@available(macCatalyst, unavailable)
+@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 % end
 fileprivate func expectAccurateDescription(_ object: ${FloatType},
   _ message: @autoclosure () -> String = "",


### PR DESCRIPTION
Unbreak an internal bot. The macCatalyst availability of Float16 is still not quite right and will have to be revisited, but this should get the bot running again.