### PR TITLE
[nfc] Remove unused variable "loc".

### DIFF
--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -342,7 +342,6 @@ void OwnershipModelEliminatorVisitor::splitDestructure(
   // instruction operands.
 
   SILModule &M = destructureInst->getModule();
-  SILLocation loc = destructureInst->getLoc();
   SILType opType = destructureOperand->getType();
 
   llvm::SmallVector<Projection, 8> projections;


### PR DESCRIPTION
Fixes a warning for unused variable in OwnershipModelEliminator.
