### PR TITLE
[basicblock-utils] Add new API: JointPostDominanceSetComputer and its method findJointPostDominatingSet(...).

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -10,11 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SIL_DEADENDBLOCKS_H
-#define SWIFT_SIL_DEADENDBLOCKS_H
+#ifndef SWIFT_SIL_BASICBLOCKUTILS_H
+#define SWIFT_SIL_BASICBLOCKUTILS_H
 
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace swift {
@@ -88,6 +89,90 @@ public:
     }
     return ReachableBlocks.empty();
   }
+};
+
+/// A struct that contains the intermediate state used in computing
+/// joint-dominance sets. Enables a pass to easily reuse the same small data
+/// structures with clearing (noting that clearing our internal state does not
+/// cause us to shrink meaning that once we malloc, we keep the malloced
+/// memory).
+struct JointPostDominanceSetComputer {
+  /// The worklist that drives the algorithm.
+  SmallVector<SILBasicBlock *, 32> worklist;
+
+  /// A set that guards our worklist. Any block before it is added to worklist
+  /// should be checked against visitedBlocks.
+  SmallPtrSet<SILBasicBlock *, 32> visitedBlocks;
+
+  /// The set of blocks where we begin our walk.
+  SmallPtrSet<SILBasicBlock *, 8> initialBlocks;
+
+  /// A subset of our initial blocks that we found as a predecessor of another
+  /// block along our walk.
+  SmallVector<SILBasicBlock *, 8> reachableInputBlocks;
+
+  /// As we process the worklist, any successors that we see that have not been
+  /// visited yet are placed in here. At the end of our worklist, any blocks
+  /// that remain here are "leaking blocks" that together with our initial set
+  /// would provide a jointly-postdominating set of our dominating value.
+  SmallSetVector<SILBasicBlock *, 8> blocksThatLeakIfNeverVisited;
+
+  DeadEndBlocks &deadEndBlocks;
+
+  JointPostDominanceSetComputer(DeadEndBlocks &deadEndBlocks)
+      : deadEndBlocks(deadEndBlocks) {}
+
+  void clear() {
+    worklist.clear();
+    visitedBlocks.clear();
+    initialBlocks.clear();
+    reachableInputBlocks.clear();
+    blocksThatLeakIfNeverVisited.clear();
+  }
+
+  /// Compute joint-postdominating set for \p dominatingBlock and \p
+  /// dominatedBlockSet found by walking up the CFG from the latter to the
+  /// former.
+  ///
+  /// We pass back the following information via callbacks so our callers can
+  /// use whatever container they need to:
+  ///
+  /// * inputBlocksFoundDuringWalk: Any blocks from the "dominated
+  ///   block set" that was found as a predecessor block during our traversal is
+  ///   passed to this callback. These can occur for two reasons:
+  ///
+  ///   1. We actually had a block in \p dominatedBlockSet that was reachable
+  ///      from another block in said set. This is a valid usage of the API
+  ///      since it could be that the user does not care about such uses and
+  ///      leave this callback empty.
+  ///
+  ///   2. We had a block in \p dominatedBlockSet that is in a sub-loop in the
+  ///      loop-nest relative to \p dominatingBlock causing us to go around a
+  ///      backedge and hit the block during our traversal. In this case, we
+  ///      have already during the traversal passed the exiting blocks of the
+  ///      sub-loop as joint postdominace completion set blocks. This is useful
+  ///      if one is using this API for lifetime extension purposes of lifetime
+  ///      ending uses and one needs to insert compensating copy_value at these
+  ///      locations due to the lack of strong control-equivalence in between
+  ///      the block and \p dominatingBlock.
+  ///
+  ///
+  /// * foundJointPostDomSetCompletionBlocks: The set of blocks not in \p
+  ///   dominatedBlockSet that together with \p dominatedBlockSet
+  ///   jointly-postdominate \p dominatedBlock. This is "completing" the joint
+  ///   post-dominance set.
+  ///
+  /// * inputBlocksInJointPostDomSet: Any of our input blocks that were never
+  ///   found as a predecessor is passed to this callback. This block is in the
+  ///   final minimal joint-postdominance set and is passed to this
+  ///   callback. This is optional and we will avoid doing work if it is not
+  ///   set.
+  void findJointPostDominatingSet(
+      SILBasicBlock *dominatingBlock,
+      ArrayRef<SILBasicBlock *> dominatedBlockSet,
+      function_ref<void(SILBasicBlock *)> inputBlocksFoundDuringWalk,
+      function_ref<void(SILBasicBlock *)> foundJointPostDomSetCompletionBlocks,
+      function_ref<void(SILBasicBlock *)> inputBlocksInJointPostDomSet = {});
 };
 
 } // namespace swift

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/BasicBlockUtils.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/SILArgument.h"
@@ -18,6 +19,7 @@
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/TerminatorUtils.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 
@@ -377,4 +379,112 @@ void DeadEndBlocks::compute() {
     for (SILBasicBlock *Pred : BB->getPredecessorBlocks())
       ReachableBlocks.insert(Pred);
   }
+}
+
+//===----------------------------------------------------------------------===//
+//                  Post Dominance Set Completion Utilities
+//===----------------------------------------------------------------------===//
+
+void JointPostDominanceSetComputer::findJointPostDominatingSet(
+    SILBasicBlock *dominatingBlock, ArrayRef<SILBasicBlock *> dominatedBlockSet,
+    function_ref<void(SILBasicBlock *)> foundInputBlocksNotInJointPostDomSet,
+    function_ref<void(SILBasicBlock *)> foundJointPostDomSetCompletionBlocks,
+    function_ref<void(SILBasicBlock *)> foundInputBlocksInJointPostDomSet) {
+  // If our reachable block set is empty, assert. This is most likely programmer
+  // error.
+  assert(dominatedBlockSet.size() != 0);
+
+  // If we have a reachable block set with a single block and that block is
+  // dominatingBlock, then we return success since a block post-doms its self so
+  // it is already complete.
+  if (dominatedBlockSet.size() == 1) {
+    if (dominatingBlock == dominatedBlockSet[0]) {
+      if (foundInputBlocksInJointPostDomSet)
+        foundInputBlocksInJointPostDomSet(dominatingBlock);
+      return;
+    }
+  }
+
+  // At the top of where we for sure are going to use state... make sure we
+  // always clean up any resources that we use!
+  SWIFT_DEFER { clear(); };
+
+  // Otherwise, we need to compute our joint post dominating set. We do this by
+  // performing a backwards walk up the CFG tracking back liveness until we find
+  // our dominating block. As we walk up, we keep track of any successor blocks
+  // that we need to visit before the walk completes lest we leak. After we
+  // finish the walk, these leaking blocks are a valid (albeit not unique)
+  // completion of the post dom set.
+  for (auto *block : dominatedBlockSet) {
+    // Skip dead end blocks.
+    if (deadEndBlocks.isDeadEnd(block))
+      continue;
+
+    // We require dominatedBlockSet to be a set and thus assert if we hit it to
+    // flag user error to our caller.
+    bool succeededInserting = visitedBlocks.insert(block).second;
+    (void)succeededInserting;
+    assert(succeededInserting &&
+           "Repeat Elt: dominatedBlockSet should be a set?!");
+    initialBlocks.insert(block);
+    worklist.push_back(block);
+  }
+
+  // Then until we run out of blocks...
+  while (!worklist.empty()) {
+    auto *block = worklist.pop_back_val();
+
+    // First remove block from blocksThatLeakIfNeverVisited if it is there since
+    // we know that it isn't leaking since we are visiting it now.
+    blocksThatLeakIfNeverVisited.remove(block);
+
+    // Then if our block is not one of our initial blocks, add the block's
+    // successors to blocksThatLeakIfNeverVisited.
+    if (!initialBlocks.count(block)) {
+      for (auto *succBlock : block->getSuccessorBlocks()) {
+        if (visitedBlocks.count(succBlock))
+          continue;
+        if (deadEndBlocks.isDeadEnd(succBlock))
+          continue;
+        blocksThatLeakIfNeverVisited.insert(succBlock);
+      }
+    }
+
+    // If we are the dominating block, we are done.
+    if (dominatingBlock == block)
+      continue;
+
+    // Otherwise for each predecessor that we have, first check if it was one of
+    // our initial blocks (signaling a loop) and then add it to the worklist if
+    // we haven't visited it already.
+    for (auto *predBlock : block->getPredecessorBlocks()) {
+      if (initialBlocks.count(predBlock)) {
+        reachableInputBlocks.push_back(predBlock);
+      }
+      if (visitedBlocks.insert(predBlock).second)
+        worklist.push_back(predBlock);
+    }
+  }
+
+  // After our worklist has emptied, any blocks left in
+  // blocksThatLeakIfNeverVisited are "leaking blocks".
+  for (auto *leakingBlock : blocksThatLeakIfNeverVisited)
+    foundJointPostDomSetCompletionBlocks(leakingBlock);
+
+  // Then unique our list of reachable input blocks and pass them to our
+  // callback.
+  sortUnique(reachableInputBlocks);
+  for (auto *block : reachableInputBlocks)
+    foundInputBlocksNotInJointPostDomSet(block);
+
+  // Then if were asked to find the subset of our input blocks that are in the
+  // joint-postdominance set, compute that.
+  if (!foundInputBlocksInJointPostDomSet)
+    return;
+
+  // Pass back the reachable input blocks that were not reachable from other
+  // input blocks to.
+  for (auto *block : dominatedBlockSet)
+    if (lower_bound(reachableInputBlocks, block) == reachableInputBlocks.end())
+      foundInputBlocksInJointPostDomSet(block);
 }


### PR DESCRIPTION
Often times when one is working with ownership one has a value V and a set of
use points Uses where you want V's lifetime to end at, but those Uses together
(while not reachable from each other) only partially post-dominate
V. JointPostDominanceSetComputer is a struct that implements a general solution
to that operation at the block level. The struct itself is just a set of state
that the computation uses so that a pass can clear the state (allowing for us to
avoid needing to remalloc if we had any small data structures that went big).

To get into the semantics, the API
JointPostDominanceSetComputer::findJointPostDominatingSet() takes in a
"dominating block" and a set of "lifetime ending" blocks that partially
post-dominate the "dominating block" and computes a set of blocks that fully
jointly-postdominate V as well as all of the passed in "lifetime ending" blocks.

Conceptually we are performing a backwards walk up the CFG from each of the
"lifetime ending" blocks towards the "dominating block". As we go, we track
successor blocks and report any successor blocks that we do not hit during our
traversal as result blocks and are passed to the result callback.

Now what does this actually mean:

1. All "lifetime ending" blocks that are at the same loop nest level as our
dominating block will always be part of the final post-dominating block set.

2. All "lifetime ending" blocks that are at a different loop nest level than our
dominating block are not going to be in our final result set. Let
LifetimeEndingBlock be such a block. Then note that our assumed condition
implies that there must be a sub-loop, SubLoop, at the same level of the
loop-nest as the dominating block that contains LifetimeEndingBlock. The
algorithm will yield to the caller the exiting blocks of that loop. It will also
flag the blocks that were found to be a different use level, so the caller can
introduce a copy at that point if needed.

NOTE: Part of the reason why I am writing this rather than using the linear
lifetime checker (LLChecker) is that LLChecker is being used in too many places
because it is convenient. Its original true use was for emitting diagnostics and
that can be seen through the implementation. I don't want to add more
contortions to that code, so as I am finding new use cases where I could either
write something new or add contortions to the LLChecker, I am doing the former.
