### PR TITLE
Temporarily disable hop_to_executor.sil test

### DIFF
--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: concurrency
 
+// This test fails on 32bit archs.
+// UNSUPPORTED: PTRSIZE=32
+
 sil_stage canonical
 
 import Builtin


### PR DESCRIPTION
It fails on i386.

rdar://71951411