### PR TITLE
[stdlib] Add a missing debug precondition to Range.init(uncheckedBounds:)

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -78,6 +78,8 @@ public struct ClosedRange<Bound: Comparable> {
   /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
   @inlinable
   public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    _debugPrecondition(bounds.lower <= bounds.upper,
+      "ClosedRange requires lowerBound <= upperBound")
     self.lowerBound = bounds.lower
     self.upperBound = bounds.upper
   }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -167,6 +167,8 @@ public struct Range<Bound: Comparable> {
   /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
   @inlinable
   public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    _debugPrecondition(bounds.lower <= bounds.upper,
+      "Range requires lowerBound <= upperBound")
     self.lowerBound = bounds.lower
     self.upperBound = bounds.upper
   }

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -116,5 +116,23 @@ RangeTraps.test("throughNaN")
   _ = ...Double.nan
 }
 
+RangeTraps.test("UncheckedHalfOpen")
+  .xfail(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "assertions are disabled in Release and Unchecked mode"))
+  .code {
+  expectCrashLater()
+  var range = Range(uncheckedBounds: (lower: 1, upper: 0))
+}
+
+RangeTraps.test("UncheckedClosed")
+  .xfail(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "assertions are disabled in Release and Unchecked mode"))
+  .code {
+  expectCrashLater()
+  var range = ClosedRange(uncheckedBounds: (lower: 1, upper: 0))
+}
+
 runAllTests()
 


### PR DESCRIPTION
Unchecked APIs must still perform checks in debug builds to ensure that invariants aren’t violated.
(I.e., these aren’t a license to perform invalid operations — they just let us get rid of the checks when we know for sure they are unnecessary.)

(This PR is a followup to the discussion in #34879.)