### PR TITLE
[Frontend] Recover missing input file by dummy input buffer.

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -572,7 +572,9 @@ private:
   /// Return the buffer ID if it is not already compiled, or None if so.
   /// Set failed on failure.
 
-  Optional<unsigned> getRecordedBufferID(const InputFile &input, bool &failed);
+  Optional<unsigned> getRecordedBufferID(const InputFile &input,
+                                         const bool shouldRecover,
+                                         bool &failed);
 
   /// Given an input file, return a buffer to use for its contents,
   /// and a buffer for the corresponding module doc file if one exists.

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -46,6 +46,9 @@ class FrontendInputsAndOutputs {
   /// Punt where needed to enable batch mode experiments.
   bool AreBatchModeChecksBypassed = false;
 
+  /// Recover missing inputs. Note that recovery itself is users responsibility.
+  bool ShouldRecoverMissingInputs = false;
+
 public:
   bool areBatchModeChecksBypassed() const { return AreBatchModeChecksBypassed; }
   void setBypassBatchModeChecks(bool bbc) { AreBatchModeChecksBypassed = bbc; }
@@ -65,6 +68,9 @@ public:
   void setIsSingleThreadedWMO(bool istw) { IsSingleThreadedWMO = istw; }
 
   bool isWholeModule() const { return !hasPrimaryInputs(); }
+
+  bool shouldRecoverMissingInputs() { return ShouldRecoverMissingInputs; }
+  void setShouldRecoverMissingInputs() { ShouldRecoverMissingInputs = true; }
 
   // Readers:
 

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -38,6 +38,7 @@ FrontendInputsAndOutputs::FrontendInputsAndOutputs(
   for (InputFile input : other.AllInputs)
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
+  ShouldRecoverMissingInputs = other.ShouldRecoverMissingInputs;
 }
 
 FrontendInputsAndOutputs &FrontendInputsAndOutputs::
@@ -46,6 +47,7 @@ operator=(const FrontendInputsAndOutputs &other) {
   for (InputFile input : other.AllInputs)
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
+  ShouldRecoverMissingInputs = other.ShouldRecoverMissingInputs;
   return *this;
 }
 

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -215,6 +215,7 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
       ++primaryCount;
     }
     assert(primaryCount < 2 && "cannot handle multiple primaries");
+
     replacementInputsAndOutputs.addInput(
         InputFile(newFilename.str(), newIsPrimary, input.getBuffer()));
   }
@@ -310,6 +311,11 @@ bool ide::initCompilerInvocation(
       resolveSymbolicLinksInInputs(
           Invocation.getFrontendOptions().InputsAndOutputs,
           UnresolvedPrimaryFile, FileSystem, Error);
+
+  // SourceKit functionalities want to proceed even if there are missing inputs.
+  Invocation.getFrontendOptions().InputsAndOutputs
+      .setShouldRecoverMissingInputs();
+
   if (!Error.empty())
     return true;
 

--- a/test/Frontend/missing_files.swift
+++ b/test/Frontend/missing_files.swift
@@ -2,17 +2,16 @@
 
 // RUN: not %target-swift-frontend -c -parse-as-library /tmp/SOMETHING_DOES_NOT_EXIST_1.swift -primary-file %s /tmp/SOMETHING_DOES_NOT_EXIST_2.swift -o %t/out.o 2> %t/error1.output
 // RUN: not test -f %t/out.o
-// RUN: %FileCheck %s -input-file %t/error1.output --check-prefixes=CHECK,CHECK_RECOVER
+// RUN: %FileCheck %s -input-file %t/error1.output --check-prefixes=CHECK
 
 // RUN: not %target-swift-frontend -c -parse-as-library -primary-file /tmp/SOMETHING_DOES_NOT_EXIST_1.swift -primary-file %s /tmp/SOMETHING_DOES_NOT_EXIST_2.swift -o %t/out1.o -o %t/out2.o 2> %t/error2.output
 // RUN: not test -f %t/out1.o
 // RUN: not test -f %t/out2.o
-// RUN: %FileCheck %s -input-file %t/error2.output --check-prefixes=CHECK,CHECK_FAIL
+// RUN: %FileCheck %s -input-file %t/error2.output --check-prefixes=CHECK
 
 // CHECK-DAG: <unknown>:0: error: error opening input file '{{[/\\]}}tmp{{[/\\]}}SOMETHING_DOES_NOT_EXIST_1.swift' ({{.*}})
 // CHECK-DAG: <unknown>:0: error: error opening input file '{{[/\\]}}tmp{{[/\\]}}SOMETHING_DOES_NOT_EXIST_2.swift' ({{.*}})
 
 public var x = INVALID_DECL
-// CHECK_RECOVER-DAG: test{{[/\\]}}Frontend{{[/\\]}}missing_files.swift:[[@LINE-1]]:16: error: cannot find 'INVALID_DECL' in scope
-// CHECK_FAIL-NOT: INVALID_DECL
+// CHECK-NOT: INVALID_DECL
 

--- a/test/Frontend/missing_files.swift
+++ b/test/Frontend/missing_files.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+
+// RUN: not %target-swift-frontend -c -parse-as-library /tmp/SOMETHING_DOES_NOT_EXIST_1.swift -primary-file %s /tmp/SOMETHING_DOES_NOT_EXIST_2.swift -o %t/out.o 2> %t/error1.output
+// RUN: not test -f %t/out.o
+// RUN: %FileCheck %s -input-file %t/error1.output --check-prefixes=CHECK,CHECK_RECOVER
+
+// RUN: not %target-swift-frontend -c -parse-as-library -primary-file /tmp/SOMETHING_DOES_NOT_EXIST_1.swift -primary-file %s /tmp/SOMETHING_DOES_NOT_EXIST_2.swift -o %t/out1.o -o %t/out2.o 2> %t/error2.output
+// RUN: not test -f %t/out1.o
+// RUN: not test -f %t/out2.o
+// RUN: %FileCheck %s -input-file %t/error2.output --check-prefixes=CHECK,CHECK_FAIL
+
+// CHECK-DAG: <unknown>:0: error: error opening input file '{{[/\\]}}tmp{{[/\\]}}SOMETHING_DOES_NOT_EXIST_1.swift' ({{.*}})
+// CHECK-DAG: <unknown>:0: error: error opening input file '{{[/\\]}}tmp{{[/\\]}}SOMETHING_DOES_NOT_EXIST_2.swift' ({{.*}})
+
+public var x = INVALID_DECL
+// CHECK_RECOVER-DAG: test{{[/\\]}}Frontend{{[/\\]}}missing_files.swift:[[@LINE-1]]:16: error: cannot find 'INVALID_DECL' in scope
+// CHECK_FAIL-NOT: INVALID_DECL
+

--- a/test/SourceKit/CodeComplete/complete_missing_files.swift
+++ b/test/SourceKit/CodeComplete/complete_missing_files.swift
@@ -1,0 +1,3 @@
+// RUN: %sourcekitd-test -req=complete -pos=1:1 %s -- /tmp/SOMETHING_DOES_NOT_EXIST_1.swift %s /tmp/SOMETHING_DOES_NOT_EXIST_2.swift | %FileCheck %s
+
+// CHECK: results: [


### PR DESCRIPTION
Recover missing input file by dummy input buffer as long as they are non-primary `.swift` files. Also, continue trying opening files even if any of primary files are missing so that the caller can know all files failed to open.

Fixes rdar://problem/33757793 where code completion failed if there's a missing input file.