### PR TITLE
Fix the build and implementation of the 16-byte atomics for MSVC

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -248,18 +248,6 @@ function(_add_host_variant_c_compile_flags target)
     endif()
   endif()
 
-  # The concurrency library uses double-word atomics.  MSVC's std::atomic
-  # uses a spin lock for this, so to get reasonable behavior we have to
-  # implement it ourselves using _InterlockedCompareExchange128.
-  # clang-cl requires us to enable the `cx16` feature to use this intrinsic.
-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
-    if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
-      if(CMAKE_C_COMPILER_ID MATCHES Clang)
-        target_compile_options(${target} PRIVATE -mcx16)
-      endif()
-    endif()
-  endif()
-
   if(LLVM_ENABLE_ASSERTIONS)
     target_compile_options(${target} PRIVATE -UNDEBUG)
   else()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -261,6 +261,18 @@ function(_add_target_variant_c_compile_flags)
     endif()
   endif()
 
+  # The concurrency library uses double-word atomics.  MSVC's std::atomic
+  # uses a spin lock for this, so to get reasonable behavior we have to
+  # implement it ourselves using _InterlockedCompareExchange128.
+  # clang-cl requires us to enable the `cx16` feature to use this intrinsic.
+  if(SWIFT_HOST_VARIANT_ARCH STREQUAL x86_64)
+    if(SWIFT_COMPILER_IS_MSVC_LIKE)
+      list(APPEND result /clang:-mcx16)
+    else()
+      list(APPEND result -mcx16)
+    endif()
+  endif()
+
   if(${CFLAGS_SDK} STREQUAL ANDROID)
     if(${CFLAGS_ARCH} STREQUAL x86_64)
       # NOTE(compnerd) Android NDK 21 or lower will generate library calls to


### PR DESCRIPTION
Credit for the cmake fix here goes to Saleem Abdulrasool.

The substantive fix is embarrassing; I didn't pay close attention to the intrinsic's argument order and just assumed that the first argument for the replacement value was the low half (the part you'd find at index 0 if it were an array), but in fact it's the high half (the part you'd find at index 1).

I also change the code to be much more reinterpret_casty, which isolates the type-punning mostly "within" the intrinsic, and which seems to match how other code I was able to find uses it.