### PR TITLE
[stdlib] Review and fix some problems with unsafe buffer and Range initialization

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -68,6 +68,8 @@ public struct ClosedRange<Bound: Comparable> {
   /// The range's upper bound.
   public let upperBound: Bound
 
+  // This works around _debugPrecondition() impacting the performance of
+  // optimized code. (rdar://72246338)
   @_alwaysEmitIntoClient @inline(__always)
   internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
     self.lowerBound = bounds.lower

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -68,6 +68,12 @@ public struct ClosedRange<Bound: Comparable> {
   /// The range's upper bound.
   public let upperBound: Bound
 
+  @_alwaysEmitIntoClient @inline(__always)
+  internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    self.lowerBound = bounds.lower
+    self.upperBound = bounds.upper
+  }
+
   /// Creates an instance with the given bounds.
   ///
   /// Because this initializer does not perform any checks, it should be used
@@ -78,8 +84,9 @@ public struct ClosedRange<Bound: Comparable> {
   /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
   @inlinable
   public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
-    self.lowerBound = bounds.lower
-    self.upperBound = bounds.upper
+    _debugPrecondition(bounds.lower <= bounds.upper,
+      "ClosedRange requires lowerBound <= upperBound")
+    self.init(_uncheckedBounds: (lower: bounds.lower, upper: bounds.upper))
   }
 }
 
@@ -336,7 +343,7 @@ extension Comparable {
   public static func ... (minimum: Self, maximum: Self) -> ClosedRange<Self> {
     _precondition(
       minimum <= maximum, "Range requires lowerBound <= upperBound")
-    return ClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
+    return ClosedRange(_uncheckedBounds: (lower: minimum, upper: maximum))
   }
 }
 

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -107,8 +107,9 @@ extension ClosedRange: RangeExpression {
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
     return Range(
-      uncheckedBounds: (
-        lower: lowerBound, upper: collection.index(after: self.upperBound)))
+      _uncheckedBounds: (
+        lower: lowerBound,
+        upper: collection.index(after: self.upperBound)))
   }
 
   /// Returns a Boolean value indicating whether the given element is contained
@@ -430,7 +431,7 @@ extension ClosedRange {
       limits.upperBound < self.upperBound ? limits.upperBound
           : limits.lowerBound > self.upperBound ? limits.lowerBound
           : self.upperBound
-    return ClosedRange(uncheckedBounds: (lower: lower, upper: upper))
+    return ClosedRange(_uncheckedBounds: (lower: lower, upper: upper))
   }
 }
 
@@ -446,7 +447,7 @@ extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
   public init(_ other: Range<Bound>) {
     _precondition(!other.isEmpty, "Can't form an empty closed range")
     let upperBound = other.upperBound.advanced(by: -1)
-    self.init(uncheckedBounds: (lower: other.lowerBound, upper: upperBound))
+    self.init(_uncheckedBounds: (lower: other.lowerBound, upper: upperBound))
   }
 }
 
@@ -483,7 +484,7 @@ extension ClosedRange: Decodable where Bound: Decodable {
           codingPath: decoder.codingPath,
           debugDescription: "Cannot initialize \(ClosedRange.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
     }
-    self.init(uncheckedBounds: (lower: lowerBound, upper: upperBound))
+    self.init(_uncheckedBounds: (lower: lowerBound, upper: upperBound))
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -315,7 +315,7 @@ extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
   /// require an upper bound of `Int.max + 1`, which is not representable as
   public init(_ other: ClosedRange<Bound>) {
     let upperBound = other.upperBound.advanced(by: 1)
-    self.init(uncheckedBounds: (lower: other.lowerBound, upper: upperBound))
+    self.init(_uncheckedBounds: (lower: other.lowerBound, upper: upperBound))
   }
 }
 
@@ -332,7 +332,7 @@ extension Range: RangeExpression {
   @inlinable // trivial-implementation
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
-    return Range(uncheckedBounds: (lower: lowerBound, upper: upperBound))
+    self
   }
 }
 
@@ -366,7 +366,7 @@ extension Range {
       limits.upperBound < self.upperBound ? limits.upperBound
           : limits.lowerBound > self.upperBound ? limits.lowerBound
           : self.upperBound
-    return Range(uncheckedBounds: (lower: lower, upper: upper))
+    return Range(_uncheckedBounds: (lower: lower, upper: upper))
   }
 }
 
@@ -442,7 +442,7 @@ extension Range: Decodable where Bound: Decodable {
           codingPath: decoder.codingPath,
           debugDescription: "Cannot initialize \(Range.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
     }
-    self.init(uncheckedBounds: (lower: lowerBound, upper: upperBound))
+    self.init(_uncheckedBounds: (lower: lowerBound, upper: upperBound))
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -157,6 +157,12 @@ public struct Range<Bound: Comparable> {
   /// instance does not contain its upper bound.
   public let upperBound: Bound
 
+  @_alwaysEmitIntoClient @inline(__always)
+  internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    self.lowerBound = bounds.lower
+    self.upperBound = bounds.upper
+  }
+
   /// Creates an instance with the given bounds.
   ///
   /// Because this initializer does not perform any checks, it should be used
@@ -167,8 +173,9 @@ public struct Range<Bound: Comparable> {
   /// - Parameter bounds: A tuple of the lower and upper bounds of the range.
   @inlinable
   public init(uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
-    self.lowerBound = bounds.lower
-    self.upperBound = bounds.upper
+    _debugPrecondition(bounds.lower <= bounds.upper,
+      "Range requires lowerBound <= upperBound")
+    self.init(_uncheckedBounds: (lower: bounds.lower, upper: bounds.upper))
   }
 
   /// Returns a Boolean value indicating whether the given element is contained
@@ -729,7 +736,7 @@ extension Comparable {
   public static func ..< (minimum: Self, maximum: Self) -> Range<Self> {
     _precondition(minimum <= maximum,
       "Range requires lowerBound <= upperBound")
-    return Range(uncheckedBounds: (lower: minimum, upper: maximum))
+    return Range(_uncheckedBounds: (lower: minimum, upper: maximum))
   }
 
   /// Returns a partial range up to, but not including, its upper bound.

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -157,6 +157,8 @@ public struct Range<Bound: Comparable> {
   /// instance does not contain its upper bound.
   public let upperBound: Bound
 
+  // This works around _debugPrecondition() impacting the performance of
+  // optimized code. (rdar://72246338)
   @_alwaysEmitIntoClient @inline(__always)
   internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
     self.lowerBound = bounds.lower

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -208,7 +208,7 @@ extension _SmallString {
         // Restore the memory type of self._storage
         _ = rawPtr.bindMemory(to: RawBitPattern.self, capacity: 1)
       }
-      return try f(UnsafeBufferPointer(start: ptr, count: count))
+      return try f(UnsafeBufferPointer(_uncheckedStart: ptr, count: count))
     }
   }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -458,6 +458,7 @@ extension String {
       contigBytes._providesContiguousBytesNoCopy
     {
       self = contigBytes.withUnsafeBytes { rawBufPtr in
+        Builtin.onFastPath() // encourage SIL Optimizer to inline this closure
         return String._fromUTF8Repairing(
           UnsafeBufferPointer(
             start: rawBufPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -902,7 +902,7 @@ extension _StringObject {
       return sharedUTF8
     }
     return UnsafeBufferPointer(
-      start: self.nativeUTF8Start, count: self.largeCount)
+      _uncheckedStart: self.nativeUTF8Start, count: self.largeCount)
   }
 
   // Whether the object stored can be bridged directly as a NSString

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -153,7 +153,7 @@ extension StringProtocol {
       let end = endIndex
       _internalInvariant(
         start.transcodedOffset == 0 && end.transcodedOffset == 0)
-      return Range(uncheckedBounds: (start._encodedOffset, end._encodedOffset))
+      return Range(_uncheckedBounds: (start._encodedOffset, end._encodedOffset))
     }
   }
 

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -30,7 +30,7 @@ extension _AbstractStringStorage {
                   "Range out of bounds")
 
     let range = Range(
-      uncheckedBounds: (aRange.location, aRange.location+aRange.length))
+      _uncheckedBounds: (aRange.location, aRange.location+aRange.length))
     let str = asString
     str._copyUTF16CodeUnits(
       into: UnsafeMutableBufferPointer(start: buffer, count: range.count),

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -105,7 +105,7 @@ public struct Substring {
 
     self._slice = Slice(
       base: slice.base,
-      bounds: Range(uncheckedBounds: (start, end)))
+      bounds: Range(_uncheckedBounds: (start, end)))
     _invariantCheck()
   }
 
@@ -132,7 +132,7 @@ extension Substring {
   @inlinable @inline(__always)
   internal var _offsetRange: Range<Int> {
     return Range(
-      uncheckedBounds: (startIndex._encodedOffset, endIndex._encodedOffset))
+      _uncheckedBounds: (startIndex._encodedOffset, endIndex._encodedOffset))
   }
 
   #if !INTERNAL_CHECKS_ENABLED

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -322,7 +322,8 @@ extension Substring: CustomDebugStringConvertible {
 
 extension Substring: LosslessStringConvertible {
   public init(_ content: String) {
-    self = content[...]
+    let range = Range(_uncheckedBounds: (content.startIndex, content.endIndex))
+    self.init(Slice(base: content, bounds: range))
   }
 }
 
@@ -727,14 +728,14 @@ extension Substring: RangeReplaceableCollection {
   public init<S: Sequence>(_ elements: S)
   where S.Element == Character {
     if let str = elements as? String {
-      self = str[...]
+      self.init(str)
       return
     }
     if let subStr = elements as? Substring {
       self = subStr
       return
     }
-    self = String(elements)[...]
+    self.init(String(elements))
   }
 
   @inlinable // specialize

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -498,6 +498,17 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Parameter slice: The buffer slice to rebase.
   @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeBufferPointer<Element>>) {
+    // NOTE: `Slice` does not guarantee that its start/end indices are valid
+    // in `base` -- it merely ensures that `startIndex <= endIndex`.
+    // We need manually check that we aren't given an invalid slice,
+    // or the resulting collection would allow access that was
+    // out-of-bounds with respect to the original base buffer.
+    // We only do this in debug builds to prevent a measurable performance
+    // degradation wrt passing around pointers not wrapped in a BufferPointer
+    // construct.
+    _debugPrecondition(
+      slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
+      "Invalid slice")
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = slice.endIndex &- slice.startIndex
     self.init(start: base, count: count)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -207,7 +207,14 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // optimizer is not capable of creating partial specializations yet.
     // NOTE: Range checks are not performed here, because it is done later by
     // the subscript function.
-    return end - start
+    // NOTE: We allow the subtraction to silently overflow in release builds
+    // to eliminate a superflous check when `start` and `end` are both valid
+    // indices. (The operation can only overflow if `start` is negative, which
+    // implies it's an invalid index.) `Collection` does not specify what
+    // `distance` should return when given an invalid index pair.
+    let result = end.subtractingReportingOverflow(start)
+    _debugPrecondition(!result.overflow)
+    return result.partialValue
   }
 
   @inlinable // unsafe-performance

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -394,6 +394,15 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
 }
 
 extension Unsafe${Mutable}BufferPointer {
+  @_alwaysEmitIntoClient
+  internal init(
+    @_nonEphemeral _uncheckedStart start: Unsafe${Mutable}Pointer<Element>?,
+    count: Int
+  ) {
+    _position = start
+    self.count = count
+  }
+
   /// Creates a new buffer pointer over the specified number of contiguous
   /// instances beginning at the given pointer.
   ///
@@ -413,8 +422,7 @@ extension Unsafe${Mutable}BufferPointer {
     _debugPrecondition(
       count == 0 || start != nil,
       "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
-    _position = start
-    self.count = _assumeNonNegative(count)
+    self.init(_uncheckedStart: start, count: _assumeNonNegative(count))
   }
 
   @inlinable // unsafe-performance

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -394,6 +394,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
 }
 
 extension Unsafe${Mutable}BufferPointer {
+  // This works around _debugPrecondition() impacting the performance of
+  // optimized code. (rdar://72246338)
   @_alwaysEmitIntoClient
   internal init(
     @_nonEphemeral _uncheckedStart start: Unsafe${Mutable}Pointer<Element>?,

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -414,7 +414,7 @@ extension Unsafe${Mutable}BufferPointer {
       count == 0 || start != nil,
       "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     _position = start
-    self.count = count
+    self.count = _assumeNonNegative(count)
   }
 
   @inlinable // unsafe-performance

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -401,9 +401,9 @@ extension Unsafe${Mutable}BufferPointer {
   public init(
     @_nonEphemeral start: Unsafe${Mutable}Pointer<Element>?, count: Int
   ) {
-    _precondition(
+    _debugPrecondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
-    _precondition(
+    _debugPrecondition(
       count == 0 || start != nil,
       "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     _position = start

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -511,6 +511,17 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter slice: The raw buffer slice to rebase.
   @inlinable
   public init(rebasing slice: Slice<UnsafeRawBufferPointer>) {
+    // NOTE: `Slice` does not guarantee that its start/end indices are valid
+    // in `base` -- it merely ensures that `startIndex <= endIndex`.
+    // We need manually check that we aren't given an invalid slice,
+    // or the resulting collection would allow access that was
+    // out-of-bounds with respect to the original base buffer.
+    // We only do this in debug builds to prevent a measurable performance
+    // degradation wrt passing around pointers not wrapped in a BufferPointer
+    // construct.
+    _debugPrecondition(
+      slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
+      "Invalid slice")
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = slice.endIndex &- slice.startIndex
     self.init(start: base, count: count)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -436,7 +436,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     _debugPrecondition(count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
     _position = start
-    _end = start.map { $0 + count }
+    _end = start.map { $0 + _assumeNonNegative(count) }
   }
 
   /// Creates a new buffer over the same memory as the given buffer.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -253,7 +253,7 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   @inlinable
   public var count: Int {
     if let pos = _position {
-      return _end! - pos
+      return _assumeNonNegative(_end! - pos)
     }
     return 0
   }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -432,8 +432,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   public init(
     @_nonEphemeral start: Unsafe${Mutable}RawPointer?, count: Int
   ) {
-    _precondition(count >= 0, "${Self} with negative count")
-    _precondition(count == 0 || start != nil,
+    _debugPrecondition(count >= 0, "${Self} with negative count")
+    _debugPrecondition(count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
     _position = start
     _end = start.map { $0 + count }

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -116,5 +116,23 @@ RangeTraps.test("throughNaN")
   _ = ...Double.nan
 }
 
+RangeTraps.test("UncheckedHalfOpen")
+  .xfail(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "assertions are disabled in Release and Unchecked mode"))
+  .code {
+    expectCrashLater()
+    var range = Range(uncheckedBounds: (lower: 1, upper: 0))
+  }
+
+RangeTraps.test("UncheckedClosed")
+  .xfail(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "assertions are disabled in Release and Unchecked mode"))
+  .code {
+    expectCrashLater()
+    var range = ClosedRange(uncheckedBounds: (lower: 1, upper: 0))
+  }
+
 runAllTests()
 

--- a/validation-test/stdlib/ArrayTraps.swift.gyb
+++ b/validation-test/stdlib/ArrayTraps.swift.gyb
@@ -172,8 +172,8 @@ ${ArrayTy}Traps.test("${'remove(at:)/%s' % index}")
 
 ArrayTraps.test("unsafeLength")
   .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+    { !_isDebugAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -O or -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
     "UnsafeBufferPointer with negative count" : "")
   .code {

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -335,15 +335,29 @@ extension ${Self} where Bound : TestProtocol1 {
 var ${TestSuite} = TestSuite("${Self}")
 
 ${TestSuite}.test("init(uncheckedBounds:)")
-  .forEach(in: [(1, 2), (1, 1), (2, 1)]) {
+  .forEach(in: [(1, 2), (1, 1)]) {
   (lowerInt, upperInt) in
 
-  // Check that 'init(uncheckedBounds:)' does not perform precondition checks,
-  // allowing to create ranges that break invariants.
   let r = ${Self}(
     uncheckedBounds: (lower: ${Bound}(lowerInt), upper: ${Bound}(upperInt)))
   expectEqual(lowerInt, r.lowerBound.value)
   expectEqual(upperInt, r.upperBound.value)
+}
+
+${TestSuite}.test("init(uncheckedBounds:) with invalid values")
+  .xfail(
+    .custom(
+      { _isDebugAssertConfiguration() },
+      reason: "unchecked initializer still checks its input in Debug mode"))
+  .code {
+  let low = 2
+  let up = 1
+  // Check that 'init(uncheckedBounds:)' does not perform precondition checks,
+  // allowing to create ranges that break invariants.
+  let r = ${Self}(
+    uncheckedBounds: (lower: ${Bound}(low), upper: ${Bound}(up)))
+  expectEqual(low, r.lowerBound.value)
+  expectEqual(up, r.upperBound.value)
 }
 
 %   for (DestinationSelf, _, _, _) in all_range_types:


### PR DESCRIPTION
The goal here is to make sure there is no performance argument against using `UnsafeBufferPointer` instead of passing around naked pointer/count values, while also making sure obvious errors are caught in debug builds at least.

1. Make `U*BP.init(start:count:)` only check for invalid input in debug builds (by @karwa in #34747)
2. Add a missing debug mode check in `[Closed]Range.init(uncheckedBounds:)` (from #34951)
3. Add a missing debug mode check in `U*BP.init(rebasing:)` (followup to #34879 based on discussions therein)
4. Eliminate a signed overflow check in `U[M]BP.distance(from:to:)` (ditto)
5. Allow the compiler the assume a nonnegative result in `U[M]RBP.count` (bonus change)

Putting on my pedantic hat, the new `_debugPreconditions` are technically source-breaking changes. However, for point (2), `Range.init(uncheckedBounds:)` was documented to strictly require these conditions, and ranges that violate the invariant aren't likely to be usable. (Code that consumes ranges invariably assumes that `lowerBound <= upperBound`.)

As for point (3), `U*BP.init(rebasing:)` can only ever trap if someone explicitly invoked the `Slice(base:bounds:)` initializer with a bogus index range -- which is highly unlikely, since passing that to `.init(rebasing:)` is far more work than just calling `.init(start:count:)`.

ABI compatibility can only be an issue for binaries built in debug mode. (Which may be a significant problem.)

If compatibility concerns prevent us from adding (2) and (3) above, then we should remove these but keep the rest.