### PR TITLE
[Concurrency] Traffic in underlying C type rather than JobFlags.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1222,6 +1222,8 @@ ERROR(super_in_closure_with_capture,none,
 NOTE(super_in_closure_with_capture_here,none,
      "'self' explicitly captured here", ())
 
+ERROR(try_before_await,none, "'await' must precede 'try'", ())
+
 // Tuples and parenthesized expressions
 ERROR(expected_expr_in_expr_list,none,
       "expected expression in list of expressions", ())

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -175,8 +175,7 @@ bool swift_task_removeStatusRecord(AsyncTask *task,
                                    TaskStatusRecord *record);
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-JobFlags
-swift_task_getJobFlags(AsyncTask* task);
+size_t swift_task_getJobFlags(AsyncTask* task);
 
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -436,6 +436,13 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
       : parseExprUnary(message, isExprBasic);
 
   if (hadTry && !sub.hasCodeCompletion() && !sub.isNull()) {
+    // "await" must precede "try".
+    if (auto await = dyn_cast<AwaitExpr>(sub.get())) {
+      diagnose(await->getLoc(), diag::try_before_await)
+        .fixItRemove(await->getLoc())
+        .fixItInsert(tryLoc, "await ");
+    }
+
     ElementContext.setCreateSyntax(SyntaxKind::TryExpr);
     switch (trySuffix ? trySuffix->getKind() : tok::NUM_TOKENS) {
     case tok::exclaim_postfix:

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -985,8 +985,9 @@ public:
   }
 
   static Context forTopLevelCode(TopLevelCodeDecl *D) {
-    // Top-level code implicitly handles errors and 'async' calls.
-    return Context(/*handlesErrors=*/true, /*handlesAsync=*/true, None);
+    // Top-level code implicitly handles errors.
+    // TODO: Eventually, it will handle async as well.
+    return Context(/*handlesErrors=*/true, /*handlesAsync=*/false, None);
   }
 
   static Context forFunction(AbstractFunctionDecl *D) {

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -89,7 +89,7 @@ public func withUnsafeContinuation<T>(
 public func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeThrowingContinuation<T>) -> Void
 ) async throws -> T {
-  return try await Builtin.withUnsafeThrowingContinuation {
+  return await try Builtin.withUnsafeThrowingContinuation {
     fn(UnsafeThrowingContinuation<T>($0))
   }
 }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -352,6 +352,6 @@ void swift::swift_task_run(AsyncTask *taskToRun) {
   taskToRun->run(ExecutorRef::generic());
 }
 
-JobFlags swift::swift_task_getJobFlags(AsyncTask *task) {
-  return task->Flags;
+size_t swift::swift_task_getJobFlags(AsyncTask *task) {
+  return task->Flags.getOpaqueValue();
 }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -8,7 +8,7 @@ import ObjCConcurrency
 func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
   let _: Bool = await slowServer.checkAvailability()
-  let _: String = try await slowServer.findAnswer()
+  let _: String = await try slowServer.findAnswer()
   let _: String = await try slowServer.findAnswerFailingly()
   let _: Void = await slowServer.doSomethingFun("jump")
   let _: (Int) -> Void = slowServer.completionHandler

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -54,11 +54,11 @@ func test_unsafeContinuations() async {
 }
 
 func test_unsafeThrowingContinuations() async {
-  let _: String = try await Task.withUnsafeThrowingContinuation { continuation in
+  let _: String = await try Task.withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
   }
 
-  let _: String = try await Task.withUnsafeThrowingContinuation { continuation in
+  let _: String = await try Task.withUnsafeThrowingContinuation { continuation in
     continuation.resume(throwing: MyError())
   }
 

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -19,7 +19,7 @@ public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
 // CHECK: tail call swiftcc void @swift_task_future_wait(
 public func testThis(_ task: __owned SomeClass) async {
   do {
-    let _ = try await task_future_wait(task)
+    let _ = await try task_future_wait(task)
   } catch _ {
     print("error")
   }

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -93,7 +93,7 @@ public func usesWithUnsafeContinuation() async {
 
 // CHECK-LABEL: sil [ossa] @$s4test34usesWithUnsafeThrowingContinuationyyYKF : $@convention(thin) @async () -> @error Error {
 public func usesWithUnsafeThrowingContinuation() async throws {
-  let _: Int = try await Builtin.withUnsafeThrowingContinuation { c in }
+  let _: Int = await try Builtin.withUnsafeThrowingContinuation { c in }
 
   // CHECK: [[FN:%.*]] = function_ref @$s4test34usesWithUnsafeThrowingContinuationyyYKFyBcXEfU_ : $@convention(thin) (Builtin.RawUnsafeContinuation) -> ()
   // CHECK: [[TMP:%.*]] = convert_function [[FN]] : $@convention(thin) (Builtin.RawUnsafeContinuation) -> () to $@convention(thin) @noescape (Builtin.RawUnsafeContinuation) -> ()

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -34,7 +34,7 @@ actor class MyActor {
   // CHECK:      } // end sil function '$s4test7MyActorC0A13AsyncFunctionyyYKF'
   func testAsyncFunction() async throws {
     await callee(p)
-    try await throwingCallee(p)
+    await try throwingCallee(p)
   }
 
   // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0A22ConsumingAsyncFunctionyyYF : $@convention(method) @async (@owned MyActor) -> () {

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -37,16 +37,16 @@ func testSlowServer(slowServer: SlowServer) async throws {
   // CHECK: [[RESULT:%.*]] = load [take] [[RESUME_BUF]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: dealloc_stack [[RESUME_BUF]]
-  let _: String = try await slowServer.findAnswer()
+  let _: String = await try slowServer.findAnswer()
 
   // CHECK: objc_method {{.*}} $@convention(objc_method) (NSString, @convention(block) () -> (), SlowServer) -> ()
   // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[VOID_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage UnsafeContinuation<()>) -> ()
   await slowServer.serverRestart("somewhere")
 
   // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[NSSTRING_INT_THROW_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage UnsafeThrowingContinuation<(String, Int)>, Optional<NSString>, Int, Optional<NSError>) -> ()
-  let (_, _): (String, Int) = try await slowServer.findMultipleAnswers()
+  let (_, _): (String, Int) = await try slowServer.findMultipleAnswers()
 
-  let (_, _): (Bool, Bool) = try await slowServer.findDifferentlyFlavoredBooleans()
+  let (_, _): (Bool, Bool) = await try slowServer.findDifferentlyFlavoredBooleans()
 
   // CHECK: [[ERROR]]([[ERROR_VALUE:%.*]] : @owned $Error):
   // CHECK:   dealloc_stack [[RESUME_BUF]]

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -20,7 +20,7 @@ func testSlowServing(p: SlowServing) async throws {
     // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int, NSString) -> (), τ_0_0) -> ()
     let _: (Int, String) = await p.requestIntAndString()
     // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int, Optional<NSString>, Optional<NSError>) -> (), τ_0_0) -> ()
-    let _: (Int, String) = try await p.tryRequestIntAndString()
+    let _: (Int, String) = await try p.tryRequestIntAndString()
 }
 
 /*

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -2,7 +2,10 @@
 
 // REQUIRES: concurrency
 
-async let x = 1 // okay
+func test() async {
+  async let x = 1 // okay
+  _ = await x
+}
 
 struct X {
   async let x = 1 // expected-error{{'async let' can only be used on local declarations}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -84,7 +84,7 @@ enum HomeworkError : Error {
 
 func testThrowingAndAsync() async throws {
   _ = await try throwingAndAsync()
-  _ = try await throwingAndAsync()
+  _ = try await throwingAndAsync() // expected-error{{'await' must precede 'try'}}{{11-17=}}{{7-7=await }}
   _ = await (try throwingAndAsync())
   _ = try (await throwingAndAsync())
 
@@ -136,13 +136,12 @@ func testStringInterpolation() async throws {
   _ = await "Eventually produces \(getInt())"
 }
 
-// Make sure try await works too
 func invalidAsyncFunction() async {
-  _ = try await throwingAndAsync() // expected-error {{errors thrown from here are not handled}}
+  _ = await try throwingAndAsync() // expected-error {{errors thrown from here are not handled}}
 }
 
 func validAsyncFunction() async throws {
-  _ = try await throwingAndAsync()
+  _ = await try throwingAndAsync()
 }
 
 // Async let checking

--- a/test/stmt/async.swift
+++ b/test/stmt/async.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+func f() async -> Int { 0 }
+
+_ = await f() // expected-error{{'async' in a function that does not support concurrency}}
+
+async let y = await f() // expected-error{{'async let' in a function that does not support concurrency}}
+// expected-error@-1{{'async' in a function that does not support concurrency}}


### PR DESCRIPTION
Suppresses a warning about returning a C++ type from a C entrypoint,
fixing rdar://71731181.