### PR TITLE
[AST] Fix linker errors when doing a 'parser only' build

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -120,6 +120,10 @@ const clang::Type *ClangTypeConverter::getFunctionType(
     ArrayRef<AnyFunctionType::Param> params, Type resultTy,
     AnyFunctionType::Representation repr) {
 
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  return nullptr;
+#endif
+
   auto resultClangTy = convert(resultTy);
   if (resultClangTy.isNull())
     return nullptr;
@@ -162,6 +166,10 @@ const clang::Type *ClangTypeConverter::getFunctionType(
 const clang::Type *ClangTypeConverter::getFunctionType(
     ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
     SILFunctionType::Representation repr) {
+
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  return nullptr;
+#endif
 
   // Using the interface type is sufficient as type parameters get mapped to
   // `id`, since ObjC lightweight generics use type erasure. (See also: SE-0057)

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1872,6 +1872,11 @@ AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
   using namespace namelookup;
   QualifiedLookupResult decls;
 
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  // Avoid calling `clang::ObjCMethodDecl::isDirectMethod()`.
+  return decls;
+#endif
+
   // Type-only lookup won't find anything on AnyObject.
   if (options & NL_OnlyTypes)
     return decls;


### PR DESCRIPTION
Parser only build avoids linking `clangAST` library and we use `SWIFT_BUILD_ONLY_SYNTAXPARSERLIB` macro to enforce it.