### PR TITLE
[Driver] Remove redundant clang '-target' flag that wasn't being used

### DIFF
--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -130,11 +130,6 @@ protected:
   /// and to not provide a specific linker otherwise.
   virtual std::string getDefaultLinker() const;
 
-  /// The target to be passed to the compiler invocation. By default, this
-  /// is the target triple, but this may be overridden to accommodate some
-  /// platforms.
-  virtual std::string getTargetForLinker() const;
-
   bool addRuntimeRPath(const llvm::Triple &T,
                        const llvm::opt::ArgList &Args) const;
 
@@ -152,9 +147,6 @@ public:
 };
 
 class LLVM_LIBRARY_VISIBILITY Android : public GenericUnix {
-protected:
-  std::string getTargetForLinker() const override;
-
 public:
   Android(const Driver &D, const llvm::Triple &Triple)
       : GenericUnix(D, Triple) {}
@@ -164,8 +156,6 @@ public:
 class LLVM_LIBRARY_VISIBILITY Cygwin : public GenericUnix {
 protected:
   std::string getDefaultLinker() const override;
-
-  std::string getTargetForLinker() const override;
 
 public:
   Cygwin(const Driver &D, const llvm::Triple &Triple)

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -109,10 +109,6 @@ std::string toolchains::GenericUnix::getDefaultLinker() const {
   }
 }
 
-std::string toolchains::GenericUnix::getTargetForLinker() const {
-  return getTriple().str();
-}
-
 bool toolchains::GenericUnix::addRuntimeRPath(const llvm::Triple &T,
                                               const llvm::opt::ArgList &Args) const {
   // If we are building a static executable, do not add a rpath for the runtime
@@ -146,12 +142,6 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
          "Invalid linker output type.");
 
   ArgStringList Arguments;
-
-  std::string Target = getTargetForLinker();
-  if (!Target.empty()) {
-    Arguments.push_back("-target");
-    Arguments.push_back(context.Args.MakeArgString(Target));
-  }
 
   switch (job.getKind()) {
   case LinkKind::None:
@@ -398,32 +388,10 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
   return II;
 }
 
-std::string toolchains::Android::getTargetForLinker() const {
-  const llvm::Triple &T = getTriple();
-  switch (T.getArch()) {
-  default:
-    // FIXME: we should just abort on an unsupported target
-    return T.str();
-  case llvm::Triple::arm:
-  case llvm::Triple::thumb:
-    // Current Android NDK versions only support ARMv7+.  Always assume ARMv7+
-    // for the arm/thumb target.
-    return "armv7-unknown-linux-androideabi";
-  case llvm::Triple::aarch64:
-    return "aarch64-unknown-linux-android";
-  case llvm::Triple::x86:
-    return "i686-unknown-linux-android";
-  case llvm::Triple::x86_64:
-    return "x86_64-unknown-linux-android";
-  }
-}
-
 std::string toolchains::Cygwin::getDefaultLinker() const {
   // Cygwin uses the default BFD linker, even on ARM.
   return "";
 }
-
-std::string toolchains::Cygwin::getTargetForLinker() const { return ""; }
 
 std::string toolchains::OpenBSD::getDefaultLinker() const {
   return "lld";

--- a/test/Driver/android-link.swift
+++ b/test/Driver/android-link.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift_driver_plain --driver-mode=swiftc -target armv7-none-linux-androideabihf -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-ARMv7
-// CHECK-ARMv7: clang{{(.exe)?"?}} -target armv7-unknown-linux-androideabi
+// RUN: %swift_driver_plain --driver-mode=swiftc -target armv7-unknown-linux-androideabihf -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-ARMv7
+// CHECK-ARMv7: clang{{(.exe)?"?.*}} --target=armv7-unknown-linux-androidhf
 
 // RUN: %swift_driver_plain --driver-mode=swiftc -target aarch64-mone-linux-androideabi -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-ARM64
-// CHECK-ARM64: clang{{(.exe)?"?}} -target aarch64-unknown-linux-android
+// CHECK-ARM64: clang{{(.exe)?"?.*}} --target=aarch64-mone-linux-android
 
-// RUN: %swift_driver_plain --driver-mode=swiftc -target x86_64-none-linux-androideabi -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-X64
-// CHECK-X64: clang{{(.exe)?"?}} -target x86_64-unknown-linux-android
+// RUN: %swift_driver_plain --driver-mode=swiftc -target x86_64-unknown-linux-androideabi -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-X64
+// CHECK-X64: clang{{(.exe)?"?.*}} --target=x86_64-unknown-linux-android
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -28,7 +28,7 @@
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target thumbv7-unknown-linux-gnueabihf -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-thumbv7 %s < %t.linux.txt
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7-none-linux-androideabi -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.android.txt
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7-unknown-linux-androideabi -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.android.txt
 // RUN: %FileCheck -check-prefix ANDROID-armv7 %s < %t.android.txt
 // RUN: %FileCheck -check-prefix ANDROID-armv7-NEGATIVE %s < %t.android.txt
 


### PR DESCRIPTION
The target was added for Unix toolchains in #901, but a later pull #1891 added it again. Since clang only uses the last target flag that's passed in, all customization done for the first one was unused these last 4+ years, so remove it and change tests that look for custom strings passed by the first one.

I ran into this because `swift-driver` copies both over and [these unused Android triples](https://github.com/apple/swift-driver/pull/370#issuecomment-738165943), so I looked into this repeated flag. I have not tested this pull, as I only build for Android since January, so I ask that someone run the linux CI and I'll fix any other tests that fail.

@CodaFi, you seem to deal with the Swift driver more than most, so I'd like your input. @compnerd, let me know what you think too.