### PR TITLE
[Sema][CSApply] Be more conservative while emitting always true conversion diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1019,6 +1019,10 @@ WARNING(isa_is_always_true,none, "'%0' test is always true",
 WARNING(isa_is_foreign_check,none,
       "'is' test is always true because %0 is a Core Foundation type",
       (Type))
+WARNING(checked_cast_ont_supported,none,
+        "runtime conversion from %0 to %1 is not supported; "
+        "%select{'is' test|cast}2 always fails",
+        (Type, Type, unsigned))
 WARNING(conditional_downcast_coercion,none,
       "conditional cast from %0 to %1 always succeeds",
       (Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1019,10 +1019,13 @@ WARNING(isa_is_always_true,none, "'%0' test is always true",
 WARNING(isa_is_foreign_check,none,
       "'is' test is always true because %0 is a Core Foundation type",
       (Type))
-WARNING(checked_cast_ont_supported,none,
+WARNING(checked_cast_not_supported,none,
         "runtime conversion from %0 to %1 is not supported; "
         "%select{'is' test|cast}2 always fails",
         (Type, Type, unsigned))
+NOTE(checked_cast_not_supported_coerce_instead,none,
+     "consider using 'as' coercion instead", ())
+
 WARNING(conditional_downcast_coercion,none,
       "conditional cast from %0 to %1 always succeeds",
       (Type, Type))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3139,6 +3139,9 @@ public:
 
   AnyFunctionType *getWithoutDifferentiability() const;
 
+  /// Return the function type without the throwing.
+  AnyFunctionType *getWithoutThrowing() const;
+
   /// True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.
   bool isNoEscape() const {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2209,18 +2209,30 @@ public:
           MemberLookupResult result, ConstraintLocator *locator);
 };
 
-class AllowCheckedCastCoercibleOptionalType final : public ContextualMismatch {
+class CheckedCastContextualMismatchWarningBase : public ContextualMismatch {
+protected:
+  CheckedCastContextualMismatchWarningBase(ConstraintSystem &cs,
+                                           FixKind fixKind, Type fromType,
+                                           Type toType, CheckedCastKind kind,
+                                           ConstraintLocator *locator)
+      : ContextualMismatch(cs, fixKind, fromType, toType, locator,
+                           /*isWarning*/ true),
+        CastKind(kind) {}
+  CheckedCastKind CastKind;
+};
+
+class AllowCheckedCastCoercibleOptionalType final
+    : public CheckedCastContextualMismatchWarningBase {
   AllowCheckedCastCoercibleOptionalType(ConstraintSystem &cs, Type fromType,
                                         Type toType, CheckedCastKind kind,
                                         ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::AllowCheckedCastCoercibleOptionalType,
-                           fromType, toType, locator, /*isWarning*/ true),
-        CastKind(kind) {}
-  CheckedCastKind CastKind;
+      : CheckedCastContextualMismatchWarningBase(
+            cs, FixKind::AllowCheckedCastCoercibleOptionalType, fromType,
+            toType, kind, locator) {}
 
 public:
   std::string getName() const override {
-    return "checked cast coecible optional";
+    return "checked cast coercible optional";
   }
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
@@ -2229,15 +2241,14 @@ public:
          ConstraintLocator *locator);
 };
 
-class AllowAlwaysSucceedCheckedCast final : public ContextualMismatch {
+class AllowAlwaysSucceedCheckedCast final
+    : public CheckedCastContextualMismatchWarningBase {
   AllowAlwaysSucceedCheckedCast(ConstraintSystem &cs, Type fromType,
                                 Type toType, CheckedCastKind kind,
                                 ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::AllowUnsupportedRuntimeCheckedCast,
-                           fromType, toType, locator,
-                           /*isWarning*/ true),
-        CastKind(kind) {}
-  CheckedCastKind CastKind;
+      : CheckedCastContextualMismatchWarningBase(
+            cs, FixKind::AllowUnsupportedRuntimeCheckedCast, fromType, toType,
+            kind, locator) {}
 
 public:
   std::string getName() const override { return "checked cast always succeed"; }
@@ -2249,15 +2260,14 @@ public:
                                                ConstraintLocator *locator);
 };
 
-class AllowUnsupportedRuntimeCheckedCast final : public ContextualMismatch {
+class AllowUnsupportedRuntimeCheckedCast final
+    : public CheckedCastContextualMismatchWarningBase {
   AllowUnsupportedRuntimeCheckedCast(ConstraintSystem &cs, Type fromType,
                                      Type toType, CheckedCastKind kind,
                                      ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::AllowUnsupportedRuntimeCheckedCast,
-                           fromType, toType, locator,
-                           /*isWarning*/ true),
-        CastKind(kind) {}
-  CheckedCastKind CastKind;
+      : CheckedCastContextualMismatchWarningBase(
+            cs, FixKind::AllowUnsupportedRuntimeCheckedCast, fromType, toType,
+            kind, locator) {}
 
 public:
   std::string getName() const override {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2209,12 +2209,12 @@ public:
           MemberLookupResult result, ConstraintLocator *locator);
 };
 
-class CheckedCastContextualMismatchWarningBase : public ContextualMismatch {
+class CheckedCastContextualMismatchWarning : public ContextualMismatch {
 protected:
-  CheckedCastContextualMismatchWarningBase(ConstraintSystem &cs,
-                                           FixKind fixKind, Type fromType,
-                                           Type toType, CheckedCastKind kind,
-                                           ConstraintLocator *locator)
+  CheckedCastContextualMismatchWarning(ConstraintSystem &cs, FixKind fixKind,
+                                       Type fromType, Type toType,
+                                       CheckedCastKind kind,
+                                       ConstraintLocator *locator)
       : ContextualMismatch(cs, fixKind, fromType, toType, locator,
                            /*isWarning*/ true),
         CastKind(kind) {}
@@ -2222,11 +2222,11 @@ protected:
 };
 
 class AllowCheckedCastCoercibleOptionalType final
-    : public CheckedCastContextualMismatchWarningBase {
+    : public CheckedCastContextualMismatchWarning {
   AllowCheckedCastCoercibleOptionalType(ConstraintSystem &cs, Type fromType,
                                         Type toType, CheckedCastKind kind,
                                         ConstraintLocator *locator)
-      : CheckedCastContextualMismatchWarningBase(
+      : CheckedCastContextualMismatchWarning(
             cs, FixKind::AllowCheckedCastCoercibleOptionalType, fromType,
             toType, kind, locator) {}
 
@@ -2242,11 +2242,11 @@ public:
 };
 
 class AllowAlwaysSucceedCheckedCast final
-    : public CheckedCastContextualMismatchWarningBase {
+    : public CheckedCastContextualMismatchWarning {
   AllowAlwaysSucceedCheckedCast(ConstraintSystem &cs, Type fromType,
                                 Type toType, CheckedCastKind kind,
                                 ConstraintLocator *locator)
-      : CheckedCastContextualMismatchWarningBase(
+      : CheckedCastContextualMismatchWarning(
             cs, FixKind::AllowUnsupportedRuntimeCheckedCast, fromType, toType,
             kind, locator) {}
 
@@ -2261,11 +2261,11 @@ public:
 };
 
 class AllowUnsupportedRuntimeCheckedCast final
-    : public CheckedCastContextualMismatchWarningBase {
+    : public CheckedCastContextualMismatchWarning {
   AllowUnsupportedRuntimeCheckedCast(ConstraintSystem &cs, Type fromType,
                                      Type toType, CheckedCastKind kind,
                                      ConstraintLocator *locator)
-      : CheckedCastContextualMismatchWarningBase(
+      : CheckedCastContextualMismatchWarning(
             cs, FixKind::AllowUnsupportedRuntimeCheckedCast, fromType, toType,
             kind, locator) {}
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2265,10 +2265,12 @@ public:
   }
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  static AllowUnsupportedRuntimeCheckedCast *create(ConstraintSystem &cs,
-                                                    Type fromType, Type toType,
-                                                    CheckedCastKind kind,
-                                                    ConstraintLocator *locator);
+  static bool runtimeSupportedFunctionTypeCast(FunctionType *fnFromType,
+                                               FunctionType *fnToType);
+
+  static AllowUnsupportedRuntimeCheckedCast *
+  attempt(ConstraintSystem &cs, Type fromType, Type toType,
+          CheckedCastKind kind, ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2207,10 +2207,13 @@ public:
 
 class AllowAlwaysSucceedCheckedCast final : public ContextualMismatch {
   AllowAlwaysSucceedCheckedCast(ConstraintSystem &cs, Type fromType,
-                                Type toType, ConstraintLocator *locator)
+                                Type toType, CheckedCastKind kind,
+                                ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::AllowAlwaysSucceedCheckedCast, fromType,
                            toType, locator,
-                           /*isWarning*/ true) {}
+                           /*isWarning*/ true),
+        CastKind(kind) {}
+  CheckedCastKind CastKind;
 
 public:
   std::string getName() const override { return "checked cast always succeed"; }
@@ -2218,6 +2221,7 @@ public:
 
   static AllowAlwaysSucceedCheckedCast *create(ConstraintSystem &cs,
                                                Type fromType, Type toType,
+                                               CheckedCastKind kind,
                                                ConstraintLocator *locator);
 };
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -302,7 +302,7 @@ enum class FixKind : uint8_t {
   /// Allow a runtime checked cast where at compile time the from is
   /// convertible, but runtime does not support such convertions. e.g.
   /// funtion type casts.
-  AllowUnsuportedRuntimeCheckedCast,
+  AllowUnsupportedRuntimeCheckedCast,
 };
 
 class ConstraintFix {
@@ -2221,10 +2221,10 @@ public:
                                                ConstraintLocator *locator);
 };
 
-class AllowUnsuportedRuntimeCheckedCast final : public ContextualMismatch {
-  AllowUnsuportedRuntimeCheckedCast(ConstraintSystem &cs, Type fromType,
+class AllowUnsupportedRuntimeCheckedCast final : public ContextualMismatch {
+  AllowUnsupportedRuntimeCheckedCast(ConstraintSystem &cs, Type fromType,
                                     Type toType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::AllowUnsuportedRuntimeCheckedCast,
+      : ContextualMismatch(cs, FixKind::AllowUnsupportedRuntimeCheckedCast,
                            fromType, toType, locator,
                            /*isWarning*/ true) {}
 
@@ -2234,9 +2234,9 @@ public:
   }
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  static AllowUnsuportedRuntimeCheckedCast *create(ConstraintSystem &cs,
-                                                   Type fromType, Type toType,
-                                                   ConstraintLocator *locator);
+  static AllowUnsupportedRuntimeCheckedCast *create(ConstraintSystem &cs,
+                                                    Type fromType, Type toType,
+                                                    ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -297,7 +297,7 @@ enum class FixKind : uint8_t {
 
   /// Allow a runtime checked cast where we statically know the result
   /// is always succeed.
-  AllowAlwaysSucceedCheckedCast,
+  AllowCheckedCastCoecibleTypes,
 
   /// Allow a runtime checked cast where at compile time the from is
   /// convertible, but runtime does not support such convertions. e.g.
@@ -2205,21 +2205,23 @@ public:
           MemberLookupResult result, ConstraintLocator *locator);
 };
 
-class AllowAlwaysSucceedCheckedCast final : public ContextualMismatch {
-  AllowAlwaysSucceedCheckedCast(ConstraintSystem &cs, Type fromType,
+class AllowCheckedCastCoecibleTypes final : public ContextualMismatch {
+  AllowCheckedCastCoecibleTypes(ConstraintSystem &cs, Type fromType,
                                 Type toType, CheckedCastKind kind,
                                 ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::AllowAlwaysSucceedCheckedCast, fromType,
+      : ContextualMismatch(cs, FixKind::AllowCheckedCastCoecibleTypes, fromType,
                            toType, locator,
                            /*isWarning*/ true),
         CastKind(kind) {}
   CheckedCastKind CastKind;
 
 public:
-  std::string getName() const override { return "checked cast always succeed"; }
+  std::string getName() const override {
+    return "checked cast types are coercible";
+  }
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  static AllowAlwaysSucceedCheckedCast *create(ConstraintSystem &cs,
+  static AllowCheckedCastCoecibleTypes *create(ConstraintSystem &cs,
                                                Type fromType, Type toType,
                                                CheckedCastKind kind,
                                                ConstraintLocator *locator);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5115,6 +5115,11 @@ AnyFunctionType *AnyFunctionType::getWithoutDifferentiability() const {
                                   getResult(), nonDiffExtInfo);
 }
 
+AnyFunctionType *AnyFunctionType::getWithoutThrowing() const {
+  auto info = getExtInfo().intoBuilder().withThrows(false).build();
+  return withExtInfo(info);
+}
+
 Optional<TangentSpace>
 TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
   assert(lookupConformance);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3558,8 +3558,6 @@ namespace {
           
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion:
-        // Check is trivially true.
-        ctx.Diags.diagnose(expr->getLoc(), diag::isa_is_always_true, "is");
         expr->setCastKind(castKind);
         break;
       case CheckedCastKind::ValueCast:
@@ -3979,7 +3977,6 @@ namespace {
     // Rewrite ForcedCheckedCastExpr based on what the solver computed.
     Expr *visitForcedCheckedCastExpr(ForcedCheckedCastExpr *expr) {
       // The subexpression is always an rvalue.
-      auto &ctx = cs.getASTContext();
       auto sub = cs.coerceToRValue(expr->getSubExpr());
       expr->setSubExpr(sub);
 
@@ -4007,19 +4004,6 @@ namespace {
         return nullptr;
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion: {
-        if (cs.getType(sub)->isEqual(toType)) {
-          ctx.Diags.diagnose(expr->getLoc(), diag::forced_downcast_noop, toType)
-              .fixItRemove(SourceRange(expr->getLoc(),
-                                       castTypeRepr->getSourceRange().End));
-
-        } else {
-          ctx.Diags
-              .diagnose(expr->getLoc(), diag::forced_downcast_coercion,
-                        cs.getType(sub), toType)
-              .fixItReplace(SourceRange(expr->getLoc(), expr->getExclaimLoc()),
-                            "as");
-        }
-
         expr->setCastKind(castKind);
         cs.setType(expr, toType);
         return expr;
@@ -4111,8 +4095,6 @@ namespace {
 
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion: {
-        ctx.Diags.diagnose(expr->getLoc(), diag::conditional_downcast_coercion,
-                           fromType, toType);
         expr->setCastKind(castKind);
         cs.setType(expr, OptionalType::get(toType));
         return expr;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7190,140 +7190,228 @@ bool MemberMissingExplicitBaseTypeFailure::diagnoseAsError() {
   return true;
 }
 
-bool CheckedCastBaseFailure::anchorHasForcedOptionalResult() const {
-  auto *expr = castToExpr<ExplicitCastExpr>(getAnchor());
+bool CheckedCastBaseFailure::isCastTypeIUO() const {
+  auto *expr = castToExpr<CheckedCastExpr>(getAnchor());
   const auto *const TR = expr->getCastTypeRepr();
-  if (TR && TR->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional) {
-    auto &cs = getConstraintSystem();
-    auto &solution = getSolution();
-    auto *locator = cs.getConstraintLocator(
-        expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
-    return solution.getDisjunctionChoice(locator);
-  }
-  return false;
+  return TR && TR->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional;
 }
 
-bool CoercibleCheckedCastFailure::diagnoseAsError() {
+SourceRange CheckedCastBaseFailure::getCastRange() const {
   auto anchor = getAnchor();
-  auto &ctx = getASTContext();
+  if (auto *forcedCastExpr = getAsExpr<ForcedCheckedCastExpr>(anchor)) {
+    return {forcedCastExpr->getLoc(), forcedCastExpr->getExclaimLoc()};
+  } else if (auto *conditionalCast =
+                 getAsExpr<ConditionalCheckedCastExpr>(anchor)) {
+    return {conditionalCast->getLoc(), conditionalCast->getQuestionLoc()};
+  } else if (auto expr = getAsExpr<IsExpr>(anchor)) {
+    return expr->getLoc();
+  }
+  llvm_unreachable("There is no other kind of checked cast!");
+}
 
-  auto *checkCastExpr = castToExpr<CheckedCastExpr>(anchor);
-  auto asLoc = checkCastExpr->getAsLoc();
-  SourceRange diagFromRange = checkCastExpr->getSubExpr()->getSourceRange();
-  SourceRange diagToRange = checkCastExpr->getCastTypeRepr()->getSourceRange();
-
-  auto fromType =
-      resolveType(getType(checkCastExpr->getSubExpr()))->getRValueType();
-  auto toType = resolveType(getType(checkCastExpr->getCastTypeRepr()));
-
+std::tuple<Type, Type, unsigned>
+CoercibleOptionalCheckedCastFailure::unwrapedTypes() const {
   SmallVector<Type, 4> fromOptionals;
   SmallVector<Type, 4> toOptionals;
-  Type unwrappedFromType = fromType->lookThroughAllOptionalTypes(fromOptionals);
-  Type unwrappedToType = toType->lookThroughAllOptionalTypes(toOptionals);
-  auto extraFromOptionals = fromOptionals.size() - toOptionals.size();
+  Type unwrappedFromType =
+      getFromType()->lookThroughAllOptionalTypes(fromOptionals);
+  Type unwrappedToType = getToType()->lookThroughAllOptionalTypes(toOptionals);
+  return std::make_tuple(unwrappedFromType, unwrappedToType,
+                         fromOptionals.size() - toOptionals.size());
+}
+
+bool CoercibleOptionalCheckedCastFailure::diagnoseIfExpr() const {
+  auto *expr = getAsExpr<IsExpr>(CastExpr);
+  if (!expr)
+    return false;
+
+  Type unwrappedFrom, unwrappedTo;
+  unsigned extraFromOptionals;
+  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrapedTypes();
+
+  SourceRange diagFromRange = getFromRange();
+  SourceRange diagToRange = getToRange();
+  SourceLoc asLoc = expr->getAsLoc();
+
+  // If we're only unwrapping a single optional, we could have just
+  // checked for 'nil'.
+  auto diag =
+      emitDiagnostic(diag::is_expr_same_type, getFromType(), getToType());
+  diag.highlight(diagFromRange);
+  diag.highlight(diagToRange);
+  diag.fixItReplace(SourceRange(asLoc, diagToRange.End), "!= nil");
+
+  // Add parentheses if needed.
+  if (!expr->getSubExpr()->canAppendPostfixExpression()) {
+    diag.fixItInsert(expr->getSubExpr()->getStartLoc(), "(");
+    diag.fixItInsertAfter(expr->getSubExpr()->getEndLoc(), ")");
+  }
+
+  return true;
+}
+
+bool CoercibleOptionalCheckedCastFailure::diagnoseForcedCastExpr() const {
+  auto *expr = getAsExpr<ForcedCheckedCastExpr>(CastExpr);
+  if (!expr)
+    return false;
+
+  auto fromType = getFromType();
+  auto toType = getToType();
+  Type unwrappedFrom, unwrappedTo;
+  unsigned extraFromOptionals;
+  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrapedTypes();
+
+  SourceRange diagFromRange = getFromRange();
+  SourceRange diagToRange = getToRange();
+
+  bool isBridged = CastKind == CheckedCastKind::BridgingCoercion;
+  if (isCastTypeIUO()) {
+    toType = toType->getOptionalObjectType();
+    extraFromOptionals++;
+  }
+
+  std::string extraFromOptionalsStr(extraFromOptionals, '!');
+  auto diag = emitDiagnostic(diag::downcast_same_type, fromType, toType,
+                             extraFromOptionalsStr, isBridged);
+  diag.highlight(diagFromRange);
+  diag.highlight(diagToRange);
+
+  /// Add the '!''s needed to adjust the type.
+  diag.fixItInsertAfter(diagFromRange.End,
+                        std::string(extraFromOptionals, '!'));
+  if (isBridged) {
+    // If it's bridged, we still need the 'as' to perform the bridging.
+    diag.fixItReplace(getCastRange(), "as");
+  } else {
+    auto &ctx = getASTContext();
+    // Otherwise, implicit conversions will handle it in most cases.
+    SourceLoc afterExprLoc =
+        Lexer::getLocForEndOfToken(ctx.SourceMgr, diagFromRange.End);
+
+    diag.fixItRemove(SourceRange(afterExprLoc, diagToRange.End));
+  }
+  return true;
+}
+
+bool CoercibleOptionalCheckedCastFailure::diagnoseConditionalCastExpr() const {
+  auto *expr = getAsExpr<ConditionalCheckedCastExpr>(CastExpr);
+  if (!expr)
+    return false;
+
+  auto fromType = getFromType();
+  auto toType = getToType();
+  Type unwrappedFrom, unwrappedTo;
+  unsigned extraFromOptionals;
+  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrapedTypes();
+
+  SourceRange diagFromRange = getFromRange();
+  SourceRange diagToRange = getToRange();
+
   bool isBridged = CastKind == CheckedCastKind::BridgingCoercion;
 
-  if (auto *expr = getAsExpr<IsExpr>(anchor)) {
-    // If we're only unwrapping a single optional, we could have just
-    // checked for 'nil'.
-    if (extraFromOptionals == 1) {
-      auto diag = emitDiagnostic(diag::is_expr_same_type,
-                                 fromType, toType);
-      diag.highlight(diagFromRange);
-      diag.highlight(diagToRange);
-      diag.fixItReplace(SourceRange(asLoc, diagToRange.End), "!= nil");
+  // A single optional is carried through. It's better to use 'as' to
+  // the appropriate optional type.
+  auto diag =
+      emitDiagnostic(diag::conditional_downcast_same_type, fromType, toType,
+                     unwrappedFrom->isEqual(toType) ? 0 : isBridged ? 2 : 1);
+  diag.highlight(diagFromRange);
+  diag.highlight(diagToRange);
 
-      // Add parentheses if needed.
-      if (!expr->getSubExpr()->canAppendPostfixExpression()) {
-        diag.fixItInsert(expr->getSubExpr()->getStartLoc(), "(");
-        diag.fixItInsertAfter(expr->getSubExpr()->getEndLoc(), ")");
-      }
-    } else {
-      emitDiagnostic(diag::isa_is_always_true, "is");
-    }
-    return true;
+  if (isBridged) {
+    // For a bridged cast, replace the 'as?' with 'as'.
+    diag.fixItReplace(getCastRange(), "as");
+
+    // Make sure we'll cast to the appropriately-optional type by adding
+    // the '?'.
+    // FIXME: Parenthesize!
+    diag.fixItInsertAfter(diagToRange.End, "?");
+  } else {
+    auto &ctx = getASTContext();
+    // Just remove the cast; implicit conversions will handle it.
+    SourceLoc afterExprLoc =
+        Lexer::getLocForEndOfToken(ctx.SourceMgr, diagFromRange.End);
+
+    if (afterExprLoc.isValid() && diagToRange.isValid())
+      diag.fixItRemove(SourceRange(afterExprLoc, diagToRange.End));
+  }
+  return true;
+}
+
+bool AlwaysSucceedCheckedCastFailure::diagnoseIfExpr() const {
+  auto *expr = getAsExpr<IsExpr>(CastExpr);
+  if (!expr)
+    return false;
+
+  emitDiagnostic(diag::isa_is_always_true, "is");
+  return true;
+}
+
+bool AlwaysSucceedCheckedCastFailure::diagnoseConditionalCastExpr() const {
+  auto *expr = getAsExpr<ConditionalCheckedCastExpr>(CastExpr);
+  if (!expr)
+    return false;
+
+  emitDiagnostic(diag::conditional_downcast_coercion, getFromType(),
+                 getToType());
+  return true;
+}
+
+bool AlwaysSucceedCheckedCastFailure::diagnoseForcedCastExpr() const {
+  auto *expr = getAsExpr<ForcedCheckedCastExpr>(CastExpr);
+  if (!expr)
+    return false;
+
+  auto fromType = getFromType();
+  auto toType = getToType();
+  auto diagLoc = expr->getLoc();
+
+  if (isCastTypeIUO()) {
+    toType = toType->getOptionalObjectType();
   }
 
-  if (auto *expr = getAsExpr<ForcedCheckedCastExpr>(anchor)) {
-    if (anchorHasForcedOptionalResult()) {
-      toType = toType->getOptionalObjectType();
-      extraFromOptionals--;
-    }
+  if (fromType->isEqual(toType)) {
+    auto castTypeRepr = expr->getCastTypeRepr();
+    emitDiagnostic(diag::forced_downcast_noop, toType)
+        .fixItRemove(SourceRange(diagLoc, castTypeRepr->getSourceRange().End));
 
-    if (extraFromOptionals > 0) {
-      std::string extraFromOptionalsStr(extraFromOptionals, '!');
-      auto diag = emitDiagnostic(diag::downcast_same_type, fromType, toType,
-                                 extraFromOptionalsStr, isBridged);
-      diag.highlight(diagFromRange);
-      diag.highlight(diagToRange);
-
-      /// Add the '!''s needed to adjust the type.
-      diag.fixItInsertAfter(diagFromRange.End,
-                            std::string(extraFromOptionals, '!'));
-      if (isBridged) {
-        // If it's bridged, we still need the 'as' to perform the bridging.
-        diag.fixItReplaceChars(asLoc, asLoc.getAdvancedLocOrInvalid(3), "as");
-      } else {
-        // Otherwise, implicit conversions will handle it in most cases.
-        SourceLoc afterExprLoc =
-            Lexer::getLocForEndOfToken(ctx.SourceMgr, diagFromRange.End);
-
-        diag.fixItRemove(SourceRange(afterExprLoc, diagToRange.End));
-      }
-    } else {
-      if (fromType->isEqual(toType)) {
-        auto castTypeRepr = expr->getCastTypeRepr();
-        emitDiagnostic(diag::forced_downcast_noop, toType)
-            .fixItRemove(SourceRange(expr->getLoc(),
-                                     castTypeRepr->getSourceRange().End));
-
-      } else {
-        emitDiagnostic(diag::forced_downcast_coercion, fromType, toType)
-            .fixItReplace(SourceRange(expr->getLoc(), expr->getExclaimLoc()),
-                          "as");
-      }
-    }
-    return true;
+  } else {
+    emitDiagnostic(diag::forced_downcast_coercion, fromType, toType)
+        .fixItReplace(getCastRange(), "as");
   }
+  return true;
+}
 
-  if (auto *expr = getAsExpr<ConditionalCheckedCastExpr>(anchor)) {
-    // Single level of optionality.
-    if (extraFromOptionals == 1) {
-      // A single optional is carried through. It's better to use 'as' to
-      // the appropriate optional type.
-      auto diag = emitDiagnostic(
-          diag::conditional_downcast_same_type, fromType, toType,
-          unwrappedFromType->isEqual(unwrappedToType) ? 0 : isBridged ? 2 : 1);
-      diag.highlight(diagFromRange);
-      diag.highlight(diagToRange);
-
-      if (isBridged) {
-        // For a bridged cast, replace the 'as?' with 'as'.
-        diag.fixItReplaceChars(asLoc, asLoc.getAdvancedLoc(3), "as");
-
-        // Make sure we'll cast to the appropriately-optional type by adding
-        // the '?'.
-        // FIXME: Parenthesize!
-        diag.fixItInsertAfter(diagToRange.End, "?");
-      } else {
-        // Just remove the cast; implicit conversions will handle it.
-        SourceLoc afterExprLoc =
-            Lexer::getLocForEndOfToken(ctx.SourceMgr, diagFromRange.End);
-
-        if (afterExprLoc.isValid() && diagToRange.isValid())
-          diag.fixItRemove(SourceRange(afterExprLoc, diagToRange.End));
-      }
-    } else {
-      emitDiagnostic(diag::conditional_downcast_coercion, fromType, toType);
-    }
+bool AlwaysSucceedCheckedCastFailure::diagnoseAsError() {
+  if (diagnoseIfExpr())
     return true;
-  }
+
+  if (diagnoseForcedCastExpr())
+    return true;
+
+  if (diagnoseConditionalCastExpr())
+    return true;
+
+  llvm_unreachable("Shouldn't reach here");
+}
+
+bool CoercibleOptionalCheckedCastFailure::diagnoseAsError() {
+  if (diagnoseIfExpr())
+    return true;
+
+  if (diagnoseForcedCastExpr())
+    return true;
+
+  if (diagnoseConditionalCastExpr())
+    return true;
 
   llvm_unreachable("Shouldn't reach here");
 }
 
 bool UnsupportedRuntimeCheckedCastFailure::diagnoseAsError() {
-  emitDiagnostic(diag::checked_cast_ont_supported, getFromType(), getToType(),
-                 isExpr<IsExpr>(getAnchor()) ? 0 : 1);
+  auto anchor = getAnchor();
+  emitDiagnostic(diag::checked_cast_not_supported, getFromType(), getToType(),
+                 isExpr<IsExpr>(anchor) ? 0 : 1);
+  emitDiagnostic(diag::checked_cast_not_supported_coerce_instead)
+      .fixItReplace(getCastRange(), "as");
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7241,7 +7241,7 @@ bool UnnecessaryCheckedCastFailure::diagnoseAsError() {
   llvm_unreachable("Shouldn't reach here");
 }
 
-bool UnsuportedRuntimeCheckedCastFailure::diagnoseAsError() {
+bool UnsupportedRuntimeCheckedCastFailure::diagnoseAsError() {
   emitDiagnostic(diag::checked_cast_ont_supported, getFromType(), getToType(),
                  isExpr<IsExpr>(getAnchor()) ? 0 : 1);
   return true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7203,7 +7203,7 @@ bool CheckedCastBaseFailure::anchorHasForcedOptionalResult() const {
   return false;
 }
 
-bool UnnecessaryCheckedCastFailure::diagnoseAsError() {
+bool CoercibleCheckedCastFailure::diagnoseAsError() {
   auto anchor = getAnchor();
   auto &ctx = getASTContext();
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2391,6 +2391,37 @@ public:
   bool diagnoseAsError() override;
 };
 
+class CheckedCastBaseFailure : public ContextualFailure {
+public:
+  CheckedCastBaseFailure(const Solution &solution, Type fromType, Type toType,
+                         ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {}
+  bool anchorHasForcedOptionalResult() const;
+};
+
+/// Warn situations where the compiler can statically know a runtime
+/// checked cast always succeed.
+class UnnecessaryCheckedCastFailure final : public CheckedCastBaseFailure {
+public:
+  UnnecessaryCheckedCastFailure(const Solution &solution, Type fromType,
+                                Type toType, ConstraintLocator *locator)
+      : CheckedCastBaseFailure(solution, fromType, toType, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
+/// Warn situations where the compiler can statically know a runtime
+/// check is not supported.
+class UnsuportedRuntimeCheckedCastFailure final
+    : public CheckedCastBaseFailure {
+public:
+  UnsuportedRuntimeCheckedCastFailure(const Solution &solution, Type fromType,
+                                      Type toType, ConstraintLocator *locator)
+      : CheckedCastBaseFailure(solution, fromType, toType, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2400,14 +2400,14 @@ public:
 };
 
 /// Warn situations where the compiler can statically know a runtime
-/// checked cast always succeed.
-class UnnecessaryCheckedCastFailure final : public CheckedCastBaseFailure {
+/// types involved in checked cast are coercible.
+class CoercibleCheckedCastFailure final : public CheckedCastBaseFailure {
   CheckedCastKind CastKind;
 
 public:
-  UnnecessaryCheckedCastFailure(const Solution &solution, Type fromType,
-                                Type toType, CheckedCastKind kind,
-                                ConstraintLocator *locator)
+  CoercibleCheckedCastFailure(const Solution &solution, Type fromType,
+                              Type toType, CheckedCastKind kind,
+                              ConstraintLocator *locator)
       : CheckedCastBaseFailure(solution, fromType, toType, locator),
         CastKind(kind) {}
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2412,10 +2412,10 @@ public:
 
 /// Warn situations where the compiler can statically know a runtime
 /// check is not supported.
-class UnsuportedRuntimeCheckedCastFailure final
+class UnsupportedRuntimeCheckedCastFailure final
     : public CheckedCastBaseFailure {
 public:
-  UnsuportedRuntimeCheckedCastFailure(const Solution &solution, Type fromType,
+  UnsupportedRuntimeCheckedCastFailure(const Solution &solution, Type fromType,
                                       Type toType, ConstraintLocator *locator)
       : CheckedCastBaseFailure(solution, fromType, toType, locator) {}
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2402,10 +2402,14 @@ public:
 /// Warn situations where the compiler can statically know a runtime
 /// checked cast always succeed.
 class UnnecessaryCheckedCastFailure final : public CheckedCastBaseFailure {
+  CheckedCastKind CastKind;
+
 public:
   UnnecessaryCheckedCastFailure(const Solution &solution, Type fromType,
-                                Type toType, ConstraintLocator *locator)
-      : CheckedCastBaseFailure(solution, fromType, toType, locator) {}
+                                Type toType, CheckedCastKind kind,
+                                ConstraintLocator *locator)
+      : CheckedCastBaseFailure(solution, fromType, toType, locator),
+        CastKind(kind) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1791,3 +1791,32 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
   return new (cs.getAllocator())
       SpecifyBaseTypeForOptionalUnresolvedMember(cs, memberName, locator);
 }
+
+AllowAlwaysSucceedCheckedCast *
+AllowAlwaysSucceedCheckedCast::create(ConstraintSystem &cs, Type fromType,
+                                      Type toType, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowAlwaysSucceedCheckedCast(cs, fromType, toType, locator);
+}
+
+bool AllowAlwaysSucceedCheckedCast::diagnose(const Solution &solution,
+                                             bool asNote) const {
+  UnnecessaryCheckedCastFailure failure(solution, getFromType(), getToType(),
+                                        getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowUnsuportedRuntimeCheckedCast *
+AllowUnsuportedRuntimeCheckedCast::create(ConstraintSystem &cs, Type fromType,
+                                          Type toType,
+                                          ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowUnsuportedRuntimeCheckedCast(cs, fromType, toType, locator);
+}
+
+bool AllowUnsuportedRuntimeCheckedCast::diagnose(const Solution &solution,
+                                                 bool asNote) const {
+  UnsuportedRuntimeCheckedCastFailure failure(solution, getFromType(),
+                                              getToType(), getLocator());
+  return failure.diagnose(asNote);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1792,18 +1792,18 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
       SpecifyBaseTypeForOptionalUnresolvedMember(cs, memberName, locator);
 }
 
-AllowAlwaysSucceedCheckedCast *
-AllowAlwaysSucceedCheckedCast::create(ConstraintSystem &cs, Type fromType,
+AllowCheckedCastCoecibleTypes *
+AllowCheckedCastCoecibleTypes::create(ConstraintSystem &cs, Type fromType,
                                       Type toType, CheckedCastKind kind,
                                       ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowAlwaysSucceedCheckedCast(cs, fromType, toType, kind, locator);
+      AllowCheckedCastCoecibleTypes(cs, fromType, toType, kind, locator);
 }
 
-bool AllowAlwaysSucceedCheckedCast::diagnose(const Solution &solution,
+bool AllowCheckedCastCoecibleTypes::diagnose(const Solution &solution,
                                              bool asNote) const {
-  UnnecessaryCheckedCastFailure failure(solution, getFromType(), getToType(),
-                                        CastKind, getLocator());
+  CoercibleCheckedCastFailure failure(solution, getFromType(), getToType(),
+                                      CastKind, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1794,15 +1794,16 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
 
 AllowAlwaysSucceedCheckedCast *
 AllowAlwaysSucceedCheckedCast::create(ConstraintSystem &cs, Type fromType,
-                                      Type toType, ConstraintLocator *locator) {
+                                      Type toType, CheckedCastKind kind,
+                                      ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowAlwaysSucceedCheckedCast(cs, fromType, toType, locator);
+      AllowAlwaysSucceedCheckedCast(cs, fromType, toType, kind, locator);
 }
 
 bool AllowAlwaysSucceedCheckedCast::diagnose(const Solution &solution,
                                              bool asNote) const {
   UnnecessaryCheckedCastFailure failure(solution, getFromType(), getToType(),
-                                        getLocator());
+                                        CastKind, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1792,32 +1792,48 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
       SpecifyBaseTypeForOptionalUnresolvedMember(cs, memberName, locator);
 }
 
-AllowCheckedCastCoecibleTypes *
-AllowCheckedCastCoecibleTypes::create(ConstraintSystem &cs, Type fromType,
+AllowCheckedCastCoercibleOptionalType *
+AllowCheckedCastCoercibleOptionalType::create(ConstraintSystem &cs,
+                                              Type fromType, Type toType,
+                                              CheckedCastKind kind,
+                                              ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowCheckedCastCoercibleOptionalType(
+      cs, fromType, toType, kind, locator);
+}
+
+bool AllowCheckedCastCoercibleOptionalType::diagnose(const Solution &solution,
+                                                     bool asNote) const {
+  CoercibleOptionalCheckedCastFailure failure(
+      solution, getFromType(), getToType(), CastKind, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowAlwaysSucceedCheckedCast *
+AllowAlwaysSucceedCheckedCast::create(ConstraintSystem &cs, Type fromType,
                                       Type toType, CheckedCastKind kind,
                                       ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowCheckedCastCoecibleTypes(cs, fromType, toType, kind, locator);
+      AllowAlwaysSucceedCheckedCast(cs, fromType, toType, kind, locator);
 }
 
-bool AllowCheckedCastCoecibleTypes::diagnose(const Solution &solution,
+bool AllowAlwaysSucceedCheckedCast::diagnose(const Solution &solution,
                                              bool asNote) const {
-  CoercibleCheckedCastFailure failure(solution, getFromType(), getToType(),
-                                      CastKind, getLocator());
+  AlwaysSucceedCheckedCastFailure failure(solution, getFromType(), getToType(),
+                                          CastKind, getLocator());
   return failure.diagnose(asNote);
 }
 
 AllowUnsupportedRuntimeCheckedCast *
 AllowUnsupportedRuntimeCheckedCast::create(ConstraintSystem &cs, Type fromType,
-                                          Type toType,
-                                          ConstraintLocator *locator) {
+                                           Type toType, CheckedCastKind kind,
+                                           ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowUnsupportedRuntimeCheckedCast(cs, fromType, toType, locator);
+      AllowUnsupportedRuntimeCheckedCast(cs, fromType, toType, kind, locator);
 }
 
 bool AllowUnsupportedRuntimeCheckedCast::diagnose(const Solution &solution,
                                                  bool asNote) const {
-  UnsupportedRuntimeCheckedCastFailure failure(solution, getFromType(),
-                                              getToType(), getLocator());
+  UnsupportedRuntimeCheckedCastFailure failure(
+      solution, getFromType(), getToType(), CastKind, getLocator());
   return failure.diagnose(asNote);
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1806,17 +1806,17 @@ bool AllowAlwaysSucceedCheckedCast::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
-AllowUnsuportedRuntimeCheckedCast *
-AllowUnsuportedRuntimeCheckedCast::create(ConstraintSystem &cs, Type fromType,
+AllowUnsupportedRuntimeCheckedCast *
+AllowUnsupportedRuntimeCheckedCast::create(ConstraintSystem &cs, Type fromType,
                                           Type toType,
                                           ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowUnsuportedRuntimeCheckedCast(cs, fromType, toType, locator);
+      AllowUnsupportedRuntimeCheckedCast(cs, fromType, toType, locator);
 }
 
-bool AllowUnsuportedRuntimeCheckedCast::diagnose(const Solution &solution,
+bool AllowUnsupportedRuntimeCheckedCast::diagnose(const Solution &solution,
                                                  bool asNote) const {
-  UnsuportedRuntimeCheckedCastFailure failure(solution, getFromType(),
+  UnsupportedRuntimeCheckedCastFailure failure(solution, getFromType(),
                                               getToType(), getLocator());
   return failure.diagnose(asNote);
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6080,6 +6080,9 @@ ConstraintSystem::simplifyCheckedCastConstraint(
     if (!(fromType->hasTypeVariable() || toType->hasTypeVariable())) {
       if (flags.contains(TMF_ApplyingFix))
         return SolutionKind::Solved;
+      
+      if (fromType->is<ArchetypeType>())
+        return SolutionKind::Solved;
 
       auto *loc = getConstraintLocator(locator);
       if (!isExpr<ExplicitCastExpr>(loc->getAnchor()))
@@ -6109,7 +6112,7 @@ ConstraintSystem::simplifyCheckedCastConstraint(
             }
           } else {
             // Runtime cannot perform such conversion.
-            (void)recordFix(AllowUnsuportedRuntimeCheckedCast::create(
+            (void)recordFix(AllowUnsupportedRuntimeCheckedCast::create(
                 *this, fromType, toType, getConstraintLocator(locator)));
           }
         } else {
@@ -10375,7 +10378,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowRefToInvalidDecl:
   case FixKind::SpecifyBaseTypeForOptionalUnresolvedMember:
   case FixKind::AllowAlwaysSucceedCheckedCast:
-  case FixKind::AllowUnsuportedRuntimeCheckedCast: {
+  case FixKind::AllowUnsupportedRuntimeCheckedCast: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6103,13 +6103,13 @@ ConstraintSystem::simplifyCheckedCastConstraint(
           // to throwing to type without throwing clause conversions are not
           // possible at runtime.
           if (fnFromType->isEqual(fnToType)) {
-            (void)recordFix(AllowAlwaysSucceedCheckedCast::create(
+            (void)recordFix(AllowCheckedCastCoecibleTypes::create(
                 *this, fromType, toType, castKind,
                 getConstraintLocator(locator)));
           } else if (!fnFromType->isThrowing() && fnToType->isThrowing()) {
             if (fnFromType->isEqual(
                     fnToType->getWithoutThrowing()->castTo<FunctionType>())) {
-              (void)recordFix(AllowAlwaysSucceedCheckedCast::create(
+              (void)recordFix(AllowCheckedCastCoecibleTypes::create(
                   *this, fromType, toType, castKind,
                   getConstraintLocator(locator)));
             }
@@ -6119,7 +6119,7 @@ ConstraintSystem::simplifyCheckedCastConstraint(
                 *this, fromType, toType, getConstraintLocator(locator)));
           }
         } else {
-          (void)recordFix(AllowAlwaysSucceedCheckedCast::create(
+          (void)recordFix(AllowCheckedCastCoecibleTypes::create(
               *this, fromType, toType, castKind,
               getConstraintLocator(locator)));
         }
@@ -10381,7 +10381,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyContextualTypeForNil:
   case FixKind::AllowRefToInvalidDecl:
   case FixKind::SpecifyBaseTypeForOptionalUnresolvedMember:
-  case FixKind::AllowAlwaysSucceedCheckedCast:
+  case FixKind::AllowCheckedCastCoecibleTypes:
   case FixKind::AllowUnsupportedRuntimeCheckedCast: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5973,7 +5973,7 @@ static bool isCastToExpressibleByNilLiteral(ConstraintSystem &cs, Type fromType,
          fromType->getOptionalObjectType();
 }
 
-static ConstraintFix *attemptFixForCheckedConvertibleTypes(
+static ConstraintFix *maybeWarnAboutExtraneousCast(
     ConstraintSystem &cs, Type origFromType, Type origToType, Type fromType,
     Type toType, SmallVector<Type, 4> fromOptionals,
     SmallVector<Type, 4> toOptionals, ConstraintSystem::TypeMatchOptions flags,
@@ -6137,7 +6137,7 @@ ConstraintSystem::simplifyCheckedCastConstraint(
     if (result != SolutionKind::Solved)
       return;
 
-    if (auto *fix = attemptFixForCheckedConvertibleTypes(
+    if (auto *fix = maybeWarnAboutExtraneousCast(
             *this, origFromType, origToType, fromType, toType, fromOptionals,
             toOptionals, flags, locator)) {
       (void)recordFix(fix);
@@ -6197,7 +6197,7 @@ ConstraintSystem::simplifyCheckedCastConstraint(
     // Attempts to record warning fixes when both types are known by the
     // compiler and we can infer that the runtime checked cast will always
     // succeed or fail.
-    if (auto *fix = attemptFixForCheckedConvertibleTypes(
+    if (auto *fix = maybeWarnAboutExtraneousCast(
             *this, origFromType, origToType, fromType, toType, fromOptionals,
             toOptionals, flags, locator)) {
       (void)recordFix(fix);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6091,7 +6091,8 @@ ConstraintSystem::simplifyCheckedCastConstraint(
       auto castKind = TypeChecker::typeCheckCheckedCast(
           fromType, toType, CheckedCastContextKind::None, DC, SourceLoc(),
           nullptr, SourceRange());
-      if (castKind == CheckedCastKind::Coercion) {
+      if (castKind == CheckedCastKind::Coercion ||
+          castKind == CheckedCastKind::BridgingCoercion) {
         auto fnFromType = fromType->getAs<FunctionType>();
         auto fnToType = toType->getAs<FunctionType>();
         if (fnFromType && fnToType) {
@@ -6103,12 +6104,14 @@ ConstraintSystem::simplifyCheckedCastConstraint(
           // possible at runtime.
           if (fnFromType->isEqual(fnToType)) {
             (void)recordFix(AllowAlwaysSucceedCheckedCast::create(
-                *this, fromType, toType, getConstraintLocator(locator)));
+                *this, fromType, toType, castKind,
+                getConstraintLocator(locator)));
           } else if (!fnFromType->isThrowing() && fnToType->isThrowing()) {
             if (fnFromType->isEqual(
                     fnToType->getWithoutThrowing()->castTo<FunctionType>())) {
               (void)recordFix(AllowAlwaysSucceedCheckedCast::create(
-                  *this, fromType, toType, getConstraintLocator(locator)));
+                  *this, fromType, toType, castKind,
+                  getConstraintLocator(locator)));
             }
           } else {
             // Runtime cannot perform such conversion.
@@ -6117,7 +6120,8 @@ ConstraintSystem::simplifyCheckedCastConstraint(
           }
         } else {
           (void)recordFix(AllowAlwaysSucceedCheckedCast::create(
-              *this, fromType, toType, getConstraintLocator(locator)));
+              *this, fromType, toType, castKind,
+              getConstraintLocator(locator)));
         }
       }
     }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1329,9 +1329,12 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   
   // Check for a bridging conversion.
   // Anything bridges to AnyObject.
-  if (toType->isAnyObject())
+  if (toType->isAnyObject()) {
+    if (fromType->is<ArchetypeType>())
+      return CheckedCastKind::Unresolved;
     return CheckedCastKind::BridgingCoercion;
-  
+  }
+
   if (isObjCBridgedTo(fromType, toType, dc, &unwrappedIUO) && !unwrappedIUO){
     return CheckedCastKind::BridgingCoercion;
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1393,30 +1393,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
                                  SourceLoc(), nullptr, SourceRange())) {
     case CheckedCastKind::Coercion:
     case CheckedCastKind::BridgingCoercion: {
-      // FIXME: Add a Fix-It, when the caller provides us with enough
-      // information.
-      if (!suppressDiagnostics) {
-        switch (contextKind) {
-        case CheckedCastContextKind::None:
-        case CheckedCastContextKind::Coercion:
-          llvm_unreachable("suppressing diagnostics");
-
-        case CheckedCastContextKind::IsExpr:
-        case CheckedCastContextKind::ConditionalCast:
-        case CheckedCastContextKind::ForcedCast:
-          // If there is more than one extra optional, don't do anything: this
-          // conditional cast is trying to unwrap some levels of optional;
-          // let the runtime handle it.
-          break;
-
-        case CheckedCastContextKind::IsPattern:
-        case CheckedCastContextKind::EnumElementPattern:
-          // Note: Don't diagnose these, because the code is testing whether
-          // the optionals can be unwrapped.
-          break;
-        }
-      }
-
       // Treat this as a value cast so we preserve the semantics.
       return CheckedCastKind::ValueCast;
     }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1329,9 +1329,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   
   // Check for a bridging conversion.
   // Anything bridges to AnyObject.
-  if (toType->isAnyObject()) {
+  if (toType->isAnyObject())
     return CheckedCastKind::BridgingCoercion;
-  }
 
   if (isObjCBridgedTo(fromType, toType, dc, &unwrappedIUO) && !unwrappedIUO){
     return CheckedCastKind::BridgingCoercion;
@@ -1594,7 +1593,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       }
 
       return CheckedCastKind::ValueCast;
-      break;
 
     case CheckedCastContextKind::IsPattern:
     case CheckedCastContextKind::EnumElementPattern:

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1396,101 +1396,17 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       // FIXME: Add a Fix-It, when the caller provides us with enough
       // information.
       if (!suppressDiagnostics) {
-        bool isBridged =
-          !fromType->isEqual(toType) && !isConvertibleTo(fromType, toType, dc);
-
         switch (contextKind) {
         case CheckedCastContextKind::None:
         case CheckedCastContextKind::Coercion:
           llvm_unreachable("suppressing diagnostics");
 
-        case CheckedCastContextKind::ForcedCast: {
-          std::string extraFromOptionalsStr(extraFromOptionals, '!');
-          auto diag = diags.diagnose(diagLoc, diag::downcast_same_type,
-                                     origFromType, origToType,
-                                     extraFromOptionalsStr,
-                                     isBridged);
-          diag.highlight(diagFromRange);
-          diag.highlight(diagToRange);
-
-          /// Add the '!''s needed to adjust the type.
-          diag.fixItInsertAfter(diagFromRange.End,
-                                std::string(extraFromOptionals, '!'));
-          if (isBridged) {
-            // If it's bridged, we still need the 'as' to perform the bridging.
-            diag.fixItReplaceChars(diagLoc, diagLoc.getAdvancedLocOrInvalid(3),
-                                   "as");
-          } else {
-            // Otherwise, implicit conversions will handle it in most cases.
-            SourceLoc afterExprLoc = Lexer::getLocForEndOfToken(Context.SourceMgr,
-                                                                diagFromRange.End);
-
-            diag.fixItRemove(SourceRange(afterExprLoc, diagToRange.End));
-          }
-          break;
-        }
-
+        case CheckedCastContextKind::IsExpr:
         case CheckedCastContextKind::ConditionalCast:
-          // If we're only unwrapping a single optional, that optional value is
-          // effectively carried through to the underlying conversion, making this
-          // the moral equivalent of a map. Complain that one can do this with
-          // 'as' more effectively.
-          if (extraFromOptionals == 1) {
-            // A single optional is carried through. It's better to use 'as' to
-            // the appropriate optional type.
-            auto diag = diags.diagnose(diagLoc,
-                                       diag::conditional_downcast_same_type,
-                                       origFromType, origToType,
-                                       fromType->isEqual(toType) ? 0
-                                                     : isBridged ? 2
-                                                     : 1);
-            diag.highlight(diagFromRange);
-            diag.highlight(diagToRange);
-
-            if (isBridged) {
-              // For a bridged cast, replace the 'as?' with 'as'.
-              diag.fixItReplaceChars(diagLoc, diagLoc.getAdvancedLocOrInvalid(3),
-                                     "as");
-
-              // Make sure we'll cast to the appropriately-optional type by adding
-              // the '?'.
-              // FIXME: Parenthesize!
-              diag.fixItInsertAfter(diagToRange.End, "?");
-            } else {
-              // Just remove the cast; implicit conversions will handle it.
-              SourceLoc afterExprLoc =
-                Lexer::getLocForEndOfToken(Context.SourceMgr, diagFromRange.End);
-
-              if (afterExprLoc.isValid() && diagToRange.isValid())
-                diag.fixItRemove(SourceRange(afterExprLoc, diagToRange.End));
-            }
-          }
-
+        case CheckedCastContextKind::ForcedCast:
           // If there is more than one extra optional, don't do anything: this
           // conditional cast is trying to unwrap some levels of optional;
           // let the runtime handle it.
-          break;
-
-        case CheckedCastContextKind::IsExpr:
-          // If we're only unwrapping a single optional, we could have just
-          // checked for 'nil'.
-          if (extraFromOptionals == 1) {
-            auto diag = diags.diagnose(diagLoc, diag::is_expr_same_type,
-                                       origFromType, origToType);
-            diag.highlight(diagFromRange);
-            diag.highlight(diagToRange);
-
-            diag.fixItReplace(SourceRange(diagLoc, diagToRange.End), "!= nil");
-
-            // Add parentheses if needed.
-            if (!fromExpr->canAppendPostfixExpression()) {
-              diag.fixItInsert(fromExpr->getStartLoc(), "(");
-              diag.fixItInsertAfter(fromExpr->getEndLoc(), ")");
-            }
-          }
-
-          // If there is more than one extra optional, don't do anything: this
-          // is performing a deeper check that the runtime will handle.
           break;
 
         case CheckedCastContextKind::IsPattern:

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1330,8 +1330,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // Check for a bridging conversion.
   // Anything bridges to AnyObject.
   if (toType->isAnyObject()) {
-    if (fromType->is<ArchetypeType>())
-      return CheckedCastKind::Unresolved;
     return CheckedCastKind::BridgingCoercion;
   }
 

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -490,19 +490,31 @@ let blockalias =  { (_: BA) in  }
 let derivedalias =  { (_: DA) in  }
 
 let _ = block is ClosureType // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to 'ClosureType' (aka '(SR13899_Derived) -> ()') is not supported; 'is' test always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-17=as}}
 let _ = blockalias is (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(BA) -> ()' (aka '(SR13899_Base) -> ()') to '(SR13899_Derived) -> Void' is not supported; 'is' test always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{20-22=as}}
 let _ = block is (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; 'is' test always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-17=as}}
 let _ = block is (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; 'is' test always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-17=as}}
 
 let _ = block as! ClosureType // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to 'ClosureType' (aka '(SR13899_Derived) -> ()') is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-18=as}}
 let _ = blockalias as! (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(BA) -> ()' (aka '(SR13899_Base) -> ()') to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{20-23=as}}
 let _ = block as! (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-18=as}}
 let _ = block as! (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-18=as}}
 
 let _ = block as? ClosureType // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to 'ClosureType' (aka '(SR13899_Derived) -> ()') is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-18=as}}
 let _ = blockalias as? (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(BA) -> ()' (aka '(SR13899_Base) -> ()') to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{20-23=as}}
 let _ = block as? (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-18=as}}
 let _ = block as? (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+// expected-note@-1 {{consider using 'as' coercion instead}} {{15-18=as}}
 
 
 let _ = derived is (SR13899_Base) -> Void // expected-warning{{always fails}}

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -470,3 +470,50 @@ func protocol_composition(_ c: ProtocolP & ProtocolQ, _ c1: ProtocolP & Composit
   _ = c1 as? StructNotComforms // expected-warning {{cast from 'ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'StructNotComforms' always fails}}
   _ = c1 as? NotConformsFinal // expected-warning {{cast from 'ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'NotConformsFinal' always fails}}
 }
+
+// SR-13899
+class SR13899_Base {}
+class SR13899_Derived: SR13899_Base {}
+
+protocol SR13899_P {}
+class SR13899_A: SR13899_P {}
+
+typealias DA = SR13899_Derived
+typealias BA = SR13899_Base
+typealias ClosureType = (SR13899_Derived) -> Void
+
+let blockp = { (_: SR13899_A) in }
+let block = { (_: SR13899_Base) in }
+let derived = { (_: SR13899_Derived) in }
+
+let blockalias =  { (_: BA) in  }
+let derivedalias =  { (_: DA) in  }
+
+let _ = block is ClosureType // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to 'ClosureType' (aka '(SR13899_Derived) -> ()') is not supported; 'is' test always fails}}
+let _ = blockalias is (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(BA) -> ()' (aka '(SR13899_Base) -> ()') to '(SR13899_Derived) -> Void' is not supported; 'is' test always fails}}
+let _ = block is (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; 'is' test always fails}}
+let _ = block is (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; 'is' test always fails}}
+
+let _ = block as! ClosureType // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to 'ClosureType' (aka '(SR13899_Derived) -> ()') is not supported; cast always fails}}
+let _ = blockalias as! (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(BA) -> ()' (aka '(SR13899_Base) -> ()') to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+let _ = block as! (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+let _ = block as! (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+
+let _ = block as? ClosureType // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to 'ClosureType' (aka '(SR13899_Derived) -> ()') is not supported; cast always fails}}
+let _ = blockalias as? (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(BA) -> ()' (aka '(SR13899_Base) -> ()') to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+let _ = block as? (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+let _ = block as? (SR13899_Derived) -> Void // expected-warning{{runtime conversion from '(SR13899_Base) -> ()' to '(SR13899_Derived) -> Void' is not supported; cast always fails}}
+
+
+let _ = derived is (SR13899_Base) -> Void // expected-warning{{always fails}}
+let _ = blockp is (SR13899_P) -> Void // expected-warning{{always fails}}
+
+// Types are trivially equal.
+let _ = block is (SR13899_Base) -> Void // expected-warning{{'is' test is always true}}
+let _ = block is (SR13899_Base) throws -> Void // expected-warning{{'is' test is always true}}
+let _ = derivedalias is (SR13899_Derived) -> Void // expected-warning{{'is' test is always true}}
+let _ = derivedalias is (SR13899_Derived) throws -> Void // expected-warning{{'is' test is always true}}
+let _ = derived is (SR13899_Derived) -> Void // expected-warning{{'is' test is always true}}
+let _ = derived is (SR13899_Derived) throws -> Void // expected-warning{{'is' test is always true}}
+let _ = blockp is (SR13899_A) -> Void //expected-warning{{'is' test is always true}}
+let _ = blockp is (SR13899_A) throws -> Void //expected-warning{{'is' test is always true}}

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -215,6 +215,7 @@ type(of: obj).foo!(obj)(5) // expected-error{{instance member 'foo' cannot be us
 // Checked casts to AnyObject
 var p: P = Y()
 var obj3 : AnyObject = (p as! AnyObject)! // expected-error{{cannot force unwrap value of non-optional type 'AnyObject'}} {{41-42=}}
+// expected-warning@-1{{forced cast from 'P' to 'AnyObject' always succeeds; did you mean to use 'as'?}} {{27-30=as}}
 
 // Implicit force of an implicitly unwrapped optional
 let uopt : AnyObject! = nil

--- a/test/Migrator/optional_try_migration.swift
+++ b/test/Migrator/optional_try_migration.swift
@@ -69,7 +69,7 @@ func testOptionalChaining() {
     let _ = try? optThing!.fetchOptInt()
 
     // No migration needed, because of the explicit cast
-    let _ = (try? optThing?.fetchOptInt()) as? Int
+    let _ = (try? optThing?.fetchOptInt()) as? Int // expected-warning{{conditional downcast from 'Int?' to 'Int' does nothing}}
 
     // Migration needed
     let _ = try? thing.fetchInt()

--- a/test/Migrator/optional_try_migration.swift.expected
+++ b/test/Migrator/optional_try_migration.swift.expected
@@ -69,7 +69,7 @@ func testOptionalChaining() {
     let _ = try? optThing!.fetchOptInt()
 
     // No migration needed, because of the explicit cast
-    let _ = (try? optThing?.fetchOptInt()) as? Int
+    let _ = (try? optThing?.fetchOptInt()) as? Int // expected-warning{{conditional downcast from 'Int?' to 'Int' does nothing}}
 
     // Migration needed
     let _ = try? thing.fetchInt()

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -201,7 +201,7 @@ let y1: Int = (x as Int!)! // expected-error {{using '!' is not allowed here; pe
 let z0: Int = x as! Int! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{24-25=?}}
 // expected-warning@-1 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
 let z1: Int = (x as! Int!)! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{25-26=?}}
-// expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
+// expected-warning@-1 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
 let w0: Int = (x as? Int!)! // expected-warning {{conditional cast from 'Int?' to 'Int?' always succeeds}}
 // expected-error@-1 {{using '!' is not allowed here; perhaps '?' was intended?}}{{25-26=?}}
 let w1: Int = (x as? Int!)!! // expected-warning {{conditional cast from 'Int?' to 'Int?' always succeeds}}

--- a/test/expr/cast/nil_value_to_optional.swift
+++ b/test/expr/cast/nil_value_to_optional.swift
@@ -23,9 +23,10 @@ class D {}
 var d = D()
 var dopt: D? = nil
 var diuopt: D! = nil
+func produceD() -> D! { D() }
 
 _ = d! // expected-error {{cannot force unwrap value of non-optional type 'D'}}
 _ = dopt == nil
 _ = diuopt == nil
 _ = diuopt is ExpressibleByNilLiteral // expected-warning {{'is' test is always true}}
-// expected-warning@-1 {{conditional cast from 'D?' to 'ExpressibleByNilLiteral' always succeeds}}
+_ = produceD() is ExpressibleByNilLiteral // expected-warning {{'is' test is always true}}


### PR DESCRIPTION
Be more conservative on always true conversion diagnostics when functions are involved.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13789.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
