### PR TITLE
Lift a silly precondition

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -876,9 +876,6 @@ extension Collection {
 
   /// Returns the distance between two indices.
   ///
-  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
-  /// `start` must be less than or equal to `end`.
-  ///
   /// - Parameters:
   ///   - start: A valid index of the collection.
   ///   - end: Another valid index of the collection. If `end` is equal to
@@ -892,10 +889,8 @@ extension Collection {
   ///   resulting distance.
   @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
-    _precondition(start <= end,
-      "Only BidirectionalCollections can have end come before start")
-
-    var start = start
+    if start > end { return -distance(from: end, to: start) }
+    var start = start    
     var count = 0
     while start != end {
       count = count + 1


### PR DESCRIPTION
The cost of this test in the default implementation of distance *ought* to be minimal.  Benchmarks will tell for sure.

Still needs tests.

Fixes SR-13937

@shahmishal how come I can't trigger the benchmarks?