### PR TITLE
[NFC] Rename SwitchEnumBuilder's optional field to subjectExprOperand.

### DIFF
--- a/lib/SILGen/SwitchEnumBuilder.h
+++ b/lib/SILGen/SwitchEnumBuilder.h
@@ -133,14 +133,14 @@ private:
 
   SILGenBuilder &builder;
   SILLocation loc;
-  ManagedValue optional;
+  ManagedValue subjectExprOperand;
   llvm::Optional<DefaultCaseData> defaultBlockData;
   llvm::SmallVector<NormalCaseData, 8> caseDataArray;
 
 public:
   SwitchEnumBuilder(SILGenBuilder &builder, SILLocation loc,
-                    ManagedValue optional)
-      : builder(builder), loc(loc), optional(optional) {}
+                    ManagedValue subjectExprOperand)
+      : builder(builder), loc(loc), subjectExprOperand(subjectExprOperand) {}
 
   void addDefaultCase(
       SILBasicBlock *defaultBlock, SwitchCaseBranchDest branchDest,


### PR DESCRIPTION
From what I can tell, this can be any enum type, not just Optional. Prior art for "scrutinee": [Rust](https://doc.rust-lang.org/1.42.0/reference/expressions/match-expr.html), [Scala](https://stackoverflow.com/questions/28839590/scrutinee-is-incompatible-with-pattern-type-found-package-someobject-required), [Haskell](https://gitlab.haskell.org/ghc/ghc/-/wikis/pattern-synonyms/implementation). 