### PR TITLE
IRGen: correct decoration handling for x86

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2972,11 +2972,19 @@ static llvm::GlobalVariable *createGOTEquivalent(IRGenModule &IGM,
 
   if (IGM.Triple.getObjectFormat() == llvm::Triple::COFF) {
     if (cast<llvm::GlobalValue>(global)->hasDLLImportStorageClass()) {
+      // Add the user label prefix *prior* to the introduction of the linker
+      // synthetic marker `__imp_`.
+      // Failure to do so will re-decorate the generated symbol and miss the
+      // user label prefix, generating e.g. `___imp_$sBoW` instead of
+      // `__imp__$sBoW`.
+      if (auto prefix = IGM.DataLayout.getGlobalPrefix())
+        globalName = (llvm::Twine(prefix) + globalName).str();
+      // Indicate to LLVM that the symbol should not be re-decorated.
       llvm::GlobalVariable *GV =
           new llvm::GlobalVariable(IGM.Module, global->getType(),
                                    /*Constant=*/true,
-                                   llvm::GlobalValue::ExternalLinkage,
-                                   nullptr, llvm::Twine("__imp_") + globalName);
+                                   llvm::GlobalValue::ExternalLinkage, nullptr,
+                                   "\01__imp_" + globalName);
       GV->setExternallyInitialized(true);
       return GV;
     }

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -58,7 +58,7 @@
 // --       field offset vector offset:
 // CHECK-SAME:   i32 0,
 // -- superclass:
-// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCMn"
+// CHECK-SAME:   @"{{got.|\\01__imp__?}}$s15resilient_class22ResilientOutsideParentCMn"
 // --       singleton metadata initialization cache:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildCMl"
 // --       resilient pattern:
@@ -69,17 +69,17 @@
 // CHECK-SAME:   i32 2,
 // CHECK-SAME:   %swift.method_override_descriptor {
 // --       base class:
-// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCMn"
+// CHECK-SAME:   @"{{got.|\\01__imp__?}}$s15resilient_class22ResilientOutsideParentCMn"
 // --       base method:
-// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentC8getValueSiyFTq"
+// CHECK-SAME:   @"{{got.|\\01__imp__?}}$s15resilient_class22ResilientOutsideParentC8getValueSiyFTq"
 // --       implementation:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildC8getValueSiyF"
 // CHECK-SAME:   }
 // CHECK-SAME:   %swift.method_override_descriptor {
 // --       base class:
-// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCMn"
+// CHECK-SAME:   @"{{got.|\\01__imp__?}}$s15resilient_class22ResilientOutsideParentCMn"
 // --       base method:
-// CHECK-SAME:   @"{{got.|__imp_}}$s15resilient_class22ResilientOutsideParentCACycfCTq"
+// CHECK-SAME:   @"{{got.|\\01__imp__?}}$s15resilient_class22ResilientOutsideParentCACycfCTq"
 // --       implementation:
 // CHECK-SAME:   @"$s16class_resilience14ResilientChildCACycfC"
 // CHECK-SAME:   }

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -46,7 +46,7 @@ public func g() {
 // CHECK-NO-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 
 // CHECK-OPT-DAG: declare dllimport %swift.refcounted* @swift_retain(%swift.refcounted* returned) local_unnamed_addr
-// CHECK-OPT-DAG: @"__imp_$s9dllexport1pMp" = external externally_initialized constant %swift.protocol*
+// CHECK-OPT-DAG: @"\01__imp_{{_?}}$s9dllexport1pMp" = external externally_initialized constant %swift.protocol*
 // CHECK-OPT-DAG: declare dllimport swiftcc i8* @"$s9dllexport2ciAA1cCvau"()
 // CHECK-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 // CHECK-OPT-DAG: declare dllimport swiftcc %swift.refcounted* @"$s9dllexport1cCfd"(%T9dllexport1cC* swiftself)

--- a/test/IRGen/keypath_witness_overrides.swift
+++ b/test/IRGen/keypath_witness_overrides.swift
@@ -5,7 +5,7 @@
 import protocol_overrides
 
 // CHECK: @keypath = private global
-// CHECK-SAME: %swift.method_descriptor** @"{{got.|__imp_}}$s18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcigTq"
+// CHECK-SAME: %swift.method_descriptor** @"{{got.|\\01__imp__?}}$s18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcigTq"
 public func getWritableKeyPath<OS: OverridesSetter>(_ c: OS, index: OS.Index) -> AnyKeyPath
 where OS.Index: Hashable {
   let keypath = \OS.[index]

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -171,7 +171,7 @@ sil_vtable C2 {}
 // CHECK-SAME: <i32 0x8000_000c>,
 // -- computed, get-only, identified by (indirected) function pointer, no args
 // CHECK-SAME: <i32 0x0200_0002>,
-// CHECK-SAME: @{{got.|__imp_}}k_id
+// CHECK-SAME: @{{got.|"\\01__imp__?}}k_id
 // CHECK-SAME: void (%TSi*, %T8keypaths1SV*)* {{.*}}@k_get{{.*}}
 
 // -- %l: computed

--- a/test/IRGen/keypaths_external.sil
+++ b/test/IRGen/keypaths_external.sil
@@ -41,13 +41,13 @@ sil @s_equals : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer,
 sil @s_hash : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer) -> Int
 
 // -- %t
-// CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"{{got.|__imp_}}$s23keypaths_external_other1GV1xxvpMV"
+// CHECK: [[KP_T:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 1, {{.*}} @"{{got.|\\01__imp__?}}$s23keypaths_external_other1GV1xxvpMV"
 // CHECK-SAME:   @"symbolic x"
 //            -- computed get-only property, identified by indirect pointer
 // CHECK-SAME:   <i32 0x0208_0002>
 
 // -- %u
-// CHECK: [[KP_U:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 3, {{.*}} @"{{got.|__imp_}}$s23keypaths_external_other1GVyxqd__cSHRd__luipMV"
+// CHECK: [[KP_U:@keypath(\..*)?]] = private global <{ {{.*}} }> <{ {{.*}} i32 3, {{.*}} @"{{got.|\\01__imp__?}}$s23keypaths_external_other1GVyxqd__cSHRd__luipMV"
 // CHECK-SAME:   @"symbolic q_"
 // CHECK-SAME:   @"symbolic x"
 // CHECK-SAME:   @"get_witness_table

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -54,7 +54,7 @@ sil_property #ExternalGeneric.rw <T: Comparable> (
 // CHECK: @"$s19property_descriptor15ExternalGenericV10computedROxvpMV" =
 // -- 0x0108_0000 - computed, readonly, has arguments, identified by indirect
 // CHECK-SAME:  <{ <i32 0x0208_0002>,
-// CHECK-SAME:     @{{got.|__imp_}}id_computed
+// CHECK-SAME:     @{{got.|"\\01__imp__?}}id_computed
 // CHECK-SAME:     [[GET_COMPUTEDRO:@keypath_get[.0-9]*]]{{(\.ptrauth)?}}
 // CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRO:@keypath_get_arg_layout[.0-9]*]]{{(\.ptrauth)?}}
 // -- default witness table
@@ -68,7 +68,7 @@ sil_property #ExternalGeneric.computedRO <T: Comparable> (
 // CHECK: @"$s19property_descriptor15ExternalGenericV10computedRWxvpMV" =
 // -- 0x01c8_0000 - computed, settable, mutating, has arguments, indirect id
 // CHECK-SAME:  <{ <i32 0x02c8_0002>, 
-// CHECK-SAME:     @{{got.|__imp_}}id_computed
+// CHECK-SAME:     @{{got.|"\\01__imp__?}}id_computed
 // CHECK-SAME:     [[GET_COMPUTEDRW:@keypath_get[.0-9]*]]{{(\.ptrauth)?}}
 // CHECK-SAME:     [[SET_COMPUTEDRW:@keypath_set[.0-9]*]]{{(\.ptrauth)?}}
 // CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRW:@keypath_get_arg_layout[.0-9]*]]{{(\.ptrauth)?}}
@@ -83,7 +83,7 @@ sil_property #ExternalGeneric.computedRW <T: Comparable> (
 // CHECK: @"$s19property_descriptor15ExternalGenericVyxqd__cSHRd__luipMV" =
 // -- 0x01c8_0000 - computed, settable, mutating, has arguments, indirect id
 // CHECK-SAME:  <{ <i32 0x02c8_0002>, 
-// CHECK-SAME:     @{{got.|__imp_}}id_computed
+// CHECK-SAME:     @{{got.|"\\01__imp__?}}id_computed
 // CHECK-SAME:     [[GET_SUBSCRIPT:@keypath_get[.0-9]*]]{{(\.ptrauth)?}}
 // CHECK-SAME:     [[SET_SUBSCRIPT:@keypath_set[.0-9]*]]{{(\.ptrauth)?}}
 // CHECK-SAME:     [[GET_ARG_LAYOUT_SUBSCRIPT:@keypath_get_arg_layout[.0-9]*]]{{(\.ptrauth)?}}

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -57,7 +57,7 @@ public struct NativeGenericType<T>: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- type metadata
-// CHECK-SAME:           @"{{got.|__imp_}}$sSiMn"
+// CHECK-SAME:           @"{{got.|\\01__imp__?}}$sSiMn"
 // -- witness table
 // CHECK-SAME:           @"$sSi28protocol_conformance_records8RuncibleAAWP"
 // -- reserved
@@ -73,7 +73,7 @@ extension Int: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
-// CHECK-SAME:           @"{{got.|__imp_}}$s16resilient_struct4SizeVMn"
+// CHECK-SAME:           @"{{got.|\\01__imp__?}}$s16resilient_struct4SizeVMn"
 // -- witness table
 // CHECK-SAME:           @"$s16resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP"
 // -- reserved
@@ -132,9 +132,9 @@ extension NativeGenericType : Spoon where T: Spoon {
 // Retroactive conformance
 // CHECK-LABEL: @"$sSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsMc" ={{ dllexport | protected | }}constant
 // -- protocol descriptor
-// CHECK-SAME:           @"{{got.|__imp_}}$s18resilient_protocol22OtherResilientProtocolMp"
+// CHECK-SAME:           @"{{got.|\\01__imp__?}}$s18resilient_protocol22OtherResilientProtocolMp"
 // -- nominal type descriptor
-// CHECK-SAME:           @"{{got.|__imp_}}$sSiMn"
+// CHECK-SAME:           @"{{got.|\\01__imp__?}}$sSiMn"
 // -- witness table pattern
 // CHECK-SAME:           i32 0,
 // -- flags

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -116,13 +116,13 @@ protocol InternalProtocol {
 // CHECK-SAME: i32 3,
 
 // -- type metadata for associated type
-// CHECK-SAME: @"{{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl"
+// CHECK-SAME: @"{{got.|\\01__imp__?}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl"
 // CHECK-SAME: @"symbolic Si"
 
-// CHECK-SAME: @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsP5firstyyFTq"
+// CHECK-SAME: @"{{got.|\\01__imp__?}}$s18resilient_protocol24ProtocolWithRequirementsP5firstyyFTq"
 // CHECK-SAME: @firstWitness
 
-// CHECK-SAME: @"{{got.|__imp_}}$s18resilient_protocol24ProtocolWithRequirementsP6secondyyFTq"
+// CHECK-SAME: @"{{got.|\\01__imp__?}}$s18resilient_protocol24ProtocolWithRequirementsP6secondyyFTq"
 // CHECK-SAME: @secondWitness
 
 // -- number of witness table entries

--- a/test/IRGen/protocol_resilience_descriptors.swift
+++ b/test/IRGen/protocol_resilience_descriptors.swift
@@ -46,7 +46,7 @@ import resilient_protocol
 // Resilient witness tables
 // ----------------------------------------------------------------------------
 // CHECK-USAGE-LABEL: $s31protocol_resilience_descriptors34ConformsToProtocolWithRequirementsVyxG010resilient_A00fgH0AAMc" =
-// CHECK-USAGE-SAME: {{got.|__imp_}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl
+// CHECK-USAGE-SAME: {{got.|\\01__imp__?}}$s1T18resilient_protocol24ProtocolWithRequirementsPTl
 // CHECK-USAGE-SAME: @"symbolic x"
 public struct ConformsToProtocolWithRequirements<Element>
     : ProtocolWithRequirements {


### PR DESCRIPTION
When building the label for the IAT synthetic, we need to pre-decorate
the symbol before we apply the synthetic symbol prefix lest we end up
placing the user-label prefix over the synthetic symbol rather than the
actual symbol.  This is required to correctly resolve symbols when
building the standard library for x86.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
