### PR TITLE
[CSBindings] Instead of using a flag track constraints which delay type variable

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4738,9 +4738,8 @@ private:
     /// The set of constraints which would be used to infer default types.
     llvm::TinyPtrVector<Constraint *> Defaults;
 
-    /// Whether these bindings should be delayed until the rest of the
-    /// constraint system is considered "fully bound".
-    bool FullyBound = false;
+    /// The set of constraints which delay attempting this type variable.
+    llvm::TinyPtrVector<Constraint *> DelayedBy;
 
     /// Whether the bindings of this type involve other type variables.
     bool InvolvesTypeVariables = false;
@@ -4762,6 +4761,10 @@ private:
 
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
+
+    /// Whether these bindings should be delayed until the rest of the
+    /// constraint system is considered "fully bound".
+    bool isFullyBound() const;
 
     /// Whether the bindings represent (potentially) incomplete set,
     /// there is no way to say with absolute certainty if that's the
@@ -4805,7 +4808,7 @@ private:
 
       return std::make_tuple(b.isHole(),
                              !hasNoDefaultableBindings,
-                             b.FullyBound,
+                             b.isFullyBound(),
                              b.isSubtypeOfExistentialType(),
                              b.InvolvesTypeVariables,
                              static_cast<unsigned char>(b.LiteralBinding),
@@ -4952,7 +4955,7 @@ public:
       out.indent(indent);
       if (isPotentiallyIncomplete())
         out << "potentially_incomplete ";
-      if (FullyBound)
+      if (isFullyBound())
         out << "fully_bound ";
       if (isSubtypeOfExistentialType())
         out << "subtype_of_existential ";

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4762,9 +4762,16 @@ private:
     /// Determine whether the set of bindings is non-empty.
     explicit operator bool() const { return !Bindings.empty(); }
 
-    /// Whether these bindings should be delayed until the rest of the
-    /// constraint system is considered "fully bound".
-    bool isFullyBound() const;
+    /// Determine whether attempting this type variable should be
+    /// delayed until the rest of the constraint system is considered
+    /// "fully bound" meaning constraints, which affect completeness
+    /// of the binding set, for this type variable such as - member
+    /// constraint, disjunction, function application etc. - are simplified.
+    ///
+    /// Note that in some situations i.e. when there are no more
+    /// disjunctions or type variables left to attempt, it's still
+    /// okay to attempt "delayed" type variable to make forward progress.
+    bool isDelayed() const;
 
     /// Whether the bindings represent (potentially) incomplete set,
     /// there is no way to say with absolute certainty if that's the
@@ -4808,7 +4815,7 @@ private:
 
       return std::make_tuple(b.isHole(),
                              !hasNoDefaultableBindings,
-                             b.isFullyBound(),
+                             b.isDelayed(),
                              b.isSubtypeOfExistentialType(),
                              b.InvolvesTypeVariables,
                              static_cast<unsigned char>(b.LiteralBinding),
@@ -4955,8 +4962,8 @@ public:
       out.indent(indent);
       if (isPotentiallyIncomplete())
         out << "potentially_incomplete ";
-      if (isFullyBound())
-        out << "fully_bound ";
+      if (isDelayed())
+        out << "delayed ";
       if (isSubtypeOfExistentialType())
         out << "subtype_of_existential ";
       if (LiteralBinding != LiteralBindingKind::None)

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -33,7 +33,7 @@ bool ConstraintSystem::PotentialBinding::isViableForJoin() const {
          !isDefaultableBinding();
 }
 
-bool ConstraintSystem::PotentialBindings::isFullyBound() const {
+bool ConstraintSystem::PotentialBindings::isDelayed() const {
   if (!DelayedBy.empty())
     return true;
 
@@ -788,7 +788,7 @@ bool ConstraintSystem::PotentialBindings::isViable(
 
 bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
     Constraint *disjunction) const {
-  if (isHole() || isFullyBound())
+  if (isHole() || isDelayed())
     return false;
 
   // If this bindings are for a closure and there are no holes,


### PR DESCRIPTION
- Keep track of all constraints which caused a particular type variable to
   be de-prioritized.

- Convert a property to a method which would determine whether
   given set of potential bindings is "fully bound" and has to
   be delayed until certain constraints are simplified.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
