### PR TITLE
[Driver] A Pile of Nits 

### DIFF
--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -493,7 +493,12 @@ public:
 
   template <typename Nodes>
   std::vector<const driver::Job *>
-  findJobsToRecompileWhenNodesChange(const Nodes &);
+  findJobsToRecompileWhenNodesChange(const Nodes &nodes) {
+    std::vector<ModuleDepGraphNode *> foundDependents;
+    for (ModuleDepGraphNode *n : nodes)
+      findPreviouslyUntracedDependents(foundDependents, n);
+    return jobsContaining(foundDependents);
+  }
 
 private:
   std::vector<const driver::Job *>

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -339,9 +339,9 @@ void DepGraphNode::dump() const {
 void DepGraphNode::dump(raw_ostream &os) const {
   key.dump(os);
   if (fingerprint.hasValue())
-    llvm::errs() << "fingerprint: " << fingerprint.getValue() << "";
+    os << "fingerprint: " << fingerprint.getValue() << "";
   else
-    llvm::errs() << "no fingerprint";
+    os << "no fingerprint";
 }
 
 void SourceFileDepGraphNode::dump() const {

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -408,23 +408,17 @@ class UsedDeclEnumerator {
   /// Cache these for efficiency
   const DependencyKey sourceFileImplementation;
 
-  function_ref<void(const DependencyKey &, const DependencyKey &)> createDefUse;
-
 public:
-  UsedDeclEnumerator(
-      const SourceFile *SF, const DependencyTracker &depTracker,
-      StringRef swiftDeps,
-      function_ref<void(const DependencyKey &, const DependencyKey &)>
-          createDefUse)
+  UsedDeclEnumerator(const SourceFile *SF, const DependencyTracker &depTracker,
+                     StringRef swiftDeps)
       : SF(SF), depTracker(depTracker), swiftDeps(swiftDeps),
-        sourceFileInterface(DependencyKey::createKeyForWholeSourceFile(
-            DeclAspect::interface, swiftDeps)),
         sourceFileImplementation(DependencyKey::createKeyForWholeSourceFile(
-            DeclAspect::implementation, swiftDeps)),
-        createDefUse(createDefUse) {}
+            DeclAspect::implementation, swiftDeps)) {}
 
 public:
-  void enumerateAllUses() {
+  using UseEnumerator =
+      llvm::function_ref<void(const DependencyKey &, const DependencyKey &)>;
+  void enumerateAllUses(UseEnumerator enumerator) {
     auto &Ctx = SF->getASTContext();
     Ctx.evaluator.enumerateReferencesInFile(SF, [&](const auto &ref) {
       std::string name = ref.name.userFacingName().str();
@@ -436,36 +430,37 @@ public:
       case Kind::Tombstone:
         llvm_unreachable("Cannot enumerate dead reference!");
       case Kind::TopLevel:
-        return enumerateUse<NodeKind::topLevel>("", name);
+        return enumerateUse<NodeKind::topLevel>("", name, enumerator);
       case Kind::Dynamic:
-        return enumerateUse<NodeKind::dynamicLookup>("", name);
+        return enumerateUse<NodeKind::dynamicLookup>("", name, enumerator);
       case Kind::PotentialMember: {
         std::string context = DependencyKey::computeContextForProvidedEntity<
             NodeKind::potentialMember>(nominal);
-        return enumerateUse<NodeKind::potentialMember>(context, "");
+        return enumerateUse<NodeKind::potentialMember>(context, "", enumerator);
       }
       case Kind::UsedMember: {
         std::string context =
             DependencyKey::computeContextForProvidedEntity<NodeKind::member>(
                 nominal);
-        return enumerateUse<NodeKind::member>(context, name);
+        return enumerateUse<NodeKind::member>(context, name, enumerator);
       }
       }
     });
-    enumerateExternalUses();
-    enumerateNominalUses();
+    enumerateExternalUses(enumerator);
+    enumerateNominalUses(enumerator);
   }
 
 private:
   template <NodeKind kind>
-  void enumerateUse(StringRef context, StringRef name) {
+  void enumerateUse(StringRef context, StringRef name,
+                    UseEnumerator createDefUse) {
     // Assume that what is depended-upon is the interface
     createDefUse(
         DependencyKey(kind, DeclAspect::interface, context.str(), name.str()),
         sourceFileImplementation);
   }
 
-  void enumerateNominalUses() {
+  void enumerateNominalUses(UseEnumerator enumerator) {
     auto &Ctx = SF->getASTContext();
     Ctx.evaluator.enumerateReferencesInFile(SF, [&](const auto &ref) {
       const NominalTypeDecl *subject = ref.subject;
@@ -476,26 +471,26 @@ private:
       std::string context =
           DependencyKey::computeContextForProvidedEntity<NodeKind::nominal>(
               subject);
-      enumerateUse<NodeKind::nominal>(context, "");
+      enumerateUse<NodeKind::nominal>(context, "", enumerator);
     });
   }
 
-  void enumerateExternalUses() {
+  void enumerateExternalUses(UseEnumerator enumerator) {
     for (StringRef s : depTracker.getIncrementalDependencies())
-      enumerateUse<NodeKind::incrementalExternalDepend>("", s);
+      enumerateUse<NodeKind::incrementalExternalDepend>("", s, enumerator);
 
     for (StringRef s : depTracker.getDependencies())
-      enumerateUse<NodeKind::externalDepend>("", s);
+      enumerateUse<NodeKind::externalDepend>("", s, enumerator);
   }
 };
 } // end namespace
 
 void FrontendSourceFileDepGraphFactory::addAllUsedDecls() {
-  UsedDeclEnumerator(SF, depTracker, swiftDeps,
-                     [&](const DependencyKey &def, const DependencyKey &use) {
-                       addAUsedDecl(def, use);
-                     })
-    .enumerateAllUses();
+  UsedDeclEnumerator(SF, depTracker, swiftDeps)
+      .enumerateAllUses(
+          [&](const DependencyKey &def, const DependencyKey &use) {
+            addAUsedDecl(def, use);
+          });
 }
 
 //==============================================================================

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -406,7 +406,6 @@ class UsedDeclEnumerator {
   StringRef swiftDeps;
 
   /// Cache these for efficiency
-  const DependencyKey sourceFileInterface;
   const DependencyKey sourceFileImplementation;
 
   function_ref<void(const DependencyKey &, const DependencyKey &)> createDefUse;

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -488,13 +488,6 @@ namespace driver {
     reloadAndRemarkDepsOnNormalExit(const Job *FinishedCmd,
                                     const bool cmdFailed, const bool forRanges,
                                     StringRef DependenciesFile) {
-      return reloadAndRemarkFineGrainedDepsOnNormalExit(
-          FinishedCmd, cmdFailed, forRanges, DependenciesFile);
-    }
-
-    std::vector<const Job *> reloadAndRemarkFineGrainedDepsOnNormalExit(
-        const Job *FinishedCmd, const bool cmdFailed, const bool forRanges,
-        StringRef DependenciesFile) {
       const auto changedNodes = getFineGrainedDepGraph(forRanges).loadFromPath(
           FinishedCmd, DependenciesFile, Comp.getDiags());
       const bool loadFailed = !changedNodes;

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -156,25 +156,6 @@ std::vector<const Job *> ModuleDepGraph::findJobsToRecompileWhenWholeJobChanges(
   return findJobsToRecompileWhenNodesChange(allNodesInJob);
 }
 
-template <typename Nodes>
-std::vector<const Job *>
-ModuleDepGraph::findJobsToRecompileWhenNodesChange(const Nodes &nodes) {
-  std::vector<ModuleDepGraphNode *> foundDependents;
-  for (ModuleDepGraphNode *n : nodes)
-    findPreviouslyUntracedDependents(foundDependents, n);
-  return jobsContaining(foundDependents);
-}
-
-template std::vector<const Job *>
-ModuleDepGraph::findJobsToRecompileWhenNodesChange<
-    std::unordered_set<ModuleDepGraphNode *>>(
-    const std::unordered_set<ModuleDepGraphNode *> &);
-
-template std::vector<const Job *>
-ModuleDepGraph::findJobsToRecompileWhenNodesChange<
-    std::vector<ModuleDepGraphNode *>>(
-    const std::vector<ModuleDepGraphNode *> &);
-
 std::vector<std::string> ModuleDepGraph::computeSwiftDepsFromNodes(
     ArrayRef<const ModuleDepGraphNode *> nodes) const {
   llvm::StringSet<> swiftDepsOfNodes;


### PR DESCRIPTION
- Correct the stream we dump the fingerprint status of a dep graph node to
- Formalize the ownership contract with the UsedDeclEnumerator - `llvm::function_ref` is non-owning.
- Move a template definition into the header and delete some manual specializations.