### PR TITLE
[Concurrency] Tweaks to heuristics for Objective-C imports

### DIFF
--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -1322,10 +1322,10 @@ bool swift::omitNeedlessWords(StringRef &baseName,
   }
 
   // If this is an asynchronous function where the completion handler is
-  // the second parameter, and the corresponding name has some additional
-  // information prior to WithCompletion(Handler), append that
+  // past the first parameter the corresponding name has some additional
+  // information prior to the completion-handled suffix, append that
   // additional text to the base name.
-  if (isAsync && *completionHandlerIndex == 1 && completionHandlerName) {
+  if (isAsync && *completionHandlerIndex >= 1 && completionHandlerName) {
     if (auto extraParamText = stripWithCompletionHandlerSuffix(
             *completionHandlerName)) {
       SmallString<32> newBaseName;
@@ -1354,20 +1354,6 @@ bool swift::omitNeedlessWords(StringRef &baseName,
     StringRef newName = omitTrailingTypeNameWithSpecialCases(
         name, paramTypes[i], role,
         role == NameRole::BaseName ? allPropertyNames : nullptr);
-
-    // If this is an asynchronous function where the completion handler is
-    // past the second parameter and has additional information in the name,
-    // add that information to the prior argument name.
-    if (isAsync && completionHandlerName && *completionHandlerIndex > 1 &&
-        *completionHandlerIndex == i + 1) {
-      if (auto extraParamText = stripWithCompletionHandlerSuffix(
-              *completionHandlerName)) {
-        SmallString<32> extendedName;
-        extendedName += newName;
-        appendSentenceCase(extendedName, *extraParamText);
-        newName = scratch.copyString(extendedName);
-      }
-    }
 
     if (name == newName) continue;
 

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -1392,5 +1392,17 @@ Optional<StringRef> swift::stripWithCompletionHandlerSuffix(StringRef name) {
     return name.drop_back(strlen("WithCompletion"));
   }
 
+  if (name.endswith("WithCompletionBlock")) {
+    return name.drop_back(strlen("WithCompletionBlock"));
+  }
+
+  if (name.endswith("WithReplyTo")) {
+    return name.drop_back(strlen("WithReplyTo"));
+  }
+
+  if (name.endswith("WithReply")) {
+    return name.drop_back(strlen("WithReply"));
+  }
+
   return None;
 }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1135,8 +1135,12 @@ Optional<ForeignErrorConvention::Info> NameImporter::considerErrorImport(
 
 /// Whether the given parameter name identifies a completion handler.
 static bool isCompletionHandlerParamName(StringRef paramName) {
-  return paramName == "completionHandler" || paramName == "completion" ||
-      paramName == "withCompletionHandler" || paramName == "withCompletion";
+  return paramName == "completionHandler" ||
+      paramName == "withCompletionHandler" ||
+      paramName == "completion" || paramName == "withCompletion" ||
+      paramName == "completionBlock" || paramName == "withCompletionBlock" ||
+      paramName == "reply" || paramName == "withReply";
+      paramName == "replyTo" || paramName == "withReplyTo";
 }
 
 // Determine whether the given type is a nullable NSError type.

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1139,7 +1139,7 @@ static bool isCompletionHandlerParamName(StringRef paramName) {
       paramName == "withCompletionHandler" ||
       paramName == "completion" || paramName == "withCompletion" ||
       paramName == "completionBlock" || paramName == "withCompletionBlock" ||
-      paramName == "reply" || paramName == "withReply";
+      paramName == "reply" || paramName == "withReply" ||
       paramName == "replyTo" || paramName == "withReplyTo";
 }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -24,7 +24,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await try slowServer.magicNumber(withSeed: 42)
 
   await slowServer.serverRestart("localhost")
-  await slowServer.server("localhost", atPriorityRestart: 0.8)
+  await slowServer.serverRestart("localhost", atPriority: 0.8)
 
   _ = await slowServer.allOperations()
 }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -13,6 +13,9 @@
 // CHECK-DAG:     func doSomethingDangerous(_ operation: String) async throws -> String
 // CHECK-DAG:     func checkAvailability(completionHandler: @escaping (Bool) -> Void)
 // CHECK-DAG:     func checkAvailability() async -> Bool
+// CHECK-DAG:     func anotherExample() async -> String
+// CHECK-DAG:     func finalExample() async -> String
+// CHECK-DAG:     func replyingOperation(_ operation: String) async -> String
 // CHECK-DAG:     func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)
 // CHECK-DAG:     func findAnswer() async throws -> String
 // CHECK-DAG:     func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -12,6 +12,9 @@
 -(void)doSomethingSlow:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
 -(void)doSomethingDangerous:(NSString *)operation completionHandler:(void (^ _Nullable)(NSString *_Nullable, NSError * _Nullable))handler;
 -(void)checkAvailabilityWithCompletionHandler:(void (^)(BOOL isAvailable))completionHandler;
+-(void)anotherExampleWithCompletionBlock:(void (^)(NSString *))block;
+-(void)finalExampleWithReplyTo:(void (^)(NSString *))block;
+-(void)replyingOperation:(NSString *)operation replyTo:(void (^)(NSString *))block;
 -(void)findAnswerAsynchronously:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswer(completionHandler:)")));
 -(BOOL)findAnswerFailinglyWithError:(NSError * _Nullable * _Nullable)error completion:(void (^)(NSString *_Nullable, NSError * _Nullable))handler __attribute__((swift_name("findAnswerFailingly(completionHandler:)")));
 -(void)doSomethingFun:(NSString *)operation then:(void (^)(void))completionHandler;


### PR DESCRIPTION
Introduce a few tweaks to the Objective-C translation to `async` based on feedback from the pitch phase:

* Add additional "completion handler" names to match: (with)CompletionBlock and (with)Reply(To)
* When one of the "with" forms matches a parameter, put any text prior to the matching part on the base name