### PR TITLE
[IRGen] Use specialized mangled name for class constants.

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2076,6 +2076,15 @@ namespace {
     /// Get the name of the class or protocol to mangle into the ObjC symbol
     /// name.
     StringRef getEntityName(llvm::SmallVectorImpl<char> &buffer) const {
+      if (auto prespecialization = getSpecializedGenericType()) {
+        buffer.clear();
+        llvm::raw_svector_ostream os(buffer);
+        os << LinkEntity::forTypeMetadata(*prespecialization,
+                                          TypeMetadataAddress::FullMetadata)
+                  .mangleAsString();
+        return os.str();
+      }
+
       if (auto theClass = getClass()) {
         return theClass->getObjCRuntimeName(buffer);
       }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
@@ -69,7 +69,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*, 
 //   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
@@ -67,7 +67,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*, 
 //   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAFySSGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
@@ -67,7 +67,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*, 
 //   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Argument1ACLLCySiGAGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
@@ -126,7 +126,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*,
 //   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Za-z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
@@ -118,7 +118,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*,
 //   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Za-z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
@@ -122,7 +122,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*,
 //   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySSGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
@@ -114,7 +114,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_constant_int.swift
@@ -112,7 +112,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP33_4D007063F2EFC1988130B7D42A21EE4C5Value to [[INT]]
+//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySSGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_subclass_argument.swift
@@ -56,7 +56,7 @@
 //              :         }*, 
 //              :         i8*, 
 //              :         i8* 
-//              :       }* @_DATA__TtC4mainP33_496329636AC05466637A72F247DC6ABC9Ancestor1 to i64
+//              :       }* @"_DATA_$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMf to i64
 //              :     ), 
 //              :     i64 2
 //              :   ), 
@@ -184,7 +184,7 @@
 //   CHECK-apple-SAME:         }*, 
 //   CHECK-apple-SAME:         i8*, 
 //   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP33_496329636AC05466637A72F247DC6ABC5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_superclass.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_generic-1argument-1st_argument_superclass.swift
@@ -108,7 +108,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA9Ancestor1ACLLCySSGGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-external-nonresilient.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-external-nonresilient.swift
@@ -81,7 +81,7 @@ import TestModule
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-fileprivate.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-fileprivate.swift
@@ -160,7 +160,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
@@ -53,7 +53,7 @@
 //                   :         }*, 
 //                   :         i8*, 
 //                   :         i8* 
-//                   :       }* @_DATA__TtC4mainP33_7FA9B79F85D716E7DB33358C0057E87D9Argument1 to i64
+//                   :       }* @"_DATA_$s4main9Argument1[[UNIQUE_ID_1]]CySiGMf" to i64
 //                   :     ), 
 //                   :     i64 2
 //                   :   ), 
@@ -148,7 +148,7 @@
 //   CHECK-apple-SAME:         }*, 
 //   CHECK-apple-SAME:         i8*, 
 //   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP33_7FA9B79F85D716E7DB33358C0057E87D5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -51,7 +51,7 @@
 //   CHECK-apple-SAME:         { i32, i32, [1 x { [[INT]]*, i8*, i8*, i32, i32 }] }*, 
 //   CHECK-apple-SAME:         i8*, 
 //   CHECK-apple-SAME:         i8* 
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[0-9A-Z_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CySiGMf" to [[INT]]
 //   CHECK-apple-SAME:     ), 
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ), 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
@@ -73,7 +73,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
@@ -72,7 +72,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
@@ -71,7 +71,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*,
 //   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[a-zA-Z0-9_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
@@ -71,7 +71,7 @@
 //   CHECK-apple-SAME:         }*,
 //   CHECK-apple-SAME:         i8*,
 //   CHECK-apple-SAME:         i8*
-//   CHECK-apple-SAME:       }* @_DATA__TtC4mainP[[UNIQUE_ID_2:[a-zA-Z0-9_]+]]5Value to [[INT]]
+//   CHECK-apple-SAME:       }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf" to [[INT]]
 //   CHECK-apple-SAME:     ),
 //   CHECK-apple-SAME:     [[INT]] 2
 //   CHECK-apple-SAME:   ),

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestor-1du-1st_ancestor_generic-fileprivate-2nd_ancestor_nongeneric.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-2ancestor-1du-1st_ancestor_generic-fileprivate-2nd_ancestor_nongeneric.swift
@@ -119,7 +119,7 @@
 //   CHECK-apple-SAME:        }*,
 //   CHECK-apple-SAME:        i8*,
 //   CHECK-apple-SAME:        i8*
-//   CHECK-apple-SAME:      }* @_DATA__TtC4mainP[[UNIQUE_ID_1]]5Value to [[INT]]
+//   CHECK-apple-SAME:      }* @"_DATA_$s4main5Value[[UNIQUE_ID_1]]LLCySiGMf" to [[INT]]
 //   CHECK-apple-SAME:    ),
 //   CHECK-apple-SAME:    [[INT]] 2
 //   CHECK-apple-SAME:  ),

--- a/test/IRGen/prespecialized-metadata/class-with-differently-mangled-method-list.swift
+++ b/test/IRGen/prespecialized-metadata/class-with-differently-mangled-method-list.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -enable-library-evolution -prespecialize-generic-metadata -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+
+// REQUIRES: VENDOR=apple || OS=linux-gnu
+// REQUIRES: objc_interop
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import Foundation
+
+struct S{}
+class Clazz<T> {
+  @objc func foo() {}
+}
+
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in }
+}
+
+func doit() {
+  //      CHECK: @"_INSTANCE_METHODS_$s4main5ClazzCyAA1SVGMf" = internal constant
+  consume(Clazz<S>.self)
+}
+
+doit()


### PR DESCRIPTION
Previously, various class constants for prespecialized generic metadata such as `_INSTANCE_METHODS_` and `_DATA_` were mangled using the objc type name of the class.  As a result, names differed from one another by a number appended at the end of the string.  That resulted in symbols which were difficult to work with.  Here, that issue is resolved by appending the mangled name of the type metadata to the prefix.

rdar://problem/72053639