### PR TITLE
CMake: fix build for Apple Silicon hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,7 +758,7 @@ elseif("${SWIFT_HOST_VARIANT_SDK}" MATCHES "(OSX|IOS*|TVOS*|WATCHOS*)")
   #
   # Primary variant is always OSX; even on iOS hosts.
   set(SWIFT_PRIMARY_VARIANT_SDK_default "OSX")
-  set(SWIFT_PRIMARY_VARIANT_ARCH_default "x86_64")
+  set(SWIFT_PRIMARY_VARIANT_ARCH_default "${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
 endif()
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -74,6 +74,7 @@ The following build options are available:
 The following build targets are available:
 
 * `swift-benchmark-macosx-x86_64`
+* `swift-benchmark-macosx-arm64`
 * `swift-benchmark-iphoneos-arm64e`
 * `swift-benchmark-iphoneos-arm64`
 * `swift-benchmark-iphoneos-armv7`
@@ -84,7 +85,7 @@ Build steps (with example options):
 
 1. `$ mkdir build; cd build`
 2. `$ cmake [path to swift src]/benchmark -G Ninja -DSWIFT_EXEC=[path to built swiftc]`
-3. `$ ninja swift-benchmark-macosx-x86_64`
+3. `$ ninja swift-benchmark-macosx-$(uname -m)`
 
 Benchmark binaries are placed in `bin`.
 
@@ -98,7 +99,7 @@ relative to the benchmark binary at the time it was executed
 For example, to benchmark against a locally built `swiftc`, including
 any standard library changes in that build, you might configure using:
 
-    cmake <src>/benchmark -G Ninja -DSWIFT_EXEC=<build>/swift-macosx-x86_64/bin/swiftc
+    cmake <src>/benchmark -G Ninja -DSWIFT_EXEC=<build>/swift-macosx-$(uname -m)/bin/swiftc
     ninja swift-benchmark-iphoneos-arm64
 
 To build against the installed Xcode, simply omit SWIFT_EXEC:
@@ -319,12 +320,12 @@ swift-source$ ./swift/utils/build-script -R -B
 ````
 you can rebuild just the benchmarks:
 ````
-swift-source$ export SWIFT_BUILD_DIR=`pwd`/build/Ninja-ReleaseAssert/swift-macosx-x86_64
-swift-source$ ninja -C ${SWIFT_BUILD_DIR} swift-benchmark-macosx-x86_64
+swift-source$ export SWIFT_BUILD_DIR=`pwd`/build/Ninja-ReleaseAssert/swift-macosx-$(uname -m)
+swift-source$ ninja -C ${SWIFT_BUILD_DIR} swift-benchmark-macosx-$(uname -m)
 ````
 
 When modifying the testing infrastructure, you should verify that your changes
 pass all the tests:
 ````
-swift-source$ ./llvm/utils/lit/lit.py -sv ${SWIFT_BUILD_DIR}/test-macosx-x86_64/benchmark
+swift-source$ ./llvm/utils/lit/lit.py -sv ${SWIFT_BUILD_DIR}/test-macosx-$(uname -m)/benchmark
 ````

--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -875,14 +875,14 @@ well as cleanups/modernizations on a code-base. Swift's cmake invocation by
 default creates one of these json databases at the root path of the swift host
 build, for example on macOS:
 
-    $PATH_TO_BUILD/swift-macosx-x86_64/compile_commands.json
+    $PATH_TO_BUILD/swift-macosx-$(uname -m)/compile_commands.json
 
 Using this file, one invokes `clang-tidy` on a specific file in the codebase
 as follows:
 
-    clang-tidy -p=$PATH_TO_BUILD/swift-macosx-x86_64/compile_commands.json $FULL_PATH_TO_FILE
+    clang-tidy -p=$PATH_TO_BUILD/swift-macosx-$(uname -m)/compile_commands.json $FULL_PATH_TO_FILE
 
 One can also use shell regex to visit multiple files in the same directory. Example:
 
-    clang-tidy -p=$PATH_TO_BUILD/swift-macosx-x86_64/compile_commands.json $FULL_PATH_TO_DIR/*.cpp
+    clang-tidy -p=$PATH_TO_BUILD/swift-macosx-$(uname -m)/compile_commands.json $FULL_PATH_TO_DIR/*.cpp
 

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -245,13 +245,13 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
    - Via Ninja:
      ```sh
      utils/build-script --skip-build-benchmarks \
-       --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "x86_64" \
+       --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "$(uname -m)" \
        --sccache --release-debuginfo --test
      ```
    - Via Xcode:
      ```sh
      utils/build-script --skip-build-benchmarks \
-       --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "x86_64" \
+       --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "$(uname -m)" \
        --sccache --release-debuginfo --test \
        --xcode
      ```
@@ -350,7 +350,8 @@ git push --set-upstream my-remote my-branch
 ### First time Xcode setup
 
 If you used `--xcode` earlier, you will see an Xcode project generated under
-`../build/Xcode-RelWithDebInfoAssert/swift-macosx-x86_64`. When you open the
+`../build/Xcode-RelWithDebInfoAssert/swift-macosx-x86_64` (or
+`../build/Xcode-RelWithDebInfoAssert/swift-macosx-arm64` on Apple Silicon Macs). When you open the
 project, Xcode might helpfully suggest "Automatically Create Schemes". Most of
 those schemes are not required in day-to-day work, so you can instead manually
 select the following schemes:
@@ -375,12 +376,12 @@ Now that you have made some changes, you will need to rebuild...
 
 To rebuild the compiler:
 ```sh
-ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64 swift-frontend
+ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m) swift-frontend
 ```
 
 To rebuild everything, including the standard library:
 ```sh
-ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64
+ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)
 ```
 
 ### Incremental builds with Xcode
@@ -396,7 +397,7 @@ build should be much faster than the from-scratch build at the beginning.
 Now check if the version string has been updated:
 
 ```sh
-../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/bin/swift-frontend --version
+../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)/bin/swift-frontend --version
 ```
 
 This should print your updated version string.
@@ -439,22 +440,22 @@ There are two main ways to run tests:
    ```sh
    # Rebuild all test dependencies and run all tests under test/.
    utils/run-test --lit ../llvm-project/llvm/utils/lit/lit.py \
-     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/test-macosx-x86_64
+     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)/test-macosx-$(uname -m)
 
    # Rebuild all test dependencies and run tests containing "MyTest".
    utils/run-test --lit ../llvm-project/llvm/utils/lit/lit.py \
-     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/test-macosx-x86_64 \
+     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)/test-macosx-$(uname -m) \
      --filter="MyTest"
    ```
 2. `lit.py`: lit doesn't know anything about dependencies. It just runs tests.
    ```sh
    # Run all tests under test/.
    ../llvm-project/llvm/utils/lit/lit.py -s -vv \
-     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/test-macosx-x86_64
+     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)/test-macosx-$(uname -m)
 
    # Run tests containing "MyTest"
    ../llvm-project/llvm/utils/lit/lit.py -s -vv \
-     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/test-macosx-x86_64 \
+     ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)/test-macosx-$(uname -m) \
      --filter="MyTest"
    ```
    The `-s` and `-vv` flags print a progress bar and the executed commands

--- a/utils/coverage/coverage-generate-data
+++ b/utils/coverage/coverage-generate-data
@@ -14,6 +14,7 @@ import logging
 import multiprocessing
 import os
 import pipes
+import platform
 import subprocess
 import sys
 import timeit
@@ -100,7 +101,7 @@ def dump_coverage_data(merged_file):
     """Dump coverage data of file at path `merged_file` using llvm-cov"""
     try:
         swift = os.path.join(global_build_subdir,
-                             'swift-macosx-x86_64/bin/swift')
+                             'swift-macosx-{}/bin/swift'.format(platform.machine()))
         coverage_log = os.path.join(os.path.dirname(merged_file),
                                     'coverage.log')
         testname = os.path.basename(os.path.dirname(merged_file))


### PR DESCRIPTION
When building with `build-script` using these arguments

```
utils/build-script --skip-build-benchmarks
  --skip-ios --skip-watchos --skip-tvos
  --swift-darwin-supported-archs "arm64"
  --sccache --release-debuginfo --test
```

the build fails with

```
ninja: error: 'stdlib/swift-test-stdlib-macosx-x86_64',
needed by 'stdlib/CMakeFiles/swift-test-stdlib', missing and no known rule to make it
```

I think that the "Getting Started" guide should avoid hardcoding `x86_64` arguments, and suggest using `$(uname -m)` instead. `SWIFT_PRIMARY_VARIANT_ARCH_default` could also get its value from `CMAKE_HOST_SYSTEM_PROCESSOR` in the root `CMakeLists.txt`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13943.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
