### PR TITLE
[ModuleInterface] Print custom attributes on function protocol requirements

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -746,7 +746,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (VD->getAttachedResultBuilder() == this) {
         if (!isa<ParamDecl>(D) &&
-            !(isa<VarDecl>(D) && isa<ProtocolDecl>(D->getDeclContext())))
+            !((isa<VarDecl>(D) || isa<FuncDecl>(D)) &&
+               isa<ProtocolDecl>(D->getDeclContext())))
           return false;
       }
     }

--- a/test/ModuleInterface/result_builders.swift
+++ b/test/ModuleInterface/result_builders.swift
@@ -63,4 +63,7 @@ public protocol ProtocolWithBuilderProperty {
 
   // CHECK: @ResultBuilders.TupleBuilder var myVar: Self.Assoc { get }
   @TupleBuilder var myVar: Assoc { get }
+
+  // CHECK: @ResultBuilders.TupleBuilder func myFunc<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2)
+  @TupleBuilder func myFunc<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2)
 }


### PR DESCRIPTION
Protocol requirements declared as a function with a result-builder
custom attribute should keep that attribute in the generated textual
swiftinterface file.

rdar://72063255