### PR TITLE
WinSDK: adjust for 32-bit builds

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -46,11 +46,11 @@ public let INVALID_SOCKET: SOCKET = SOCKET(bitPattern: -1)
 public let FIONBIO: Int32 = Int32(bitPattern: 0x8004667e)
 
 // WinUser.h
-public let CW_USEDEFAULT: Int32 = Int32(truncatingIfNeeded: 2147483648)
+public let CW_USEDEFAULT: Int32 = Int32(bitPattern: 2147483648)
 public let WS_OVERLAPPEDWINDOW: UINT =
     UINT(WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
 public let WS_POPUPWINDOW: UINT =
-    UINT(Int32(WS_POPUP) | WS_BORDER | WS_SYSMENU)
+    UINT(numericCast(WS_POPUP) | WS_BORDER | WS_SYSMENU)
 
 // fileapi.h
 public let INVALID_FILE_ATTRIBUTES: DWORD = DWORD(bitPattern: -1)
@@ -91,16 +91,17 @@ public let DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT =
     DPI_AWARENESS_CONTEXT(bitPattern: -5)!
 
 // winreg.h
-public let HKEY_CLASSES_ROOT: HKEY = HKEY(bitPattern: 0x80000000)!
-public let HKEY_CURRENT_USER: HKEY = HKEY(bitPattern: 0x80000001)!
-public let HKEY_LOCAL_MACHINE: HKEY = HKEY(bitPattern: 0x80000002)!
-public let HKEY_USERS: HKEY = HKEY(bitPattern: 0x80000003)!
-public let HKEY_PERFORMANCE_DATA: HKEY = HKEY(bitPattern: 0x80000004)!
-public let HKEY_PERFORMANCE_TEXT: HKEY = HKEY(bitPattern: 0x80000050)!
-public let HKEY_PERFORMANCE_NLSTEXT: HKEY = HKEY(bitPattern: 0x80000060)!
-public let HKEY_CURRENT_CONFIG: HKEY = HKEY(bitPattern: 0x80000005)!
-public let HKEY_DYN_DATA: HKEY = HKEY(bitPattern: 0x80000006)!
-public let HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY = HKEY(bitPattern: 0x80000007)!
+public let HKEY_CLASSES_ROOT: HKEY = HKEY(bitPattern: UInt(0x80000000))!
+public let HKEY_CURRENT_USER: HKEY = HKEY(bitPattern: UInt(0x80000001))!
+public let HKEY_LOCAL_MACHINE: HKEY = HKEY(bitPattern: UInt(0x80000002))!
+public let HKEY_USERS: HKEY = HKEY(bitPattern: UInt(0x80000003))!
+public let HKEY_PERFORMANCE_DATA: HKEY = HKEY(bitPattern: UInt(0x80000004))!
+public let HKEY_PERFORMANCE_TEXT: HKEY = HKEY(bitPattern: UInt(0x80000050))!
+public let HKEY_PERFORMANCE_NLSTEXT: HKEY = HKEY(bitPattern: UInt(0x80000060))!
+public let HKEY_CURRENT_CONFIG: HKEY = HKEY(bitPattern: UInt(0x80000005))!
+public let HKEY_DYN_DATA: HKEY = HKEY(bitPattern: UInt(0x80000006))!
+public let HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY =
+    HKEY(bitPattern: UInt(0x80000007))!
 
 // Richedit.h
 public let MSFTEDIT_CLASS: [WCHAR] = Array<WCHAR>("RICHEDIT50W".utf16)


### PR DESCRIPTION
Due to the type differences between 32-bit and 64-bit, the SDK overlay
would fail to build on Windows.  This adjusts that to allow building the
SDK overlay on 32-bit Windows again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
