### PR TITLE
Remove SILArgumentConvention::Direct_Deallocating

### DIFF
--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -32,7 +32,6 @@ struct SILArgumentConvention {
     Indirect_Out,
     Direct_Owned,
     Direct_Unowned,
-    Direct_Deallocating,
     Direct_Guaranteed,
   } Value;
 
@@ -86,7 +85,6 @@ struct SILArgumentConvention {
       case SILArgumentConvention::Indirect_Out:
       case SILArgumentConvention::Direct_Unowned:
       case SILArgumentConvention::Direct_Owned:
-      case SILArgumentConvention::Direct_Deallocating:
       case SILArgumentConvention::Direct_Guaranteed:
         return false;
     }
@@ -105,7 +103,6 @@ struct SILArgumentConvention {
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Direct_Unowned:
-    case SILArgumentConvention::Direct_Deallocating:
       return false;
     }
     llvm_unreachable("covered switch isn't covered?!");
@@ -123,7 +120,6 @@ struct SILArgumentConvention {
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Direct_Unowned:
     case SILArgumentConvention::Direct_Owned:
-    case SILArgumentConvention::Direct_Deallocating:
       return false;
     }
     llvm_unreachable("covered switch isn't covered?!");
@@ -143,7 +139,6 @@ struct SILArgumentConvention {
     case SILArgumentConvention::Direct_Unowned:
     case SILArgumentConvention::Direct_Guaranteed:
     case SILArgumentConvention::Direct_Owned:
-    case SILArgumentConvention::Direct_Deallocating:
       return false;
     }
     llvm_unreachable("covered switch isn't covered?!");

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -216,8 +216,6 @@ ValueOwnershipKind::ValueOwnershipKind(const SILFunction &F, SILType Type,
   case SILArgumentConvention::Direct_Guaranteed:
     value = OwnershipKind::Guaranteed;
     return;
-  case SILArgumentConvention::Direct_Deallocating:
-    llvm_unreachable("Not handled");
   }
 }
 

--- a/lib/SIL/Verifier/MemoryLifetime.cpp
+++ b/lib/SIL/Verifier/MemoryLifetime.cpp
@@ -781,7 +781,6 @@ void MemoryLifetimeVerifier::setFuncOperandBits(BlockState &state, Operand &op,
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Direct_Owned:
     case SILArgumentConvention::Direct_Unowned:
-    case SILArgumentConvention::Direct_Deallocating:
     case SILArgumentConvention::Direct_Guaranteed:
       break;
   }
@@ -968,7 +967,6 @@ void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
       break;
     case SILArgumentConvention::Direct_Owned:
     case SILArgumentConvention::Direct_Unowned:
-    case SILArgumentConvention::Direct_Deallocating:
     case SILArgumentConvention::Direct_Guaranteed:
       break;
   }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -462,7 +462,6 @@ struct ImmutableAddressUseVerifier {
     case SILArgumentConvention::Direct_Unowned:
     case SILArgumentConvention::Direct_Guaranteed:
     case SILArgumentConvention::Direct_Owned:
-    case SILArgumentConvention::Direct_Deallocating:
       assert(conv.isIndirectConvention() && "Expect an indirect convention");
       return true; // return something "conservative".
     }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -447,7 +447,6 @@ static ManagedValue createInputFunctionArgument(SILGenBuilder &B, SILType type,
     return ManagedValue::forLValue(arg);
   case SILArgumentConvention::Indirect_In_Constant:
     llvm_unreachable("Convention not produced by SILGen");
-  case SILArgumentConvention::Direct_Deallocating:
   case SILArgumentConvention::Indirect_Out:
     llvm_unreachable("unsupported convention for API");
   }

--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -148,7 +148,6 @@ static void getAssignByWrapperArgsRecursively(SmallVectorImpl<SILValue> &args,
     case SILArgumentConvention::Indirect_Inout:
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Indirect_Out:
-    case SILArgumentConvention::Direct_Deallocating:
       llvm_unreachable("wrong convention for setter/initializer src argument");
   }
   args.push_back(src);


### PR DESCRIPTION
When we exhaustively switch over the argument convention, we want to make sure we've handled all cases correctly, so we can't leave around extra cases that aren't clearly specified.
