### PR TITLE
[semantic-arc] Change SemanticARCOptVisitor to be a SILValueVisitor instead of a SILInstructionVisitor.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -36,7 +36,7 @@ namespace semanticarc {
 /// visitors do, we maintain a visitedSinceLastMutation list to ensure that we
 /// revisit all interesting instructions in between mutations.
 struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
-    : SILInstructionVisitor<SemanticARCOptVisitor, bool> {
+    : SILValueVisitor<SemanticARCOptVisitor, bool> {
   /// Our main worklist. We use this after an initial run through.
   SmallBlotSetVector<SILValue, 32> worklist;
 
@@ -127,9 +127,19 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
         });
   }
 
-  /// The default visitor.
   bool visitSILInstruction(SILInstruction *i) {
-    assert(!isa<OwnershipForwardingInst>(i) &&
+    assert((isa<OwnershipForwardingTermInst>(i) ||
+            !isa<OwnershipForwardingInst>(i)) &&
+           "Should have forwarding visitor for all ownership forwarding "
+           "non-term instructions");
+    return false;
+  }
+
+  /// The default visitor.
+  bool visitValueBase(ValueBase *v) {
+    auto *inst = v->getDefiningInstruction();
+    (void)inst;
+    assert((!inst || !isa<OwnershipForwardingInst>(inst)) &&
            "Should have forwarding visitor for all ownership forwarding "
            "instructions");
     return false;
@@ -138,6 +148,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool visitCopyValueInst(CopyValueInst *cvi);
   bool visitBeginBorrowInst(BeginBorrowInst *bbi);
   bool visitLoadInst(LoadInst *li);
+
   static bool shouldVisitInst(SILInstruction *i) {
     switch (i->getKind()) {
     default:
@@ -186,20 +197,6 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   FORWARDING_INST(DifferentiableFunctionExtract)
   FORWARDING_INST(LinearFunctionExtract)
 #undef FORWARDING_INST
-
-#define FORWARDING_TERM(NAME)                                                  \
-  bool visit##NAME##Inst(NAME##Inst *cls) {                                    \
-    for (auto succValues : cls->getSuccessorBlockArgumentLists()) {            \
-      for (SILValue v : succValues) {                                          \
-        worklist.insert(v);                                                    \
-      }                                                                        \
-    }                                                                          \
-    return false;                                                              \
-  }
-  FORWARDING_TERM(SwitchEnum)
-  FORWARDING_TERM(CheckedCastBranch)
-  FORWARDING_TERM(Branch)
-#undef FORWARDING_TERM
 
   bool processWorklist();
   bool optimize();


### PR DESCRIPTION
Our worklist already uses values, so it makes sense to use a SILValueVisitor. It
will also let me throw in a few ARC dead argument elimination optimizations so
clean up a pattern from my ARC RAUW thing. Once we have simplify-cfg it will not
be needed, but I want to know I am good before I flip the switch.

This should be NFCI.