### PR TITLE
Improve handling of copy_value and destroy_value in MemoryBehaviorVisitor

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -1158,6 +1158,10 @@ public:
   /// Note that if \p RI is a retain-instruction always false is returned.
   bool canEscapeTo(SILValue V, RefCountingInst *RI);
 
+  /// Returns true if the value \p V can escape to the destroy_value instruction
+  /// \p DVI.
+  bool canEscapeTo(SILValue V, DestroyValueInst *DVI);
+
   /// Return true if \p releasedReference deinitialization may release memory
   /// pointed to by \p accessedAddress.
   bool mayReleaseContent(SILValue releasedReference, SILValue accessedAddress);

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -182,6 +182,7 @@ public:
   MemBehavior visitBuiltinInst(BuiltinInst *BI);
   MemBehavior visitStrongReleaseInst(StrongReleaseInst *BI);
   MemBehavior visitReleaseValueInst(ReleaseValueInst *BI);
+  MemBehavior visitDestroyValueInst(DestroyValueInst *DVI);
   MemBehavior visitSetDeallocatingInst(SetDeallocatingInst *BI);
   MemBehavior visitBeginCOWMutationInst(BeginCOWMutationInst *BCMI);
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
@@ -225,6 +226,7 @@ public:
   }
   REFCOUNTINC_MEMBEHAVIOR_INST(StrongRetainInst)
   REFCOUNTINC_MEMBEHAVIOR_INST(RetainValueInst)
+  REFCOUNTINC_MEMBEHAVIOR_INST(CopyValueInst)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   REFCOUNTINC_MEMBEHAVIOR_INST(Name##RetainValueInst)                          \
   REFCOUNTINC_MEMBEHAVIOR_INST(StrongCopy##Name##ValueInst)
@@ -486,6 +488,13 @@ MemoryBehaviorVisitor::visit##Name##ReleaseInst(Name##ReleaseInst *SI) { \
 
 MemBehavior MemoryBehaviorVisitor::visitReleaseValueInst(ReleaseValueInst *SI) {
   if (!EA->canEscapeTo(V, SI))
+    return MemBehavior::None;
+  return MemBehavior::MayHaveSideEffects;
+}
+
+MemBehavior
+MemoryBehaviorVisitor::visitDestroyValueInst(DestroyValueInst *DVI) {
+  if (!EA->canEscapeTo(V, DVI))
     return MemBehavior::None;
   return MemBehavior::MayHaveSideEffects;
 }

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -146,15 +146,6 @@ static bool inline isPerformingRLE(RLEKind Kind) {
 /// general sense but are inert from a load store perspective.
 static bool isRLEInertInstruction(SILInstruction *Inst) {
   switch (Inst->getKind()) {
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  case SILInstructionKind::StrongCopy##Name##ValueInst:
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
-  case SILInstructionKind::Name##RetainInst:                                   \
-  case SILInstructionKind::StrongRetain##Name##Inst:                           \
-  case SILInstructionKind::StrongCopy##Name##ValueInst:
-#include "swift/AST/ReferenceStorage.def"
-  case SILInstructionKind::StrongRetainInst:
-  case SILInstructionKind::RetainValueInst:
   case SILInstructionKind::DeallocStackInst:
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::IsEscapingClosureInst:

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -85,6 +85,14 @@ class EscapeAnalysisDumper : public SILModuleTransform {
                              << " to " << ii;
               }
             }
+            if (DestroyValueInst *dvi = dyn_cast<DestroyValueInst>(&ii)) {
+              for (unsigned i = 0, e = Values.size(); i != e; ++i) {
+                SILValue val = Values[i];
+                bool escape = EA->canEscapeTo(val, dvi);
+                llvm::outs() << (escape ? "May" : "No") << "Escape: " << val
+                             << " to " << ii;
+              }
+            }
           }
         }
       }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1962,3 +1962,22 @@ bb0(%0 : $Z):
   unreachable
 }
 
+// CHECK-LABEL: CG of test_destroy_value
+// CHECK:   Arg %0 Esc: A, Succ: (%1)
+// CHECK:   Con [ref] %1 Esc: A, Succ: (%1.1)
+// CHECK:   Con [int] %1.1 Esc: G, Succ: (%1.2)
+// CHECK:   Con [ref] %1.2 Esc: G, Succ:
+// CHECK-LABEL: End
+// CHECK: NoEscape: %0 = argument of bb0 : $*X
+// CHECK:  to   destroy_value %1 : $X
+// CHECK: MayEscape:   %1 = load [copy] %0 : $*X
+// CHECK:  to   destroy_value %1 : $X
+sil [ossa] @test_destroy_value : $@convention(thin) (@in X) -> () {
+bb0 (%0 : $*X):
+  %1 = load [copy] %0 : $*X
+  destroy_value %1 : $X
+  destroy_addr %0 : $*X
+  %2 = tuple()
+  return %2 : $()
+}
+

--- a/test/SILOptimizer/mem-behavior-all.sil
+++ b/test/SILOptimizer/mem-behavior-all.sil
@@ -244,3 +244,45 @@ bb0(%0 : $*C, %1 : $*C, %2: $*C):
   return %6 : $()
 }
 
+// CHECK-LABEL: @test_destroy_value
+// CHECK: PAIR #0.
+// CHECK-NEXT:     %1 = load [copy] %0 : $*C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=1,w=0
+// CHECK: PAIR #2.
+// CHECK-NEXT:     destroy_value %1 : $C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0
+// CHECK: PAIR #3.
+// CHECK-NEXT:     destroy_value %1 : $C
+// CHECK-NEXT:     %1 = load [copy] %0 : $*C
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @test_destroy_value : $@convention(thin) (@in C) -> () {
+bb0 (%0 : $*C):
+  %1 = load [copy] %0 : $*C
+  destroy_value %1 : $C
+  destroy_addr %0 : $*C
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: @test_copy_value
+// CHECK: PAIR #3.
+// CHECK-NEXT:     %2 = copy_value %1 : $C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0
+// CHECK: PAIR #4.
+// CHECK-NEXT:     %2 = copy_value %1 : $C
+// CHECK-NEXT:     %1 = load [copy] %0 : $*C
+// CHECK-NEXT:   r=0,w=0
+sil [ossa] @test_copy_value : $@convention(thin) (@in C) -> () {
+bb0 (%0 : $*C):
+  %1 = load [copy] %0 : $*C
+  %2 = copy_value %1 : $C
+  destroy_value %1 : $C
+  destroy_value %2 : $C
+  destroy_addr %0 : $*C
+  %3 = tuple()
+  return %3 : $()
+}
+


### PR DESCRIPTION
- Also, compute use points for destroy_value
- Cleanup explicit checks for refcount instructions in RLE


