### PR TITLE
[concurrency] partially implement @MainActor + convenience method for UnsafeThrowingContinuation

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -514,10 +514,15 @@ SILValue SILGenFunction::emitLoadGlobalActorExecutor(Type globalActor) {
   Type instanceType =
     actorType->getTypeOfMember(SGM.SwiftModule, sharedInstanceDecl);
 
+  auto metaRepr =
+    nominal->isResilient(SGM.SwiftModule, ResilienceExpansion::Maximal)
+    ? MetatypeRepresentation::Thick
+    : MetatypeRepresentation::Thin;
+
   ManagedValue actorMetaType =
     ManagedValue::forUnmanaged(B.createMetatype(loc,
       SILType::getPrimitiveObjectType(
-        CanMetatypeType::get(actorType, MetatypeRepresentation::Thin))));
+        CanMetatypeType::get(actorType, metaRepr))));
 
   RValue actorInstanceRV = emitRValueForStorageLoad(loc, actorMetaType,
     actorType, /*isSuper*/ false, sharedInstanceDecl, PreparedArguments(),

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -38,3 +38,17 @@ public func _defaultActorDestroy(_ actor: AnyObject)
 @_silgen_name("swift_defaultActor_enqueue")
 public func _defaultActorEnqueue(partialTask: PartialAsyncTask,
                                  actor: AnyObject)
+
+/// A singleton actor whose executor is equivalent to 
+/// \c DispatchQueue.main, which is the main dispatch queue.
+@globalActor public final class MainActor {
+  public static let shared = _Impl()
+  
+  public actor class _Impl {
+    @actorIndependent
+    public func enqueue(partialTask: PartialAsyncTask) {
+      // TODO: implement this.
+      _ = (nil as String?)! + "MainActor is not implemented yet."
+    }
+  }
+}

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -47,6 +47,15 @@ public struct UnsafeThrowingContinuation<T> {
   public func resume(returning: __owned T)
   @_silgen_name("swift_continuation_throwingResumeWithError")
   public func resume(throwing: __owned Error)
+
+  public func resume<E: Error>(with result: Result<T, E>) {
+    switch result {
+      case .success(let val):
+        self.resume(returning: val)
+      case .failure(let err):
+        self.resume(throwing: err)
+    }
+  }
 }
 
 #if _runtime(_ObjC)

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -1,0 +1,44 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// XFAIL: *
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+import Foundation
+
+// CHECK: starting
+// CHECK-NOT: ERROR
+// CHECK: hello from main actor!
+// CHECK-NOT: ERROR
+// CHECK: ending
+
+@MainActor func helloMainActor() {
+  if Thread.isMainThread {
+    print("hello from main actor!")
+  } else {
+    print("ERROR: not on correct thread!")
+  }
+}
+
+func someFunc() async {
+  await helloMainActor()
+}
+
+runAsyncAndBlock {
+  print("starting")
+  let handle = Task.runDetached(operation: someFunc)
+  do {
+    try await handle.get()
+  } catch {
+    print("ERROR: exception was thrown while waiting for task to complete")
+  }
+  print("ending")
+}

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -62,6 +62,16 @@ func test_unsafeThrowingContinuations() async {
     continuation.resume(throwing: MyError())
   }
 
+  // using resume(with:)
+  let _: String = try await withUnsafeThrowingContinuation { continuation in
+    let result : Result<String, MyError> = .success("")
+    continuation.resume(with: result)
+  }
+
+  let _: String = try await withUnsafeThrowingContinuation { continuation in
+    continuation.resume(with: .failure(MyError()))
+  }
+
   // TODO: Potentially could offer some warnings if we know that a continuation was resumed or escaped at all in a closure?
 }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -19,6 +19,16 @@ struct GenericGlobalActor<T> {
 }
 
 // ----------------------------------------------------------------------
+// Check that MainActor exists
+// ----------------------------------------------------------------------
+
+@MainActor protocol Aluminium {
+  func method()
+}
+@MainActor class Copper {}
+@MainActor func iron() {}
+
+// ----------------------------------------------------------------------
 // Global actor inference for protocols
 // ----------------------------------------------------------------------
 

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -1,0 +1,10 @@
+@globalActor public final class MeowActor {
+  public static let shared = _Impl()
+  
+  public actor class _Impl {
+    @actorIndependent
+    public func enqueue(partialTask: PartialAsyncTask) {
+      // DOES NOTHING! :)
+    }
+  }
+}

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -enable-experimental-concurrency -emit-module-interface-path %t/Library.swiftinterface -module-name Library %s
+// RUN: %FileCheck --check-prefix CHECK-EXTENSION %s <%t/Library.swiftinterface
+// RUN: %FileCheck --check-prefix CHECK %s <%t/Library.swiftinterface
+
+/// This test ensures that, when generating a swiftinterface file,
+/// the actor class decl itself is what may conform to the Actor protocol,
+/// and not via some extension. The requirement is due to the unique
+/// optimizations applied to the implementation of actors.
+
+// CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
+
+// CHECK: actor public class PlainActorClass {
+public actor class PlainActorClass {
+  @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
+}
+
+// CHECK: actor public class ExplicitActorClass : _Concurrency.Actor {
+public actor class ExplicitActorClass : Actor {
+  @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
+}
+
+// CHECK: actor public class EmptyActorClass {
+public actor class EmptyActorClass {}
+
+// CHECK: public protocol Cat : _Concurrency.Actor {
+public protocol Cat : Actor {
+  func mew()
+}
+
+// CHECK: actor public class HouseCat : Library.Cat {
+public actor class HouseCat : Cat {
+  @asyncHandler public func mew() {}
+  @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
+}
+
+// CHECK: public protocol ToothyMouth {
+public protocol ToothyMouth {
+  func chew()
+}
+
+// CHECK: actor public class Lion : Library.ToothyMouth, _Concurrency.Actor {
+public actor class Lion : ToothyMouth, Actor {
+  @asyncHandler public func chew() {}
+  @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
+}

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+import MeowActor
+
+@MeowActor func doMeow() {}
+
+// RUN: %target-swift-frontend -enable-experimental-concurrency -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
+// RUN: %target-swift-frontend -enable-experimental-concurrency -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-RESILIENT %s
+// CHECK-RESILIENT: metatype $@thick MeowActor.Type
+
+// RUN: %target-swift-frontend -enable-experimental-concurrency -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
+// RUN: %target-swift-frontend -enable-experimental-concurrency -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
+// CHECK-FRAGILE: metatype $@thin MeowActor.Type
+
+func someFunc() async {
+  await doMeow()
+}


### PR DESCRIPTION
To help enable further porting work, this PR implements new functionality for the _Concurrency module:

1. An implementation of the global actor `@MainActor`.
2. A convenience method for UnsafeThrowingContinuation.

Resolves rdar://71870249&72161578&72604101
Partially resolves rdar://72105129

TODO:
- [x] initial declaration of MainActor
- [x] fix IRGen compilation error when building MainActor execution test
- [x] ~get MainActor execution test working~ stub out implementation of MainActor in release & debug builds.