### PR TITLE
Extend the Concept of "Interface Hash" To Entire Modules

### DIFF
--- a/include/swift/AST/AbstractSourceFileDepGraphFactory.h
+++ b/include/swift/AST/AbstractSourceFileDepGraphFactory.h
@@ -87,6 +87,12 @@ protected:
 
   void addAUsedDecl(const DependencyKey &def, const DependencyKey &use);
 
+  /// Add an external dependency node to the graph. If the provided fingerprint
+  /// is not \c None, it is added to the def key.
+  void addAnExternalDependency(const DependencyKey &def,
+                               const DependencyKey &use,
+                               Optional<Fingerprint> dependencyFingerprint);
+
   static Optional<Fingerprint>
   getFingerprintIfAny(std::pair<const NominalTypeDecl *, const ValueDecl *>) {
     return None;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -734,7 +734,20 @@ public:
 
   /// Calls \p callback for each source file of the module.
   void collectBasicSourceFileInfo(
-      llvm::function_ref<void(const BasicSourceFileInfo &)> callback);
+      llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const;
+
+public:
+  /// Retrieve a fingerprint value that summarizes the contents of this module.
+  ///
+  /// This interface hash a of a module is guaranteed to change if the interface
+  /// hash of any of its (primary) source files changes. For example, when
+  /// building incrementally, the interface hash of this module will change when
+  /// the primaries contributing to its content changes. In contrast, when
+  /// a module is deserialized, the hash of every source file contributes to
+  /// the module's interface hash. It therefore serves as an effective, if
+  /// coarse-grained, way of determining when top-level changes to a module's
+  /// contents have been made.
+  Fingerprint getFingerprint() const;
 
   SourceRange getSourceRange() const { return SourceRange(); }
 

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -104,7 +104,7 @@ struct BasicSourceFileInfo {
 
   BasicSourceFileInfo() {}
 
-  bool populate(SourceFile *SF);
+  bool populate(const SourceFile *SF);
 };
 
 } // namespace swift

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -520,12 +520,24 @@ public:
   /// Set the root refinement context for the file.
   void setTypeRefinementContext(TypeRefinementContext *TRC);
 
-  /// Whether this file has an interface hash available.
+  /// Whether this file can compute an interface hash.
   bool hasInterfaceHash() const {
     return ParsingOpts.contains(ParsingFlags::EnableInterfaceHash);
   }
 
-  /// Output this file's interface hash into the provided string buffer.
+  /// Retrieve a fingerprint value that summarizes the declarations in this
+  /// source file.
+  ///
+  /// Note that the interface hash merely summarizes the top-level declarations
+  /// in this file. Type body fingerprints are currently implemented such that
+  /// they divert tokens away from the hasher used for fingerprints. That is,
+  /// changes to the bodies of types and extensions will not result in a change
+  /// to the interface hash.
+  ///
+  /// In order for the interface hash to be enabled, this source file must be a
+  /// primary and the compiler must be set in incremental mode. If this is not
+  /// the case, this function will try to signal with an assert. It is useful
+  /// to guard requests for the interface hash with \c hasInterfaceHash().
   Fingerprint getInterfaceHash() const;
 
   void dumpInterfaceHash(llvm::raw_ostream &out) {

--- a/include/swift/Basic/Fingerprint.h
+++ b/include/swift/Basic/Fingerprint.h
@@ -95,6 +95,11 @@ public:
   }
 
 public:
+  bool operator<(const Fingerprint &other) const {
+    return core < other.core;
+  }
+
+public:
   /// The fingerprint value consisting of 32 bytes of zeroes.
   ///
   /// This fingerprint is a perfectly fine value for a hash, but it is

--- a/lib/AST/AbstractSourceFileDepGraphFactory.cpp
+++ b/lib/AST/AbstractSourceFileDepGraphFactory.cpp
@@ -108,3 +108,16 @@ void AbstractSourceFileDepGraphFactory::addAUsedDecl(
   assert(useNode->getIsProvides() && "Use (using node) must be a provides");
   g.addArc(defNode, useNode);
 }
+
+void AbstractSourceFileDepGraphFactory::addAnExternalDependency(
+    const DependencyKey &defKey, const DependencyKey &useKey,
+    Optional<Fingerprint> maybeFP) {
+  auto *defNode = g.findExistingNodeOrCreateIfNew(defKey, maybeFP,
+                                                  false /* = !isProvides */);
+
+  auto nullableUse = g.findExistingNode(useKey);
+  assert(nullableUse.isNonNull() && "Use must be an already-added provides");
+  auto *useNode = nullableUse.get();
+  assert(useNode->getIsProvides() && "Use (using node) must be a provides");
+  g.addArc(defNode, useNode);
+}

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -499,19 +499,10 @@ void FrontendSourceFileDepGraphFactory::addAllUsedDecls() {
 
 ModuleDepGraphFactory::ModuleDepGraphFactory(const ModuleDecl *Mod,
                                              bool emitDot)
-    : AbstractSourceFileDepGraphFactory(Mod->getASTContext().hadError(),
-                                        Mod->getNameStr(), Fingerprint::ZERO(),
-                                        emitDot, Mod->getASTContext().Diags),
-
-      Mod(Mod) {
-  // Since a fingerprint only summarizes the state of the module but not
-  // the state of its fingerprinted sub-declarations, and since a module
-  // contains no state other than sub-declarations, its fingerprint does not
-  // matter and can just be some arbitrary value. Should it be the case that a
-  // change in a declaration that does not have a fingerprint must cause
-  // a rebuild of a file outside of the module, this assumption will need
-  // to be revisited.
-}
+    : AbstractSourceFileDepGraphFactory(
+          Mod->getASTContext().hadError(), Mod->getNameStr(),
+          Mod->getFingerprint(), emitDot, Mod->getASTContext().Diags),
+      Mod(Mod) {}
 
 void ModuleDepGraphFactory::addAllDefinedDecls() {
   // TODO: express the multiple provides and depends streams with variadic

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1536,9 +1536,9 @@ const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
 }
 
 void ModuleDecl::collectBasicSourceFileInfo(
-    llvm::function_ref<void(const BasicSourceFileInfo &)> callback) {
-  for (FileUnit *fileUnit : getFiles()) {
-    if (SourceFile *SF = dyn_cast<SourceFile>(fileUnit)) {
+    llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const {
+  for (const FileUnit *fileUnit : getFiles()) {
+    if (const auto *SF = dyn_cast<SourceFile>(fileUnit)) {
       BasicSourceFileInfo info;
       if (info.populate(SF))
         continue;

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -50,9 +50,10 @@ DependencyTracker::addDependency(StringRef File, bool IsSystem) {
                                      /*IsMissing=*/false);
 }
 
-void DependencyTracker::addIncrementalDependency(StringRef File) {
+void DependencyTracker::addIncrementalDependency(StringRef File,
+                                                 Fingerprint FP) {
   if (incrementalDepsUniquer.insert(File).second) {
-    incrementalDeps.emplace_back(File.str());
+    incrementalDeps.emplace_back(File.str(), FP);
   }
 }
 
@@ -61,7 +62,7 @@ DependencyTracker::getDependencies() const {
   return clangCollector->getDependencies();
 }
 
-ArrayRef<std::string>
+ArrayRef<DependencyTracker::IncrementalDependency>
 DependencyTracker::getIncrementalDependencies() const {
   return incrementalDeps;
 }

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -240,7 +240,7 @@ CharSourceRange RawComment::getCharSourceRange() {
   return CharSourceRange(Start, Length);
 }
 
-bool BasicSourceFileInfo::populate(SourceFile *SF) {
+bool BasicSourceFileInfo::populate(const SourceFile *SF) {
   SourceManager &SM = SF->getASTContext().SourceMgr;
 
   auto filename = SF->getFilename();

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1107,17 +1107,6 @@ namespace driver {
         }
       };
 
-      // Load our priors, which are always adjacent to the build record. We
-      // don't care if this load succeeds or not. If it fails, and we succeed at
-      // integrating one of the external files below, the changeset will be the
-      // entire module!
-      const auto *externalPriorJob = Comp.addExternalJob(
-          std::make_unique<Job>(Comp.getDerivedOutputFileMap(),
-                                Comp.getExternalSwiftDepsFilePath()));
-      getFineGrainedDepGraph().loadFromPath(
-          externalPriorJob, Comp.getExternalSwiftDepsFilePath(),
-          Comp.getDiags());
-
       for (auto external : getFineGrainedDepGraph()
                                .getIncrementalExternalDependencies()) {
         llvm::sys::fs::file_status depStatus;

--- a/lib/FrontendTool/MakeStyleDependencies.cpp
+++ b/lib/FrontendTool/MakeStyleDependencies.cpp
@@ -75,8 +75,9 @@ swift::frontend::utils::escapeForMake(StringRef raw,
 /// should appear in roughly the same order relative to other paths. Ultimately,
 /// this makes it easier to test the contents of the emitted files with tools
 /// like FileCheck.
+template <typename Container>
 static std::vector<std::string>
-reversePathSortedFilenames(const ArrayRef<std::string> elts) {
+reversePathSortedFilenames(const Container &elts) {
   std::vector<std::string> tmp(elts.begin(), elts.end());
   std::sort(tmp.begin(), tmp.end(),
             [](const std::string &a, const std::string &b) -> bool {
@@ -127,7 +128,7 @@ bool swift::emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
     dependencyString.append(frontend::utils::escapeForMake(path, buffer).str());
   }
   auto incrementalDependencyPaths =
-      reversePathSortedFilenames(depTracker->getIncrementalDependencies());
+      reversePathSortedFilenames(depTracker->getIncrementalDependencyPaths());
   for (auto const &path : incrementalDependencyPaths) {
     dependencyString.push_back(' ');
     dependencyString.append(frontend::utils::escapeForMake(path, buffer).str());

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -199,7 +199,7 @@ forEachDependencyUntilTrue(CompilerInstance &CI, unsigned excludeBufferID,
     if (callback(dep))
       return true;
   }
-  for (auto &dep : CI.getDependencyTracker()->getIncrementalDependencies()) {
+  for (auto dep : CI.getDependencyTracker()->getIncrementalDependencyPaths()) {
     if (callback(dep))
       return true;
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1001,7 +1001,8 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
     // Don't record cached artifacts as dependencies.
     if (!isCached(DepPath)) {
       if (M->hasIncrementalInfo()) {
-        dependencyTracker->addIncrementalDependency(DepPath);
+        dependencyTracker->addIncrementalDependency(DepPath,
+                                                    M->getFingerprint());
       } else {
         dependencyTracker->addDependency(DepPath, /*isSystem=*/false);
       }

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/A.json
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/A.json
@@ -1,0 +1,11 @@
+{
+  "A.swift": {
+    "object": "./A.o",
+    "swift-dependencies": "./A.swiftdeps",
+    "swiftmodule": "./A~partial.swiftmodule",
+    "swiftdoc": "./A.swiftdoc"
+  },
+  "": {
+    "swift-dependencies": "./A~buildrecord.swiftdeps"
+  }
+}

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/A.swift
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/A.swift
@@ -1,0 +1,6 @@
+import B
+import C
+
+public func use() {
+  fromB()
+}

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/B.json
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/B.json
@@ -1,0 +1,11 @@
+{
+  "B.swift": {
+    "object": "./B.o",
+    "swift-dependencies": "./B.swiftdeps",
+    "swiftmodule": "./B~partial.swiftmodule",
+    "swiftdoc": "./B.swiftdoc"
+  },
+  "": {
+    "swift-dependencies": "./B~buildrecord.swiftdeps"
+  }
+}

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/B.swift
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/B.swift
@@ -1,0 +1,5 @@
+import C
+
+public func fromB() {
+  return fromC()
+}

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/C.json
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/C.json
@@ -1,0 +1,11 @@
+{
+  "C.swift": {
+    "object": "./C.o",
+    "swift-dependencies": "./C.swiftdeps",
+    "swiftmodule": "./C~partial.swiftmodule",
+    "swiftdoc": "./C.swiftdoc"
+  },
+  "": {
+    "swift-dependencies": "./C~buildrecord.swiftdeps"
+  }
+}

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/C.swift
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/C.swift
@@ -1,0 +1,2 @@
+public func fromC(parameter: Int = 0) {}
+

--- a/test/Incremental/CrossModule/module-fingerprint.swift
+++ b/test/Incremental/CrossModule/module-fingerprint.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/module-fingerprint/* %t
+
+//
+// Set up a clean incremental build of all three modules
+//
+
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle C.swift
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle B.swift
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle A.swift
+
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print C -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-CLEAN-C
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print B -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-CLEAN-B
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print A -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-CLEAN-A
+
+// CHECK-CLEAN-C: fingerprint=6e60fd224d614a59568a348e0ac9b55a
+// CHECK-CLEAN-B: fingerprint=bfa14052e1df9253b7bf7e0eb7cfc505
+// CHECK-CLEAN-A: fingerprint=a939d89f07c766a4607c5fe1a1715cf5
+
+//
+// Now change C and ensure that B rebuilds but A does not
+//
+
+// RUN: cd %t && echo "public func other() {}" >> C.swift
+
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle C.swift
+// RUN: touch %t/C.swiftmodule
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle B.swift
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle A.swift
+
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print C -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL-C
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print B -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL-B
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print A -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL-A
+
+// CHECK-INCREMENTAL-C: fingerprint=3e68d59b74032e18401ec978cdb11cf3
+// CHECK-INCREMENTAL-B: fingerprint=bfa14052e1df9253b7bf7e0eb7cfc505
+// CHECK-INCREMENTAL-A: fingerprint=a939d89f07c766a4607c5fe1a1715cf5

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2516,6 +2516,7 @@ static int doPrintModuleGroups(const CompilerInvocation &InitInvok,
 
 static void printModuleMetadata(ModuleDecl *MD) {
   auto &OS = llvm::outs();
+  OS << "fingerprint=" << MD->getFingerprint().getRawValue() << "\n";
   MD->collectLinkLibraries([&](LinkLibrary lib) {
     OS << "link library: " << lib.getName()
        << ", force load: " << (lib.shouldForceLoad() ? "true" : "false") << "\n";


### PR DESCRIPTION
We need a signal for when a modules contents change in a way that requires recompiling all dependents. The driver already has such a concept for source files: the interface hash. Extend this concept to entire modules. 

The interface hash of a module is akin to the interface hash for an SourceFile. That is, a change in the interface hash signals that a change to a top-level declaration *somewhere* in the module has been made. Quite where that change occurred is still something the driver has to figure out for itself.

However, we have to be sensitive to the many representations a Swift module can have, and how those representations are generated. In the easy case, we're in incremental (batch) mode. We write down a list of interface hashes from each of our primaries into the module and keep going. However, in order to complete merge-modules, we need the notion of a "unified" interface hash for each of the files. This is the tricky case: when any of the files in the module is serialized.

To define a stable interface hash for a module composed of many (serialized) sub-units:

* For each sub-unit, extract its list of interface hashes.
* Sort these interface hashes - lexicographically will do - to remove non-determinism inherent in batch mode
* Combine each of these hashes

The resulting hash is invariant with respect to the ordering of primary hashes. And to satisfy the avalanche invariant of Fingerprints, will change whenever any of the hashes of any of the primaries changes at any time.

With this in hand, teach the frontend to write down the interface hash for incremental external dependencies. Then, teach the driver to reconcile that hash with the one deserialized from the corresponding swiftmodule file's incremental dependency section.

rdar://72113278