### PR TITLE
[next] Remove hash_value(const llvm::Optional<T> &opt) in favor of LLVM's

### DIFF
--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -29,14 +29,6 @@ namespace llvm {
   hash_code hash_value(const llvm::PointerUnion<PT1, PT2> &ptr) {
     return hash_value(ptr.getOpaqueValue());
   }
-
-  // FIXME: Belongs in LLVM itself
-  template<typename T>
-  hash_code hash_value(const llvm::Optional<T> &opt) {
-    if (!opt)
-      return 1;
-    return hash_value(*opt);
-  }
 }
 
 namespace swift {


### PR DESCRIPTION
A similar overload was introduced in LLVM's swift/next branch recently.