### PR TITLE
Concurrency: repair the build after #34902

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -20,8 +20,10 @@
 #include "swift/Runtime/HeapObject.h"
 #include "TaskPrivate.h"
 
+#if defined(__APPLE__)
 // TODO: We shouldn't need this
 #include <dispatch/dispatch.h>
+#endif
 
 using namespace swift;
 using FutureFragment = AsyncTask::FutureFragment;


### PR DESCRIPTION
libdispatch is not part of the system on Linux and Windows, and dispatch
has not been used for the standard library up until this point.  The
current usage is limited to the Apple platforms, so rather than adding
another build of dispatch, conditionally include the header instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
