### PR TITLE
[build] Remove redundant block applying '-mcx16' flag again for Android x86_64

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -273,21 +273,6 @@ function(_add_target_variant_c_compile_flags)
     endif()
   endif()
 
-  if(${CFLAGS_SDK} STREQUAL ANDROID)
-    if(${CFLAGS_ARCH} STREQUAL x86_64)
-      # NOTE(compnerd) Android NDK 21 or lower will generate library calls to
-      # `__sync_val_compare_and_swap_16` rather than lowering to the CPU's
-      # `cmpxchg16b` instruction as the `cx16` feature is disabled due to a bug
-      # in Clang.  This is being fixed in the current master Clang and will
-      # hopefully make it into Clang 9.0.  In the mean time, workaround this in
-      # the build.
-      if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_VERSION
-          VERSION_LESS 9.0.0)
-        list(APPEND result -mcx16)
-      endif()
-    endif()
-  endif()
-
   if(CFLAGS_ENABLE_ASSERTIONS)
     list(APPEND result "-UNDEBUG")
   else()


### PR DESCRIPTION
~@rjmccall and @compnerd, this fixes a bug in #34958. I just noticed this because it was wrongly applying this flag when cross-compiling the stdlib for Android AArch64 too, and clang put out a bunch of warnings about it.~

Fix has now been merged in another pull #35102, this is just the remaining cleanup.