### PR TITLE
Introduce OperandOwnership to classify OSSA uses.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -337,7 +337,7 @@ public:
   }
 
   /// Return the SILArgumentConvention for the given applied argument operand.
-  SILArgumentConvention getArgumentConvention(Operand &oper) const {
+  SILArgumentConvention getArgumentConvention(const Operand &oper) const {
     unsigned calleeArgIdx =
         getCalleeArgIndexOfFirstAppliedArg() + getAppliedArgIndex(oper);
     return getSubstCalleeConv().getSILArgumentConvention(calleeArgIdx);
@@ -615,7 +615,8 @@ public:
   /// Returns true if \p op is an operand that passes an indirect
   /// result argument to the apply site.
   bool isIndirectResultOperand(const Operand &op) const {
-    return getCalleeArgIndex(op) < getNumIndirectSILResults();
+    return isArgumentOperand(op)
+      && (getCalleeArgIndex(op) < getNumIndirectSILResults());
   }
 
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -226,6 +226,8 @@ struct OwnershipKind {
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const OwnershipKind &kind);
 
+enum class OperandOwnership;
+
 /// A value representing the specific ownership semantics that a SILValue may
 /// have.
 struct ValueOwnershipKind {
@@ -285,6 +287,8 @@ struct ValueOwnershipKind {
     }
     llvm_unreachable("covered switch");
   }
+
+  OperandOwnership getForwardingOperandOwnership() const;
 
   /// Returns true if \p Other can be merged successfully with this, implying
   /// that the two ownership kinds are "compatibile".
@@ -597,12 +601,6 @@ public:
     return lifetimeConstraint;
   }
 
-  /// Return a constraint that is appropriate for an operand that can accept a
-  /// value with any ownership kind without ending said value's lifetime.
-  static OwnershipConstraint any() {
-    return {OwnershipKind::Any, UseLifetimeConstraint::NonLifetimeEnding};
-  }
-
   bool satisfiedBy(const Operand *use) const;
 
   bool satisfiesConstraint(ValueOwnershipKind testKind) const {
@@ -617,6 +615,124 @@ public:
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               OwnershipConstraint constraint);
+
+/// Categorize all uses in terms of their ownership effect.
+///
+/// Used to verify completeness of the ownership use model and exhaustively
+/// switch over any category of ownership use. Implies ownership constraints and
+/// lifetime constraints.
+enum class OperandOwnership {
+  /// Uses of ownership None. These uses are incompatible with values that have
+  /// ownership but are otherwise not verified.
+  None,
+
+  /// MARK: Uses of any ownership values:
+
+  /// Point-in-time use. Uses the value instantaneously.
+  /// (copy_value, single-instruction apply with @guaranteed argument)
+  InstantaneousUse,
+  // FIXME: The PointerEscape category should be eliminated. All pointer escapes
+  // should be InteriorPointer, guarded by a borrow scope.
+  PointerEscape,
+  /// Bitwise escape. Escapes the nontrivial contents of the value.
+  /// OSSA does not enforce the lifetime of the escaping bits.
+  /// The programmer must explicitly force lifetime extension.
+  /// (ref_to_unowned, unchecked_trivial_bitcast)
+  BitwiseEscape,
+
+  /// MARK: Uses of Unowned values:
+
+  /// Forwarding instruction with an Unowned result must have Unowned operands.
+  ForwardingUnowned,
+
+  /// MARK: Uses of Owned values:
+
+  /// Borrow. Propagates the owned value within a scope, without consuming it.
+  /// (begin_borrow, begin_apply with @guaranteed argument)
+  Borrow,
+  /// Destroying Consume. Destroys the owned value immediately.
+  /// (store, destroy, @owned destructure).
+  DestroyingConsume,
+  /// Forwarding Consume. Consumes the owned value indirectly via a move.
+  /// (br, destructure, tuple, struct, cast, switch).
+  ForwardingConsume,
+
+  /// MARK: Uses of Guaranteed values:
+
+  /// Nested Borrow. Propagates the guaranteed value within a nested borrow
+  /// scope, without ending the outer borrow scope, following stack discipline.
+  /// (begin_borrow, begin_apply with @guaranteed).
+  NestedBorrow,
+  /// Interior Pointer. Propagates an address into the guaranteed value within
+  /// the base's borrow scope.  (ref_element_addr, open_existential_box)
+  InteriorPointer,
+  /// Forwarded Borrow. Propagates the guaranteed value within the base's
+  /// borrow scope.
+  /// (tuple_extract, struct_extract, cast, switch)
+  ForwardingBorrow,
+  /// End Borrow. End the borrow scope opened directly by the operand.
+  /// The operand must be a begin_borrow, begin_apply, or function argument.
+  /// (end_borrow, end_apply)
+  EndBorrow,
+  // Reborrow. Ends the borrow scope opened directly by the operand and begins
+  // one or multiple disjoint borrow scopes. If a forwarded value is reborrowed,
+  // then its base must also be reborrowed at the same point.
+  // (br, FIXME: should also include destructure, tuple, struct)
+  Reborrow
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, OperandOwnership operandOwnership);
+
+/// Return the OwnershipConstraint for a OperandOwnership.
+///
+/// Defined inline so the switch is eliminated for constant OperandOwnership.
+inline OwnershipConstraint
+getOwnershipConstraint(OperandOwnership operandOwnership) {
+  switch (operandOwnership) {
+  case OperandOwnership::None:
+    return {OwnershipKind::None, UseLifetimeConstraint::NonLifetimeEnding};
+  case OperandOwnership::InstantaneousUse:
+  case OperandOwnership::PointerEscape:
+  case OperandOwnership::BitwiseEscape:
+    return {OwnershipKind::Any, UseLifetimeConstraint::NonLifetimeEnding};
+  case OperandOwnership::ForwardingUnowned:
+    return {OwnershipKind::Unowned, UseLifetimeConstraint::NonLifetimeEnding};
+  case OperandOwnership::Borrow:
+    return {OwnershipKind::Owned, UseLifetimeConstraint::NonLifetimeEnding};
+  case OperandOwnership::DestroyingConsume:
+  case OperandOwnership::ForwardingConsume:
+    return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
+  case OperandOwnership::NestedBorrow:
+  case OperandOwnership::InteriorPointer:
+  case OperandOwnership::ForwardingBorrow:
+    return {OwnershipKind::Guaranteed,
+            UseLifetimeConstraint::NonLifetimeEnding};
+  case OperandOwnership::EndBorrow:
+  case OperandOwnership::Reborrow:
+    return {OwnershipKind::Guaranteed, UseLifetimeConstraint::LifetimeEnding};
+  }
+}
+
+// Forwarding instructions have a dynamic ownership kind. Their forwarded
+// operand constraint depends on that dynamic result ownership. If the result is
+// owned, then the instruction moves owned operand to its result, ending its
+// lifetime. If the result is guaranteed value, then the instruction propagates
+// the lifetime of its borrows operand through its result.
+inline OperandOwnership
+ValueOwnershipKind::getForwardingOperandOwnership() const {
+  switch (value) {
+  case OwnershipKind::Any:
+    llvm_unreachable("invalid value ownership");
+  case OwnershipKind::None:
+    return OperandOwnership::None;
+  case OwnershipKind::Unowned:
+    return OperandOwnership::ForwardingUnowned;
+  case OwnershipKind::Guaranteed:
+    return OperandOwnership::ForwardingBorrow;
+  case OwnershipKind::Owned:
+    return OperandOwnership::ForwardingConsume;
+  }
+}
 
 /// A formal SIL reference to a value, suitable for use as a stored
 /// operand.
@@ -695,12 +811,22 @@ public:
   /// Return which operand this is in the operand list of the using instruction.
   unsigned getOperandNumber() const;
 
+  /// Return the use ownership of this operand. Returns none if the operand is a
+  /// type dependent operand.
+  ///
+  /// NOTE: This is implemented in OperandOwnership.cpp.
+  Optional<OperandOwnership> getOperandOwnership() const;
+
   /// Return the ownership constraint that restricts what types of values this
   /// Operand can contain. Returns none if the operand is a type dependent
   /// operand.
-  ///
-  /// NOTE: This is implemented in OperandOwnership.cpp.
-  Optional<OwnershipConstraint> getOwnershipConstraint() const;
+  Optional<OwnershipConstraint> getOwnershipConstraint() const {
+    auto operandOwnership = getOperandOwnership();
+    if (!operandOwnership) {
+      return None;
+    }
+    return swift::getOwnershipConstraint(operandOwnership.getValue());
+  }
 
   /// Returns true if changing the operand to use a value with the given
   /// ownership kind would not cause the operand to violate the operand's
@@ -711,8 +837,9 @@ public:
   /// operand constraint.
   bool satisfiesConstraints() const;
 
-  /// Returns true if this operand acts as a use that consumes its associated
-  /// value.
+  /// Returns true if this operand acts as a use that ends the lifetime its
+  /// associated value, either by consuming the owned value or ending the
+  /// guaranteed scope.
   bool isLifetimeEnding() const;
 
   SILBasicBlock *getParentBlock() const;
@@ -720,15 +847,18 @@ public:
 
 private:
   void removeFromCurrent() {
-    if (!Back) return;
+    if (!Back)
+      return;
     *Back = NextUse;
-    if (NextUse) NextUse->Back = Back;
+    if (NextUse)
+      NextUse->Back = Back;
   }
 
   void insertIntoCurrent() {
     Back = &TheValue->FirstUse;
     NextUse = TheValue->FirstUse;
-    if (NextUse) NextUse->Back = &NextUse;
+    if (NextUse)
+      NextUse->Back = &NextUse;
     TheValue->FirstUse = this;
   }
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -20,35 +20,32 @@
 using namespace swift;
 
 //===----------------------------------------------------------------------===//
-//                      OwnershipConstraintClassifier
+//                         OperandOwnershipClassifier
 //===----------------------------------------------------------------------===//
 
 namespace {
 
-class OwnershipConstraintClassifier
-    : public SILInstructionVisitor<OwnershipConstraintClassifier,
-                                   OwnershipConstraint> {
+class OperandOwnershipClassifier
+  : public SILInstructionVisitor<OperandOwnershipClassifier, OperandOwnership> {
   LLVM_ATTRIBUTE_UNUSED SILModule &mod;
 
   const Operand &op;
 
 public:
-  /// Create a new OwnershipConstraintClassifier.
+  /// Create a new OperandOwnershipClassifier.
   ///
   /// In most cases, one should only pass in \p Op and \p BaseValue will be set
   /// to Op.get(). In cases where one is trying to verify subobjects, Op.get()
   /// should be the subobject and Value should be the parent object. An example
   /// of where one would want to do this is in the case of value projections
   /// like struct_extract.
-  OwnershipConstraintClassifier(SILModule &mod, const Operand &op)
+  OperandOwnershipClassifier(SILModule &mod, const Operand &op)
       : mod(mod), op(op) {}
 
   SILValue getValue() const { return op.get(); }
 
   ValueOwnershipKind getOwnershipKind() const {
-    assert(getValue().getOwnershipKind() == op.get().getOwnershipKind() &&
-           "Expected ownership kind of parent value and operand");
-    return getValue().getOwnershipKind();
+    return op.get().getOwnershipKind();
   }
 
   unsigned getOperandIndex() const { return op.getOperandNumber(); }
@@ -63,23 +60,11 @@ public:
     return getOwnershipKind() == kind;
   }
 
-  bool isAddressOrTrivialType() const {
-    if (getType().isAddress())
-      return true;
-    return getOwnershipKind() == OwnershipKind::None;
-  }
-
-  OwnershipConstraint visitApplyParameter(ValueOwnershipKind requiredConvention,
-                                          UseLifetimeConstraint requirement);
-  OwnershipConstraint visitFullApply(FullApplySite apply);
-
-  OwnershipConstraint visitCallee(CanSILFunctionType substCalleeType);
-  OwnershipConstraint
-  checkTerminatorArgumentMatchesDestBB(SILBasicBlock *destBB, unsigned opIndex);
+  OperandOwnership visitFullApply(FullApplySite apply);
 
 // Create declarations for all instructions, so we get a warning at compile
 // time if any instructions do not have an implementation.
-#define INST(Id, Parent) OwnershipConstraint visit##Id(Id *);
+#define INST(Id, Parent) OperandOwnership visit##Id(Id *);
 #include "swift/SIL/SILNodes.def"
 };
 
@@ -89,7 +74,7 @@ public:
 /// not valid in ossa or do not have operands. Since we should never visit
 /// these, we just assert.
 #define SHOULD_NEVER_VISIT_INST(INST)                                          \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
+  OperandOwnership OperandOwnershipClassifier::visit##INST##Inst(              \
       INST##Inst *i) {                                                         \
     llvm::errs() << "Unhandled inst: " << *i;                                  \
     llvm::report_fatal_error(                                                  \
@@ -127,559 +112,389 @@ SHOULD_NEVER_VISIT_INST(GetAsyncContinuation)
 #include "swift/AST/ReferenceStorage.def"
 #undef SHOULD_NEVER_VISIT_INST
 
-/// Instructions that are interior pointers into a guaranteed value.
-#define INTERIOR_POINTER_PROJECTION(INST)                                      \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
-      INST##Inst *i) {                                                         \
+// FIXME: The assert should be moved to the verifier.
+#define OPERAND_OWNERSHIP(OWNERSHIP, INST)                                     \
+  OperandOwnership                                                             \
+  OperandOwnershipClassifier::visit##INST##Inst(INST##Inst *i) {               \
     assert(i->getNumOperands() && "Expected to have non-zero operands");       \
-    return {OwnershipKind::Guaranteed,                                         \
-            UseLifetimeConstraint::NonLifetimeEnding};                         \
+    return OperandOwnership::OWNERSHIP;                                        \
   }
-INTERIOR_POINTER_PROJECTION(RefElementAddr)
-INTERIOR_POINTER_PROJECTION(RefTailAddr)
-#undef INTERIOR_POINTER_PROJECTION
 
-/// Instructions whose arguments are always compatible with one convention.
-#define CONSTANT_OWNERSHIP_INST(OWNERSHIP, USE_LIFETIME_CONSTRAINT, INST)      \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
-      INST##Inst *i) {                                                         \
-    assert(i->getNumOperands() && "Expected to have non-zero operands");       \
-    return {OwnershipKind::OWNERSHIP,                                          \
-            UseLifetimeConstraint::USE_LIFETIME_CONSTRAINT};                   \
-  }
-CONSTANT_OWNERSHIP_INST(Guaranteed, NonLifetimeEnding, OpenExistentialValue)
-CONSTANT_OWNERSHIP_INST(Guaranteed, NonLifetimeEnding, OpenExistentialBox)
-CONSTANT_OWNERSHIP_INST(Guaranteed, NonLifetimeEnding, HopToExecutor)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, AutoreleaseValue)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, DeallocBox)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, DeallocExistentialBox)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, DeallocRef)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, DestroyValue)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, EndLifetime)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, BeginCOWMutation)
-CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, EndCOWMutation)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, AwaitAsyncContinuation)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, AbortApply)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, AddressToPointer)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, BeginAccess)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, BeginUnpairedAccess)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, BindMemory)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, CheckedCastAddrBranch)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, CondFail)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, CopyAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, DeallocStack)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, DebugValueAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, DeinitExistentialAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, DestroyAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, EndAccess)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, EndApply)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, EndUnpairedAccess)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, GetAsyncContinuationAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, IndexAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, IndexRawPointer)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, InitBlockStorageHeader)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, InitEnumDataAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, InitExistentialAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, InitExistentialMetatype)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, InjectEnumAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, IsUnique)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, Load)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, LoadBorrow)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, MarkFunctionEscape)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding,
-                        ObjCExistentialMetatypeToObject)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ObjCMetatypeToObject)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ObjCToThickMetatype)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, OpenExistentialAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, OpenExistentialMetatype)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, PointerToAddress)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, PointerToThinFunction)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ProjectBlockStorage)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ProjectValueBuffer)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, RawPointerToRef)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, SelectEnumAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, SelectValue)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, StructElementAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, SwitchEnumAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, SwitchValue)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, TailAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ThickToObjCMetatype)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ThinFunctionToPointer)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, ThinToThickFunction)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, TupleElementAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, UncheckedAddrCast)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, UncheckedRefCastAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, UncheckedTakeEnumDataAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, UnconditionalCheckedCastAddr)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, AllocValueBuffer)
-CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, DeallocValueBuffer)
+// Instructions that require trivial operands.
+OPERAND_OWNERSHIP(None, AwaitAsyncContinuation)
+OPERAND_OWNERSHIP(None, AbortApply)
+OPERAND_OWNERSHIP(None, AddressToPointer)
+OPERAND_OWNERSHIP(None, AllocRef)        // with tail operand
+OPERAND_OWNERSHIP(None, AllocRefDynamic) // with tail operand
+OPERAND_OWNERSHIP(None, BeginAccess)
+OPERAND_OWNERSHIP(None, BeginUnpairedAccess)
+OPERAND_OWNERSHIP(None, BindMemory)
+OPERAND_OWNERSHIP(None, CheckedCastAddrBranch)
+OPERAND_OWNERSHIP(None, CondBranch)
+OPERAND_OWNERSHIP(None, CondFail)
+OPERAND_OWNERSHIP(None, CopyAddr)
+OPERAND_OWNERSHIP(None, DeallocStack)
+OPERAND_OWNERSHIP(None, DebugValueAddr)
+OPERAND_OWNERSHIP(None, DeinitExistentialAddr)
+OPERAND_OWNERSHIP(None, DestroyAddr)
+OPERAND_OWNERSHIP(None, EndAccess)
+OPERAND_OWNERSHIP(None, EndApply)
+OPERAND_OWNERSHIP(None, EndUnpairedAccess)
+OPERAND_OWNERSHIP(None, GetAsyncContinuationAddr)
+OPERAND_OWNERSHIP(None, IndexAddr)
+OPERAND_OWNERSHIP(None, IndexRawPointer)
+OPERAND_OWNERSHIP(None, InitBlockStorageHeader)
+OPERAND_OWNERSHIP(None, InitEnumDataAddr)
+OPERAND_OWNERSHIP(None, InitExistentialAddr)
+OPERAND_OWNERSHIP(None, InitExistentialMetatype)
+OPERAND_OWNERSHIP(None, InjectEnumAddr)
+OPERAND_OWNERSHIP(None, IsUnique)
+OPERAND_OWNERSHIP(None, Load)
+OPERAND_OWNERSHIP(None, LoadBorrow)
+OPERAND_OWNERSHIP(None, MarkFunctionEscape)
+OPERAND_OWNERSHIP(None, ObjCExistentialMetatypeToObject)
+OPERAND_OWNERSHIP(None, ObjCMetatypeToObject)
+OPERAND_OWNERSHIP(None, ObjCToThickMetatype)
+OPERAND_OWNERSHIP(None, OpenExistentialAddr)
+OPERAND_OWNERSHIP(None, OpenExistentialMetatype)
+OPERAND_OWNERSHIP(None, PointerToAddress)
+OPERAND_OWNERSHIP(None, PointerToThinFunction)
+OPERAND_OWNERSHIP(None, ProjectBlockStorage)
+OPERAND_OWNERSHIP(None, ProjectValueBuffer)
+OPERAND_OWNERSHIP(None, RawPointerToRef)
+OPERAND_OWNERSHIP(None, SelectEnumAddr)
+OPERAND_OWNERSHIP(None, SelectValue)
+OPERAND_OWNERSHIP(None, StructElementAddr)
+OPERAND_OWNERSHIP(None, SwitchEnumAddr)
+OPERAND_OWNERSHIP(None, SwitchValue)
+OPERAND_OWNERSHIP(None, TailAddr)
+OPERAND_OWNERSHIP(None, ThickToObjCMetatype)
+OPERAND_OWNERSHIP(None, ThinFunctionToPointer)
+OPERAND_OWNERSHIP(None, ThinToThickFunction)
+OPERAND_OWNERSHIP(None, TupleElementAddr)
+OPERAND_OWNERSHIP(None, UncheckedAddrCast)
+OPERAND_OWNERSHIP(None, UncheckedRefCastAddr)
+OPERAND_OWNERSHIP(None, UncheckedTakeEnumDataAddr)
+OPERAND_OWNERSHIP(None, UnconditionalCheckedCastAddr)
+OPERAND_OWNERSHIP(None, AllocValueBuffer)
+OPERAND_OWNERSHIP(None, DeallocValueBuffer)
+
+// Point-in-time uses of any ownership.
+OPERAND_OWNERSHIP(InstantaneousUse, CopyValue)
+OPERAND_OWNERSHIP(InstantaneousUse, DebugValue)
+OPERAND_OWNERSHIP(InstantaneousUse, ExistentialMetatype)
+OPERAND_OWNERSHIP(InstantaneousUse, FixLifetime)
+OPERAND_OWNERSHIP(InstantaneousUse, WitnessMethod)
+OPERAND_OWNERSHIP(InstantaneousUse, DynamicMethodBranch)
+OPERAND_OWNERSHIP(InstantaneousUse, ValueMetatype)
+OPERAND_OWNERSHIP(InstantaneousUse, IsEscapingClosure)
+OPERAND_OWNERSHIP(InstantaneousUse, ClassMethod)
+OPERAND_OWNERSHIP(InstantaneousUse, ObjCMethod)
+OPERAND_OWNERSHIP(InstantaneousUse, ObjCSuperMethod)
+OPERAND_OWNERSHIP(InstantaneousUse, SuperMethod)
+OPERAND_OWNERSHIP(InstantaneousUse, BridgeObjectToWord)
+OPERAND_OWNERSHIP(InstantaneousUse, ClassifyBridgeObject)
+OPERAND_OWNERSHIP(InstantaneousUse, CopyBlock)
+OPERAND_OWNERSHIP(InstantaneousUse, SetDeallocating)
+OPERAND_OWNERSHIP(InstantaneousUse, UnmanagedRetainValue)
+OPERAND_OWNERSHIP(InstantaneousUse, UnmanagedReleaseValue)
+OPERAND_OWNERSHIP(InstantaneousUse, UnmanagedAutoreleaseValue)
+#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
+  OPERAND_OWNERSHIP(InstantaneousUse, RefTo##Name)                             \
+  OPERAND_OWNERSHIP(InstantaneousUse, Name##ToRef)                             \
+  OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  OPERAND_OWNERSHIP(InstantaneousUse, RefTo##Name)                             \
+  OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
+#include "swift/AST/ReferenceStorage.def"
+
+// Instructions that currently violate structural ownership requirements,
+// and therefore completely defeat canonicalization and optimization of any
+// OSSA value that they use.
+OPERAND_OWNERSHIP(PointerEscape, ProjectBox) // The result is a T*.
+OPERAND_OWNERSHIP(PointerEscape, ProjectExistentialBox)
+OPERAND_OWNERSHIP(PointerEscape, UncheckedOwnershipConversion)
+
+// Instructions that escape reference bits with unenforced lifetime.
+OPERAND_OWNERSHIP(BitwiseEscape, UncheckedBitwiseCast)
+OPERAND_OWNERSHIP(BitwiseEscape, ValueToBridgeObject)
+OPERAND_OWNERSHIP(BitwiseEscape, RefToRawPointer)
+OPERAND_OWNERSHIP(BitwiseEscape, UncheckedTrivialBitCast)
+// FIXME: verify that no-escape results are always trivial
+OPERAND_OWNERSHIP(BitwiseEscape, ConvertEscapeToNoEscape)
+
+// Instructions that end the lifetime of an owned value.
+OPERAND_OWNERSHIP(DestroyingConsume, AutoreleaseValue)
+OPERAND_OWNERSHIP(DestroyingConsume, DeallocBox)
+OPERAND_OWNERSHIP(DestroyingConsume, DeallocExistentialBox)
+OPERAND_OWNERSHIP(DestroyingConsume, DeallocRef)
+OPERAND_OWNERSHIP(DestroyingConsume, DestroyValue)
+OPERAND_OWNERSHIP(DestroyingConsume, EndLifetime)
+OPERAND_OWNERSHIP(DestroyingConsume, BeginCOWMutation)
+OPERAND_OWNERSHIP(DestroyingConsume, EndCOWMutation)
+
+// Instructions that move an owned value.
+OPERAND_OWNERSHIP(ForwardingConsume, CheckedCastValueBranch)
+OPERAND_OWNERSHIP(ForwardingConsume, UnconditionalCheckedCastValue)
+OPERAND_OWNERSHIP(ForwardingConsume, InitExistentialValue)
+OPERAND_OWNERSHIP(ForwardingConsume, DeinitExistentialValue)
+OPERAND_OWNERSHIP(ForwardingConsume, MarkUninitialized)
+OPERAND_OWNERSHIP(ForwardingConsume, Throw)
+
+// Instructions that expose a pointer within a borrow scope.
+OPERAND_OWNERSHIP(InteriorPointer, RefElementAddr)
+OPERAND_OWNERSHIP(InteriorPointer, RefTailAddr)
+OPERAND_OWNERSHIP(InteriorPointer, OpenExistentialBox)
+// FIXME: HopToExecutorInst should be an instantaneous use.
+OPERAND_OWNERSHIP(InteriorPointer, HopToExecutor)
+
+// Instructions that propagate a value value within a borrow scope.
+OPERAND_OWNERSHIP(ForwardingBorrow, TupleExtract)
+OPERAND_OWNERSHIP(ForwardingBorrow, StructExtract)
+OPERAND_OWNERSHIP(ForwardingBorrow, DifferentiableFunctionExtract)
+OPERAND_OWNERSHIP(ForwardingBorrow, LinearFunctionExtract)
+// FIXME: OpenExistential[Box]Value should be able to take owned values too by
+// using getForwardingOperandOwnership.
+OPERAND_OWNERSHIP(ForwardingBorrow, OpenExistentialValue)
+OPERAND_OWNERSHIP(ForwardingBorrow, OpenExistentialBoxValue)
+
+OPERAND_OWNERSHIP(EndBorrow, EndBorrow)
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
-  CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, Load##Name)
+  OPERAND_OWNERSHIP(None, Load##Name)
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
-  CONSTANT_OWNERSHIP_INST(Owned, LifetimeEnding, Name##Release)
+  OPERAND_OWNERSHIP(DestroyingConsume, Name##Release)
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
   NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...")                              \
   ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  CONSTANT_OWNERSHIP_INST(None, NonLifetimeEnding, Name##ToRef)
+#define UNCHECKED_REF_STORAGE(Name, ...) OPERAND_OWNERSHIP(None, Name##ToRef)
 #include "swift/AST/ReferenceStorage.def"
-#undef CONSTANT_OWNERSHIP_INST
-
-/// Instructions whose arguments are always compatible with one convention.
-#define CONSTANT_OR_NONE_OWNERSHIP_INST(OWNERSHIP, USE_LIFETIME_CONSTRAINT,    \
-                                        INST)                                  \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
-      INST##Inst *i) {                                                         \
-    assert(i->getNumOperands() && "Expected to have non-zero operands");       \
-    return {OwnershipKind::OWNERSHIP,                                          \
-            UseLifetimeConstraint::USE_LIFETIME_CONSTRAINT};                   \
-  }
-CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, LifetimeEnding, CheckedCastValueBranch)
-CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, LifetimeEnding,
-                                UnconditionalCheckedCastValue)
-CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, LifetimeEnding, InitExistentialValue)
-CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, LifetimeEnding, DeinitExistentialValue)
-#undef CONSTANT_OR_NONE_OWNERSHIP_INST
-
-#define ACCEPTS_ANY_OWNERSHIP_INST(INST)                                       \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
-      INST##Inst *i) {                                                         \
-    return OwnershipConstraint::any();                                         \
-  }
-ACCEPTS_ANY_OWNERSHIP_INST(BeginBorrow)
-ACCEPTS_ANY_OWNERSHIP_INST(CopyValue)
-ACCEPTS_ANY_OWNERSHIP_INST(DebugValue)
-ACCEPTS_ANY_OWNERSHIP_INST(FixLifetime)
-ACCEPTS_ANY_OWNERSHIP_INST(UncheckedBitwiseCast) // Is this right?
-ACCEPTS_ANY_OWNERSHIP_INST(WitnessMethod)        // Is this right?
-ACCEPTS_ANY_OWNERSHIP_INST(ProjectBox)           // The result is a T*.
-ACCEPTS_ANY_OWNERSHIP_INST(DynamicMethodBranch)
-ACCEPTS_ANY_OWNERSHIP_INST(UncheckedTrivialBitCast)
-ACCEPTS_ANY_OWNERSHIP_INST(ExistentialMetatype)
-ACCEPTS_ANY_OWNERSHIP_INST(ValueMetatype)
-ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
-ACCEPTS_ANY_OWNERSHIP_INST(ValueToBridgeObject)
-ACCEPTS_ANY_OWNERSHIP_INST(IsEscapingClosure)
-ACCEPTS_ANY_OWNERSHIP_INST(ClassMethod)
-ACCEPTS_ANY_OWNERSHIP_INST(ObjCMethod)
-ACCEPTS_ANY_OWNERSHIP_INST(ObjCSuperMethod)
-ACCEPTS_ANY_OWNERSHIP_INST(SuperMethod)
-ACCEPTS_ANY_OWNERSHIP_INST(BridgeObjectToWord)
-ACCEPTS_ANY_OWNERSHIP_INST(ClassifyBridgeObject)
-ACCEPTS_ANY_OWNERSHIP_INST(CopyBlock)
-ACCEPTS_ANY_OWNERSHIP_INST(RefToRawPointer)
-ACCEPTS_ANY_OWNERSHIP_INST(SetDeallocating)
-ACCEPTS_ANY_OWNERSHIP_INST(ProjectExistentialBox)
-ACCEPTS_ANY_OWNERSHIP_INST(UnmanagedRetainValue)
-ACCEPTS_ANY_OWNERSHIP_INST(UnmanagedReleaseValue)
-ACCEPTS_ANY_OWNERSHIP_INST(UnmanagedAutoreleaseValue)
-ACCEPTS_ANY_OWNERSHIP_INST(ConvertEscapeToNoEscape)
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
-  ACCEPTS_ANY_OWNERSHIP_INST(RefTo##Name)                                      \
-  ACCEPTS_ANY_OWNERSHIP_INST(Name##ToRef)                                      \
-  ACCEPTS_ANY_OWNERSHIP_INST(StrongCopy##Name##Value)
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  ACCEPTS_ANY_OWNERSHIP_INST(RefTo##Name)                                      \
-  ACCEPTS_ANY_OWNERSHIP_INST(StrongCopy##Name##Value)
-#include "swift/AST/ReferenceStorage.def"
-#undef ACCEPTS_ANY_OWNERSHIP_INST
-
-#define FORWARD_ANY_OWNERSHIP_INST(INST)                                       \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
-      INST##Inst *i) {                                                         \
-    assert(isa<OwnershipForwardingInst>(i));                                   \
-    auto kind = i->getOwnershipKind();                                         \
-    auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();          \
-    return {kind, lifetimeConstraint};                                         \
-  }
-FORWARD_ANY_OWNERSHIP_INST(Tuple)
-FORWARD_ANY_OWNERSHIP_INST(Struct)
-FORWARD_ANY_OWNERSHIP_INST(Object)
-FORWARD_ANY_OWNERSHIP_INST(Enum)
-FORWARD_ANY_OWNERSHIP_INST(OpenExistentialRef)
-FORWARD_ANY_OWNERSHIP_INST(Upcast)
-FORWARD_ANY_OWNERSHIP_INST(UncheckedRefCast)
-FORWARD_ANY_OWNERSHIP_INST(ConvertFunction)
-FORWARD_ANY_OWNERSHIP_INST(RefToBridgeObject)
-FORWARD_ANY_OWNERSHIP_INST(BridgeObjectToRef)
-FORWARD_ANY_OWNERSHIP_INST(UnconditionalCheckedCast)
-FORWARD_ANY_OWNERSHIP_INST(UncheckedEnumData)
-FORWARD_ANY_OWNERSHIP_INST(InitExistentialRef)
-FORWARD_ANY_OWNERSHIP_INST(DifferentiableFunction)
-FORWARD_ANY_OWNERSHIP_INST(LinearFunction)
-FORWARD_ANY_OWNERSHIP_INST(UncheckedValueCast)
-FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
-FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
-#undef FORWARD_ANY_OWNERSHIP_INST
-
-// An instruction that forwards a constant ownership or trivial ownership.
-#define FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(OWNERSHIP, INST)               \
-  OwnershipConstraint OwnershipConstraintClassifier::visit##INST##Inst(        \
-      INST##Inst *i) {                                                         \
-    assert(i->getNumOperands() && "Expected to have non-zero operands");       \
-    assert(isa<OwnershipForwardingInst>(i));                                   \
-    ValueOwnershipKind kind = OwnershipKind::OWNERSHIP;                        \
-    return {kind, kind.getForwardingLifetimeConstraint()};                     \
-  }
-FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, TupleExtract)
-FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, StructExtract)
-FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed,
-                                        DifferentiableFunctionExtract)
-FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, LinearFunctionExtract)
-FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, OpenExistentialBoxValue)
-FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MarkUninitialized)
-#undef FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST
-
-OwnershipConstraint OwnershipConstraintClassifier::visitDeallocPartialRefInst(
-    DeallocPartialRefInst *i) {
-  if (getValue() == i->getInstance()) {
-    return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
-  }
-
-  return OwnershipConstraint::any();
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitSelectEnumInst(SelectEnumInst *i) {
-  if (getValue() == i->getEnumOperand()) {
-    return OwnershipConstraint::any();
-  }
-
-  auto kind = i->getOwnershipKind();
-  auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();
-  return {kind, lifetimeConstraint};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitAllocRefInst(AllocRefInst *i) {
-  assert(i->getNumOperands() != 0 &&
-         "If we reach this point, we must have a tail operand");
-  return OwnershipConstraint::any();
-}
-
-OwnershipConstraint OwnershipConstraintClassifier::visitAllocRefDynamicInst(
-    AllocRefDynamicInst *i) {
-  assert(i->getNumOperands() != 0 &&
-         "If we reach this point, we must have a tail operand");
-  return OwnershipConstraint::any();
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::checkTerminatorArgumentMatchesDestBB(
-    SILBasicBlock *destBB, unsigned opIndex) {
-  // Grab the ownership kind of the destination block.
-  ValueOwnershipKind destBlockArgOwnershipKind =
-      destBB->getArgument(opIndex)->getOwnershipKind();
-  auto lifetimeConstraint =
-      destBlockArgOwnershipKind.getForwardingLifetimeConstraint();
-  return {destBlockArgOwnershipKind, lifetimeConstraint};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitBranchInst(BranchInst *bi) {
-  ValueOwnershipKind destBlockArgOwnershipKind =
-      bi->getDestBB()->getArgument(getOperandIndex())->getOwnershipKind();
-
-  // If we have a guaranteed parameter, treat this as consuming.
-  if (destBlockArgOwnershipKind == OwnershipKind::Guaranteed) {
-    return {destBlockArgOwnershipKind, UseLifetimeConstraint::LifetimeEnding};
-  }
-
-  // Otherwise, defer to defaults.
-  auto lifetimeConstraint =
-      destBlockArgOwnershipKind.getForwardingLifetimeConstraint();
-  return {destBlockArgOwnershipKind, lifetimeConstraint};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitCondBranchInst(CondBranchInst *cbi) {
-  // In ossa, cond_br insts are not allowed to take non-trivial values. Thus, we
-  // just accept anything since we know all of our operands will be trivial.
-  return OwnershipConstraint::any();
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitSwitchEnumInst(SwitchEnumInst *sei) {
-  auto kind = getOwnershipKind();
-  auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();
-  return {kind, lifetimeConstraint};
-}
-
-OwnershipConstraint OwnershipConstraintClassifier::visitCheckedCastBranchInst(
-    CheckedCastBranchInst *ccbi) {
-  auto kind = getOwnershipKind();
-  auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();
-  return {kind, lifetimeConstraint};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitReturnInst(ReturnInst *ri) {
-  auto kind = ri->getOwnershipKind();
-  auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();
-  return {kind, lifetimeConstraint};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitEndBorrowInst(EndBorrowInst *i) {
-  /// An end_borrow is modeled as invalidating the guaranteed value preventing
-  /// any further uses of the value.
-  return {OwnershipKind::Guaranteed, UseLifetimeConstraint::LifetimeEnding};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitThrowInst(ThrowInst *i) {
-  return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
-}
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
-  OwnershipConstraint OwnershipConstraintClassifier::visitStore##Name##Inst(   \
-      Store##Name##Inst *i) {                                                  \
-    /* A store instruction implies that the value to be stored to be live, */  \
-    /* but it does not touch the strong reference count of the value. We */    \
-    /* also just care about liveness for the dest. So just match everything */ \
-    /* as must be live. */                                                     \
-    return OwnershipConstraint::any();                                         \
-  }
+  OPERAND_OWNERSHIP(InstantaneousUse, Store##Name)
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
   NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
 #include "swift/AST/ReferenceStorage.def"
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitStoreBorrowInst(StoreBorrowInst *i) {
+#undef OPERAND_OWNERSHIP
+
+// Conditionally either ForwardingConsume or ForwardingBorrow, depending on
+// instruction result's dynamic ownership kind.
+#define FORWARD_ANY_OWNERSHIP(INST)                                            \
+  OperandOwnership                                                             \
+  OperandOwnershipClassifier::visit##INST##Inst(INST##Inst *i) {               \
+    return i->getOwnershipKind().getForwardingOperandOwnership();              \
+  }
+FORWARD_ANY_OWNERSHIP(Object)
+FORWARD_ANY_OWNERSHIP(Enum)
+FORWARD_ANY_OWNERSHIP(OpenExistentialRef)
+FORWARD_ANY_OWNERSHIP(Upcast)
+FORWARD_ANY_OWNERSHIP(UncheckedRefCast)
+FORWARD_ANY_OWNERSHIP(ConvertFunction)
+FORWARD_ANY_OWNERSHIP(RefToBridgeObject)
+FORWARD_ANY_OWNERSHIP(BridgeObjectToRef)
+FORWARD_ANY_OWNERSHIP(UnconditionalCheckedCast)
+FORWARD_ANY_OWNERSHIP(UncheckedEnumData)
+FORWARD_ANY_OWNERSHIP(InitExistentialRef)
+FORWARD_ANY_OWNERSHIP(DifferentiableFunction)
+FORWARD_ANY_OWNERSHIP(LinearFunction)
+FORWARD_ANY_OWNERSHIP(UncheckedValueCast)
+FORWARD_ANY_OWNERSHIP(SwitchEnum)
+FORWARD_ANY_OWNERSHIP(CheckedCastBranch)
+FORWARD_ANY_OWNERSHIP(Return)
+
+// FIXME: Guaranteed Tuple, Struct, and Destructure should be Reborrow, not
+// ForwardingBorrow, because the borrowed value is different on either side of
+// the operation and the lifetimes of borrowed members could differ.
+FORWARD_ANY_OWNERSHIP(Tuple)
+FORWARD_ANY_OWNERSHIP(Struct)
+FORWARD_ANY_OWNERSHIP(DestructureStruct)
+FORWARD_ANY_OWNERSHIP(DestructureTuple)
+#undef FORWARD_ANY_OWNERSHIP
+
+// A begin_borrow is conditionally nested.
+OperandOwnership
+OperandOwnershipClassifier::visitBeginBorrowInst(BeginBorrowInst *borrow) {
+  switch (borrow->getOperand().getOwnershipKind()) {
+  case OwnershipKind::Any:
+    llvm_unreachable("invalid value ownership");
+  case OwnershipKind::None:
+    return OperandOwnership::None;
+  case OwnershipKind::Unowned:
+    return OperandOwnership::InstantaneousUse;
+  case OwnershipKind::Guaranteed:
+    return OperandOwnership::NestedBorrow;
+  case OwnershipKind::Owned:
+    return OperandOwnership::Borrow;
+  }
+}
+
+// MARK: Instructions whose use ownership depends on the operand in question.
+
+OperandOwnership OperandOwnershipClassifier::
+visitDeallocPartialRefInst(DeallocPartialRefInst *i) {
+  if (getValue() == i->getInstance()) {
+    return OperandOwnership::DestroyingConsume;
+  }
+  return OperandOwnership::None;
+}
+
+OperandOwnership
+OperandOwnershipClassifier::visitSelectEnumInst(SelectEnumInst *i) {
+  if (getValue() == i->getEnumOperand()) {
+    return OperandOwnership::InstantaneousUse;
+  }
+  return getOwnershipKind().getForwardingOperandOwnership();
+}
+
+OperandOwnership OperandOwnershipClassifier::visitBranchInst(BranchInst *bi) {
+  ValueOwnershipKind destBlockArgOwnershipKind =
+      bi->getDestBB()->getArgument(getOperandIndex())->getOwnershipKind();
+
+  if (destBlockArgOwnershipKind == OwnershipKind::Guaranteed) {
+    return OperandOwnership::Reborrow;
+  }
+  return destBlockArgOwnershipKind.getForwardingOperandOwnership();
+}
+
+OperandOwnership
+OperandOwnershipClassifier::visitStoreBorrowInst(StoreBorrowInst *i) {
   if (getValue() == i->getSrc()) {
-    return {OwnershipKind::Guaranteed,
-            UseLifetimeConstraint::NonLifetimeEnding};
+    return OperandOwnership::ForwardingBorrow;
   }
-  return OwnershipConstraint::any();
+  return OperandOwnership::None;
 }
 
-// FIXME: Why not use SILArgumentConvention here?
-OwnershipConstraint
-OwnershipConstraintClassifier::visitCallee(CanSILFunctionType substCalleeType) {
-  ParameterConvention conv = substCalleeType->getCalleeConvention();
-  switch (conv) {
-  case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
-    assert(!SILModuleConventions(mod).isSILIndirect(
-                                      SILParameterInfo(substCalleeType, conv)));
-    return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
-  case ParameterConvention::Indirect_In_Guaranteed:
-    assert(!SILModuleConventions(mod).isSILIndirect(
-                                      SILParameterInfo(substCalleeType, conv)));
-    return {OwnershipKind::Guaranteed,
-            UseLifetimeConstraint::NonLifetimeEnding};
-  case ParameterConvention::Indirect_Inout:
-  case ParameterConvention::Indirect_InoutAliasable:
-    llvm_unreachable("Illegal convention for callee");
-  case ParameterConvention::Direct_Unowned:
-    return OwnershipConstraint::any();
-  case ParameterConvention::Direct_Owned:
-    return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
-  case ParameterConvention::Direct_Guaranteed:
-    if (substCalleeType->isNoEscape())
-      return OwnershipConstraint::any();
-    return {OwnershipKind::Guaranteed,
-            UseLifetimeConstraint::NonLifetimeEnding};
-  }
+static OperandOwnership getFunctionArgOwnership(SILArgumentConvention argConv) {
+  switch (argConv) {
+  case SILArgumentConvention::Indirect_In:
+  case SILArgumentConvention::Direct_Owned:
+    return OperandOwnership::ForwardingConsume;
 
-  llvm_unreachable("Unhandled ParameterConvention in switch.");
+  // A guaranteed argument is forwarded into the callee. However, from the
+  // caller's point of view it looks like an instantaneous use. Consequently,
+  // owned values may be passed to guaranteed arguments without an explicit
+  // borrow scope in the caller.
+  case SILArgumentConvention::Indirect_In_Constant:
+  case SILArgumentConvention::Indirect_In_Guaranteed:
+  case SILArgumentConvention::Direct_Guaranteed:
+  case SILArgumentConvention::Direct_Unowned:
+    return OperandOwnership::InstantaneousUse;
+
+  case SILArgumentConvention::Indirect_Out:
+  case SILArgumentConvention::Indirect_Inout:
+  case SILArgumentConvention::Indirect_InoutAliasable:
+    llvm_unreachable("Illegal convention for non-address types");
+  }
 }
 
-// We allow for trivial cases of enums with non-trivial cases to be passed in
-// non-trivial argument positions. This fits with modeling of a
-// SILFunctionArgument as a phi in a global program graph.
-OwnershipConstraint OwnershipConstraintClassifier::visitApplyParameter(
-    ValueOwnershipKind kind, UseLifetimeConstraint requirement) {
-  return {kind, requirement};
+OperandOwnership
+OperandOwnershipClassifier::visitFullApply(FullApplySite apply) {
+  // Before considering conventions, filter all (trivial) indirect
+  // arguments. This also rules out result arguments.
+  if (getValue()->getType().isAddress()) {
+    return OperandOwnership::None;
+  }
+  SILArgumentConvention argConv = apply.isCalleeOperand(op)
+    ? SILArgumentConvention(apply.getSubstCalleeType()->getCalleeConvention())
+    : apply.getArgumentConvention(op);
+
+  auto operandOwnership = getFunctionArgOwnership(argConv);
+
+  // Allow passing callee operands with no ownership as guaranteed.
+  // FIXME: why do we allow this?
+  if (operandOwnership == OperandOwnership::ForwardingBorrow
+      && apply.isCalleeOperand(op)) {
+    return OperandOwnership::InstantaneousUse;
+  }
+  return operandOwnership;
 }
 
-// Handle Apply and TryApply.
-OwnershipConstraint
-OwnershipConstraintClassifier::visitFullApply(FullApplySite apply) {
-  // If we are visiting the callee operand, handle it specially.
-  if (apply.isCalleeOperand(op)) {
-    return visitCallee(apply.getSubstCalleeType());
-  }
-
-  // Indirect return arguments are address types.
-  if (apply.isIndirectResultOperand(op)) {
-    return OwnershipConstraint::any();
-  }
-
-  // We should have early exited if we saw a type dependent operand, so we
-  // should never hit this.
-  //
-  // Lets just assert to be careful though.
-  assert(!apply.getInstruction()->isTypeDependentOperand(op));
-
-  unsigned argIndex = apply.getCalleeArgIndex(op);
-  auto conv = apply.getSubstCalleeConv();
-  SILParameterInfo paramInfo = conv.getParamInfoForSILArg(argIndex);
-
-  switch (paramInfo.getConvention()) {
-  case ParameterConvention::Direct_Owned:
-    return visitApplyParameter(OwnershipKind::Owned,
-                               UseLifetimeConstraint::LifetimeEnding);
-  case ParameterConvention::Direct_Unowned:
-    return OwnershipConstraint::any();
-
-  case ParameterConvention::Indirect_In: {
-    // This expects an @trivial if we have lowered addresses and @
-    if (conv.useLoweredAddresses()) {
-      return OwnershipConstraint::any();
-    }
-    // TODO: Once trivial is subsumed in any, this goes away.
-    auto map = visitApplyParameter(OwnershipKind::Owned,
-                                   UseLifetimeConstraint::LifetimeEnding);
-    return map;
-  }
-
-  case ParameterConvention::Indirect_In_Guaranteed: {
-    // This expects an @trivial if we have lowered addresses and @
-    if (conv.useLoweredAddresses()) {
-      return OwnershipConstraint::any();
-    }
-    return visitApplyParameter(OwnershipKind::Guaranteed,
-                               UseLifetimeConstraint::NonLifetimeEnding);
-  }
-
-  // The following conventions should take address types and thus be
-  // trivial.
-  case ParameterConvention::Indirect_In_Constant:
-  case ParameterConvention::Indirect_Inout:
-  case ParameterConvention::Indirect_InoutAliasable:
-    return OwnershipConstraint::any();
-
-  case ParameterConvention::Direct_Guaranteed:
-    // A +1 value may be passed to a guaranteed argument. From the caller's
-    // point of view, this is just like a normal non-consuming use.
-    // Direct_Guaranteed only accepts non-trivial types, but trivial types are
-    // already handled above.
-    return visitApplyParameter(OwnershipKind::Guaranteed,
-                               UseLifetimeConstraint::NonLifetimeEnding);
-  }
-  llvm_unreachable("unhandled convension");
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitBeginApplyInst(BeginApplyInst *i) {
+OperandOwnership
+OperandOwnershipClassifier::visitBeginApplyInst(BeginApplyInst *i) {
   return visitFullApply(i);
 }
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitApplyInst(ApplyInst *i) {
+OperandOwnership OperandOwnershipClassifier::visitApplyInst(ApplyInst *i) {
   return visitFullApply(i);
 }
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitTryApplyInst(TryApplyInst *i) {
+OperandOwnership
+OperandOwnershipClassifier::visitTryApplyInst(TryApplyInst *i) {
   return visitFullApply(i);
 }
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitPartialApplyInst(PartialApplyInst *i) {
+OperandOwnership
+OperandOwnershipClassifier::visitPartialApplyInst(PartialApplyInst *i) {
   // partial_apply [stack] does not take ownership of its operands.
-  if (i->isOnStack())
-    return OwnershipConstraint::any();
-
+  if (i->isOnStack()) {
+    return OperandOwnership::InstantaneousUse;
+  }
   // All non-trivial types should be captured.
-  return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
+  return OperandOwnership::ForwardingConsume;
 }
 
-// TODO: FIX THIS
-OwnershipConstraint
-OwnershipConstraintClassifier::visitYieldInst(YieldInst *i) {
-  // Indirect return arguments are address types.
-  //
-  // TODO: Change this to check if this operand is an indirect result
-  if (isAddressOrTrivialType())
-    return OwnershipConstraint::any();
-
+OperandOwnership OperandOwnershipClassifier::visitYieldInst(YieldInst *i) {
+  // Before considering conventions, filter all indirect arguments.
+  if (getValue()->getType().isAddress()) {
+    return OperandOwnership::None;
+  }
   auto fnType = i->getFunction()->getLoweredFunctionType();
-  auto yieldInfo = fnType->getYields()[getOperandIndex()];
-  switch (yieldInfo.getConvention()) {
-  case ParameterConvention::Indirect_In:
-  case ParameterConvention::Direct_Owned:
-    return visitApplyParameter(OwnershipKind::Owned,
-                               UseLifetimeConstraint::LifetimeEnding);
-  case ParameterConvention::Indirect_In_Constant:
-  case ParameterConvention::Direct_Unowned:
-    // We accept unowned, owned, and guaranteed in unowned positions.
-    return OwnershipConstraint::any();
-  case ParameterConvention::Indirect_In_Guaranteed:
-  case ParameterConvention::Direct_Guaranteed:
-    return visitApplyParameter(OwnershipKind::Guaranteed,
-                               UseLifetimeConstraint::NonLifetimeEnding);
-  // The following conventions should take address types.
-  case ParameterConvention::Indirect_Inout:
-  case ParameterConvention::Indirect_InoutAliasable:
-    llvm_unreachable("Unexpected non-trivial parameter convention.");
-  }
-  llvm_unreachable("unhandled convension");
+  SILArgumentConvention argConv(
+    fnType->getYields()[getOperandIndex()].getConvention());
+  return getFunctionArgOwnership(argConv);
 }
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitAssignInst(AssignInst *i) {
+OperandOwnership OperandOwnershipClassifier::visitAssignInst(AssignInst *i) {
   if (getValue() != i->getSrc()) {
-    return OwnershipConstraint::any();
+    return OperandOwnership::None;
   }
-
-  return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
+  return OperandOwnership::DestroyingConsume;
 }
 
-OwnershipConstraint OwnershipConstraintClassifier::visitAssignByWrapperInst(
-    AssignByWrapperInst *i) {
+OperandOwnership
+OperandOwnershipClassifier::visitAssignByWrapperInst(AssignByWrapperInst *i) {
+  if (getValue() == i->getSrc()) {
+    return OperandOwnership::DestroyingConsume;
+  }
+  if (getValue() == i->getDest()) {
+    return OperandOwnership::None;
+  }
+  return OperandOwnership::InstantaneousUse; // initializer/setter closure
+}
+
+OperandOwnership OperandOwnershipClassifier::visitStoreInst(StoreInst *i) {
   if (getValue() != i->getSrc()) {
-    return OwnershipConstraint::any();
+    return OperandOwnership::None;
   }
-
-  return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
+  return OperandOwnership::DestroyingConsume;
 }
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitStoreInst(StoreInst *i) {
-  if (getValue() != i->getSrc()) {
-    return OwnershipConstraint::any();
-  }
-
-  return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
-}
-
-OwnershipConstraint
-OwnershipConstraintClassifier::visitCopyBlockWithoutEscapingInst(
+OperandOwnership OperandOwnershipClassifier::visitCopyBlockWithoutEscapingInst(
     CopyBlockWithoutEscapingInst *i) {
   // Consumes the closure parameter.
   if (getValue() == i->getClosure()) {
-    return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
+    return OperandOwnership::ForwardingConsume;
   }
-
-  return OwnershipConstraint::any();
+  return OperandOwnership::InstantaneousUse;
 }
 
-OwnershipConstraint OwnershipConstraintClassifier::visitMarkDependenceInst(
-    MarkDependenceInst *mdi) {
+OperandOwnership
+OperandOwnershipClassifier::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   // If we are analyzing "the value", we forward ownership.
   if (getValue() == mdi->getValue()) {
-    auto kind = mdi->getOwnershipKind();
-    if (kind == OwnershipKind::None)
-      return OwnershipConstraint::any();
-    auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();
-    return {kind, lifetimeConstraint};
+    return getOwnershipKind().getForwardingOperandOwnership();
   }
-
-  // If we are not the "value" of the mark_dependence, then we must be the
-  // "base". This means that any use that would destroy "value" can not be moved
-  // before any uses of "base". We treat this as non-consuming and rely on the
-  // rest of the optimizer to respect the movement restrictions.
-  return OwnershipConstraint::any();
+  // FIXME: Add an end_dependence instruction so we can treat mark_dependence as
+  // a borrow of the base (mark_dependence %base -> end_dependence is analogous
+  // to a borrow scope).
+  return OperandOwnership::PointerEscape;
 }
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitKeyPathInst(KeyPathInst *I) {
+OperandOwnership OperandOwnershipClassifier::visitKeyPathInst(KeyPathInst *I) {
   // KeyPath moves the value in memory out of address operands, but the
   // ownership checker doesn't reason about that yet.
-  return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
+  return OperandOwnership::ForwardingConsume;
 }
 
 //===----------------------------------------------------------------------===//
@@ -688,205 +503,204 @@ OwnershipConstraintClassifier::visitKeyPathInst(KeyPathInst *I) {
 
 namespace {
 
-struct OperandOwnershipKindBuiltinClassifier
-    : SILBuiltinVisitor<OperandOwnershipKindBuiltinClassifier,
-                        OwnershipConstraint> {
-  using Map = OwnershipConstraint;
+struct OperandOwnershipBuiltinClassifier
+    : SILBuiltinVisitor<OperandOwnershipBuiltinClassifier, OperandOwnership> {
+  using Map = OperandOwnership;
 
-  OwnershipConstraint visitLLVMIntrinsic(BuiltinInst *bi,
-                                         llvm::Intrinsic::ID id) {
+  OperandOwnership visitLLVMIntrinsic(BuiltinInst *bi, llvm::Intrinsic::ID id) {
     // LLVM intrinsics do not traffic in ownership, so if we have a result, it
     // must be trivial.
-    return OwnershipConstraint::any();
+    return OperandOwnership::None;
   }
 
   // BUILTIN_TYPE_CHECKER_OPERATION does not live past the type checker.
 #define BUILTIN_TYPE_CHECKER_OPERATION(ID, NAME)
 
 #define BUILTIN(ID, NAME, ATTRS)                                               \
-  OwnershipConstraint visit##ID(BuiltinInst *bi, StringRef attr);
+  OperandOwnership visit##ID(BuiltinInst *bi, StringRef attr);
 #include "swift/AST/Builtins.def"
 
-  OwnershipConstraint check(BuiltinInst *bi) { return visit(bi); }
+  OperandOwnership check(BuiltinInst *bi) { return visit(bi); }
 };
 
 } // end anonymous namespace
 
-#define ANY_OWNERSHIP_BUILTIN(ID)                                              \
-  OwnershipConstraint OperandOwnershipKindBuiltinClassifier::visit##ID(        \
-      BuiltinInst *, StringRef) {                                              \
-    return OwnershipConstraint::any();                                         \
+#define BUILTIN_OPERAND_OWNERSHIP(OWNERSHIP, ID)                               \
+  OperandOwnership                                                             \
+  OperandOwnershipBuiltinClassifier::visit##ID(BuiltinInst *, StringRef) {     \
+    return OperandOwnership::OWNERSHIP;                                        \
   }
-ANY_OWNERSHIP_BUILTIN(ErrorInMain)
-ANY_OWNERSHIP_BUILTIN(UnexpectedError)
-ANY_OWNERSHIP_BUILTIN(WillThrow)
-ANY_OWNERSHIP_BUILTIN(AShr)
-ANY_OWNERSHIP_BUILTIN(GenericAShr)
-ANY_OWNERSHIP_BUILTIN(Add)
-ANY_OWNERSHIP_BUILTIN(GenericAdd)
-ANY_OWNERSHIP_BUILTIN(Alignof)
-ANY_OWNERSHIP_BUILTIN(AllocRaw)
-ANY_OWNERSHIP_BUILTIN(And)
-ANY_OWNERSHIP_BUILTIN(GenericAnd)
-ANY_OWNERSHIP_BUILTIN(AssertConf)
-ANY_OWNERSHIP_BUILTIN(AssignCopyArrayNoAlias)
-ANY_OWNERSHIP_BUILTIN(AssignCopyArrayFrontToBack)
-ANY_OWNERSHIP_BUILTIN(AssignCopyArrayBackToFront)
-ANY_OWNERSHIP_BUILTIN(AssignTakeArray)
-ANY_OWNERSHIP_BUILTIN(AssumeNonNegative)
-ANY_OWNERSHIP_BUILTIN(AssumeTrue)
-ANY_OWNERSHIP_BUILTIN(AtomicLoad)
-ANY_OWNERSHIP_BUILTIN(AtomicRMW)
-ANY_OWNERSHIP_BUILTIN(AtomicStore)
-ANY_OWNERSHIP_BUILTIN(BitCast)
-ANY_OWNERSHIP_BUILTIN(CanBeObjCClass)
-ANY_OWNERSHIP_BUILTIN(CondFailMessage)
-ANY_OWNERSHIP_BUILTIN(CmpXChg)
-ANY_OWNERSHIP_BUILTIN(CondUnreachable)
-ANY_OWNERSHIP_BUILTIN(CopyArray)
-ANY_OWNERSHIP_BUILTIN(DeallocRaw)
-ANY_OWNERSHIP_BUILTIN(DestroyArray)
-ANY_OWNERSHIP_BUILTIN(ExactSDiv)
-ANY_OWNERSHIP_BUILTIN(GenericExactSDiv)
-ANY_OWNERSHIP_BUILTIN(ExactUDiv)
-ANY_OWNERSHIP_BUILTIN(GenericExactUDiv)
-ANY_OWNERSHIP_BUILTIN(ExtractElement)
-ANY_OWNERSHIP_BUILTIN(FAdd)
-ANY_OWNERSHIP_BUILTIN(GenericFAdd)
-ANY_OWNERSHIP_BUILTIN(FCMP_OEQ)
-ANY_OWNERSHIP_BUILTIN(FCMP_OGE)
-ANY_OWNERSHIP_BUILTIN(FCMP_OGT)
-ANY_OWNERSHIP_BUILTIN(FCMP_OLE)
-ANY_OWNERSHIP_BUILTIN(FCMP_OLT)
-ANY_OWNERSHIP_BUILTIN(FCMP_ONE)
-ANY_OWNERSHIP_BUILTIN(FCMP_ORD)
-ANY_OWNERSHIP_BUILTIN(FCMP_UEQ)
-ANY_OWNERSHIP_BUILTIN(FCMP_UGE)
-ANY_OWNERSHIP_BUILTIN(FCMP_UGT)
-ANY_OWNERSHIP_BUILTIN(FCMP_ULE)
-ANY_OWNERSHIP_BUILTIN(FCMP_ULT)
-ANY_OWNERSHIP_BUILTIN(FCMP_UNE)
-ANY_OWNERSHIP_BUILTIN(FCMP_UNO)
-ANY_OWNERSHIP_BUILTIN(FDiv)
-ANY_OWNERSHIP_BUILTIN(GenericFDiv)
-ANY_OWNERSHIP_BUILTIN(FMul)
-ANY_OWNERSHIP_BUILTIN(GenericFMul)
-ANY_OWNERSHIP_BUILTIN(FNeg)
-ANY_OWNERSHIP_BUILTIN(FPExt)
-ANY_OWNERSHIP_BUILTIN(FPToSI)
-ANY_OWNERSHIP_BUILTIN(FPToUI)
-ANY_OWNERSHIP_BUILTIN(FPTrunc)
-ANY_OWNERSHIP_BUILTIN(FRem)
-ANY_OWNERSHIP_BUILTIN(GenericFRem)
-ANY_OWNERSHIP_BUILTIN(FSub)
-ANY_OWNERSHIP_BUILTIN(GenericFSub)
-ANY_OWNERSHIP_BUILTIN(Fence)
-ANY_OWNERSHIP_BUILTIN(GetObjCTypeEncoding)
-ANY_OWNERSHIP_BUILTIN(ICMP_EQ)
-ANY_OWNERSHIP_BUILTIN(ICMP_NE)
-ANY_OWNERSHIP_BUILTIN(ICMP_SGE)
-ANY_OWNERSHIP_BUILTIN(ICMP_SGT)
-ANY_OWNERSHIP_BUILTIN(ICMP_SLE)
-ANY_OWNERSHIP_BUILTIN(ICMP_SLT)
-ANY_OWNERSHIP_BUILTIN(ICMP_UGE)
-ANY_OWNERSHIP_BUILTIN(ICMP_UGT)
-ANY_OWNERSHIP_BUILTIN(ICMP_ULE)
-ANY_OWNERSHIP_BUILTIN(ICMP_ULT)
-ANY_OWNERSHIP_BUILTIN(InsertElement)
-ANY_OWNERSHIP_BUILTIN(IntToFPWithOverflow)
-ANY_OWNERSHIP_BUILTIN(IntToPtr)
-ANY_OWNERSHIP_BUILTIN(IsOptionalType)
-ANY_OWNERSHIP_BUILTIN(IsPOD)
-ANY_OWNERSHIP_BUILTIN(IsConcrete)
-ANY_OWNERSHIP_BUILTIN(IsBitwiseTakable)
-ANY_OWNERSHIP_BUILTIN(IsSameMetatype)
-ANY_OWNERSHIP_BUILTIN(LShr)
-ANY_OWNERSHIP_BUILTIN(GenericLShr)
-ANY_OWNERSHIP_BUILTIN(Mul)
-ANY_OWNERSHIP_BUILTIN(GenericMul)
-ANY_OWNERSHIP_BUILTIN(OnFastPath)
-ANY_OWNERSHIP_BUILTIN(Once)
-ANY_OWNERSHIP_BUILTIN(OnceWithContext)
-ANY_OWNERSHIP_BUILTIN(Or)
-ANY_OWNERSHIP_BUILTIN(GenericOr)
-ANY_OWNERSHIP_BUILTIN(PtrToInt)
-ANY_OWNERSHIP_BUILTIN(SAddOver)
-ANY_OWNERSHIP_BUILTIN(SDiv)
-ANY_OWNERSHIP_BUILTIN(GenericSDiv)
-ANY_OWNERSHIP_BUILTIN(SExt)
-ANY_OWNERSHIP_BUILTIN(SExtOrBitCast)
-ANY_OWNERSHIP_BUILTIN(SIToFP)
-ANY_OWNERSHIP_BUILTIN(SMulOver)
-ANY_OWNERSHIP_BUILTIN(SRem)
-ANY_OWNERSHIP_BUILTIN(GenericSRem)
-ANY_OWNERSHIP_BUILTIN(SSubOver)
-ANY_OWNERSHIP_BUILTIN(SToSCheckedTrunc)
-ANY_OWNERSHIP_BUILTIN(SToUCheckedTrunc)
-ANY_OWNERSHIP_BUILTIN(Expect)
-ANY_OWNERSHIP_BUILTIN(Shl)
-ANY_OWNERSHIP_BUILTIN(GenericShl)
-ANY_OWNERSHIP_BUILTIN(Sizeof)
-ANY_OWNERSHIP_BUILTIN(StaticReport)
-ANY_OWNERSHIP_BUILTIN(Strideof)
-ANY_OWNERSHIP_BUILTIN(StringObjectOr)
-ANY_OWNERSHIP_BUILTIN(Sub)
-ANY_OWNERSHIP_BUILTIN(GenericSub)
-ANY_OWNERSHIP_BUILTIN(TakeArrayNoAlias)
-ANY_OWNERSHIP_BUILTIN(TakeArrayBackToFront)
-ANY_OWNERSHIP_BUILTIN(TakeArrayFrontToBack)
-ANY_OWNERSHIP_BUILTIN(Trunc)
-ANY_OWNERSHIP_BUILTIN(TruncOrBitCast)
-ANY_OWNERSHIP_BUILTIN(TSanInoutAccess)
-ANY_OWNERSHIP_BUILTIN(UAddOver)
-ANY_OWNERSHIP_BUILTIN(UDiv)
-ANY_OWNERSHIP_BUILTIN(GenericUDiv)
-ANY_OWNERSHIP_BUILTIN(UIToFP)
-ANY_OWNERSHIP_BUILTIN(UMulOver)
-ANY_OWNERSHIP_BUILTIN(URem)
-ANY_OWNERSHIP_BUILTIN(GenericURem)
-ANY_OWNERSHIP_BUILTIN(USubOver)
-ANY_OWNERSHIP_BUILTIN(UToSCheckedTrunc)
-ANY_OWNERSHIP_BUILTIN(UToUCheckedTrunc)
-ANY_OWNERSHIP_BUILTIN(Unreachable)
-ANY_OWNERSHIP_BUILTIN(UnsafeGuaranteedEnd)
-ANY_OWNERSHIP_BUILTIN(Xor)
-ANY_OWNERSHIP_BUILTIN(GenericXor)
-ANY_OWNERSHIP_BUILTIN(ZExt)
-ANY_OWNERSHIP_BUILTIN(ZExtOrBitCast)
-ANY_OWNERSHIP_BUILTIN(ZeroInitializer)
-ANY_OWNERSHIP_BUILTIN(Swift3ImplicitObjCEntrypoint)
-ANY_OWNERSHIP_BUILTIN(PoundAssert)
-ANY_OWNERSHIP_BUILTIN(GlobalStringTablePointer)
-ANY_OWNERSHIP_BUILTIN(TypePtrAuthDiscriminator)
-ANY_OWNERSHIP_BUILTIN(IntInstrprofIncrement)
-#undef ANY_OWNERSHIP_BUILTIN
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ErrorInMain)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UnexpectedError)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, WillThrow)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AShr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericAShr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Add)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericAdd)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Alignof)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AllocRaw)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, And)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericAnd)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssertConf)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssignCopyArrayNoAlias)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssignCopyArrayFrontToBack)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssignCopyArrayBackToFront)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssignTakeArray)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssumeNonNegative)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AssumeTrue)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AtomicLoad)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AtomicRMW)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AtomicStore)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, BitCast)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CanBeObjCClass)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CondFailMessage)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CmpXChg)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CondUnreachable)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CopyArray)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, DeallocRaw)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, DestroyArray)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ExactSDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericExactSDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ExactUDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericExactUDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ExtractElement)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FAdd)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericFAdd)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_OEQ)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_OGE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_OGT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_OLE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_OLT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_ONE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_ORD)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_UEQ)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_UGE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_UGT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_ULE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_ULT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_UNE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FCMP_UNO)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericFDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FMul)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericFMul)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FNeg)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FPExt)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FPToSI)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FPToUI)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FPTrunc)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FRem)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericFRem)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, FSub)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericFSub)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Fence)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GetObjCTypeEncoding)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_EQ)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_NE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_SGE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_SGT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_SLE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_SLT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_UGE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_UGT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_ULE)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ICMP_ULT)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, InsertElement)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IntToFPWithOverflow)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IntToPtr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IsOptionalType)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IsPOD)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IsConcrete)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IsBitwiseTakable)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IsSameMetatype)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, LShr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericLShr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Mul)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericMul)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, OnFastPath)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Once)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, OnceWithContext)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Or)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericOr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, PtrToInt)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SAddOver)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericSDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SExt)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SExtOrBitCast)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SIToFP)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SMulOver)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SRem)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericSRem)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SSubOver)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SToSCheckedTrunc)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, SToUCheckedTrunc)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Expect)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Shl)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericShl)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Sizeof)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, StaticReport)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Strideof)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, StringObjectOr)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Sub)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericSub)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TakeArrayNoAlias)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TakeArrayBackToFront)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TakeArrayFrontToBack)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Trunc)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TruncOrBitCast)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TSanInoutAccess)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UAddOver)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericUDiv)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UIToFP)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UMulOver)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, URem)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericURem)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, USubOver)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UToSCheckedTrunc)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UToUCheckedTrunc)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Unreachable)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, UnsafeGuaranteedEnd)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Xor)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GenericXor)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ZExt)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ZExtOrBitCast)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, ZeroInitializer)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, Swift3ImplicitObjCEntrypoint)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, PoundAssert)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GlobalStringTablePointer)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TypePtrAuthDiscriminator)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IntInstrprofIncrement)
 
-// This is correct today since we do not have any builtins which return
-// @guaranteed parameters. This means that we can only have a lifetime ending
-// use with our builtins if it is owned.
-#define CONSTANT_OWNERSHIP_BUILTIN(OWNERSHIP, USE_LIFETIME_CONSTRAINT, ID)     \
-  OwnershipConstraint OperandOwnershipKindBuiltinClassifier::visit##ID(        \
-      BuiltinInst *, StringRef) {                                              \
-    return {OwnershipKind::OWNERSHIP,                                          \
-            UseLifetimeConstraint::USE_LIFETIME_CONSTRAINT};                   \
-  }
-CONSTANT_OWNERSHIP_BUILTIN(Owned, LifetimeEnding, COWBufferForReading)
-CONSTANT_OWNERSHIP_BUILTIN(Owned, LifetimeEnding, UnsafeGuaranteed)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, CancelAsyncTask)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, CreateAsyncTask)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, CreateAsyncTaskFuture)
-CONSTANT_OWNERSHIP_BUILTIN(None, NonLifetimeEnding, AutoDiffCreateLinearMapContext)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, AutoDiffAllocateSubcontext)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, AutoDiffProjectTopLevelSubcontext)
-CONSTANT_OWNERSHIP_BUILTIN(Owned, LifetimeEnding, ConvertTaskToJob)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, InitializeDefaultActor)
-CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, NonLifetimeEnding, DestroyDefaultActor)
+BUILTIN_OPERAND_OWNERSHIP(ForwardingConsume, COWBufferForReading)
+BUILTIN_OPERAND_OWNERSHIP(ForwardingConsume, UnsafeGuaranteed)
 
-#undef CONSTANT_OWNERSHIP_BUILTIN
+// FIXME: These are considered InteriorPointer because they may propagate a
+// pointer into a borrowed values. If they do not propagate an interior pointer,
+// then they should be InstantaneousUse instead and should not require a
+// guaranteed value.
+BUILTIN_OPERAND_OWNERSHIP(InteriorPointer, CancelAsyncTask)
+BUILTIN_OPERAND_OWNERSHIP(InteriorPointer, CreateAsyncTask)
+BUILTIN_OPERAND_OWNERSHIP(InteriorPointer, CreateAsyncTaskFuture)
+BUILTIN_OPERAND_OWNERSHIP(InteriorPointer, InitializeDefaultActor)
+BUILTIN_OPERAND_OWNERSHIP(InteriorPointer, DestroyDefaultActor)
+
+// FIXME: Why do these reqiuire a borrowed value at all?
+BUILTIN_OPERAND_OWNERSHIP(ForwardingBorrow, AutoDiffAllocateSubcontext)
+BUILTIN_OPERAND_OWNERSHIP(ForwardingBorrow, AutoDiffProjectTopLevelSubcontext)
+
+// FIXME: ConvertTaskToJob is documented as taking NativePointer. It's operand's
+// ownership should be 'None'.
+BUILTIN_OPERAND_OWNERSHIP(ForwardingConsume, ConvertTaskToJob)
+
+BUILTIN_OPERAND_OWNERSHIP(None, AutoDiffCreateLinearMapContext)
+
+#undef BUILTIN_OPERAND_OWNERSHIP
 
 #define SHOULD_NEVER_VISIT_BUILTIN(ID)                                         \
-  OwnershipConstraint OperandOwnershipKindBuiltinClassifier::visit##ID(        \
-      BuiltinInst *, StringRef) {                                              \
+  OperandOwnership                                                             \
+  OperandOwnershipBuiltinClassifier::visit##ID(BuiltinInst *, StringRef) {     \
     llvm_unreachable(                                                          \
         "Builtin should never be visited! E.x.: It may not have arguments");   \
   }
@@ -896,23 +710,22 @@ SHOULD_NEVER_VISIT_BUILTIN(GetCurrentAsyncTask)
 // Builtins that should be lowered to SIL instructions so we should never see
 // them.
 #define BUILTIN_SIL_OPERATION(ID, NAME, CATEGORY)                              \
-  OwnershipConstraint OperandOwnershipKindBuiltinClassifier::visit##ID(        \
-      BuiltinInst *, StringRef) {                                              \
+  OperandOwnership                                                             \
+  OperandOwnershipBuiltinClassifier::visit##ID(BuiltinInst *, StringRef) {     \
     llvm_unreachable("Builtin should have been lowered to SIL instruction?!"); \
   }
 #define BUILTIN(X, Y, Z)
 #include "swift/AST/Builtins.def"
 
-OwnershipConstraint
-OwnershipConstraintClassifier::visitBuiltinInst(BuiltinInst *bi) {
-  return OperandOwnershipKindBuiltinClassifier().check(bi);
+OperandOwnership OperandOwnershipClassifier::visitBuiltinInst(BuiltinInst *bi) {
+  return OperandOwnershipBuiltinClassifier().check(bi);
 }
 
 //===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
-Optional<OwnershipConstraint> Operand::getOwnershipConstraint() const {
+Optional<OperandOwnership> Operand::getOperandOwnership() const {
   if (isTypeDependent())
     return None;
 
@@ -925,16 +738,13 @@ Optional<OwnershipConstraint> Operand::getOwnershipConstraint() const {
          "Can not lookup ownership constraint unless inserted into block");
   if (auto *block = getUser()->getParent()) {
     auto *func = block->getParent();
-    if (!func) {
-      // If we don't have a function, then we must have a SILGlobalVariable. In
-      // that case, we act as if we aren't in ownership.
-      return {{OwnershipKind::Any, UseLifetimeConstraint::NonLifetimeEnding}};
+    // If we don't have a function, then we must have a SILGlobalVariable. In
+    // that case, we act as if we aren't in ownership.
+    if (!func || !func->hasOwnership()) {
+      return OperandOwnership::InstantaneousUse;
     }
-
-    if (!func->hasOwnership())
-      return {{OwnershipKind::Any, UseLifetimeConstraint::NonLifetimeEnding}};
   }
 
-  OwnershipConstraintClassifier classifier(getUser()->getModule(), *this);
+  OperandOwnershipClassifier classifier(getUser()->getModule(), *this);
   return classifier.visit(const_cast<SILInstruction *>(getUser()));
 }

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -327,19 +327,6 @@ bool Operand::canAcceptKind(ValueOwnershipKind kind) const {
   if (constraint->satisfiesConstraint(kind))
     return true;
 
-  // Then see if our preferred ownership constraint was not guaranteed or our
-  // use lifetime constraint was LifetimeEnding. If it wasn't, then we fail
-  // since we do not allow for implicit borrows in such situations.
-  if (kind == OwnershipKind::Owned && !isLifetimeEnding()) {
-    // Otherwise, we now know that our constraint is non lifetime ending
-    // and guaranteed and our value had owned ownership. If our user
-    // allows for implicit borrows and thus can accept owned values,
-    // return true.
-    if (auto borrowingOperand = BorrowingOperand::get(this))
-      if (borrowingOperand->canAcceptOwnedValues())
-        return true;
-  }
-
   return false;
 }
 
@@ -380,4 +367,50 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
                "Kind:" << constraint.getPreferredKind()
             << " LifetimeConstraint:" << constraint.getLifetimeConstraint()
             << ">";
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     OperandOwnership operandOwnership) {
+  switch (operandOwnership) {
+  case OperandOwnership::None:
+    os << "none";
+    break;
+  case OperandOwnership::InstantaneousUse:
+    os << "instantaneous";
+    break;
+  case OperandOwnership::PointerEscape:
+    os << "pointer-escape";
+    break;
+  case OperandOwnership::BitwiseEscape:
+    os << "bitwise-escape";
+    break;
+  case OperandOwnership::ForwardingUnowned:
+    os << "bitwise-escape";
+    break;
+  case OperandOwnership::Borrow:
+    os << "borrow";
+    break;
+  case OperandOwnership::DestroyingConsume:
+    os << "destroying-consume";
+    break;
+  case OperandOwnership::ForwardingConsume:
+    os << "forwarding-consume";
+    break;
+  case OperandOwnership::NestedBorrow:
+    os << "nested-borrow";
+    break;
+  case OperandOwnership::InteriorPointer:
+    os << "interior-pointer";
+    break;
+  case OperandOwnership::ForwardingBorrow:
+    os << "forwarded-borrow";
+    break;
+  case OperandOwnership::EndBorrow:
+    os << "end-borrow";
+    break;
+  case OperandOwnership::Reborrow:
+    os << "reborrow";
+    break;
+  }
+  return os;
 }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -26,6 +26,8 @@ bool swift::isValueAddressOrTrivial(SILValue v) {
 }
 
 // These operations forward both owned and guaranteed ownership.
+//
+// FIXME: Should be implemented as a SILInstruction type check-cast.
 static bool isOwnershipForwardingValueKind(SILNodeKind kind) {
   switch (kind) {
   case SILNodeKind::TupleInst:
@@ -71,45 +73,7 @@ static bool isGuaranteedForwardingValueKind(SILNodeKind kind) {
   }
 }
 
-static bool isOwnedForwardingValueKind(SILNodeKind kind) {
-  switch (kind) {
-  case SILNodeKind::MarkUninitializedInst:
-    return true;
-  default:
-    return isOwnershipForwardingValueKind(kind);
-  }
-}
-
-bool swift::isOwnedForwardingUse(Operand *op) {
-  auto *user = op->getUser();
-  auto kind = user->getKind();
-  bool result = isOwnershipForwardingValueKind(SILNodeKind(kind));
-  if (result) {
-    assert(!isa<GuaranteedFirstArgForwardingSingleValueInst>(user));
-    assert(isa<OwnershipForwardingInst>(user));
-  }
-  return result;
-}
-
-bool swift::isOwnedForwardingValue(SILValue value) {
-  // If we have a SILArgument and we are the successor block of a transforming
-  // terminator, we are fine.
-  if (auto *arg = dyn_cast<SILPhiArgument>(value))
-    if (auto *predTerm = arg->getSingleTerminator())
-      if (predTerm->isTransformationTerminator()) {
-        assert(isa<OwnershipForwardingInst>(predTerm));
-        return true;
-      }
-  auto *node = value->getRepresentativeSILNodeInObject();
-  bool result = isOwnedForwardingValueKind(node->getKind());
-  if (result) {
-    assert(!isa<GuaranteedFirstArgForwardingSingleValueInst>(node));
-    assert(isa<OwnershipForwardingInst>(node));
-  }
-  return result;
-}
-
-bool swift::isGuaranteedForwardingValue(SILValue value) {
+bool swift::canOpcodeForwardGuaranteedValues(SILValue value) {
   // If we have an argument from a transforming terminator, we can forward
   // guaranteed.
   if (auto *arg = dyn_cast<SILArgument>(value))
@@ -128,18 +92,45 @@ bool swift::isGuaranteedForwardingValue(SILValue value) {
   return result;
 }
 
-bool swift::isGuaranteedForwardingUse(Operand *use) {
+bool swift::canOpcodeForwardGuaranteedValues(Operand *use) {
   auto *user = use->getUser();
-  auto kind = SILNodeKind(user->getKind());
-  bool result = isGuaranteedForwardingValueKind(kind);
+  auto kind = user->getKind();
+  bool result = isOwnershipForwardingValueKind(SILNodeKind(kind));
   if (result) {
-    assert(!isa<OwnedFirstArgForwardingSingleValueInst>(user));
+    assert(!isa<GuaranteedFirstArgForwardingSingleValueInst>(user));
     assert(isa<OwnershipForwardingInst>(user));
   }
   return result;
 }
 
-bool swift::isOwnershipForwardingUse(Operand *use) {
+static bool isOwnedForwardingValueKind(SILNodeKind kind) {
+  switch (kind) {
+  case SILNodeKind::MarkUninitializedInst:
+    return true;
+  default:
+    return isOwnershipForwardingValueKind(kind);
+  }
+}
+
+bool swift::canOpcodeForwardOwnedValues(SILValue value) {
+  // If we have a SILArgument and we are the successor block of a transforming
+  // terminator, we are fine.
+  if (auto *arg = dyn_cast<SILPhiArgument>(value))
+    if (auto *predTerm = arg->getSingleTerminator())
+      if (predTerm->isTransformationTerminator()) {
+        assert(isa<OwnershipForwardingInst>(predTerm));
+        return true;
+      }
+  auto *node = value->getRepresentativeSILNodeInObject();
+  bool result = isOwnedForwardingValueKind(node->getKind());
+  if (result) {
+    assert(!isa<GuaranteedFirstArgForwardingSingleValueInst>(node));
+    assert(isa<OwnershipForwardingInst>(node));
+  }
+  return result;
+}
+
+bool swift::canOpcodeForwardOwnedValues(Operand *use) {
   auto *user = use->getUser();
   auto kind = SILNodeKind(user->getKind());
   bool result = isOwnershipForwardingValueKind(kind);
@@ -699,7 +690,7 @@ bool swift::getAllBorrowIntroducingValues(SILValue inputValue,
 
     // Otherwise if v is an ownership forwarding value, add its defining
     // instruction
-    if (isGuaranteedForwardingValue(value)) {
+    if (isForwardingBorrow(value)) {
       if (auto *i = value->getDefiningInstruction()) {
         llvm::copy(i->getOperandValues(true /*skip type dependent ops*/),
                    std::back_inserter(worklist));
@@ -740,7 +731,7 @@ swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
 
     // Otherwise if v is an ownership forwarding value, add its defining
     // instruction
-    if (isGuaranteedForwardingValue(currentValue)) {
+    if (isForwardingBorrow(currentValue)) {
       if (auto *i = currentValue->getDefiningInstruction()) {
         auto instOps = i->getOperandValues(true /*ignore type dependent ops*/);
         // If we have multiple incoming values, return .None. We can't handle
@@ -799,7 +790,7 @@ bool swift::getAllOwnedValueIntroducers(
 
     // Otherwise if v is an ownership forwarding value, add its defining
     // instruction
-    if (isOwnedForwardingValue(value)) {
+    if (isForwardingConsume(value)) {
       if (auto *i = value->getDefiningInstruction()) {
         llvm::copy(i->getOperandValues(true /*skip type dependent ops*/),
                    std::back_inserter(worklist));
@@ -840,7 +831,7 @@ swift::getSingleOwnedValueIntroducer(SILValue inputValue) {
 
     // Otherwise if v is an ownership forwarding value, add its defining
     // instruction
-    if (isOwnedForwardingValue(currentValue)) {
+    if (isForwardingConsume(currentValue)) {
       if (auto *i = currentValue->getDefiningInstruction()) {
         auto instOps = i->getOperandValues(true /*ignore type dependent ops*/);
         // If we have multiple incoming values, return .None. We can't handle
@@ -882,11 +873,29 @@ Optional<ForwardingOperand> ForwardingOperand::get(Operand *use) {
   if (use->isTypeDependent())
     return None;
 
-  if (isa<OwnershipForwardingInst>(use->getUser())) {
-    return {use};
+  if (!isa<OwnershipForwardingInst>(use->getUser())) {
+    return None;
   }
-
-  return None;
+#ifndef NDEBUG
+  switch (use->getOperandOwnership().getValue()) {
+  case OperandOwnership::None:
+  case OperandOwnership::ForwardingUnowned:
+  case OperandOwnership::ForwardingConsume:
+  case OperandOwnership::ForwardingBorrow:
+    break;
+  case OperandOwnership::InstantaneousUse:
+  case OperandOwnership::PointerEscape:
+  case OperandOwnership::BitwiseEscape:
+  case OperandOwnership::Borrow:
+  case OperandOwnership::DestroyingConsume:
+  case OperandOwnership::NestedBorrow:
+  case OperandOwnership::InteriorPointer:
+  case OperandOwnership::EndBorrow:
+  case OperandOwnership::Reborrow:
+    llvm_unreachable("this isn't the operand being forwarding!");
+  }
+#endif
+  return {use};
 }
 
 ValueOwnershipKind ForwardingOperand::getOwnershipKind() const {
@@ -1028,7 +1037,6 @@ void ForwardingOperand::replaceOwnershipKind(ValueOwnershipKind oldKind,
 }
 
 SILValue ForwardingOperand::getSingleForwardedValue() const {
-  assert(isGuaranteedForwardingUse(use));
   if (auto *svi = dyn_cast<SingleValueInstruction>(use->getUser()))
     return svi;
   return SILValue();
@@ -1037,8 +1045,6 @@ SILValue ForwardingOperand::getSingleForwardedValue() const {
 bool ForwardingOperand::visitForwardedValues(
     function_ref<bool(SILValue)> visitor) {
   auto *user = use->getUser();
-
-  assert(isGuaranteedForwardingUse(use));
 
   // See if we have a single value instruction... if we do that is always the
   // transitive result.

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -290,7 +290,7 @@ bool SILValueOwnershipChecker::gatherUsers(
   // this value forwards guaranteed ownership. In such a case, we are going to
   // validate it as part of the borrow introducer from which the forwarding
   // value originates. So we can just return true and continue.
-  if (isGuaranteedForwardingValue(value))
+  if (isForwardingBorrow(value))
     return true;
 
   // Ok, we have some sort of borrow introducer. We need to recursively validate
@@ -326,7 +326,7 @@ bool SILValueOwnershipChecker::gatherUsers(
     // Example: A guaranteed parameter of a co-routine.
 
     // Now check if we have a non guaranteed forwarding inst...
-    if (!isGuaranteedForwardingUse(op)) {
+    if (op->getOperandOwnership() != OperandOwnership::ForwardingBorrow) {
       // First check if we are visiting an operand that is a consuming use...
       if (op->isLifetimeEnding()) {
         // If its underlying value is our original value, then this is a true
@@ -557,8 +557,8 @@ bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses(
   // Check if we are a guaranteed subobject. In such a case, we should never
   // have lifetime ending uses, since our lifetime is guaranteed by our
   // operand, so there is nothing further to do. So just return true.
-  if (isGuaranteedForwardingValue(value) &&
-      value.getOwnershipKind() == OwnershipKind::Guaranteed)
+  if (value.getOwnershipKind() == OwnershipKind::Guaranteed
+      && isForwardingBorrow(value))
     return true;
 
   // If we have an unowned value, then again there is nothing left to do.
@@ -676,8 +676,8 @@ bool SILValueOwnershipChecker::checkUses() {
   // Check if we are an instruction that forwards forwards guaranteed
   // ownership. In such a case, we are a subobject projection. We should not
   // have any lifetime ending uses.
-  if (isGuaranteedForwardingValue(value) &&
-      value.getOwnershipKind() == OwnershipKind::Guaranteed) {
+  if (value.getOwnershipKind() == OwnershipKind::Guaranteed
+      && isForwardingBorrow(value)) {
     if (!isSubobjectProjectionWithLifetimeEndingUses(value,
                                                      lifetimeEndingUsers)) {
       return false;

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -72,7 +72,7 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
     // support it though if we need to.
     auto *ti = dyn_cast<TermInst>(user);
     if ((ti && !ti->isTransformationTerminator()) ||
-        !isGuaranteedForwardingUse(op) ||
+        !canOpcodeForwardGuaranteedValues(op) ||
         1 != count_if(user->getOperandValues(
                           true /*ignore type dependent operands*/),
                       [&](SILValue v) {


### PR DESCRIPTION
Migrating to this classification was made easy by the recent rewrite
of the OSSA constraint model. It's also consistent with
instruction-level abstractions for working with different kinds of
OperandOwnership that are being designed.

This classification vastly simplifies OSSA passes that rewrite OSSA
live ranges, making it straightforward to reason about completeness
and correctness. It will allow a simple utility to canonicalize OSSA
live ranges on-the-fly.

This avoids the need for OSSA-based utilities and passes to hard-code
SIL opcodes. This will allow several of those unmaintainable pieces of
code to be replaces with a trivial OperandOwnership check.

It's extremely important for SIL maintainers to see a list of all SIL
opcodes associated with a simply OSSA classification and set of
well-specified rules for each opcode class, without needing to guess
or reverse-engineer the meaning from the implementation. This
classification does that while eliminating a pile of unreadable
macros.

This classification system is the model that CopyPropagation was
initially designed to use. Now, rather than relying on a separate
pass, an extremely simple, lightweight utility will canonicalize OSSA
live ranges.

The major problem with writing optimizations based on OperandOwnership
is that some operations don't follow structural OSSA requirements,
such as project_box and unchecked_ownership_conversion. Those are
classified as PointerEscape which prevents the compiler from reasoning
about, or rewriting the OSSA live range.

Functional Changes:

As a side effect, this corrects many operand constraints that should in fact require trivial operand values.
