### PR TITLE
[ownership] Do not insert an end_borrow when calling emitEndBorrowOperation on a value with OwnershipKind::None.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -782,7 +782,7 @@ public:
   }
 
   void emitEndBorrowOperation(SILLocation loc, SILValue v) {
-    if (!hasOwnership())
+    if (!hasOwnership() || v.getOwnershipKind() == OwnershipKind::None)
       return;
     createEndBorrow(loc, v);
   }


### PR DESCRIPTION
This is safe to do since our end_borrow isn't returned to our user.
