### PR TITLE
[NFC] Add Compilation::Result

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -82,15 +82,20 @@ public:
   struct Result {
     /// Set to true if any job exits abnormally (i.e. crashes).
     bool hadAbnormalExit;
+    /// The exit code of this driver process.
     int exitCode;
+    /// The dependency graph built up during the compilation of this module.
+    ///
+    /// This data is used for cross-module module dependencies.
     fine_grained_dependencies::ModuleDepGraph depGraph;
 
     Result(const Result &) = delete;
-    Result(Result &&) = default;
-
     Result &operator=(const Result &) = delete;
+
+    Result(Result &&) = default;
     Result &operator=(Result &&) = default;
 
+    /// Construct a \c Compilation::Result from just an exit code.
     static Result code(int code) {
       return Compilation::Result{false, code,
                                  fine_grained_dependencies::ModuleDepGraph()};

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -84,6 +84,12 @@ public:
     bool hadAbnormalExit;
     int exitCode;
     fine_grained_dependencies::ModuleDepGraph depGraph;
+
+    Result(const Result &) = delete;
+    Result(Result &&) = default;
+
+    Result &operator=(const Result &) = delete;
+    Result &operator=(Result &&) = default;
   };
 
   class IncrementalSchemeComparator {

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -80,6 +80,8 @@ using CommandSet = llvm::SmallPtrSet<const Job *, 16>;
 class Compilation {
 public:
   struct Result {
+    /// Set to true if any job exits abnormally (i.e. crashes).
+    bool hadAbnormalExit;
     int exitCode;
     fine_grained_dependencies::ModuleDepGraph depGraph;
   };
@@ -540,14 +542,11 @@ private:
 private:
   /// Perform all jobs.
   ///
-  /// \param[out] abnormalExit Set to true if any job exits abnormally (i.e.
-  /// crashes).
   /// \param TQ The task queue on which jobs will be scheduled.
   ///
   /// \returns exit code of the first failed Job, or 0 on success. If a Job
   /// crashes during execution, a negative value will be returned.
-  Compilation::Result performJobsImpl(bool &abnormalExit,
-                                      std::unique_ptr<sys::TaskQueue> &&TQ);
+  Compilation::Result performJobsImpl(std::unique_ptr<sys::TaskQueue> &&TQ);
 
   /// Performs a single Job by executing in place, if possible.
   ///

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -90,6 +90,11 @@ public:
 
     Result &operator=(const Result &) = delete;
     Result &operator=(Result &&) = default;
+
+    static Result code(int code) {
+      return Compilation::Result{false, code,
+                                 fine_grained_dependencies::ModuleDepGraph()};
+    }
   };
 
   class IncrementalSchemeComparator {

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -24,6 +24,7 @@
 #include "swift/Basic/OutputFileMap.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Driver/Driver.h"
+#include "swift/Driver/FineGrainedDependencyDriverGraph.h"
 #include "swift/Driver/Job.h"
 #include "swift/Driver/Util.h"
 #include "llvm/ADT/StringRef.h"
@@ -78,6 +79,11 @@ using CommandSet = llvm::SmallPtrSet<const Job *, 16>;
 
 class Compilation {
 public:
+  struct Result {
+    int exitCode;
+    fine_grained_dependencies::ModuleDepGraph depGraph;
+  };
+
   class IncrementalSchemeComparator {
     const bool EnableIncrementalBuildWhenConstructed;
     const bool &EnableIncrementalBuild;
@@ -490,7 +496,7 @@ public:
   ///
   /// \returns result code for the Compilation's Jobs; 0 indicates success and
   /// -2 indicates that one of the Compilation's Jobs crashed during execution
-  int performJobs(std::unique_ptr<sys::TaskQueue> &&TQ);
+  Compilation::Result performJobs(std::unique_ptr<sys::TaskQueue> &&TQ);
 
   /// Returns whether the callee is permitted to pass -emit-loaded-module-trace
   /// to a frontend job.
@@ -540,7 +546,8 @@ private:
   ///
   /// \returns exit code of the first failed Job, or 0 on success. If a Job
   /// crashes during execution, a negative value will be returned.
-  int performJobsImpl(bool &abnormalExit, std::unique_ptr<sys::TaskQueue> &&TQ);
+  Compilation::Result performJobsImpl(bool &abnormalExit,
+                                      std::unique_ptr<sys::TaskQueue> &&TQ);
 
   /// Performs a single Job by executing in place, if possible.
   ///
@@ -550,7 +557,7 @@ private:
   /// will no longer exist, or it will call exit() if the program was
   /// successfully executed. In the event of an error, this function will return
   /// a negative value indicating a failure to execute.
-  int performSingleCommand(const Job *Cmd);
+  Compilation::Result performSingleCommand(const Job *Cmd);
 };
 
 } // end namespace driver

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -188,8 +188,8 @@ class ModuleDepGraph {
   std::unordered_map<std::string, unsigned> dotFileSequenceNumber;
 
 public:
-  const bool verifyFineGrainedDependencyGraphAfterEveryImport;
-  const bool emitFineGrainedDependencyDotFileAfterEveryImport;
+  bool verifyFineGrainedDependencyGraphAfterEveryImport;
+  bool emitFineGrainedDependencyDotFileAfterEveryImport;
 
 private:
   /// If tracing dependencies, holds a vector used to hold the current path
@@ -203,7 +203,7 @@ private:
       dependencyPathsToJobs;
 
   /// For helping with performance tuning, may be null:
-  UnifiedStatsReporter *const stats;
+  UnifiedStatsReporter *stats;
 
   //==============================================================================
   // MARK: ModuleDepGraph - mutating dependencies

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -244,7 +244,7 @@ namespace driver {
     std::unique_ptr<TaskQueue> TQ;
 
     /// Cumulative result of PerformJobs(), accumulated from subprocesses.
-    int Result = EXIT_SUCCESS;
+    int ResultCode = EXIT_SUCCESS;
 
     /// True if any Job crashed.
     bool AnyAbnormalExit = false;
@@ -719,8 +719,8 @@ namespace driver {
       // Store this task's ReturnCode as our Result if we haven't stored
       // anything yet.
 
-      if (Result == EXIT_SUCCESS)
-        Result = ReturnCode;
+      if (ResultCode == EXIT_SUCCESS)
+        ResultCode = ReturnCode;
 
       if (!isa<CompileJobAction>(FinishedCmd->getSource()) ||
           ReturnCode != EXIT_FAILURE) {
@@ -825,7 +825,7 @@ namespace driver {
       }
 
       // Since the task signalled, unconditionally set result to -2.
-      Result = -2;
+      ResultCode = -2;
       AnyAbnormalExit = true;
 
       return TaskFinishedResponse::StopExecution;
@@ -1536,7 +1536,7 @@ namespace driver {
                                   _3, _4, _5, _6),
                         std::bind(&PerformJobsState::taskSignalled, this, _1,
                                   _2, _3, _4, _5, _6, _7))) {
-          if (Result == EXIT_SUCCESS) {
+          if (ResultCode == EXIT_SUCCESS) {
             // FIXME: Error from task queue while Result == EXIT_SUCCESS most
             // likely means some fork/exec or posix_spawn failed; TaskQueue saw
             // "an error" at some stage before even calling us with a process
@@ -1546,7 +1546,7 @@ namespace driver {
             Comp.getDiags().diagnose(SourceLoc(),
                                      diag::error_unable_to_execute_command,
                                      "<unknown>");
-            Result = -2;
+            ResultCode = -2;
             AnyAbnormalExit = true;
             return;
           }
@@ -1554,13 +1554,13 @@ namespace driver {
 
         // Returning without error from TaskQueue::execute should mean either an
         // empty TaskQueue or a failed subprocess.
-        assert(!(Result == 0 && TQ->hasRemainingTasks()));
+        assert(!(ResultCode == 0 && TQ->hasRemainingTasks()));
 
         // Task-exit callbacks from TaskQueue::execute may have unblocked jobs,
         // which means there might be PendingExecution jobs to enqueue here. If
         // there are, we need to continue trying to make progress on the
         // TaskQueue before we start marking deferred jobs as skipped, below.
-        if (!PendingExecution.empty() && Result == 0) {
+        if (!PendingExecution.empty() && ResultCode == 0) {
           formBatchJobsAndAddPendingJobsToTaskQueue();
           continue;
         }
@@ -1585,11 +1585,11 @@ namespace driver {
 
         // If we added jobs to the TaskQueue, and we are not in an error state,
         // we want to give the TaskQueue another run.
-      } while (Result == 0 && TQ->hasRemainingTasks());
+      } while (ResultCode == 0 && TQ->hasRemainingTasks());
     }
 
     void checkUnfinishedJobs() {
-      if (Result == 0) {
+      if (ResultCode == 0) {
         assert(BlockingCommands.empty() &&
                "some blocking commands never finished properly");
       } else {
@@ -1693,10 +1693,12 @@ namespace driver {
                            });
     }
 
-    int getResult() {
-      if (Result == 0)
-        Result = Comp.getDiags().hadAnyError();
-      return Result;
+    Compilation::Result takeResult() && {
+      if (ResultCode == 0)
+        ResultCode = Comp.getDiags().hadAnyError();
+      const bool forRanges = Comp.getEnableSourceRangeDependencies();
+      return Compilation::Result{
+          ResultCode, std::move(*this).takeFineGrainedDepGraph(forRanges)};
     }
 
     bool hadAnyAbnormalExit() {
@@ -1755,6 +1757,12 @@ namespace driver {
     const fine_grained_dependencies::ModuleDepGraph &
     getFineGrainedDepGraph(const bool forRanges) const {
       return forRanges ? FineGrainedDepGraphForRanges : FineGrainedDepGraph;
+    }
+
+    fine_grained_dependencies::ModuleDepGraph &&
+    takeFineGrainedDepGraph(const bool forRanges) && {
+      return forRanges ? std::move(FineGrainedDepGraphForRanges)
+                       : std::move(FineGrainedDepGraph);
     }
   };
 } // namespace driver
@@ -1936,8 +1944,9 @@ static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,
   return ok;
 }
 
-int Compilation::performJobsImpl(bool &abnormalExit,
-                                 std::unique_ptr<TaskQueue> &&TQ) {
+Compilation::Result
+Compilation::performJobsImpl(bool &abnormalExit,
+                             std::unique_ptr<TaskQueue> &&TQ) {
   PerformJobsState State(*this, std::move(TQ));
 
   State.runJobs();
@@ -1946,20 +1955,25 @@ int Compilation::performJobsImpl(bool &abnormalExit,
     InputInfoMap InputInfo;
     State.populateInputInfoMap(InputInfo);
     checkForOutOfDateInputs(Diags, InputInfo);
+
+    abnormalExit = State.hadAnyAbnormalExit();
+    auto result = std::move(State).takeResult();
     writeCompilationRecord(CompilationRecordPath, ArgsHash, BuildStartTime,
                            InputInfo);
+    return result;
+  } else {
+    abnormalExit = State.hadAnyAbnormalExit();
+    return std::move(State).takeResult();
   }
-  abnormalExit = State.hadAnyAbnormalExit();
-  return State.getResult();
 }
 
-int Compilation::performSingleCommand(const Job *Cmd) {
+Compilation::Result Compilation::performSingleCommand(const Job *Cmd) {
   assert(Cmd->getInputs().empty() &&
          "This can only be used to run a single command with no inputs");
 
   switch (Cmd->getCondition()) {
   case Job::Condition::CheckDependencies:
-    return 0;
+    return Compilation::Result{0, fine_grained_dependencies::ModuleDepGraph()};
   case Job::Condition::RunWithoutCascading:
   case Job::Condition::Always:
   case Job::Condition::NewlyAdded:
@@ -1967,7 +1981,7 @@ int Compilation::performSingleCommand(const Job *Cmd) {
   }
 
   if (!writeFilelistIfNecessary(Cmd, *TranslatedArgs.get(), Diags))
-    return 1;
+    return Compilation::Result{1, fine_grained_dependencies::ModuleDepGraph()};
 
   switch (Level) {
   case OutputLevel::Normal:
@@ -1975,7 +1989,7 @@ int Compilation::performSingleCommand(const Job *Cmd) {
     break;
   case OutputLevel::PrintJobs:
     Cmd->printCommandLineAndEnvironment(llvm::outs());
-    return 0;
+    return Compilation::Result{0, fine_grained_dependencies::ModuleDepGraph()};
   case OutputLevel::Verbose:
     Cmd->printCommandLine(llvm::errs());
     break;
@@ -1999,11 +2013,14 @@ int Compilation::performSingleCommand(const Job *Cmd) {
           "expected environment variable to be set successfully");
     // Bail out early in release builds.
     if (envResult != 0) {
-      return envResult;
+      return Compilation::Result{envResult,
+                                 fine_grained_dependencies::ModuleDepGraph()};
     }
   }
 
-  return ExecuteInPlace(ExecPath, argv);
+  const auto returnCode = ExecuteInPlace(ExecPath, argv);
+  return Compilation::Result{returnCode,
+                             fine_grained_dependencies::ModuleDepGraph()};
 }
 
 static bool writeAllSourcesFile(DiagnosticEngine &diags, StringRef path,
@@ -2026,10 +2043,11 @@ static bool writeAllSourcesFile(DiagnosticEngine &diags, StringRef path,
   return true;
 }
 
-int Compilation::performJobs(std::unique_ptr<TaskQueue> &&TQ) {
+Compilation::Result Compilation::performJobs(std::unique_ptr<TaskQueue> &&TQ) {
   if (AllSourceFilesPath)
     if (!writeAllSourcesFile(Diags, AllSourceFilesPath, getInputFiles()))
-      return EXIT_FAILURE;
+      return Compilation::Result{EXIT_FAILURE,
+                                 fine_grained_dependencies::ModuleDepGraph()};
 
   // If we don't have to do any cleanup work, just exec the subprocess.
   if (Level < OutputLevel::Parseable &&
@@ -2045,7 +2063,7 @@ int Compilation::performJobs(std::unique_ptr<TaskQueue> &&TQ) {
   }
 
   bool abnormalExit;
-  int result = performJobsImpl(abnormalExit, std::move(TQ));
+  auto result = performJobsImpl(abnormalExit, std::move(TQ));
 
   if (IncrementalComparator)
     IncrementalComparator->outputComparison();
@@ -2057,7 +2075,7 @@ int Compilation::performJobs(std::unique_ptr<TaskQueue> &&TQ) {
     }
   }
   if (Stats)
-    Stats->noteCurrentProcessExitStatus(result);
+    Stats->noteCurrentProcessExitStatus(result.exitCode);
   return result;
 }
 

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -248,7 +248,7 @@ static int run_driver(StringRef ExecName,
     std::unique_ptr<sys::TaskQueue> TQ = TheDriver.buildTaskQueue(*C);
     if (!TQ)
         return 1;
-    return C->performJobs(std::move(TQ));
+    return C->performJobs(std::move(TQ)).exitCode;
   }
 
   return 0;


### PR DESCRIPTION
Add a data structure to encapsulate the return code, the "had abnormal exit" bit, and the module dependency graph. The last of these is needed for a future patch to turn on cross-module incremental builds.