### PR TITLE
Fixup Float16 availability for macCatalyst/x86_64

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -56,7 +56,7 @@ public typealias CLong = Int
 /// The C 'long long' type.
 public typealias CLongLong = Int64
 
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 /// The C '_Float16' type.
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 public typealias CFloat16 = Float16

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -4730,7 +4730,7 @@ extension RawRepresentable where RawValue == Float, Self: Decodable {
   }
 }
 
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 extension Float16: Codable {
   /// Creates a new instance by decoding from the given decoder.

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1894,9 +1894,9 @@ extension BinaryFloatingPoint {
     // count and significand bit count, then they must share the same encoding
     // for finite and infinite values.
     switch (Source.exponentBitCount, Source.significandBitCount) {
-#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
     case (5, 10):
-      guard #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
+      guard #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
         // Convert signaling NaN to quiet NaN by multiplying by 1.
         self = Self._convert(from: value).value * 1
         break

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -43,7 +43,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 % if bits == 80:
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
 
 %if bits == 16:

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -66,7 +66,7 @@ else:
 % if bits == 80:
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
 
 ${SelfDocComment}
@@ -1111,7 +1111,7 @@ extension ${Self} {
 %   if srcBits == 80:
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %   elif srcBits == 16:
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %   end
 
 %   if srcBits == bits:

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1130,7 +1130,7 @@ public struct ${Self}
 %     if FloatType == 'Float80':
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %     elif FloatType == 'Float16':
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     end
 
   /// Creates an integer from the given floating-point value, rounding toward

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -293,7 +293,7 @@ internal struct _Buffer72 {
   }
 }
 
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 // Note that this takes a Float32 argument instead of Float16, because clang
 // doesn't have _Float16 on all platforms yet.
 @_silgen_name("swift_float16ToString")

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -254,7 +254,7 @@ extension ${Self}: SIMDScalar {
 
 %for (Self, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
 % if bits == 16:
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 % end
 extension ${Self} : SIMDScalar {

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -345,7 +345,7 @@ let PrintTests = TestSuite("FloatingPointPrinting")
 
 % for FloatType in ['Float16', 'Float', 'Double', 'Float80']:
 % if FloatType == 'Float16':
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 % elif FloatType == 'Float80':
 #if !os(Windows) && (arch(i386) || arch(x86_64))
@@ -583,7 +583,7 @@ PrintTests.test("Printable_CDouble") {
   expectDescription("-1.0", CDouble(-1.0))
 }
 
-#if !(os(macOS) && arch(x86_64))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 PrintTests.test("Printable_Float16") {
   func asFloat16(_ f: Float16) -> Float16 { return f }


### PR DESCRIPTION
When building for macCatalyst, os(macOS) does not evaluate to true, so we need to add a targetEnvironment(macCatalyst) check to these conditionals.