### PR TITLE
runtime: enable shims for Float16 on Windows (x86)

### DIFF
--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -30,7 +30,7 @@
 // Android NDK <r21 do not provide `__aeabi_d2h` in the compiler runtime,
 // provide shims in that case.
 #if (defined(__ANDROID__) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
-  ((defined(__i686__) || defined(__x86_64__)) && !defined(__APPLE__))
+  ((defined(__i386__) || defined(__i686__) || defined(__x86_64__)) && !defined(__APPLE__))
 
 #include "../SwiftShims/Visibility.h"
 


### PR DESCRIPTION
When building for Windows x86, we do not have `__i686__` defined, but do
have `__i386__` defined.  Ensure that the routines are included for the
x86 Windows target.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
