### PR TITLE
[SourceKit] Fix flakey VFS completion tests

### DIFF
--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs.swift
@@ -4,32 +4,30 @@ func foo(value: MyStruct) {
 
 // REQUIRES: shell
 
-// RUN: DEPCHECK_INTERVAL=2
-// RUN: SLEEP_TIME=3
-
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)
 // RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 
 // RUN:   -shell -- echo "### Modify" == \
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 // RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 
 // RUN:   -shell -- echo "### Keep" == \
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 // RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 
-// RUN:   -shell -- echo "### Rollback without sleep" == \
+// RUN:   -shell -- echo "### Rollback without check" == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
 // RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 
-// RUN:   -shell -- echo "### After sleep" == \
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -shell -- echo "### Check" == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 // RUN:   -req=complete -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift \
 
 // RUN:   |  %FileCheck %s
@@ -58,7 +56,7 @@ func foo(value: MyStruct) {
 // CHECK: ]
 // CHECK: key.reusingastcontext: 1
 
-// CHECK-LABEL: ### Rollback without sleep
+// CHECK-LABEL: ### Rollback without check
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod_mod()"
 // CHECK-DAG: key.description: "extensionMethod()"
@@ -66,7 +64,7 @@ func foo(value: MyStruct) {
 // CHECK: ]
 // CHECK: key.reusingastcontext: 1
 
-// CHECK-LABEL: ### After sleep
+// CHECK-LABEL: ### Check
 // CHECK: key.results: [
 // CHECK-DAG: key.description: "myStructMethod()"
 // CHECK-DAG: key.description: "extensionMethod()"

--- a/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_vfs_open.swift
@@ -4,26 +4,24 @@ func foo(value: MyStruct) {
 
 // REQUIRES: shell
 
-// RUN: DEPCHECK_INTERVAL=1
-// RUN: SLEEP_TIME=2
-
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/VFS)
 // RUN: cp %S/Inputs/checkdeps/MyProject/LibraryExt.swift %t/VFS/
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=${DEPCHECK_INTERVAL} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
 
 // RUN:   -shell -- echo "### Initial" == \
 // RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
 
 // RUN:   -shell -- echo "### Modify" == \
-// RUN:   -shell -- sleep ${SLEEP_TIME} == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
 // RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s == \
 
 // RUN:   -shell -- echo "### Keep" == \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=100 == \
 // RUN:   -req=complete.open -pos=2:9 -pass-as-sourcetext -vfs-files=%t/VFS/Main.swift=@%s,%t/VFS/Library.swift=@%S/Inputs/checkdeps/MyProject_mod/Library.swift %t/VFS/Main.swift -- -target %target-triple %t/VFS/Main.swift %t/VFS/LibraryExt.swift %t/VFS/Library.swift == \
 // RUN:   -req=complete.close -pos=2:9 -name %t/VFS/Main.swift %s \
 


### PR DESCRIPTION
These tests relied on timing between completion runs in order to check
that fast completion was working properly for completions in VFS files.
That is, they would assume that two runs happening one after another
without a sleep inbetween would always run fast completion.

However, that's not necessarily the case and there have been cases where
a dependency check happens despite its interval being fairly long
(multi-second).

This change simulates the same behaviour by changing the interval
between 0/100, which should prevent any timing issues.

Resolves rdar://72144331