### PR TITLE
ICU: Upgrade to version 68.1 on non-Darwin platforms

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -73,7 +73,7 @@
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "release",
-                "icu": "release-65-1",
+                "icu": "release-68-1",
                 "yams": "3.0.1",
                 "cmake": "v3.16.5",
                 "indexstore-db": "main",


### PR DESCRIPTION
Linux is currently using ICU 65.1, upgrade to the latest release version.

Any regressions are usually caught by the tests in swift-corelibs-foundation in the `*Formatter` classes.
