### PR TITLE
NFC: Fix signed unsigned comparison warnings in unittests

### DIFF
--- a/unittests/Basic/MultiMapCacheTest.cpp
+++ b/unittests/Basic/MultiMapCacheTest.cpp
@@ -32,23 +32,23 @@ TEST(MultiMapCache, powersTest) {
   for (unsigned index : range(1, 256)) {
     auto array = *cache.get(index);
     for (unsigned power : array) {
-      EXPECT_EQ(power % index, 0);
+      EXPECT_EQ(power % index, 0u);
     }
   }
   EXPECT_FALSE(cache.empty());
-  EXPECT_EQ(cache.size(), 255);
+  EXPECT_EQ(cache.size(), 255u);
   for (unsigned index : range(1, 256)) {
     auto array = *cache.get(index);
     for (unsigned power : array) {
-      EXPECT_EQ(power % index, 0);
+      EXPECT_EQ(power % index, 0u);
     }
   }
   EXPECT_FALSE(cache.empty());
-  EXPECT_EQ(cache.size(), 255);
+  EXPECT_EQ(cache.size(), 255u);
 
   cache.clear();
   EXPECT_TRUE(cache.empty());
-  EXPECT_EQ(cache.size(), 0);
+  EXPECT_EQ(cache.size(), 0u);
 }
 
 TEST(MultiMapCache, smallTest) {
@@ -66,21 +66,21 @@ TEST(MultiMapCache, smallTest) {
   for (unsigned index : range(1, 256)) {
     auto array = *cache.get(index);
     for (unsigned power : array) {
-      EXPECT_EQ(power % index, 0);
+      EXPECT_EQ(power % index, 0u);
     }
   }
   EXPECT_FALSE(cache.empty());
-  EXPECT_EQ(cache.size(), 255);
+  EXPECT_EQ(cache.size(), 255u);
   for (unsigned index : range(1, 256)) {
     auto array = *cache.get(index);
     for (unsigned power : array) {
-      EXPECT_EQ(power % index, 0);
+      EXPECT_EQ(power % index, 0u);
     }
   }
   EXPECT_FALSE(cache.empty());
-  EXPECT_EQ(cache.size(), 255);
+  EXPECT_EQ(cache.size(), 255u);
 
   cache.clear();
   EXPECT_TRUE(cache.empty());
-  EXPECT_EQ(cache.size(), 0);
+  EXPECT_EQ(cache.size(), 0u);
 }

--- a/unittests/Sema/UnresolvedMemberLookupTests.cpp
+++ b/unittests/Sema/UnresolvedMemberLookupTests.cpp
@@ -41,7 +41,7 @@ TEST_F(SemaTest, TestLookupAlwaysLooksThroughOptionalBase) {
   cs.solve(solutions);
 
   // We should have a solution.
-  ASSERT_EQ(solutions.size(), 1);
+  ASSERT_EQ(solutions.size(), 1u);
 
   auto &solution = solutions[0];
   auto *locator = cs.getConstraintLocator(UME,
@@ -75,7 +75,7 @@ TEST_F(SemaTest, TestLookupPrefersResultsOnOptionalRatherThanBase) {
   cs.solve(solutions);
 
   // We should have a solution.
-  ASSERT_EQ(solutions.size(), 1);
+  ASSERT_EQ(solutions.size(), 1u);
 
   auto &solution = solutions[0];
   auto *locator = cs.getConstraintLocator(UME,
@@ -85,6 +85,6 @@ TEST_F(SemaTest, TestLookupPrefersResultsOnOptionalRatherThanBase) {
 
   // The `test` member on `Optional` should be chosen over the member on `Int`,
   // even though the score is otherwise worse.
-  ASSERT_EQ(score.Data[SK_ValueToOptional], 1);
+  ASSERT_EQ(score.Data[SK_ValueToOptional], 1u);
   ASSERT_EQ(choice.getDecl(), optMember);
 }


### PR DESCRIPTION
This patch fixes the unsigned/signed comparison warnings in the
unittests caused by comparing an unsigned integer with the signed
integer literal. The offending signed integer literals have been
replaced with unsigned integer literals.