### PR TITLE
[sil-combine] Use high level ARC APIs instead of low level ARC APIs in a few cases to make code work in ossa and non-ossa.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -85,8 +85,7 @@ SILCombiner::visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {
   //      retain_value %value    // must insert the release after this retain
   //      strong_release %box
   Builder.setInsertionPoint(singleRelease);
-  Builder.createReleaseValue(AEBI->getLoc(), boxedValue,
-                             singleRelease->getAtomicity());
+  Builder.emitDestroyValueOperation(AEBI->getLoc(), boxedValue);
 
   eraseInstIncludingUsers(AEBI);
   return nullptr;


### PR DESCRIPTION
These are just a few cases where I could 1-1 translate the APIs to do the correct thing in both OSSA and non-OSSA.