### PR TITLE
[concurrency] type-checking global-actor-isolated references in ordinary functions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4132,6 +4132,10 @@ NOTE(note_add_async_to_function,none,
      "add 'async' to function %0 to make it asynchronous", (DeclName))
 NOTE(note_add_asynchandler_to_function,none,
      "add '@asyncHandler' to function %0 to create an implicit asynchronous context", (DeclName))
+NOTE(note_add_globalactor_to_function,none,
+     "add '@%0' to make %1 %2 part of global actor %3", 
+     (StringRef, DescriptiveDeclKind, DeclName, Type))
+FIXIT(insert_globalactor_attr, "@%0 ", (Type))
 ERROR(not_objc_function_async,none,
       "'async' function cannot be represented in Objective-C", ())
 NOTE(not_objc_function_type_async,none,
@@ -4217,10 +4221,10 @@ ERROR(global_actor_from_other_global_actor_context,none,
       "%0 %1 isolated to global actor %2 can not be referenced from "
       "different global actor %3",
       (DescriptiveDeclKind, DeclName, Type, Type))
-ERROR(global_actor_from_independent_context,none,
-      "%0 %1 isolated to global actor %2 can not be referenced from an "
-      "'@actorIndependent' context",
-      (DescriptiveDeclKind, DeclName, Type))
+ERROR(global_actor_from_nonactor_context,none,
+      "%0 %1 isolated to global actor %2 can not be referenced from "
+      "%select{this|an '@actorIndependent'}3 context",
+      (DescriptiveDeclKind, DeclName, Type, bool))
 ERROR(actor_isolated_partial_apply,none,
         "actor-isolated %0 %1 can not be partially applied",
         (DescriptiveDeclKind, DeclName))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -118,7 +118,10 @@ void swift::addAsyncNotes(AbstractFunctionDecl const* func) {
   if (!isa<DestructorDecl>(func))
     func->diagnose(diag::note_add_async_to_function, func->getName());
     // TODO: we need a source location for effects attributes so that we 
-    // can emit a fix-it.
+    // can also emit a fix-it that inserts 'async' in the right place for func.
+    // It's possibly a bit tricky to get the right source location from
+    // just the AbstractFunctionDecl, but it's important to circle-back
+    // to this.
 
   if (func->canBeAsyncHandler()) {
     func->diagnose(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -40,7 +40,7 @@ class ValueDecl;
 
 /// Add notes suggesting the addition of 'async' or '@asyncHandler', as
 /// appropriate, to a diagnostic for a function that isn't an async context.
-void addAsyncNotes(FuncDecl *func);
+void addAsyncNotes(AbstractFunctionDecl const* func);
 
 /// Check actor isolation rules.
 void checkTopLevelActorIsolation(TopLevelCodeDecl *decl);

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1382,11 +1382,8 @@ public:
     if (!Function)
       return;
 
-    auto func = dyn_cast_or_null<FuncDecl>(Function->getAbstractFunctionDecl());
-    if (!func)
-      return;
-
-    addAsyncNotes(func);
+    if (auto func = Function->getAbstractFunctionDecl())
+      addAsyncNotes(func);
   }
 
   void diagnoseUnhandledAsyncSite(DiagnosticEngine &Diags, ASTNode node) {

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -125,8 +125,8 @@ func anotherAsyncFunc() async {
 
 }
 
-// expected-note@+2 {{add 'async' to function 'regularFunc()' to make it asynchronous}}
-// expected-note@+1 {{add '@asyncHandler' to function 'regularFunc()' to create an implicit asynchronous context}}
+// expected-note@+2 {{add 'async' to function 'regularFunc()' to make it asynchronous}} {{none}}
+// expected-note@+1 {{add '@asyncHandler' to function 'regularFunc()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 func regularFunc() {
   let a = BankAccount(initialDeposit: 34)
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -44,7 +44,7 @@ extension MyActor {
     set { }
   }
 
-  // expected-note@+1 {{add 'async' to function 'actorIndependentFunc(otherActor:)' to make it asynchronous}}
+  // expected-note@+1 {{add 'async' to function 'actorIndependentFunc(otherActor:)' to make it asynchronous}} {{none}}
   @actorIndependent func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from an '@actorIndependent' context}}
@@ -261,8 +261,8 @@ struct GenericStruct<T> {
     f() // okay
   }
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'h()' to create an implicit asynchronous context}}
-  // expected-note@+1 {{add 'async' to function 'h()' to make it asynchronous}}
+  // expected-note@+2 {{add '@asyncHandler' to function 'h()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
+  // expected-note@+1 {{add 'async' to function 'h()' to make it asynchronous}} {{none}}
   @GenericGlobalActor<String> func h() {
     f() // expected-error{{'async' in a function that does not support concurrency}}
     _ = f // expected-error{{instance method 'f()' isolated to global actor 'GenericGlobalActor<T>' can not be referenced from different global actor 'GenericGlobalActor<String>'}}

--- a/test/Concurrency/async_throwing.swift
+++ b/test/Concurrency/async_throwing.swift
@@ -44,8 +44,8 @@ func throwingTask() async throws -> String {
   return "ok!"
 }
 
-// expected-note@+2 7 {{add '@asyncHandler' to function 'syncTest()' to create an implicit asynchronous context}}
-// expected-note@+1 7 {{add 'async' to function 'syncTest()' to make it asynchronous}}
+// expected-note@+2 7 {{add '@asyncHandler' to function 'syncTest()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
+// expected-note@+1 7 {{add 'async' to function 'syncTest()' to make it asynchronous}} {{none}}
 func syncTest() {
   let _ = invoke(fn: normalTask) // expected-error{{'async' in a function that does not support concurrency}}
   let _ = invokeAuto(42) // expected-error{{'async' in a function that does not support concurrency}}

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -27,7 +27,7 @@ actor class Alex {
 }
 
 
-// expected-note@+1 4 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor()' part of global actor 'SomeGlobalActor'}}
+// expected-note@+1 4 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func referenceGlobalActor() {
   let a = Alex()
   // expected-error@+1 {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
@@ -40,7 +40,7 @@ func referenceGlobalActor() {
 }
 
 
-// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor2()' part of global actor 'SomeGlobalActor'}}
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor2()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func referenceGlobalActor2() {
   // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
   let x = syncGlobActorFn
@@ -48,17 +48,17 @@ func referenceGlobalActor2() {
 }
 
 
-// expected-note@+2 {{add '@asyncHandler' to function 'referenceAsyncGlobalActor()' to create an implicit asynchronous context}}
-// expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}}
+// expected-note@+2 {{add '@asyncHandler' to function 'referenceAsyncGlobalActor()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
+// expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}} {{none}}
 func referenceAsyncGlobalActor() {
   let y = asyncGlobalActFn
   y() // expected-error{{'async' in a function that does not support concurrency}}
 }
 
 
-// expected-note@+3 {{add '@asyncHandler' to function 'callGlobalActor()' to create an implicit asynchronous context}}
-// expected-note@+2 {{add 'async' to function 'callGlobalActor()' to make it asynchronous}}
-// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'callGlobalActor()' part of global actor 'SomeGlobalActor'}}
+// expected-note@+3 {{add '@asyncHandler' to function 'callGlobalActor()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
+// expected-note@+2 {{add 'async' to function 'callGlobalActor()' to make it asynchronous}} {{none}}
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'callGlobalActor()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func callGlobalActor() {
   syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
 }
@@ -76,7 +76,7 @@ func fromClosure() {
 }
 
 class Taylor {
-  init() { // expected-note {{add 'async' to function 'init()' to make it asynchronous}}
+  init() { // expected-note {{add 'async' to function 'init()' to make it asynchronous}} {{none}}
     syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
@@ -90,9 +90,9 @@ class Taylor {
     _ = syncGlobActorFn
   }
 
-  // expected-note@+3 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}}
-  // expected-note@+2 {{add '@asyncHandler' to function 'method1()' to create an implicit asynchronous context}}
-  // expected-note@+1 {{add 'async' to function 'method1()' to make it asynchronous}}
+  // expected-note@+3 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
+  // expected-note@+2 {{add '@asyncHandler' to function 'method1()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
+  // expected-note@+1 {{add 'async' to function 'method1()' to make it asynchronous}} {{none}}
   func method1() {
     syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
 
@@ -100,7 +100,7 @@ class Taylor {
     _ = syncGlobActorFn
   }
 
-  // expected-note@+2 2 {{add '@SomeGlobalActor' to make instance method 'cannotBeHandler()' part of global actor 'SomeGlobalActor'}}
+  // expected-note@+2 2 {{add '@SomeGlobalActor' to make instance method 'cannotBeHandler()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
   // expected-note@+1 {{add 'async' to function 'cannotBeHandler()' to make it asynchronous}}
   func cannotBeHandler() -> Int {
     syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -1,0 +1,131 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+// provides coverage for rdar://71548470
+
+actor class TestActor {}
+
+@globalActor
+struct SomeGlobalActor {
+  static var shared: TestActor { TestActor() }
+}
+
+// expected-note@+1 13 {{calls to global function 'syncGlobActorFn()' from outside of its actor context are implicitly asynchronous}}
+@SomeGlobalActor func syncGlobActorFn() { }
+@SomeGlobalActor func asyncGlobalActFn() async { }
+
+actor class Alex {
+  @SomeGlobalActor let const_memb = 20
+  @SomeGlobalActor var mut_memb = 30 // expected-note 2 {{mutable state is only available within the actor instance}}
+  @SomeGlobalActor func method() {} // expected-note 2 {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  @SomeGlobalActor subscript(index : Int) -> Int { // expected-note 4 {{subscript declared here}}
+    get {
+      return index * 2
+    }
+    set {}
+  }
+}
+
+
+// expected-note@+1 4 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor()' part of global actor 'SomeGlobalActor'}}
+func referenceGlobalActor() {
+  let a = Alex()
+  // expected-error@+1 {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  _ = a.method
+  _ = a.const_memb
+  _ = a.mut_memb  // expected-error{{property 'mut_memb' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+
+  _ = a[1]  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+}
+
+
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor2()' part of global actor 'SomeGlobalActor'}}
+func referenceGlobalActor2() {
+  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  let x = syncGlobActorFn
+  x()
+}
+
+
+// expected-note@+2 {{add '@asyncHandler' to function 'referenceAsyncGlobalActor()' to create an implicit asynchronous context}}
+// expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}}
+func referenceAsyncGlobalActor() {
+  let y = asyncGlobalActFn
+  y() // expected-error{{'async' in a function that does not support concurrency}}
+}
+
+
+// expected-note@+3 {{add '@asyncHandler' to function 'callGlobalActor()' to create an implicit asynchronous context}}
+// expected-note@+2 {{add 'async' to function 'callGlobalActor()' to make it asynchronous}}
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'callGlobalActor()' part of global actor 'SomeGlobalActor'}}
+func callGlobalActor() {
+  syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+}
+
+func fromClosure() {
+  { () -> Void in
+    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    let x = syncGlobActorFn
+    x()
+  }()
+
+  // expected-error@+2 {{'async' in a function that does not support concurrency}}
+  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  let _ = { syncGlobActorFn() }()
+}
+
+class Taylor {
+  init() { // expected-note {{add 'async' to function 'init()' to make it asynchronous}}
+    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+
+    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    _ = syncGlobActorFn
+  }
+
+  deinit {
+    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+
+    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    _ = syncGlobActorFn
+  }
+
+  // expected-note@+3 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}}
+  // expected-note@+2 {{add '@asyncHandler' to function 'method1()' to create an implicit asynchronous context}}
+  // expected-note@+1 {{add 'async' to function 'method1()' to make it asynchronous}}
+  func method1() {
+    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+
+    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    _ = syncGlobActorFn
+  }
+
+  // expected-note@+2 2 {{add '@SomeGlobalActor' to make instance method 'cannotBeHandler()' part of global actor 'SomeGlobalActor'}}
+  // expected-note@+1 {{add 'async' to function 'cannotBeHandler()' to make it asynchronous}}
+  func cannotBeHandler() -> Int {
+    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+
+    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    _ = syncGlobActorFn
+    return 0
+  }
+}
+
+
+func fromAsync() async {
+  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  let x = syncGlobActorFn
+  x()
+
+  let y = asyncGlobalActFn
+  y() // expected-error{{call is 'async' but is not marked with 'await'}}
+
+  let a = Alex()
+  // expected-error@+1 {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  _ = a.method
+  _ = a.const_memb
+  _ = a.mut_memb  // expected-error{{property 'mut_memb' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+
+  _ = a[1]  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -35,8 +35,8 @@ protocol P2 {
 class C1: P1 {
   func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
+  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{none}}
   @OtherGlobalActor func testMethod() {
     method() // expected-error {{'async' in a function that does not support concurrency}}
     _ = method  // expected-error {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -47,8 +47,8 @@ class C2: P2 {
   func method1() { }  // expected-note{{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
   func method2() { }
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
+  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{none}}
   @OtherGlobalActor func testMethod() {
     method1() // expected-error{{'async' in a function that does not support concurrency}}
     _ = method1 // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -83,8 +83,8 @@ class C5 {
   func method2() { }  // expected-note {{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
 }
 
-// expected-note@+2 5 {{add '@asyncHandler' to function 'testGlobalActorInference(c3:c4:c5:)' to create an implicit asynchronous context}}
-// expected-note@+1 5 {{add 'async' to function 'testGlobalActorInference(c3:c4:c5:)' to make it asynchronous}}
+// expected-note@+2 5 {{add '@asyncHandler' to function 'testGlobalActorInference(c3:c4:c5:)' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
+// expected-note@+1 5 {{add 'async' to function 'testGlobalActorInference(c3:c4:c5:)' to make it asynchronous}} {{none}}
 @OtherGlobalActor func testGlobalActorInference(c3: C3, c4: C4, c5: C5) {
   // Propagation via class annotation
   c3.method1() // expected-error{{'async' in a function that does not support concurrency}}
@@ -145,8 +145,8 @@ actor class GenericSub<T> : GenericSuper<[T]> {
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
   @actorIndependent override func method3() { } // expected-error{{actor-independent instance method 'method3()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}}
+  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{none}}
   @OtherGlobalActor func testMethod() {
     method() // expected-error{{'async' in a function that does not support concurrency}}
     _ = method  // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[T]>' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -190,9 +190,9 @@ func bar() async {
   foo() // expected-error{{call is 'async' but is not marked with 'await'}}
 }
 
-// expected-note@+3 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}}
-// expected-note@+2 {{add '@asyncHandler' to function 'barSync()' to create an implicit asynchronous context}}
-// expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}}
+// expected-note@+3 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
+// expected-note@+2 {{add '@asyncHandler' to function 'barSync()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
+// expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}} {{none}}
 func barSync() {
   foo() // expected-error {{'async' in a function that does not support concurrency}}
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -181,6 +181,7 @@ struct OtherContainer<U> {
 // Global actor inference for unspecified contexts
 // ----------------------------------------------------------------------
 
+// expected-note@+1 {{calls to global function 'foo()' from outside of its actor context are implicitly asynchronous}}
 @SomeGlobalActor func foo() { sibling() }
 
 @SomeGlobalActor func sibling() { foo() }
@@ -189,8 +190,9 @@ func bar() async {
   foo() // expected-error{{call is 'async' but is not marked with 'await'}}
 }
 
+// expected-note@+3 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}}
 // expected-note@+2 {{add '@asyncHandler' to function 'barSync()' to create an implicit asynchronous context}}
 // expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}}
 func barSync() {
-  foo() // expected-error{{'async' in a function that does not support concurrency}}
+  foo() // expected-error {{'async' in a function that does not support concurrency}}
 }

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -60,8 +60,8 @@ class Y: P {
   // @asyncHandler is not inferred for classes
 
   func callback() {
-    // expected-note@-1{{add 'async' to function 'callback()' to make it asynchronous}}
-    // expected-note@-2{{add '@asyncHandler' to function 'callback()' to create an implicit asynchronous context}}
+    // expected-note@-1{{add 'async' to function 'callback()' to make it asynchronous}} {{none}}
+    // expected-note@-2{{add '@asyncHandler' to function 'callback()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
 
     // okay, it's an async context
     let _ = await globalAsyncFunction() // expected-error{{'async' in a function that does not support concurrency}}

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -37,8 +37,8 @@ actor class MyActor {
 
   // Actor-isolated entities cannot be exposed to Objective-C.
   @objc func synchronousBad() { } // expected-error{{actor-isolated instance method 'synchronousBad()' cannot be @objc}}
-  // expected-note@-1{{add 'async' to function 'synchronousBad()' to make it asynchronous}}
-  // expected-note@-2{{add '@asyncHandler' to function 'synchronousBad()' to create an implicit asynchronous context}}
+  // expected-note@-1{{add 'async' to function 'synchronousBad()' to make it asynchronous}} {{none}}
+  // expected-note@-2{{add '@asyncHandler' to function 'synchronousBad()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
 
   @objc var badProp: AnyObject { self } // expected-error{{actor-isolated property 'badProp' cannot be @objc}}
   @objc subscript(index: Int) -> AnyObject { self } // expected-error{{actor-isolated subscript 'subscript(_:)' cannot be @objc}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -22,7 +22,7 @@ func test2(
   print("foo")
 }
 
-func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}}
+func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}} {{none}}
   // expected-note@-1{{add '@asyncHandler' to function 'test3()' to create an implicit asynchronous context}}{{1-1=@asyncHandler }}
   _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
 }
@@ -41,7 +41,7 @@ func acceptAutoclosureAsync(_: @autoclosure () async -> Int) async { }
 
 func acceptAutoclosureNonAsyncBad(_: @autoclosure () async -> Int) -> Int { 0 }
 // expected-error@-1{{'async' autoclosure parameter in a non-'async' function}}
-// expected-note@-2{{add 'async' to function 'acceptAutoclosureNonAsyncBad' to make it asynchronous}}
+// expected-note@-2{{add 'async' to function 'acceptAutoclosureNonAsyncBad' to make it asynchronous}} {{none}}
 
 struct HasAsyncBad {
   init(_: @autoclosure () async -> Int) { }
@@ -183,8 +183,8 @@ func testAsyncLet() async throws {
   _ = await x5
 }
 
-// expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}}
-// expected-note@+1 4{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}}
+// expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{none}}
+// expected-note@+1 4{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 func testAsyncLetOutOfAsync() {
   async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}
   // FIXME: expected-error@-1{{'async' in a function that does not support concurrency}}
@@ -192,4 +192,3 @@ func testAsyncLetOutOfAsync() {
   _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
   _ = x // expected-error{{'async let' in a function that does not support concurrency}}
 }
-


### PR DESCRIPTION
Non-actor isolated synchronous functions were mistakenly allowed to call & reference global-actor isolated declarations:

```swift
actor class TestActor {}

@globalActor
struct SomeGlobalActor {
  static var shared: TestActor { TestActor() }
}

@SomeGlobalActor func syncGlobActorFn() { }

func ordinaryFunc() {
  syncGlobActorFn() // reference A
  let x = syncGlobActorFn // reference B
  x()
}
```

There are two invalid references to global-actor isolated declarations. There are various ways to fix such problems:

1. marking `ordinaryFunc` as `@asyncHandler`
2. marking `ordinaryFunc` as `async`
3. making `ordinaryFunc` part of the global-actor that `syncGlobActorFn` belongs to.

We only suggest fix (3) if the incorrect global-actor reference is not part of an apply (i.e., reference B). For reference A, which directly applies the function, we suggest all 3 as possible fixes.

Thus, in terms of new fix-its: If the caller is not associated with an actor and is a synchronous function that refers to a global-actor isolated declaration, we will suggest the option of making that synchronous function part of the global-actor's context (fixing rdar://71698464). We do *not* suggest becoming part of the global-actor if the reference appears in an async context.

Resolves rdar://71548470&71698464

TODOs:
- [x] enhance regression test with fix-it checking (+ manually verify that they produce valid code)