### PR TITLE
[CodeCompletion] Annotate 'async' functions/initializers in results

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -89,14 +89,8 @@ public:
     /// The "override" keyword.
     OverrideKeyword,
 
-    /// The "throws" keyword.
-    ThrowsKeyword,
-
-    /// The "rethrows" keyword.
-    RethrowsKeyword,
-
-    /// The "async" keyword.
-    AsyncKeyword,
+    /// The "throws", "rethrows" and "async" keyword.
+    EffectsSpecifierKeyword,
 
     /// The keyword part of a declaration before the name, like "func".
     DeclIntroducer,
@@ -223,9 +217,7 @@ public:
   static bool chunkHasText(ChunkKind Kind) {
     return Kind == ChunkKind::AccessControlKeyword ||
            Kind == ChunkKind::OverrideKeyword ||
-           Kind == ChunkKind::ThrowsKeyword ||
-           Kind == ChunkKind::RethrowsKeyword ||
-           Kind == ChunkKind::AsyncKeyword ||
+           Kind == ChunkKind::EffectsSpecifierKeyword ||
            Kind == ChunkKind::DeclAttrKeyword ||
            Kind == ChunkKind::DeclIntroducer ||
            Kind == ChunkKind::Keyword ||

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -95,6 +95,9 @@ public:
     /// The "rethrows" keyword.
     RethrowsKeyword,
 
+    /// The "async" keyword.
+    AsyncKeyword,
+
     /// The keyword part of a declaration before the name, like "func".
     DeclIntroducer,
 
@@ -222,6 +225,7 @@ public:
            Kind == ChunkKind::OverrideKeyword ||
            Kind == ChunkKind::ThrowsKeyword ||
            Kind == ChunkKind::RethrowsKeyword ||
+           Kind == ChunkKind::AsyncKeyword ||
            Kind == ChunkKind::DeclAttrKeyword ||
            Kind == ChunkKind::DeclIntroducer ||
            Kind == ChunkKind::Keyword ||

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2642,7 +2642,7 @@ public:
                                    genericSig, includeDefaultArgs);
   }
 
-  static void addAsyncThrows(CodeCompletionResultBuilder &Builder,
+  static void addEffectsSpecifiers(CodeCompletionResultBuilder &Builder,
                              const AnyFunctionType *AFT,
                              const AbstractFunctionDecl *AFD) {
     assert(AFT != nullptr);
@@ -2809,7 +2809,7 @@ public:
       else
         Builder.addAnnotatedRightParen();
 
-      addAsyncThrows(Builder, AFT, AFD);
+      addEffectsSpecifiers(Builder, AFT, AFD);
 
       if (AFD &&
           AFD->isImplicitlyUnwrappedOptional())
@@ -2956,14 +2956,14 @@ public:
         Builder.addRightParen();
       } else if (trivialTrailingClosure) {
         Builder.addBraceStmtWithCursor(" { code }");
-        addAsyncThrows(Builder, AFT, FD);
+        addEffectsSpecifiers(Builder, AFT, FD);
       } else {
         Builder.addLeftParen();
         addCallArgumentPatterns(Builder, AFT, FD->getParameters(),
                                 FD->getGenericSignatureOfContext(),
                                 includeDefaultArgs);
         Builder.addRightParen();
-        addAsyncThrows(Builder, AFT, FD);
+        addEffectsSpecifiers(Builder, AFT, FD);
       }
 
       // Build type annotation.
@@ -3104,7 +3104,7 @@ public:
       else
         Builder.addAnnotatedRightParen();
 
-      addAsyncThrows(Builder, ConstructorType, CD);
+      addEffectsSpecifiers(Builder, ConstructorType, CD);
 
       if (!Result.hasValue())
         Result = ConstructorType->getResult();

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -385,9 +385,7 @@ void CodeCompletionString::print(raw_ostream &OS) const {
     case ChunkKind::DeclAttrKeyword:
     case ChunkKind::DeclAttrParamKeyword:
     case ChunkKind::OverrideKeyword:
-    case ChunkKind::ThrowsKeyword:
-    case ChunkKind::RethrowsKeyword:
-    case ChunkKind::AsyncKeyword:
+    case ChunkKind::EffectsSpecifierKeyword:
     case ChunkKind::DeclIntroducer:
     case ChunkKind::Text:
     case ChunkKind::LeftParen:
@@ -1377,9 +1375,7 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     case ChunkKind::Whitespace:
     case ChunkKind::AccessControlKeyword:
     case ChunkKind::OverrideKeyword:
-    case ChunkKind::ThrowsKeyword:
-    case ChunkKind::RethrowsKeyword:
-    case ChunkKind::AsyncKeyword:
+    case ChunkKind::EffectsSpecifierKeyword:
     case ChunkKind::DeclIntroducer:
     case ChunkKind::CallParameterColon:
     case ChunkKind::CallParameterTypeBegin:
@@ -1433,9 +1429,7 @@ void CodeCompletionString::getName(raw_ostream &OS) const {
         --i;
         continue;
       }
-      case ChunkKind::ThrowsKeyword:
-      case ChunkKind::RethrowsKeyword:
-      case ChunkKind::AsyncKeyword:
+      case ChunkKind::EffectsSpecifierKeyword:
         shouldPrint = true; // Even when they're annotations.
         break;
       default:

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -230,6 +230,17 @@ public:
        " throws");
   }
 
+  void addAnnotatedAsync() {
+    addAsync();
+    getLastChunk().setIsAnnotation();
+  }
+
+  void addAsync() {
+    addChunkWithTextNoCopy(
+       CodeCompletionString::Chunk::ChunkKind::AsyncKeyword,
+       " async");
+  }
+
   void addDeclDocCommentWords(ArrayRef<std::pair<StringRef, StringRef>> Pairs) {
     assert(Kind == CodeCompletionResult::ResultKind::Declaration);
     CommentWords = Pairs;

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -226,7 +226,7 @@ public:
 
   void addThrows() {
     addChunkWithTextNoCopy(
-       CodeCompletionString::Chunk::ChunkKind::ThrowsKeyword,
+       CodeCompletionString::Chunk::ChunkKind::EffectsSpecifierKeyword,
        " throws");
   }
 
@@ -237,7 +237,7 @@ public:
 
   void addAsync() {
     addChunkWithTextNoCopy(
-       CodeCompletionString::Chunk::ChunkKind::AsyncKeyword,
+       CodeCompletionString::Chunk::ChunkKind::EffectsSpecifierKeyword,
        " async");
   }
 
@@ -253,7 +253,8 @@ public:
 
   void addRethrows() {
     addChunkWithTextNoCopy(
-        CodeCompletionString::Chunk::ChunkKind::RethrowsKeyword, " rethrows");
+        CodeCompletionString::Chunk::ChunkKind::EffectsSpecifierKeyword,
+        " rethrows");
   }
 
   void addAnnotatedLeftParen() {

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -102,6 +102,7 @@ class AnnotatingResultPrinter {
     case ChunkKind::AccessControlKeyword:
     case ChunkKind::ThrowsKeyword:
     case ChunkKind::RethrowsKeyword:
+    case ChunkKind::AsyncKeyword:
     case ChunkKind::DeclIntroducer:
       printWithTag("keyword", C.getText());
       break;

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -100,9 +100,7 @@ class AnnotatingResultPrinter {
     case ChunkKind::Keyword:
     case ChunkKind::OverrideKeyword:
     case ChunkKind::AccessControlKeyword:
-    case ChunkKind::ThrowsKeyword:
-    case ChunkKind::RethrowsKeyword:
-    case ChunkKind::AsyncKeyword:
+    case ChunkKind::EffectsSpecifierKeyword:
     case ChunkKind::DeclIntroducer:
       printWithTag("keyword", C.getText());
       break;

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -38,9 +38,7 @@ static std::string toInsertableString(CodeCompletionResult *Result) {
     switch (C.getKind()) {
     case CodeCompletionString::Chunk::ChunkKind::AccessControlKeyword:
     case CodeCompletionString::Chunk::ChunkKind::OverrideKeyword:
-    case CodeCompletionString::Chunk::ChunkKind::ThrowsKeyword:
-    case CodeCompletionString::Chunk::ChunkKind::RethrowsKeyword:
-    case CodeCompletionString::Chunk::ChunkKind::AsyncKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::EffectsSpecifierKeyword:
     case CodeCompletionString::Chunk::ChunkKind::DeclAttrKeyword:
     case CodeCompletionString::Chunk::ChunkKind::DeclIntroducer:
     case CodeCompletionString::Chunk::ChunkKind::Keyword:

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -40,6 +40,7 @@ static std::string toInsertableString(CodeCompletionResult *Result) {
     case CodeCompletionString::Chunk::ChunkKind::OverrideKeyword:
     case CodeCompletionString::Chunk::ChunkKind::ThrowsKeyword:
     case CodeCompletionString::Chunk::ChunkKind::RethrowsKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::AsyncKeyword:
     case CodeCompletionString::Chunk::ChunkKind::DeclAttrKeyword:
     case CodeCompletionString::Chunk::ChunkKind::DeclIntroducer:
     case CodeCompletionString::Chunk::ChunkKind::Keyword:

--- a/test/IDE/complete_asyncannotation.swift
+++ b/test/IDE/complete_asyncannotation.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
+
+func globalFuncAsync() async {}
+func globalFuncAsyncThrows() async throws {}
+func globalFuncAsyncRethrows(_ x: () async throws -> ()) async rethrows {}
+struct HasAsyncMembers {
+  func memberAsync() async {}
+  func memberAsyncThrows() async throws {}
+  func memberAsyncRethrows(_ x: () async throws -> ()) async rethrows {}
+
+  init() async {}
+  init(withAsync: Int) async {}
+  init(withAsyncThrows: Int) async throws {}
+  init(withAsyncRethrows: () async throws -> Void) async rethrows {}
+}
+
+func testGlobalFuncAsync() {
+  globalFuncAsync#^CHECK_globalFuncAsync^#
+// CHECK_globalFuncAsync: Begin completions
+// CHECK_globalFuncAsync-DAG: Decl[FreeFunction]/CurrModule: ()[' async'][#Void#]; name=() async
+// CHECK_globalFuncAsync: End completions
+}
+func testGlobalFuncAsyncThrows() {
+  globalFuncAsyncThrows#^CHECK_globalFuncAsyncThrows^#
+// CHECK_globalFuncAsyncThrows: Begin completions
+// CHECK_globalFuncAsyncThrows-DAG: Decl[FreeFunction]/CurrModule: ()[' async'][' throws'][#Void#]; name=() async throws
+// CHECK_globalFuncAsyncThrows: End completions
+}
+func testGlobalFuncAsyncRethrows() {
+  globalFuncAsyncRethrows#^CHECK_globalFuncAsyncRethrows^#
+// CHECK_globalFuncAsyncRethrows: Begin completions
+// CHECK_globalFuncAsyncRethrows-DAG: Decl[FreeFunction]/CurrModule: ({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=(x: () async throws -> ()) async rethrows
+// CHECK_globalFuncAsyncRethrows: End completions
+}
+func testAsyncMembers(_ x: HasAsyncMembers) {
+  x.#^CHECK_members^#
+// CHECK_members: Begin completions
+// CHECK_members-DAG: Decl[InstanceMethod]/CurrNominal:   memberAsync()[' async'][#Void#]; name=memberAsync() async
+// CHECK_members-DAG: Decl[InstanceMethod]/CurrNominal:   memberAsyncThrows()[' async'][' throws'][#Void#]; name=memberAsyncThrows() async throws
+// CHECK_members-DAG: Decl[InstanceMethod]/CurrNominal:   memberAsyncRethrows {|}[' async'][' rethrows'][#Void#]; name=memberAsyncRethrows { code } async rethrows
+// CHECK_members-DAG: Decl[InstanceMethod]/CurrNominal:   memberAsyncRethrows({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=memberAsyncRethrows(x: () async throws -> ()) async rethrows
+// CHECK_members: End completions
+}
+func testMemberAsync(_ x: HasAsyncMembers) {
+  x.memberAsync#^CHECK_memberAsync^#
+// CHECK_memberAsync: Begin completions
+// CHECK_memberAsync-DAG: Decl[InstanceMethod]/CurrNominal: ()[' async'][#Void#]; name=() async
+// CHECK_memberAsync: End completions
+}
+func testMemberAsyncThrows(_ x: HasAsyncMembers) {
+  x.memberAsyncThrows#^CHECK_memberAsyncThrows^#
+// CHECK_memberAsyncThrows: Begin completions
+// CHECK_memberAsyncThrows-DAG: Decl[InstanceMethod]/CurrNominal: ()[' async'][' throws'][#Void#]; name=() async throws
+// CHECK_memberAsyncThrows: End completions
+}
+func testMemberAsyncRethrows(_ x: HasAsyncMembers) {
+  x.memberAsyncRethrows#^CHECK_memberAsyncRethrows^#
+// CHECK_memberAsyncRethrows: Begin completions
+// CHECK_memberAsyncRethrows-DAG: Decl[InstanceMethod]/CurrNominal: ({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=(x: () async throws -> ()) async rethrows
+// CHECK_memberAsyncRethrows: End completions
+}
+
+func testAsyncIntiializers() {
+  HasAsyncMembers(#^CHECK_initializers^#
+// CHECK_initializers: Begin completions
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal: ['('][')'][#HasAsyncMembers#]; name=
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal: ['(']{#withAsync: Int#}[')'][#HasAsyncMembers#]; name=withAsync: Int
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal: ['(']{#withAsyncThrows: Int#}[')'][' throws'][#HasAsyncMembers#]; name=withAsyncThrows: Int throws
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal: ['(']{#withAsyncRethrows: () async throws -> Void##() async throws -> Void#}[')'][' rethrows'][#HasAsyncMembers#]; name=withAsyncRethrows: () async throws -> Void rethrows
+// CHECK_initializers: End completions
+}

--- a/test/SourceKit/CodeComplete/complete_structure.swift
+++ b/test/SourceKit/CodeComplete/complete_structure.swift
@@ -40,8 +40,8 @@ func test1(_ x: S1) {
 // S1_DOT: {name:method4}({params:{t:Int}, {t:Int}})
 // S1_DOT: {name:method5}({params:{t:&Int}, {n:b:}{t: &Int}})
 // FIXME: put throws in a range!
-// S1_DOT: {name:method6}({params:{l:c:}{t: Int}}){throws: throws}
-// S1_DOT: {name:method7}({params:{l:callback:}{t: () throws -> ()}}){throws: rethrows}
+// S1_DOT: {name:method6}({params:{l:c:}{t: Int}}) throws
+// S1_DOT: {name:method7}({params:{l:callback:}{t: () throws -> ()}}) rethrows
 // S1_DOT: {name:method8}({params:{l:d:}{t: (T, U) -> T}, {n:e:}{t: (T) -> U}})
 // S1_DOT: {name:v1}
 // S1_DOT: {name:v2}

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -120,7 +120,6 @@ struct CodeCompletionInfo {
   struct DescriptionStructure {
     IndexRange baseName;
     IndexRange parameterRange;
-    IndexRange throwsRange;
   };
 
   Optional<DescriptionStructure> descriptionStructure;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -271,12 +271,6 @@ static void getResultStructure(
     if (C.is(ChunkKind::BraceStmtWithCursor))
       break;
 
-    if (C.is(ChunkKind::ThrowsKeyword) ||
-        C.is(ChunkKind::RethrowsKeyword)) {
-      structure.throwsRange.begin = textSize;
-      structure.throwsRange.end = textSize + C.getText().size();
-    }
-
     if (C.is(ChunkKind::CallParameterBegin)) {
       CodeCompletionInfo::ParameterStructure param;
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2263,8 +2263,6 @@ bool SKGroupedCodeCompletionConsumer::handleResult(const CodeCompletionInfo &R) 
              R.descriptionStructure->baseName);
     addRange(structure, KeyBodyOffset, KeyBodyLength,
              R.descriptionStructure->parameterRange);
-    addRange(structure, KeyThrowOffset, KeyThrowLength,
-             R.descriptionStructure->throwsRange);
 
     if (R.parametersStructure) {
       auto params = structure.setArray(KeySubStructure);

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -83,8 +83,6 @@ UID_KEYS = [
     KEY('NameLength', 'key.namelength'),
     KEY('BodyOffset', 'key.bodyoffset'),
     KEY('BodyLength', 'key.bodylength'),
-    KEY('ThrowOffset', 'key.throwoffset'),
-    KEY('ThrowLength', 'key.throwlength'),
     KEY('DocOffset', 'key.docoffset'),
     KEY('DocLength', 'key.doclength'),
     KEY('IsLocal', 'key.is_local'),


### PR DESCRIPTION
Similar to how it shows "throws" today.
Introduced `CodeCompletionStringChunk::ChunkKind::AsyncKeyword`

rdar://problem/72198530
