### PR TITLE
Re-enable test/IRGen/objc_super.swift with optimized, no asserts stdlib

### DIFF
--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -4,8 +4,7 @@
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
-
-// REQUIRES: rdar_72091795
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 import gizmo
 


### PR DESCRIPTION
Fixes rdar://72091795
