### PR TITLE
[swift-driver] Make checked build-record paths in many tests insensitive to ./ prefix

### DIFF
--- a/test/Driver/Dependencies/check-interface-implementation-fine.swift
+++ b/test/Driver/Dependencies/check-interface-implementation-fine.swift
@@ -14,9 +14,9 @@
 // CHECK-FIRST: Handled c.swift
 // CHECK-FIRST: Handled bad.swift
 
-// CHECK-RECORD-CLEAN-DAG: "./a.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./bad.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./c.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}a.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}bad.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}c.swift": [
 
 
 // RUN: touch -t 201401240006 %t/a.swift
@@ -29,9 +29,9 @@
 // CHECK-A: Handled bad.swift
 // NEGATIVE-A-NOT: Handled c.swift
 
-// CHECK-RECORD-A-DAG: "./a.swift": [
-// CHECK-RECORD-A-DAG: "./bad.swift": !private [
-// CHECK-RECORD-A-DAG: "./c.swift": !private [
+// CHECK-RECORD-A-DAG: "{{(./)?}}a.swift": [
+// CHECK-RECORD-A-DAG: "{{(./)?}}bad.swift": !private [
+// CHECK-RECORD-A-DAG: "{{(./)?}}c.swift": !private [
 
 // RUN: cd %t &&   %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./c.swift  -module-name main -j1 -v  -driver-show-incremental 2>&1 | %FileCheck -check-prefix CHECK-BC %s
 

--- a/test/Driver/Dependencies/crash-added-fine.swift
+++ b/test/Driver/Dependencies/crash-added-fine.swift
@@ -17,9 +17,9 @@
 // CHECK-ADDED: Handled crash.swift
 // CHECK-ADDED-NOT: Handled
 
-// CHECK-RECORD-ADDED-DAG: "./crash.swift": !private [
-// CHECK-RECORD-ADDED-DAG: "./main.swift": [
-// CHECK-RECORD-ADDED-DAG: "./other.swift": [
+// CHECK-RECORD-ADDED-DAG: "{{(./)?}}crash.swift": !private [
+// CHECK-RECORD-ADDED-DAG: "{{(./)?}}main.swift": [
+// CHECK-RECORD-ADDED-DAG: "{{(./)?}}other.swift": [
 
 
 // RUN: %empty-directory(%t)

--- a/test/Driver/Dependencies/crash-simple-fine.swift
+++ b/test/Driver/Dependencies/crash-simple-fine.swift
@@ -20,9 +20,9 @@
 
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
-// CHECK-RECORD-DAG: "./crash.swift": !private [
-// CHECK-RECORD-DAG: "./main.swift": !private [
-// CHECK-RECORD-DAG: "./other.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}crash.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}main.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}other.swift": !private [
 
 // RUN: cd %t &&  %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 

--- a/test/Driver/Dependencies/dependencies-preservation-fine.swift
+++ b/test/Driver/Dependencies/dependencies-preservation-fine.swift
@@ -9,7 +9,7 @@
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json
 
 // RUN: %FileCheck -check-prefix CHECK-ORIGINAL %s < main~buildrecord.swiftdeps~
-// CHECK-ORIGINAL: inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}
+// CHECK-ORIGINAL: inputs: {"{{(./)?}}main.swift": [443865900, 0], "{{(./)?}}other.swift": [443865900, 0]}
 
 // RUN: %FileCheck -check-prefix CHECK-OVERWRITTEN %s < main~buildrecord.swiftdeps
 // CHECK-OVERWRITTEN: version: "{{.*}}"

--- a/test/Driver/Dependencies/dependencies-preservation-fine.swift
+++ b/test/Driver/Dependencies/dependencies-preservation-fine.swift
@@ -16,5 +16,5 @@
 // CHECK-OVERWRITTEN: options: "{{.*}}"
 // CHECK-OVERWRITTEN: build_time: [{{[0-9]*}}, {{[0-9]*}}]
 // CHECK-OVERWRITTEN: inputs:
-// CHECK-OVERWRITTEN: "./main.swift": [443865900, 0]
-// CHECK-OVERWRITTEN: "./other.swift": [443865900, 0]
+// CHECK-OVERWRITTEN: "{{(./)?}}main.swift": [443865900, 0]
+// CHECK-OVERWRITTEN: "{{(./)?}}other.swift": [443865900, 0]

--- a/test/Driver/Dependencies/fail-added-fine.swift
+++ b/test/Driver/Dependencies/fail-added-fine.swift
@@ -17,9 +17,9 @@
 // CHECK-ADDED: Handled bad.swift
 // CHECK-ADDED-NOT: Handled
 
-// CHECK-RECORD-ADDED-DAG: "./bad.swift": !private [
-// CHECK-RECORD-ADDED-DAG: "./main.swift": [
-// CHECK-RECORD-ADDED-DAG: "./other.swift": [
+// CHECK-RECORD-ADDED-DAG: "{{(./)?}}bad.swift": !private [
+// CHECK-RECORD-ADDED-DAG: "{{(./)?}}main.swift": [
+// CHECK-RECORD-ADDED-DAG: "{{(./)?}}other.swift": [
 
 
 // RUN: %empty-directory(%t)

--- a/test/Driver/Dependencies/fail-chained-fine.swift
+++ b/test/Driver/Dependencies/fail-chained-fine.swift
@@ -16,13 +16,13 @@
 // CHECK-FIRST: Handled f.swift
 // CHECK-FIRST: Handled bad.swift
 
-// CHECK-RECORD-CLEAN-DAG: "./a.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./b.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./c.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./d.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./e.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./f.swift": [
-// CHECK-RECORD-CLEAN-DAG: "./bad.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}a.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}b.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}c.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}d.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}e.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}f.swift": [
+// CHECK-RECORD-CLEAN-DAG: "{{(./)?}}bad.swift": [
 
 
 // RUN: touch -t 201401240006 %t/a.swift
@@ -39,13 +39,13 @@
 // NEGATIVE-A-NOT: Handled e.swift
 // NEGATIVE-A-NOT: Handled f.swift
 
-// CHECK-RECORD-A-DAG: "./a.swift": [
-// CHECK-RECORD-A-DAG: "./b.swift": [
-// CHECK-RECORD-A-DAG: "./c.swift": !private [
-// CHECK-RECORD-A-DAG: "./d.swift": !private [
-// CHECK-RECORD-A-DAG: "./e.swift": !private [
-// CHECK-RECORD-A-DAG: "./f.swift": [
-// CHECK-RECORD-A-DAG: "./bad.swift": !private [
+// CHECK-RECORD-A-DAG: "{{(./)?}}a.swift": [
+// CHECK-RECORD-A-DAG: "{{(./)?}}b.swift": [
+// CHECK-RECORD-A-DAG: "{{(./)?}}c.swift": !private [
+// CHECK-RECORD-A-DAG: "{{(./)?}}d.swift": !private [
+// CHECK-RECORD-A-DAG: "{{(./)?}}e.swift": !private [
+// CHECK-RECORD-A-DAG: "{{(./)?}}f.swift": [
+// CHECK-RECORD-A-DAG: "{{(./)?}}bad.swift": !private [
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/a2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/a2.txt
@@ -81,13 +81,13 @@
 // NEGATIVE-B-NOT: Handled e.swift
 // NEGATIVE-B-NOT: Handled f.swift
 
-// CHECK-RECORD-B-DAG: "./a.swift": [
-// CHECK-RECORD-B-DAG: "./b.swift": [
-// CHECK-RECORD-B-DAG: "./c.swift": [
-// CHECK-RECORD-B-DAG: "./d.swift": [
-// CHECK-RECORD-B-DAG: "./e.swift": [
-// CHECK-RECORD-B-DAG: "./f.swift": [
-// CHECK-RECORD-B-DAG: "./bad.swift": !private [
+// CHECK-RECORD-B-DAG: "{{(./)?}}a.swift": [
+// CHECK-RECORD-B-DAG: "{{(./)?}}b.swift": [
+// CHECK-RECORD-B-DAG: "{{(./)?}}c.swift": [
+// CHECK-RECORD-B-DAG: "{{(./)?}}d.swift": [
+// CHECK-RECORD-B-DAG: "{{(./)?}}e.swift": [
+// CHECK-RECORD-B-DAG: "{{(./)?}}f.swift": [
+// CHECK-RECORD-B-DAG: "{{(./)?}}bad.swift": !private [
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B2 %s < %t/b2.txt

--- a/test/Driver/Dependencies/fail-interface-hash-fine.swift
+++ b/test/Driver/Dependencies/fail-interface-hash-fine.swift
@@ -24,10 +24,10 @@
 // CHECK-SECOND: Handled bad.swift
 // CHECK-SECOND-NOT: Handled depends
 
-// CHECK-RECORD-DAG: "./bad.swift": !private [
-// CHECK-RECORD-DAG: "./main.swift": [
-// CHECK-RECORD-DAG: "./depends-on-main.swift": !private [
-// CHECK-RECORD-DAG: "./depends-on-bad.swift": [
+// CHECK-RECORD-DAG: "{{(./)?}}bad.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}main.swift": [
+// CHECK-RECORD-DAG: "{{(./)?}}depends-on-main.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}depends-on-bad.swift": [
 
 // RUN: cd %t &&  %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 

--- a/test/Driver/Dependencies/fail-simple-fine.swift
+++ b/test/Driver/Dependencies/fail-simple-fine.swift
@@ -19,9 +19,9 @@
 // CHECK-SECOND-NOT: Handled main.swift
 // CHECK-SECOND-NOT: Handled other.swift
 
-// CHECK-RECORD-DAG: "./bad.swift": !private [
-// CHECK-RECORD-DAG: "./main.swift": !private [
-// CHECK-RECORD-DAG: "./other.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}bad.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}main.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}other.swift": !private [
 
 // RUN: cd %t &&  %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 

--- a/test/Driver/Dependencies/fail-with-bad-deps-fine.swift
+++ b/test/Driver/Dependencies/fail-with-bad-deps-fine.swift
@@ -42,9 +42,9 @@
 // CHECK-WITH-FAIL: Handled bad.swift
 // CHECK-WITH-FAIL-NOT: Handled depends
 
-// CHECK-RECORD-DAG: "./bad.swift": !private [
-// CHECK-RECORD-DAG: "./main.swift": [
-// CHECK-RECORD-DAG: "./depends-on-main.swift": !private [
-// CHECK-RECORD-DAG: "./depends-on-bad.swift": [
+// CHECK-RECORD-DAG: "{{(./)?}}bad.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}main.swift": [
+// CHECK-RECORD-DAG: "{{(./)?}}depends-on-main.swift": !private [
+// CHECK-RECORD-DAG: "{{(./)?}}depends-on-bad.swift": [
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental ./bad.swift ./main.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BUILD-ALL %s

--- a/test/Driver/Dependencies/whole-module-build-record.swift
+++ b/test/Driver/Dependencies/whole-module-build-record.swift
@@ -10,8 +10,8 @@
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Produced main.o
 
-// CHECK-RECORD-DAG: "./main.swift": [
-// CHECK-RECORD-DAG: "./other.swift": [
+// CHECK-RECORD-DAG: "{{(./)?}}main.swift": [
+// CHECK-RECORD-DAG: "{{(./)?}}other.swift": [
 
 
 // RUN: touch -t 201401240006 %t/other.swift


### PR DESCRIPTION
The swift-driver normalizes relative paths with the effect that an input file "./main.swift" gets written to a build record entry as "main.swift", without the "./". Remove the check of that part of the path from those tests in `Driver/Dependencies` where it is easy to do so, in service of getting the new driver to pass.