### PR TITLE
[Concurrency] Schedule "async let" child tasks.

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -428,6 +428,10 @@ public func _runChildTask<T>(operation: @escaping () async throws -> T) async
   // Create the asynchronous task future.
   let (task, _) = Builtin.createAsyncTaskFuture(
       flags.bits, currentTask, operation)
+
+  // Enqueue the resulting job.
+  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+
   return task
 }
 

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -1,0 +1,83 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+actor class Counter {
+  private var value = 0
+  private let scratchBuffer: UnsafeMutableBufferPointer<Int>
+
+  init(maxCount: Int) {
+    scratchBuffer = .allocate(capacity: maxCount)
+  }
+
+  func next() -> Int {
+    let current = value
+
+    // Make sure we haven't produced this value before
+    assert(scratchBuffer[current] == 0)
+    scratchBuffer[current] = 1
+
+    value = value + 1
+    return current
+  }
+}
+
+
+func worker(
+  identity: Int, counters: [Counter], numIterations: Int,
+  scratchBuffer: UnsafeMutableBufferPointer<Int>
+) async {
+  for i in 0..<numIterations {
+    let counterIndex = Int.random(in: 0 ..< counters.count)
+    let counter = counters[counterIndex]
+    let nextValue = await counter.next()
+    print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+  }
+}
+
+func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
+  let scratchBuffer = UnsafeMutableBufferPointer<Int>.allocate(
+    capacity: numCounters * numWorkers * numIterations
+  )
+
+  // Create counter actors.
+  var counters: [Counter] = []
+  for i in 0..<numCounters {
+    counters.append(Counter(maxCount: numWorkers * numIterations))
+  }
+
+  // Create a bunch of worker threads.
+  var workers: [Task.Handle<Void>] = []
+  for i in 0..<numWorkers {
+    workers.append(
+      Task.runDetached {
+        usleep(UInt32.random(in: 0..<100) * 1000)
+        await worker(
+          identity: i, counters: counters, numIterations: numIterations,
+          scratchBuffer: scratchBuffer
+        )
+      }
+    )
+  }
+
+  // Wait until all of the workers have finished.
+  for worker in workers {
+    await try! worker.get()
+  }
+
+  // Clear out the scratch buffer.
+  scratchBuffer.deallocate()
+  print("DONE!")
+}
+
+runAsyncAndBlock {
+  await runTest(numCounters: 10, numWorkers: 100, numIterations: 1000)
+}

--- a/test/Concurrency/Runtime/async_let_fibonacci.swift
+++ b/test/Concurrency/Runtime/async_let_fibonacci.swift
@@ -1,0 +1,53 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+func fib(_ n: Int) -> Int {
+  var first = 0
+  var second = 1
+  for _ in 0..<n {
+    let temp = first
+    first = second
+    second = temp + first
+  }
+  return first
+}
+
+func asyncFib(_ n: Int) async -> Int {
+  if n == 0 || n == 1 {
+    return n
+  }
+
+  async let first = await asyncFib(n-2)
+  async let second = await asyncFib(n-1)
+
+  // Sleep a random amount of time waiting on the result producing a result.
+  usleep(UInt32.random(in: 0..<100) * 1000)
+
+  let result = await first + second
+
+  // Sleep a random amount of time before producing a result.
+  usleep(UInt32.random(in: 0..<100) * 1000)
+
+  return result
+}
+
+func runFibonacci(_ n: Int) async {
+  let result = await asyncFib(n)
+
+  print()
+  print("Async fib = \(result), sequential fib = \(fib(n))")
+  assert(result == fib(n))
+}
+
+runAsyncAndBlock {
+  await runFibonacci(10)
+}


### PR DESCRIPTION
This provides runtime support for "async let". Add a simple test of
"async let" along with a simple test of the actor runtime.
