### PR TITLE
shims: add a workaround for `sqrtf` on Windows x86

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -129,7 +129,12 @@ float _stdlib_remainderf(float _self, float _other) {
   
 static inline SWIFT_ALWAYS_INLINE
 float _stdlib_squareRootf(float _self) {
+#if defined(_WIN32) && (defined(_M_IX86) || defined(__i386__))
+  typedef float __m128 __attribute__((__vector_size__(16), __aligned__(16)));
+  return __builtin_ia32_sqrtss(__extension__ (__m128){ _self, 0, 0, 0 })[0];
+#else
   return __builtin_sqrtf(_self);
+#endif
 }
 
 static inline SWIFT_ALWAYS_INLINE


### PR DESCRIPTION
When building for Windows x86, we have a few conspiring issues to
contend with.  `__builtin_sqrtf` is treated by clang as a `__builtin_`
prefixed libm call.  On windows, there is no libm, with the role being
taken up by ucrt.  However, on 32-bit x86 targets, ucrt does not provide
an implementation of `sqrtf` instead defining it inline as a wrapper
which widens the argument to a double precision and invokes `sqrt`, the
result of which is narrowed to the result.  This function is locally
defined and expected to be inlined and no out-of-line definition is
provided by ucrt that can be referenced.

Adjusting the shims to use the intrinsics would be the next option
(thanks @stephentyrone!) which would work.  However, when building the
standard library, we need to combine the system headers which results in
the use of the MSVCRT headers for `xmmintrin.h` rather than clang.  As a
result, we cannot directly use the intrinsics.

Opt to instead open-code the intrinsic path by using the compiler
builtin for sqrt.  This both yields the optimal implementation and
avoids providing an additional entry point in the runtime.  It also has
code size benefits.

A special thanks to @stephentyrone for all the discussion and help with
this!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
