### PR TITLE
PrebuiltModules: being resilient to 0-specified build number

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -81,6 +81,26 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   DiagnosticOpts.LocalizationPath = std::string(DiagnosticMessagesDir.str());
 }
 
+static std::string
+getVersionedPrebuiltModulePath(Optional<llvm::VersionTuple> sdkVer,
+                               StringRef defaultPrebuiltPath) {
+  if (!sdkVer.hasValue())
+    return defaultPrebuiltPath.str();
+  std::string versionStr = sdkVer->getAsString();
+  StringRef vs = versionStr;
+  do {
+    SmallString<64> pathWithSDKVer = defaultPrebuiltPath;
+    llvm::sys::path::append(pathWithSDKVer, vs);
+    if (llvm::sys::fs::exists(pathWithSDKVer)) {
+      return pathWithSDKVer.str().str();
+    } else if (vs.endswith(".0")) {
+      vs = vs.substr(0, vs.size() - 2);
+    } else {
+      return defaultPrebuiltPath.str();
+    }
+  } while(true);
+}
+
 void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
 
   if (!FrontendOpts.PrebuiltModuleCachePath.empty())
@@ -101,18 +121,8 @@ void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
 
   // If the SDK version is given, we should check if SDK-versioned prebuilt
   // module cache is available and use it if so.
-  if (auto ver = LangOpts.SDKVersion) {
-    // "../macosx/prebuilt-modules"
-    SmallString<64> defaultPrebuiltPathWithSDKVer = defaultPrebuiltPath;
-    // "../macosx/prebuilt-modules/10.15"
-    llvm::sys::path::append(defaultPrebuiltPathWithSDKVer, ver->getAsString());
-    // If the versioned prebuilt module cache exists in the disk, use it.
-    if (llvm::sys::fs::exists(defaultPrebuiltPathWithSDKVer)) {
-      FrontendOpts.PrebuiltModuleCachePath = std::string(defaultPrebuiltPathWithSDKVer.str());
-      return;
-    }
-  }
-  FrontendOpts.PrebuiltModuleCachePath = std::string(defaultPrebuiltPath.str());
+  FrontendOpts.PrebuiltModuleCachePath =
+    getVersionedPrebuiltModulePath(LangOpts.SDKVersion, defaultPrebuiltPath);
 }
 
 static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,

--- a/test/ModuleInterface/default-prebuilt-module-location-sdk-versioned.swift
+++ b/test/ModuleInterface/default-prebuilt-module-location-sdk-versioned.swift
@@ -24,6 +24,18 @@
 // 6. Make sure we installed a forwarding module in the module cache.
 // RUN: %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
 
+// 5.1. Import this prebuilt module, but DON'T pass in -prebuilt-module-cache-path, it should use the implicit one from the SDK-versioned prebuilt module cache dir.
+// RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -target-sdk-version 10.15.0
+
+// 6.1. Make sure we installed a forwarding module in the module cache.
+// RUN: %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
+
+// 5.2. Import this prebuilt module, but DON'T pass in -prebuilt-module-cache-path, it should use the implicit one from the SDK-versioned prebuilt module cache dir.
+// RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -target-sdk-version 10.15.0.0
+
+// 6.2. Make sure we installed a forwarding module in the module cache.
+// RUN: %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
+
 // 7. Remove the prebuilt module from the SDK-versioned prebuilt module cache dir.
 // RUN: %empty-directory(%t/ResourceDir/%target-sdk-name/prebuilt-modules/10.15)
 
@@ -31,6 +43,18 @@
 // RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -target-sdk-version 10.15
 
 // 9. Make sure we built a binary module in the module cache.
+// RUN: not %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
+
+// 8.1. Import this prebuilt module, it should not find the prebuilt module cache.
+// RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -target-sdk-version 10.15.0
+
+// 9.1. Make sure we built a binary module in the module cache.
+// RUN: not %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
+
+// 8.2. Import this prebuilt module, it should not find the prebuilt module cache.
+// RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -target-sdk-version 10.15.0.0
+
+// 9.2. Make sure we built a binary module in the module cache.
 // RUN: not %{python} %S/ModuleCache/Inputs/check-is-forwarding-module.py %t/ModuleCache/PrebuiltModule-*.swiftmodule
 
 import PrebuiltModule


### PR DESCRIPTION
swift-driver passes down an SDK version number with a non-existing build number as 0.
The compiler should be resilient to this so we can locate prebuilt module cache.

rdar://72230172
