### PR TITLE
[Parse/CodeCompletion] Implement effects specifier completion

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -748,6 +748,9 @@ ERROR(expected_dynamic_func_attr,none,
 ERROR(async_after_throws,none,
       "'async' must precede %select{'throws'|'rethrows'}0", (bool))
 ERROR(async_init,none, "initializer cannot be marked 'async'", ())
+ERROR(duplicate_effect_specifier,none,
+      "unexpected %select{'throws'|'rethrows'|'async'}0",
+      (unsigned))
 
 // Enum Types
 ERROR(expected_expr_enum_case_raw_value,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -732,8 +732,7 @@ ERROR(rethrowing_function_type,none,
       "only function declarations may be marked 'rethrows'; "
       "did you mean 'throws'?", ())
 ERROR(async_or_throws_in_wrong_position,none,
-      "%select{'throws'|'rethrows'|'async'}0 may only occur before '->'",
-      (unsigned))
+      "'%0' may only occur before '->'", (StringRef))
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())
 ERROR(expected_type_before_arrow,none,
@@ -748,8 +747,8 @@ ERROR(expected_dynamic_func_attr,none,
 ERROR(async_after_throws,none,
       "'async' must precede %select{'throws'|'rethrows'}0", (bool))
 ERROR(async_init,none, "initializer cannot be marked 'async'", ())
-ERROR(duplicate_effect_specifier,none,
-      "unexpected '%0' specifier", (StringRef))
+ERROR(duplicate_effects_specifier,none,
+      "'%0' has already been specified", (StringRef))
 
 // Enum Types
 ERROR(expected_expr_enum_case_raw_value,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -749,8 +749,7 @@ ERROR(async_after_throws,none,
       "'async' must precede %select{'throws'|'rethrows'}0", (bool))
 ERROR(async_init,none, "initializer cannot be marked 'async'", ())
 ERROR(duplicate_effect_specifier,none,
-      "unexpected %select{'throws'|'rethrows'|'async'}0",
-      (unsigned))
+      "unexpected '%0' specifier", (StringRef))
 
 // Enum Types
 ERROR(expected_expr_enum_case_raw_value,PointsToFirstBadToken,

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -549,6 +549,7 @@ enum class CompletionKind {
   AccessorBeginning,
   AttributeBegin,
   AttributeDeclParen,
+  EffectsSpecifier,
   PoundAvailablePlatform,
   CallArg,
   LabeledTrailingClosure,

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -181,6 +181,9 @@ public:
   /// @available.
   virtual void completeDeclAttrParam(DeclAttrKind DK, int Index) {};
 
+  /// Complete 'async' and 'throws' at effects specifier position.
+  virtual void completeEffectsSpecifier(bool hasAsync, bool hasThrows) {};
+
   /// Complete within a precedence group decl or after a colon in an
   /// operator decl.
   virtual void completeInPrecedenceGroup(SyntaxKind SK) {};

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1563,8 +1563,9 @@ public:
   /// \param explicitResultType The explicit result type, if specified.
   /// \param inLoc The location of the 'in' keyword, if present.
   ///
-  /// \returns true if an error occurred, false otherwise.
-  bool parseClosureSignatureIfPresent(
+  /// \returns ParserStatus error if an error occurred. Success if no signature
+  /// is present or succssfully parsed.
+  ParserStatus parseClosureSignatureIfPresent(
           SourceRange &bracketRange,
           SmallVectorImpl<CaptureListEntry> &captureList,
           VarDecl *&capturedSelfParamDecl,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1357,6 +1357,9 @@ public:
                                       SourceLoc &asyncLoc, SourceLoc &throwsLoc,
                                       bool *rethrows);
 
+  /// Returns 'true' if \p T is considered effects specifier.
+  bool isEffectsSpecifier(const Token &T);
+
   //===--------------------------------------------------------------------===//
   // Pattern Parsing
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1353,9 +1353,9 @@ public:
   ///
   /// \param rethrows If non-NULL, will also parse the 'rethrows' keyword in
   /// lieu of 'throws'.
-  void parseAsyncThrows(
-      SourceLoc existingArrowLoc, SourceLoc &asyncLoc, SourceLoc &throwsLoc,
-      bool *rethrows);
+  ParserStatus parseEffectsSpecifiers(SourceLoc existingArrowLoc,
+                                      SourceLoc &asyncLoc, SourceLoc &throwsLoc,
+                                      bool *rethrows);
 
   //===--------------------------------------------------------------------===//
   // Pattern Parsing
@@ -1432,6 +1432,15 @@ public:
   ///   qualified-decl-name-base-type: simple-type-identifier '.'
   /// \endverbatim
   bool canParseBaseTypeForQualifiedDeclName();
+
+  /// Returns true if the current token is '->' or effects specifiers followed
+  /// by '->'.
+  ///
+  /// e.g.
+  ///  throws ->       // true
+  ///  async throws -> // true
+  ///  throws {        // false
+  bool isAtFunctionTypeArrow();
 
   //===--------------------------------------------------------------------===//
   // Expression Parsing

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1640,6 +1640,7 @@ public:
   void completeCaseStmtBeginning(CodeCompletionExpr *E) override;
   void completeDeclAttrBeginning(bool Sil, bool isIndependent) override;
   void completeDeclAttrParam(DeclAttrKind DK, int Index) override;
+  void completeEffectsSpecifier(bool hasAsync, bool hasThrows) override;
   void completeInPrecedenceGroup(SyntaxKind SK) override;
   void completeNominalMemberBeginning(
       SmallVectorImpl<StringRef> &Keywords, SourceLoc introducerLoc) override;
@@ -5465,6 +5466,17 @@ void CodeCompletionCallbacksImpl::completeDeclAttrParam(DeclAttrKind DK,
   CurDeclContext = P.CurDeclContext;
 }
 
+void CodeCompletionCallbacksImpl::completeEffectsSpecifier(bool hasAsync,
+                                                           bool hasThrows) {
+  Kind = CompletionKind::EffectsSpecifier;
+  CurDeclContext = P.CurDeclContext;
+  ParsedKeywords.clear();
+  if (hasAsync)
+    ParsedKeywords.emplace_back("async");
+  if (hasThrows)
+    ParsedKeywords.emplace_back("throws");
+}
+
 void CodeCompletionCallbacksImpl::completeDeclAttrBeginning(
     bool Sil, bool isIndependent) {
   Kind = CompletionKind::AttributeBegin;
@@ -5778,6 +5790,15 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
   case CompletionKind::PrecedenceGroup:
   case CompletionKind::StmtLabel:
     break;
+
+  case CompletionKind::EffectsSpecifier: {
+    if (!llvm::is_contained(ParsedKeywords, "async") &&
+        Context.LangOpts.EnableExperimentalConcurrency)
+      addKeyword(Sink, "async", CodeCompletionKeywordKind::None);
+    if (!llvm::is_contained(ParsedKeywords, "throws"))
+      addKeyword(Sink, "throws", CodeCompletionKeywordKind::kw_throws);
+    break;
+  }
 
   case CompletionKind::AccessorBeginning: {
     // TODO: Omit already declared or mutally exclusive accessors.
@@ -6756,6 +6777,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   }
   case CompletionKind::AfterIfStmtElse:
   case CompletionKind::CaseStmtKeyword:
+  case CompletionKind::EffectsSpecifier:
     // Handled earlier by keyword completions.
     break;
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7511,7 +7511,11 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   SourceLoc asyncLoc;
   SourceLoc throwsLoc;
   bool rethrows = false;
-  parseAsyncThrows(SourceLoc(), asyncLoc, throwsLoc, &rethrows);
+  Status |= parseEffectsSpecifiers(SourceLoc(), asyncLoc, throwsLoc, &rethrows);
+  if (Status.hasCodeCompletion() && !CodeCompletion) {
+    // Trigger delayed parsing, no need to continue.
+    return Status;
+  }
 
   if (rethrows) {
     Attributes.add(new (Context) RethrowsAttr(throwsLoc));

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -139,7 +139,7 @@ ParserResult<Expr> Parser::parseExprArrow() {
     assert(throwsLoc.isValid() || asyncLoc.isValid());
     diagnose(throwsLoc.isValid() ? throwsLoc : asyncLoc,
              diag::async_or_throws_in_wrong_position,
-             throwsLoc.isValid() ? 0 : 2);
+             throwsLoc.isValid() ? "throws" : "async");
     return nullptr;
   }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2374,6 +2374,8 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
         if (consumeIf(tok::arrow)) {
           if (!canParseType())
             return makeParserSuccess();
+
+          consumeEffectsSpecifiers();
         }
       }
 
@@ -2396,6 +2398,8 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
       if (consumeIf(tok::arrow)) {
         if (!canParseType())
           return makeParserSuccess();
+
+        consumeEffectsSpecifiers();
       }
     }
     
@@ -2606,6 +2610,10 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
         status.setIsParseError();
       } else {
         explicitResultType = new (Context) TypeExpr(explicitResultTypeRepr);
+
+        // Check for 'throws' and 'rethrows' after the type and correct it.
+        parseEffectsSpecifiers(arrowLoc, asyncLoc, throwsLoc,
+                               /*rethrows*/nullptr);
       }
     }
   }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -787,7 +787,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
 
   // Check for the 'async' and 'throws' keywords.
   rethrows = false;
-  parseAsyncThrows(SourceLoc(), asyncLoc, throwsLoc, &rethrows);
+  Status |= parseEffectsSpecifiers(SourceLoc(), asyncLoc, throwsLoc, &rethrows);
 
   // If there's a trailing arrow, parse the rest as the result type.
   SourceLoc arrowLoc;
@@ -802,7 +802,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
 
     // Check for 'throws' and 'rethrows' after the arrow, but
     // before the type, and correct it.
-    parseAsyncThrows(arrowLoc, asyncLoc, throwsLoc, &rethrows);
+    parseEffectsSpecifiers(arrowLoc, asyncLoc, throwsLoc, &rethrows);
 
     ParserResult<TypeRepr> ResultType =
         parseDeclResultType(diag::expected_type_function_result);
@@ -812,7 +812,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
       return Status;
 
     // Check for 'throws' and 'rethrows' after the type and correct it.
-    parseAsyncThrows(arrowLoc, asyncLoc, throwsLoc, &rethrows);
+    parseEffectsSpecifiers(arrowLoc, asyncLoc, throwsLoc, &rethrows);
   } else {
     // Otherwise, we leave retType null.
     retType = nullptr;
@@ -821,52 +821,88 @@ Parser::parseFunctionSignature(Identifier SimpleName,
   return Status;
 }
 
-void Parser::parseAsyncThrows(
-    SourceLoc existingArrowLoc, SourceLoc &asyncLoc, SourceLoc &throwsLoc,
-    bool *rethrows) {
-  if (shouldParseExperimentalConcurrency() &&
-      Tok.isContextualKeyword("async")) {
-    asyncLoc = consumeToken();
+ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
+                                            SourceLoc &asyncLoc,
+                                            SourceLoc &throwsLoc,
+                                            bool *rethrows) {
+  ParserStatus status;
 
-    if (existingArrowLoc.isValid()) {
-      diagnose(asyncLoc, diag::async_or_throws_in_wrong_position, 2)
-        .fixItRemove(asyncLoc)
-        .fixItInsert(existingArrowLoc, "async ");
-    }
-  }
-
-  if (Tok.isAny(tok::kw_throws, tok::kw_throw, tok::kw_try) ||
-      (rethrows && Tok.is(tok::kw_rethrows))) {
-    // If we allowed parsing rethrows, record whether we did in fact parse it.
-    if (rethrows)
-      *rethrows = Tok.is(tok::kw_rethrows);
-
-    // Replace 'throw' or 'try' with 'throws'.
-    if (Tok.isAny(tok::kw_throw, tok::kw_try)) {
-      diagnose(Tok, diag::throw_in_function_type)
-        .fixItReplace(Tok.getLoc(), "throws");
-    }
-
-    StringRef keyword = Tok.getText();
-    throwsLoc = consumeToken();
-
-    if (existingArrowLoc.isValid()) {
-      diagnose(throwsLoc, diag::async_or_throws_in_wrong_position,
-               rethrows ? (*rethrows ? 1 : 0) : 0)
-        .fixItRemove(throwsLoc)
-        .fixItInsert(existingArrowLoc, (keyword + " ").str());
-    }
-
+  while (true) {
+    // 'async'
     if (shouldParseExperimentalConcurrency() &&
         Tok.isContextualKeyword("async")) {
-      asyncLoc = consumeToken();
 
-      diagnose(asyncLoc, diag::async_after_throws, rethrows && *rethrows)
-        .fixItRemove(asyncLoc)
-        .fixItInsert(
-          existingArrowLoc.isValid() ? existingArrowLoc : throwsLoc, "async ");
+      if (asyncLoc.isValid()) {
+        diagnose(Tok, diag::duplicate_effect_specifier, 2)
+            .fixItRemove(Tok.getLoc());
+      } else if (existingArrowLoc.isValid()) {
+        SourceLoc insertLoc = existingArrowLoc;
+        if (throwsLoc.isValid() &&
+            SourceMgr.isBeforeInBuffer(throwsLoc, insertLoc))
+          insertLoc = throwsLoc;
+        diagnose(Tok, diag::async_or_throws_in_wrong_position, 2)
+            .fixItRemove(Tok.getLoc())
+            .fixItInsert(insertLoc, "async ");
+      } else if (throwsLoc.isValid()) {
+        // 'async' cannot be after 'throws'.
+        assert(existingArrowLoc.isInvalid());
+        diagnose(Tok, diag::async_after_throws, rethrows && *rethrows)
+            .fixItRemove(Tok.getLoc())
+            .fixItInsert(throwsLoc, "async ");
+      }
+      if (asyncLoc.isInvalid())
+        asyncLoc = Tok.getLoc();
+      consumeToken();
+      continue;
     }
+
+    // 'throws'/'rethrows', or diagnose 'throw'/'try'.
+    if (Tok.isAny(tok::kw_throws, tok::kw_rethrows) ||
+        (Tok.isAny(tok::kw_throw, tok::kw_try) && !Tok.isAtStartOfLine())) {
+      bool isRethrows = Tok.is(tok::kw_rethrows);
+
+      if (Tok.isAny(tok::kw_throw, tok::kw_try)) {
+        // Replace 'throw' or 'try' with 'throws'.
+        diagnose(Tok, diag::throw_in_function_type)
+            .fixItReplace(Tok.getLoc(), "throws");
+      } else if (!rethrows && isRethrows) {
+        // Replace 'rethrows' with 'throws' unless it's allowed.
+        diagnose(Tok, diag::rethrowing_function_type)
+            .fixItReplace(Tok.getLoc(), "throws");
+      } else if (throwsLoc.isValid()) {
+        diagnose(Tok, diag::duplicate_effect_specifier,
+                 rethrows ? (isRethrows ? 1 : 0) : 0)
+            .fixItRemove(Tok.getLoc());
+      } else if (existingArrowLoc.isValid()) {
+        diagnose(Tok, diag::async_or_throws_in_wrong_position,
+                 rethrows ? (isRethrows ? 1 : 0) : 0)
+            .fixItRemove(Tok.getLoc())
+            .fixItInsert(existingArrowLoc, (Tok.getText() + " ").str());
+      }
+
+      if (throwsLoc.isInvalid()) {
+        if (rethrows)
+          *rethrows = isRethrows;
+        throwsLoc = Tok.getLoc();
+      }
+      consumeToken();
+      continue;
+    }
+
+    // Code completion.
+    if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine() &&
+        !existingArrowLoc.isValid()) {
+      if (CodeCompletion)
+        CodeCompletion->completeEffectsSpecifier(asyncLoc.isValid(),
+                                                 throwsLoc.isValid());
+      consumeToken(tok::code_complete);
+      status.setHasCodeCompletionAndIsError();
+      continue;
+    }
+
+    break;
   }
+  return status;
 }
 
 /// Parse a pattern with an optional type annotation.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -821,6 +821,21 @@ Parser::parseFunctionSignature(Identifier SimpleName,
   return Status;
 }
 
+bool Parser::isEffectsSpecifier(const Token &T) {
+  // NOTE: If this returns 'true', that token must be handled in
+  //       'parseEffectsSpecifiers()'.
+
+  if (shouldParseExperimentalConcurrency() &&
+      T.isContextualKeyword("async"))
+    return true;
+
+  if (T.isAny(tok::kw_throws, tok::kw_rethrows) ||
+      (T.isAny(tok::kw_throw, tok::kw_try) && !T.isAtStartOfLine()))
+    return true;
+
+  return false;
+}
+
 ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
                                             SourceLoc &asyncLoc,
                                             SourceLoc &throwsLoc,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -848,14 +848,15 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
         Tok.isContextualKeyword("async")) {
 
       if (asyncLoc.isValid()) {
-        diagnose(Tok, diag::duplicate_effect_specifier, Tok.getText())
+        diagnose(Tok, diag::duplicate_effects_specifier, Tok.getText())
+            .highlight(asyncLoc)
             .fixItRemove(Tok.getLoc());
       } else if (existingArrowLoc.isValid()) {
         SourceLoc insertLoc = existingArrowLoc;
         if (throwsLoc.isValid() &&
             SourceMgr.isBeforeInBuffer(throwsLoc, insertLoc))
           insertLoc = throwsLoc;
-        diagnose(Tok, diag::async_or_throws_in_wrong_position, 2)
+        diagnose(Tok, diag::async_or_throws_in_wrong_position, "async")
             .fixItRemove(Tok.getLoc())
             .fixItInsert(insertLoc, "async ");
       } else if (throwsLoc.isValid()) {
@@ -877,7 +878,8 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
       bool isRethrows = Tok.is(tok::kw_rethrows);
 
       if (throwsLoc.isValid()) {
-        diagnose(Tok, diag::duplicate_effect_specifier, Tok.getText())
+        diagnose(Tok, diag::duplicate_effects_specifier, Tok.getText())
+            .highlight(throwsLoc)
             .fixItRemove(Tok.getLoc());
       } else if (Tok.isAny(tok::kw_throw, tok::kw_try)) {
         // Replace 'throw' or 'try' with 'throws'.
@@ -888,8 +890,7 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
         diagnose(Tok, diag::rethrowing_function_type)
             .fixItReplace(Tok.getLoc(), "throws");
       } else if (existingArrowLoc.isValid()) {
-        diagnose(Tok, diag::async_or_throws_in_wrong_position,
-                 rethrows ? (isRethrows ? 1 : 0) : 0)
+        diagnose(Tok, diag::async_or_throws_in_wrong_position, Tok.getText())
             .fixItRemove(Tok.getLoc())
             .fixItInsert(existingArrowLoc, (Tok.getText() + " ").str());
       }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -848,7 +848,7 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
         Tok.isContextualKeyword("async")) {
 
       if (asyncLoc.isValid()) {
-        diagnose(Tok, diag::duplicate_effect_specifier, 2)
+        diagnose(Tok, diag::duplicate_effect_specifier, Tok.getText())
             .fixItRemove(Tok.getLoc());
       } else if (existingArrowLoc.isValid()) {
         SourceLoc insertLoc = existingArrowLoc;
@@ -876,7 +876,10 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
         (Tok.isAny(tok::kw_throw, tok::kw_try) && !Tok.isAtStartOfLine())) {
       bool isRethrows = Tok.is(tok::kw_rethrows);
 
-      if (Tok.isAny(tok::kw_throw, tok::kw_try)) {
+      if (throwsLoc.isValid()) {
+        diagnose(Tok, diag::duplicate_effect_specifier, Tok.getText())
+            .fixItRemove(Tok.getLoc());
+      } else if (Tok.isAny(tok::kw_throw, tok::kw_try)) {
         // Replace 'throw' or 'try' with 'throws'.
         diagnose(Tok, diag::throw_in_function_type)
             .fixItReplace(Tok.getLoc(), "throws");
@@ -884,10 +887,6 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
         // Replace 'rethrows' with 'throws' unless it's allowed.
         diagnose(Tok, diag::rethrowing_function_type)
             .fixItReplace(Tok.getLoc(), "throws");
-      } else if (throwsLoc.isValid()) {
-        diagnose(Tok, diag::duplicate_effect_specifier,
-                 rethrows ? (isRethrows ? 1 : 0) : 0)
-            .fixItRemove(Tok.getLoc());
       } else if (existingArrowLoc.isValid()) {
         diagnose(Tok, diag::async_or_throws_in_wrong_position,
                  rethrows ? (isRethrows ? 1 : 0) : 0)

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -365,49 +365,22 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   auto tyR = ty.get();
   auto status = ParserStatus(ty);
 
-  // Parse an async specifier.
+  // Parse effects specifiers.
+  // Don't consume them, if there's no following '->', so we can emit a more
+  // useful diagnostic when parsing a function decl.
   SourceLoc asyncLoc;
-  if (shouldParseExperimentalConcurrency() &&
-      Tok.isContextualKeyword("async") &&
-      peekToken().isAny(tok::arrow, tok::kw_throws)) {
-    asyncLoc = consumeToken();
-  }
-
-  // Parse a throws specifier.
-  // Don't consume 'throws', if the next token is not '->' or 'async', so we
-  // can emit a more useful diagnostic when parsing a function decl.
   SourceLoc throwsLoc;
-  if (Tok.isAny(tok::kw_throws, tok::kw_rethrows, tok::kw_throw, tok::kw_try) &&
-      (peekToken().is(tok::arrow) ||
-       (shouldParseExperimentalConcurrency() &&
-        peekToken().isContextualKeyword("async")))) {
-    if (Tok.isAny(tok::kw_rethrows, tok::kw_throw, tok::kw_try)) {
-      // 'rethrows' is only allowed on function declarations for now.
-      // 'throw' or 'try' are probably typos for 'throws'.
-      Diag<> DiagID = Tok.is(tok::kw_rethrows) ?
-        diag::rethrowing_function_type : diag::throw_in_function_type;
-      diagnose(Tok.getLoc(), DiagID)
-        .fixItReplace(Tok.getLoc(), "throws");
-    }
-    throwsLoc = consumeToken();
-
-    // 'async' must preceed 'throws'; accept this but complain.
-    if (shouldParseExperimentalConcurrency() &&
-        Tok.isContextualKeyword("async")) {
-      asyncLoc = consumeToken();
-
-      diagnose(asyncLoc, diag::async_after_throws, false)
-        .fixItRemove(asyncLoc)
-        .fixItInsert(throwsLoc, "async ");
-    }
+  if (isAtFunctionTypeArrow()) {
+    status |= parseEffectsSpecifiers(SourceLoc(), asyncLoc, throwsLoc,
+                                     /*rethrows=*/nullptr);
   }
 
+  // Handle type-function if we have an arrow.
   if (Tok.is(tok::arrow)) {
-    // Handle type-function if we have an arrow.
     SourceLoc arrowLoc = consumeToken();
 
     // Handle async/throws in the wrong place.
-    parseAsyncThrows(arrowLoc, asyncLoc, throwsLoc, /*rethrows=*/nullptr);
+    parseEffectsSpecifiers(arrowLoc, asyncLoc, throwsLoc, /*rethrows=*/nullptr);
 
     ParserResult<TypeRepr> SecondHalf =
         parseType(diag::expected_type_function_result);
@@ -1660,4 +1633,42 @@ bool Parser::canParseTypeTupleBody() {
   }
   
   return consumeIf(tok::r_paren);
+}
+
+bool Parser::isAtFunctionTypeArrow() {
+  if (Tok.is(tok::arrow))
+    return true;
+
+  auto isEffectsSpecifier = [this](const Token &T) -> bool {
+    if (shouldParseExperimentalConcurrency() &&
+        T.isContextualKeyword("async"))
+      return true;
+    if (T.isAny(tok::kw_throws, tok::kw_rethrows))
+      return true;
+    if (T.isAny(tok::kw_throw, tok::kw_try) && !T.isAtStartOfLine())
+      return true;
+    return false;
+  };
+
+  if (isEffectsSpecifier(Tok)) {
+    if (peekToken().is(tok::arrow))
+      return true;
+    if (isEffectsSpecifier(peekToken())) {
+      BacktrackingScope backtrack(*this);
+      consumeToken();
+      consumeToken();
+      return isAtFunctionTypeArrow();
+    }
+    // Don't look for '->' in code completion. The user may write it later.
+    if (peekToken().is(tok::code_complete) && !peekToken().isAtStartOfLine())
+      return true;
+
+    return false;
+  }
+
+  // Don't look for '->' in code completion. The user may write it later.
+  if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine())
+    return true;
+
+  return false;
 }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1639,17 +1639,6 @@ bool Parser::isAtFunctionTypeArrow() {
   if (Tok.is(tok::arrow))
     return true;
 
-  auto isEffectsSpecifier = [this](const Token &T) -> bool {
-    if (shouldParseExperimentalConcurrency() &&
-        T.isContextualKeyword("async"))
-      return true;
-    if (T.isAny(tok::kw_throws, tok::kw_rethrows))
-      return true;
-    if (T.isAny(tok::kw_throw, tok::kw_try) && !T.isAtStartOfLine())
-      return true;
-    return false;
-  };
-
   if (isEffectsSpecifier(Tok)) {
     if (peekToken().is(tok::arrow))
       return true;

--- a/test/IDE/complete_concurrency_specifier.swift
+++ b/test/IDE/complete_concurrency_specifier.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
+
+// SPECIFIER: Begin completions
+// SPECIFIER-DAG: Keyword/None:                       async; name=async
+// SPECIFIER-DAG: Keyword[throws]/None:               throws; name=throws
+// SPECIFIER: End completions
+
+// SPECIFIER_WITHASYNC: Begin completions
+// SPECIFIER_WITHASYNC-NOT: async
+// SPECIFIER_WITHASYNC-DAG: Keyword[throws]/None:               throws; name=throws
+// SPECIFIER_WITHASYNC-NOT: async
+// SPECIFIER_WITHASYNC: End completions
+
+// SPECIFIER_WITHTHROWS: Begin completions
+// SPECIFIER_WITHTHROWS-NOT: async
+// SPECIFIER_WITHTHROWS-DAG: Keyword/None:               async; name=async
+// SPECIFIER_WITHTHROWS-NOT: async
+// SPECIFIER_WITHTHROWS: End completions
+
+// SPECIFIER_WITHASYNCTHROWS-NOT: Begin completions
+
+func testSpecifier() #^SPECIFIER^#
+func testSpecifierWithAsync() async #^SPECIFIER_WITHASYNC^#
+func testSpecifierWithThrows() throws #^SPECIFIER_WITHTHROWS^#
+func testSpecifierWithAsyncThorws() async throws #^SPECIFIER_WITHASYNCTHROWS^#
+
+func testTypeSpecifier(_: () #^TYPE_SPECIFICER?check=SPECIFIER^#) {}
+func testTypeSpecifierWithAsync(_: () async #^TYPE_SPECIFICER_WITHASYNC?check=SPECIFIER_WITHASYNC^#) {}
+func testTypeSpecifierWithThrows(_: () throws #^TYPE_SPECIFICER_WITHTHROWS?check=SPECIFIER_WITHTHROWS^#) {}
+func testTypeSpecifierWithAsyncThrows(_: () async throws #^TYPE_SPECIFICER_WITHASYNCTHROWS?check=SPECIFIER_WITHASYNCTHROWS^#) {}
+func testTypeSpecifierWithArrow(_: () #^TYPE_SPECIFICER_WITHARROW?check=SPECIFIER^#) {}
+func testTypeSpecifierWithAsyncArrow(_: () async #^TYPE_SPECIFICER_WITHASYNCARROW?check=SPECIFIER_WITHASYNC^# -> Void) {}
+func testTypeSpecifierWithThrowsArrow(_: () throws #^TYPE_SPECIFICER_WITHTHROWSARROW?check=SPECIFIER_WITHTHROWS^# -> Void
+func testTypeSpecifierWithAsyncThrowsArrow(_: () async throws #^TYPE_SPECIFICER_WITHASYNCTHROWSARROW?check=SPECIFIER_WITHASYNCTHROWS^# -> Void) {}

--- a/test/IDE/complete_concurrency_specifier.swift
+++ b/test/IDE/complete_concurrency_specifier.swift
@@ -32,3 +32,12 @@ func testTypeSpecifierWithArrow(_: () #^TYPE_SPECIFICER_WITHARROW?check=SPECIFIE
 func testTypeSpecifierWithAsyncArrow(_: () async #^TYPE_SPECIFICER_WITHASYNCARROW?check=SPECIFIER_WITHASYNC^# -> Void) {}
 func testTypeSpecifierWithThrowsArrow(_: () throws #^TYPE_SPECIFICER_WITHTHROWSARROW?check=SPECIFIER_WITHTHROWS^# -> Void
 func testTypeSpecifierWithAsyncThrowsArrow(_: () async throws #^TYPE_SPECIFICER_WITHASYNCTHROWSARROW?check=SPECIFIER_WITHASYNCTHROWS^# -> Void) {}
+
+_ = { () #^CLOSURE?check=SPECIFIER^# in }
+_ = { () async #^CLOSURE_WITHASYNC?check=SPECIFIER_WITHASYNC^# in }
+_ = { () throws #^CLOSURE_WITHTHROWS?check=SPECIFIER_WITHTHROWS^# in }
+_ = { () async throws #^CLOSURE_WITHAASYNCTHROWS?check=SPECIFIER_WITHASYNCTHROWS^# in }
+_ = { () #^CLOSURE_WITHARROW?check=SPECIFIER^# -> Void in }
+_ = { () async #^CLOSURE_WITHASYNCARROW?check=SPECIFIER_WITHASYNC^# -> Void in }
+_ = { () throws #^CLOSURE_WITHTHROWSARROW?check=SPECIFIER_WITHTHROWS^# -> Void in }
+_ = { () async throws #^CLOSURE_WITHASYNCTHROWSARROW?check=SPECIFIER_WITHASYNCTHROWS^# -> Void in }

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -22,6 +22,11 @@ func asyncGlobal6() -> Int throws async { }
 
 func asyncGlobal7() throws -> Int async { } // expected-error{{'async' may only occur before '->'}}{{35-41=}}{{21-21=async }}
 
+func asyncGlobal8() async throws async -> async Int async {}
+// expected-error@-1{{unexpected 'async' specifier}} {{34-40=}}
+// expected-error@-2{{unexpected 'async' specifier}} {{43-49=}}
+// expected-error@-3{{unexpected 'async' specifier}} {{53-59=}}
+
 class X {
   init() async { } // expected-error{{initializer cannot be marked 'async'}}
 

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -12,20 +12,15 @@ func asyncGlobal3(fn: () throws -> Int) rethrows async { } // expected-error{{'a
 
 func asyncGlobal4() -> Int async { } // expected-error{{'async' may only occur before '->'}}{{28-34=}}{{21-21=async }}
 
-// If both async and throws follow the return type in the correct order,
-// throws will get the error and fix-it first. Applying the fix-it will cause
-// the async error and fix-it to be emitted. Applying that will place the async
-// in the appropriate place.
-
-// expected-error@+1{{'throws' may only occur before '->'}}{{34-41=}}{{21-21=throws }}
 func asyncGlobal5() -> Int async throws { }
+// expected-error@-1{{'async' may only occur before '->'}}{{28-34=}}{{21-21=async }}
+// expected-error@-2{{'throws' may only occur before '->'}}{{34-41=}}{{21-21=throws }}
 
-// If they are in the wrong order, the first fix-it will put them in the right
-// order and will be the same as the above case
-// expected-error@+1{{'async' must precede 'throws'}}{{35-41=}}{{28-28=async }}
 func asyncGlobal6() -> Int throws async { }
+// expected-error@-1{{'throws' may only occur before '->'}}{{28-35=}}{{21-21=throws }}
+// expected-error@-2{{'async' may only occur before '->'}}{{35-41=}}{{21-21=async }}
 
-func asyncGlobal7() throws -> Int async { } // expected-error{{'async' may only occur before '->'}}{{35-41=}}{{28-28=async }}
+func asyncGlobal7() throws -> Int async { } // expected-error{{'async' may only occur before '->'}}{{35-41=}}{{21-21=async }}
 
 class X {
   init() async { } // expected-error{{initializer cannot be marked 'async'}}

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -23,9 +23,9 @@ func asyncGlobal6() -> Int throws async { }
 func asyncGlobal7() throws -> Int async { } // expected-error{{'async' may only occur before '->'}}{{35-41=}}{{21-21=async }}
 
 func asyncGlobal8() async throws async -> async Int async {}
-// expected-error@-1{{unexpected 'async' specifier}} {{34-40=}}
-// expected-error@-2{{unexpected 'async' specifier}} {{43-49=}}
-// expected-error@-3{{unexpected 'async' specifier}} {{53-59=}}
+// expected-error@-1{{'async' has already been specified}} {{34-40=}}
+// expected-error@-2{{'async' has already been specified}} {{43-49=}}
+// expected-error@-3{{'async' has already been specified}} {{53-59=}}
 
 class X {
   init() async { } // expected-error{{initializer cannot be marked 'async'}}

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -121,20 +121,20 @@ func postThrows3() {
 }
 
 func dupThrows1() throws rethrows -> throws Int throw {}
-// expected-error@-1 {{unexpected 'rethrows' specifier}} {{26-35=}}
-// expected-error@-2 {{unexpected 'throws' specifier}} {{38-45=}}
-// expected-error@-3 {{unexpected 'throw' specifier}} {{49-55=}}
+// expected-error@-1 {{'rethrows' has already been specified}} {{26-35=}}
+// expected-error@-2 {{'throws' has already been specified}} {{38-45=}}
+// expected-error@-3 {{'throw' has already been specified}} {{49-55=}}
 
 func dupThrows2(_ f: () throws -> rethrows Int) {}
-// expected-error@-1 {{unexpected 'rethrows' specifier}} {{35-44=}}
+// expected-error@-1 {{'rethrows' has already been specified}} {{35-44=}}
 
 func dupThrows3() {
   _ = { () try throws in }
 // expected-error@-1 {{expected throwing specifier; did you mean 'throws'?}} {{12-15=throws}}
-// expected-error@-2 {{unexpected 'throws' specifier}} {{16-23=}}
+// expected-error@-2 {{'throws' has already been specified}} {{16-23=}}
 
   _ = { () throws -> Int throws in }
-// expected-error@-1 {{unexpected 'throws' specifier}} {{26-33=}}
+// expected-error@-1 {{'throws' has already been specified}} {{26-33=}}
 }
 
 func incompleteThrowType() {

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -116,6 +116,27 @@ func postRethrows2(_ f: () throws -> Int) -> rethrows Int { // expected-error{{'
   return try f()
 }
 
+func postThrows3() {
+  _ = { () -> Int throws in } // expected-error {{'throws' may only occur before '->'}} {{19-26=}} {{12-12=throws }}
+}
+
+func dupThrows1() throws rethrows -> throws Int throw {}
+// expected-error@-1 {{unexpected 'rethrows' specifier}} {{26-35=}}
+// expected-error@-2 {{unexpected 'throws' specifier}} {{38-45=}}
+// expected-error@-3 {{unexpected 'throw' specifier}} {{49-55=}}
+
+func dupThrows2(_ f: () throws -> rethrows Int) {}
+// expected-error@-1 {{unexpected 'rethrows' specifier}} {{35-44=}}
+
+func dupThrows3() {
+  _ = { () try throws in }
+// expected-error@-1 {{expected throwing specifier; did you mean 'throws'?}} {{12-15=throws}}
+// expected-error@-2 {{unexpected 'throws' specifier}} {{16-23=}}
+
+  _ = { () throws -> Int throws in }
+// expected-error@-1 {{unexpected 'throws' specifier}} {{26-33=}}
+}
+
 func incompleteThrowType() {
   // FIXME: Bad recovery for incomplete function type.
   let _: () throws


### PR DESCRIPTION
Complete `async` and `throws` in function signature, function type, and closure signature.

Along with that, rewrote effects specifier parsing so that we can handle them with unified function `parseEffectsSpeficier()` in various position (i.e. function signature, function type, and closure signature).
Also, this improves diagnostics for them, e.g. duplicated specifiers.

rdar://problem/72199413