### PR TITLE
[Concurrency] Fix fix-it for async after ->

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -368,7 +368,8 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   // Parse an async specifier.
   SourceLoc asyncLoc;
   if (shouldParseExperimentalConcurrency() &&
-      Tok.isContextualKeyword("async")) {
+      Tok.isContextualKeyword("async") &&
+      peekToken().isAny(tok::arrow, tok::kw_throws)) {
     asyncLoc = consumeToken();
   }
 

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -10,6 +10,23 @@ func asyncGlobal3() throws async { } // expected-error{{'async' must precede 'th
 
 func asyncGlobal3(fn: () throws -> Int) rethrows async { } // expected-error{{'async' must precede 'rethrows'}}{{50-56=}}{{41-41=async }}
 
+func asyncGlobal4() -> Int async { } // expected-error{{'async' may only occur before '->'}}{{28-34=}}{{21-21=async }}
+
+// If both async and throws follow the return type in the correct order,
+// throws will get the error and fix-it first. Applying the fix-it will cause
+// the async error and fix-it to be emitted. Applying that will place the async
+// in the appropriate place.
+
+// expected-error@+1{{'throws' may only occur before '->'}}{{34-41=}}{{21-21=throws }}
+func asyncGlobal5() -> Int async throws { }
+
+// If they are in the wrong order, the first fix-it will put them in the right
+// order and will be the same as the above case
+// expected-error@+1{{'async' must precede 'throws'}}{{35-41=}}{{28-28=async }}
+func asyncGlobal6() -> Int throws async { }
+
+func asyncGlobal7() throws -> Int async { } // expected-error{{'async' may only occur before '->'}}{{35-41=}}{{28-28=async }}
+
 class X {
   init() async { } // expected-error{{initializer cannot be marked 'async'}}
 


### PR DESCRIPTION
The `async` was being incorrectly consumed in `parseType` and as a
result, was not getting propagated back up to `parseFunctionSignature`
to be emitted as an error. Unless the next token is an arrow or a
throws, we don't consume it.

Now if you have `func f() -> Int async { 0 }`, it'll emit an error and a fixit to move the async before the arrow.

Fixes: rdar://71812259