### PR TITLE
[Diagnostics] Special case assignment between nominal types with optional promotion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3722,14 +3722,15 @@ bool ConstraintSystem::repairFailures(
         if (lhs->is<FunctionType>() && rhs->is<FunctionType>())
           return false;
 
-        // If either object type is a bound generic or existential it means
-        // that follow-up to value-to-optional is going to be:
+        // If either object type is a generic, nominal or existential type
+        // it means that follow-up to value-to-optional is going to be:
         //
         // 1. "deep equality" check, which is handled by generic argument(s)
-        //    mismatch fix, or
+        //    or contextual mismatch fix, or
         // 2. "existential" check, which is handled by a missing conformance
         //    fix.
         if ((lhs->is<BoundGenericType>() && rhs->is<BoundGenericType>()) ||
+            (lhs->is<NominalType>() && rhs->is<NominalType>()) ||
             rhs->isAnyExistentialType())
           return false;
       }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -345,7 +345,7 @@ var afterMessageCount : Int?
 func uintFunc() -> UInt {}
 func takeVoidVoidFn(_ a : () -> ()) {}
 takeVoidVoidFn { () -> Void in
-  afterMessageCount = uintFunc()  // expected-error {{cannot assign value of type 'UInt' to type 'Int'}}
+  afterMessageCount = uintFunc()  // expected-error {{cannot assign value of type 'UInt' to type 'Int?'}} {{23-23=Int(}} {{33-33=)}}
 }
 
 // <rdar://problem/19997471> Swift: Incorrect compile error when calling a function inside a closure

--- a/test/Constraints/sr13951.swift
+++ b/test/Constraints/sr13951.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol TheProtocol {}
+struct TheType1: TheProtocol {}
+
+enum TheEnum: RawRepresentable {
+  typealias RawValue = TheProtocol
+
+  case case1
+  case case2
+
+  init?(rawValue: TheProtocol) {
+    self = .case1
+  }
+
+  var rawValue: TheProtocol {
+    return TheType1()
+  }
+}
+
+func aTransformer(input: Int) -> TheEnum {
+  if input % 2 == 0 {
+    return .case1
+  } else {
+    return .case2
+  }
+}
+
+func theProblem(input: Int?) {
+  var enumValue: TheEnum?
+
+  if let input = input {
+    enumValue = aTransformer(input: input) // Ok
+  }
+
+  _ = enumValue // To silence the warning
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1100,12 +1100,12 @@ struct TestComposition {
   // expected-error@-2 {{composed wrapper type 'WrapperE<Int>' does not match former 'wrappedValue' type 'WrapperC<Value>'}}
 
 	func triggerErrors(d: Double) { // expected-note 6 {{mark method 'mutating' to make 'self' mutable}} {{2-2=mutating }}
-		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int'}} {{8-8=Int(}} {{9-9=)}}
+		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}} {{8-8=Int(}} {{9-9=)}}
     // expected-error@-1 {{cannot assign to property: 'self' is immutable}}
-		p2 = d // expected-error{{cannot assign value of type 'Double' to type 'String'}}
+		p2 = d // expected-error{{cannot assign value of type 'Double' to type 'String?'}}
     // expected-error@-1 {{cannot assign to property: 'self' is immutable}}
     // TODO(diagnostics): Looks like source range for 'd' here is reported as starting at 10, but it should be 8
-    p3 = d // expected-error{{cannot assign value of type 'Double' to type 'Int'}} {{10-10=Int(}} {{11-11=)}}
+    p3 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}} {{10-10=Int(}} {{11-11=)}}
     // expected-error@-1 {{cannot assign to property: 'self' is immutable}}
 
 		_p1 = d // expected-error{{cannot assign value of type 'Double' to type 'WrapperA<WrapperB<WrapperC<Int>>>'}}


### PR DESCRIPTION
Skip fixing situation where source and destination of assignment are both
nominal types with different optionality until restriction is attempted.

Otherwise fix could be too greedy and diagnose valid code if all of the
types are known in advance.

Resolves: SR-13951
Resolves: rdar://problem/72166791

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
