### PR TITLE
[driver] Use if/else instead of ternary, to please VS2017.

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1802,8 +1802,11 @@ namespace driver {
 
     fine_grained_dependencies::ModuleDepGraph &&
     takeFineGrainedDepGraph(const bool forRanges) && {
-      return forRanges ? std::move(FineGrainedDepGraphForRanges)
-                       : std::move(FineGrainedDepGraph);
+      if (forRanges) {
+        return std::move(FineGrainedDepGraphForRanges);
+      } else {
+        return std::move(FineGrainedDepGraph);
+      }
     }
   };
 } // namespace driver


### PR DESCRIPTION
VS2017 seems to have problems with ternaries where the two branches are
given as std::move() (see https://stackoverflow.com/questions/53374182)
and the compiler was given a warning C4172 "returning address of local
or temporary".

Switching the ternary operator into a `if/else` works correctly for
VS2017 and should work for other compilers too, without changing the
meaning (as far as I see).

This was causing the Windows VS2017 CI to fail compiling the stdlib.
When bisecting, the problem was reduced to the changes in #35034. In a
debugger I managed to see the problem being a heap corruption. With all
the moves I was suspicious that something was being used while
destroyed, but the code was correct. While recompiling, the compiler
warning gave me the clue.
