### PR TITLE
Frontend: allow specifying only one module trace output path in batch mode

### DIFF
--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -354,6 +354,15 @@ SupplementaryOutputPathsComputer::getSupplementaryFilenamesFromArguments(
 
   if (paths.size() == N)
     return paths;
+  else if (pathID == options::OPT_emit_loaded_module_trace_path &&
+           paths.size() < N) {
+    // We only need one file to output the module trace file because they
+    // are all equivalent. Add additional empty output paths for module trace to
+    // make sure the compiler won't panic for diag::error_wrong_number_of_arguments.
+    for(unsigned I = paths.size(); I != N; I ++)
+      paths.emplace_back();
+    return paths;
+  }
 
   if (paths.empty())
     return std::vector<std::string>(N, std::string());

--- a/test/Frontend/batch_mode_missing_module_trace_output.swift
+++ b/test/Frontend/batch_mode_missing_module_trace_output.swift
@@ -1,0 +1,5 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift
+// RUN: touch %t/file-02.swift
+// RUN: cd %t
+// RUN: %target-swift-frontend -emit-module -primary-file file-01.swift -primary-file file-02.swift -o file-01.swiftmodule -o file-02.swiftmodule -module-name foo -emit-loaded-module-trace-path=%t/trace.json


### PR DESCRIPTION
We only need one primary file to emit the module trace file.

rdar://72261567