### PR TITLE
Make Swift headers standalone parsable

### DIFF
--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -17,6 +17,9 @@
 #ifndef SWIFT_ABI_EXECUTOR_H
 #define SWIFT_ABI_EXECUTOR_H
 
+#include "swift/Basic/RelativePointer.h"
+#include "swift/Runtime/Config.h"
+#include <cassert>
 #include <inttypes.h>
 #include "swift/ABI/HeapObject.h"
 #include "swift/Runtime/Casting.h"

--- a/include/swift/AST/IfConfigClause.h
+++ b/include/swift/AST/IfConfigClause.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_IFCONFIGCLAUSE_H
 #define SWIFT_AST_IFCONFIGCLAUSE_H
 
+#include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace swift {

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_LAZYRESOLVER_H
 #define SWIFT_AST_LAZYRESOLVER_H
 
+#include "swift/AST/Attr.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
 

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_LOOKUPKINDS_H
 #define SWIFT_LOOKUPKINDS_H
 
+#include "llvm/Support/raw_ostream.h"
+
 namespace swift {
 
 /// NLKind - This is a specifier for the kind of name lookup being performed

--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -17,6 +17,9 @@
 #ifndef SWIFT_AST_PROPERTY_WRAPPERS_H
 #define SWIFT_AST_PROPERTY_WRAPPERS_H
 
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+
 namespace llvm {
   class raw_ostream;
 }

--- a/include/swift/AST/ReferenceCounting.h
+++ b/include/swift/AST/ReferenceCounting.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_AST_REFERENCE_COUNTING_H
 #define SWIFT_AST_REFERENCE_COUNTING_H
 
+#include <cstdint>
+
 namespace swift {
 
 /// The kind of reference counting implementation a heap object uses.

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -14,7 +14,9 @@
 #define SWIFT_AST_SEARCHPATHOPTIONS_H
 
 #include "swift/Basic/ArrayRefView.h"
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <string>
 #include <vector>

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_STORAGEIMPL_H
 #define SWIFT_STORAGEIMPL_H
 
+#include "swift/Basic/LLVM.h"
 #include "swift/Basic/Range.h"
 
 namespace swift {

--- a/include/swift/AST/TypeResolutionStage.h
+++ b/include/swift/AST/TypeResolutionStage.h
@@ -12,6 +12,8 @@
 #ifndef SWIFT_AST_TYPE_RESOLUTION_STAGE_H
 #define SWIFT_AST_TYPE_RESOLUTION_STAGE_H
 
+#include <cstdint>
+
 namespace llvm {
 class raw_ostream;
 }

--- a/include/swift/Basic/OptionalEnum.h
+++ b/include/swift/Basic/OptionalEnum.h
@@ -14,6 +14,9 @@
 #define SWIFT_BASIC_OPTIONALENUM_H
 
 #include "swift/Basic/type_traits.h"
+#include "llvm/ADT/None.h"
+#include <cassert>
+#include <cstdint>
 #include <type_traits>
 
 namespace swift {

--- a/include/swift/Basic/PathRemapper.h
+++ b/include/swift/Basic/PathRemapper.h
@@ -24,6 +24,7 @@
 #ifndef SWIFT_BASIC_PATHREMAPPER_H
 #define SWIFT_BASIC_PATHREMAPPER_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
 

--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -132,7 +132,9 @@
 #ifndef SWIFT_BASIC_RELATIVEPOINTER_H
 #define SWIFT_BASIC_RELATIVEPOINTER_H
 
+#include <cassert>
 #include <cstdint>
+#include <type_traits>
 
 namespace swift {
 

--- a/include/swift/ClangImporter/SwiftAbstractBasicReader.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicReader.h
@@ -21,6 +21,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/AbstractTypeReader.h"
+#include "llvm/ADT/SmallVector.h"
 
 // This include is required to instantiate the template code in
 // AbstractBasicReader.h, i.e. it's a workaround to an include-what-you-use
@@ -72,7 +73,7 @@ public:
       return clang::Selector();
 
     unsigned numArgs = unsigned(numArgsPlusOne - 1);
-    SmallVector<clang::IdentifierInfo *, 4> chunks;
+    llvm::SmallVector<clang::IdentifierInfo *, 4> chunks;
     for (unsigned i = 0, e = std::max(numArgs, 1U); i != e; ++i)
       chunks.push_back(asImpl().readIdentifier());
 

--- a/include/swift/IDE/IDETypeIDs.h
+++ b/include/swift/IDE/IDETypeIDs.h
@@ -18,6 +18,8 @@
 #define SWIFT_IDE_IDETYPEIDS_H
 
 #include "swift/Basic/TypeID.h"
+#include "swift/IDE/Utils.h"
+
 namespace swift {
 
 #define SWIFT_TYPEID_ZONE IDETypes

--- a/include/swift/IDE/Indenting.h
+++ b/include/swift/IDE/Indenting.h
@@ -13,6 +13,11 @@
 #ifndef SWIFT_INDENTING_H
 #define SWIFT_INDENTING_H
 
+#include "swift/AST/SourceFile.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceManager.h"
+#include "llvm/ADT/StringRef.h"
+
 namespace swift {
 namespace ide {
 

--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -12,6 +12,9 @@
 #ifndef SWIFT_IRGEN_IRGENPUBLIC_H
 #define SWIFT_IRGEN_IRGENPUBLIC_H
 
+#include "swift/Basic/LLVM.h"
+#include <utility>
+
 namespace llvm {
   class LLVMContext;
   template<typename T, unsigned N> class SmallVector;

--- a/include/swift/Markup/SourceLoc.h
+++ b/include/swift/Markup/SourceLoc.h
@@ -14,6 +14,7 @@
 #ifndef SWIFT_MARKUP_SOURCELOC_H
 #define SWIFT_MARKUP_SOURCELOC_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 #include <algorithm>
 #include <cassert>

--- a/include/swift/Markup/XMLUtils.h
+++ b/include/swift/Markup/XMLUtils.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_MARKUP_XML_UTILS_H
 #define SWIFT_MARKUP_XML_UTILS_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/include/swift/Migrator/EditorAdapter.h
+++ b/include/swift/Migrator/EditorAdapter.h
@@ -20,6 +20,8 @@
 #ifndef SWIFT_MIGRATOR_EDITORADAPTER_H
 #define SWIFT_MIGRATOR_EDITORADAPTER_H
 
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
 #include "swift/Migrator/Replacement.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -18,6 +18,7 @@
 #define SWIFT_MIGRATOR_FIXITFILTER_H
 
 #include "swift/AST/DiagnosticConsumer.h"
+#include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
 
 namespace swift {

--- a/include/swift/Migrator/MigrationState.h
+++ b/include/swift/Migrator/MigrationState.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_MIGRATOR_MIGRATIONSTATE_H
 #define SWIFT_MIGRATOR_MIGRATIONSTATE_H
 
+#include "swift/Basic/LLVM.h"
 #include "swift/Syntax/References.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"

--- a/include/swift/Migrator/Migrator.h
+++ b/include/swift/Migrator/Migrator.h
@@ -17,7 +17,9 @@
 #ifndef SWIFT_MIGRATOR_MIGRATOR_H
 #define SWIFT_MIGRATOR_MIGRATOR_H
 
+#include "swift/Frontend/Frontend.h"
 #include "swift/Migrator/MigrationState.h"
+#include "swift/Migrator/MigratorOptions.h"
 #include "swift/Syntax/References.h"
 
 namespace swift {

--- a/include/swift/Migrator/MigratorOptions.h
+++ b/include/swift/Migrator/MigratorOptions.h
@@ -17,6 +17,9 @@
 #ifndef SWIFT_MIGRATOR_MIGRATOROPTIONS_H
 #define SWIFT_MIGRATOR_MIGRATOROPTIONS_H
 
+#include <string>
+#include <vector>
+
 namespace swift {
 
 struct MigratorOptions {

--- a/include/swift/Migrator/Replacement.h
+++ b/include/swift/Migrator/Replacement.h
@@ -12,6 +12,9 @@
 
 #ifndef SWIFT_MIGRATOR_REPLACEMENT_H
 #define SWIFT_MIGRATOR_REPLACEMENT_H
+
+#include <string>
+
 namespace swift {
 namespace migrator {
 

--- a/include/swift/Reflection/MetadataSourceBuilder.h
+++ b/include/swift/Reflection/MetadataSourceBuilder.h
@@ -18,6 +18,7 @@
 #define SWIFT_REFLECTION_METADATASOURCEBUILDER_H
 
 #include "swift/Reflection/MetadataSource.h"
+#include <vector>
 
 namespace swift {
 namespace reflection {

--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_REFLECTION_RECORDS_H
 #define SWIFT_REFLECTION_RECORDS_H
 
+#include "swift/Basic/LLVM.h"
 #include "swift/Basic/RelativePointer.h"
 #include "swift/Demangling/Demangle.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -21,6 +21,8 @@
 #ifndef SWIFT_REFLECTION_RUNTIME_INTERNALS_H
 #define SWIFT_REFLECTION_RUNTIME_INTERNALS_H
 
+#include <cstdint>
+
 namespace swift {
 
 namespace reflection {

--- a/include/swift/Remote/TypeInfoProvider.h
+++ b/include/swift/Remote/TypeInfoProvider.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_REMOTE_TYPEINFOPROVIDER_H
 #define SWIFT_REMOTE_TYPEINFOPROVIDER_H
 
+#include "llvm/ADT/StringRef.h"
+
 namespace swift {
 namespace reflection {
 class TypeInfo;

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_RUNTIME_ENUM_H
 #define SWIFT_RUNTIME_ENUM_H
 
+#include "swift/ABI/MetadataValues.h"
 #include "swift/Runtime/Config.h"
 
 namespace swift {

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_ABI_OBJCBRIDGE_H
 #define SWIFT_ABI_OBJCBRIDGE_H
 
+#include "swift/ABI/Metadata.h"
 #include "swift/Runtime/Config.h"
 #include <cstdint>
 

--- a/include/swift/SIL/Consumption.h
+++ b/include/swift/SIL/Consumption.h
@@ -18,6 +18,9 @@
 #ifndef SWIFT_SIL_CONSUMPTION_H
 #define SWIFT_SIL_CONSUMPTION_H
 
+#include "llvm/Support/ErrorHandling.h"
+#include <cstdint>
+
 namespace swift {
 
 /// Is an operation a "take"?  A take consumes the original value,

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/AST/Types.h"
+#include "swift/SIL/SILDeclRef.h"
 
 namespace swift {
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -24,6 +24,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Debug.h"
+#include "swift/Sema/Constraint.h"
 #include "swift/Sema/ConstraintLocator.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -21,6 +21,7 @@
 
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/SourceLoc.h"
+#include "llvm/ADT/DenseMap.h"
 #include <memory>
 #include <tuple>
 

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_IDE_TYPE_CHECKING_REQUESTS_H
 #define SWIFT_IDE_TYPE_CHECKING_REQUESTS_H
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/SimpleRequest.h"

--- a/include/swift/Sema/SolutionResult.h
+++ b/include/swift/Sema/SolutionResult.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_TYPECHECK_SOLUTION_RESULT_H
 #define SWIFT_TYPECHECK_SOLUTION_RESULT_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace swift {

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -14,6 +14,8 @@
 #define SWIFT_SERIALIZATION_SERIALIZATIONOPTIONS_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SERIALIZATION_VALIDATION_H
 #define SWIFT_SERIALIZATION_VALIDATION_H
 
+#include "swift/AST/ASTContext.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/include/swift/SwiftDemangle/SwiftDemangle.h
+++ b/include/swift/SwiftDemangle/SwiftDemangle.h
@@ -21,6 +21,8 @@
 
 #include <swift/SwiftDemangle/Platform.h>
 
+#include "stddef.h"
+
 /// @{
 /// Version constants for libswiftDemangle library.
 

--- a/include/swift/Syntax/TokenKinds.h
+++ b/include/swift/Syntax/TokenKinds.h
@@ -19,6 +19,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
+#include "swift/Basic/LLVM.h"
 
 namespace swift {
 enum class tok {


### PR DESCRIPTION
This commit makes all headers in the swift parsable on their own. All changes here are either:

* Adding includes that were missing (e.g., using 'uint8_t` without including `cstdint`).
* Add missing namespace scopes to some headers that were relying on their including files to provide the respective using/typedef/etc. (e.g. `SmallVector` from `LLVM.h` instead of `llvm::SmallVector`).