### PR TITLE
Add -sil-verify-all and -sil-verify-none to the sil-opt tool.

### DIFF
--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -184,11 +184,24 @@ static llvm::cl::opt<int>
 SILInlineThreshold("sil-inline-threshold", llvm::cl::Hidden,
                    llvm::cl::init(-1));
 
+// Legacy option name still in use. The frontend uses -sil-verify-all.
 static llvm::cl::opt<bool>
 EnableSILVerifyAll("enable-sil-verify-all",
                    llvm::cl::Hidden,
                    llvm::cl::init(true),
                    llvm::cl::desc("Run sil verifications after every pass."));
+
+static llvm::cl::opt<bool>
+SILVerifyAll("sil-verify-all",
+             llvm::cl::Hidden,
+             llvm::cl::init(true),
+             llvm::cl::desc("Run sil verifications after every pass."));
+
+static llvm::cl::opt<bool>
+SILVerifyNone("sil-verify-none",
+              llvm::cl::Hidden,
+              llvm::cl::init(false),
+              llvm::cl::desc("Completely disable SIL verification"));
 
 static llvm::cl::opt<bool>
 RemoveRuntimeAsserts("remove-runtime-asserts",
@@ -381,7 +394,8 @@ int main(int argc, char **argv) {
   // Setup the SIL Options.
   SILOptions &SILOpts = Invocation.getSILOptions();
   SILOpts.InlineThreshold = SILInlineThreshold;
-  SILOpts.VerifyAll = EnableSILVerifyAll;
+  SILOpts.VerifyAll = SILVerifyAll || EnableSILVerifyAll;
+  SILOpts.VerifyNone = SILVerifyNone;
   SILOpts.RemoveRuntimeAsserts = RemoveRuntimeAsserts;
   SILOpts.AssertConfig = AssertConfId;
   if (OptimizationGroup != OptGroup::Diagnostics)


### PR DESCRIPTION
Make sil-opt verification options consistent with sil-frontend and allow experimenting with test cases that fail in the verifier.