### PR TITLE
[ConstraintSystem] Strengthen dependent member type checks while infe…

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/sr13856.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr13856.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol OptionalType {
+  associatedtype Wrapped
+  var wrapped: Wrapped? { get }
+}
+
+protocol DefaultsBridge {
+  associatedtype T
+}
+
+protocol DefaultsSerializable {
+  typealias T = Bridge.T
+  associatedtype Bridge: DefaultsBridge
+}
+
+protocol DefaultsKeyStore {}
+
+struct DefaultsKeys: DefaultsKeyStore {}
+struct DefaultsKey<ValueType> {}
+
+@dynamicMemberLookup
+struct DefaultsAdapter<KeyStore: DefaultsKeyStore> {
+  @available(*, unavailable)
+  subscript(dynamicMember member: String) -> Never {
+    fatalError()
+  }
+
+  subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T {
+    get { fatalError() }
+    set { fatalError() }
+  }
+
+  subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T {
+    get { fatalError() }
+    set { fatalError() }
+  }
+}
+
+
+var Defaults = DefaultsAdapter<DefaultsKeys>()
+Defaults[\.missingKey] = "" // expected-error {{}}


### PR DESCRIPTION
…rring bindings

Look through specifier (inout, l-value) and optional types while
checking for presence of dependent member types to avoid inferring
incorrect bindings (which could lead to infinite recursion in the
solver).

Resolves: SR-13856
Resolves: rdar://problem/71383770


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
