### PR TITLE
[NFC] Re-Core Fingerprint

### DIFF
--- a/include/swift/Basic/Fingerprint.h
+++ b/include/swift/Basic/Fingerprint.h
@@ -60,53 +60,51 @@ namespace swift {
 class Fingerprint final {
 public:
   /// The size (in bytes) of the raw value of all fingerprints.
-  ///
-  /// This constant's value is justified by a static assertion in the
-  /// corresponding cpp file.
   constexpr static size_t DIGEST_LENGTH = 32;
 
+  using Core = std::pair<uint64_t, uint64_t>;
 private:
-  std::string Core;
+  Core core;
 
 public:
+  /// Creates a fingerprint value from a pair of 64-bit integers.
+  explicit Fingerprint(Fingerprint::Core value) : core(value) {}
+
   /// Creates a fingerprint value from the given input string that is known to
   /// be a 32-byte hash value.
   ///
   /// In +asserts builds, strings that violate this invariant will crash. If a
   /// fingerprint value is needed to represent an "invalid" state, use a
   /// vocabulary type like \c Optional<Fingerprint> instead.
-  explicit Fingerprint(std::string value) : Core(std::move(value)) {
-    assert(Core.size() == Fingerprint::DIGEST_LENGTH &&
-           "Only supports 32-byte hash values!");
-  }
+  static Fingerprint fromString(llvm::StringRef value);
 
   /// Creates a fingerprint value from the given input string literal.
   template <std::size_t N>
   explicit Fingerprint(const char (&literal)[N])
-    : Core{literal, N-1} {
+    : Fingerprint{Fingerprint::fromString({literal, N-1}).core} {
       static_assert(N == Fingerprint::DIGEST_LENGTH + 1,
                     "String literal must be 32 bytes in length!");
     }
 
   /// Creates a fingerprint value by consuming the given \c MD5Result from LLVM.
   explicit Fingerprint(llvm::MD5::MD5Result &&MD5Value)
-      : Core{MD5Value.digest().str()} {}
+      : core{MD5Value.words()} {}
 
 public:
   /// Retrieve the raw underlying bytes of this fingerprint.
-  llvm::StringRef getRawValue() const { return Core; }
+  llvm::SmallString<Fingerprint::DIGEST_LENGTH> getRawValue() const;
 
 public:
   friend bool operator==(const Fingerprint &lhs, const Fingerprint &rhs) {
-    return lhs.Core == rhs.Core;
+    return lhs.core == rhs.core;
   }
 
   friend bool operator!=(const Fingerprint &lhs, const Fingerprint &rhs) {
-    return lhs.Core != rhs.Core;
+    return lhs.core != rhs.core;
   }
 
   friend llvm::hash_code hash_value(const Fingerprint &fp) {
-    return llvm::hash_value(fp.Core);
+    return llvm::hash_value(fp.core);
   }
 
 public:
@@ -115,7 +113,7 @@ public:
   /// This fingerprint is a perfectly fine value for an MD5 hash, but it is
   /// completely arbitrary.
   static Fingerprint ZERO() {
-    return Fingerprint("00000000000000000000000000000000");
+    return Fingerprint(Fingerprint::Core{0, 0});
   }
 
 private:
@@ -124,7 +122,7 @@ private:
   ///
   /// Very well, LLVM. A default value you shall have.
   friend class llvm::yaml::IO;
-  Fingerprint() : Core(DIGEST_LENGTH, '0') {}
+  Fingerprint() : core{Fingerprint::Core{0, 0}} {}
 };
 
 void simple_display(llvm::raw_ostream &out, const Fingerprint &fp);

--- a/lib/AST/FineGrainedDependencyFormat.cpp
+++ b/lib/AST/FineGrainedDependencyFormat.cpp
@@ -232,7 +232,7 @@ bool Deserializer::readFineGrainedDependencyGraph(SourceFileDepGraph &g,
       if (node == nullptr)
         llvm::report_fatal_error("Unexpected FINGERPRINT_NODE record");
 
-      node->setFingerprint(Fingerprint{BlobData.str()});
+      node->setFingerprint(Fingerprint::fromString(BlobData));
       break;
     }
 

--- a/lib/Basic/Fingerprint.cpp
+++ b/lib/Basic/Fingerprint.cpp
@@ -12,7 +12,11 @@
 
 #include "swift/Basic/Fingerprint.h"
 #include "swift/Basic/STLExtras.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include <inttypes.h>
+#include <sstream>
 
 using namespace swift;
 
@@ -25,19 +29,26 @@ void swift::simple_display(llvm::raw_ostream &out, const Fingerprint &fp) {
   out << fp.getRawValue();
 }
 
-namespace {
-  template <class T> struct SmallStringBound;
-  template <size_t N> struct SmallStringBound<llvm::SmallString<N>> {
-    static constexpr size_t value = N;
-  };
-};
+Fingerprint Fingerprint::fromString(StringRef value) {
+  assert(value.size() == Fingerprint::DIGEST_LENGTH &&
+         "Only supports 32-byte hash values!");
+  auto fp = Fingerprint::ZERO();
+  {
+    std::istringstream s(value.drop_back(Fingerprint::DIGEST_LENGTH/2).str());
+    s >> std::hex >> fp.core.first;
+  }
+  {
+    std::istringstream s(value.drop_front(Fingerprint::DIGEST_LENGTH/2).str());
+    s >> std::hex >> fp.core.second;
+  }
+  return fp;
+}
 
-// Assert that the \c DIGEST_LENGTH value we export from the \c Fingerprint
-// has the right byte length. It's unlikely this value will change in LLVM,
-// but it's always good to have compile-time justification for a
-// magic constant - especially one that gets used for serialization.
-using MD5Digest_t =
-    decltype (&llvm::MD5::MD5Result::digest)(llvm::MD5::MD5Result);
-static_assert(SmallStringBound<std::result_of<MD5Digest_t>::type>::value ==
-                  Fingerprint::DIGEST_LENGTH,
-              "MD5 digest size does not match size expected by Fingerprint!");
+llvm::SmallString<Fingerprint::DIGEST_LENGTH> Fingerprint::getRawValue() const {
+  llvm::SmallString<Fingerprint::DIGEST_LENGTH> Str;
+  llvm::raw_svector_ostream Res(Str);
+  Res << llvm::format_hex_no_prefix(core.first, 16);
+  Res << llvm::format_hex_no_prefix(core.second, 16);
+  assert(*this == Fingerprint::fromString(Str));
+  return Str;
+}

--- a/lib/Serialization/ModuleFileCoreTableInfo.h
+++ b/lib/Serialization/ModuleFileCoreTableInfo.h
@@ -600,9 +600,9 @@ public:
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
     using namespace llvm::support;
-    auto str = std::string{reinterpret_cast<const char *>(data),
-                           Fingerprint::DIGEST_LENGTH};
-    return Fingerprint{str};
+    auto str = llvm::StringRef{reinterpret_cast<const char *>(data),
+                               Fingerprint::DIGEST_LENGTH};
+    return Fingerprint::fromString(str);
   }
 };
 

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -69,7 +69,7 @@ template <> struct ScalarTraits<swift::Fingerprint> {
     os << fp.getRawValue();
   }
   static StringRef input(StringRef s, void *, swift::Fingerprint &fp) {
-    fp = swift::Fingerprint{s.str()};
+    fp = swift::Fingerprint::fromString(s);
     return StringRef();
   }
   static QuotingType mustQuote(StringRef S) { return needsQuotes(S); }

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
@@ -45,7 +45,7 @@ mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
   assert(!swiftDeps.empty());
   swiftDeps.resize(Fingerprint::DIGEST_LENGTH, 'X');
   auto interfaceHash =
-    interfaceHashIfNonEmpty.getValueOr(Fingerprint{swiftDeps});
+    interfaceHashIfNonEmpty.getValueOr(Fingerprint::fromString(swiftDeps));
 
   SourceManager sm;
   DiagnosticEngine diags(sm);

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
@@ -57,7 +57,7 @@ void UnitTestSourceFileDepGraphFactory::addADefinedDecl(StringRef s,
   fingerprintString.resize(Fingerprint::DIGEST_LENGTH, 'X');
   const Optional<Fingerprint> fingerprint = fingerprintString.empty()
                                               ? Optional<Fingerprint>()
-                                              : Fingerprint{fingerprintString};
+                                              : Fingerprint::fromString(fingerprintString);
 
   AbstractSourceFileDepGraphFactory::addADefinedDecl(key.getValue(),
                                                      fingerprint);


### PR DESCRIPTION
Switch from a string core to a 128-bit integral core. This should make
Fingerprints much cheaper to copy around and sets us up for a future
where we can provide alternative implementations of the ambient hashing
algorithm.

rdar://72313506