### PR TITLE
[TBDGen] @asyncHandlers don't have public async function pointers.

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -721,7 +721,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
 
   visitDefaultArguments(AFD, AFD->getParameters());
 
-  if (AFD->isAsyncContext()) {
+  if (AFD->hasAsync()) {
     addSymbol(LinkEntity::forAsyncFunctionPointer(AFD));
   }
 }

--- a/test/TBD/async-function-pointer.swift
+++ b/test/TBD/async-function-pointer.swift
@@ -1,0 +1,7 @@
+// REQUIRES: VENDOR=apple 
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-concurrency -validate-tbd-against-ir=all -module-name test | %FileCheck %s
+
+// CHECK: @"$s4test6testityyYFAD" = hidden global %swift.async_func_pointer
+
+@asyncHandler
+public func testit() { }


### PR DESCRIPTION
Previously, an async function pointer symbol was being emitted into the TBD for all AbstractFunctionDecls which returned true for "hasAsynContext", i.e. both those that were async and those which were asnycHandlers.  That was not correct because the async function portion of an asyncHandler is not ABI.  Here, that mistake is fixed by only emitting this symbol for functions which are annotated async (i.e. those for which "hasAsync" returns true).

rdar://problem/72329062