### PR TITLE
[metadata prespecialization] Fixed OldRemangler's remangling for canonical prespecialized metaclasses.

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2177,8 +2177,8 @@ void Remangler::mangleObjCAsyncCompletionHandlerImpl(Node *node) {
 }
 
 void Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node) {
-  Buffer << "MM";
   mangleSingleChildNode(node); // type
+  Buffer << "MM";
 }
 
 void Remangler::mangleCanonicalSpecializedGenericTypeMetadataAccessFunction(


### PR DESCRIPTION
The OldRemangler's implementation of mangleCanonicalSpecializedGenericMetaclass will never be used and could be replaced with llvm_unreachable.  The function is defined, though, so it should be defined correctly.  Previously, the suffix was added to the buffer before the metaclass itself.  Here, that is fixed.