### PR TITLE
[Concurrency] Emit fixit to add actorIndependent attribute

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4132,6 +4132,9 @@ NOTE(note_add_async_to_function,none,
      "add 'async' to function %0 to make it asynchronous", (DeclName))
 NOTE(note_add_asynchandler_to_function,none,
      "add '@asyncHandler' to function %0 to create an implicit asynchronous context", (DeclName))
+NOTE(note_add_actorindependent_to_decl,none,
+     "add '@actorIndependent' to %0 to make this %1 independent of the actor",
+     (DeclName, DescriptiveDeclKind))
 NOTE(note_add_globalactor_to_function,none,
      "add '@%0' to make %1 %2 part of global actor %3", 
      (StringRef, DescriptiveDeclKind, DeclName, Type))
@@ -4254,10 +4257,6 @@ WARNING(shared_mutable_state_access,none,
         "shared mutable state", (DescriptiveDeclKind, DeclName))
 ERROR(actor_isolated_witness,none,
      "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement",
-     (DescriptiveDeclKind, DeclName))
-ERROR(actor_isolated_witness_could_be_async_handler,none,
-     "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement; "
-     "did you mean to make it an asychronous handler?",
      (DescriptiveDeclKind, DeclName))
 ERROR(global_actor_isolated_requirement,none,
       "%0 %1 must be isolated to the global actor %2 to satisfy corresponding "

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -37,9 +37,12 @@ actor class OtherActor: SyncProtocol {
 
   var propertyA: Int { 17 }
   // expected-error@-1{{actor-isolated property 'propertyA' cannot be used to satisfy a protocol requirement}}
+  // expected-note@-2{{add '@actorIndependent' to 'propertyA' to make this property independent of the actor}}{{3-3=@actorIndependent }}
 
   func syncMethodA() { }
-  // expected-error@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}{{3-3=@asyncHandler }}
+  // expected-error@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy a protocol requirement}}
+  // expected-note@-2{{add '@actorIndependent' to 'syncMethodA()' to make this instance method independent of the actor}}{{3-3=@actorIndependent }}
+  // expected-note@-3{{add '@asyncHandler' to function 'syncMethodA()' to create an implicit asynchronous context}}{{3-3=@asyncHandler }}
 
   // Async handlers are okay.
   @asyncHandler
@@ -51,6 +54,7 @@ actor class OtherActor: SyncProtocol {
 
   subscript (index: Int) -> String { "\(index)" }
   // expected-error@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy a protocol requirement}}
+  // expected-note@-2{{add '@actorIndependent' to 'subscript(_:)' to make this subscript independent of the actor}}{{3-3=@actorIndependent }}
 
   // Static methods and properties are okay.
   static func staticMethod() { }

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -41,7 +41,9 @@ class C1: Actor {
 
 // Method that is not usable as a witness.
 actor class BA1 {
-  func enqueue(partialTask: PartialAsyncTask) { } // expected-error{{actor-isolated instance method 'enqueue(partialTask:)' cannot be used to satisfy a protocol requirement; did you mean to make it an asychronous handler?}}
+  func enqueue(partialTask: PartialAsyncTask) { } // expected-error{{actor-isolated instance method 'enqueue(partialTask:)' cannot be used to satisfy a protocol requirement}}
+  //expected-note@-1{{add '@asyncHandler' to function 'enqueue(partialTask:)' to create an implicit asynchronous context}}{{3-3=@asyncHandler }}
+  //expected-note@-2{{add '@actorIndependent' to 'enqueue(partialTask:)' to make this instance method independent of the actor}}{{3-3=@actorIndependent }}
 }
 
 // Method that isn't part of the main class definition cannot be used to


### PR DESCRIPTION
Actor properties can't contribute to protocol conformance. If they're marked `@actorIndependent`, they do contribute. The `actorIndependent` attribute can't be applied to stored properties, so I'm not emitting the fix-it if the property is stored. It might make sense to still mark it and let the programmer work through the error messages though. I'll leave that up for review discussion.

Resolves: rdar://70571291