### PR TITLE
Hacks to avoid request evaluator caching overhead

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -418,7 +418,7 @@ protected:
     HasNestedTypeDeclarations : 1
   );
 
-  SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2+1,
+  SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2+1+1+1,
     /// Whether we've computed the 'static' flag yet.
     IsStaticComputed : 1,
 
@@ -437,6 +437,12 @@ protected:
     /// Backing bits for 'self' access kind.
     SelfAccess : 2,
 
+    /// Whether we've computed the IsAsyncHandlerRequest.
+    IsAsyncHandlerComputed : 1,
+
+    /// The value of IsAsyncHandlerRequest.
+    IsAsyncHandler : 1,
+
     /// Whether this is a top-level function which should be treated
     /// as if it were in local context for the purposes of capture
     /// analysis.
@@ -444,14 +450,15 @@ protected:
   );
 
   SWIFT_INLINE_BITFIELD(AccessorDecl, FuncDecl, 4 + 1 + 1,
-                        /// The kind of accessor this is.
-                        AccessorKind : 4,
+    /// The kind of accessor this is.
+    AccessorKind : 4,
 
-                        /// Whether the accessor is transparent.
-                        IsTransparent : 1,
+    /// Whether the accessor is transparent.
+    IsTransparent : 1,
 
-                        /// Whether we have computed the above.
-                        IsTransparentComputed : 1);
+    /// Whether we have computed the above.
+    IsTransparentComputed : 1
+  );
 
   SWIFT_INLINE_BITFIELD(ConstructorDecl, AbstractFunctionDecl, 1+1,
     /// Whether this constructor can fail, by building an Optional type.
@@ -5926,6 +5933,7 @@ class FuncDecl : public AbstractFunctionDecl {
   friend class SelfAccessKindRequest;
   friend class IsStaticRequest;
   friend class ResultTypeRequest;
+  friend class IsAsyncHandlerRequest;
 
   SourceLoc StaticLoc;  // Location of the 'static' token or invalid.
   SourceLoc FuncLoc;    // Location of the 'func' token.
@@ -5957,6 +5965,8 @@ protected:
     Bits.FuncDecl.SelfAccessComputed = false;
     Bits.FuncDecl.IsStaticComputed = false;
     Bits.FuncDecl.IsStatic = false;
+    Bits.FuncDecl.IsAsyncHandlerComputed = false;
+    Bits.FuncDecl.IsAsyncHandler = false;
     Bits.FuncDecl.HasTopLevelLocalContextCaptures = false;
   }
 
@@ -5985,6 +5995,18 @@ private:
       return Bits.FuncDecl.IsStatic;
 
     return None;
+  }
+
+  Optional<bool> getCachedIsAsyncHandler() const {
+    if (Bits.FuncDecl.IsAsyncHandlerComputed)
+      return Bits.FuncDecl.IsAsyncHandler;
+
+    return None;
+  }
+
+  void setIsAsyncHandler(bool value) {
+    Bits.FuncDecl.IsAsyncHandlerComputed = true;
+    Bits.FuncDecl.IsAsyncHandler = value;
   }
 
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -802,7 +802,7 @@ public:
 class IsAsyncHandlerRequest :
     public SimpleRequest<IsAsyncHandlerRequest,
                          bool(FuncDecl *),
-                         RequestFlags::Cached> {
+                         RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -812,8 +812,10 @@ private:
   bool evaluate(Evaluator &evaluator, FuncDecl *func) const;
 
 public:
-  // Caching
+  // Separate caching.
   bool isCached() const { return true; }
+  Optional<bool> getCachedResult() const;
+  void cacheResult(bool value) const;
 };
 
 /// Determine whether the given function can be an @asyncHandler, without

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5910,6 +5910,11 @@ void VarDecl::visitAuxiliaryDecls(llvm::function_ref<void(VarDecl *)> visit) con
   if (getDeclContext()->isTypeContext())
     return;
 
+  // Avoid request evaluator overhead in the common case where there's
+  // no wrapper.
+  if (!getAttrs().hasAttribute<CustomAttr>())
+    return;
+
   if (auto *backingVar = getPropertyWrapperBackingProperty())
     visit(backingVar);
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -617,6 +617,20 @@ void SelfAccessKindRequest::cacheResult(SelfAccessKind value) const {
 }
 
 //----------------------------------------------------------------------------//
+// IsAsyncHandlerRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<bool> IsAsyncHandlerRequest::getCachedResult() const {
+  auto *funcDecl = std::get<0>(getStorage());
+  return funcDecl->getCachedIsAsyncHandler();
+}
+
+void IsAsyncHandlerRequest::cacheResult(bool value) const {
+  auto *funcDecl = std::get<0>(getStorage());
+  funcDecl->setIsAsyncHandler(value);
+}
+
+//----------------------------------------------------------------------------//
 // IsGetterMutatingRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1926,6 +1926,9 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 /// expression and folding sequence expressions.
 bool ConstraintSystem::preCheckExpression(Expr *&expr, DeclContext *dc,
                                           bool replaceInvalidRefsWithErrors) {
+  auto &ctx = dc->getASTContext();
+  FrontendStatsTracer StatsTracer(ctx.Stats, "precheck-expr", expr);
+
   PreCheckExpression preCheck(dc, expr, replaceInvalidRefsWithErrors);
   // Perform the pre-check.
   if (auto result = expr->walk(preCheck)) {


### PR DESCRIPTION
This PR recovers some of the performance regression from 5.3 to main when building swift-syntax in batch and WMO, by avoiding request evaluator caching in some hot paths. I have a few fixes coming up in a separate PR that deals with the other remaining regressions.