### PR TITLE
[CodeCompletion][Sema] Don't guess whether a solution will be applied to the AST based on solutions formed for code completion.

### DIFF
--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -45,6 +45,8 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_ERROR | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_FIXME | %FileCheck %s --check-prefix=NORESULTS
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=REGULAR_MULTICLOSURE_APPLIED | %FileCheck %s --check-prefix=POINT_MEMBER
+
 
 struct A {
   func doAThings() -> A { return self }
@@ -424,4 +426,15 @@ CreateThings {
       point.#^MULTICLOSURE_FUNCBUILDER_FIXME^#
     }
     Thing. // ErrorExpr
+}
+
+
+func takesClosureOfPoint(_: (Point)->()) {}
+func overloadedWithDefaulted(_: ()->()) {}
+func overloadedWithDefaulted(_: ()->(), _ defaulted: Int = 10) {}
+
+takesClosureOfPoint { p in
+  overloadedWithDefaulted {
+    if p.#^REGULAR_MULTICLOSURE_APPLIED^# {}
+  }
 }


### PR DESCRIPTION
When solving for code completion, we do several things differently than when solving for regular type checking, such as ignoring missing arguments after the argument containing the code completion location, not favoring overloads with a number of params matching the number of arguments in a call, and so on. Because of this, we shouldn't assume multiple solutions being formed when solving for code completion means there won't be a single best solution formed when solving for regular type-checking, but were.

In the example below, when typeCheckExpression is called for the call to foo, typeCheckForCodeCompletion forms a solution for both overloads of bar because it doesn't do overload favoring, while regular type checking does and ignores the overload with a defaulted parameter. Because of this difference typeCheckForCodeCompletion incorrectly assumes regular type-checking won't apply any solution to the AST and won't call typeCheckExpression for the expressions within the closure body. Because of this, in an attempt to still give some useful completion results, it manually type checks in isolation the expression in the closure body that contains the completion expression in case that lets us gets us types for the completion expression or its base that we can use to form the completion results. It doesn't though because no type has been applied to v yet.

```swift
struct S {
    var someProp = true
}
func foo(_: (S)->()) {}
func bar(_: ()->()) {}
func bar(_: ()->(), _ defaulted: Int = 10) {}

foo { v in
  bar {
    if v.#^COMPLETE^# {}
  }
}
```

This PR works around this issue by not immediately falling back to solving the expression within the closure in isolation, and instead falling back to the regular type checking path. If there is no subsequent typeCheckExpression call for the body, there is already higher-level fallback logic that considers the expression in the closure in isolation. We will end up solving twice (once for code completion, and once for regular type-checking) in such fallback cases when we wouldn't have before, but will also now give correct results in cases like the above.

Resolves rdar://problem/72362275