### PR TITLE
[syntax-parse] Migrate parsing of literals and magic identifiers

### DIFF
--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -34,7 +34,18 @@ public:
   //===--------------------------------------------------------------------===//
   // MARK: - Expressions
 public:
+  Expr *generate(const BooleanLiteralExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const FloatLiteralExprSyntax &Expr, const SourceLoc &Loc);
   Expr *generate(const IntegerLiteralExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const NilLiteralExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundColumnExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundDsohandleExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundFileExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundFileIDExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundFilePathExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundLineExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const PoundFunctionExprSyntax &Expr, const SourceLoc &Loc);
+  Expr *generate(const UnknownExprSyntax &Expr, const SourceLoc &Loc);
 
 private:
   /// Map magic literal tokens such as #file to their MagicIdentifierLiteralExpr

--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -1,0 +1,64 @@
+//===--- ASTGen.h ---------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PARSE_ASTGEN_H
+#define SWIFT_PARSE_ASTGEN_H
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Expr.h"
+#include "swift/Syntax/SyntaxNodes.h"
+#include "llvm/ADT/DenseMap.h"
+
+namespace swift {
+
+using namespace swift::syntax;
+
+class ComponentIdentTypeRepr;
+class TupleTypeRepr;
+
+/// Generates AST nodes from Syntax nodes.
+class ASTGen {
+  ASTContext &Context;
+public:
+  explicit ASTGen(ASTContext &Context) : Context(Context) {}
+
+  //===--------------------------------------------------------------------===//
+  // MARK: - Expressions
+public:
+  Expr *generate(const IntegerLiteralExprSyntax &Expr, const SourceLoc &Loc);
+
+private:
+  /// Map magic literal tokens such as #file to their MagicIdentifierLiteralExpr
+  /// kind.
+  MagicIdentifierLiteralExpr::Kind getMagicIdentifierLiteralKind(tok Kind);
+
+  Expr *
+  generateMagicIdentifierLiteralExpr(const TokenSyntax &PoundToken,
+                                     const SourceLoc &Loc);
+
+  //===--------------------------------------------------------------------===//
+  // MARK: - Other
+public:
+  /// Copy a numeric literal value into AST-owned memory, stripping underscores
+  /// so the semantic part of the value can be parsed by APInt/APFloat parsers.
+  static StringRef copyAndStripUnderscores(StringRef Orig, ASTContext &Context);
+
+private:
+  StringRef copyAndStripUnderscores(StringRef Orig);
+
+  static SourceLoc advanceLocBegin(const SourceLoc &Loc, const Syntax &Node);
+  static SourceLoc advanceLocEnd(const SourceLoc &Loc, const TokenSyntax &Token);
+  static SourceLoc advanceLocAfter(const SourceLoc &Loc, const Syntax &Node);
+};
+} // namespace swift
+
+#endif // SWIFT_PARSE_ASTGEN_H

--- a/include/swift/Parse/HiddenLibSyntaxAction.h
+++ b/include/swift/Parse/HiddenLibSyntaxAction.h
@@ -1,0 +1,114 @@
+//===--- HiddenLibSyntaxAction.h ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 202- Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PARSE_HIDDENLIBSYNTAXACTION_H
+#define SWIFT_PARSE_HIDDENLIBSYNTAXACTION_H
+
+#include "swift/Parse/SyntaxParseActions.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
+#include "llvm/Support/Allocator.h"
+
+namespace swift {
+namespace syntax {
+class RawSyntax;
+}
+
+// TODO: (syntax-parse) remove when possible
+/// Dispatches all syntax actions to both an explicit action and an implicit
+/// (hidden) action that generates a libSyntax tree. It thereby guarantees that
+/// the libSyntax tree is always generated. The returned opaque nodes contain
+/// both the node created by the explicit action and the implicit action.
+/// \c getLibSyntaxNodeFor and \c getExplicitNodeFor can be used to retrieve
+/// the opaque nodes of the underlying actions.
+class HiddenLibSyntaxAction : public SyntaxParseActions {
+
+  /// The type of the opaque nodes returned by the \c HiddenLibSyntaxAction.
+  /// Contains a pointer to the explicit action's opaque node and the opaque
+  /// libSyntax node.
+  struct HiddenNode {
+    OpaqueSyntaxNode ExplicitActionNode;
+    OpaqueSyntaxNode LibSyntaxNode;
+
+    HiddenNode(OpaqueSyntaxNode explicitActionNode,
+               OpaqueSyntaxNode libSyntaxNode)
+        : ExplicitActionNode(explicitActionNode), LibSyntaxNode(libSyntaxNode) {
+    }
+  };
+
+  /// The explicit action. 
+  std::shared_ptr<SyntaxParseActions> ExplicitAction;
+
+  /// The implicit action that generates the libSyntax tree. Is never \c 
+  /// nullptr.
+  std::shared_ptr<SyntaxTreeCreator> LibSyntaxAction;
+
+  /// An allocator using which the \c HiddenNodes are created.
+  llvm::SpecificBumpPtrAllocator<HiddenNode> NodeAllocator;
+
+  /// Create a hidden node that contains the given explicit and libSyntax node.
+  OpaqueSyntaxNode makeHiddenNode(OpaqueSyntaxNode explicitActionNode,
+                                  OpaqueSyntaxNode libSyntaxNode);
+
+public:
+  /// Create a new HiddenLibSyntaxAction. \c LibSyntaxAction must not be \c
+  /// null.
+  HiddenLibSyntaxAction(
+      const std::shared_ptr<SyntaxParseActions> &explicitAction,
+      const std::shared_ptr<SyntaxTreeCreator> &libSyntaxAction)
+      : ExplicitAction(explicitAction),
+        LibSyntaxAction(libSyntaxAction) {
+    assert(libSyntaxAction != nullptr);
+  };
+
+  OpaqueSyntaxNode recordToken(tok tokenKind,
+                               ArrayRef<ParsedTriviaPiece> leadingTrivia,
+                               ArrayRef<ParsedTriviaPiece> trailingTrivia,
+                               CharSourceRange range) override;
+
+  OpaqueSyntaxNode recordMissingToken(tok tokenKind, SourceLoc loc) override;
+
+  OpaqueSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
+                                   ArrayRef<OpaqueSyntaxNode> elements,
+                                   CharSourceRange range) override;
+
+  /// Realize the syntax root using the implicit \c LibSyntaxAction.
+  Optional<syntax::SourceFileSyntax>
+  realizeSyntaxRoot(OpaqueSyntaxNode root, const SourceFile &SF) override;
+
+  void discardRecordedNode(OpaqueSyntaxNode node) override;
+
+  /// Look a node at the given lexer offset up using the \c ExplicitAction.
+  ///
+  /// IMPORTANT: The \c LibSyntaxAction will not be called during the node
+  /// lookup and the LibSyntaxNode part of the resulting \c HiddenNode will be a
+  /// \c nullptr.
+  ///
+  /// Discussion: We only perform the lookup because otherwise we could get a
+  /// lookup mismatch between the two actions. In that case, it is not clear,
+  /// what kind of node and lexer offset we should return. For now, just
+  /// performing the lookup in the explicit action seems to be sufficient and
+  /// since \c HiddenLibSyntax action is designed to only be temporary, we
+  /// should be able to live with it.
+  std::pair<size_t, OpaqueSyntaxNode>
+  lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
+
+  /// Returns the libSyntax node from the specified node that has been created
+  /// by this action.
+  syntax::RawSyntax *getLibSyntaxNodeFor(OpaqueSyntaxNode node);
+
+  /// Returns the node created by explicit syntax action from the specified
+  /// node that has been created by this action.
+  OpaqueSyntaxNode getExplicitNodeFor(OpaqueSyntaxNode node);
+};
+} // namespace swift
+
+#endif // SWIFT_PARSE_HIDDENLIBSYNTAXACTION_H

--- a/include/swift/Parse/HiddenLibSyntaxAction.h
+++ b/include/swift/Parse/HiddenLibSyntaxAction.h
@@ -108,6 +108,11 @@ public:
   /// Returns the node created by explicit syntax action from the specified
   /// node that has been created by this action.
   OpaqueSyntaxNode getExplicitNodeFor(OpaqueSyntaxNode node);
+
+  /// Returns the underlying libSyntax \c SyntaxTreeCreator.
+  std::shared_ptr<SyntaxTreeCreator> getLibSyntaxAction() {
+    return LibSyntaxAction;
+  }
 };
 } // namespace swift
 

--- a/include/swift/Parse/LibSyntaxGenerator.h
+++ b/include/swift/Parse/LibSyntaxGenerator.h
@@ -1,0 +1,82 @@
+//===----------- LibSyntaxGenerator.h -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PARSE_LIBSYNTAXGENERATOR_H
+#define SWIFT_PARSE_LIBSYNTAXGENERATOR_H
+
+#include "swift/Parse/HiddenLibSyntaxAction.h"
+#include "swift/Parse/ParsedRawSyntaxNode.h"
+#include "swift/Parse/ParsedRawSyntaxRecorder.h"
+#include "swift/Parse/SyntaxParsingCache.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
+
+namespace swift {
+// TODO: (swift-parse) remove when possible
+/// Generates libSyntax nodes either by looking them up using
+/// HiddenLibSyntaxAction (based on provided OpaqueSyntaxNode) or by recording
+/// them with ParsedRawSyntaxRecorder.
+class LibSyntaxGenerator {
+  std::shared_ptr<HiddenLibSyntaxAction> Actions;
+  ParsedRawSyntaxRecorder Recorder;
+
+public:
+  explicit LibSyntaxGenerator(std::shared_ptr<HiddenLibSyntaxAction> spActions)
+      : Actions(std::move(spActions)), Recorder(Actions->getLibSyntaxAction()) {
+  }
+
+  /// Create a \c TokenSyntax from the raw data and record it in the
+  /// \c HiddenLibSyntaxAction's \c LibSyntaxAction.
+  TokenSyntax createToken(ParsedRawSyntaxNode Node) {
+    assert(Node.isDeferredToken());
+
+    auto Kind = Node.getTokenKind();
+    auto Range = Node.getDeferredTokenRangeWithTrivia();
+    auto LeadingTriviaPieces = Node.getDeferredLeadingTriviaPieces();
+    auto TrailingTriviaPieces = Node.getDeferredTrailingTriviaPieces();
+
+    auto Recorded = Recorder.recordToken(Kind, Range, LeadingTriviaPieces,
+                                         TrailingTriviaPieces);
+    auto Raw = static_cast<RawSyntax *>(Recorded.getOpaqueNode());
+    return make<TokenSyntax>(Raw);
+  }
+
+  /// Create a \c SyntaxNode from the raw data and record it in the
+  /// \c HiddenLibSyntaxAction's \c LibSyntaxAction.
+  template <typename SyntaxNode>
+  SyntaxNode createNode(ParsedRawSyntaxNode Node) {
+    assert(Node.isDeferredLayout());
+    auto Kind = Node.getKind();
+    auto Children = Node.getDeferredChildren();
+
+    auto Recorded = Recorder.recordRawSyntax(Kind, Children);
+    RC<RawSyntax> Raw{static_cast<RawSyntax *>(Recorded.takeOpaqueNode())};
+    Raw->Release(); // -1 since it's transfer of ownership.
+    return make<SyntaxNode>(Raw);
+  }
+
+  /// Return the libSyntax node stored in the given opaque \c Node.
+  /// Assumes that \c Node is of type \c HiddenNode.
+  TokenSyntax getLibSyntaxTokenFor(OpaqueSyntaxNode Node) {
+    return getLibSyntaxNodeFor<TokenSyntax>(Node);
+  }
+
+  /// Return the libSyntax node stored in the given opaque \c Node.
+  /// Assumes that \c Node is of type \c HiddenNode.
+  template <typename SyntaxNode>
+  SyntaxNode getLibSyntaxNodeFor(OpaqueSyntaxNode Node) {
+    return make<SyntaxNode>(Actions->getLibSyntaxNodeFor(Node));
+  }
+};
+} // namespace swift
+
+#endif // SWIFT_PARSE_LIBSYNTAXGENERATOR_H

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -65,10 +65,28 @@ public:
 
   static Parsed${node.name} makeBlank${node.syntax_kind}(SourceLoc loc,
       SyntaxParsingContext &SPCtx);
+%   elif node.is_unknown():
+private:
+  static Parsed${node.name} record${node.syntax_kind}(
+      MutableArrayRef<ParsedRawSyntaxNode> elts,
+      ParsedRawSyntaxRecorder &rec);
+  static Parsed${node.name} defer${node.syntax_kind}(
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
+      SyntaxParsingContext &SPCtx);
+public:
+  static Parsed${node.name} make${node.syntax_kind}(
+      MutableArrayRef<ParsedSyntax> elts,
+      SyntaxParsingContext &SPCtx);
 %   end
 % end
 
 #pragma mark - Convenience APIs
+
+public:
+  static ParsedTokenSyntax makeToken(const Token &Tok,
+                                     const ParsedTrivia &LeadingTrivia,
+                                     const ParsedTrivia &TrailingTrivia,
+                                     SyntaxParsingContext &SPCtx);
 
   /// Records an unlabelled TupleTypeElementSyntax with the provided type and
   /// optional trailing comma.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -408,14 +408,14 @@ public:
 public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
          SILParserStateBase *SIL, PersistentParserState *PersistentState,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
+         std::shared_ptr<HiddenLibSyntaxAction> SPActions = nullptr);
   Parser(unsigned BufferID, SourceFile &SF, SILParserStateBase *SIL,
          PersistentParserState *PersistentState = nullptr,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
+         std::shared_ptr<HiddenLibSyntaxAction> SPActions = nullptr);
   Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
          SILParserStateBase *SIL = nullptr,
          PersistentParserState *PersistentState = nullptr,
-         std::shared_ptr<SyntaxParseActions> SPActions = nullptr);
+         std::shared_ptr<HiddenLibSyntaxAction> SPActions = nullptr);
   ~Parser();
 
   /// Returns true if the buffer being parsed is allowed to contain SIL.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -26,10 +26,12 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/OptionSet.h"
+#include "swift/Parse/ASTGen.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/LocalContext.h"
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Parse/Token.h"
+#include "swift/Parse/ParsedSyntaxNodes.h"
 #include "swift/Parse/ParserPosition.h"
 #include "swift/Parse/ParserResult.h"
 #include "swift/Parse/SyntaxParsingContext.h"
@@ -404,6 +406,9 @@ public:
 
   /// Has \c AvailabilityMacros been computed?
   bool AvailabilityMacrosComputed = false;
+
+  /// The AST generator that generates AST nodes from libSyntax nodes.
+  ASTGen ASTGenerator;
 
 public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
@@ -892,6 +897,16 @@ public:
   }
   ParserResult<BraceStmt> parseBraceItemList(Diag<> ID);
   
+  //===--------------------------------------------------------------------===//
+  // MARK: - Primitive Parsing using libSyntax
+
+  /// Consume a token and return the corresponding \c ParsedTokenSyntax.
+  ParsedTokenSyntax consumeTokenSyntax();
+  ParsedTokenSyntax consumeTokenSyntax(tok K) {
+    assert(Tok.is(K) && "Consuming wrong token kind");
+    return consumeTokenSyntax();
+  }
+
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 
@@ -1615,6 +1630,21 @@ public:
   UnresolvedDeclRefExpr *parseExprOperator();
 
   void validateCollectionElement(ParserResult<Expr> element);
+
+  //===--------------------------------------------------------------------===//
+  // MARK: - Expression parsing using libSyntax
+
+  // TODO: (syntax-parse) remove when possible
+  /// Parse the upcoming expression of type \c SyntaxNode through libSyntax,
+  /// i.e. parse it into a libSyntax node and generate the \c Expr node from the
+  /// libSyntax node using \c ASTGen.
+  template <typename SyntaxNode> ParserResult<Expr> parseExprAST();
+
+  // TODO: (syntax-parse) create new result type for ParsedSyntax
+  // TODO: (syntax-parse) turn into proper non-templated methods later
+  /// Parse the upcoming expression of type \c SyntaxNode into a libSyntax node
+  /// and return it.
+  template <typename SyntaxNode> ParsedExprSyntax parseExprSyntax();
 
   //===--------------------------------------------------------------------===//
   // Statement Parsing

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -13,11 +13,12 @@
 #ifndef SWIFT_PARSE_SYNTAXPARSINGCONTEXT_H
 #define SWIFT_PARSE_SYNTAXPARSINGCONTEXT_H
 
-#include "llvm/ADT/PointerUnion.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/SourceLoc.h"
+#include "swift/Parse/HiddenLibSyntaxAction.h"
 #include "swift/Parse/ParsedRawSyntaxNode.h"
 #include "swift/Parse/ParsedRawSyntaxRecorder.h"
+#include "llvm/ADT/PointerUnion.h"
 
 namespace swift {
 
@@ -99,7 +100,7 @@ public:
 
     RootContextData(SourceFile &SF, DiagnosticEngine &Diags,
                     SourceManager &SourceMgr, unsigned BufferID,
-                    std::shared_ptr<SyntaxParseActions> spActions)
+                    std::shared_ptr<HiddenLibSyntaxAction> spActions)
         : SF(SF), Diags(Diags), SourceMgr(SourceMgr), BufferID(BufferID),
           Recorder(std::move(spActions)) {}
   };
@@ -194,7 +195,7 @@ public:
   /// Construct root context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SourceFile &SF,
                        unsigned BufferID,
-                       std::shared_ptr<SyntaxParseActions> SPActions);
+                       std::shared_ptr<HiddenLibSyntaxAction> SPActions);
 
   /// Designated constructor for child context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder)

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -198,11 +198,7 @@ public:
 
   /// True if the token is any keyword.
   bool isKeyword() const {
-    switch (Kind) {
-#define KEYWORD(X) case tok::kw_##X: return true;
-#include "swift/Syntax/TokenKinds.def"
-    default: return false;
-    }
+    return isTokenKeyword(Kind);
   }
 
   /// True if the token is any literal.

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -61,7 +61,7 @@ namespace swift {
   class SourceFile;
   enum class SourceFileKind;
   class SourceManager;
-  class SyntaxParseActions;
+  class HiddenLibSyntaxAction;
   class SyntaxParsingCache;
   struct TBDGenOptions;
   class Token;
@@ -278,7 +278,7 @@ namespace swift {
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                const LangOptions &LangOpts, const TypeCheckerOptions &TyOpts,
                StringRef ModuleName,
-               std::shared_ptr<SyntaxParseActions> spActions = nullptr,
+               std::shared_ptr<HiddenLibSyntaxAction> spActions = nullptr,
                SyntaxParsingCache *SyntaxCache = nullptr);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -81,9 +81,9 @@ public:
   /// ${line}
 %       end
 %       if child.is_optional:
-  llvm::Optional<${child.type_name}> get${child.name}();
+  llvm::Optional<${child.type_name}> get${child.name}() const;
 %       else:
-  ${child.type_name} get${child.name}();
+  ${child.type_name} get${child.name}() const;
 %       end
 
 %       child_node = NODE_MAP.get(child.syntax_kind)

--- a/include/swift/Syntax/TokenKinds.h
+++ b/include/swift/Syntax/TokenKinds.h
@@ -32,6 +32,9 @@ bool isTokenTextDetermined(tok kind);
 /// If a token kind has determined text, return the text; otherwise assert.
 StringRef getTokenText(tok kind);
 
+/// True if the token is any keyword.
+bool isTokenKeyword(tok kind);
+
 void dumpTokenKind(llvm::raw_ostream &os, tok kind);
 } // end namespace swift
 

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -55,7 +55,6 @@ public:
   Optional<syntax::SourceFileSyntax>
   realizeSyntaxRoot(OpaqueSyntaxNode root, const SourceFile &SF) override;
 
-private:
   OpaqueSyntaxNode recordToken(tok tokenKind,
                                ArrayRef<ParsedTriviaPiece> leadingTrivia,
                                ArrayRef<ParsedTriviaPiece> trailingTrivia,

--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -1,0 +1,54 @@
+//===--- ASTGen.cpp -------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/ASTGen.h"
+#include "swift/AST/TypeRepr.h"
+#include "swift/Basic/SourceManager.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+StringRef ASTGen::copyAndStripUnderscores(StringRef Orig, ASTContext &Context) {
+  char *start = static_cast<char *>(Context.Allocate(Orig.size(), 1));
+  char *p = start;
+
+  if (p) {
+    for (char c : Orig) {
+      if (c != '_') {
+        *p++ = c;
+      }
+    }
+  }
+
+  return StringRef(start, p - start);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: - Other
+
+StringRef ASTGen::copyAndStripUnderscores(StringRef Orig) {
+  return copyAndStripUnderscores(Orig, Context);
+}
+
+SourceLoc ASTGen::advanceLocBegin(const SourceLoc &Loc, const Syntax &Node) {
+  return Loc.getAdvancedLoc(Node.getAbsolutePosition().getOffset());
+}
+
+SourceLoc ASTGen::advanceLocEnd(const SourceLoc &Loc,
+                                const TokenSyntax &Token) {
+  return advanceLocAfter(Loc, Token.withTrailingTrivia({}));
+}
+
+SourceLoc ASTGen::advanceLocAfter(const SourceLoc &Loc, const Syntax &Node) {
+  return Loc.getAdvancedLoc(
+      Node.getAbsoluteEndPositionAfterTrailingTrivia().getOffset());
+}

--- a/lib/Parse/ASTGenExpr.cpp
+++ b/lib/Parse/ASTGenExpr.cpp
@@ -1,0 +1,54 @@
+//===--- ASTGenExpr.cpp ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/ASTGen.h"
+#include "swift/AST/TypeRepr.h"
+#include "swift/Basic/SourceManager.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+Expr *ASTGen::generate(const IntegerLiteralExprSyntax &Expr, const SourceLoc &Loc) {
+  TokenSyntax Digits = Expr.getDigits();
+  StringRef Text = copyAndStripUnderscores(Digits.getText());
+  auto DigitsLoc = advanceLocBegin(Loc, Digits);
+  return new (Context) IntegerLiteralExpr(Text, DigitsLoc);
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: - Private
+
+Expr *ASTGen::generateMagicIdentifierLiteralExpr(const TokenSyntax &PoundToken,
+                                                 const SourceLoc &Loc) {
+  auto Kind = getMagicIdentifierLiteralKind(PoundToken.getTokenKind());
+  SourceLoc TokenLoc = advanceLocBegin(Loc, PoundToken);
+  return new (Context) MagicIdentifierLiteralExpr(Kind, TokenLoc);
+}
+
+/// Map magic literal tokens such as #file to their
+/// MagicIdentifierLiteralExpr kind.
+MagicIdentifierLiteralExpr::Kind
+ASTGen::getMagicIdentifierLiteralKind(tok Kind) {
+  switch (Kind) {
+  case tok::pound_file:
+    // TODO: Enable by default at the next source break. (SR-13199)
+    return Context.LangOpts.EnableConcisePoundFile
+               ? MagicIdentifierLiteralExpr::FileIDSpelledAsFile
+               : MagicIdentifierLiteralExpr::FilePathSpelledAsFile;
+#define MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN)                                    \
+  case tok::TOKEN:                                                             \
+    return MagicIdentifierLiteralExpr::Kind::NAME;
+#include "swift/AST/MagicIdentifierKinds.def"
+  default:
+    llvm_unreachable("not a magic literal");
+  }
+}

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 add_swift_host_library(swiftParse STATIC
   Confusables.cpp
+  HiddenLibSyntaxAction.cpp
   Lexer.cpp
   ParseDecl.cpp
   ParsedRawSyntaxNode.cpp

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -7,6 +7,8 @@ else()
 endif()
 
 add_swift_host_library(swiftParse STATIC
+  ASTGen.cpp
+  ASTGenExpr.cpp
   Confusables.cpp
   HiddenLibSyntaxAction.cpp
   Lexer.cpp

--- a/lib/Parse/HiddenLibSyntaxAction.cpp
+++ b/lib/Parse/HiddenLibSyntaxAction.cpp
@@ -1,0 +1,167 @@
+//===--- HiddenLibSyntaxAction.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/HiddenLibSyntaxAction.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/Parse/Token.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/SyntaxNodes.h"
+#include "swift/Syntax/Trivia.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace swift;
+using namespace swift::syntax;
+using namespace llvm;
+
+OpaqueSyntaxNode
+HiddenLibSyntaxAction::makeHiddenNode(OpaqueSyntaxNode explicitActionNode,
+                                      OpaqueSyntaxNode libSyntaxNode) {
+  auto dat = NodeAllocator.Allocate();
+  return new (dat) HiddenNode(explicitActionNode, libSyntaxNode);
+}
+
+OpaqueSyntaxNode HiddenLibSyntaxAction::recordToken(
+    tok tokenKind, ArrayRef<ParsedTriviaPiece> leadingTrivia,
+    ArrayRef<ParsedTriviaPiece> trailingTrivia, CharSourceRange range) {
+
+  OpaqueSyntaxNode explicitActionNode;
+  if (ExplicitAction) {
+    explicitActionNode = ExplicitAction->recordToken(
+      tokenKind, leadingTrivia, trailingTrivia, range);
+  } else {
+    explicitActionNode = nullptr;
+  }
+
+  OpaqueSyntaxNode libSyntaxActionNode;
+  if (ExplicitAction == LibSyntaxAction) {
+    libSyntaxActionNode = explicitActionNode;
+  } else {
+    libSyntaxActionNode = LibSyntaxAction->recordToken(tokenKind, leadingTrivia,
+                                                       trailingTrivia, range);
+  }
+
+  return makeHiddenNode(explicitActionNode, libSyntaxActionNode);
+}
+
+OpaqueSyntaxNode HiddenLibSyntaxAction::recordMissingToken(tok tokenKind,
+                                                           SourceLoc loc) {
+  OpaqueSyntaxNode explicitActionNode;
+  if (ExplicitAction) {
+    explicitActionNode =
+        ExplicitAction->recordMissingToken(tokenKind, loc);
+  } else {
+    explicitActionNode = nullptr;
+  }
+
+  OpaqueSyntaxNode libSyntaxActionNode;
+  if (ExplicitAction == LibSyntaxAction) {
+    libSyntaxActionNode = explicitActionNode;
+  } else {
+    libSyntaxActionNode = LibSyntaxAction->recordMissingToken(tokenKind, loc);
+  }
+
+  return makeHiddenNode(explicitActionNode, libSyntaxActionNode);
+}
+
+OpaqueSyntaxNode
+HiddenLibSyntaxAction::recordRawSyntax(syntax::SyntaxKind kind,
+                                       ArrayRef<OpaqueSyntaxNode> elements,
+                                       CharSourceRange range) {
+  OpaqueSyntaxNode explicitActionNode;
+  if (ExplicitAction) {
+    SmallVector<OpaqueSyntaxNode, 4> explicitActionElements;
+    explicitActionElements.reserve(elements.size());
+    for (auto element : elements) {
+      OpaqueSyntaxNode explicitActionElement = nullptr;
+      if (element) {
+        explicitActionElement =
+            static_cast<HiddenNode *>(element)->ExplicitActionNode;
+      }
+      explicitActionElements.push_back(explicitActionElement);
+    }
+
+    explicitActionNode =
+        ExplicitAction->recordRawSyntax(kind, explicitActionElements, range);
+  } else {
+    explicitActionNode = nullptr;
+  }
+
+  OpaqueSyntaxNode libSyntaxActionNode;
+  if (ExplicitAction == LibSyntaxAction) {
+    libSyntaxActionNode = explicitActionNode;
+  } else {
+    SmallVector<OpaqueSyntaxNode, 4> libSyntaxActionElements;
+    libSyntaxActionElements.reserve(elements.size());
+    for (auto element : elements) {
+      OpaqueSyntaxNode libSyntaxActionElement = nullptr;
+      if (element) {
+        libSyntaxActionElement =
+            static_cast<HiddenNode *>(element)->LibSyntaxNode;
+      }
+      libSyntaxActionElements.push_back(libSyntaxActionElement);
+    }
+    libSyntaxActionNode =
+        LibSyntaxAction->recordRawSyntax(kind, libSyntaxActionElements, range);
+  }
+
+  return makeHiddenNode(explicitActionNode, libSyntaxActionNode);
+}
+
+Optional<syntax::SourceFileSyntax>
+HiddenLibSyntaxAction::realizeSyntaxRoot(OpaqueSyntaxNode root,
+                                         const SourceFile &SF) {
+  auto node = static_cast<HiddenNode *>(root);
+  return LibSyntaxAction->realizeSyntaxRoot(node->LibSyntaxNode, SF);
+}
+
+void HiddenLibSyntaxAction::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
+  if (!opaqueN) {
+    return;
+  }
+  auto node = static_cast<HiddenNode *>(opaqueN);
+  if (ExplicitAction) {
+    ExplicitAction->discardRecordedNode(node->ExplicitActionNode);
+  }
+  if (ExplicitAction != LibSyntaxAction) {
+    LibSyntaxAction->discardRecordedNode(node->LibSyntaxNode);
+  }
+}
+
+std::pair<size_t, OpaqueSyntaxNode>
+HiddenLibSyntaxAction::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
+  if (ExplicitAction) {
+    // TODO: (syntax-parse) We only perform the node lookup in the explicit action
+    // If HiddenSyntaxAction should stay, we should find an implementation that
+    // also performs lookup in the LibSyntaxAction
+    size_t length;
+    OpaqueSyntaxNode n;
+    std::tie(length, n) = ExplicitAction->lookupNode(lexerOffset, kind);
+    if (length == 0) {
+      return {0, nullptr};
+    }
+    return {length, makeHiddenNode(n, nullptr)};
+  } else {
+    return {0, nullptr};
+
+  }
+}
+
+RawSyntax *HiddenLibSyntaxAction::getLibSyntaxNodeFor(OpaqueSyntaxNode node) {
+  auto hiddenNode = static_cast<HiddenNode *>(node);
+  return static_cast<RawSyntax *>(hiddenNode->LibSyntaxNode);
+}
+
+OpaqueSyntaxNode
+HiddenLibSyntaxAction::getExplicitNodeFor(OpaqueSyntaxNode node) {
+  return static_cast<HiddenNode *>(node)->ExplicitActionNode;
+}

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1037,18 +1037,6 @@ getMagicIdentifierLiteralKind(tok Kind, const LangOptions &Opts) {
   }
 }
 
-/// Map magic literal kinds such as #file to their SyntaxKind.
-static SyntaxKind
-getMagicIdentifierSyntaxKind(MagicIdentifierLiteralExpr::Kind LiteralKind) {
-  switch (LiteralKind) {
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-  case MagicIdentifierLiteralExpr::NAME: \
-    return SyntaxKind::SYNTAX_KIND;
-#include "swift/AST/MagicIdentifierKinds.def"
-  }
-  llvm_unreachable("not a magic literal kind");
-}
-
 ParserResult<Expr>
 Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
                                bool periodHasKeyPathBehavior,
@@ -1413,6 +1401,38 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   switch (Tok.getKind()) {
   case tok::integer_literal:
     return parseExprAST<IntegerLiteralExprSyntax>();
+  case tok::floating_literal:
+    return parseExprAST<FloatLiteralExprSyntax>();
+  case tok::kw_nil:
+    return parseExprAST<NilLiteralExprSyntax>();
+  case tok::kw_true:
+  case tok::kw_false:
+    return parseExprAST<BooleanLiteralExprSyntax>();
+  // Cases for magic identifier tokens
+  case tok::pound_file:
+#define MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN) case tok::TOKEN:
+#include "swift/AST/MagicIdentifierKinds.def"
+  {
+    auto Kind = getMagicIdentifierLiteralKind(Tok.getKind(), Context.LangOpts);
+    switch (Kind) {
+    case MagicIdentifierLiteralExpr::FileID:
+      return parseExprAST<PoundFileIDExprSyntax>();
+    case MagicIdentifierLiteralExpr::FilePath:
+      return parseExprAST<PoundFilePathExprSyntax>();
+    case MagicIdentifierLiteralExpr::FileIDSpelledAsFile:
+      return parseExprAST<PoundFileExprSyntax>();
+    case MagicIdentifierLiteralExpr::FilePathSpelledAsFile:
+      return parseExprAST<PoundFileExprSyntax>();
+    case MagicIdentifierLiteralExpr::Function:
+      return parseExprAST<PoundFunctionExprSyntax>();
+    case MagicIdentifierLiteralExpr::Line:
+      return parseExprAST<PoundLineExprSyntax>();
+    case MagicIdentifierLiteralExpr::Column:
+      return parseExprAST<PoundColumnExprSyntax>();
+    case MagicIdentifierLiteralExpr::DSOHandle:
+      return parseExprAST<PoundDsohandleExprSyntax>();
+    }
+  }
   default:
     break;
   }
@@ -1420,21 +1440,6 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   // Direct parsing of tokens to an AST
   SyntaxParsingContext ExprContext(SyntaxContext, SyntaxContextKind::Expr);
   switch (Tok.getKind()) {
-  case tok::integer_literal: {
-    StringRef Text = copyAndStripUnderscores(Tok.getText());
-    SourceLoc Loc = consumeToken(tok::integer_literal);
-    ExprContext.setCreateSyntax(SyntaxKind::IntegerLiteralExpr);
-    return makeParserResult(new (Context)
-                                IntegerLiteralExpr(Text, Loc,
-                                                   /*Implicit=*/false));
-  }
-  case tok::floating_literal: {
-    StringRef Text = copyAndStripUnderscores(Tok.getText());
-    SourceLoc Loc = consumeToken(tok::floating_literal);
-    ExprContext.setCreateSyntax(SyntaxKind::FloatLiteralExpr);
-    return makeParserResult(new (Context) FloatLiteralExpr(Text, Loc,
-                                                           /*Implicit=*/false));
-  }
   case tok::at_sign:
     // Objective-C programmers habitually type @"foo", so recover gracefully
     // with a fixit.  If this isn't @"foo", just handle it like an unknown
@@ -1449,49 +1454,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       
   case tok::string_literal:  // "foo"
     return parseExprStringLiteral();
-  
-  case tok::kw_nil:
-    ExprContext.setCreateSyntax(SyntaxKind::NilLiteralExpr);
-    return makeParserResult(new (Context)
-                                NilLiteralExpr(consumeToken(tok::kw_nil)));
 
-  case tok::kw_true:
-  case tok::kw_false: {
-    ExprContext.setCreateSyntax(SyntaxKind::BooleanLiteralExpr);
-    bool isTrue = Tok.is(tok::kw_true);
-    return makeParserResult(new (Context)
-                                BooleanLiteralExpr(isTrue, consumeToken()));
-  }
-
-  // Cases for deprecated magic identifier tokens
-#define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN) case tok::TOKEN:
-#include "swift/AST/MagicIdentifierKinds.def"
-  {
-    auto Kind = getMagicIdentifierLiteralKind(Tok.getKind(), Context.LangOpts);
-    auto replacement = MagicIdentifierLiteralExpr::getKindString(Kind);
-
-    diagnose(Tok.getLoc(), diag::snake_case_deprecated,
-             Tok.getText(), replacement)
-      .fixItReplace(Tok.getLoc(), replacement);
-    LLVM_FALLTHROUGH;
-  }
-
-  // Cases for non-deprecated magic identifier tokens
-  case tok::pound_file:
-#define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN)
-#define MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN) case tok::TOKEN:
-#include "swift/AST/MagicIdentifierKinds.def"
-  {
-    auto Kind = getMagicIdentifierLiteralKind(Tok.getKind(), Context.LangOpts);
-    SyntaxKind SKind = getMagicIdentifierSyntaxKind(Kind);
-
-    ExprContext.setCreateSyntax(SKind);
-    SourceLoc Loc = consumeToken();
-
-    return makeParserResult(new (Context) MagicIdentifierLiteralExpr(
-        Kind, Loc, /*implicit=*/false));
-  }
-      
   case tok::identifier:  // foo
   case tok::kw_self:     // self
 
@@ -3732,8 +3695,119 @@ template <typename SyntaxNode> ParserResult<Expr> Parser::parseExprAST() {
 }
 
 template <>
+ParsedExprSyntax Parser::parseExprSyntax<BooleanLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax();
+  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(std::move(Token),
+                                                      *SyntaxContext);
+}
+
+template <> ParsedExprSyntax Parser::parseExprSyntax<FloatLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::floating_literal);
+  return ParsedSyntaxRecorder::makeFloatLiteralExpr(std::move(Token),
+                                                    *SyntaxContext);
+}
+
+template <>
 ParsedExprSyntax Parser::parseExprSyntax<IntegerLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::integer_literal);
   return ParsedSyntaxRecorder::makeIntegerLiteralExpr(std::move(Token),
                                                       *SyntaxContext);
+}
+
+template <> ParsedExprSyntax Parser::parseExprSyntax<NilLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::kw_nil);
+  return ParsedSyntaxRecorder::makeNilLiteralExpr(std::move(Token),
+                                                  *SyntaxContext);
+}
+
+template <> ParsedExprSyntax Parser::parseExprSyntax<PoundColumnExprSyntax>() {
+  if (Tok.getKind() == tok::kw___COLUMN__) {
+    StringRef fixit = "#column";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___COLUMN__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_column);
+  return ParsedSyntaxRecorder::makePoundColumnExpr(std::move(Token),
+                                                   *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundDsohandleExprSyntax>() {
+  if (Tok.getKind() == tok::kw___DSO_HANDLE__) {
+    StringRef fixit = "#dsohandle";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token =
+        consumeTokenSyntax(tok::kw___DSO_HANDLE__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_dsohandle);
+  return ParsedSyntaxRecorder::makePoundDsohandleExpr(std::move(Token),
+                                                      *SyntaxContext);
+}
+
+template <> ParsedExprSyntax Parser::parseExprSyntax<PoundFileExprSyntax>() {
+  if (Tok.getKind() == tok::kw___FILE__) {
+    StringRef fixit = "#file";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___FILE__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_file);
+  return ParsedSyntaxRecorder::makePoundFileExpr(std::move(Token),
+                                                 *SyntaxContext);
+}
+
+template <> ParsedExprSyntax Parser::parseExprSyntax<PoundFileIDExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::pound_fileID);
+  return ParsedSyntaxRecorder::makePoundFileIDExpr(std::move(Token),
+                                                   *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundFilePathExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::pound_filePath);
+  return ParsedSyntaxRecorder::makePoundFilePathExpr(std::move(Token),
+                                                     *SyntaxContext);
+}
+
+template <> ParsedExprSyntax Parser::parseExprSyntax<PoundLineExprSyntax>() {
+  if (Tok.getKind() == tok::kw___LINE__) {
+    StringRef fixit = "#line";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___LINE__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  // FIXME: #line was renamed to #sourceLocation
+  auto Token = consumeTokenSyntax(tok::pound_line);
+  return ParsedSyntaxRecorder::makePoundLineExpr(std::move(Token),
+                                                 *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundFunctionExprSyntax>() {
+  if (Tok.getKind() == tok::kw___FUNCTION__) {
+    StringRef fixit = "#function";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___FUNCTION__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_function);
+  return ParsedSyntaxRecorder::makePoundFunctionExpr(std::move(Token),
+                                                     *SyntaxContext);
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1409,6 +1409,15 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 ///     expr-selector
 ///
 ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
+  // Parsing of expressions through the libSyntax tree
+  switch (Tok.getKind()) {
+  case tok::integer_literal:
+    return parseExprAST<IntegerLiteralExprSyntax>();
+  default:
+    break;
+  }
+
+  // Direct parsing of tokens to an AST
   SyntaxParsingContext ExprContext(SyntaxContext, SyntaxContextKind::Expr);
   switch (Tok.getKind()) {
   case tok::integer_literal: {
@@ -3701,4 +3710,30 @@ Parser::parsePlatformVersionConstraintSpec() {
   Version = canonicalizePlatformVersion(*Platform, Version);
   return makeParserResult(new (Context) PlatformVersionConstraintAvailabilitySpec(
       Platform.getValue(), PlatformLoc, Version, RuntimeVersion, VersionRange));
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: - Expression parsing using libSyntax
+
+template <typename SyntaxNode> ParserResult<Expr> Parser::parseExprAST() {
+  EnableContextRAII enableSyntaxParsing(*SyntaxContext);
+
+  auto Loc = leadingTriviaLoc();
+  SyntaxContext->addSyntax(parseExprSyntax<SyntaxNode>());
+  // TODO: (syntax-parse) improve this somehow
+  if (SyntaxContext->isTopNode<UnknownExprSyntax>()) {
+    auto Expr = SyntaxContext->topNode<UnknownExprSyntax>();
+    auto ExprAST = ASTGenerator.generate(Expr, Loc);
+    return makeParserResult(ExprAST);
+  }
+  auto Expr = SyntaxContext->topNode<SyntaxNode>();
+  auto ExprAST = ASTGenerator.generate(Expr, Loc);
+  return makeParserResult(ExprAST);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<IntegerLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::integer_literal);
+  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(std::move(Token),
+                                                      *SyntaxContext);
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -899,21 +899,8 @@ ParserResult<Expr> Parser::parseExprSuper() {
                                                      /*Implicit=*/false));
 }
 
-/// Copy a numeric literal value into AST-owned memory, stripping underscores
-/// so the semantic part of the value can be parsed by APInt/APFloat parsers.
 StringRef Parser::copyAndStripUnderscores(StringRef orig) {
-  char *start = static_cast<char*>(Context.Allocate(orig.size(), 1));
-  char *p = start;
-
-  if (p) {
-    for (char c : orig) {
-      if (c != '_') {
-        *p++ = c;
-      }
-    }
-  }
-  
-  return StringRef(start, p - start);
+  return ASTGen::copyAndStripUnderscores(orig, Context);
 }
 
 /// Disambiguate the parse after '{' token that is in a place that might be

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -163,8 +163,53 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
   }
   return Parsed${node.name}(std::move(raw));
 }
+%   elif node.is_unknown():
+Parsed${node.name}
+ParsedSyntaxRecorder::record${node.syntax_kind}(
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
+    ParsedRawSyntaxRecorder &rec) {
+  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
+  return Parsed${node.name}(std::move(raw));
+}
+
+Parsed${node.name}
+ParsedSyntaxRecorder::defer${node.syntax_kind}(
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
+    SyntaxParsingContext &SPCtx) {
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
+                             layout, SPCtx);
+  return Parsed${node.name}(std::move(raw));
+}
+
+Parsed${node.name}
+ParsedSyntaxRecorder::make${node.syntax_kind}(
+    MutableArrayRef<ParsedSyntax> elements,
+    SyntaxParsingContext &SPCtx) {
+  SmallVector<ParsedRawSyntaxNode, 16> layout;
+  layout.reserve(elements.size());
+  for (auto &element : elements) {
+    layout.push_back(element.takeRaw());
+  }
+  if (SPCtx.shouldDefer())
+    return defer${node.syntax_kind}(layout, SPCtx);
+  return record${node.syntax_kind}(layout, SPCtx.getRecorder());
+}
 %   end
 % end
+
+ParsedTokenSyntax
+ParsedSyntaxRecorder::makeToken(const Token &Tok,
+                                const ParsedTrivia &LeadingTrivia,
+                                const ParsedTrivia &TrailingTrivia,
+                                SyntaxParsingContext &SPCtx) {
+  ParsedRawSyntaxNode raw;
+  if (SPCtx.shouldDefer()) {
+    raw = ParsedRawSyntaxNode::makeDeferred(Tok, LeadingTrivia, TrailingTrivia, SPCtx);
+  } else {
+    raw = SPCtx.getRecorder().recordToken(Tok, LeadingTrivia, TrailingTrivia);
+  }
+  return ParsedTokenSyntax(std::move(raw));
+}
 
 ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -379,14 +379,14 @@ static LexerMode sourceFileKindToLexerMode(SourceFileKind kind) {
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, SILParserStateBase *SIL,
                PersistentParserState *PersistentState,
-               std::shared_ptr<SyntaxParseActions> SPActions)
+               std::shared_ptr<HiddenLibSyntaxAction> SPActions)
     : Parser(BufferID, SF, &SF.getASTContext().Diags, SIL, PersistentState,
              std::move(SPActions)) {}
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
                SILParserStateBase *SIL,
                PersistentParserState *PersistentState,
-               std::shared_ptr<SyntaxParseActions> SPActions)
+               std::shared_ptr<HiddenLibSyntaxAction> SPActions)
     : Parser(
           std::unique_ptr<Lexer>(new Lexer(
               SF.getASTContext().LangOpts, SF.getASTContext().SourceMgr,
@@ -518,20 +518,25 @@ public:
 
 Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
                SILParserStateBase *SIL, PersistentParserState *PersistentState,
-               std::shared_ptr<SyntaxParseActions> SPActions)
-  : SourceMgr(SF.getASTContext().SourceMgr),
-    Diags(SF.getASTContext().Diags),
-    SF(SF),
-    L(Lex.release()),
-    SIL(SIL),
-    CurDeclContext(&SF),
-    Context(SF.getASTContext()),
-    TokReceiver(SF.shouldCollectTokens() ?
-                new TokenRecorder(SF.getASTContext(), L->getBufferID()) :
-                new ConsumeTokenReceiver()),
-    SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF,
-                                           L->getBufferID(),
-                                           std::move(SPActions))) {
+               std::shared_ptr<HiddenLibSyntaxAction> SPActions)
+    : SourceMgr(SF.getASTContext().SourceMgr), Diags(SF.getASTContext().Diags),
+      SF(SF), L(Lex.release()), SIL(SIL), CurDeclContext(&SF),
+      Context(SF.getASTContext()),
+      TokReceiver(SF.shouldCollectTokens()
+                      ? new TokenRecorder(SF.getASTContext(), L->getBufferID())
+                      : new ConsumeTokenReceiver()) {
+  // If no syntax parsing actions were provided, generate a hidden syntax
+  // parsing action that only generates the libSyntax tree. This makes sure
+  // that the libSyntax tree is always generated.
+  if (SPActions == nullptr) {
+    auto LibSyntaxTreeCreator = std::make_shared<SyntaxTreeCreator>(
+        SourceMgr, L->getBufferID(), SF.SyntaxParsingCache,
+        Context.getSyntaxArena());
+    SPActions =
+        std::make_shared<HiddenLibSyntaxAction>(nullptr, LibSyntaxTreeCreator);
+  }
+  SyntaxContext =
+      new SyntaxParsingContext(SyntaxContext, SF, L->getBufferID(), SPActions);
   State = PersistentState;
   if (!State) {
     OwnedState.reset(new PersistentParserState());
@@ -1209,7 +1214,7 @@ bool Parser::shouldReturnSingleExpressionElement(ArrayRef<ASTNode> Body) {
 }
 
 struct ParserUnit::Implementation {
-  std::shared_ptr<SyntaxParseActions> SPActions;
+  std::shared_ptr<HiddenLibSyntaxAction> SPActions;
   LangOptions LangOpts;
   TypeCheckerOptions TypeCheckerOpts;
   SearchPathOptions SearchPathOpts;
@@ -1222,7 +1227,7 @@ struct ParserUnit::Implementation {
   Implementation(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                  const LangOptions &Opts, const TypeCheckerOptions &TyOpts,
                  StringRef ModuleName,
-                 std::shared_ptr<SyntaxParseActions> spActions)
+                 std::shared_ptr<HiddenLibSyntaxAction> spActions)
       : SPActions(std::move(spActions)), LangOpts(Opts),
         TypeCheckerOpts(TyOpts), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts,
@@ -1252,7 +1257,7 @@ ParserUnit::ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned Buffer
                        const LangOptions &LangOpts,
                        const TypeCheckerOptions &TypeCheckOpts,
                        StringRef ModuleName,
-                       std::shared_ptr<SyntaxParseActions> spActions,
+                       std::shared_ptr<HiddenLibSyntaxAction> spActions,
                        SyntaxParsingCache *SyntaxCache)
     : Impl(*new Implementation(SM, SFKind, BufferID, LangOpts, TypeCheckOpts,
                                ModuleName, std::move(spActions))) {
@@ -1296,7 +1301,7 @@ OpaqueSyntaxNode ParserUnit::parse() {
 
   auto rawNode = P.finalizeSyntaxTree();
   Optional<SourceFileSyntax> syntaxRoot;
-  if (Impl.SPActions) {
+  if (rawNode) {
     if (auto root = Impl.SPActions->realizeSyntaxRoot(rawNode, *Impl.SF))
       syntaxRoot.emplace(*root);
   }
@@ -1304,6 +1309,9 @@ OpaqueSyntaxNode ParserUnit::parse() {
   auto result = SourceFileParsingResult{ctx.AllocateCopy(decls), tokensRef,
                                         P.CurrentTokenHash, syntaxRoot};
   ctx.evaluator.cacheOutput(ParseSourceFileRequest{&P.SF}, std::move(result));
+  if (rawNode) {
+    rawNode = Impl.SPActions->getExplicitNodeFor(rawNode);
+  }
   return rawNode;
 }
 

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -58,7 +58,7 @@ void SyntaxParsingContext::cancelBacktrack() {
 }
 
 size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
-  if (!Enabled)
+  if (!isEnabled())
     return 0;
 
   // Avoid doing lookup for a previous parsed node when we are in backtracking
@@ -206,7 +206,7 @@ ParsedTokenSyntax SyntaxParsingContext::popToken() {
 void SyntaxParsingContext::addToken(Token &Tok,
                                     const ParsedTrivia &LeadingTrivia,
                                     const ParsedTrivia &TrailingTrivia) {
-  if (!Enabled)
+  if (!isEnabled())
     return;
 
   ParsedRawSyntaxNode raw;
@@ -220,7 +220,7 @@ void SyntaxParsingContext::addToken(Token &Tok,
 
 /// Add Syntax to the parts.
 void SyntaxParsingContext::addSyntax(ParsedSyntax Node) {
-  if (!Enabled)
+  if (!isEnabled())
     return;
   addRawSyntax(Node.takeRaw());
 }
@@ -242,7 +242,7 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind,
                                           SyntaxNodeCreationKind nodeCreateK) {
   assert(isTopOfContextStack());
-  if (!Enabled)
+  if (!isEnabled())
     return;
 
   switch (Kind) {
@@ -281,7 +281,7 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind,
                                          SyntaxNodeCreationKind nodeCreateK) {
   assert(isCollectionKind(ColletionKind));
   assert(isTopOfContextStack());
-  if (!Enabled)
+  if (!isEnabled())
     return;
   auto Parts = getParts();
   auto Count = 0;
@@ -315,7 +315,7 @@ static ParsedRawSyntaxNode finalizeSourceFile(RootContextData &RootData,
 }
 
 OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
-  if (!Enabled)
+  if (!isEnabled())
     return nullptr;
   assert(isTopOfContextStack() && "some sub-contexts are not destructed");
   assert(isRoot() && "only root context can finalize the tree");
@@ -334,7 +334,7 @@ OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
 }
 
 void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
-  if (!Enabled)
+  if (!isEnabled())
     return;
 
   ParsedRawSyntaxNode raw;
@@ -367,7 +367,7 @@ SyntaxParsingContext::~SyntaxParsingContext() {
       delete RootDataOrParent.get<RootContextData*>();
   };
 
-  if (!Enabled)
+  if (!isEnabled())
     return;
 
   auto &Storage = getStorage();
@@ -425,7 +425,7 @@ SyntaxParsingContext::~SyntaxParsingContext() {
 
   // Never.
   case AccumulationMode::NotSet:
-    assert(!Enabled && "Cleanup mode must be specified before destruction");
+    assert(!isEnabled() && "Cleanup mode must be specified before destruction");
     break;
   }
 }

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -35,7 +35,7 @@ using RootContextData = SyntaxParsingContext::RootContextData;
 
 SyntaxParsingContext::SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder,
                                            SourceFile &SF, unsigned BufferID,
-                                 std::shared_ptr<SyntaxParseActions> SPActions)
+                              std::shared_ptr<HiddenLibSyntaxAction> SPActions)
     : RootDataOrParent(new RootContextData(
           SF, SF.getASTContext().Diags, SF.getASTContext().SourceMgr, BufferID,
           std::move(SPActions))),

--- a/lib/Syntax/SyntaxKind.cpp.gyb
+++ b/lib/Syntax/SyntaxKind.cpp.gyb
@@ -44,6 +44,14 @@ StringRef getTokenText(tok kind) {
   return text;
 }
 
+bool isTokenKeyword(tok kind) {
+  switch (kind) {
+#define KEYWORD(X) case tok::kw_##X: return true;
+#include "swift/Syntax/TokenKinds.def"
+  default: return false;
+  }
+}
+
 bool parserShallOmitWhenNoChildren(syntax::SyntaxKind Kind) {
   switch(Kind) {
 %   for node in SYNTAX_NODES:

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -55,14 +55,14 @@ void ${node.name}::validate() const {
 
 %   for child in node.children:
 %     if child.is_optional:
-llvm::Optional<${child.type_name}> ${node.name}::get${child.name}() {
+llvm::Optional<${child.type_name}> ${node.name}::get${child.name}() const {
   auto ChildData = Data->getChild(Cursor::${child.name});
   if (!ChildData)
     return llvm::None;
   return ${child.type_name} {Root, ChildData.get()};
 }
 %     else:
-${child.type_name} ${node.name}::get${child.name}() {
+${child.type_name} ${node.name}::get${child.name}() const {
   return ${child.type_name} {Root, Data->getChild(Cursor::${child.name}).get()};
 }
 %     end

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 # Add generated libSyntax headers to global dependencies.
 list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
+list(APPEND LLVM_COMMON_DEPENDS swift-parse-syntax-generated-headers)
 if(SWIFT_BUILD_SOURCEKIT)
   list(APPEND LLVM_COMMON_DEPENDS generated_sourcekit_uids)
 endif()

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1604,11 +1604,14 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
             SM, BufferID, Invocation.getMainFileSyntaxParsingCache(),
             syntaxArena);
 
+    auto hiddenAction =
+        std::make_shared<HiddenLibSyntaxAction>(SynTreeCreator, SynTreeCreator);
+
     ParserUnit Parser(SM, SourceFileKind::Main, BufferID,
                       Invocation.getLangOptions(),
                       Invocation.getTypeCheckerOptions(),
                       Invocation.getModuleName(),
-                      SynTreeCreator,
+                      hiddenAction,
                       Invocation.getMainFileSyntaxParsingCache());
 
     registerParseRequestFunctions(Parser.getParser().Context.evaluator);
@@ -1838,11 +1841,14 @@ static int doStructureAnnotation(const CompilerInvocation &InitInvok,
           SM, BufferID, Invocation.getMainFileSyntaxParsingCache(),
           syntaxArena);
 
+  auto hiddenAction =
+      std::make_shared<HiddenLibSyntaxAction>(SynTreeCreator, SynTreeCreator);
+
   ParserUnit Parser(SM, SourceFileKind::Main, BufferID,
                     Invocation.getLangOptions(),
                     Invocation.getTypeCheckerOptions(),
                     Invocation.getModuleName(),
-                    SynTreeCreator,
+                    hiddenAction,
                     Invocation.getMainFileSyntaxParsingCache());
 
   registerParseRequestFunctions(Parser.getParser().Context.evaluator);


### PR DESCRIPTION
This is an effort migrate the parser to generate a libSyntax tree and have a separate `ASTGen` class generate an AST from the libSyntax tree.

The gist of these changes has previously been made in https://github.com/apple/swift/pull/25193, been reverted, re-applied in #26403 and then been reverted again due to performance issues.

AFAIU the major performance issue that caused the final revert of the changes previously was because the libSyntax tree was **always** created, even for syntax elements that hadn't been migrated to the new parsing approach yet. In particular, this meant that we were no longer able to skip function bodies since the parser wanted to generate the libSyntax tree for the body.

I believe, we can mitigate the performance impact that we saw earlier by only selectively enabling the syntax parsing context in places where we need it. This will work as follows: 
– During normal compilation the syntax context will be disable just like it is today
– Whenever we encounter a syntax element that has been migrated, we enable the syntax parsing context, and set its accumulation mode to discard
– Once parsing of that syntax element is finished, we disable the syntax parsing context again.


That way, we’d only pay the cost of unnecessarily creating the libSyntax tree for non-migrated elements nested inside migrated elements. As long as we don’t migrate declaration parsing, this cost should be negligible (Rintaro’s case of nesting declarations inside string literal interpolations should be pretty niche and the nested declarations small).

Once we start migrating declarations, we need to find a way to skip function bodies etc. to maintain performant parsing. I’m confident that this is a problem we’re able to solve once we get to it – in essence we need to teach libSyntax to also skip function bodies.

CC: @jansvoboda11