### PR TITLE
[Test] Mark protocol_conformance_collision.swift as requiring executable_test.

### DIFF
--- a/test/Runtime/protocol_conformance_collision.swift
+++ b/test/Runtime/protocol_conformance_collision.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/oldSDK oldSDK
 
 // REQUIRES: VENDOR=apple
+// REQUIRES: executable_test
 
 // Simulators refuse to run binaries built with an SDK newer than the simulator.
 // UNSUPPORTED: DARWIN_SIMULATOR=ios


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/35125 to 5.4.