### PR TITLE
Update links to the Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ diligently to make the Swift community welcoming to everyone.
 To give clarity of what is expected of our members, Swift has adopted the
 code of conduct defined by the Contributor Covenant. This document is used
 across many open source communities, and we think it articulates our values
-well. For more, see the [Code of Conduct](https://swift.org/community/#code-of-conduct).
+well. For more, see the [Code of Conduct](https://swift.org/code-of-conduct/).
 
 ## Getting Started
 

--- a/docs/HowToGuides/FirstPullRequest.md
+++ b/docs/HowToGuides/FirstPullRequest.md
@@ -73,7 +73,7 @@ highlighting the parts that you think are important.
 Remember that the [Swift Code of Conduct][] applies whenever you are
 participating in the Swift project.
 
-[Swift Code of Conduct]: https://swift.org/community/#code-of-conduct
+[Swift Code of Conduct]: https://swift.org/code-of-conduct/
 
 ### I didn't get a response from someone. What should I do?
 


### PR DESCRIPTION
The code of conduct on Swift\.org has moved to a [new page](https://swift.org/code-of-conduct/).

1.  Can the new page update from [v1.3][] to [v2.0][] of the Contributor Covenant?

2.  Can all Swift\.org projects link to the new page, instead of having their own copy?

3.  Does the <conduct@swift.org> email address in [CODE_OF_CONDUCT.md](https://github.com/apple/swift/blob/main/CODE_OF_CONDUCT.md) still work?
    Other addresses have changed to use the forums.
    (e.g. <code-owners@forums.swift.org> and <swift-infrastructure@forums.swift.org>).

[v1.3]: <https://www.contributor-covenant.org/version/1/3/0/code-of-conduct/code_of_conduct.md>
[v2.0]: <https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.md>