### PR TITLE
[Concurrency] NFC: Adding top-level sync call with inout global actor state

### DIFF
--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -129,3 +129,10 @@ func fromAsync() async {
   _ = a[1]  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
   a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 }
+
+// expected-note@+1{{mutable state is only available within the actor instance}}
+@SomeGlobalActor var value: Int = 42
+
+func topLevelSyncFunction(_ number: inout Int) { }
+// expected-error@+1{{var 'value' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+topLevelSyncFunction(&value)


### PR DESCRIPTION
Adding a call at the top-level that takes global actor state via an
inout outside of the global actor context. This is not legal.

This requires no changes to the compiler, but adds a test case to verify that we properly handle disallowing passing the global actor state into synchronous functions at the top-level.