### PR TITLE
[5.4][CodeCompletion][Sema] Don't guess whether a solution will be applied to the AST based on solutions formed for code completion.

### DIFF
--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -45,6 +45,8 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_ERROR | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_FIXME | %FileCheck %s --check-prefix=NORESULTS
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=REGULAR_MULTICLOSURE_APPLIED | %FileCheck %s --check-prefix=POINT_MEMBER
+
 
 struct A {
   func doAThings() -> A { return self }
@@ -424,4 +426,15 @@ CreateThings {
       point.#^MULTICLOSURE_FUNCBUILDER_FIXME^#
     }
     Thing. // ErrorExpr
+}
+
+
+func takesClosureOfPoint(_: (Point)->()) {}
+func overloadedWithDefaulted(_: ()->()) {}
+func overloadedWithDefaulted(_: ()->(), _ defaulted: Int = 10) {}
+
+takesClosureOfPoint { p in
+  overloadedWithDefaulted {
+    if p.#^REGULAR_MULTICLOSURE_APPLIED^# {}
+  }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/35113 for 5.4.

When solving for code completion, we ignore missing arguments after the one containing the code completion location, don't favor overloads with a number of params matching the number of arguments in a call and so on. Because of this, we can't assume multiple solutions being formed when solving for code completion means there won't be a single best solution formed when solving for regular type-checking.

Resolves rdar://problem/72362275