### PR TITLE
[Async CC] Pass witness metadata to callees.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2449,6 +2449,18 @@ public:
       auto fieldLayout = layout.getLocalContextLayout();
       saveValue(fieldLayout, localExplosion, isOutlined);
     }
+    if (auto selfMetadata = witnessMetadata->SelfMetadata) {
+      Explosion selfMetadataExplosion;
+      selfMetadataExplosion.add(selfMetadata);
+      auto fieldLayout = layout.getSelfMetadataLayout();
+      saveValue(fieldLayout, selfMetadataExplosion, isOutlined);
+    }
+    if (auto selfWitnessTable = witnessMetadata->SelfWitnessTable) {
+      Explosion selfWitnessTableExplosion;
+      selfWitnessTableExplosion.add(selfWitnessTable);
+      auto fieldLayout = layout.getSelfWitnessTableLayout();
+      saveValue(fieldLayout, selfWitnessTableExplosion, isOutlined);
+    }
   }
   void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {
     auto layout = getAsyncContextLayout();

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2712,12 +2712,14 @@ static void save(const NecessaryBindings &bindings, IRGenFunction &IGF,
       [&](GenericRequirement requirement) -> llvm::Value * {
         CanType type = requirement.TypeParameter;
         if (auto protocol = requirement.Protocol) {
-          if (auto archetype = dyn_cast<ArchetypeType>(type)) {
+          CanArchetypeType archetype;
+          ProtocolConformanceRef conformance =
+              bindings.getConformance(requirement);
+          if ((archetype = dyn_cast<ArchetypeType>(type)) && !conformance) {
             auto wtable =
                 emitArchetypeWitnessTableRef(IGF, archetype, protocol);
             return transform(requirement, wtable);
           } else {
-            auto conformance = bindings.getConformance(requirement);
             auto wtable = emitWitnessTableRef(IGF, type, conformance);
             return transform(requirement, wtable);
           }

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -131,8 +131,8 @@ public:
     }
   }
 
-  bool forPartialApply() { return kind == Kind::PartialApply; }
-  bool forAsyncFunction() { return kind == Kind::AsyncFunction; }
+  bool forPartialApply() const { return kind == Kind::PartialApply; }
+  bool forAsyncFunction() const { return kind == Kind::AsyncFunction; }
 
 private:
   static NecessaryBindings computeBindings(IRGenModule &IGM,

--- a/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
+++ b/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -emit-ir | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import _Concurrency
+
+func printGeneric<T>(_ t: T) {
+  print(t)
+}
+
+protocol P {
+  func f() async
+}
+
+// CHECK: entering call_f
+// CHECK: entering f
+// CHECK: X
+// CHECK: main.X
+// CHECK: exiting f
+// CHECK: exiting call_f
+
+// CHECK-LL: @"$s4main1PPAAE1fyyYFTu" = hidden global %swift.async_func_pointer
+// CHECK-LL: @"$s4main6call_fyyxYAA1PRzlFTu" = hidden global %swift.async_func_pointer
+// CHECK-LL: @"$s4main1XCAA1PA2aDP1fyyYFTWTu" = internal global %swift.async_func_pointer
+
+extension P {
+  // CHECK-LL: define hidden swiftcc void @"$s4main1PPAAE1fyyYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+  func f() async {
+    print("entering f")
+    printGeneric(Self.self)
+    printGeneric(self)
+    print("exiting f")
+  }
+}
+
+// CHECK-LL: define internal swiftcc void @"$s4main1XCAA1PA2aDP1fyyYFTW"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+extension X : P {}
+
+// CHECK-LL: define hidden swiftcc void @"$s4main6call_fyyxYAA1PRzlF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+func call_f<T : P>(_ t: T) async {
+  print("entering call_f")
+  await t.f()
+  print("exiting call_f")
+}
+
+class X {}
+
+runAsyncAndBlock {
+  let x = X()
+  await call_f(x)
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar72397303.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar72397303.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-ir -enable-experimental-concurrency
+
+protocol P {
+  func f<T>() async throws -> T?
+}
+extension P {
+  func f<T>() async throws -> T? { nil }
+}
+class X: P {}
+


### PR DESCRIPTION
Previously, the WitnessMetadata values that were collected were just ignored when making a function call, although space was reserved for them in the async context.  Here, that error is corrected by actually storing them into the async context if they are present.

Previously, when saving NecessaryBindings for an async function, if a type that was passed-in happened to be an archetype, a lookup for that type's conformance would always be done.  However, that lookup was not always necessary or possible such as in the case where both the metadata and the witness table were provided to the function in an async context.  Here, that is fixed by using the conformance that was seen when constructing the NecessaryBindings if one is available.

rdar://problem/72397303