### PR TITLE
[Concurrency] Workaround for _runAsyncHandler.

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -314,6 +314,7 @@ extension Task {
 
 }
 
+@_optimize(none)
 public func _runAsyncHandler(operation: @escaping () async -> ()) {
   _ = Task.runDetached(operation: operation)
 }


### PR DESCRIPTION
Work around an expected miscompile in _runAsyncHandler.
