### PR TITLE
Add -b flag to checkout

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -343,7 +343,7 @@ git remote add my-remote https://github.com/username/swift.git
 Finally, create a new branch.
 ```sh
 # Using 'my-branch' as a placeholder name
-git checkout my-branch
+git checkout -b my-branch
 git push --set-upstream my-remote my-branch
 ```
 


### PR DESCRIPTION
I think this is necessary to create a new branch

<!-- What's in this pull request? -->
I'm going through the initial setup steps, and I think this step needs to be updated to include the -b flag so a new branch is checked out rather than checking out an existing branch, which devs won't yet have.

I don't think I should run CI here since it's a non-code change, but let me know if I should do it anyway. Thanks!
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
