### PR TITLE
[Concurrency] IRGen: correct substitution for the createAsyncTaskFuture builtin.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -3664,22 +3664,22 @@ llvm::Value *irgen::emitTaskCreate(
   // Determine the size of the async context for the closure.
   ASTContext &ctx = IGF.IGM.IRGen.SIL.getASTContext();
   auto extInfo = ASTExtInfoBuilder().withAsync().withThrows().build();
-  AnyFunctionType *taskFunctionType;
+  CanSILFunctionType taskFunctionType;
+  CanSILFunctionType substTaskFunctionType;
   if (futureResultType) {
     auto genericParam = GenericTypeParamType::get(0, 0, ctx);
     auto genericSig = GenericSignature::get({genericParam}, {});
-    taskFunctionType = GenericFunctionType::get(
-        genericSig, { }, genericParam, extInfo);
+    auto *ty = GenericFunctionType::get(genericSig, { }, genericParam, extInfo);
 
-    taskFunctionType = Type(taskFunctionType).subst(subs)->castTo<FunctionType>();
+    taskFunctionType = IGF.IGM.getLoweredType(ty).castTo<SILFunctionType>();
+    substTaskFunctionType = taskFunctionType->withInvocationSubstitutions(subs);
   } else {
-    taskFunctionType = FunctionType::get(
-        { }, ctx.TheEmptyTupleType, extInfo);
+    auto *ty = FunctionType::get({ }, ctx.TheEmptyTupleType, extInfo);
+    taskFunctionType = IGF.IGM.getLoweredType(ty).castTo<SILFunctionType>();
+    substTaskFunctionType = taskFunctionType;
   }
-  CanSILFunctionType taskFunctionCanSILType =
-      IGF.IGM.getLoweredType(taskFunctionType).castTo<SILFunctionType>();
   auto layout = getAsyncContextLayout(
-      IGF.IGM, taskFunctionCanSILType, taskFunctionCanSILType, subs);
+      IGF.IGM, taskFunctionType, substTaskFunctionType, subs);
 
   CanSILFunctionType taskContinuationFunctionTy = [&]() {
     ASTContext &ctx = IGF.IGM.IRGen.SIL.getASTContext();
@@ -3700,7 +3700,7 @@ llvm::Value *irgen::emitTaskCreate(
   llvm::CallInst *result;
   llvm::Value *theSize, *theFunction;
   auto taskFunctionPointer = FunctionPointer::forExplosionValue(
-      IGF, taskFunction, taskFunctionCanSILType);
+      IGF, taskFunction, substTaskFunctionType);
   std::tie(theFunction, theSize) =
       getAsyncFunctionAndSize(IGF, SILFunctionTypeRepresentation::Thick,
                               taskFunctionPointer, localContextInfo);

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -281,7 +281,6 @@ extension Task {
 
 }
 
-@_optimize(none)
 public func _runAsyncHandler(operation: @escaping () async -> ()) {
   _ = Task.runDetached(operation: operation)
 }

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -59,9 +59,27 @@ bb0(%0 : $Int, %1: @unowned $Optional<Builtin.NativeObject>, %2: @guaranteed $@a
   // CHECK: [[NEW_TASK_AND_CONTEXT:%.*]] = call swiftcc %swift.async_task_and_context @swift_task_create_future_f(
   // CHECK-NEXT: [[NEW_CONTEXT_RAW:%.*]] = extractvalue %swift.async_task_and_context [[NEW_TASK_AND_CONTEXT]], 1
   // CHECK-NEXT: [[NEW_CONTEXT:%.*]] = bitcast %swift.context* [[NEW_CONTEXT_RAW]] to
-  // CHECK-NEXT: [[CONTEXT_INFO_LOC:%.*]] = getelementptr inbounds <{{.*}}>* [[NEW_CONTEXT]]
+  // CHECK-NEXT: [[CONTEXT_INFO_LOC:%.*]] = getelementptr inbounds <{{.*}}>* [[NEW_CONTEXT]], i32 0, i32 7
   // CHECK-NEXT: store %swift.refcounted* [[FN_CONTEXT]], %swift.refcounted** [[CONTEXT_INFO_LOC]]
   %20 = builtin "createAsyncTaskFuture"<T>(%0 : $Int, %4 : $Optional<Builtin.NativeObject>, %10 : $@thick Any.Type, %2 : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+  end_borrow %4 : $Optional<Builtin.NativeObject>
+  destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
+  %21 = tuple ()
+  return %21 : $()
+}
+
+sil hidden [ossa] @launch_void_future : $@convention(method) (Int, Optional<Builtin.NativeObject>, @guaranteed @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) -> () {
+bb0(%0 : $Int, %1: @unowned $Optional<Builtin.NativeObject>, %2: @guaranteed $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>):
+  %4 = begin_borrow %1 : $Optional<Builtin.NativeObject>
+  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[FN_CONTEXT:%.*]])
+  %8 = metatype $@thick ().Type                   // user: %9
+  %9 = init_existential_metatype %8 : $@thick ().Type, $@thick Any.Type // user: %10
+  // CHECK: [[NEW_TASK_AND_CONTEXT:%.*]] = call swiftcc %swift.async_task_and_context @swift_task_create_future_f(
+  // CHECK-NEXT: [[NEW_CONTEXT_RAW:%.*]] = extractvalue %swift.async_task_and_context [[NEW_TASK_AND_CONTEXT]], 1
+  // CHECK-NEXT: [[NEW_CONTEXT:%.*]] = bitcast %swift.context* [[NEW_CONTEXT_RAW]] to
+  // CHECK-NEXT: [[CONTEXT_INFO_LOC:%.*]] = getelementptr inbounds <{{.*}}>* [[NEW_CONTEXT]], i32 0, i32 7
+  // CHECK-NEXT: store %swift.refcounted* [[FN_CONTEXT]], %swift.refcounted** [[CONTEXT_INFO_LOC]]
+  %20 = builtin "createAsyncTaskFuture"<()>(%0 : $Int, %4 : $Optional<Builtin.NativeObject>, %9 : $@thick Any.Type, %2 : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
   end_borrow %4 : $Optional<Builtin.NativeObject>
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %21 = tuple ()


### PR DESCRIPTION
Instead of substituting the AST type, substitute the SIL type. This preserves the calling convention.
E.g. if a function has an indirect @out T result, the substituted function must also have an indirect result.
The substituted AST type would just have a direct empty-tuple result.

Fixes a miscompile
rdar://72386504
