### PR TITLE
shims: invert the condition and prefer the clang path

### DIFF
--- a/stdlib/public/SwiftShims/SwiftStddef.h
+++ b/stdlib/public/SwiftShims/SwiftStddef.h
@@ -17,15 +17,22 @@
 // result, using stddef.h here would pull in Darwin module (which includes
 // libc). This creates a dependency cycle, so we can't use stddef.h in
 // SwiftShims.
+//
 // On Linux, the story is different. We get the error message
 // "/usr/include/x86_64-linux-gnu/sys/types.h:146:10: error: 'stddef.h' file not
 // found"
 // This is a known Clang/Ubuntu bug.
-#if !defined(__APPLE__) && !defined(__linux__)
+//
+// On Windows, the complicated setup between clang and MSVC causes a cicular
+// dependency between `ucrt` and `SwiftShims`, preventing a successful build of
+// the module.
+//
+// Opt to use teh compiler vended type whenever possible.
+#if defined(__clang__)
+typedef __SIZE_TYPE__ __swift_size_t;
+#else
 #include <stddef.h>
 typedef size_t __swift_size_t;
-#else
-typedef __SIZE_TYPE__ __swift_size_t;
 #endif
 
 // This selects the signed equivalent of the unsigned type chosen for size_t.

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -55,13 +55,11 @@ bfunc()
 // CHECK-NORMAL-SAME: [[PUBLIC:![0-9]+]],
 // CHECK-NORMAL-SAME: [[SWIFTONONESUPPORT:![0-9]+]],
 // CHECK-NORMAL-SAME: [[SWIFTCORE:![0-9]+]],
-// CHECK-NORMAL-windows-msvc-SAME: [[STDIO:![0-9]+]],
 
 // This is the same set as the above, just in a different order due to a
 // different traversal of the transitive import graph.
 // CHECK-IMPL_ONLY-SAME: [[SWIFTONONESUPPORT:![0-9]+]],
 // CHECK-IMPL_ONLY-SAME: [[SWIFTCORE:![0-9]+]],
-// CHECK-IMPL_ONLY-windows-msvc-SAME: [[STDIO:![0-9]+]],
 // CHECK-IMPL_ONLY-SAME: [[MODULE:![0-9]+]],
 // CHECK-IMPL_ONLY-SAME: [[PUBLIC:![0-9]+]],
 
@@ -77,7 +75,6 @@ bfunc()
 // CHECK-DAG: [[PUBLIC]] = !{!{{"-lautolinking_public"|"/DEFAULTLIB:autolinking_public.lib"}}}
 // CHECK-DAG: [[SWIFTONONESUPPORT]] = !{!{{"-lswiftSwiftOnoneSupport"|"/DEFAULTLIB:swiftSwiftOnoneSupport.lib"}}}
 // CHECK-DAG: [[SWIFTCORE]] = !{!{{"-lswiftCore"|"/DEFAULTLIB:swiftCore.lib"}}}
-// CHECK-windows-msvc-DAG: [[STDIO]] = !{!"/DEFAULTLIB:legacy_stdio_definitions.lib"}
 // CHECK-DAG: [[OTHER]] = !{!{{"-lautolinking_other"|"/DEFAULTLIB:autolinking_other.lib"}}}
 // CHECK-DAG: [[OTHER2]] = !{!{{"-lautolinking_other2"|"/DEFAULTLIB:autolinking_other2.lib"}}}
 // CHECK-DAG: [[OBJC]] = !{!{{"-lobjc"|"/DEFAULTLIB:objc.lib"}}}


### PR DESCRIPTION
Because the shims are generally meant for the standard library build,
which requires clang, we can default to using the compiler vended
information for the types.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
