### PR TITLE
[Test] Disable concurrency tests on arm64e temporarily.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -355,6 +355,10 @@ run_ptrauth = 'ptrauth' if run_cpu == 'arm64e' else 'noptrauth'
 run_endian = 'little' if run_cpu != 's390x' else 'big'
 run_objc_interop = 'nonobjc'      # overwritten later
 
+if run_cpu == 'arm64e':
+    lit_config.warning('Skipping concurrency tests on arm64e for now.  Remove with rdar://problem/72357371 .')
+    config.available_features.discard('concurrency')
+
 sdk_overlay_link_path = ""
 sdk_overlay_linker_opt = ""
 sdk_overlay_dir_opt = ""


### PR DESCRIPTION
For now, when the run_cpu is arm64e, make the "concurrency" feature unavailable for testing.

rdar://problem/72357371