### PR TITLE
[concurrency] warn about future reservation of 'await' as contextual keyword

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1224,6 +1224,9 @@ NOTE(super_in_closure_with_capture_here,none,
      "'self' explicitly captured here", ())
 
 ERROR(try_before_await,none, "'await' must precede 'try'", ())
+WARNING(warn_await_keyword,none, 
+      "future versions of Swift reserve the word 'await'; "
+      "if this name is unavoidable, use backticks to escape it", ())
 
 // Tuples and parenthesized expressions
 ERROR(expected_expr_in_expr_list,none,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -399,16 +399,22 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   SyntaxParsingContext ElementContext(SyntaxContext,
                                       SyntaxContextKind::Expr);
 
-  if (shouldParseExperimentalConcurrency() && Tok.isContextualKeyword("await")) {
-    SourceLoc awaitLoc = consumeToken();
-    ParserResult<Expr> sub =
-      parseExprSequenceElement(diag::expected_expr_after_await, isExprBasic);
-    if (!sub.hasCodeCompletion() && !sub.isNull()) {
-      ElementContext.setCreateSyntax(SyntaxKind::AwaitExpr);
-      sub = makeParserResult(new (Context) AwaitExpr(awaitLoc, sub.get()));
-    }
+  if (Tok.isContextualKeyword("await")) {
+    if (shouldParseExperimentalConcurrency()) {
+      SourceLoc awaitLoc = consumeToken();
+      ParserResult<Expr> sub =
+        parseExprSequenceElement(diag::expected_expr_after_await, isExprBasic);
+      if (!sub.hasCodeCompletion() && !sub.isNull()) {
+        ElementContext.setCreateSyntax(SyntaxKind::AwaitExpr);
+        sub = makeParserResult(new (Context) AwaitExpr(awaitLoc, sub.get()));
+      }
 
-    return sub;
+      return sub;
+    } else {
+      // warn that future versions of Swift will parse this token differently.
+      diagnose(Tok.getLoc(), diag::warn_await_keyword)
+        .fixItReplace(Tok.getLoc(), "`await`");
+    }
   }
 
   SourceLoc tryLoc;

--- a/test/Compatibility/unescaped_await.swift
+++ b/test/Compatibility/unescaped_await.swift
@@ -1,0 +1,68 @@
+// RUN: %target-typecheck-verify-swift
+    // now check that the fix-its, if applied, will fix the warnings.
+// RUN: %empty-directory(%t.scratch)
+// RUN: cp %s %t.scratch/fixits.swift
+// RUN: %target-swift-frontend -typecheck %t.scratch/fixits.swift -fixit-all -emit-fixits-path %t.scratch/fixits.remap 2> /dev/null
+// RUN: %{python} %utils/apply-fixit-edits.py %t.scratch
+// RUN: %target-swift-frontend -typecheck %t.scratch/fixits.swift -warnings-as-errors
+// RUN: %target-swift-frontend -typecheck %t.scratch/fixits.swift -warnings-as-errors -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+func await(_ f : () -> Void) {}
+
+func ordinaryCalls() {
+  await({})
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  await {}
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  let _ = `await`
+  let _ = `await`({})
+  
+  let _ = await
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  let k = Klass()
+  k.await()
+  _ = k.await
+}
+
+func localVar() {
+  var await = 1
+
+  let two = await + await
+  // expected-warning@-1 2 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+  
+  _ = await==two-await
+  // expected-warning@-1 2 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  takesInout(await: &await)
+}
+
+func takesUnitFunc(_ f : () -> Void) {}
+
+func takesInout(await : inout Int) {
+  await += 1
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+}
+
+class Klass {
+  init() { await() }
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  func await() {
+
+    takesUnitFunc(await)
+    // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+  }
+
+  func method() {
+    let _ = self.await
+    self.await()
+
+    await()
+    // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+  }
+}


### PR DESCRIPTION
Based on how the reviews of async/await are going, it seems we're slated to reserve `await` in a future version of Swift for expressions such as `await <expr>`. This PR provides a warnings and fix-it to help users upgrade / future-proof their code. The fix-it surrounds the use of `await` with backticks. Other approaches were considered (to, say, emit a note on the declaration to suggest renaming it, or provide a fix-it that fully-qualifies the declaration reference), but in order to not accidentally warn about a backtick'd `await`, this warning was implemented in the parser, so such information is not available.

Resolves rdar://67000350

TODO:
- [x] Fix bug where the await in `let _ = self.await` is still being flagged as being unqualified.
- [x] Fix bug where references where `await` was surrounded by backticks are still being warned about.
- [x] Warn of uses of `await` as an identifier in local bindings?