### PR TITLE
[Driver] Add -assert-config as module interface option

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -793,7 +793,7 @@ def debug_info_store_invocation : Flag<["-"], "debug-info-store-invocation">,
 
 // Assert configuration identifiers.
 def AssertConfig : Separate<["-"], "assert-config">,
-  Flags<[FrontendOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Specify the assert_configuration replacement. "
            "Possible values are Debug, Release, Unchecked, DisableReplacement.">;
 


### PR DESCRIPTION
Currently the `-assert-config` flag is not serialized into the module interface. This can cause a subtle issue when rebuilding a Swift module from the corresponding .swiftinterface when the module cache has gone stale.

This change adds `-assert-config` as a module interface option so that
it will be serialized into the header of the .swiftinterface file of the
module.

rdar://72452477