### PR TITLE
Refactor request evaluator dependency tracking a bit

### DIFF
--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -83,6 +83,7 @@ struct AnyRequestVTable {
   const std::function<void(const void *, DiagnosticEngine &)> noteCycleStep;
   const std::function<SourceLoc(const void *)> getNearestLoc;
   const std::function<bool(const void *)> isCached;
+  bool isDependencySource;
 
   template <typename Request,
             typename std::enable_if<Request::isEverCached>::type * = nullptr>
@@ -99,6 +100,7 @@ struct AnyRequestVTable {
         &Impl<Request>::noteCycleStep,
         &Impl<Request>::getNearestLoc,
         &Impl<Request>::isCached,
+        Request::isDependencySource,
     };
     return &vtable;
   }
@@ -118,6 +120,7 @@ struct AnyRequestVTable {
         &Impl<Request>::noteCycleStep,
         &Impl<Request>::getNearestLoc,
         [](auto){ return false; },
+        Request::isDependencySource,
     };
     return &vtable;
   }
@@ -222,6 +225,10 @@ public:
 
   bool isCached() const {
     return getVTable()->isCached(getRawStorage());
+  }
+
+  bool isDependencySource() const {
+    return getVTable()->isDependencySource;
   }
 
   /// Compare two instances for equality.

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -406,7 +406,7 @@ private:
 public:
   // Incremental dependencies
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           LookupResult res) const;
+                           const LookupResult &res) const;
 };
 
 using QualifiedLookupResult = SmallVector<ValueDecl *, 4>;
@@ -434,7 +434,7 @@ private:
 public:
   // Incremental dependencies
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           QualifiedLookupResult l) const;
+                           const QualifiedLookupResult &l) const;
 };
 
 /// Perform \c AnyObject lookup for a given member.
@@ -457,7 +457,7 @@ private:
 public:
   // Incremental dependencies
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           QualifiedLookupResult l) const;
+                           const QualifiedLookupResult &l) const;
 };
 
 class ModuleQualifiedLookupRequest
@@ -482,7 +482,7 @@ private:
 public:
   // Incremental dependencies
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           QualifiedLookupResult lookupResult) const;
+                           const QualifiedLookupResult &lookupResult) const;
 };
 
 class QualifiedLookupRequest
@@ -555,7 +555,7 @@ private:
 public:
   // Incremental dependencies
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           TinyPtrVector<ValueDecl *> result) const;
+                           const TinyPtrVector<ValueDecl *> &result) const;
 };
 
 class OperatorLookupDescriptor final {
@@ -636,7 +636,7 @@ private:
 public:
   // Incremental dependencies.
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           TinyPtrVector<OperatorDecl *> ops) const;
+                           const TinyPtrVector<OperatorDecl *> &ops) const;
 };
 
 /// Looks up an precedencegroup in a given file or module without looking
@@ -659,7 +659,7 @@ private:
 public:
   // Incremental dependencies.
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           TinyPtrVector<PrecedenceGroupDecl *> groups) const;
+                           const TinyPtrVector<PrecedenceGroupDecl *> &groups) const;
 };
 
 class LookupConformanceDescriptor final {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2504,7 +2504,7 @@ public:
 
   // Incremental dependencies
   void writeDependencySink(evaluator::DependencyCollector &tracker,
-                           ProtocolConformanceLookupResult r) const;
+                           const ProtocolConformanceLookupResult &r) const;
 };
 
 class CheckRedeclarationRequest

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include <vector>
 
 using namespace swift;
 
@@ -369,126 +370,110 @@ void Evaluator::dumpDependenciesGraphviz() const {
   printDependenciesGraphviz(llvm::dbgs());
 }
 
-void evaluator::DependencyRecorder::realize(
-    const DependencyCollector::Reference &ref) {
-  auto *source = getActiveDependencySourceOrNull().get();
-  if (!source->isPrimary()) {
+void evaluator::DependencyRecorder::beginRequest(
+    const swift::ActiveRequest &req) {
+  if (!req.isCached() && !req.isDependencySource())
     return;
+
+  activeRequestReferences.push_back({});
+}
+
+void evaluator::DependencyRecorder::endRequest(
+    const swift::ActiveRequest &req) {
+  if (!req.isCached() && !req.isDependencySource())
+    return;
+
+  // Grab all the dependencies we've recorded so far, and pop
+  // the stack.
+  auto recorded = std::move(activeRequestReferences.back());
+  activeRequestReferences.pop_back();
+
+  // If we didn't record anything, there is nothing to do.
+  if (recorded.empty())
+    return;
+
+  // Convert the set of dependencies into a vector.
+  std::vector<DependencyCollector::Reference>
+      vec(recorded.begin(), recorded.end());
+
+  // The recorded dependencies bubble up to the parent request.
+  if (!activeRequestReferences.empty()) {
+    activeRequestReferences.back().insert(vec.begin(),
+                                          vec.end());
   }
-  fileReferences[source].insert(ref);
+
+  // Finally, record the dependencies so we can replay them
+  // later when the request is re-evaluated.
+  requestReferences.insert({AnyRequest(req), vec});
+}
+
+void evaluator::DependencyRecorder::replayCachedRequest(
+    const swift::ActiveRequest &req) {
+  assert(req.isCached());
+
+  if (activeRequestReferences.empty())
+    return;
+
+  auto found = requestReferences.find_as(req);
+  if (found == requestReferences.end())
+    return;
+
+  activeRequestReferences.back().insert(found->second.begin(),
+                                        found->second.end());
+}
+
+void evaluator::DependencyRecorder::handleDependencySourceRequest(
+    const swift::ActiveRequest &req,
+    SourceFile *source) {
+  auto found = requestReferences.find_as(req);
+  if (found != requestReferences.end()) {
+    fileReferences[source].insert(found->second.begin(),
+                                  found->second.end());
+  }
+}
+
+void evaluator::DependencyRecorder::recordDependency(
+    const DependencyCollector::Reference &ref) {
+  if (activeRequestReferences.empty())
+    return;
+
+  activeRequestReferences.back().insert(ref);
+}
+
+evaluator::DependencyCollector::DependencyCollector(
+    evaluator::DependencyRecorder &parent) : parent(parent) {
+#ifndef NDEBUG
+  assert(!parent.isRecording &&
+         "Probably not a good idea to allow nested recording");
+  parent.isRecording = true;
+#endif
+}
+
+evaluator::DependencyCollector::~DependencyCollector() {
+#ifndef NDEBUG
+  assert(parent.isRecording &&
+         "Should have been recording this whole time");
+  parent.isRecording = false;
+#endif
 }
 
 void evaluator::DependencyCollector::addUsedMember(NominalTypeDecl *subject,
                                                    DeclBaseName name) {
-  scratch.insert(Reference::usedMember(subject, name));
-  return parent.realize(Reference::usedMember(subject, name));
+  return parent.recordDependency(Reference::usedMember(subject, name));
 }
 
 void evaluator::DependencyCollector::addPotentialMember(
     NominalTypeDecl *subject) {
-  scratch.insert(Reference::potentialMember(subject));
-  return parent.realize(Reference::potentialMember(subject));
+  return parent.recordDependency(Reference::potentialMember(subject));
 }
 
 void evaluator::DependencyCollector::addTopLevelName(DeclBaseName name) {
-  scratch.insert(Reference::topLevel(name));
-  return parent.realize(Reference::topLevel(name));
+  return parent.recordDependency(Reference::topLevel(name));
 }
 
 void evaluator::DependencyCollector::addDynamicLookupName(DeclBaseName name) {
-  scratch.insert(Reference::dynamic(name));
-  return parent.realize(Reference::dynamic(name));
+  return parent.recordDependency(Reference::dynamic(name));
 }
-
-void evaluator::DependencyRecorder::record(
-    const llvm::SetVector<swift::ActiveRequest> &stack,
-    llvm::function_ref<void(DependencyCollector &)> rec) {
-  assert(!isRecording && "Probably not a good idea to allow nested recording");
-  auto source = getActiveDependencySourceOrNull();
-  if (source.isNull() || !source.get()->isPrimary()) {
-    return;
-  }
-
-  llvm::SaveAndRestore<bool> restore(isRecording, true);
-
-  DependencyCollector collector{*this};
-  rec(collector);
-  if (collector.empty()) {
-    return;
-  }
-
-  return unionNearestCachedRequest(stack.getArrayRef(), collector.scratch);
-}
-
-void evaluator::DependencyRecorder::replay(
-    const llvm::SetVector<swift::ActiveRequest> &stack,
-    const swift::ActiveRequest &req) {
-  assert(!isRecording && "Probably not a good idea to allow nested recording");
-
-  auto source = getActiveDependencySourceOrNull();
-  if (source.isNull() || !source.get()->isPrimary()) {
-    return;
-  }
-
-  if (!req.isCached()) {
-    return;
-  }
-
-  auto entry = requestReferences.find_as(req);
-  if (entry == requestReferences.end()) {
-    return;
-  }
-
-  for (const auto &ref : entry->second) {
-    realize(ref);
-  }
-
-  // N.B. This is a particularly subtle detail of the replay unioning step. The
-  // evaluator does not push cached requests onto the active request stack,
-  // so it is possible (and, in fact, quite likely) we'll wind up with an
-  // empty request stack. The remaining troublesome case is when we have a
-  // cached request being run through the uncached path - take the
-  // InterfaceTypeRequest, which involves many component requests, most of which
-  // are themselves cached. In such a case, the active stack will look like
-  //
-  // -> TypeCheckSourceFileRequest
-  // -> ...
-  // -> InterfaceTypeRequest
-  // -> ...
-  // -> UnderlyingTypeRequest
-  //
-  // We want the UnderlyingTypeRequest to union its names into the
-  // InterfaceTypeRequest, and if we were to just start searching the active
-  // stack backwards for a cached request we would find...
-  // the UnderlyingTypeRequest! So, we'll just drop it from consideration.
-  //
-  // We do *not* have to consider this during the recording step because none
-  // of the name lookup requests (or any dependency sinks in general) are
-  // cached. Should this change in the future, we will need to sink this logic
-  // into the union step itself.
-  const size_t d = (!stack.empty() && req == stack.back()) ? 1 : 0;
-  return unionNearestCachedRequest(stack.getArrayRef().drop_back(d),
-                                   entry->second);
-}
-
-void evaluator::DependencyRecorder::unionNearestCachedRequest(
-    ArrayRef<swift::ActiveRequest> stack,
-    const DependencyCollector::ReferenceSet &scratch) {
-  auto nearest = std::find_if(stack.rbegin(), stack.rend(),
-                              [](const auto &req){ return req.isCached(); });
-  if (nearest == stack.rend()) {
-    return;
-  }
-
-  auto entry = requestReferences.find_as(*nearest);
-  if (entry == requestReferences.end()) {
-    requestReferences.insert({AnyRequest(*nearest), scratch});
-  } else {
-    entry->second.insert(scratch.begin(), scratch.end());
-  }
-}
-
-using namespace swift;
 
 void evaluator::DependencyRecorder::enumerateReferencesInFile(
     const SourceFile *SF, ReferenceEnumerator f) const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1109,7 +1109,7 @@ syntax::SourceFileSyntax SourceFile::getSyntaxRoot() const {
 
 void DirectOperatorLookupRequest::writeDependencySink(
     evaluator::DependencyCollector &reqTracker,
-    TinyPtrVector<OperatorDecl *> ops) const {
+    const TinyPtrVector<OperatorDecl *> &ops) const {
   auto &desc = std::get<0>(getStorage());
   reqTracker.addTopLevelName(desc.name);
 }
@@ -1144,7 +1144,7 @@ void SourceFile::lookupOperatorDirect(
 
 void DirectPrecedenceGroupLookupRequest::writeDependencySink(
     evaluator::DependencyCollector &reqTracker,
-    TinyPtrVector<PrecedenceGroupDecl *> groups) const {
+    const TinyPtrVector<PrecedenceGroupDecl *> &groups) const {
   auto &desc = std::get<0>(getStorage());
   reqTracker.addTopLevelName(desc.name);
 }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -184,8 +184,7 @@ void ExtendedNominalRequest::writeDependencySink(
   auto *SF = std::get<0>(getStorage())->getParentSourceFile();
   if (!SF)
     return;
-  if (SF != tracker.getRecorder().getActiveDependencySourceOrNull().getPtrOrNull())
-    return;
+
   tracker.addPotentialMember(value);
 }
 

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -175,7 +175,8 @@ void ExtendedNominalRequest::cacheResult(NominalTypeDecl *value) const {
 }
 
 void ExtendedNominalRequest::writeDependencySink(
-    evaluator::DependencyCollector &tracker, NominalTypeDecl *value) const {
+    evaluator::DependencyCollector &tracker,
+    NominalTypeDecl *value) const {
   if (!value)
     return;
 
@@ -303,7 +304,7 @@ SourceLoc swift::extractNearestSourceLoc(const OperatorLookupDescriptor &desc) {
 
 void DirectLookupRequest::writeDependencySink(
     evaluator::DependencyCollector &tracker,
-    TinyPtrVector<ValueDecl *> result) const {
+    const TinyPtrVector<ValueDecl *> &result) const {
   auto &desc = std::get<0>(getStorage());
   tracker.addUsedMember(desc.DC, desc.Name.getBaseName());
 }
@@ -313,7 +314,8 @@ void DirectLookupRequest::writeDependencySink(
 //----------------------------------------------------------------------------//
 
 void LookupInModuleRequest::writeDependencySink(
-    evaluator::DependencyCollector &reqTracker, QualifiedLookupResult l) const {
+    evaluator::DependencyCollector &reqTracker,
+    const QualifiedLookupResult &l) const {
   auto *DC = std::get<0>(getStorage());
   auto member = std::get<1>(getStorage());
 
@@ -340,7 +342,8 @@ void swift::simple_display(llvm::raw_ostream &out,
 }
 
 void AnyObjectLookupRequest::writeDependencySink(
-    evaluator::DependencyCollector &reqTracker, QualifiedLookupResult l) const {
+    evaluator::DependencyCollector &reqTracker,
+    const QualifiedLookupResult &l) const {
   auto member = std::get<1>(getStorage());
   reqTracker.addDynamicLookupName(member.getBaseName());
 }
@@ -355,7 +358,8 @@ swift::extractNearestSourceLoc(const LookupConformanceDescriptor &desc) {
 //----------------------------------------------------------------------------//
 
 void ModuleQualifiedLookupRequest::writeDependencySink(
-    evaluator::DependencyCollector &reqTracker, QualifiedLookupResult l) const {
+    evaluator::DependencyCollector &reqTracker,
+    const QualifiedLookupResult &l) const {
   auto *module = std::get<1>(getStorage());
   auto member = std::get<2>(getStorage());
 
@@ -395,7 +399,8 @@ void LookupConformanceInModuleRequest::writeDependencySink(
 //----------------------------------------------------------------------------//
 
 void UnqualifiedLookupRequest::writeDependencySink(
-    evaluator::DependencyCollector &track, LookupResult res) const {
+    evaluator::DependencyCollector &track,
+    const LookupResult &res) const {
   auto &desc = std::get<0>(getStorage());
   track.addTopLevelName(desc.Name.getBaseName());
 }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1290,7 +1290,7 @@ void CheckRedeclarationRequest::writeDependencySink(
 
 void LookupAllConformancesInContextRequest::writeDependencySink(
     evaluator::DependencyCollector &tracker,
-    ProtocolConformanceLookupResult conformances) const {
+    const ProtocolConformanceLookupResult &conformances) const {
   for (auto conformance : conformances) {
     tracker.addPotentialMember(conformance->getProtocol());
   }


### PR DESCRIPTION
ther than simplifying some code, the big improvement here is
that we 'freeze' the reference dependencies for a request down
to a simple vector. We only use a DenseSet to store dependencies
of active requests.