### PR TITLE
Remove the default DEBlocks = nullptr argument from verifyOwnership.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1106,7 +1106,7 @@ public:
   /// NOTE: The ownership verifier is always run when performing normal IR
   /// verification, so this verification can be viewed as a subset of
   /// SILFunction::verify.
-  void verifyOwnership(DeadEndBlocks *deadEndBlocks = nullptr) const;
+  void verifyOwnership(DeadEndBlocks *deadEndBlocks) const;
 
   /// Verify that all non-cond-br critical edges have been split.
   ///

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -568,7 +568,7 @@ public:
   ValueOwnershipKind getOwnershipKind() const;
 
   /// Verify that this SILValue and its uses respects ownership invariants.
-  void verifyOwnership(DeadEndBlocks *DEBlocks = nullptr) const;
+  void verifyOwnership(DeadEndBlocks *DEBlocks) const;
 };
 
 inline bool ValueOwnershipKind::isCompatibleWith(SILValue other) const {

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -772,16 +772,9 @@ verifySILValueHelper(const SILFunction *f, SILValue value,
     return;
 
   SmallPtrSet<SILBasicBlock *, 32> liveBlocks;
-  if (deadEndBlocks) {
-    SILValueOwnershipChecker(*deadEndBlocks, value, errorBuilder, liveBlocks,
-                             reborrowVerifier)
-        .check();
-  } else {
-    DeadEndBlocks deadEndBlocks(f);
-    SILValueOwnershipChecker(deadEndBlocks, value, errorBuilder, liveBlocks,
-                             reborrowVerifier)
-        .check();
-  }
+  SILValueOwnershipChecker(*deadEndBlocks, value, errorBuilder, liveBlocks,
+                           reborrowVerifier)
+    .check();
 }
 
 void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {


### PR DESCRIPTION
This was undefined behavior. The code assumed non-null DEBlocks..
