### PR TITLE
Update API Digester test w/ temporary RangeSet removal

### DIFF
--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -37,20 +37,10 @@
 // declarations are shuffled. rdar://problem/46618883
 // UNSUPPORTED: swift_evolve
 
-Func Collection.removingSubranges(_:) has been removed
-Func Collection.subranges(of:) has been removed
-Func Collection.subranges(where:) has been removed
-Func MutableCollection.moveSubranges(_:to:) has been removed
-Func MutableCollection.removeSubranges(_:) has been removed
-Func RangeReplaceableCollection.removeSubranges(_:) has been removed
 Func _collectReferencesInsideObject(_:) is a new API without @available attribute
 Func _loadDestroyTLSCounter() is a new API without @available attribute
 Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @available attribute
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
-Struct DiscontiguousSlice has been removed
-Struct RangeSet has been removed
 Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
 Struct _RuntimeFunctionCounters is a new API without @available attribute
-Subscript Collection.subscript(_:) has been removed
-Subscript MutableCollection.subscript(_:) has been removed

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -35,3 +35,14 @@ Func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(_:_:_:_:_:_:) is a new AP
 Func _getMetadataSection(_:) is a new API without @available attribute
 Func _getMetadataSectionCount() is a new API without @available attribute
 Func _getMetadataSectionName(_:) is a new API without @available attribute
+
+Func Collection.removingSubranges(_:) has been removed
+Func Collection.subranges(of:) has been removed
+Func Collection.subranges(where:) has been removed
+Func MutableCollection.moveSubranges(_:to:) has been removed
+Func MutableCollection.removeSubranges(_:) has been removed
+Func RangeReplaceableCollection.removeSubranges(_:) has been removed
+Struct DiscontiguousSlice has been removed
+Struct RangeSet has been removed
+Subscript Collection.subscript(_:) has been removed
+Subscript MutableCollection.subscript(_:) has been removed


### PR DESCRIPTION
Resolves failure in https://ci.swift.org/job/oss-swift-package-osx/
