### PR TITLE
Remove the ExpandASTScopeRequest

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -247,13 +247,7 @@ private:
 
 #pragma mark - Scope tree creation
 public:
-  /// expandScope me, sending deferred nodes to my descendants.
-  /// Return the scope into which to place subsequent decls
-  ASTScopeImpl *expandAndBeCurrentDetectingRecursion(ScopeCreator &);
-
-  /// Expand or reexpand the scope if unexpanded or if not current.
-  /// There are several places in the compiler that mutate the AST after the
-  /// fact, above and beyond adding Decls to the SourceFile.
+  /// Expand the scope. Asserts if it was already expanded.
   ASTScopeImpl *expandAndBeCurrent(ScopeCreator &);
 
   bool getWasExpanded() const { return wasExpanded; }
@@ -629,8 +623,6 @@ public:
 
 public:
   NullablePtr<ASTScopeImpl> insertionPointForDeferredExpansion() override;
-
-  void countBodies(ScopeCreator &) const;
 };
 
 class NominalTypeScope final : public IterableTypeScope {

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -350,30 +350,6 @@ public:
   void cacheResult(GenericParamList *value) const;
 };
 
-/// Expand the given ASTScope. Requestified to detect recursion.
-class ExpandASTScopeRequest
-    : public SimpleRequest<ExpandASTScopeRequest,
-                           ast_scope::ASTScopeImpl *(ast_scope::ASTScopeImpl *,
-                                                     ast_scope::ScopeCreator *),
-                           RequestFlags::SeparatelyCached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  ast_scope::ASTScopeImpl *
-  evaluate(Evaluator &evaluator, ast_scope::ASTScopeImpl *,
-           ast_scope::ScopeCreator *) const;
-
-public:
-  // Separate caching.
-  bool isCached() const;
-  Optional<ast_scope::ASTScopeImpl *> getCachedResult() const;
-  void cacheResult(ast_scope::ASTScopeImpl *) const {}
-};
-
 /// The input type for an unqualified lookup request.
 class UnqualifiedLookupDescriptor {
   using LookupOptions = OptionSet<UnqualifiedLookupFlags>;

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -31,10 +31,6 @@ SWIFT_REQUEST(NameLookup, DirectOperatorLookupRequest,
 SWIFT_REQUEST(NameLookup, DirectPrecedenceGroupLookupRequest,
               TinyPtrVector<PrecedenceGroupDecl *>(OperatorLookupDescriptor),
               Uncached, NoLocationInfo)
-SWIFT_REQUEST(NameLookup, ExpandASTScopeRequest,
-              ast_scope::ASTScopeImpl* (ast_scope::ASTScopeImpl*, ast_scope::ScopeCreator*),
-              SeparatelyCached,
-              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExtendedNominalRequest,
               NominalTypeDecl *(ExtensionDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -144,20 +144,11 @@ FRONTEND_STATISTIC(AST, NumModuleLookupValue)
 /// AnyObject lookup.
 FRONTEND_STATISTIC(AST, NumModuleLookupClassMember)
 
-/// Number of body scopes for iterable types
-FRONTEND_STATISTIC(AST, NumIterableTypeBodyASTScopes)
-
-/// Number of expansions of body scopes for iterable types
-FRONTEND_STATISTIC(AST, NumIterableTypeBodyASTScopeExpansions)
-
-/// Number of brace statment scopes for iterable types
-FRONTEND_STATISTIC(AST, NumBraceStmtASTScopes)
-
-/// Number of expansions of brace statement scopes for iterable types
-FRONTEND_STATISTIC(AST, NumBraceStmtASTScopeExpansions)
-
 /// Number of ASTScope lookups
 FRONTEND_STATISTIC(AST, NumASTScopeLookups)
+
+/// Number of ASTScope expansions
+FRONTEND_STATISTIC(AST, NumASTScopeExpansions)
 
 /// Number of lookups of the cached import graph for a module or
 /// source file.

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -82,8 +82,7 @@ public:
     if (auto *ip = child->insertionPointForDeferredExpansion().getPtrOrNull())
       return ip;
 
-    ASTScopeImpl *insertionPoint =
-        child->expandAndBeCurrentDetectingRecursion(*this);
+    ASTScopeImpl *insertionPoint = child->expandAndBeCurrent(*this);
     return insertionPoint;
   }
 
@@ -224,15 +223,18 @@ ASTSourceFileScope *ASTScope::createScopeTree(SourceFile *SF) {
 }
 
 void ASTSourceFileScope::buildFullyExpandedTree() {
-  expandAndBeCurrentDetectingRecursion(*scopeCreator);
+  if (!getWasExpanded())
+    expandAndBeCurrent(*scopeCreator);
   preOrderChildrenDo([&](ASTScopeImpl *s) {
-    s->expandAndBeCurrentDetectingRecursion(*scopeCreator);
+    if (!s->getWasExpanded())
+      s->expandAndBeCurrent(*scopeCreator);
   });
 }
 
 void ASTSourceFileScope::
     buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals() {
-      expandAndBeCurrentDetectingRecursion(*scopeCreator);
+  if (!getWasExpanded())
+    expandAndBeCurrent(*scopeCreator);
 }
 
 void ASTSourceFileScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
@@ -242,7 +244,8 @@ void ASTSourceFileScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
   if (sr.isInvalid())
     return;
   ASTScopeImpl *bodyScope = findInnermostEnclosingScope(sr.Start, nullptr);
-  bodyScope->expandAndBeCurrentDetectingRecursion(*scopeCreator);
+  if (!bodyScope->getWasExpanded())
+    bodyScope->expandAndBeCurrent(*scopeCreator);
 }
 
 ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
@@ -411,8 +414,6 @@ public:
       endLocForBraceStmt = *endLoc;
 
     ASTContext &ctx = scopeCreator.getASTContext();
-    if (auto *s = ctx.Stats)
-      ++s->getFrontendCounters().NumBraceStmtASTScopes;
 
     return
         scopeCreator.constructExpandAndInsert<BraceStmtScope>(
@@ -596,25 +597,16 @@ void ASTScopeImpl::addChild(ASTScopeImpl *child, ASTContext &ctx) {
 
 #pragma mark implementations of expansion
 
-ASTScopeImpl *
-ASTScopeImpl::expandAndBeCurrentDetectingRecursion(ScopeCreator &scopeCreator) {
-  return evaluateOrDefault(scopeCreator.getASTContext().evaluator,
-                           ExpandASTScopeRequest{this, &scopeCreator}, nullptr);
-}
-
-ASTScopeImpl *
-ExpandASTScopeRequest::evaluate(Evaluator &evaluator, ASTScopeImpl *parent,
-                                ScopeCreator *scopeCreator) const {
-  auto *insertionPoint = parent->expandAndBeCurrent(*scopeCreator);
-  ASTScopeAssert(insertionPoint,
-                 "Used to return a null pointer if the insertion point would "
-                 "not be used, but it breaks the request dependency hashing");
-  return insertionPoint;
-}
-
 ASTScopeImpl *ASTScopeImpl::expandAndBeCurrent(ScopeCreator &scopeCreator) {
   ASTScopeAssert(!getWasExpanded(),
                  "Cannot expand the same scope twice");
+
+  // Set the flag before we actually expand, to detect re-entrant calls
+  // via the above assertion.
+  setWasExpanded();
+
+  if (auto *s = scopeCreator.getASTContext().Stats)
+    ++s->getFrontendCounters().NumASTScopeExpansions;
 
   auto *insertionPoint = expandSpecifically(scopeCreator);
   ASTScopeAssert(!insertionPointForDeferredExpansion() ||
@@ -623,8 +615,6 @@ ASTScopeImpl *ASTScopeImpl::expandAndBeCurrent(ScopeCreator &scopeCreator) {
                  "In order for lookups into lazily-expanded scopes to be "
                  "accurate before expansion, the insertion point before "
                  "expansion must be the same as after expansion.");
-
-  setWasExpanded();
 
   return insertionPoint;
 }
@@ -825,9 +815,6 @@ BraceStmtScope::expandAScopeThatCreatesANewInsertionPoint(
     insertionPoint = scopeCreator.addToScopeTreeAndReturnInsertionPoint(
         nd, insertionPoint, endLoc);
   }
-
-  if (auto *s = scopeCreator.getASTContext().Stats)
-    ++s->getFrontendCounters().NumBraceStmtASTScopeExpansions;
 
   return {
       insertionPoint,
@@ -1085,24 +1072,17 @@ ASTScopeImpl *GenericTypeOrExtensionWherePortion::expandScope(
 
 #pragma mark createBodyScope
 
-void IterableTypeScope::countBodies(ScopeCreator &scopeCreator) const {
-  if (auto *s = scopeCreator.getASTContext().Stats)
-    ++s->getFrontendCounters().NumIterableTypeBodyASTScopes;
-}
-
 void ExtensionScope::createBodyScope(ASTScopeImpl *leaf,
                                      ScopeCreator &scopeCreator) {
   scopeCreator.constructWithPortionExpandAndInsert<ExtensionScope,
                                                    IterableTypeBodyPortion>(
       leaf, decl);
-  countBodies(scopeCreator);
 }
 void NominalTypeScope::createBodyScope(ASTScopeImpl *leaf,
                                        ScopeCreator &scopeCreator) {
   scopeCreator.constructWithPortionExpandAndInsert<NominalTypeScope,
                                                    IterableTypeBodyPortion>(
       leaf, decl);
-  countBodies(scopeCreator);
 }
 
 #pragma mark createTrailingWhereClauseScope
@@ -1192,9 +1172,6 @@ void GenericTypeOrExtensionScope::expandBody(ScopeCreator &) {}
 void IterableTypeScope::expandBody(ScopeCreator &scopeCreator) {
   for (auto *d : getIterableDeclContext().get()->getMembers())
     scopeCreator.addToScopeTree(ASTNode(d), this);
-
-  if (auto *s = scopeCreator.getASTContext().Stats)
-    ++s->getFrontendCounters().NumIterableTypeBodyASTScopeExpansions;
 }
 
 #pragma mark getScopeCreator
@@ -1240,17 +1217,4 @@ IterableTypeBodyPortion::insertionPointForDeferredExpansion(
 void ast_scope::simple_display(llvm::raw_ostream &out,
                                const ScopeCreator *scopeCreator) {
   scopeCreator->print(out);
-}
-
-//----------------------------------------------------------------------------//
-// ExpandASTScopeRequest computation.
-//----------------------------------------------------------------------------//
-
-bool ExpandASTScopeRequest::isCached() const {
-  ASTScopeImpl *scope = std::get<0>(getStorage());
-  return scope->getWasExpanded();
-}
-
-Optional<ASTScopeImpl *> ExpandASTScopeRequest::getCachedResult() const {
-  return std::get<0>(getStorage());
 }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -579,7 +579,7 @@ ScopeCreator::addPatternBindingToScopeTree(PatternBindingDecl *patternBinding,
 
 void ASTScopeImpl::addChild(ASTScopeImpl *child, ASTContext &ctx) {
   ASTScopeAssert(!child->getParent(), "child should not already have parent");
-  child->parent = this;
+  child->parentAndWasExpanded.setPointer(this);
 
 #ifndef NDEBUG
   checkSourceRangeBeforeAddingChild(child, ctx);
@@ -587,11 +587,9 @@ void ASTScopeImpl::addChild(ASTScopeImpl *child, ASTContext &ctx) {
 
   // If this is the first time we've added children, notify the ASTContext
   // that there's a SmallVector that needs to be cleaned up.
-  // FIXME: If we had access to SmallVector::isSmall(), we could do better.
-  if (storedChildren.empty() && !haveAddedCleanup) {
+  if (storedChildren.empty())
     ctx.addDestructorCleanup(storedChildren);
-    haveAddedCleanup = true;
-  }
+
   storedChildren.push_back(child);
 }
 

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -64,7 +64,8 @@ ASTScopeImpl::findInnermostEnclosingScope(SourceLoc loc,
 ASTScopeImpl *ASTScopeImpl::findInnermostEnclosingScopeImpl(
     SourceLoc loc, NullablePtr<raw_ostream> os, SourceManager &sourceMgr,
     ScopeCreator &scopeCreator) {
-  expandAndBeCurrentDetectingRecursion(scopeCreator);
+  if (!getWasExpanded())
+    expandAndBeCurrent(scopeCreator);
   auto child = findChildContaining(loc, sourceMgr);
   if (!child)
     return this;


### PR DESCRIPTION
This doesn't really fit the request evaluator model since the
result of evaluating the request is the new insertion point,
but we don't have a way to get the insertion point of an
already-expanded scope.

Instead, let's change the callers of the now-removed
expandAndBeCurrentDetectingRecursion() to instead call
expandAndBeCurrent(), while checking first if the scope was
already expanded.