### PR TITLE
[cxx-interop] Add "nonnull" and "dereferenceable(n)" attributes to constructor params.

### DIFF
--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -90,7 +90,7 @@ public func createTemplatedConstructor() {
   // ITANIUM_X64: call void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i32 [[IVAL]])
   // ITANIUM_X64: ret void
   
-  // ITANIUM_X64-LABEL: define linkonce_odr void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* %this, i32 %value.coerce)
+  // ITANIUM_X64-LABEL: define linkonce_odr void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* nonnull dereferenceable(4) {{.*}}, i32 {{.*}})
   
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$ss26createTemplatedConstructoryyF"()
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
@@ -99,7 +99,7 @@ public func createTemplatedConstructor() {
   // ITANIUM_ARM:  call %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], [1 x i32] [[IVAL]])
   // ITANIUM_ARM: ret void
   
-  // ITANIUM_ARM-LABEL: define linkonce_odr %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* returned %this, [1 x i32] %value.coerce)
+  // ITANIUM_ARM-LABEL: define linkonce_odr %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* nonnull returned dereferenceable(4) {{.*}}, [1 x i32] {{.*}})
 
   // MICROSOFT_X64-LABEL: define dllexport swiftcc void @"$ss26createTemplatedConstructoryyF"()
   // MICROSOFT_X64: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
@@ -108,6 +108,6 @@ public func createTemplatedConstructor() {
   // MICROSOFT_X64: call %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i32 [[IVAL]])
   // MICROSOFT_X64: ret void
   
-  // MICROSOFT_X64-LABEL: define linkonce_odr dso_local %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* returned %this, i32 %value.coerce)
+  // MICROSOFT_X64-LABEL: define linkonce_odr dso_local %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* nonnull returned dereferenceable(4) {{.*}}, i32 {{.*}})
   let templated = TemplatedConstructor(ArgType())
 }

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -8,4 +8,4 @@ import MemberInline
 public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs - rhs }
 
 // CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN18LoadableIntWrappermiES_|"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z")]](%struct.LoadableIntWrapper* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval align 4}} {{%[0-9]+}})
-// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* %this, {{i32 %rhs.coerce|\[1 x i32\] %rhs.coerce|i64 %rhs.coerce|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %rhs}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %rhs.coerce|\[1 x i32\] %rhs.coerce|i64 %rhs.coerce|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %rhs}})

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -8,4 +8,4 @@ import MemberOutOfLine
 public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
 
 // CHECK: call {{i32|i64}} [[NAME:@_ZNK6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval align 4}} %{{[0-9]+}})
-// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox*, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval\(%struct.IntBox\) align 4}})
+// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox* nonnull dereferenceable(4), {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval\(%struct.IntBox\) align 4}})

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -46,10 +46,10 @@ public func initStaticVars() -> CInt {
 // CHECK: ret i32 16
 
 // CHECK: define internal void @{{__cxx_global_var_init.4|"\?\?__EstaticNonTrivial@@YAXXZ"}}()
-// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* @_ZL16staticNonTrivial, i32 1024\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* @staticNonTrivial, i32 1024\)}}
+// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* nonnull dereferenceable\(4\) @_ZL16staticNonTrivial, i32 1024\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* nonnull dereferenceable\(4\) @staticNonTrivial, i32 1024\)}}
 
 // CHECK: define internal void @{{__cxx_global_var_init.5|"\?\?__EstaticConstNonTrivial@@YAXXZ"}}()
-// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* @_ZL21staticConstNonTrivial, i32 2048\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* @staticConstNonTrivial, i32 2048\)}}
+// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* nonnull dereferenceable\(4\) @_ZL21staticConstNonTrivial, i32 2048\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* nonnull dereferenceable\(4\) @staticConstNonTrivial, i32 2048\)}}
 
 public func readStaticVar() -> CInt {
   return staticVar


### PR DESCRIPTION
This reflects a change in Clang 13's codegen. Test-only fix for swift/rebranch. SR-13974.