### PR TITLE
[sil] Eliminate a confusing optional method result by changing type dependent operands to have OwnershipKind::None instead of returning Optional::None from Operand::getOperandOwnership().

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -86,7 +86,7 @@ public:
   OwnershipConstraint getOwnershipConstraint() const {
     // We use a force unwrap since a ForwardingOperand should always have an
     // ownership constraint.
-    return *use->getOwnershipConstraint();
+    return use->getOwnershipConstraint();
   }
   ValueOwnershipKind getOwnershipKind() const;
   void setOwnershipKind(ValueOwnershipKind newKind) const;

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -855,21 +855,15 @@ public:
   /// Return which operand this is in the operand list of the using instruction.
   unsigned getOperandNumber() const;
 
-  /// Return the use ownership of this operand. Returns none if the operand is a
-  /// type dependent operand.
+  /// Return the use ownership of this operand.
   ///
   /// NOTE: This is implemented in OperandOwnership.cpp.
-  Optional<OperandOwnership> getOperandOwnership() const;
+  OperandOwnership getOperandOwnership() const;
 
   /// Return the ownership constraint that restricts what types of values this
-  /// Operand can contain. Returns none if the operand is a type dependent
-  /// operand.
-  Optional<OwnershipConstraint> getOwnershipConstraint() const {
-    auto operandOwnership = getOperandOwnership();
-    if (!operandOwnership) {
-      return None;
-    }
-    return operandOwnership->getOwnershipConstraint();
+  /// Operand can contain.
+  OwnershipConstraint getOwnershipConstraint() const {
+    return getOperandOwnership().getOwnershipConstraint();
   }
 
   /// Returns true if changing the operand to use a value with the given

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -775,9 +775,15 @@ OperandOwnership OperandOwnershipClassifier::visitBuiltinInst(BuiltinInst *bi) {
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
-Optional<OperandOwnership> Operand::getOperandOwnership() const {
+OperandOwnership Operand::getOperandOwnership() const {
+  // We consider type dependent uses to be instantaneous uses.
+  //
+  // NOTE: We could instead try to exclude type dependent uses from our system,
+  // but that adds a bunch of Optionals and unnecessary types. This doesn't hurt
+  // anything and allows us to eliminate Optionals and thus confusion in between
+  // Optional::None and OwnershipKind::None.
   if (isTypeDependent())
-    return None;
+    return OperandOwnership::InstantaneousUse;
 
   // If we do not have ownership enabled, just return any. This ensures that we
   // do not have any consuming uses and everything from an ownership perspective

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -343,14 +343,11 @@ static bool canAcceptUnownedValue(OperandOwnership operandOwnership) {
 
 bool Operand::canAcceptKind(ValueOwnershipKind kind) const {
   auto operandOwnership = getOperandOwnership();
-  if (!operandOwnership) {
-    return false;
-  }
-  auto constraint = operandOwnership->getOwnershipConstraint();
+  auto constraint = operandOwnership.getOwnershipConstraint();
   if (constraint.satisfiesConstraint(kind)) {
     // Constraints aren't precise enough to enforce Unowned value uses.
     if (kind == OwnershipKind::Unowned) {
-      return canAcceptUnownedValue(operandOwnership.getValue());
+      return canAcceptUnownedValue(operandOwnership);
     }
     return true;
   }
@@ -365,13 +362,8 @@ bool Operand::satisfiesConstraints() const {
 bool Operand::isLifetimeEnding() const {
   auto constraint = getOwnershipConstraint();
 
-  // If we got back Optional::None, then our operand is for a type dependent
-  // operand. So return false.
-  if (!constraint)
-    return false;
-
   // If our use lifetime constraint is NonLifetimeEnding, just return false.
-  if (!constraint->isLifetimeEnding())
+  if (!constraint.isLifetimeEnding())
     return false;
 
   // Otherwise, we may have a lifetime ending use. We consider two cases here:

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -877,7 +877,7 @@ Optional<ForwardingOperand> ForwardingOperand::get(Operand *use) {
     return None;
   }
 #ifndef NDEBUG
-  switch (use->getOperandOwnership().getValue()) {
+  switch (use->getOperandOwnership()) {
   case OperandOwnership::None:
   case OperandOwnership::ForwardingUnowned:
   case OperandOwnership::ForwardingConsume:

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -188,7 +188,7 @@ bool SILValueOwnershipChecker::isCompatibleDefUse(
     return true;
   }
 
-  auto constraint = *op->getOwnershipConstraint();
+  auto constraint = op->getOwnershipConstraint();
   errorBuilder.handleMalformedSIL([&]() {
     llvm::errs() << "Have operand with incompatible ownership?!\n"
                  << "Value: " << op->get() << "User: " << *user
@@ -326,8 +326,7 @@ bool SILValueOwnershipChecker::gatherUsers(
     // Example: A guaranteed parameter of a co-routine.
 
     // Now check if we have a non guaranteed forwarding inst...
-    if (op->getOperandOwnership().getValue()
-        != OperandOwnership::ForwardingBorrow) {
+    if (op->getOperandOwnership() != OperandOwnership::ForwardingBorrow) {
       // First check if we are visiting an operand that is a consuming use...
       if (op->isLifetimeEnding()) {
         // If its underlying value is our original value, then this is a true
@@ -744,7 +743,7 @@ void SILInstruction::verifyOperandOwnership() const {
     if (op.satisfiesConstraints())
       continue;
 
-    auto constraint = *op.getOwnershipConstraint();
+    auto constraint = op.getOwnershipConstraint();
     SILValue opValue = op.get();
     auto valueOwnershipKind = opValue.getOwnershipKind();
     errorBuilder->handleMalformedSIL([&] {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1127,21 +1127,12 @@ public:
       // type dependent operand then we should have a constraint of
       // OwnershipKind::Any, UseLifetimeConstraint::NonLifetimeEnding.
       if (!I->getFunction()->hasOwnership()) {
-        if (operand.isTypeDependent()) {
-          require(
-              !operand.getOwnershipConstraint(),
-              "Non Optional::None constraint for a type dependent operand?!");
-        } else {
-          auto constraint = operand.getOwnershipConstraint();
-          require(constraint.hasValue(),
-                  "All non-type dependent operands must have a "
-                  "non-Optional::None constraint?!");
-          require(constraint->getPreferredKind() == OwnershipKind::Any &&
-                      constraint->getLifetimeConstraint() ==
-                          UseLifetimeConstraint::NonLifetimeEnding,
-                  "In non-ossa all non-type dependent operands must have a "
-                  "constraint of Any, NonLifetimeEnding");
-        }
+        auto constraint = operand.getOwnershipConstraint();
+        require(constraint.getPreferredKind() == OwnershipKind::Any &&
+                    constraint.getLifetimeConstraint() ==
+                        UseLifetimeConstraint::NonLifetimeEnding,
+                "In non-ossa all non-type dependent operands must have a "
+                "constraint of Any, NonLifetimeEnding");
       }
     }
 


### PR DESCRIPTION
This eliminates when talking about this API an ambiguity in between
Optional::None (the C++ ADT) and OwnershipKind::None (the ownership kind).
