### PR TITLE
[SILOpt] Fix build by only accessing seenUse in non-assert builds

### DIFF
--- a/include/swift/SILOptimizer/Utils/PrunedLiveness.h
+++ b/include/swift/SILOptimizer/Utils/PrunedLiveness.h
@@ -145,7 +145,7 @@ private:
 public:
   bool empty() const { return liveBlocks.empty(); }
 
-  void clear() { liveBlocks.clear(); seenUse = false; }
+  void clear() { liveBlocks.clear(); SWIFT_ASSERT_ONLY(seenUse = false); }
 
   void initializeDefBlock(SILBasicBlock *defBB) {
     assert(!seenUse && "cannot initialize more defs with partial liveness");

--- a/lib/SILOptimizer/Utils/PrunedLiveness.cpp
+++ b/lib/SILOptimizer/Utils/PrunedLiveness.cpp
@@ -50,7 +50,7 @@ void PrunedLiveBlocks::computeUseBlockLiveness(SILBasicBlock *userBB) {
 ///
 /// Terminators are not live out of the block.
 PrunedLiveBlocks::IsLive PrunedLiveBlocks::updateForUse(Operand *use) {
-  seenUse = true;
+  SWIFT_ASSERT_ONLY(seenUse = true);
 
   auto *bb = use->getUser()->getParent();
   switch (getBlockLiveness(bb)) {


### PR DESCRIPTION
#35158 broke non-assert builds by accessing the `seenUse` member in non-assert contexts, even though it was declared as being an assert-only member.

Wrap all accessed to `seenUse` in `SWIFT_ASSERT_ONLY` to fix the issue.

Disclaimer: I'm not 100% sure this is the right fix, I'm mostly trying to fix the build.