### PR TITLE
[ASTDumper] Don't call isFinal()

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -772,14 +772,14 @@ namespace {
       }
 
       auto VarD = dyn_cast<VarDecl>(VD);
-      if (VD->isFinal() && !(VarD && VarD->isLet()))
+      const auto &attrs = VD->getAttrs();
+      if (attrs.hasAttribute<FinalAttr>() && !(VarD && VarD->isLet()))
         OS << " final";
-      if (VD->getAttrs().hasAttribute<ObjCAttr>())
+      if (attrs.hasAttribute<ObjCAttr>())
         OS << " @objc";
-      if (VD->getAttrs().hasAttribute<DynamicAttr>())
+      if (attrs.hasAttribute<DynamicAttr>())
         OS << " dynamic";
-      if (auto *attr =
-              VD->getAttrs().getAttribute<DynamicReplacementAttr>()) {
+      if (auto *attr = attrs.getAttribute<DynamicReplacementAttr>()) {
         OS << " @_dynamicReplacement(for: \"";
         OS << attr->getReplacedFunctionName();
         OS << "\")";

--- a/test/Frontend/dump-parse-syntactically-valid.swift
+++ b/test/Frontend/dump-parse-syntactically-valid.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -dump-parse %s
+
+// Make sure we don't do any Sema and don't crash.
+extension X {
+  typealias Y = Z
+}


### PR DESCRIPTION
Avoid triggering the semantic `IsFinalRequest` and instead check for the presence of the final attribute.

Resolves SR-13230.
