### PR TITLE
[Incremental Swift Driver] Generalize Driver/Dependencies tests

### DIFF
--- a/test/Driver/Dependencies/Inputs/bindings-build-record/added.swift
+++ b/test/Driver/Dependencies/Inputs/bindings-build-record/added.swift
@@ -1,2 +1,1 @@
-# Dependencies after compilation:
-depends-nominal: [z]
+

--- a/test/Driver/Dependencies/Inputs/bindings-build-record/main.swift
+++ b/test/Driver/Dependencies/Inputs/bindings-build-record/main.swift
@@ -1,3 +1,1 @@
-# Dependencies after compilation:
-depends-top-level: [a]
-provides-nominal: [z]
+

--- a/test/Driver/Dependencies/Inputs/bindings-build-record/other.swift
+++ b/test/Driver/Dependencies/Inputs/bindings-build-record/other.swift
@@ -1,2 +1,1 @@
-# Dependencies after compilation:
-provides-top-level: [a]
+

--- a/test/Driver/Dependencies/Inputs/bindings-build-record/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/bindings-build-record/yet-another.swift
@@ -1,2 +1,1 @@
-# Dependencies after compilation:
-depends-nominal: [z]
+

--- a/test/Driver/Dependencies/Inputs/one-way-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-fine/output.json
@@ -8,8 +8,8 @@
   "./other.swift": {
     "object": "./other.o",
     "swift-dependencies": "./other.swiftdeps",
-    "swiftmodule": "./main.swiftmodule",
-    "swiftdoc": "./main.swiftdoc",
+    "swiftmodule": "./other.swiftmodule",
+    "swiftdoc": "./other.swiftdoc",
   },
   "": {
     "swift-dependencies": "./main~buildrecord.swiftdeps"

--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -6,36 +6,43 @@
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -driver-show-incremental -output-file-map %t/output.json 2>&1 |%FileCheck %s -check-prefix=MUST-EXEC
 
 // MUST-EXEC-NOT: warning
-// MUST-EXEC: inputs: ["{{(\.\/)?}}main.swift"], output: {object: "{{(\.\/)?}}main.o", swift-dependencies: "{{(\.\/)?}}main.swiftdeps"}
-// MUST-EXEC: inputs: ["{{(\.\/)?}}other.swift"], output: {object: "{{(\.\/)?}}other.o", swift-dependencies: "{{(\.\/)?}}other.swiftdeps"}
-// MUST-EXEC: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {object: "{{(\.\/)?}}yet-another.o", swift-dependencies: "{{(\.\/)?}}yet-another.swiftdeps"}
-// MUST-EXEC: Disabling incremental build: could not read build record
+// MUST-EXEC-DAG: inputs: ["{{(\.\/)?}}main.swift"], output: {object: "{{(\.\/)?}}main.o", swift-dependencies: "{{(\.\/)?}}main.swiftdeps"}
+// MUST-EXEC-DAG: inputs: ["{{(\.\/)?}}other.swift"], output: {object: "{{(\.\/)?}}other.o", swift-dependencies: "{{(\.\/)?}}other.swiftdeps"}
+// MUST-EXEC-DAG: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {object: "{{(\.\/)?}}yet-another.o", swift-dependencies: "{{(\.\/)?}}yet-another.swiftdeps"}
+// MUST-EXEC-DAG: Disabling incremental build: could not read build record
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0], "./yet-another.swift": [443865900, 0]}, build_time: [443865901, 0]}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// NO-EXEC: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}, condition: check-dependencies
-// NO-EXEC: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}, condition: check-dependencies
-// NO-EXEC: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]}}, condition: check-dependencies
+// Run it once to produce swiftdeps files for the new driver to have
+// RUN: cd %t && %swiftc_driver ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json
+
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0], "./yet-another.swift": [443865900, 0]}, build_time: [443865901, 0]}' > %t/main~buildrecord.swiftdeps
+
+
+// RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 -driver-show-incremental -driver-show-job-lifecycle |tee /tmp/x| %FileCheck %s -check-prefix=NO-EXEC
+
+// NO-EXEC: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}{{(, condition: check-dependencies)?}}
+// NO-EXEC: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}{{(, condition: check-dependencies)?}}
+// NO-EXEC: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]}}{{(, condition: check-dependencies)?}}
 
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": !private [443865900, 0], "./yet-another.swift": !dirty [443865900, 0]}, build_time: [443865901, 0]}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=BUILD-RECORD
 
-// BUILD-RECORD: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}, condition: check-dependencies{{$}}
-// BUILD-RECORD: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}, condition: run-without-cascading{{$}}
+// BUILD-RECORD: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}{{(, condition: check-dependencies$)?}}
+// BUILD-RECORD: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}{{(, condition: run-without-cascading$)?}}
 // BUILD-RECORD: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]$}}
 
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift ./added.swift -incremental -output-file-map %t/output.json 2>&1 > %t/added.txt
 // RUN: %FileCheck %s -check-prefix=BUILD-RECORD < %t/added.txt
 // RUN: %FileCheck %s -check-prefix=FILE-ADDED < %t/added.txt
 
-// FILE-ADDED: inputs: ["{{(\.\/)?}}added.swift"], output: {{[{].*[}]}}, condition: newly-added{{$}}
+// FILE-ADDED: inputs: ["{{(\.\/)?}}added.swift"], output: {{[{].*[}]}}{{(, condition: newly-added$)?}}
 
 // RUN: %{python} %S/Inputs/touch.py 443865960 %t/main.swift
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=BUILD-RECORD-PLUS-CHANGE
-// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}, condition: run-without-cascading
-// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}, condition: run-without-cascading{{$}}
+// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}{{(, condition: run-without-cascading)?}}
+// BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}{{(, condition: run-without-cascading$)?}}
 // BUILD-RECORD-PLUS-CHANGE: inputs: ["{{(\.\/)?}}yet-another.swift"], output: {{[{].*[}]$}}
 
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*

--- a/test/Driver/Dependencies/driver-show-incremental-inputs-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs-fine.swift
@@ -20,5 +20,5 @@
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json 2>&1 | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
 // CHECK-INPUTS-MISMATCH: Incremental compilation has been disabled{{.*}}inputs
-// CHECK-INPUTS-MISMATCH: ./other.swift
+// CHECK-INPUTS-MISMATCH: {{(./)?}}other.swift
 // CHECK-INPUTS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-mutual-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual-fine.swift
@@ -15,5 +15,5 @@
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 // CHECK-THIRD: Queuing (initial): {compile: other.o <= other.swift}
-// CHECK-THIRD: Queuing because of the initial set: {compile: main.o <= main.swift}
-// CHECK-THIRD-NEXT: interface of top-level name 'a' in other.swift -> interface of source file main.swiftdeps
+// CHECK-THIRD-DAG: Queuing because of the initial set: {compile: main.o <= main.swift}
+// CHECK-THIRD-DAG: interface of top-level name 'a' in other.swift -> interface of source file main.swiftdeps

--- a/test/Driver/Dependencies/embed-bitcode-parallel-fine.swift
+++ b/test/Driver/Dependencies/embed-bitcode-parallel-fine.swift
@@ -4,88 +4,95 @@
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output >%t/first.json  2>&1
+
+// RUN: %FileCheck -check-prefix=CHECK-FIRST %s <%t/first.json
+// RUN: %FileCheck -check-prefix=CHECK-FIRST %s <%t/first.json
+// RUN: %FileCheck -check-prefix=CHECK-FIRST %s <%t/first.json
+// RUN: %FileCheck -check-prefix=CHECK-FIRST %s <%t/first.json
+// RUN: %FileCheck -check-prefix=CHECK-FIRST %s <%t/first.json
 
 // CHECK-FIRST-NOT: warning
+
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled main.swift\n"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "output"{{ ?}}: "Handled main.swift\n"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/other.swift"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled other.swift\n"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "output"{{ ?}}: "Handled other.swift\n"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "backend"
-// CHECK-FIRST: ".\/main.o"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "backend"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}main.o"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "backend"
-// CHECK-FIRST: "output": "Produced main.o\n"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "backend"
+// CHECK-FIRST-DAG: "output"{{ ?}}: "Produced main.o\n"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "backend"
-// CHECK-FIRST: ".\/other.o"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "backend"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}other.o"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "backend"
-// CHECK-FIRST: "output": "Produced other.o\n"
+// CHECK-FIRST-DAT: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-DAT: "name"{{ ?}}: "backend"
+// CHECK-FIRST-DAT: "output"{{ ?}}: "Produced other.o\n"
 // CHECK-FIRST: {{^}$}}
 
 
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
-// CHECK-SECOND: "kind": "began"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "began"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND-NOT: finished
 
-// CHECK-SECOND: "kind": "began"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/other.swift"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "began"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND-NOT: began
 
-// CHECK-SECOND: "kind": "finished"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: "output": "Handled {{other.swift|main.swift}}\n"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "finished"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-DAG: "output"{{ ?}}: "Handled {{other.swift|main.swift}}\n"
 // CHECK-SECOND: {{^}$}}
 
-// CHECK-SECOND: "kind": "began"
-// CHECK-SECOND: "name": "backend"
-// CHECK-SECOND: ".\/{{other.o|main.o}}"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "began"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "backend"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}{{other.o|main.o}}"
 // CHECK-SECOND: {{^}$}}
 
-// CHECK-SECOND: "kind": "finished"
-// CHECK-SECOND: "name": "backend"
-// CHECK-SECOND: "output": "Produced {{other.o|main.o}}\n"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "finished"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "backend"
+// CHECK-SECOND-DAG: "output"{{ ?}}: "Produced {{other.o|main.o}}\n"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND-NOT: "skipped"

--- a/test/Driver/Dependencies/independent-parseable-fine.swift
+++ b/test/Driver/Dependencies/independent-parseable-fine.swift
@@ -6,23 +6,23 @@
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FIRST: "kind"{{ ?}}: "finished"
+// CHECK-FIRST: "name"{{ ?}}: "compile"
+// CHECK-FIRST: "output"{{ ?}}: "Handled main.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "skipped"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-SECOND: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/*
@@ -36,41 +36,41 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 // CHECK-FIRST-MULTI: {{^{$}}
-// CHECK-FIRST-MULTI: "kind": "began"
-// CHECK-FIRST-MULTI: "name": "compile"
-// CHECK-FIRST-MULTI: ".\/main.swift"
+// CHECK-FIRST-MULTI-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-MULTI-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-MULTI-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-FIRST-MULTI: {{^}$}}
 
 // CHECK-FIRST-MULTI: {{^{$}}
-// CHECK-FIRST-MULTI: "kind": "finished"
-// CHECK-FIRST-MULTI: "name": "compile"
-// CHECK-FIRST-MULTI: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FIRST-MULTI-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-MULTI-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-MULTI-DAG: "output"{{ ?}}: "Handled main.swift{{(\\r)?}}\n"
 // CHECK-FIRST-MULTI: {{^}$}}
 
 // CHECK-FIRST-MULTI: {{^{$}}
-// CHECK-FIRST-MULTI: "kind": "began"
-// CHECK-FIRST-MULTI: "name": "compile"
-// CHECK-FIRST-MULTI: ".\/other.swift"
+// CHECK-FIRST-MULTI-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-MULTI-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-MULTI-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-FIRST-MULTI: {{^}$}}
 
 // CHECK-FIRST-MULTI: {{^{$}}
-// CHECK-FIRST-MULTI: "kind": "finished"
-// CHECK-FIRST-MULTI: "name": "compile"
-// CHECK-FIRST-MULTI: "output": "Handled other.swift{{(\\r)?}}\n"
+// CHECK-FIRST-MULTI-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-MULTI-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-MULTI-DAG: "output"{{ ?}}: "Handled other.swift{{(\\r)?}}\n"
 // CHECK-FIRST-MULTI: {{^}$}}
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND-MULTI %s
 
 // CHECK-SECOND-MULTI: {{^{$}}
-// CHECK-SECOND-MULTI: "kind": "skipped"
-// CHECK-SECOND-MULTI: "name": "compile"
-// CHECK-SECOND-MULTI: ".\/main.swift"
+// CHECK-SECOND-MULTI-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-SECOND-MULTI-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-MULTI-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-SECOND-MULTI: {{^}$}}
 
 // CHECK-SECOND-MULTI: {{^{$}}
-// CHECK-SECOND-MULTI: "kind": "skipped"
-// CHECK-SECOND-MULTI: "name": "compile"
-// CHECK-SECOND-MULTI: ".\/other.swift"
+// CHECK-SECOND-MULTI-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-SECOND-MULTI-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-MULTI-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-SECOND-MULTI: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/*

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -11,6 +11,9 @@
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Produced master.swiftmodule
 
+// swift-driver checks existence of all outputs
+// RUN: touch -t 201401240006 %t/{main,other}.swift{module,doc,sourceinfo}
+
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: warning

--- a/test/Driver/Dependencies/one-way-parallel-fine.swift
+++ b/test/Driver/Dependencies/one-way-parallel-fine.swift
@@ -8,54 +8,54 @@
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST-DAG: "kind"{{ *}}: "began"
+// CHECK-FIRST-DAG: "name"{{ *}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled main.swift\n"
+// CHECK-FIRST-DAG: "kind"{{ *}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ *}}: "compile"
+// CHECK-FIRST-DAG: "output"{{ *}}: "Handled main.swift\n"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/other.swift"
+// CHECK-FIRST-DAG: "kind"{{ *}}: "began"
+// CHECK-FIRST-DAG: "name"{{ *}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled other.swift\n"
+// CHECK-FIRST-DAG: "kind"{{ *}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ *}}: "compile"
+// CHECK-FIRST-DAG: "output"{{ *}}: "Handled other.swift\n"
 // CHECK-FIRST: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "began"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/other.swift"
+// CHECK-SECOND-DAG: "kind"{{ *}}: "began"
+// CHECK-SECOND-DAG: "name"{{ *}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "began"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND-DAG: "kind"{{ *}}: "began"
+// CHECK-SECOND-DAG: "name"{{ *}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "finished"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: "output": "Handled {{other.swift|main.swift}}\n"
+// CHECK-SECOND-DAG: "kind"{{ *}}: "finished"
+// CHECK-SECOND-DAG: "name"{{ *}}: "compile"
+// CHECK-SECOND-DAG: "output"{{ *}}: "Handled {{other.swift|main.swift}}\n"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "finished"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: "output": "Handled {{main.swift|other.swift}}\n"
+// CHECK-SECOND-DAG: "kind"{{ *}}: "finished"
+// CHECK-SECOND-DAG: "name"{{ *}}: "compile"
+// CHECK-SECOND-DAG: "output"{{ *}}: "Handled {{main.swift|other.swift}}\n"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND-NOT: "skipped"

--- a/test/Driver/Dependencies/one-way-parseable-fine.swift
+++ b/test/Driver/Dependencies/one-way-parseable-fine.swift
@@ -6,87 +6,87 @@
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "output"{{ ?}}: "Handled main.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "began"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: ".\/other.swift"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "began"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-FIRST: {{^}$}}
 
 // CHECK-FIRST: {{^{$}}
-// CHECK-FIRST: "kind": "finished"
-// CHECK-FIRST: "name": "compile"
-// CHECK-FIRST: "output": "Handled other.swift{{(\\r)?}}\n"
+// CHECK-FIRST-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FIRST-DAG: "name"{{ ?}}: "compile"
+// CHECK-FIRST-DAG: "output"{{ ?}}: "Handled other.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "skipped"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-SECOND: {{^}$}}
 
 // CHECK-SECOND: {{^{$}}
-// CHECK-SECOND: "kind": "skipped"
-// CHECK-SECOND: "name": "compile"
-// CHECK-SECOND: ".\/other.swift"
+// CHECK-SECOND-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-SECOND-DAG: "name"{{ ?}}: "compile"
+// CHECK-SECOND-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-SECOND: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: {{^{$}}
-// CHECK-THIRD: "kind": "began"
-// CHECK-THIRD: "name": "compile"
-// CHECK-THIRD: ".\/main.swift"
+// CHECK-THIRD-DAG: "kind"{{ ?}}: "began"
+// CHECK-THIRD-DAG: "name"{{ ?}}: "compile"
+// CHECK-THIRD-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-THIRD: {{^}$}}
 
 // CHECK-THIRD: {{^{$}}
-// CHECK-THIRD: "kind": "finished"
-// CHECK-THIRD: "name": "compile"
-// CHECK-THIRD: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-THIRD-DAG: "kind"{{ ?}}: "finished"
+// CHECK-THIRD-DAG: "name"{{ ?}}: "compile"
+// CHECK-THIRD-DAG: "output"{{ ?}}: "Handled main.swift{{(\\r)?}}\n"
 // CHECK-THIRD: {{^}$}}
 
 // CHECK-THIRD: {{^{$}}
-// CHECK-THIRD: "kind": "began"
-// CHECK-THIRD: "name": "compile"
-// CHECK-THIRD: ".\/other.swift"
+// CHECK-THIRD-DAG: "kind"{{ ?}}: "began"
+// CHECK-THIRD-DAG: "name"{{ ?}}: "compile"
+// CHECK-THIRD-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-THIRD: {{^}$}}
 
 // CHECK-THIRD: {{^{$}}
-// CHECK-THIRD: "kind": "finished"
-// CHECK-THIRD: "name": "compile"
-// CHECK-THIRD: "output": "Handled other.swift{{(\\r)?}}\n"
+// CHECK-THIRD-DAG: "kind"{{ ?}}: "finished"
+// CHECK-THIRD-DAG: "name"{{ ?}}: "compile"
+// CHECK-THIRD-DAG: "output"{{ ?}}: "Handled other.swift{{(\\r)?}}\n"
 // CHECK-THIRD: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/main.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH: {{^{$}}
-// CHECK-FOURTH: "kind": "began"
-// CHECK-FOURTH: "name": "compile"
-// CHECK-FOURTH: ".\/main.swift"
+// CHECK-FOURTH-DAG: "kind"{{ ?}}: "began"
+// CHECK-FOURTH-DAG: "name"{{ ?}}: "compile"
+// CHECK-FOURTH-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-FOURTH: {{^}$}}
 
 // CHECK-FOURTH: {{^{$}}
-// CHECK-FOURTH: "kind": "finished"
-// CHECK-FOURTH: "name": "compile"
-// CHECK-FOURTH: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FOURTH-DAG: "kind"{{ ?}}: "finished"
+// CHECK-FOURTH-DAG: "name"{{ ?}}: "compile"
+// CHECK-FOURTH-DAG: "output"{{ ?}}: "Handled main.swift{{(\\r)?}}\n"
 // CHECK-FOURTH: {{^}$}}
 
 // CHECK-FOURTH: {{^{$}}
-// CHECK-FOURTH: "kind": "skipped"
-// CHECK-FOURTH: "name": "compile"
-// CHECK-FOURTH: ".\/other.swift"
+// CHECK-FOURTH-DAG: "kind"{{ ?}}: "skipped"
+// CHECK-FOURTH-DAG: "name"{{ ?}}: "compile"
+// CHECK-FOURTH-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-FOURTH: {{^}$}}

--- a/test/Driver/Dependencies/one-way-while-editing-fine.swift
+++ b/test/Driver/Dependencies/one-way-while-editing-fine.swift
@@ -7,7 +7,6 @@
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // CHECK: Handled main.swift
-// CHECK: Handled other.swift
 // CHECK-NOT: error
 // CHECK: error: input file 'other.swift' was modified during the build
 // CHECK-NOT: error
@@ -22,7 +21,6 @@
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED %s
 
 // CHECK-REVERSED: Handled other.swift
-// CHECK-REVERSED: Handled main.swift
 // CHECK-REVERSED-NOT: error
 // CHECK-REVERSED: error: input file 'main.swift' was modified during the build
 // CHECK-REVERSED-NOT: error


### PR DESCRIPTION
Modify the legacy lit tests to support the swift-driver (given some pending PRs). See the individual commits.
To summarize:
- swift-driver removes "./" from start of paths written to build record
- swift-driver uses different white space in JSON output, and reorders entries within a map
- swift-driver uses a different architecture, so cannot reasonably include job conditions when printing bindings
- swift-driver checks every output for existence before deciding to skip a compilation
- swift-driver does not even start compiling a file that has been modified during the build