### PR TITLE
[sil-combine] Update fix_lifetime opts for ownership

### DIFF
--- a/test/SILOptimizer/sil_combine_misc_visitor_opts_ossa.sil
+++ b/test/SILOptimizer/sil_combine_misc_visitor_opts_ossa.sil
@@ -1,0 +1,50 @@
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+class Klass {}
+
+// We test both the ossa and non-ossa variants.
+//
+// CHECK-LABEL: sil [ossa] @fix_lifetime_promotion_ossa : $@convention(thin) (@owned Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[STACK:%.*]] = alloc_stack $Klass
+// CHECK:   store [[ARG]] to [init] [[STACK]]
+// CHECK:   [[BORROW:%.*]] = load_borrow [[STACK]]
+// CHECK:   fix_lifetime [[BORROW]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   destroy_addr [[STACK]]
+// CHECK:   dealloc_stack [[STACK]]
+// CHECK: } // end sil function 'fix_lifetime_promotion_ossa'
+sil [ossa] @fix_lifetime_promotion_ossa : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack $Klass
+  store %0 to [init] %1 : $*Klass
+  fix_lifetime %1 : $*Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @fix_lifetime_promotion : $@convention(thin) (@owned Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[STACK:%.*]] = alloc_stack $Klass
+// CHECK:   store [[ARG]] to [[STACK]]
+// CHECK:   [[BORROW:%.*]] = load [[STACK]]
+// CHECK:   fix_lifetime [[BORROW]]
+// CHECK:   destroy_addr [[STACK]]
+// CHECK:   dealloc_stack [[STACK]]
+// CHECK: } // end sil function 'fix_lifetime_promotion'
+sil @fix_lifetime_promotion : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : $Klass):
+  %1 = alloc_stack $Klass
+  store %0 to %1 : $*Klass
+  fix_lifetime %1 : $*Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
The one opt we perform here is that we promote fix_lifetime on loadable
alloc_stack addresses to fix_lifetimes on objects by loading the underlying
value and putting the fix lifetime upon it.

