### PR TITLE
[CodeCompletion] Zero check interval should always check dependencies

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -607,7 +607,7 @@ bool CompletionInstance::shouldCheckDependencies() const {
   auto now = system_clock::now();
   auto threshold = DependencyCheckedTimestamp +
                    seconds(Opts.DependencyCheckIntervalSecond);
-  return threshold < now;
+  return threshold <= now;
 }
 
 void CompletionInstance::setOptions(CompletionInstance::Options NewOpts) {


### PR DESCRIPTION
This hopefully fixes the various complete_checkdeps* tests failing on the ASAN and simulator builds.