### PR TITLE
Concurrency: Introduce a `CheckedContinuation` adapter.

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -345,6 +345,10 @@ void swift_continuation_throwingResumeWithError(/* +1 */ SwiftError *error,
                                                 void *continuation,
                                                 const Metadata *resumeType);
 
+/// SPI helper to log a misuse of a `CheckedContinuation` to the appropriate places in the OS.
+extern "C" SWIFT_CC(swift)
+void swift_continuation_logFailedCheck(const char *message);
+
 }
 
 #endif

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Actor.cpp
   Actor.swift
+  CheckedContinuation.swift
   GlobalExecutor.cpp
   PartialAsyncTask.swift
   Task.cpp

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -1,0 +1,183 @@
+import Swift
+
+@_silgen_name("swift_continuation_logFailedCheck")
+internal func logFailedCheck(_ message: UnsafeRawPointer)
+
+/// A wrapper class for `UnsafeContinuation` that logs misuses of the
+/// continuation, logging a message if the continuation is resumed
+/// multiple times, or if an object is destroyed without its continuation
+/// ever being resumed.
+///
+/// Raw `UnsafeContinuation`, like other unsafe constructs, requires the
+/// user to apply it correctly in order to maintain invariants. The key
+/// invariant is that the continuation must be resumed exactly once,
+/// and bad things happen if this invariant is not upheld--if a continuation
+/// is abandoned without resuming the task, then the task will be stuck in
+/// the suspended state forever, and conversely, if the same continuation is
+/// resumed multiple times, it will put the task in an undefined state.
+/// `UnsafeContinuation` avoids enforcing these invariants at runtime because
+/// it aims to be a low-overhead mechanism for interfacing Swift tasks with
+/// event loops, delegate methods, callbacks, and other non-`async` scheduling
+/// mechanisms. However, during development, being able to verify that the
+/// invariants are being upheld in testing is important.
+///
+/// `CheckedContinuation` is designed to be a drop-in API replacement for
+/// `UnsafeContinuation` that can be used for testing purposes, at the cost
+/// of an extra allocation and indirection for the wrapper object.
+/// Changing a call of `withUnsafeContinuation` into a call of
+/// `withCheckedContinuation` should be enough to obtain the extra checking
+/// without further source modification in most circumstances.
+public final class CheckedContinuation<T> {
+  var continuation: UnsafeContinuation<T>?
+  var function: String
+  
+  /// Initialize a `CheckedContinuation` wrapper around an
+  /// `UnsafeContinuation`.
+  ///
+  /// In most cases, you should use `withCheckedContinuation` instead.
+  /// You only need to initialize your own `CheckedContinuation<T>` if you
+  /// already have an `UnsafeContinuation` you want to impose checking on.
+  ///
+  /// - Parameters:
+  ///   - continuation: a fresh `UnsafeContinuation` that has not yet
+  ///     been resumed. The `UnsafeContinuation` must not be used outside of
+  ///     this object once it's been given to the new object.
+  ///   - function: a string identifying the declaration that is the notional
+  ///     source for the continuation, used to identify the continuation in
+  ///     runtime diagnostics related to misuse of this continuation.
+  public init(continuation: UnsafeContinuation<T>, function: String = #function) {
+    self.continuation = continuation
+    self.function = function
+  }
+  
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// A continuation must be resumed exactly once. If the continuation has
+  /// already been resumed through this object, then the attempt to resume
+  /// the continuation again will be logged, but otherwise have no effect.
+  public func resume(returning x: __owned T) {
+    if let c = continuation {
+      c.resume(returning: x)
+      // Clear out the continuation so we don't try to resume again
+      continuation = nil
+    } else {
+      logFailedCheck("SWIFT TASK CONTINUATION MISUSE: \(function) tried to resume its continuation more than once, returning \(x)!\n")
+    }
+  }
+  
+  /// Log if the object is deallocated before its continuation is resumed.
+  deinit {
+    if continuation != nil {
+      logFailedCheck("SWIFT TASK CONTINUATION MISUSE: \(function) leaked its continuation!\n")
+    }
+  }
+}
+
+public func withCheckedContinuation<T>(
+    function: String = #function,
+    _ body: (CheckedContinuation<T>) -> Void
+) async -> T {
+  return await withUnsafeContinuation {
+    body(CheckedContinuation(continuation: $0, function: function))
+  }
+}
+
+/// A wrapper class for `UnsafeThrowingContinuation` that logs misuses of the
+/// continuation, logging a message if the continuation is resumed
+/// multiple times, or if an object is destroyed without its continuation
+/// ever being resumed.
+///
+/// Raw `UnsafeThrowingContinuation`, like other unsafe constructs, requires the
+/// user to apply it correctly in order to maintain invariants. The key
+/// invariant is that the continuation must be resumed exactly once,
+/// and bad things happen if this invariant is not upheld--if a continuation
+/// is abandoned without resuming the task, then the task will be stuck in
+/// the suspended state forever, and conversely, if the same continuation is
+/// resumed multiple times, it will put the task in an undefined state.
+/// `UnsafeThrowingContinuation` avoids enforcing these invariants at runtime because
+/// it aims to be a low-overhead mechanism for interfacing Swift tasks with
+/// event loops, delegate methods, callbacks, and other non-`async` scheduling
+/// mechanisms. However, during development, being able to verify that the
+/// invariants are being upheld in testing is important.
+///
+/// `CheckedThrowingContinuation` is designed to be a drop-in API replacement for
+/// `UnsafeThrowingContinuation` that can be used for testing purposes, at the cost
+/// of an extra allocation and indirection for the wrapper object.
+/// Changing a call of `withUnsafeThrowingContinuation` into a call of
+/// `withCheckedThrowingContinuation` should be enough to obtain the extra checking
+/// without further source modification in most circumstances.
+public final class CheckedThrowingContinuation<T> {
+  var continuation: UnsafeThrowingContinuation<T>?
+  var function: String
+  
+  /// Initialize a `CheckedThrowingContinuation` wrapper around an
+  /// `UnsafeThrowingContinuation`.
+  ///
+  /// In most cases, you should use `withCheckedThrowingContinuation` instead.
+  /// You only need to initialize your own `CheckedThrowingContinuation<T>` if you
+  /// already have an `UnsafeThrowingContinuation` you want to impose checking on.
+  ///
+  /// - Parameters:
+  ///   - continuation: a fresh `UnsafeThrowingContinuation` that has not yet
+  ///     been resumed. The `UnsafeThrowingContinuation` must not be used outside of
+  ///     this object once it's been given to the new object.
+  ///   - function: a string identifying the declaration that is the notional
+  ///     source for the continuation, used to identify the continuation in
+  ///     runtime diagnostics related to misuse of this continuation.
+  public init(continuation: UnsafeThrowingContinuation<T>, function: String = #function) {
+    self.continuation = continuation
+    self.function = function
+  }
+  
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// A continuation must be resumed exactly once. If the continuation has
+  /// already been resumed through this object, whether by `resume(returning:)`
+  /// or by `resume(throwing:)`, then the attempt to resume
+  /// the continuation again will be logged, but otherwise have no effect.
+  public func resume(returning x: __owned T) {
+    if let c = continuation {
+      c.resume(returning: x)
+      // Clear out the continuation so we don't try to resume again
+      continuation = nil
+    } else {
+      logFailedCheck("SWIFT TASK CONTINUATION MISUSE: \(function) tried to resume its continuation more than once, returning \(x)!\n")
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it throw an error
+  /// from its suspension point.
+  ///
+  /// A continuation must be resumed exactly once. If the continuation has
+  /// already been resumed through this object, whether by `resume(returning:)`
+  /// or by `resume(throwing:)`, then the attempt to resume
+  /// the continuation again will be logged, but otherwise have no effect.
+  public func resume(throwing x: __owned Error) {
+    if let c = continuation {
+      c.resume(throwing: x)
+      // Clear out the continuation so we don't try to resume again
+      continuation = nil
+    } else {
+      logFailedCheck("SWIFT TASK CONTINUATION MISUSE: \(function) tried to resume its continuation more than once, throwing \(x)!\n")
+    }
+  }
+  
+  /// Log if the object is deallocated before its continuation is resumed.
+  deinit {
+    if continuation != nil {
+      logFailedCheck("SWIFT TASK CONTINUATION MISUSE: \(function) leaked its continuation!\n")
+    }
+  }
+}
+
+public func withCheckedThrowingContinuation<T>(
+    function: String = #function,
+    _ body: (CheckedThrowingContinuation<T>) -> Void
+) async throws -> T {
+  return await try withUnsafeThrowingContinuation {
+    body(CheckedThrowingContinuation(continuation: $0, function: function))
+  }
+}
+

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -523,3 +523,8 @@ void swift::swift_continuation_throwingResumeWithError(/* +1 */ SwiftError *erro
 bool swift::swift_task_isCancelled(AsyncTask *task) {
   return task->isCancelled();
 }
+
+SWIFT_CC(swift)
+void swift::swift_continuation_logFailedCheck(const char *message) {
+  swift_reportError(0, message);
+}

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+import _Concurrency
+
+struct TestError: Error {}
+
+runAsyncAndBlock {
+    let x: Int = await withCheckedContinuation { c in
+        c.resume(returning: 17)
+        c.resume(returning: 38)
+    }
+    // CHECK: main tried to resume its continuation more than once, returning 38!
+
+    do {
+        let x: Int = await try withCheckedThrowingContinuation { c in
+            c.resume(throwing: TestError())
+            c.resume(returning: 679)
+            c.resume(throwing: TestError())
+        }
+    } catch {
+        // CHECK-NEXT: main tried to resume its continuation more than once, returning 679!
+        // CHECK-NEXT: main tried to resume its continuation more than once, throwing TestError()!
+    }
+    
+    _ = Task.runDetached {
+        let _: Void = await withCheckedContinuation { _ in
+            /*do nothing, leaking the task*/
+        }
+        // TODO: Whether the detached task gets a chance to run or not before
+        // the process exits is currently platform-dependent, and we don't yet
+        // have the API for yielding to the task runtime.
+        // C/HECK-NEXT: main leaked its continuation!
+    }
+}


### PR DESCRIPTION
To help catch runtime issues adopting `withUnsafeContinuation`, such as callback-based APIs that misleadingly
invoke their callback multiple times and/or not at all, provide a couple of classes that can take ownership of
a fresh `UnsafeContinuation` or `UnsafeThrowingContinuation`, and log attempts to resume the continuation multiple times
or discard the object without ever resuming the continuation.