### PR TITLE
[5.4][CodeCompletion] Zero check interval should always check dependencies

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -607,7 +607,7 @@ bool CompletionInstance::shouldCheckDependencies() const {
   auto now = system_clock::now();
   auto threshold = DependencyCheckedTimestamp +
                    seconds(Opts.DependencyCheckIntervalSecond);
-  return threshold < now;
+  return threshold <= now;
 }
 
 void CompletionInstance::setOptions(CompletionInstance::Options NewOpts) {


### PR DESCRIPTION
Cherry-pick of 428516c0f87828bac2618cfd900cba57b7b283cc (https://github.com/apple/swift/pull/35187) to 5.4